### PR TITLE
Deploy cloudformation via Riffraff

### DIFF
--- a/lib/deploy/build-riffraff-bundle.js
+++ b/lib/deploy/build-riffraff-bundle.js
@@ -15,6 +15,8 @@ const { getSites, root, dist, target } = require('../../config');
 // target
 // ├── build.json
 // ├── riff-raff.yaml
+// ├── frontend-cfn
+// |   └── cloudformation.yml
 // ├── frontend-static
 // │   └── guui
 // │       ├── assets
@@ -25,9 +27,17 @@ const { getSites, root, dist, target } = require('../../config');
 // │           │   └── **
 // │           │       └── *
 // │           └── etc
-// └── guui
+// └── rendering
 //     └── dist
-//         └── guui.zip
+//         └── rendering.zip
+
+const copyCfn = () => {
+    log(' - copying cloudformation config');
+    return cpy(
+        ['sites/frontend/cloudformation.yml'],
+        path.resolve(target, 'frontend-cfn'),
+    );
+};
 
 const copyStatic = () => {
     log(' - copying static');
@@ -76,12 +86,20 @@ const zipBundle = () => {
     log(' - zipping bundle');
     return execa(
         'zip',
-        ['-r', 'guui.zip', '.', '-x', 'node_modules/**\\*', '-x', '.git/**\\*'],
+        [
+            '-r',
+            'rendering.zip',
+            '.',
+            '-x',
+            'node_modules/**\\*',
+            '-x',
+            '.git/**\\*',
+        ],
         {
             shell: true,
         },
     ).then(() => {
-        cpy(['guui.zip'], path.resolve(target, 'guui', 'dist'));
+        cpy(['rendering.zip'], path.resolve(target, 'rendering', 'dist'));
     });
 };
 
@@ -102,7 +120,7 @@ const createBuildConfig = () => {
     );
 };
 
-Promise.all([copyStatic(), copyDist(), copyRiffRaff()])
+Promise.all([copyCfn(), copyStatic(), copyDist(), copyRiffRaff()])
     .then(zipBundle)
     .then(createBuildConfig)
     .catch(err => {

--- a/lib/deploy/riff-raff.yaml
+++ b/lib/deploy/riff-raff.yaml
@@ -1,8 +1,19 @@
 stacks: [frontend]
 regions: [eu-west-1]
 deployments:
-  guui:
-    type: autoscaling    
+  frontend-cfn:
+    type: cloud-formation
+    parameters:
+      templatePath: cloudformation.yml
+      cloudFormationStackByTags: false
+      cloudFormationStackName: rendering
+      amiParametersToTags:
+        AMI:
+          Recipe: frontend-base
+          BuiltBy: amigo
+          AmigoStage: PROD
+  rendering:
+    type: autoscaling
     parameters:
       bucket: aws-frontend-artifacts
     dependencies:

--- a/packages/rendering/server.js
+++ b/packages/rendering/server.js
@@ -43,6 +43,10 @@ if (process.env.NODE_ENV === 'production') {
 
     app.use(express.json({ limit: '50mb' }));
 
+    app.get('/_healthcheck', (req, res) => {
+        res.status(200).send('OKAY');
+    });
+
     // if running prod server locally, serve local assets
     if (!process.env.GU_PUBLIC) {
         app.use(

--- a/sites/frontend/cloudformation.yml
+++ b/sites/frontend/cloudformation.yml
@@ -3,15 +3,15 @@ Description: Frontend rendering service
 
 Parameters:
   Subnets:
-    Description: The subnets where guui instances will run
+    Description: The subnets where rendering instances will run
     Type: List<AWS::EC2::Subnet::Id>
   VpcId:
-    Description: The VPC in which guui instances will run
+    Description: The VPC in which rendering instances will run
     Type: AWS::EC2::VPC::Id
   App:
     Description: Application name
     Type: String
-    Default: guui
+    Default: rendering
   Stage:
     Description: Stage name
     Type: String
@@ -32,7 +32,7 @@ Mappings:
     Stack:
       Value: frontend
     App:
-      Value: guui
+      Value: rendering
 
 Resources:
   LoadBalancerSecurityGroup:
@@ -60,7 +60,7 @@ Resources:
   InstanceSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: guui instance
+      GroupDescription: rendering instance
       VpcId:
         Ref: VpcId
       SecurityGroupIngress:
@@ -126,7 +126,7 @@ Resources:
       - { LoadBalancerPort: 80, InstancePort: 9000, Protocol: HTTP }
       CrossZone: true
       HealthCheck:
-        Target: TCP:9000
+        Target: HTTP:9000/_healthcheck
         HealthyThreshold: 2
         UnhealthyThreshold: 10
         Interval: 30
@@ -188,9 +188,9 @@ Resources:
               export NVM_DIR="$HOME/.nvm"
               [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 
-              aws --region eu-west-1 s3 cp s3://aws-frontend-artifacts/frontend/${Stage}/guui/dist/guui.zip ./
-              unzip guui.zip -d guui
-              cd guui
+              aws --region eu-west-1 s3 cp s3://aws-frontend-artifacts/frontend/${Stage}/${App}/dist/${App}.zip ./
+              unzip ${App}.zip -d ${App}
+              cd ${App}
 
               export TERM=xterm-256color
 
@@ -202,8 +202,7 @@ Resources:
   AutoscalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
-      AvailabilityZones:
-        - eu-west-1a
+      AvailabilityZones: !GetAZs ''
       VPCZoneIdentifier:
         Ref: Subnets
       LaunchConfigurationName:

--- a/sites/frontend/cloudformation.yml
+++ b/sites/frontend/cloudformation.yml
@@ -89,6 +89,8 @@ Resources:
   InstanceRole:
     Type: AWS::IAM::Role
     Properties:
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM
       AssumeRolePolicyDocument:
         Statement:
         - Effect: Allow

--- a/sites/frontend/cloudformation.yml
+++ b/sites/frontend/cloudformation.yml
@@ -166,7 +166,7 @@ Resources:
         Ref: AMI
       SecurityGroups:
       - Ref: InstanceSecurityGroup
-      InstanceType: c4.large
+      InstanceType: t2.medium
       IamInstanceProfile:
         Ref: InstanceProfile
       AssociatePublicIpAddress: true

--- a/sites/frontend/cloudformation.yml
+++ b/sites/frontend/cloudformation.yml
@@ -211,7 +211,6 @@ Resources:
         Ref: LaunchConfig
       MinSize: 1
       MaxSize: 2
-      DesiredCapacity: 1
       HealthCheckType: ELB
       HealthCheckGracePeriod: 120
       LoadBalancerNames:


### PR DESCRIPTION
**Note: ssm for ssh doesn't appear to work though I'm not sure why at the moment - any wisdom appreciated. - e.g. try `ssm ssh -t rendering,frontend,CODE --profile frontend --oldest`.**

Replaces https://github.com/guardian/dotcom-rendering/pull/83 as it was easier to recreate than trying to merge given the changes are quite small.

## What does this change?

Adds continuous delivery for the cloudformation.

Also changes the associated stack name (guui -> rendering) and adds a custom healthcheck, which can be kept fast and lightweight.

## Why?

Manual deploys are riskier and more likely to get out of sync/be forgotten.