### PR TITLE
Swap out Preact for React

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -8,7 +8,7 @@ module.exports = {
     ],
     presets: [
         '@babel/preset-flow',
-        ['@babel/preset-react', { pragma: 'h' }],
+        '@babel/preset-react',
         [
             '@babel/preset-env',
             {

--- a/packages/guui/SiteMessage.js
+++ b/packages/guui/SiteMessage.js
@@ -6,15 +6,15 @@ import pallete from '@guardian/pasteup/palette';
 import CloseButton from '@guardian/guui/buttons/Close';
 
 type SiteMessageProps = {
-    foregroundColor: string,
-    backgroundColor: string,
+    foregroundcolor: string,
+    backgroundcolor: string,
     children?: React.Node,
 };
 
 const duration = 100;
 
 const Overlay = styled('div')(
-    ({ foregroundColor, backgroundColor, close }) => ({
+    ({ foregroundcolor: foregroundColor, backgroundcolor: backgroundColor, close }) => ({
         backgroundColor: transparentize(0.03, backgroundColor),
         color: foregroundColor,
         fill: foregroundColor,
@@ -33,8 +33,8 @@ const Overlay = styled('div')(
 
 export default class SiteMessage extends Component<SiteMessageProps, *> {
     static defaultProps: SiteMessageProps = {
-        foregroundColor: 'white',
-        backgroundColor: pallete.neutral[1],
+        foregroundcolor: 'white',
+        backgroundcolor: pallete.neutral[1],
     };
 
     constructor(props: SiteMessageProps) {
@@ -59,15 +59,15 @@ export default class SiteMessage extends Component<SiteMessageProps, *> {
         return (
             renderOverlay && (
                 <Overlay
-                    foregroundColor={this.props.foregroundColor}
-                    backgroundColor={this.props.backgroundColor}
+                    foregroundcolor={this.props.foregroundcolor}
+                    backgroundcolor={this.props.backgroundcolor}
                     close={this.state.close}
                     {...this.props}
                 >
                     {this.props.children}
                     <CloseButton
-                        foregroundColor={this.props.foregroundColor}
-                        backgroundColor={this.props.backgroundColor}
+                        foregroundcolor={this.props.foregroundcolor}
+                        backgroundcolor={this.props.backgroundcolor}
                         onClick={this.close}
                     />
                 </Overlay>

--- a/packages/guui/SiteMessage.js
+++ b/packages/guui/SiteMessage.js
@@ -14,7 +14,11 @@ type SiteMessageProps = {
 const duration = 100;
 
 const Overlay = styled('div')(
-    ({ foregroundcolor: foregroundColor, backgroundcolor: backgroundColor, close }) => ({
+    ({
+        foregroundcolor: foregroundColor,
+        backgroundcolor: backgroundColor,
+        close,
+    }) => ({
         backgroundColor: transparentize(0.03, backgroundColor),
         color: foregroundColor,
         fill: foregroundColor,

--- a/packages/guui/buttons/Close.js
+++ b/packages/guui/buttons/Close.js
@@ -3,7 +3,7 @@ import { styled } from '@guardian/guui';
 import CloseIcon from '@guardian/pasteup/icons/x.svg';
 
 const CloseButton = styled(CloseIcon)(
-    ({ backgroundColor, foregroundColor }) => ({
+    ({ foregroundcolor: foregroundColor, backgroundColor }) => ({
         borderColor: foregroundColor,
         fill: foregroundColor,
         borderWidth: 1,

--- a/packages/guui/document.js
+++ b/packages/guui/document.js
@@ -1,8 +1,6 @@
 // @flow
 
-import { 
-    renderToString
-} from '@guardian/guui';
+import { renderToString } from '@guardian/guui';
 import assets from './lib/assets';
 import htmlTemplate from './htmlTemplate';
 
@@ -14,7 +12,7 @@ export default ({
     data: { page: string, site: string },
 }) => {
     const bundle = assets.dist(`${data.site}.${data.page.toLowerCase()}.js`);
-    const { html, css, ids: cssIDs } = renderToString(<Page />);  
+    const { html, css, ids: cssIDs } = renderToString(<Page />);
 
     return htmlTemplate({
         bundle,

--- a/packages/guui/document.js
+++ b/packages/guui/document.js
@@ -1,6 +1,8 @@
 // @flow
 
-import { renderToString } from '@guardian/guui';
+import { 
+    renderToString
+} from '@guardian/guui';
 import assets from './lib/assets';
 import htmlTemplate from './htmlTemplate';
 
@@ -12,7 +14,7 @@ export default ({
     data: { page: string, site: string },
 }) => {
     const bundle = assets.dist(`${data.site}.${data.page.toLowerCase()}.js`);
-    const { html, css, ids: cssIDs } = renderToString(<Page />);
+    const { html, css, ids: cssIDs } = renderToString(<Page />);  
 
     return htmlTemplate({
         bundle,

--- a/packages/guui/index.js
+++ b/packages/guui/index.js
@@ -3,15 +3,10 @@
 // provide a consistent wrapper around the libs guui depends on.
 
 import { hydrate as hydrateCSS } from 'emotion';
-
 import { extractCritical } from 'emotion-server';
-
 import { Component } from 'react';
-
 import { hydrate as hydrateApp } from 'react-dom';
-
 import { renderToString as reactRenderToString } from 'react-dom/server';
-
 import styled from 'react-emotion';
 
 type renderToStringResult = {

--- a/packages/guui/index.js
+++ b/packages/guui/index.js
@@ -2,25 +2,15 @@
 
 // provide a consistent wrapper around the libs guui depends on.
 
-import { 
-    hydrate as hydrateCSS 
-} from 'emotion';
+import { hydrate as hydrateCSS } from 'emotion';
 
-import { 
-    extractCritical 
-} from 'emotion-server';
+import { extractCritical } from 'emotion-server';
 
-import { 
-    Component
-} from 'react';
+import { Component } from 'react';
 
-import { 
-    hydrate as hydrateApp
-} from 'react-dom';
+import { hydrate as hydrateApp } from 'react-dom';
 
-import { 
-    renderToString as reactRenderToString,
-} from 'react-dom/server';
+import { renderToString as reactRenderToString } from 'react-dom/server';
 
 import styled from 'react-emotion';
 
@@ -33,10 +23,4 @@ type renderToStringResult = {
 const renderToString = (ComponentToRender: React.Node): renderToStringResult =>
     extractCritical(reactRenderToString(ComponentToRender));
 
-export { 
-    hydrateApp,
-    renderToString,
-    hydrateCSS,
-    styled,
-    Component
-};
+export { hydrateApp, renderToString, hydrateCSS, styled, Component };

--- a/packages/guui/index.js
+++ b/packages/guui/index.js
@@ -2,11 +2,27 @@
 
 // provide a consistent wrapper around the libs guui depends on.
 
-import { Component, render as hydrateApp } from 'preact';
-import preactRenderToString from 'preact-render-to-string';
-import { hydrate as hydrateCSS } from 'emotion';
-import styled from 'preact-emotion';
-import { extractCritical } from 'emotion-server';
+import { 
+    hydrate as hydrateCSS 
+} from 'emotion';
+
+import { 
+    extractCritical 
+} from 'emotion-server';
+
+import { 
+    Component
+} from 'react';
+
+import { 
+    hydrate as hydrateApp
+} from 'react-dom';
+
+import { 
+    renderToString as reactRenderToString,
+} from 'react-dom/server';
+
+import styled from 'react-emotion';
 
 type renderToStringResult = {
     html: string,
@@ -15,6 +31,12 @@ type renderToStringResult = {
 };
 
 const renderToString = (ComponentToRender: React.Node): renderToStringResult =>
-    extractCritical(preactRenderToString(ComponentToRender));
+    extractCritical(reactRenderToString(ComponentToRender));
 
-export { hydrateApp, renderToString, hydrateCSS, styled, Component };
+export { 
+    hydrateApp,
+    renderToString,
+    hydrateCSS,
+    styled,
+    Component
+};

--- a/packages/guui/package.json
+++ b/packages/guui/package.json
@@ -13,10 +13,10 @@
     "emotion": "^9.1.1",
     "emotion-server": "^9.1.1",
     "polished": "^1.9.2",
-    "preact": "^8.2.7",
-    "preact-emotion": "^9.1.1",
-    "preact-render-to-string": "^3.7.0",
     "prop-types": "^15.6.1",
+    "react": "^16.4.0",
+    "react-dom": "^16.4.0",
+    "react-emotion": "^9.1.3",
     "reset-css": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/rendering/browser.js
+++ b/packages/rendering/browser.js
@@ -2,10 +2,7 @@
 
 // __SITE__ and __PAGE__ strings are replaced by string-replace-loader in webpack.config.js
 
-import { 
-    hydrateApp, 
-    hydrateCSS 
-} from '@guardian/guui';
+import { hydrateApp, hydrateCSS } from '@guardian/guui';
 
 // $FlowFixMe: shut up, flow
 import Page from '../../sites/__SITE__/pages/__PAGE__'; // eslint-disable-line import/no-unresolved,import/extensions

--- a/packages/rendering/browser.js
+++ b/packages/rendering/browser.js
@@ -14,7 +14,6 @@ const { data, cssIDs } = window.gu.app;
 
 if (module.hot) {
     module.hot.accept();
-    // require('preact/debug'); // eslint-disable-line global-require,import/no-extraneous-dependencies
 }
 
 const container = document.getElementById('app');

--- a/packages/rendering/browser.js
+++ b/packages/rendering/browser.js
@@ -2,7 +2,10 @@
 
 // __SITE__ and __PAGE__ strings are replaced by string-replace-loader in webpack.config.js
 
-import { hydrateApp, hydrateCSS } from '@guardian/guui';
+import { 
+    hydrateApp, 
+    hydrateCSS 
+} from '@guardian/guui';
 
 // $FlowFixMe: shut up, flow
 import Page from '../../sites/__SITE__/pages/__PAGE__'; // eslint-disable-line import/no-unresolved,import/extensions
@@ -14,14 +17,12 @@ const { data, cssIDs } = window.gu.app;
 
 if (module.hot) {
     module.hot.accept();
-    require('preact/debug'); // eslint-disable-line global-require,import/no-extraneous-dependencies
+    // require('preact/debug'); // eslint-disable-line global-require,import/no-extraneous-dependencies
 }
 
 const container = document.getElementById('app');
+
 if (container) {
-    const replacer = container.lastElementChild;
-    if (replacer) {
-        hydrateCSS(cssIDs);
-        hydrateApp(<App Page={Page} data={data} />, container, replacer);
-    }
+    hydrateCSS(cssIDs);
+    hydrateApp(<App Page={Page} data={data} />, container);
 }

--- a/sites/frontend/App.js
+++ b/sites/frontend/App.js
@@ -1,6 +1,6 @@
 // @flow
 import createStore from 'unistore';
-import { Provider } from 'unistore/preact';
+import { Provider } from 'unistore/react';
 
 type Props = {
     data: {},

--- a/sites/frontend/components/CapiComponent.js
+++ b/sites/frontend/components/CapiComponent.js
@@ -1,6 +1,6 @@
 // @flow
 import { Component } from '@guardian/guui';
-import { connect } from 'unistore/preact';
+import { connect } from 'unistore/react';
 
 export const keyRegister = new Set();
 

--- a/sites/frontend/components/Epic.js
+++ b/sites/frontend/components/Epic.js
@@ -22,8 +22,8 @@ type Props = {
 export default function Epic({ children }: Props) {
     return (
         <SiteMessage
-            foregroundColor={pallete.neutral[2]}
-            backgroundColor={pallete.yellow.medium}
+            foregroundcolor={pallete.neutral[2]}
+            backgroundcolor={pallete.yellow.medium}
         >
             <Content>{children}</Content>
         </SiteMessage>

--- a/sites/frontend/components/Header/Nav/Links/index.js
+++ b/sites/frontend/components/Header/Nav/Links/index.js
@@ -1,6 +1,6 @@
 // @flow
 import { styled } from '@guardian/guui';
-import { connect } from 'unistore/preact';
+import { connect } from 'unistore/react';
 
 import SupportTheGuardian from './SupportTheGuardian';
 import Link from './Link';

--- a/sites/frontend/components/Header/Nav/SubNav/SubNavList/SubNavListItem/SecondarySubNavList/index.js
+++ b/sites/frontend/components/Header/Nav/SubNav/SubNavList/SubNavListItem/SecondarySubNavList/index.js
@@ -33,6 +33,6 @@ type Props = { pillar: PillarType, showSecondaryNav: boolean };
 
 export default ({ pillar, showSecondaryNav }: Props) => (
     <SecondarySubNavList showSecondaryNav={showSecondaryNav}>
-        {pillar.links.map(link => <SecondarySubNavListItem link={link} />)}
+        {pillar.links.map(link => <SecondarySubNavListItem link={link} key={link.label}/>)}
     </SecondarySubNavList>
 );

--- a/sites/frontend/components/Header/Nav/SubNav/SubNavList/SubNavListItem/SecondarySubNavList/index.js
+++ b/sites/frontend/components/Header/Nav/SubNav/SubNavList/SubNavListItem/SecondarySubNavList/index.js
@@ -33,6 +33,8 @@ type Props = { pillar: PillarType, showSecondaryNav: boolean };
 
 export default ({ pillar, showSecondaryNav }: Props) => (
     <SecondarySubNavList showSecondaryNav={showSecondaryNav}>
-        {pillar.links.map(link => <SecondarySubNavListItem link={link} key={link.label}/>)}
+        {pillar.links.map(link => (
+            <SecondarySubNavListItem link={link} key={link.label} />
+        ))}
     </SecondarySubNavList>
 );

--- a/sites/frontend/components/MostViewed.js
+++ b/sites/frontend/components/MostViewed.js
@@ -63,7 +63,7 @@ export default class MostViewed extends Component {
                 <Heading>Most Viewed</Heading>
                 <ul>
                     {this.state.trails.map((trail, i) => (
-                        <ListItem>
+                        <ListItem key={trail.url}>
                             <Number>
                                 <Numbers index={i + 1} />
                             </Number>

--- a/sites/frontend/document.js
+++ b/sites/frontend/document.js
@@ -1,6 +1,8 @@
 // @flow
 
-import { renderToString } from '@guardian/guui';
+import { 
+    renderToString 
+} from '@guardian/guui';
 import assets from '@guardian/guui/lib/assets';
 import htmlTemplate from '@guardian/guui/htmlTemplate';
 
@@ -19,12 +21,15 @@ type Props = {
 
 export default ({ Page, data: { body, ...data } }: Props) => {
     const cleanedData = { ...parseCAPI(body), ...data };
+    
     const bundle = assets.dist(
         `${cleanedData.site}.${cleanedData.page.toLowerCase()}.js`,
     );
+    
     const { html, css, ids: cssIDs } = renderToString(
         <App data={{ ...cleanedData }} Page={Page} />,
     );
+    
     /**
      * To save sending CAPI data twice (in the HEAD and BODY)
      * we replace any keys present in the CapiComponent keyRegister

--- a/sites/frontend/document.js
+++ b/sites/frontend/document.js
@@ -1,8 +1,6 @@
 // @flow
 
-import { 
-    renderToString 
-} from '@guardian/guui';
+import { renderToString } from '@guardian/guui';
 import assets from '@guardian/guui/lib/assets';
 import htmlTemplate from '@guardian/guui/htmlTemplate';
 
@@ -21,15 +19,15 @@ type Props = {
 
 export default ({ Page, data: { body, ...data } }: Props) => {
     const cleanedData = { ...parseCAPI(body), ...data };
-    
+
     const bundle = assets.dist(
         `${cleanedData.site}.${cleanedData.page.toLowerCase()}.js`,
     );
-    
+
     const { html, css, ids: cssIDs } = renderToString(
         <App data={{ ...cleanedData }} Page={Page} />,
     );
-    
+
     /**
      * To save sending CAPI data twice (in the HEAD and BODY)
      * we replace any keys present in the CapiComponent keyRegister

--- a/sites/frontend/pages/Article.js
+++ b/sites/frontend/pages/Article.js
@@ -97,7 +97,7 @@ const SeriesLabel = styled(SectionLabel)({
 export default () => (
     <Page>
         <Header />
-        {/* <Main>
+        <Main>
             <article>
                 <Row>
                     <Cols wide={3} leftCol={2}>
@@ -132,6 +132,6 @@ export default () => (
                     </strong>
                 </Epic>
             </article>
-        </Main> */}
+        </Main>
     </Page>
 );

--- a/sites/frontend/pages/Article.js
+++ b/sites/frontend/pages/Article.js
@@ -3,7 +3,6 @@
 /* eslint-disable react/no-danger */
 
 import { styled } from '@guardian/guui';
-
 import { Row, Cols } from '@guardian/guui/grid';
 import { textEgyptian, headline } from '@guardian/pasteup/fonts';
 import palette from '@guardian/pasteup/palette';
@@ -98,7 +97,7 @@ const SeriesLabel = styled(SectionLabel)({
 export default () => (
     <Page>
         <Header />
-        <Main>
+        {/* <Main>
             <article>
                 <Row>
                     <Cols wide={3} leftCol={2}>
@@ -133,6 +132,6 @@ export default () => (
                     </strong>
                 </Epic>
             </article>
-        </Main>
+        </Main> */}
     </Page>
 );

--- a/webpack/index.js
+++ b/webpack/index.js
@@ -55,7 +55,7 @@ const common = ({ platform, site, page = '' }) => ({
             },
             {
                 test: /\.svg$/,
-                use: ['desvg-loader/preact', 'svg-loader'],
+                use: ['desvg-loader/react', 'svg-loader'],
             },
             {
                 // make sure webpack tree-shakes this stuff
@@ -70,7 +70,7 @@ const common = ({ platform, site, page = '' }) => ({
     },
     plugins: [
         new webpack.ProvidePlugin({
-            h: ['preact', 'h'],
+            "React": "react",
         }),
         new webpack.DefinePlugin({
             'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
@@ -85,12 +85,6 @@ const common = ({ platform, site, page = '' }) => ({
                 logLevel: 'warn',
             }),
     ].filter(Boolean),
-    resolve: {
-        alias: {
-            // for libs that expect React
-            react: 'preact',
-        },
-    },
 });
 
 module.exports = getSites()

--- a/webpack/index.js
+++ b/webpack/index.js
@@ -70,7 +70,7 @@ const common = ({ platform, site, page = '' }) => ({
     },
     plugins: [
         new webpack.ProvidePlugin({
-            "React": "react",
+            React: 'react',
         }),
         new webpack.DefinePlugin({
             'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),

--- a/yarn.lock
+++ b/yarn.lock
@@ -605,9 +605,23 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@emotion/is-prop-valid@^0.5.2":
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.5.2.tgz#4f47717c2bcce8759e11997520e6bcb14326f54a"
+"@emotion/hash@^0.6.2":
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.6.3.tgz#0e7a5604626fc6c6d4ac4061a2f5ac80d50262a4"
+
+"@emotion/is-prop-valid@^0.6.1":
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.6.2.tgz#a76a16b174ff03f8e3a27faf6259bacd21a02adc"
+  dependencies:
+    "@emotion/memoize" "^0.6.2"
+
+"@emotion/memoize@^0.6.1", "@emotion/memoize@^0.6.2":
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.6.2.tgz#138e00b332d519b4e307bded6159e5ba48aba3ae"
+
+"@emotion/stylis@^0.6.5":
+  version "0.6.8"
+  resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.6.8.tgz#6ad4e8d32b19b440efa4481bbbcb98a8c12765bb"
 
 "@guardian/guui@0.1.0-alpha.1":
   version "0.1.0-alpha.1"
@@ -1162,6 +1176,22 @@ babel-plugin-emotion@^9.1.0:
     babel-plugin-syntax-jsx "^6.18.0"
     convert-source-map "^1.5.0"
     emotion-utils "^9.1.0"
+    find-root "^1.1.0"
+    mkdirp "^0.5.1"
+    source-map "^0.5.7"
+    touch "^1.0.0"
+
+babel-plugin-emotion@^9.1.2:
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-9.1.2.tgz#e26b313fa0fecd0f2cc07b1e4ef05da167e4f740"
+  dependencies:
+    "@babel/helper-module-imports" "7.0.0-beta.32"
+    "@emotion/hash" "^0.6.2"
+    "@emotion/memoize" "^0.6.1"
+    "@emotion/stylis" "^0.6.5"
+    babel-plugin-macros "^2.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    convert-source-map "^1.5.0"
     find-root "^1.1.0"
     mkdirp "^0.5.1"
     source-map "^0.5.7"
@@ -2414,12 +2444,11 @@ create-emotion-server@^9.1.1:
     multipipe "^1.0.2"
     through "^2.3.8"
 
-create-emotion-styled@^9.1.1:
-  version "9.1.1"
-  resolved "https://registry.yarnpkg.com/create-emotion-styled/-/create-emotion-styled-9.1.1.tgz#872911dde3d38871703be632580becd05e636f10"
+create-emotion-styled@^9.1.2:
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/create-emotion-styled/-/create-emotion-styled-9.1.2.tgz#1528d9ff5ecc7e3abdf9986510a85ad2a9d73648"
   dependencies:
-    "@emotion/is-prop-valid" "^0.5.2"
-    emotion-utils "^9.1.0"
+    "@emotion/is-prop-valid" "^0.6.1"
 
 create-emotion@^9.1.1:
   version "9.1.1"
@@ -4959,7 +4988,7 @@ loglevelnext@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/loglevelnext/-/loglevelnext-1.0.4.tgz#0d991d9998180991dac8bd81e73a596a8720a645"
 
-loose-envify@^1.0.0, loose-envify@^1.3.1:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -6175,23 +6204,6 @@ postcss@^6.0.1:
     source-map "^0.6.1"
     supports-color "^5.3.0"
 
-preact-emotion@^9.1.1:
-  version "9.1.1"
-  resolved "https://registry.yarnpkg.com/preact-emotion/-/preact-emotion-9.1.1.tgz#e6b4de65a6c14162a85c856f00bf56bbbf99bd93"
-  dependencies:
-    babel-plugin-emotion "^9.1.0"
-    create-emotion-styled "^9.1.1"
-
-preact-render-to-string@^3.7.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/preact-render-to-string/-/preact-render-to-string-3.7.0.tgz#7db4177454bc01395e0d01d6ac07bc5e838e31ee"
-  dependencies:
-    pretty-format "^3.5.1"
-
-preact@^8.2.7:
-  version "8.2.7"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-8.2.7.tgz#316249fb678cd5e93e7cee63cea7bfb62dbd6814"
-
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -6222,10 +6234,6 @@ pretty-bytes@^1.0.0:
 pretty-bytes@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-4.0.2.tgz#b2bf82e7350d65c6c33aa95aaa5a4f6327f61cd9"
-
-pretty-format@^3.5.1:
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-3.8.0.tgz#bfbed56d5e9a776645f4b1ff7aa1a3ac4fa3c385"
 
 private@^0.1.6, private@^0.1.7, private@~0.1.5:
   version "0.1.8"
@@ -6399,6 +6407,31 @@ rc@^1.1.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-dom@^16.4.0:
+  version "16.4.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.0.tgz#099f067dd5827ce36a29eaf9a6cdc7cbf6216b1e"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+
+react-emotion@^9.1.3:
+  version "9.1.3"
+  resolved "https://registry.yarnpkg.com/react-emotion/-/react-emotion-9.1.3.tgz#299c29731d12d6236e33277845f5692ec8ba92d6"
+  dependencies:
+    babel-plugin-emotion "^9.1.2"
+    create-emotion-styled "^9.1.2"
+
+react@^16.4.0:
+  version "16.4.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.4.0.tgz#402c2db83335336fba1962c08b98c6272617d585"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
 read-chunk@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
## What does this change?

Update to use `React` instead of `Preact`.

Main changes are swapping dependencies in `guui` package and updating webapack config to remove `preact` references/config.

The changes to Components in `frontend` were required as `React` is stricter than `Preact` when it comes to using keys on list items and what it considers valid `prop` names.

## Why?

Upcoming UX and Performance improvements (async rendering, time slicing etc), large active community/ecosystem, no need to polyfill missing features so easier to configure.

