### PR TITLE
Verbump 3.0.0-alpha.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@guardian/dotcom-rendering",
-    "version": "0.1.0-alpha",
+    "version": "3.0.0-alpha.1",
     "private": true,
     "workspaces": [
         "sites/*",


### PR DESCRIPTION
## What does this change?

Are we happy to skip straight to version 3?

## Why?

Because 1 and 2 were used in the exploration phase