### PR TITLE
Add optional property htmlTag to Grid Row/Cols

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,6 +29,7 @@ module.exports = {
                 extensions: ['.js'],
             },
         ],
+        'react/default-props-match-prop-types': 'off',
     },
     overrides: [
         {

--- a/packages/guui/SiteMessage.js
+++ b/packages/guui/SiteMessage.js
@@ -8,7 +8,7 @@ import CloseButton from '@guardian/guui/buttons/Close';
 type SiteMessageProps = {
     foregroundcolor: string,
     backgroundcolor: string,
-    children?: React.Node,
+    children?: React$Node,
 };
 
 const duration = 100;

--- a/packages/guui/grid.js
+++ b/packages/guui/grid.js
@@ -118,7 +118,7 @@ export const Row = ({
     children,
 }: {
     htmlTag?: string,
-    children: React.Node,
+    children: React$Node,
 }) => {
     const GridRow = RowStyled.withComponent(htmlTag);
 
@@ -139,7 +139,7 @@ export const Cols = ({
 }: {
     htmlTag?: string,
     [Breakpoint]: BreakpointProps | number,
-    children: React.Node,
+    children: React$Node,
 }) => {
     const GridCol = ColsStyled.withComponent(htmlTag);
     return (

--- a/packages/guui/grid.js
+++ b/packages/guui/grid.js
@@ -113,25 +113,47 @@ const normaliseProps = (props: BreakpointProps | number): BreakpointProps => {
     return props;
 };
 
-export const Row = ({ children }: { children: React.Node }) => (
-    <RowStyled>{children}</RowStyled>
-);
+export const Row = ({
+    htmlTag,
+    children,
+}: {
+    htmlTag?: string,
+    children: React.Node,
+}) => {
+    const GridRow = RowStyled.withComponent(htmlTag);
+
+    return <GridRow>{children}</GridRow>;
+};
+
+Row.defaultProps = {
+    htmlTag: 'div',
+};
+
 export const Cols = ({
+    htmlTag,
     tablet,
     desktop,
     leftCol,
     wide,
     children,
 }: {
+    htmlTag?: string,
     [Breakpoint]: BreakpointProps | number,
     children: React.Node,
-}) => (
-    <ColsStyled
-        tablet={normaliseProps(tablet || [columns.tablet.max, {}])}
-        desktop={normaliseProps(desktop || [columns.desktop.max, {}])}
-        leftCol={normaliseProps(leftCol || [columns.leftCol.max, {}])}
-        wide={normaliseProps(wide || [columns.wide.max, {}])}
-    >
-        {children}
-    </ColsStyled>
-);
+}) => {
+    const GridCol = ColsStyled.withComponent(htmlTag);
+    return (
+        <GridCol
+            tablet={normaliseProps(tablet || [columns.tablet.max, {}])}
+            desktop={normaliseProps(desktop || [columns.desktop.max, {}])}
+            leftCol={normaliseProps(leftCol || [columns.leftCol.max, {}])}
+            wide={normaliseProps(wide || [columns.wide.max, {}])}
+        >
+            {children}
+        </GridCol>
+    );
+};
+
+Cols.defaultProps = {
+    htmlTag: 'div',
+};

--- a/packages/guui/grid.js
+++ b/packages/guui/grid.js
@@ -160,4 +160,4 @@ Cols.defaultProps = {
     desktop: [columns.desktop.max, {}],
     leftCol: [columns.leftCol.max, {}],
     wide: [columns.wide.max, {}],
-}
+};

--- a/packages/guui/grid.js
+++ b/packages/guui/grid.js
@@ -144,10 +144,10 @@ export const Cols = ({
     const GridCol = ColsStyled.withComponent(htmlTag);
     return (
         <GridCol
-            tablet={normaliseProps(tablet || [columns.tablet.max, {}])}
-            desktop={normaliseProps(desktop || [columns.desktop.max, {}])}
-            leftCol={normaliseProps(leftCol || [columns.leftCol.max, {}])}
-            wide={normaliseProps(wide || [columns.wide.max, {}])}
+            tablet={normaliseProps(tablet)}
+            desktop={normaliseProps(desktop)}
+            leftCol={normaliseProps(leftCol)}
+            wide={normaliseProps(wide)}
         >
             {children}
         </GridCol>
@@ -156,4 +156,8 @@ export const Cols = ({
 
 Cols.defaultProps = {
     htmlTag: 'div',
-};
+    tablet: [columns.tablet.max, {}],
+    desktop: [columns.desktop.max, {}],
+    leftCol: [columns.leftCol.max, {}],
+    wide: [columns.wide.max, {}],
+}

--- a/sites/frontend/components/Epic.js
+++ b/sites/frontend/components/Epic.js
@@ -16,7 +16,7 @@ const Content = styled('div')({
 });
 
 type Props = {
-    children: React.Node,
+    children: React$Node,
 };
 
 export default function Epic({ children }: Props) {

--- a/sites/frontend/components/Header/Nav/Pillars/Pillar.js
+++ b/sites/frontend/components/Header/Nav/Pillars/Pillar.js
@@ -69,7 +69,7 @@ const Link = styled('a')(({ pillar }) => ({
 }));
 
 type Props = {
-    children: React.Node,
+    children: React$Node,
     pillar: PillarType,
 };
 


### PR DESCRIPTION
## What does this change?

Currently the Grid component's Rows and Cols are rendered as `<div>`s. There's currently no way of overriding the tag type used. For example, If you wanted to create a row which is a `<ul>` and it's columns are `<li>`s you can't use the Grid component to do this.

This PR introduces a new property `htmlTag` to the `Row` and `Cols` components which allows you to specify the tag type to use. The default if not specified is `<div>`.

## Why?

Increased flexibility of the Grid component
