### PR TITLE
remove displayName property

### DIFF
--- a/sites/frontend/components/Header/Nav/Links/index.js
+++ b/sites/frontend/components/Header/Nav/Links/index.js
@@ -13,7 +13,6 @@ const Links = styled('div')({
     top: 0,
     position: 'absolute',
 });
-Links.displayName = 'Links';
 
 export default connect('header')(({ isPayingMember, isRecentContributor }) => (
     <Links>

--- a/sites/frontend/components/Header/Nav/MainMenu/MainMenuColumns/MainMenuColumn/MainMenuColumnButton.js
+++ b/sites/frontend/components/Header/Nav/MainMenu/MainMenuColumns/MainMenuColumn/MainMenuColumnButton.js
@@ -59,7 +59,6 @@ const MainMenuColumnButton = styled('button')(
         },
     }),
 );
-MainMenuColumnButton.displayName = 'MainMenuColumnButton';
 
 type Props = {
     column: ColumnType,

--- a/sites/frontend/components/Header/Nav/MainMenu/MainMenuColumns/MainMenuColumn/MainMenuColumnLinks/MainMenuLink/MainMenuLinkTitle.js
+++ b/sites/frontend/components/Header/Nav/MainMenu/MainMenuColumns/MainMenuColumn/MainMenuColumnLinks/MainMenuLink/MainMenuLinkTitle.js
@@ -44,8 +44,6 @@ const MainMenuColumnLinkTitle = styled('a')(({ column, isPillar }) => ({
     },
 }));
 
-MainMenuColumnLinkTitle.displayName = 'MainMenuColumnLinkTitle';
-
 type Props = {
     column: ColumnType,
     isPillar: boolean,

--- a/sites/frontend/components/Header/Nav/MainMenu/MainMenuColumns/MainMenuColumn/MainMenuColumnLinks/MainMenuLink/index.js
+++ b/sites/frontend/components/Header/Nav/MainMenu/MainMenuColumns/MainMenuColumn/MainMenuColumnLinks/MainMenuLink/index.js
@@ -11,7 +11,6 @@ const MainMenuLink = styled('li')({
     position: 'relative',
     width: '100%',
 });
-MainMenuLink.displayName = 'MainMenuLink';
 
 type Props = {
     column: ColumnType,

--- a/sites/frontend/components/Header/Nav/MainMenu/MainMenuColumns/MainMenuColumn/MainMenuColumnLinks/index.js
+++ b/sites/frontend/components/Header/Nav/MainMenu/MainMenuColumns/MainMenuColumn/MainMenuColumnLinks/index.js
@@ -28,7 +28,6 @@ const MainMenuColumnLinks = styled('ul')(({ showColumnLinks, isPillar }) => ({
         padding: '0 5px',
     },
 }));
-MainMenuColumnLinks.displayName = 'MainMenuColumnLinks';
 
 type Props = {
     column: ColumnType,

--- a/sites/frontend/components/Header/Nav/MainMenu/MainMenuColumns/MainMenuColumn/index.js
+++ b/sites/frontend/components/Header/Nav/MainMenu/MainMenuColumns/MainMenuColumn/index.js
@@ -40,8 +40,6 @@ const MainMenuColumnStyled = styled('li')(({ isPillar }) => {
     return styles;
 });
 
-MainMenuColumnStyled.displayName = 'MainMenuColumnStyled';
-
 type Props = { column: ColumnType };
 
 export default class MainMenuColumn extends Component<

--- a/sites/frontend/components/Header/Nav/MainMenu/MainMenuColumns/index.js
+++ b/sites/frontend/components/Header/Nav/MainMenu/MainMenuColumns/index.js
@@ -24,7 +24,6 @@ const MainMenuColumns = styled('ul')({
         maxWidth: 1300,
     },
 });
-MainMenuColumns.displayName = 'MainMenuColumns';
 
 export default () => (
     <MainMenuColumns role="menubar" tabindex="-1">

--- a/sites/frontend/components/Header/Nav/MainMenu/index.js
+++ b/sites/frontend/components/Header/Nav/MainMenu/index.js
@@ -58,7 +58,6 @@ const MainMenu = styled('div')(({ showMainMenu }) => ({
         },
     },
 }));
-MainMenu.displayName = 'MainMenu';
 
 type Props = {
     showMainMenu: boolean,

--- a/sites/frontend/components/Header/Nav/MainMenuToggle/VeggieBurger.js
+++ b/sites/frontend/components/Header/Nav/MainMenuToggle/VeggieBurger.js
@@ -44,10 +44,8 @@ const VeggieBurgerStyles = ({ showMainMenu }) => {
 };
 
 const VeggieBurgerLabel = styled('label')(VeggieBurgerStyles);
-VeggieBurgerLabel.displayName = 'VeggieBurger';
 
 const VeggieBurgerButton = styled('label')(VeggieBurgerStyles);
-VeggieBurgerButton.displayName = 'VeggieBurger';
 
 const VeggieBurgerIcon = styled('span')(({ showMainMenu }) => {
     const beforeAfterStyles = {
@@ -90,7 +88,6 @@ const VeggieBurgerIcon = styled('span')(({ showMainMenu }) => {
 
     return styles;
 });
-VeggieBurgerIcon.displayName = 'VeggieBurgerIcon';
 
 type Props = {
     toggleMainMenu: () => void,

--- a/sites/frontend/components/Header/Nav/MainMenuToggle/index.js
+++ b/sites/frontend/components/Header/Nav/MainMenuToggle/index.js
@@ -48,7 +48,6 @@ const OpenMainMenuCheckbox = styled('input')({
         },
     },
 });
-OpenMainMenuCheckbox.displayName = 'OpenMainMenuCheckbox';
 
 const OpenMainMenuLabel = styled('label')({
     ...openMainMenuStyles,
@@ -56,12 +55,10 @@ const OpenMainMenuLabel = styled('label')({
         display: 'inline-block',
     },
 });
-OpenMainMenuLabel.displayName = 'OpenMainMenu';
 
 const OpenMainMenuButton = styled('button')({
     ...openMainMenuStyles,
 });
-OpenMainMenuButton.displayName = 'OpenMainMenu';
 
 const OpenMainMenuText = styled('span')({
     display: 'block',

--- a/sites/frontend/components/Header/Nav/Pillars/index.js
+++ b/sites/frontend/components/Header/Nav/Pillars/index.js
@@ -15,7 +15,6 @@ const Pillars = styled('ul')({
         paddingLeft: 20,
     },
 });
-Pillars.displayName = 'Pillars';
 
 export default () => (
     <Pillars>

--- a/sites/frontend/components/Header/Nav/index.js
+++ b/sites/frontend/components/Header/Nav/index.js
@@ -30,7 +30,6 @@ const NavStyled = styled('nav')(
     },
     clearFix,
 );
-NavStyled.displayName = 'Nav';
 
 export default class Nav extends Component<{}, { showMainMenu: boolean }> {
     constructor(props: {}) {

--- a/sites/frontend/components/Header/index.js
+++ b/sites/frontend/components/Header/index.js
@@ -13,7 +13,6 @@ const Header = styled('header')({
         display: 'block',
     },
 });
-Header.displayName = 'Header';
 
 export default () => (
     <Header>


### PR DESCRIPTION
`displayName` is peppered around our Components inconsistently. I'm removing any references for now as it's unclear the best way to use it and it's a distraction thinking about whether to add it. We need to look at React devTools and see how it should be applied to styled/functional/stateful components and where it should be added. 