### PR TITLE
Header Component updates - part 2

### DIFF
--- a/sites/frontend/components/Header/Nav/Logo.js
+++ b/sites/frontend/components/Header/Nav/Logo.js
@@ -14,22 +14,54 @@ import TheGuardianLogoSVG from '@guardian/pasteup/logos/the-guardian.svg';
 
 const Link = styled('a')({
     float: 'right',
-    marginBottom: '15px',
-    marginRight: '45px',
-    marginTop: '5px',
+    marginBottom: 15,
+    marginRight: 45,
+    marginTop: 3,
     [mobileMedium]: {
-        marginRight: '5px',
+        marginRight: 5,
     },
     [mobileLandscape]: {
-        marginRight: '17px',
+        marginRight: 17,
     },
     [desktop]: {
-        marginBottom: '-34px',
-        marginTop: '5px',
+        marginBottom: -34,
+        marginRight: 17,
+        marginTop: 5,
         position: 'relative',
         zIndex: 1071,
     },
 });
+
+
+// margin-bottom: $gs-baseline + $gs-baseline / 4;
+//     margin-right: $gs-gutter / 4 + $veggie-burger-small;
+//     margin-top: $gs-baseline / 4;
+
+//     @include mq(mobileMedium) {
+//         margin-right: $gs-gutter / 4;
+//     }
+
+//     @include mq(mobileLandscape) {
+//         margin-right: $gs-gutter - 3;
+//     }
+
+//     @include mq(desktop) {
+//         margin-bottom: -34px;
+//         margin-top: 5px;
+//         position: relative;
+//         z-index: $zindex-main-menu + 1;
+//     }
+
+//     body:not(.has-page-skin) & {
+//         @include mq(leftCol) {
+//             margin-bottom: -40px;
+//         }
+
+//         @include mq(wide) {
+//             margin-right: 96px;
+//         }
+//     }
+
 
 const ScreenReaderText = styled('span')(screenReaderOnly);
 

--- a/sites/frontend/components/Header/Nav/Logo.js
+++ b/sites/frontend/components/Header/Nav/Logo.js
@@ -32,37 +32,6 @@ const Link = styled('a')({
     },
 });
 
-
-// margin-bottom: $gs-baseline + $gs-baseline / 4;
-//     margin-right: $gs-gutter / 4 + $veggie-burger-small;
-//     margin-top: $gs-baseline / 4;
-
-//     @include mq(mobileMedium) {
-//         margin-right: $gs-gutter / 4;
-//     }
-
-//     @include mq(mobileLandscape) {
-//         margin-right: $gs-gutter - 3;
-//     }
-
-//     @include mq(desktop) {
-//         margin-bottom: -34px;
-//         margin-top: 5px;
-//         position: relative;
-//         z-index: $zindex-main-menu + 1;
-//     }
-
-//     body:not(.has-page-skin) & {
-//         @include mq(leftCol) {
-//             margin-bottom: -40px;
-//         }
-
-//         @include mq(wide) {
-//             margin-right: 96px;
-//         }
-//     }
-
-
 const ScreenReaderText = styled('span')(screenReaderOnly);
 
 const SVG = styled(TheGuardianLogoSVG)({

--- a/sites/frontend/components/Header/Nav/Logo.js
+++ b/sites/frontend/components/Header/Nav/Logo.js
@@ -7,6 +7,7 @@ import {
     desktop,
     leftCol,
     from,
+    wide,
 } from '@guardian/pasteup/breakpoints';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';
 
@@ -25,10 +26,15 @@ const Link = styled('a')({
     },
     [desktop]: {
         marginBottom: -34,
-        marginRight: 17,
         marginTop: 5,
         position: 'relative',
         zIndex: 1071,
+    },
+    [leftCol]: {
+        marginBottom: -40,
+    },
+    [wide]: {
+        marginRight: 96,
     },
 });
 

--- a/sites/frontend/components/Header/Nav/MainMenu/MainMenuColumns/MainMenuColumn/MainMenuColumnButton.js
+++ b/sites/frontend/components/Header/Nav/MainMenu/MainMenuColumns/MainMenuColumn/MainMenuColumnButton.js
@@ -5,8 +5,6 @@ import { headline } from '@guardian/pasteup/fonts';
 import { pillars } from '@guardian/pasteup/palette';
 import { desktop } from '@guardian/pasteup/breakpoints';
 
-import { pillarsConfig } from '../../../../Nav/__config__';
-
 import type { MainMenuColumnType } from '../../../../Nav/__config__';
 
 const MainMenuColumnButton = styled('button')(
@@ -65,6 +63,7 @@ type Props = {
     showColumnLinks: boolean,
     toggleColumnLinks: () => void,
     ariaControls: string,
+    isLastIndex: boolean,
 };
 
 export default ({
@@ -72,22 +71,19 @@ export default ({
     showColumnLinks,
     toggleColumnLinks,
     ariaControls,
-}: Props) => {
-    const isLastIndex = column === pillarsConfig[pillarsConfig.length - 1];
-
-    return (
-        <MainMenuColumnButton
-            pillar={column.id}
-            isLastIndex={isLastIndex}
-            showColumnLinks={showColumnLinks}
-            onClick={() => {
-                toggleColumnLinks();
-            }}
-            aria-haspopup="true"
-            aria-controls={ariaControls}
-            role="menuitem"
-        >
-            {column.label}
-        </MainMenuColumnButton>
-    );
-};
+    isLastIndex,
+}: Props) => (
+    <MainMenuColumnButton
+        pillar={column.id}
+        isLastIndex={isLastIndex}
+        showColumnLinks={showColumnLinks}
+        onClick={() => {
+            toggleColumnLinks();
+        }}
+        aria-haspopup="true"
+        aria-controls={ariaControls}
+        role="menuitem"
+    >
+        {column.label}
+    </MainMenuColumnButton>
+);

--- a/sites/frontend/components/Header/Nav/MainMenu/MainMenuColumns/MainMenuColumn/MainMenuColumnButton.js
+++ b/sites/frontend/components/Header/Nav/MainMenu/MainMenuColumns/MainMenuColumn/MainMenuColumnButton.js
@@ -5,9 +5,9 @@ import { headline } from '@guardian/pasteup/fonts';
 import { pillars } from '@guardian/pasteup/palette';
 import { desktop } from '@guardian/pasteup/breakpoints';
 
-import { columnsConfig } from '../../../../Nav/__config__';
+import { pillarsConfig } from '../../../../Nav/__config__';
 
-import type { ColumnType } from '../../../../Nav/__config__';
+import type { MainMenuColumnType } from '../../../../Nav/__config__';
 
 const MainMenuColumnButton = styled('button')(
     ({ pillar, isLastIndex, showColumnLinks }) => ({
@@ -61,7 +61,7 @@ const MainMenuColumnButton = styled('button')(
 );
 
 type Props = {
-    column: ColumnType,
+    column: MainMenuColumnType,
     showColumnLinks: boolean,
     toggleColumnLinks: () => void,
     ariaControls: string,
@@ -73,14 +73,11 @@ export default ({
     toggleColumnLinks,
     ariaControls,
 }: Props) => {
-    const pillarColumns = columnsConfig.filter(
-        columnConfig => !!columnConfig.pillar,
-    );
-    const isLastIndex = column === pillarColumns[pillarColumns.length - 1];
+    const isLastIndex = column === pillarsConfig[pillarsConfig.length - 1];
 
     return (
         <MainMenuColumnButton
-            pillar={column.pillar}
+            pillar={column.id}
             isLastIndex={isLastIndex}
             showColumnLinks={showColumnLinks}
             onClick={() => {

--- a/sites/frontend/components/Header/Nav/MainMenu/MainMenuColumns/MainMenuColumn/MainMenuColumnLinks/MainMenuLink/MainMenuLinkTitle.js
+++ b/sites/frontend/components/Header/Nav/MainMenu/MainMenuColumns/MainMenuColumn/MainMenuColumnLinks/MainMenuLink/MainMenuLinkTitle.js
@@ -5,9 +5,9 @@ import { tablet, desktop } from '@guardian/pasteup/breakpoints';
 import { egyptian } from '@guardian/pasteup/fonts';
 import { pillars } from '@guardian/pasteup/palette';
 
-import type { ColumnType } from '../../../../../../Nav/__config__';
+import type { MainMenuColumnType } from '../../../../../../Nav/__config__';
 
-const MainMenuColumnLinkTitle = styled('a')(({ column, isPillar }) => ({
+const MainMenuColumnLinkTitle = styled('a')(({ column }) => ({
     backgroundColor: 'transparent',
     textDecoration: 'none',
     border: 0,
@@ -32,11 +32,11 @@ const MainMenuColumnLinkTitle = styled('a')(({ column, isPillar }) => ({
         padding: '6px 0',
     },
     ':hover': {
-        color: isPillar ? pillars[column.pillar] : '#5d5f5f',
+        color: column.isPillar ? pillars[column.id] : '#5d5f5f',
         textDecoration: 'underline',
     },
     ':focus': {
-        color: isPillar ? pillars[column.pillar] : '#5d5f5f',
+        color: column.isPillar ? pillars[column.id] : '#5d5f5f',
         textDecoration: 'underline',
     },
     '> *': {
@@ -45,18 +45,16 @@ const MainMenuColumnLinkTitle = styled('a')(({ column, isPillar }) => ({
 }));
 
 type Props = {
-    column: ColumnType,
-    isPillar: boolean,
+    column: MainMenuColumnType,
     link: { href: string, label: string },
 };
 
-export default ({ link, column, isPillar }: Props) => (
+export default ({ link, column }: Props) => (
     <MainMenuColumnLinkTitle
         href={link.href}
         role="menuitem"
         link={link}
         column={column}
-        isPillar={isPillar}
     >
         {link.label}
     </MainMenuColumnLinkTitle>

--- a/sites/frontend/components/Header/Nav/MainMenu/MainMenuColumns/MainMenuColumn/MainMenuColumnLinks/MainMenuLink/index.js
+++ b/sites/frontend/components/Header/Nav/MainMenu/MainMenuColumns/MainMenuColumn/MainMenuColumnLinks/MainMenuLink/index.js
@@ -1,25 +1,32 @@
 // @flow
 import { styled } from '@guardian/guui';
 
+import { desktop } from '@guardian/pasteup/breakpoints';
+
 import MainMenuLinkTitle from './MainMenuLinkTitle';
 
-import type { ColumnType } from '../../../../../../Nav/__config__';
+import type {
+    MainMenuColumnType,
+    LinkType,
+} from '../../../../../../Nav/__config__';
 
-const MainMenuLink = styled('li')({
+const MainMenuLink = styled('li')(({ mobileOnly }) => ({
     boxSizing: 'border-box',
     overflow: 'hidden',
     position: 'relative',
     width: '100%',
-});
+    [desktop]: {
+        display: mobileOnly ? 'none' : 'list-item',
+    },
+}));
 
 type Props = {
-    column: ColumnType,
-    isPillar: boolean,
-    link: { href: string, label: string },
+    column: MainMenuColumnType,
+    link: LinkType,
 };
 
-export default ({ link, column, isPillar }: Props) => (
-    <MainMenuLink role="none">
-        <MainMenuLinkTitle link={link} column={column} isPillar={isPillar} />
+export default ({ link, column }: Props) => (
+    <MainMenuLink role="none" mobileOnly={link.mobileOnly || false}>
+        <MainMenuLinkTitle link={link} column={column} />
     </MainMenuLink>
 );

--- a/sites/frontend/components/Header/Nav/MainMenu/MainMenuColumns/MainMenuColumn/MainMenuColumnLinks/index.js
+++ b/sites/frontend/components/Header/Nav/MainMenu/MainMenuColumns/MainMenuColumn/MainMenuColumnLinks/index.js
@@ -5,7 +5,9 @@ import { desktop } from '@guardian/pasteup/breakpoints';
 
 import MainMenuLink from './MainMenuLink';
 
-import type { ColumnType } from '../../../../../Nav/__config__';
+import { brandExtenstionsConfig } from '../../../../../Nav/__config__';
+
+import type { MainMenuColumnType } from '../../../../../Nav/__config__';
 
 const MainMenuColumnLinks = styled('ul')(({ showColumnLinks, isPillar }) => ({
     boxSizing: 'border-box',
@@ -30,27 +32,34 @@ const MainMenuColumnLinks = styled('ul')(({ showColumnLinks, isPillar }) => ({
 }));
 
 type Props = {
-    column: ColumnType,
+    column: MainMenuColumnType,
     showColumnLinks: boolean,
     id: string,
-    isPillar: boolean,
 };
 
-export default ({ column, showColumnLinks, isPillar, id }: Props) => (
-    <MainMenuColumnLinks
-        showColumnLinks={showColumnLinks}
-        isPillar={isPillar}
-        aria-expanded={showColumnLinks}
-        role="menu"
-        id={id}
-    >
-        {column.links.map(link => (
-            <MainMenuLink
-                link={link}
-                key={link.label}
-                column={column}
-                isPillar={isPillar}
-            />
-        ))}
-    </MainMenuColumnLinks>
-);
+export default ({ column, showColumnLinks, id }: Props) => {
+    const links =
+        column.id === 'more'
+            ? [
+                  ...brandExtenstionsConfig.map(brandExtenstion => ({
+                      ...brandExtenstion,
+                      mobileOnly: true,
+                  })),
+                  ...column.links,
+              ]
+            : column.links;
+
+    return (
+        <MainMenuColumnLinks
+            showColumnLinks={showColumnLinks}
+            isPillar={column.isPillar}
+            aria-expanded={showColumnLinks}
+            role="menu"
+            id={id}
+        >
+            {links.map(link => (
+                <MainMenuLink link={link} key={link.label} column={column} />
+            ))}
+        </MainMenuColumnLinks>
+    );
+};

--- a/sites/frontend/components/Header/Nav/MainMenu/MainMenuColumns/MainMenuColumn/index.js
+++ b/sites/frontend/components/Header/Nav/MainMenu/MainMenuColumns/MainMenuColumn/index.js
@@ -42,6 +42,7 @@ const MainMenuColumnStyled = styled('li')(({ isPillar }) => {
 
 type Props = {
     column: MainMenuColumnType,
+    isLastIndex: boolean,
 };
 
 export default class MainMenuColumn extends Component<
@@ -64,7 +65,7 @@ export default class MainMenuColumn extends Component<
 
     render() {
         const { showColumnLinks } = this.state;
-        const { column } = this.props;
+        const { column, isLastIndex } = this.props;
         const subNavId = `${column.id}Links`;
         const ColumnButton = () => {
             if (column.isPillar) {
@@ -76,6 +77,7 @@ export default class MainMenuColumn extends Component<
                             this.toggleColumnLinks();
                         }}
                         ariaControls={subNavId}
+                        isLastIndex={isLastIndex}
                     />
                 );
             }

--- a/sites/frontend/components/Header/Nav/MainMenu/MainMenuColumns/MainMenuColumn/index.js
+++ b/sites/frontend/components/Header/Nav/MainMenu/MainMenuColumns/MainMenuColumn/index.js
@@ -6,7 +6,7 @@ import { desktop, leftCol } from '@guardian/pasteup/breakpoints';
 import MainMenuColumnButton from './MainMenuColumnButton';
 import MainMenuColumnLinks from './MainMenuColumnLinks';
 
-import type { ColumnType } from '../../../../Nav/__config__';
+import type { MainMenuColumnType } from '../../../../Nav/__config__';
 
 const MainMenuColumnStyled = styled('li')(({ isPillar }) => {
     const styles = {
@@ -40,7 +40,9 @@ const MainMenuColumnStyled = styled('li')(({ isPillar }) => {
     return styles;
 });
 
-type Props = { column: ColumnType };
+type Props = {
+    column: MainMenuColumnType,
+};
 
 export default class MainMenuColumn extends Component<
     Props,
@@ -63,10 +65,9 @@ export default class MainMenuColumn extends Component<
     render() {
         const { showColumnLinks } = this.state;
         const { column } = this.props;
-        const isPillar = !!column.pillar;
         const subNavId = `${column.id}Links`;
         const ColumnButton = () => {
-            if (isPillar) {
+            if (column.isPillar) {
                 return (
                     <MainMenuColumnButton
                         column={column}
@@ -82,13 +83,12 @@ export default class MainMenuColumn extends Component<
         };
 
         return (
-            <MainMenuColumnStyled role="none" isPillar={isPillar}>
+            <MainMenuColumnStyled role="none" isPillar={column.isPillar}>
                 <ColumnButton />
                 <MainMenuColumnLinks
                     column={column}
                     showColumnLinks={showColumnLinks}
                     id={subNavId}
-                    isPillar={isPillar}
                 />
             </MainMenuColumnStyled>
         );

--- a/sites/frontend/components/Header/Nav/MainMenu/MainMenuColumns/index.js
+++ b/sites/frontend/components/Header/Nav/MainMenu/MainMenuColumns/index.js
@@ -100,8 +100,12 @@ const BrandExtensionLink = styled('a')({
 
 export default () => (
     <MainMenuColumns role="menubar" tabindex="-1">
-        {columnsConfig.map(column => (
-            <MainMenuColumn column={column} key={column.id} />
+        {columnsConfig.map((column, i) => (
+            <MainMenuColumn
+                column={column}
+                key={column.id}
+                isLastIndex={i === columnsConfig.length - 1}
+            />
         ))}
         <BrandExtensionColumn role="none">
             <BrandExtensionList role="menu">

--- a/sites/frontend/components/Header/Nav/MainMenu/MainMenuColumns/index.js
+++ b/sites/frontend/components/Header/Nav/MainMenu/MainMenuColumns/index.js
@@ -110,7 +110,7 @@ export default () => (
         <BrandExtensionColumn role="none">
             <BrandExtensionList role="menu">
                 {brandExtenstionsConfig.map(brandExtension => (
-                    <BrandExtensionListItem>
+                    <BrandExtensionListItem key={brandExtension.label}>
                         <BrandExtensionLink
                             href={brandExtension.href}
                             key={brandExtension.label}

--- a/sites/frontend/components/Header/Nav/MainMenu/MainMenuColumns/index.js
+++ b/sites/frontend/components/Header/Nav/MainMenu/MainMenuColumns/index.js
@@ -1,10 +1,11 @@
 // @flow
 import { styled } from '@guardian/guui';
 
-import { desktop, leftCol, wide } from '@guardian/pasteup/breakpoints';
+import { tablet, desktop, leftCol, wide } from '@guardian/pasteup/breakpoints';
+import { egyptian } from '@guardian/pasteup/fonts';
 
 import MainMenuColumn from './MainMenuColumn';
-import { columnsConfig } from '../../../Nav/__config__';
+import { columnsConfig, brandExtenstionsConfig } from '../../../Nav/__config__';
 
 const MainMenuColumns = styled('ul')({
     boxSizing: 'border-box',
@@ -25,10 +26,96 @@ const MainMenuColumns = styled('ul')({
     },
 });
 
+const BrandExtensionColumn = styled('li')({
+    display: 'none',
+    position: 'absolute',
+    right: 20,
+    top: 18,
+    bottom: 0,
+    [desktop]: {
+        display: 'block',
+    },
+});
+
+const BrandExtensionList = styled('ul')({
+    width: 186,
+    boxSizing: 'border-box',
+    fontSize: 18,
+    flexWrap: 'wrap',
+    listStyle: 'none',
+    margin: 0,
+    padding: '0 0 12px',
+    display: 'flex',
+    flexDirection: 'column',
+    paddingBottom: 0,
+    [leftCol]: {
+        width: 220,
+    },
+    [wide]: {
+        width: 300,
+    },
+});
+
+const BrandExtensionListItem = styled('li')({
+    marginRight: 0,
+    marginTop: -6,
+    paddingBottom: 0,
+});
+
+const BrandExtensionLink = styled('a')({
+    fontSize: 24,
+    fontWeight: 700,
+    lineHeight: 1.1,
+    backgroundColor: 'transparent',
+    border: 0,
+    boxSizing: 'border-box',
+    color: '#121212',
+    cursor: 'pointer',
+    display: 'inline-block',
+    fontFamily: egyptian,
+    outline: 'none',
+    padding: '8px 34px 8px 50px',
+    position: 'relative',
+    textAlign: 'left',
+    width: '100%',
+    textDecoration: 'none',
+    [tablet]: {
+        paddingLeft: 60,
+    },
+    [desktop]: {
+        padding: '6px 0',
+    },
+    ':hover': {
+        color: '#5d5f5f',
+        textDecoration: 'underline',
+    },
+    ':focus': {
+        color: '#5d5f5f',
+        textDecoration: 'underline',
+    },
+    '> *': {
+        pointerEvents: 'none',
+    },
+});
+
 export default () => (
     <MainMenuColumns role="menubar" tabindex="-1">
         {columnsConfig.map(column => (
             <MainMenuColumn column={column} key={column.id} />
         ))}
+        <BrandExtensionColumn>
+            <BrandExtensionList>
+                {brandExtenstionsConfig.map(brandExtension => (
+                    <BrandExtensionListItem>
+                        <BrandExtensionLink
+                            href={brandExtension.href}
+                            key={brandExtension.label}
+                        >
+                            {brandExtension.label}
+                        </BrandExtensionLink>
+                    </BrandExtensionListItem>
+                ))}
+            </BrandExtensionList>
+        </BrandExtensionColumn>
     </MainMenuColumns>
 );

--- a/sites/frontend/components/Header/Nav/MainMenu/MainMenuColumns/index.js
+++ b/sites/frontend/components/Header/Nav/MainMenu/MainMenuColumns/index.js
@@ -103,13 +103,14 @@ export default () => (
         {columnsConfig.map(column => (
             <MainMenuColumn column={column} key={column.id} />
         ))}
-        <BrandExtensionColumn>
-            <BrandExtensionList>
+        <BrandExtensionColumn role="none">
+            <BrandExtensionList role="menu">
                 {brandExtenstionsConfig.map(brandExtension => (
                     <BrandExtensionListItem>
                         <BrandExtensionLink
                             href={brandExtension.href}
                             key={brandExtension.label}
+                            role="menuitem"
                         >
                             {brandExtension.label}
                         </BrandExtensionLink>

--- a/sites/frontend/components/Header/Nav/MainMenuToggle/index.js
+++ b/sites/frontend/components/Header/Nav/MainMenuToggle/index.js
@@ -60,7 +60,7 @@ const OpenMainMenuButton = styled('button')({
     ...openMainMenuStyles,
 });
 
-const OpenMainMenuText = styled('span')({
+const OpenMainMenuText = styled('span')(({ showMainMenu }) => ({
     display: 'block',
     height: '100%',
     ':after': {
@@ -71,15 +71,19 @@ const OpenMainMenuText = styled('span')({
         display: 'inline-block',
         height: 8,
         marginLeft: 6,
-        transform: 'translateY(-3px) rotate(45deg)',
+        transform: showMainMenu
+            ? 'translateY(1px) rotate(-135deg)'
+            : 'translateY(-3px) rotate(45deg)',
         transition: 'transform 250ms ease-out',
         verticalAlign: 'middle',
         width: 8,
     },
     ':hover:after': {
-        transform: 'translateY(0) rotate(45deg)',
+        transform: showMainMenu
+            ? 'translateY(-2px) rotate(-135deg)'
+            : 'translateY(0) rotate(45deg)',
     },
-});
+}));
 
 type Props = {
     toggleMainMenu: () => void,
@@ -131,7 +135,9 @@ class MainMenuToggle extends Component<Props, { enhanceCheckbox: boolean }> {
                     key="OpenMainMenuButton"
                 >
                     <ScreenReadable>Show</ScreenReadable>
-                    <OpenMainMenuText>More</OpenMainMenuText>
+                    <OpenMainMenuText showMainMenu={showMainMenu}>
+                        More
+                    </OpenMainMenuText>
                 </OpenMainMenuButton>,
             ];
         }

--- a/sites/frontend/components/Header/Nav/Pillars/Pillar.js
+++ b/sites/frontend/components/Header/Nav/Pillars/Pillar.js
@@ -28,7 +28,7 @@ const Pillar = styled('li')({
     },
 });
 
-const Link = styled('a')(({ pillar }) => ({
+const Link = styled('a')(({ showMainMenu, pillar }) => ({
     fontFamily: headline,
     fontWeight: 600,
     textDecoration: 'none',
@@ -49,6 +49,9 @@ const Link = styled('a')(({ pillar }) => ({
     },
     [desktop]: {
         height: 48,
+    },
+    ':hover': {
+        textDecoration: showMainMenu ? 'underline' : 'none',
     },
     ':after': {
         content: '""',
@@ -71,11 +74,12 @@ const Link = styled('a')(({ pillar }) => ({
 type Props = {
     children: React$Node,
     pillar: PillarType,
+    showMainMenu: boolean,
 };
 
-export default ({ children, pillar }: Props) => (
+export default ({ children, pillar, showMainMenu }: Props) => (
     <Pillar>
-        <Link href={pillar.href} pillar={pillar.id}>
+        <Link href={pillar.href} pillar={pillar.id} showMainMenu={showMainMenu}>
             {children}
         </Link>
     </Pillar>

--- a/sites/frontend/components/Header/Nav/Pillars/index.js
+++ b/sites/frontend/components/Header/Nav/Pillars/index.js
@@ -17,13 +17,17 @@ const Pillars = styled('ul')({
 });
 
 type Props = {
-    showMainMenu: boolean
+    showMainMenu: boolean,
 };
 
 export default ({ showMainMenu }: Props) => (
     <Pillars>
         {pillarsConfig.map(pillar => (
-            <Pillar showMainMenu={showMainMenu} pillar={pillar} key={pillar.label}>
+            <Pillar
+                showMainMenu={showMainMenu}
+                pillar={pillar}
+                key={pillar.label}
+            >
                 {pillar.label}
             </Pillar>
         ))}

--- a/sites/frontend/components/Header/Nav/Pillars/index.js
+++ b/sites/frontend/components/Header/Nav/Pillars/index.js
@@ -16,10 +16,14 @@ const Pillars = styled('ul')({
     },
 });
 
-export default () => (
+type Props = {
+    showMainMenu: boolean
+};
+
+export default ({ showMainMenu }) => (
     <Pillars>
         {pillarsConfig.map(pillar => (
-            <Pillar pillar={pillar} key={pillar.label}>
+            <Pillar showMainMenu={showMainMenu} pillar={pillar} key={pillar.label}>
                 {pillar.label}
             </Pillar>
         ))}

--- a/sites/frontend/components/Header/Nav/Pillars/index.js
+++ b/sites/frontend/components/Header/Nav/Pillars/index.js
@@ -20,7 +20,7 @@ type Props = {
     showMainMenu: boolean
 };
 
-export default ({ showMainMenu }) => (
+export default ({ showMainMenu }: Props) => (
     <Pillars>
         {pillarsConfig.map(pillar => (
             <Pillar showMainMenu={showMainMenu} pillar={pillar} key={pillar.label}>

--- a/sites/frontend/components/Header/Nav/__config__.js
+++ b/sites/frontend/components/Header/Nav/__config__.js
@@ -5,14 +5,18 @@ export type PillarType = {
     href: string,
 };
 
-export type ColumnType = {
+export type LinkType = {
+    label: string,
+    href: string,
+    mobileOnly?: boolean,
+};
+
+export type MainMenuColumnType = {
     id: string,
     label?: string,
-    pillar?: string,
-    links: Array<{
-        label: string,
-        href: string,
-    }>,
+    href?: string,
+    links: Array<LinkType>,
+    isPillar: boolean,
 };
 
 export const pillarsConfig: Array<PillarType> = [
@@ -43,11 +47,37 @@ export const pillarsConfig: Array<PillarType> = [
     },
 ];
 
-export const columnsConfig: Array<ColumnType> = [
+export const brandExtenstionsConfig: Array<LinkType> = [
+    {
+        label: 'Jobs',
+        href: 'https://jobs.theguardian.com?INTCMP=jobs_uk_web_newheader',
+    },
+    {
+        label: 'Dating',
+        href:
+            'https://soulmates.theguardian.com?INTCMP=soulmates_uk_web_newheader',
+    },
+    {
+        label: 'Holidays',
+        href:
+            'https://holidays.theguardian.com?INTCMP=holidays_uk_web_newheader',
+    },
+    {
+        label: 'Masterclasses',
+        href:
+            'https://membership.theguardian.com/masterclasses?INTCMP=masterclasses_uk_web_newheader',
+    },
+    {
+        label: 'Digital Archive',
+        href: 'https://theguardian.newspapers.com',
+    },
+];
+
+export const columnsConfig: Array<MainMenuColumnType> = [
     {
         id: 'news',
         label: 'News',
-        pillar: 'news',
+        isPillar: true,
         links: [
             {
                 label: 'UK news',
@@ -105,8 +135,8 @@ export const columnsConfig: Array<ColumnType> = [
     },
     {
         id: 'opinion',
-        pillar: 'opinion',
         label: 'Opinion',
+        isPillar: true,
         links: [
             {
                 label: 'The Guardian view',
@@ -133,8 +163,8 @@ export const columnsConfig: Array<ColumnType> = [
     },
     {
         id: 'sport',
-        pillar: 'sport',
         label: 'Sport',
+        isPillar: true,
         links: [
             {
                 label: 'World Cup 2018',
@@ -188,8 +218,8 @@ export const columnsConfig: Array<ColumnType> = [
     },
     {
         id: 'culture',
-        pillar: 'culture',
         label: 'Culture',
+        isPillar: true,
         links: [
             {
                 label: 'Film',
@@ -228,8 +258,8 @@ export const columnsConfig: Array<ColumnType> = [
     },
     {
         id: 'lifestyle',
-        pillar: 'lifestyle',
         label: 'Lifestyle',
+        isPillar: true,
         links: [
             {
                 label: 'Fashion',
@@ -281,6 +311,7 @@ export const columnsConfig: Array<ColumnType> = [
     },
     {
         id: 'more',
+        isPillar: false,
         links: [
             {
                 label: 'Video',

--- a/sites/frontend/components/Header/Nav/index.js
+++ b/sites/frontend/components/Header/Nav/index.js
@@ -57,7 +57,7 @@ export default class Nav extends Component<{}, { showMainMenu: boolean }> {
             <NavStyled role="navigation" aria-label="Guardian sections">
                 <Logo />
                 <Links />
-                <Pillars showMainMenu={showMainMenu}/>
+                <Pillars showMainMenu={showMainMenu} />
                 <MainMenuToggle
                     showMainMenu={showMainMenu}
                     toggleMainMenu={toggleMainMenu}

--- a/sites/frontend/components/Header/Nav/index.js
+++ b/sites/frontend/components/Header/Nav/index.js
@@ -57,7 +57,7 @@ export default class Nav extends Component<{}, { showMainMenu: boolean }> {
             <NavStyled role="navigation" aria-label="Guardian sections">
                 <Logo />
                 <Links />
-                <Pillars />
+                <Pillars showMainMenu={showMainMenu}/>
                 <MainMenuToggle
                     showMainMenu={showMainMenu}
                     toggleMainMenu={toggleMainMenu}


### PR DESCRIPTION
## What does this change?

- Adds "brand extension" links to the `Header` Component. This involved reorganising the `Nav/__config__` exports.
- rotate `MainMenuToggle` icon on opening `MainMenu`
- Add `:hover` styles to `Pillar` Component's `Link`
- Adjust margin/padding for `Logo`