### PR TITLE
Publish pasteup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ dist
 jsconfig.json
 target
 guui.zip
+
+# publishable files
+packages/pasteup/src

--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,4 @@ target
 guui.zip
 
 # publishable files
-packages/pasteup/src
+packages/pasteup/tmp

--- a/makefile
+++ b/makefile
@@ -123,18 +123,18 @@ flow-typed: yarn.lock
 # packages #########################################
 
 clean-pasteup:
-	@rm -rf packages/pasteup/dist packages/pasteup/src
+	@rm -rf packages/pasteup/dist packages/pasteup/tmp
 
 pre-publish-pasteup:
 	$(call log, "building pasteup")
-	@mkdir packages/pasteup/src
+	@mkdir packages/pasteup/tmp
 	@NODE_ENV=production webpack --config webpack/pasteup
-	@mv packages/pasteup/*.js packages/pasteup/src
+	@mv packages/pasteup/*.js packages/pasteup/tmp
 	@mv packages/pasteup/dist/*.js packages/pasteup
 
 post-publish-pasteup:
 	$(call log, "clean up after publishing pasteup")
-	@mv packages/pasteup/src/*.js packages/pasteup
+	@mv packages/pasteup/tmp/*.js packages/pasteup
 
 publish-pasteup: clear clean-pasteup install
 	$(call log, "publishing pasteup")

--- a/makefile
+++ b/makefile
@@ -125,10 +125,19 @@ flow-typed: yarn.lock
 clean-pasteup:
 	@rm -rf packages/pasteup/dist packages/pasteup/src
 
-publish-pasteup: clear clean-pasteup install
+pre-publish-pasteup:
 	$(call log, "building pasteup")
 	@mkdir packages/pasteup/src
 	@NODE_ENV=production webpack --config webpack/pasteup
 	@mv packages/pasteup/*.js packages/pasteup/src
 	@mv packages/pasteup/dist/*.js packages/pasteup
+
+publish-pasteup-private:
 	$(call log, "publishing pasteup")
+	# Boop
+
+post-publish-pasteup:
+	$(call log, "clean up after publishing pasteup")
+	@mv packages/pasteup/src/*.js packages/pasteup
+
+publish-pasteup: clear clean-pasteup install pre-publish-pasteup publish-pasteup-private post-publish-pasteup

--- a/makefile
+++ b/makefile
@@ -132,12 +132,10 @@ pre-publish-pasteup:
 	@mv packages/pasteup/*.js packages/pasteup/src
 	@mv packages/pasteup/dist/*.js packages/pasteup
 
-publish-pasteup-private:
-	$(call log, "publishing pasteup")
-	# Boop
-
 post-publish-pasteup:
 	$(call log, "clean up after publishing pasteup")
 	@mv packages/pasteup/src/*.js packages/pasteup
 
-publish-pasteup: clear clean-pasteup install pre-publish-pasteup publish-pasteup-private post-publish-pasteup
+publish-pasteup: clear clean-pasteup install
+	$(call log, "publishing pasteup")
+	@cd packages/pasteup && yarn pack

--- a/makefile
+++ b/makefile
@@ -119,3 +119,12 @@ flow-typed: yarn.lock
 	@cd packages/guui && ../../node_modules/.bin/flow-typed install -p ../../
 	@cd packages/pasteup && ../../node_modules/.bin/flow-typed install -p ../../
 	@flow-typed install
+
+# packages #########################################
+
+clean-dist-pasteup:
+	@rm -rf packages/pasteup/dist
+
+build-pasteup: clear clean-dist-pasteup install
+	$(call log, "building pasteup")
+	@NODE_ENV=production webpack --config webpack/pasteup

--- a/makefile
+++ b/makefile
@@ -122,9 +122,13 @@ flow-typed: yarn.lock
 
 # packages #########################################
 
-clean-dist-pasteup:
-	@rm -rf packages/pasteup/dist
+clean-pasteup:
+	@rm -rf packages/pasteup/dist packages/pasteup/src
 
-build-pasteup: clear clean-dist-pasteup install
+publish-pasteup: clear clean-pasteup install
 	$(call log, "building pasteup")
+	@mkdir packages/pasteup/src
 	@NODE_ENV=production webpack --config webpack/pasteup
+	@mv packages/pasteup/*.js packages/pasteup/src
+	@mv packages/pasteup/dist/*.js packages/pasteup
+	$(call log, "publishing pasteup")

--- a/makefile
+++ b/makefile
@@ -138,4 +138,4 @@ post-publish-pasteup:
 
 publish-pasteup: clear clean-pasteup install
 	$(call log, "publishing pasteup")
-	@cd packages/pasteup && yarn pack
+	@cd packages/pasteup && yarn publish

--- a/packages/guui/package.json
+++ b/packages/guui/package.json
@@ -9,7 +9,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@guardian/guui": "2.0.0-alpha.1",
-    "@guardian/pasteup": "0.1.0-alpha.1",
+    "@guardian/pasteup": "1.0.0-alpha.1",
     "emotion": "^9.1.1",
     "emotion-server": "^9.1.1",
     "polished": "^1.9.2",

--- a/packages/pasteup/README.md
+++ b/packages/pasteup/README.md
@@ -1,0 +1,90 @@
+# Pasteup
+
+Guardian design tokens. These tokens are intended to be used in conjunction with a CSS-in-JS library
+such as [Emotion](https://emotion.sh).
+
+*Alpha package - under construction 🚧*
+This package is still under heavy construction, please do not install this in applications intended for
+use in production. The API may change significantly before it is out of alpha. If you enjoy working on shifting sands and wish to use this package in your application, please talk to the Platform team, or email dotcom.platform.
+
+## Install
+
+```bash
+$ npm install @guardian/pasteup
+```
+
+```bash
+$ yarn add @guardian/pasteup
+```
+
+## Usage
+
+### Breakpoints
+
+```js
+import {
+    mobile,
+    from
+} from '@guardian/pasteup/breakpoints'
+
+const MyComponent = styled('div')({
+    [mobile]: {
+        width: '150px',
+    },
+    [from.mobileMedium.until.tablet]: {
+        width: '175px',
+    },
+    [from.tablet.until.desktop]: {
+        width: '224px',
+    },
+    [from.desktop.until.leftCol]: {
+        width: '249px',
+    },
+})
+```
+
+### Fonts
+
+```js
+import { headline } from '@guardian/pasteup/fonts'
+
+const MyComponent = styled('div')({
+    fontFamily: headline,
+})
+```
+
+### Mixins
+
+```js
+import { screenReaderOnly } from '@guardian/pasteup/mixins'
+
+const ScreenReaderText = styled('span')(screenReaderOnly)
+```
+
+### Palette
+
+```js
+import palette from '@guardian/pasteup/palette'
+
+const MyComponent = styled('div')({
+    color: palette.neutral.header,
+    backgroundColor: palette.neutral['1'],
+})
+```
+
+## Contribute
+
+### Publish
+
+From the root directory of the `dotcom-rendering` project, run:
+
+```bash
+$ make publish-pasteup
+```
+
+Note: if publishing fails, the pasteup directory will be left in a strange state. To correct this,
+manually run:
+
+```bash
+$ make post-publish-pasteup
+```

--- a/packages/pasteup/README.md
+++ b/packages/pasteup/README.md
@@ -3,7 +3,8 @@
 Guardian design tokens. These tokens are intended to be used in conjunction with a CSS-in-JS library
 such as [Emotion](https://emotion.sh).
 
-*Alpha package - under construction 🚧*
+**Alpha package - under construction 🚧**
+
 This package is still under heavy construction, please do not install this in applications intended for
 use in production. The API may change significantly before it is out of alpha. If you enjoy working on shifting sands and wish to use this package in your application, please talk to the Platform team, or email dotcom.platform.
 

--- a/packages/pasteup/package.json
+++ b/packages/pasteup/package.json
@@ -6,6 +6,14 @@
     "type": "git",
     "url": "https://github.com/guardian/dotcom-rendering"
   },
+  "files": [
+    "breakpoints.js",
+    "fonts.js",
+    "mixins.js",
+    "palette.js",
+    "icons",
+    "logos"
+  ],
   "scripts": {
     "test": "jest"
   },

--- a/packages/pasteup/package.json
+++ b/packages/pasteup/package.json
@@ -15,7 +15,9 @@
     "logos"
   ],
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "prepublish": "cd ../.. && make pre-publish-pasteup",
+    "postpublish": "cd ../.. && make post-publish-pasteup"
   },
   "license": "Apache-2.0"
 }

--- a/packages/pasteup/package.json
+++ b/packages/pasteup/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@guardian/pasteup",
-  "version": "0.1.0-alpha.1",
+  "version": "1.0.0-alpha.1",
   "description": "Guardian design tokens",
-  "main": "index.js",
+  "repository": { 
+    "type" : "git",
+    "url" : "https://github.com/guardian/dotcom-rendering"
+  },
   "scripts": {
     "test": "jest"
   },

--- a/packages/pasteup/package.json
+++ b/packages/pasteup/package.json
@@ -2,18 +2,12 @@
   "name": "@guardian/pasteup",
   "version": "1.0.0-alpha.1",
   "description": "Guardian design tokens",
-  "repository": { 
-    "type" : "git",
-    "url" : "https://github.com/guardian/dotcom-rendering"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/guardian/dotcom-rendering"
   },
   "scripts": {
     "test": "jest"
   },
-  "license": "Apache-2.0",
-  "devDependencies": {
-    "@babel/core": "^7.0.0-beta.44",
-    "@babel/plugin-proposal-class-properties": "^7.0.0-beta.44",
-    "@babel/plugin-proposal-object-rest-spread": "^7.0.0-beta.44",
-    "@babel/preset-flow": "^7.0.0-beta.44"
-  }
+  "license": "Apache-2.0"
 }

--- a/sites/frontend/package.json
+++ b/sites/frontend/package.json
@@ -9,7 +9,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@guardian/guui": "2.0.0-alpha.1",
-    "@guardian/pasteup": "0.1.0-alpha.1",
+    "@guardian/pasteup": "1.0.0-alpha.1",
     "compose-function": "^3.0.3",
     "curlyquotes": "^1.3.2",
     "dompurify": "^1.0.3",

--- a/webpack/pasteup.js
+++ b/webpack/pasteup.js
@@ -1,0 +1,26 @@
+const path = require('path');
+
+module.exports = {
+    mode: 'production',
+    entry: {
+        breakpoints: './packages/pasteup/breakpoints.js',
+        fonts: './packages/pasteup/fonts.js',
+        mixins: './packages/pasteup/mixins.js',
+        palette: './packages/pasteup/palette.js',
+    },
+    output: {
+        filename: '[name].js',
+        path: path.join(__dirname, '..', 'packages', 'pasteup', 'dist'),
+        library: 'pasteup',
+        libraryTarget: 'commonjs2',
+    },
+    module: {
+        rules: [
+            {
+                test: /\.js$/,
+                exclude: /node_modules/,
+                use: ['babel-loader'],
+            },
+        ],
+    },
+};


### PR DESCRIPTION
## What does this change?

This change makes this version of pasteup publishable, for use in external libraries and applications.

## Why?

In conjunction with a published version of GUUI, this provides an alternative way to use Guardian components, rather than creating a new page or site in the `dotcom-rendering` repo.