### PR TITLE
Architectural decision records

### DIFF
--- a/docs/architecture/000-architecture-decision-records.md
+++ b/docs/architecture/000-architecture-decision-records.md
@@ -2,7 +2,9 @@
 
 ## Context
 
-This project is growing to the size and maturity where documenting the decisions made in it's creation will be strongly beneficial.
+This project is growing to the size and maturity where documenting the decisions made in its creation will be strongly beneficial.
+
+Decisions are already being made in isolation without documentation and existing documentation around decisions is dispersed and hard to find.
 
 The convention of lightweight architectural decisions [is set out by think relevance](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions). It is set out in the form of an architectural decision record.
 

--- a/docs/architecture/000-architecture-decision-records.md
+++ b/docs/architecture/000-architecture-decision-records.md
@@ -1,0 +1,15 @@
+# To Adopt the Lightweight Architectural Design Decision Format
+
+## Context
+
+This project is growing to the size and maturity where documenting the decisions made in it's creation will be strongly beneficial.
+
+The convention of lightweight architectural decisions [is set out by think relevance](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions). It is set out in the form of an architectural decision record.
+
+## Decision
+
+For all architectural decisions in this project, an architectural decision record will be created with a filename of `XXX-decision-title.md` where XXX is the monotonically increasing number described in the linked document.
+
+## Status
+
+Proposed

--- a/docs/architecture/001-dotcom-rendering.md
+++ b/docs/architecture/001-dotcom-rendering.md
@@ -1,0 +1,26 @@
+# To extract the rendering layer of frontend into a new service
+
+## Context
+
+The Frontend rendering layer has a CSS problem. We are sending too much to CSS to the client (95% of CSS delivered to the browser is unused). The
+fragility of the CSS is a source of presentational bugs.
+
+Frontend also has a developer experience problem. The feedback cycle is slow. There is poor separation of concerns which makes it difficult to find
+related code and isolate changes. There is also a lack of prescriptiveness, so developers have to make more decisions, leading to inconsistent code
+and sub-optimal patterns.
+
+We attempted to rectify these issues by building a CSS componetisation system into Frontend, running inside JVM's Nashorn JavaScript engine. However
+the debugging experience was poor, and community and support for Nashorn was practically non-existant.
+
+## Decision
+
+Build an entirely new rendering layer that runs outside the existing frontend, via the addition of an API to frontend. Pages served from this view will 
+consist entirely of new components. Other legacy pages are still served from the old rendering layer. 
+
+This solution has the disadvantages of introducing duplication (feature X may need supporting in two separate views) and requiring a complete page as a
+minimum deliverable. However it has the advantage of producing value even without 100% migration, as any page it serves is clean. Also this solution
+"fails fast": it can be assessed and potentially rejected comparatively early on.
+
+## Status
+
+Approved

--- a/docs/architecture/001-dotcom-rendering.md
+++ b/docs/architecture/001-dotcom-rendering.md
@@ -21,6 +21,8 @@ This solution has the disadvantages of introducing duplication (feature X may ne
 minimum deliverable. However it has the advantage of producing value even without 100% migration, as any page it serves is clean. Also this solution
 "fails fast": it can be assessed and potentially rejected comparatively early on.
 
+Node.js offers an excellent debugging experience, fast feedback and a vast community to draw on.
+
 ## Status
 
 Approved


### PR DESCRIPTION
## What does this change?

Adds architectural decision records for:

- the architectural decision documentation process itself (so meta)
- the "rendering as a separate service" decision

This takes inspiration from the [manage-frontend](https://github.com/guardian/manage-frontend/blob/master/docs/00-lightweight-architecture-decisions.md) project

## Why?

- To prevent decisions being made in isolation
- To centralise the existing dispersed documentation around decisions

Hence:

- To make it easier for new devs (and future us) to see why a decision was taken
- To help us make better decisions in the future

From [Documenting Architecture Decisions](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions):

> One of the hardest things to track during the life of a project is the motivation behind certain decisions. A new person coming on to a project may be perplexed, baffled, delighted, or infuriated by some past decision. Without understanding the rationale or consequences, this person has only two choices:
>
> 1. Blindly accept the decision.
>
> This response may be OK, if the decision is still valid. It may not be good, however, if the context has changed and the decision should really be revisited. If the project accumulates too many decisions accepted without understanding, then the development team becomes afraid to change anything and the project collapses under its own weight.
>
> 2. Blindly change it.
>
> Again, this may be OK if the decision needs to be reversed. On the other hand, changing the decision without understanding its motivation or consequences could mean damaging the project's overall value without realizing it. (E.g., the decision supported a non-functional requirement that hasn't been tested yet.)
>
> It's better to avoid either blind acceptance or blind reversal.