### PR TITLE
add ophan tracking

### DIFF
--- a/packages/rendering/browser.js
+++ b/packages/rendering/browser.js
@@ -4,6 +4,8 @@
 
 import { hydrateApp, hydrateCSS } from '@guardian/guui';
 
+import 'ophan-tracker-js/build/ophan.ng';
+
 // $FlowFixMe: shut up, flow
 import Page from '../../sites/__SITE__/pages/__PAGE__'; // eslint-disable-line import/no-unresolved,import/extensions
 

--- a/packages/rendering/browser.js
+++ b/packages/rendering/browser.js
@@ -4,7 +4,7 @@
 
 import { hydrateApp, hydrateCSS } from '@guardian/guui';
 
-import 'ophan-tracker-js/build/ophan.ng';
+import 'ophan-tracker-js';
 
 // $FlowFixMe: shut up, flow
 import Page from '../../sites/__SITE__/pages/__PAGE__'; // eslint-disable-line import/no-unresolved,import/extensions

--- a/packages/rendering/package.json
+++ b/packages/rendering/package.json
@@ -11,6 +11,7 @@
     "@guardian/guui": "0.1.0-alpha.1",
     "express": "^4.16.3",
     "glob": "^7.1.2",
+    "ophan-tracker-js": "^1.3.9",
     "pm2": "^2.10.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5573,6 +5573,10 @@ opener@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.4.3.tgz#5c6da2c5d7e5831e8ffa3964950f8d6674ac90b8"
 
+ophan-tracker-js@^1.3.9:
+  version "1.3.9"
+  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.3.9.tgz#97f2be458e05fdf6a63e17721e4011faac6b87e4"
+
 optionator@^0.8.1, optionator@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"


### PR DESCRIPTION
## What does this change?
this adds ophan tracking	
## Why?
because we need it
## Are you sure this is the right way to do this?
not really
## How come?
`import "ophan-js-tracking/build/ophan.ng"` feels decidedly wrong
i think we could do something with webpack here, but am opening the pr to see how we all feel about it