### PR TITLE
Basic footer

### DIFF
--- a/sites/frontend/components/Footer/index.js
+++ b/sites/frontend/components/Footer/index.js
@@ -118,6 +118,11 @@ const Footer = styled('footer')({
         display: 'flex',
         flexWrap: 'wrap',
         flexDirection: 'row',
+        borderTop: '1px solid #434343',
+
+        [tablet]: {
+            borderTop: 'none',
+        },
     },
 
     ul: {

--- a/sites/frontend/components/Footer/index.js
+++ b/sites/frontend/components/Footer/index.js
@@ -1,0 +1,148 @@
+// @flow
+import { styled } from '@guardian/guui';
+
+// import { tablet } from '@guardian/pasteup/breakpoints';
+
+type Link = {
+    title: string,
+    url: string,
+};
+
+const footerLinks: Array<Array<Link>> = [
+    [
+        {
+            title: 'jobs',
+            url: '/',
+        },
+        {
+            title: 'dating',
+            url: '/',
+        },
+        {
+            title: 'make a contribution',
+            url: '/',
+        },
+        {
+            title: 'subscribe',
+            url: '/',
+        },
+        {
+            title: 'guardian labs',
+            url: '/',
+        },
+    ],
+    [
+        {
+            title: 'about us',
+            url: '/',
+        },
+        {
+            title: 'work for us',
+            url: '/',
+        },
+        {
+            title: 'advertise with us',
+            url: '/',
+        },
+        {
+            title: 'contact us',
+            url: '/',
+        },
+        {
+            title: 'help',
+            url: '/',
+        },
+    ],
+    [
+        {
+            title: 'terms & conditions',
+            url: '/',
+        },
+        {
+            title: 'privacy policy',
+            url: '/',
+        },
+        {
+            title: 'cookie policy',
+            url: '/',
+        },
+        {
+            title: 'securedrop',
+            url: '/',
+        },
+        {
+            title: 'digital newspaper archive',
+            url: '/',
+        },
+        {
+            title: 'complaints and corrections',
+            url: '/',
+        },
+    ],
+    [
+        {
+            title: 'all topics',
+            url: '/',
+        },
+        {
+            title: 'all contributors',
+            url: '/',
+        },
+        {
+            title: 'modern slavery act',
+            url: '/',
+        },
+        {
+            title: 'facebook',
+            url: '/',
+        },
+        {
+            title: 'twitter',
+            url: '/',
+        },
+    ],
+];
+
+const Footer = styled('footer')({
+    backgroundColor: '#333',
+    color: '#dcdcdc',
+
+    a: {
+        color: '#dcdcdc',
+        textDecoration: 'none',
+    },
+
+    '.footer-links': {
+        display: 'flex',
+        flexWrap: 'wrap',
+        flexDirection: 'row',
+    },
+});
+
+type Props = {
+    links: Array<Array<Link>>,
+};
+
+const FooterLinks = ({ links }: Props) => {
+    const linkGroups = links.map(linkGroup => {
+        const ls = linkGroup.map(l => (
+            <li>
+                <a href={l.url}>{l.title}</a>
+            </li>
+        ));
+
+        return <ul>{ls}</ul>;
+    });
+
+    return <div className="footer-links">{linkGroups}</div>;
+};
+
+export default () => (
+    <Footer>
+        <FooterLinks links={footerLinks} />
+        <div>
+            © 2018 Guardian News and Media Limited or its affiliated companies.
+            All rights reserved.
+        </div>
+    </Footer>
+);

--- a/sites/frontend/components/Footer/index.js
+++ b/sites/frontend/components/Footer/index.js
@@ -1,7 +1,9 @@
 // @flow
 import { styled } from '@guardian/guui';
 
-// import { tablet } from '@guardian/pasteup/breakpoints';
+import { leftCol, tablet } from '@guardian/pasteup/breakpoints';
+
+import Main from '../Main';
 
 type Link = {
     title: string,
@@ -117,6 +119,31 @@ const Footer = styled('footer')({
         flexWrap: 'wrap',
         flexDirection: 'row',
     },
+
+    ul: {
+        width: '50%',
+
+        [tablet]: {
+            margin: '0 10px 36px 0',
+            flex: '1 0 0',
+        },
+
+        borderLeft: '1px solid #434343',
+        paddingLeft: '10px',
+    },
+
+    '.email-sub__iframe': {
+        [leftCol]: {
+            float: 'left',
+            width: '300px',
+            marginRight: '180px',
+        },
+    },
+
+    '.footer-inner': {
+        paddingTop: '12px',
+        paddingBottom: '6px',
+    },
 });
 
 type Props = {
@@ -139,10 +166,24 @@ const FooterLinks = ({ links }: Props) => {
 
 export default () => (
     <Footer>
-        <FooterLinks links={footerLinks} />
-        <div>
-            © 2018 Guardian News and Media Limited or its affiliated companies.
-            All rights reserved.
-        </div>
+        <Main className="footer-inner">
+            <iframe
+                title="Guardian Email Sign-up Form"
+                src="https://www.theguardian.com/email/form/footer/today-uk"
+                scrolling="no"
+                seamless=""
+                id="footer__email-form"
+                className="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe"
+                data-form-success-desc="We will send you our picks of the most important headlines tomorrow morning."
+                data-node-uid="2"
+                height="86px"
+                frameBorder="0"
+            />
+            <FooterLinks links={footerLinks} />
+            <div>
+                © 2018 Guardian News and Media Limited or its affiliated
+                companies. All rights reserved.
+            </div>
+        </Main>
     </Footer>
 );

--- a/sites/frontend/components/Footer/index.js
+++ b/sites/frontend/components/Footer/index.js
@@ -199,7 +199,7 @@ type Props = {
 const FooterLinks = ({ links }: Props) => {
     const linkGroups = links.map(linkGroup => {
         const ls = linkGroup.map(l => (
-            <li>
+            <li key={l.url}>
                 <a href={l.url}>{l.title}</a>
             </li>
         ));

--- a/sites/frontend/components/Footer/index.js
+++ b/sites/frontend/components/Footer/index.js
@@ -14,94 +14,98 @@ type Link = {
 const footerLinks: Array<Array<Link>> = [
     [
         {
-            title: 'jobs',
-            url: '/',
+            title: 'Jobs',
+            url: 'https://jobs.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_JOBS',
         },
         {
-            title: 'dating',
-            url: '/',
+            title: 'Dating',
+            url:
+                'https://soulmates.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_SOULMATES',
         },
         {
-            title: 'make a contribution',
-            url: '/',
+            title: 'Make a contribution',
+            url:
+                'https://support.theguardian.com/contribute?INTCMP=footer_support_contribute&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentType%22%3A%22ACQUISITIONS_FOOTER%22%2C%22componentId%22%3A%22footer_support_contribute%22%2C%22referrerPageviewId%22%3A%22jjztcoahsd3lnjj62kb8%22%2C%22referrerUrl%22%3A%22https%3A%2F%2Fwww.theguardian.com%2Fbooks%2F2018%2Fjul%2F24%2Fman-booker-prize-2018-longlist-nick-drnaso-sabrina-ondaatje-graphic-novel%22%7D',
         },
         {
-            title: 'subscribe',
-            url: '/',
+            title: 'Subscribe',
+            url:
+                'https://support.theguardian.com/subscribe?INTCMP=footer_support_subscribe&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentType%22%3A%22ACQUISITIONS_FOOTER%22%2C%22componentId%22%3A%22footer_support_subscribe%22%2C%22referrerPageviewId%22%3A%22jjztcoahsd3lnjj62kb8%22%2C%22referrerUrl%22%3A%22https%3A%2F%2Fwww.theguardian.com%2Fbooks%2F2018%2Fjul%2F24%2Fman-booker-prize-2018-longlist-nick-drnaso-sabrina-ondaatje-graphic-novel%22%7D',
         },
         {
-            title: 'guardian labs',
-            url: '/',
-        },
-    ],
-    [
-        {
-            title: 'about us',
-            url: '/',
-        },
-        {
-            title: 'work for us',
-            url: '/',
-        },
-        {
-            title: 'advertise with us',
-            url: '/',
-        },
-        {
-            title: 'contact us',
-            url: '/',
-        },
-        {
-            title: 'help',
-            url: '/',
+            title: 'Guardian Labs',
+            url: '/guardian-labs',
         },
     ],
     [
         {
-            title: 'terms & conditions',
-            url: '/',
+            title: 'About us',
+            url: '/about',
         },
         {
-            title: 'privacy policy',
-            url: '/',
+            title: 'Work for us',
+            url: 'https://workforus.theguardian.com/locations/london',
         },
         {
-            title: 'cookie policy',
-            url: '/',
+            title: 'Advertise with us',
+            url: 'https://advertising.theguardian.com/',
         },
         {
-            title: 'securedrop',
-            url: '/',
+            title: 'Contact us',
+            url: '/help/contact-us',
         },
         {
-            title: 'digital newspaper archive',
-            url: '/',
-        },
-        {
-            title: 'complaints and corrections',
-            url: '/',
+            title: 'Help',
+            url: '/help',
         },
     ],
     [
         {
-            title: 'all topics',
-            url: '/',
+            title: 'Terms & conditions',
+            url: '/help/terms-of-service',
         },
         {
-            title: 'all contributors',
-            url: '/',
+            title: 'Privacy policy',
+            url: '/info/privacy',
         },
         {
-            title: 'modern slavery act',
-            url: '/',
+            title: 'Cookie policy',
+            url: '/info/cookies',
         },
         {
-            title: 'facebook',
-            url: '/',
+            title: 'Securedrop',
+            url: 'https://securedrop.theguardian.com/',
         },
         {
-            title: 'twitter',
-            url: '/',
+            title: 'Digital newspaper archive',
+            url: 'https://theguardian.newspapers.com/',
+        },
+        {
+            title: 'Complaints and corrections',
+            url: '/info/complaints-and-corrections',
+        },
+    ],
+    [
+        {
+            title: 'All topics',
+            url: '/index/subjects/a',
+        },
+        {
+            title: 'All contributors',
+            url: '/index/contributors',
+        },
+        {
+            title: 'Modern Slavery Act',
+            url:
+                '/info/2016/jul/27/modern-slavery-and-our-supply-chains?INTCMP=NGW_FOOTER_UK_GU_MODERN_SLAVERY_ACT',
+        },
+        {
+            title: 'Facebook',
+            url: 'https://www.facebook.com/theguardian',
+        },
+        {
+            title: 'Twitter',
+            url: 'https://twitter.com/guardian',
         },
     ],
 ];

--- a/sites/frontend/components/Footer/index.js
+++ b/sites/frontend/components/Footer/index.js
@@ -1,7 +1,8 @@
 // @flow
 import { styled } from '@guardian/guui';
 
-import { leftCol, tablet } from '@guardian/pasteup/breakpoints';
+import { leftCol, tablet, until } from '@guardian/pasteup/breakpoints';
+import { textSans } from '@guardian/pasteup/fonts';
 
 import Main from '../Main';
 
@@ -108,6 +109,8 @@ const footerLinks: Array<Array<Link>> = [
 const Footer = styled('footer')({
     backgroundColor: '#333',
     color: '#dcdcdc',
+    fontFamily: textSans,
+    fontSize: '14px',
 
     a: {
         color: '#dcdcdc',
@@ -123,21 +126,49 @@ const Footer = styled('footer')({
         [tablet]: {
             borderTop: 'none',
         },
-    },
 
-    ul: {
-        width: '50%',
-
-        [tablet]: {
-            margin: '0 10px 36px 0',
-            flex: '1 0 0',
+        a: {
+            paddingBottom: '12px',
+            display: 'block',
         },
 
-        borderLeft: '1px solid #434343',
-        paddingLeft: '10px',
+        ul: {
+            width: '50%',
+            borderLeft: '1px solid #434343',
+
+            [until.tablet]: {
+                ':nth-child(odd)': {
+                    borderLeft: 0,
+                    paddingLeft: 0,
+                },
+
+                ':nth-child(3)': {
+                    paddingTop: 0,
+                },
+                ':nth-child(4)': {
+                    paddingTop: 0,
+                },
+            },
+
+            [until.leftCol]: {
+                ':nth-child(1)': {
+                    borderLeft: 0,
+                    paddingLeft: 0,
+                },
+            },
+
+            [tablet]: {
+                margin: '0 10px 36px 0',
+                flex: '1 0 0',
+            },
+
+            padding: '12px 0 0 10px',
+        },
     },
 
     '.email-sub__iframe': {
+        paddingTop: '12px',
+
         [leftCol]: {
             float: 'left',
             width: '300px',
@@ -146,8 +177,14 @@ const Footer = styled('footer')({
     },
 
     '.footer-inner': {
-        paddingTop: '12px',
         paddingBottom: '6px',
+    },
+
+    '.copyright': {
+        fontSize: '12px',
+        padding: '6px 0 18px',
+        borderTop: '1px solid #434343',
+        marginTop: '12px',
     },
 });
 
@@ -181,11 +218,11 @@ export default () => (
                 className="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe"
                 data-form-success-desc="We will send you our picks of the most important headlines tomorrow morning."
                 data-node-uid="2"
-                height="86px"
+                height="100px"
                 frameBorder="0"
             />
             <FooterLinks links={footerLinks} />
-            <div>
+            <div className="copyright">
                 © 2018 Guardian News and Media Limited or its affiliated
                 companies. All rights reserved.
             </div>

--- a/sites/frontend/pages/Article.js
+++ b/sites/frontend/pages/Article.js
@@ -12,6 +12,7 @@ import Page from '../components/Page';
 import Main from '../components/Main';
 import MostViewed from '../components/MostViewed';
 import Header from '../components/Header';
+import Footer from '../components/Footer';
 import Epic from '../components/Epic';
 import { CapiComponent } from '../components/CapiComponent';
 
@@ -133,5 +134,6 @@ export default () => (
                 </Epic>
             </article>
         </Main>
+        <Footer />
     </Page>
 );


### PR DESCRIPTION
I paired with @zeftilldeath on this! Some initial feedback was that we should have an automatic CSS->emotion CSS converter, as otherwise copy+paste becomes quite tedious because of all the mechanical changes (semi-colon->comma, hyphen-case to camelCase, etc.).

There are questions about how to write components. I have strong opinions(!) now that I've written a few of these. I'll share those in the dropdown PR and link that from here when it's opened (should be soon).

## What does this change?

Adds a basic footer implementation:

![screen shot 2018-07-24 at 15 44 03](https://user-images.githubusercontent.com/858402/43147286-9acce840-8f5a-11e8-90c9-48b33b74c953.png)
![screen shot 2018-07-24 at 15 44 13](https://user-images.githubusercontent.com/858402/43147288-9aef27a2-8f5a-11e8-95a7-76b50b2a5ef5.png)
![screen shot 2018-07-24 at 15 44 21](https://user-images.githubusercontent.com/858402/43147289-9b09fb18-8f5a-11e8-833a-5982182a618d.png)
![screen shot 2018-07-24 at 15 44 31](https://user-images.githubusercontent.com/858402/43147291-9b27cc4c-8f5a-11e8-9b22-1ba0fd2f2486.png)

## Why?

Because we need it!