### PR TITLE
Enable sourceMaps of for emotion in development env

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -20,4 +20,12 @@ module.exports = {
             },
         ],
     ],
+    env: {
+        production: {
+            plugins: [['emotion', { sourceMap: false }]],
+        },
+        development: {
+            plugins: [['emotion', { sourceMap: true }]],
+        },
+    },
 };

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "babel-eslint": "^8.2.1",
         "babel-loader": "^8.0.0-beta.2",
         "babel-plugin-dynamic-import-node": "^1.2.0",
-        "babel-plugin-emotion": "~9.2.6",
+        "babel-plugin-emotion": "^9.2.6",
         "eslint": "^4.18.0",
         "eslint-config-airbnb": "^16.1.0",
         "eslint-config-prettier": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "babel-eslint": "^8.2.1",
         "babel-loader": "^8.0.0-beta.2",
         "babel-plugin-dynamic-import-node": "^1.2.0",
+        "babel-plugin-emotion": "~9.2.6",
         "eslint": "^4.18.0",
         "eslint-config-airbnb": "^16.1.0",
         "eslint-config-prettier": "^2.6.0",

--- a/packages/rendering/browser.js
+++ b/packages/rendering/browser.js
@@ -21,8 +21,8 @@ const container = document.getElementById('app');
 if (container) {
     /**
      * TODO: Remove conditional when Emotion's issue is resolved.
-     * We're having to prevent emotion hydrating styles in the browser 
-     * in development mode to retain the sourceMap info. As detailed 
+     * We're having to prevent emotion hydrating styles in the browser
+     * in development mode to retain the sourceMap info. As detailed
      * in the issue raised here https://github.com/emotion-js/emotion/issues/487
      */
     if (process.env.NODE_ENV !== 'development') {

--- a/packages/rendering/browser.js
+++ b/packages/rendering/browser.js
@@ -19,6 +19,8 @@ if (module.hot) {
 const container = document.getElementById('app');
 
 if (container) {
-    hydrateCSS(cssIDs);
+    if (process.env.NODE_ENV !== 'development') {
+        hydrateCSS(cssIDs);
+    }
     hydrateApp(<App Page={Page} data={data} />, container);
 }

--- a/packages/rendering/browser.js
+++ b/packages/rendering/browser.js
@@ -19,6 +19,12 @@ if (module.hot) {
 const container = document.getElementById('app');
 
 if (container) {
+    /**
+     * TODO: Remove conditional when Emotion's issue is resolved.
+     * We're having to prevent emotion hydrating styles in the browser 
+     * in development mode to retain the sourceMap info. As detailed 
+     * in the issue raised here https://github.com/emotion-js/emotion/issues/487
+     */
     if (process.env.NODE_ENV !== 'development') {
         hydrateCSS(cssIDs);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1276,7 +1276,7 @@ babel-plugin-emotion@^9.1.2:
     source-map "^0.5.7"
     touch "^1.0.0"
 
-babel-plugin-emotion@~9.2.6:
+babel-plugin-emotion@^9.2.6:
   version "9.2.6"
   resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-9.2.6.tgz#992d48f316c20610c28a95ae90e6bd193014eec5"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -115,6 +115,13 @@
     "@babel/types" "7.0.0-beta.44"
     lodash "^4.2.0"
 
+"@babel/helper-module-imports@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.51.tgz#ce00428045fbb7d5ebc0ea7bf835789f15366ab2"
+  dependencies:
+    "@babel/types" "7.0.0-beta.51"
+    lodash "^4.17.5"
+
 "@babel/helper-module-transforms@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-beta.44.tgz#185dc17b37c4b9cc3daee0f0f44e74f000e21bb7"
@@ -605,9 +612,32 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
+"@babel/types@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.51.tgz#d802b7b543b5836c778aa691797abf00f3d97ea9"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.5"
+    to-fast-properties "^2.0.0"
+
+"@emotion/babel-utils@^0.6.4":
+  version "0.6.7"
+  resolved "https://registry.yarnpkg.com/@emotion/babel-utils/-/babel-utils-0.6.7.tgz#273910399321f91f9023d05222f6a75887ece42d"
+  dependencies:
+    "@emotion/hash" "^0.6.5"
+    "@emotion/memoize" "^0.6.5"
+    "@emotion/serialize" "^0.8.5"
+    convert-source-map "^1.5.1"
+    find-root "^1.1.0"
+    source-map "^0.7.2"
+
 "@emotion/hash@^0.6.2":
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.6.3.tgz#0e7a5604626fc6c6d4ac4061a2f5ac80d50262a4"
+
+"@emotion/hash@^0.6.5":
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.6.5.tgz#097729b84a5164f71f9acd2570ecfd1354d7b360"
 
 "@emotion/is-prop-valid@^0.6.1":
   version "0.6.2"
@@ -619,9 +649,34 @@
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.6.2.tgz#138e00b332d519b4e307bded6159e5ba48aba3ae"
 
+"@emotion/memoize@^0.6.5":
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.6.5.tgz#f868c314b889e7c3d84868a1d1cc323fbb40ca86"
+
+"@emotion/serialize@^0.8.5":
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-0.8.5.tgz#169a1f7acbc18b3bc84f83d1ffddd39335c1539b"
+  dependencies:
+    "@emotion/hash" "^0.6.5"
+    "@emotion/memoize" "^0.6.5"
+    "@emotion/unitless" "^0.6.5"
+    "@emotion/utils" "^0.7.3"
+
+"@emotion/stylis@^0.6.10":
+  version "0.6.12"
+  resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.6.12.tgz#3fb58220e0fc9e380bcabbb3edde396ddc1dfe6e"
+
 "@emotion/stylis@^0.6.5":
   version "0.6.8"
   resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.6.8.tgz#6ad4e8d32b19b440efa4481bbbcb98a8c12765bb"
+
+"@emotion/unitless@^0.6.5":
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.6.5.tgz#6a397794dc78ca7df4bf68893061709590a7ec81"
+
+"@emotion/utils@^0.7.3":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.7.3.tgz#4240c5eee8af86843452af7497ac2808be04a77d"
 
 "@guardian/guui@0.1.0-alpha.1":
   version "0.1.0-alpha.1"
@@ -999,6 +1054,30 @@ babel-core@^6.26.0:
     slash "^1.0.0"
     source-map "^0.5.6"
 
+babel-core@^6.26.3:
+  version "6.26.3"
+  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.3.tgz#b2e2f09e342d0f0c88e2f02e067794125e75c207"
+  dependencies:
+    babel-code-frame "^6.26.0"
+    babel-generator "^6.26.0"
+    babel-helpers "^6.24.1"
+    babel-messages "^6.23.0"
+    babel-register "^6.26.0"
+    babel-runtime "^6.26.0"
+    babel-template "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    convert-source-map "^1.5.1"
+    debug "^2.6.9"
+    json5 "^0.5.1"
+    lodash "^4.17.4"
+    minimatch "^3.0.4"
+    path-is-absolute "^1.0.1"
+    private "^0.1.8"
+    slash "^1.0.0"
+    source-map "^0.5.7"
+
 babel-eslint@^8.2.1:
   version "8.2.2"
   resolved "http://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.2.tgz#1102273354c6f0b29b4ea28a65f97d122296b68b"
@@ -1189,6 +1268,24 @@ babel-plugin-emotion@^9.1.2:
     "@emotion/hash" "^0.6.2"
     "@emotion/memoize" "^0.6.1"
     "@emotion/stylis" "^0.6.5"
+    babel-plugin-macros "^2.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    convert-source-map "^1.5.0"
+    find-root "^1.1.0"
+    mkdirp "^0.5.1"
+    source-map "^0.5.7"
+    touch "^1.0.0"
+
+babel-plugin-emotion@~9.2.6:
+  version "9.2.6"
+  resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-9.2.6.tgz#992d48f316c20610c28a95ae90e6bd193014eec5"
+  dependencies:
+    "@babel/helper-module-imports" "7.0.0-beta.51"
+    "@emotion/babel-utils" "^0.6.4"
+    "@emotion/hash" "^0.6.2"
+    "@emotion/memoize" "^0.6.1"
+    "@emotion/stylis" "^0.6.10"
+    babel-core "^6.26.3"
     babel-plugin-macros "^2.0.0"
     babel-plugin-syntax-jsx "^6.18.0"
     convert-source-map "^1.5.0"
@@ -2357,7 +2454,7 @@ continuation-local-storage@^3.1.4:
     async-listener "^0.6.0"
     emitter-listener "^1.1.1"
 
-convert-source-map@^1.1.0, convert-source-map@^1.5.0:
+convert-source-map@^1.1.0, convert-source-map@^1.5.0, convert-source-map@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
 
@@ -6235,7 +6332,7 @@ pretty-bytes@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-4.0.2.tgz#b2bf82e7350d65c6c33aa95aaa5a4f6327f61cd9"
 
-private@^0.1.6, private@^0.1.7, private@~0.1.5:
+private@^0.1.6, private@^0.1.7, private@^0.1.8, private@~0.1.5:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
 
@@ -7163,6 +7260,10 @@ source-map@0.5.x, source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, sourc
 source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+
+source-map@^0.7.2:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
 
 spdx-correct@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## What does this change?

Adds [babel-plugin-emotion](https://github.com/emotion-js/emotion/tree/master/packages/babel-plugin-emotion) dependency and enables `sourceMaps` for emotion css-in-js in `development`.

## Why?

Currently when you select an element the location of the element's associated style definitions points to the inline styles in the `<head>`. You can't actually see where they're defined in the source. This change means you can jump straight to the source in development mode. Examples of accessing the styles of the same element on `master` and on `gh-sourceMap-css-in-js` are shown below:

**master**
![sourcemap-off](https://user-images.githubusercontent.com/1590704/43153765-18b87fda-8f6a-11e8-9069-ef127f25b1b7.gif)

**gh-sourceMap-css-in-js**
![sourcemap-on](https://user-images.githubusercontent.com/1590704/43153799-2ded60e6-8f6a-11e8-9992-e28fc3e8805d.gif)
