### PR TITLE
Dropdown

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     ],
     plugins: ['flowtype', 'react', 'prettier'],
     rules: {
+        'no-underscore-dangle': 'off',
         'prettier/prettier': ['error'],
         'react/react-in-jsx-scope': 'off',
         'react/prop-types': 'off',

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "eslint-plugin-flow-header": "^0.2.0",
         "eslint-plugin-flowtype": "^2.45.0",
         "eslint-plugin-import": "^2.7.0",
-        "eslint-plugin-jsx-a11y": "^6.0.2",
+        "eslint-plugin-jsx-a11y": "^6.1.1",
         "eslint-plugin-prettier": "^2.6.0",
         "eslint-plugin-react": "^7.4.0",
         "flow-bin": "^0.73.0",

--- a/packages/guui/dropdown/index.js
+++ b/packages/guui/dropdown/index.js
@@ -158,8 +158,8 @@ export default class Dropdown extends Component<
 
     componentDidMount() {
         const dismiss = (event: KeyboardEvent) => {
-            const escKey = 27;
-            if (event.keyCode === escKey) {
+            const escKey = 'Escape';
+            if (event.code === escKey) {
                 this.setState(() => ({
                     isExpanded: false,
                 }));

--- a/packages/guui/dropdown/index.js
+++ b/packages/guui/dropdown/index.js
@@ -153,7 +153,8 @@ export default class Dropdown extends Component<
     constructor(props: Props) {
         super(props);
         this.state = { isExpanded: false, noJS: true };
-        this.toggle = this.toggle.bind(this);
+        // eslint-disable-next-line no-underscore-dangle
+        this.toggle_ = this.toggle.bind(this);
     }
 
     componentDidMount() {
@@ -175,7 +176,8 @@ export default class Dropdown extends Component<
         });
     }
 
-    toggle: () => void; // indicate method writable for flow so can bind in constructor
+    toggle_: () => void;
+
     toggle() {
         this.setState(prevState => ({
             isExpanded: !prevState.isExpanded,
@@ -216,7 +218,7 @@ export default class Dropdown extends Component<
                     ]
                 ) : (
                     <button
-                        onClick={this.toggle}
+                        onClick={this.toggle_}
                         className={this.state.isExpanded ? 'expanded' : ''}
                         aria-controls={dropdownID}
                         aria-expanded={this.state.isExpanded ? 'true' : 'false'}

--- a/packages/guui/dropdown/index.js
+++ b/packages/guui/dropdown/index.js
@@ -44,7 +44,7 @@ const Div = styled('div')({
             display: 'inline-block',
             width: '4px',
             height: '4px',
-            transform: 'translateY(2px) rotate(45deg)',
+            transform: 'translateY(-2px) rotate(45deg)',
             border: '1px solid currentColor',
             borderLeft: 'transparent',
             borderTop: 'transparent',
@@ -164,16 +164,22 @@ export default class Dropdown extends Component<Props> {
     render() {
         const { label, links } = this.props;
 
+        // needs to be unique to allow multiple dropdowns on same page
+        // this should be unique because JS is single-threaded
+        const id = `id-${Date.now()}`;
+
         return (
             <Div>
                 <button
                     onClick={this.toggle}
                     className={this.state.isExpanded ? 'expanded' : ''}
+                    aria-controls={id}
+                    aria-expanded={this.state.isExpanded ? 'true' : 'false'}
                 >
                     {label}
                 </button>
                 {this.state.isExpanded && (
-                    <ul>
+                    <ul id={id}>
                         {links.map(link => (
                             <li key={link.title}>
                                 <a

--- a/packages/guui/dropdown/index.js
+++ b/packages/guui/dropdown/index.js
@@ -1,0 +1,30 @@
+// @flow
+/*
+ * A dropdown component
+ */
+
+import { styled } from '@guardian/guui';
+
+type Link = {
+    url: string,
+    title: string,
+};
+
+type Props = {
+    links: Array<Link>,
+};
+
+const Ul = styled('ul')({
+    position: 'absolute',
+    right: '15px',
+});
+
+export default ({ links }: Props) => (
+    <Ul>
+        {links.map(link => (
+            <li>
+                <a href={link.url}>{link.title}</a>
+            </li>
+        ))}
+    </Ul>
+);

--- a/packages/guui/dropdown/index.js
+++ b/packages/guui/dropdown/index.js
@@ -153,7 +153,6 @@ export default class Dropdown extends Component<
     constructor(props: Props) {
         super(props);
         this.state = { isExpanded: false, noJS: true };
-        // eslint-disable-next-line no-underscore-dangle
         this.toggle_ = this.toggle.bind(this);
     }
 

--- a/packages/guui/dropdown/index.js
+++ b/packages/guui/dropdown/index.js
@@ -142,6 +142,20 @@ export default class Dropdown extends Component<Props> {
         this.toggle = this.toggle.bind(this);
     }
 
+    // hide on ESC key
+    componentDidMount() {
+        const dismiss = event => {
+            const escKey = 27;
+            if (event.keyCode === escKey) {
+                this.setState(() => ({
+                    isExpanded: false,
+                }));
+            }
+        };
+
+        document.addEventListener('keydown', dismiss, false);
+    }
+
     toggle() {
         this.setState(prevState => ({
             isExpanded: !prevState.isExpanded,

--- a/packages/guui/dropdown/index.js
+++ b/packages/guui/dropdown/index.js
@@ -145,10 +145,6 @@ const NoJSCheckbox = styled('input')({
     },
 });
 
-// TODOs:
-// - handle select by passing to parent
-// - accessibility stuff (navigate with keyboard, ESC, etc., tags?)
-
 export default class Dropdown extends Component<Props> {
     constructor(props: Props) {
         super(props);

--- a/packages/guui/dropdown/index.js
+++ b/packages/guui/dropdown/index.js
@@ -131,14 +131,13 @@ const Div = styled('div')({
 });
 
 // TODOs:
-// - add parent link
-// - toggle display
+// - handle select by passing to parent
 // - accessibility stuff (navigate with keyboard, ESC, etc., tags?)
 
 export default class Dropdown extends Component<Props> {
     constructor(props: Props) {
         super(props);
-        this.state = { isExpanded: true };
+        this.state = { isExpanded: false };
         this.toggle = this.toggle.bind(this);
     }
 

--- a/packages/guui/dropdown/index.js
+++ b/packages/guui/dropdown/index.js
@@ -3,7 +3,7 @@
  * A dropdown component
  */
 
-import { styled } from '@guardian/guui';
+import { styled, Component } from '@guardian/guui';
 
 type Link = {
     url: string,
@@ -11,20 +11,46 @@ type Link = {
 };
 
 type Props = {
+    label: string,
     links: Array<Link>,
 };
 
-const Ul = styled('ul')({
-    position: 'absolute',
-    right: '15px',
-});
+const Div = styled('div')({});
 
-export default ({ links }: Props) => (
-    <Ul>
-        {links.map(link => (
-            <li>
-                <a href={link.url}>{link.title}</a>
-            </li>
-        ))}
-    </Ul>
-);
+// TODOs:
+// - add parent link
+// - toggle display
+// - accessibility stuff (navigate with keyboard, ESC, etc., tags?)
+
+export default class Dropdown extends Component<Props> {
+    constructor(props: Props) {
+        super(props);
+        this.state = { isExpanded: false };
+        this.toggle = this.toggle.bind(this);
+    }
+
+    toggle() {
+        this.setState(prevState => ({
+            isExpanded: !prevState.isExpanded,
+        }));
+    }
+
+    render() {
+        const { label, links } = this.props;
+
+        return (
+            <Div>
+                <button onClick={this.toggle}>{label}</button>
+                {this.state.isExpanded && (
+                    <ul>
+                        {links.map(link => (
+                            <li key={link.title}>
+                                <a href={link.url}>{link.title}</a>
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </Div>
+        );
+    }
+}

--- a/packages/guui/dropdown/index.js
+++ b/packages/guui/dropdown/index.js
@@ -8,10 +8,10 @@ import palette from '@guardian/pasteup/palette';
 import { textSans } from '@guardian/pasteup/fonts';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';
 
-type Link = {
+export type Link = {
     url: string,
     title: string,
-    isActive: boolean,
+    isActive?: boolean,
 };
 
 type Props = {
@@ -145,16 +145,18 @@ const NoJSCheckbox = styled('input')({
     },
 });
 
-export default class Dropdown extends Component<Props> {
+export default class Dropdown extends Component<
+    Props,
+    { isExpanded: boolean, noJS: boolean },
+> {
     constructor(props: Props) {
         super(props);
         this.state = { isExpanded: false, noJS: true };
         this.toggle = this.toggle.bind(this);
     }
 
-    // hide on ESC key
     componentDidMount() {
-        const dismiss = event => {
+        const dismiss = (event: KeyboardEvent) => {
             const escKey = 27;
             if (event.keyCode === escKey) {
                 this.setState(() => ({
@@ -172,6 +174,7 @@ export default class Dropdown extends Component<Props> {
         });
     }
 
+    toggle: () => void; // indicate method writable for flow so can bind in constructor
     toggle() {
         this.setState(prevState => ({
             isExpanded: !prevState.isExpanded,

--- a/packages/guui/dropdown/index.js
+++ b/packages/guui/dropdown/index.js
@@ -10,6 +10,7 @@ import { textSans } from '@guardian/pasteup/fonts';
 type Link = {
     url: string,
     title: string,
+    isActive: boolean,
 };
 
 type Props = {
@@ -75,6 +76,10 @@ const Div = styled('div')({
     'a:hover': {
         backgroundColor: '#ededed',
     },
+
+    'a.active': {
+        fontWeight: 'bold',
+    },
 });
 
 // TODOs:
@@ -104,7 +109,10 @@ export default class Dropdown extends Component<Props> {
                 {this.state.isExpanded && (
                     <ul>
                         {links.map(link => (
-                            <li key={link.title}>
+                            <li
+                                key={link.title}
+                                className={link.isActive ? 'active' : ''}
+                            >
                                 <a href={link.url}>{link.title}</a>
                             </li>
                         ))}

--- a/packages/guui/dropdown/index.js
+++ b/packages/guui/dropdown/index.js
@@ -30,7 +30,6 @@ const Div = styled('div')({
         fontSize: 14,
         fontFamily: textSans,
         color: palette.neutral['1'],
-        lineHeight: 1.2,
         transition: 'color 80ms ease-out',
         padding: '6px 10px',
         margin: '1px 0 0',
@@ -202,7 +201,7 @@ export default class Dropdown extends Component<Props> {
                             aria-expanded={
                                 this.state.isExpanded ? 'true' : 'false'
                             }
-                            tabindex="0"
+                            tabIndex="0"
                         >
                             {label}
                         </label>,

--- a/packages/guui/dropdown/index.js
+++ b/packages/guui/dropdown/index.js
@@ -38,7 +38,26 @@ const Div = styled('div')({
         ':focus': {
             textDecoration: 'underline',
         },
+
+        ':after': {
+            content: '""',
+            display: 'inline-block',
+            width: '0.25rem',
+            height: '0.25rem',
+            transform: 'translateY(-0.125rem) rotate(45deg)',
+            border: '0.0625rem solid currentColor',
+            borderLeft: 'transparent',
+            borderTop: 'transparent',
+            marginLeft: '6px',
+            verticalAlign: 'middle',
+            transition: 'transform 250ms ease-out',
+        },
     },
+
+    'button.expanded:after': {
+        transform: 'translateY(0.0625rem) rotate(-135deg)',
+    },
+
     ul: {
         listStyle: 'none',
         backgroundColor: 'white',
@@ -52,18 +71,18 @@ const Div = styled('div')({
     },
     'li a': {
         display: 'block',
-        padding: '0.4375rem 1.25rem 0.9375rem 1.875rem',
+        padding: '10px 18px 15px 30px',
     },
 
     a: {
-        fontSize: 14,
+        fontSize: '15px',
         fontFamily: textSans,
         color: palette.neutral['1'],
         lineHeight: 1.2,
         position: 'relative',
         transition: 'color 80ms ease-out',
         padding: '6px 10px',
-        margin: '1px 0 0',
+        margin: '-1px 0 0 0',
         textDecoration: 'none',
         ':hover': {
             textDecoration: 'underline',
@@ -71,14 +90,39 @@ const Div = styled('div')({
         ':focus': {
             textDecoration: 'underline',
         },
+
+        ':before': {
+            content: '""',
+            borderTop: '0.0625rem solid #ededed',
+            display: 'block',
+            position: 'absolute',
+            top: 0,
+            left: '1.875rem',
+            right: 0,
+        },
     },
 
     'a:hover': {
         backgroundColor: '#ededed',
+        textDecoration: 'none',
     },
 
     'a.active': {
         fontWeight: 'bold',
+        backgroundColor: '#ededed',
+
+        ':after': {
+            content: '""',
+            border: '0.125rem solid #c70000',
+            borderTop: 0,
+            borderRight: 0,
+            position: 'absolute',
+            top: '14px',
+            left: '10px',
+            width: '10px',
+            height: '4px',
+            transform: 'rotate(-45deg)',
+        },
     },
 });
 
@@ -105,15 +149,22 @@ export default class Dropdown extends Component<Props> {
 
         return (
             <Div>
-                <button onClick={this.toggle}>{label}</button>
+                <button
+                    onClick={this.toggle}
+                    className={this.state.isExpanded ? 'expanded' : ''}
+                >
+                    {label}
+                </button>
                 {this.state.isExpanded && (
                     <ul>
                         {links.map(link => (
-                            <li
-                                key={link.title}
-                                className={link.isActive ? 'active' : ''}
-                            >
-                                <a href={link.url}>{link.title}</a>
+                            <li key={link.title}>
+                                <a
+                                    href={link.url}
+                                    className={link.isActive ? 'active' : ''}
+                                >
+                                    {link.title}
+                                </a>
                             </li>
                         ))}
                     </ul>

--- a/packages/guui/dropdown/index.js
+++ b/packages/guui/dropdown/index.js
@@ -59,6 +59,7 @@ const Div = styled('div')({
     },
 
     ul: {
+        zIndex: 1072,
         listStyle: 'none',
         backgroundColor: 'white',
         padding: '0.375rem 0',
@@ -67,7 +68,6 @@ const Div = styled('div')({
         position: 'absolute',
         right: '0',
         width: '12.5rem',
-        zIndex: 1072,
     },
     'li a': {
         display: 'block',
@@ -109,7 +109,6 @@ const Div = styled('div')({
 
     'a.active': {
         fontWeight: 'bold',
-        backgroundColor: '#ededed',
 
         ':after': {
             content: '""',

--- a/packages/guui/dropdown/index.js
+++ b/packages/guui/dropdown/index.js
@@ -4,6 +4,8 @@
  */
 
 import { styled, Component } from '@guardian/guui';
+import palette from '@guardian/pasteup/palette';
+import { textSans } from '@guardian/pasteup/fonts';
 
 type Link = {
     url: string,
@@ -15,7 +17,65 @@ type Props = {
     links: Array<Link>,
 };
 
-const Div = styled('div')({});
+const Div = styled('div')({
+    button: {
+        cursor: 'pointer',
+        background: 'none',
+        border: 'none',
+
+        fontSize: 14,
+        fontFamily: textSans,
+        color: palette.neutral['1'],
+        lineHeight: 1.2,
+        transition: 'color 80ms ease-out',
+        padding: '6px 10px',
+        margin: '1px 0 0',
+        textDecoration: 'none',
+        ':hover': {
+            textDecoration: 'underline',
+        },
+        ':focus': {
+            textDecoration: 'underline',
+        },
+    },
+    ul: {
+        listStyle: 'none',
+        backgroundColor: 'white',
+        padding: '0.375rem 0',
+        boxShadow: '0 0 0 0.0625rem rgba(0,0,0,0.1)',
+        borderRadius: '0.1875rem',
+        position: 'absolute',
+        right: '0',
+        width: '12.5rem',
+        zIndex: 1072,
+    },
+    'li a': {
+        display: 'block',
+        padding: '0.4375rem 1.25rem 0.9375rem 1.875rem',
+    },
+
+    a: {
+        fontSize: 14,
+        fontFamily: textSans,
+        color: palette.neutral['1'],
+        lineHeight: 1.2,
+        position: 'relative',
+        transition: 'color 80ms ease-out',
+        padding: '6px 10px',
+        margin: '1px 0 0',
+        textDecoration: 'none',
+        ':hover': {
+            textDecoration: 'underline',
+        },
+        ':focus': {
+            textDecoration: 'underline',
+        },
+    },
+
+    'a:hover': {
+        backgroundColor: '#ededed',
+    },
+});
 
 // TODOs:
 // - add parent link
@@ -25,7 +85,7 @@ const Div = styled('div')({});
 export default class Dropdown extends Component<Props> {
     constructor(props: Props) {
         super(props);
-        this.state = { isExpanded: false };
+        this.state = { isExpanded: true };
         this.toggle = this.toggle.bind(this);
     }
 

--- a/packages/guui/dropdown/index.js
+++ b/packages/guui/dropdown/index.js
@@ -15,6 +15,7 @@ export type Link = {
 };
 
 type Props = {
+    id: string,
     label: string,
     links: Array<Link>,
 };
@@ -186,14 +187,13 @@ export default class Dropdown extends Component<
 
         // needs to be unique to allow multiple dropdowns on same page
         // this should be unique because JS is single-threaded
-        const dropdownID = `dropbox-id-${Date.now()}`;
-        const checkboxID = `checkbox-id-${Date.now()}`;
+        const dropdownID = `dropbox-id-${this.props.id}`;
+        const checkboxID = `checkbox-id-${this.props.id}`;
 
         return (
             <Div>
                 {this.state.noJS ? (
                     [
-                        // eslint-disable-next-line jsx-a11y/label-has-for
                         <label
                             htmlFor={checkboxID}
                             className={this.state.isExpanded ? 'expanded' : ''}

--- a/packages/guui/dropdown/index.js
+++ b/packages/guui/dropdown/index.js
@@ -57,6 +57,13 @@ const Div = styled('div')({
         },
     },
 
+    input: {
+        ...screenReaderOnly,
+        ':checked + ul': {
+            display: 'block',
+        },
+    },
+
     'button.expanded:after, label.expanded:after': {
         transform: 'translateY(1px) rotate(-135deg)',
     },
@@ -139,13 +146,6 @@ const Div = styled('div')({
     },
 });
 
-const NoJSCheckbox = styled('input')({
-    ...screenReaderOnly,
-    ':checked + ul': {
-        display: 'block',
-    },
-});
-
 export default class Dropdown extends Component<
     Props,
     { isExpanded: boolean, noJS: boolean },
@@ -202,16 +202,17 @@ export default class Dropdown extends Component<
                                 this.state.isExpanded ? 'true' : 'false'
                             }
                         >
+                            <input
+                                type="checkbox"
+                                id={checkboxID}
+                                aria-controls={dropdownID}
+                                aria-checked="false"
+                                tabIndex="-1"
+                                key="OpenMainMenuCheckbox"
+                                role="menuitemcheckbox"
+                            />
                             {label}
                         </label>,
-                        <NoJSCheckbox
-                            type="checkbox"
-                            id={checkboxID}
-                            aria-controls={dropdownID}
-                            tabIndex="-1"
-                            key="OpenMainMenuCheckbox"
-                            role="menuitemcheckbox"
-                        />,
                     ]
                 ) : (
                     <button

--- a/packages/guui/dropdown/index.js
+++ b/packages/guui/dropdown/index.js
@@ -190,6 +190,7 @@ export default class Dropdown extends Component<Props> {
             <Div>
                 {this.state.noJS ? (
                     [
+                        // eslint-disable-next-line jsx-a11y/label-has-for
                         <label
                             htmlFor={checkboxID}
                             className={this.state.isExpanded ? 'expanded' : ''}
@@ -197,7 +198,6 @@ export default class Dropdown extends Component<Props> {
                             aria-expanded={
                                 this.state.isExpanded ? 'true' : 'false'
                             }
-                            tabIndex="0"
                         >
                             {label}
                         </label>,

--- a/packages/guui/dropdown/index.js
+++ b/packages/guui/dropdown/index.js
@@ -42,10 +42,10 @@ const Div = styled('div')({
         ':after': {
             content: '""',
             display: 'inline-block',
-            width: '0.25rem',
-            height: '0.25rem',
-            transform: 'translateY(-0.125rem) rotate(45deg)',
-            border: '0.0625rem solid currentColor',
+            width: '4px',
+            height: '4px',
+            transform: 'translateY(2px) rotate(45deg)',
+            border: '1px solid currentColor',
             borderLeft: 'transparent',
             borderTop: 'transparent',
             marginLeft: '6px',
@@ -55,19 +55,19 @@ const Div = styled('div')({
     },
 
     'button.expanded:after': {
-        transform: 'translateY(0.0625rem) rotate(-135deg)',
+        transform: 'translateY(1px) rotate(-135deg)',
     },
 
     ul: {
         zIndex: 1072,
         listStyle: 'none',
         backgroundColor: 'white',
-        padding: '0.375rem 0',
-        boxShadow: '0 0 0 0.0625rem rgba(0,0,0,0.1)',
-        borderRadius: '0.1875rem',
+        padding: '6px 0',
+        boxShadow: '0 0 0 1px rgba(0,0,0,0.1)',
+        borderRadius: '3px',
         position: 'absolute',
         right: '0',
-        width: '12.5rem',
+        width: '200px',
     },
     'li a': {
         display: 'block',
@@ -93,11 +93,11 @@ const Div = styled('div')({
 
         ':before': {
             content: '""',
-            borderTop: '0.0625rem solid #ededed',
+            borderTop: '1px solid #ededed',
             display: 'block',
             position: 'absolute',
             top: 0,
-            left: '1.875rem',
+            left: '30px',
             right: 0,
         },
     },
@@ -117,7 +117,7 @@ const Div = styled('div')({
 
         ':after': {
             content: '""',
-            border: '0.125rem solid #c70000',
+            border: '2px solid #c70000',
             borderTop: 0,
             borderRight: 0,
             position: 'absolute',

--- a/packages/guui/dropdown/index.js
+++ b/packages/guui/dropdown/index.js
@@ -202,6 +202,7 @@ export default class Dropdown extends Component<Props> {
                             aria-expanded={
                                 this.state.isExpanded ? 'true' : 'false'
                             }
+                            tabindex="0"
                         >
                             {label}
                         </label>,

--- a/packages/guui/dropdown/index.js
+++ b/packages/guui/dropdown/index.js
@@ -102,6 +102,11 @@ const Div = styled('div')({
         },
     },
 
+    // no top border for first item
+    'li:first-child a:before': {
+        content: 'none',
+    },
+
     'a:hover': {
         backgroundColor: '#ededed',
         textDecoration: 'none',

--- a/sites/frontend/components/Header/Nav/EditionDropdown.js
+++ b/sites/frontend/components/Header/Nav/EditionDropdown.js
@@ -1,6 +1,12 @@
 // @flow
-// import styled from '@guardian/guui';
 import Dropdown from '@guardian/guui/dropdown';
+
+import { styled } from '@guardian/guui';
+
+const EditionDropdown = styled('div')({
+    position: 'absolute',
+    right: '15px',
+});
 
 export default () => {
     const links = [
@@ -17,5 +23,10 @@ export default () => {
             title: 'bar3',
         },
     ];
-    return <Dropdown links={links} />;
+
+    return (
+        <EditionDropdown>
+            <Dropdown label="edition" links={links} />
+        </EditionDropdown>
+    );
 };

--- a/sites/frontend/components/Header/Nav/EditionDropdown.js
+++ b/sites/frontend/components/Header/Nav/EditionDropdown.js
@@ -6,6 +6,7 @@ import { styled } from '@guardian/guui';
 const EditionDropdown = styled('div')({
     position: 'absolute',
     right: '15px',
+    zIndex: 1072,
 });
 
 export default () => {

--- a/sites/frontend/components/Header/Nav/EditionDropdown.js
+++ b/sites/frontend/components/Header/Nav/EditionDropdown.js
@@ -33,7 +33,7 @@ export default () => {
 
     return (
         <EditionDropdown>
-            <Dropdown label="UK Edition" links={links} />
+            <Dropdown label="UK Edition" links={links} id="edition" />
         </EditionDropdown>
     );
 };

--- a/sites/frontend/components/Header/Nav/EditionDropdown.js
+++ b/sites/frontend/components/Header/Nav/EditionDropdown.js
@@ -1,0 +1,21 @@
+// @flow
+// import styled from '@guardian/guui';
+import Dropdown from '@guardian/guui/dropdown';
+
+export default () => {
+    const links = [
+        {
+            url: 'foo',
+            title: 'bar1',
+        },
+        {
+            url: 'foo',
+            title: 'bar2',
+        },
+        {
+            url: 'foo',
+            title: 'bar3',
+        },
+    ];
+    return <Dropdown links={links} />;
+};

--- a/sites/frontend/components/Header/Nav/EditionDropdown.js
+++ b/sites/frontend/components/Header/Nav/EditionDropdown.js
@@ -13,6 +13,7 @@ export default () => {
         {
             url: 'foo',
             title: 'UK Edition',
+            isActive: true,
         },
         {
             url: 'foo',

--- a/sites/frontend/components/Header/Nav/EditionDropdown.js
+++ b/sites/frontend/components/Header/Nav/EditionDropdown.js
@@ -12,21 +12,25 @@ export default () => {
     const links = [
         {
             url: 'foo',
-            title: 'bar1',
+            title: 'UK Edition',
         },
         {
             url: 'foo',
-            title: 'bar2',
+            title: 'US Edition',
         },
         {
             url: 'foo',
-            title: 'bar3',
+            title: 'Australian Edition',
+        },
+        {
+            url: 'foo',
+            title: 'International Edition',
         },
     ];
 
     return (
         <EditionDropdown>
-            <Dropdown label="edition" links={links} />
+            <Dropdown label="UK Edition" links={links} />
         </EditionDropdown>
     );
 };

--- a/sites/frontend/components/Header/Nav/EditionDropdown.js
+++ b/sites/frontend/components/Header/Nav/EditionDropdown.js
@@ -1,5 +1,6 @@
 // @flow
 import Dropdown from '@guardian/guui/dropdown';
+import type { Link } from '@guardian/guui/dropdown';
 
 import { styled } from '@guardian/guui';
 
@@ -10,7 +11,7 @@ const EditionDropdown = styled('div')({
 });
 
 export default () => {
-    const links = [
+    const links: Array<Link> = [
         {
             url: '/preference/edition/uk',
             title: 'UK Edition',

--- a/sites/frontend/components/Header/Nav/EditionDropdown.js
+++ b/sites/frontend/components/Header/Nav/EditionDropdown.js
@@ -12,20 +12,20 @@ const EditionDropdown = styled('div')({
 export default () => {
     const links = [
         {
-            url: 'foo',
+            url: '/preference/edition/uk',
             title: 'UK Edition',
             isActive: true,
         },
         {
-            url: 'foo',
+            url: '/preference/edition/us',
             title: 'US Edition',
         },
         {
-            url: 'foo',
+            url: '/preference/edition/au',
             title: 'Australian Edition',
         },
         {
-            url: 'foo',
+            url: '/preference/edition/int',
             title: 'International Edition',
         },
     ];

--- a/sites/frontend/components/Header/Nav/index.js
+++ b/sites/frontend/components/Header/Nav/index.js
@@ -7,6 +7,7 @@ import { clearFix } from '@guardian/pasteup/mixins';
 import { tablet, desktop, leftCol, wide } from '@guardian/pasteup/breakpoints';
 
 import Logo from './Logo';
+import EditionDropdown from './EditionDropdown';
 import Links from './Links';
 import Pillars from './Pillars';
 import MainMenuToggle from './MainMenuToggle';
@@ -65,6 +66,7 @@ export default class Nav extends Component<{}, { showMainMenu: boolean }> {
             return (
                 <div>
                     <NavStyled role="navigation" aria-label="Guardian sections">
+                        <EditionDropdown />
                         <Logo />
                         <Links />
                         <Pillars

--- a/yarn.lock
+++ b/yarn.lock
@@ -785,9 +785,9 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-aria-query@^0.7.0:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-0.7.1.tgz#26cbb5aff64144b0a825be1846e0b16cfa00b11e"
+aria-query@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-3.0.0.tgz#65b3fcc1ca1155a8c9ae64d6eee297f15d5133cc"
   dependencies:
     ast-types-flow "0.0.7"
     commander "^2.11.0"
@@ -893,7 +893,7 @@ assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
 
-ast-types-flow@0.0.7:
+ast-types-flow@0.0.7, ast-types-flow@^0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
 
@@ -961,9 +961,9 @@ aws4@^1.2.1, aws4@^1.6.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.7.0.tgz#d4d0e9b9dbfca77bf08eeb0a8a471550fe39e289"
 
-axobject-query@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-0.1.0.tgz#62f59dbc59c9f9242759ca349960e7a2fe3c36c0"
+axobject-query@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.0.1.tgz#05dfa705ada8ad9db993fa6896f22d395b0b0a07"
   dependencies:
     ast-types-flow "0.0.7"
 
@@ -2637,7 +2637,7 @@ cyclist@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
 
-damerau-levenshtein@^1.0.0:
+damerau-levenshtein@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz#03191c432cb6eea168bb77f3a55ffdccb8978514"
 
@@ -2916,7 +2916,7 @@ emitter-listener@^1.1.1:
   dependencies:
     shimmer "^1.2.0"
 
-emoji-regex@^6.1.0:
+emoji-regex@^6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.5.1.tgz#9baea929b155565c11ea41c6626eaa65cef992c2"
 
@@ -3094,17 +3094,18 @@ eslint-plugin-import@^2.7.0:
     minimatch "^3.0.3"
     read-pkg-up "^2.0.0"
 
-eslint-plugin-jsx-a11y@^6.0.2:
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.0.3.tgz#54583d1ae442483162e040e13cc31865465100e5"
+eslint-plugin-jsx-a11y@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.1.1.tgz#7bf56dbe7d47d811d14dbb3ddff644aa656ce8e1"
   dependencies:
-    aria-query "^0.7.0"
+    aria-query "^3.0.0"
     array-includes "^3.0.3"
-    ast-types-flow "0.0.7"
-    axobject-query "^0.1.0"
-    damerau-levenshtein "^1.0.0"
-    emoji-regex "^6.1.0"
-    jsx-ast-utils "^2.0.0"
+    ast-types-flow "^0.0.7"
+    axobject-query "^2.0.1"
+    damerau-levenshtein "^1.0.4"
+    emoji-regex "^6.5.1"
+    has "^1.0.3"
+    jsx-ast-utils "^2.0.1"
 
 eslint-plugin-prettier@^2.6.0:
   version "2.6.0"
@@ -3985,6 +3986,12 @@ has@^1.0.1:
   dependencies:
     function-bind "^1.0.2"
 
+has@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  dependencies:
+    function-bind "^1.1.1"
+
 hash-base@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/hash-base/-/hash-base-2.0.2.tgz#66ea1d856db4e8a5470cadf6fce23ae5244ef2e1"
@@ -4752,7 +4759,7 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-jsx-ast-utils@^2.0.0, jsx-ast-utils@^2.0.1:
+jsx-ast-utils@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz#e801b1b39985e20fffc87b40e3748080e2dcac7f"
   dependencies:


### PR DESCRIPTION
~**Not quite ready for review yet.**~

Adds a dropdown component to Guui and tests it out on the Edition picker in the header.

I'm not sure I've covered the accessibility stuff well - e.g. tabIndexes so feedback welcome.

Note for self: linting fails with:

    /Users/nlong/projects/dotcom-rendering/packages/guui/dropdown/index.js
      197:25  error  Form label must have associated control                     jsx-a11y/label-has-for
      204:29  error  `tabIndex` should only be declared on interactive elements  jsx-a11y/no-noninteractive-tabindex

The first seems weird as I thought that was done.