### PR TITLE
Add account dropdown

### DIFF
--- a/frontend/components/Header/Nav/Links/index.js
+++ b/frontend/components/Header/Nav/Links/index.js
@@ -1,50 +1,138 @@
 // @flow
-import styled from 'react-emotion';
+
+import { css } from 'react-emotion';
 import { connect } from 'unistore/react';
 
+import Dropdown from '@guardian/guui/components/Dropdown';
+import type { Link as DropdownLink } from '@guardian/guui/components/Dropdown';
+
+import palette from '@guardian/pasteup/palette';
+import { textSans } from '@guardian/pasteup/fonts';
+
+import { tablet, desktop } from '@guardian/pasteup/breakpoints';
+
 import SupportTheGuardian from './SupportTheGuardian';
-import Link from './Link';
-import Search from './Search';
 
-import type { LinkType } from '../__config__';
+const profileSubdomain = 'https://profile.theguardian.com';
+const subscribeUrl =
+    'https://support.theguardian.com/subscribe?INTCMP=header_support_subscribe&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentType%22%3A%22ACQUISITIONS_HEADER%22%2C%22componentId%22%3A%22header_support_subscribe%22%2C%22referrerPageviewId%22%3A%22jkjutjbkxfh1d8yyadfc%22%2C%22referrerUrl%22%3A%22https%3A%2F%2Fwww.theguardian.com%2Fuk%22%7D';
+const jobsUrl = 'https://jobs.theguardian.com/?INTCMP=jobs_uk_web_newheader';
+const signInUrl = `${profileSubdomain}/signin?INTCMP=DOTCOM_NEWHEADER_SIGNIN&ABCMP=ab-sign-in`;
 
-const Links = styled('div')({
-    left: 0,
-    top: 0,
-    position: 'absolute',
-});
-
-const userLinks: Array<LinkType> = [
+const identityLinks: Array<DropdownLink> = [
     {
-        title: 'Subscribe',
-        longTitle: 'Subscribe',
-        url: '/',
+        url: `${profileSubdomain}/user/id/123`, // TODO use actual user ID once we have a user model
+        title: 'Comments and replies',
     },
     {
-        title: 'Find a job',
-        longTitle: 'Find a job',
-        url: '/',
+        url: `${profileSubdomain}/public/edit`,
+        title: 'Public profile',
     },
     {
-        title: 'Sign in',
-        longTitle: 'Sign in',
-        url: '/',
+        url: `${profileSubdomain}/account/edit`,
+        title: 'Account details',
+    },
+    {
+        url: `${profileSubdomain}/email-prefs`,
+        title: 'Emails and marketing',
+    },
+    {
+        url: `${profileSubdomain}/membership/edit`,
+        title: 'Membership',
+    },
+    {
+        url: `${profileSubdomain}/contribution/recurring/edit`,
+        title: 'Contributions',
+    },
+    {
+        url: `${profileSubdomain}/digitalpack/edit`,
+        title: 'Digital pack',
+    },
+    {
+        url: `${profileSubdomain}/signout`,
+        title: 'Sign out',
     },
 ];
 
-export default connect('header')(({ isPayingMember, isRecentContributor }) => (
-    <Links>
-        {isPayingMember ||
-            isRecentContributor || (
-                <SupportTheGuardian href="/">
-                    Support The Guardian
-                </SupportTheGuardian>
+const linkPosition = showAtTablet => css`
+    display: none;
+    float: left;
+    position: relative;
+    display: none;
+
+    ${tablet} {
+        display: ${showAtTablet ? 'block' : 'none'};
+    }
+
+    ${desktop} {
+        display: block;
+    }
+`;
+
+const linkStyle = css`
+    font-size: 14px;
+    font-family: ${textSans};
+    color: ${palette.neutral['1']};
+    line-height: 1.2;
+    transition: color 80ms ease-out;
+    padding: 6px 10px;
+    margin: 1px 0 0;
+    text-decoration: none;
+
+    :hover {
+        text-decoration: underline;
+    }
+
+    :focus {
+        text-decoration: underline;
+    }
+`;
+
+const link = showAtTablet => css`
+    ${linkStyle};
+    ${linkPosition(showAtTablet)};
+`;
+
+const linksPositioning = css`
+    left: 0;
+    top: 0;
+    position: absolute;
+`;
+
+export default connect('header')(
+    ({ isPayingMember, isRecentContributor, isSignedIn }) => (
+        <div className={linksPositioning}>
+            {isPayingMember ||
+                isRecentContributor || (
+                    <SupportTheGuardian href="/">
+                        Support The Guardian
+                    </SupportTheGuardian>
+                )}
+
+            <a className={link(true)} href={subscribeUrl} showAtTablet>
+                Subscribe
+            </a>
+            <a className={link(true)} href={jobsUrl}>
+                Find a job
+            </a>
+
+            {isSignedIn ? (
+                <div className={linkPosition(false)}>
+                    <Dropdown
+                        label="My account"
+                        links={identityLinks}
+                        id="my-account"
+                    />
+                </div>
+            ) : (
+                <a className={link(false)} href={signInUrl}>
+                    Sign in / Register
+                </a>
             )}
-        {userLinks.map(({ url, title }, i) => (
-            <Link href={url} key={title} showAtTablet={i < 2}>
-                {title}
-            </Link>
-        ))}
-        <Search href="/">Search</Search>
-    </Links>
-));
+
+            <a className={link(false)} href="/">
+                Search
+            </a>
+        </div>
+    ),
+);


### PR DESCRIPTION
This PR assumes future work. I'm happy to do this here if people think it's simpler, though my preference is to do a few smaller PRs. But work not yet covered includes:

* search dropdown re-added and with dropdown actually in place
* slight styling tweak to Dropdown to have groups of lists (at the moment every link has a horizontal border but it should support groupings instead)

I've stuck to our new(!) component guidelines and think it's pretty nice actually. :)

## What does this change?

Note, at the moment we don't have a user model so this won't get displayed.

I've also inlined the search component temporarily as it doesn't work at the moment and, again, would be nice to tackle this in a separate PR.

## Why?

Because we need this behaviour.

![screen shot 2018-08-08 at 15 40 52](https://user-images.githubusercontent.com/858402/43846427-3c99d512-9b26-11e8-8e22-354aeae5fbc6.png)
