### PR TITLE
Frontend should use own react/emotion dependencies

### DIFF
--- a/frontend/components/CapiComponent.js
+++ b/frontend/components/CapiComponent.js
@@ -1,5 +1,5 @@
 // @flow
-import { Component } from '@guardian/guui';
+import { Component } from 'react';
 import { connect } from 'unistore/react';
 
 type CapiKey = string;

--- a/frontend/components/Epic.js
+++ b/frontend/components/Epic.js
@@ -1,5 +1,5 @@
 // @flow
-import { styled } from '@guardian/guui';
+import styled from 'react-emotion';
 import pallete from '@guardian/pasteup/palette';
 import { headline } from '@guardian/pasteup/fonts';
 

--- a/frontend/components/Footer/index.js
+++ b/frontend/components/Footer/index.js
@@ -1,5 +1,5 @@
 // @flow
-import { styled } from '@guardian/guui';
+import styled from 'react-emotion';
 
 import { leftCol, tablet, until } from '@guardian/pasteup/breakpoints';
 import { textSans } from '@guardian/pasteup/fonts';

--- a/frontend/components/Header/Nav/EditionDropdown.js
+++ b/frontend/components/Header/Nav/EditionDropdown.js
@@ -2,7 +2,7 @@
 import Dropdown from '@guardian/guui/dropdown';
 import type { Link } from '@guardian/guui/dropdown';
 
-import { styled } from '@guardian/guui';
+import styled from 'react-emotion';
 
 const EditionDropdown = styled('div')({
     position: 'absolute',

--- a/frontend/components/Header/Nav/Links/Link.js
+++ b/frontend/components/Header/Nav/Links/Link.js
@@ -1,5 +1,5 @@
 // @flow
-import { styled } from '@guardian/guui';
+import styled from 'react-emotion';
 
 import palette from '@guardian/pasteup/palette';
 import { textSans } from '@guardian/pasteup/fonts';

--- a/frontend/components/Header/Nav/Links/Search.js
+++ b/frontend/components/Header/Nav/Links/Search.js
@@ -1,5 +1,5 @@
 // @flow
-import { styled } from '@guardian/guui';
+import styled from 'react-emotion';
 
 import Link from './Link';
 

--- a/frontend/components/Header/Nav/Links/SupportTheGuardian.js
+++ b/frontend/components/Header/Nav/Links/SupportTheGuardian.js
@@ -1,5 +1,5 @@
 // @flow
-import { styled } from '@guardian/guui';
+import styled from 'react-emotion';
 
 import palette, { pillars } from '@guardian/pasteup/palette';
 import { headline } from '@guardian/pasteup/fonts';

--- a/frontend/components/Header/Nav/Links/index.js
+++ b/frontend/components/Header/Nav/Links/index.js
@@ -1,5 +1,5 @@
 // @flow
-import { styled } from '@guardian/guui';
+import styled from 'react-emotion';
 import { connect } from 'unistore/react';
 
 import SupportTheGuardian from './SupportTheGuardian';

--- a/frontend/components/Header/Nav/Logo.js
+++ b/frontend/components/Header/Nav/Logo.js
@@ -1,5 +1,5 @@
 // @flow
-import { styled } from '@guardian/guui';
+import styled from 'react-emotion';
 
 import {
     mobileMedium,

--- a/frontend/components/Header/Nav/MainMenu/MainMenuColumns/MainMenuColumn/MainMenuColumnButton.js
+++ b/frontend/components/Header/Nav/MainMenu/MainMenuColumns/MainMenuColumn/MainMenuColumnButton.js
@@ -1,5 +1,5 @@
 // @flow
-import { styled } from '@guardian/guui';
+import styled from 'react-emotion';
 
 import { headline } from '@guardian/pasteup/fonts';
 import { pillars } from '@guardian/pasteup/palette';

--- a/frontend/components/Header/Nav/MainMenu/MainMenuColumns/MainMenuColumn/MainMenuColumnLinks/MainMenuLink/MainMenuLinkTitle.js
+++ b/frontend/components/Header/Nav/MainMenu/MainMenuColumns/MainMenuColumn/MainMenuColumnLinks/MainMenuLink/MainMenuLinkTitle.js
@@ -1,5 +1,5 @@
 // @flow
-import { styled } from '@guardian/guui';
+import styled from 'react-emotion';
 
 import { tablet, desktop } from '@guardian/pasteup/breakpoints';
 import { egyptian } from '@guardian/pasteup/fonts';

--- a/frontend/components/Header/Nav/MainMenu/MainMenuColumns/MainMenuColumn/MainMenuColumnLinks/MainMenuLink/index.js
+++ b/frontend/components/Header/Nav/MainMenu/MainMenuColumns/MainMenuColumn/MainMenuColumnLinks/MainMenuLink/index.js
@@ -1,5 +1,5 @@
 // @flow
-import { styled } from '@guardian/guui';
+import styled from 'react-emotion';
 
 import { desktop } from '@guardian/pasteup/breakpoints';
 

--- a/frontend/components/Header/Nav/MainMenu/MainMenuColumns/MainMenuColumn/MainMenuColumnLinks/index.js
+++ b/frontend/components/Header/Nav/MainMenu/MainMenuColumns/MainMenuColumn/MainMenuColumnLinks/index.js
@@ -1,5 +1,5 @@
 // @flow
-import { styled } from '@guardian/guui';
+import styled from 'react-emotion';
 
 import { desktop } from '@guardian/pasteup/breakpoints';
 

--- a/frontend/components/Header/Nav/MainMenu/MainMenuColumns/MainMenuColumn/index.js
+++ b/frontend/components/Header/Nav/MainMenu/MainMenuColumns/MainMenuColumn/index.js
@@ -1,5 +1,6 @@
 // @flow
-import { styled, Component } from '@guardian/guui';
+import { Component } from 'react';
+import styled from 'react-emotion';
 
 import { desktop, leftCol } from '@guardian/pasteup/breakpoints';
 

--- a/frontend/components/Header/Nav/MainMenu/MainMenuColumns/index.js
+++ b/frontend/components/Header/Nav/MainMenu/MainMenuColumns/index.js
@@ -1,5 +1,5 @@
 // @flow
-import { styled } from '@guardian/guui';
+import styled from 'react-emotion';
 
 import { tablet, desktop, leftCol, wide } from '@guardian/pasteup/breakpoints';
 import { egyptian } from '@guardian/pasteup/fonts';

--- a/frontend/components/Header/Nav/MainMenu/index.js
+++ b/frontend/components/Header/Nav/MainMenu/index.js
@@ -1,5 +1,5 @@
 // @flow
-import { styled } from '@guardian/guui';
+import styled from 'react-emotion';
 
 import {
     until,

--- a/frontend/components/Header/Nav/MainMenuToggle/VeggieBurger.js
+++ b/frontend/components/Header/Nav/MainMenuToggle/VeggieBurger.js
@@ -1,5 +1,5 @@
 // @flow
-import { styled } from '@guardian/guui';
+import styled from 'react-emotion';
 
 import {
     tablet,

--- a/frontend/components/Header/Nav/MainMenuToggle/index.js
+++ b/frontend/components/Header/Nav/MainMenuToggle/index.js
@@ -1,5 +1,6 @@
 // @flow
-import { styled, Component } from '@guardian/guui';
+import { Component } from 'react';
+import styled from 'react-emotion';
 
 import { desktop } from '@guardian/pasteup/breakpoints';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';

--- a/frontend/components/Header/Nav/Pillars/index.js
+++ b/frontend/components/Header/Nav/Pillars/index.js
@@ -1,5 +1,5 @@
 // @flow
-import { styled } from '@guardian/guui';
+import styled from 'react-emotion';
 
 import {
     tablet,

--- a/frontend/components/Header/Nav/SubNav.js
+++ b/frontend/components/Header/Nav/SubNav.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { styled } from '@guardian/guui';
+import styled from 'react-emotion';
 import type { LinkType } from './__config__';
 
 type Props = {

--- a/frontend/components/Header/Nav/index.js
+++ b/frontend/components/Header/Nav/index.js
@@ -1,6 +1,7 @@
 // @flow
 
-import { styled, Component } from '@guardian/guui';
+import { Component } from 'react';
+import styled from 'react-emotion';
 import { connect } from 'unistore/react';
 import { Row, Cols } from '@guardian/guui/grid';
 import { clearFix } from '@guardian/pasteup/mixins';

--- a/frontend/components/Header/index.js
+++ b/frontend/components/Header/index.js
@@ -1,5 +1,5 @@
 // @flow
-import { styled } from '@guardian/guui';
+import styled from 'react-emotion';
 
 import { tablet } from '@guardian/pasteup/breakpoints';
 

--- a/frontend/components/Main.js
+++ b/frontend/components/Main.js
@@ -1,5 +1,5 @@
 // @flow
-import { styled } from '@guardian/guui';
+import styled from 'react-emotion';
 
 import { tablet, desktop, leftCol, wide } from '@guardian/pasteup/breakpoints';
 

--- a/frontend/components/MostViewed.js
+++ b/frontend/components/MostViewed.js
@@ -1,5 +1,6 @@
 // @flow
-import { Component, styled } from '@guardian/guui';
+import { Component } from 'react';
+import styled from 'react-emotion';
 import { headline, textEgyptian } from '@guardian/pasteup/fonts';
 import palette from '@guardian/pasteup/palette';
 import { desktop } from '@guardian/pasteup/breakpoints';

--- a/frontend/components/Page.js
+++ b/frontend/components/Page.js
@@ -1,5 +1,5 @@
 // @flow
-import { styled } from '@guardian/guui';
+import styled from 'react-emotion';
 
 const Page = styled('div')();
 

--- a/frontend/document.js
+++ b/frontend/document.js
@@ -1,6 +1,8 @@
 // @flow
 
-import { renderToString } from '@guardian/guui';
+import { extractCritical } from 'emotion-server';
+import { renderToString } from 'react-dom/server';
+
 import assets from '@guardian/guui/lib/assets';
 import htmlTemplate from '@guardian/guui/htmlTemplate';
 
@@ -17,6 +19,12 @@ type Props = {
     Page: React.ComponentType<{}>,
 };
 
+type renderToStringResult = {
+    html: string,
+    css: string,
+    ids: Array<string>,
+};
+
 export default ({ Page, data: { body, ...data } }: Props) => {
     const cleanedData = { ...parseCAPI(body), ...data };
 
@@ -24,8 +32,8 @@ export default ({ Page, data: { body, ...data } }: Props) => {
         `${cleanedData.site}.${cleanedData.page.toLowerCase()}.js`,
     );
 
-    const { html, css, ids: cssIDs } = renderToString(
-        <App data={{ ...cleanedData }} Page={Page} />,
+    const { html, css, ids: cssIDs }: renderToStringResult = extractCritical(
+        renderToString(<App data={{ ...cleanedData }} Page={Page} />),
     );
 
     /**

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "compose-function": "^3.0.3",
     "curlyquotes": "^1.3.2",
     "dompurify": "^1.0.3",
+    "emotion": "^9.1.1",
     "html-minifier": "^3.5.14",
     "jsdom": "^11.7.0",
     "lodash.get": "^4.4.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,11 +14,13 @@
     "curlyquotes": "^1.3.2",
     "dompurify": "^1.0.3",
     "emotion": "^9.1.1",
+    "emotion-server": "^9.1.1",
     "html-minifier": "^3.5.14",
     "jsdom": "^11.7.0",
     "lodash.get": "^4.4.2",
     "polished": "^1.9.2",
     "react": "^16.4.0",
+    "react-dom": "^16.4.0",
     "react-emotion": "^9.1.3",
     "unistore": "^3.0.4"
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,8 @@
     "jsdom": "^11.7.0",
     "lodash.get": "^4.4.2",
     "polished": "^1.9.2",
+    "react": "^16.4.0",
+    "react-emotion": "^9.1.3",
     "unistore": "^3.0.4"
   }
 }

--- a/frontend/pages/Article.js
+++ b/frontend/pages/Article.js
@@ -2,7 +2,7 @@
 
 /* eslint-disable react/no-danger */
 
-import { styled } from '@guardian/guui';
+import styled from 'react-emotion';
 import { Row, Cols } from '@guardian/guui/grid';
 import { textEgyptian, headline } from '@guardian/pasteup/fonts';
 import palette from '@guardian/pasteup/palette';


### PR DESCRIPTION
## What does this change?

Updates all components in `frontend` to use `React` and `emotion` related dependencies from `frontend` not `guui`.

## Why?

We'd like to use `guui` as a component library alone.  Going forward`frontend` should consume  component's from `guui` but no longer use it as a "service".

`frontend` should therefore use it's own `React` and `emotion` related dependencies from now on.

**TODO:**
Following PRs will be raised which will update `guui` to reorganise the components directory and remove the "service" exports no longer used by frontend.
