### PR TITLE
Introduce scaling policies and latency based scaling alarm

### DIFF
--- a/frontend/cloudformation.yml
+++ b/frontend/cloudformation.yml
@@ -26,6 +26,22 @@ Parameters:
   AMI:
     Description: AMI to use for instances
     Type: AWS::EC2::Image::Id
+  LatencyAlarmThreshold:
+    Type: String
+    Description: (Optional) Latency Threshold
+    Default: '0.5'
+  LatencyAlarmPeriod:
+    Type: String
+    Description: (Optional) Duration in seconds over which the latency is applied
+    Default: '60'
+  LatencyScalingEvaluationPeriods:
+    Type: String
+    Description: (Optional) Number of periods over which the latency is compared to the threshold before to scale up
+    Default: '1'
+  LatencyNotificationEvaluationPeriods:
+    Type: String
+    Description: (Optional) Number of periods over which the latency is compared to the threshold before to send a notification
+    Default: '5'
 
 Mappings:
   Constants:
@@ -244,6 +260,27 @@ Resources:
       AutoScalingGroupName: !Ref AutoscalingGroup
       Cooldown: '600'
       ScalingAdjustment: '100'
+      
+  LatencyScalingAlarm:
+    Condition: HasLatencyScalingAlarm
+    Properties:
+      AlarmDescription: !Sub |
+        Scale-Up if latency is greater than ${LatencyAlarmThreshold} seconds over ${LatencyScalingEvaluationPeriods} period(s) of ${LatencyAlarmPeriod} seconds
+      Dimensions:
+      - Name: LoadBalancerName
+        Value: !Ref Elb
+      EvaluationPeriods: !Ref LatencyScalingEvaluationPeriods
+      MetricName: Latency
+      Namespace: AWS/ELB
+      Period: !Ref LatencyAlarmPeriod
+      Statistic: Average
+      Threshold: !Ref LatencyAlarmThreshold
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      OKActions:
+      - !Ref ScaleDownPolicy
+      AlarmActions:
+      - !Ref ScaleUpPolicy
+    Type: AWS::CloudWatch::Alarm
 
 Outputs:
   LoadBalancerUrl:

--- a/frontend/cloudformation.yml
+++ b/frontend/cloudformation.yml
@@ -229,6 +229,22 @@ Resources:
           Fn::FindInMap: [ Constants, App, Value ]
         PropagateAtLaunch: true
 
+  ScaleDownPolicy:
+    Type: AWS::AutoScaling::ScalingPolicy
+    Properties:
+      AdjustmentType: ChangeInCapacity
+      AutoScalingGroupName: !Ref AutoscalingGroup
+      Cooldown: '1200'
+      ScalingAdjustment: '-1'
+
+  ScaleUpPolicy:
+    Type: AWS::AutoScaling::ScalingPolicy
+    Properties:
+      AdjustmentType: PercentChangeInCapacity
+      AutoScalingGroupName: !Ref AutoscalingGroup
+      Cooldown: '600'
+      ScalingAdjustment: '100'
+
 Outputs:
   LoadBalancerUrl:
     Value:

--- a/frontend/cloudformation.yml
+++ b/frontend/cloudformation.yml
@@ -28,7 +28,7 @@ Parameters:
     Type: AWS::EC2::Image::Id
   LatencyAlarmThreshold:
     Type: String
-    Description: (Optional) Latency Threshold
+    Description: (Optional) Latency Threshold in seconds
     Default: '0.5'
   LatencyAlarmPeriod:
     Type: String

--- a/frontend/cloudformation.yml
+++ b/frontend/cloudformation.yml
@@ -42,6 +42,9 @@ Parameters:
     Type: String
     Description: (Optional) Number of periods over which the latency is compared to the threshold before to send a notification
     Default: '5'
+    
+Conditions:
+    HasLatencyScalingAlarm: !Equals [!Ref Stage, 'PROD']
 
 Mappings:
   Constants:
@@ -262,6 +265,7 @@ Resources:
       ScalingAdjustment: '100'
 
   LatencyScalingAlarm:
+    Condition: HasLatencyScalingAlarm
     Properties:
       AlarmDescription: !Sub |
         Scale-Up if latency is greater than ${LatencyAlarmThreshold} seconds over ${LatencyScalingEvaluationPeriods} period(s) of ${LatencyAlarmPeriod} seconds

--- a/frontend/cloudformation.yml
+++ b/frontend/cloudformation.yml
@@ -260,14 +260,14 @@ Resources:
       AutoScalingGroupName: !Ref AutoscalingGroup
       Cooldown: '600'
       ScalingAdjustment: '100'
-      
+
   LatencyScalingAlarm:
     Properties:
       AlarmDescription: !Sub |
         Scale-Up if latency is greater than ${LatencyAlarmThreshold} seconds over ${LatencyScalingEvaluationPeriods} period(s) of ${LatencyAlarmPeriod} seconds
       Dimensions:
       - Name: LoadBalancerName
-        Value: !Ref Elb
+        Value: !Ref LoadBalancer
       EvaluationPeriods: !Ref LatencyScalingEvaluationPeriods
       MetricName: Latency
       Namespace: AWS/ELB

--- a/frontend/cloudformation.yml
+++ b/frontend/cloudformation.yml
@@ -262,7 +262,6 @@ Resources:
       ScalingAdjustment: '100'
       
   LatencyScalingAlarm:
-    Condition: HasLatencyScalingAlarm
     Properties:
       AlarmDescription: !Sub |
         Scale-Up if latency is greater than ${LatencyAlarmThreshold} seconds over ${LatencyScalingEvaluationPeriods} period(s) of ${LatencyAlarmPeriod} seconds


### PR DESCRIPTION
## What does this change?

Introduces our standing scale up/down policies, and an alarm to scale up and down based on latency. This mirrors how the frontend apps such as article work. Not too concerned about the exact numbers of the latency scaling right now, just wanted to get the code in. It's using the same values as article does as defaults.

## Why?

We stated explicitly that the simple article objective can only be considered achieved when it's actually in production, and we can't be in production without proper scaling.