### PR TITLE
Conditionally render the subnav on articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ That's it – everything else should be installed for you on demand.
 ## Development
 `make dev` starts the development server.
 
+### Change preview article
+You can preview an article from `theguardian.com` by appending the query string parameter `url` to your localhost article page. EG. `http://localhost:3000/frontend/Article?url=https://www.theguardian.com/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance`
+
 ## Production
  - `make build` creates production-ready bundles.
  - `make start` starts the production server.

--- a/frontend/components/Header/Nav/index.js
+++ b/frontend/components/Header/Nav/index.js
@@ -85,14 +85,18 @@ export default class Nav extends Component<{}, { showMainMenu: boolean }> {
                             nav={nav}
                         />
                     </NavStyled>
-                    <Row>
-                        <Cols wide={16} leftCol={16}>
-                            <SubNav
-                                parent={nav.subNavSections.parent}
-                                links={nav.subNavSections.links}
-                            />
-                        </Cols>
-                    </Row>
+                    {nav.subNavSections &&
+                        nav.subNavSections.parent &&
+                        nav.subNavSections.links && (
+                            <Row>
+                                <Cols wide={16} leftCol={16}>
+                                    <SubNav
+                                        parent={nav.subNavSections.parent}
+                                        links={nav.subNavSections.links}
+                                    />
+                                </Cols>
+                            </Row>
+                        )}
                 </div>
             );
         });


### PR DESCRIPTION
## What does this change?

The property `subNavSections` isn't always available on the `nav` object, if it isn't there the article won't render. This conditionally renders the subnav depending on if `subNavSections` exists.
