### PR TITLE
Article body

### DIFF
--- a/dev-server.js
+++ b/dev-server.js
@@ -46,7 +46,7 @@ const go = async () => {
         async (req, res, next) => {
             const { html, ...config } = await fetch(
                 `${req.query.url ||
-                    'https://www.theguardian.com/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance'}.json?guui`,
+                    'https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software'}.json?guui`,
             ).then(article => article.json());
 
             req.body = config;

--- a/frontend/components/ArticleBody.js
+++ b/frontend/components/ArticleBody.js
@@ -1,0 +1,184 @@
+// @flow
+
+import { css } from 'react-emotion';
+import { connect } from 'unistore/react';
+import palette from '@guardian/pasteup/palette';
+
+import {
+    from,
+    until,
+    wide,
+    leftCol,
+    desktop,
+} from '@guardian/pasteup/breakpoints';
+
+const wrapper = css`
+    padding-top: 6px;
+    margin-right: 0;
+    margin-left: 0;
+
+    ${desktop} {
+        max-width: 620px;
+        margin-right: 310px;
+        padding-left: 10px;
+    }
+
+    ${leftCol} {
+        margin-left: 150px;
+        margin-right: 310px;
+    }
+
+    ${wide} {
+        margin-left: 230px;
+    }
+
+    header {
+        display: flex;
+        flex-direction: column;
+
+        ${leftCol} {
+            display: grid;
+            grid-template-areas: 'section headline' 'meta main-media';
+            grid-template-columns: 160px 1fr;
+            margin-left: -160px;
+        }
+
+        ${wide} {
+            grid-template-columns: 240px 1fr;
+            margin-left: -240px;
+        }
+    }
+`;
+
+const standfirst = css`
+    font-family: 'Guardian Text Egyptian Web', Georgia, serif;
+    font-weight: 700;
+    font-size: 17px;
+    line-height: 22px;
+    color: ${palette.neutral[1]};
+    margin-bottom: 12px;
+`;
+
+const secondaryColumn = css`
+    position: absolute;
+    top: 0;
+    right: 0;
+    margin-right: 20px;
+    width: 300px;
+    margin-left: 20px;
+    margin-top: 6px;
+
+    background-color: ${palette.neutral[6]};
+    min-height: 300px;
+    display: none;
+
+    ${desktop} {
+        display: block;
+    }
+`;
+
+const section = css`
+    grid-template-area: section;
+`;
+
+const headline = css`
+    grid-template-area: headline;
+`;
+
+const meta = css`
+    grid-template-area: meta;
+
+    ${from.tablet.until.leftCol} {
+        order: 1;
+    }
+`;
+
+const mainMedia = css`
+    grid-template-area: main-media;
+
+    margin-bottom: 6px;
+
+    ${until.tablet} {
+        margin: 0 -20px;
+        order: -1;
+
+        figcaption {
+            display: none;
+        }
+    }
+
+    img {
+        width: 100%;
+        height: 100%;
+    }
+
+    figcaption {
+        font-size: 12px;
+        line-height: 16px;
+        font-family: 'Guardian Text Sans Web', 'Helvetica Neue', Helvetica,
+            Arial, 'Lucida Grande', sans-serif;
+        color: ${palette.neutral[3]};
+    }
+`;
+
+const headerStyle = css`
+    font-size: 34px;
+    line-height: 38px;
+    font-family: 'Guardian Egyptian Web', Georgia, serif;
+    font-weight: 400;
+    padding-bottom: 24px;
+`;
+
+const bodyStyle = css`
+    ${from.tablet.until.desktop} {
+        padding-right: 80px;
+    }
+
+    p {
+        font-size: 16px;
+        line-height: 24px;
+        font-family: 'Guardian Text Egyptian Web', Georgia, serif;
+        margin-bottom: 12px;
+    }
+`;
+
+const ArticleBody = () => {
+    /* eslint-disable react/no-danger */
+    const Body = connect('CAPI')(({ CAPI = {} }) => (
+        <div className={wrapper}>
+            <header>
+                <div className={section}>Section</div>
+                <div className={headline}>
+                    <h1 className={headerStyle}>{CAPI.headline}</h1>
+                    <div
+                        className={standfirst}
+                        dangerouslySetInnerHTML={{
+                            __html: CAPI.standfirst,
+                        }}
+                    />
+                </div>
+                <div className={meta}>Meta</div>
+                <div
+                    className={mainMedia}
+                    dangerouslySetInnerHTML={{
+                        __html: CAPI.main,
+                    }}
+                />
+            </header>
+            <div>
+                <div
+                    className={bodyStyle}
+                    dangerouslySetInnerHTML={{
+                        __html: CAPI.body,
+                    }}
+                />
+                <div>Submeta</div>
+            </div>
+            <div className={secondaryColumn} />
+        </div>
+    ));
+
+    return <Body />;
+};
+
+export default ArticleBody;

--- a/frontend/pages/Article.js
+++ b/frontend/pages/Article.js
@@ -2,118 +2,50 @@
 
 /* eslint-disable react/no-danger */
 
-import styled from 'react-emotion';
-import { GridRow, GridCols, Container } from '@guardian/guui';
-import { textEgyptian, headline } from '@guardian/pasteup/fonts';
+import { Container } from '@guardian/guui';
+import { css } from 'react-emotion';
 import palette from '@guardian/pasteup/palette';
-import { clearFix } from '@guardian/pasteup/mixins';
 
 import Page from '../components/Page';
 import MostViewed from '../components/MostViewed';
 import Header from '../components/Header';
 import Footer from '../components/Footer';
-import { CapiComponent } from '../components/CapiComponent';
+import ArticleBody from '../components/ArticleBody';
 
-const HeadlineStyled = styled('h1')({
-    fontFamily: headline,
-    fontSize: 34,
-    lineHeight: 1.1,
-    fontWeight: 700,
-    color: palette.red.dark,
-    paddingBottom: 36,
-    paddingTop: 3,
-});
-const Headline = CapiComponent(HeadlineStyled, 'headline');
+const articleWrapper = css`
+    background-color: rgba(18, 18, 18, 0.05);
 
-const BodyStyled = styled('section')({
-    p: {
-        fontFamily: textEgyptian,
-        lineHeight: 1.4,
-        marginBottom: '1rem',
-        color: palette.neutral[1],
-    },
-    h2: {
-        fontFamily: headline,
-        color: palette.neutral[1],
-        fontSize: 20,
-        lineHeight: 1.2,
-        fontWeight: 900,
-        marginTop: 27,
-        marginBottom: 1,
-    },
-    '.gu-video': {
-        maxWidth: '100%',
-    },
-});
-const Body = CapiComponent(BodyStyled, 'body');
+    :before {
+        background-image: repeating-linear-gradient(
+            to bottom,
+            ${palette.neutral[5]},
+            ${palette.neutral[5]} 1px,
+            transparent 1px,
+            transparent 4px
+        );
+        background-repeat: repeat-x;
+        background-position: bottom;
+        background-size: 1px 13px;
+        background-color: ${palette.neutral[8]};
+        content: '';
+        display: block;
+        height: 13px;
+    }
+`;
 
-const StandfirstStyled = styled('p')({
-    color: palette.neutral[1],
-    fontFamily: textEgyptian,
-    fontSize: 20,
-    fontWeight: 100,
-    lineHeight: 1.2,
-    marginBottom: 12,
-    maxWidth: 540,
-    paddingTop: 2,
-
-    a: {
-        color: palette.red.dark,
-        textDecoration: 'none',
-        borderBottomWidth: 1,
-        borderBottomStyle: 'solid',
-        borderBottomColor: palette.neutral[5],
-    },
-
-    '.bullet': {
-        color: 'transparent',
-        height: '0.75em',
-        width: '0.75em',
-        borderRadius: '50%',
-        marginRight: 2,
-        backgroundColor: palette.red.dark,
-        display: 'inline-block',
-        lineHeight: 0.8,
-    },
-});
-const Standfirst = CapiComponent(StandfirstStyled, 'standfirst');
-
-const Labels = styled('div')({ ...clearFix, paddingTop: 6 });
-
-const SectionLabel = styled('div')({
-    color: palette.red.dark,
-    fontFamily: textEgyptian,
-    fontWeight: 900,
-    paddingRight: 6,
-    float: 'left',
-});
-
-const SeriesLabel = styled(SectionLabel)({
-    fontSize: 15,
-    fontWeight: 500,
-});
+const articleContainer = css`
+    position: relative;
+    background-color: ${palette.neutral[8]};
+    padding: 0 20px;
+`;
 
 const Article = () => (
     <Page>
         <Header />
-        <main>
-            <Container>
+        <main className={articleWrapper}>
+            <Container className={articleContainer}>
                 <article>
-                    <GridRow>
-                        <GridCols wide={3} leftCol={2}>
-                            <Labels>
-                                <SectionLabel>The NSA files</SectionLabel>
-                                <SeriesLabel>
-                                    Glenn Greenwald on security and liberty
-                                </SeriesLabel>
-                            </Labels>
-                        </GridCols>
-                        <GridCols wide={13} leftCol={12}>
-                            <Headline />
-                            <Standfirst />
-                        </GridCols>
-                    </GridRow>
-                    <Body />
+                    <ArticleBody />
                     <MostViewed />
                 </article>
             </Container>

--- a/frontend/pages/Article.js
+++ b/frontend/pages/Article.js
@@ -93,7 +93,7 @@ const SeriesLabel = styled(SectionLabel)({
     fontWeight: 500,
 });
 
-export default () => (
+const Article = () => (
     <Page>
         <Header />
         <main>
@@ -121,3 +121,5 @@ export default () => (
         <Footer />
     </Page>
 );
+
+export default Article;

--- a/packages/pasteup/palette.js
+++ b/packages/pasteup/palette.js
@@ -38,6 +38,7 @@ const palette = {
         '5': '#dcdcdc',
         '6': '#ececec',
         '7': '#f6f6f6',
+        '8': '#ffffff',
     },
 };
 


### PR DESCRIPTION
Have discussed with @SiAdcock and it's not clear we can use our custom Grid here that easily so sticking with CSS grid/flex for now - which is basically copied from how the current site works.

I'm not too concerned about this though. The dev benefits of dotcom-rendering are not really around having perfectly manicured CSS, but being able to change things easily if we need too.

## What does this change?

This adds basic responsive layout to the main content section of the page - things like the article headline, meta data, main media, and article body. It's mostly about adjusting layout across breakpoints, with a little styling thrown in to give a sense of things.

It's a lightweight pass; there is obviously a lot of work still to be done. But attempting to bundle everything into a single PR is probably not a good strategy. Once this is merged, people can potentially work in parallel on what remains. But either way, getting early feedback/smaller PRs seems better. I've suffered enough from merge conflicts!

## Why?

Article MVP.

## Pictures

![screen shot 2018-08-15 at 18 02 06](https://user-images.githubusercontent.com/858402/44161719-0ac56200-a0b6-11e8-8966-ca3e6e09d7e9.png)
![screen shot 2018-08-15 at 18 02 17](https://user-images.githubusercontent.com/858402/44161721-0ac56200-a0b6-11e8-884c-6dec5dfd0698.png)
![screen shot 2018-08-15 at 18 02 32](https://user-images.githubusercontent.com/858402/44161722-0ac56200-a0b6-11e8-99ad-b6eb80e970f4.png)
![screen shot 2018-08-15 at 18 02 43](https://user-images.githubusercontent.com/858402/44161723-0b5df880-a0b6-11e8-85b3-84df9c898fed.png)
![screen shot 2018-08-15 at 18 02 55](https://user-images.githubusercontent.com/858402/44161724-0b5df880-a0b6-11e8-8330-2783e206bfbd.png)
![screen shot 2018-08-15 at 18 03 05](https://user-images.githubusercontent.com/858402/44161725-0b5df880-a0b6-11e8-98cd-4de53910d087.png)
