### PR TITLE
Preload webfonts

### DIFF
--- a/frontend/document.js
+++ b/frontend/document.js
@@ -96,6 +96,6 @@ export default ({ Page, data: { body, ...data } }: Props) => {
             CAPI,
         },
         cssIDs,
-        fontFiles
+        fontFiles,
     });
 };

--- a/frontend/document.js
+++ b/frontend/document.js
@@ -28,7 +28,7 @@ type renderToStringResult = {
 export default ({ Page, data: { body, ...data } }: Props) => {
     const cleanedData = { ...parseCAPI(body), ...data };
 
-    const bundle = assets.dist(
+    const bundleJS = assets.dist(
         `${cleanedData.site}.${cleanedData.page.toLowerCase()}.js`,
     );
 
@@ -52,8 +52,43 @@ export default ({ Page, data: { body, ...data } }: Props) => {
         return acc;
     }, {});
 
+    /**
+     * Preload the following woff2 font files
+     * TODO: Identify critical fonts to preload
+     */
+    const fontFiles = [
+        'GHGuardianHeadline/GHGuardianHeadline-Bold.woff2',
+        'GHGuardianHeadline/GHGuardianHeadline-Regular.woff2',
+        'GuardianTextEgyptianWeb/GuardianTextEgyptianWeb-Regular.woff2',
+        // 'GuardianTextEgyptianWeb/GuardianTextEgyptianWeb-RegularItalic.woff2',
+        'GuardianTextEgyptianWeb/GuardianTextEgyptianWeb-Medium.woff2',
+        // 'GuardianTextEgyptianWeb/GuardianTextEgyptianWeb-MediumItalic.woff2',
+        // 'GuardianTextEgyptianWeb/GuardianTextEgyptianWeb-Bold.woff2',
+        // 'GuardianTextEgyptianWeb/GuardianTextEgyptianWeb-BoldItalic.woff2',
+        'GuardianTextEgyptianWeb/GuardianTextEgyptianWeb-Black.woff2',
+        // 'GuardianTextEgyptianWeb/GuardianTextEgyptianWeb-BlackItalic.woff2',
+        'GuardianTextSansWeb/GuardianTextSansWeb-Regular.woff2',
+        // 'GuardianTextSansWeb/GuardianTextSansWeb-RegularItalic.woff2',
+        // 'GuardianTextSansWeb/GuardianTextSansWeb-Medium.woff2',
+        // 'GuardianTextSansWeb/GuardianTextSansWeb-MediumItalic.woff2',
+        // 'GuardianTextSansWeb/GuardianTextSansWeb-Bold.woff2',
+        // 'GuardianTextSansWeb/GuardianTextSansWeb-BoldItalic.woff2',
+        // 'GuardianTextSansWeb/GuardianTextSansWeb-Black.woff2',
+        // 'GuardianTextSansWeb/GuardianTextSansWeb-BlackItalic.woff2',
+        // 'GuardianEgyptianWeb/GuardianEgyptianWeb-Light.woff2',
+        'GuardianEgyptianWeb/GuardianEgyptianWeb-Regular.woff2',
+        // 'GuardianEgyptianWeb/GuardianEgyptianWeb-RegularItalic.woff2',
+        // 'GuardianEgyptianWeb/GuardianEgyptianWeb-Semibold.woff2',
+        // 'GuardianEgyptianWeb/GuardianEgyptianWeb-SemiboldItalic.woff2',
+        // 'GuardianEgyptianWeb/GuardianEgyptianWeb-Medium.woff2',
+        'GuardianEgyptianWeb/GuardianEgyptianWeb-Bold.woff2',
+        // 'GuardianEgyptianWeb/GuardianEgyptianWeb-BoldItalic.woff2',
+        // 'GuardianEgyptianWeb/GuardianEgyptianWeb-BoldItalic.woff2',
+        // 'GuardianEgyptianWeb/GuardianEgyptianWeb-Bold.woff2',
+    ];
+
     return htmlTemplate({
-        bundle,
+        bundleJS,
         css,
         html,
         data: {
@@ -61,5 +96,6 @@ export default ({ Page, data: { body, ...data } }: Props) => {
             CAPI,
         },
         cssIDs,
+        fontFiles
     });
 };

--- a/frontend/htmlTemplate.js
+++ b/frontend/htmlTemplate.js
@@ -4,19 +4,16 @@ import assets from './lib/assets';
 
 export default ({
     title = 'The Guardian',
-    vendor = assets.dist('vendor.js'),
-    fonts = assets.static('css/fonts.css'),
-    bundle,
+    bundleJS,
     css,
     html,
     data,
     cssIDs,
     nonBlockingJS = '',
+    fontFiles = [],
 }: {
     title?: string,
-    vendor?: string,
-    fonts?: string,
-    bundle: string,
+    bundleJS: string,
     css: string,
     html: string,
     data: {
@@ -25,18 +22,24 @@ export default ({
     },
     cssIDs: Array<string>,
     nonBlockingJS?: string,
+    fontFiles?: Array<string>
 }) => {
     const sanitiseDomRefs = jsString =>
         jsString.replace(/"(document.*?innerHTML)"/g, '$1');
+    const vendorJS = assets.dist('vendor.js');
+    const fontCSS = assets.static('css/fonts.css');
 
     return `<!doctype html>
         <html>
             <head>
                 <title>${title}</title>
                 <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-                <link rel="preload" href="${vendor}" as="script">
-                <link rel="preload" href="${bundle}" as="script">
-                <link rel="stylesheet" href="${fonts}" media="nope!" onload="this.media='all'">
+                <link rel="preload" href="${vendorJS}}" as="script">
+                <link rel="preload" href="${bundleJS}" as="script">
+                ${fontFiles.map(fontFile => 
+                    `<link rel="preload" href="https://interactive.guim.co.uk/fonts/guss-webfonts/${fontFile}" as="font" crossorigin>`
+                ).join( '\n')}
+                <link rel="stylesheet" href="${fontCSS}" media="nope!" onload="this.media='all'">
                 <style>${resetCSS}${css}</style>
             </head>
             <body>
@@ -51,8 +54,8 @@ export default ({
                     }),
                 )};
                 </script>
-                <script src="${vendor}"></script>
-                <script src="${bundle}"></script>
+                <script src="${vendorJS}"></script>
+                <script src="${bundleJS}"></script>
                 <script>${nonBlockingJS}</script>
             </body>
         </html>`;

--- a/frontend/htmlTemplate.js
+++ b/frontend/htmlTemplate.js
@@ -22,7 +22,7 @@ export default ({
     },
     cssIDs: Array<string>,
     nonBlockingJS?: string,
-    fontFiles?: Array<string>
+    fontFiles?: Array<string>,
 }) => {
     const sanitiseDomRefs = jsString =>
         jsString.replace(/"(document.*?innerHTML)"/g, '$1');
@@ -36,9 +36,12 @@ export default ({
                 <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
                 <link rel="preload" href="${vendorJS}}" as="script">
                 <link rel="preload" href="${bundleJS}" as="script">
-                ${fontFiles.map(fontFile => 
-                    `<link rel="preload" href="https://interactive.guim.co.uk/fonts/guss-webfonts/${fontFile}" as="font" crossorigin>`
-                ).join( '\n')}
+                ${fontFiles
+                    .map(
+                        fontFile =>
+                            `<link rel="preload" href="https://interactive.guim.co.uk/fonts/guss-webfonts/${fontFile}" as="font" crossorigin>`,
+                    )
+                    .join('\n')}
                 <link rel="stylesheet" href="${fontCSS}" media="nope!" onload="this.media='all'">
                 <style>${resetCSS}${css}</style>
             </head>

--- a/frontend/htmlTemplate.js
+++ b/frontend/htmlTemplate.js
@@ -28,6 +28,7 @@ export default ({
         jsString.replace(/"(document.*?innerHTML)"/g, '$1');
     const vendorJS = assets.dist('vendor.js');
     const fontCSS = assets.static('css/fonts.css');
+    const fontDomain = 'https://interactive.guim.co.uk/fonts/guss-webfonts/';
 
     return `<!doctype html>
         <html>
@@ -39,7 +40,7 @@ export default ({
                 ${fontFiles
                     .map(
                         fontFile =>
-                            `<link rel="preload" href="https://interactive.guim.co.uk/fonts/guss-webfonts/${fontFile}" as="font" crossorigin>`,
+                            `<link rel="preload" href="${fontDomain}${fontFile}" as="font" crossorigin>`,
                     )
                     .join('\n')}
                 <link rel="stylesheet" href="${fontCSS}" media="nope!" onload="this.media='all'">


### PR DESCRIPTION
- Adds `fontFiles` argument to `htmlTemplate.js`, this is an array of font file names. For each font file adds a `<link rel="preload" />` in the `<head>` of the server side rendered page.
- Currently the 8 fonts we'll preload are the 8 used on the current article, we need to identify the critical fonts we should preload.
- Remove the `vendor` and `fonts` arguments from `htmlTemplate.js`, these are leftovers of the multi sites setup - we were always using the defaults specified in `htmlTemplate`. 
