### PR TITLE
CapiComponent refactor

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,4 +52,7 @@ module.exports = {
             },
         },
     ],
+    globals: {
+        React: true,
+    },
 };

--- a/frontend/components/ArticleBody.js
+++ b/frontend/components/ArticleBody.js
@@ -12,6 +12,8 @@ import {
     desktop,
 } from '@guardian/pasteup/breakpoints';
 
+import { CapiComponent } from '../components/CapiComponent';
+
 const wrapper = css`
     padding-top: 6px;
     margin-right: 0;
@@ -150,12 +152,13 @@ const ArticleBody = () => {
                 <div className={section}>Section</div>
                 <div className={headline}>
                     <h1 className={headerStyle}>{CAPI.headline}</h1>
-                    <div
+                    {/* <div
                         className={standfirst}
                         dangerouslySetInnerHTML={{
                             __html: CAPI.standfirst,
                         }}
-                    />
+                    /> */}
+                    <CapiComponent htmlTag={"div"} capiKey={"standfirst"} className={standfirst} />
                 </div>
                 <div className={meta}>Meta</div>
                 <div

--- a/frontend/components/ArticleBody.js
+++ b/frontend/components/ArticleBody.js
@@ -152,7 +152,11 @@ const ArticleBody = () => {
                 <div className={section}>Section</div>
                 <div className={headline}>
                     <h1 className={headerStyle}>{CAPI.headline}</h1>
-                    <CapiComponent htmlTag={"div"} capiKey={"standfirst"} className={standfirst} />
+                    <CapiComponent
+                        htmlTag="div"
+                        capiKey="standfirst"
+                        className={standfirst}
+                    />
                 </div>
                 <div className={meta}>Meta</div>
                 <div

--- a/frontend/components/ArticleBody.js
+++ b/frontend/components/ArticleBody.js
@@ -152,12 +152,6 @@ const ArticleBody = () => {
                 <div className={section}>Section</div>
                 <div className={headline}>
                     <h1 className={headerStyle}>{CAPI.headline}</h1>
-                    {/* <div
-                        className={standfirst}
-                        dangerouslySetInnerHTML={{
-                            __html: CAPI.standfirst,
-                        }}
-                    /> */}
                     <CapiComponent htmlTag={"div"} capiKey={"standfirst"} className={standfirst} />
                 </div>
                 <div className={meta}>Meta</div>

--- a/frontend/components/CapiComponent.js
+++ b/frontend/components/CapiComponent.js
@@ -6,32 +6,42 @@ type CapiKey = string;
 
 export const keyRegister: Set<CapiKey> = new Set();
 
-export const CapiComponent = (
-    MyComponent: React.ComponentType<{}>,
-    capiKey: CapiKey,
-) =>
-    class extends Component<{}, {}> {
-        shouldComponentUpdate() {
-            return false;
-        }
+type Props = {
+    htmlTag: string,
+    className: string,
+    capiKey: string,
+};
 
-        render() {
-            const ContentComponent = connect('CAPI')(({ CAPI = {} }) => {
-                const capiContent = CAPI[capiKey];
+export const CapiComponent = class extends Component<Props> {
+    shouldComponentUpdate() {
+        return false;
+    }
 
-                keyRegister.add(capiKey);
+    render() {
+        const {
+            htmlTag,
+            className,
+            capiKey
+        } = this.props;
 
-                return (
-                    <MyComponent
-                        {...this.props}
-                        data-capi-key={capiKey}
-                        dangerouslySetInnerHTML={{
-                            __html: capiContent,
-                        }}
-                    />
-                );
-            });
+        const ContentComponent = connect('CAPI')(({ CAPI = {} }) => {
+            const capiContent = CAPI[capiKey];
 
-            return <ContentComponent />;
-        }
-    };
+            keyRegister.add(capiKey);
+
+            return (
+                <>
+                    {React.createElement(
+                        htmlTag,
+                        {
+                            className,
+                            dangerouslySetInnerHTML: {__html: capiContent}
+                        },
+                    )}
+                </>
+            );
+        });
+
+        return <ContentComponent />;
+    }
+}

--- a/frontend/components/CapiComponent.js
+++ b/frontend/components/CapiComponent.js
@@ -18,11 +18,7 @@ export const CapiComponent = class extends Component<Props> {
     }
 
     render() {
-        const {
-            htmlTag,
-            className,
-            capiKey
-        } = this.props;
+        const { htmlTag, className, capiKey } = this.props;
 
         const ContentComponent = connect('CAPI')(({ CAPI = {} }) => {
             const capiContent = CAPI[capiKey];
@@ -31,17 +27,14 @@ export const CapiComponent = class extends Component<Props> {
 
             return (
                 <>
-                    {React.createElement(
-                        htmlTag,
-                        {
-                            className,
-                            dangerouslySetInnerHTML: {__html: capiContent}
-                        },
-                    )}
+                    {React.createElement(htmlTag, {
+                        className,
+                        dangerouslySetInnerHTML: { __html: capiContent },
+                    })}
                 </>
             );
         });
 
         return <ContentComponent />;
     }
-}
+};


### PR DESCRIPTION
## What does this change?

I noted in the article refactor PR https://github.com/guardian/dotcom-rendering/pull/138 raised by @nicl that the `CapiComponent` was no longer used. I wanted to see if we could reintroduce it.

This updates the API of the `CapiComponent` that was originally introduced here: https://github.com/guardian/dotcom-rendering/pull/86

Originally CapiComponents were defined by creating a styled component and passing it as an argument along with a CapiKey:

```js
const StandfirstStyled = styled('div')({
  color: "red"
});
const Standfirst = CapiComponent(StandfirstStyled, 'standfirst');
const Page = () => (<Standfirst />)
```

Now we've removed use of `styled` I wanted to come up with a way of creating a `CapiComponent` which didn't involve having to create a component to then pass it to `CapiComponent` to create another component to use in the "Page". 

This is the style I've come up with:

```js
const standfirst = css`
  color: red;
`;
const Page = () => (<CapiComponent capiKey={'standfirst'} htmlTag={'div'} className={standfirst} />)
```

Thoughts on whether this feels OK would be appreciated!
