### PR TITLE
Add key to footer links group

### DIFF
--- a/frontend/components/Footer.js
+++ b/frontend/components/Footer.js
@@ -207,8 +207,9 @@ const FooterLinks = ({ links }: Props) => {
                 </a>
             </li>
         ));
+        const key = linkGroup.reduce((acc, { title }) => `acc-${title}`, '');
 
-        return <ul>{ls}</ul>;
+        return <ul key={key}>{ls}</ul>;
     });
 
     return <div className={footerList}>{linkGroups}</div>;


### PR DESCRIPTION
## What does this change?

Adds a unique key to each group of footer links

## Why?

Kills the React warning that items should have unique keys