### PR TITLE
Fix menu layout bug

### DIFF
--- a/frontend/components/Header/Nav/MainMenu/index.js
+++ b/frontend/components/Header/Nav/MainMenu/index.js
@@ -42,7 +42,6 @@ const MainMenu = styled('div')(({ showMainMenu }) => ({
     },
     [desktop]: {
         display: showMainMenu ? 'block' : 'none',
-        marginTop: -20,
         position: 'absolute',
         paddingBottom: 0,
         paddingTop: 0,


### PR DESCRIPTION
## What does this change?

Removes negative margin that was causing the menu to obscure the logo

## Why?

**Before**
![screen shot 2018-08-17 at 16 51 38](https://user-images.githubusercontent.com/5931528/44275906-ef855e80-a23d-11e8-91b3-fd1c1a8fd699.png)

**After**
![screen shot 2018-08-17 at 16 53 09](https://user-images.githubusercontent.com/5931528/44275947-0af06980-a23e-11e8-928f-f2ec9c78958d.png)
