### PR TITLE
Remove guui dependency from packages/rendering

### DIFF
--- a/packages/rendering/package.json
+++ b/packages/rendering/package.json
@@ -8,9 +8,8 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@guardian/guui": "0.1.0-alpha.1",
-    "express": "^4.16.3",
     "emotion": "^9.1.1",
+    "express": "^4.16.3",
     "glob": "^7.1.2",
     "ophan-tracker-js": "^1.3.9",
     "pm2": "^2.10.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -783,10 +783,6 @@
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.7.3.tgz#4240c5eee8af86843452af7497ac2808be04a77d"
 
-"@guardian/guui@0.1.0-alpha.1":
-  version "0.1.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@guardian/guui/-/guui-0.1.0-alpha.1.tgz#61886f5a1ebab6369044fef3d2f69930ca9fa688"
-
 "@kossnocorp/desvg@^0.1.1":
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@kossnocorp/desvg/-/desvg-0.1.2.tgz#3d120b180d4dbb1f646603c3b9f2c89774c368dc"


### PR DESCRIPTION
## What does this change?

Removes old `@guardian/guui` dependency from `packages/rendering`

## Why?

- because it isn't used there
- because it is requesting an old version of guui, which seems to slow Yarn down a lot. This change hugely speeds up installation of new JS libs