### PR TITLE
Introduce aws parameterstore implementation

### DIFF
--- a/packages/rendering/lib/aws-parameters.js
+++ b/packages/rendering/lib/aws-parameters.js
@@ -1,0 +1,71 @@
+// @flow
+
+process.env.AWS_PROFILE = 'frontend';
+
+const AWS = require('aws-sdk');
+
+AWS.config.update({ region: 'eu-west-1' });
+
+const STACK = 'frontend';
+
+const ssm = new AWS.SSM();
+
+// gets params from AWS parameter store. This is a PAGED api, the token
+// indicates the next set of results to get (or undefined for the first call)
+
+const getParams = function getAWSParameterStoreParameters(
+    stage: string,
+    token = undefined,
+) {
+    const params = {
+        Path: `/${STACK}/${stage}/`,
+        Recursive: true,
+        WithDecryption: true,
+        NextToken: token,
+    };
+
+    return ssm.getParametersByPath(params).promise();
+};
+
+// a recursive function to retrieve all pages of guardian configuration
+// parameters. The final result is an array of config objects.
+
+const getAllParams = function getGuardianConfigurationRecursiveStep(
+    stage: string,
+    params = [],
+    token = undefined,
+) {
+    return getParams(stage, token).then(response => {
+        if (!response.NextToken) {
+            return params;
+        }
+        return getAllParams(
+            stage,
+            params.concat(response.Parameters),
+            response.NextToken === '' ? undefined : response.NextToken,
+        );
+    });
+};
+
+// returns a configuration object with two functions: getParameter(key:string)
+// and getAllParameters()
+
+const getGuardianConfiguration = function(stage: string) {
+    return getAllParams(stage).then(params => {
+        const configuration = params.reduce((map, p) => {
+            const newMap = map;
+            newMap[p.Name] = p.Value;
+            return map;
+        }, {});
+
+        return {
+            getParameter: key => configuration[`/${STACK}/${stage}/${key}`],
+            getAllParameters: () => configuration,
+            size: () => params.length,
+        };
+    });
+};
+
+module.exports = {
+    getGuardianConfiguration,
+};

--- a/packages/rendering/lib/aws-parameters.js
+++ b/packages/rendering/lib/aws-parameters.js
@@ -13,10 +13,8 @@ const ssm = new AWS.SSM();
 // gets params from AWS parameter store. This is a PAGED api, the token
 // indicates the next set of results to get (or undefined for the first call)
 
-const getParams = function getAWSParameterStoreParameters(
-    stage: string,
-    token = undefined,
-) {
+const getParams = function getAWSParameterStoreParameters(stage: string, token=undefined) {
+
     const params = {
         Path: `/${STACK}/${stage}/`,
         Recursive: true,
@@ -25,47 +23,45 @@ const getParams = function getAWSParameterStoreParameters(
     };
 
     return ssm.getParametersByPath(params).promise();
+
 };
 
 // a recursive function to retrieve all pages of guardian configuration
-// parameters. The final result is an array of config objects.
 
-const getAllParams = function getGuardianConfigurationRecursiveStep(
-    stage: string,
-    params = [],
-    token = undefined,
-) {
-    return getParams(stage, token).then(response => {
+const getAllParams = function getGuardianConfigurationRecursiveStep(stage: string, params=[], token=undefined) {
+    return getParams(stage, token).then((response)=>{
         if (!response.NextToken) {
             return params;
+        } else {
+            return getAllParams(
+                stage,
+                params.concat(response.Parameters),
+                response.NextToken === "" ? undefined : response.NextToken
+            );
         }
-        return getAllParams(
-            stage,
-            params.concat(response.Parameters),
-            response.NextToken === '' ? undefined : response.NextToken,
-        );
     });
 };
 
-// returns a configuration object with two functions: getParameter(key:string)
-// and getAllParameters()
+// returns a configuration object
 
 const getGuardianConfiguration = function(stage: string) {
-    return getAllParams(stage).then(params => {
-        const configuration = params.reduce((map, p) => {
+    return getAllParams(stage).then((params)=>{
+
+        const configuration = params.reduce(function(map, p) {
             const newMap = map;
             newMap[p.Name] = p.Value;
             return map;
         }, {});
 
         return {
-            getParameter: key => configuration[`/${STACK}/${stage}/${key}`],
+            getParameter: (key) => configuration[`/${STACK}/${stage}/${key}`],
             getAllParameters: () => configuration,
             size: () => params.length,
         };
-    });
+
+    })
 };
 
 module.exports = {
-    getGuardianConfiguration,
+    getGuardianConfiguration
 };

--- a/packages/rendering/lib/aws-parameters.ts
+++ b/packages/rendering/lib/aws-parameters.ts
@@ -9,8 +9,8 @@ const STACK = 'frontend';
 const ssm = new AWS.SSM();
 
 interface AWSParameter {
-    Name: string,
-    Value: string,
+    Name: string;
+    Value: string;
 }
 
 interface ConfigMap {
@@ -18,15 +18,15 @@ interface ConfigMap {
 }
 
 interface GuardianConfiguration {
-    getParameter: (key: string) => string,
-    getAllParameters: () => any,
-    size: () => number,
+    getParameter: (key: string) => string;
+    getAllParameters: () => any;
+    size: () => number;
 }
 
 // gets params from AWS parameter store. This is a PAGED api, the token
 // indicates the next set of results to get (or undefined for the first call)
 
-const getParams = function getAWSParameterStoreParameters (
+const getParams = function getAWSParameterStoreParameters(
     stage: string,
     token: string | undefined = undefined,
 ): Promise<any> {
@@ -50,22 +50,21 @@ const getAllParams = function getGuardianConfigurationRecursiveStep(
     return getParams(stage, token).then(response => {
         if (!response.NextToken) {
             return params;
-        } else {
-            return getAllParams(
-                stage,
-                params.concat(response.Parameters),
-                response.NextToken === '' ? undefined : response.NextToken,
-            );
         }
+        return getAllParams(
+            stage,
+            params.concat(response.Parameters),
+            response.NextToken === '' ? undefined : response.NextToken,
+        );
     });
 };
 
 // returns a configuration object
 
-const getGuardianConfiguration = (stage: string): Promise<GuardianConfiguration> => {
-
+const getGuardianConfiguration = (
+    stage: string,
+): Promise<GuardianConfiguration> => {
     return getAllParams(stage).then(params => {
-
         const configuration: ConfigMap = params.reduce((map: ConfigMap, p) => {
             const newMap = map;
             newMap[p.Name] = p.Value;
@@ -73,12 +72,12 @@ const getGuardianConfiguration = (stage: string): Promise<GuardianConfiguration>
         }, {});
 
         return {
-            getParameter: (key: string) => configuration[`/${STACK}/${stage}/${key}`],
+            getParameter: (key: string) =>
+                configuration[`/${STACK}/${stage}/${key}`],
             getAllParameters: () => configuration,
             size: () => params.length,
         };
     });
-
 };
 
 export { getGuardianConfiguration, GuardianConfiguration };

--- a/packages/rendering/lib/aws-parameters.ts
+++ b/packages/rendering/lib/aws-parameters.ts
@@ -1,8 +1,6 @@
-// @flow
+import AWS from 'aws-sdk';
 
 process.env.AWS_PROFILE = 'frontend';
-
-const AWS = require('aws-sdk');
 
 AWS.config.update({ region: 'eu-west-1' });
 
@@ -13,7 +11,7 @@ const ssm = new AWS.SSM();
 // gets params from AWS parameter store. This is a PAGED api, the token
 // indicates the next set of results to get (or undefined for the first call)
 
-const getParams = function getAWSParameterStoreParameters(stage: string, token=undefined) {
+const getParams = function getAWSParameterStoreParameters(stage: string, token: string|undefined=undefined) {
 
     const params = {
         Path: `/${STACK}/${stage}/`,
@@ -28,7 +26,7 @@ const getParams = function getAWSParameterStoreParameters(stage: string, token=u
 
 // a recursive function to retrieve all pages of guardian configuration
 
-const getAllParams = function getGuardianConfigurationRecursiveStep(stage: string, params=[], token=undefined) {
+const getAllParams = function getGuardianConfigurationRecursiveStep(stage: string, params=[], token:string|undefined=undefined) {
     return getParams(stage, token).then((response)=>{
         if (!response.NextToken) {
             return params;
@@ -62,6 +60,4 @@ const getGuardianConfiguration = function(stage: string) {
     })
 };
 
-module.exports = {
-    getGuardianConfiguration
-};
+export { getGuardianConfiguration };

--- a/packages/rendering/server.ts
+++ b/packages/rendering/server.ts
@@ -2,10 +2,14 @@ import * as path from 'path';
 import express from 'express';
 
 import recordBaselineCloudWatchMetrics from './lib/metrics-baseline';
-import { getGuardianConfiguration, GuardianConfiguration } from './lib/aws-parameters';
+import {
+    getGuardianConfiguration,
+    GuardianConfiguration,
+} from './lib/aws-parameters';
 import document from '../../frontend/document';
 import Article from '../../frontend/pages/Article';
 import { dist, getPagesForSite, root } from '../../config';
+import { log, warn } from '../../lib/log';
 
 const render = async (
     { params, body }: express.Request,
@@ -32,12 +36,12 @@ export default () => render;
 // this is the actual production server
 if (process.env.NODE_ENV === 'production') {
     getGuardianConfiguration('prod')
-        .then((config:GuardianConfiguration) => {
-            console.log(`loaded ${config.size()} configuration parameters`);
+        .then((config: GuardianConfiguration) => {
+            log(`loaded ${config.size()} configuration parameters`);
         })
         .catch((err: any) => {
-            console.error('Failed to get configuration. Bad AWS credentials?');
-            console.error(err);
+            warn('Failed to get configuration. Bad AWS credentials?');
+            warn(err);
         });
 
     const app = express();

--- a/packages/rendering/server.ts
+++ b/packages/rendering/server.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import express from 'express';
 
 import recordBaselineCloudWatchMetrics from './lib/metrics-baseline';
-import { getGuardianConfiguration } from './lib/aws-parameters';
+import { getGuardianConfiguration, GuardianConfiguration } from './lib/aws-parameters';
 import document from '../../frontend/document';
 import Article from '../../frontend/pages/Article';
 import { dist, getPagesForSite, root } from '../../config';
@@ -32,10 +32,10 @@ export default () => render;
 // this is the actual production server
 if (process.env.NODE_ENV === 'production') {
     getGuardianConfiguration('prod')
-        .then(config => {
+        .then((config:GuardianConfiguration) => {
             console.log(`loaded ${config.size()} configuration parameters`);
         })
-        .catch(err => {
+        .catch((err: any) => {
             console.error('Failed to get configuration. Bad AWS credentials?');
             console.error(err);
         });

--- a/packages/rendering/server.ts
+++ b/packages/rendering/server.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import express from 'express';
 
 import recordBaselineCloudWatchMetrics from './lib/metrics-baseline';
+import { getGuardianConfiguration } from './lib/aws-parameters';
 import document from '../../frontend/document';
 import Article from '../../frontend/pages/Article';
 import { dist, getPagesForSite, root } from '../../config';
@@ -30,6 +31,15 @@ export default () => render;
 
 // this is the actual production server
 if (process.env.NODE_ENV === 'production') {
+    getGuardianConfiguration('prod')
+        .then(config => {
+            console.log(`loaded ${config.size()} configuration parameters`);
+        })
+        .catch(err => {
+            console.error('Failed to get configuration. Bad AWS credentials?');
+            console.error(err);
+        });
+
     const app = express();
 
     app.use(express.json({ limit: '50mb' }));


### PR DESCRIPTION
## What does this change?

Introduces an implementation of Guardian Configuration that sources configuration params from the AWS parameter store.

This code is not currently used to do anything on this PR, but will be used in the near future on a follow-up PR that integrates this app with the kibana ELK stack.

## Why?

It turns out that this is a pre-requisite for getting Kibana working, as we need to get the logging kinesis stream name from the aws parameter store. This implementation of the parameter store is self contained enough to be on it's own PR.