### PR TITLE
Google Analytics MVP

### DIFF
--- a/docs/duplication.md
+++ b/docs/duplication.md
@@ -16,3 +16,4 @@ Logical duplication:
 * social share icon links
 * tracking consent cookie logic
 * pillars
+* Google Analytics pageview data

--- a/docs/tracking/google-analytics.md
+++ b/docs/tracking/google-analytics.md
@@ -5,28 +5,32 @@
 The following data is tracked in Google Analytics on page view. The data is 
 extracted from the request body in [`parse-capi`](../../frontend/lib/parse-capi/index.ts)
 
-Dimension   | Value                      | Description            |
----------   | -------------------------- | ---------------------- |
-forceSSL    | true                       |                        |
-title       | GA.webTitle                |                        |
-anonymizeIp | true                       |                        |
-dimension1  | ophan.pageViewId           |                        |
-dimension2  | ophan.browserId            |                        |
-dimension3  | 'theguardian.com'          | Platform               |
-dimension4  | GA.section                 |                        |
-dimension5  | GA.contentType             |                        |
-dimension6  | GA.commissioningDesks      |                        |
-dimension7  | GA.contentId               |                        |
-dimension8  | GA.authorIds               |                        |
-dimension9  | GA.keywordIds              |                        |
-dimension10 | GA.toneIds                 |                        |
-dimension11 | GA.seriesId                |                        |
-dimension15 | identityId                 |                        |
-dimension16 | !!identityId               | is user logged in      |
-dimension21 | getQueryParam('INTCMP')    | internal campaign code |
-dimension22 | getQueryParam('CMP_BUNIT') | campaign business unit |
-dimension23 | getQueryParam('CMP_TU')    | campaign team          |
-dimension26 | GA.isHosted                |                        |
-dimension27 | navigator.userAgent        |                        |
-dimension29 | window.location.href       |                        |
-dimension30 | GA.edition                 |                        |
+Dimension   | Value                      | Description                                                            |
+---------   | -------------------------- | ---------------------------------------------------------------------- |
+forceSSL    | true                       |                                                                        |
+title       | GA.webTitle                |                                                                        |
+anonymizeIp | true                       |                                                                        |
+dimension1  | ophan.pageViewId           |                                                                        |
+dimension2  | ophan.browserId            |                                                                        |
+dimension3  | 'theguardian.com'          | Platform                                                               |
+dimension4  | GA.section                 |                                                                        |
+dimension5  | GA.contentType             |                                                                        |
+dimension6  | GA.commissioningDesks      |                                                                        |
+dimension7  | GA.contentId               |                                                                        |
+dimension8  | GA.authorIds               |                                                                        |
+dimension9  | GA.keywordIds              |                                                                        |
+dimension10 | GA.toneIds                 |                                                                        |
+dimension11 | GA.seriesId                |                                                                        |
+dimension15 | identityId                 |                                                                        |
+dimension16 | !!identityId               | is user logged in                                                      |
+dimension21 | getQueryParam('INTCMP')    | internal campaign code                                                 |
+dimension22 | getQueryParam('CMP_BUNIT') | campaign business unit                                                 |
+dimension23 | getQueryParam('CMP_TU')    | campaign team                                                          |
+dimension26 | GA.isHosted                |                                                                        |
+dimension27 | navigator.userAgent        |                                                                        |
+dimension29 | window.location.href       |                                                                        |
+dimension30 | GA.edition                 |                                                                        |
+dimension31 | GA.sponsorLogos            | Not yet implemented                                                    |
+dimension42 | GA.brandingType            | Not yet implemented                                                    |
+dimension43 | 'dotcom-rendering'         | 'Experience' dimension, for short-lived experiment values.             |
+dimension50 | GA.pillar                  |                                                                        |

--- a/docs/tracking/google-analytics.md
+++ b/docs/tracking/google-analytics.md
@@ -1,0 +1,32 @@
+# Google Analytics
+
+## Page view
+
+The following data is tracked in Google Analytics on page view. The data is 
+extracted from the request body in [`parse-capi`](../../frontend/lib/parse-capi/index.ts)
+
+Dimension   | Value                      | Description            |
+---------   | -------------------------- | ---------------------- |
+forceSSL    | true                       |                        |
+title       | GA.webTitle                |                        |
+anonymizeIp | true                       |                        |
+dimension1  | ophan.pageViewId           |                        |
+dimension2  | ophan.browserId            |                        |
+dimension3  | 'theguardian.com'          | Platform               |
+dimension4  | GA.section                 |                        |
+dimension5  | GA.contentType             |                        |
+dimension6  | GA.commissioningDesks      |                        |
+dimension7  | GA.contentId               |                        |
+dimension8  | GA.authorIds               |                        |
+dimension9  | GA.keywordIds              |                        |
+dimension10 | GA.toneIds                 |                        |
+dimension11 | GA.seriesId                |                        |
+dimension15 | identityId                 |                        |
+dimension16 | !!identityId               | is user logged in      |
+dimension21 | getQueryParam('INTCMP')    | internal campaign code |
+dimension22 | getQueryParam('CMP_BUNIT') | campaign business unit |
+dimension23 | getQueryParam('CMP_TU')    | campaign team          |
+dimension26 | GA.isHosted                |                        |
+dimension27 | navigator.userAgent        |                        |
+dimension29 | window.location.href       |                        |
+dimension30 | GA.edition                 |                        |

--- a/frontend/document.tsx
+++ b/frontend/document.tsx
@@ -13,6 +13,7 @@ interface Props {
         CAPI: CAPIType;
         NAV: NavType;
         config: ConfigType;
+        GA: GADataType;
     };
 }
 

--- a/frontend/document.tsx
+++ b/frontend/document.tsx
@@ -5,6 +5,7 @@ import { renderToString } from 'react-dom/server';
 import assets from './lib/assets';
 import htmlTemplate from './htmlTemplate';
 import Article from './pages/Article';
+import { GADataType } from './lib/parse-capi';
 
 interface Props {
     data: {

--- a/frontend/htmlTemplate.ts
+++ b/frontend/htmlTemplate.ts
@@ -101,6 +101,10 @@ export default ({
                         browserId: getCookieValue('bwid')
                     };
                 })(window, document);
+                (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+                    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+                    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
                 </script>
                 <script src="${vendorJS}"></script>
                 <script src="${bundleJS}"></script>

--- a/frontend/htmlTemplate.ts
+++ b/frontend/htmlTemplate.ts
@@ -105,7 +105,6 @@ export default ({
                 <script src="${vendorJS}"></script>
                 <script src="${bundleJS}"></script>
                 <script>${nonBlockingJS}</script>
-                <script async src='https://www.google-analytics.com/analytics.js'></script>
             </body>
-        </html>`; // We load google analytics asynchronously in the foot, and set up the queue in ga.ts
+        </html>`;
 };

--- a/frontend/htmlTemplate.ts
+++ b/frontend/htmlTemplate.ts
@@ -105,6 +105,7 @@ export default ({
                 <script src="${vendorJS}"></script>
                 <script src="${bundleJS}"></script>
                 <script>${nonBlockingJS}</script>
+                <script async src='https://www.google-analytics.com/analytics.js'></script>
             </body>
-        </html>`;
+        </html>`; // We load google analytics asynchronously in the foot, and set up the queue in ga.ts
 };

--- a/frontend/index.d.ts
+++ b/frontend/index.d.ts
@@ -74,7 +74,23 @@ interface CAPIType {
  * this data could eventually be defined in dotcom-rendering
  */
 interface ConfigType {
-    ajaxUrl: string
+    ajaxUrl: string;
+}
+
+interface GADataType {
+    pillar: string;
+    webTitle: string;
+    section: string;
+    contentType: string;
+    commissioningDesks: string;
+    contentId: string;
+    authorIds: string;
+    keywordIds: string;
+    toneIds: string;
+    seriesId: string;
+    isHosted: string;
+    edition: string;
+    beaconUrl: string;
 }
 
 // 3rd party type declarations

--- a/frontend/index.d.ts
+++ b/frontend/index.d.ts
@@ -77,22 +77,6 @@ interface ConfigType {
     ajaxUrl: string;
 }
 
-interface GADataType {
-    pillar: string;
-    webTitle: string;
-    section: string;
-    contentType: string;
-    commissioningDesks: string;
-    contentId: string;
-    authorIds: string;
-    keywordIds: string;
-    toneIds: string;
-    seriesId: string;
-    isHosted: string;
-    edition: string;
-    beaconUrl: string;
-}
-
 // 3rd party type declarations
 declare module "emotion-server" {
     export const extractCritical: any;

--- a/frontend/lib/parse-capi/index.ts
+++ b/frontend/lib/parse-capi/index.ts
@@ -370,6 +370,22 @@ export const extractConfigMeta = (data: {}): ConfigType => {
     };
 };
 
+export interface GADataType {
+    pillar: string;
+    webTitle: string;
+    section: string;
+    contentType: string;
+    commissioningDesks: string;
+    contentId: string;
+    authorIds: string;
+    keywordIds: string;
+    toneIds: string;
+    seriesId: string;
+    isHosted: string;
+    edition: string;
+    beaconUrl: string;
+}
+
 // All GA fields should  fall back to default values -
 // we should not bring down the website if a trackable field is missing!
 export const extractGAMeta = (data: {}): GADataType => {

--- a/frontend/lib/parse-capi/index.ts
+++ b/frontend/lib/parse-capi/index.ts
@@ -370,7 +370,8 @@ export const extractConfigMeta = (data: {}): ConfigType => {
     };
 };
 
-// All GA fields are optional, we should not bring down the website if a trackable field is missing!
+// All GA fields should  fall back to default values -
+// we should not bring down the website if a trackable field is missing!
 export const extractGAMeta = (data: {}): GADataType => {
     const edition = getString(
         data,
@@ -395,10 +396,10 @@ export const extractGAMeta = (data: {}): GADataType => {
         contentId: getString(data, 'config.page.contentId', ''),
         authorIds: getString(data, 'config.page.authorIds', ''),
         keywordIds: getString(data, 'config.page.keywordIds', ''),
-        toneIds: getString(data, 'config.page.toneIds'),
-        seriesId: getString(data, 'config.page.seriesId'),
+        toneIds: getString(data, 'config.page.toneIds', ''),
+        seriesId: getString(data, 'config.page.seriesId', ''),
         isHosted: getBoolean(data, 'config.page.isHosted', false).toString(),
         edition: edition === 'int' ? 'international' : edition,
-        beaconUrl: getString(data, 'config.page.beaconUrl'),
+        beaconUrl: getString(data, 'config.page.beaconUrl', ''),
     };
 };

--- a/frontend/lib/parse-capi/index.ts
+++ b/frontend/lib/parse-capi/index.ts
@@ -369,3 +369,36 @@ export const extractConfigMeta = (data: {}): ConfigType => {
         ajaxUrl: getNonEmptyString(data, 'config.page.ajaxUrl'),
     };
 };
+
+// All GA fields are optional, we should not bring down the website if a trackable field is missing!
+export const extractGAMeta = (data: {}): GADataType => {
+    const edition = getString(
+        data,
+        'guardian.config.page.edition',
+        '',
+    ).toLowerCase();
+
+    return {
+        webTitle: getString(data, 'config.page.webTitle', ''),
+        pillar:
+            findPillar(getNonEmptyString(data, 'config.page.pillar')) || 'news',
+        section: getString(data, 'config.page.section', ''),
+        contentType: getString(data, 'config.page.contentType', '')
+            .toLowerCase()
+            .split(' ')
+            .join(''),
+        commissioningDesks: getString(
+            data,
+            'config.page.commissioningDesks',
+            '',
+        ),
+        contentId: getString(data, 'config.page.contentId', ''),
+        authorIds: getString(data, 'config.page.authorIds', ''),
+        keywordIds: getString(data, 'config.page.keywordIds', ''),
+        toneIds: getString(data, 'config.page.toneIds'),
+        seriesId: getString(data, 'config.page.seriesId'),
+        isHosted: getBoolean(data, 'config.page.isHosted', false).toString(),
+        edition: edition === 'int' ? 'international' : edition,
+        beaconUrl: getString(data, 'config.page.beaconUrl'),
+    };
+};

--- a/frontend/lib/tracking/ga.ts
+++ b/frontend/lib/tracking/ga.ts
@@ -7,9 +7,11 @@ interface TrackerConfig {
     siteSpeedSampleRate: number;
 }
 
-const getQueryParam = (key: string): string => {
-    const query = window.location.search.substring(1);
-    const params = query.split('&');
+const getQueryParam = (
+    key: string,
+    queryString: string,
+): string | undefined => {
+    const params = queryString.substring(1).split('&');
     const pairs = params.map(x => x.split('='));
 
     return pairs
@@ -60,9 +62,9 @@ export const init = (): void => {
     ga(set, 'dimension11', GA.seriesId);
     ga(set, 'dimension15', identityId);
     ga(set, 'dimension16', !!identityId);
-    ga(set, 'dimension21', getQueryParam('INTCMP')); // internal campaign code
-    ga(set, 'dimension22', getQueryParam('CMP_BUNIT')); // campaign business unit
-    ga(set, 'dimension23', getQueryParam('CMP_TU')); // campaign team
+    ga(set, 'dimension21', getQueryParam('INTCMP', window.location.search)); // internal campaign code
+    ga(set, 'dimension22', getQueryParam('CMP_BUNIT', window.location.search)); // campaign business unit
+    ga(set, 'dimension23', getQueryParam('CMP_TU', window.location.search)); // campaign team
     ga(set, 'dimension26', GA.isHosted);
     ga(set, 'dimension27', navigator.userAgent); // I bet you a pint
     ga(set, 'dimension29', window.location.href); // That both of these are already tracked.

--- a/frontend/lib/tracking/ga.ts
+++ b/frontend/lib/tracking/ga.ts
@@ -1,78 +1,121 @@
+import { getCookie } from '../cookie';
+
 interface TrackerConfig {
     name: string;
     id: string;
     sampleRate: number;
-}
-interface Config {
-    tracker: TrackerConfig;
-    pillar: Pillar;
+    siteSpeedSampleRate: number;
 }
 
-// const getAnalyticsEdition = () => {
-//     const edition = (guardian.config.page.edition || '').toLowerCase();
-//     return edition === 'int' ? 'international' : edition;
-// };
+const getQueryParam = (key: string): string => {
+    const query = window.location.search.substring(1);
+    const params = query.split('&');
+    const pairs = params.map(x => x.split('='));
 
-export const init: (_: Config) => void = ({ tracker, pillar }) => {
-    const coldQueue = (...args: any[]) => {
-        (ga.q = ga.q || []).push(args);
-    };
-
-    ga = ga || (coldQueue as UniversalAnalytics.ga);
-    ga.l = +new Date();
-    ga('create', tracker.id, 'auto', '@tracker.trackerName', {
-        sampleRate: 100, // WARNING: we are sampling everyone!
-        siteSpeedSampleRate: tracker.sampleRate,
-        // TODO: 'userId': identityId
-    });
-    ga('set', 'forceSSL', true);
-    // ga('set', 'title', guardian.config.page.webTitle || '');
-    ga('set', 'anonymizeIp', true);
-    /***************************************************************************************
-     * Custom dimensions common to all platforms across the whole Guardian estate           *
-     ***************************************************************************************/
-    // ga('set', 'dimension1', guardian.config.ophan.pageViewId);
-    // ga('set', 'dimension2', guardian.config.ophan.browserId);
-    ga('set', 'dimension3', 'theguardian.com'); /* Platform */
-    /***************************************************************************************
-     * Custom dimensions for 'editorial' platforms (this site, the mobile apps, etc.)       *
-     * Some of these will be undefined for non-content pages, but that's fine.              *
-     ****************************************************************************************/
-
-    // ga('set', 'dimension4', guardian.config.page.section);
-    // ga(
-    //     'set',
-    //     'dimension5',
-    //     convertContentType(guardian.config.page.contentType),
-    // );
-    // ga('set', 'dimension6', guardian.config.page.commissioningDesks);
-    // ga('set', 'dimension7', guardian.config.page.contentId);
-    // ga('set', 'dimension8', guardian.config.page.authorIds);
-    // ga('set', 'dimension9', guardian.config.page.keywordIds);
-    // ga('set', 'dimension10', guardian.config.page.toneIds);
-    // ga('set', 'dimension11', guardian.config.page.seriesId);
-    // ga('set', 'dimension15', identityId);
-    // ga('set', 'dimension16', isLoggedIn);
-    // ga('set', 'dimension21', getQueryParam('INTCMP')); @* internal campaign code *@
-    // ga('set', 'dimension22', getQueryParam('CMP_BUNIT')); @* campaign business unit*@
-    // ga('set', 'dimension23', getQueryParam('CMP_TU')); @* campaign team*@
-    // ga('set', 'dimension26', (!!guardian.config.page.isHosted).toString());
-    ga('set', 'dimension27', navigator.userAgent); // I bet you a pint
-    ga('set', 'dimension29', window.location.href); // That both of these are already tracked.
-    // ga('set', 'dimension30', getAnalyticsEdition());
-    // @for(sponsorLogos <- listSponsorLogosOnPage(page)) {
-    //   ga('set', 'dimension31', '@Html(sponsorLogos.mkString("|"))');
-    // }
-    // @for(brandingType <- Commercial.brandingType(page)) {
-    //   ga('set', 'dimension42', '@brandingType.name');
-    // }
-    ga('set', 'dimension43', 'guui');
-    ga('set', 'dimension50', pillar);
-
-    // if(document.location.hash === '#fbLogin') {
-    //     ga('set', 'referrer', null);
-    //     document.location.hash = '';
-    // }
+    return pairs
+        .filter(xs => xs.length === 2 && xs[0] === key)
+        .map(xs => xs[1])[0];
 };
 
-export default ga;
+export const init = (): void => {
+    const { ophan } = window.guardian.config;
+    const { GA } = window.guardian.app.data;
+    const tracker: TrackerConfig = {
+        name: 'allEditorialPropertyTracker',
+        id: 'UA-78705427-1',
+        sampleRate: 100,
+        siteSpeedSampleRate: 1,
+    };
+
+    // Standard Google Analytics loader script, modified to make it more TypeScript-friendly
+    // TODO: find a better way to load third party scripts
+    /* tslint:disable */
+    const currdate: any = new Date();
+    const gaNewElem: any = {};
+    const gaElems: any = {};
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i.ga=i.ga||function(){
+    (i.ga.q=i.ga.q||[]).push(arguments)},i.ga.l=1*currdate;a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga', gaNewElem, gaElems);
+    /* tslint:enable */
+
+    const identityId = getCookie('GU_U');
+    const set = `${tracker.id}.set`;
+    const send = `${tracker.id}.send`;
+
+    ga('create', tracker.id, 'auto', tracker.name, {
+        sampleRate: tracker.sampleRate,
+        siteSpeedSampleRate: tracker.siteSpeedSampleRate,
+        userId: identityId,
+    });
+    ga(set, 'forceSSL', true);
+    ga(set, 'title', GA.webTitle);
+    ga(set, 'anonymizeIp', true);
+    /***************************************************************************************
+     * Custom dimensions common to all platforms across the whole Guardian estate          *
+     ***************************************************************************************/
+    ga(set, 'dimension1', ophan.pageViewId);
+    ga(set, 'dimension2', ophan.browserId);
+    ga(set, 'dimension3', 'theguardian.com'); /* Platform */
+    /***************************************************************************************
+     * Custom dimensions for 'editorial' platforms (this site, the mobile apps, etc.)      *
+     * Some of these will be undefined for non-content pages, but that's fine.             *
+     ***************************************************************************************/
+    ga(set, 'dimension4', GA.section);
+    ga(set, 'dimension5', GA.contentType);
+    ga(set, 'dimension6', GA.commissioningDesks);
+    ga(set, 'dimension7', GA.contentId);
+    ga(set, 'dimension8', GA.authorIds);
+    ga(set, 'dimension9', GA.keywordIds);
+    ga(set, 'dimension10', GA.toneIds);
+    ga(set, 'dimension11', GA.seriesId);
+    ga(set, 'dimension15', identityId);
+    ga(set, 'dimension16', !!identityId);
+    ga(set, 'dimension21', getQueryParam('INTCMP')); // internal campaign code
+    ga(set, 'dimension22', getQueryParam('CMP_BUNIT')); // campaign business unit
+    ga(set, 'dimension23', getQueryParam('CMP_TU')); // campaign team
+    ga(set, 'dimension26', GA.isHosted);
+    ga(set, 'dimension27', navigator.userAgent); // I bet you a pint
+    ga(set, 'dimension29', window.location.href); // That both of these are already tracked.
+    ga(set, 'dimension30', GA.edition);
+
+    // TODO: sponsor logos
+    // ga(set, 'dimension31', GA.sponsorLogos);
+
+    // TODO: commercial branding
+    // ga(set, 'dimension42', 'GA.brandingType');
+
+    ga(set, 'dimension43', 'dotcom-rendering');
+    ga(set, 'dimension50', GA.pillar);
+
+    if (window.location.hash === '#fbLogin') {
+        ga(set, 'referrer', null);
+        window.location.hash = '';
+    }
+
+    try {
+        const NG_STORAGE_KEY = 'gu.analytics.referrerVars';
+        const referrerVarsData = window.sessionStorage.getItem(NG_STORAGE_KEY);
+        const referrerVars = JSON.parse(referrerVarsData || '""');
+        if (referrerVars && referrerVars.value) {
+            const d = new Date().getTime();
+            if (d - referrerVars.value.time < 60 * 1000) {
+                // One minute
+                ga(send, 'event', 'Click', 'Internal', referrerVars.value.tag, {
+                    nonInteraction: true, // to avoid affecting bounce rate
+                    dimension12: referrerVars.value.path,
+                });
+            }
+            window.sessionStorage.removeItem(NG_STORAGE_KEY);
+        }
+    } catch (e) {
+        // do nothing
+    }
+
+    ga(send, 'pageview', {
+        hitCallback() {
+            const image = new Image();
+            image.src = `${GA.beaconUrl}/count/pvg.gif`;
+        },
+    });
+};

--- a/frontend/lib/tracking/ga.ts
+++ b/frontend/lib/tracking/ga.ts
@@ -18,6 +18,7 @@ const getQueryParam = (key: string): string => {
 };
 
 export const init = (): void => {
+    const { ga } = window;
     const { ophan } = window.guardian.config;
     const { GA } = window.guardian.app.data;
     const tracker: TrackerConfig = {

--- a/frontend/lib/tracking/ga.ts
+++ b/frontend/lib/tracking/ga.ts
@@ -1,0 +1,78 @@
+interface TrackerConfig {
+    name: string;
+    id: string;
+    sampleRate: number;
+}
+interface Config {
+    tracker: TrackerConfig;
+    pillar: Pillar;
+}
+
+// const getAnalyticsEdition = () => {
+//     const edition = (guardian.config.page.edition || '').toLowerCase();
+//     return edition === 'int' ? 'international' : edition;
+// };
+
+export const init: (_: Config) => void = ({ tracker, pillar }) => {
+    const coldQueue = (...args: any[]) => {
+        (ga.q = ga.q || []).push(args);
+    };
+
+    ga = ga || (coldQueue as UniversalAnalytics.ga);
+    ga.l = +new Date();
+    ga('create', tracker.id, 'auto', '@tracker.trackerName', {
+        sampleRate: 100, // WARNING: we are sampling everyone!
+        siteSpeedSampleRate: tracker.sampleRate,
+        // TODO: 'userId': identityId
+    });
+    ga('set', 'forceSSL', true);
+    // ga('set', 'title', guardian.config.page.webTitle || '');
+    ga('set', 'anonymizeIp', true);
+    /***************************************************************************************
+     * Custom dimensions common to all platforms across the whole Guardian estate           *
+     ***************************************************************************************/
+    // ga('set', 'dimension1', guardian.config.ophan.pageViewId);
+    // ga('set', 'dimension2', guardian.config.ophan.browserId);
+    ga('set', 'dimension3', 'theguardian.com'); /* Platform */
+    /***************************************************************************************
+     * Custom dimensions for 'editorial' platforms (this site, the mobile apps, etc.)       *
+     * Some of these will be undefined for non-content pages, but that's fine.              *
+     ****************************************************************************************/
+
+    // ga('set', 'dimension4', guardian.config.page.section);
+    // ga(
+    //     'set',
+    //     'dimension5',
+    //     convertContentType(guardian.config.page.contentType),
+    // );
+    // ga('set', 'dimension6', guardian.config.page.commissioningDesks);
+    // ga('set', 'dimension7', guardian.config.page.contentId);
+    // ga('set', 'dimension8', guardian.config.page.authorIds);
+    // ga('set', 'dimension9', guardian.config.page.keywordIds);
+    // ga('set', 'dimension10', guardian.config.page.toneIds);
+    // ga('set', 'dimension11', guardian.config.page.seriesId);
+    // ga('set', 'dimension15', identityId);
+    // ga('set', 'dimension16', isLoggedIn);
+    // ga('set', 'dimension21', getQueryParam('INTCMP')); @* internal campaign code *@
+    // ga('set', 'dimension22', getQueryParam('CMP_BUNIT')); @* campaign business unit*@
+    // ga('set', 'dimension23', getQueryParam('CMP_TU')); @* campaign team*@
+    // ga('set', 'dimension26', (!!guardian.config.page.isHosted).toString());
+    ga('set', 'dimension27', navigator.userAgent); // I bet you a pint
+    ga('set', 'dimension29', window.location.href); // That both of these are already tracked.
+    // ga('set', 'dimension30', getAnalyticsEdition());
+    // @for(sponsorLogos <- listSponsorLogosOnPage(page)) {
+    //   ga('set', 'dimension31', '@Html(sponsorLogos.mkString("|"))');
+    // }
+    // @for(brandingType <- Commercial.brandingType(page)) {
+    //   ga('set', 'dimension42', '@brandingType.name');
+    // }
+    ga('set', 'dimension43', 'guui');
+    ga('set', 'dimension50', pillar);
+
+    // if(document.location.hash === '#fbLogin') {
+    //     ga('set', 'referrer', null);
+    //     document.location.hash = '';
+    // }
+};
+
+export default ga;

--- a/frontend/lib/tracking/ga.ts
+++ b/frontend/lib/tracking/ga.ts
@@ -27,21 +27,9 @@ export const init = (): void => {
         siteSpeedSampleRate: 1,
     };
 
-    // Standard Google Analytics loader script, modified to make it more TypeScript-friendly
-    // TODO: find a better way to load third party scripts
-    /* tslint:disable */
-    const currdate: any = new Date();
-    const gaNewElem: any = {};
-    const gaElems: any = {};
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i.ga=i.ga||function(){
-    (i.ga.q=i.ga.q||[]).push(arguments)},i.ga.l=1*currdate;a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga', gaNewElem, gaElems);
-    /* tslint:enable */
-
     const identityId = getCookie('GU_U');
-    const set = `${tracker.id}.set`;
-    const send = `${tracker.id}.send`;
+    const set = `${tracker.name}.set`;
+    const send = `${tracker.name}.send`;
 
     ga('create', tracker.id, 'auto', tracker.name, {
         sampleRate: tracker.sampleRate,

--- a/frontend/ophan.d.ts
+++ b/frontend/ophan.d.ts
@@ -1,0 +1,1 @@
+declare module 'ophan-tracker-js'

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
     "@types/compose-function": "^0.0.30",
     "@types/dateformat": "^1.0.1",
     "@types/dompurify": "^0.0.31",
+    "@types/gapi.analytics": "^0.0.2",
     "@types/google.analytics": "^0.0.39",
     "@types/html-minifier": "^3.5.2",
     "@types/jsdom": "^11.0.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
     "@types/compose-function": "^0.0.30",
     "@types/dateformat": "^1.0.1",
     "@types/dompurify": "^0.0.31",
+    "@types/google.analytics": "^0.0.39",
     "@types/html-minifier": "^3.5.2",
     "@types/jsdom": "^11.0.6",
     "@types/lodash.get": "^4.4.4",

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,15 +6,17 @@ declare global {
         guardian: {
             app: {
                 data: any;
-                cssIDs: Array<string>;
+                cssIDs: string[];
             };
             config: {
-                ophan?: {
-                    browserId?: string;
-                    pageViewId?: string;
+                ophan: {
+                    browserId: string;
+                    pageViewId: string;
                 };
             };
-        }; 
+        };
+        GoogleAnalyticsObject: string;
+        ga: UniversalAnalytics.ga;
     }
 }
 /*~ this line is required as per TypeScript's global-modifying-module.d.ts instructions */

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,6 +17,5 @@ declare global {
         }; 
     }
 }
-
 /*~ this line is required as per TypeScript's global-modifying-module.d.ts instructions */
 export {};

--- a/packages/rendering/browser.ts
+++ b/packages/rendering/browser.ts
@@ -1,8 +1,8 @@
 import React from 'react';
 import { hydrate as hydrateCSS } from 'emotion';
 import { hydrate as hydrateApp } from 'react-dom';
+import 'ophan-tracker-js';
 
-// @ts-ignore
 import Article from '../../frontend/pages/Article';
 
 const { data, cssIDs } = window.guardian.app;
@@ -27,9 +27,6 @@ if (container) {
     hydrateApp(React.createElement(Article, { data }), container);
 }
 
-// tslint:disable-next-line:no-console
-import('ophan-tracker-js').then(() => console.log('ophan!'));
-
-import('../../frontend/lib/tracking/ga').then(({ init }) =>
-    init({ tracker: { name: '', id: '', sampleRate: 0 }, pillar: 'news' }),
-);
+import('../../frontend/lib/tracking/ga').then(({ init }) => {
+    init();
+});

--- a/packages/rendering/browser.ts
+++ b/packages/rendering/browser.ts
@@ -2,8 +2,6 @@ import React from 'react';
 import { hydrate as hydrateCSS } from 'emotion';
 import { hydrate as hydrateApp } from 'react-dom';
 
-import 'ophan-tracker-js';
-
 // @ts-ignore
 import Article from '../../frontend/pages/Article';
 
@@ -28,3 +26,10 @@ if (container) {
 
     hydrateApp(React.createElement(Article, { data }), container);
 }
+
+// tslint:disable-next-line:no-console
+import('ophan-tracker-js').then(() => console.log('ophan!'));
+
+import('../../frontend/lib/tracking/ga').then(({ init }) =>
+    init({ tracker: { name: '', id: '', sampleRate: 0 }, pillar: 'news' }),
+);

--- a/packages/rendering/package.json
+++ b/packages/rendering/package.json
@@ -13,7 +13,7 @@
     "emotion": "^9.1.1",
     "express": "^4.16.3",
     "glob": "^7.1.2",
-    "ophan-tracker-js": "^1.3.9",
+    "ophan-tracker-js": "^1.3.13",
     "pm2": "^2.10.2",
     "react-dom": "^16.4.0"
   },

--- a/packages/rendering/server.ts
+++ b/packages/rendering/server.ts
@@ -14,6 +14,7 @@ import {
     extractArticleMeta,
     extractNavMeta,
     extractConfigMeta,
+    extractGAMeta,
 } from '../../frontend/lib/parse-capi';
 
 const renderArticle = ({ body }: express.Request, res: express.Response) => {
@@ -25,6 +26,7 @@ const renderArticle = ({ body }: express.Request, res: express.Response) => {
                 CAPI: extractArticleMeta(body),
                 NAV: extractNavMeta(body),
                 config: extractConfigMeta(body),
+                GA: extractGAMeta(body),
             },
         });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -768,6 +768,16 @@
     "@types/express-serve-static-core" "*"
     "@types/serve-static" "*"
 
+"@types/gapi.analytics@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@types/gapi.analytics/-/gapi.analytics-0.0.2.tgz#ac4bebaa7e0837a835996077678a97de1b7b3e59"
+  dependencies:
+    "@types/gapi" "*"
+
+"@types/gapi@*":
+  version "0.0.36"
+  resolved "https://registry.yarnpkg.com/@types/gapi/-/gapi-0.0.36.tgz#e7fb3d4d4a6fbdbd0a9aef1cbd93d3b115d59a3d"
+
 "@types/google.analytics@^0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/google.analytics/-/google.analytics-0.0.39.tgz#19a952003dbf3c7373d655a5c3203b4726b8b802"

--- a/yarn.lock
+++ b/yarn.lock
@@ -768,6 +768,10 @@
     "@types/express-serve-static-core" "*"
     "@types/serve-static" "*"
 
+"@types/google.analytics@^0.0.39":
+  version "0.0.39"
+  resolved "https://registry.yarnpkg.com/@types/google.analytics/-/google.analytics-0.0.39.tgz#19a952003dbf3c7373d655a5c3203b4726b8b802"
+
 "@types/html-minifier@^3.5.2":
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/@types/html-minifier/-/html-minifier-3.5.2.tgz#f897a13d847a774e9b6fd91497e9b0e0ead71c35"
@@ -5990,9 +5994,9 @@ opener@^1.4.3:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.1.tgz#6d2f0e77f1a0af0032aca716c2c1fbb8e7e8abed"
 
-ophan-tracker-js@^1.3.9:
-  version "1.3.11"
-  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.3.11.tgz#8556420e75920c05e73c83386aac61dc85e09f14"
+ophan-tracker-js@^1.3.13:
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.3.13.tgz#715aa8655c1ec4c8e45379bae55a95b535522ff6"
 
 optionator@^0.8.1:
   version "0.8.2"


### PR DESCRIPTION
## What does this change?

- [x] extract data for GA from request body
- [x] dynamically load GA module 
- [x] async load GA script
- [x] replicate page view data from frontend
- [x] send GA event

Not going to do as part of AB test:

- Track commercial branding
- Track sponsorship logos
- Track performance metrics
- Track custom interaction events 
- Add confidence beacon for `noscript` clients

## Why?

To collect page view data in GA, to achieve adequate data integrity parity with frontend.