### PR TITLE
Remove all the hard coded colour and change to Zef's grey nav.

### DIFF
--- a/frontend/components/Footer.tsx
+++ b/frontend/components/Footer.tsx
@@ -147,7 +147,7 @@ const footerList = css`
     display: flex;
     flex-wrap: wrap;
     flex-direction: row;
-    border-top: 1px solid #434343;
+    border-top: 1px solid ${palette.neutral[20]};
 
     ${tablet} {
         border-top: none;
@@ -155,7 +155,7 @@ const footerList = css`
 
     ul {
         width: 50%;
-        border-left: 1px solid #434343;
+        border-left: 1px solid ${palette.neutral[20]};
 
         ${until.tablet} {
             :nth-child(odd) {
@@ -191,7 +191,7 @@ const footerList = css`
 const copyright = css`
     font-size: 12px;
     padding: 6px 0 18px;
-    border-top: 1px solid #434343;
+    border-top: 1px solid ${palette.neutral[20]};
     margin-top: 12px;
 `;
 

--- a/frontend/components/Header/Nav/Links/SupportTheGuardian.tsx
+++ b/frontend/components/Header/Nav/Links/SupportTheGuardian.tsx
@@ -4,7 +4,7 @@ import { cx, css } from 'react-emotion';
 import { headline } from '@guardian/pasteup/fonts';
 import { palette } from '@guardian/pasteup/palette';
 const style = css`
-    color: ${palette.nav.faded};
+    color: ${palette.neutral[97]};
     font-family: ${headline};
     font-size: 14px;
     font-weight: 500;

--- a/frontend/components/Header/Nav/MainMenu/CollapseColumnButton.tsx
+++ b/frontend/components/Header/Nav/MainMenu/CollapseColumnButton.tsx
@@ -2,6 +2,8 @@ import React, { Component } from 'react';
 import { headline, egyptian } from '@guardian/pasteup/fonts';
 import { css, cx } from 'react-emotion';
 import { hideDesktop } from './Column';
+import { palette } from '@guardian/pasteup/palette';
+
 const showColumnLinksStyle = css`
     :before {
         margin-top: 8px;
@@ -29,7 +31,7 @@ const collapseColumnButton = css`
     text-transform: capitalize;
     :before {
         margin-top: 4px;
-        color: #5d5f5f;
+        color: ${palette.neutral[20]};
         left: 25px;
         position: absolute;
         border: 2px solid currentColor;
@@ -44,7 +46,7 @@ const collapseColumnButton = css`
     }
 
     :after {
-        background-color: #abc2c9;
+        background-color: ${palette.neutral[86]};
         bottom: 0;
         content: '';
         display: block;

--- a/frontend/components/Header/Nav/MainMenu/Column.tsx
+++ b/frontend/components/Header/Nav/MainMenu/Column.tsx
@@ -15,9 +15,6 @@ export const hideDesktop = css`
 
 const perPillarStyles = pillarMap(
     pillar => css`
-        ul {
-            background-color: #d9e4e7;
-        }
         button {
             color: ${pillarPalette[pillar].main};
         }
@@ -38,7 +35,7 @@ const perPillarStyles = pillarMap(
                 top: 0;
                 bottom: 0;
                 width: 1px;
-                background-color: #abc2c9;
+                background-color: ${palette.neutral[86]};
             }
         }
     `,
@@ -70,7 +67,7 @@ const columnLinkTitle = css`
     }
     :hover,
     :focus {
-        color: #5d5f5f;
+        color: ${palette.neutral[20]};
         text-decoration: underline;
     }
 
@@ -113,20 +110,20 @@ const columnLinks = css`
     margin: 0;
     padding: 0 0 12px;
     position: relative;
-    background-color: ${palette.nav.faded};
+    background-color: ${palette.neutral[97]};
     ${desktop} {
         display: flex;
         flex-direction: column;
         flex-wrap: nowrap;
         order: 1;
-        background-color: ${palette.nav.faded};
+        background-color: ${palette.neutral[97]};
         width: 100%;
         padding: 0 5px;
     }
 `;
 
 const isPillarStyle = css`
-    background-color: #d9e4e7;
+    background-color: ${palette.neutral[93]};
 `;
 
 const hide = css`

--- a/frontend/components/Header/Nav/MainMenu/Columns.tsx
+++ b/frontend/components/Header/Nav/MainMenu/Columns.tsx
@@ -12,7 +12,7 @@ const ColumnsStyle = css`
     max-width: none;
     ${desktop} {
         max-width: 980px;
-        background-color: ${palette.nav.faded};
+        background-color: ${palette.neutral[97]};
         padding: 0 20px;
         position: relative;
         margin: 0 auto;
@@ -69,7 +69,7 @@ const brandExtensionLink = css`
     background-color: transparent;
     border: 0;
     box-sizing: border-box;
-    color: #121212;
+    color: ${palette.neutral[7]};
     cursor: pointer;
     display: inline-block;
     font-family: ${egyptian};
@@ -87,7 +87,7 @@ const brandExtensionLink = css`
     }
     :hover,
     :focus {
-        color: #5d5f5f;
+        color: ${palette.neutral[20]};
         text-decoration: underline;
     }
     > * {

--- a/frontend/components/Header/Nav/MainMenu/index.tsx
+++ b/frontend/components/Header/Nav/MainMenu/index.tsx
@@ -20,7 +20,7 @@ const showMenu = css`
 `;
 
 const mainMenu = css`
-    background-color: ${palette.nav.faded};
+    background-color: ${palette.neutral[97]};
     box-sizing: border-box;
     font-size: 20px;
     left: 0;
@@ -56,7 +56,7 @@ const mainMenu = css`
         left: 0;
         right: 0;
         width: 100%;
-        border-bottom: 1px solid #abc2c9;
+        border-bottom: 1px solid ${palette.neutral[86]};
         @supports (width: 100vw) {
             left: 50%;
             right: 50%;

--- a/frontend/components/Header/Nav/MainMenuToggle/VeggieBurger.tsx
+++ b/frontend/components/Header/Nav/MainMenuToggle/VeggieBurger.tsx
@@ -12,7 +12,7 @@ const veggieBurger = ({ showMainMenu }: { showMainMenu: boolean }) => css`
     background-color: ${palette.neutral[7]};
     top: 24px;
     box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.08);
-    color: ${palette.nav.faded};
+    color: ${palette.neutral[97]};
     cursor: pointer;
     height: 40px;
     min-width: 40px;

--- a/frontend/components/Header/Nav/MainMenuToggle/index.tsx
+++ b/frontend/components/Header/Nav/MainMenuToggle/index.tsx
@@ -12,7 +12,7 @@ const screenReadable = css`
     ${screenReaderOnly};
 `;
 const navPrimaryColour = palette.neutral[7];
-const navSecondaryColour = '#5d5f5f';
+const navSecondaryColour = palette.neutral[20];
 const openMainMenu = css`
     display: none;
     font-family: ${headline};

--- a/frontend/components/Header/Nav/Pillars/index.tsx
+++ b/frontend/components/Header/Nav/Pillars/index.tsx
@@ -10,6 +10,7 @@ import {
 
 import { headline } from '@guardian/pasteup/fonts';
 import { pillarMap, pillarPalette } from '../../../../pillars';
+import { palette } from '@guardian/pasteup/palette';
 
 const pillarColours = pillarMap(
     pillar =>
@@ -39,7 +40,7 @@ const pillarsStyles = css`
                 top: 0;
                 bottom: 0;
                 width: 1px;
-                background-color: #abc2c9;
+                background-color: ${palette.neutral[86]};
             }
         }
         ${leftCol} {

--- a/frontend/components/Header/Nav/index.tsx
+++ b/frontend/components/Header/Nav/index.tsx
@@ -32,7 +32,7 @@ const centered = css`
 
 const subnav = css`
     background-color: white;
-    border-top: 0.0625rem solid ${palette.nav.dark};
+    border-top: 0.0625rem solid ${palette.neutral[86]};
 `;
 
 interface Props {

--- a/frontend/components/Header/index.tsx
+++ b/frontend/components/Header/index.tsx
@@ -8,7 +8,7 @@ import { palette } from '@guardian/pasteup/palette';
 
 const header = css`
     margin-bottom: 0;
-    background-color: ${palette.nav.faded};
+    background-color: ${palette.neutral[97]};
     position: relative;
     ${tablet} {
         display: block;

--- a/packages/pasteup/mixins.ts
+++ b/packages/pasteup/mixins.ts
@@ -13,8 +13,8 @@ export const screenReaderOnly = css`
 
 export const clearFix = css`
     :after {
-        content: '',
-        display: table,
-        clear: both,
+        content: '';
+        display: table;
+        clear: both;
     }
 `;

--- a/packages/pasteup/palette.ts
+++ b/packages/pasteup/palette.ts
@@ -25,7 +25,6 @@ export interface OtherColours {
         97: colour;
         100: colour;
     };
-    nav: { dark: colour; main: colour; faded: colour };
     specialReport: { dark: colour };
     labs: { dark: colour; main: colour };
     green: { dark: colour; main: colour };
@@ -80,11 +79,6 @@ export const palette: AllPillarColours & OtherColours = {
         93: '#ededed',
         97: '#f6f6f6',
         100: '#ffffff',
-    },
-    nav: {
-        dark: '#bbcdd3',
-        main: '#dae4e7',
-        faded: '#e9eff1',
     },
     specialReport: { dark: '#3f464a' },
     labs: {


### PR DESCRIPTION
## What does this change?
Removes the blue-grey nav and its colours.
## Why?
So we just rely on `palette` for colours and to use the new nav colours. 
Also fixes some accidental commas in the `clearFix`.