### PR TITLE
Support running alongside identity so we can use their cookies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ That's it – everything else should be installed for you on demand.
 `make dev` starts the development server.
 
 ### Change preview article
-You can preview an article from `theguardian.com` by appending the query string parameter `url` to your localhost article page. EG. `http://localhost:3000/frontend/Article?url=https://www.theguardian.com/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance`
+You can preview an article from `theguardian.com` by appending the query string parameter `url` to your localhost article page. EG. `http://localhost:3003/frontend/Article?url=https://www.theguardian.com/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance`
 
 ## Production
  - `make build` creates production-ready bundles.

--- a/README.md
+++ b/README.md
@@ -24,8 +24,12 @@ That's it – everything else should be installed for you on demand.
 `make dev` starts the development server.
 
 ### Running alongside identity
+You may want local identity cookies to be available in dotcom-rendering. To enable this:
 
-Add `127.0.0.1   r.thegulocal.com` to the end of your hosts file. Follow the installation steps in [identity-platform/nginx](https://github.com/guardian/identity-platform/tree/master/nginx) and then run `./setup.sh` in `nginx`. This will allow you to access dotcom-rendering through https://r.thegulocal.com which will allow local identity cookies to be read.
+1. Add `127.0.0.1   r.thegulocal.com` to the end of your hosts file
+2. Follow the installation steps in [identity-platform/nginx](https://github.com/guardian/identity-platform/tree/master/nginx) 
+3. run `./nginx/setup.sh`
+4. access dotcom-rendering through https://r.thegulocal.com
 
 ### Change preview article
 You can preview an article from `theguardian.com` by appending the query string parameter `url` to your localhost article page. EG. `http://localhost:3001/frontend/Article?url=https://www.theguardian.com/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance`

--- a/README.md
+++ b/README.md
@@ -20,11 +20,15 @@ check the [.nvmrc](https://github.com/guardian/guui/blob/master/.nvmrc) for the 
 
 That's it – everything else should be installed for you on demand.
 
+### Nginx
+
+Add `127.0.0.1   r.thegulocal.com` to the end of your hosts file. Follow the installation steps in [identity-platform/nginx](https://github.com/guardian/identity-platform/tree/master/nginx) and then run `./setup.sh` in `nginx`. This will allow you to access dotcom-rendering through https://r.thegulocal.com which will allow local identity cookies to be read.
+
 ## Development
 `make dev` starts the development server.
 
 ### Change preview article
-You can preview an article from `theguardian.com` by appending the query string parameter `url` to your localhost article page. EG. `http://localhost:3003/frontend/Article?url=https://www.theguardian.com/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance`
+You can preview an article from `theguardian.com` by appending the query string parameter `url` to your localhost article page. EG. `http://localhost:3001/frontend/Article?url=https://www.theguardian.com/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance`
 
 ## Production
  - `make build` creates production-ready bundles.

--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ check the [.nvmrc](https://github.com/guardian/guui/blob/master/.nvmrc) for the 
 
 That's it – everything else should be installed for you on demand.
 
-### Nginx
-
-Add `127.0.0.1   r.thegulocal.com` to the end of your hosts file. Follow the installation steps in [identity-platform/nginx](https://github.com/guardian/identity-platform/tree/master/nginx) and then run `./setup.sh` in `nginx`. This will allow you to access dotcom-rendering through https://r.thegulocal.com which will allow local identity cookies to be read.
-
 ## Development
 `make dev` starts the development server.
+
+### Running alongside identity
+
+Add `127.0.0.1   r.thegulocal.com` to the end of your hosts file. Follow the installation steps in [identity-platform/nginx](https://github.com/guardian/identity-platform/tree/master/nginx) and then run `./setup.sh` in `nginx`. This will allow you to access dotcom-rendering through https://r.thegulocal.com which will allow local identity cookies to be read.
 
 ### Change preview article
 You can preview an article from `theguardian.com` by appending the query string parameter `url` to your localhost article page. EG. `http://localhost:3001/frontend/Article?url=https://www.theguardian.com/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance`

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You may want local identity cookies to be available in dotcom-rendering. To enab
 4. access dotcom-rendering through https://r.thegulocal.com
 
 ### Change preview article
-You can preview an article from `theguardian.com` by appending the query string parameter `url` to your localhost article page. EG. `http://localhost:3001/frontend/Article?url=https://www.theguardian.com/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance`
+You can preview an article from `theguardian.com` by appending the query string parameter `url` to your localhost article page. EG. `http://localhost:3030/frontend/Article?url=https://www.theguardian.com/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance`
 
 ## Production
  - `make build` creates production-ready bundles.

--- a/dev-server.js
+++ b/dev-server.js
@@ -77,7 +77,7 @@ const go = async () => {
         res.status(500).send(err.stack);
     });
 
-    app.listen(3000);
+    app.listen(3001);
 };
 
 go();

--- a/dev-server.js
+++ b/dev-server.js
@@ -77,7 +77,7 @@ const go = async () => {
         res.status(500).send(err.stack);
     });
 
-    app.listen(3001);
+    app.listen(3030);
 };
 
 go();

--- a/frontend/lib/cookie.ts
+++ b/frontend/lib/cookie.ts
@@ -1,0 +1,126 @@
+const ERR_INVALID_COOKIE_NAME = `Cookie must not contain invalid characters (space, tab and the following characters: '()<>@,;"/[]?={}')`;
+
+// subset of https://github.com/guzzle/guzzle/pull/1131
+const isValidCookieValue = (name: string): boolean =>
+    !/[()<>@,;"\\/[\]?={} \t]/g.test(name);
+
+const getShortDomain = (isCrossSubdomain = false): string => {
+    const domain = document.domain || '';
+    // Trim any possible subdomain (will be shared with supporter, identity, etc)
+    if (isCrossSubdomain) {
+        return ['', ...domain.split('.').slice(-2)].join('.');
+    }
+    // Trim subdomains for prod (www.theguardian), code (m.code.dev-theguardian) and dev (dev.theguardian, m.thegulocal)
+    return domain.replace(/^(www|m\.code|dev|m)\./, '.');
+};
+
+const getDomainAttribute = (isCrossSubdomain = false): string => {
+    const shortDomain = getShortDomain(isCrossSubdomain);
+    return shortDomain === 'localhost' ? '' : ` domain=${shortDomain};`;
+};
+
+const removeCookie = (
+    name: string,
+    currentDomainOnly: boolean = false,
+): void => {
+    const expires = 'expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+    const path = 'path=/;';
+
+    // Remove cookie, implicitly using the document's domain.
+    document.cookie = `${name}=;${path}${expires}`;
+    if (!currentDomainOnly) {
+        // also remove from the short domain
+        document.cookie = `${name}=;${path}${expires} domain=${getShortDomain()};`;
+    }
+};
+
+const addCookie = (
+    name: string,
+    value: string,
+    daysToLive?: number,
+    isCrossSubdomain: boolean = false,
+): void => {
+    const expires = new Date();
+
+    if (!isValidCookieValue(name) || !isValidCookieValue(value)) {
+        throw new Error(`${ERR_INVALID_COOKIE_NAME} .${name}=${value}`);
+    }
+
+    if (daysToLive) {
+        expires.setDate(expires.getDate() + daysToLive);
+    } else {
+        expires.setMonth(expires.getMonth() + 5);
+        expires.setDate(1);
+    }
+
+    document.cookie = `${name}=${value}; path=/; expires=${expires.toUTCString()};${getDomainAttribute(
+        isCrossSubdomain,
+    )}`;
+};
+
+const cleanUp = (names: string[]): void => {
+    names.forEach(name => {
+        removeCookie(name);
+    });
+};
+
+const addForMinutes = (
+    name: string,
+    value: string,
+    minutesToLive: number,
+): void => {
+    const expires = new Date();
+
+    if (!isValidCookieValue(name) || !isValidCookieValue(value)) {
+        throw new Error(`${ERR_INVALID_COOKIE_NAME} .${name}=${value}`);
+    }
+
+    expires.setMinutes(expires.getMinutes() + minutesToLive);
+    document.cookie = `${name}=${value}; path=/; expires=${expires.toUTCString()};${getDomainAttribute()}`;
+};
+
+const addSessionCookie = (name: string, value: string): void => {
+    if (!isValidCookieValue(name) || !isValidCookieValue(value)) {
+        throw new Error(`${ERR_INVALID_COOKIE_NAME} .${name}=${value}`);
+    }
+    document.cookie = `${name}=${value}; path=/;${getDomainAttribute()}`;
+};
+
+const getCookieValues = (name: string): string[] => {
+    const nameEq = `${name}=`;
+    const cookies = document.cookie.split(';');
+
+    return cookies.reduce<string[]>((acc, cookie) => {
+        const cookieTrimmed = cookie.trim();
+
+        if (cookieTrimmed.indexOf(nameEq) === 0) {
+            acc.push(
+                cookieTrimmed.substring(nameEq.length, cookieTrimmed.length),
+            );
+        }
+
+        return acc;
+    }, []);
+};
+
+const getCookie = (name: string): string | null => {
+    const cookieVal = getCookieValues(name);
+
+    if (cookieVal.length > 0) {
+        return cookieVal[0];
+    }
+    return null;
+};
+
+export const _ = {
+    isValidCookieValue,
+};
+
+export {
+    cleanUp,
+    addCookie,
+    addSessionCookie,
+    addForMinutes,
+    removeCookie,
+    getCookie,
+};

--- a/frontend/lib/cookie.ts
+++ b/frontend/lib/cookie.ts
@@ -19,7 +19,7 @@ const getDomainAttribute = (isCrossSubdomain = false): string => {
     return shortDomain === 'localhost' ? '' : ` domain=${shortDomain};`;
 };
 
-const removeCookie = (
+export const removeCookie = (
     name: string,
     currentDomainOnly: boolean = false,
 ): void => {
@@ -34,7 +34,7 @@ const removeCookie = (
     }
 };
 
-const addCookie = (
+export const addCookie = (
     name: string,
     value: string,
     daysToLive?: number,
@@ -58,13 +58,13 @@ const addCookie = (
     )}`;
 };
 
-const cleanUp = (names: string[]): void => {
+export const cleanUp = (names: string[]): void => {
     names.forEach(name => {
         removeCookie(name);
     });
 };
 
-const addForMinutes = (
+export const addForMinutes = (
     name: string,
     value: string,
     minutesToLive: number,
@@ -79,7 +79,7 @@ const addForMinutes = (
     document.cookie = `${name}=${value}; path=/; expires=${expires.toUTCString()};${getDomainAttribute()}`;
 };
 
-const addSessionCookie = (name: string, value: string): void => {
+export const addSessionCookie = (name: string, value: string): void => {
     if (!isValidCookieValue(name) || !isValidCookieValue(value)) {
         throw new Error(`${ERR_INVALID_COOKIE_NAME} .${name}=${value}`);
     }
@@ -103,24 +103,11 @@ const getCookieValues = (name: string): string[] => {
     }, []);
 };
 
-const getCookie = (name: string): string | null => {
+export const getCookie = (name: string): string | null => {
     const cookieVal = getCookieValues(name);
 
     if (cookieVal.length > 0) {
         return cookieVal[0];
     }
     return null;
-};
-
-export const _ = {
-    isValidCookieValue,
-};
-
-export {
-    cleanUp,
-    addCookie,
-    addSessionCookie,
-    addForMinutes,
-    removeCookie,
-    getCookie,
 };

--- a/nginx/dotcom-rendering.conf
+++ b/nginx/dotcom-rendering.conf
@@ -1,0 +1,31 @@
+server {
+    server_name r.thegulocal.com;
+
+    location / {
+        proxy_pass http://localhost:3000/;
+        proxy_set_header Host $http_host;
+    }
+}
+
+server {
+    listen 443;
+    server_name r.thegulocal.com;
+
+    ssl on;
+    ssl_certificate wildcard-thegulocal-com-exp2019-01-09.crt; ## Supplied by https://github.com/guardian/identity-platform#setup-nginx-for-local-development
+    ssl_certificate_key wildcard-thegulocal-com-exp2019-01-09.key; ## ditto
+
+    ssl_session_timeout 5m;
+
+    ssl_protocols TLSv1;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+    ssl_prefer_server_ciphers on;
+
+    location / {
+        proxy_pass http://localhost:3000/;
+        proxy_set_header Host $http_host;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+    }
+}

--- a/nginx/dotcom-rendering.conf
+++ b/nginx/dotcom-rendering.conf
@@ -2,7 +2,7 @@ server {
     server_name r.thegulocal.com;
 
     location / {
-        proxy_pass http://localhost:3001/;
+        proxy_pass http://localhost:3030/;
         proxy_set_header Host $http_host;
     }
 }
@@ -22,7 +22,7 @@ server {
     ssl_prefer_server_ciphers on;
 
     location / {
-        proxy_pass http://localhost:3001/;
+        proxy_pass http://localhost:3030/;
         proxy_set_header Host $http_host;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;

--- a/nginx/dotcom-rendering.conf
+++ b/nginx/dotcom-rendering.conf
@@ -2,7 +2,7 @@ server {
     server_name r.thegulocal.com;
 
     location / {
-        proxy_pass http://localhost:3000/;
+        proxy_pass http://localhost:3001/;
         proxy_set_header Host $http_host;
     }
 }
@@ -22,7 +22,7 @@ server {
     ssl_prefer_server_ciphers on;
 
     location / {
-        proxy_pass http://localhost:3000/;
+        proxy_pass http://localhost:3001/;
         proxy_set_header Host $http_host;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;

--- a/nginx/setup.sh
+++ b/nginx/setup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NGINX_HOME=$(nginx -V 2>&1 | grep 'configure arguments:' | sed 's#.*conf-path=\([^ ]*\)/nginx\.conf.*#\1#g')
+
+echo "🌏 This script will now attempt to install the nginx config for this project."
+echo "🌍 This script needs root access to configure nginx, please enter your sudo password if prompted"
+sudo mkdir -p $NGINX_HOME/sites-enabled
+sudo ln -fs $DIR/dotcom-rendering.conf $NGINX_HOME/sites-enabled/dotcom-rendering.conf
+
+if [[ $(sudo lsof -iTCP:443 -sTCP:LISTEN ) ]];
+then
+  echo "🤖 Attempting to restart nginx."
+  sudo nginx -s reload
+else
+  echo "🚒 NGINX is not running."
+fi
+echo "🌎 Succesfully installed config."

--- a/webpack/browser.js
+++ b/webpack/browser.js
@@ -8,7 +8,7 @@ const friendlyErrorsWebpackPlugin = new FriendlyErrorsWebpackPlugin({
     compilationSuccessInfo: {
         messages: [
             `DEV server running at ${chalk.blue.underline(
-                'http://localhost:3001',
+                'http://localhost:3030',
             )}`,
         ],
     },

--- a/webpack/browser.js
+++ b/webpack/browser.js
@@ -8,7 +8,7 @@ const friendlyErrorsWebpackPlugin = new FriendlyErrorsWebpackPlugin({
     compilationSuccessInfo: {
         messages: [
             `DEV server running at ${chalk.blue.underline(
-                'http://localhost:3000',
+                'http://localhost:3003',
             )}`,
         ],
     },

--- a/webpack/browser.js
+++ b/webpack/browser.js
@@ -8,7 +8,7 @@ const friendlyErrorsWebpackPlugin = new FriendlyErrorsWebpackPlugin({
     compilationSuccessInfo: {
         messages: [
             `DEV server running at ${chalk.blue.underline(
-                'http://localhost:3003',
+                'http://localhost:3001',
             )}`,
         ],
     },


### PR DESCRIPTION
## What does this change?
Changes the port of the dev server to 3001 to allow dotcom rendering to run alongside other parts of the stack. And adds nginx config.
## Why?
