### PR TITLE
Expose font stacks as variants of sans and serif

### DIFF
--- a/frontend/components/ArticleBody.tsx
+++ b/frontend/components/ArticleBody.tsx
@@ -8,11 +8,7 @@ import EmailIcon from '@guardian/pasteup/icons/email.svg';
 import ShareIcon from '@guardian/pasteup/icons/share.svg';
 import ClockIcon from '@guardian/pasteup/icons/clock.svg';
 import dateformat from 'dateformat';
-import {
-    headline as headlineFont,
-    textEgyptian,
-    textSans,
-} from '@guardian/pasteup/fonts';
+import { sans, serif } from '@guardian/pasteup/fonts';
 
 // tslint:disable:react-no-dangerous-html
 
@@ -75,7 +71,7 @@ const wrapper = css`
 `;
 
 const standfirst = css`
-    font-family: ${textEgyptian};
+    font-family: ${serif.body};
     font-weight: 700;
     font-size: 17px;
     line-height: 22px;
@@ -100,7 +96,7 @@ const section = (colour: string) => css`
 
     font-size: 16px;
     line-height: 20px;
-    font-family: ${headlineFont};
+    font-family: ${serif.headline};
     font-weight: 900;
 
     color: ${colour};
@@ -141,7 +137,7 @@ const meta = css`
 const captionFont = css`
     font-size: 12px;
     line-height: 16px;
-    font-family: ${textSans};
+    font-family: ${sans.body};
     color: ${palette.neutral[46]};
 `;
 
@@ -172,7 +168,7 @@ const mainMedia = css`
 const headerStyle = css`
     font-size: 34px;
     line-height: 38px;
-    font-family: ${headlineFont};
+    font-family: ${serif.headline};
     font-weight: 400;
     padding-bottom: 24px;
     padding-top: 3px;
@@ -186,7 +182,7 @@ const bodyStyle = css`
     p {
         font-size: 16px;
         line-height: 24px;
-        font-family: ${textEgyptian};
+        font-family: ${serif.body};
         margin-bottom: 12px;
     }
 `;
@@ -196,7 +192,7 @@ const profile = (colour: string) => css`
 
     font-size: 16px;
     line-height: 20px;
-    font-family: ${headlineFont};
+    font-family: ${serif.headline};
     font-weight: 700;
     margin-bottom: 4px;
 `;
@@ -246,7 +242,7 @@ const shareIcon = (colour: string) => css`
 const ageWarning = (colour: string) => css`
     font-size: 12px;
     line-height: 16px;
-    font-family: ${textSans};
+    font-family: ${sans.body};
     display: inline-block;
     color: ${colour};
     margin-bottom: 12px;
@@ -256,7 +252,7 @@ const ageWarning = (colour: string) => css`
 const shareCount = css`
     font-size: 18px;
     line-height: 18px;
-    font-family: ${textSans};
+    font-family: ${sans.body};
     font-weight: bold;
     letter-spacing: -1px;
     padding-top: 2px;
@@ -267,7 +263,7 @@ const shareCount = css`
 const twitterHandle = css`
     font-size: 12px;
     line-height: 16px;
-    font-family: ${textSans};
+    font-family: ${sans.body};
     font-weight: bold;
     color: ${palette.neutral[46]};
 

--- a/frontend/components/Footer.tsx
+++ b/frontend/components/Footer.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'react-emotion';
 
 import { leftCol, tablet, until } from '@guardian/pasteup/breakpoints';
-import { textSans } from '@guardian/pasteup/fonts';
+import { sans } from '@guardian/pasteup/fonts';
 
 import { Container } from '@guardian/guui';
 import { palette } from '@guardian/pasteup/palette';
@@ -114,7 +114,7 @@ const footerLinks: Link[][] = [
 const footer = css`
     background-color: ${palette.neutral[20]};
     color: ${palette.neutral[86]};
-    font-family: ${textSans};
+    font-family: ${sans.body};
     font-size: 14px;
 `;
 

--- a/frontend/components/Header/Nav/Links/SupportTheGuardian.tsx
+++ b/frontend/components/Header/Nav/Links/SupportTheGuardian.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { cx, css } from 'react-emotion';
 
-import { headline } from '@guardian/pasteup/fonts';
+import { serif } from '@guardian/pasteup/fonts';
 import { palette } from '@guardian/pasteup/palette';
 const style = css`
     color: ${palette.neutral[97]};
-    font-family: ${headline};
+    font-family: ${serif.headline};
     font-size: 14px;
     font-weight: 500;
     text-decoration: none;

--- a/frontend/components/Header/Nav/Links/index.tsx
+++ b/frontend/components/Header/Nav/Links/index.tsx
@@ -5,7 +5,7 @@ import Dropdown, {
     Link as DropdownLink,
 } from '@guardian/guui/components/Dropdown';
 import { palette } from '@guardian/pasteup/palette';
-import { textSans } from '@guardian/pasteup/fonts';
+import { sans } from '@guardian/pasteup/fonts';
 import { tablet, desktop } from '@guardian/pasteup/breakpoints';
 
 import SupportTheGuardian from './SupportTheGuardian';
@@ -34,7 +34,7 @@ const search = css`
 
 const link = ({ showAtTablet }: { showAtTablet: boolean }) => css`
     font-size: 14px;
-    font-family: ${textSans};
+    font-family: ${sans.body};
     color: ${palette.neutral[7]};
     float: left;
     line-height: 1.2;

--- a/frontend/components/Header/Nav/MainMenu/CollapseColumnButton.tsx
+++ b/frontend/components/Header/Nav/MainMenu/CollapseColumnButton.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { headline } from '@guardian/pasteup/fonts';
+import { serif } from '@guardian/pasteup/fonts';
 import { css, cx } from 'react-emotion';
 import { hideDesktop } from './Column';
 import { palette } from '@guardian/pasteup/palette';
@@ -16,7 +16,7 @@ const collapseColumnButton = css`
     box-sizing: border-box;
     cursor: pointer;
     display: block;
-    font-family: ${headline};
+    font-family: ${serif.headline};
     font-size: 24px;
     font-weight: 700;
     line-height: 1;

--- a/frontend/components/Header/Nav/MainMenu/Column.tsx
+++ b/frontend/components/Header/Nav/MainMenu/Column.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { headline } from '@guardian/pasteup/fonts';
+import { serif } from '@guardian/pasteup/fonts';
 import { css, cx } from 'react-emotion';
 
 import { desktop, tablet, leftCol } from '@guardian/pasteup/breakpoints';
@@ -50,7 +50,7 @@ const columnLinkTitle = css`
     cursor: pointer;
     display: inline-block;
     font-size: 20px;
-    font-family: ${headline};
+    font-family: ${serif.headline};
     font-weight: 400;
     outline: none;
     padding: 8px 34px 8px 50px;

--- a/frontend/components/Header/Nav/MainMenu/Columns.tsx
+++ b/frontend/components/Header/Nav/MainMenu/Columns.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'react-emotion';
 
 import { tablet, desktop, leftCol, wide } from '@guardian/pasteup/breakpoints';
-import { headline } from '@guardian/pasteup/fonts';
+import { serif } from '@guardian/pasteup/fonts';
 
 import { Column, More } from './Column';
 import { palette } from '@guardian/pasteup/palette';
@@ -72,7 +72,7 @@ const brandExtensionLink = css`
     color: ${palette.neutral[7]};
     cursor: pointer;
     display: inline-block;
-    font-family: ${headline};
+    font-family: ${serif.headline};
     outline: none;
     padding: 8px 34px 8px 50px;
     position: relative;

--- a/frontend/components/Header/Nav/MainMenuToggle/index.tsx
+++ b/frontend/components/Header/Nav/MainMenuToggle/index.tsx
@@ -3,7 +3,7 @@ import { css, cx } from 'react-emotion';
 
 import { desktop } from '@guardian/pasteup/breakpoints';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';
-import { headline } from '@guardian/pasteup/fonts';
+import { serif } from '@guardian/pasteup/fonts';
 
 import { VeggieBurger } from './VeggieBurger';
 import { palette } from '@guardian/pasteup/palette';
@@ -15,7 +15,7 @@ const navPrimaryColour = palette.neutral[7];
 const navSecondaryColour = palette.neutral[20];
 const openMainMenu = css`
     display: none;
-    font-family: ${headline};
+    font-family: ${serif.headline};
     font-weight: 400;
     text-decoration: none;
     color: ${navSecondaryColour};

--- a/frontend/components/Header/Nav/Pillars/index.tsx
+++ b/frontend/components/Header/Nav/Pillars/index.tsx
@@ -8,7 +8,7 @@ import {
     mobileLandscape,
 } from '@guardian/pasteup/breakpoints';
 
-import { headline } from '@guardian/pasteup/fonts';
+import { serif } from '@guardian/pasteup/fonts';
 import { pillarMap, pillarPalette } from '../../../../pillars';
 import { palette } from '@guardian/pasteup/palette';
 
@@ -56,7 +56,7 @@ const showMenuUnderline = css`
 `;
 
 const linkStyle = css`
-    font-family: ${headline};
+    font-family: ${serif.headline};
     font-weight: 600;
     text-decoration: none;
     cursor: pointer;

--- a/frontend/components/Header/Nav/SubNav.tsx
+++ b/frontend/components/Header/Nav/SubNav.tsx
@@ -1,7 +1,7 @@
 import React, { Component, createRef } from 'react';
 import { css } from 'react-emotion';
 import { palette } from '@guardian/pasteup/palette';
-import { headline } from '@guardian/pasteup/fonts';
+import { serif } from '@guardian/pasteup/fonts';
 import { desktop } from '@guardian/pasteup/breakpoints';
 
 const wrapperExpanded = css`
@@ -33,7 +33,7 @@ const subnavCollapsed = css`
 `;
 
 const fontStyle = css`
-    font-family: ${headline};
+    font-family: ${serif.headline};
     font-weight: 400;
     color: ${palette.neutral[7]};
     padding: 0 6px;

--- a/frontend/components/MostViewed.tsx
+++ b/frontend/components/MostViewed.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { css } from 'react-emotion';
-import { headline } from '@guardian/pasteup/fonts';
+import { serif } from '@guardian/pasteup/fonts';
 import { palette } from '@guardian/pasteup/palette';
 import {
     desktop,
@@ -20,7 +20,7 @@ const container = css`
 `;
 
 const heading = css`
-    font-family: ${headline};
+    font-family: ${serif.headline};
     color: ${palette.neutral[7]};
     font-size: 24px;
     font-weight: 900;
@@ -140,7 +140,7 @@ const headlineHeader = css`
 const headlineLink = css`
     text-decoration: none;
     color: ${palette.neutral[7]};
-    font-family: ${headline};
+    font-family: ${serif.headline};
     font-size: 16px;
     line-height: 1.2;
     font-weight: 500;

--- a/packages/guui/components/Dropdown/index.tsx
+++ b/packages/guui/components/Dropdown/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css, cx } from 'react-emotion';
 import { palette } from '@guardian/pasteup/palette';
-import { textSans } from '@guardian/pasteup/fonts';
+import { sans } from '@guardian/pasteup/fonts';
 
 export interface Link {
     url: string;
@@ -41,7 +41,7 @@ const ulExpanded = css`
 
 const link = css`
     font-size: 15px;
-    font-family: ${textSans};
+    font-family: ${sans.body};
     color: ${palette.neutral[7]};
     line-height: 1.2;
     position: relative;
@@ -102,7 +102,7 @@ const button = css`
     border: none;
     line-height: 1.2;
     font-size: 14px;
-    font-family: ${textSans};
+    font-family: ${sans.body};
     color: ${palette.neutral[7]};
     transition: color 80ms ease-out;
     padding: 6px 10px;

--- a/packages/pasteup/fonts.ts
+++ b/packages/pasteup/fonts.ts
@@ -1,14 +1,15 @@
-export const textSans = [
-    'GuardianTextSans',
-    'Helvetica Neue',
-    'Helvetica',
-    'Arial',
-    'Lucida Grande',
-    'sans-serif',
-].join(',');
+export const serif = {
+    headline: ['GH Guardian Headline', 'Georgia', 'serif'].join(','),
+    body: ['GuardianTextEgyptian', 'Georgia', 'serif'].join(','),
+};
 
-export const textEgyptian = ['GuardianTextEgyptian', 'Georgia', 'serif'].join(
-    ',',
-);
-
-export const headline = ['GH Guardian Headline', 'Georgia', 'serif'].join(',');
+export const sans = {
+    body: [
+        'GuardianTextSans',
+        'Helvetica Neue',
+        'Helvetica',
+        'Arial',
+        'Lucida Grande',
+        'sans-serif',
+    ].join(','),
+};


### PR DESCRIPTION
## What does this change?

Exposes font stacks as variants of sans and serif, and updates all references to the old font stacks

## Why?

- Better reflects how font designers categories the fonts
- Decouples application code from the names of font families
