### PR TITLE
Outsource all the state stuff for client rendered things to one place

### DIFF
--- a/frontend/components/ArticleBody.tsx
+++ b/frontend/components/ArticleBody.tsx
@@ -19,6 +19,7 @@ import {
     leftCol,
     desktop,
 } from '@guardian/pasteup/breakpoints';
+import { ClientComponent } from './ClientComponent';
 
 const wrapper = css`
     padding-top: 6px;
@@ -300,7 +301,6 @@ const metaExtras = css`
 const pillarColour = palette.lifestyle.main; // TODO make dynamic
 
 const dtFormat = (date: Date) => dateformat(date, 'ddd d mmm yyyy HH:MM "GMT"');
-
 const ArticleBody: React.SFC<{
     CAPI: CAPIType;
 }> = ({ CAPI }) => (
@@ -309,6 +309,11 @@ const ArticleBody: React.SFC<{
             <div className={section(pillarColour)}>{CAPI.sectionName}</div>
             <div className={headline}>
                 <h1 className={headerStyle}>{CAPI.headline}</h1>
+                {/* demo code ahoy */}
+                <ClientComponent f={async () => 'hello'}>
+                    {({ data }) => <h1>{data || 'no'}</h1>}
+                </ClientComponent>
+                {/* demo code over */}
                 <div
                     className={standfirst}
                     dangerouslySetInnerHTML={{

--- a/frontend/components/ArticleBody.tsx
+++ b/frontend/components/ArticleBody.tsx
@@ -309,11 +309,6 @@ const ArticleBody: React.SFC<{
             <div className={section(pillarColour)}>{CAPI.sectionName}</div>
             <div className={headline}>
                 <h1 className={headerStyle}>{CAPI.headline}</h1>
-                {/* demo code ahoy */}
-                <ClientComponent f={async () => 'hello'}>
-                    {({ data }) => <h1>{data || 'no'}</h1>}
-                </ClientComponent>
-                {/* demo code over */}
                 <div
                     className={standfirst}
                     dangerouslySetInnerHTML={{

--- a/frontend/components/ArticleBody.tsx
+++ b/frontend/components/ArticleBody.tsx
@@ -19,7 +19,6 @@ import {
     leftCol,
     desktop,
 } from '@guardian/pasteup/breakpoints';
-import { ClientComponent } from './ClientComponent';
 
 const wrapper = css`
     padding-top: 6px;

--- a/frontend/components/ClientComponent.tsx
+++ b/frontend/components/ClientComponent.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export interface ClientComponentProps<T> {
+    f: () => Promise<T>;
+    children: React.SFC<{ data: T | undefined }>;
+}
+
+export class ClientComponent<T> extends React.Component<
+    ClientComponentProps<T>,
+    { data: T | undefined }
+> {
+    public state = { data: undefined };
+    public componentDidMount() {
+        this.props.f().then(data => {
+            this.setState({ data });
+        });
+    }
+    public render() {
+        const data = this.state.data;
+        return this.props.children({ data });
+    }
+}

--- a/frontend/components/MostViewed.tsx
+++ b/frontend/components/MostViewed.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { css } from 'react-emotion';
 import { serif } from '@guardian/pasteup/fonts';
 import { palette } from '@guardian/pasteup/palette';
@@ -9,6 +9,7 @@ import {
     leftCol,
 } from '@guardian/pasteup/breakpoints';
 import { BigNumber } from '@guardian/guui';
+import { ClientComponent } from './ClientComponent';
 
 const container = css`
     border-top: 1px solid ${palette.neutral[86]};
@@ -151,30 +152,19 @@ interface Trail {
     linkText: string;
 }
 
-export default class MostViewed extends Component<{}, { trails: Trail[] }> {
-    constructor(props: {}) {
-        super(props);
-        this.state = {
-            trails: [],
-        };
-    }
-
-    public componentDidMount() {
-        fetch('https://api.nextgen.guardianapps.co.uk/most-read-geo.json?guui')
-            .then(resp => resp.json())
-            .then(({ trails }) => {
-                this.setState({
-                    trails,
-                });
-            });
-    }
-
-    public render() {
-        return (
-            <div className={container}>
-                <h2 className={heading}>Most Viewed</h2>
+const fetchTrails = async () => {
+    const resp = await fetch(
+        'https://api.nextgen.guardianapps.co.uk/most-read-geo.json?guui',
+    );
+    return resp.json() as Promise<Trail[]>;
+};
+export const MostViewed: React.SFC = () => (
+    <div className={container}>
+        <h2 className={heading}>Most Viewed</h2>
+        <ClientComponent f={fetchTrails}>
+            {({ data }) => (
                 <ul className={list}>
-                    {this.state.trails.map((trail, i) => (
+                    {(data || ([] as Trail[])).map((trail, i) => (
                         <li className={listItem} key={trail.url}>
                             <span className={bigNumber}>
                                 <BigNumber index={i + 1} />
@@ -187,7 +177,7 @@ export default class MostViewed extends Component<{}, { trails: Trail[] }> {
                         </li>
                     ))}
                 </ul>
-            </div>
-        );
-    }
-}
+            )}
+        </ClientComponent>
+    </div>
+);

--- a/frontend/components/MostViewed.tsx
+++ b/frontend/components/MostViewed.tsx
@@ -151,14 +151,21 @@ interface Trail {
     url: string;
     linkText: string;
 }
-
-const fetchTrails = async () => {
-    const resp = await fetch(
-        'https://api.nextgen.guardianapps.co.uk/most-read-geo.json?guui',
-    );
-    const j = await resp.json();
-    return j.trails as Promise<Trail[]>;
-};
+const fetchTrails: () => Promise<Trail[]> = () =>
+    new Promise((resolve, reject) => {
+        fetch('https://api.nextgen.guardianapps.co.uk/most-read-geo.json?guui')
+            .then(response => {
+                if (!response.ok) {
+                    resolve([]);
+                }
+                return response.json();
+            })
+            .then(mostRead => {
+                if ('trails' in mostRead) return mostRead.trails as Trail[];
+                return [];
+            })
+            .catch(_ => resolve([]));
+    });
 
 export const MostViewed: React.SFC = () => (
     <div className={container}>

--- a/frontend/components/MostViewed.tsx
+++ b/frontend/components/MostViewed.tsx
@@ -9,7 +9,7 @@ import {
     leftCol,
 } from '@guardian/pasteup/breakpoints';
 import { BigNumber } from '@guardian/guui';
-import { ClientComponent } from './ClientComponent';
+import { AsyncClientComponent } from './lib/AsyncClientComponent';
 
 const container = css`
     border-top: 1px solid ${palette.neutral[86]};
@@ -163,7 +163,7 @@ const fetchTrails = async () => {
 export const MostViewed: React.SFC = () => (
     <div className={container}>
         <h2 className={heading}>Most Viewed</h2>
-        <ClientComponent f={fetchTrails}>
+        <AsyncClientComponent f={fetchTrails}>
             {({ data }) => (
                 <ul>
                     {(data || []).map((trail, i) => (
@@ -180,6 +180,6 @@ export const MostViewed: React.SFC = () => (
                     ))}
                 </ul>
             )}
-        </ClientComponent>
+        </AsyncClientComponent>
     </div>
 );

--- a/frontend/components/MostViewed.tsx
+++ b/frontend/components/MostViewed.tsx
@@ -156,15 +156,17 @@ const fetchTrails = async () => {
     const resp = await fetch(
         'https://api.nextgen.guardianapps.co.uk/most-read-geo.json?guui',
     );
-    return resp.json() as Promise<Trail[]>;
+    const j = await resp.json();
+    return j.trails as Promise<Trail[]>;
 };
+
 export const MostViewed: React.SFC = () => (
     <div className={container}>
         <h2 className={heading}>Most Viewed</h2>
         <ClientComponent f={fetchTrails}>
             {({ data }) => (
-                <ul className={list}>
-                    {(data || ([] as Trail[])).map((trail, i) => (
+                <ul>
+                    {(data || []).map((trail, i) => (
                         <li className={listItem} key={trail.url}>
                             <span className={bigNumber}>
                                 <BigNumber index={i + 1} />

--- a/frontend/components/lib/AsyncClientComponent.tsx
+++ b/frontend/components/lib/AsyncClientComponent.tsx
@@ -5,7 +5,7 @@ export interface ClientComponentProps<T> {
     children: React.SFC<{ data: T | undefined }>;
 }
 
-export class ClientComponent<T> extends React.Component<
+export class AsyncClientComponent<T> extends React.Component<
     ClientComponentProps<T>,
     { data: T | undefined }
 > {

--- a/frontend/pages/Article.tsx
+++ b/frontend/pages/Article.tsx
@@ -4,7 +4,7 @@ import { css } from 'react-emotion';
 import { palette } from '@guardian/pasteup/palette';
 import { desktop, mobileLandscape } from '@guardian/pasteup/breakpoints';
 
-import MostViewed from '../components/MostViewed';
+import { MostViewed } from '../components/MostViewed';
 import Header from '../components/Header';
 import Footer from '../components/Footer';
 import ArticleBody from '../components/ArticleBody';


### PR DESCRIPTION
## What does this change?

## Why?

Thinking about cookies, it became clear that we could do with one pattern for loading things on the client. 

If we had some kind of component that took ` f: () => Promise<❓>` as a prop, and only allowed children that were `React.SFC<{ data: ❓ | undefined }>` then it could handle all the pesky wiring and state stuff until React Suspense is released. 

```tsx
                {/* demo code ahoy */}
                <ClientComponent f={async () => 'hello'}>
                    {({ data }) => <h1>{data || 'no'}</h1>}
                </ClientComponent>
                {/* demo code over */}
```

## Questions?

- Is this the right API for this component?
- Does it live in frontend?