### PR TITLE
Display correct page title

### DIFF
--- a/frontend/document.tsx
+++ b/frontend/document.tsx
@@ -23,6 +23,7 @@ interface RenderToStringResult {
 
 export default ({ data }: Props) => {
     const { page, site, CAPI, NAV } = data;
+    const title = `${CAPI.headline} | ${CAPI.sectionName} | The Guardian`;
     const bundleJS = assets.dist(`${site}.${page.toLowerCase()}.js`);
 
     const { html, css, ids: cssIDs }: RenderToStringResult = extractCritical(
@@ -61,5 +62,6 @@ export default ({ data }: Props) => {
         cssIDs,
         fontFiles,
         data,
+        title,
     });
 };

--- a/frontend/lib/parse-capi/index.ts
+++ b/frontend/lib/parse-capi/index.ts
@@ -115,7 +115,7 @@ export const extractArticleMeta = (data: {}): CAPIType => ({
     webPublicationDate: new Date(
         getNumber(data, 'config.page.webPublicationDate'),
     ),
-    sectionName: getNonEmptyString(data, 'config.page.section'),
+    sectionName: getNonEmptyString(data, 'config.page.sectionName'),
 });
 
 export const extractNavMeta = (data: {}): NavType => {


### PR DESCRIPTION
## What does this change?

The page title is to be formed from:

[headline] | [section name] | The Guardian

## Why?

Because SEO