### PR TITLE
Exclude built files from linting

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -39,5 +39,10 @@
         "react-no-dangerous-html":true,
         "prettier": true
     },
-    "rulesDirectory": []
+    "rulesDirectory": [],
+    "linterOptions": {
+        "exclude": [
+            "packages/*/dist/**/*.js"
+        ]
+    }
 }


### PR DESCRIPTION
## What does this change?

Currently, if you run `make build validate`, TSLint lints the dist files for the packages. This change excludes these files from linting.

## Why?

Built files are optimised for performance, not readability, so should not be linted.