### PR TITLE
Share Count updates

### DIFF
--- a/frontend/components/ArticleBody.tsx
+++ b/frontend/components/ArticleBody.tsx
@@ -9,6 +9,7 @@ import ShareIcon from '@guardian/pasteup/icons/share.svg';
 import ClockIcon from '@guardian/pasteup/icons/clock.svg';
 import dateformat from 'dateformat';
 import { sans, serif } from '@guardian/pasteup/fonts';
+import { screenReaderOnly } from '@guardian/pasteup/mixins';
 
 // tslint:disable:react-no-dangerous-html
 
@@ -34,7 +35,6 @@ const wrapper = css`
     ${leftCol} {
         margin-left: 150px;
         margin-right: 310px;
-
         position: relative;
         :before {
             content: '';
@@ -91,29 +91,33 @@ const leftColWidth = css`
 
 const section = (colour: string) => css`
     ${leftColWidth};
-
     grid-template-areas: section;
-
     font-size: 16px;
     line-height: 20px;
     font-family: ${serif.headline};
     font-weight: 900;
-
     color: ${colour};
 
     ${leftCol} {
         font-size: 22px;
         line-height: 28px;
     }
+
+    ${until.phablet} {
+        padding: 0 10px;
+    }
 `;
 
 const headline = css`
     grid-template-areas: headline;
+
+    ${until.phablet} {
+        padding: 0 10px;
+    }
 `;
 
 const meta = css`
     ${leftColWidth};
-
     grid-template-areas: meta;
 
     ${from.tablet.until.leftCol} {
@@ -132,6 +136,11 @@ const meta = css`
     background-size: 1px 13px;
     padding-top: 15px;
     margin-bottom: 6px;
+
+    ${until.phablet} {
+        padding-left: 10px;
+        padding-right: 10px;
+    }
 `;
 
 const captionFont = css`
@@ -143,11 +152,10 @@ const captionFont = css`
 
 const mainMedia = css`
     grid-template-areas: main-media;
-
     margin-bottom: 6px;
 
     ${until.tablet} {
-        margin: 0 -20px;
+        margin: 0;
         order: -1;
 
         figcaption {
@@ -189,7 +197,6 @@ const bodyStyle = css`
 
 const profile = (colour: string) => css`
     color: ${colour};
-
     font-size: 16px;
     line-height: 20px;
     font-family: ${serif.headline};
@@ -197,12 +204,17 @@ const profile = (colour: string) => css`
     margin-bottom: 4px;
 `;
 
-const shareIcons = css`
-    ${leftCol} {
-        border-bottom: 1px solid ${palette.neutral[86]};
-        padding-bottom: 6px;
-        margin-bottom: 6px;
+const shareIconList = css`
+    ${wide} {
+        flex: auto;
     }
+`;
+
+const shareIconsListItem = css`
+    padding: 0 3px 6px 0;
+    float: left;
+    min-width: 32px;
+    cursor: pointer;
 `;
 
 const shareIcon = (colour: string) => css`
@@ -218,8 +230,8 @@ const shareIcon = (colour: string) => css`
     display: inline-block;
     vertical-align: middle;
     position: relative;
-
     fill: ${colour};
+    box-sizing: content-box;
 
     svg {
         height: 88%;
@@ -239,6 +251,46 @@ const shareIcon = (colour: string) => css`
     }
 `;
 
+const shareCount = css`
+    font-size: 18px;
+    line-height: 18px;
+    font-family: ${textSans};
+    font-weight: bold;
+    color: ${palette.neutral[46]};
+
+    ${leftCol} {
+        border-top: 1px solid ${palette.neutral[86]};
+        width: 100%;
+        padding-top: 6px;
+    }
+
+    ${wide} {
+        flex: 1;
+        border: 0;
+        padding-top: 0;
+        text-align: right;
+    }
+`;
+
+const shareCountContainer = css`
+    ${leftCol} {
+        display: inline-block;
+    }
+`;
+
+const shareCountHeader = css`
+    position: relative;
+    height: 15px;
+    margin: 0;
+`;
+
+const shareCountIcon = css`
+    position: absolute;
+    top: 0;
+    right: 0;
+    fill: ${palette.neutral[46]};
+`;
+
 const ageWarning = (colour: string) => css`
     font-size: 12px;
     line-height: 16px;
@@ -247,17 +299,11 @@ const ageWarning = (colour: string) => css`
     color: ${colour};
     margin-bottom: 12px;
     fill: ${colour};
-`;
+    width: 100%;
 
-const shareCount = css`
-    font-size: 18px;
-    line-height: 18px;
-    font-family: ${sans.body};
-    font-weight: bold;
-    letter-spacing: -1px;
-    padding-top: 2px;
-    display: block;
-    color: ${palette.neutral[46]};
+    ${leftCol} {
+        margin-top: 6px;
+    }
 `;
 
 const twitterHandle = css`
@@ -289,22 +335,33 @@ const metaExtras = css`
     border-top: 1px solid ${palette.neutral[86]};
     padding-top: 6px;
     margin-bottom: 6px;
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
 
-    ${until.desktop} {
-        display: flex;
-        justify-content: space-between;
-        flex-wrap: wrap;
+    ${until.phablet} {
+        margin-left: -10px;
+        margin-right: -10px;
+        padding-left: 10px;
+        padding-right: 10px;
     }
 `;
 
 const pillarColour = palette.lifestyle.main; // TODO make dynamic
 
 const dtFormat = (date: Date) => dateformat(date, 'ddd d mmm yyyy HH:MM "GMT"');
+
+const header = css`
+    ${until.phablet} {
+        margin: 0 -10px;
+    }
+`;
+
 const ArticleBody: React.SFC<{
     CAPI: CAPIType;
 }> = ({ CAPI }) => (
     <div className={wrapper}>
-        <header>
+        <header className={header}>
             <div className={section(pillarColour)}>{CAPI.sectionName}</div>
             <div className={headline}>
                 <h1 className={headerStyle}>{CAPI.headline}</h1>
@@ -325,25 +382,43 @@ const ArticleBody: React.SFC<{
                     {dtFormat(CAPI.webPublicationDate)}
                 </div>
                 <div className={metaExtras}>
-                    <div className={shareIcons}>
-                        <a href="/" role="button">
-                            <span className={shareIcon(pillarColour)}>
-                                <FacebookIcon />
-                            </span>
-                        </a>
-                        <a href="/" role="button">
-                            <span className={shareIcon(pillarColour)}>
-                                <TwitterIconPadded />
-                            </span>
-                        </a>
-                        <a href="/" role="button">
-                            <span className={shareIcon(pillarColour)}>
-                                <EmailIcon />
-                            </span>
-                        </a>
-                    </div>
+                    <ul className={shareIconList}>
+                        <li className={shareIconsListItem}>
+                            <a href="/" role="button">
+                                <span className={shareIcon(pillarColour)}>
+                                    <FacebookIcon />
+                                </span>
+                            </a>
+                        </li>
+                        <li className={shareIconsListItem}>
+                            <a href="/" role="button">
+                                <span className={shareIcon(pillarColour)}>
+                                    <TwitterIconPadded />
+                                </span>
+                            </a>
+                        </li>
+                        <li className={shareIconsListItem}>
+                            <a href="/" role="button">
+                                <span className={shareIcon(pillarColour)}>
+                                    <EmailIcon />
+                                </span>
+                            </a>
+                        </li>
+                    </ul>
                     <div className={shareCount}>
-                        <ShareIcon /> 1055
+                        <div className={shareCountContainer}>
+                            <h3 className={shareCountHeader}>
+                                <ShareIcon className={shareCountIcon} />
+                                <span
+                                    className={css`
+                                        ${screenReaderOnly};
+                                    `}
+                                >
+                                    Shares
+                                </span>
+                            </h3>
+                            <div>1055</div>
+                        </div>
                     </div>
                     <div className={ageWarning(pillarColour)}>
                         <ClockIcon /> This article is over 1 year old.

--- a/frontend/components/ArticleBody.tsx
+++ b/frontend/components/ArticleBody.tsx
@@ -5,11 +5,10 @@ import TwitterIconPadded from '@guardian/pasteup/icons/twitter-padded.svg';
 import TwitterIcon from '@guardian/pasteup/icons/twitter.svg';
 import FacebookIcon from '@guardian/pasteup/icons/facebook.svg';
 import EmailIcon from '@guardian/pasteup/icons/email.svg';
-import ShareIcon from '@guardian/pasteup/icons/share.svg';
 import ClockIcon from '@guardian/pasteup/icons/clock.svg';
 import dateformat from 'dateformat';
 import { sans, serif } from '@guardian/pasteup/fonts';
-import { screenReaderOnly } from '@guardian/pasteup/mixins';
+import ShareCount from './ShareCount';
 
 // tslint:disable:react-no-dangerous-html
 
@@ -251,46 +250,6 @@ const shareIcon = (colour: string) => css`
     }
 `;
 
-const shareCount = css`
-    font-size: 18px;
-    line-height: 18px;
-    font-family: ${textSans};
-    font-weight: bold;
-    color: ${palette.neutral[46]};
-
-    ${leftCol} {
-        border-top: 1px solid ${palette.neutral[86]};
-        width: 100%;
-        padding-top: 6px;
-    }
-
-    ${wide} {
-        flex: 1;
-        border: 0;
-        padding-top: 0;
-        text-align: right;
-    }
-`;
-
-const shareCountContainer = css`
-    ${leftCol} {
-        display: inline-block;
-    }
-`;
-
-const shareCountHeader = css`
-    position: relative;
-    height: 15px;
-    margin: 0;
-`;
-
-const shareCountIcon = css`
-    position: absolute;
-    top: 0;
-    right: 0;
-    fill: ${palette.neutral[46]};
-`;
-
 const ageWarning = (colour: string) => css`
     font-size: 12px;
     line-height: 16px;
@@ -359,7 +318,8 @@ const header = css`
 
 const ArticleBody: React.SFC<{
     CAPI: CAPIType;
-}> = ({ CAPI }) => (
+    config: ConfigType;
+}> = ({ CAPI, config }) => (
     <div className={wrapper}>
         <header className={header}>
             <div className={section(pillarColour)}>{CAPI.sectionName}</div>
@@ -405,21 +365,7 @@ const ArticleBody: React.SFC<{
                             </a>
                         </li>
                     </ul>
-                    <div className={shareCount}>
-                        <div className={shareCountContainer}>
-                            <h3 className={shareCountHeader}>
-                                <ShareIcon className={shareCountIcon} />
-                                <span
-                                    className={css`
-                                        ${screenReaderOnly};
-                                    `}
-                                >
-                                    Shares
-                                </span>
-                            </h3>
-                            <div>1055</div>
-                        </div>
-                    </div>
+                    <ShareCount config={config} CAPI={CAPI} />
                     <div className={ageWarning(pillarColour)}>
                         <ClockIcon /> This article is over 1 year old.
                     </div>

--- a/frontend/components/ShareCount.tsx
+++ b/frontend/components/ShareCount.tsx
@@ -3,14 +3,14 @@ import { css } from 'react-emotion';
 import { palette } from '@guardian/pasteup/palette';
 import ShareIcon from '@guardian/pasteup/icons/share.svg';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';
-import { textSans } from '@guardian/pasteup/fonts';
+import { sans } from '@guardian/pasteup/fonts';
 import { from, wide, leftCol } from '@guardian/pasteup/breakpoints';
 import { integerCommas } from '../lib/formatters';
 
 const shareCount = css`
     font-size: 18px;
     line-height: 18px;
-    font-family: ${textSans};
+    font-family: ${sans.body};
     font-weight: bold;
     color: ${palette.neutral[46]};
 

--- a/frontend/components/ShareCount.tsx
+++ b/frontend/components/ShareCount.tsx
@@ -1,0 +1,128 @@
+import React, { Component } from 'react';
+import { css } from 'react-emotion';
+import { palette } from '@guardian/pasteup/palette';
+import ShareIcon from '@guardian/pasteup/icons/share.svg';
+import { screenReaderOnly } from '@guardian/pasteup/mixins';
+import { textSans } from '@guardian/pasteup/fonts';
+import { from, wide, leftCol } from '@guardian/pasteup/breakpoints';
+import { integerCommas } from '../lib/formatters';
+
+const shareCount = css`
+    font-size: 18px;
+    line-height: 18px;
+    font-family: ${textSans};
+    font-weight: bold;
+    color: ${palette.neutral[46]};
+
+    ${leftCol} {
+        border-top: 1px solid ${palette.neutral[86]};
+        width: 100%;
+        padding-top: 6px;
+    }
+
+    ${wide} {
+        flex: 1;
+        border: 0;
+        padding-top: 0;
+        text-align: right;
+    }
+`;
+
+const shareCountContainer = css`
+    ${leftCol} {
+        display: inline-block;
+    }
+`;
+
+const shareCountHeader = css`
+    position: relative;
+    height: 15px;
+    margin: 0;
+`;
+
+const shareCountIcon = css`
+    position: absolute;
+    top: 0;
+    right: 0;
+    fill: ${palette.neutral[46]};
+`;
+
+const countFull = css`
+    display: block;
+
+    ${from.leftCol.until.wide} {
+        display: none;
+    }
+`;
+
+const countShort = css`
+    display: none;
+
+    ${from.leftCol.until.wide} {
+        display: block;
+    }
+`;
+
+interface Props {
+    config: ConfigType;
+    CAPI: CAPIType;
+}
+
+export default class ShareCount extends Component<
+    Props,
+    { shareCount?: number }
+> {
+    constructor(props: Props) {
+        super(props);
+        this.state = {};
+    }
+
+    public componentDidMount() {
+        const { config, CAPI } = this.props;
+        const url = `${config.ajaxUrl}/sharecount/${CAPI.pageId}.json`;
+
+        fetch(url)
+            .then(resp => {
+                if (resp.ok) {
+                    return resp.json();
+                }
+            })
+            .then(data => {
+                this.setState({
+                    shareCount: data.share_count,
+                });
+            });
+    }
+
+    public render() {
+        if (!this.state.shareCount) {
+            return '';
+        }
+
+        const displayCount = parseInt(this.state.shareCount.toFixed(0), 10);
+        const formattedDisplayCount = integerCommas(displayCount);
+        const shortDisplayCount =
+            displayCount > 10000
+                ? `${Math.round(displayCount / 1000)}k`
+                : displayCount;
+
+        return (
+            <div className={shareCount}>
+                <div className={shareCountContainer}>
+                    <h3 className={shareCountHeader}>
+                        <ShareIcon className={shareCountIcon} />
+                        <span
+                            className={css`
+                                ${screenReaderOnly};
+                            `}
+                        >
+                            Shares
+                        </span>
+                    </h3>
+                    <div className={countFull}>{formattedDisplayCount}</div>
+                    <div className={countShort}>{shortDisplayCount}</div>
+                </div>
+            </div>
+        );
+    }
+}

--- a/frontend/document.tsx
+++ b/frontend/document.tsx
@@ -24,6 +24,7 @@ interface RenderToStringResult {
 
 export default ({ data }: Props) => {
     const { page, site, CAPI, NAV, config } = data;
+    const title = `${CAPI.headline} | ${CAPI.sectionName} | The Guardian`;
     const bundleJS = assets.dist(`${site}.${page.toLowerCase()}.js`);
 
     const { html, css, ids: cssIDs }: RenderToStringResult = extractCritical(

--- a/frontend/document.tsx
+++ b/frontend/document.tsx
@@ -12,6 +12,7 @@ interface Props {
         site: string;
         CAPI: CAPIType;
         NAV: NavType;
+        config: ConfigType;
     };
 }
 
@@ -22,12 +23,11 @@ interface RenderToStringResult {
 }
 
 export default ({ data }: Props) => {
-    const { page, site, CAPI, NAV } = data;
-    const title = `${CAPI.headline} | ${CAPI.sectionName} | The Guardian`;
+    const { page, site, CAPI, NAV, config } = data;
     const bundleJS = assets.dist(`${site}.${page.toLowerCase()}.js`);
 
     const { html, css, ids: cssIDs }: RenderToStringResult = extractCritical(
-        renderToString(<Article data={{ CAPI, NAV }} />),
+        renderToString(<Article data={{ CAPI, NAV, config }} />),
     );
 
     /**

--- a/frontend/index.d.ts
+++ b/frontend/index.d.ts
@@ -38,8 +38,18 @@ interface CAPIType {
     author: string,
     webPublicationDate: Date,
     sectionName: string,
+    pageId: string
 }
 
+/**
+ * the config model will contain useful app/site
+ * level data. Although currently derived from the config model
+ * constructed in frontend and passed to dotcom-rendering 
+ * this data could eventually be defined in dotcom-rendering
+ */
+interface ConfigType {
+    ajaxUrl: string
+}
 
 // 3rd party type declarations
 declare module "emotion-server" {

--- a/frontend/lib/formatters.ts
+++ b/frontend/lib/formatters.ts
@@ -1,0 +1,14 @@
+const integerCommas = (val: number): string => {
+    const digits = val.toFixed(0).split('');
+    const len = digits.length;
+
+    for (let i = digits.length - 1; i >= 1; i -= 1) {
+        if ((len - i) % 3 === 0) {
+            digits.splice(i, 0, ',');
+        }
+    }
+
+    return digits.join('');
+};
+
+export { integerCommas };

--- a/frontend/lib/parse-capi/index.ts
+++ b/frontend/lib/parse-capi/index.ts
@@ -115,7 +115,8 @@ export const extractArticleMeta = (data: {}): CAPIType => ({
     webPublicationDate: new Date(
         getNumber(data, 'config.page.webPublicationDate'),
     ),
-    sectionName: getNonEmptyString(data, 'config.page.sectionName'),
+    sectionName: getNonEmptyString(data, 'config.page.section'),
+    pageId: getNonEmptyString(data, 'config.page.pageId'),
 });
 
 export const extractNavMeta = (data: {}): NavType => {
@@ -147,5 +148,11 @@ export const extractNavMeta = (data: {}): NavType => {
                   ),
               }
             : undefined,
+    };
+};
+
+export const extractConfigMeta = (data: {}): ConfigType => {
+    return {
+        ajaxUrl: getNonEmptyString(data, 'config.page.ajaxUrl'),
     };
 };

--- a/frontend/pages/Article.tsx
+++ b/frontend/pages/Article.tsx
@@ -12,6 +12,7 @@ import ArticleBody from '../components/ArticleBody';
 interface Props {
     CAPI: CAPIType;
     NAV: NavType;
+    config: ConfigType;
 }
 
 // TODO: find a better of setting opacity
@@ -72,7 +73,7 @@ const Article: React.SFC<{
         <main className={articleWrapper}>
             <Container className={articleContainer}>
                 <article>
-                    <ArticleBody CAPI={data.CAPI} />
+                    <ArticleBody CAPI={data.CAPI} config={data.config} />
                     <div className={secondaryColumn} />
                 </article>
                 <MostViewed />

--- a/packages/rendering/server.ts
+++ b/packages/rendering/server.ts
@@ -7,13 +7,13 @@ import {
     GuardianConfiguration,
 } from './lib/aws-parameters';
 import document from '../../frontend/document';
-import Article from '../../frontend/pages/Article';
-import { dist, getPagesForSite, root } from '../../config';
+import { dist, root } from '../../config';
 import { log, warn } from '../../lib/log';
 
 import {
     extractArticleMeta,
     extractNavMeta,
+    extractConfigMeta,
 } from '../../frontend/lib/parse-capi';
 
 const renderArticle = ({ body }: express.Request, res: express.Response) => {
@@ -24,6 +24,7 @@ const renderArticle = ({ body }: express.Request, res: express.Response) => {
                 page: 'Article',
                 CAPI: extractArticleMeta(body),
                 NAV: extractNavMeta(body),
+                config: extractConfigMeta(body),
             },
         });
 


### PR DESCRIPTION
## What does this change?

1. ShareCount component now fetches the correct share count for an article

2. Fixes various style issues:

**Old (note incorrect margins on meta container)**
![screen shot 2018-09-20 at 13 49 57](https://user-images.githubusercontent.com/1590704/45819399-21c22a00-bcdc-11e8-8441-fae4fe32c379.png)

**New**
![screen shot 2018-09-20 at 13 48 58](https://user-images.githubusercontent.com/1590704/45819451-3bfc0800-bcdc-11e8-82db-3327e2f58817.png)

**Old (share count icon wrong colour and position)**
![screen shot 2018-09-20 at 13 47 04](https://user-images.githubusercontent.com/1590704/45819466-474f3380-bcdc-11e8-9f37-4c062f213ccd.png)

**New**
![screen shot 2018-09-20 at 13 47 16](https://user-images.githubusercontent.com/1590704/45819483-5209c880-bcdc-11e8-8a2c-2e9ed3a5780b.png)

**Old (share count icon wrong colour and position)**
![screen shot 2018-09-20 at 13 46 51](https://user-images.githubusercontent.com/1590704/45819503-5cc45d80-bcdc-11e8-9be2-51f24361e3f0.png)

**New**
![screen shot 2018-09-20 at 13 46 43](https://user-images.githubusercontent.com/1590704/45819535-71085a80-bcdc-11e8-91e1-0b1a27a98a24.png)

**Old (share count icon wrong colour and position)**
![screen shot 2018-09-20 at 13 46 11](https://user-images.githubusercontent.com/1590704/45819547-76fe3b80-bcdc-11e8-986b-828dad3b3a9e.png)

**New**
![screen shot 2018-09-20 at 13 46 27](https://user-images.githubusercontent.com/1590704/45819558-83829400-bcdc-11e8-8b48-d4b28b6405be.png)

## Why?

Visual parity
