### PR TITLE
`getNonEmptyString` -> `getString` to allow for missing fields

### DIFF
--- a/frontend/components/Header/Nav/index.tsx
+++ b/frontend/components/Header/Nav/index.tsx
@@ -99,7 +99,6 @@ export default class Nav extends Component<Props, { showMainMenu: boolean }> {
                     />
                 </nav>
                 {nav.subNavSections &&
-                    nav.subNavSections.parent &&
                     nav.subNavSections.links && (
                         <div className={subnav}>
                             <div className={centered}>

--- a/frontend/index.d.ts
+++ b/frontend/index.d.ts
@@ -26,7 +26,7 @@ interface NavType {
     otherLinks: MoreType,
     brandExtensions: Array<LinkType>,
     subNavSections?: {
-        parent: LinkType,
+        parent?: LinkType,
         links: Array<LinkType>,
     },
 }

--- a/frontend/lib/parse-capi/index.ts
+++ b/frontend/lib/parse-capi/index.ts
@@ -146,17 +146,21 @@ export const extractNavMeta = (data: {}): NavType => {
             title: 'More',
             longTitle: 'More',
             more: true,
-            children: getArray<Object>(data, 'config.nav.otherLinks', []).map(l =>
-                getLink(l, { isPillar: false }),
+            children: getArray<object>(data, 'config.nav.otherLinks', []).map(
+                l => getLink(l, { isPillar: false }),
             ),
         },
-        brandExtensions: getArray<Object>(data, 'config.nav.brandExtensions', []).map(
-            l => getLink(l, { isPillar: false }),
-        ),
+        brandExtensions: getArray<object>(
+            data,
+            'config.nav.brandExtensions',
+            [],
+        ).map(l => getLink(l, { isPillar: false })),
         subNavSections: subnav
             ? {
-                  parent: subnav.parent ? getLink(subnav.parent, { isPillar: false }) : undefined,
-                  links: getArray<any>(subnav, 'links').map(l =>
+                  parent: subnav.parent
+                      ? getLink(subnav.parent, { isPillar: false })
+                      : undefined,
+                  links: getArray<object>(subnav, 'links').map(l =>
                       getLink(l, { isPillar: false }),
                   ),
               }

--- a/frontend/lib/parse-capi/index.ts
+++ b/frontend/lib/parse-capi/index.ts
@@ -24,7 +24,11 @@ const apply = (input: string, ...fns: Array<(_: string) => string>): string => {
     return fns.reduce((acc, fn) => fn(acc), input);
 };
 
-const getString = (obj: object, selector: string, fallbackValue?: string): string => {
+const getString = (
+    obj: object,
+    selector: string,
+    fallbackValue?: string,
+): string => {
     const found = get(obj, selector);
     if (typeof found === 'string') {
         return found;
@@ -66,7 +70,11 @@ const getNonEmptyString = (obj: object, selector: string): string => {
     );
 };
 
-const getArray = (obj: object, selector: string, fallbackValue?: any[]): any[] => {
+const getArray = (
+    obj: object,
+    selector: string,
+    fallbackValue?: any[],
+): any[] => {
     const found = get(obj, selector);
     if (Array.isArray(found)) {
         return found;
@@ -142,8 +150,8 @@ export const extractNavMeta = (data: {}): NavType => {
                 getLink(l, { isPillar: false }),
             ),
         },
-        brandExtensions: getArray(data, 'config.nav.brandExtensions', []).map(l =>
-            getLink(l, { isPillar: false }),
+        brandExtensions: getArray(data, 'config.nav.brandExtensions', []).map(
+            l => getLink(l, { isPillar: false }),
         ),
         subNavSections: subnav
             ? {

--- a/frontend/lib/parse-capi/index.ts
+++ b/frontend/lib/parse-capi/index.ts
@@ -82,10 +82,10 @@ const findPillar: (name: string) => Pillar | undefined = name => {
 };
 
 const getLink = (data: {}, { isPillar }: { isPillar: boolean }): LinkType => ({
-    title: getNonEmptyString(data, 'title'),
+    title: getString(data, 'title'),
     longTitle: getString(data, 'longTitle'),
-    url: getNonEmptyString(data, 'url'),
-    pillar: isPillar ? findPillar(getNonEmptyString(data, 'title')) : undefined,
+    url: getString(data, 'url'),
+    pillar: isPillar ? findPillar(getString(data, 'title')) : undefined,
     children: getArray(data, 'children').map(
         l => getLink(l, { isPillar: false }), // children are never pillars
     ),
@@ -102,7 +102,7 @@ export const extractArticleMeta = (data: {}): CAPIType => ({
         curly,
     ),
     standfirst: apply(
-        getNonEmptyString(data, 'contentFields.fields.standfirst'),
+        getString(data, 'contentFields.fields.standfirst'),
         clean,
         bigBullets,
     ),
@@ -111,7 +111,7 @@ export const extractArticleMeta = (data: {}): CAPIType => ({
         .map(block => block.bodyHtml)
         .filter(Boolean)
         .join(''),
-    author: getNonEmptyString(data, 'config.page.author'),
+    author: getString(data, 'config.page.author'),
     webPublicationDate: new Date(
         getNumber(data, 'config.page.webPublicationDate'),
     ),

--- a/frontend/lib/parse-capi/index.ts
+++ b/frontend/lib/parse-capi/index.ts
@@ -70,11 +70,11 @@ const getNonEmptyString = (obj: object, selector: string): string => {
     );
 };
 
-const getArray = (
+const getArray = <T>(
     obj: object,
     selector: string,
-    fallbackValue?: any[],
-): any[] => {
+    fallbackValue?: T[],
+): T[] => {
     const found = get(obj, selector);
     if (Array.isArray(found)) {
         return found;
@@ -100,7 +100,7 @@ const getLink = (data: {}, { isPillar }: { isPillar: boolean }): LinkType => ({
     longTitle: getString(data, 'longTitle'),
     url: getString(data, 'url'),
     pillar: isPillar ? findPillar(getString(data, 'title')) : undefined,
-    children: getArray(data, 'children', []).map(
+    children: getArray<object>(data, 'children', []).map(
         l => getLink(l, { isPillar: false }), // children are never pillars
     ),
     mobileOnly: false,
@@ -121,7 +121,7 @@ export const extractArticleMeta = (data: {}): CAPIType => ({
         bigBullets,
     ),
     main: apply(getString(data, 'contentFields.fields.main', ''), clean),
-    body: getArray(data, 'contentFields.fields.blocks.body')
+    body: getArray<any>(data, 'contentFields.fields.blocks.body')
         .map(block => block.bodyHtml)
         .filter(Boolean)
         .join(''),
@@ -133,7 +133,7 @@ export const extractArticleMeta = (data: {}): CAPIType => ({
 });
 
 export const extractNavMeta = (data: {}): NavType => {
-    let pillars = getArray(data, 'config.nav.pillars');
+    let pillars = getArray<any>(data, 'config.nav.pillars');
 
     pillars = pillars.map(link => getLink(link, { isPillar: true }));
 
@@ -146,17 +146,17 @@ export const extractNavMeta = (data: {}): NavType => {
             title: 'More',
             longTitle: 'More',
             more: true,
-            children: getArray(data, 'config.nav.otherLinks', []).map(l =>
+            children: getArray<Object>(data, 'config.nav.otherLinks', []).map(l =>
                 getLink(l, { isPillar: false }),
             ),
         },
-        brandExtensions: getArray(data, 'config.nav.brandExtensions', []).map(
+        brandExtensions: getArray<Object>(data, 'config.nav.brandExtensions', []).map(
             l => getLink(l, { isPillar: false }),
         ),
         subNavSections: subnav
             ? {
                   parent: subnav.parent ? getLink(subnav.parent, { isPillar: false }) : undefined,
-                  links: getArray(subnav, 'links').map(l =>
+                  links: getArray<any>(subnav, 'links').map(l =>
                       getLink(l, { isPillar: false }),
                   ),
               }

--- a/frontend/lib/parse-capi/index.ts
+++ b/frontend/lib/parse-capi/index.ts
@@ -96,10 +96,10 @@ const findPillar: (name: string) => Pillar | undefined = name => {
 };
 
 const getLink = (data: {}, { isPillar }: { isPillar: boolean }): LinkType => ({
-    title: getString(data, 'title', ''),
-    longTitle: getString(data, 'longTitle', ''),
-    url: getString(data, 'url', ''),
-    pillar: isPillar ? findPillar(getString(data, 'title', '')) : undefined,
+    title: getString(data, 'title'),
+    longTitle: getString(data, 'longTitle'),
+    url: getString(data, 'url'),
+    pillar: isPillar ? findPillar(getString(data, 'title')) : undefined,
     children: getArray(data, 'children', []).map(
         l => getLink(l, { isPillar: false }), // children are never pillars
     ),
@@ -155,7 +155,7 @@ export const extractNavMeta = (data: {}): NavType => {
         ),
         subNavSections: subnav
             ? {
-                  parent: getLink(subnav.parent, { isPillar: false }),
+                  parent: subnav.parent ? getLink(subnav.parent, { isPillar: false }) : undefined,
                   links: getArray(subnav, 'links').map(l =>
                       getLink(l, { isPillar: false }),
                   ),

--- a/frontend/lib/parse-capi/index.ts
+++ b/frontend/lib/parse-capi/index.ts
@@ -166,10 +166,7 @@ export const extractArticleMeta = (data: {}): CAPIType => {
             clean,
             bigBullets,
         ),
-        main: apply(
-            getString(data, 'contentFields.fields.main', ''),
-            clean,
-        ),
+        main: apply(getString(data, 'contentFields.fields.main', ''), clean),
         body: getArray<any>(data, 'contentFields.fields.blocks.body')
             .map(block => block.bodyHtml)
             .filter(Boolean)


### PR DESCRIPTION
This attempts to fix https://trello.com/c/Vsktboaj/143-fix-overzealous-validation by allowing more fields to be missing or empty. I've added a 'fallbackValue' optional parameter to the getter functions to make this work, happy to consider another approach too! 
