### PR TITLE
Add pillars colours to article

### DIFF
--- a/frontend/components/ArticleBody.tsx
+++ b/frontend/components/ArticleBody.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'react-emotion';
+import { css, cx } from 'react-emotion';
 import TwitterIcon from '@guardian/pasteup/icons/twitter.svg';
 import { palette } from '@guardian/pasteup/palette';
 import ClockIcon from '@guardian/pasteup/icons/clock.svg';
@@ -17,6 +17,7 @@ import {
     leftCol,
     desktop,
 } from '@guardian/pasteup/breakpoints';
+import { pillarMap, pillarPalette } from '../pillars';
 
 const wrapper = css`
     padding-top: 6px;
@@ -66,6 +67,18 @@ const wrapper = css`
         }
     }
 `;
+const pillarColours = pillarMap(
+    pillar =>
+        css`
+            color: ${pillarPalette[pillar].main};
+        `,
+);
+const pillarFill = pillarMap(
+    pillar =>
+        css`
+            fill: ${pillarPalette[pillar].main};
+        `,
+);
 
 const standfirst = css`
     font-family: ${serif.body};
@@ -86,14 +99,13 @@ const leftColWidth = css`
     }
 `;
 
-const section = (colour: string) => css`
+const section = css`
     ${leftColWidth};
     grid-template-areas: section;
     font-size: 16px;
     line-height: 20px;
     font-family: ${serif.headline};
     font-weight: 700;
-    color: ${colour};
 
     ${leftCol} {
         font-size: 22px;
@@ -192,8 +204,7 @@ const bodyStyle = css`
     }
 `;
 
-const profile = (colour: string) => css`
-    color: ${colour};
+const profile = css`
     font-size: 16px;
     line-height: 20px;
     font-family: ${serif.headline};
@@ -201,14 +212,12 @@ const profile = (colour: string) => css`
     margin-bottom: 4px;
 `;
 
-const ageWarning = (colour: string) => css`
+const ageWarning = css`
     font-size: 12px;
     line-height: 16px;
     font-family: ${sans.body};
     display: inline-block;
-    color: ${colour};
     margin-bottom: 12px;
-    fill: ${colour};
     width: 100%;
 
     ${leftCol} {
@@ -257,8 +266,6 @@ const metaExtras = css`
     }
 `;
 
-const pillarColour = palette.lifestyle.main; // TODO make dynamic
-
 const dtFormat = (date: Date) => dateformat(date, 'ddd d mmm yyyy HH:MM "GMT"');
 
 const header = css`
@@ -273,7 +280,9 @@ const ArticleBody: React.SFC<{
 }> = ({ CAPI, config }) => (
     <div className={wrapper}>
         <header className={header}>
-            <div className={section(pillarColour)}>{CAPI.sectionName}</div>
+            <div className={cx(section, pillarColours[CAPI.pillar])}>
+                {CAPI.sectionName}
+            </div>
             <div className={headline}>
                 <h1 className={headerStyle}>{CAPI.headline}</h1>
                 <div
@@ -284,7 +293,9 @@ const ArticleBody: React.SFC<{
                 />
             </div>
             <div className={meta}>
-                <div className={profile(pillarColour)}>{CAPI.author}</div>
+                <div className={cx(profile, pillarColours[CAPI.pillar])}>
+                    {CAPI.author}
+                </div>
                 <div className={twitterHandle}>
                     {/* TODO - from the contributor type tag */}
                     <TwitterIcon /> @ByRobDavies
@@ -295,12 +306,18 @@ const ArticleBody: React.SFC<{
                 <div className={metaExtras}>
                     <SharingIcons
                         sharingUrls={CAPI.sharingUrls}
-                        pillarColour={pillarColour}
+                        pillarColour={pillarColours[CAPI.pillar]}
                         displayIcons={['facebook', 'twitter', 'email']}
                     />
                     <ShareCount config={config} CAPI={CAPI} />
                     {CAPI.ageWarning && (
-                        <div className={ageWarning(pillarColour)}>
+                        <div
+                            className={cx(
+                                ageWarning,
+                                pillarColours[CAPI.pillar],
+                                pillarFill[CAPI.pillar],
+                            )}
+                        >
                             <ClockIcon /> {CAPI.ageWarning}
                         </div>
                     )}

--- a/frontend/components/ArticleBody.tsx
+++ b/frontend/components/ArticleBody.tsx
@@ -67,6 +67,7 @@ const wrapper = css`
         }
     }
 `;
+
 const pillarColours = pillarMap(
     pillar =>
         css`
@@ -204,6 +205,18 @@ const bodyStyle = css`
     }
 `;
 
+const linkColour = (pillar: Pillar) => css`
+    a {
+        text-decoration: none;
+        border-bottom: 1px solid #dcdcdc;
+        ${pillarColours[pillar]};
+
+        :hover {
+            border-bottom: 1px solid ${pillarPalette[pillar].main};
+        }
+    }
+`;
+
 const profile = css`
     font-size: 16px;
     line-height: 20px;
@@ -332,7 +345,7 @@ const ArticleBody: React.SFC<{
         </header>
         <div>
             <div
-                className={bodyStyle}
+                className={cx(bodyStyle, linkColour(CAPI.pillar))}
                 dangerouslySetInnerHTML={{
                     __html: CAPI.body,
                 }}

--- a/frontend/components/ArticleBody.tsx
+++ b/frontend/components/ArticleBody.tsx
@@ -205,17 +205,19 @@ const bodyStyle = css`
     }
 `;
 
-const linkColour = (pillar: Pillar) => css`
-    a {
-        text-decoration: none;
-        border-bottom: 1px solid #dcdcdc;
-        ${pillarColours[pillar]};
+const linkColour = pillarMap(
+    pillar => css`
+        a {
+            text-decoration: none;
+            border-bottom: 1px solid #dcdcdc;
+            ${pillarColours[pillar]};
 
-        :hover {
-            border-bottom: 1px solid ${pillarPalette[pillar].main};
+            :hover {
+                border-bottom: 1px solid ${pillarPalette[pillar].main};
+            }
         }
-    }
-`;
+    `,
+);
 
 const profile = css`
     font-size: 16px;
@@ -345,7 +347,7 @@ const ArticleBody: React.SFC<{
         </header>
         <div>
             <div
-                className={cx(bodyStyle, linkColour(CAPI.pillar))}
+                className={cx(bodyStyle, linkColour[CAPI.pillar])}
                 dangerouslySetInnerHTML={{
                     __html: CAPI.body,
                 }}

--- a/frontend/components/ArticleBody.tsx
+++ b/frontend/components/ArticleBody.tsx
@@ -319,7 +319,7 @@ const ArticleBody: React.SFC<{
                 <div className={metaExtras}>
                     <SharingIcons
                         sharingUrls={CAPI.sharingUrls}
-                        pillarColour={pillarColours[CAPI.pillar]}
+                        pillar={CAPI.pillar}
                         displayIcons={['facebook', 'twitter', 'email']}
                     />
                     <ShareCount config={config} CAPI={CAPI} />

--- a/frontend/components/ShareIcons.tsx
+++ b/frontend/components/ShareIcons.tsx
@@ -1,11 +1,19 @@
 import React from 'react';
-import { css } from 'react-emotion';
+import { css, cx } from 'react-emotion';
 import { palette } from '@guardian/pasteup/palette';
 import TwitterIconPadded from '@guardian/pasteup/icons/twitter-padded.svg';
 import FacebookIcon from '@guardian/pasteup/icons/facebook.svg';
 import EmailIcon from '@guardian/pasteup/icons/email.svg';
 import { wide } from '@guardian/pasteup/breakpoints';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';
+import { pillarMap, pillarPalette } from '../pillars';
+
+const pillarFill = pillarMap(
+    pillar =>
+        css`
+            fill: ${pillarPalette[pillar].main};
+        `,
+);
 
 const shareIconList = css`
     ${wide} {
@@ -33,7 +41,6 @@ const shareIcon = (colour: string) => css`
     display: inline-block;
     vertical-align: middle;
     position: relative;
-    fill: ${colour};
     box-sizing: content-box;
 
     svg {
@@ -69,8 +76,8 @@ export const SharingIcons: React.SFC<{
         }
     };
     displayIcons: SharePlatform[];
-    pillarColour: string;
-}> = ({ sharingUrls, displayIcons, pillarColour }) => {
+    pillar: Pillar;
+}> = ({ sharingUrls, displayIcons, pillar }) => {
     const icons: { [K in SharePlatform]?: React.ComponentType } = {
         facebook: FacebookIcon,
         twitter: TwitterIconPadded,
@@ -110,7 +117,12 @@ export const SharingIcons: React.SFC<{
                             >
                                 {userMessage}
                             </span>
-                            <span className={shareIcon(pillarColour)}>
+                            <span
+                                className={cx(
+                                    shareIcon(pillarPalette[pillar].main),
+                                    pillarFill[pillar],
+                                )}
+                            >
                                 <Icon />
                             </span>
                         </a>

--- a/frontend/index.d.ts
+++ b/frontend/index.d.ts
@@ -47,12 +47,13 @@ interface CAPIType {
             userMessage: string;
         }
     },
+    pillar: Pillar
 }
 
 /**
  * the config model will contain useful app/site
  * level data. Although currently derived from the config model
- * constructed in frontend and passed to dotcom-rendering 
+ * constructed in frontend and passed to dotcom-rendering
  * this data could eventually be defined in dotcom-rendering
  */
 interface ConfigType {

--- a/frontend/lib/parse-capi/index.ts
+++ b/frontend/lib/parse-capi/index.ts
@@ -179,8 +179,7 @@ export const extractArticleMeta = (data: {}): CAPIType => {
         pageId: getNonEmptyString(data, 'config.page.pageId'),
         sharingUrls: getSharingUrls(data),
         pillar:
-            findPillar(getNonEmptyString(data, 'config.page.sectionName')) ||
-            'news',
+            findPillar(getNonEmptyString(data, 'config.page.pillar')) || 'news',
         ageWarning: getAgeWarning(webPublicationDate),
     };
 };

--- a/frontend/lib/parse-capi/index.ts
+++ b/frontend/lib/parse-capi/index.ts
@@ -177,6 +177,9 @@ export const extractArticleMeta = (data: {}): CAPIType => {
         sectionName: getNonEmptyString(data, 'config.page.section'),
         pageId: getNonEmptyString(data, 'config.page.pageId'),
         sharingUrls: getSharingUrls(data),
+        pillar:
+            findPillar(getNonEmptyString(data, 'config.page.sectionName')) ||
+            'news',
     };
 
     const ageWarning = getAgeWarning(webPublicationDate);

--- a/frontend/lib/parse-capi/index.ts
+++ b/frontend/lib/parse-capi/index.ts
@@ -108,7 +108,7 @@ const getLink = (data: {}, { isPillar }: { isPillar: boolean }): LinkType => ({
     mobileOnly: false,
 });
 
-const getAgeWarning = (webPublicationDate: Date): string | void => {
+const getAgeWarning = (webPublicationDate: Date): string | undefined => {
     const warnLimitDays = 30;
     const currentDate = new Date();
     const dateThreshold = new Date();
@@ -146,6 +146,7 @@ const getAgeWarning = (webPublicationDate: Date): string | void => {
             return `${message} 1 month old`;
         }
     }
+    return undefined;
 };
 
 // TODO really it would be nice if we passed just the data we needed and
@@ -156,7 +157,7 @@ export const extractArticleMeta = (data: {}): CAPIType => {
         getNumber(data, 'config.page.webPublicationDate'),
     );
 
-    const articleMeta: CAPIType = {
+    return {
         webPublicationDate,
         headline: apply(
             getNonEmptyString(data, 'config.page.headline'),
@@ -180,15 +181,8 @@ export const extractArticleMeta = (data: {}): CAPIType => {
         pillar:
             findPillar(getNonEmptyString(data, 'config.page.sectionName')) ||
             'news',
+        ageWarning: getAgeWarning(webPublicationDate),
     };
-
-    const ageWarning = getAgeWarning(webPublicationDate);
-
-    if (ageWarning) {
-        articleMeta.ageWarning = ageWarning;
-    }
-
-    return articleMeta;
 };
 
 export const extractNavMeta = (data: {}): NavType => {

--- a/frontend/pages/Article.tsx
+++ b/frontend/pages/Article.tsx
@@ -10,7 +10,7 @@ import Footer from '../components/Footer';
 import ArticleBody from '../components/ArticleBody';
 import BackToTop from '../components/BackToTop';
 
-interface Props {
+interface ArticleProps {
     CAPI: CAPIType;
     NAV: NavType;
     config: ConfigType;
@@ -67,7 +67,7 @@ const articleContainer = css`
 `;
 
 const Article: React.SFC<{
-    data: Props;
+    data: ArticleProps;
 }> = ({ data }) => (
     <div>
         <Header nav={data.NAV} />


### PR DESCRIPTION
## What does this change?

Brings actual pillar support to the article body:

- Content label
- Byline
- Sharing icons
- Body links

## Why?

Visual party 🎉 