### PR TITLE
Use correct font sizes and weights

### DIFF
--- a/frontend/components/ArticleBody.tsx
+++ b/frontend/components/ArticleBody.tsx
@@ -94,7 +94,7 @@ const section = (colour: string) => css`
     font-size: 16px;
     line-height: 20px;
     font-family: ${serif.headline};
-    font-weight: 900;
+    font-weight: 700;
     color: ${colour};
 
     ${leftCol} {

--- a/frontend/components/ArticleBody.tsx
+++ b/frontend/components/ArticleBody.tsx
@@ -176,7 +176,7 @@ const headerStyle = css`
     font-size: 34px;
     line-height: 38px;
     font-family: ${serif.headline};
-    font-weight: 400;
+    font-weight: 500;
     padding-bottom: 24px;
     padding-top: 3px;
 `;
@@ -187,7 +187,7 @@ const bodyStyle = css`
     }
 
     p {
-        font-size: 16px;
+        font-size: 17px;
         line-height: 24px;
         font-family: ${serif.body};
         margin-bottom: 12px;

--- a/frontend/components/Header/Nav/MainMenuToggle/index.tsx
+++ b/frontend/components/Header/Nav/MainMenuToggle/index.tsx
@@ -16,7 +16,7 @@ const navSecondaryColour = palette.neutral[20];
 const openMainMenu = css`
     display: none;
     font-family: ${serif.headline};
-    font-weight: 400;
+    font-weight: 500;
     text-decoration: none;
     color: ${navSecondaryColour};
     cursor: pointer;

--- a/frontend/components/Header/Nav/Pillars/index.tsx
+++ b/frontend/components/Header/Nav/Pillars/index.tsx
@@ -24,6 +24,7 @@ const pillarsStyles = css`
     margin: 0;
     list-style: none;
     list-style-image: none;
+    padding-left: 10px;
     ${mobileLandscape} {
         padding-left: 20px;
     }
@@ -55,9 +56,15 @@ const showMenuUnderline = css`
     }
 `;
 
+const pillarStyle = css`
+    & :first-child > a {
+        padding-left: 0;
+    }
+`;
+
 const linkStyle = css`
     font-family: ${serif.headline};
-    font-weight: 600;
+    font-weight: 700;
     text-decoration: none;
     cursor: pointer;
     display: block;
@@ -103,7 +110,7 @@ const Pillars: React.SFC<{
 }> = ({ showMainMenu, pillars }) => (
     <ul className={pillarsStyles}>
         {pillars.map(pillar => (
-            <li key={pillar.title}>
+            <li key={pillar.title} className={pillarStyle}>
                 <a
                     className={cx(linkStyle, pillarColours[pillar.pillar], {
                         showMenuUnderline: showMainMenu,

--- a/frontend/components/Header/Nav/SubNav.tsx
+++ b/frontend/components/Header/Nav/SubNav.tsx
@@ -2,20 +2,32 @@ import React, { Component, createRef } from 'react';
 import { css } from 'react-emotion';
 import { palette } from '@guardian/pasteup/palette';
 import { serif } from '@guardian/pasteup/fonts';
-import { desktop } from '@guardian/pasteup/breakpoints';
+import {
+    desktop,
+    tablet,
+    mobileMedium,
+    mobileLandscape,
+} from '@guardian/pasteup/breakpoints';
 
-const wrapperExpanded = css`
-    padding: 0 16px;
-`;
+const wrapperExpanded = css``;
 
 const wrapperCollapsed = css`
     ${wrapperExpanded};
-    height: 42px;
+    height: 36px;
     overflow: hidden;
+
+    ${tablet} {
+        height: 42px;
+    }
 `;
 
 const subnav = css`
     list-style: none;
+    padding: 0 5px;
+
+    ${tablet} {
+        padding: 0 15px;
+    }
 
     li {
         float: left;
@@ -29,17 +41,31 @@ const subnavExpanded = css`
 
 const subnavCollapsed = css`
     ${subnav};
-    max-width: calc(100% - 70px);
+    max-width: calc(100% - 60px);
+
+    ${mobileLandscape} {
+        max-width: calc(100% - 70px);
+    }
 `;
 
 const fontStyle = css`
     font-family: ${serif.headline};
-    font-weight: 400;
+    font-weight: 500;
     color: ${palette.neutral[7]};
     padding: 0 5px;
-    font-size: 15px;
+    font-size: 14px;
     height: 36px;
     line-height: 36px;
+
+    ${mobileMedium} {
+        font-size: 15px;
+    }
+
+    ${tablet} {
+        font-size: 16px;
+        height: 42px;
+        line-height: 42px;
+    }
 `;
 
 const linkStyle = css`

--- a/frontend/components/Header/Nav/SubNav.tsx
+++ b/frontend/components/Header/Nav/SubNav.tsx
@@ -9,10 +9,7 @@ import {
     mobileLandscape,
 } from '@guardian/pasteup/breakpoints';
 
-const wrapperExpanded = css``;
-
 const wrapperCollapsed = css`
-    ${wrapperExpanded};
     height: 36px;
     overflow: hidden;
 
@@ -205,7 +202,7 @@ export default class Subnav extends Component<
             );
         } else if (this.state.isExpanded) {
             el = (
-                <div className={wrapperExpanded}>
+                <div>
                     <ul ref={this.ulRef} className={subnavExpanded}>
                         {lis}
                     </ul>

--- a/frontend/components/Header/Nav/SubNav.tsx
+++ b/frontend/components/Header/Nav/SubNav.tsx
@@ -36,10 +36,10 @@ const fontStyle = css`
     font-family: ${serif.headline};
     font-weight: 400;
     color: ${palette.neutral[7]};
-    padding: 0 6px;
-    font-size: 16px;
-    height: 42px;
-    line-height: 42px;
+    padding: 0 5px;
+    font-size: 15px;
+    height: 36px;
+    line-height: 36px;
 `;
 
 const linkStyle = css`

--- a/frontend/document.tsx
+++ b/frontend/document.tsx
@@ -36,8 +36,10 @@ export default ({ data }: Props) => {
      * TODO: Identify critical fonts to preload
      */
     const fontFiles = [
-        'fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.woff2',
         'fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Regular.woff2',
+        'fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.woff2',
+        // 'fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Semibold.woff2',
+        'fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.woff2',
         'fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff2',
         // 'fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.woff2',
         'fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Medium.woff2',


### PR DESCRIPTION
## What does this change?

- preload the medium weight Guardian Headline font
- use correct font sizes and weights for most fonts. Due to changes in the font weight mappings, the `font-weight` values may look different to frontend, but the appearance on the page should be the same.

## dotcom-rendering before

![screen shot 2018-09-25 at 15 57 58](https://user-images.githubusercontent.com/5931528/46023099-ce851880-c0db-11e8-9a51-d3ee65892b49.png)

## dotcom-rendering after

![screen shot 2018-09-25 at 15 57 08](https://user-images.githubusercontent.com/5931528/46023111-d3e26300-c0db-11e8-9b3c-04cc42699727.png)

## frontend production

![screen shot 2018-09-25 at 15 56 56](https://user-images.githubusercontent.com/5931528/46023121-d8a71700-c0db-11e8-95f7-9c06fa398f9d.png)

## Why?

Closer to visual parity