### PR TITLE
Construct correct urls to be used on social share icons

### DIFF
--- a/frontend/components/ArticleBody.tsx
+++ b/frontend/components/ArticleBody.tsx
@@ -1,14 +1,12 @@
 import React from 'react';
 import { css } from 'react-emotion';
-import { palette } from '@guardian/pasteup/palette';
-import TwitterIconPadded from '@guardian/pasteup/icons/twitter-padded.svg';
 import TwitterIcon from '@guardian/pasteup/icons/twitter.svg';
-import FacebookIcon from '@guardian/pasteup/icons/facebook.svg';
-import EmailIcon from '@guardian/pasteup/icons/email.svg';
+import { palette } from '@guardian/pasteup/palette';
 import ClockIcon from '@guardian/pasteup/icons/clock.svg';
 import dateformat from 'dateformat';
 import { sans, serif } from '@guardian/pasteup/fonts';
-import ShareCount from './ShareCount';
+import { ShareCount } from './ShareCount';
+import { SharingIcons } from './ShareIcons';
 
 // tslint:disable:react-no-dangerous-html
 
@@ -203,53 +201,6 @@ const profile = (colour: string) => css`
     margin-bottom: 4px;
 `;
 
-const shareIconList = css`
-    ${wide} {
-        flex: auto;
-    }
-`;
-
-const shareIconsListItem = css`
-    padding: 0 3px 6px 0;
-    float: left;
-    min-width: 32px;
-    cursor: pointer;
-`;
-
-const shareIcon = (colour: string) => css`
-    border: 1px solid ${palette.neutral[86]};
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    min-width: 32px;
-    max-width: 100%;
-    width: auto;
-    height: 32px;
-    border-radius: 50%;
-    display: inline-block;
-    vertical-align: middle;
-    position: relative;
-    fill: ${colour};
-    box-sizing: content-box;
-
-    svg {
-        height: 88%;
-        width: 88%;
-        top: 0;
-        bottom: 0;
-        right: 0;
-        left: 0;
-        margin: auto;
-        position: absolute;
-    }
-
-    :hover {
-        background-color: ${colour};
-        border-color: ${colour};
-        fill: white;
-    }
-`;
-
 const ageWarning = (colour: string) => css`
     font-size: 12px;
     line-height: 16px;
@@ -342,29 +293,10 @@ const ArticleBody: React.SFC<{
                     {dtFormat(CAPI.webPublicationDate)}
                 </div>
                 <div className={metaExtras}>
-                    <ul className={shareIconList}>
-                        <li className={shareIconsListItem}>
-                            <a href="/" role="button">
-                                <span className={shareIcon(pillarColour)}>
-                                    <FacebookIcon />
-                                </span>
-                            </a>
-                        </li>
-                        <li className={shareIconsListItem}>
-                            <a href="/" role="button">
-                                <span className={shareIcon(pillarColour)}>
-                                    <TwitterIconPadded />
-                                </span>
-                            </a>
-                        </li>
-                        <li className={shareIconsListItem}>
-                            <a href="/" role="button">
-                                <span className={shareIcon(pillarColour)}>
-                                    <EmailIcon />
-                                </span>
-                            </a>
-                        </li>
-                    </ul>
+                    <SharingIcons
+                        sharingUrls={CAPI.sharingUrls}
+                        pillarColour={pillarColour}
+                    />
                     <ShareCount config={config} CAPI={CAPI} />
                     {CAPI.ageWarning && (
                         <div className={ageWarning(pillarColour)}>

--- a/frontend/components/ArticleBody.tsx
+++ b/frontend/components/ArticleBody.tsx
@@ -296,6 +296,7 @@ const ArticleBody: React.SFC<{
                     <SharingIcons
                         sharingUrls={CAPI.sharingUrls}
                         pillarColour={pillarColour}
+                        displayIcons={['facebook', 'twitter', 'email']}
                     />
                     <ShareCount config={config} CAPI={CAPI} />
                     {CAPI.ageWarning && (

--- a/frontend/components/ShareCount.tsx
+++ b/frontend/components/ShareCount.tsx
@@ -68,10 +68,7 @@ interface Props {
     CAPI: CAPIType;
 }
 
-export default class ShareCount extends Component<
-    Props,
-    { shareCount?: number }
-> {
+export class ShareCount extends Component<Props, { shareCount?: number }> {
     constructor(props: Props) {
         super(props);
         this.state = {};

--- a/frontend/components/ShareIcons.tsx
+++ b/frontend/components/ShareIcons.tsx
@@ -79,7 +79,7 @@ export const SharingIcons: React.SFC<{
 
     const shareList = displayIcons.reduce((list: ShareListItemType[], id) => {
         const icon = icons[id];
-        const sharingUrl = sharingUrls[id as SharePlatform];
+        const sharingUrl = sharingUrls[id];
 
         if (icon && sharingUrl) {
             const listItem: ShareListItemType = Object.assign(

--- a/frontend/components/ShareIcons.tsx
+++ b/frontend/components/ShareIcons.tsx
@@ -5,6 +5,7 @@ import TwitterIconPadded from '@guardian/pasteup/icons/twitter-padded.svg';
 import FacebookIcon from '@guardian/pasteup/icons/facebook.svg';
 import EmailIcon from '@guardian/pasteup/icons/email.svg';
 import { wide } from '@guardian/pasteup/breakpoints';
+import { screenReaderOnly } from '@guardian/pasteup/mixins';
 
 const shareIconList = css`
     ${wide} {
@@ -53,12 +54,9 @@ const shareIcon = (colour: string) => css`
     }
 `;
 
-interface ShareIconType {
+interface ShareListItemType {
     id: SharePlatform;
     Icon: React.ComponentType;
-}
-
-interface ShareListItemType extends ShareIconType {
     url: string;
     userMessage: string;
 }
@@ -70,31 +68,25 @@ export const SharingIcons: React.SFC<{
             userMessage: string;
         }
     };
+    displayIcons: SharePlatform[];
     pillarColour: string;
-}> = ({ sharingUrls, pillarColour }) => {
-    const icons: ShareIconType[] = [
-        {
-            id: 'facebook',
-            Icon: FacebookIcon,
-        },
-        {
-            id: 'twitter',
-            Icon: TwitterIconPadded,
-        },
-        {
-            id: 'email',
-            Icon: EmailIcon,
-        },
-    ];
+}> = ({ sharingUrls, displayIcons, pillarColour }) => {
+    const icons: { [K in SharePlatform]?: React.ComponentType } = {
+        facebook: FacebookIcon,
+        twitter: TwitterIconPadded,
+        email: EmailIcon,
+    };
 
-    const shareList = icons.reduce((list: ShareListItemType[], icon) => {
-        const { id } = icon;
+    const shareList = displayIcons.reduce((list: ShareListItemType[], id) => {
+        const icon = icons[id];
         const sharingUrl = sharingUrls[id as SharePlatform];
 
-        if (sharingUrl) {
+        if (icon && sharingUrl) {
             const listItem: ShareListItemType = Object.assign(
-                {},
-                icon,
+                {
+                    id,
+                    Icon: icon,
+                },
                 sharingUrl,
             );
             list.push(listItem);
@@ -106,11 +98,18 @@ export const SharingIcons: React.SFC<{
     return (
         <ul className={shareIconList}>
             {shareList.map(shareListItem => {
-                const { Icon, id, url } = shareListItem;
+                const { Icon, id, url, userMessage } = shareListItem;
 
                 return (
                     <li className={shareIconsListItem} key={`${id}Share`}>
                         <a href={url} role="button">
+                            <span
+                                className={css`
+                                    ${screenReaderOnly};
+                                `}
+                            >
+                                {userMessage}
+                            </span>
                             <span className={shareIcon(pillarColour)}>
                                 <Icon />
                             </span>

--- a/frontend/components/ShareIcons.tsx
+++ b/frontend/components/ShareIcons.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { css } from 'react-emotion';
+import { palette } from '@guardian/pasteup/palette';
+import TwitterIconPadded from '@guardian/pasteup/icons/twitter-padded.svg';
+import FacebookIcon from '@guardian/pasteup/icons/facebook.svg';
+import EmailIcon from '@guardian/pasteup/icons/email.svg';
+import { wide } from '@guardian/pasteup/breakpoints';
+
+const shareIconList = css`
+    ${wide} {
+        flex: auto;
+    }
+`;
+
+const shareIconsListItem = css`
+    padding: 0 3px 6px 0;
+    float: left;
+    min-width: 32px;
+    cursor: pointer;
+`;
+
+const shareIcon = (colour: string) => css`
+    border: 1px solid ${palette.neutral[86]};
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 32px;
+    max-width: 100%;
+    width: auto;
+    height: 32px;
+    border-radius: 50%;
+    display: inline-block;
+    vertical-align: middle;
+    position: relative;
+    fill: ${colour};
+    box-sizing: content-box;
+
+    svg {
+        height: 88%;
+        width: 88%;
+        top: 0;
+        bottom: 0;
+        right: 0;
+        left: 0;
+        margin: auto;
+        position: absolute;
+    }
+
+    :hover {
+        background-color: ${colour};
+        border-color: ${colour};
+        fill: white;
+    }
+`;
+
+interface ShareIconType {
+    id: SharePlatform;
+    Icon: React.ComponentType;
+}
+
+interface ShareListItemType extends ShareIconType {
+    url: string;
+    userMessage: string;
+}
+
+export const SharingIcons: React.SFC<{
+    sharingUrls: {
+        [K in SharePlatform]?: {
+            url: string;
+            userMessage: string;
+        }
+    };
+    pillarColour: string;
+}> = ({ sharingUrls, pillarColour }) => {
+    const icons: ShareIconType[] = [
+        {
+            id: 'facebook',
+            Icon: FacebookIcon,
+        },
+        {
+            id: 'twitter',
+            Icon: TwitterIconPadded,
+        },
+        {
+            id: 'email',
+            Icon: EmailIcon,
+        },
+    ];
+
+    const shareList = icons.reduce((list: ShareListItemType[], icon) => {
+        const { id } = icon;
+        const sharingUrl = sharingUrls[id as SharePlatform];
+
+        if (sharingUrl) {
+            const listItem: ShareListItemType = Object.assign(
+                {},
+                icon,
+                sharingUrl,
+            );
+            list.push(listItem);
+        }
+
+        return list;
+    }, []);
+
+    return (
+        <ul className={shareIconList}>
+            {shareList.map(shareListItem => {
+                const { Icon, id, url } = shareListItem;
+
+                return (
+                    <li className={shareIconsListItem} key={`${id}Share`}>
+                        <a href={url} role="button">
+                            <span className={shareIcon(pillarColour)}>
+                                <Icon />
+                            </span>
+                        </a>
+                    </li>
+                );
+            })}
+        </ul>
+    );
+};

--- a/frontend/index.d.ts
+++ b/frontend/index.d.ts
@@ -1,6 +1,6 @@
 type Pillar = 'news' | 'opinion' | 'sport' | 'culture' | 'lifestyle' ;
 
-type SharePlatform = 'facebook' | 'twitter' | 'email' | 'googlePlus' | 'whatsApp';
+type SharePlatform = 'facebook' | 'twitter' | 'email' | 'googlePlus' | 'whatsApp' | 'pinterest' | 'linkedIn' | 'messenger';
 
 // shared type declarations
 interface LinkType {

--- a/frontend/index.d.ts
+++ b/frontend/index.d.ts
@@ -1,5 +1,6 @@
 type Pillar = 'news' | 'opinion' | 'sport' | 'culture' | 'lifestyle' ;
 
+type SharePlatform = 'facebook' | 'twitter' | 'email' | 'googlePlus' | 'whatsApp';
 
 // shared type declarations
 interface LinkType {
@@ -39,7 +40,13 @@ interface CAPIType {
     webPublicationDate: Date,
     sectionName: string,
     pageId: string,
-    ageWarning?: string 
+    ageWarning?: string,
+    sharingUrls: {
+        [K in SharePlatform]?: {
+            url: string;
+            userMessage: string;
+        }
+    },
 }
 
 /**

--- a/frontend/lib/parse-capi/sharing-urls.ts
+++ b/frontend/lib/parse-capi/sharing-urls.ts
@@ -43,7 +43,7 @@ export const getSharingUrls: (
                 href: articleUrl,
                 CMP: 'share_btn_fb',
             },
-            baseUrl: 'https://twitter.com/intent/tweet',
+            baseUrl: 'https://www.facebook.com/dialog/share',
         },
         twitter: {
             userMessage: 'Share on Twitter',
@@ -52,7 +52,7 @@ export const getSharingUrls: (
                 url: articleUrl,
                 CMP: 'share_btn_tw',
             },
-            baseUrl: 'https://www.facebook.com/dialog/share',
+            baseUrl: 'https://twitter.com/intent/tweet',
         },
         email: {
             userMessage: 'Share via Email',

--- a/frontend/lib/parse-capi/sharing-urls.ts
+++ b/frontend/lib/parse-capi/sharing-urls.ts
@@ -1,0 +1,131 @@
+import { getNonEmptyString } from './';
+
+const appendParamsToUrl: (
+    baseUrl: string,
+    params: {
+        [key: string]: string;
+    },
+) => string = (baseUrl, params) =>
+    Object.keys(params).reduce((shareUrl: string, param: string, i: number) => {
+        const seperator = i > 0 ? '&amp;' : '?';
+
+        return `${shareUrl}${seperator}${encodeURIComponent(
+            param,
+        )}=${encodeURIComponent(params[param])}`;
+    }, baseUrl);
+
+export const getSharingUrls: (
+    data: any,
+) => {
+    [K in SharePlatform]?: {
+        url: string;
+        userMessage: string;
+    }
+} = data => {
+    const platforms: {
+        [K in SharePlatform]: {
+            campaignCode: string;
+            userMessage: string;
+            getShareUrl: (href: string, title: string) => string;
+        }
+    } = {
+        facebook: {
+            campaignCode: 'share_btn_fb',
+            userMessage: 'Share on Facebook',
+            getShareUrl: href => {
+                const params: {
+                    [key: string]: string;
+                } = {
+                    href,
+                    app_id: '202314643182694',
+                };
+                const baseUrl = 'https://twitter.com/intent/tweet';
+
+                return appendParamsToUrl(baseUrl, params);
+            },
+        },
+        twitter: {
+            campaignCode: 'share_btn_tw',
+            userMessage: 'Share on Twitter',
+            getShareUrl: (href, title) => {
+                const regex = /Leave.EU/gi;
+                const params: {
+                    [key: string]: string;
+                } = {
+                    text: title.replace(regex, 'Leave. EU'),
+                    url: href,
+                };
+                const baseUrl = 'https://www.facebook.com/dialog/share';
+
+                return appendParamsToUrl(baseUrl, params);
+            },
+        },
+        email: {
+            campaignCode: 'share_btn_link',
+            userMessage: 'Share via Email',
+            getShareUrl: (href, title) => {
+                const params: {
+                    [key: string]: string;
+                } = {
+                    subject: title,
+                    body: href,
+                };
+                const baseUrl = 'mailto:';
+
+                return appendParamsToUrl(baseUrl, params);
+            },
+        },
+        googlePlus: {
+            campaignCode: 'share_btn_gp',
+            userMessage: 'Share on Google+',
+            getShareUrl: href => {
+                const params = {
+                    url: href,
+                    hl: 'en-GB',
+                    wwc: '1',
+                };
+                const baseUrl = 'https://plus.google.com/share';
+
+                return appendParamsToUrl(baseUrl, params);
+            },
+        },
+        whatsApp: {
+            campaignCode: 'share_btn_wa',
+            userMessage: 'Share on WhatsApp',
+            getShareUrl: (href, title) => {
+                const params = {
+                    text: `"${title}" ${href}`,
+                };
+                const baseUrl = 'whatsapp://send';
+
+                return appendParamsToUrl(baseUrl, params);
+            },
+        },
+    };
+    const siteURL = 'https://www.theguardian.com';
+    const webUrl = `${siteURL}/${getNonEmptyString(
+        data,
+        'config.page.pageId',
+    )}`;
+    const getHref = (platform: SharePlatform): string =>
+        `${webUrl}?CMP=${platforms[platform].campaignCode}`;
+
+    return Object.keys(platforms).reduce((shareUrls, platform) => {
+        const href = getHref(platform as SharePlatform);
+        const title = getNonEmptyString(data, 'config.page.webTitle');
+
+        return Object.assign(
+            {
+                [platform]: {
+                    url: platforms[platform as SharePlatform].getShareUrl(
+                        href,
+                        title,
+                    ),
+                    userMessage:
+                        platforms[platform as SharePlatform].userMessage,
+                },
+            },
+            shareUrls,
+        );
+    }, {});
+};

--- a/frontend/lib/parse-capi/sharing-urls.ts
+++ b/frontend/lib/parse-capi/sharing-urls.ts
@@ -1,6 +1,6 @@
 import { getNonEmptyString } from './';
 
-const appendParamsToUrl: (
+const appendParamsToBaseUrl: (
     baseUrl: string,
     params: {
         [key: string]: string;
@@ -30,90 +30,94 @@ export const getSharingUrls: (
     const platforms: {
         [K in SharePlatform]: {
             userMessage: string;
-            getShareUrl: () => string;
+            params: {
+                [key: string]: string;
+            };
+            baseUrl: string;
         }
     } = {
         facebook: {
             userMessage: 'Share on Facebook',
-            getShareUrl: () => {
-                const params: {
-                    [key: string]: string;
-                } = {
-                    app_id: '202314643182694',
-                    href: articleUrl,
-                    CMP: 'share_btn_fb',
-                };
-                const baseUrl = 'https://twitter.com/intent/tweet';
-
-                return appendParamsToUrl(baseUrl, params);
+            params: {
+                app_id: '202314643182694',
+                href: articleUrl,
+                CMP: 'share_btn_fb',
             },
+            baseUrl: 'https://twitter.com/intent/tweet',
         },
         twitter: {
             userMessage: 'Share on Twitter',
-            getShareUrl: () => {
-                const regex = /Leave.EU/gi;
-                const params: {
-                    [key: string]: string;
-                } = {
-                    text: title.replace(regex, 'Leave. EU'),
-                    url: articleUrl,
-                    CMP: 'share_btn_tw',
-                };
-                const baseUrl = 'https://www.facebook.com/dialog/share';
-
-                return appendParamsToUrl(baseUrl, params);
+            params: {
+                text: title.replace(/Leave.EU/gi, 'Leave. EU'),
+                url: articleUrl,
+                CMP: 'share_btn_tw',
             },
+            baseUrl: 'https://www.facebook.com/dialog/share',
         },
         email: {
             userMessage: 'Share via Email',
-            getShareUrl: () => {
-                const params: {
-                    [key: string]: string;
-                } = {
-                    subject: title,
-                    body: articleUrl,
-                    CMP: 'share_btn_link',
-                };
-                const baseUrl = 'mailto:';
-
-                return appendParamsToUrl(baseUrl, params);
+            params: {
+                subject: title,
+                body: articleUrl,
+                CMP: 'share_btn_link',
             },
+            baseUrl: 'mailto:',
         },
         googlePlus: {
             userMessage: 'Share on Google+',
-            getShareUrl: () => {
-                const params = {
-                    url: articleUrl,
-                    hl: 'en-GB',
-                    wwc: '1',
-                    CMP: 'share_btn_gp',
-                };
-                const baseUrl = 'https://plus.google.com/share';
-
-                return appendParamsToUrl(baseUrl, params);
+            params: {
+                url: articleUrl,
+                hl: 'en-GB',
+                wwc: '1',
+                CMP: 'share_btn_gp',
             },
+            baseUrl: 'https://plus.google.com/share',
         },
         whatsApp: {
             userMessage: 'Share on WhatsApp',
-            getShareUrl: () => {
-                const params = {
-                    text: `"${title}" ${articleUrl}`,
-                    CMP: 'share_btn_wa',
-                };
-                const baseUrl = 'whatsapp://send';
-
-                return appendParamsToUrl(baseUrl, params);
+            params: {
+                text: `"${title}" ${articleUrl}`,
+                CMP: 'share_btn_wa',
             },
+            baseUrl: 'whatsapp://send',
+        },
+        pinterest: {
+            userMessage: 'Share on Pinterest',
+            params: {
+                url: articleUrl,
+            },
+            baseUrl: 'http://www.pinterest.com/pin/find/',
+        },
+        linkedIn: {
+            userMessage: 'Share on LinkedIn',
+            params: {
+                title,
+                mini: 'true',
+                url: articleUrl,
+            },
+            baseUrl: 'http://www.linkedin.com/shareArticle',
+        },
+        messenger: {
+            userMessage: 'Share on Messenger',
+            params: {
+                link: articleUrl,
+                app_id: '180444840287',
+                CMP: 'share_btn_me',
+            },
+            baseUrl: 'fb-messenger://share',
         },
     };
 
     return Object.keys(platforms).reduce((shareUrls, platform) => {
+        const { userMessage, baseUrl, params } = platforms[
+            platform as SharePlatform
+        ];
+
         return Object.assign(
             {
                 [platform]: {
-                    url: platforms[platform as SharePlatform].getShareUrl(),
-                    userMessage:
-                        platforms[platform as SharePlatform].userMessage,
+                    userMessage,
+                    url: appendParamsToBaseUrl(baseUrl, params),
                 },
             },
             shareUrls,

--- a/frontend/lib/parse-capi/sharing-urls.ts
+++ b/frontend/lib/parse-capi/sharing-urls.ts
@@ -22,22 +22,26 @@ export const getSharingUrls: (
         userMessage: string;
     }
 } = data => {
+    const articleUrl = `https://www.theguardian.com/${getNonEmptyString(
+        data,
+        'config.page.pageId',
+    )}`;
+    const title = getNonEmptyString(data, 'config.page.webTitle');
     const platforms: {
         [K in SharePlatform]: {
-            campaignCode: string;
             userMessage: string;
-            getShareUrl: (href: string, title: string) => string;
+            getShareUrl: () => string;
         }
     } = {
         facebook: {
-            campaignCode: 'share_btn_fb',
             userMessage: 'Share on Facebook',
-            getShareUrl: href => {
+            getShareUrl: () => {
                 const params: {
                     [key: string]: string;
                 } = {
-                    href,
                     app_id: '202314643182694',
+                    href: articleUrl,
+                    CMP: 'share_btn_fb',
                 };
                 const baseUrl = 'https://twitter.com/intent/tweet';
 
@@ -45,15 +49,15 @@ export const getSharingUrls: (
             },
         },
         twitter: {
-            campaignCode: 'share_btn_tw',
             userMessage: 'Share on Twitter',
-            getShareUrl: (href, title) => {
+            getShareUrl: () => {
                 const regex = /Leave.EU/gi;
                 const params: {
                     [key: string]: string;
                 } = {
                     text: title.replace(regex, 'Leave. EU'),
-                    url: href,
+                    url: articleUrl,
+                    CMP: 'share_btn_tw',
                 };
                 const baseUrl = 'https://www.facebook.com/dialog/share';
 
@@ -61,14 +65,14 @@ export const getSharingUrls: (
             },
         },
         email: {
-            campaignCode: 'share_btn_link',
             userMessage: 'Share via Email',
-            getShareUrl: (href, title) => {
+            getShareUrl: () => {
                 const params: {
                     [key: string]: string;
                 } = {
                     subject: title,
-                    body: href,
+                    body: articleUrl,
+                    CMP: 'share_btn_link',
                 };
                 const baseUrl = 'mailto:';
 
@@ -76,13 +80,13 @@ export const getSharingUrls: (
             },
         },
         googlePlus: {
-            campaignCode: 'share_btn_gp',
             userMessage: 'Share on Google+',
-            getShareUrl: href => {
+            getShareUrl: () => {
                 const params = {
-                    url: href,
+                    url: articleUrl,
                     hl: 'en-GB',
                     wwc: '1',
+                    CMP: 'share_btn_gp',
                 };
                 const baseUrl = 'https://plus.google.com/share';
 
@@ -90,11 +94,11 @@ export const getSharingUrls: (
             },
         },
         whatsApp: {
-            campaignCode: 'share_btn_wa',
             userMessage: 'Share on WhatsApp',
-            getShareUrl: (href, title) => {
+            getShareUrl: () => {
                 const params = {
-                    text: `"${title}" ${href}`,
+                    text: `"${title}" ${articleUrl}`,
+                    CMP: 'share_btn_wa',
                 };
                 const baseUrl = 'whatsapp://send';
 
@@ -102,25 +106,12 @@ export const getSharingUrls: (
             },
         },
     };
-    const siteURL = 'https://www.theguardian.com';
-    const webUrl = `${siteURL}/${getNonEmptyString(
-        data,
-        'config.page.pageId',
-    )}`;
-    const getHref = (platform: SharePlatform): string =>
-        `${webUrl}?CMP=${platforms[platform].campaignCode}`;
 
     return Object.keys(platforms).reduce((shareUrls, platform) => {
-        const href = getHref(platform as SharePlatform);
-        const title = getNonEmptyString(data, 'config.page.webTitle');
-
         return Object.assign(
             {
                 [platform]: {
-                    url: platforms[platform as SharePlatform].getShareUrl(
-                        href,
-                        title,
-                    ),
+                    url: platforms[platform as SharePlatform].getShareUrl(),
                     userMessage:
                         platforms[platform as SharePlatform].userMessage,
                 },


### PR DESCRIPTION
## What does this change?

-  Creates module `parse-capi/sharing-urls.ts` which exports `getSharingUrls`. `getSharingUrls` exports an function that returns object with urls for each social platform we support sharing on, this object is added to the `sharingUrls` property of `CAPI`.
- Takes share icons logic out of `<ArticleBody>` and creates new `<ShareIcons>` component, as this will almost certainly be reused.
- `<ShareIcons>` takes a list of `displayIcons` and returns an list of share icons to display using the data from `CAPI.sharingUrls`.

## What this doesn't do

- I have only included icons for facebook, twitter and email for now in `ShareIcons.tsx`, when we need to we can add the remaining icons.
- `parse-capi/sharing-urls.ts` contains logic for constructing sharing urls for a number of platforms, what it doesn't contain is logic to handle various edge cases depending on the article's tag type etc. I'll document these edge case and create a ticket to handle them.