### PR TITLE
Create window.guardian

### DIFF
--- a/frontend/htmlTemplate.ts
+++ b/frontend/htmlTemplate.ts
@@ -61,7 +61,7 @@ export default ({
             <body>
                 <div id='app'>${html}</div>
                 <script>
-                window.gu = ${sanitiseDomRefs(
+                window.guardian = ${sanitiseDomRefs(
                     JSON.stringify({
                         app: {
                             data,

--- a/frontend/htmlTemplate.ts
+++ b/frontend/htmlTemplate.ts
@@ -74,7 +74,6 @@ export default ({
                 )};
 
                 (function (window, document) {
-
                     function getCookieValue(name) {
                         var nameEq = name + "=",
                             cookies = document.cookie.split(';'),
@@ -89,8 +88,6 @@ export default ({
                         });
                         return value;
                     }
-                
-                
                     window.guardian.config.ophan.browserId = getCookieValue('bwid');
                 })(window, document);
                 </script>

--- a/frontend/htmlTemplate.ts
+++ b/frontend/htmlTemplate.ts
@@ -67,22 +67,7 @@ export default ({
                             data,
                             cssIDs,
                         },
-                        config: {
-                            ophan: {
-                                // This is duplicated from
-                                // https://github.com/guardian/ophan/blob/master/tracker-js/assets/coffee/ophan/transmit.coffee
-                                // Please do not change this without talking to the Ophan project first.
-                                // WHY?
-                                // https://github.com/guardian/frontend/pull/9982
-                                pageViewId:
-                                    new Date().getTime().toString(36) +
-                                    'xxxxxxxxxxxx'.replace(/x/g, () => {
-                                        return Math.floor(
-                                            Math.random() * 36,
-                                        ).toString(36);
-                                    }),
-                            },
-                        },
+                        config: {},
                     }),
                 )};
 
@@ -101,7 +86,20 @@ export default ({
                         });
                         return value;
                     }
-                    window.guardian.config.ophan.browserId = getCookieValue('bwid');
+                    window.guardian.config.ophan = {
+                        // This is duplicated from
+                        // https://github.com/guardian/ophan/blob/master/tracker-js/assets/coffee/ophan/transmit.coffee
+                        // Please do not change this without talking to the Ophan project first.
+                        // WHY?
+                        // https://github.com/guardian/frontend/pull/9982
+                        pageViewId: new Date().getTime().toString(36) +
+                            'xxxxxxxxxxxx'.replace(/x/g, () => {
+                                return Math.floor(
+                                    Math.random() * 36,
+                                ).toString(36);
+                            }),
+                        browserId: getCookieValue('bwid')
+                    };
                 })(window, document);
                 </script>
                 <script src="${vendorJS}"></script>

--- a/frontend/htmlTemplate.ts
+++ b/frontend/htmlTemplate.ts
@@ -68,21 +68,31 @@ export default ({
                             cssIDs,
                         },
                         config: {
-                            ophan: {
-                                // This is duplicated from
-                                // https://github.com/guardian/ophan/blob/master/tracker-js/assets/coffee/ophan/transmit.coffee
-                                // Please do not change this without talking to the Ophan project first.
-                                pageViewId:
-                                    new Date().getTime().toString(36) +
-                                    'xxxxxxxxxxxx'.replace(/x/g, () => {
-                                        return Math.floor(
-                                            Math.random() * 36,
-                                        ).toString(36);
-                                    }),
-                            },
+                            ophan: {},
                         },
                     }),
                 )};
+
+                (function (window, document) {
+
+                    function getCookieValue(name) {
+                        var nameEq = name + "=",
+                            cookies = document.cookie.split(';'),
+                            value = null;
+                        cookies.forEach(function (cookie) {
+                            while (cookie.charAt(0) === ' ') {
+                                cookie = cookie.substring(1, cookie.length);
+                            }
+                            if (cookie.indexOf(nameEq) === 0) {
+                                value = cookie.substring(nameEq.length, cookie.length);
+                            }
+                        });
+                        return value;
+                    }
+                
+                
+                    window.guardian.config.ophan.browserId = getCookieValue('bwid');
+                })(window, document);
                 </script>
                 <script src="${vendorJS}"></script>
                 <script src="${bundleJS}"></script>

--- a/frontend/htmlTemplate.ts
+++ b/frontend/htmlTemplate.ts
@@ -68,7 +68,20 @@ export default ({
                             cssIDs,
                         },
                         config: {
-                            ophan: {},
+                            ophan: {
+                                // This is duplicated from
+                                // https://github.com/guardian/ophan/blob/master/tracker-js/assets/coffee/ophan/transmit.coffee
+                                // Please do not change this without talking to the Ophan project first.
+                                // WHY?
+                                // https://github.com/guardian/frontend/pull/9982
+                                pageViewId:
+                                    new Date().getTime().toString(36) +
+                                    'xxxxxxxxxxxx'.replace(/x/g, () => {
+                                        return Math.floor(
+                                            Math.random() * 36,
+                                        ).toString(36);
+                                    }),
+                            },
                         },
                     }),
                 )};

--- a/frontend/htmlTemplate.ts
+++ b/frontend/htmlTemplate.ts
@@ -67,6 +67,20 @@ export default ({
                             data,
                             cssIDs,
                         },
+                        config: {
+                            ophan: {
+                                // This is duplicated from
+                                // https://github.com/guardian/ophan/blob/master/tracker-js/assets/coffee/ophan/transmit.coffee
+                                // Please do not change this without talking to the Ophan project first.
+                                pageViewId:
+                                    new Date().getTime().toString(36) +
+                                    'xxxxxxxxxxxx'.replace(/x/g, () => {
+                                        return Math.floor(
+                                            Math.random() * 36,
+                                        ).toString(36);
+                                    }),
+                            },
+                        },
                     }),
                 )};
                 </script>

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,11 @@ declare global {
             app: {
                 data: any,
                 cssIDs: Array<string>
+            },
+            config: {
+                ophan: {
+                    pageViewId: number,
+                }
             }
         }; 
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ declare global {
      *~ existing declarations in the global namespace
      */
     interface Window { 
-        gu: {
+        guardian: {
             app: {
                 data: any,
                 cssIDs: Array<string>

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ declare global {
             },
             config: {
                 ophan: {
-                    pageViewId: number,
+                    browserId: string,
                 }
             }
         }; 

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,14 +5,15 @@ declare global {
     interface Window { 
         guardian: {
             app: {
-                data: any,
-                cssIDs: Array<string>
-            },
+                data: any;
+                cssIDs: Array<string>;
+            };
             config: {
-                ophan: {
-                    browserId: string,
-                }
-            }
+                ophan?: {
+                    browserId?: string;
+                    pageViewId?: string;
+                };
+            };
         }; 
     }
 }

--- a/packages/rendering/browser.ts
+++ b/packages/rendering/browser.ts
@@ -7,7 +7,7 @@ import 'ophan-tracker-js';
 // @ts-ignore
 import Article from '../../frontend/pages/Article';
 
-const { data, cssIDs } = window.gu.app;
+const { data, cssIDs } = window.guardian.app;
 
 if (module.hot) {
     module.hot.accept();


### PR DESCRIPTION
## What does this change?

- Renames `window.gu` to `window.guardian`
- Adds `ophan` object to `window.guardian.config`, specifically for capturing the `browserId` and `pageViewId`.

## Why?

- Consistency with Frontend
- Better integration with Ophan
- Pre-empting the need to capture browser ID and page view ID for Google Analytics (#164)
- Pre-empting the need to to pre-generate `pageViewId` for better integration with certain ads platforms (guardian/frontend#9982). 