### PR TITLE
remove -s option from tslint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "packages/*"
     ],
     "scripts": {
-        "lint": "yarn tslint -s tslint.json -p . -t stylish",
+        "lint": "yarn tslint -p . -t stylish",
         "tsc": "tsc"
     },
     "bundlesize": [


### PR DESCRIPTION
## What does this change?

The [`-s` option](https://palantir.github.io/tslint/usage/cli/) is used to specify a formatters directory, however here it is being used incorrectly. 

## Why?

Removing the option doesn't seem to change anything, so let's get rid of it.