### PR TITLE
Re-apply styles to section label container

### DIFF
--- a/frontend/components/ArticleBody.tsx
+++ b/frontend/components/ArticleBody.tsx
@@ -328,7 +328,7 @@ const ArticleBody: React.SFC<{
         <header className={header}>
             {CAPI.sectionLabel &&
                 CAPI.sectionUrl && (
-                    <div>
+                    <div className={section}>
                         <a
                             className={cx(
                                 sectionLabelLink,


### PR DESCRIPTION
## What does this change?

The styles for the section label were somehow removed in the course of fixing conflicts in https://github.com/guardian/dotcom-rendering/pull/192. This re-applies them.
