### PR TITLE
Body elements

### DIFF
--- a/frontend/components/ArticleBody.tsx
+++ b/frontend/components/ArticleBody.tsx
@@ -200,11 +200,46 @@ const bodyStyle = css`
         padding-right: 80px;
     }
 
+    h2 {
+        font-size: 1.25rem;
+        line-height: 1.5rem;
+        margin-bottom: 0.0625rem;
+        font-family: ${serif.body};
+        font-weight: 900;
+    }
+
+    strong {
+        font-weight: bold;
+    }
+
     p {
+        font-family: ${serif.body};
+        margin-bottom: 16px;
         font-size: 17px;
         line-height: 24px;
+    }
+
+    ul {
+        margin-bottom: 16px;
+    }
+
+    li {
         font-family: ${serif.body};
-        margin-bottom: 12px;
+        margin-bottom: 6px;
+        padding-left: 20px;
+        font-size: 17px;
+        line-height: 24px;
+    }
+
+    li:before {
+        display: inline-block;
+        content: '';
+        border-radius: 6px;
+        height: 12px;
+        width: 12px;
+        margin-right: 8px;
+        background-color: ${palette.neutral[86]};
+        margin-left: -20px;
     }
 `;
 

--- a/frontend/components/ArticleBody.tsx
+++ b/frontend/components/ArticleBody.tsx
@@ -219,6 +219,20 @@ const bodyStyle = css`
         line-height: 24px;
     }
 
+    img {
+        width: 100%;
+        height: auto;
+    }
+
+    figcaption {
+        ${captionFont};
+    }
+
+    figure {
+        margin-top: 16px;
+        margin-bottom: 12px;
+    }
+
     ul {
         margin-bottom: 16px;
     }

--- a/frontend/components/Header/Nav/SubNav.tsx
+++ b/frontend/components/Header/Nav/SubNav.tsx
@@ -185,7 +185,7 @@ export default class Subnav extends Component<
             );
         }
 
-        return {};
+        return null;
     }
 
     private renderSubnav(links: LinkType[], parent?: LinkType | undefined) {

--- a/frontend/lib/parse-capi/index.ts
+++ b/frontend/lib/parse-capi/index.ts
@@ -108,7 +108,15 @@ const getLink = (data: {}, { isPillar }: { isPillar: boolean }): LinkType => ({
     mobileOnly: false,
 });
 
-const getAgeWarning = (webPublicationDate: Date): string | undefined => {
+const getAgeWarning = (
+    tags: TagType[],
+    webPublicationDate: Date,
+): string | undefined => {
+    const isNews = tags.some(t => t.id === 'tone/news');
+    if (!isNews) {
+        return;
+    }
+
     const warnLimitDays = 30;
     const currentDate = new Date();
     const dateThreshold = new Date();
@@ -301,8 +309,8 @@ export const extractArticleMeta = (data: {}): CAPIType => {
         sharingUrls: getSharingUrls(data),
         pillar:
             findPillar(getNonEmptyString(data, 'config.page.pillar')) || 'news',
-        ageWarning: getAgeWarning(webPublicationDate),
         tags: getTags(data),
+        ageWarning: getAgeWarning(tags, webPublicationDate),
         isImmersive: getBoolean(data, 'config.page.isImmersive', false),
         subMetaSectionLinks: getSubMetaSectionLinks({
             tags,


### PR DESCRIPTION
Add styling for some basic elements we were missing. Useful test case:

https://www.theguardian.com/help/2018/apr/18/subscriptions

Also fixes a couple of bugs I noticed while testing:

* age warning should be restricted to tone/news
* empty subnav shouldn't blow up

Image styling is tidied, but is not exactly like prod as prod moves images about (float left etc.) based on position in article and possibly other logic.

E.g. things like below are **not** covered:

![screen shot 2018-10-09 at 15 52 50](https://user-images.githubusercontent.com/858402/46677931-6b1ae080-cbdb-11e8-8c99-23ad67a45007.png)

including share icons. We'll have to do this separately.