### PR TITLE
Most viewed endpoint - correct logic

### DIFF
--- a/frontend/components/MostViewed.tsx
+++ b/frontend/components/MostViewed.tsx
@@ -151,45 +151,65 @@ interface Trail {
     url: string;
     linkText: string;
 }
-const fetchTrails: () => Promise<Trail[]> = () =>
-    new Promise((resolve, reject) => {
-        fetch('https://api.nextgen.guardianapps.co.uk/most-read-geo.json?guui')
-            .then(response => {
-                if (!response.ok) {
+
+export const MostViewed: React.SFC<{
+    sectionName: string;
+}> = ({ sectionName }) => {
+    const fetchTrails: () => Promise<Trail[]> = () => {
+        const sectionsWithoutPopular = ['info', 'global'];
+        const hasSection =
+            sectionName && !sectionsWithoutPopular.includes(sectionName);
+        const endpoint = `/most-read${
+            hasSection ? `/${sectionName}` : ''
+        }.json`;
+
+        console.log('endpoint --->', endpoint);
+
+        return new Promise((resolve, reject) => {
+            fetch(
+                `https://api.nextgen.guardianapps.co.uk${endpoint}?guui`,
+            )
+                .then(response => {
+                    if (!response.ok) {
+                        resolve([]);
+                    }
+                    return response.json();
+                })
+                .then(mostRead => {
+                    if ('trails' in mostRead) {
+                        resolve(mostRead.trails as Trail[]);
+                    }
+
                     resolve([]);
-                }
-                return response.json();
-            })
-            .then(mostRead => {
-                if ('trails' in mostRead) {
-                    resolve(mostRead.trails as Trail[]);
-                }
+                })
+                .catch(_ => resolve([]));
+        });
+    };
 
-                resolve([]);
-            })
-            .catch(_ => resolve([]));
-    });
-
-export const MostViewed: React.SFC = () => (
-    <div className={container}>
-        <h2 className={heading}>Most Viewed</h2>
-        <AsyncClientComponent f={fetchTrails}>
-            {({ data }) => (
-                <ul className={list}>
-                    {(data || []).map((trail, i) => (
-                        <li className={listItem} key={trail.url}>
-                            <span className={bigNumber}>
-                                <BigNumber index={i + 1} />
-                            </span>
-                            <h2 className={headlineHeader}>
-                                <a className={headlineLink} href={trail.url}>
-                                    {trail.linkText}
-                                </a>
-                            </h2>
-                        </li>
-                    ))}
-                </ul>
-            )}
-        </AsyncClientComponent>
-    </div>
-);
+    return (
+        <div className={container}>
+            <h2 className={heading}>Most Viewed</h2>
+            <AsyncClientComponent f={fetchTrails}>
+                {({ data }) => (
+                    <ul className={list}>
+                        {(data || []).map((trail, i) => (
+                            <li className={listItem} key={trail.url}>
+                                <span className={bigNumber}>
+                                    <BigNumber index={i + 1} />
+                                </span>
+                                <h2 className={headlineHeader}>
+                                    <a
+                                        className={headlineLink}
+                                        href={trail.url}
+                                    >
+                                        {trail.linkText}
+                                    </a>
+                                </h2>
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </AsyncClientComponent>
+        </div>
+    );
+};

--- a/frontend/components/MostViewed.tsx
+++ b/frontend/components/MostViewed.tsx
@@ -240,7 +240,7 @@ export class MostViewed extends Component<Props, { selectedTabIndex: number }> {
                         <div className={listContainer}>
                             {Array.isArray(data) &&
                                 data.length > 1 && (
-                                    <ol
+                                    <ul
                                         className={tabsContainer}
                                         role="tablist"
                                     >
@@ -278,10 +278,10 @@ export class MostViewed extends Component<Props, { selectedTabIndex: number }> {
                                                 </button>
                                             </li>
                                         ))}
-                                    </ol>
+                                    </ul>
                                 )}
                             {(data || []).map((tab, i) => (
-                                <ul
+                                <ol
                                     className={cx(list, {
                                         [hideList]:
                                             i !== this.state.selectedTabIndex,
@@ -309,7 +309,7 @@ export class MostViewed extends Component<Props, { selectedTabIndex: number }> {
                                             </h2>
                                         </li>
                                     ))}
-                                </ul>
+                                </ol>
                             ))}
                         </div>
                     )}

--- a/frontend/components/MostViewed.tsx
+++ b/frontend/components/MostViewed.tsx
@@ -8,6 +8,7 @@ import {
     leftCol,
     phablet,
 } from '@guardian/pasteup/breakpoints';
+import { screenReaderOnly } from '@guardian/pasteup/mixins';
 import { BigNumber } from '@guardian/guui';
 import { AsyncClientComponent } from './lib/AsyncClientComponent';
 
@@ -168,8 +169,8 @@ const tabsContainer = css`
 const listTab = css`
     width: 50%;
     float: left;
-    border-top: 3px solid #ededed;
-    background-color: #ededed;
+    border-top: 3px solid ${palette.neutral[93]};
+    background-color: ${palette.neutral[93]};
 
     ${phablet} {
         width: 230px;
@@ -177,10 +178,13 @@ const listTab = css`
 `;
 
 const selectedListTab = css`
-    background-color: #ffffff;
+    background-color: ${palette.neutral[100]};
 `;
 
-const tabLink = css`
+const tabButton = css`
+    margin: 0;
+    border: 0;
+    background: transparent;
     padding-left: 10px;
     padding-right: 6px;
     padding-top: 4px;
@@ -192,6 +196,7 @@ const tabLink = css`
     font-weight: 600;
     min-height: 36px;
     display: block;
+    width: 100%;
 
     ${tablet} {
         font-size: 16px;
@@ -227,8 +232,6 @@ export class MostViewed extends Component<Props, { selectedTabIndex: number }> {
     }
 
     public render() {
-        console.log(this.state.selectedTabIndex);
-
         return (
             <div className={container}>
                 <h2 className={heading}>Most Viewed</h2>
@@ -237,7 +240,10 @@ export class MostViewed extends Component<Props, { selectedTabIndex: number }> {
                         <div className={listContainer}>
                             {Array.isArray(data) &&
                                 data.length > 1 && (
-                                    <ol className={tabsContainer}>
+                                    <ol
+                                        className={tabsContainer}
+                                        role="tablist"
+                                    >
                                         {(data || []).map((tab, i) => (
                                             <li
                                                 className={cx(listTab, {
@@ -246,15 +252,30 @@ export class MostViewed extends Component<Props, { selectedTabIndex: number }> {
                                                         this.state
                                                             .selectedTabIndex,
                                                 })}
+                                                role="tab"
+                                                aria-selected={
+                                                    i ===
+                                                    this.state.selectedTabIndex
+                                                }
+                                                aria-controls={`tabs-popular-${i}`}
+                                                id={`tabs-popular-${i}-tab`}
+                                                key={`tabs-popular-${i}-tab`}
                                             >
-                                                <a
-                                                    className={tabLink}
+                                                <button
+                                                    className={tabButton}
                                                     onClick={() =>
                                                         this.tabSelected(i)
                                                     }
                                                 >
+                                                    <span
+                                                        className={css`
+                                                            ${screenReaderOnly};
+                                                        `}
+                                                    >
+                                                        Most viewed{' '}
+                                                    </span>
                                                     {tab.heading}
-                                                </a>
+                                                </button>
                                             </li>
                                         ))}
                                     </ol>
@@ -265,6 +286,10 @@ export class MostViewed extends Component<Props, { selectedTabIndex: number }> {
                                         [hideList]:
                                             i !== this.state.selectedTabIndex,
                                     })}
+                                    id={`tabs-popular-${i}`}
+                                    key={`tabs-popular-${i}`}
+                                    role="tabpanel"
+                                    aria-labelledby={`tabs-popular-${i}-tab`}
                                 >
                                     {(tab.trails || []).map((trail, ii) => (
                                         <li

--- a/frontend/index.d.ts
+++ b/frontend/index.d.ts
@@ -62,6 +62,7 @@ interface CAPIType {
     isArticle: boolean,
     sectionLabel?: string,
     sectionUrl?: string,
+    sectionName: string,
     subMetaSectionLinks: SimpleLinkType[],
     subMetaKeywordLinks: SimpleLinkType[],
 }

--- a/frontend/lib/parse-capi/index.ts
+++ b/frontend/lib/parse-capi/index.ts
@@ -281,6 +281,7 @@ export const extractArticleMeta = (data: {}): CAPIType => {
     return {
         isArticle,
         webPublicationDate,
+        sectionName,
         headline: apply(
             getNonEmptyString(data, 'config.page.headline'),
             clean,

--- a/frontend/pages/Article.tsx
+++ b/frontend/pages/Article.tsx
@@ -78,7 +78,7 @@ const Article: React.SFC<{
                     <ArticleBody CAPI={data.CAPI} config={data.config} />
                     <div className={secondaryColumn} />
                 </article>
-                <MostViewed />
+                <MostViewed sectionName={data.CAPI.sectionName} />
             </Container>
         </main>
 


### PR DESCRIPTION
## What does this change?

Copies the logic from [frontend](https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/common/modules/onward/popular.js) for deciding the endpoint to hit for "most read" article list.

These endpoints can return an array of lists, so this PR also handles that and if there are multiple lists builds tabs for toggling between the 2 lists, I've made an assumption in the styles there will never be more than 2 lists, I've never seen this on frontend.

**Two lists:**

![mostviewed](https://user-images.githubusercontent.com/1590704/46728491-dd8ecd80-cc7a-11e8-9fde-1d1323b11e5c.gif)

**One list:**

![screen shot 2018-10-10 at 10 48 52](https://user-images.githubusercontent.com/1590704/46728512-ed0e1680-cc7a-11e8-9ee3-6262e9cc5719.png)


