### PR TITLE
Use cleaned html for body and main

### DIFF
--- a/frontend/lib/parse-capi/index.ts
+++ b/frontend/lib/parse-capi/index.ts
@@ -299,11 +299,8 @@ export const extractArticleMeta = (data: {}): CAPIType => {
             clean,
             bigBullets,
         ),
-        main: apply(getString(data, 'contentFields.fields.main', ''), clean),
-        body: getArray<any>(data, 'contentFields.fields.blocks.body')
-            .map(block => block.bodyHtml)
-            .filter(Boolean)
-            .join(''),
+        main: apply(getString(data, 'contentFields.cleanedMainBlockHtml', ''), clean),
+        body: apply(getString(data, 'contentFields.cleanedBodyHtml', ''), clean),
         author: getString(data, 'config.page.author'),
         pageId: getNonEmptyString(data, 'config.page.pageId'),
         sharingUrls: getSharingUrls(data),

--- a/frontend/lib/parse-capi/index.ts
+++ b/frontend/lib/parse-capi/index.ts
@@ -299,8 +299,14 @@ export const extractArticleMeta = (data: {}): CAPIType => {
             clean,
             bigBullets,
         ),
-        main: apply(getString(data, 'contentFields.cleanedMainBlockHtml', ''), clean),
-        body: apply(getString(data, 'contentFields.cleanedBodyHtml', ''), clean),
+        main: apply(
+            getString(data, 'contentFields.cleanedMainBlockHtml', ''),
+            clean,
+        ),
+        body: apply(
+            getString(data, 'contentFields.cleanedBodyHtml', ''),
+            clean,
+        ),
         author: getString(data, 'config.page.author'),
         pageId: getNonEmptyString(data, 'config.page.pageId'),
         sharingUrls: getSharingUrls(data),


### PR DESCRIPTION
## What does this change?

We want to use i.guim links for images in the article body. In frontend, this is done by a cleaner, so we need to use the cleaned version of the html in dotcomponents instead of the raw stuff from capi. 

We already have a field for this on the model so we can just hopefully switch to using the cleaned html and it should work.

This work does not cover the main media image yet, we'll need to think of a separate solution for that I think.

https://www.theguardian.com/artanddesign/2018/sep/13/diana-funeral-re-enacted-salford-jill-dando-mariachi-band-princess-wales is a good article to test with as it has multiple body images.

## Why?
