### PR TITLE
Fix share links

### DIFF
--- a/frontend/lib/parse-capi/sharing-urls.ts
+++ b/frontend/lib/parse-capi/sharing-urls.ts
@@ -7,9 +7,9 @@ const appendParamsToBaseUrl: (
     },
 ) => string = (baseUrl, params) =>
     Object.keys(params).reduce((shareUrl: string, param: string, i: number) => {
-        const seperator = i > 0 ? '&amp;' : '?';
+        const separator = i > 0 ? '&' : '?';
 
-        return `${shareUrl}${seperator}${encodeURIComponent(
+        return `${shareUrl}${separator}${encodeURIComponent(
             param,
         )}=${encodeURIComponent(params[param])}`;
     }, baseUrl);


### PR DESCRIPTION
It looks like we were just encoding the ampersand unneccessarily here.
