### PR TITLE
Most viewed live kicker

### DIFF
--- a/frontend/components/Header/Nav/Links/index.tsx
+++ b/frontend/components/Header/Nav/Links/index.tsx
@@ -79,6 +79,7 @@ const links = css`
     left: 0;
     top: 0;
     position: absolute;
+    padding-left: 10px;
 `;
 
 const profileSubdomain = 'https://profile.theguardian.com';

--- a/frontend/components/MostViewed.tsx
+++ b/frontend/components/MostViewed.tsx
@@ -203,9 +203,22 @@ const tabButton = css`
     }
 `;
 
+const liveKicker = css`
+    color: ${palette.news.main};
+    font-weight: 700;
+
+    &::after {
+        content: '/';
+        display: inline-block;
+        font-weight: 900;
+        margin: 0 4px;
+    }
+`;
+
 interface Trail {
     url: string;
     linkText: string;
+    isLiveBlog: boolean;
 }
 
 interface Tab {
@@ -304,6 +317,15 @@ export class MostViewed extends Component<Props, { selectedTabIndex: number }> {
                                                     className={headlineLink}
                                                     href={trail.url}
                                                 >
+                                                    {!trail.isLiveBlog && (
+                                                        <span
+                                                            className={
+                                                                liveKicker
+                                                            }
+                                                        >
+                                                            Live
+                                                        </span>
+                                                    )}
                                                     {trail.linkText}
                                                 </a>
                                             </h2>

--- a/frontend/components/MostViewed.tsx
+++ b/frontend/components/MostViewed.tsx
@@ -6,6 +6,7 @@ import {
     desktop,
     tablet,
     leftCol,
+    wide,
     phablet,
 } from '@guardian/pasteup/breakpoints';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';
@@ -47,6 +48,10 @@ const heading = css`
             top: -6px;
         }
     }
+
+    ${wide} {
+        width: 210px;
+    }
 `;
 
 const listContainer = css`
@@ -54,6 +59,10 @@ const listContainer = css`
 
     ${leftCol} {
         margin-left: 160px;
+    }
+
+    ${wide} {
+        margin-left: 230px;
     }
 `;
 
@@ -317,7 +326,7 @@ export class MostViewed extends Component<Props, { selectedTabIndex: number }> {
                                                     className={headlineLink}
                                                     href={trail.url}
                                                 >
-                                                    {!trail.isLiveBlog && (
+                                                    {trail.isLiveBlog && (
                                                         <span
                                                             className={
                                                                 liveKicker


### PR DESCRIPTION
## What does this change?

Adds the live kicker if a trail has the property `isLiveBlog: true`, plus fixes some styles for most viewed at the wide breakpoint.

This change needs a change in frontend to be visible live as `isLiveBlog` is hardcoded to always be false here:

https://github.com/guardian/frontend/blob/master/onward/app/models/OnwardCollection.scala#L53

I'll raise a PR on frontend to fix this.

**Before**

![screen shot 2018-10-10 at 18 01 38](https://user-images.githubusercontent.com/1590704/46753027-a2aa8b00-ccb6-11e8-8072-a2c74b1da291.png)

**After**

![screen shot 2018-10-10 at 17 57 05](https://user-images.githubusercontent.com/1590704/46753047-afc77a00-ccb6-11e8-99a2-9fd6576ee776.png)
