### PR TITLE
Fix jumpy nav

### DIFF
--- a/frontend/components/Header/Nav/MainMenuToggle/index.tsx
+++ b/frontend/components/Header/Nav/MainMenuToggle/index.tsx
@@ -48,11 +48,6 @@ const checkbox = css`
         }
     }
 `;
-const label = css`
-    ${desktop} {
-        display: inline-block;
-    }
-`;
 const text = ({ showMainMenu }: { showMainMenu: boolean }) => css`
     display: block;
     height: 100%;
@@ -144,7 +139,7 @@ class MainMenuToggle extends Component<Props, { enhanceCheckbox: boolean }> {
             />,
             // We can't nest the input inside the label because the structure is important for CSS reasons
             <label
-                className={cx(openMainMenu, label)}
+                className={openMainMenu}
                 htmlFor={CHECKBOX_ID}
                 tabIndex={0}
                 key="OpenMainMenuLabel"


### PR DESCRIPTION
## What does this change?

Currently if you reload a Guui page there's a small (10px) gap between the bottom of the pillar dividers in the nav and the bottom of the nav, this disappears after second once the nav has been update in the client (non-js fallbacks replaced by js friendly nav elements). This fixes that bug and means the nav doesn't jump when we enhance it.

Before...
![jumpynav](https://user-images.githubusercontent.com/1590704/46868510-76ab1900-ce20-11e8-92ad-b89f42947f77.gif)

After...
![notjumpynav](https://user-images.githubusercontent.com/1590704/46868515-7ca0fa00-ce20-11e8-9494-b150e8795373.gif)