### PR TITLE
IE11 grid and flex bug

### DIFF
--- a/frontend/components/ArticleBody.tsx
+++ b/frontend/components/ArticleBody.tsx
@@ -193,7 +193,7 @@ const mainMedia = css`
             display: none;
         }
     }
-    background: pink;
+
     img {
         flex: 0 0 auto; /* IE */
         width: 100%;

--- a/frontend/components/ArticleBody.tsx
+++ b/frontend/components/ArticleBody.tsx
@@ -198,7 +198,6 @@ const mainMedia = css`
         flex: 0 0 auto; /* IE */
         width: 100%;
         height: 100%;
-        border-bottom: 1px;
     }
 
     figcaption {

--- a/frontend/components/ArticleBody.tsx
+++ b/frontend/components/ArticleBody.tsx
@@ -56,15 +56,19 @@ const wrapper = css`
         flex-direction: column;
 
         ${leftCol} {
-            display: grid;
-            grid-template-areas: 'section headline' 'meta main-media';
-            grid-template-columns: 160px 1fr;
-            margin-left: -160px;
+            @supports (display: grid) {
+                display: grid;
+                grid-template-areas: 'section headline' 'meta main-media';
+                grid-template-columns: 160px 1fr;
+                margin-left: -160px;
+            }
         }
 
         ${wide} {
-            grid-template-columns: 240px 1fr;
-            margin-left: -240px;
+            @supports (display: grid) {
+                grid-template-columns: 240px 1fr;
+                margin-left: -240px;
+            }
         }
     }
 `;
@@ -103,7 +107,9 @@ const leftColWidth = css`
 
 const section = css`
     ${leftColWidth};
-    grid-template-areas: section;
+    @supports (display: grid) {
+        grid-template-areas: 'section';
+    }
     font-size: 16px;
     line-height: 20px;
     font-family: ${serif.headline};
@@ -120,8 +126,9 @@ const section = css`
 `;
 
 const headline = css`
-    grid-template-areas: headline;
-
+    @supports (display: grid) {
+        grid-template-areas: 'headline';
+    }
     ${until.phablet} {
         padding: 0 10px;
     }
@@ -129,8 +136,9 @@ const headline = css`
 
 const meta = css`
     ${leftColWidth};
-    grid-template-areas: meta;
-
+    @supports (display: grid) {
+        grid-template-areas: 'meta';
+    }
     ${from.tablet.until.leftCol} {
         order: 1;
     }
@@ -164,7 +172,17 @@ const captionFont = css`
 `;
 
 const mainMedia = css`
-    grid-template-areas: main-media;
+    @supports (display: grid) {
+        grid-template-areas: 'main-media';
+    }
+
+    min-height: 1px;
+    /*
+    Thank you IE11, broken in stasis for all eternity.
+
+    https://github.com/philipwalton/flexbugs/issues/75#issuecomment-161800607
+    */
+
     margin-bottom: 6px;
 
     ${until.tablet} {
@@ -175,10 +193,12 @@ const mainMedia = css`
             display: none;
         }
     }
-
+    background: pink;
     img {
+        flex: 0 0 auto; /* IE */
         width: 100%;
         height: 100%;
+        border-bottom: 1px;
     }
 
     figcaption {


### PR DESCRIPTION
## What does this change?
Wraps grid stuff with `@supports (display: grid)`  and `grid-template-areas` with strings. 

```css
grid-template-area: bad
```
❌❌❌

```css
grid-template-area: 'good'
```
✅✅✅

Also it fixes a weird IE11 flow bug that came out of that fix. 
https://github.com/philipwalton/flexbugs/issues/75#issuecomment-161800607

## Why?

### 𝟙

IE11 not applying grid directives.
![image](https://user-images.githubusercontent.com/2670496/46869114-a78c4d80-ce22-11e8-9d90-cc003940c75d.png)

### ⓶ 

IE11 adding a whole bunch of phantom whitespace.

![image](https://user-images.githubusercontent.com/2670496/46869100-92172380-ce22-11e8-8bd1-7e739273e370.png)

### 𝟹

This PR is done now. 

![image](https://user-images.githubusercontent.com/2670496/46869078-87f52500-ce22-11e8-93c2-c97e4c52c030.png)

<img width="118" alt="image" src="https://user-images.githubusercontent.com/2670496/46869466-d6ef8a00-ce23-11e8-8c24-5b692d863f2e.png">

_phantom whitespace_