### PR TITLE
Show the triangle icon before figcaptions on main media

### DIFF
--- a/frontend/components/ArticleBody.tsx
+++ b/frontend/components/ArticleBody.tsx
@@ -81,6 +81,17 @@ const pillarFill = pillarMap(
             fill: ${pillarPalette[pillar].main};
         `,
 );
+const pillarFigCaptionIconColor = pillarMap(
+    pillar =>
+        css`
+            figcaption {
+                &::before {
+                    border-color: transparent transparent
+                        ${pillarPalette[pillar].main} transparent;
+                }
+            }
+        `,
+);
 
 const standfirst = css`
     font-family: ${serif.body};
@@ -183,6 +194,16 @@ const mainMedia = css`
 
     figcaption {
         ${captionFont};
+
+        &::before {
+            content: '';
+            width: 0;
+            height: 0;
+            border-style: solid;
+            border-width: 0 5.5px 10px 5.5px;
+            display: inline-block;
+            margin-right: 2px;
+        }
     }
 `;
 
@@ -437,7 +458,10 @@ const ArticleBody: React.SFC<{
                     </div>
                 </div>
                 <div
-                    className={mainMedia}
+                    className={cx(
+                        mainMedia,
+                        pillarFigCaptionIconColor[CAPI.pillar],
+                    )}
                     dangerouslySetInnerHTML={{
                         __html: CAPI.main,
                     }}

--- a/frontend/components/MostViewed.tsx
+++ b/frontend/components/MostViewed.tsx
@@ -207,6 +207,10 @@ const tabButton = css`
     display: block;
     width: 100%;
 
+    &:hover {
+        cursor: pointer;
+    }
+
     ${tablet} {
         font-size: 16px;
     }

--- a/packages/pasteup/icons/triangle.svg
+++ b/packages/pasteup/icons/triangle.svg
@@ -1,0 +1,1 @@
+<svg width="11" height="10" viewBox="0 0 11 10"><path fill-rule="evenodd" d="M5.5 0L11 10H0z"/></svg>


### PR DESCRIPTION
## What does this change?

Show the triangle icon before figcaptions on main media. Uses CSS rather than an svg as we do in frontend as the the figcaption is in the HTML passed down from CAPI.

![screen shot 2018-10-12 at 14 20 19](https://user-images.githubusercontent.com/1590704/46871726-18833380-ce2a-11e8-8df2-56e1d2a89fb8.png)

