### PR TITLE
Fix alignment of veggie burger on tablet

### DIFF
--- a/frontend/components/Header/Nav/MainMenu/index.tsx
+++ b/frontend/components/Header/Nav/MainMenu/index.tsx
@@ -6,6 +6,7 @@ import {
     mobileMedium,
     mobileLandscape,
     desktop,
+    tablet,
 } from '@guardian/pasteup/breakpoints';
 import { Columns } from './Columns';
 import { palette } from '@guardian/pasteup/palette';
@@ -46,6 +47,9 @@ const mainMenu = css`
     }
     ${mobileLandscape} {
         margin-right: 70px;
+    }
+    ${tablet} {
+        margin-right: 100px;
     }
     ${desktop} {
         display: none;

--- a/frontend/components/Header/Nav/MainMenuToggle/VeggieBurger.tsx
+++ b/frontend/components/Header/Nav/MainMenuToggle/VeggieBurger.tsx
@@ -5,6 +5,7 @@ import {
     desktop,
     mobileMedium,
     mobileLandscape,
+    tablet,
 } from '@guardian/pasteup/breakpoints';
 import { palette } from '@guardian/pasteup/palette';
 
@@ -30,6 +31,9 @@ const veggieBurger = ({ showMainMenu }: { showMainMenu: boolean }) => css`
     }
     ${mobileLandscape} {
         right: 51px;
+    }
+    ${tablet} {
+        right: 58px;
     }
     ${desktop} {
         display: none;


### PR DESCRIPTION
## What does this change?

Fixes alignment of veggie burger at `tablet` breakpoint. As described here: https://trello.com/c/P55gHXFc/210-veggie-burger-should-line-up-perfectly-with-the-i-in-guardian-at-tablet-width
