### PR TITLE
Gh pixel prefect nav

### DIFF
--- a/frontend/components/Header/Nav/EditionDropdown.tsx
+++ b/frontend/components/Header/Nav/EditionDropdown.tsx
@@ -2,18 +2,22 @@ import React from 'react';
 import { css } from 'react-emotion';
 
 import { Dropdown } from '@guardian/guui';
-import { until, wide } from '@guardian/pasteup/breakpoints';
+import { desktop, leftCol, wide } from '@guardian/pasteup/breakpoints';
 import { Link } from '@guardian/guui/components/Dropdown';
 
 const editionDropdown = css`
+    display: none;
     position: absolute;
-    right: 15px;
+    right: 11px;
     z-index: 1072;
-    ${until.desktop} {
-        display: none;
+    ${desktop} {
+        display: block;
     }
-
+    ${leftCol} {
+        right: 24px;
+    }
     ${wide} {
+        right: 14px;
         margin-right: 90px;
     }
 `;
@@ -22,26 +26,26 @@ const EditionDropdown: React.SFC = () => {
     const links: Link[] = [
         {
             url: '/preference/edition/uk',
-            title: 'UK Edition',
+            title: 'UK edition',
             isActive: true,
         },
         {
             url: '/preference/edition/us',
-            title: 'US Edition',
+            title: 'US edition',
         },
         {
             url: '/preference/edition/au',
-            title: 'Australian Edition',
+            title: 'Australian edition',
         },
         {
             url: '/preference/edition/int',
-            title: 'International Edition',
+            title: 'International edition',
         },
     ];
 
     return (
         <div className={editionDropdown}>
-            <Dropdown label="UK Edition" links={links} id="edition" />
+            <Dropdown label="UK edition" links={links} id="edition" />
         </div>
     );
 };

--- a/frontend/components/Header/Nav/Links/SupportTheGuardian.tsx
+++ b/frontend/components/Header/Nav/Links/SupportTheGuardian.tsx
@@ -3,7 +3,11 @@ import { cx, css } from 'react-emotion';
 
 import { serif } from '@guardian/pasteup/fonts';
 import { palette } from '@guardian/pasteup/palette';
-import { mobileLandscape, tablet, mobileMedium } from '@guardian/pasteup/breakpoints';
+import {
+    mobileLandscape,
+    tablet,
+    mobileMedium,
+} from '@guardian/pasteup/breakpoints';
 import ProfileIcon from '@guardian/pasteup/icons/profile.svg';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';
 

--- a/frontend/components/Header/Nav/Links/SupportTheGuardian.tsx
+++ b/frontend/components/Header/Nav/Links/SupportTheGuardian.tsx
@@ -3,7 +3,7 @@ import { cx, css } from 'react-emotion';
 
 import { serif } from '@guardian/pasteup/fonts';
 import { palette } from '@guardian/pasteup/palette';
-import { mobileLandscape, tablet } from '@guardian/pasteup/breakpoints';
+import { mobileLandscape, tablet, mobileMedium } from '@guardian/pasteup/breakpoints';
 import ProfileIcon from '@guardian/pasteup/icons/profile.svg';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';
 
@@ -18,7 +18,7 @@ const style = css`
     text-decoration: none;
 
     ${mobileLandscape} {
-        margin-left: 0;
+        margin-left: -10px;
     }
 
     :before {
@@ -59,12 +59,13 @@ const text = css`
 
 const mobileSignInContainer = css`
     display: block;
-    padding-top: 12px;
-    padding-right: 10px;
-    padding-bottom: 10px;
-    padding-left: 10px;
+    padding: 10px;
     margin-left: -8px;
     float: left;
+
+    ${mobileMedium} {
+        padding-top: 12px;
+    }
 
     ${tablet} {
         display: none;
@@ -72,8 +73,14 @@ const mobileSignInContainer = css`
 `;
 
 const mobileSignInIcon = css`
-    height: 23px;
-    width: 23px;
+    height: 18px;
+    width: 18px;
+
+    ${mobileMedium} {
+        height: 23px;
+        width: 23px;
+    }
+
     fill: ${palette.neutral[46]};
 `;
 

--- a/frontend/components/Header/Nav/Links/index.tsx
+++ b/frontend/components/Header/Nav/Links/index.tsx
@@ -14,15 +14,15 @@ const search = css`
     :after {
         content: '';
         display: inline-block;
-        width: 4px;
-        height: 4px;
+        width: 5px;
+        height: 5px;
         transform: translateY(-2px) rotate(45deg);
         border-width: 1px;
         border-style: solid;
         border-color: currentColor;
         border-left: none;
         border-top: none;
-        margin-left: 4px;
+        margin-left: 5px;
         vertical-align: middle;
         backface-visibility: hidden;
         transition: transform 250ms ease-out;
@@ -61,7 +61,7 @@ const link = ({ showAtTablet }: { showAtTablet: boolean }) => css`
 `;
 
 const paddedLink = css`
-    padding: 6px 10px;
+    padding: 5px 10px;
     margin: 1px 0 0;
 `;
 

--- a/frontend/components/Header/Nav/Logo.tsx
+++ b/frontend/components/Header/Nav/Logo.tsx
@@ -2,11 +2,12 @@ import React from 'react';
 import { css } from 'react-emotion';
 
 import {
+    mobile,
     mobileMedium,
     mobileLandscape,
+    tablet,
     desktop,
     leftCol,
-    from,
     wide,
 } from '@guardian/pasteup/breakpoints';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';
@@ -15,45 +16,44 @@ import TheGuardianLogoSVG from '@guardian/pasteup/logos/the-guardian.svg';
 
 const link = css`
     float: right;
-    margin-bottom: 15px;
-    margin-right: 45px;
+    margin-bottom: 16px;
+    margin-right: 50px;
     margin-top: 3px;
     ${mobileMedium} {
-        margin-right: 5px;
+        margin-right: 45px;
     }
-
+    ${mobileMedium} {
+        margin-right: 6px;
+    }
     ${mobileLandscape} {
         margin-right: 17px;
     }
-
     ${desktop} {
-        margin-bottom: -34px;
+        margin-bottom: -38px;
         margin-top: 5px;
         position: relative;
         z-index: 1071;
     }
-
     ${leftCol} {
-        margin-bottom: -40px;
+        margin-bottom: -44px;
     }
-
     ${wide} {
         margin-right: 96px;
     }
 `;
 
 const style = css`
-    height: 51px;
-    width: 159px;
-    ${from.mobileMedium.until.tablet} {
+    height: 44px;
+    width: 135px;
+    ${mobileMedium} {
         height: 56px;
         width: 175px;
     }
-    ${from.tablet.until.desktop} {
+    ${tablet} {
         height: 72px;
         width: 224px;
     }
-    ${from.desktop.until.leftCol} {
+    ${desktop} {
         height: 80px;
         width: 249px;
     }

--- a/frontend/components/Header/Nav/MainMenu/Column.tsx
+++ b/frontend/components/Header/Nav/MainMenu/Column.tsx
@@ -26,20 +26,24 @@ const perPillarStyles = pillarMap(
             color: ${pillarPalette[pillar].main};
             text-decoration: underline;
         }
-        ${desktop} {
-            :after {
-                content: '';
-                display: block;
-                position: absolute;
-                right: 0;
-                top: 0;
-                bottom: 0;
-                width: 1px;
-                background-color: ${palette.neutral[86]};
-            }
-        }
     `,
 );
+
+const pillarDivider = css`
+    ${desktop} {
+        :before {
+            content: '';
+            display: block;
+            position: absolute;
+            left: 0;
+            top: 0;
+            bottom: -100px;
+            width: 1px;
+            background-color: ${palette.neutral[86]};
+            z-index: 1;
+        }
+    }
+`;
 
 const columnLinkTitle = css`
     background-color: transparent;
@@ -51,7 +55,7 @@ const columnLinkTitle = css`
     display: inline-block;
     font-size: 20px;
     font-family: ${serif.headline};
-    font-weight: 400;
+    font-weight: 500;
     outline: none;
     padding: 8px 34px 8px 50px;
     position: relative;
@@ -137,7 +141,7 @@ const ColumnLinks: React.SFC<{
 }> = ({ column, showColumnLinks, id }) => {
     return (
         <ul
-            className={cx(columnLinks, {
+            className={cx(columnLinks, pillarDivider, {
                 [hide]: !showColumnLinks,
             })}
             aria-expanded={showColumnLinks}
@@ -190,7 +194,10 @@ export const More: React.SFC<{
 };
 
 export class Column extends Component<
-    { column: PillarType },
+    {
+        column: PillarType;
+        index: number;
+    },
     { showColumnLinks: boolean }
 > {
     public state = {
@@ -205,12 +212,14 @@ export class Column extends Component<
 
     public render() {
         const { showColumnLinks } = this.state;
-        const { column } = this.props;
+        const { column, index } = this.props;
         const subNavId = `${column.title.toLowerCase()}Links`;
 
         return (
             <li
-                className={cx(columnStyle, perPillarStyles[column.pillar])}
+                className={cx(columnStyle, perPillarStyles[column.pillar], {
+                    [pillarDivider]: index > 0,
+                })}
                 role="none"
             >
                 <CollapseColumnButton

--- a/frontend/components/Header/Nav/MainMenu/Columns.tsx
+++ b/frontend/components/Header/Nav/MainMenu/Columns.tsx
@@ -100,7 +100,11 @@ export const Columns: React.SFC<{
 }> = ({ nav }) => (
     <ul className={ColumnsStyle} role="menubar" tabIndex={-1}>
         {nav.pillars.map((column, i) => (
-            <Column column={column} key={column.title.toLowerCase()} />
+            <Column
+                column={column}
+                key={column.title.toLowerCase()}
+                index={i}
+            />
         ))}
         <More
             column={nav.otherLinks}

--- a/frontend/components/Header/Nav/MainMenu/index.tsx
+++ b/frontend/components/Header/Nav/MainMenu/index.tsx
@@ -30,6 +30,7 @@ const mainMenu = css`
     padding-bottom: 24px;
     top: 0;
     z-index: 1070;
+    overflow: hidden;
     ${until.desktop} {
         transform: translateX(-110%);
         transition: transform 0.4s cubic-bezier(0.23, 1, 0.32, 1);
@@ -61,6 +62,7 @@ const mainMenu = css`
         right: 0;
         width: 100%;
         border-bottom: 1px solid ${palette.neutral[86]};
+        margin-top: -20px;
         @supports (width: 100vw) {
             left: 50%;
             right: 50%;

--- a/frontend/components/Header/Nav/MainMenuToggle/VeggieBurger.tsx
+++ b/frontend/components/Header/Nav/MainMenuToggle/VeggieBurger.tsx
@@ -6,12 +6,12 @@ import {
     mobileMedium,
     mobileLandscape,
     tablet,
+    phablet,
 } from '@guardian/pasteup/breakpoints';
 import { palette } from '@guardian/pasteup/palette';
 
 const veggieBurger = ({ showMainMenu }: { showMainMenu: boolean }) => css`
     background-color: ${palette.neutral[7]};
-    top: 24px;
     box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.08);
     color: ${palette.neutral[97]};
     cursor: pointer;
@@ -21,8 +21,12 @@ const veggieBurger = ({ showMainMenu }: { showMainMenu: boolean }) => css`
     border: 0;
     border-radius: 50%;
     outline: none;
-    right: 5px;
     z-index: ${showMainMenu ? 1071 : 0};
+    top: 17px;
+    right: 5px;
+    ${mobileLandscape} {
+        top: 24px;
+    }
     ${mobileMedium} {
         bottom: -6px;
         height: 48px;
@@ -30,10 +34,12 @@ const veggieBurger = ({ showMainMenu }: { showMainMenu: boolean }) => css`
         top: auto;
     }
     ${mobileLandscape} {
-        right: 51px;
+        right: 46px;
     }
     ${tablet} {
         right: 58px;
+        height: 56px;
+        min-width: 56px;
     }
     ${desktop} {
         display: none;

--- a/frontend/components/Header/Nav/MainMenuToggle/index.tsx
+++ b/frontend/components/Header/Nav/MainMenuToggle/index.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { css, cx } from 'react-emotion';
 
-import { desktop } from '@guardian/pasteup/breakpoints';
+import { desktop, leftCol } from '@guardian/pasteup/breakpoints';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';
 import { serif } from '@guardian/pasteup/fonts';
 
@@ -27,18 +27,33 @@ const openMainMenu = css`
     background-color: transparent;
     font-size: 22px;
     height: 48px;
-    padding-top: 0;
     padding-bottom: 0;
     padding-right: 20px;
     padding-left: 5px;
+    padding-top: 9px;
+    margin-top: -6px;
     ${desktop} {
         display: block;
+    }
+    ${leftCol} {
+        margin-top: -5px;
+        font-size: 24px;
     }
     :hover {
         color: ${navPrimaryColour};
     }
     :focus {
         color: ${navPrimaryColour};
+    }
+    :before {
+        content: '';
+        display: block;
+        position: absolute;
+        left: 0;
+        top: 4px;
+        bottom: 0;
+        width: 1px;
+        background-color: ${palette.neutral[86]};
     }
 `;
 const checkbox = css`

--- a/frontend/components/Header/Nav/Pillars/index.tsx
+++ b/frontend/components/Header/Nav/Pillars/index.tsx
@@ -137,12 +137,10 @@ const Pillars: React.SFC<{
 }> = ({ showMainMenu, pillars, pillar }) => (
     <ul className={pillarsStyles}>
         {pillars.map((p, i) => (
-            <li key={p.title} className={
-                cx(
-                    pillarStyle,
-                    { [pillarDivider]: i > 0 },
-                )
-                }>
+            <li
+                key={p.title}
+                className={cx(pillarStyle, { [pillarDivider]: i > 0 })}
+            >
                 <a
                     className={cx(
                         linkStyle,

--- a/frontend/components/Header/Nav/Pillars/index.tsx
+++ b/frontend/components/Header/Nav/Pillars/index.tsx
@@ -32,28 +32,11 @@ const pillarsStyles = css`
     li {
         float: left;
         position: relative;
-        :after {
-            content: '';
-            display: block;
-            position: absolute;
-            right: 0;
-            top: 0;
-            bottom: 0;
-            width: 1px;
-            background-color: ${palette.neutral[86]};
-        }
         ${desktop} {
             width: 118px;
         }
         ${leftCol} {
             width: 140px;
-        }
-    }
-    li:last-of-type {
-        ${until.desktop} {
-            :after {
-                display: none;
-            }
         }
     }
 `;
@@ -67,6 +50,19 @@ const showMenuUnderline = css`
 const pillarStyle = css`
     & :first-child > a {
         padding-left: 0;
+    }
+`;
+
+const pillarDivider = css`
+    :before {
+        content: '';
+        display: block;
+        position: absolute;
+        left: 0;
+        top: 4px;
+        bottom: 0;
+        width: 1px;
+        background-color: ${palette.neutral[86]};
     }
 `;
 
@@ -88,8 +84,9 @@ const linkStyle = css`
         padding-right: 20px;
         padding-left: 5px;
     }
-    ${desktop} {
+    ${leftCol} {
         height: 48px;
+        font-size: 24px;
     }
     :after {
         content: '';
@@ -139,8 +136,13 @@ const Pillars: React.SFC<{
     pillar: Pillar;
 }> = ({ showMainMenu, pillars, pillar }) => (
     <ul className={pillarsStyles}>
-        {pillars.map(p => (
-            <li key={p.title} className={pillarStyle}>
+        {pillars.map((p, i) => (
+            <li key={p.title} className={
+                cx(
+                    pillarStyle,
+                    { [pillarDivider]: i > 0 },
+                )
+                }>
                 <a
                     className={cx(
                         linkStyle,

--- a/frontend/components/Header/Nav/SubNav.tsx
+++ b/frontend/components/Header/Nav/SubNav.tsx
@@ -117,7 +117,7 @@ const parentStyle = (pillar?: Pillar): string => {
             border-top: 6px solid transparent;
             border-bottom: 6px solid transparent;
             border-left: 10px solid ${colour};
-            margin-left: 2px;
+            margin-left: 4px;
         }
     `;
 };

--- a/frontend/components/Header/Nav/index.tsx
+++ b/frontend/components/Header/Nav/index.tsx
@@ -29,6 +29,7 @@ const centered = css`
     position: relative;
     margin: 0 auto;
     ${clearFix};
+    height: 108px;
 `;
 
 interface Props {
@@ -78,8 +79,8 @@ export default class Nav extends Component<
                     role="navigation"
                     aria-label="Guardian sections"
                 >
-                    <EditionDropdown />
-                    <Logo />
+                    {/* <EditionDropdown />
+                    <Logo /> */}
                     {/*
                         TODO: The properties of the Links component
                         have been hardcoded to false. At some point
@@ -90,7 +91,7 @@ export default class Nav extends Component<
                         isRecentContributor={false}
                         isSignedIn={isSignedIn}
                     />
-                    <Pillars
+                    {/* <Pillars
                         showMainMenu={showMainMenu}
                         pillars={nav.pillars}
                         pillar={pillar}
@@ -104,9 +105,9 @@ export default class Nav extends Component<
                         showMainMenu={showMainMenu}
                         id={mainMenuId}
                         nav={nav}
-                    />
+                    /> */}
                 </nav>
-                <SubNav subnav={nav.subNavSections} pillar={pillar} />
+                {/* <SubNav subnav={nav.subNavSections} pillar={pillar} /> */}
             </div>
         );
     }

--- a/frontend/components/Header/Nav/index.tsx
+++ b/frontend/components/Header/Nav/index.tsx
@@ -29,7 +29,6 @@ const centered = css`
     position: relative;
     margin: 0 auto;
     ${clearFix};
-    height: 108px;
 `;
 
 interface Props {
@@ -79,8 +78,8 @@ export default class Nav extends Component<
                     role="navigation"
                     aria-label="Guardian sections"
                 >
-                    {/* <EditionDropdown />
-                    <Logo /> */}
+                    <EditionDropdown />
+                    <Logo />
                     {/*
                         TODO: The properties of the Links component
                         have been hardcoded to false. At some point
@@ -91,7 +90,7 @@ export default class Nav extends Component<
                         isRecentContributor={false}
                         isSignedIn={isSignedIn}
                     />
-                    {/* <Pillars
+                    <Pillars
                         showMainMenu={showMainMenu}
                         pillars={nav.pillars}
                         pillar={pillar}
@@ -101,13 +100,13 @@ export default class Nav extends Component<
                         toggleMainMenu={toggleMainMenu}
                         ariaControls={mainMenuId}
                     />
-                    <MainMenu
+                    {/* <MainMenu
                         showMainMenu={showMainMenu}
                         id={mainMenuId}
                         nav={nav}
                     /> */}
                 </nav>
-                {/* <SubNav subnav={nav.subNavSections} pillar={pillar} /> */}
+                <SubNav subnav={nav.subNavSections} pillar={pillar} />
             </div>
         );
     }

--- a/frontend/components/Header/Nav/index.tsx
+++ b/frontend/components/Header/Nav/index.tsx
@@ -100,11 +100,11 @@ export default class Nav extends Component<
                         toggleMainMenu={toggleMainMenu}
                         ariaControls={mainMenuId}
                     />
-                    {/* <MainMenu
+                    <MainMenu
                         showMainMenu={showMainMenu}
                         id={mainMenuId}
                         nav={nav}
-                    /> */}
+                    />
                 </nav>
                 <SubNav subnav={nav.subNavSections} pillar={pillar} />
             </div>

--- a/packages/guui/components/Dropdown/index.tsx
+++ b/packages/guui/components/Dropdown/index.tsx
@@ -106,7 +106,7 @@ const button = css`
     font-family: ${sans.body};
     color: ${palette.neutral[7]};
     transition: color 80ms ease-out;
-    padding: 6px 10px;
+    padding: 5px 10px;
     margin: 1px 0 0;
     text-decoration: none;
 
@@ -121,13 +121,13 @@ const button = css`
     :after {
         content: '';
         display: inline-block;
-        width: 4px;
-        height: 4px;
+        width: 5px;
+        height: 5px;
         transform: translateY(-2px) rotate(45deg);
         border: 1px solid currentColor;
         border-left: transparent;
         border-top: transparent;
-        margin-left: 6px;
+        margin-left: 5px;
         vertical-align: middle;
         transition: transform 250ms ease-out;
     }


### PR DESCRIPTION
## What does this change?

Adjust a number of styles to ensure the `dotcom-rendering` nav matches the `frontend` nav so there's no jumping when switching between page's rendered between the 2. This has been tested across every one of our breakpoints. This affects everything from the `SubNav` component up.

**Before...**

![brokennav](https://user-images.githubusercontent.com/1590704/47074098-9ad87280-d1f1-11e8-9672-76327bfd8d92.gif)

**After...**

![fixednav](https://user-images.githubusercontent.com/1590704/47074111-a461da80-d1f1-11e8-9609-30d785824818.gif)

## Why?

Visual parity
