### PR TITLE
Remove pillar divider from lefhand side of News column in expanded nav

### DIFF
--- a/frontend/components/Header/Nav/MainMenu/Column.tsx
+++ b/frontend/components/Header/Nav/MainMenu/Column.tsx
@@ -124,6 +124,16 @@ const columnLinks = css`
         width: 100%;
         padding: 0 5px;
     }
+    ${pillarDivider};
+`;
+
+const firstColumn = css`
+    ${desktop} {
+        padding-left: 0;
+        :before {
+            display: none;
+        }
+    }
 `;
 
 const hide = css`
@@ -134,12 +144,17 @@ const ColumnLinks: React.SFC<{
     column: LinkType;
     showColumnLinks: boolean;
     id: string;
-}> = ({ column, showColumnLinks, id }) => {
+    index?: number;
+}> = ({ column, showColumnLinks, id, index }) => {
     return (
         <ul
-            className={cx(columnLinks, pillarDivider, {
-                [hide]: !showColumnLinks,
-            })}
+            className={cx(
+                columnLinks,
+                { [firstColumn]: index === 0 },
+                {
+                    [hide]: !showColumnLinks,
+                },
+            )}
             aria-expanded={showColumnLinks}
             role="menu"
             id={id}
@@ -231,6 +246,7 @@ export class Column extends Component<
                     column={column}
                     showColumnLinks={showColumnLinks}
                     id={subNavId}
+                    index={index}
                 />
             </li>
         );


### PR DESCRIPTION
## What does this change?

Fixes layout bug introduced by https://github.com/guardian/dotcom-rendering/pull/224

**Before...**
![screen shot 2018-10-17 at 13 40 55](https://user-images.githubusercontent.com/1590704/47086758-4e515f00-d212-11e8-988f-da7ce08143af.png)

**After...**
![screen shot 2018-10-17 at 11 53 27](https://user-images.githubusercontent.com/1590704/47086796-5e693e80-d212-11e8-960d-fd23d636c24f.png)
