### PR TITLE
Get edition from right place

### DIFF
--- a/frontend/lib/parse-capi/index.ts
+++ b/frontend/lib/parse-capi/index.ts
@@ -391,11 +391,7 @@ export interface GADataType {
 // All GA fields should  fall back to default values -
 // we should not bring down the website if a trackable field is missing!
 export const extractGAMeta = (data: {}): GADataType => {
-    const edition = getString(
-        data,
-        'guardian.config.page.edition',
-        '',
-    ).toLowerCase();
+    const edition = getString(data, 'config.page.edition', '').toLowerCase();
 
     return {
         webTitle: getString(data, 'config.page.webTitle', ''),


### PR DESCRIPTION
## What does this change?

The edition is being pulled from a non-existent property on the request body. This change fixes this

## Why?

We pass the edition to Google Analytics