### PR TITLE
Detect and reflect active edition

### DIFF
--- a/frontend/components/Header/Nav/EditionDropdown.tsx
+++ b/frontend/components/Header/Nav/EditionDropdown.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { css } from 'react-emotion';
 
 import { Dropdown } from '@guardian/guui';
 import { desktop, leftCol, wide } from '@guardian/pasteup/breakpoints';
 import { Link } from '@guardian/guui/components/Dropdown';
+import { getCookie } from '../../../lib/cookie';
 
 const editionDropdown = css`
     display: none;
@@ -22,32 +23,68 @@ const editionDropdown = css`
     }
 `;
 
-const EditionDropdown: React.SFC = () => {
-    const links: Link[] = [
-        {
-            url: '/preference/edition/uk',
-            title: 'UK edition',
-            isActive: true,
-        },
-        {
-            url: '/preference/edition/us',
-            title: 'US edition',
-        },
-        {
-            url: '/preference/edition/au',
-            title: 'Australian edition',
-        },
-        {
-            url: '/preference/edition/int',
-            title: 'International edition',
-        },
-    ];
-
-    return (
-        <div className={editionDropdown}>
-            <Dropdown label="UK edition" links={links} id="edition" />
-        </div>
-    );
+const uk: Link = {
+    url: '/preference/edition/uk',
+    title: 'UK edition',
+    isActive: true,
 };
 
-export default EditionDropdown;
+const us: Link = {
+    url: '/preference/edition/us',
+    title: 'US edition',
+};
+
+const au: Link = {
+    url: '/preference/edition/au',
+    title: 'Australian edition',
+};
+
+const int: Link = {
+    url: '/preference/edition/int',
+    title: 'International edition',
+};
+
+const defaultEdition = 'UK';
+
+const editions: { [key: string]: Link } = {
+    UK: uk,
+    US: us,
+    AU: au,
+    INT: int,
+};
+
+export default class EditionDropdown extends Component<
+    {},
+    { edition: string }
+> {
+    constructor(props: {}) {
+        super(props);
+        this.state = { edition: defaultEdition };
+    }
+
+    public componentDidMount() {
+        const selectedEdition = getCookie('GU_EDITION');
+
+        if (selectedEdition && this.state.edition !== selectedEdition) {
+            this.setState({ edition: selectedEdition });
+        }
+    }
+
+    public render() {
+        const activeEdition = editions[this.state.edition];
+        const links = [uk, us, au, int].filter(
+            ed => ed.url !== activeEdition.url,
+        );
+        links.unshift(activeEdition);
+
+        return (
+            <div className={editionDropdown}>
+                <Dropdown
+                    label={activeEdition.title}
+                    links={links}
+                    id="edition"
+                />
+            </div>
+        );
+    }
+}


### PR DESCRIPTION
Trello: https://trello.com/c/3Wi9ZpVF.

Ensures edition dropdown updates for current edition.

Note, there are some extra cases here which I *think* we can ignore for now:

https://github.com/guardian/frontend/blob/master/common/app/common/Edition.scala#L69

(They relate to ajax request-handling. Also note the comment is wrong around the cookie from what I can tell - it does get used/passed on prod).

I'm not entirely happy with this code as things stand - it seems to repeat itself a bit, and also hardcodes things like cookie IDs, which seems fragile.

Perhaps we should define this kind of stuff in a config of some kind?
