### PR TITLE
Fix navigation highlighting

### DIFF
--- a/frontend/lib/parse-capi/index.ts
+++ b/frontend/lib/parse-capi/index.ts
@@ -79,7 +79,12 @@ const getArray = <T>(
 };
 
 const findPillar: (name: string) => Pillar | undefined = name => {
-    const pillar: string = name.toLowerCase();
+    let pillar: string = name.toLowerCase();
+    // The pillar name is "arts" in CAPI, but "culture" everywhere else,
+    // therefore we perform this substitution here.
+    if (pillar === 'arts') {
+        pillar = 'culture';
+    }
     return pillarNames.find(_ => _ === pillar);
 };
 


### PR DESCRIPTION
The following article: 

https://www.theguardian.com/books/2018/oct/18/anthea-bell-magnificent-translator-of-asterix-and-kafka-dies-aged-82

is in "Culture", but is incorrectly highlighted as "News" because the CAPI pillar is "Arts" while we use "Culture" in our code base.

The solution was to rename `arts` into `culture`, in the `findPillar` in `parse-capi`.

**Before**

![before](https://user-images.githubusercontent.com/6035518/47164732-80d18980-d2f0-11e8-80cc-2f0376423cd0.png)

**After**

![after](https://user-images.githubusercontent.com/6035518/47164812-a2327580-d2f0-11e8-9130-816c120d5b1b.png)

