### PR TITLE
Remove nav HTML until necessary

### DIFF
--- a/frontend/components/Header/Nav/MainMenu/index.tsx
+++ b/frontend/components/Header/Nav/MainMenu/index.tsx
@@ -83,6 +83,6 @@ export const MainMenu: React.SFC<{
         aria-hidden={!showMainMenu}
         id={id}
     >
-        <Columns nav={nav} />
+        {showMainMenu && <Columns nav={nav} />}
     </div>
 );


### PR DESCRIPTION
## What does this change?

Currently we include the entire HTML for the `MainMenu` component in the initial server side rendered Document sent to the browser. This is unnecessary as the `MainMenu` element is hidden by default and only visible upon the user clicking the `MainMenuToggle`.

This change only renders the innerHTML for the `MainMenu` when the user clicks `MainMenuToggle`, therefore reducing the markup sent to the browser.

## Why?

Total page size with MainMenu HTML in initial response is 22.9kb, after this change it drops to 20.6kb
