### PR TITLE
make fonts.css unblocking

### DIFF
--- a/frontend/htmlTemplate.ts
+++ b/frontend/htmlTemplate.ts
@@ -44,7 +44,7 @@ export default ({
                     .join('\n')}
                 <link rel="stylesheet" href="${assets.static(
                     'css/fonts.css',
-                )}" />
+                )}" media="nope!" onload="this.media='all'"/>
                 <style>${resetCSS}${css}</style>
             </head>
             <body>


### PR DESCRIPTION
## What does this change?

The PR https://github.com/guardian/dotcom-rendering/pull/229 removed the attributes `media="nope!" onload="this.media='all'"` from the `link` element in the head used to load in `fonts.css`. These attributes serve a purpose, they trick the browser to load the css asynchronously and therefore it becomes unblocking. The technique is explained below:

> Another way is to set a stylesheet link's media attribute to a media type (or query) that does not match the user's current browsing environment, say perhaps media="print", or even something unrecognizable like media="nope!". Browsers will consider stylesheets for inapplicable media to be low-priority, and download them without blocking page rendering. That's good to know, but in order to display the stylesheet's rules once it loads, we need to use a JavaScript onload event handler to toggle the media value to something that matches the user's browsing environment, like screen or all.

https://www.filamentgroup.com/lab/async-css.html

## Why?

First Meaningful Paint time should drop now that `fonts.css` is not blocking!
