### PR TITLE
Correct the capitalisation of "Most viewed"

### DIFF
--- a/frontend/components/MostViewed.tsx
+++ b/frontend/components/MostViewed.tsx
@@ -260,7 +260,7 @@ export class MostViewed extends Component<Props, { selectedTabIndex: number }> {
     public render() {
         return (
             <div className={container}>
-                <h2 className={heading}>Most Viewed</h2>
+                <h2 className={heading}>Most viewed</h2>
                 <AsyncClientComponent f={this.fetchTrails}>
                     {({ data }) => (
                         <div className={listContainer}>


### PR DESCRIPTION
## What does this change?

Correct the display of "Most Viewed" to "Most viewed"

**Main site**:

![screenshot 2018-10-22 at 16 24 37](https://user-images.githubusercontent.com/6035518/47301533-028a2580-d617-11e8-8315-fe42e6e803aa.png)




**Component**:

![screenshot 2018-10-22 at 16 24 45](https://user-images.githubusercontent.com/6035518/47301537-061dac80-d617-11e8-8b1e-644ddd142dab.png)
