### PR TITLE
Make Phil and Pascal code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # https://help.github.com/articles/about-codeowners
-* @GHaberis @SiAdcock @sndrs @nicl @aware
+* @GHaberis @SiAdcock @sndrs @nicl @aware @shtukas @philmcmahon


### PR DESCRIPTION
## What does this change?

Makes Phil and Pascal code owners

## Why?

- They'll get copied in on every PR
- They'll get an unspecified level of prestige and joy of ownership