### PR TITLE
Remove Ophan pre-configuration

### DIFF
--- a/docs/tracking/google-analytics.md
+++ b/docs/tracking/google-analytics.md
@@ -10,8 +10,8 @@ Dimension   | Value                      | Description                          
 forceSSL    | true                       |                                                                        |
 title       | GA.webTitle                |                                                                        |
 anonymizeIp | true                       |                                                                        |
-dimension1  | ophan.pageViewId           |                                                                        |
-dimension2  | ophan.browserId            |                                                                        |
+~dimension1~|~ophan.pageViewId~          | Inactive due to GDPR                                                   |
+~dimension2~|~ophan.browserId~           | Inactive due to GDPR                                                   |
 dimension3  | 'theguardian.com'          | Platform                                                               |
 dimension4  | GA.section                 |                                                                        |
 dimension5  | GA.contentType             |                                                                        |

--- a/frontend/htmlTemplate.ts
+++ b/frontend/htmlTemplate.ts
@@ -59,37 +59,6 @@ export default ({
                         config: {},
                     }),
                 )};
-
-                (function (window, document) {
-                    function getCookieValue(name) {
-                        var nameEq = name + "=",
-                            cookies = document.cookie.split(';'),
-                            value = null;
-                        cookies.forEach(function (cookie) {
-                            while (cookie.charAt(0) === ' ') {
-                                cookie = cookie.substring(1, cookie.length);
-                            }
-                            if (cookie.indexOf(nameEq) === 0) {
-                                value = cookie.substring(nameEq.length, cookie.length);
-                            }
-                        });
-                        return value;
-                    }
-                    window.guardian.config.ophan = {
-                        // This is duplicated from
-                        // https://github.com/guardian/ophan/blob/master/tracker-js/assets/coffee/ophan/transmit.coffee
-                        // Please do not change this without talking to the Ophan project first.
-                        // WHY?
-                        // https://github.com/guardian/frontend/pull/9982
-                        pageViewId: new Date().getTime().toString(36) +
-                            'xxxxxxxxxxxx'.replace(/x/g, () => {
-                                return Math.floor(
-                                    Math.random() * 36,
-                                ).toString(36);
-                            }),
-                        browserId: getCookieValue('bwid')
-                    };
-                })(window, document);
                 (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
                     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
                     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)

--- a/frontend/lib/tracking/ga.ts
+++ b/frontend/lib/tracking/ga.ts
@@ -21,7 +21,6 @@ const getQueryParam = (
 
 export const init = (): void => {
     const { ga } = window;
-    const { ophan } = window.guardian.config;
     const { GA } = window.guardian.app.data;
     const tracker: TrackerConfig = {
         name: 'allEditorialPropertyTracker',
@@ -45,8 +44,6 @@ export const init = (): void => {
     /***************************************************************************************
      * Custom dimensions common to all platforms across the whole Guardian estate          *
      ***************************************************************************************/
-    ga(set, 'dimension1', ophan.pageViewId);
-    ga(set, 'dimension2', ophan.browserId);
     ga(set, 'dimension3', 'theguardian.com'); /* Platform */
     /***************************************************************************************
      * Custom dimensions for 'editorial' platforms (this site, the mobile apps, etc.)      *

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,12 +8,6 @@ declare global {
                 data: any;
                 cssIDs: string[];
             };
-            config: {
-                ophan: {
-                    browserId: string;
-                    pageViewId: string;
-                };
-            };
         };
         GoogleAnalyticsObject: string;
         ga: UniversalAnalytics.ga;


### PR DESCRIPTION
## What does this change?

- Removes the pre-calculation of Ophan values (browser ID and page view ID)
- Stops sending these values to Google Analytics

## Why?

- The Ophan values are needed for commercial code, possibly. Anyway, they aren't needed yet, so let's stop calculating them for now.
- These values are marked as Inactive in Google Analytics due to GDPR requirements. There is no longer any needed to send these values to GA

![screen shot 2018-10-23 at 16 31 00](https://user-images.githubusercontent.com/5931528/47372172-20bc5800-d6e1-11e8-921e-c041a0a7f983.png)
