### PR TITLE
Reader Revenue Links updates

### DIFF
--- a/frontend/index.d.ts
+++ b/frontend/index.d.ts
@@ -25,6 +25,21 @@ interface MoreType extends LinkType {
     more: true
 }
 
+interface ReaderRevenueLinks {
+    header: {
+        subscribe: string;
+        support: string;
+    },
+    footer: {
+        subscribe: string;
+        contribute: string;
+    },
+    sideMenu: {
+        subscribe: string;
+        contribute: string;
+    },
+}
+
 interface NavType {
     pillars: Array<PillarType>,
     otherLinks: MoreType,
@@ -34,6 +49,7 @@ interface NavType {
         parent?: LinkType,
         links: Array<LinkType>,
     },
+    readerRevenueLinks: ReaderRevenueLinks
 }
 
 interface AuthorType {

--- a/frontend/lib/parse-capi/index.ts
+++ b/frontend/lib/parse-capi/index.ts
@@ -374,6 +374,27 @@ export const extractNavMeta = (data: {}): NavType => {
                   ),
               }
             : undefined,
+        // TODO: replace with data from Frontend
+        readerRevenueLinks: {
+            header: {
+                subscribe:
+                    'https://support.theguardian.com/subscribe?INTCMP=header_support_subscribe&amp;acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentType%22%3A%22ACQUISITIONS_HEADER%22%2C%22componentId%22%3A%22header_support_subscribe%22%2C%22referrerPageviewId%22%3A%22jnmzvcxd5o7u2p94r35e%22%2C%22referrerUrl%22%3A%22https%3A%2F%2Fwww.theguardian.com%2Fuk%22%7D',
+                support:
+                    'https://support.theguardian.com/?INTCMP=header_support&amp;acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentType%22%3A%22ACQUISITIONS_HEADER%22%2C%22componentId%22%3A%22header_support%22%2C%22referrerPageviewId%22%3A%22jnmzvcxd5o7u2p94r35e%22%2C%22referrerUrl%22%3A%22https%3A%2F%2Fwww.theguardian.com%2Fuk%22%7D',
+            },
+            footer: {
+                subscribe:
+                    'https://support.theguardian.com/subscribe?INTCMP=footer_support_subscribe&amp;acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentType%22%3A%22ACQUISITIONS_FOOTER%22%2C%22componentId%22%3A%22footer_support_subscribe%22%2C%22referrerPageviewId%22%3A%22jnmzvcxd5o7u2p94r35e%22%2C%22referrerUrl%22%3A%22https%3A%2F%2Fwww.theguardian.com%2Fuk%22%7D',
+                contribute:
+                    'https://support.theguardian.com/contribute?INTCMP=footer_support_contribute&amp;acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentType%22%3A%22ACQUISITIONS_FOOTER%22%2C%22componentId%22%3A%22footer_support_contribute%22%2C%22referrerPageviewId%22%3A%22jnmzvcxd5o7u2p94r35e%22%2C%22referrerUrl%22%3A%22https%3A%2F%2Fwww.theguardian.com%2Fuk%22%7D',
+            },
+            sideMenu: {
+                subscribe:
+                    'https://support.theguardian.com/subscribe?INTCMP=side_menu_support_subscribe&amp;acquisitionData=%7B&quot;source&quot;:&quot;GUARDIAN_WEB&quot;,&quot;componentType&quot;:&quot;ACQUISITIONS_HEADER&quot;,&quot;componentId&quot;:&quot;side_menu_support_subscribe&quot;%7D',
+                contribute:
+                    'https://support.theguardian.com/contribute?INTCMP=side_menu_support_contribute&amp;acquisitionData=%7B&quot;source&quot;:&quot;GUARDIAN_WEB&quot;,&quot;componentType&quot;:&quot;ACQUISITIONS_HEADER&quot;,&quot;componentId&quot;:&quot;side_menu_support_contribute&quot;%7D',
+            },
+        },
     };
 };
 

--- a/frontend/web/components/Header/Nav/Links/SupportTheGuardian.tsx
+++ b/frontend/web/components/Header/Nav/Links/SupportTheGuardian.tsx
@@ -88,13 +88,15 @@ const mobileSignInIcon = css`
     fill: ${palette.neutral[46]};
 `;
 
-const SupportTheGuardian: React.SFC<{}> = () => (
+const SupportTheGuardian: React.SFC<{
+    url: string;
+}> = ({ url }) => (
     <AsyncClientComponent f={shouldShow}>
         {({ data }) => (
             <>
                 {data && (
                     <>
-                        <a className={style} href="/">
+                        <a className={style} href={url}>
                             <div className={text}>
                                 Support The
                                 <br /> Guardian

--- a/frontend/web/components/Header/Nav/Links/index.tsx
+++ b/frontend/web/components/Header/Nav/Links/index.tsx
@@ -83,8 +83,6 @@ const links = css`
 `;
 
 const profileSubdomain = 'https://profile.theguardian.com';
-const subscribeUrl =
-    'https://support.theguardian.com/subscribe?INTCMP=header_support_subscribe&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentType%22%3A%22ACQUISITIONS_HEADER%22%2C%22componentId%22%3A%22header_support_subscribe%22%2C%22referrerPageviewId%22%3A%22jkjutjbkxfh1d8yyadfc%22%2C%22referrerUrl%22%3A%22https%3A%2F%2Fwww.theguardian.com%2Fuk%22%7D';
 const jobsUrl = 'https://jobs.theguardian.com/?INTCMP=jobs_uk_web_newheader';
 const datingUrl =
     'https://soulmates.theguardian.com/?INTCMP=soulmates_uk_web_newheader';
@@ -129,11 +127,20 @@ const Links: React.SFC<{
     isPayingMember: boolean;
     isRecentContributor: boolean;
     isSignedIn: boolean;
-}> = ({ isPayingMember, isRecentContributor, isSignedIn }) => (
+    readerRevenueLinks: ReaderRevenueLinks;
+}> = ({
+    isPayingMember,
+    isRecentContributor,
+    isSignedIn,
+    readerRevenueLinks,
+}) => (
     <div className={links}>
-        {isPayingMember || isRecentContributor || <SupportTheGuardian />}
+        {isPayingMember ||
+            isRecentContributor || (
+                <SupportTheGuardian url={readerRevenueLinks.header.support} />
+            )}
         <a
-            href={subscribeUrl}
+            href={readerRevenueLinks.header.subscribe}
             className={cx(link({ showAtTablet: true }), paddedLink)}
         >
             Subscribe

--- a/frontend/web/components/Header/Nav/MainMenu/Column.tsx
+++ b/frontend/web/components/Header/Nav/MainMenu/Column.tsx
@@ -229,11 +229,7 @@ export const More: React.SFC<{
     return (
         <li className={cx(columnStyle)} role="none">
             <MembershipLinks />
-            <ColumnLinks
-                column={more}
-                showColumnLinks={true}
-                id={subNavId}
-            />
+            <ColumnLinks column={more} showColumnLinks={true} id={subNavId} />
         </li>
     );
 };

--- a/frontend/web/components/Header/Nav/MainMenu/Column.tsx
+++ b/frontend/web/components/Header/Nav/MainMenu/Column.tsx
@@ -90,7 +90,7 @@ const mainMenuLinkStyle = css`
     }
 `;
 
-const membershipLinks = css`
+const readerRevenueLinksStyle = css`
     background-color: ${palette.neutral[93]};
 `;
 
@@ -185,24 +185,26 @@ const columnStyle = css`
     }
 `;
 
-const MembershipLinks: React.SFC<{}> = () => {
+export const ReaderRevenueLinks: React.SFC<{
+    readerRevenueLinks: ReaderRevenueLinks;
+}> = ({ readerRevenueLinks }) => {
     const links: LinkType[] = [
         {
             longTitle: 'Make a contribution',
             title: 'Make a contribution',
             mobileOnly: true,
-            url: '#',
+            url: readerRevenueLinks.sideMenu.contribute,
         },
         {
             longTitle: 'Subscribe',
             title: 'Subscribe',
             mobileOnly: true,
-            url: '#',
+            url: readerRevenueLinks.sideMenu.subscribe,
         },
     ];
 
     return (
-        <ul className={cx(membershipLinks, hideDesktop)}>
+        <ul className={cx(readerRevenueLinksStyle, hideDesktop)}>
             {(links || []).map(link => (
                 <ColumnLink link={link} key={link.title.toLowerCase()} />
             ))}
@@ -228,7 +230,6 @@ export const More: React.SFC<{
     };
     return (
         <li className={cx(columnStyle)} role="none">
-            <MembershipLinks />
             <ColumnLinks column={more} showColumnLinks={true} id={subNavId} />
         </li>
     );

--- a/frontend/web/components/Header/Nav/MainMenu/Column.tsx
+++ b/frontend/web/components/Header/Nav/MainMenu/Column.tsx
@@ -205,7 +205,7 @@ export const ReaderRevenueLinks: React.SFC<{
 
     return (
         <ul className={cx(readerRevenueLinksStyle, hideDesktop)}>
-            {(links || []).map(link => (
+            {links.map(link => (
                 <ColumnLink link={link} key={link.title.toLowerCase()} />
             ))}
         </ul>

--- a/frontend/web/components/Header/Nav/MainMenu/Column.tsx
+++ b/frontend/web/components/Header/Nav/MainMenu/Column.tsx
@@ -90,6 +90,10 @@ const mainMenuLinkStyle = css`
     }
 `;
 
+const membershipLinks = css`
+    background-color: ${palette.neutral[93]};
+`;
+
 const ColumnLink: React.SFC<{
     link: LinkType;
 }> = ({ link }) => (
@@ -181,6 +185,31 @@ const columnStyle = css`
     }
 `;
 
+const MembershipLinks: React.SFC<{}> = () => {
+    const links: LinkType[] = [
+        {
+            longTitle: 'Make a contribution',
+            title: 'Make a contribution',
+            mobileOnly: true,
+            url: '#',
+        },
+        {
+            longTitle: 'Subscribe',
+            title: 'Subscribe',
+            mobileOnly: true,
+            url: '#',
+        },
+    ];
+
+    return (
+        <ul className={cx(membershipLinks, hideDesktop)}>
+            {(links || []).map(link => (
+                <ColumnLink link={link} key={link.title.toLowerCase()} />
+            ))}
+        </ul>
+    );
+};
+
 export const More: React.SFC<{
     column: LinkType;
     brandExtensions: LinkType[];
@@ -199,7 +228,12 @@ export const More: React.SFC<{
     };
     return (
         <li className={cx(columnStyle)} role="none">
-            <ColumnLinks column={more} showColumnLinks={true} id={subNavId} />
+            <MembershipLinks />
+            <ColumnLinks
+                column={more}
+                showColumnLinks={true}
+                id={subNavId}
+            />
         </li>
     );
 };

--- a/frontend/web/components/Header/Nav/MainMenu/Columns.tsx
+++ b/frontend/web/components/Header/Nav/MainMenu/Columns.tsx
@@ -4,7 +4,7 @@ import { css } from 'react-emotion';
 import { tablet, desktop, leftCol, wide } from '@guardian/pasteup/breakpoints';
 import { serif } from '@guardian/pasteup/fonts';
 
-import { Column, More } from './Column';
+import { Column, More, ReaderRevenueLinks } from './Column';
 import { palette } from '@guardian/pasteup/palette';
 
 const ColumnsStyle = css`
@@ -106,6 +106,7 @@ export const Columns: React.SFC<{
                 index={i}
             />
         ))}
+        <ReaderRevenueLinks readerRevenueLinks={nav.readerRevenueLinks} />
         <More
             column={nav.otherLinks}
             brandExtensions={nav.brandExtensions}

--- a/frontend/web/components/Header/Nav/index.tsx
+++ b/frontend/web/components/Header/Nav/index.tsx
@@ -88,6 +88,7 @@ export default class Nav extends Component<
                         isPayingMember={false}
                         isRecentContributor={false}
                         isSignedIn={isSignedIn}
+                        readerRevenueLinks={nav.readerRevenueLinks}
                     />
                     <Pillars
                         showMainMenu={showMainMenu}


### PR DESCRIPTION
## What does this change?

- Adds `ReaderRevenueLinks` component into the main menu, only visible at mobile breakpoint
- Adds `readerRevenueLinks` to the `nav` data model, and updates `Links` and `Support The Guardian` to use the data from this model.

Before:
![screen shot 2018-10-24 at 11 45 52](https://user-images.githubusercontent.com/1590704/47425506-7137c200-d782-11e8-88d7-6d47262feca7.png)

After:
![screen shot 2018-10-24 at 11 45 28](https://user-images.githubusercontent.com/1590704/47425515-78f76680-d782-11e8-9826-0959820eb4ed.png)

**TODO**
- `readerRevenueLinks` should come from `frontend` in the `nav` model it sends over.
- The links in the `Footer` component should also come from frontend eventually.
