### PR TITLE
Load priority scripts asynchronously

### DIFF
--- a/frontend/web/document.tsx
+++ b/frontend/web/document.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { extractCritical } from 'emotion-server';
 import { renderToString } from 'react-dom/server';
 
-import assets from '../lib/assets';
 import htmlTemplate from './htmlTemplate';
 import Article from './pages/Article';
+import assets from '../lib/assets';
 import { GADataType } from '../lib/parse-capi';
 
 interface Props {
@@ -27,7 +27,6 @@ interface RenderToStringResult {
 export default ({ data }: Props) => {
     const { page, site, CAPI, NAV, config } = data;
     const title = `${CAPI.headline} | ${CAPI.sectionLabel} | The Guardian`;
-    const bundleJS = assets.dist(`${site}.${page.toLowerCase()}.js`);
     const { html, css, ids: cssIDs }: RenderToStringResult = extractCritical(
         renderToString(<Article data={{ CAPI, NAV, config }} />),
     );
@@ -50,8 +49,16 @@ export default ({ data }: Props) => {
         'fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Bold.woff2',
     ];
 
+    /**
+     * The highest priority scripts.
+     * Only scripts critical to application execution may go in here
+     */
+    const bundleJS = assets.dist(`${site}.${page.toLowerCase()}.js`);
+    const vendorJS = assets.dist('vendor.js');
+    const priorityScripts = [vendorJS, bundleJS];
+
     return htmlTemplate({
-        bundleJS,
+        priorityScripts,
         css,
         html,
         cssIDs,


### PR DESCRIPTION
## What does this change?

Currently, all scripts are loaded synchronously at the bottom of the body. This optimises for first paint, as JavaScript will not block the main thread. It does compromise on time to interactive, as JavaScript finishes executing much later.

This change loads prioritised scripts asynchronously. The script loads are kicked off in the head of the document, ensuring they finish doing their thing much sooner. The time to interactive should be reduced. This may come at the expense of first paint times, as the JavaScript blocks the initial render.

## Why?

This is an attempt to reduce the time to interactive. It also provides developers with a convenient "bucket" to add high priority scripts.

I've ran a few lighthouse tests, but I have not noticed any conclusive changes to first paint or interactive times. I suggest we put this change live for a few days and see what Speedcurve makes of it. If successful, I'll write up some better docs for the `priorityScripts` array.