### PR TITLE
Update to adr for elements

### DIFF
--- a/docs/architecture/011-capi-elements-as-components.md
+++ b/docs/architecture/011-capi-elements-as-components.md
@@ -4,6 +4,10 @@
 
 CAPI provides a representation of content which is strongly typed and like components.
 
+Frontend uses this representation to render liveblogs.
+
+_Note: This document has been updated with the knowledge that the `model.liveblog` representation is a dotcom abstraction and not directly from CAPI._
+
 ## Decision
 
 The CAPI Blocks API exposes a suite of strongly typed elements. A component should be made for each element to render it.
@@ -12,13 +16,13 @@ Each element must have a type in dotcom rendering which specifies the data it ma
 
 #### Unaltered Elements
 
-Some elements are represented in CAPI in a form which is directly renderable. For instance the `TextBlockElement`. These may be sent unaltered to dotcom rendering.
+Some elements are ~~represented in CAPI in a~~ converted for the liveblog into a form which is directly renderable. For instance the `TextBlockElement`. These may be sent unaltered to dotcom rendering.
 
-Their `_type` field must remain unaltered from the CAPI response. They should be of the form `model.liveblog.`.
+~~Their `_type` field must remain unaltered from the CAPI response. They should be of the form `model.liveblog.`.~~
 
 ### Altered Elements
 
-Some elements contain data which is unsuitable for direct rendering, these should be transformed outside of dotcom rendering. Their `_type` field should be set and should read `dotcom.element.`.
+Some elements contain data which is unsuitable for direct rendering, these should be transformed outside of dotcom rendering. Their `_type` field should be set ~~and should read `dotcom.element`.~~
 
 The transformed element should contain all of the `Props` required by the Components which render the element. It should not dictate HTML to be rendered into the page except where unavoidable. An element might need to directly set HTML if it contains text with markup. For instance, bold, italics and inline text in a `textBlockElement`.
 

--- a/docs/architecture/011-capi-elements-as-components.md
+++ b/docs/architecture/011-capi-elements-as-components.md
@@ -16,13 +16,11 @@ Each element must have a type in dotcom rendering which specifies the data it ma
 
 #### Unaltered Elements
 
-Some elements are ~~represented in CAPI in a~~ converted for the liveblog into a form which is directly renderable. For instance the `TextBlockElement`. These may be sent unaltered to dotcom rendering.
-
-~~Their `_type` field must remain unaltered from the CAPI response. They should be of the form `model.liveblog.`.~~
+Some elements are converted for the liveblog into a form which is directly renderable. For instance the `TextBlockElement`. These may be sent unaltered to dotcom rendering.
 
 ### Altered Elements
 
-Some elements contain data which is unsuitable for direct rendering, these should be transformed outside of dotcom rendering. Their `_type` field should be set ~~and should read `dotcom.element`.~~
+Some elements contain data which is unsuitable for direct rendering, these should be transformed outside of dotcom rendering. Their `_type` field should be set.
 
 The transformed element should contain all of the `Props` required by the Components which render the element. It should not dictate HTML to be rendered into the page except where unavoidable. An element might need to directly set HTML if it contains text with markup. For instance, bold, italics and inline text in a `textBlockElement`.
 


### PR DESCRIPTION
## What does this change?
Updates the elements adr as the api is actually a dotcom one and not a CAPI one, so we should probably discuss what we want to do here.

## Why?
https://github.com/guardian/dotcom-rendering/pull/256