### PR TITLE
Install node-fetch

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@guardian/frontend-rendering",
   "version": "0.1.0-alpha.1",
-  "description": "guardian.com rendering tier",
+  "description": "theguardian.com rendering tier",
   "main": "index.js",
   "scripts": {
     "test": "jest"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "friendly-errors-webpack-plugin": "^1.7.0",
         "log-update": "^2.3.0",
         "minify-css-string": "^1.0.0",
+        "node-fetch": "^2.2.1",
         "prettier": "^1.7.4",
         "simple-progress-webpack-plugin": "^1.1.2",
         "string-replace-loader": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5563,6 +5563,10 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
+node-fetch@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.2.1.tgz#1fe551e0ded6c45b3b3b937d0fb46f76df718d1e"
+
 node-gyp@^3.6.2:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-3.8.0.tgz#540304261c330e80d0d5edce253a68cb3964218c"


### PR DESCRIPTION
## What does this change?

Installs the `node-fetch` library

## Why?

`node-fetch` is used by the `dev-server` but is not installed as a `devDependency`. Right now it's a miracle the application even runs.