### PR TITLE
Use guardian fonts in amp project.

### DIFF
--- a/frontend/amp/components/elements/TextBlockComponent.tsx
+++ b/frontend/amp/components/elements/TextBlockComponent.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { css } from 'react-emotion';
 import { palette } from '@guardian/pasteup/palette';
 import { pillarPalette } from '../../../lib/pillars';
+import { serif } from '@guardian/pasteup/fonts';
 
 // tslint:disable:react-no-dangerous-html
 const style = (pillar: Pillar) => css`
@@ -22,6 +23,7 @@ const style = (pillar: Pillar) => css`
             border-bottom: 1px solid ${pillarPalette[pillar].main};
         }
     }
+    font-family: ${serif.body};
 `;
 export const TextBlockComponent: React.SFC<{
     html: string;

--- a/frontend/amp/document.tsx
+++ b/frontend/amp/document.tsx
@@ -1,6 +1,7 @@
 import { extractCritical } from 'emotion-server';
 import { renderToString } from 'react-dom/server';
 import resetCSS from /* preval */ '../lib/reset-css';
+import fontsCss from '../lib/fonts-css';
 
 interface RenderToStringResult {
     html: string;
@@ -18,6 +19,7 @@ export default ({ body }: { body: React.ReactElement<any> }) => {
     <meta charset="utf-8">
     <link rel="canonical" href="self.html" />
     <meta name="viewport" content="width=device-width,minimum-scale=1">
+    <style>${fontsCss}${resetCSS}${css}</style>
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <script async src="https://cdn.ampproject.org/v0.js"></script>
     <style amp-custom>${resetCSS}${css}</style>


### PR DESCRIPTION
## What does this change?
Imports prexisting fontsCSS into the AMP templates

We haven't bothered with https://www.ampproject.org/docs/reference/components/amp-font at the moment as we're not sure how much value it adds...maybe something for further down the line.

## Why?
So that AMP pages are more on brand

![font gif](https://media.giphy.com/media/7bciO9vprkuqc/giphy.gif)