### PR TITLE
Polyfill.io callback

### DIFF
--- a/frontend/web/browser.ts
+++ b/frontend/web/browser.ts
@@ -5,28 +5,38 @@ import 'ophan-tracker-js';
 
 import Article from './pages/Article';
 
-const { data, cssIDs } = window.guardian.app;
+// kick off the app
+const go = () => {
+    const { data, cssIDs } = window.guardian.app;
 
-if (module.hot) {
-    module.hot.accept();
-}
-
-const container = document.getElementById('app');
-
-if (container) {
-    /**
-     * TODO: Remove conditional when Emotion's issue is resolved.
-     * We're having to prevent emotion hydrating styles in the browser
-     * in development mode to retain the sourceMap info. As detailed
-     * in the issue raised here https://github.com/emotion-js/emotion/issues/487
-     */
-    if (process.env.NODE_ENV !== 'development') {
-        hydrateCSS(cssIDs);
+    if (module.hot) {
+        module.hot.accept();
     }
 
-    hydrateApp(React.createElement(Article, { data }), container);
-}
+    const container = document.getElementById('app');
 
-import('./lib/ga').then(({ init }) => {
-    init();
-});
+    if (container) {
+        /**
+         * TODO: Remove conditional when Emotion's issue is resolved.
+         * We're having to prevent emotion hydrating styles in the browser
+         * in development mode to retain the sourceMap info. As detailed
+         * in the issue raised here https://github.com/emotion-js/emotion/issues/487
+         */
+        if (process.env.NODE_ENV !== 'development') {
+            hydrateCSS(cssIDs);
+        }
+
+        hydrateApp(React.createElement(Article, { data }), container);
+    }
+
+    import('./lib/ga').then(({ init }) => {
+        init();
+    });
+};
+
+// make sure we've patched the env before running the app
+if (window.guardian.polyfilled) {
+    go();
+} else {
+    window.guardian.onPolyfilled = go;
+}

--- a/frontend/web/document.tsx
+++ b/frontend/web/document.tsx
@@ -57,7 +57,7 @@ export default ({ data }: Props) => {
     const bundleJS = assets.dist(`${site}.${page.toLowerCase()}.js`);
     const vendorJS = assets.dist('vendor.js');
     const polyfillIO =
-        'https://assets.guim.co.uk/polyfill.io/v2/polyfill.min.js?rum=0&features=es6,es7,es2017,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry&flags=gated&unknown=polyfill';
+        'https://assets.guim.co.uk/polyfill.io/v2/polyfill.min.js?rum=0&features=es6,es7,es2017,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry&flags=gated&callback=guardianPolyfilled&unknown=polyfill';
     const priorityScripts = [polyfillIO, vendorJS, bundleJS];
 
     return htmlTemplate({

--- a/frontend/web/htmlTemplate.ts
+++ b/frontend/web/htmlTemplate.ts
@@ -49,8 +49,8 @@ export default ({
                 <script>
                 (function() {
                     var firstScript = document.scripts[0];
-                    [${priorityScripts.map(
-                        script => `'${script}'`,
+                    [${priorityScripts.map(script =>
+                        JSON.stringify(script),
                     )}].forEach(url => {
                         if ('async' in firstScript) {
                             // modern browsers

--- a/frontend/web/htmlTemplate.ts
+++ b/frontend/web/htmlTemplate.ts
@@ -47,6 +47,15 @@ export default ({
                     .join('\n')}
                 <style>${fontsCSS}${resetCSS}${css}</style>
                 <script>
+                // this is a global that's called at the bottom of the pf.io response,
+                // once the polyfills have run. This may be useful for debugging.
+                // mainly to support browsers that don't support async=false or defer
+                function guardianPolyfilled() {
+                    try {
+                        window.guardian.polyfilled = true;
+                        window.guardian.onPolyfilled();
+                    } catch (e) {};
+                }
                 (function() {
                     var firstScript = document.scripts[0];
                     [${priorityScripts.map(script =>
@@ -69,7 +78,7 @@ export default ({
                 </script>
             </head>
             <body>
-                <div id='app'>${html}</div>
+                <div id="app">${html}</div>
                 <script>
                 window.guardian = ${sanitiseDomRefs(
                     JSON.stringify({

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,8 @@ declare global {
                 data: any;
                 cssIDs: string[];
             };
+            polyfilled: boolean;
+            onPolyfilled: () => void;
         };
         GoogleAnalyticsObject: string;
         ga: UniversalAnalytics.ga;


### PR DESCRIPTION
## What does this change?

Passes a callback to polyfill.io to ensure the pf.io script has loaded and executed before executing our application code.

## Why?

This should be happening in modern browsers anyway since the scripts are loaded and executed in order using `async=false`. This is for belt and braces and legacy browser support.