### PR TITLE
Initial attempt at images in AMP.

### DIFF
--- a/frontend/amp/components/elements/ImageBlockComponent.tsx
+++ b/frontend/amp/components/elements/ImageBlockComponent.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Img } from '../primitives/Img';
+
+const getFallback: (images: Image[]) => Image = images =>
+    images.find(_ => _.fields.isMaster === 'true') || images[0];
+export const ImageBlockComponent: React.SFC<{ element: ImageBlockElement }> = ({
+    element,
+}) => {
+    const image = getFallback(element.media.allImages);
+    return (
+        <Img
+            src={image.url}
+            alt={element.data.alt}
+            attribution={element.data.credit}
+            height={image.fields.height}
+            width={image.fields.width}
+        />
+    );
+};

--- a/frontend/amp/components/elements/ImageBlockComponent.tsx
+++ b/frontend/amp/components/elements/ImageBlockComponent.tsx
@@ -14,6 +14,7 @@ export const ImageBlockComponent: React.SFC<{ element: ImageBlockElement }> = ({
             attribution={element.data.credit}
             height={image.fields.height}
             width={image.fields.width}
+            layout="responsive"
         />
     );
 };

--- a/frontend/amp/components/lib/AMPRenderer.tsx
+++ b/frontend/amp/components/lib/AMPRenderer.tsx
@@ -1,6 +1,7 @@
 import { TextBlockComponent } from '../elements/TextBlockComponent';
 
 import React from 'react';
+import { ImageBlockComponent } from '../elements/ImageBlockComponent';
 
 export const AmpRenderer: React.SFC<{
     elements: CAPIElement[];
@@ -17,6 +18,8 @@ export const AmpRenderer: React.SFC<{
                             pillar={pillar}
                         />
                     );
+                case 'model.liveblog.ImageBlockElement':
+                    return <ImageBlockComponent key={i} element={element} />;
                 default:
                     // tslint:disable-next-line:no-console
                     console.log('Unsupported Element', JSON.stringify(element));

--- a/frontend/amp/components/primitives/Img.tsx
+++ b/frontend/amp/components/primitives/Img.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+export const Img: React.SFC<ImgProps> = props => <amp-img {...props} />;
+
+interface Props {
+    alt: string;
+    attribution: string;
+    height: string;
+    width: string;
+}
+
+interface Responsive {
+    srcSet: SrcSet[];
+    sizes: Size[];
+}
+
+export type ImgProps = Props & (Src | Responsive);
+
+export interface Src {
+    src: string;
+}
+export interface SrcSet {
+    src: string;
+    w: string;
+}
+export interface Size {
+    mediaQuery: string;
+    width: string;
+}

--- a/frontend/amp/components/primitives/Img.tsx
+++ b/frontend/amp/components/primitives/Img.tsx
@@ -1,13 +1,6 @@
 import React from 'react';
 import { AMPCommon } from './primitives';
 
-// tslint:disable-next-line:no-namespace
-declare namespace JSX {
-    interface IntrinsicElements {
-        'amp-img': any;
-    }
-}
-
 export const Img: React.SFC<ImgProps> = props => <amp-img {...props} />;
 
 interface Props {

--- a/frontend/amp/components/primitives/Img.tsx
+++ b/frontend/amp/components/primitives/Img.tsx
@@ -1,4 +1,12 @@
 import React from 'react';
+import { AMPCommon } from './primitives';
+
+// tslint:disable-next-line:no-namespace
+declare namespace JSX {
+    interface IntrinsicElements {
+        'amp-img': any;
+    }
+}
 
 export const Img: React.SFC<ImgProps> = props => <amp-img {...props} />;
 
@@ -14,7 +22,7 @@ interface Responsive {
     sizes: Size[];
 }
 
-export type ImgProps = Props & (Src | Responsive);
+export type ImgProps = AMPCommon & Props & (Src | Responsive);
 
 export interface Src {
     src: string;

--- a/frontend/amp/components/primitives/amp.d.ts
+++ b/frontend/amp/components/primitives/amp.d.ts
@@ -1,0 +1,5 @@
+declare namespace JSX {
+    interface IntrinsicElements {
+        'amp-img': any;
+    }
+}

--- a/frontend/amp/components/primitives/primitives.ts
+++ b/frontend/amp/components/primitives/primitives.ts
@@ -1,0 +1,29 @@
+interface AMPCommonBase {
+    layout?:
+        | 'nodisplay'
+        | 'fixed'
+        | 'responsive'
+        | 'fixed-height'
+        | 'fill'
+        | 'container'
+        | 'flex-item'
+        | 'intrinsic';
+    height?: string;
+    width?: string;
+    noloading?: true;
+    on?: string;
+    placeholder?: true;
+    sizes: 'string';
+    fallback?: true;
+}
+interface Sized {
+    layout: 'fixed' | 'responsive' | 'intrinsic';
+    height: string;
+    width: string;
+}
+interface FixedHeight {
+    layout: 'fixed-height';
+    height: string;
+    width: undefined;
+}
+export type AMPCommon = AMPCommonBase | Sized | FixedHeight;


### PR DESCRIPTION
## What does this change?
Initial rendering of `ImageBlockElement` in amp.
## Why?
