### PR TITLE
Update Dateline component to use CAPI data

### DIFF
--- a/frontend/index.d.ts
+++ b/frontend/index.d.ts
@@ -72,6 +72,7 @@ interface CAPIType {
     elements: Array<CAPIElement>,
     author: AuthorType,
     webPublicationDate: Date,
+    webPublicationDateDisplay: string,
     pageId: string,
     ageWarning?: string,
     sharingUrls: {

--- a/frontend/lib/parse-capi/index.ts
+++ b/frontend/lib/parse-capi/index.ts
@@ -290,12 +290,12 @@ export const extractArticleMeta = (data: {}): CAPIType => {
     return {
         isArticle,
         webPublicationDate,
+        tags,
+        sectionName,
         webPublicationDateDisplay: getNonEmptyString(
             data,
             'config.page.webPublicationDateDisplay',
         ),
-        tags,
-        sectionName,
         headline: apply(
             getNonEmptyString(data, 'config.page.headline'),
             clean,

--- a/frontend/lib/parse-capi/index.ts
+++ b/frontend/lib/parse-capi/index.ts
@@ -290,6 +290,10 @@ export const extractArticleMeta = (data: {}): CAPIType => {
     return {
         isArticle,
         webPublicationDate,
+        webPublicationDateDisplay: getNonEmptyString(
+            data,
+            'config.page.webPublicationDateDisplay',
+        ),
         tags,
         sectionName,
         headline: apply(

--- a/frontend/web/components/ArticleBody.tsx
+++ b/frontend/web/components/ArticleBody.tsx
@@ -405,13 +405,6 @@ const twitterHandle = css`
     }
 `;
 
-const dateline = css`
-    ${captionFont};
-
-    padding-top: 2px;
-    margin-bottom: 6px;
-`;
-
 const metaExtras = css`
     border-top: 1px solid ${palette.neutral[86]};
     padding-top: 6px;
@@ -573,11 +566,7 @@ const ArticleBody: React.SFC<{
                             </a>
                         </div>
                     )}
-                    <div className={dateline}>
-                        <Dateline
-                            dateDisplay={CAPI.webPublicationDateDisplay}
-                        />
-                    </div>
+                    <Dateline dateDisplay={CAPI.webPublicationDateDisplay} />
                     <div className={metaExtras}>
                         <SharingIcons
                             sharingUrls={CAPI.sharingUrls}

--- a/frontend/web/components/ArticleBody.tsx
+++ b/frontend/web/components/ArticleBody.tsx
@@ -574,7 +574,9 @@ const ArticleBody: React.SFC<{
                         </div>
                     )}
                     <div className={dateline}>
-                        <Dateline capiDate={CAPI.webPublicationDate} />
+                        <Dateline
+                            dateDisplay={CAPI.webPublicationDateDisplay}
+                        />
                     </div>
                     <div className={metaExtras}>
                         <SharingIcons

--- a/frontend/web/components/Dateline.tsx
+++ b/frontend/web/components/Dateline.tsx
@@ -1,36 +1,15 @@
 import { Component } from 'react';
-import { getCookie } from '../lib/cookie';
-import dateformat from 'dateformat';
-
-const dtFormatGU = (date: Date, edition: string): string => {
-    let datetimeFormatted: string = dateformat(date, 'ddd d mmm yyyy HH:MM Z');
-    if (edition === 'UK') {
-        datetimeFormatted = datetimeFormatted.replace('GMT+0100', 'BST');
-    }
-    return datetimeFormatted;
-};
-
-const defaultEdition = 'UK';
 
 class Dateline extends Component<
-    { capiDate: Date },
-    { capiDate: Date; edition: string }
+    { dateDisplay: string },
+    { dateDisplay: string }
 > {
-    constructor(props: { capiDate: Date }) {
+    constructor(props: { dateDisplay: string }) {
         super(props);
-        this.state = { capiDate: this.props.capiDate, edition: defaultEdition };
-    }
-    public componentDidMount() {
-        const cookieEdition = getCookie('GU_EDITION');
-        if (cookieEdition && this.state.edition !== cookieEdition) {
-            this.setState({
-                capiDate: this.state.capiDate,
-                edition: cookieEdition,
-            });
-        }
+        this.state = { dateDisplay: this.props.dateDisplay };
     }
     public render() {
-        return dtFormatGU(this.state.capiDate, this.state.edition);
+        return this.state.dateDisplay;
     }
 }
 

--- a/frontend/web/components/Dateline.tsx
+++ b/frontend/web/components/Dateline.tsx
@@ -2,6 +2,6 @@ import React from 'react';
 
 const Dateline: React.SFC<{
     dateDisplay: string;
-}> = ({dateDisplay}) => ( <>{dateDisplay}</> );
+}> = ({ dateDisplay }) => <>{dateDisplay}</>;
 
 export default Dateline;

--- a/frontend/web/components/Dateline.tsx
+++ b/frontend/web/components/Dateline.tsx
@@ -1,7 +1,29 @@
 import React from 'react';
 
+import { css } from 'react-emotion';
+import { palette } from '@guardian/pasteup/palette';
+import { sans } from '@guardian/pasteup/fonts';
+
+const captionFont = css`
+    font-size: 12px;
+    line-height: 16px;
+    font-family: ${sans.body};
+    color: ${palette.neutral[46]};
+`;
+
+const dateline = css`
+    ${captionFont};
+
+    padding-top: 2px;
+    margin-bottom: 6px;
+`;
+
 const Dateline: React.SFC<{
     dateDisplay: string;
-}> = ({ dateDisplay }) => <>{dateDisplay}</>;
+}> = ({ dateDisplay }) => (
+    <>
+        <div className={dateline}>{dateDisplay}</div>
+    </>
+);
 
 export default Dateline;

--- a/frontend/web/components/Dateline.tsx
+++ b/frontend/web/components/Dateline.tsx
@@ -1,16 +1,7 @@
-import { Component } from 'react';
+import React from 'react';
 
-class Dateline extends Component<
-    { dateDisplay: string },
-    { dateDisplay: string }
-> {
-    constructor(props: { dateDisplay: string }) {
-        super(props);
-        this.state = { dateDisplay: this.props.dateDisplay };
-    }
-    public render() {
-        return this.state.dateDisplay;
-    }
-}
+const Dateline: React.SFC<{
+    dateDisplay: string;
+}> = ({dateDisplay}) => ( <>{dateDisplay}</> );
 
 export default Dateline;


### PR DESCRIPTION
## What does this change?

Modify the `DateLine` component 

*Before*: Was using the `GU_EDITION` cookie and building the datetime string itself (bad idea)
*After*: Use the backend precomputed `webPublicationDateDisplay`

## Why?

Because:
1. Manual datetime manipulation is the door to hell
2. We are moving to an architecture where we avoid processing on the front end.
3. It's a good thing to have the backend and the front end agree on data display and have a single place to change the date display conventions