### PR TITLE
AMP header initial work (and minor footer update)

### DIFF
--- a/frontend/amp/components/Footer.tsx
+++ b/frontend/amp/components/Footer.tsx
@@ -6,10 +6,10 @@ import InnerContainer from './InnerContainer';
 import { footerLinks, Link } from '@frontend/lib/footer-links';
 
 const footer = css`
-    background-color: ${palette.neutral[20]};
+    background-color: #052962;
     color: ${palette.neutral[86]};
     font-family: ${sans.body};
-    font-size: 14px;
+    font-size: 16px;
 `;
 
 const footerInner = css`
@@ -17,13 +17,13 @@ const footerInner = css`
 `;
 
 const footerLink = css`
-    color: ${palette.neutral[86]};
+    color: ${palette.neutral[100]};
     text-decoration: none;
     padding-bottom: 12px;
     display: block;
 
     :hover {
-        text-decoration: underline;
+        color: ${palette.highlight.main};
     }
 `;
 
@@ -31,12 +31,10 @@ const footerList = css`
     display: flex;
     flex-wrap: wrap;
     flex-direction: row;
-    border-top: 1px solid ${palette.neutral[46]};
 
     ul {
         width: 50%;
         border-left: 1px solid ${palette.neutral[46]};
-        margin: 0;
 
         :nth-child(odd) {
             border-left: 0px;
@@ -56,7 +54,8 @@ const footerList = css`
             padding-left: 0px;
         }
 
-        padding: 12px 0 0 10px;
+        padding: 0 0 0 10px;
+        margin-top: 12px;
     }
 `;
 

--- a/frontend/amp/components/Footer.tsx
+++ b/frontend/amp/components/Footer.tsx
@@ -6,7 +6,7 @@ import InnerContainer from './InnerContainer';
 import { footerLinks, Link } from '@frontend/lib/footer-links';
 
 const footer = css`
-    background-color: #052962;
+    background-color: ${palette.brand.blue};
     color: ${palette.neutral[86]};
     font-family: ${sans.body};
     font-size: 16px;

--- a/frontend/amp/components/Header.tsx
+++ b/frontend/amp/components/Header.tsx
@@ -1,0 +1,240 @@
+import React from 'react';
+import { css, cx } from 'react-emotion';
+import Logo from '@guardian/pasteup/logos/the-guardian.svg';
+import { screenReaderOnly } from '@guardian/pasteup/mixins';
+import { serif } from '@guardian/pasteup/fonts';
+import { pillarMap, pillarPalette } from '../../lib/pillars';
+import Sidebar from './Sidebar';
+import ArrowRight from '@guardian/pasteup/icons/arrow-right.svg';
+import { palette } from '@guardian/pasteup/palette';
+
+const headerStyles = css`
+    border-bottom: 1px solid #dcdcdc;
+    background-color: #052962;
+`;
+
+const row = css`
+    display: flex;
+    justify-content: space-between;
+    position: relative;
+`;
+
+const supportStyles = css`
+    align-self: flex-start;
+    position: relative;
+    margin-left: 20px;
+    margin-top: 20px;
+    background-color: ${palette.highlight.main};
+    border-radius: 20px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 0 15px;
+    min-height: 30px;
+`;
+
+const supportLinkStyles = css`
+    position: relative;
+    color: ${palette.neutral[7]};
+    font-size: 16px;
+    font-weight: 700;
+    display: block;
+    text-decoration: none;
+    font-family: ${serif.body};
+    padding-right: 20px;
+
+    svg {
+        position: absolute;
+        top: -6px;
+    }
+`;
+
+const logoStyles = css`
+    align-self: flex-start;
+    height: 57px;
+    width: 175px;
+    margin-top: 3px;
+    margin-right: 20px;
+    margin-bottom: 35px;
+
+    path {
+        fill: white;
+    }
+`;
+
+const pillarUnderline = pillarMap(
+    pillar => css`
+        :after {
+            transform: translateY(4px);
+        }
+    `,
+);
+
+const pillarListStyles = css`
+    list-style: none;
+    line-height: 0;
+`;
+
+const pillarListItemStyle = css`
+    display: inline-block;
+
+    :first-child {
+        margin-left: 20px;
+
+        a {
+            padding-left: 0;
+
+            :before {
+                display: none;
+            }
+        }
+    }
+`;
+
+const pillarLinkStyle = (pillar: Pillar) => css`
+    font-family: ${serif.headline};
+    font-weight: 700;
+    text-decoration: none;
+    cursor: pointer;
+    display: block;
+    font-size: 20px;
+    height: 36px;
+    line-height: 1;
+    padding: 4px 4px;
+    color: white;
+    position: relative;
+    overflow: hidden;
+
+    :hover {
+        ${pillarUnderline[pillar]};
+    }
+
+    :before {
+        border-left: 1px solid rgba(255, 255, 255, 0.3);
+        top: 0;
+        z-index: 1;
+        content: '';
+        display: block;
+        left: 0;
+        position: absolute;
+        bottom: 0;
+    }
+
+    :after {
+        content: '';
+        display: block;
+        top: -4px;
+        left: 0;
+        right: 0;
+        position: absolute;
+        border-top: 4px solid ${pillarPalette[pillar].dark};
+        transition: transform 0.3s ease-in-out;
+    }
+`;
+
+const veggieStyles = css`
+    background-color: ${palette.highlight.main};
+    color: ${palette.neutral[97]};
+    height: 42px;
+    min-width: 42px;
+    border: 0;
+    border-radius: 50%;
+    outline: none;
+    z-index: 1;
+    bottom: -3px;
+    right: 20px;
+    position: absolute;
+`;
+
+const lineStyles = css`
+    height: 2px;
+    position: absolute;
+    width: 20px;
+    background-color: black;
+`;
+
+const pattyStyles = css`
+    left: 11px;
+
+    ${lineStyles};
+
+    :before {
+        content: '';
+        top: -6px;
+        left: 0;
+        ${lineStyles};
+    }
+
+    :after {
+        content: '';
+        top: 6px;
+        left: 0;
+        ${lineStyles};
+    }
+`;
+
+const navRow = css`
+    border-top: 1px solid rgba(255, 255, 255, 0.3);
+`;
+
+const pillarLinks = (pillars: PillarType[], activePillar: Pillar) => (
+    <nav>
+        <ul className={pillarListStyles}>
+            {pillars.map((p, i) => (
+                <li className={pillarListItemStyle} key={p.title}>
+                    <a
+                        className={cx(pillarLinkStyle(p.pillar), {
+                            [pillarUnderline[p.pillar]]:
+                                p.pillar === activePillar,
+                        })}
+                        href={p.url}
+                    >
+                        {p.title}
+                    </a>
+                </li>
+            ))}
+        </ul>
+    </nav>
+);
+
+const supportLink =
+    'https://support.theguardian.com/?INTCMP=header_support&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support%22%7D';
+
+const Header: React.SFC<{ nav: NavType; activePillar: Pillar }> = ({
+    nav,
+    activePillar,
+}) => (
+    <header className={headerStyles}>
+        <div className={row}>
+            <div className={supportStyles}>
+                <a className={supportLinkStyles} href={supportLink}>
+                    Support us
+                    <ArrowRight />
+                </a>
+            </div>
+
+            <a className={logoStyles} href="/">
+                <span
+                    className={css`
+                        ${screenReaderOnly};
+                    `}
+                >
+                    The Guardian - Back to home
+                </span>
+                <Logo className={logoStyles} />
+            </a>
+        </div>
+
+        <div className={cx(row, navRow)}>
+            {pillarLinks(nav.pillars, activePillar)}
+
+            <button className={veggieStyles} on="tap:sidebar1.toggle">
+                <span className={pattyStyles} />
+            </button>
+        </div>
+
+        <Sidebar nav={nav} />
+    </header>
+);
+
+export default Header;

--- a/frontend/amp/components/Header.tsx
+++ b/frontend/amp/components/Header.tsx
@@ -9,8 +9,8 @@ import ArrowRight from '@guardian/pasteup/icons/arrow-right.svg';
 import { palette } from '@guardian/pasteup/palette';
 
 const headerStyles = css`
-    border-bottom: 1px solid #dcdcdc;
-    background-color: #052962;
+    border-bottom: 1px solid ${palette.neutral[86]};
+    background-color: ${palette.brand.blue};
 `;
 
 const row = css`
@@ -58,7 +58,7 @@ const logoStyles = css`
     margin-bottom: 35px;
 
     path {
-        fill: white;
+        fill: ${palette.neutral[100]};
     }
 `;
 
@@ -101,7 +101,7 @@ const pillarLinkStyle = (pillar: Pillar) => css`
     height: 36px;
     line-height: 1;
     padding: 4px 4px;
-    color: white;
+    color: ${palette.neutral[100]};
     position: relative;
     overflow: hidden;
 
@@ -150,7 +150,7 @@ const lineStyles = css`
     height: 2px;
     position: absolute;
     width: 20px;
-    background-color: black;
+    background-color: ${palette.neutral[7]};
 `;
 
 const pattyStyles = css`

--- a/frontend/amp/components/Sidebar.tsx
+++ b/frontend/amp/components/Sidebar.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { css } from 'react-emotion';
+
+const sidebarStyles = css`
+    width: 80vh;
+`;
+
+const template = `
+<ul>
+    {{ #topLevelSections }}
+        <li>
+            <amp-accordion>
+                <section>
+                    <h2
+                        data-link-name="amp : nav : secondary : {{ title }}">
+                        <i></i>
+                        {{ title }}
+                    </h2>
+
+                    <ul>
+                        {{ #subSections }}
+                            <li>
+                                <a
+                                    href="{{ url }}"
+                                    data-link-name="amp : nav : secondary : {{ title }}">
+                                    {{ title }}
+                                </a>
+                            </li>
+                        {{ /subSections }}
+                    </ul>
+                </section>
+            </amp-accordion>
+        </li>
+    {{ /topLevelSections }}
+</ul>
+
+<ul
+    role="menubar">
+    {{ #readerRevenueLinks }}
+        <li
+            role="menuitem">
+
+            <a
+                href="{{ url }}"
+                data-link-name="amp : nav : {{ title }}">
+                {{ title }}
+            </a>
+        </li>
+    {{ /readerRevenueLinks }}
+
+    <li>
+        <a href="@{Configuration.id.url}/signin?INTCMP=DOTCOM_HEADER_SIGNIN"
+            data-link-name="amp : nav : sign in"
+            >
+            Sign in / Register
+        </a>
+    </li>
+</ul>
+
+<ul>
+    {{ #secondarySections }}
+        <li>
+            <a
+                href="{{ url }}"
+                data-link-name="amp : nav : {{ title }}">
+                {{ title }}
+            </a>
+        </li>
+    {{ /secondarySections }}
+</ul>
+`;
+
+// tslint:disable:react-no-dangerous-html
+const Sidebar: React.SFC<{ nav: NavType }> = ({ nav }) => (
+    <amp-sidebar class={sidebarStyles} layout="nodisplay" id="sidebar1">
+        <amp-list
+            layout="fill"
+            src="https://amp.theguardian.com/editionalised-nav.json"
+        >
+            <template type="amp-mustache">
+                <div dangerouslySetInnerHTML={{ __html: template }} />
+            </template>
+            />
+        </amp-list>
+    </amp-sidebar>
+);
+
+export default Sidebar;

--- a/frontend/amp/components/elements/TextBlockComponent.tsx
+++ b/frontend/amp/components/elements/TextBlockComponent.tsx
@@ -7,8 +7,7 @@ import { serif } from '@guardian/pasteup/fonts';
 // tslint:disable:react-no-dangerous-html
 const style = (pillar: Pillar) => css`
     p {
-        margin: 0 0 12px;
-        padding: 0;
+        padding: 0 0 12px;
         font-size: 16px;
         font-weight: 300;
         word-wrap: break-word;

--- a/frontend/amp/components/lib/AMPAttributes.ts
+++ b/frontend/amp/components/lib/AMPAttributes.ts
@@ -1,0 +1,11 @@
+import _ from 'react';
+
+// Provides type definition for AMP attributes on React/JSX elements.
+
+// Note, we cannot declare this in the global type definitions because it is not
+// possible to merge modules this way (only override them).
+declare module 'react' {
+    interface HTMLAttributes<T> extends DOMAttributes<T> {
+        on?: string;
+    }
+}

--- a/frontend/amp/components/primitives/amp.d.ts
+++ b/frontend/amp/components/primitives/amp.d.ts
@@ -1,5 +1,0 @@
-declare namespace JSX {
-    interface IntrinsicElements {
-        'amp-img': any;
-    }
-}

--- a/frontend/amp/document.tsx
+++ b/frontend/amp/document.tsx
@@ -22,6 +22,13 @@ export default ({ body }: { body: React.ReactElement<any> }) => {
     <style>${fontsCss}${resetCSS}${css}</style>
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <script async src="https://cdn.ampproject.org/v0.js"></script>
+
+    <!-- Custom AMP elements to support -->
+    <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
+    <script async custom-element="amp-sidebar" src="https://cdn.ampproject.org/v0/amp-sidebar-0.1.js"></script>
+    <script async custom-element="amp-accordion" src="https://cdn.ampproject.org/v0/amp-accordion-0.1.js"></script>
+    <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
+
     <style amp-custom>${resetCSS}${css}</style>
     </head>
     <body>

--- a/frontend/amp/pages/Article.tsx
+++ b/frontend/amp/pages/Article.tsx
@@ -2,13 +2,31 @@ import React from 'react';
 import Footer from '@frontend/amp/components/Footer';
 import Container from '@frontend/amp/components/Container';
 import { AmpRenderer } from '@frontend/amp/components/lib/AMPRenderer';
+import Header from '@frontend/amp/components/Header';
+import { palette } from '@guardian/pasteup/palette';
+import { css } from 'react-emotion';
+import InnerContainer from '@frontend/amp/components/InnerContainer';
+
+const backgroundColour = css`
+    background-color: ${palette.neutral[97]};
+`;
+
+const body = css`
+    background-color: white;
+`;
 
 export const Article: React.SFC<{
     pillar: Pillar;
     elements: CAPIElement[];
-}> = ({ pillar, elements }) => (
-    <Container>
-        <AmpRenderer pillar={pillar} elements={elements} />
-        <Footer />
-    </Container>
+    nav: NavType;
+}> = ({ pillar, elements, nav }) => (
+    <div className={backgroundColour}>
+        <Container>
+            <Header nav={nav} activePillar={pillar} />
+            <InnerContainer className={body}>
+                <AmpRenderer pillar={pillar} elements={elements} />
+            </InnerContainer>
+            <Footer />
+        </Container>
+    </div>
 );

--- a/frontend/app/server.tsx
+++ b/frontend/app/server.tsx
@@ -43,8 +43,15 @@ const renderAMPArticle = ({ body }: express.Request, res: express.Response) => {
     try {
         const CAPI = extractArticleMeta(body);
         const resp = AMPDocument({
-            body: <AMPArticle elements={CAPI.elements} pillar={CAPI.pillar} />,
+            body: (
+                <AMPArticle
+                    elements={CAPI.elements}
+                    pillar={CAPI.pillar}
+                    nav={extractNavMeta(body)}
+                />
+            ),
         });
+
         res.status(200).send(resp);
     } catch (e) {
         res.status(500).send(`<pre>${e.stack}</pre>`);
@@ -103,6 +110,7 @@ if (process.env.NODE_ENV === 'production') {
                     <ul>
                         <li><a href="/Article">Article</a></li>
                         <li><a href="/AMPArticle">⚡️Article</a></li>
+
                     </ul>
                 </body>
                 </html>

--- a/frontend/index.d.ts
+++ b/frontend/index.d.ts
@@ -125,3 +125,14 @@ declare module "minify-css-string" {
     const minifyCSSString: any;
     export default minifyCSSString;
 }
+
+/* AMP types */
+declare namespace JSX {
+	interface IntrinsicElements {
+        'amp-sidebar': any;
+        'amp-accordion': any;
+        'amp-img': any;
+        'amp-list': any;
+        'template': any;
+    }
+}

--- a/packages/pasteup/palette.ts
+++ b/packages/pasteup/palette.ts
@@ -28,6 +28,7 @@ export interface OtherColours {
     specialReport: { dark: colour };
     labs: { dark: colour; main: colour };
     green: { dark: colour; main: colour };
+    brand: { blue: colour };
 }
 
 export const palette: AllPillarColours & OtherColours = {
@@ -86,4 +87,5 @@ export const palette: AllPillarColours & OtherColours = {
         main: '#69d1ca',
     },
     green: { dark: '#236925', main: '#3db540' },
+    brand: { blue: '#052962' },
 };


### PR DESCRIPTION
Adds a basic version of the header with the new design, some minimal body styling, and also minor changes to the footer for new colours.

To get this merged quicker, I've intentionally left stuff for further PRs:

* the AMP sidebar (veggie burger menu) styling
* some header and footer styling as the new versions aren't live yet and I don't want to overcommit on this work until they are/we know the design is fixed!

![screen shot 2018-11-08 at 14 17 26](https://user-images.githubusercontent.com/858402/48204300-5f007b00-e361-11e8-9310-0d03f228e2ed.png)

(...)

![screen shot 2018-11-08 at 14 17 18](https://user-images.githubusercontent.com/858402/48204310-632c9880-e361-11e8-9830-3ecc8377c9d2.png)
