### PR TITLE
Add edition to CAPIType

### DIFF
--- a/frontend/index.d.ts
+++ b/frontend/index.d.ts
@@ -73,6 +73,7 @@ interface CAPIType {
     author: AuthorType,
     webPublicationDate: Date,
     webPublicationDateDisplay: string,
+    editionLongForm: string,
     pageId: string,
     ageWarning?: string,
     sharingUrls: {

--- a/frontend/lib/parse-capi/index.ts
+++ b/frontend/lib/parse-capi/index.ts
@@ -296,6 +296,11 @@ export const extractArticleMeta = (data: {}): CAPIType => {
             data,
             'config.page.webPublicationDateDisplay',
         ),
+        editionLongForm: getString(
+            data,
+            'config.page.edition',
+            '',
+        ).toLowerCase(),
         headline: apply(
             getNonEmptyString(data, 'config.page.headline'),
             clean,


### PR DESCRIPTION
## What does this change?

Add an edition field to CAPIType (to later be read from where it is needed). The information already exists in `GADataType`, but the latter feels like a bad place to read it from.

## Why?

Harmony.