### PR TITLE
Add editionId to CAPIType

### DIFF
--- a/frontend/index.d.ts
+++ b/frontend/index.d.ts
@@ -74,6 +74,7 @@ interface CAPIType {
     webPublicationDate: Date,
     webPublicationDateDisplay: string,
     editionLongForm: string,
+    editionId: string,
     pageId: string,
     ageWarning?: string,
     sharingUrls: {

--- a/frontend/index.d.ts
+++ b/frontend/index.d.ts
@@ -74,7 +74,7 @@ interface CAPIType {
     webPublicationDate: Date,
     webPublicationDateDisplay: string,
     editionLongForm: string,
-    editionId: string,
+    editionId: 'UK' | 'US' | 'INT' | 'AU',
     pageId: string,
     ageWarning?: string,
     sharingUrls: {

--- a/frontend/index.d.ts
+++ b/frontend/index.d.ts
@@ -6,6 +6,8 @@ interface ArticleProps {
 
 type Pillar = 'news' | 'opinion' | 'sport' | 'culture' | 'lifestyle' ;
 
+type Edition = 'UK' | 'US' | 'INT' | 'AU'
+
 type SharePlatform = 'facebook' | 'twitter' | 'email' | 'googlePlus' | 'whatsApp' | 'pinterest' | 'linkedIn' | 'messenger';
 
 // shared type declarations
@@ -74,7 +76,7 @@ interface CAPIType {
     webPublicationDate: Date,
     webPublicationDateDisplay: string,
     editionLongForm: string,
-    editionId: 'UK' | 'US' | 'INT' | 'AU',
+    editionId: Edition,
     pageId: string,
     ageWarning?: string,
     sharingUrls: {

--- a/frontend/lib/parse-capi/index.ts
+++ b/frontend/lib/parse-capi/index.ts
@@ -287,6 +287,19 @@ export const extractArticleMeta = (data: {}): CAPIType => {
         tag => tag.type === 'Contributor',
     )[0];
 
+    // From the server we get the values: "UK edition", "US edition", "Australia edition", "International edition"
+    // editionLongForm is that value, or empty string.
+    const editionLongForm = getString(data, 'config.page.edition', '');
+
+    // We compute the editionId from the editionLongForm
+    // Possible values for the editionId: "uk", "us", "au", "int"
+    const editionId = (editionLongForm === ''
+        ? ''
+        : editionLongForm.split(' ')[0]
+    )
+        .replace('australia', 'au')
+        .replace('international', 'int');
+
     return {
         isArticle,
         webPublicationDate,
@@ -296,11 +309,8 @@ export const extractArticleMeta = (data: {}): CAPIType => {
             data,
             'config.page.webPublicationDateDisplay',
         ),
-        editionLongForm: getString(
-            data,
-            'config.page.edition',
-            '',
-        ).toLowerCase(),
+        editionLongForm,
+        editionId,
         headline: apply(
             getNonEmptyString(data, 'config.page.headline'),
             clean,

--- a/frontend/lib/parse-capi/index.ts
+++ b/frontend/lib/parse-capi/index.ts
@@ -305,12 +305,12 @@ export const extractArticleMeta = (data: {}): CAPIType => {
         webPublicationDate,
         tags,
         sectionName,
+        editionLongForm,
+        editionId,
         webPublicationDateDisplay: getNonEmptyString(
             data,
             'config.page.webPublicationDateDisplay',
         ),
-        editionLongForm,
-        editionId,
         headline: apply(
             getNonEmptyString(data, 'config.page.headline'),
             clean,

--- a/frontend/lib/parse-capi/index.ts
+++ b/frontend/lib/parse-capi/index.ts
@@ -79,13 +79,18 @@ const getArray = <T>(
 };
 
 const findPillar: (name: string) => Pillar | undefined = name => {
-    let pillar: string = name.toLowerCase();
+    const pillar: string = name.toLowerCase();
     // The pillar name is "arts" in CAPI, but "culture" everywhere else,
     // therefore we perform this substitution here.
     if (pillar === 'arts') {
-        pillar = 'culture';
+        return 'culture';
     }
     return pillarNames.find(_ => _ === pillar);
+};
+
+const findEdition: (name: string) => Edition | undefined = name => {
+    const editions: Edition[] = ['UK', 'US', 'INT', 'AU'];
+    return editions.find(_ => _ === name);
 };
 
 const getLink = (data: {}, { isPillar }: { isPillar: boolean }): LinkType => {
@@ -293,12 +298,13 @@ export const extractArticleMeta = (data: {}): CAPIType => {
 
     // We compute the editionId from the editionLongForm
     // Possible values for the editionId: "UK", "US", "AU", "INT"
-    const editionId = (editionLongForm === ''
-        ? ''
-        : editionLongForm.split(' ')[0]
-    )
-        .replace('Australia', 'AU')
-        .replace('International', 'INT');
+    const editionId = findEdition(
+        (editionLongForm === '' ? '' : editionLongForm.split(' ')[0])
+            .replace('Australia', 'AU')
+            .replace('International', 'INT'),
+    );
+
+    if (editionId === undefined) throw new Error('goodbye');
 
     return {
         isArticle,

--- a/frontend/lib/parse-capi/index.ts
+++ b/frontend/lib/parse-capi/index.ts
@@ -292,13 +292,13 @@ export const extractArticleMeta = (data: {}): CAPIType => {
     const editionLongForm = getString(data, 'config.page.edition', '');
 
     // We compute the editionId from the editionLongForm
-    // Possible values for the editionId: "uk", "us", "au", "int"
+    // Possible values for the editionId: "UK", "US", "AU", "INT"
     const editionId = (editionLongForm === ''
         ? ''
         : editionLongForm.split(' ')[0]
     )
-        .replace('australia', 'au')
-        .replace('international', 'int');
+        .replace('Australia', 'AU')
+        .replace('International', 'INT');
 
     return {
         isArticle,


### PR DESCRIPTION
## What does this change?

1. Introduce the attribute `editionId` to CAPIType
2. A bit of refactoring.
3. Correct the value of `editionLongForm` to avoid lowercasing it. (This won't break anything, just an update from the previous PR: https://github.com/guardian/dotcom-rendering/pull/277)

## Why?

This will let us use the `editionId` as provided by the server.