### PR TITLE
Move window.guardian declaration into the head

### DIFF
--- a/frontend/web/htmlTemplate.ts
+++ b/frontend/web/htmlTemplate.ts
@@ -47,6 +47,15 @@ export default ({
                     .join('\n')}
                 <style>${fontsCSS}${resetCSS}${css}</style>
                 <script>
+                window.guardian = ${sanitiseDomRefs(
+                    JSON.stringify({
+                        app: {
+                            data,
+                            cssIDs,
+                        },
+                        config: {},
+                    }),
+                )};
                 // this is a global that's called at the bottom of the pf.io response,
                 // once the polyfills have run. This may be useful for debugging.
                 // mainly to support browsers that don't support async=false or defer
@@ -80,15 +89,6 @@ export default ({
             <body>
                 <div id="app">${html}</div>
                 <script>
-                window.guardian = ${sanitiseDomRefs(
-                    JSON.stringify({
-                        app: {
-                            data,
-                            cssIDs,
-                        },
-                        config: {},
-                    }),
-                )};
                 (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
                     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
                     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)

--- a/frontend/web/htmlTemplate.ts
+++ b/frontend/web/htmlTemplate.ts
@@ -23,11 +23,7 @@ export default ({
     cssIDs: string[];
     nonBlockingJS?: string;
     fontFiles?: string[];
-}) => {
-    const sanitiseDomRefs = (jsString: string) =>
-        jsString.replace(/"(document.*?innerHTML)"/g, '$1');
-
-    return `<!doctype html>
+}) => `<!doctype html>
         <html>
             <head>
                 <title>${title}</title>
@@ -47,15 +43,13 @@ export default ({
                     .join('\n')}
                 <style>${fontsCSS}${resetCSS}${css}</style>
                 <script>
-                window.guardian = ${sanitiseDomRefs(
-                    JSON.stringify({
-                        app: {
-                            data,
-                            cssIDs,
-                        },
-                        config: {},
-                    }),
-                )};
+                window.guardian = ${JSON.stringify({
+                    app: {
+                        data,
+                        cssIDs,
+                    },
+                    config: {},
+                })};
                 // this is a global that's called at the bottom of the pf.io response,
                 // once the polyfills have run. This may be useful for debugging.
                 // mainly to support browsers that don't support async=false or defer
@@ -97,4 +91,3 @@ export default ({
                 <script>${nonBlockingJS}</script>
             </body>
         </html>`;
-};


### PR DESCRIPTION
## What does this change?

There's a race condition where the `guardianPolyfilled` callback is often called before `window.guardian` has been defined. When this happens we don't successfully set `window.guardian.polyfilled` to` true`, this in turn means we never kick off our clientside bundle. 

This PR moves our `window.guardian` declaration into the head so it's already defined when required.