### PR TITLE
Aliases for module imports

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -9,6 +9,7 @@ module.exports = {
             {
                 root: ['./'],
                 alias: {
+                    '@root': '.',
                     '@frontend': './frontend',
                 },
             },

--- a/babel.config.js
+++ b/babel.config.js
@@ -4,6 +4,15 @@ module.exports = {
         'babel-plugin-dynamic-import-node',
         ['@babel/plugin-proposal-object-rest-spread', { useBuiltIns: true }],
         '@babel/plugin-proposal-class-properties',
+        [
+            'module-resolver',
+            {
+                root: ['./'],
+                alias: {
+                    '@frontend': './frontend',
+                },
+            },
+        ],
     ],
     presets: [
         '@babel/preset-typescript',

--- a/frontend/amp/components/Footer.tsx
+++ b/frontend/amp/components/Footer.tsx
@@ -3,7 +3,7 @@ import { css } from 'react-emotion';
 import { sans } from '@guardian/pasteup/fonts';
 import { palette } from '@guardian/pasteup/palette';
 import InnerContainer from './InnerContainer';
-import { footerLinks, Link } from '../../lib/footer-links';
+import { footerLinks, Link } from '@frontend/lib/footer-links';
 
 const footer = css`
     background-color: ${palette.neutral[20]};

--- a/frontend/amp/components/elements/ImageBlockComponent.tsx
+++ b/frontend/amp/components/elements/ImageBlockComponent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Img } from '../primitives/Img';
+import { Img } from '@frontend/amp/components/primitives/Img';
 import { sans } from '@guardian/pasteup/fonts';
 import { palette } from '@guardian/pasteup/palette';
 import { css } from 'react-emotion';

--- a/frontend/amp/components/elements/ImageBlockComponent.tsx
+++ b/frontend/amp/components/elements/ImageBlockComponent.tsx
@@ -3,7 +3,7 @@ import { Img } from '../primitives/Img';
 import { sans } from '@guardian/pasteup/fonts';
 import { palette } from '@guardian/pasteup/palette';
 import { css } from 'react-emotion';
-import { pillarPalette } from '../../../lib/pillars';
+import { pillarPalette } from '@frontend/lib/pillars';
 const figureStyle = css`
     margin-top: 16px;
     margin-bottom: 8px;

--- a/frontend/amp/components/elements/TextBlockComponent.tsx
+++ b/frontend/amp/components/elements/TextBlockComponent.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from 'react-emotion';
 import { palette } from '@guardian/pasteup/palette';
-import { pillarPalette } from '../../../lib/pillars';
+import { pillarPalette } from '@frontend/lib/pillars';
 import { serif } from '@guardian/pasteup/fonts';
 
 // tslint:disable:react-no-dangerous-html

--- a/frontend/amp/components/lib/AMPRenderer.tsx
+++ b/frontend/amp/components/lib/AMPRenderer.tsx
@@ -1,7 +1,7 @@
-import { TextBlockComponent } from '../elements/TextBlockComponent';
+import { TextBlockComponent } from '@frontend/amp/components/elements/TextBlockComponent';
 
 import React from 'react';
-import { ImageBlockComponent } from '../elements/ImageBlockComponent';
+import { ImageBlockComponent } from '@frontend/amp/components/elements/ImageBlockComponent';
 
 export const AmpRenderer: React.SFC<{
     elements: CAPIElement[];

--- a/frontend/amp/document.tsx
+++ b/frontend/amp/document.tsx
@@ -1,7 +1,7 @@
 import { extractCritical } from 'emotion-server';
 import { renderToString } from 'react-dom/server';
-import resetCSS from /* preval */ '../lib/reset-css';
-import fontsCss from '../lib/fonts-css';
+import resetCSS from /* preval */ '@frontend/lib/reset-css';
+import fontsCss from '@frontend/lib/fonts-css';
 
 interface RenderToStringResult {
     html: string;

--- a/frontend/amp/pages/Article.tsx
+++ b/frontend/amp/pages/Article.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import Footer from '../components/Footer';
-import Container from '../components/Container';
+import Footer from '@frontend/amp/components/Footer';
+import Container from '@frontend/amp/components/Container';
 import { AmpRenderer } from '@frontend/amp/components/lib/AMPRenderer';
 
 export const Article: React.SFC<{

--- a/frontend/amp/pages/Article.tsx
+++ b/frontend/amp/pages/Article.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Footer from '../components/Footer';
 import Container from '../components/Container';
-import { AmpRenderer } from '../components/lib/AMPRenderer';
+import { AmpRenderer } from '@frontend/amp/components/lib/AMPRenderer';
 
 export const Article: React.SFC<{
     pillar: Pillar;

--- a/frontend/app/server.tsx
+++ b/frontend/app/server.tsx
@@ -7,18 +7,18 @@ import {
     getGuardianConfiguration,
     GuardianConfiguration,
 } from './aws/aws-parameters';
-import document from '../web/document';
-import AMPDocument from '../amp/document';
-import { Article as AMPArticle } from '../amp/pages/Article';
-import { dist, root } from '../../config';
-import { log, warn } from '../../lib/log';
+import document from '@frontend/web/document';
+import AMPDocument from '@frontend/amp/document';
+import { Article as AMPArticle } from '@frontend/amp/pages/Article';
+import { dist, root } from '@root/config';
+import { log, warn } from '@root/lib/log';
 
 import {
     extractArticleMeta,
     extractNavMeta,
     extractConfigMeta,
     extractGAMeta,
-} from '../lib/parse-capi';
+} from '@frontend/lib/parse-capi';
 
 const renderArticle = ({ body }: express.Request, res: express.Response) => {
     try {

--- a/frontend/lib/parse-capi/index.ts
+++ b/frontend/lib/parse-capi/index.ts
@@ -3,8 +3,8 @@ import get from 'lodash.get';
 
 import clean from './clean';
 import bigBullets from './big-bullets';
-import { pillarNames } from '../pillars';
-import { getSharingUrls } from './sharing-urls';
+import { pillarNames } from '@frontend/lib/pillars';
+import { getSharingUrls } from '@frontend/lib/parse-capi/sharing-urls';
 
 // tslint:disable:prefer-array-literal
 const apply = (input: string, ...fns: Array<(_: string) => string>): string => {

--- a/frontend/web/browser.ts
+++ b/frontend/web/browser.ts
@@ -29,7 +29,7 @@ const go = () => {
         hydrateApp(React.createElement(Article, { data }), container);
     }
 
-    import('./lib/ga').then(({ init }) => {
+    import('@frontend/web/lib/ga').then(({ init }) => {
         init();
     });
 };

--- a/frontend/web/components/ArticleBody.tsx
+++ b/frontend/web/components/ArticleBody.tsx
@@ -19,8 +19,8 @@ import {
     desktop,
     tablet,
 } from '@guardian/pasteup/breakpoints';
-import { pillarMap, pillarPalette } from '../../lib/pillars';
-import { ArticleRenderer } from './lib/ArticleRenderer';
+import { pillarMap, pillarPalette } from '@frontend/lib/pillars';
+import { ArticleRenderer } from '@frontend/web/components/lib/ArticleRenderer';
 
 const wrapper = css`
     padding-top: 6px;

--- a/frontend/web/components/CookieBanner.test.tsx
+++ b/frontend/web/components/CookieBanner.test.tsx
@@ -4,12 +4,12 @@ import CookieBanner from './CookieBanner';
 import {
     getCookie as getCookie_,
     addCookie as addCookie_,
-} from '../lib/cookie';
+} from '@frontend/web/lib/cookie';
 
 const getCookie: any = getCookie_;
 const addCookie: any = addCookie_;
 
-jest.mock('../lib/cookie', () => ({
+jest.mock('@frontend/web/lib/cookie', () => ({
     getCookie: jest.fn(() => null),
     addCookie: jest.fn(() => null),
 }));

--- a/frontend/web/components/CookieBanner.tsx
+++ b/frontend/web/components/CookieBanner.tsx
@@ -4,7 +4,7 @@ import { palette } from '@guardian/pasteup/palette';
 import { sans, serif } from '@guardian/pasteup/fonts';
 import { Container } from '@guardian/guui';
 import TickIcon from '@guardian/pasteup/icons/tick.svg';
-import { getCookie, addCookie } from '../lib/cookie';
+import { getCookie, addCookie } from '@frontend/web/lib/cookie';
 
 const banner = css`
     position: fixed;

--- a/frontend/web/components/Footer.tsx
+++ b/frontend/web/components/Footer.tsx
@@ -6,7 +6,7 @@ import { sans } from '@guardian/pasteup/fonts';
 
 import { Container } from '@guardian/guui';
 import { palette } from '@guardian/pasteup/palette';
-import { footerLinks, Link } from '../../lib/footer-links';
+import { footerLinks, Link } from '@frontend/lib/footer-links';
 
 const footer = css`
     background-color: ${palette.neutral[20]};

--- a/frontend/web/components/Header/Nav/EditionDropdown.tsx
+++ b/frontend/web/components/Header/Nav/EditionDropdown.tsx
@@ -4,7 +4,7 @@ import { css } from 'react-emotion';
 import { Dropdown } from '@guardian/guui';
 import { desktop, leftCol, wide } from '@guardian/pasteup/breakpoints';
 import { Link } from '@guardian/guui/components/Dropdown';
-import { getCookie } from '../../../lib/cookie';
+import { getCookie } from '@frontend/web/lib/cookie';
 
 const editionDropdown = css`
     display: none;

--- a/frontend/web/components/Header/Nav/Links/SupportTheGuardian.test.tsx
+++ b/frontend/web/components/Header/Nav/Links/SupportTheGuardian.test.tsx
@@ -4,12 +4,12 @@ import SupportTheGuardian from './SupportTheGuardian';
 import {
     getCookie as getCookie_,
     addCookie as addCookie_,
-} from '../../../../lib/cookie';
+} from '@frontend/web/lib/cookie';
 
 const getCookie: any = getCookie_;
 const addCookie: any = addCookie_;
 
-jest.mock('../../../../lib/cookie', () => ({
+jest.mock('@frontend/web/lib/cookie', () => ({
     getCookie: jest.fn(() => null),
     addCookie: jest.fn(() => null),
 }));

--- a/frontend/web/components/Header/Nav/Links/SupportTheGuardian.tsx
+++ b/frontend/web/components/Header/Nav/Links/SupportTheGuardian.tsx
@@ -11,8 +11,8 @@ import {
 import ProfileIcon from '@guardian/pasteup/icons/profile.svg';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';
 
-import { getCookie } from '../../../../lib/cookie';
-import { AsyncClientComponent } from '../../../lib/AsyncClientComponent';
+import { getCookie } from '@frontend/web/lib/cookie';
+import { AsyncClientComponent } from '@frontend/web/components/lib/AsyncClientComponent';
 
 const style = css`
     position: relative;

--- a/frontend/web/components/Header/Nav/MainMenu/Column.tsx
+++ b/frontend/web/components/Header/Nav/MainMenu/Column.tsx
@@ -3,7 +3,7 @@ import { serif } from '@guardian/pasteup/fonts';
 import { css, cx } from 'react-emotion';
 
 import { desktop, tablet, leftCol } from '@guardian/pasteup/breakpoints';
-import { pillarMap, pillarPalette } from '../../../../../lib/pillars';
+import { pillarMap, pillarPalette } from '@frontend/lib/pillars';
 import { palette } from '@guardian/pasteup/palette';
 import { CollapseColumnButton } from './CollapseColumnButton';
 

--- a/frontend/web/components/Header/Nav/Pillars/index.tsx
+++ b/frontend/web/components/Header/Nav/Pillars/index.tsx
@@ -9,7 +9,7 @@ import {
 } from '@guardian/pasteup/breakpoints';
 
 import { serif } from '@guardian/pasteup/fonts';
-import { pillarMap, pillarPalette } from '../../../../../lib/pillars';
+import { pillarMap, pillarPalette } from '@frontend/lib/pillars';
 import { palette } from '@guardian/pasteup/palette';
 
 const pillarColours = pillarMap(

--- a/frontend/web/components/Header/Nav/SubNav/Inner.tsx
+++ b/frontend/web/components/Header/Nav/SubNav/Inner.tsx
@@ -8,7 +8,7 @@ import {
     mobileMedium,
     mobileLandscape,
 } from '@guardian/pasteup/breakpoints';
-import { pillarPalette, pillarMap } from '../../../../../lib/pillars';
+import { pillarPalette, pillarMap } from '@frontend/lib/pillars';
 
 const wrapperCollapsed = css`
     height: 36px;

--- a/frontend/web/components/Header/Nav/index.tsx
+++ b/frontend/web/components/Header/Nav/index.tsx
@@ -10,7 +10,7 @@ import Pillars from './Pillars';
 import MainMenuToggle from './MainMenuToggle';
 import { MainMenu } from './MainMenu';
 import SubNav from './SubNav/SubNav';
-import { getCookie } from '../../../lib/cookie';
+import { getCookie } from '@frontend/web/lib/cookie';
 
 const centered = css`
     ${tablet} {

--- a/frontend/web/components/ShareCount.test.tsx
+++ b/frontend/web/components/ShareCount.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, wait, waitForElement } from 'react-testing-library';
 import { ShareCount } from './ShareCount';
-import { CAPI } from '../../../test/fixtures/CAPI';
+import { CAPI } from '@root/test/fixtures/CAPI';
 
 const fetchResult: (
     shareCount: number,

--- a/frontend/web/components/ShareCount.tsx
+++ b/frontend/web/components/ShareCount.tsx
@@ -5,7 +5,7 @@ import ShareIcon from '@guardian/pasteup/icons/share.svg';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';
 import { sans } from '@guardian/pasteup/fonts';
 import { from, wide, leftCol } from '@guardian/pasteup/breakpoints';
-import { integerCommas } from '../../lib/formatters';
+import { integerCommas } from '@frontend/lib/formatters';
 
 const shareCount = css`
     font-size: 18px;

--- a/frontend/web/components/ShareIcons.tsx
+++ b/frontend/web/components/ShareIcons.tsx
@@ -11,7 +11,7 @@ import WhatsAppIcon from '@guardian/pasteup/icons/whatsapp.svg';
 import MessengerIcon from '@guardian/pasteup/icons/messenger.svg';
 import { phablet, wide } from '@guardian/pasteup/breakpoints';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';
-import { pillarMap, pillarPalette } from '../../lib/pillars';
+import { pillarMap, pillarPalette } from '@frontend/lib/pillars';
 
 const pillarFill = pillarMap(
     pillar =>

--- a/frontend/web/components/SubMetaLinksList.tsx
+++ b/frontend/web/components/SubMetaLinksList.tsx
@@ -3,7 +3,7 @@ import { css, cx } from 'react-emotion';
 import { palette } from '@guardian/pasteup/palette';
 import { sans, serif } from '@guardian/pasteup/fonts';
 
-import { pillarMap, pillarPalette } from '../../lib/pillars';
+import { pillarMap, pillarPalette } from '@frontend/lib/pillars';
 
 const pillarColours = pillarMap(
     pillar =>

--- a/frontend/web/components/elements/ImageBlockComponent.tsx
+++ b/frontend/web/components/elements/ImageBlockComponent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Picture, ImageSource } from '../Picture';
+import { Picture, ImageSource } from '@frontend/web/components/Picture';
 
 const makeSource: (image: Image) => ImageSource = image => {
     return {

--- a/frontend/web/components/lib/ArticleRenderer.tsx
+++ b/frontend/web/components/lib/ArticleRenderer.tsx
@@ -1,5 +1,5 @@
-import { TextBlockComponent } from '../elements/TextBlockComponent';
-import { ImageBlockComponent } from '../elements/ImageBlockComponent';
+import { TextBlockComponent } from '@frontend/web/components/elements/TextBlockComponent';
+import { ImageBlockComponent } from '@frontend/web/components/elements/ImageBlockComponent';
 import React from 'react';
 
 export const ArticleRenderer: React.SFC<{ elements: CAPIElement[] }> = ({

--- a/frontend/web/document.tsx
+++ b/frontend/web/document.tsx
@@ -4,8 +4,8 @@ import { renderToString } from 'react-dom/server';
 
 import htmlTemplate from './htmlTemplate';
 import Article from './pages/Article';
-import assets from '../lib/assets';
-import { GADataType } from '../lib/parse-capi';
+import assets from '@frontend/lib/assets';
+import { GADataType } from '@frontend/lib/parse-capi';
 
 interface Props {
     data: {

--- a/frontend/web/htmlTemplate.ts
+++ b/frontend/web/htmlTemplate.ts
@@ -1,6 +1,6 @@
-import resetCSS from /* preval */ '../lib/reset-css';
-import fontsCSS from '../lib/fonts-css';
-import assets from '../lib/assets';
+import resetCSS from /* preval */ '@frontend/lib/reset-css';
+import fontsCSS from '@frontend/lib/fonts-css';
+import assets from '@frontend/lib/assets';
 
 export default ({
     title = 'The Guardian',

--- a/frontend/web/pages/Article.tsx
+++ b/frontend/web/pages/Article.tsx
@@ -4,13 +4,13 @@ import { css } from 'react-emotion';
 import { palette } from '@guardian/pasteup/palette';
 import { desktop, mobileLandscape } from '@guardian/pasteup/breakpoints';
 
-import { MostViewed } from '../components/MostViewed';
-import Header from '../components/Header';
-import Footer from '../components/Footer';
-import ArticleBody from '../components/ArticleBody';
-import BackToTop from '../components/BackToTop';
-import SubNav from '../components/Header/Nav/SubNav/SubNav';
-import CookieBanner from '../components/CookieBanner';
+import { MostViewed } from '@frontend/web/components/MostViewed';
+import Header from '@frontend/web/components/Header';
+import Footer from '@frontend/web/components/Footer';
+import ArticleBody from '@frontend/web/components/ArticleBody';
+import BackToTop from '@frontend/web/components/BackToTop';
+import SubNav from '@frontend/web/components/Header/Nav/SubNav/SubNav';
+import CookieBanner from '@frontend/web/components/CookieBanner';
 
 // TODO: find a better of setting opacity
 const articleWrapper = css`

--- a/lib/deploy/build-riffraff-bundle.js
+++ b/lib/deploy/build-riffraff-bundle.js
@@ -4,8 +4,8 @@ const writeFile = promisify(require('fs').writeFile);
 const execa = require('execa');
 const path = require('path');
 const cpy = require('cpy');
-const { warn, log } = require('../log');
-const { siteName, root, dist, target } = require('../../config');
+const { warn, log } = require('@root/lib/log');
+const { siteName, root, dist, target } = require('@root/config');
 
 // This task generates the riff-raff bundle. It creates the following
 // directory layout under target/

--- a/lib/deploy/build-riffraff-bundle.js
+++ b/lib/deploy/build-riffraff-bundle.js
@@ -4,8 +4,8 @@ const writeFile = promisify(require('fs').writeFile);
 const execa = require('execa');
 const path = require('path');
 const cpy = require('cpy');
-const { warn, log } = require('@root/lib/log');
-const { siteName, root, dist, target } = require('@root/config');
+const { warn, log } = require('../log');
+const { siteName, root, dist, target } = require('../../config');
 
 // This task generates the riff-raff bundle. It creates the following
 // directory layout under target/

--- a/package.json
+++ b/package.json
@@ -106,10 +106,10 @@
         "setupTestFrameworkScriptFile": "<rootDir>/test/jest.setup.ts",
         "snapshotSerializers": ["jest-emotion/serializer"],
         "moduleNameMapper": {
-            "^svgs/(.*)$": "<rootDir>/__mocks__/svgMock.tsx",
-            "^(.*)\\.svg$": "<rootDir>/__mocks__/svgMock.tsx",
+            "^@root(.*)$": "<rootDir>$1",
             "^@frontend(.*)$": "<rootDir>/frontend$1",
-            "^@root(.*)$": "<rootDir>$1"
+            "^svgs/(.*)$": "<rootDir>/__mocks__/svgMock.tsx",
+            "^(.*)\\.svg$": "<rootDir>/__mocks__/svgMock.tsx"
         },
         "testResultsProcessor": "jest-teamcity-reporter"
     }

--- a/package.json
+++ b/package.json
@@ -107,7 +107,9 @@
         "snapshotSerializers": ["jest-emotion/serializer"],
         "moduleNameMapper": {
             "^svgs/(.*)$": "<rootDir>/__mocks__/svgMock.tsx",
-            "^(.*)\\.svg$": "<rootDir>/__mocks__/svgMock.tsx"
+            "^(.*)\\.svg$": "<rootDir>/__mocks__/svgMock.tsx",
+            "^@frontend(.*)$": "<rootDir>/frontend$1",
+            "^@root(.*)$": "<rootDir>$1"
         },
         "testResultsProcessor": "jest-teamcity-reporter"
     }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "babel-loader": "^8.0.0",
         "babel-plugin-dynamic-import-node": "^1.2.0",
         "babel-plugin-emotion": "^9.2.6",
+        "babel-plugin-module-resolver": "^3.1.1",
         "babel-plugin-preval": "^3.0.0",
         "bundlesize": "^0.17.0",
         "friendly-errors-webpack-plugin": "^1.7.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,6 +41,7 @@
         "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
         /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
         "paths": {
+            /* Aliases should also be added to the webpack, babel and jest configurations */
             "@root/*": ["./*"],
             "@frontend/*": ["frontend/*"],
          },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,6 @@
         // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
         // "downlevelIteration": true,            /* Provide full suppotrt for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
         // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-
         /* Strict Type-Checking Options */
         "strict": true  /* Enable all strict type-checking options. */,
         // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
@@ -39,11 +38,11 @@
 
         /* Module Resolution Options */
         "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-        // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-        //  "paths": {
-        //      "*":["node_modules/*"]
-        //      //"@guardian/*":["packages/*"]
-        //  },                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+        "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+        /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+        "paths": {
+             "@frontend/*": ["frontend/*"],
+         },
         // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
         // "typeRoots": [],                       /* List of folders to include type definitions from. */
         // "types": [],                           /* Type declaration files to be included in compilation. */
@@ -63,5 +62,5 @@
     },
     "exclude": [
         "node_modules"
-    ]
+    ],
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,7 +41,8 @@
         "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
         /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
         "paths": {
-             "@frontend/*": ["frontend/*"],
+            "@root/*": ["./*"],
+            "@frontend/*": ["frontend/*"],
          },
         // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
         // "typeRoots": [],                       /* List of folders to include type definitions from. */

--- a/webpack/browser.js
+++ b/webpack/browser.js
@@ -2,7 +2,7 @@ const webpack = require('webpack');
 const AssetsManifest = require('webpack-assets-manifest');
 const FriendlyErrorsWebpackPlugin = require('friendly-errors-webpack-plugin');
 const chalk = require('chalk');
-const { siteName } = require('../config');
+const { siteName } = require('@root/config');
 
 const friendlyErrorsWebpackPlugin = new FriendlyErrorsWebpackPlugin({
     compilationSuccessInfo: {

--- a/webpack/browser.js
+++ b/webpack/browser.js
@@ -2,7 +2,7 @@ const webpack = require('webpack');
 const AssetsManifest = require('webpack-assets-manifest');
 const FriendlyErrorsWebpackPlugin = require('friendly-errors-webpack-plugin');
 const chalk = require('chalk');
-const { siteName } = require('@root/config');
+const { siteName } = require('../config');
 
 const friendlyErrorsWebpackPlugin = new FriendlyErrorsWebpackPlugin({
     compilationSuccessInfo: {

--- a/webpack/index.js
+++ b/webpack/index.js
@@ -24,6 +24,9 @@ const common = ({ platform, page = '' }) => ({
             ? 'sourcemap'
             : 'cheap-module-eval-source-map',
     resolve: {
+        alias: {
+            '@frontend': path.resolve(__dirname, '..', 'frontend'),
+        },
         extensions: ['.js', '.ts', '.tsx', '.jsx'],
     },
     module: {

--- a/webpack/index.js
+++ b/webpack/index.js
@@ -25,6 +25,7 @@ const common = ({ platform, page = '' }) => ({
             : 'cheap-module-eval-source-map',
     resolve: {
         alias: {
+            '@root': path.resolve(__dirname, '.'),
             '@frontend': path.resolve(__dirname, '..', 'frontend'),
         },
         extensions: ['.js', '.ts', '.tsx', '.jsx'],

--- a/webpack/index.js
+++ b/webpack/index.js
@@ -2,9 +2,9 @@ const path = require('path');
 const webpack = require('webpack');
 const { smart: merge } = require('webpack-merge');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
-const ReportBundleSize = require('@root/lib/report-bundle-size');
-const Progress = require('@root/lib/webpack-progress');
-const { root, dist, siteName, getPagesForSite } = require('@root/config');
+const ReportBundleSize = require('../lib/report-bundle-size');
+const Progress = require('../lib/webpack-progress');
+const { root, dist, siteName, getPagesForSite } = require('../config');
 
 const PROD = process.env.NODE_ENV === 'production';
 

--- a/webpack/index.js
+++ b/webpack/index.js
@@ -2,9 +2,9 @@ const path = require('path');
 const webpack = require('webpack');
 const { smart: merge } = require('webpack-merge');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
-const ReportBundleSize = require('../lib/report-bundle-size');
-const Progress = require('../lib/webpack-progress');
-const { root, dist, siteName, getPagesForSite } = require('../config');
+const ReportBundleSize = require('@root/lib/report-bundle-size');
+const Progress = require('@root/lib/webpack-progress');
+const { root, dist, siteName, getPagesForSite } = require('@root/config');
 
 const PROD = process.env.NODE_ENV === 'production';
 

--- a/webpack/server.js
+++ b/webpack/server.js
@@ -1,4 +1,4 @@
-const { siteName } = require('@root/config');
+const { siteName } = require('../config');
 
 module.exports = () => ({
     entry: {

--- a/webpack/server.js
+++ b/webpack/server.js
@@ -1,4 +1,4 @@
-const { siteName } = require('../config');
+const { siteName } = require('@root/config');
 
 module.exports = () => ({
     entry: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1605,6 +1605,16 @@ babel-plugin-macros@^2.0.0, babel-plugin-macros@^2.2.2:
   dependencies:
     cosmiconfig "^5.0.5"
 
+babel-plugin-module-resolver@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.1.1.tgz#881cf67e3d4b8400d5eaaefc1be44d2dc1fe404f"
+  dependencies:
+    find-babel-config "^1.1.0"
+    glob "^7.1.2"
+    pkg-up "^2.0.0"
+    reselect "^3.0.1"
+    resolve "^1.4.0"
+
 babel-plugin-preval@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-preval/-/babel-plugin-preval-3.0.0.tgz#16fd31f5ac7869b0648211c21d93b34af7281a4f"
@@ -3548,6 +3558,13 @@ finalhandler@1.1.1:
     parseurl "~1.3.2"
     statuses "~1.4.0"
     unpipe "~1.0.0"
+
+find-babel-config@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/find-babel-config/-/find-babel-config-1.1.0.tgz#acc01043a6749fec34429be6b64f542ebb5d6355"
+  dependencies:
+    json5 "^0.5.1"
+    path-exists "^3.0.0"
 
 find-cache-dir@^1.0.0:
   version "1.0.0"
@@ -6244,6 +6261,12 @@ pkg-dir@^3.0.0:
   dependencies:
     find-up "^3.0.0"
 
+pkg-up@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-2.0.0.tgz#c819ac728059a461cab1c3889a2be3c49a004d7f"
+  dependencies:
+    find-up "^2.1.0"
+
 pm2-axon-rpc@^0.5.0, pm2-axon-rpc@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/pm2-axon-rpc/-/pm2-axon-rpc-0.5.1.tgz#ad3c43c43811c71f13e5eee2821194d03ceb03fe"
@@ -7249,6 +7272,10 @@ require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
 
+reselect@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
+
 reset-css@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/reset-css/-/reset-css-3.0.0.tgz#9b421d34fefc6e5d5b915ee7bfd72b1bc19cfbb0"
@@ -7275,7 +7302,7 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.1.6, resolve@^1.3.2:
+resolve@^1.1.6, resolve@^1.3.2, resolve@^1.4.0:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   dependencies:


### PR DESCRIPTION
## What does this change?

Currently our code is full of relative paths i our module imports. eg.

`import { pillarPalette } from '../../../lib/pillars';`

This PR introduces two new aliases `@frontend` and `@root`. So the above import would become...

`import { pillarPalette } from '@frontend/lib/pillars';`

The `@` at the beginning of the alias names is a convention that makes it easier to identify aliases when browsing code.

## Why?

Relative paths for imports make code hard to maintain (paths break when you move modules) and make it difficult to identify where the dependency lives relative to the current module.