### PR TITLE
Read edition value from page data object

### DIFF
--- a/frontend/lib/parse-capi/index.ts
+++ b/frontend/lib/parse-capi/index.ts
@@ -296,7 +296,6 @@ export const extractArticleMeta = (data: {}): CAPIType => {
     // editionLongForm is that value, or empty string.
     const editionLongForm = getString(data, 'config.page.edition', '');
 
-    // We compute the editionId from the editionLongForm
     // Possible values for the editionId: "UK", "US", "AU", "INT"
     const editionId = getEditionValue(
         getString(data, 'config.page.editionId', ''),

--- a/frontend/lib/parse-capi/index.ts
+++ b/frontend/lib/parse-capi/index.ts
@@ -88,14 +88,14 @@ const findPillar: (name: string) => Pillar | undefined = name => {
     return pillarNames.find(_ => _ === pillar);
 };
 
-const findEdition: (name: string) => Edition | undefined = name => {
+const getEditionValue: (name: string) => Edition = name => {
     const editions: Edition[] = ['UK', 'US', 'INT', 'AU'];
-    return editions.find(_ => _ === name);
+    const edition = editions.find(_ => _ === name);
+    return edition === undefined ? 'UK' : edition;
 };
 
 const getLink = (data: {}, { isPillar }: { isPillar: boolean }): LinkType => {
     const title = getString(data, 'title');
-
     return {
         title,
         longTitle: getString(data, 'longTitle') || title,
@@ -298,10 +298,8 @@ export const extractArticleMeta = (data: {}): CAPIType => {
 
     // We compute the editionId from the editionLongForm
     // Possible values for the editionId: "UK", "US", "AU", "INT"
-    const editionId = findEdition(
-        (editionLongForm === '' ? '' : editionLongForm.split(' ')[0])
-            .replace('Australia', 'AU')
-            .replace('International', 'INT'),
+    const editionId = getEditionValue(
+        getString(data, 'config.page.editionId', ''),
     );
 
     if (editionId === undefined) throw new Error('goodbye');

--- a/test/fixtures/CAPI.ts
+++ b/test/fixtures/CAPI.ts
@@ -1,7 +1,10 @@
 const pillar: Pillar = 'lifestyle';
 
+const editionId: Edition = 'UK';
+
 export const CAPI = {
     pillar,
+    editionId,
     isArticle: true,
     webPublicationDate: new Date('November 02, 2018 09:45:30'),
     webPublicationDateDisplay: 'Fri 02 Mar 2018 09.45 GMT',


### PR DESCRIPTION
## What does this change?

1. Now that the `editionId` has been added to frontend we read it from there instead of computing it from the `editionLongForm`.

2. This also fixes `test/fixtures/CAPI.ts` which was broken here: https://github.com/guardian/dotcom-rendering/pull/278

## Why?

To limit the amount of processing done on the client side.