### PR TITLE
Move EditionDropdown to stateless component

### DIFF
--- a/frontend/amp/components/Header.tsx
+++ b/frontend/amp/components/Header.tsx
@@ -200,10 +200,10 @@ const pillarLinks = (pillars: PillarType[], activePillar: Pillar) => (
 const supportLink =
     'https://support.theguardian.com/?INTCMP=header_support&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support%22%7D';
 
-const Header: React.SFC<{ nav: NavType; activePillar: Pillar }> = ({
-    nav,
-    activePillar,
-}) => (
+const Header: React.SFC<{
+    nav: NavType;
+    activePillar: Pillar;
+}> = ({ nav, activePillar }) => (
     <header className={headerStyles}>
         <div className={row}>
             <div className={supportStyles}>

--- a/frontend/web/components/Header/Nav/EditionDropdown.tsx
+++ b/frontend/web/components/Header/Nav/EditionDropdown.tsx
@@ -1,10 +1,9 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { css } from 'react-emotion';
 
 import { Dropdown } from '@guardian/guui';
 import { desktop, leftCol, wide } from '@guardian/pasteup/breakpoints';
 import { Link } from '@guardian/guui/components/Dropdown';
-import { getCookie } from '@frontend/web/lib/cookie';
 
 const editionDropdown = css`
     display: none;
@@ -23,65 +22,57 @@ const editionDropdown = css`
     }
 `;
 
-const uk: Link = {
+const ukEditionLink: Link = {
     url: '/preference/edition/uk',
     title: 'UK edition',
     isActive: true,
 };
 
-const us: Link = {
+const usEditionLink: Link = {
     url: '/preference/edition/us',
     title: 'US edition',
 };
 
-const au: Link = {
+const auEditionLink: Link = {
     url: '/preference/edition/au',
     title: 'Australian edition',
 };
 
-const int: Link = {
+const intEditionLink: Link = {
     url: '/preference/edition/int',
     title: 'International edition',
 };
 
-const defaultEdition = 'UK';
-
-const editions: { [key: string]: Link } = {
-    UK: uk,
-    US: us,
-    AU: au,
-    INT: int,
+const lookUpEditionLink = (edition: Edition): Link => {
+    const mapping = {
+        UK: ukEditionLink,
+        US: usEditionLink,
+        AU: auEditionLink,
+        INT: intEditionLink,
+    };
+    return mapping[edition];
 };
 
-export default class EditionDropdown extends Component<
-    {},
-    { edition: string }
-> {
-    constructor(props: {}) {
-        super(props);
-        this.state = { edition: defaultEdition };
-    }
-    public componentDidMount() {
-        const selectedEdition = getCookie('GU_EDITION');
-        if (selectedEdition && this.state.edition !== selectedEdition) {
-            this.setState({ edition: selectedEdition });
-        }
-    }
-    public render() {
-        const activeEdition = editions[this.state.edition];
-        const links = [uk, us, au, int].filter(
-            ed => ed.url !== activeEdition.url,
-        );
-        links.unshift(activeEdition);
+const EditionDropdown: React.SFC<{
+    edition: Edition;
+}> = ({ edition }) => {
+    const activeEditionLink = lookUpEditionLink(edition);
+    const links = [
+        ukEditionLink,
+        usEditionLink,
+        auEditionLink,
+        intEditionLink,
+    ].filter(ed => ed.url !== activeEditionLink.url);
+    links.unshift(activeEditionLink);
+    return (
+        <div className={editionDropdown}>
+            <Dropdown
+                label={activeEditionLink.title}
+                links={links}
+                id="edition"
+            />
+        </div>
+    );
+};
 
-        return (
-            <div className={editionDropdown}>
-                <Dropdown
-                    label={activeEdition.title}
-                    links={links}
-                    id="edition"
-                />
-            </div>
-        );
-    }
-}
+export default EditionDropdown;

--- a/frontend/web/components/Header/Nav/index.tsx
+++ b/frontend/web/components/Header/Nav/index.tsx
@@ -33,6 +33,7 @@ const centered = css`
 interface Props {
     nav: NavType;
     pillar: Pillar;
+    edition: Edition;
 }
 
 export default class Nav extends Component<
@@ -77,7 +78,7 @@ export default class Nav extends Component<
                     role="navigation"
                     aria-label="Guardian sections"
                 >
-                    <EditionDropdown />
+                    <EditionDropdown edition={this.props.edition} />
                     <Logo />
                     {/*
                         TODO: The properties of the Links component

--- a/frontend/web/components/Header/index.tsx
+++ b/frontend/web/components/Header/index.tsx
@@ -18,9 +18,10 @@ const header = css`
 const Header: React.SFC<{
     nav: NavType;
     pillar: Pillar;
-}> = ({ nav, pillar }) => (
+    edition: Edition;
+}> = ({ nav, pillar, edition }) => (
     <header className={header}>
-        <Nav nav={nav} pillar={pillar} />
+        <Nav nav={nav} pillar={pillar} edition={edition} />
     </header>
 );
 

--- a/frontend/web/pages/Article.tsx
+++ b/frontend/web/pages/Article.tsx
@@ -65,7 +65,11 @@ const Article: React.SFC<{
     data: ArticleProps;
 }> = ({ data }) => (
     <div>
-        <Header nav={data.NAV} pillar={data.CAPI.pillar} />
+        <Header
+            nav={data.NAV}
+            pillar={data.CAPI.pillar}
+            edition={data.CAPI.editionId}
+        />
         <main className={articleWrapper}>
             <Container className={articleContainer}>
                 <article>


### PR DESCRIPTION
## What does this change?

Move EditionDropdown to stateless component

## Why?

To comply with the principle that we should be using stateless components as often as possible.