### PR TITLE
(AMP) header part two

### DIFF
--- a/frontend/amp/components/Body.tsx
+++ b/frontend/amp/components/Body.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import InnerContainer from '@frontend/amp/components/InnerContainer';
+import { Elements } from '@frontend/amp/components/lib/Elements';
+import { css } from 'react-emotion';
+import { ArticleModel } from '@frontend/amp/pages/Article';
+import { MainBlock } from '@frontend/amp/components/MainBlock';
+
+const body = css`
+    background-color: white;
+`;
+
+const Body: React.SFC<{
+    pillar: Pillar;
+    data: ArticleModel;
+    config: ConfigType;
+}> = ({ pillar, data, config }) => (
+    <InnerContainer className={body}>
+        <MainBlock config={config} articleData={data} />
+        <Elements pillar={pillar} elements={data.elements} />
+    </InnerContainer>
+);
+
+export default Body;

--- a/frontend/amp/components/Sidebar.tsx
+++ b/frontend/amp/components/Sidebar.tsx
@@ -1,72 +1,185 @@
 import React from 'react';
-import { css } from 'react-emotion';
+import { css, cx } from 'react-emotion';
+import { palette } from '@guardian/pasteup/palette';
+import { serif } from '@guardian/pasteup/fonts';
 
 const sidebarStyles = css`
     width: 80vh;
+    background-color: ${palette.brand.blue};
+
+    a {
+        color: ${palette.neutral[100]};
+    }
+
+    [aria-expanded='true'] {
+        i {
+            margin-top: 2px;
+        }
+
+        i:before {
+            transform: rotate(-135deg);
+        }
+    }
+`;
+
+const group = css`
+    padding-bottom: 0.75rem;
+`;
+
+const pillarLink = css`
+    background-color: transparent;
+    border: 0;
+    box-sizing: border-box;
+    display: block;
+    font-size: 20px;
+    font-weight: 400;
+    line-height: 20px;
+    outline: none;
+    padding: 8px 10px 8px 50px;
+    padding-top: 8px;
+    padding-bottom: 8px;
+    position: relative;
+    text-align: left;
+    width: 100%;
+    font-weight: 500;
+    font-size: 24px;
+    padding-bottom: 16px;
+    padding-top: 6px;
+    color: ${palette.neutral[100]};
+    font-family: ${serif.headline};
+
+    i {
+        margin-top: -4px;
+        left: 25px;
+        position: absolute;
+
+        :before {
+            border: 2px solid #fff;
+            border-top: 0;
+            border-left: 0;
+            content: '';
+            display: inline-block;
+            height: 8px;
+            transform: rotate(45deg);
+            width: 8px;
+            color: ${palette.neutral[100]};
+        }
+    }
+`;
+
+const link = css`
+    background-color: transparent;
+    border: 0;
+    box-sizing: border-box;
+    color: ${palette.neutral[100]};
+    text-decoration: none;
+    display: block;
+    font-size: 20px;
+    font-weight: 400;
+    line-height: 20px;
+    outline: none;
+    padding: 8px 10px 8px 50px;
+    position: relative;
+    text-align: left;
+    width: 100%;
+    font-family: ${serif.body};
+`;
+
+const subLinks = css`
+    background-color: #041f4a;
+    padding-bottom: 12px;
+
+    a {
+        ${link};
+    }
+`;
+
+const otherLinks = css`
+    a {
+        ${link};
+    }
+`;
+
+const membershipLinks = css`
+    a {
+        color: #ffe500;
+    }
+`;
+
+const menuItem = css`
+    position: relative;
+
+    :not(:last-child):after {
+        background-color: rgba(255, 255, 255, 0.3);
+        bottom: 0;
+        content: '';
+        display: block;
+        height: 1px;
+        left: 50px;
+        position: absolute;
+        width: 100%;
+    }
 `;
 
 const template = `
-<ul>
-    {{ #topLevelSections }}
-        <li>
-            <amp-accordion>
-                <section>
-                    <h2
-                        data-link-name="amp : nav : secondary : {{ title }}">
-                        <i></i>
-                        {{ title }}
-                    </h2>
+<ul class=${group}>
+{{ #topLevelSections }}
+    <li class=${menuItem}>
+        <amp-accordion>
+            <section>
+                <h2 class=${pillarLink}
+                    data-link-name="amp : nav : secondary : {{ title }}">
+                    <i></i>
+                    {{ title }}
+                </h2>
 
-                    <ul>
-                        {{ #subSections }}
-                            <li>
-                                <a
-                                    href="{{ url }}"
-                                    data-link-name="amp : nav : secondary : {{ title }}">
-                                    {{ title }}
-                                </a>
-                            </li>
-                        {{ /subSections }}
-                    </ul>
-                </section>
-            </amp-accordion>
-        </li>
-    {{ /topLevelSections }}
+                <ul class=${subLinks}>
+                    {{ #subSections }}
+                        <li>
+                            <a
+                                href="{{ url }}"
+                                data-link-name="amp : nav : secondary : {{ title }}">
+                                {{ title }}
+                            </a>
+                        </li>
+                    {{ /subSections }}
+                </ul>
+            </section>
+        </amp-accordion>
+    </li>
+{{ /topLevelSections }}
 </ul>
 
-<ul
-    role="menubar">
-    {{ #readerRevenueLinks }}
-        <li
-            role="menuitem">
+<ul class=${cx(otherLinks, membershipLinks)}>
+{{ #readerRevenueLinks }}
+    <li
+        role="menuitem">
 
-            <a
-                href="{{ url }}"
-                data-link-name="amp : nav : {{ title }}">
-                {{ title }}
-            </a>
-        </li>
-    {{ /readerRevenueLinks }}
-
-    <li>
-        <a href="@{Configuration.id.url}/signin?INTCMP=DOTCOM_HEADER_SIGNIN"
-            data-link-name="amp : nav : sign in"
-            >
-            Sign in / Register
+        <a
+            href="{{ url }}"
+            data-link-name="amp : nav : {{ title }}">
+            {{ title }}
         </a>
     </li>
+{{ /readerRevenueLinks }}
+
+<li>
+    <a href="https://profile.theguardian.com/signin?INTCMP=DOTCOM_NEWHEADER_SIGNIN&ABCMP=ab-sign-in"
+        data-link-name="amp : nav : sign in">
+        Sign in / Register
+    </a>
+</li>
 </ul>
 
-<ul>
-    {{ #secondarySections }}
-        <li>
-            <a
-                href="{{ url }}"
-                data-link-name="amp : nav : {{ title }}">
-                {{ title }}
-            </a>
-        </li>
-    {{ /secondarySections }}
+<ul class=${cx(otherLinks, group)}>
+{{ #secondarySections }}
+    <li>
+        <a href="{{ url }}"
+            data-link-name="amp : nav : {{ title }}">
+            {{ title }}
+        </a>
+    </li>
+{{ /secondarySections }}
 </ul>
 `;
 
@@ -80,7 +193,6 @@ const Sidebar: React.SFC<{ nav: NavType }> = ({ nav }) => (
             <template type="amp-mustache">
                 <div dangerouslySetInnerHTML={{ __html: template }} />
             </template>
-            />
         </amp-list>
     </amp-sidebar>
 );

--- a/frontend/amp/components/Sidebar.tsx
+++ b/frontend/amp/components/Sidebar.tsx
@@ -22,7 +22,7 @@ const sidebarStyles = css`
     }
 `;
 
-const group = css`
+const menuGroup = css`
     padding-bottom: 0.75rem;
 `;
 
@@ -106,7 +106,7 @@ const membershipLinks = css`
     }
 `;
 
-const menuItem = css`
+const pillar = css`
     position: relative;
 
     :not(:last-child):after {
@@ -122,9 +122,9 @@ const menuItem = css`
 `;
 
 const template = `
-<ul class=${group}>
+<ul class=${menuGroup}>
 {{ #topLevelSections }}
-    <li class=${menuItem}>
+    <li class=${pillar}>
         <amp-accordion>
             <section>
                 <h2 class=${pillarLink}
@@ -171,7 +171,7 @@ const template = `
 </li>
 </ul>
 
-<ul class=${cx(otherLinks, group)}>
+<ul class=${cx(otherLinks, menuGroup)}>
 {{ #secondarySections }}
     <li>
         <a href="{{ url }}"

--- a/frontend/amp/components/lib/Elements.tsx
+++ b/frontend/amp/components/lib/Elements.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { ImageBlockComponent } from '@frontend/amp/components/elements/ImageBlockComponent';
 import { InstagramBlockComponent } from '../elements/InstagramBlockComponent';
 
-export const AmpRenderer: React.SFC<{
+export const Elements: React.SFC<{
     elements: CAPIElement[];
     pillar: Pillar;
 }> = ({ elements, pillar }) => {

--- a/frontend/amp/pages/Article.tsx
+++ b/frontend/amp/pages/Article.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import Footer from '@frontend/amp/components/Footer';
 import Container from '@frontend/amp/components/Container';
-import { AmpRenderer } from '@frontend/amp/components/lib/AMPRenderer';
+import Body from '@frontend/amp/components/Body';
 import Header from '@frontend/amp/components/Header';
 import { palette } from '@guardian/pasteup/palette';
 import { css } from 'react-emotion';
+<<<<<<< HEAD
 import InnerContainer from '@frontend/amp/components/InnerContainer';
 import { MainBlock } from '@frontend/amp/components/MainBlock';
+=======
+>>>>>>> Tidy up body structure
 
 const backgroundColour = css`
     background-color: ${palette.neutral[97]};
@@ -43,14 +46,10 @@ export const Article: React.SFC<{
     <div className={backgroundColour}>
         <Container>
             <Header nav={nav} activePillar={articleData.pillar} />
-            <InnerContainer className={body}>
-                <MainBlock config={config} articleData={articleData} />
-                <AmpRenderer
-                    pillar={articleData.pillar}
-                    elements={articleData.elements}
-                />
-            </InnerContainer>
+            <Body pillar={articleData.pillar} data={articleData} config={config}/>
             <Footer />
         </Container>
     </div>
 );
+
+export default Article;

--- a/frontend/amp/pages/Article.tsx
+++ b/frontend/amp/pages/Article.tsx
@@ -5,18 +5,9 @@ import Body from '@frontend/amp/components/Body';
 import Header from '@frontend/amp/components/Header';
 import { palette } from '@guardian/pasteup/palette';
 import { css } from 'react-emotion';
-<<<<<<< HEAD
-import InnerContainer from '@frontend/amp/components/InnerContainer';
-import { MainBlock } from '@frontend/amp/components/MainBlock';
-=======
->>>>>>> Tidy up body structure
 
 const backgroundColour = css`
     background-color: ${palette.neutral[97]};
-`;
-
-const body = css`
-    background-color: white;
 `;
 
 export interface ArticleModel {
@@ -46,7 +37,11 @@ export const Article: React.SFC<{
     <div className={backgroundColour}>
         <Container>
             <Header nav={nav} activePillar={articleData.pillar} />
-            <Body pillar={articleData.pillar} data={articleData} config={config}/>
+            <Body
+                pillar={articleData.pillar}
+                data={articleData}
+                config={config}
+            />
             <Footer />
         </Container>
     </div>

--- a/frontend/app/server.tsx
+++ b/frontend/app/server.tsx
@@ -9,7 +9,7 @@ import {
 } from './aws/aws-parameters';
 import document from '@frontend/web/document';
 import AMPDocument from '@frontend/amp/document';
-import { Article as AMPArticle } from '@frontend/amp/pages/Article';
+import AMPArticle from '@frontend/amp/pages/Article';
 import { dist, root } from '@root/config';
 import { log, warn } from '@root/lib/log';
 


### PR DESCRIPTION
## What does this change?

Implements the nav sidebar.

There is one exclusion - the select edition dropdown, as I think that requires frontend changes which I'll make separately.

I've also introduced a Body component to improve grouping and naming of related components. But **this will probably cause conflicts with people unfortunately.**

<img width="744" alt="screenshot 2018-11-15 at 17 30 10" src="https://user-images.githubusercontent.com/858402/48570442-457ca780-e8fc-11e8-93f4-d9df94cc66f6.png">

## Why?

Part of migrating AMP articles!
