### PR TITLE
Move config and dev-server under frontend

### DIFF
--- a/frontend/app/server.tsx
+++ b/frontend/app/server.tsx
@@ -10,7 +10,7 @@ import {
 import document from '@frontend/web/document';
 import AMPDocument from '@frontend/amp/document';
 import AMPArticle from '@frontend/amp/pages/Article';
-import { dist, root } from '@root/config';
+import { dist, root, prodPort, siteName } from '@frontend/config';
 import { log, warn } from '@root/lib/log';
 
 import {
@@ -25,7 +25,7 @@ const renderArticle = ({ body }: express.Request, res: express.Response) => {
     try {
         const resp = document({
             data: {
-                site: 'frontend',
+                site: siteName,
                 page: 'Article',
                 CAPI: extractArticleMeta(body),
                 NAV: extractNavMeta(body),
@@ -92,7 +92,7 @@ if (process.env.NODE_ENV === 'production') {
             express.static(
                 path.relative(
                     __dirname,
-                    path.resolve(root, 'frontend', 'static'),
+                    path.resolve(root, siteName, 'static'),
                 ),
             ),
         );
@@ -131,5 +131,5 @@ if (process.env.NODE_ENV === 'production') {
         recordBaselineCloudWatchMetrics();
     }, 10 * 1000);
 
-    app.listen(9000);
+    app.listen(prodPort);
 }

--- a/frontend/config.js
+++ b/frontend/config.js
@@ -11,6 +11,8 @@ const getPagesForSite = () =>
 const root = __dirname;
 const dist = resolve(root, 'dist');
 const target = resolve(root, 'target');
+const prodPort = 9000;
+const devServerPort = 3030;
 
 module.exports = {
     dist,
@@ -18,4 +20,6 @@ module.exports = {
     target,
     getPagesForSite,
     siteName,
+    prodPort,
+    devServerPort,
 };

--- a/frontend/dev-server/index.js
+++ b/frontend/dev-server/index.js
@@ -7,17 +7,17 @@ const webpackDevMiddleware = require('webpack-dev-middleware');
 const webpackHotMiddleware = require('webpack-hot-middleware');
 const webpackHotServerMiddleware = require('webpack-hot-server-middleware');
 
-const { siteName, root } = require('./config');
+const { siteName, root, devServerPort } = require('../config');
 
 const go = async () => {
-    const webpackConfig = await require('./webpack');
+    const webpackConfig = await require('../../webpack');
     const compiler = await webpack(webpackConfig);
 
     const app = express();
 
     app.use(
         `/static/${siteName}`,
-        express.static(path.join(root, siteName, 'static')),
+        express.static(path.join(root, 'static')),
     );
 
     app.use(
@@ -73,13 +73,6 @@ const go = async () => {
         }),
     );
 
-    app.get(
-        '/static/frontend',
-        express.static(
-            path.relative(__dirname, path.resolve(root, 'frontend', 'static')),
-        ),
-    );
-
     app.get('/', (req, res) => {
         res.send(`
             <!DOCTYPE html>
@@ -102,7 +95,7 @@ const go = async () => {
         res.status(500).send(err.stack);
     });
 
-    app.listen(3030);
+    app.listen(devServerPort);
 };
 
 go();

--- a/frontend/dev-server/index.js
+++ b/frontend/dev-server/index.js
@@ -15,10 +15,7 @@ const go = async () => {
 
     const app = express();
 
-    app.use(
-        `/static/${siteName}`,
-        express.static(path.join(root, 'static')),
-    );
+    app.use(`/static/${siteName}`, express.static(path.join(root, 'static')));
 
     app.use(
         webpackDevMiddleware(compiler, {

--- a/lib/deploy/build-riffraff-bundle.js
+++ b/lib/deploy/build-riffraff-bundle.js
@@ -5,7 +5,7 @@ const execa = require('execa');
 const path = require('path');
 const cpy = require('cpy');
 const { warn, log } = require('../log');
-const { siteName, root, dist, target } = require('../../config');
+const { siteName, root, dist, target } = require('../../frontend/config');
 
 // This task generates the riff-raff bundle. It creates the following
 // directory layout under target/

--- a/makefile
+++ b/makefile
@@ -54,8 +54,8 @@ logs:
 # dev #########################################
 
 dev: clear clean-dist install
-	$(call log, "starting DEV server")
-	@NODE_ENV=development node dev-server frontend
+	$(call log, "starting frontend DEV server")
+	@NODE_ENV=development node frontend/dev-server
 
 # quality #########################################
 

--- a/webpack/browser.js
+++ b/webpack/browser.js
@@ -2,13 +2,13 @@ const webpack = require('webpack');
 const AssetsManifest = require('webpack-assets-manifest');
 const FriendlyErrorsWebpackPlugin = require('friendly-errors-webpack-plugin');
 const chalk = require('chalk');
-const { siteName } = require('../config');
+const { siteName, devServerPort } = require('../frontend/config');
 
 const friendlyErrorsWebpackPlugin = new FriendlyErrorsWebpackPlugin({
     compilationSuccessInfo: {
         messages: [
             `DEV server running at ${chalk.blue.underline(
-                'http://localhost:3030',
+                `http://localhost:${devServerPort}`,
             )}`,
         ],
     },
@@ -27,7 +27,7 @@ module.exports = ({ page }) => ({
         [`${siteName}.${page.toLowerCase()}`]: [
             DEV &&
                 'webpack-hot-middleware/client?name=browser&overlayWarnings=true',
-            './frontend/web/browser.ts',
+            `./${siteName}/web/browser.ts`,
         ].filter(Boolean),
     },
     output: {

--- a/webpack/index.js
+++ b/webpack/index.js
@@ -4,7 +4,7 @@ const { smart: merge } = require('webpack-merge');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const ReportBundleSize = require('../lib/report-bundle-size');
 const Progress = require('../lib/webpack-progress');
-const { root, dist, siteName, getPagesForSite } = require('../config');
+const { root, dist, siteName, getPagesForSite } = require('../frontend/config');
 
 const PROD = process.env.NODE_ENV === 'production';
 

--- a/webpack/server.js
+++ b/webpack/server.js
@@ -1,4 +1,4 @@
-const { siteName } = require('../config');
+const { siteName } = require('../frontend/config');
 
 module.exports = () => ({
     entry: {


### PR DESCRIPTION
## What does this change?

Moves the config file and the dev-server under frontend

## Why?

The config file and the dev-server are specific to the frontend site, rather than dotcom-rendering as a whole. They should therefore find a natural home under frontend, rather than polluting the top level of the project