### PR TITLE
⚡️⚓️ (amp rich links)

### DIFF
--- a/docs/elements/7-richlink.md
+++ b/docs/elements/7-richlink.md
@@ -1,0 +1,12 @@
+# RichLink Element
+
+An element which contains a contiguous block of marked up body text.
+
+## CAPI representation
+
+This has an `ElementType` of [RICH_LINK](https://github.com/guardian/content-api-models/blob/master/models/src/main/thrift/content/v1.thrift#L80) with fields described by [RichLinkElementFields](https://github.com/guardian/content-api-models/blob/master/models/src/main/thrift/content/v1.thrift#L599)
+
+
+## Frontend Liveblog Representation
+
+This is represented in frontend by [RichLinkBlockElement](https://github.com/guardian/frontend/blob/9a2e342437858c621b39eda3ea459e893770af93/common/app/model/liveblog/BlockElement.scala#L44).

--- a/frontend/amp/components/elements/RichLinkBlockComponent.tsx
+++ b/frontend/amp/components/elements/RichLinkBlockComponent.tsx
@@ -22,7 +22,7 @@ export const RichLinkBlockComponent: React.SFC<{
 
 const style = css`
     float: left;
-    width: 130px;
+    width: 140px;
     padding: 4px;
     padding-bottom: 18px;
 
@@ -33,8 +33,8 @@ const style = css`
 `;
 const linkStyle = (pillar: Pillar) => css`
     color: ${pillarPalette[pillar].main};
-    font-family: ${serif.body};
-    font-weight: 700;
+    font-family: ${serif.headline};
+    font-weight: 500;
     border: 0;
     text-decoration: none;
     font-size: 14px;
@@ -50,6 +50,6 @@ const linkStyle = (pillar: Pillar) => css`
         font-size: 12px;
         line-height: 16px;
         font-family: ${sans.body};
-        font-weight: 300;
+        font-weight: 400;
     }
 `;

--- a/frontend/amp/components/elements/RichLinkBlockComponent.tsx
+++ b/frontend/amp/components/elements/RichLinkBlockComponent.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { css } from 'emotion';
+import { palette } from '@guardian/pasteup/palette';
+import { serif, sans } from '@guardian/pasteup/fonts';
+import { pillarPalette } from '@frontend/lib/pillars';
+
+export const RichLinkBlockComponent: React.SFC<{
+    element: RichLinkBlockElement;
+    pillar: Pillar;
+}> = ({ element, pillar }) => {
+    if (element.sponsorship) {
+        throw new Error('Sponsored rich links not supported');
+    }
+    return (
+        <aside className={style}>
+            <a className={linkStyle(pillar)} href={element.url}>
+                {element.text}
+            </a>
+        </aside>
+    );
+};
+
+const style = css`
+    float: left;
+    width: 130px;
+    padding: 4px;
+    padding-bottom: 18px;
+
+    margin: 4px 10px 12px 0;
+    background-color: ${palette.neutral[93]};
+    border-top: 1px solid ${palette.neutral[86]};
+    margin-right: 20px;
+`;
+const linkStyle = (pillar: Pillar) => css`
+    color: ${pillarPalette[pillar].main};
+    font-family: ${serif.body};
+    font-weight: 700;
+    border: 0;
+    text-decoration: none;
+    font-size: 14px;
+    line-height: 16px;
+    word-wrap: break-word;
+    :hover {
+        text-decoration: underline;
+    }
+    ::before {
+        content: 'More on this topic';
+        display: block;
+        color: ${palette.neutral[46]};
+        font-size: 12px;
+        line-height: 16px;
+        font-family: ${sans.body};
+        font-weight: 300;
+    }
+`;

--- a/frontend/amp/components/elements/RichLinkBlockComponent.tsx
+++ b/frontend/amp/components/elements/RichLinkBlockComponent.tsx
@@ -1,38 +1,25 @@
 import React from 'react';
-import { css } from 'emotion';
+import { css, cx } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
 import { serif, sans } from '@guardian/pasteup/fonts';
 import { pillarPalette } from '@frontend/lib/pillars';
 
-export const RichLinkBlockComponent: React.SFC<{
-    element: RichLinkBlockElement;
-    pillar: Pillar;
-}> = ({ element, pillar }) => {
-    if (element.sponsorship) {
-        throw new Error('Sponsored rich links not supported');
-    }
-    return (
-        <aside className={style}>
-            <a className={linkStyle(pillar)} href={element.url}>
-                {element.text}
-            </a>
-        </aside>
-    );
-};
-
-const style = css`
+const richLinkContainer = css`
     float: left;
     width: 140px;
     padding: 4px;
     padding-bottom: 18px;
-
     margin: 4px 10px 12px 0;
     background-color: ${palette.neutral[93]};
     border-top: 1px solid ${palette.neutral[86]};
     margin-right: 20px;
 `;
-const linkStyle = (pillar: Pillar) => css`
+
+const pillarColour = (pillar: Pillar) => css`
     color: ${pillarPalette[pillar].main};
+`;
+
+const richLink = css`
     font-family: ${serif.headline};
     font-weight: 500;
     border: 0;
@@ -53,3 +40,22 @@ const linkStyle = (pillar: Pillar) => css`
         font-weight: 400;
     }
 `;
+
+export const RichLinkBlockComponent: React.SFC<{
+    element: RichLinkBlockElement;
+    pillar: Pillar;
+}> = ({ element, pillar }) => {
+    if (element.sponsorship) {
+        throw new Error('Sponsored rich links not supported');
+    }
+    return (
+        <aside className={richLinkContainer}>
+            <a
+                className={cx(richLink, pillarColour(pillar))}
+                href={element.url}
+            >
+                {element.text}
+            </a>
+        </aside>
+    );
+};

--- a/frontend/amp/components/elements/TextBlockComponent.tsx
+++ b/frontend/amp/components/elements/TextBlockComponent.tsx
@@ -12,6 +12,7 @@ const style = (pillar: Pillar) => css`
         font-weight: 300;
         word-wrap: break-word;
         color: ${palette.neutral[7]};
+        line-height: 1.5;
     }
     a {
         color: ${pillarPalette[pillar].main};

--- a/frontend/amp/components/lib/Elements.tsx
+++ b/frontend/amp/components/lib/Elements.tsx
@@ -3,6 +3,7 @@ import { TextBlockComponent } from '@frontend/amp/components/elements/TextBlockC
 import React from 'react';
 import { ImageBlockComponent } from '@frontend/amp/components/elements/ImageBlockComponent';
 import { InstagramBlockComponent } from '../elements/InstagramBlockComponent';
+import { RichLinkBlockComponent } from '../elements/RichLinkBlockComponent';
 
 export const Elements: React.SFC<{
     elements: CAPIElement[];
@@ -29,6 +30,13 @@ export const Elements: React.SFC<{
                     );
                 case 'model.dotcomrendering.pageElements.InstagramBlockElement':
                     return <InstagramBlockComponent element={element} />;
+                case 'model.dotcomrendering.pageElements.RichLinkBlockElement':
+                    return (
+                        <RichLinkBlockComponent
+                            element={element}
+                            pillar={pillar}
+                        />
+                    );
                 default:
                     // tslint:disable-next-line:no-console
                     console.log('Unsupported Element', JSON.stringify(element));

--- a/frontend/lib/content.d.ts
+++ b/frontend/lib/content.d.ts
@@ -1,10 +1,18 @@
- interface TextBlockElement {
+interface TextBlockElement {
     _type: 'model.dotcomrendering.pageElements.TextBlockElement';
     html: string;
 }
 
+interface RichLinkBlockElement {
+    _type: 'model.dotcomrendering.pageElements.RichLinkBlockElement';
+    url: string;
+    text: string;
+    prefix: string;
+    sponsorship: string;
+}
+
 interface ImageBlockElement {
-    _type: 'model.dotcomrendering.pageElements.ImageBlockElement' ;
+    _type: 'model.dotcomrendering.pageElements.ImageBlockElement';
     media: { allImages: Image[] };
     data: { alt: string; credit: string; caption?: string };
 }
@@ -28,5 +36,8 @@ interface Image {
     url: string;
 }
 
-type CAPIElement = TextBlockElement | ImageBlockElement | InstagramBlockElement;
-
+type CAPIElement =
+    | TextBlockElement
+    | ImageBlockElement
+    | InstagramBlockElement
+    | RichLinkBlockElement;


### PR DESCRIPTION
## What does this change?
⚡️rich links
 
I dropped the weight on the sans in the `::before` to 400 as we're not loading a medium weight for it.

current:
![image](https://user-images.githubusercontent.com/2670496/48628523-4de1ea80-e9af-11e8-8292-79432c6503bb.png)
dcr:
![image](https://user-images.githubusercontent.com/2670496/48628910-3bb47c00-e9b0-11e8-9d67-28be82240747.png)

