### PR TITLE
⚡️ AMP header editions

### DIFF
--- a/frontend/amp/components/Header.tsx
+++ b/frontend/amp/components/Header.tsx
@@ -87,10 +87,10 @@ const pillarLinkStyle = (pillar: Pillar) => css`
     text-decoration: none;
     cursor: pointer;
     display: block;
-    font-size: 20px;
+    font-size: 17px;
     height: 36px;
     line-height: 1;
-    padding: 4px 4px;
+    padding: 9px 4px;
     color: ${palette.neutral[100]};
     position: relative;
     overflow: hidden;

--- a/frontend/amp/components/Header.tsx
+++ b/frontend/amp/components/Header.tsx
@@ -62,14 +62,6 @@ const logoStyles = css`
     }
 `;
 
-const pillarUnderline = pillarMap(
-    pillar => css`
-        :after {
-            transform: translateY(4px);
-        }
-    `,
-);
-
 const pillarListStyles = css`
     list-style: none;
     line-height: 0;
@@ -79,10 +71,8 @@ const pillarListItemStyle = css`
     display: inline-block;
 
     :first-child {
-        margin-left: 20px;
-
         a {
-            padding-left: 0;
+            padding-left: 20px;
 
             :before {
                 display: none;
@@ -105,10 +95,6 @@ const pillarLinkStyle = (pillar: Pillar) => css`
     position: relative;
     overflow: hidden;
 
-    :hover {
-        ${pillarUnderline[pillar]};
-    }
-
     :before {
         border-left: 1px solid rgba(255, 255, 255, 0.3);
         top: 0;
@@ -123,7 +109,7 @@ const pillarLinkStyle = (pillar: Pillar) => css`
     :after {
         content: '';
         display: block;
-        top: -4px;
+        top: 0;
         left: 0;
         right: 0;
         position: absolute;
@@ -182,13 +168,7 @@ const pillarLinks = (pillars: PillarType[], activePillar: Pillar) => (
         <ul className={pillarListStyles}>
             {pillars.map((p, i) => (
                 <li className={pillarListItemStyle} key={p.title}>
-                    <a
-                        className={cx(pillarLinkStyle(p.pillar), {
-                            [pillarUnderline[p.pillar]]:
-                                p.pillar === activePillar,
-                        })}
-                        href={p.url}
-                    >
+                    <a className={pillarLinkStyle(p.pillar)} href={p.url}>
                         {p.title}
                     </a>
                 </li>

--- a/frontend/amp/components/Header.tsx
+++ b/frontend/amp/components/Header.tsx
@@ -3,7 +3,7 @@ import { css, cx } from 'react-emotion';
 import Logo from '@guardian/pasteup/logos/the-guardian.svg';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';
 import { serif } from '@guardian/pasteup/fonts';
-import { pillarMap, pillarPalette } from '../../lib/pillars';
+import { pillarPalette } from '../../lib/pillars';
 import Sidebar from './Sidebar';
 import ArrowRight from '@guardian/pasteup/icons/arrow-right.svg';
 import { palette } from '@guardian/pasteup/palette';

--- a/frontend/amp/components/Header.tsx
+++ b/frontend/amp/components/Header.tsx
@@ -113,7 +113,7 @@ const pillarLinkStyle = (pillar: Pillar) => css`
         left: 0;
         right: 0;
         position: absolute;
-        border-top: 4px solid ${pillarPalette[pillar].dark};
+        border-top: 4px solid ${pillarPalette[pillar].bright};
         transition: transform 0.3s ease-in-out;
     }
 `;

--- a/frontend/amp/components/Sidebar.tsx
+++ b/frontend/amp/components/Sidebar.tsx
@@ -7,10 +7,6 @@ const sidebarStyles = css`
     width: 80vh;
     background-color: ${palette.brand.blue};
 
-    a {
-        color: ${palette.neutral[100]};
-    }
-
     [aria-expanded='true'] {
         i {
             margin-top: 0px;
@@ -158,9 +154,9 @@ const template = `
 {{ /topLevelSections }}
 </ul>
 
-<ul class=${cx(otherLinks, membershipLinks)}>
+<ul class=${otherLinks}>
 {{ #readerRevenueLinks }}
-    <li
+    <li class=${membershipLinks}
         role="menuitem">
 
         <a

--- a/frontend/amp/components/Sidebar.tsx
+++ b/frontend/amp/components/Sidebar.tsx
@@ -13,7 +13,7 @@ const sidebarStyles = css`
 
     [aria-expanded='true'] {
         i {
-            margin-top: 2px;
+            margin-top: 0px;
         }
 
         i:before {
@@ -24,6 +24,26 @@ const sidebarStyles = css`
 
 const menuGroup = css`
     padding-bottom: 0.75rem;
+`;
+
+const toggle = css`
+    i {
+        margin-top: -4px;
+        left: 25px;
+        position: absolute;
+
+        :before {
+            border: 2px solid #fff;
+            border-top: 0;
+            border-left: 0;
+            content: '';
+            display: inline-block;
+            height: 8px;
+            transform: rotate(45deg);
+            width: 8px;
+            color: ${palette.neutral[100]};
+        }
+    }
 `;
 
 const pillarLink = css`
@@ -48,23 +68,7 @@ const pillarLink = css`
     color: ${palette.neutral[100]};
     font-family: ${serif.headline};
 
-    i {
-        margin-top: -4px;
-        left: 25px;
-        position: absolute;
-
-        :before {
-            border: 2px solid #fff;
-            border-top: 0;
-            border-left: 0;
-            content: '';
-            display: inline-block;
-            height: 8px;
-            transform: rotate(45deg);
-            width: 8px;
-            color: ${palette.neutral[100]};
-        }
-    }
+    ${toggle};
 `;
 
 const link = css`
@@ -121,6 +125,10 @@ const pillar = css`
     }
 `;
 
+const editionLink = css`
+    ${toggle};
+`;
+
 const template = `
 <ul class=${menuGroup}>
 {{ #topLevelSections }}
@@ -170,6 +178,26 @@ const template = `
     </a>
 </li>
 </ul>
+
+<amp-accordion>
+<section>
+    <h2 class=${cx(link, editionLink)}>
+        <i></i>
+        Switch edition
+    </h2>
+
+    <ul class=${subLinks}>
+    {{ #editions }}
+        <li>
+            <a data-link-name="amp : nav : edition-picker : {{ id }}"
+            href="{{ optInLink }}">
+               {{ displayName }}
+            </a>
+        </li>
+    {{ /editions }}
+    </ul>
+</section>
+</amp-accordion>
 
 <ul class=${cx(otherLinks, menuGroup)}>
 {{ #secondarySections }}


### PR DESCRIPTION
*Note: depends on https://github.com/guardian/frontend/pull/20732 before merging.*

## What does this change?

Various updates to the AMP header and sidebar.

* add editions picker/dropdown in sidebar
* colour revenue links yellow
* other minor style changes to pillar links (use new 'bright' colours and reduce font size)

## Why?

To complete the header work!

![screenshot 2018-11-19 at 17 00 40](https://user-images.githubusercontent.com/858402/48722827-e5984080-ec1c-11e8-8d12-31edc2acdf55.png)
![screenshot 2018-11-19 at 17 02 43](https://user-images.githubusercontent.com/858402/48722852-f648b680-ec1c-11e8-8941-189585adc4a2.png)

