### PR TITLE
Report test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ guui.zip
 
 # publishable files
 packages/pasteup/tmp
+
+# test coverage reports
+coverage

--- a/makefile
+++ b/makefile
@@ -89,7 +89,7 @@ bundlesize: clear clean-dist install build
 validate: clear clean-dist install tsc lint stylelint test validate-build
 	$(call log, "everything seems 👌")
 
-validate-ci: clear install tsc lint stylelint test-cli bundlesize
+validate-ci: clear install tsc lint stylelint test-ci bundlesize
 	$(call log, "everything seems 👌")
 
 # helpers #########################################

--- a/makefile
+++ b/makefile
@@ -79,13 +79,17 @@ test: clear clean-dist install
 	$(call log, "running tests")
 	@yarn test --verbose  --runInBand
 
+test-ci: clear clean-dist install
+	$(call log, "running tests")
+	@yarn test --verbose  --runInBand --collectCoverage --coverageReporters=teamcity
+
 bundlesize: clear clean-dist install build
 	@bundlesize
 
 validate: clear clean-dist install tsc lint stylelint test validate-build
 	$(call log, "everything seems 👌")
 
-validate-ci: clear install tsc lint stylelint test bundlesize
+validate-ci: clear install tsc lint stylelint test-cli bundlesize
 	$(call log, "everything seems 👌")
 
 # helpers #########################################

--- a/package.json
+++ b/package.json
@@ -112,6 +112,9 @@
             "^svgs/(.*)$": "<rootDir>/__mocks__/svgMock.tsx",
             "^(.*)\\.svg$": "<rootDir>/__mocks__/svgMock.tsx"
         },
-        "testResultsProcessor": "jest-teamcity-reporter"
+        "testResultsProcessor": "jest-teamcity-reporter",
+        "collectCoverageFrom": [
+            "{packages,frontend}/**/*.{ts,tsx}"
+        ]
     }
 }


### PR DESCRIPTION
## What does this change?

This PR introduces a new make task `test-ci` this is run on Teamcity and generates test coverage reports using Istanbul's built in `teamcity` coverage reporter.