### PR TITLE
Extract validators from parse-capi

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
           }
         },
         "testMatch": [
-          "**/*.test.+(ts|tsx|js)"
+            "**/*.test.+(ts|tsx|js)"
         ],
         "setupTestFrameworkScriptFile": "<rootDir>/scripts/jest/setup.ts",
         "moduleNameMapper": {
@@ -113,7 +113,7 @@
         },
         "testResultsProcessor": "jest-teamcity-reporter",
         "collectCoverageFrom": [
-            "{packages,frontend}/**/*.{ts,tsx}"
+            "packages/**/*.{ts,tsx}"
         ]
     }
 }

--- a/packages/frontend/lib/parse-capi/index.ts
+++ b/packages/frontend/lib/parse-capi/index.ts
@@ -3,86 +3,22 @@ import get from 'lodash.get';
 
 import clean from './clean';
 import bigBullets from './big-bullets';
+import {
+    getString,
+    getNumber,
+    getNonEmptyString,
+    getBoolean,
+    getArray,
+} from './validators';
+import { getSharingUrls } from './sharing-urls';
 import { pillarNames } from '@frontend/lib/pillars';
-import { getSharingUrls } from '@frontend/lib/parse-capi/sharing-urls';
 
 // tslint:disable:prefer-array-literal
 const apply = (input: string, ...fns: Array<(_: string) => string>): string => {
     return fns.reduce((acc, fn) => fn(acc), input);
 };
 
-const getString = (
-    obj: object,
-    selector: string,
-    fallbackValue?: string,
-): string => {
-    const found = get(obj, selector);
-    if (typeof found === 'string') {
-        return found;
-    }
-    if (fallbackValue !== undefined) {
-        return fallbackValue;
-    }
-
-    throw new Error(
-        `expected string at '${selector}', got '${found}', in '${JSON.stringify(
-            obj,
-        )}'`,
-    );
-};
-
-const getNumber = (obj: object, selector: string): number => {
-    const found = get(obj, selector);
-    if (typeof found === 'number') {
-        return found;
-    }
-
-    throw new Error(
-        `expected number at '${selector}', got '${found}', in '${JSON.stringify(
-            obj,
-        )}'`,
-    );
-};
-
-// TODO temporary export we should move all validation functions into their own module
-export const getNonEmptyString = (obj: object, selector: string): string => {
-    const found = get(obj, selector);
-    if (typeof found === 'string' && found.length > 0) {
-        return found;
-    }
-
-    throw new Error(
-        `expected non-empty string at '${selector}', got '${found}', in '${JSON.stringify(
-            obj,
-        )}'`,
-    );
-};
-
-const getArray = <T>(
-    obj: object,
-    selector: string,
-    fallbackValue?: T[],
-): T[] => {
-    const found = get(obj, selector);
-    if (Array.isArray(found)) {
-        return found;
-    }
-    if (fallbackValue !== undefined) {
-        return fallbackValue;
-    }
-
-    throw new Error(
-        `expected array at '${selector}', got '${found}', in '${JSON.stringify(
-            obj,
-        )}'`,
-    );
-};
-
-const findPillar: (name?: string) => Pillar | undefined = name => {
-    if (!name) {
-        return undefined;
-    }
-
+const findPillar: (name: string) => Pillar | undefined = name => {
     const pillar: string = name.toLowerCase();
     // The pillar name is "arts" in CAPI, but "culture" everywhere else,
     // therefore we perform this substitution here.
@@ -161,28 +97,6 @@ const getAgeWarning = (
     }
 
     return;
-};
-
-const getBoolean = (
-    obj: object,
-    selector: string,
-    fallbackValue?: boolean,
-): boolean => {
-    const found = get(obj, selector);
-
-    if (typeof found === 'boolean') {
-        return found;
-    }
-
-    if (fallbackValue !== undefined) {
-        return fallbackValue;
-    }
-
-    throw new Error(
-        `expected boolean  at '${selector}', got '${found}', in '${JSON.stringify(
-            obj,
-        )}'`,
-    );
 };
 
 // TODO this is a simple implementation of section data

--- a/packages/frontend/lib/parse-capi/sharing-urls.ts
+++ b/packages/frontend/lib/parse-capi/sharing-urls.ts
@@ -1,4 +1,4 @@
-import { getNonEmptyString } from './';
+import { getNonEmptyString } from './validators';
 
 const appendParamsToBaseUrl: (
     baseUrl: string,

--- a/packages/frontend/lib/parse-capi/validators.test.ts
+++ b/packages/frontend/lib/parse-capi/validators.test.ts
@@ -1,0 +1,213 @@
+import {
+    getString,
+    getNumber,
+    getNonEmptyString,
+    getBoolean,
+    getArray,
+} from './validators';
+
+describe('validators', () => {
+    describe('getString', () => {
+        it('returns string successfully if defined and type string', () => {
+            const data = {
+                config: {
+                    prop: 'foo',
+                },
+            };
+
+            expect(getString(data, 'config.prop')).toBe('foo');
+        });
+
+        it('returns fallback value if not type string', () => {
+            const data = {
+                config: {
+                    prop: true,
+                },
+            };
+
+            expect(getString(data, 'config.prop', 'foo')).toBe('foo');
+        });
+
+        it('returns fallback value if undefined', () => {
+            const data = {
+                config: {},
+            };
+
+            expect(getString(data, 'config.prop', 'foo')).toBe('foo');
+        });
+
+        it('throws error if undefined and no fallback', () => {
+            const data = {
+                config: {},
+            };
+
+            expect(() => {
+                getString(data, 'config.prop');
+            }).toThrow();
+        });
+    });
+
+    describe('getNonEmptyString', () => {
+        it('returns string successfully if defined and type string', () => {
+            const data = {
+                config: {
+                    prop: 'foo',
+                },
+            };
+
+            expect(getNonEmptyString(data, 'config.prop')).toBe('foo');
+        });
+
+        it('throws error if not a string', () => {
+            const data = {
+                config: {
+                    prop: true,
+                },
+            };
+
+            expect(() => {
+                getNonEmptyString(data, 'config.prop');
+            }).toThrow();
+        });
+
+        it('throws error if empty string', () => {
+            const data = {
+                config: {
+                    prop: '',
+                },
+            };
+
+            expect(() => {
+                getNonEmptyString(data, 'config.prop');
+            }).toThrow();
+        });
+
+        it('throws error if undefined', () => {
+            const data = {
+                config: {},
+            };
+
+            expect(() => {
+                getNonEmptyString(data, 'config.prop');
+            }).toThrow();
+        });
+    });
+
+    describe('getNumber', () => {
+        it('returns number successfully if defined', () => {
+            const data = {
+                config: {
+                    prop: 101,
+                },
+            };
+
+            expect(getNumber(data, 'config.prop')).toBe(101);
+        });
+
+        it('throws error if not a number', () => {
+            const data = {
+                config: {
+                    prop: true,
+                },
+            };
+
+            expect(() => {
+                getNumber(data, 'config.prop');
+            }).toThrow();
+        });
+
+        it('throws error if undefined', () => {
+            const data = {
+                config: {},
+            };
+
+            expect(() => {
+                getNumber(data, 'config.prop');
+            }).toThrow();
+        });
+    });
+
+    describe('getBoolean', () => {
+        it('returns boolean successfully if defined', () => {
+            const data = {
+                config: {
+                    prop: true,
+                },
+            };
+
+            expect(getBoolean(data, 'config.prop')).toBe(true);
+        });
+
+        it('returns fallback value if not type boolean', () => {
+            const data = {
+                config: {
+                    prop: 'foo',
+                },
+            };
+
+            expect(getBoolean(data, 'config.prop', true)).toBe(true);
+        });
+
+        it('returns fallback value if undefined', () => {
+            const data = {
+                config: {},
+            };
+
+            expect(getBoolean(data, 'config.prop', true)).toBe(true);
+        });
+
+        it('throws error if undefined and no fallback', () => {
+            const data = {
+                config: {},
+            };
+
+            expect(() => {
+                getBoolean(data, 'config.prop');
+            }).toThrow();
+        });
+    });
+
+    describe('getArray', () => {
+        it('returns array successfully if defined', () => {
+            const data = {
+                config: {
+                    prop: ['foo', 'bar'],
+                },
+            };
+
+            expect(getArray(data, 'config.prop').length).toBe(2);
+        });
+
+        it('returns fallback value if not type array', () => {
+            const data = {
+                config: {
+                    prop: 'foo',
+                },
+            };
+
+            expect(getArray(data, 'config.prop', ['foo', 'bar']).length).toBe(
+                2,
+            );
+        });
+
+        it('returns fallback value if undefined', () => {
+            const data = {
+                config: {},
+            };
+
+            expect(getArray(data, 'config.prop', ['foo', 'bar']).length).toBe(
+                2,
+            );
+        });
+
+        it('throws error if undefined and no fallback', () => {
+            const data = {
+                config: {},
+            };
+
+            expect(() => {
+                getArray(data, 'config.prop');
+            }).toThrow();
+        });
+    });
+});

--- a/packages/frontend/lib/parse-capi/validators.ts
+++ b/packages/frontend/lib/parse-capi/validators.ts
@@ -1,0 +1,90 @@
+import get from 'lodash.get';
+
+export const getString = (
+    obj: object,
+    selector: string,
+    fallbackValue?: string,
+): string => {
+    const found = get(obj, selector);
+    if (typeof found === 'string') {
+        return found;
+    }
+    if (fallbackValue !== undefined) {
+        return fallbackValue;
+    }
+
+    throw new Error(
+        `expected string at '${selector}', got '${found}', in '${JSON.stringify(
+            obj,
+        )}'`,
+    );
+};
+
+export const getNumber = (obj: object, selector: string): number => {
+    const found = get(obj, selector);
+    if (typeof found === 'number') {
+        return found;
+    }
+
+    throw new Error(
+        `expected number at '${selector}', got '${found}', in '${JSON.stringify(
+            obj,
+        )}'`,
+    );
+};
+
+export const getNonEmptyString = (obj: object, selector: string): string => {
+    const found = get(obj, selector);
+    if (typeof found === 'string' && found.length > 0) {
+        return found;
+    }
+
+    throw new Error(
+        `expected non-empty string at '${selector}', got '${found}', in '${JSON.stringify(
+            obj,
+        )}'`,
+    );
+};
+
+export const getBoolean = (
+    obj: object,
+    selector: string,
+    fallbackValue?: boolean,
+): boolean => {
+    const found = get(obj, selector);
+
+    if (typeof found === 'boolean') {
+        return found;
+    }
+
+    if (fallbackValue !== undefined) {
+        return fallbackValue;
+    }
+
+    throw new Error(
+        `expected boolean  at '${selector}', got '${found}', in '${JSON.stringify(
+            obj,
+        )}'`,
+    );
+};
+
+export const getArray = <T>(
+    obj: object,
+    selector: string,
+    fallbackValue?: T[],
+): T[] => {
+    const found = get(obj, selector);
+
+    if (Array.isArray(found)) {
+        return found;
+    }
+    if (fallbackValue !== undefined) {
+        return fallbackValue;
+    }
+
+    throw new Error(
+        `expected array at '${selector}', got '${found}', in '${JSON.stringify(
+            obj,
+        )}'`,
+    );
+};


### PR DESCRIPTION
## What does this change?

Small refactor of `parse-capi` by pulling out the validation functions into their own module. 
