### PR TITLE
Low priority scripts

### DIFF
--- a/packages/frontend/web/browser.ts
+++ b/packages/frontend/web/browser.ts
@@ -3,7 +3,10 @@ import { hydrate as hydrateCSS } from 'emotion';
 import { hydrate as hydrateApp } from 'react-dom';
 import 'ophan-tracker-js';
 
-import { init as initGa } from '@frontend/web/lib/ga';
+import {
+    init as initGa,
+    sendPageView as sendGaPageView,
+} from '@frontend/web/lib/ga';
 import Article from './pages/Article';
 
 // kick off the app
@@ -13,6 +16,8 @@ const go = () => {
     if (module.hot) {
         module.hot.accept();
     }
+
+    initGa();
 
     const container = document.getElementById('app');
 
@@ -29,7 +34,8 @@ const go = () => {
 
         hydrateApp(React.createElement(Article, { data }), container);
     }
-    initGa();
+
+    sendGaPageView();
 };
 
 // make sure we've patched the env before running the app

--- a/packages/frontend/web/browser.ts
+++ b/packages/frontend/web/browser.ts
@@ -3,6 +3,7 @@ import { hydrate as hydrateCSS } from 'emotion';
 import { hydrate as hydrateApp } from 'react-dom';
 import 'ophan-tracker-js';
 
+import { init as initGa } from '@frontend/web/lib/ga';
 import Article from './pages/Article';
 
 // kick off the app
@@ -28,10 +29,7 @@ const go = () => {
 
         hydrateApp(React.createElement(Article, { data }), container);
     }
-
-    import('@frontend/web/lib/ga').then(({ init }) => {
-        init();
-    });
+    initGa();
 };
 
 // make sure we've patched the env before running the app

--- a/packages/frontend/web/document.tsx
+++ b/packages/frontend/web/document.tsx
@@ -60,8 +60,18 @@ export default ({ data }: Props) => {
         'https://assets.guim.co.uk/polyfill.io/v2/polyfill.min.js?rum=0&features=es6,es7,es2017,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry&flags=gated&callback=guardianPolyfilled&unknown=polyfill';
     const priorityScripts = [polyfillIO, vendorJS, bundleJS];
 
+    /**
+     * Low priority scripts.
+     * These scripts will be requested asynchronously after the main
+     * HTML has been parsed. Execution order is not guaranteed.
+     */
+    const lowPriorityScripts = [
+        'https://www.google-analytics.com/analytics.js',
+    ];
+
     return htmlTemplate({
         priorityScripts,
+        lowPriorityScripts,
         css,
         html,
         cssIDs,

--- a/packages/frontend/web/htmlTemplate.ts
+++ b/packages/frontend/web/htmlTemplate.ts
@@ -5,6 +5,7 @@ import assets from '@frontend/lib/assets';
 export default ({
     title = 'The Guardian',
     priorityScripts,
+    lowPriorityScripts,
     css,
     html,
     data,
@@ -14,6 +15,7 @@ export default ({
 }: {
     title?: string;
     priorityScripts: string[];
+    lowPriorityScripts: string[];
     css: string;
     html: string;
     data: {
@@ -82,7 +84,9 @@ export default ({
             </head>
             <body>
                 <div id="app">${html}</div>
-                <script async src='https://www.google-analytics.com/analytics.js'></script>
+                ${lowPriorityScripts
+                    .map(script => `<script async src="${script}"></script>`)
+                    .join('\n')}
                 <script>${nonBlockingJS}</script>
             </body>
         </html>`;

--- a/packages/frontend/web/htmlTemplate.ts
+++ b/packages/frontend/web/htmlTemplate.ts
@@ -82,12 +82,7 @@ export default ({
             </head>
             <body>
                 <div id="app">${html}</div>
-                <script>
-                (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-                    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-                    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-                    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-                </script>
+                <script async src='https://www.google-analytics.com/analytics.js'></script>
                 <script>${nonBlockingJS}</script>
             </body>
         </html>`;

--- a/packages/frontend/web/lib/ga.ts
+++ b/packages/frontend/web/lib/ga.ts
@@ -7,6 +7,13 @@ interface TrackerConfig {
     siteSpeedSampleRate: number;
 }
 
+const tracker: TrackerConfig = {
+    name: 'allEditorialPropertyTracker',
+    id: 'UA-78705427-1',
+    sampleRate: 100,
+    siteSpeedSampleRate: 1,
+};
+
 const getQueryParam = (
     key: string,
     queryString: string,
@@ -24,16 +31,7 @@ export const init = (): void => {
         (ga.q = ga.q || []).push(args);
     };
     const ga = window.ga || (coldQueue as UniversalAnalytics.ga);
-    const { GA } = window.guardian.app.data;
-    const tracker: TrackerConfig = {
-        name: 'allEditorialPropertyTracker',
-        id: 'UA-78705427-1',
-        sampleRate: 100,
-        siteSpeedSampleRate: 1,
-    };
     const identityId = getCookie('GU_U');
-    const set = `${tracker.name}.set`;
-    const send = `${tracker.name}.send`;
 
     window.GoogleAnalyticsObject = 'ga';
     ga.l = +new Date();
@@ -43,6 +41,14 @@ export const init = (): void => {
         siteSpeedSampleRate: tracker.siteSpeedSampleRate,
         userId: identityId,
     });
+};
+
+export const sendPageView = (): void => {
+    const { GA } = window.guardian.app.data;
+    const set = `${tracker.name}.set`;
+    const send = `${tracker.name}.send`;
+    const identityId = getCookie('GU_U');
+
     ga(set, 'forceSSL', true);
     ga(set, 'title', GA.webTitle);
     ga(set, 'anonymizeIp', true);

--- a/packages/frontend/web/lib/ga.ts
+++ b/packages/frontend/web/lib/ga.ts
@@ -20,7 +20,10 @@ const getQueryParam = (
 };
 
 export const init = (): void => {
-    const { ga } = window;
+    const coldQueue = (...args: any[]) => {
+        (ga.q = ga.q || []).push(args);
+    };
+    const ga = window.ga || (coldQueue as UniversalAnalytics.ga);
     const { GA } = window.guardian.app.data;
     const tracker: TrackerConfig = {
         name: 'allEditorialPropertyTracker',
@@ -28,10 +31,12 @@ export const init = (): void => {
         sampleRate: 100,
         siteSpeedSampleRate: 1,
     };
-
     const identityId = getCookie('GU_U');
     const set = `${tracker.name}.set`;
     const send = `${tracker.name}.send`;
+
+    window.GoogleAnalyticsObject = 'ga';
+    ga.l = +new Date();
 
     ga('create', tracker.id, 'auto', tracker.name, {
         sampleRate: tracker.sampleRate,


### PR DESCRIPTION
## What does this change?

Defines a `lowPriorityScripts` array in the document module. Scripts specific here are requested asynchronously, after the main HTML is parsed. The only script being loaded in this way is the Google Analytics script.

This change also does away with the `isogram` method for loading the GA script, moving the cold queue logic out of the HTML template and into the `ga` module.

## Why?

- Creates a generic bucket for low priority (non-critical) scripts (see [lines-in-the-sand.md](https://github.com/guardian/dotcom-rendering/blob/master/docs/principles/lines-in-the-sand.md#non-critical-scripts-will-not-block-rendering)). 
- The `ga` TypeScript module is a more appropriate place for the GA loading / queueing logic than the HTML template