### PR TITLE
Avoid duplicate loading of styles

### DIFF
--- a/packages/frontend/amp/document.tsx
+++ b/packages/frontend/amp/document.tsx
@@ -24,7 +24,6 @@ export default ({
     <head>
     <meta charset="utf-8">
     <link rel="canonical" href="self.html" />
-    <style>${fontsCss}${resetCSS}${css}</style>
     <meta name="viewport" content="width=device-width,minimum-scale=1">
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <script async src="https://cdn.ampproject.org/v0.js"></script>
@@ -35,7 +34,7 @@ export default ({
     <script async custom-element="amp-accordion" src="https://cdn.ampproject.org/v0/amp-accordion-0.1.js"></script>
     <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
 
-    <style amp-custom>${resetCSS}${css}</style>
+    <style amp-custom>${fontsCss}${resetCSS}${css}</style>
     </head>
     <body>
     ${html}


### PR DESCRIPTION
Also ensure we use valid AMP here (amp-custom).

I think this was just added by mistake at some point and none of us noticed.