### PR TITLE
Guardian Accelerated Pages (GAP)

### DIFF
--- a/makefile
+++ b/makefile
@@ -143,3 +143,10 @@ post-publish-pasteup:
 publish-pasteup: clear clean-pasteup install
 	$(call log, "publishing pasteup")
 	@cd packages/pasteup && yarn publish
+
+clean-gap:
+	@rm -rf packages/gap/dist packages/gap/tmp
+
+publish-gap: clear clean-gap install
+	$(call log, "publishing gap")
+	@NODE_ENV=production webpack --config scripts/webpack/gap.js

--- a/makefile
+++ b/makefile
@@ -145,8 +145,9 @@ publish-pasteup: clear clean-pasteup install
 	@cd packages/pasteup && yarn publish
 
 clean-gap:
-	@rm -rf packages/gap/dist packages/gap/tmp
+	@rm -rf packages/gap/dist
 
 publish-gap: clear clean-gap install
 	$(call log, "publishing gap")
-	@NODE_ENV=production webpack --config scripts/webpack/gap.js
+	webpack --mode=production --config scripts/webpack/gap.js
+	@./scripts/deploy/publish-gap.sh

--- a/makefile
+++ b/makefile
@@ -151,3 +151,7 @@ publish-gap: clear clean-gap install
 	$(call log, "publishing gap")
 	webpack --mode=production --config scripts/webpack/gap.js
 	@./scripts/deploy/publish-gap.sh
+
+dev-gap: clear clean-gap install
+	$(call log, "starting gap dev server...")
+	webpack-dev-server --mode=development --config scripts/webpack/gap.js

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
         "webpack-bundle-analyzer": "^2.11.1",
         "webpack-cli": "^3.1.1",
         "webpack-dev-middleware": "^3.1.2",
+        "webpack-dev-server": "^3.1.10",
         "webpack-hot-middleware": "^2.22.0",
         "webpack-hot-server-middleware": "^0.5.0",
         "webpack-merge": "^4.1.2",
@@ -88,18 +89,18 @@
     },
     "jest": {
         "moduleFileExtensions": [
-          "ts",
-          "tsx",
-          "js"
+            "ts",
+            "tsx",
+            "js"
         ],
         "transform": {
             "^.+\\.(ts|tsx)$": "ts-jest"
         },
         "globals": {
-          "ts-jest": {
-            "diagnostics": false,
-            "tsConfigFile": "tsconfig.json"
-          }
+            "ts-jest": {
+                "diagnostics": false,
+                "tsConfigFile": "tsconfig.json"
+            }
         },
         "testMatch": [
             "**/*.test.+(ts|tsx|js)"

--- a/packages/gap/README.md
+++ b/packages/gap/README.md
@@ -1,5 +1,7 @@
 # GAP
 
+## Design goals
+
 Guardian Accelerated Pages (GAP) is an AMP-inspired system to manage client-side
 performance.
 
@@ -13,4 +15,10 @@ So it's a bit more relaxed than AMP, which should make it a better fit for exist
 
 Like AMP, Gap is a combination of HTML-guidelines/restrictions, and a Javascript runtime ('gap-core') augmented by custom elements ('extensions').
 
+## How to use
 
+As a minimum, include gap-core in your page. This must be loaded *before*
+extensions. `defer` is a good way to achieve this. E.g. in your page head:
+
+    <script defer src="https://s3-eu-west-1.amazonaws.com/com-gu-gap/v0/gap-core.js" />
+    .. // some extensions

--- a/packages/gap/README.md
+++ b/packages/gap/README.md
@@ -1,0 +1,16 @@
+# GAP
+
+Guardian Accelerated Pages (GAP) is an AMP-inspired system to manage client-side
+performance.
+
+It has slightly different design goals from AMP though:
+
+* designed to meet current Guardian requirements
+* extensions can be used without being accepted as official
+* not-mobile specific
+
+So it's a bit more relaxed than AMP, which should make it a better fit for existing news-sites, which often have requirements that don't fit within AMP. The downside is it is easier to mess up performance/do the wrong thing in GAP.
+
+Like AMP, Gap is a combination of HTML-guidelines/restrictions, and a Javascript runtime ('gap-core') augmented by custom elements ('extensions').
+
+

--- a/packages/gap/gap-core/gap-core.ts
+++ b/packages/gap/gap-core/gap-core.ts
@@ -11,7 +11,7 @@
  */
 
 interface Extension {
-    do: (el: HTMLElement) => void;
+    do: (el: Element) => void;
 }
 
 const extensions: Map<string, Extension> = new Map();
@@ -22,7 +22,12 @@ const extensions: Map<string, Extension> = new Map();
  * Instructs extension elements to execute. Eventually this will do clever
  * things like buffer and batch.
  */
-const render = () => undefined;
+const render = () => {
+    extensions.forEach((extension, tag) => {
+        const tags = document.getElementsByTagName(tag);
+        Array.prototype.forEach.call(tags, (el: Element) => extension.do(el));
+    });
+};
 
 window.GAP = {
     registerElement: (tag: string, extension: Extension) => {

--- a/packages/gap/gap-core/gap-core.ts
+++ b/packages/gap/gap-core/gap-core.ts
@@ -23,6 +23,7 @@ const extensions: Map<string, Extension> = new Map();
  * things like buffer and batch.
  */
 const render = () => {
+    // caching and throttling
     extensions.forEach((extension, tag) => {
         const tags = document.getElementsByTagName(tag);
         Array.prototype.forEach.call(tags, (el: Element) => extension.do(el));

--- a/packages/gap/gap-core/gap-core.ts
+++ b/packages/gap/gap-core/gap-core.ts
@@ -11,7 +11,7 @@
  */
 
 interface Extension {
-    do: (el: Element) => void;
+    do: (el: Element) => Promise<void>;
 }
 
 const extensions: Map<string, Extension> = new Map();
@@ -29,9 +29,11 @@ const render = () => {
     });
 };
 
-window.GAP = {
+const GAP = {
     registerElement: (tag: string, extension: Extension) => {
         extensions.set(tag, extension);
         render();
     },
 };
+
+window.GAP = GAP;

--- a/packages/gap/gap-core/gap-core.ts
+++ b/packages/gap/gap-core/gap-core.ts
@@ -1,0 +1,32 @@
+/**
+ * This is the main loader for Gap.
+ *
+ * It exposes a GAP global. Extensions should register themselves on this using
+ * GAP. E.g.
+ *
+ *     GAP.registerElement('gap-list', GapList)
+ *
+ * where gap-list is the tag name for the extension, and GapList is the
+ * extension class.
+ */
+
+interface Extension {
+    do: (el: HTMLElement) => void;
+}
+
+const extensions: Map<string, Extension> = new Map();
+
+/**
+ * Main rendering function
+ *
+ * Instructs extension elements to execute. Eventually this will do clever
+ * things like buffer and batch.
+ */
+const render = () => undefined;
+
+window.GAP = {
+    registerElement: (tag: string, extension: Extension) => {
+        extensions.set(tag, extension);
+        render();
+    },
+};

--- a/packages/gap/gap-core/gap-core.ts
+++ b/packages/gap/gap-core/gap-core.ts
@@ -16,12 +16,16 @@ const extensions: Map<string, Extension> = new Map();
 
 let proxy: GAPProxy | null = null;
 
+/**
+ * A collection of GAP utilities. It is expected that extensions use these for
+ * associated functionality. GAP is then free to optimise these over time, for
+ * example to batch or cache API calls.
+ *
+ * But it is also useful to stub or mock these for testing purposes.
+ */
 export interface GAPHelpers {
     renderTemplate: (tpl: string, data: any) => string;
-    fetchWithProxy(
-        input?: Request | string,
-        init?: RequestInit,
-    ): Promise<Response>;
+    fetch(input?: Request | string, init?: RequestInit): Promise<Response>;
 }
 
 /**
@@ -56,7 +60,7 @@ export const defaultHelpers = {
     renderTemplate: (tpl: string, data: any) => {
         return Mustache.render(tpl, data, null, ['[[', ']]']);
     },
-    fetchWithProxy: (
+    fetch: (
         input?: Request | string,
         init?: RequestInit,
     ): Promise<Response> => {

--- a/packages/gap/gap-core/gap-core.ts
+++ b/packages/gap/gap-core/gap-core.ts
@@ -54,7 +54,7 @@ export interface Extension {
 
 export const defaultHelpers = {
     renderTemplate: (tpl: string, data: any) => {
-        return Mustache.render(tpl, data);
+        return Mustache.render(tpl, data, null, ['[[', ']]']);
     },
     fetchWithProxy: (
         input?: Request | string,

--- a/packages/gap/gap-core/gap-core.ts
+++ b/packages/gap/gap-core/gap-core.ts
@@ -12,8 +12,40 @@ import Mustache from 'mustache';
  * extension class.
  */
 
+const extensions: Map<string, Extension> = new Map();
+
+let proxy: GAPProxy | null = null;
+
 export interface GAPHelpers {
     renderTemplate: (tpl: string, data: any) => string;
+    fetchWithProxy(
+        input?: Request | string,
+        init?: RequestInit,
+    ): Promise<Response>;
+}
+
+/**
+ * **NOT RECOMMENDED FOR PRODUCTION USE.**
+ *
+ * GAP uses Mustache for templating. This is fast and lightweight, but does not
+ * support data transformation. Coupled with the lack of custom Javascript in
+ * GAP, this means data has to provided exactly as needed from the source API.
+ * In practice, this is not always possible. And it is not desirable for quick
+ * development and testing.
+ *
+ * To solve this problem, GAP allows registering of a proxy. This allows pattern
+ * matching on requests, to transform data before it is returned from source.
+ *
+ * Register the proxy *after* gap-core but *before* other extensions.
+ *
+ * Transform functions have the potential to be very slow if operating on larger
+ * data structures so care is needed.
+ *
+ * A core principle of GAP is to avoid custom client-side Javascript. As such,
+ * use of GAPPRoxy in production is *strong discouraged*.
+ */
+export interface GAPProxy {
+    transform: (resp: Response) => Response;
 }
 
 export interface Extension {
@@ -24,9 +56,16 @@ export const defaultHelpers = {
     renderTemplate: (tpl: string, data: any) => {
         return Mustache.render(tpl, data);
     },
+    fetchWithProxy: (
+        input?: Request | string,
+        init?: RequestInit,
+    ): Promise<Response> => {
+        return fetch(input, init).then(r => {
+            if (proxy) return proxy.transform(r);
+            return r;
+        });
+    },
 };
-
-const extensions: Map<string, Extension> = new Map();
 
 /**
  * Main rendering function
@@ -49,6 +88,8 @@ const GAP = {
         extensions.set(tag, extension);
         render();
     },
+    // See gap-proxy readme for info. NOT RECOMMENDED FOR PRODUCTION.
+    registerProxy: (prox: GAPProxy) => (proxy = prox),
 };
 
 window.GAP = GAP;

--- a/packages/gap/gap-core/gap-core.ts
+++ b/packages/gap/gap-core/gap-core.ts
@@ -1,3 +1,5 @@
+import Mustache from 'mustache';
+
 /**
  * This is the main loader for Gap.
  *
@@ -10,9 +12,19 @@
  * extension class.
  */
 
-interface Extension {
-    do: (el: Element) => Promise<void>;
+export interface GAPHelpers {
+    renderTemplate: (tpl: string, data: any) => string;
 }
+
+export interface Extension {
+    do: (el: Element, helpers: GAPHelpers) => Promise<void>;
+}
+
+export const defaultHelpers = {
+    renderTemplate: (tpl: string, data: any) => {
+        return Mustache.render(tpl, data);
+    },
+};
 
 const extensions: Map<string, Extension> = new Map();
 
@@ -26,7 +38,9 @@ const render = () => {
     // caching and throttling
     extensions.forEach((extension, tag) => {
         const tags = document.getElementsByTagName(tag);
-        Array.prototype.forEach.call(tags, (el: Element) => extension.do(el));
+        Array.prototype.forEach.call(tags, (el: Element) =>
+            extension.do(el, defaultHelpers),
+        );
     });
 };
 

--- a/packages/gap/gap-list/gap-list.test.ts
+++ b/packages/gap/gap-list/gap-list.test.ts
@@ -1,4 +1,5 @@
 import GapList from './gap-list';
+import { defaultHelpers } from '../gap-core/gap-core';
 
 describe('gap-list', () => {
     it('should populate the template', async () => {
@@ -8,7 +9,7 @@ describe('gap-list', () => {
             json: () => ({ foo: 1 }),
         };
         globalAny.fetch = jest.fn(async () => resp);
-        document.body.innerHTML = `<gap-list id='test' data-src='example.json'>`;
+        document.body.innerHTML = `<gap-list id='test' data-src='example.json'><template>{{ foo }}</template></gap-list>`;
         const el = document.getElementById('test');
 
         if (el === null) {
@@ -16,7 +17,7 @@ describe('gap-list', () => {
             return;
         }
 
-        await GapList.do(el as Element);
-        expect(el.innerHTML).toBe('<div>1</div>');
+        await GapList.do(el as Element, defaultHelpers);
+        expect(el.innerHTML).toBe('1');
     });
 });

--- a/packages/gap/gap-list/gap-list.test.ts
+++ b/packages/gap/gap-list/gap-list.test.ts
@@ -9,7 +9,7 @@ describe('gap-list', () => {
             json: () => ({ foo: 1 }),
         };
         globalAny.fetch = jest.fn(async () => resp);
-        document.body.innerHTML = `<gap-list id='test' data-src='example.json'><template>{{ foo }}</template></gap-list>`;
+        document.body.innerHTML = `<gap-list id='test' data-src='example.json'><template>[[ foo ]]</template></gap-list>`;
         const el = document.getElementById('test');
 
         if (el === null) {

--- a/packages/gap/gap-list/gap-list.test.ts
+++ b/packages/gap/gap-list/gap-list.test.ts
@@ -1,0 +1,22 @@
+import GapList from './gap-list';
+
+describe('gap-list', () => {
+    it('should populate the template', async () => {
+        const globalAny: any = global;
+        const resp = {
+            ok: true,
+            json: () => ({ foo: 1 }),
+        };
+        globalAny.fetch = jest.fn(async () => resp);
+        document.body.innerHTML = `<gap-list id='test' data-src='example.json'>`;
+        const el = document.getElementById('test');
+
+        if (el === null) {
+            fail();
+            return;
+        }
+
+        await GapList.do(el as Element);
+        expect(el.innerHTML).toBe('<div>1</div>');
+    });
+});

--- a/packages/gap/gap-list/gap-list.ts
+++ b/packages/gap/gap-list/gap-list.ts
@@ -4,9 +4,14 @@
  */
 
 const GapList: Extension = {
-    do: (el: HTMLElement): void =>
+    do: (el: Element): void => {
+        if (el === null) return;
+        const src = el.attributes.getNamedItem('data-src');
+
+        if (src === null) return;
         // tslint:disable-next-line:no-console
-        console.log(`Calling gap-list do on element: ${el.id}`),
+        console.log(`Calling gap-list do on element: ${src.value}`);
+    },
 };
 
 window.GAP.registerElement('gap-list', GapList);

--- a/packages/gap/gap-list/gap-list.ts
+++ b/packages/gap/gap-list/gap-list.ts
@@ -11,7 +11,7 @@ const GapList: Extension = {
         const res = await fetch(src.value);
         const json = await res.json();
 
-        el.innerHTML = `<div>${json.foo}</div>`;
+        el.innerHTML = `<div>${JSON.stringify(json)}</div>`;
         return;
     },
 };

--- a/packages/gap/gap-list/gap-list.ts
+++ b/packages/gap/gap-list/gap-list.ts
@@ -13,7 +13,7 @@ const GapList: Extension = {
         const tpl = el.querySelector('template');
         if (tpl === null) return;
 
-        const res = await fetch(src.value);
+        const res = await helpers.fetchWithProxy(src.value);
         const json = await res.json();
         const html = helpers.renderTemplate(tpl.innerHTML, json);
 

--- a/packages/gap/gap-list/gap-list.ts
+++ b/packages/gap/gap-list/gap-list.ts
@@ -1,0 +1,12 @@
+/**
+ * Loads JSON content from a CORS endpoint and renders it through a provided
+ * template.
+ */
+
+const GapList: Extension = {
+    do: (el: HTMLElement): void =>
+        // tslint:disable-next-line:no-console
+        console.log(`Calling gap-list do on element: ${el.id}`),
+};
+
+window.GAP.registerElement('gap-list', GapList);

--- a/packages/gap/gap-list/gap-list.ts
+++ b/packages/gap/gap-list/gap-list.ts
@@ -1,3 +1,5 @@
+import Mustache from 'mustache';
+
 /**
  * Loads JSON content from a CORS endpoint and renders it through a provided
  * template.
@@ -6,13 +8,16 @@
 const GapList: Extension = {
     do: async (el: Element): Promise<void> => {
         const src = el.attributes.getNamedItem('data-src');
-
         if (src === null) return;
+
+        const tpl = el.querySelector('template');
+        if (tpl === null) return;
+
         const res = await fetch(src.value);
         const json = await res.json();
+        const html = Mustache.render(tpl.innerHTML, json);
 
-        el.innerHTML = `<div>${JSON.stringify(json)}</div>`;
-        return;
+        el.innerHTML = html;
     },
 };
 

--- a/packages/gap/gap-list/gap-list.ts
+++ b/packages/gap/gap-list/gap-list.ts
@@ -4,14 +4,20 @@
  */
 
 const GapList: Extension = {
-    do: (el: Element): void => {
-        if (el === null) return;
+    do: async (el: Element): Promise<void> => {
         const src = el.attributes.getNamedItem('data-src');
 
         if (src === null) return;
-        // tslint:disable-next-line:no-console
-        console.log(`Calling gap-list do on element: ${src.value}`);
+        const res = await fetch(src.value);
+        const json = await res.json();
+
+        el.innerHTML = `<div>${json.foo}</div>`;
+        return;
     },
 };
 
-window.GAP.registerElement('gap-list', GapList);
+export default GapList;
+
+if (window.GAP) {
+    window.GAP.registerElement('gap-list', GapList);
+}

--- a/packages/gap/gap-list/gap-list.ts
+++ b/packages/gap/gap-list/gap-list.ts
@@ -13,7 +13,7 @@ const GapList: Extension = {
         const tpl = el.querySelector('template');
         if (tpl === null) return;
 
-        const res = await helpers.fetchWithProxy(src.value);
+        const res = await helpers.fetch(src.value);
         const json = await res.json();
         const html = helpers.renderTemplate(tpl.innerHTML, json);
 

--- a/packages/gap/gap-list/gap-list.ts
+++ b/packages/gap/gap-list/gap-list.ts
@@ -1,4 +1,4 @@
-import Mustache from 'mustache';
+import { Extension, GAPHelpers } from '../gap-core/gap-core';
 
 /**
  * Loads JSON content from a CORS endpoint and renders it through a provided
@@ -6,7 +6,7 @@ import Mustache from 'mustache';
  */
 
 const GapList: Extension = {
-    do: async (el: Element): Promise<void> => {
+    do: async (el: Element, helpers: GAPHelpers): Promise<void> => {
         const src = el.attributes.getNamedItem('data-src');
         if (src === null) return;
 
@@ -15,7 +15,7 @@ const GapList: Extension = {
 
         const res = await fetch(src.value);
         const json = await res.json();
-        const html = Mustache.render(tpl.innerHTML, json);
+        const html = helpers.renderTemplate(tpl.innerHTML, json);
 
         el.innerHTML = html;
     },

--- a/packages/gap/gap-proxy/gap-proxy.ts
+++ b/packages/gap/gap-proxy/gap-proxy.ts
@@ -1,0 +1,12 @@
+import { GAPProxy } from '../gap-core/gap-core';
+
+const customProxy: GAPProxy = {
+    transform: (resp: Response): Response => {
+        // do custom transforms here, perhaps using resp.url
+        return resp;
+    },
+};
+
+if (window.GAP) {
+    window.GAP.registerProxy(customProxy);
+}

--- a/packages/gap/index.d.ts
+++ b/packages/gap/index.d.ts
@@ -1,8 +1,13 @@
+export interface GAPProxy {
+    transform: (resp: Response) => Response;
+}
+
 declare global {
 
     interface Window { 
         GAP: {
             registerElement: (tag: string, extension: any) => any;
+            registerProxy: (prox: GAPProxy) => void,
         }
     }
 }

--- a/packages/gap/index.d.ts
+++ b/packages/gap/index.d.ts
@@ -1,0 +1,10 @@
+declare global {
+
+    interface Window { 
+        GAP: {
+            registerElement: (tag: string, extension: any) => any;
+        }
+    }
+}
+/*~ this line is required as per TypeScript's global-modifying-module.d.ts instructions */
+export {};

--- a/packages/gap/index.html
+++ b/packages/gap/index.html
@@ -4,6 +4,10 @@
     <script async src="https://s3-eu-west-1.amazonaws.com/com-gu-gap/v0/gap-list.js"></script>
 </head>
 <body>
-    <gap-list data-src="https://amp.theguardian.com/editionalised-nav.json" />
+    <gap-list data-src="https://amp.theguardian.com/editionalised-nav.json">
+        <template>
+            {{ refreshStatus }}
+        </template>
+    </gap-list>
 </body>
 </html>

--- a/packages/gap/index.html
+++ b/packages/gap/index.html
@@ -4,6 +4,6 @@
     <script async src="https://s3-eu-west-1.amazonaws.com/com-gu-gap/v0/gap-list.js"></script>
 </head>
 <body>
-    <gap-list data-src="foo.json" />
+    <gap-list data-src="https://amp.theguardian.com/editionalised-nav.json" />
 </body>
 </html>

--- a/packages/gap/index.html
+++ b/packages/gap/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <head>
-    <script src="https://s3-eu-west-1.amazonaws.com/com-gu-gap/v0/gap-core.js"></script>
-    <script async src="https://s3-eu-west-1.amazonaws.com/com-gu-gap/v0/gap-list.js"></script>
+    <script defer src="https://s3-eu-west-1.amazonaws.com/com-gu-gap/v0/gap-core.js"></script>
+    <script defer src="https://s3-eu-west-1.amazonaws.com/com-gu-gap/v0/gap-list.js"></script>
 </head>
 <body>
     <gap-list data-src="https://amp.theguardian.com/editionalised-nav.json">

--- a/packages/gap/index.html
+++ b/packages/gap/index.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<head>
+    <script src="https://s3-eu-west-1.amazonaws.com/com-gu-gap/v0/gap-core.js"></script>
+    <script async src="https://s3-eu-west-1.amazonaws.com/com-gu-gap/v0/gap-list.js"></script>
+</head>
+<body>
+    <gap-list data-src="foo.json" />
+</body>
+</html>

--- a/packages/gap/package.json
+++ b/packages/gap/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "gap",
+    "version": "0.1.0-alpha.1",
+    "description": "Guardian Accelerated Pages",
+    "license": "Apache-2.0",
+    "dependencies": {
+        "@types/mustache": "^0.8.32",
+        "mustache": "^3.0.1"
+    }
+}

--- a/scripts/deploy/publish-gap.sh
+++ b/scripts/deploy/publish-gap.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+TARGET=packages/gap/dist
+aws s3 cp --profile frontend --acl bucket-owner-full-control --region=eu-west-1 --recursive $TARGET s3://com-gu-gap/v0/
+echo GAP core and extensions uploaded!

--- a/scripts/deploy/publish-gap.sh
+++ b/scripts/deploy/publish-gap.sh
@@ -3,5 +3,5 @@
 set -e
 
 TARGET=packages/gap/dist
-aws s3 cp --profile frontend --acl bucket-owner-full-control --region=eu-west-1 --recursive $TARGET s3://com-gu-gap/v0/
+aws s3 cp --profile frontend --acl public-read --region=eu-west-1 --recursive $TARGET s3://com-gu-gap/v0/
 echo GAP core and extensions uploaded!

--- a/scripts/webpack/gap.js
+++ b/scripts/webpack/gap.js
@@ -4,6 +4,7 @@ module.exports = () => ({
     entry: {
         'gap-core': './packages/gap/gap-core/gap-core.ts',
         'gap-list': './packages/gap/gap-list/gap-list.ts',
+        'gap-proxy': './packages/gap/gap-proxy/gap-proxy.ts',
     },
     output: {
         path: resolve(__dirname, `../../packages/gap/dist/`),

--- a/scripts/webpack/gap.js
+++ b/scripts/webpack/gap.js
@@ -1,0 +1,33 @@
+const { resolve } = require('path');
+
+module.exports = () => ({
+    entry: {
+        'gap-core': './packages/gap/gap-core/gap-core.ts',
+        'gap-list': './packages/gap/gap-list/gap-list.ts',
+    },
+    output: {
+        path: resolve(__dirname, `../../packages/gap/dist/`),
+        filename: `[name].js`,
+        chunkFilename: `[name].js`,
+        libraryTarget: 'global',
+        pathinfo: true,
+    },
+    resolve: {
+        extensions: [ '.tsx', '.ts', '.js' ]
+    },
+    module: {
+        rules: [
+            {
+                test: /\.tsx?$/,
+                use: 'babel-loader',
+                exclude: /node_modules/
+            }
+        ]
+    },
+    target: 'web',
+    optimization: {
+        minimize: false,
+        namedModules: true,
+        runtimeChunk: false,
+    },
+});

--- a/scripts/webpack/gap.js
+++ b/scripts/webpack/gap.js
@@ -25,9 +25,4 @@ module.exports = () => ({
         ]
     },
     target: 'web',
-    optimization: {
-        minimize: false,
-        namedModules: true,
-        runtimeChunk: false,
-    },
 });

--- a/scripts/webpack/gap.js
+++ b/scripts/webpack/gap.js
@@ -23,7 +23,12 @@ module.exports = () => ({
                 use: 'babel-loader',
                 exclude: /node_modules/
             }
-        ]
+        ],
     },
+    devServer: {
+        contentBase: resolve(__dirname, '../../packages/gap/dist/'),
+        compress: false,
+        port: 3040
+    },    
     target: 'web',
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -950,6 +950,10 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.0.tgz#5a7306e367c539b9f6543499de8dd519fac37a8b"
 
+"@types/mustache@^0.8.32":
+  version "0.8.32"
+  resolved "https://registry.yarnpkg.com/@types/mustache/-/mustache-0.8.32.tgz#7db3b81f2bf450bd38805f596d20eca97c4ed595"
+
 "@types/node@*":
   version "10.9.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.9.4.tgz#0f4cb2dc7c1de6096055357f70179043c33e9897"
@@ -5698,6 +5702,10 @@ multipipe@^1.0.2:
   dependencies:
     duplexer2 "^0.1.2"
     object-assign "^4.1.0"
+
+mustache@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/mustache/-/mustache-3.0.1.tgz#873855f23aa8a95b150fb96d9836edbc5a1d248a"
 
 mute-stream@0.0.7, mute-stream@~0.0.4:
   version "0.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1174,7 +1174,7 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
 
-accepts@~1.3.5:
+accepts@~1.3.4, accepts@~1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.5.tgz#eb777df6011723a3b14e8a72c0805c8e86746bd2"
   dependencies:
@@ -1354,6 +1354,10 @@ array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
 
+array-flatten@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-2.1.1.tgz#426bb9da84090c1838d812c8150af20a8331e296"
+
 array-union@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
@@ -1432,6 +1436,10 @@ async@2.6.1, async@^2.1.4, async@^2.4.1, async@^2.5.0, async@^2.6, async@^2.6.0,
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
   dependencies:
     lodash "^4.17.10"
+
+async@^1.5.2:
+  version "1.5.2"
+  resolved "http://registry.npmjs.org/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -1750,6 +1758,10 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
+batch@0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
+
 bcrypt-pbkdf@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
@@ -1830,6 +1842,17 @@ body-parser@1.18.3:
     qs "6.5.2"
     raw-body "2.3.3"
     type-is "~1.6.16"
+
+bonjour@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/bonjour/-/bonjour-3.5.0.tgz#8e890a183d8ee9a2393b3844c691a42bcf7bc9f5"
+  dependencies:
+    array-flatten "^2.1.0"
+    deep-equal "^1.0.1"
+    dns-equal "^1.0.0"
+    dns-txt "^2.0.2"
+    multicast-dns "^6.0.1"
+    multicast-dns-service-types "^1.1.0"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -1990,6 +2013,10 @@ buffer-from@1.x, buffer-from@^1.0.0:
 buffer-from@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-0.1.2.tgz#15f4b9bcef012044df31142c14333caf6e0260d0"
+
+buffer-indexof@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/buffer-indexof/-/buffer-indexof-1.1.1.tgz#52fabcc6a606d1a00302802648ef68f639da268c"
 
 buffer-xor@^1.0.3:
   version "1.0.3"
@@ -2193,7 +2220,7 @@ check-types@^7.3.0:
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/check-types/-/check-types-7.4.0.tgz#0378ec1b9616ec71f774931a3c6516fad8c152f4"
 
-chokidar@^2.0.2, chokidar@^2.0.4:
+chokidar@^2.0.0, chokidar@^2.0.2, chokidar@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.0.4.tgz#356ff4e2b0e8e43e322d18a372460bbcf3accd26"
   dependencies:
@@ -2403,6 +2430,24 @@ compose-function@^3.0.3:
   dependencies:
     arity-n "^1.0.4"
 
+compressible@~2.0.14:
+  version "2.0.15"
+  resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.15.tgz#857a9ab0a7e5a07d8d837ed43fe2defff64fe212"
+  dependencies:
+    mime-db ">= 1.36.0 < 2"
+
+compression@^1.5.2:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/compression/-/compression-1.7.3.tgz#27e0e176aaf260f7f2c2813c3e440adb9f1993db"
+  dependencies:
+    accepts "~1.3.5"
+    bytes "3.0.0"
+    compressible "~2.0.14"
+    debug "2.6.9"
+    on-headers "~1.0.1"
+    safe-buffer "5.1.2"
+    vary "~1.1.2"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -2415,6 +2460,10 @@ concat-stream@^1.4.1, concat-stream@^1.5.0:
     inherits "^2.0.3"
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
+
+connect-history-api-fallback@^1.3.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz#b06873934bc5e344fef611a196a6faae0aee015a"
 
 console-browserify@^1.1.0:
   version "1.1.0"
@@ -2777,7 +2826,7 @@ debug@3.1.0, debug@=3.1.0, debug@^3.0.0, debug@^3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^3.0, debug@^3.1:
+debug@^3.0, debug@^3.1, debug@^3.2.5:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   dependencies:
@@ -2810,6 +2859,10 @@ decompress-response@^3.3.0:
   dependencies:
     mimic-response "^1.0.0"
 
+deep-equal@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
+
 deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
@@ -2827,6 +2880,13 @@ deep-metrics@0.0.2:
 deepmerge@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.1.1.tgz#e862b4e45ea0555072bf51e7fd0d9845170ae768"
+
+default-gateway@^2.6.0:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/default-gateway/-/default-gateway-2.7.2.tgz#b7ef339e5e024b045467af403d50348db4642d0f"
+  dependencies:
+    execa "^0.10.0"
+    ip-regex "^2.1.0"
 
 default-require-extensions@^1.0.0:
   version "1.0.0"
@@ -2881,6 +2941,17 @@ del@^2.0.2:
     pinkie-promise "^2.0.0"
     rimraf "^2.2.8"
 
+del@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/del/-/del-3.0.0.tgz#53ecf699ffcbcb39637691ab13baf160819766e5"
+  dependencies:
+    globby "^6.1.0"
+    is-path-cwd "^1.0.0"
+    is-path-in-cwd "^1.0.0"
+    p-map "^1.1.1"
+    pify "^3.0.0"
+    rimraf "^2.2.8"
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
@@ -2932,6 +3003,10 @@ detect-newline@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
 
+detect-node@^2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
+
 diff@^3.2.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
@@ -2956,6 +3031,23 @@ diskusage@^0.2.5:
   resolved "https://registry.yarnpkg.com/diskusage/-/diskusage-0.2.5.tgz#f2e0d86b1722c0ca5284c938e194290202c2e4f8"
   dependencies:
     nan "^2.5.0"
+
+dns-equal@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/dns-equal/-/dns-equal-1.0.0.tgz#b39e7f1da6eb0a75ba9c17324b34753c47e0654d"
+
+dns-packet@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-1.3.1.tgz#12aa426981075be500b910eedcd0b47dd7deda5a"
+  dependencies:
+    ip "^1.1.0"
+    safe-buffer "^5.0.1"
+
+dns-txt@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/dns-txt/-/dns-txt-2.0.2.tgz#b91d806f5d27188e4ab3e7d107d881a1cc4642b6"
+  dependencies:
+    buffer-indexof "^1.0.0"
 
 doctrine@0.7.2:
   version "0.7.2"
@@ -3244,9 +3336,19 @@ eventemitter2@~0.4.14:
   version "0.4.14"
   resolved "http://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz#8f61b75cde012b2e9eb284d4545583b5643b61ab"
 
+eventemitter3@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
+
 events@1.1.1, events@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+
+eventsource@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-1.0.7.tgz#8fbc72c93fcd34088090bc0a4e64f4b5cee6d8d0"
+  dependencies:
+    original "^1.0.0"
 
 evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
   version "1.0.3"
@@ -3491,6 +3593,18 @@ fastparse@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.1.tgz#d1e2643b38a94d7583b479060e6c4affc94071f8"
 
+faye-websocket@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.10.0.tgz#4e492f8d04dfb6f89003507f6edbf2d501e7c6f4"
+  dependencies:
+    websocket-driver ">=0.5.1"
+
+faye-websocket@~0.11.1:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.11.1.tgz#f0efe18c4f56e4f40afc7e06c719fd5ee6188f38"
+  dependencies:
+    websocket-driver ">=0.5.1"
+
 fb-watchman@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.0.tgz#54e9abf7dfa2f26cd9b1636c588c1afc05de5d58"
@@ -3651,6 +3765,12 @@ follow-redirects@1.0.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.0.0.tgz#8e34298cbd2e176f254effec75a1c78cc849fd37"
   dependencies:
     debug "^2.2.0"
+
+follow-redirects@^1.0.0:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  dependencies:
+    debug "=3.1.0"
 
 follow-redirects@^1.2.3:
   version "1.5.9"
@@ -3877,7 +3997,7 @@ globby@^5.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-globby@^6.0.0:
+globby@^6.0.0, globby@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-6.1.0.tgz#f5a6d70e8395e21c858fb0489d64df02424d506c"
   dependencies:
@@ -3934,6 +4054,10 @@ gzip-size@^4.0.0, gzip-size@^4.1.0:
   dependencies:
     duplexer "^0.1.1"
     pify "^3.0.0"
+
+handle-thing@^1.2.5:
+  version "1.2.5"
+  resolved "http://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz#fd7aad726bf1a5fd16dfc29b2f7a6601d27139c4"
 
 handlebars@^4.0.3:
   version "4.0.12"
@@ -4048,6 +4172,15 @@ hosted-git-info@^2.1.4:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
 
+hpack.js@^2.1.6:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/hpack.js/-/hpack.js-2.1.6.tgz#87774c0949e513f42e84575b3c45681fade2a0b2"
+  dependencies:
+    inherits "^2.0.1"
+    obuf "^1.0.0"
+    readable-stream "^2.0.1"
+    wbuf "^1.1.0"
+
 html-comment-regex@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/html-comment-regex/-/html-comment-regex-1.1.1.tgz#668b93776eaae55ebde8f3ad464b307a4963625e"
@@ -4099,6 +4232,10 @@ htmlparser2@^3.9.2:
     inherits "^2.0.1"
     readable-stream "^2.0.2"
 
+http-deceiver@^1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/http-deceiver/-/http-deceiver-1.2.7.tgz#fa7168944ab9a519d337cb0bec7284dc3e723d87"
+
 http-errors@1.6.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.2.tgz#0a002cc85707192a7e7946ceedc11155f60ec736"
@@ -4116,6 +4253,27 @@ http-errors@1.6.3, http-errors@~1.6.2, http-errors@~1.6.3:
     inherits "2.0.3"
     setprototypeof "1.1.0"
     statuses ">= 1.4.0 < 2"
+
+http-parser-js@>=0.4.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.5.0.tgz#d65edbede84349d0dc30320815a15d39cc3cbbd8"
+
+http-proxy-middleware@~0.18.0:
+  version "0.18.0"
+  resolved "http://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz#0987e6bb5a5606e5a69168d8f967a87f15dd8aab"
+  dependencies:
+    http-proxy "^1.16.2"
+    is-glob "^4.0.0"
+    lodash "^4.17.5"
+    micromatch "^3.1.9"
+
+http-proxy@^1.16.2:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.17.0.tgz#7ad38494658f84605e2f6db4436df410f4e5be9a"
+  dependencies:
+    eventemitter3 "^3.0.0"
+    follow-redirects "^1.0.0"
+    requires-port "^1.0.0"
 
 http-signature@~1.2.0:
   version "1.2.0"
@@ -4267,6 +4425,13 @@ inquirer@^5.2.0:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
+internal-ip@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/internal-ip/-/internal-ip-3.0.1.tgz#df5c99876e1d2eb2ea2d74f520e3f669a00ece27"
+  dependencies:
+    default-gateway "^2.6.0"
+    ipaddr.js "^1.5.2"
+
 interpret@^1.0.0, interpret@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
@@ -4289,9 +4454,21 @@ invert-kv@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
 
+ip-regex@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
+
+ip@^1.1.0, ip@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
+
 ipaddr.js@1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.8.0.tgz#eaa33d6ddd7ace8f7f6fe0c9ca0440e706738b1e"
+
+ipaddr.js@^1.5.2:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.8.1.tgz#fa4b79fa47fd3def5e3b159825161c0a519c9427"
 
 is-absolute-url@^2.0.0:
   version "2.1.0"
@@ -4569,6 +4746,10 @@ is-windows@^1.0.2:
 is-word-character@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-word-character/-/is-word-character-1.0.2.tgz#46a5dac3f2a1840898b91e576cd40d493f3ae553"
+
+is-wsl@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
 
 is@^3.2.0:
   version "3.2.1"
@@ -5121,6 +5302,10 @@ json-stringify-safe@5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
+json3@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
+
 json5@2.x:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.0.tgz#e7a0c62c48285c628d20a10b85c89bb807c32850"
@@ -5139,6 +5324,10 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+killable@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/killable/-/killable-1.0.1.tgz#4c8ce441187a061c7474fb87ca08e2a638194892"
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -5326,6 +5515,10 @@ log-update@2.3.x, log-update@^2.3.0:
     ansi-escapes "^3.0.0"
     cli-cursor "^2.0.0"
     wrap-ansi "^3.0.1"
+
+loglevel@^1.4.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.1.tgz#e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa"
 
 long@4.0.0:
   version "4.0.0"
@@ -5534,7 +5727,7 @@ micromatch@^2.3.11:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
-micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.8:
+micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.8, micromatch@^3.1.9:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
   dependencies:
@@ -5559,6 +5752,10 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
+"mime-db@>= 1.36.0 < 2", mime-db@~1.37.0:
+  version "1.37.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.37.0.tgz#0b6a0ce6fdbe9576e25f1f2d2fde8830dc0ad0d8"
+
 mime-db@~1.36.0:
   version "1.36.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.36.0.tgz#5020478db3c7fe93aad7bbcc4dcf869c43363397"
@@ -5568,6 +5765,12 @@ mime-types@^2.1.12, mime-types@~2.1.18, mime-types@~2.1.19:
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.20.tgz#930cb719d571e903738520f8470911548ca2cc19"
   dependencies:
     mime-db "~1.36.0"
+
+mime-types@~2.1.17:
+  version "2.1.21"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.21.tgz#28995aa1ecb770742fe6ae7e58f9181c744b3f96"
+  dependencies:
+    mime-db "~1.37.0"
 
 mime@1.4.1:
   version "1.4.1"
@@ -5661,7 +5864,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@0.5.1, mkdirp@0.x, "mkdirp@>=0.5 0", mkdirp@^0.5, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
+mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@0.x, "mkdirp@>=0.5 0", mkdirp@^0.5, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -5695,6 +5898,17 @@ ms@2.0.0:
 ms@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
+
+multicast-dns-service-types@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz#899f11d9686e5e05cb91b35d5f0e63b773cfc901"
+
+multicast-dns@^6.0.1:
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/multicast-dns/-/multicast-dns-6.2.3.tgz#a0ec7bd9055c4282f790c3c82f4e28db3b31b229"
+  dependencies:
+    dns-packet "^1.3.1"
+    thunky "^1.0.2"
 
 multipipe@^1.0.2:
   version "1.0.2"
@@ -5785,6 +5999,10 @@ node-fetch@^1.0.1:
 node-fetch@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.2.1.tgz#1fe551e0ded6c45b3b3b937d0fb46f76df718d1e"
+
+node-forge@0.7.5:
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.5.tgz#6c152c345ce11c52f465c2abd957e8639cd674df"
 
 node-gyp@^3.6.2:
   version "3.8.0"
@@ -6015,11 +6233,19 @@ object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
+obuf@^1.0.0, obuf@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
+
 on-finished@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
   dependencies:
     ee-first "1.1.1"
+
+on-headers@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.1.tgz#928f5d0f470d49342651ea6794b0857c100693f7"
 
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
@@ -6041,6 +6267,12 @@ ophan-tracker-js@^1.3.13:
   version "1.3.13"
   resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.3.13.tgz#715aa8655c1ec4c8e45379bae55a95b535522ff6"
 
+opn@^5.1.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/opn/-/opn-5.4.0.tgz#cb545e7aab78562beb11aa3bfabc7042e1761035"
+  dependencies:
+    is-wsl "^1.1.0"
+
 optimist@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
@@ -6058,6 +6290,12 @@ optionator@^0.8.1:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
     wordwrap "~1.0.0"
+
+original@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/original/-/original-1.0.2.tgz#e442a61cffe1c5fd20a65f3261c26663b303f25f"
+  dependencies:
+    url-parse "^1.4.3"
 
 os-browserify@^0.3.0:
   version "0.3.0"
@@ -6129,6 +6367,10 @@ p-locate@^3.0.0:
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
   dependencies:
     p-limit "^2.0.0"
+
+p-map@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
 
 p-try@^1.0.0:
   version "1.0.0"
@@ -6404,6 +6646,14 @@ pn@^1.1.0:
 polished@^1.9.2:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/polished/-/polished-1.9.3.tgz#d61b8a0c4624efe31e2583ff24a358932b6b75e1"
+
+portfinder@^1.0.9:
+  version "1.0.19"
+  resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.19.tgz#07e87914a55242dcda5b833d42f018d6875b595f"
+  dependencies:
+    async "^1.5.2"
+    debug "^2.2.0"
+    mkdirp "0.5.x"
 
 posix-character-classes@^0.1.0:
   version "0.1.1"
@@ -6939,6 +7189,10 @@ querystring@0.2.0, querystring@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
 
+querystringify@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.0.tgz#7ded8dfbf7879dcc60d0a644ac6754b283ad17ef"
+
 quick-lru@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
@@ -7062,7 +7316,7 @@ read@^1.0.4:
   dependencies:
     mute-stream "~0.0.4"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.2.9, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   dependencies:
@@ -7336,6 +7590,10 @@ require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
 
+requires-port@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+
 reselect@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
@@ -7480,6 +7738,16 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
+select-hose@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
+
+selfsigned@^1.9.1:
+  version "1.10.4"
+  resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.10.4.tgz#cdd7eccfca4ed7635d47a08bf2d5d3074092e2cd"
+  dependencies:
+    node-forge "0.7.5"
+
 "semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
@@ -7517,6 +7785,18 @@ send@0.16.2:
 serialize-javascript@^1.4.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.5.0.tgz#1aa336162c88a890ddad5384baebc93a655161fe"
+
+serve-index@^1.7.2:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/serve-index/-/serve-index-1.9.1.tgz#d3768d69b1e7d82e5ce050fff5b453bea12a9239"
+  dependencies:
+    accepts "~1.3.4"
+    batch "0.6.1"
+    debug "2.6.9"
+    escape-html "~1.0.3"
+    http-errors "~1.6.2"
+    mime-types "~2.1.17"
+    parseurl "~1.3.2"
 
 serve-static@1.13.2:
   version "1.13.2"
@@ -7663,6 +7943,24 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
+sockjs-client@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/sockjs-client/-/sockjs-client-1.3.0.tgz#12fc9d6cb663da5739d3dc5fb6e8687da95cb177"
+  dependencies:
+    debug "^3.2.5"
+    eventsource "^1.0.7"
+    faye-websocket "~0.11.1"
+    inherits "^2.0.3"
+    json3 "^3.3.2"
+    url-parse "^1.4.3"
+
+sockjs@0.3.19:
+  version "0.3.19"
+  resolved "https://registry.yarnpkg.com/sockjs/-/sockjs-0.3.19.tgz#d976bbe800af7bd20ae08598d582393508993c0d"
+  dependencies:
+    faye-websocket "^0.10.0"
+    uuid "^3.0.1"
+
 sort-keys@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-1.1.2.tgz#441b6d4d346798f1b4e49e8920adfba0e543f9ad"
@@ -7733,6 +8031,29 @@ spdx-expression-parse@^3.0.0:
 spdx-license-ids@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz#7a7cd28470cc6d3a1cfe6d66886f6bc430d3ac87"
+
+spdy-transport@^2.0.18:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/spdy-transport/-/spdy-transport-2.1.1.tgz#c54815d73858aadd06ce63001e7d25fa6441623b"
+  dependencies:
+    debug "^2.6.8"
+    detect-node "^2.0.3"
+    hpack.js "^2.1.6"
+    obuf "^1.1.1"
+    readable-stream "^2.2.9"
+    safe-buffer "^5.0.1"
+    wbuf "^1.7.2"
+
+spdy@^3.4.1:
+  version "3.4.7"
+  resolved "https://registry.yarnpkg.com/spdy/-/spdy-3.4.7.tgz#42ff41ece5cc0f99a3a6c28aabb73f5c3b03acbc"
+  dependencies:
+    debug "^2.6.8"
+    handle-thing "^1.2.5"
+    http-deceiver "^1.2.7"
+    safe-buffer "^5.0.1"
+    select-hose "^2.0.0"
+    spdy-transport "^2.0.18"
 
 specificity@^0.4.0:
   version "0.4.1"
@@ -8030,7 +8351,7 @@ supports-color@^4.0.0:
   dependencies:
     has-flag "^2.0.0"
 
-supports-color@^5.3.0, supports-color@^5.4.0, supports-color@^5.5.0:
+supports-color@^5.1.0, supports-color@^5.3.0, supports-color@^5.4.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   dependencies:
@@ -8157,6 +8478,10 @@ through2@~0.4.1:
 through@^2.3.6, through@^2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+
+thunky@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.0.3.tgz#f5df732453407b09191dae73e2a8cc73f381a826"
 
 timers-browserify@^2.0.4:
   version "2.0.10"
@@ -8579,6 +8904,13 @@ url-join@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/url-join/-/url-join-4.0.0.tgz#4d3340e807d3773bda9991f8305acdcc2a665d2a"
 
+url-parse@^1.4.3:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.4.tgz#cac1556e95faa0303691fec5cf9d5a1bc34648f8"
+  dependencies:
+    querystringify "^2.0.0"
+    requires-port "^1.0.0"
+
 url@0.10.3:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
@@ -8752,6 +9084,12 @@ watchpack@^1.5.0:
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
 
+wbuf@^1.1.0, wbuf@^1.7.2:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/wbuf/-/wbuf-1.7.3.tgz#c1d8d149316d3ea852848895cb6a0bfe887b87df"
+  dependencies:
+    minimalistic-assert "^1.0.0"
+
 wcwidth@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
@@ -8806,6 +9144,15 @@ webpack-cli@^3.1.1:
     v8-compile-cache "^2.0.2"
     yargs "^12.0.2"
 
+webpack-dev-middleware@3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-3.4.0.tgz#1132fecc9026fd90f0ecedac5cbff75d1fb45890"
+  dependencies:
+    memory-fs "~0.4.1"
+    mime "^2.3.1"
+    range-parser "^1.0.3"
+    webpack-log "^2.0.0"
+
 webpack-dev-middleware@^3.1.2:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-3.2.0.tgz#a20ceef194873710052da678f3c6ee0aeed92552"
@@ -8817,6 +9164,39 @@ webpack-dev-middleware@^3.1.2:
     range-parser "^1.0.3"
     url-join "^4.0.0"
     webpack-log "^2.0.0"
+
+webpack-dev-server@^3.1.10:
+  version "3.1.10"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-3.1.10.tgz#507411bee727ee8d2fdffdc621b66a64ab3dea2b"
+  dependencies:
+    ansi-html "0.0.7"
+    bonjour "^3.5.0"
+    chokidar "^2.0.0"
+    compression "^1.5.2"
+    connect-history-api-fallback "^1.3.0"
+    debug "^3.1.0"
+    del "^3.0.0"
+    express "^4.16.2"
+    html-entities "^1.2.0"
+    http-proxy-middleware "~0.18.0"
+    import-local "^2.0.0"
+    internal-ip "^3.0.1"
+    ip "^1.1.5"
+    killable "^1.0.0"
+    loglevel "^1.4.1"
+    opn "^5.1.0"
+    portfinder "^1.0.9"
+    schema-utils "^1.0.0"
+    selfsigned "^1.9.1"
+    serve-index "^1.7.2"
+    sockjs "0.3.19"
+    sockjs-client "1.3.0"
+    spdy "^3.4.1"
+    strip-ansi "^3.0.0"
+    supports-color "^5.1.0"
+    webpack-dev-middleware "3.4.0"
+    webpack-log "^2.0.0"
+    yargs "12.0.2"
 
 webpack-hot-middleware@^2.22.0:
   version "2.23.1"
@@ -8889,6 +9269,17 @@ webpack@^4.5.0:
     uglifyjs-webpack-plugin "^1.2.4"
     watchpack "^1.5.0"
     webpack-sources "^1.0.1"
+
+websocket-driver@>=0.5.1:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.0.tgz#0caf9d2d755d93aee049d4bdd0d3fe2cca2a24eb"
+  dependencies:
+    http-parser-js ">=0.4.0"
+    websocket-extensions ">=0.1.1"
+
+websocket-extensions@>=0.1.1:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
 
 whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   version "1.0.4"
@@ -9099,6 +9490,23 @@ yargs-parser@^9.0.2:
   dependencies:
     camelcase "^4.1.0"
 
+yargs@12.0.2, yargs@^12.0.2:
+  version "12.0.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-12.0.2.tgz#fe58234369392af33ecbef53819171eff0f5aadc"
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^2.0.0"
+    find-up "^3.0.0"
+    get-caller-file "^1.0.1"
+    os-locale "^3.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1 || ^4.0.0"
+    yargs-parser "^10.1.0"
+
 yargs@^11.0.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.1.0.tgz#90b869934ed6e871115ea2ff58b03f4724ed2d77"
@@ -9115,23 +9523,6 @@ yargs@^11.0.0:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^9.0.2"
-
-yargs@^12.0.2:
-  version "12.0.2"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-12.0.2.tgz#fe58234369392af33ecbef53819171eff0f5aadc"
-  dependencies:
-    cliui "^4.0.0"
-    decamelize "^2.0.0"
-    find-up "^3.0.0"
-    get-caller-file "^1.0.1"
-    os-locale "^3.0.0"
-    require-directory "^2.1.1"
-    require-main-filename "^1.0.1"
-    set-blocking "^2.0.0"
-    string-width "^2.0.0"
-    which-module "^2.0.0"
-    y18n "^3.2.1 || ^4.0.0"
-    yargs-parser "^10.1.0"
 
 yarn@^1.5.1:
   version "1.9.4"


### PR DESCRIPTION
WIP proposal doc now here: https://docs.google.com/document/d/10A8e_3s6dE1vSMpAsAR7winTYx31fOtVeaGh3e-kF7k/edit?usp=sharing .

Just raising this for visibility - so that people know how to find it and can ask any questions.

But it's not intended to be merged.

Excerpt from readme below to save clicks:

--

# GAP

## Design goals

Guardian Accelerated Pages (GAP) is an AMP-inspired system to manage client-side
performance.

It has slightly different design goals from AMP though:

* designed to meet current Guardian requirements
* extensions can be used without being accepted as official
* not-mobile specific

So it's a bit more relaxed than AMP, which should make it a better fit for existing news-sites, which often have requirements that don't fit within AMP. The downside is it is easier to mess up performance/do the wrong thing in GAP.

Like AMP, Gap is a combination of HTML-guidelines/restrictions, and a Javascript runtime ('gap-core') augmented by custom elements ('extensions').

## How to use

As a minimum, include gap-core in your page. This must be loaded *before*
extensions. `defer` is a good way to achieve this. E.g. in your page head:

    <script defer src="https://s3-eu-west-1.amazonaws.com/com-gu-gap/v0/gap-core.js" />
    .. // some extensions