### PR TITLE
Add recommended VSCode extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,8 @@ node_modules
 
 # IDE files
 .idea
-.vscode
+.vscode/*
+!.vscode/extensions.json
 
 # System files
 .DS_Store

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+    "recommendations": [
+        "eg2.tslint",
+        "esbenp.prettier-vscode",
+        "wix.vscode-import-cost",
+        "eamodio.gitlens",
+        "orta.vscode-jest"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # 𝐆𝐔𝐔𝐈 [![GitHub version](https://badge.fury.io/gh/guardian%2Fguui.svg)](https://badge.fury.io/gh/guardian%2Fguui) [![Build Status](https://travis-ci.org/guardian/guui.svg?branch=master)](https://travis-ci.org/guardian/guui) [![Known Vulnerabilities](https://snyk.io/test/github/guardian/guui/badge.svg?targetFile=package.json)](https://snyk.io/test/github/guardian/guui?targetFile=package.json)
 
-
-
 Frontend rendering framework for theguardian.com. It uses [react](https://reactjs.org/), [emotion](https://emotion.sh) for CSS.
 
 _Any/all of these could change before we reach `2.0.0`._
@@ -9,6 +7,7 @@ _Any/all of these could change before we reach `2.0.0`._
 Chat room: [Digital/dotcom-rendering](https://chat.google.com/room/AAAA6yBswlI)
 
 ## Setup
+
 ### Node
 
 The only thing you need to make sure you have installed before you get going is Node.
@@ -21,36 +20,41 @@ check the [.nvmrc](https://github.com/guardian/guui/blob/master/.nvmrc) for the 
 That's it – everything else should be installed for you on demand.
 
 ## Development
+
 `make dev` starts the development server.
 
 ### Running alongside identity
+
 You may want local identity cookies to be available in dotcom-rendering. To enable this:
 
-1. Add `127.0.0.1   r.thegulocal.com` to the end of your hosts file
-2. Follow the installation steps in [identity-platform/nginx](https://github.com/guardian/identity-platform/tree/master/nginx) 
+1. Add `127.0.0.1 r.thegulocal.com` to the end of your hosts file
+2. Follow the installation steps in [identity-platform/nginx](https://github.com/guardian/identity-platform/tree/master/nginx)
 3. run `./scripts/nginx/setup.sh`
 4. access dotcom-rendering through https://r.thegulocal.com
 
 ### Change preview article
+
 You can preview an article from `theguardian.com` by appending the query string parameter `url` to your localhost article page. EG. `http://localhost:3030/Article?url=https://www.theguardian.com/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance`
 
 ### Debugging tools
 
 In order to ease development you may want to install:
 
-- Chrome Extension [React Developer Tools](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi?hl=en).
+-   Chrome Extension [React Developer Tools](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi?hl=en).
 
 ## Production
- - `make build` creates production-ready bundles.
- - `make start` starts the production server.
- - `make stop` stops the production server.
+
+-   `make build` creates production-ready bundles.
+-   `make start` starts the production server.
+-   `make stop` stops the production server.
 
 ## Other tasks
 
 ### Code quality
-- `make lint`
-- `make tsc`
-- `make test`
+
+-   `make lint`
+-   `make tsc`
+-   `make test`
 
 `make validate` runs all of the above, plus a final `make build`.
 
@@ -61,21 +65,17 @@ See [the makefile](https://github.com/guardian/guui/blob/master/makefile) for th
 ## IDE setup
 
 ### VSCode
-We use [babel-plugin-module-resolver](https://github.com/tleunen/babel-plugin-module-resolver) to allow us to import things cleanly (You need to have Xcode installed as the plugin installer uses `xcode-select`). If you're using VSCode, adding the following to a `./jsconfig.json` file will help it resolve modules usefully:
+
+We recommend using the Visual Studio Code (VSCode) IDE. VSCode includes built in TypeScript language support and has a rich library of extensions which let you add formatters, debuggers,and tools to your installation to support your development workflow.
+
+You can download VSCode from [https://code.visualstudio.com/](https://code.visualstudio.com/)
+
+Recommended VSCode extensions are listed in `.vscode/extensions.json` and VSCode should prompt you to install these when you open the project. You can also find these extensions Command Palette (shift + cmd + P) and typing the 'Extensions: Show Recommended Extensions command' or by searching for '@recommended' in the extensions pane.
+
+#### Auto fix on save
+
+We recommend you update your workspace setting to auto fix prettier errors on save. You can use the Command Palette (shift + cmd + P) to open user or workspace settings, just type in `Preferences: Open Workspace Settings`. You can then search for 'tslint.autoFixOnSave'. In your `settings.json` then set:
 
 ```json
-{
-    "compilerOptions": {
-        "baseUrl": "src/",
-    }
-}
+    "tslint.autoFixOnSave": true,
 ```
-
-The following extensions will life easier:
-
-- [tslint](https://marketplace.visualstudio.com/items?itemName=eg2.tslint) (esp. with `tslint.autoFixOnSave` enabled)
-
-Also:
-
-- [css-in-js syntax highlighting](https://marketplace.visualstudio.com/items?itemName=jpoissonnier.vscode-styled-components)
-- [colour highlighting in JS](https://marketplace.visualstudio.com/items?itemName=naumovs.color-highlight)

--- a/README.md
+++ b/README.md
@@ -66,15 +66,17 @@ See [the makefile](https://github.com/guardian/guui/blob/master/makefile) for th
 
 ### VSCode
 
-We recommend using the Visual Studio Code (VSCode) IDE. VSCode includes built in TypeScript language support and has a rich library of extensions which let you add formatters, debuggers,and tools to your installation to support your development workflow.
+We recommend using the [VSCode](https://code.visualstudio.com/) IDE. VSCode includes built in TypeScript language support and has a rich library of extensions which let you add formatters, debuggers and tools to your installation to support your development workflow.
 
-You can download VSCode from [https://code.visualstudio.com/](https://code.visualstudio.com/)
-
-Recommended VSCode extensions are listed in `.vscode/extensions.json` and VSCode should prompt you to install these when you open the project. You can also find these extensions Command Palette (shift + cmd + P) and typing the 'Extensions: Show Recommended Extensions command' or by searching for '@recommended' in the extensions pane.
+Recommended VSCode extensions are listed in `.vscode/extensions.json` and VSCode should prompt you to install these when you open the project. You can also find these extensions using Command Palette (shift + cmd + P) and typing the 'Extensions: Show Recommended Extensions command' or by searching for '@recommended' in the extensions pane.
 
 #### Auto fix on save
 
-We recommend you update your workspace setting to auto fix prettier errors on save. You can use the Command Palette (shift + cmd + P) to open user or workspace settings, just type in `Preferences: Open Workspace Settings`. You can then search for 'tslint.autoFixOnSave'. In your `settings.json` then set:
+We recommend you update your workspace settings to automatically fix formatting errors on save. Follow these steps to do this:
+
+1. Open the Command Palette (shift + cmd + P) and type `Preferences: Open Workspace Settings`.
+2. Search for 'tslint.autoFixOnSave'.
+3. Update your `settings.json` with:
 
 ```json
     "tslint.autoFixOnSave": true,


### PR DESCRIPTION
## What does this change?

VSCode supports the inclusion of [recommended extension](https://code.visualstudio.com/docs/editor/extension-gallery#_workspace-recommended-extensions)s in your workspace, these are defined in an `extensions.json` file located in the workspace's `.vscode` folder, In this file you can add a list of extension identifiers. I've included this file in this PR with the following recommendations:

```json
{
    "recommendations": [
        "eg2.tslint", // TSLint
        "esbenp.prettier-vscode", // Prettier
        "wix.vscode-import-cost", // Import Cost
        "eamodio.gitlens", // GitLens
        "orta.vscode-jest" // Jest
    ]
}
```

I've also included VSCode guidance in the README.md to give client-side developers a bit of guidance on the IDE and how to set it up!

Inspired by @katebee's PR on `frontend` https://github.com/guardian/frontend/pull/20490
