### PR TITLE
⚡️ Meta links footer

### DIFF
--- a/packages/frontend/amp/components/Body.tsx
+++ b/packages/frontend/amp/components/Body.tsx
@@ -23,6 +23,7 @@ const Body: React.SFC<{
             keywords={data.subMetaKeywordLinks}
             pillar={pillar}
             sharingURLs={data.sharingUrls}
+            pageID={data.pageId}
         />
     </InnerContainer>
 );

--- a/packages/frontend/amp/components/Body.tsx
+++ b/packages/frontend/amp/components/Body.tsx
@@ -4,6 +4,7 @@ import { Elements } from '@frontend/amp/components/lib/Elements';
 import { css } from 'react-emotion';
 import { ArticleModel } from '@frontend/amp/pages/Article';
 import { MainBlock } from '@frontend/amp/components/MainBlock';
+import Submeta from '@frontend/amp/components/Submeta';
 
 const body = css`
     background-color: white;
@@ -17,6 +18,7 @@ const Body: React.SFC<{
     <InnerContainer className={body}>
         <MainBlock config={config} articleData={data} />
         <Elements pillar={pillar} elements={data.elements} />
+        <Submeta tags={data.tags} pillar={pillar} />
     </InnerContainer>
 );
 

--- a/packages/frontend/amp/components/Body.tsx
+++ b/packages/frontend/amp/components/Body.tsx
@@ -18,7 +18,11 @@ const Body: React.SFC<{
     <InnerContainer className={body}>
         <MainBlock config={config} articleData={data} />
         <Elements pillar={pillar} elements={data.elements} />
-        <Submeta tags={data.tags} pillar={pillar} />
+        <Submeta
+            sections={data.subMetaSectionLinks}
+            keywords={data.subMetaKeywordLinks}
+            pillar={pillar}
+        />
     </InnerContainer>
 );
 

--- a/packages/frontend/amp/components/Body.tsx
+++ b/packages/frontend/amp/components/Body.tsx
@@ -5,6 +5,7 @@ import { css } from 'react-emotion';
 import { ArticleModel } from '@frontend/amp/pages/Article';
 import { MainBlock } from '@frontend/amp/components/MainBlock';
 import Submeta from '@frontend/amp/components/Submeta';
+import { ShareIcons } from '@frontend/amp/components/ShareIcons';
 
 const body = css`
     background-color: white;
@@ -22,6 +23,20 @@ const Body: React.SFC<{
             sections={data.subMetaSectionLinks}
             keywords={data.subMetaKeywordLinks}
             pillar={pillar}
+        />
+        <ShareIcons
+            sharingUrls={data.sharingUrls}
+            pillar={data.pillar}
+            displayIcons={[
+                'facebook',
+                'twitter',
+                'email',
+                'linkedIn',
+                'pinterest',
+                'googlePlus',
+                'whatsApp',
+                'messenger',
+            ]}
         />
     </InnerContainer>
 );

--- a/packages/frontend/amp/components/Body.tsx
+++ b/packages/frontend/amp/components/Body.tsx
@@ -5,7 +5,6 @@ import { css } from 'react-emotion';
 import { ArticleModel } from '@frontend/amp/pages/Article';
 import { MainBlock } from '@frontend/amp/components/MainBlock';
 import Submeta from '@frontend/amp/components/Submeta';
-import { ShareIcons } from '@frontend/amp/components/ShareIcons';
 
 const body = css`
     background-color: white;
@@ -23,20 +22,7 @@ const Body: React.SFC<{
             sections={data.subMetaSectionLinks}
             keywords={data.subMetaKeywordLinks}
             pillar={pillar}
-        />
-        <ShareIcons
-            sharingUrls={data.sharingUrls}
-            pillar={data.pillar}
-            displayIcons={[
-                'facebook',
-                'twitter',
-                'email',
-                'linkedIn',
-                'pinterest',
-                'googlePlus',
-                'whatsApp',
-                'messenger',
-            ]}
+            sharingURLs={data.sharingUrls}
         />
     </InnerContainer>
 );

--- a/packages/frontend/amp/components/MainBlock.tsx
+++ b/packages/frontend/amp/components/MainBlock.tsx
@@ -7,7 +7,7 @@ import Dateline from '../../web/components/Dateline';
 import { ShareCount } from '../../web/components/ShareCount';
 import ClockIcon from '@guardian/pasteup/icons/clock.svg';
 import TwitterIcon from '@guardian/pasteup/icons/twitter.svg';
-import { SharingIcons } from '@frontend/web/components/ShareIcons';
+import { ShareIcons } from '@frontend/amp/components/ShareIcons';
 import { ArticleModel } from '../pages/Article';
 
 const byline = css`
@@ -253,7 +253,7 @@ export const MainBlock: React.SFC<{
             )}
             <Dateline dateDisplay={articleData.webPublicationDateDisplay} />
             <div className={metaExtras}>
-                <SharingIcons
+                <ShareIcons
                     sharingUrls={articleData.sharingUrls}
                     pillar={articleData.pillar}
                     displayIcons={['facebook', 'twitter', 'email']}

--- a/packages/frontend/amp/components/ShareIcons.tsx
+++ b/packages/frontend/amp/components/ShareIcons.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { css, cx } from 'react-emotion';
+import { palette } from '@guardian/pasteup/palette';
+import TwitterIconPadded from '@guardian/pasteup/icons/twitter-padded.svg';
+import FacebookIcon from '@guardian/pasteup/icons/facebook.svg';
+import EmailIcon from '@guardian/pasteup/icons/email.svg';
+import LinkedInIcon from '@guardian/pasteup/icons/linked-in.svg';
+import PinterestIcon from '@guardian/pasteup/icons/pinterest.svg';
+import GooglePlusIcon from '@guardian/pasteup/icons/google-plus.svg';
+import WhatsAppIcon from '@guardian/pasteup/icons/whatsapp.svg';
+import MessengerIcon from '@guardian/pasteup/icons/messenger.svg';
+import { screenReaderOnly } from '@guardian/pasteup/mixins';
+import { pillarMap, pillarPalette } from '@frontend/lib/pillars';
+
+const pillarFill = pillarMap(
+    pillar =>
+        css`
+            fill: ${pillarPalette[pillar].main};
+        `,
+);
+
+const shareIconsListItem = css`
+    padding: 0 3px 6px 0;
+    display: inline-block;
+    min-width: 32px;
+`;
+
+const shareIcon = (colour: string) => css`
+    border: 1px solid ${palette.neutral[86]};
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 32px;
+    max-width: 100%;
+    width: auto;
+    height: 32px;
+    border-radius: 50%;
+    display: inline-block;
+    vertical-align: middle;
+    position: relative;
+    box-sizing: content-box;
+
+    svg {
+        height: 88%;
+        width: 88%;
+        top: 0;
+        bottom: 0;
+        right: 0;
+        left: 0;
+        margin: auto;
+        position: absolute;
+    }
+
+    :hover {
+        background-color: ${colour};
+        border-color: ${colour};
+        fill: white;
+    }
+`;
+
+interface ShareListItemType {
+    id: SharePlatform;
+    Icon: React.ComponentType;
+    url: string;
+    userMessage: string;
+    mobileOnly: boolean;
+}
+
+export const ShareIcons: React.SFC<{
+    sharingUrls: {
+        [K in SharePlatform]?: {
+            url: string;
+            userMessage: string;
+        }
+    };
+    displayIcons: SharePlatform[];
+    pillar: Pillar;
+    className?: string;
+}> = ({ sharingUrls, displayIcons, pillar, className }) => {
+    const icons: { [K in SharePlatform]?: React.ComponentType } = {
+        facebook: FacebookIcon,
+        twitter: TwitterIconPadded,
+        email: EmailIcon,
+        linkedIn: LinkedInIcon,
+        pinterest: PinterestIcon,
+        googlePlus: GooglePlusIcon,
+        whatsApp: WhatsAppIcon,
+        messenger: MessengerIcon,
+    };
+
+    const mobileOnlyIcons: SharePlatform[] = ['whatsApp', 'messenger'];
+
+    const shareList = displayIcons.reduce((list: ShareListItemType[], id) => {
+        const icon = icons[id];
+        const sharingUrl = sharingUrls[id];
+
+        if (icon && sharingUrl) {
+            const listItem: ShareListItemType = Object.assign(
+                {
+                    id,
+                    Icon: icon,
+                    mobileOnly: mobileOnlyIcons.includes(id),
+                },
+                sharingUrl,
+            );
+            list.push(listItem);
+        }
+
+        return list;
+    }, []);
+
+    return (
+        <ul className={cx([className])}>
+            {shareList.map(shareListItem => {
+                const { Icon, id, url, userMessage } = shareListItem;
+
+                return (
+                    <li className={shareIconsListItem} key={`${id}Share`}>
+                        <a href={url} role="button">
+                            <span
+                                className={css`
+                                    ${screenReaderOnly};
+                                `}
+                            >
+                                {userMessage}
+                            </span>
+                            <span
+                                className={cx(
+                                    shareIcon(pillarPalette[pillar].main),
+                                    pillarFill[pillar],
+                                )}
+                            >
+                                <Icon />
+                            </span>
+                        </a>
+                    </li>
+                );
+            })}
+        </ul>
+    );
+};

--- a/packages/frontend/amp/components/Submeta.tsx
+++ b/packages/frontend/amp/components/Submeta.tsx
@@ -18,28 +18,27 @@ const guardianLines = css`
     background-size: 1px 13px;
     padding-top: 18px;
     margin-bottom: 6px;
-
-    margin-top: 0.75rem;
+    margin-top: 12px;
 `;
 
 const linkStyle = (pillar: Pillar) => css`
     position: relative;
-    padding-left: 0.3rem;
-    padding-right: 0.35rem;
+    padding-left: 5px;
+    padding-right: 6px;
     text-decoration: none;
     color: ${pillarPalette[pillar].main};
     font-family: ${serif.body};
     font-size: 15px;
-    line-height: 1.5rem;
+    line-height: 24px;
 
     :after {
         content: '/';
-        font-size: 1em;
+        font-size: 16px;
         position: absolute;
         pointer-events: none;
         top: 0;
-        right: -0.19em;
-        color: #767676;
+        right: -3px;
+        color: ${palette.neutral[46]};
     }
 `;
 
@@ -53,54 +52,55 @@ const itemStyle = css`
 
 const keywordListStyle = css`
     display: block;
-    margin-left: -0.35rem;
-    padding-top: 0.375rem;
-    padding-bottom: 0.75rem;
-    border-bottom: 0.0625rem solid #dcdcdc;
-    margin-bottom: 0.375rem;
+    margin-left: -6px;
+    padding-top: 6px;
+    padding-bottom: 12px;
+    border-bottom: 1px solid ${palette.neutral[86]};
+    margin-bottom: 6px;
 `;
 
 const sectionLinkStyle = (pillar: Pillar) => css`
     position: relative;
-    padding-left: 0.3rem;
-    padding-right: 0.35rem;
+    padding-left: 5px;
+    padding-right: 6px;
     text-decoration: none;
     color: ${pillarPalette[pillar].main};
     font-family: ${serif.body};
     font-size: 16px;
-    line-height: 1.375rem;
+    line-height: 22px;
 
     :after {
         content: '/';
-        font-size: 1em;
+        font-size: 16px;
         position: absolute;
         pointer-events: none;
         top: 0;
-        right: -0.19em;
-        color: #767676;
+        right: -3px;
+        color: ${palette.neutral[46]};
     }
 `;
 
 const sectionListStyle = css`
     display: block;
-    margin-left: -0.35rem;
+    margin-left: -6px;
 `;
 
 const labelStyle = css`
-    font-size: 0.75rem;
-    line-height: 1rem;
-    color: #767676;
+    font-size: 12px;
+    line-height: 16px;
+    color: ${palette.neutral[46]};
     display: block;
-    margin-bottom: -0.1875rem;
+    margin-bottom: -3px;
+    font-family: ${sans.body};
 `;
 
 const siteLinkStyle = css`
-    font-size: 0.8125rem;
+    font-size: 13px;
     font-weight: bold;
     text-decoration: none;
     color: ${palette.neutral[7]};
     font-family: ${sans.body};
-    line-height: 2.25rem;
+    line-height: 36px;
 `;
 
 const Submeta: React.SFC<{

--- a/packages/frontend/amp/components/Submeta.tsx
+++ b/packages/frontend/amp/components/Submeta.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from 'react-emotion';
 import { pillarPalette } from '@frontend/lib/pillars';
-import { serif } from '@guardian/pasteup/fonts';
+import { serif, sans } from '@guardian/pasteup/fonts';
 import { palette } from '@guardian/pasteup/palette';
 import { ShareIcons } from '@frontend/amp/components/ShareIcons';
 
@@ -94,6 +94,15 @@ const labelStyle = css`
     margin-bottom: -0.1875rem;
 `;
 
+const siteLinkStyle = css`
+    font-size: 0.8125rem;
+    font-weight: bold;
+    text-decoration: none;
+    color: ${palette.neutral[7]};
+    font-family: ${sans.body};
+    line-height: 2.25rem;
+`;
+
 const Submeta: React.SFC<{
     pillar: Pillar;
     sections: SimpleLinkType[];
@@ -104,7 +113,8 @@ const Submeta: React.SFC<{
             userMessage: string;
         }
     };
-}> = ({ pillar, sections, keywords, sharingURLs }) => {
+    pageID: string;
+}> = ({ pillar, sections, keywords, sharingURLs, pageID }) => {
     const sectionListItems = sections.map(link => (
         <li className={itemStyle} key={link.url}>
             <a
@@ -148,6 +158,12 @@ const Submeta: React.SFC<{
                     'messenger',
                 ]}
             />
+            {/* TODO link to actual (non-AMP) site here. Also handle comment count behaviour. */}
+            <div className={guardianLines}>
+                <a className={siteLinkStyle} href={`/${pageID}`}>
+                    View on theguardian.com
+                </a>
+            </div>
         </>
     );
 };

--- a/packages/frontend/amp/components/Submeta.tsx
+++ b/packages/frontend/amp/components/Submeta.tsx
@@ -29,6 +29,7 @@ const linkStyle = (pillar: Pillar) => css`
     color: ${pillarPalette[pillar].main};
     font-family: ${serif.body};
     font-size: 15px;
+    line-height: 1.5rem;
 
     :after {
         content: '/';
@@ -49,31 +50,81 @@ const itemStyle = css`
     }
 `;
 
-const listStyle = css`
-    display: inline;
+const keywordListStyle = css`
+    display: block;
     margin-left: -0.35rem;
+    padding-top: 0.375rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 0.0625rem solid #dcdcdc;
+    margin-bottom: 0.375rem;
+`;
+
+const sectionLinkStyle = (pillar: Pillar) => css`
+    position: relative;
+    padding-left: 0.3rem;
+    padding-right: 0.35rem;
+    text-decoration: none;
+    color: ${pillarPalette[pillar].main};
+    font-family: ${serif.body};
+    font-size: 16px;
+    line-height: 1.375rem;
+
+    :after {
+        content: '/';
+        font-size: 1em;
+        position: absolute;
+        pointer-events: none;
+        top: 0;
+        right: -0.19em;
+        color: #767676;
+    }
+`;
+
+const sectionListStyle = css`
+    display: block;
+    margin-left: -0.35rem;
+`;
+
+const labelStyle = css`
+    font-size: 0.75rem;
+    line-height: 1rem;
+    color: #767676;
+    display: block;
+    margin-bottom: -0.1875rem;
 `;
 
 const Submeta: React.SFC<{
     pillar: Pillar;
-    tags: TagType[];
-}> = ({ pillar, tags }) => {
-    const keywords = tags.filter(tag => tag.type === 'Keyword');
+    sections: SimpleLinkType[];
+    keywords: SimpleLinkType[];
+}> = ({ pillar, sections, keywords }) => {
+    const sectionListItems = sections.map(link => (
+        <li className={itemStyle} key={link.url}>
+            <a
+                className={sectionLinkStyle(pillar)}
+                href={`https://www.theguardian.com/${link.url}`}
+            >
+                {link.title}
+            </a>
+        </li>
+    ));
 
-    const links = keywords.map(tag => (
-        <li className={itemStyle} key={tag.id}>
+    const keywordListItems = keywords.map(link => (
+        <li className={itemStyle} key={link.url}>
             <a
                 className={linkStyle(pillar)}
-                href={`https://www.theguardian.com/${tag.id}`}
+                href={`https://www.theguardian.com/${link.url}`}
             >
-                {tag.title}
+                {link.title}
             </a>
         </li>
     ));
 
     return (
         <div className={guardianLines}>
-            <ul className={listStyle}>{links}</ul>
+            <span className={labelStyle}>Topics</span>
+            <ul className={sectionListStyle}>{sectionListItems}</ul>
+            <ul className={keywordListStyle}>{keywordListItems}</ul>
         </div>
     );
 };

--- a/packages/frontend/amp/components/Submeta.tsx
+++ b/packages/frontend/amp/components/Submeta.tsx
@@ -3,6 +3,7 @@ import { css } from 'react-emotion';
 import { pillarPalette } from '@frontend/lib/pillars';
 import { serif } from '@guardian/pasteup/fonts';
 import { palette } from '@guardian/pasteup/palette';
+import { ShareIcons } from '@frontend/amp/components/ShareIcons';
 
 const guardianLines = css`
     background-image: repeating-linear-gradient(
@@ -97,7 +98,13 @@ const Submeta: React.SFC<{
     pillar: Pillar;
     sections: SimpleLinkType[];
     keywords: SimpleLinkType[];
-}> = ({ pillar, sections, keywords }) => {
+    sharingURLs: {
+        [K in SharePlatform]?: {
+            url: string;
+            userMessage: string;
+        }
+    };
+}> = ({ pillar, sections, keywords, sharingURLs }) => {
     const sectionListItems = sections.map(link => (
         <li className={itemStyle} key={link.url}>
             <a
@@ -121,11 +128,27 @@ const Submeta: React.SFC<{
     ));
 
     return (
-        <div className={guardianLines}>
-            <span className={labelStyle}>Topics</span>
-            <ul className={sectionListStyle}>{sectionListItems}</ul>
-            <ul className={keywordListStyle}>{keywordListItems}</ul>
-        </div>
+        <>
+            <div className={guardianLines}>
+                <span className={labelStyle}>Topics</span>
+                <ul className={sectionListStyle}>{sectionListItems}</ul>
+                <ul className={keywordListStyle}>{keywordListItems}</ul>
+            </div>
+            <ShareIcons
+                sharingUrls={sharingURLs}
+                pillar={pillar}
+                displayIcons={[
+                    'facebook',
+                    'twitter',
+                    'email',
+                    'linkedIn',
+                    'pinterest',
+                    'googlePlus',
+                    'whatsApp',
+                    'messenger',
+                ]}
+            />
+        </>
     );
 };
 

--- a/packages/frontend/amp/components/Submeta.tsx
+++ b/packages/frontend/amp/components/Submeta.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { css } from 'react-emotion';
+import { pillarPalette } from '@frontend/lib/pillars';
+import { serif } from '@guardian/pasteup/fonts';
+import { palette } from '@guardian/pasteup/palette';
+
+const guardianLines = css`
+    background-image: repeating-linear-gradient(
+        to bottom,
+        ${palette.neutral[86]},
+        ${palette.neutral[86]} 1px,
+        transparent 1px,
+        transparent 4px
+    );
+    background-repeat: repeat-x;
+    background-position: top;
+    background-size: 1px 13px;
+    padding-top: 18px;
+    margin-bottom: 6px;
+
+    margin-top: 0.75rem;
+`;
+
+const linkStyle = (pillar: Pillar) => css`
+    position: relative;
+    padding-left: 0.3rem;
+    padding-right: 0.35rem;
+    text-decoration: none;
+    color: ${pillarPalette[pillar].main};
+    font-family: ${serif.body};
+    font-size: 15px;
+
+    :after {
+        content: '/';
+        font-size: 1em;
+        position: absolute;
+        pointer-events: none;
+        top: 0;
+        right: -0.19em;
+        color: #767676;
+    }
+`;
+
+const itemStyle = css`
+    display: inline-block;
+
+    :last-of-type > a::after {
+        content: '';
+    }
+`;
+
+const listStyle = css`
+    display: inline;
+    margin-left: -0.35rem;
+`;
+
+const Submeta: React.SFC<{
+    pillar: Pillar;
+    tags: TagType[];
+}> = ({ pillar, tags }) => {
+    const keywords = tags.filter(tag => tag.type === 'Keyword');
+
+    const links = keywords.map(tag => (
+        <li className={itemStyle} key={tag.id}>
+            <a
+                className={linkStyle(pillar)}
+                href={`https://www.theguardian.com/${tag.id}`}
+            >
+                {tag.title}
+            </a>
+        </li>
+    ));
+
+    return (
+        <div className={guardianLines}>
+            <ul className={listStyle}>{links}</ul>
+        </div>
+    );
+};
+
+export default Submeta;

--- a/packages/frontend/amp/pages/Article.tsx
+++ b/packages/frontend/amp/pages/Article.tsx
@@ -28,6 +28,8 @@ export interface ArticleModel {
     sectionLabel?: string;
     sectionUrl?: string;
     tags: TagType[];
+    subMetaSectionLinks: SimpleLinkType[];
+    subMetaKeywordLinks: SimpleLinkType[];
 }
 
 export const Article: React.SFC<{

--- a/packages/frontend/amp/pages/Article.tsx
+++ b/packages/frontend/amp/pages/Article.tsx
@@ -27,6 +27,7 @@ export interface ArticleModel {
     pillar: Pillar;
     sectionLabel?: string;
     sectionUrl?: string;
+    tags: TagType[];
 }
 
 export const Article: React.SFC<{


### PR DESCRIPTION
Adds AMP submeta:

* keyword/section links
* bottom share icons
* canonical link

![screenshot 2018-12-10 at 15 09 39](https://user-images.githubusercontent.com/858402/49741239-e2c5c400-fc8d-11e8-9016-99c3c75364e0.png)

There are a couple of things still to do:

* pass in non-AMP host to use in canonical link (requires scala work)
* handle articles with comments in the canonical link

I'll sort out these once I've updated the model sent from Frontend.

Also note, I've copied the shareicons component into AMP. The requirements are slightly different (for example, we don't want to hide some links at mobile breakpoint) and I'm keen to preserve our no shared components approach.
 
