### PR TITLE
Add dotcomrendering to "tests"

### DIFF
--- a/packages/frontend/web/server/htmlTemplate.ts
+++ b/packages/frontend/web/server/htmlTemplate.ts
@@ -50,6 +50,11 @@ export default ({
                         data,
                         cssIDs,
                     },
+                    config: {
+                        tests: {
+                            renderer: 'new',
+                        },
+                    },
                 })};
                 // this is a global that's called at the bottom of the pf.io response,
                 // once the polyfills have run. This may be useful for debugging.


### PR DESCRIPTION
## What does this change?
Fakes an AB test so we can filter dotcom rendering out in ophan.
## Why?
To look at RUM
