### PR TITLE
Remove Alex S from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # https://help.github.com/articles/about-codeowners
-* @GHaberis @SiAdcock @sndrs @nicl @aware @shtukas @philmcmahon
+* @GHaberis @SiAdcock @nicl @aware @shtukas @philmcmahon


### PR DESCRIPTION
## What does this change?

Removes @sndrs  from `CODEOWNERS`

## Why?

He probably doesn't want to be pinged for a review of every PR 😄 