### PR TITLE
Remove emotion dependency from pasteup

### DIFF
--- a/packages/pasteup/mixins.ts
+++ b/packages/pasteup/mixins.ts
@@ -1,6 +1,4 @@
-import { css } from 'react-emotion';
-
-export const screenReaderOnly = css`
+export const screenReaderOnly = `
     position: absolute;
     width: 1px;
     height: 1px;
@@ -11,7 +9,7 @@ export const screenReaderOnly = css`
     border: 0;
 `;
 
-export const clearFix = css`
+export const clearFix = `
     :after {
         content: '';
         display: table;

--- a/packages/pasteup/package.json
+++ b/packages/pasteup/package.json
@@ -19,8 +19,6 @@
     "prepublish": "cd ../.. && make pre-publish-pasteup",
     "postpublish": "cd ../.. && make post-publish-pasteup"
   },
-  "dependencies": {
-    "react-emotion": "^9.1.3"
-  },
+  "dependencies": {},
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
## What does this change?

Removes the `react-emotion` dependency, and all references, from pasteup.

## Why?

As a package of CSS in JS design tokens, pasteup should be agnostic to specific CSS in JS libraries. There is therefore no need for this dependency