### PR TITLE
Upgrade to Emotion 10 (part 1)

### DIFF
--- a/packages/frontend/amp/components/Body.tsx
+++ b/packages/frontend/amp/components/Body.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import InnerContainer from '@frontend/amp/components/InnerContainer';
 import { Elements } from '@frontend/amp/components/lib/Elements';
-import { css } from 'react-emotion';
+import { css } from 'emotion';
 import { ArticleModel } from '@frontend/amp/pages/Article';
 import { MainBlock } from '@frontend/amp/components/MainBlock';
 import Submeta from '@frontend/amp/components/Submeta';

--- a/packages/frontend/amp/components/Container.tsx
+++ b/packages/frontend/amp/components/Container.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css, cx } from 'react-emotion';
+import { css, cx } from 'emotion';
 
 const container = css`
     margin: auto;

--- a/packages/frontend/amp/components/Footer.tsx
+++ b/packages/frontend/amp/components/Footer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'react-emotion';
+import { css } from 'emotion';
 import { sans } from '@guardian/pasteup/typography';
 import { palette } from '@guardian/pasteup/palette';
 import InnerContainer from './InnerContainer';

--- a/packages/frontend/amp/components/Header.tsx
+++ b/packages/frontend/amp/components/Header.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css, cx } from 'react-emotion';
+import { css, cx } from 'emotion';
 import Logo from '@guardian/pasteup/logos/the-guardian.svg';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';
 import { serif } from '@guardian/pasteup/typography';

--- a/packages/frontend/amp/components/InnerContainer.tsx
+++ b/packages/frontend/amp/components/InnerContainer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css, cx } from 'react-emotion';
+import { css, cx } from 'emotion';
 
 const style = css`
     padding-left: 20px;

--- a/packages/frontend/amp/components/MainBlock.tsx
+++ b/packages/frontend/amp/components/MainBlock.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { css, cx } from 'react-emotion';
 import { sans, serif } from '@guardian/pasteup/typography';
+import { css, cx } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
 import { pillarMap, pillarPalette } from '../../lib/pillars';
 import Dateline from '../../web/components/Dateline';

--- a/packages/frontend/amp/components/Onward.tsx
+++ b/packages/frontend/amp/components/Onward.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'react-emotion';
+import { css } from 'emotion';
 import Plus from '@guardian/pasteup/icons/plus.svg';
 import InnerContainer from '@frontend/amp/components/InnerContainer';
 import { OnwardContainer } from '@frontend/amp/components/OnwardContainer';

--- a/packages/frontend/amp/components/ShareIcons.tsx
+++ b/packages/frontend/amp/components/ShareIcons.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css, cx } from 'react-emotion';
+import { css, cx } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
 import TwitterIconPadded from '@guardian/pasteup/icons/twitter-padded.svg';
 import FacebookIcon from '@guardian/pasteup/icons/facebook.svg';

--- a/packages/frontend/amp/components/Sidebar.tsx
+++ b/packages/frontend/amp/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css, cx } from 'react-emotion';
+import { css, cx } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
 import { serif } from '@guardian/pasteup/typography';
 

--- a/packages/frontend/amp/components/Submeta.tsx
+++ b/packages/frontend/amp/components/Submeta.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'react-emotion';
+import { css } from 'emotion';
 import { pillarPalette } from '@frontend/lib/pillars';
 import { serif, sans } from '@guardian/pasteup/typography';
 import { palette } from '@guardian/pasteup/palette';

--- a/packages/frontend/amp/components/elements/CommentBlockComponent.tsx
+++ b/packages/frontend/amp/components/elements/CommentBlockComponent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'react-emotion';
+import { css } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
 import { sans } from '@guardian/pasteup/typography';
 

--- a/packages/frontend/amp/components/elements/ImageBlockComponent.tsx
+++ b/packages/frontend/amp/components/elements/ImageBlockComponent.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Img } from '@frontend/amp/components/primitives/Img';
 import { sans } from '@guardian/pasteup/typography';
 import { palette } from '@guardian/pasteup/palette';
-import { css } from 'react-emotion';
+import { css } from 'emotion';
 import { pillarPalette } from '@frontend/lib/pillars';
 import {
     bestFitImage,

--- a/packages/frontend/amp/components/elements/TextBlockComponent.tsx
+++ b/packages/frontend/amp/components/elements/TextBlockComponent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'react-emotion';
+import { css } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
 import { pillarPalette } from '@frontend/lib/pillars';
 import { serif } from '@guardian/pasteup/typography';

--- a/packages/frontend/amp/pages/Article.tsx
+++ b/packages/frontend/amp/pages/Article.tsx
@@ -4,8 +4,8 @@ import Container from '@frontend/amp/components/Container';
 import Body from '@frontend/amp/components/Body';
 import Header from '@frontend/amp/components/Header';
 import { palette } from '@guardian/pasteup/palette';
-import { css } from 'react-emotion';
 import { Onward } from '@frontend/amp/components/Onward';
+import { css } from 'emotion';
 
 const backgroundColour = css`
     background-color: ${palette.neutral[97]};

--- a/packages/frontend/amp/server/document.tsx
+++ b/packages/frontend/amp/server/document.tsx
@@ -1,5 +1,8 @@
+import React from 'react';
 import { extractCritical } from 'emotion-server';
 import { renderToString } from 'react-dom/server';
+import { CacheProvider } from '@emotion/core';
+import { cache } from 'emotion';
 import resetCSS from /* preval */ '@frontend/lib/reset-css';
 import fontsCss from '@frontend/lib/fonts-css';
 
@@ -16,7 +19,8 @@ export default ({
     scripts: string[];
 }) => {
     const { html, css }: RenderToStringResult = extractCritical(
-        renderToString(body),
+        // TODO: CacheProvider can be removed when we've moved over to using @emotion/core
+        renderToString(<CacheProvider value={cache}>{body}</CacheProvider>),
     );
 
     return `<!doctype html>

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -13,8 +13,8 @@
     "dateformat": "^3.0.3",
     "diskusage": "^0.2.5",
     "dompurify": "^1.0.3",
-    "emotion": "^9.1.1",
-    "emotion-server": "^9.1.1",
+    "emotion": "^10.0.5",
+    "emotion-server": "^10.0.5",
     "express": "^4.16.4",
     "glob": "^7.1.3",
     "html-minifier": "^3.5.14",
@@ -25,8 +25,7 @@
     "pm2": "^3.2.2",
     "polished": "^1.9.2",
     "react": "^16.4.0",
-    "react-dom": "^16.4.0",
-    "react-emotion": "^9.1.3"
+    "react-dom": "^16.4.0"
   },
   "devDependencies": {
     "@types/amphtml-validator": "^1.0.0",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "license": "Apache-2.0",
   "dependencies": {
+    "@emotion/core": "^10.0.5",
     "@guardian/guui": "2.0.0-alpha.1",
     "@guardian/pasteup": "1.0.0-alpha.1",
     "aws-sdk": "^2.340.0",

--- a/packages/frontend/web/components/ArticleBody.tsx
+++ b/packages/frontend/web/components/ArticleBody.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css, cx } from 'react-emotion';
+import { css, cx } from 'emotion';
 import TwitterIcon from '@guardian/pasteup/icons/twitter.svg';
 import { palette } from '@guardian/pasteup/palette';
 import ClockIcon from '@guardian/pasteup/icons/clock.svg';

--- a/packages/frontend/web/components/BackToTop.tsx
+++ b/packages/frontend/web/components/BackToTop.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Container } from '@guardian/guui';
-import { css } from 'react-emotion';
+import { css } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
 import { sans } from '@guardian/pasteup/typography';
 

--- a/packages/frontend/web/components/CookieBanner.tsx
+++ b/packages/frontend/web/components/CookieBanner.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { css } from 'react-emotion';
+import { css } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
 import { sans, serif } from '@guardian/pasteup/typography';
 import { Container } from '@guardian/guui';

--- a/packages/frontend/web/components/Dateline.tsx
+++ b/packages/frontend/web/components/Dateline.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { css } from 'react-emotion';
+import { css } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
 import { sans } from '@guardian/pasteup/typography';
 

--- a/packages/frontend/web/components/Footer.tsx
+++ b/packages/frontend/web/components/Footer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'react-emotion';
+import { css } from 'emotion';
 
 import { leftCol, tablet, until } from '@guardian/pasteup/breakpoints';
 import { sans } from '@guardian/pasteup/typography';

--- a/packages/frontend/web/components/Header/Header.tsx
+++ b/packages/frontend/web/components/Header/Header.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'react-emotion';
+import { css } from 'emotion';
 
 import { tablet } from '@guardian/pasteup/breakpoints';
 

--- a/packages/frontend/web/components/Header/Nav/EditionDropdown.tsx
+++ b/packages/frontend/web/components/Header/Nav/EditionDropdown.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'react-emotion';
+import { css } from 'emotion';
 
 import { Dropdown } from '@guardian/guui';
 import { desktop, leftCol, wide } from '@guardian/pasteup/breakpoints';

--- a/packages/frontend/web/components/Header/Nav/Links/Links.tsx
+++ b/packages/frontend/web/components/Header/Nav/Links/Links.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css, cx } from 'react-emotion';
+import { css, cx } from 'emotion';
 
 import Dropdown, {
     Link as DropdownLink,

--- a/packages/frontend/web/components/Header/Nav/Links/SupportTheGuardian.tsx
+++ b/packages/frontend/web/components/Header/Nav/Links/SupportTheGuardian.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'react-emotion';
+import { css } from 'emotion';
 
 import { serif } from '@guardian/pasteup/typography';
 import { palette } from '@guardian/pasteup/palette';

--- a/packages/frontend/web/components/Header/Nav/Logo.tsx
+++ b/packages/frontend/web/components/Header/Nav/Logo.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'react-emotion';
+import { css } from 'emotion';
 
 import {
     mobileMedium,

--- a/packages/frontend/web/components/Header/Nav/MainMenu/CollapseColumnButton.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenu/CollapseColumnButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { serif } from '@guardian/pasteup/typography';
-import { css, cx } from 'react-emotion';
+import { css, cx } from 'emotion';
 import { hideDesktop } from './Column';
 import { palette } from '@guardian/pasteup/palette';
 

--- a/packages/frontend/web/components/Header/Nav/MainMenu/Column.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenu/Column.tsx
@@ -99,7 +99,7 @@ const ColumnLink: React.SFC<{
 }> = ({ link }) => (
     <li
         className={cx(mainMenuLinkStyle, {
-            [hideDesktop]: link.mobileOnly,
+            [hideDesktop]: !!link.mobileOnly,
         })}
         role="none"
     >

--- a/packages/frontend/web/components/Header/Nav/MainMenu/Column.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenu/Column.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { serif } from '@guardian/pasteup/typography';
-import { css, cx } from 'react-emotion';
+import { css, cx } from 'emotion';
 
 import { desktop, tablet, leftCol } from '@guardian/pasteup/breakpoints';
 import { pillarMap, pillarPalette } from '@frontend/lib/pillars';

--- a/packages/frontend/web/components/Header/Nav/MainMenu/Columns.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenu/Columns.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'react-emotion';
+import { css } from 'emotion';
 
 import { tablet, desktop, leftCol, wide } from '@guardian/pasteup/breakpoints';
 import { serif } from '@guardian/pasteup/typography';

--- a/packages/frontend/web/components/Header/Nav/MainMenu/MainMenu.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenu/MainMenu.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css, cx } from 'react-emotion';
+import { css, cx } from 'emotion';
 
 import {
     until,

--- a/packages/frontend/web/components/Header/Nav/MainMenuToggle/MainMenuToggle.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenuToggle/MainMenuToggle.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { css, cx } from 'react-emotion';
+import { css, cx } from 'emotion';
 
 import { desktop, leftCol } from '@guardian/pasteup/breakpoints';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';

--- a/packages/frontend/web/components/Header/Nav/MainMenuToggle/VeggieBurger.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenuToggle/VeggieBurger.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'react-emotion';
+import { css } from 'emotion';
 
 import {
     desktop,

--- a/packages/frontend/web/components/Header/Nav/Nav.tsx
+++ b/packages/frontend/web/components/Header/Nav/Nav.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { css } from 'react-emotion';
+import { css } from 'emotion';
 import { clearFix } from '@guardian/pasteup/mixins';
 import { tablet, desktop, leftCol, wide } from '@guardian/pasteup/breakpoints';
 

--- a/packages/frontend/web/components/Header/Nav/Pillars.tsx
+++ b/packages/frontend/web/components/Header/Nav/Pillars.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css, cx } from 'react-emotion';
+import { css, cx } from 'emotion';
 
 import {
     tablet,

--- a/packages/frontend/web/components/Header/Nav/SubNav/Inner.tsx
+++ b/packages/frontend/web/components/Header/Nav/SubNav/Inner.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css, cx } from 'react-emotion';
+import { css, cx } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
 import { serif } from '@guardian/pasteup/typography';
 import {

--- a/packages/frontend/web/components/Header/Nav/SubNav/SubNav.tsx
+++ b/packages/frontend/web/components/Header/Nav/SubNav/SubNav.tsx
@@ -1,5 +1,5 @@
 import React, { Component, createRef } from 'react';
-import { css } from 'react-emotion';
+import { css } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
 
 import { Container } from '@guardian/guui';

--- a/packages/frontend/web/components/MostViewed.tsx
+++ b/packages/frontend/web/components/MostViewed.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
-import { css, cx } from 'react-emotion';
 import { serif } from '@guardian/pasteup/typography';
+import { css, cx } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
 import {
     desktop,

--- a/packages/frontend/web/components/ShareCount.tsx
+++ b/packages/frontend/web/components/ShareCount.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { css } from 'react-emotion';
+import { css } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
 import ShareIcon from '@guardian/pasteup/icons/share.svg';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';

--- a/packages/frontend/web/components/ShareIcons.tsx
+++ b/packages/frontend/web/components/ShareIcons.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css, cx } from 'react-emotion';
+import { css, cx } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
 import TwitterIconPadded from '@guardian/pasteup/icons/twitter-padded.svg';
 import FacebookIcon from '@guardian/pasteup/icons/facebook.svg';

--- a/packages/frontend/web/components/SubMetaLinksList.tsx
+++ b/packages/frontend/web/components/SubMetaLinksList.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css, cx } from 'react-emotion';
+import { css, cx } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
 import { sans, serif } from '@guardian/pasteup/typography';
 

--- a/packages/frontend/web/pages/Article.tsx
+++ b/packages/frontend/web/pages/Article.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Container } from '@guardian/guui';
-import { css } from 'react-emotion';
+import { css } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
 import { desktop, mobileLandscape } from '@guardian/pasteup/breakpoints';
 

--- a/packages/frontend/web/server/document.tsx
+++ b/packages/frontend/web/server/document.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { extractCritical } from 'emotion-server';
 import { renderToString } from 'react-dom/server';
+import { cache } from 'emotion';
+import { CacheProvider } from '@emotion/core';
 
 import htmlTemplate from './htmlTemplate';
 import Article from '../pages/Article';
@@ -28,7 +30,12 @@ export default ({ data }: Props) => {
     const { page, site, CAPI, NAV, config } = data;
     const title = `${CAPI.headline} | ${CAPI.sectionLabel} | The Guardian`;
     const { html, css, ids: cssIDs }: RenderToStringResult = extractCritical(
-        renderToString(<Article data={{ CAPI, NAV, config }} />),
+        renderToString(
+            // TODO: CacheProvider can be removed when we've moved over to using @emotion/core
+            <CacheProvider value={cache}>
+                <Article data={{ CAPI, NAV, config }} />
+            </CacheProvider>,
+        ),
     );
 
     /**

--- a/packages/guui/components/CloseButton/CloseButton.tsx
+++ b/packages/guui/components/CloseButton/CloseButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'react-emotion';
+import { css } from 'emotion';
 import CloseIcon from '@guardian/pasteup/icons/x.svg';
 
 const closeButton = (foregroundColour: string, backgroundColour: string) => css`

--- a/packages/guui/components/Container/Container.tsx
+++ b/packages/guui/components/Container/Container.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css, cx } from 'react-emotion';
+import { css, cx } from 'emotion';
 
 import { tablet, desktop, leftCol, wide } from '@guardian/pasteup/breakpoints';
 

--- a/packages/guui/components/Dropdown/Dropdown.tsx
+++ b/packages/guui/components/Dropdown/Dropdown.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css, cx } from 'react-emotion';
+import { css, cx } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
 import { sans } from '@guardian/pasteup/typography';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';

--- a/packages/guui/components/Dropdown/Dropdown.tsx
+++ b/packages/guui/components/Dropdown/Dropdown.tsx
@@ -250,7 +250,7 @@ export default class Dropdown extends React.Component<
                                 href={l.url}
                                 className={cx({
                                     [link]: true,
-                                    [linkActive]: l.isActive,
+                                    [linkActive]: !!l.isActive,
                                     [linkFirst]: index === 0,
                                 })}
                             >

--- a/packages/guui/components/Grid/Grid.tsx
+++ b/packages/guui/components/Grid/Grid.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'react-emotion';
+import { css } from 'emotion';
 import {
     tablet as tabletMq,
     desktop as desktopMq,

--- a/packages/guui/package.json
+++ b/packages/guui/package.json
@@ -15,15 +15,13 @@
   "devDependencies": {
     "css-loader": "^0.28.11",
     "desvg-loader": "^0.1.0",
-    "emotion": "^9.1.1",
+    "emotion": "^10.0.5",
     "react": "^16.4.0",
-    "react-emotion": "^9.1.3",
     "svg-loader": "^0.0.2",
     "to-string-loader": "^1.1.5"
   },
   "peerDependencies": {
-    "emotion": "^9.1.1",
     "react": "^16.4.0",
-    "react-emotion": "^9.1.3"
+    "emotion": "^10.0.5"
   }
 }

--- a/packages/pasteup/mixins.ts
+++ b/packages/pasteup/mixins.ts
@@ -1,6 +1,4 @@
-import { css } from 'react-emotion';
-
-export const screenReaderOnly = css`
+export const screenReaderOnly = `
     position: absolute;
     width: 1px;
     height: 1px;
@@ -11,7 +9,7 @@ export const screenReaderOnly = css`
     border: 0;
 `;
 
-export const clearFix = css`
+export const clearFix = `
     :after {
         content: '';
         display: table;

--- a/packages/pasteup/package.json
+++ b/packages/pasteup/package.json
@@ -19,8 +19,6 @@
     "prepublish": "cd ../.. && make pre-publish-pasteup",
     "postpublish": "cd ../.. && make post-publish-pasteup"
   },
-  "dependencies": {
-    "react-emotion": "^9.1.3"
-  },
+  "dependencies": {},
   "license": "Apache-2.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -691,8 +691,8 @@
     to-fast-properties "^2.0.0"
 
 "@babel/types@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0.tgz#6e191793d3c854d19c6749989e3bc55f0e962118"
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.2.2.tgz#44e10fc24e33af524488b716cdaee5360ea8ed1e"
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.10"
@@ -717,6 +717,19 @@
     find-root "^1.1.0"
     source-map "^0.7.2"
 
+"@emotion/cache@10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.0.tgz#e22eadcb770de4131ec707c84207e9e1ce210413"
+  dependencies:
+    "@emotion/sheet" "0.9.2"
+    "@emotion/stylis" "0.8.3"
+    "@emotion/utils" "0.11.1"
+    "@emotion/weak-memoize" "0.2.2"
+
+"@emotion/hash@0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.7.1.tgz#9833722341379fb7d67f06a4b00ab3c37913da53"
+
 "@emotion/hash@^0.6.2", "@emotion/hash@^0.6.5":
   version "0.6.5"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.6.5.tgz#097729b84a5164f71f9acd2570ecfd1354d7b360"
@@ -727,9 +740,23 @@
   dependencies:
     "@emotion/memoize" "^0.6.5"
 
+"@emotion/memoize@0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.1.tgz#e93c13942592cf5ef01aa8297444dc192beee52f"
+
 "@emotion/memoize@^0.6.1", "@emotion/memoize@^0.6.5":
   version "0.6.5"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.6.5.tgz#f868c314b889e7c3d84868a1d1cc323fbb40ca86"
+
+"@emotion/serialize@^0.11.3":
+  version "0.11.3"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-0.11.3.tgz#c4af2d96e3ddb9a749b7b567daa7556bcae45af2"
+  dependencies:
+    "@emotion/hash" "0.7.1"
+    "@emotion/memoize" "0.7.1"
+    "@emotion/unitless" "0.7.3"
+    "@emotion/utils" "0.11.1"
+    csstype "^2.5.7"
 
 "@emotion/serialize@^0.9.0":
   version "0.9.0"
@@ -740,21 +767,37 @@
     "@emotion/unitless" "^0.6.6"
     "@emotion/utils" "^0.8.1"
 
-"@emotion/stylis@^0.6.10":
-  version "0.6.12"
-  resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.6.12.tgz#3fb58220e0fc9e380bcabbb3edde396ddc1dfe6e"
+"@emotion/sheet@0.9.2":
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-0.9.2.tgz#74e5c6b5e489a1ba30ab246ab5eedd96916487c4"
+
+"@emotion/stylis@0.8.3":
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.3.tgz#3ca7e9bcb31b3cb4afbaeb66156d86ee85e23246"
 
 "@emotion/stylis@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.7.0.tgz#4c30e6fccc9555e42fa6fef98b3bd0788b954684"
 
-"@emotion/unitless@^0.6.2", "@emotion/unitless@^0.6.6":
+"@emotion/unitless@0.7.3":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.3.tgz#6310a047f12d21a1036fb031317219892440416f"
+
+"@emotion/unitless@^0.6.6":
   version "0.6.6"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.6.6.tgz#988957ecd0a9be00ee9de27172f8c56d41595a93"
+
+"@emotion/utils@0.11.1":
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.11.1.tgz#8529b7412a6eb4b48bdf6e720cc1b8e6e1e17628"
 
 "@emotion/utils@^0.8.1":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.8.1.tgz#f3a81587ad8d0ef33cdad6f3b4310774fcc1053e"
+
+"@emotion/weak-memoize@0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.2.tgz#63985d3d8b02530e0869962f4da09142ee8e200e"
 
 "@fimbul/bifrost@^0.11.0":
   version "0.11.0"
@@ -1585,6 +1628,21 @@ babel-plugin-dynamic-import-node@^1.2.0:
   dependencies:
     babel-plugin-syntax-dynamic-import "^6.18.0"
 
+babel-plugin-emotion@^10.0.5:
+  version "10.0.5"
+  resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-10.0.5.tgz#05ec47cde94f984b0b2aebdd41f81876cf9cbb24"
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@emotion/hash" "0.7.1"
+    "@emotion/memoize" "0.7.1"
+    "@emotion/serialize" "^0.11.3"
+    babel-plugin-macros "^2.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    convert-source-map "^1.5.0"
+    escape-string-regexp "^1.0.5"
+    find-root "^1.1.0"
+    source-map "^0.5.7"
+
 babel-plugin-emotion@^9.2.6, babel-plugin-emotion@^9.2.8:
   version "9.2.8"
   resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-9.2.8.tgz#4df55ef10625c391f25b031f7e3006abac359e09"
@@ -1616,7 +1674,14 @@ babel-plugin-jest-hoist@^23.2.0:
   version "23.2.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz#e61fae05a1ca8801aadee57a6d66b8cefaf44167"
 
-babel-plugin-macros@^2.0.0, babel-plugin-macros@^2.2.2:
+babel-plugin-macros@^2.0.0:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.4.3.tgz#870345aa538d85f04b4614fea5922b55c45dd551"
+  dependencies:
+    cosmiconfig "^5.0.5"
+    resolve "^1.8.1"
+
+babel-plugin-macros@^2.2.2:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.4.0.tgz#6c5f9836e1f6c0a9743b3bab4af29f73e437e544"
   dependencies:
@@ -2062,9 +2127,21 @@ call-me-maybe@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/call-me-maybe/-/call-me-maybe-1.0.1.tgz#26d208ea89e37b5cbde60250a15f031c16a4d66b"
 
+caller-callsite@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/caller-callsite/-/caller-callsite-2.0.0.tgz#847e0fce0a223750a9a027c54b33731ad3154134"
+  dependencies:
+    callsites "^2.0.0"
+
+caller-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-2.0.0.tgz#468f83044e369ab2010fac5f06ceee15bb2cb1f4"
+  dependencies:
+    caller-callsite "^2.0.0"
+
 callsites@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
+  resolved "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
 
 camel-case@3.0.x:
   version "3.0.0"
@@ -2441,11 +2518,11 @@ continuation-local-storage@^3.1.4:
     async-listener "^0.6.0"
     emitter-listener "^1.1.1"
 
-convert-source-map@^1.1.0, convert-source-map@^1.5.0, convert-source-map@^1.5.1:
+convert-source-map@^1.1.0, convert-source-map@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
 
-convert-source-map@^1.4.0:
+convert-source-map@^1.4.0, convert-source-map@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
   dependencies:
@@ -2486,10 +2563,19 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cosmiconfig@^5.0.0, cosmiconfig@^5.0.5:
+cosmiconfig@^5.0.0:
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.0.6.tgz#dca6cf680a0bd03589aff684700858c81abeeb39"
   dependencies:
+    is-directory "^0.3.1"
+    js-yaml "^3.9.0"
+    parse-json "^4.0.0"
+
+cosmiconfig@^5.0.5:
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.0.7.tgz#39826b292ee0d78eda137dfa3173bd1c21a43b04"
+  dependencies:
+    import-fresh "^2.0.0"
     is-directory "^0.3.1"
     js-yaml "^3.9.0"
     parse-json "^4.0.0"
@@ -2520,10 +2606,11 @@ create-ecdh@^4.0.0:
     bn.js "^4.1.0"
     elliptic "^6.0.0"
 
-create-emotion-server@^9.2.8:
-  version "9.2.8"
-  resolved "https://registry.yarnpkg.com/create-emotion-server/-/create-emotion-server-9.2.8.tgz#3d5db78b113afdff7f729e034724be42949d7bd3"
+create-emotion-server@10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/create-emotion-server/-/create-emotion-server-10.0.0.tgz#d7089cbff60f6ba8776601b9a6d22ab39e260633"
   dependencies:
+    "@emotion/utils" "0.11.1"
     html-tokenize "^2.0.0"
     multipipe "^1.0.2"
     through "^2.3.8"
@@ -2534,17 +2621,14 @@ create-emotion-styled@^9.2.8:
   dependencies:
     "@emotion/is-prop-valid" "^0.6.1"
 
-create-emotion@^9.2.6:
-  version "9.2.6"
-  resolved "https://registry.yarnpkg.com/create-emotion/-/create-emotion-9.2.6.tgz#f64cf1c64cf82fe7d22725d1d77498ddd2d39edb"
+create-emotion@^10.0.5:
+  version "10.0.5"
+  resolved "https://registry.yarnpkg.com/create-emotion/-/create-emotion-10.0.5.tgz#22487f19b59a7ed10144f808289eadffebcfab06"
   dependencies:
-    "@emotion/hash" "^0.6.2"
-    "@emotion/memoize" "^0.6.1"
-    "@emotion/stylis" "^0.6.10"
-    "@emotion/unitless" "^0.6.2"
-    csstype "^2.5.2"
-    stylis "^3.5.0"
-    stylis-rule-sheet "^0.0.10"
+    "@emotion/cache" "10.0.0"
+    "@emotion/serialize" "^0.11.3"
+    "@emotion/sheet" "0.9.2"
+    "@emotion/utils" "0.11.1"
 
 create-hash@^1.1.0, create-hash@^1.1.2:
   version "1.2.0"
@@ -2705,9 +2789,13 @@ cssstyle@^1.0.0, cssstyle@^1.1.1:
   dependencies:
     cssom "0.3.x"
 
-csstype@^2.2.0, csstype@^2.5.2:
+csstype@^2.2.0:
   version "2.5.6"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.5.6.tgz#2ae1db2319642d8b80a668d2d025c6196071e788"
+
+csstype@^2.5.7:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.0.tgz#6cf7b2fa7fc32aab3d746802c244d4eda71371a2"
 
 culvert@^0.1.2:
   version "0.1.2"
@@ -3076,18 +3164,18 @@ emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
 
-emotion-server@^9.1.1:
-  version "9.2.8"
-  resolved "https://registry.yarnpkg.com/emotion-server/-/emotion-server-9.2.8.tgz#857c5b301e215cc9cb7277b88e3e90fdeb58d625"
+emotion-server@^10.0.5:
+  version "10.0.5"
+  resolved "https://registry.yarnpkg.com/emotion-server/-/emotion-server-10.0.5.tgz#85f24ba5dd95c37be44a0709ca71f27210f9ba9b"
   dependencies:
-    create-emotion-server "^9.2.8"
+    create-emotion-server "10.0.0"
 
-emotion@^9.1.1:
-  version "9.2.8"
-  resolved "https://registry.yarnpkg.com/emotion/-/emotion-9.2.8.tgz#b89e754be1a109f4e47ff0031928f94e40d7984a"
+emotion@^10.0.5:
+  version "10.0.5"
+  resolved "https://registry.yarnpkg.com/emotion/-/emotion-10.0.5.tgz#9b22cee820de0a45bc102e4750553c1b81098b00"
   dependencies:
-    babel-plugin-emotion "^9.2.8"
-    create-emotion "^9.2.6"
+    babel-plugin-emotion "^10.0.5"
+    create-emotion "^10.0.5"
 
 encodeurl@~1.0.2:
   version "1.0.2"
@@ -4185,6 +4273,13 @@ iltorb@^1.0.9:
     nan "^2.6.2"
     node-gyp "^3.6.2"
     prebuild-install "^2.3.0"
+
+import-fresh@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-2.0.0.tgz#d81355c15612d386c61f9ddd3922d4304822a546"
+  dependencies:
+    caller-path "^2.0.0"
+    resolve-from "^3.0.0"
 
 import-lazy@^3.1.0:
   version "3.1.0"
@@ -5301,11 +5396,11 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
+lodash@^4.13.1, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
-lodash@^4.17.11:
+lodash@^4.17.10, lodash@^4.17.11:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
@@ -6241,7 +6336,7 @@ path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
-path-parse@^1.0.5:
+path-parse@^1.0.5, path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
 
@@ -7364,6 +7459,12 @@ resolve@^1.1.6, resolve@^1.3.2, resolve@^1.4.0:
   dependencies:
     path-parse "^1.0.5"
 
+resolve@^1.8.1:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.9.0.tgz#a14c6fdfa8f92a7df1d996cb7105fa744658ea06"
+  dependencies:
+    path-parse "^1.0.6"
+
 restore-cursor@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
@@ -7742,7 +7843,7 @@ sprintf-js@1.1.1:
 
 sprintf-js@~1.0.2:
   version "1.0.3"
-  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+  resolved "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
 sshpk@^1.7.0:
   version "1.14.2"
@@ -7991,14 +8092,6 @@ stylelint@^9.5.0:
     sugarss "^2.0.0"
     svg-tags "^1.0.0"
     table "^4.0.1"
-
-stylis-rule-sheet@^0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
-
-stylis@^3.5.0:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.3.tgz#99fdc46afba6af4deff570825994181a5e6ce546"
 
 sugarss@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -726,6 +726,24 @@
     "@emotion/utils" "0.11.1"
     "@emotion/weak-memoize" "0.2.2"
 
+"@emotion/core@^10.0.5":
+  version "10.0.5"
+  resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.0.5.tgz#fda655bb040deb69090faf2fa9d66d39b2bbe4bf"
+  dependencies:
+    "@emotion/cache" "10.0.0"
+    "@emotion/css" "^10.0.5"
+    "@emotion/serialize" "^0.11.3"
+    "@emotion/sheet" "0.9.2"
+    "@emotion/utils" "0.11.1"
+
+"@emotion/css@^10.0.5":
+  version "10.0.5"
+  resolved "https://registry.yarnpkg.com/@emotion/css/-/css-10.0.5.tgz#3bc6593fb98ba096a1ccd843d9f32744929b6cfd"
+  dependencies:
+    "@emotion/serialize" "^0.11.3"
+    "@emotion/utils" "0.11.1"
+    babel-plugin-emotion "^10.0.5"
+
 "@emotion/hash@0.7.1":
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.7.1.tgz#9833722341379fb7d67f06a4b00ab3c37913da53"

--- a/yarn.lock
+++ b/yarn.lock
@@ -752,12 +752,6 @@
   version "0.6.5"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.6.5.tgz#097729b84a5164f71f9acd2570ecfd1354d7b360"
 
-"@emotion/is-prop-valid@^0.6.1":
-  version "0.6.7"
-  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.6.7.tgz#1767d39c29ba786b7afc3d8d727a2896995f01eb"
-  dependencies:
-    "@emotion/memoize" "^0.6.5"
-
 "@emotion/memoize@0.7.1":
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.1.tgz#e93c13942592cf5ef01aa8297444dc192beee52f"
@@ -1661,7 +1655,7 @@ babel-plugin-emotion@^10.0.5:
     find-root "^1.1.0"
     source-map "^0.5.7"
 
-babel-plugin-emotion@^9.2.6, babel-plugin-emotion@^9.2.8:
+babel-plugin-emotion@^9.2.6:
   version "9.2.8"
   resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-9.2.8.tgz#4df55ef10625c391f25b031f7e3006abac359e09"
   dependencies:
@@ -2632,12 +2626,6 @@ create-emotion-server@10.0.0:
     html-tokenize "^2.0.0"
     multipipe "^1.0.2"
     through "^2.3.8"
-
-create-emotion-styled@^9.2.8:
-  version "9.2.8"
-  resolved "https://registry.yarnpkg.com/create-emotion-styled/-/create-emotion-styled-9.2.8.tgz#c0050e768ba439609bec108600467adf2de67cc3"
-  dependencies:
-    "@emotion/is-prop-valid" "^0.6.1"
 
 create-emotion@^10.0.5:
   version "10.0.5"
@@ -7108,13 +7096,6 @@ react-dom@^16.4.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.0"
-
-react-emotion@^9.1.3:
-  version "9.2.8"
-  resolved "https://registry.yarnpkg.com/react-emotion/-/react-emotion-9.2.8.tgz#e4e24540bdcb7daacf87c405760ed619bddbb61b"
-  dependencies:
-    babel-plugin-emotion "^9.2.8"
-    create-emotion-styled "^9.2.8"
 
 react-testing-library@^5.2.3:
   version "5.2.3"


### PR DESCRIPTION
## What does this change?

- upgrades `emotion` to `^10.0.5`
- removes `react-emotion` dependency
- uses `<CacheProvider>` from `@emotion/core` to simplify migration (see [SSR docs](https://emotion.sh/docs/ssr))
- fixes some type errors that the v10 upgrade introduced in the (now-deprecated) `cx`

## Why?

Keeps us up to date with all the [latest Emotion 10 goodies](https://medium.com/emotion-js/announcing-emotion-10-f1a4b17b8ccd)

## TODO

There are still a few outstanding tasks, but we can fix them in a subsequent PR, to prevent this one getting too large.

Here is a summary of [migration steps](https://emotion.sh/docs/migrating-to-emotion-10) left to do:

- Fix warnings about `:first-child` and `:nth-child` being unsafe in SSR
- Use `css` function from `@emotion/core` instead of `emotion`. 
- Migrate from `classNames` to the `css` prop
- Import the [`jsx` pragma](https://emotion.sh/docs/css-prop#jsx-pragma) in every JSX module
- Move away from using `cx` to the simplified API
- Remove `<CacheProvider>` from AMP and web server rendering documents
- Remove `emotion` (as going forward we would be using `@emotion/core`)