### PR TITLE
Use imageSources array for inline picture elements

### DIFF
--- a/packages/frontend/web/components/Picture.tsx
+++ b/packages/frontend/web/components/Picture.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 // tslint:disable:react-no-dangerous-html
 // IE 9 needs this workaround as per https://scottjehl.github.io/picturefill/
 
-export interface ImageSource {
-    width: string;
-    minWidth: string;
+export interface PictureSource {
+    width: number;
+    minWidth: number;
     srcset: string;
     hidpi: boolean;
 }
 
-const mq: (source: ImageSource) => string = source =>
+const mq: (source: PictureSource) => string = source =>
     source.hidpi
         ? `(min-width: ${
               source.minWidth
@@ -18,13 +18,13 @@ const mq: (source: ImageSource) => string = source =>
           }px) and (min-resolution: 120dpi)"`
         : `(min-width: ${source.minWidth}px)"`;
 
-const forSource: (source: ImageSource) => string = source =>
-    ` <source media="${mq(source)}" sizes="${source.width}" srcset="${
+const forSource: (source: PictureSource) => string = source =>
+    ` <source media="${mq(source)}" sizes="${source.width}px" srcset="${
         source.srcset
     }" />`;
 
 export const Picture: React.SFC<{
-    sources: ImageSource[];
+    sources: PictureSource[];
     alt: string;
     src: string;
 }> = ({ sources, alt, src }) => (

--- a/packages/frontend/web/components/elements/ImageBlockComponent.tsx
+++ b/packages/frontend/web/components/elements/ImageBlockComponent.tsx
@@ -1,25 +1,42 @@
 import React from 'react';
 import { Picture, PictureSource } from '@frontend/web/components/Picture';
 
+const widths = [660, 480, 0];
+
+const bestFor = (desiredWidth: number, inlineSrcSets: SrcSet[]): SrcSet => {
+    const sorted = inlineSrcSets.sort((a, b) => b.width - a.width);
+
+    return sorted.reduce((best, current) => {
+        if (current.width < best.width && current.width >= desiredWidth) {
+            return current;
+        }
+
+        return best;
+    });
+};
 const makeSources = (imageSources: ImageSource[]): PictureSource[] => {
     const inlineSrcSets = imageSources.filter(
         ({ weighting }) => weighting === 'inline',
     )[0].srcSet;
     const sources: PictureSource[] = [];
 
-    inlineSrcSets.forEach(srcSet => {
-        sources.push(makeSource(true, srcSet));
-        sources.push(makeSource(false, srcSet));
+    widths.forEach(width => {
+        sources.push(makeSource(true, width, bestFor(width, inlineSrcSets)));
+        sources.push(makeSource(false, width, bestFor(width, inlineSrcSets)));
     });
 
     return sources;
 };
 
-const makeSource = (hidpi: boolean, srcSet: SrcSet): PictureSource => {
+const makeSource = (
+    hidpi: boolean,
+    minWidth: number,
+    srcSet: SrcSet,
+): PictureSource => {
     return {
         hidpi,
+        minWidth,
         width: srcSet.width,
-        minWidth: srcSet.width < 320 ? 320 : srcSet.width,
         srcset: `${srcSet.src} ${hidpi ? srcSet.width * 2 : srcSet.width}w`,
     };
 };

--- a/packages/frontend/web/components/elements/ImageBlockComponent.tsx
+++ b/packages/frontend/web/components/elements/ImageBlockComponent.tsx
@@ -20,6 +20,10 @@ const makeSources = (imageSources: ImageSource[]): PictureSource[] => {
     )[0].srcSet;
     const sources: PictureSource[] = [];
 
+    // TODO: ideally the imageSources array will come from frontend with prebaked URLs for
+    // hidpi images.
+    // Until that happens, here we're manually injecting (inadequate) <source> elements for
+    // those images, albeit without the necessary query params for hidpi images :(
     widths.forEach(width => {
         sources.push(makeSource(true, width, bestFor(width, inlineSrcSets)));
         sources.push(makeSource(false, width, bestFor(width, inlineSrcSets)));

--- a/packages/frontend/web/components/elements/ImageBlockComponent.tsx
+++ b/packages/frontend/web/components/elements/ImageBlockComponent.tsx
@@ -1,13 +1,26 @@
 import React from 'react';
-import { Picture, ImageSource } from '@frontend/web/components/Picture';
+import { Picture, PictureSource } from '@frontend/web/components/Picture';
 
-const makeSource: (image: Image) => ImageSource = image => {
+const makeSources = (imageSources: ImageSource[]): PictureSource[] => {
+    const inlineSrcSets = imageSources.filter(
+        ({ weighting }) => weighting === 'inline',
+    )[0].srcSet;
+    const sources: PictureSource[] = [];
+
+    inlineSrcSets.forEach(srcSet => {
+        sources.push(makeSource(true, srcSet));
+        sources.push(makeSource(false, srcSet));
+    });
+
+    return sources;
+};
+
+const makeSource = (hidpi: boolean, srcSet: SrcSet): PictureSource => {
     return {
-        width: image.fields.width,
-        minWidth:
-            parseFloat(image.fields.width) < 320 ? '320' : image.fields.width,
-        srcset: `${image.url} ${image.fields.width}w`,
-        hidpi: false,
+        hidpi,
+        width: srcSet.width,
+        minWidth: srcSet.width < 320 ? 320 : srcSet.width,
+        srcset: `${srcSet.src} ${hidpi ? srcSet.width * 2 : srcSet.width}w`,
     };
 };
 
@@ -17,9 +30,11 @@ const getFallback: (images: Image[]) => string = images =>
 export const ImageBlockComponent: React.SFC<{ element: ImageBlockElement }> = ({
     element,
 }) => {
+    const sources = makeSources(element.imageSources);
+
     return (
         <Picture
-            sources={element.media.allImages.map(makeSource)}
+            sources={sources}
             alt={element.data.alt}
             src={getFallback(element.media.allImages)}
         />


### PR DESCRIPTION
## What does this change?

Previously, we were using the `media.allImages` array to populate inline image elements in the article.

This change uses `imageSources` with an `"inline"` weighting.

## Why?

`media.allImages` gets images from `media.guim.co.uk`, whereas we want them to come from Fastly's image service. This allows us to select images of the appropriate size and quality for the user's screen resolution and viewport width.

## More to do

`imageSources` only contains sources for normal DPI. Ideally, frontend would send us `imageSources` for hidpi too. These would have the params `quality=45` and `DPR=2`