### PR TITLE
Fix most viewed &nbsp;

### DIFF
--- a/packages/frontend/web/components/MostViewed.tsx
+++ b/packages/frontend/web/components/MostViewed.tsx
@@ -258,6 +258,7 @@ export class MostViewed extends Component<Props, { selectedTabIndex: number }> {
     }
 
     public render() {
+        const nonBreakingSpaceChar = String.fromCharCode(160);
         return (
             <div className={container}>
                 <h2 className={heading}>Most viewed</h2>
@@ -300,7 +301,9 @@ export class MostViewed extends Component<Props, { selectedTabIndex: number }> {
                                                     >
                                                         Most viewed{' '}
                                                     </span>
-                                                    {tab.heading}
+                                                    {i === 0
+                                                        ? `Across The${nonBreakingSpaceChar}Guardian`
+                                                        : tab.heading}
                                                 </button>
                                             </li>
                                         ))}

--- a/packages/frontend/web/components/MostViewed.tsx
+++ b/packages/frontend/web/components/MostViewed.tsx
@@ -258,7 +258,6 @@ export class MostViewed extends Component<Props, { selectedTabIndex: number }> {
     }
 
     public render() {
-        const nonBreakingSpaceChar = String.fromCharCode(160);
         return (
             <div className={container}>
                 <h2 className={heading}>Most viewed</h2>
@@ -301,9 +300,12 @@ export class MostViewed extends Component<Props, { selectedTabIndex: number }> {
                                                     >
                                                         Most viewed{' '}
                                                     </span>
-                                                    {i === 0
-                                                        ? `Across The${nonBreakingSpaceChar}Guardian`
-                                                        : tab.heading}
+                                                    <span // tslint:disable-line:react-no-dangerous-html
+                                                        // "Across The Guardian" has a non-breaking space entity between "The" and "Guardian"
+                                                        dangerouslySetInnerHTML={{
+                                                            __html: tab.heading,
+                                                        }}
+                                                    />
                                                 </button>
                                             </li>
                                         ))}


### PR DESCRIPTION
## What does this change?

A recent change (guardian/frontend#20814) introduced an `&nbsp;` HTML entity into the response from the Most Popular endpoint. This does not play well with React as it is not decoded into a non-breaking space.

~To work around this, I have made the assumption that the first tab in the Most Popular tabs layout will always be called "Across the Guardian", and hardcoded the title in the `MostPopular` component, complete with non-breaking space.~

EDIT: after discussion with @nicl, we agreed the least hacky way of dealing with this situation is to always dangerously set the inner HTML of the button with the heading coming from frontend.

Note that the lower casing issue will hopefully be resolved by guardian/frontend#20878

## Screenshots

**Before**

![screen shot 2018-12-28 at 16 53 17](https://user-images.githubusercontent.com/5931528/50522105-1d6a9180-0ac1-11e9-9ff7-36242f1e65af.png)

**After**

![screen shot 2018-12-28 at 16 53 24](https://user-images.githubusercontent.com/5931528/50522109-252a3600-0ac1-11e9-930b-34241bfdd45b.png)

## Why?

It looks not broken, although it adds some duplication between frontend and dotcom-rendering