### PR TITLE
Add onward containers

### DIFF
--- a/fixtures/CAPI.ts
+++ b/fixtures/CAPI.ts
@@ -172,4 +172,6 @@ export const CAPI: CAPIType = {
     webURL:
         'https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
     guardianBaseURL: 'https://www.theguardian.com',
+    hasRelated: false,
+    hasStoryPackage: false,
 };

--- a/packages/frontend/amp/components/Onward.tsx
+++ b/packages/frontend/amp/components/Onward.tsx
@@ -3,42 +3,24 @@ import { css } from 'react-emotion';
 import Plus from '@guardian/pasteup/icons/plus.svg';
 import InnerContainer from '@frontend/amp/components/InnerContainer';
 import { OnwardContainer } from '@frontend/amp/components/OnwardContainer';
-import { palette } from '@guardian/pasteup/palette';
 
 const wrapper = css`
     background-color: white;
     padding-top: 24px;
 `;
 
-const container = css`
-    border-top: 1px solid ${palette.neutral[86]};
-    padding-bottom: 24px;
-`;
-
-const outbrain = css`
-    ${container};
+const outbrainStyle = css`
     border-top: none;
 `;
 
-export const Onward: React.SFC<{
-    shouldHideAds: boolean;
-    webURL: string;
-    onwardURLs: string[];
-    guardianBaseURL: string;
-}> = ({ shouldHideAds, webURL, onwardURLs, guardianBaseURL }) => {
+const outbrainContainer = (webURL: string, isCompliant: boolean) => {
     const encodedWebURL = encodeURIComponent(`${webURL}`);
     const encodedAMPURL = encodeURIComponent(`${webURL}?amp`);
-
-    const outbrainParams = `widgetIds=AMP_1&htmlURL=${encodedWebURL}&ampURL=${encodedAMPURL}`;
+    const widgetID = isCompliant ? 'AMP_1' : 'AMP_2';
+    const outbrainParams = `widgetIds=${widgetID}&htmlURL=${encodedWebURL}&ampURL=${encodedAMPURL}`;
     const outbrainURL = `https://widgets.outbrain.com/hub/amp.html#${outbrainParams}`;
 
-    const containers = onwardURLs.map(path => (
-        <div key={path} className={container}>
-            <OnwardContainer guardianBaseURL={guardianBaseURL} path={path} />
-        </div>
-    ));
-
-    const outbrainContainer = (
+    return (
         <amp-iframe
             key={outbrainURL}
             height="480"
@@ -46,7 +28,7 @@ export const Onward: React.SFC<{
             layout="fixed-height"
             frameborder="0"
             src={outbrainURL}
-            class={outbrain}
+            class={outbrainStyle}
         >
             <div overflow="true">
                 More stories
@@ -54,11 +36,109 @@ export const Onward: React.SFC<{
             </div>
         </amp-iframe>
     );
+};
 
-    // insert outbrain as second container if ads supported
-    if (!shouldHideAds) {
-        containers.splice(1, 0, outbrainContainer);
-    }
+const sectionHasMostViewed = (sectionID: string): boolean => {
+    const whitelist = new Set([
+        'commentisfree',
+        'sport',
+        'football',
+        'fashion',
+        'lifeandstyle',
+        'education',
+        'culture',
+        'business',
+        'technology',
+        'politics',
+        'environment',
+        'travel',
+        'film',
+        'media',
+        'money',
+        'society',
+        'science',
+        'music',
+        'books',
+        'stage',
+        'cities',
+        'tv-and-radio',
+        'artanddesign',
+        'global-development',
+    ]);
+
+    return whitelist.has(sectionID);
+};
+
+export const Onward: React.SFC<{
+    shouldHideAds: boolean;
+    pageID: string;
+    webURL: string;
+    sectionID?: string;
+    hasStoryPackage: boolean;
+    hasRelated: boolean;
+    seriesTags: TagType[];
+    guardianBaseURL: string;
+}> = ({
+    shouldHideAds,
+    pageID,
+    webURL,
+    sectionID,
+    hasStoryPackage,
+    hasRelated,
+    seriesTags,
+    guardianBaseURL,
+}) => {
+    const container = (path: string) => (
+        <OnwardContainer
+            key={path}
+            guardianBaseURL={guardianBaseURL}
+            path={path}
+        />
+    );
+
+    const storyPackage = hasStoryPackage
+        ? [container(`${guardianBaseURL}/story-package/${pageID}.json`)]
+        : [];
+
+    const series = seriesTags.map(tag =>
+        container(`${guardianBaseURL}/series-mf2/${tag.id}.json`),
+    );
+
+    const related =
+        hasRelated && series.length < 1
+            ? [container(`${guardianBaseURL}/related-mf2/${pageID}.json`)]
+            : [];
+
+    const mostRead = container(`${guardianBaseURL}/most-read-mf2.json`);
+
+    const hasSectionMostViewed = sectionID && sectionHasMostViewed(sectionID);
+    const sectionMostViewed = hasSectionMostViewed
+        ? container(
+              `${guardianBaseURL}/container/count/3/offset/0/${sectionID}/mf2.json`,
+          )
+        : container(`${guardianBaseURL}/container/count/1/offset/0/mf2.json`);
+
+    const headlines = container(
+        `${guardianBaseURL}/container/count/3/offset/${
+            hasSectionMostViewed ? 0 : 1 // TODO not entirely sure why this is needed
+        }/mf2.json`,
+    );
+
+    // Outbrain is compliant if it appears in the top 2 containers
+    const outbrainIsCompliant = storyPackage.concat(series).length > 1;
+    const outbrain = shouldHideAds
+        ? []
+        : [outbrainContainer(webURL, outbrainIsCompliant)];
+
+    // Note, if order changes, you may need to recalculate outbrain compliance
+    const containers = storyPackage.concat(
+        series,
+        related,
+        outbrain,
+        sectionMostViewed,
+        mostRead,
+        headlines,
+    );
 
     return <InnerContainer className={wrapper}>{containers}</InnerContainer>;
 };

--- a/packages/frontend/amp/components/OnwardContainer.tsx
+++ b/packages/frontend/amp/components/OnwardContainer.tsx
@@ -13,13 +13,15 @@ import Camera from '@guardian/pasteup/icons/camera.svg';
 import VolumeHigh from '@guardian/pasteup/icons/volume-high.svg';
 import Quote from '@guardian/pasteup/icons/quote.svg';
 import Clock from '@guardian/pasteup/icons/clock.svg';
-
+import { palette } from '@guardian/pasteup/palette';
 import { css } from 'emotion';
 
 const inner = css`
     padding-top: 3px;
     overflow: hidden;
     position: relative;
+    border-top: 1px solid ${palette.neutral[86]};
+    padding-bottom: 24px;
 `;
 const header = css`
     font-family: ${serif.headline};
@@ -79,7 +81,7 @@ export const OnwardContainer: React.SFC<{
 }> = ({ guardianBaseURL, path }) => (
     <amp-list
         layout="fixed-height"
-        height="470"
+        height="184"
         src={path}
         credentials="include"
     >

--- a/packages/frontend/amp/pages/Article.tsx
+++ b/packages/frontend/amp/pages/Article.tsx
@@ -34,7 +34,18 @@ export interface ArticleModel {
     webURL: string;
     shouldHideAds: boolean;
     guardianBaseURL: string;
+    hasRelated: boolean;
+    hasStoryPackage: boolean;
 }
+
+// TODO move somewhere better
+const tagsOfType = (tags: TagType[], tagType: string): TagType[] => {
+    return tags.filter(
+        tag =>
+            tag.type === tagType ||
+            (tag.type === 'PaidContent' && tag.paidContentType === tagType),
+    );
+};
 
 export const Article: React.SFC<{
     nav: NavType;
@@ -51,9 +62,13 @@ export const Article: React.SFC<{
             />
             <Onward
                 shouldHideAds={articleData.shouldHideAds}
+                pageID={articleData.pageId}
                 webURL={articleData.webURL}
-                onwardURLs={['https://amp.theguardian.com/most-read-mf2.json']}
-                guardianBaseURL={articleData.guardianBaseURL}
+                sectionID={articleData.sectionUrl}
+                hasRelated={false}
+                hasStoryPackage={false}
+                seriesTags={tagsOfType(articleData.tags, 'Series')}
+                guardianBaseURL={'https://amp.theguardian.com'}
             />
             <Footer />
         </Container>

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -103,7 +103,11 @@ interface CAPIType {
     subMetaKeywordLinks: SimpleLinkType[];
     shouldHideAds: boolean;
     webURL: string;
+
+    // AMP specific (for now)
     guardianBaseURL: string;
+    hasRelated: boolean;
+    hasStoryPackage: boolean;
 }
 
 interface TagType {

--- a/packages/frontend/model/extract-capi.ts
+++ b/packages/frontend/model/extract-capi.ts
@@ -251,8 +251,10 @@ export const extract = (data: {}): CAPIType => {
             ...sectionData,
         }),
         ...sectionData,
-        shouldHideAds: getBoolean(data, 'config.page.shouldHideAds'),
+        shouldHideAds: getBoolean(data, 'config.page.shouldHideAds', false),
         webURL: getNonEmptyString(data, 'config.page.webURL'),
         guardianBaseURL: getNonEmptyString(data, 'config.page.guardianBaseURL'),
+        hasRelated: getBoolean(data, 'config.page.hasRelated', false),
+        hasStoryPackage: getBoolean(data, 'config.page.hasStoryPackage', false),
     };
 };


### PR DESCRIPTION
Adds the additional onward containers (we already had styling, but needed to add the specific containers and associated display logic).

Required for go live!

Note, this expects a few extra fields in the JSON model:

    hasStoryPackage: boolean
    hasRelated: boolean

These are used to decide which containers to display.

In addition, rather than pass in a whole load of related content, the idea is to call a json endpoint for the data - in the same way the other onward containers work. To achieve this, we'll need to add a `story-package-mf2/:pageID.json` endpoint to Frontend.

I'll link these changes here once they are in a PR. However, this code will work (or degrade gracefully) even without the frontend work being merged first.

UPDATE: corresponding Frontend PR is here: https://github.com/guardian/frontend/pull/20886.