### PR TITLE
pre-push git-hook for tsc

### DIFF
--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+const execa = require('execa')
+
+const typeScriptBuild = () =>
+    execa(
+        'tsc',
+        [],
+        {
+            stdio: 'inherit',
+        }
+    );
+
+typeScriptBuild();
+
+


### PR DESCRIPTION
## What does this change?

Create a git hook that performs `tsc` on all commits 

## Why?

To enforce that the code compile, at least, as TC does it automatically.