### PR TITLE
Get reader revenue links from frontend

### DIFF
--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -41,19 +41,16 @@ interface MoreType extends LinkType {
     more: true;
 }
 
+interface ReaderRevenueLink {
+    contribute: string;
+    subscribe: string;
+    support: string;
+}
+
 interface ReaderRevenueLinks {
-    header: {
-        subscribe: string;
-        support: string;
-    };
-    footer: {
-        subscribe: string;
-        contribute: string;
-    };
-    sideMenu: {
-        subscribe: string;
-        contribute: string;
-    };
+    header: ReaderRevenueLink;
+    footer: ReaderRevenueLink;
+    sideMenu: ReaderRevenueLink;
 }
 
 interface NavType {

--- a/packages/frontend/model/extract-nav.ts
+++ b/packages/frontend/model/extract-nav.ts
@@ -50,25 +50,57 @@ export const extract = (data: {}): NavType => {
                   ),
               }
             : undefined,
-        // TODO: replace with data from Frontend
         readerRevenueLinks: {
             header: {
-                subscribe:
-                    'https://support.theguardian.com/subscribe?INTCMP=header_support_subscribe&amp;acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentType%22%3A%22ACQUISITIONS_HEADER%22%2C%22componentId%22%3A%22header_support_subscribe%22%2C%22referrerPageviewId%22%3A%22jnmzvcxd5o7u2p94r35e%22%2C%22referrerUrl%22%3A%22https%3A%2F%2Fwww.theguardian.com%2Fuk%22%7D',
-                support:
-                    'https://support.theguardian.com/?INTCMP=header_support&amp;acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentType%22%3A%22ACQUISITIONS_HEADER%22%2C%22componentId%22%3A%22header_support%22%2C%22referrerPageviewId%22%3A%22jnmzvcxd5o7u2p94r35e%22%2C%22referrerUrl%22%3A%22https%3A%2F%2Fwww.theguardian.com%2Fuk%22%7D',
+                contribute: getString(
+                    data,
+                    'config.readerRevenueLinks.header.contribute',
+                    '',
+                ),
+                subscribe: getString(
+                    data,
+                    'config.readerRevenueLinks.header.subscribe',
+                    '',
+                ),
+                support: getString(
+                    data,
+                    'config.readerRevenueLinks.header.support',
+                    '',
+                ),
             },
             footer: {
-                subscribe:
-                    'https://support.theguardian.com/subscribe?INTCMP=footer_support_subscribe&amp;acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentType%22%3A%22ACQUISITIONS_FOOTER%22%2C%22componentId%22%3A%22footer_support_subscribe%22%2C%22referrerPageviewId%22%3A%22jnmzvcxd5o7u2p94r35e%22%2C%22referrerUrl%22%3A%22https%3A%2F%2Fwww.theguardian.com%2Fuk%22%7D',
-                contribute:
-                    'https://support.theguardian.com/contribute?INTCMP=footer_support_contribute&amp;acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentType%22%3A%22ACQUISITIONS_FOOTER%22%2C%22componentId%22%3A%22footer_support_contribute%22%2C%22referrerPageviewId%22%3A%22jnmzvcxd5o7u2p94r35e%22%2C%22referrerUrl%22%3A%22https%3A%2F%2Fwww.theguardian.com%2Fuk%22%7D',
+                contribute: getString(
+                    data,
+                    'config.readerRevenueLinks.footer.contribute',
+                    '',
+                ),
+                subscribe: getString(
+                    data,
+                    'config.readerRevenueLinks.footer.subscribe',
+                    '',
+                ),
+                support: getString(
+                    data,
+                    'config.readerRevenueLinks.footer.support',
+                    '',
+                ),
             },
             sideMenu: {
-                subscribe:
-                    'https://support.theguardian.com/subscribe?INTCMP=side_menu_support_subscribe&amp;acquisitionData=%7B&quot;source&quot;:&quot;GUARDIAN_WEB&quot;,&quot;componentType&quot;:&quot;ACQUISITIONS_HEADER&quot;,&quot;componentId&quot;:&quot;side_menu_support_subscribe&quot;%7D',
-                contribute:
-                    'https://support.theguardian.com/contribute?INTCMP=side_menu_support_contribute&amp;acquisitionData=%7B&quot;source&quot;:&quot;GUARDIAN_WEB&quot;,&quot;componentType&quot;:&quot;ACQUISITIONS_HEADER&quot;,&quot;componentId&quot;:&quot;side_menu_support_contribute&quot;%7D',
+                contribute: getString(
+                    data,
+                    'config.readerRevenueLinks.sideMenu.contribute',
+                    '',
+                ),
+                subscribe: getString(
+                    data,
+                    'config.readerRevenueLinks.sideMenu.subscribe',
+                    '',
+                ),
+                support: getString(
+                    data,
+                    'config.readerRevenueLinks.sideMenu.support',
+                    '',
+                ),
             },
         },
     };


### PR DESCRIPTION
## What does this change?

Updates `extract-nav` to retrieve readerRevenueLinks from the JSON sent by `frontend`.
