### PR TITLE
Remove code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# https://help.github.com/articles/about-codeowners
-* @GHaberis @SiAdcock @nicl @aware @shtukas @philmcmahon @MatthewJWalls


### PR DESCRIPTION
## What does this change?

My old mam used to say, "Look at the state of ya, it looks like no-one owns ya!" 

And I used to think "But no-one _does_ own me..."

Now, dotcom-rendering can enjoy the same freedom. God help it.

## Why?

Less noise in the inboxes, less chance of missing an important PR an individual actually does need to review!