### PR TITLE
Defaults for code climate

### DIFF
--- a/.codeclimate.json
+++ b/.codeclimate.json
@@ -1,0 +1,60 @@
+{
+    "version": "2",
+    "checks": {
+      "argument-count": {
+        "config": {
+          "threshold": 4
+        }
+      },
+      "complex-logic": {
+        "config": {
+          "threshold": 4
+        }
+      },
+      "file-lines": {
+        "config": {
+          "threshold": 250
+        }
+      },
+      "method-complexity": {
+        "config": {
+          "threshold": 5
+        }
+      },
+      "method-count": {
+        "config": {
+          "threshold": 20
+        }
+      },
+      "method-lines": {
+        "config": {
+          "threshold": 100
+        }
+      },
+      "nested-control-flow": {
+        "config": {
+          "threshold": 4
+        }
+      },
+      "return-statements": {
+        "config": {
+          "threshold": 4
+        }
+      },
+      "similar-code": {
+        "config": {
+          "threshold": null
+        }
+      },
+      "identical-code": {
+        "config": {
+          "threshold": null
+        }
+      },
+      "exclude_patterns": [
+        "**/*.d.ts",
+        "**/*.test.ts",
+        "fixtures/"
+      ]
+    }
+  }

--- a/.codeclimate.json
+++ b/.codeclimate.json
@@ -42,14 +42,10 @@
         }
       },
       "similar-code": {
-        "config": {
-          "threshold": null
-        }
+        "enabled": false
       },
       "identical-code": {
-        "config": {
-          "threshold": null
-        }
+        "enabled": false
       }
     },
     "exclude_patterns": [

--- a/.codeclimate.json
+++ b/.codeclimate.json
@@ -50,11 +50,11 @@
         "config": {
           "threshold": null
         }
-      },
-      "exclude_patterns": [
-        "**/*.d.ts",
-        "**/*.test.ts",
-        "fixtures/"
-      ]
-    }
+      }
+    },
+    "exclude_patterns": [
+      "**/*.d.ts",
+      "**/*.test.ts",
+      "fixtures/"
+    ]
   }


### PR DESCRIPTION
## What does this change?

Adds some new defaults for Code Climate. Ostensibly:

- Excludes tests and fixtures
- Allows functions up to 100 lines (previous maximum was 25 lines). Component render functions tend to get quite long, especially with prettier keep line length tight.
- Ignores problems with code duplication and similarity. We have a lot of justifiably similar code due to the way components are styled, and across web and AMP.

## Why?

Code Climate is currently very noisy. This is an attempt to calm it down a bit initially. 

## More to do

Further iteration will likely be needed to reach the right level for our project. 

We also need some documentation on what the goals are and how to integrate Code Climate's PR checks into our workflow.