### PR TITLE
Add gzip

### DIFF
--- a/packages/frontend/app/server.ts
+++ b/packages/frontend/app/server.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import express from 'express';
+import compression from 'compression';
 
 import recordBaselineCloudWatchMetrics from './aws/metrics-baseline';
 import {
@@ -31,6 +32,7 @@ if (process.env.NODE_ENV === 'production') {
     const app = express();
 
     app.use(express.json({ limit: '50mb' }));
+    app.use(compression());
 
     app.get('/_healthcheck', (req, res) => {
         res.status(200).send('OKAY');

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -10,6 +10,7 @@
     "@guardian/pasteup": "1.0.0-alpha.1",
     "aws-sdk": "^2.340.0",
     "compose-function": "^3.0.3",
+    "compression": "^1.7.3",
     "curlyquotes": "^1.3.2",
     "dateformat": "^3.0.3",
     "diskusage": "^0.2.5",
@@ -32,6 +33,7 @@
   "devDependencies": {
     "@types/amphtml-validator": "^1.0.0",
     "@types/compose-function": "^0.0.30",
+    "@types/compression": "^0.0.36",
     "@types/dateformat": "^1.0.1",
     "@types/dompurify": "^0.0.31",
     "@types/express": "^4.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -916,6 +916,12 @@
   version "0.0.30"
   resolved "https://registry.yarnpkg.com/@types/compose-function/-/compose-function-0.0.30.tgz#1fbe97dda4caeb7f5e45a553dee8d46d91e48c5b"
 
+"@types/compression@^0.0.36":
+  version "0.0.36"
+  resolved "https://registry.yarnpkg.com/@types/compression/-/compression-0.0.36.tgz#7646602ffbfc43ea48a8bf0b2f1d5e5f9d75c0d0"
+  dependencies:
+    "@types/express" "*"
+
 "@types/connect@*":
   version "3.4.32"
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.32.tgz#aa0e9616b9435ccad02bc52b5b454ffc2c70ba28"
@@ -942,7 +948,7 @@
     "@types/node" "*"
     "@types/range-parser" "*"
 
-"@types/express@^4.16.0":
+"@types/express@*", "@types/express@^4.16.0":
   version "4.16.0"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.16.0.tgz#6d8bc42ccaa6f35cf29a2b7c3333cb47b5a32a19"
   dependencies:
@@ -2493,6 +2499,24 @@ compose-function@^3.0.3:
   resolved "https://registry.yarnpkg.com/compose-function/-/compose-function-3.0.3.tgz#9ed675f13cc54501d30950a486ff6a7ba3ab185f"
   dependencies:
     arity-n "^1.0.4"
+
+compressible@~2.0.14:
+  version "2.0.15"
+  resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.15.tgz#857a9ab0a7e5a07d8d837ed43fe2defff64fe212"
+  dependencies:
+    mime-db ">= 1.36.0 < 2"
+
+compression@^1.7.3:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/compression/-/compression-1.7.3.tgz#27e0e176aaf260f7f2c2813c3e440adb9f1993db"
+  dependencies:
+    accepts "~1.3.5"
+    bytes "3.0.0"
+    compressible "~2.0.14"
+    debug "2.6.9"
+    on-headers "~1.0.1"
+    safe-buffer "5.1.2"
+    vary "~1.1.2"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -5662,6 +5686,10 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
+"mime-db@>= 1.36.0 < 2":
+  version "1.37.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.37.0.tgz#0b6a0ce6fdbe9576e25f1f2d2fde8830dc0ad0d8"
+
 mime-db@~1.36.0:
   version "1.36.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.36.0.tgz#5020478db3c7fe93aad7bbcc4dcf869c43363397"
@@ -6119,6 +6147,10 @@ on-finished@~2.3.0:
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
   dependencies:
     ee-first "1.1.1"
+
+on-headers@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.1.tgz#928f5d0f470d49342651ea6794b0857c100693f7"
 
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
This is a basic optimisation. I'm still establishing the exact performance increase.

## Without Gzip (CODE, 1 * t3.medium)

```
$ vegeta attack -targets=targets.txt -duration=300s -rate=50 -header="Content-Type: application/json" | tee results.bin | vegeta report
Requests      [total, rate]            15000, 50.00
Duration      [total, attack, wait]    5m0.49418077s, 4m59.990233s, 503.94777ms
Latencies     [mean, 50, 95, 99, max]  1.581154392s, 702.112041ms, 5.956441276s, 10.247213956s, 42.455166734s
Bytes In      [total, mean]            934751070, 62316.74
Bytes Out     [total, mean]            2025095130, 135006.34
Success       [ratio]                  98.20%
Status Codes  [code:count]             0:270  200:14730  
```

### With GZIP

```
$ vegeta attack -targets=targets-code.txt -duration=300s -rate=50 -header="Content-Type: application/json" | tee results.bin | vegeta report
Requests      [total, rate]            15000, 50.00
Duration      [total, attack, wait]    5m0.036254486s, 4m59.989438s, 46.816486ms
Latencies     [mean, 50, 95, 99, max]  437.999337ms, 57.07538ms, 3.864362122s, 6.201623375s, 9.105618054s
Bytes In      [total, mean]            943989288, 62932.62
Bytes Out     [total, mean]            2042417736, 136161.18
Success       [ratio]                  98.91%
Status Codes  [code:count]             0:144  200:14837  504:19  
```

This is an improvement, particularly in latency - the mean is ⅓ of before (1.5s - .5s), still too high but much better. Errors have fallen from 270 to 163 (40% fall).
