### PR TITLE
Use correct body font

### DIFF
--- a/packages/frontend/web/components/ArticleBody.tsx
+++ b/packages/frontend/web/components/ArticleBody.tsx
@@ -3,7 +3,7 @@ import { css, cx } from 'emotion';
 import TwitterIcon from '@guardian/pasteup/icons/twitter.svg';
 import { palette } from '@guardian/pasteup/palette';
 import ClockIcon from '@guardian/pasteup/icons/clock.svg';
-import { headline, textSans } from '@guardian/pasteup/typography';
+import { headline, textSans, body } from '@guardian/pasteup/typography';
 import { ShareCount } from './ShareCount';
 import { SharingIcons } from './ShareIcons';
 import { SubMetaLinksList } from './SubMetaLinksList';
@@ -123,7 +123,7 @@ const listStyles = css`
 `;
 
 const standfirst = css`
-    ${textSans(1)};
+    ${body(2)};
     font-weight: 700;
     color: ${palette.neutral[7]};
     margin-bottom: 12px;
@@ -287,11 +287,6 @@ const bodyStyle = css`
 
     strong {
         font-weight: bold;
-    }
-
-    p {
-        margin-bottom: 16px;
-        ${textSans(5)};
     }
 
     img {

--- a/packages/frontend/web/components/SubMetaLinksList.tsx
+++ b/packages/frontend/web/components/SubMetaLinksList.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
-import { body, textSans } from '@guardian/pasteup/typography';
+import { headline, textSans } from '@guardian/pasteup/typography';
 
 import { pillarMap, pillarPalette } from '@frontend/lib/pillars';
 
@@ -17,11 +17,11 @@ const subMetaLinksList = css`
 `;
 
 const subMetaSectionLinksList = css`
-    font-weight: 500;
     line-height: 24px;
 `;
 
 const subMetaKeywordLinksList = css`
+    line-height: 24px;
     padding-bottom: 12px;
     margin-bottom: 6px;
     border-bottom: 1px solid ${palette.neutral[86]};
@@ -57,11 +57,11 @@ const subMetaLink = css`
 `;
 
 const subMetaSectionLink = css`
-    ${body(2)};
+    ${headline(2)};
 `;
 
 const subMetaKeywordLink = css`
-    ${textSans(3)};
+    ${textSans(4)};
 `;
 
 const hideSlash = css`

--- a/packages/frontend/web/components/elements/TextBlockComponent.tsx
+++ b/packages/frontend/web/components/elements/TextBlockComponent.tsx
@@ -1,8 +1,18 @@
 import React from 'react';
+import { css } from 'emotion';
+import { body } from '@guardian/pasteup/typography';
 // tslint:disable:react-no-dangerous-html
+
+const para = css`
+    p {
+        margin-bottom: 16px;
+        ${body(2)};
+    }
+`;
 
 export const TextBlockComponent: React.SFC<{ html: string }> = ({ html }) => (
     <span
+        className={para}
         dangerouslySetInnerHTML={{
             __html: html,
         }}

--- a/packages/pasteup/typography.test.ts
+++ b/packages/pasteup/typography.test.ts
@@ -8,7 +8,7 @@ it('headline evaluates correctly', () => {
 
 it('body evaluates correctly', () => {
     expect(body(2)).toBe(
-        'font-size: 16px; line-height: 24px; font-family: GuardianTextEgyptian, Georgia, serif',
+        'font-size: 17px; line-height: 24px; font-family: GuardianTextEgyptian, Georgia, serif',
     );
 });
 

--- a/packages/pasteup/typography.ts
+++ b/packages/pasteup/typography.ts
@@ -33,7 +33,7 @@ const fontScaleMapping: any = {
     },
     body: {
         1: { fontSize: 14, lineHeight: 20 },
-        2: { fontSize: 16, lineHeight: 24 },
+        2: { fontSize: 17, lineHeight: 24 },
         3: { fontSize: 18, lineHeight: 28 },
     },
     textSans: {


### PR DESCRIPTION
## What does this change?

An earlier refactor moved our body and standfirst text to `textSans` instead of `body`. It also updated the submeta section to use `body` instead of `headline`.

This changes corrects these issues. 

It introduces a slight discrepancy between frontend and dotcom-rendering

- In frontend, standfirst has `font-size: 17px` and `line-height: 22px`
- In dotcom-rendering, standfirst has `font-size: 17px` and `line-height: 24px`

## Why?

Visual parity (ed: parity-ish)