### PR TITLE
Use actual values rather than dummies

### DIFF
--- a/packages/frontend/amp/pages/Article.tsx
+++ b/packages/frontend/amp/pages/Article.tsx
@@ -66,8 +66,8 @@ export const Article: React.SFC<{
                 pageID={articleData.pageId}
                 webURL={articleData.webURL}
                 sectionID={articleData.sectionUrl}
-                hasRelated={false}
-                hasStoryPackage={false}
+                hasRelated={articleData.hasRelated}
+                hasStoryPackage={articleData.hasStoryPackage}
                 seriesTags={tagsOfType(articleData.tags, 'Series')}
                 guardianBaseURL={'https://amp.theguardian.com'}
             />


### PR DESCRIPTION
Fixes some of the onwards components. (I think originally I just hard-coded these to be able to merge before the related frontend changes.)

A related fix is here:

https://github.com/guardian/platform/pull/1337.
