### PR TITLE
⚡️ Update standfirst and body text to 'body' instead of 'textSans'

### DIFF
--- a/packages/frontend/amp/components/MainBlock.tsx
+++ b/packages/frontend/amp/components/MainBlock.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { headline, textSans } from '@guardian/pasteup/typography';
+import { headline, textSans, body } from '@guardian/pasteup/typography';
 import { css, cx } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
 import { pillarMap, pillarPalette } from '../../lib/pillars';
@@ -103,7 +103,7 @@ const listStyles = css`
 `;
 
 const standfirstCss = css`
-    ${textSans(5)};
+    ${body(2)};
     font-weight: 700;
     color: ${palette.neutral[7]};
     margin-bottom: 12px;

--- a/packages/frontend/amp/components/elements/TextBlockComponent.tsx
+++ b/packages/frontend/amp/components/elements/TextBlockComponent.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
 import { pillarPalette } from '@frontend/lib/pillars';
-import { textSans } from '@guardian/pasteup/typography';
+import { textSans, body } from '@guardian/pasteup/typography';
 
 // tslint:disable:react-no-dangerous-html
 const style = (pillar: Pillar) => css`
@@ -15,7 +15,7 @@ const style = (pillar: Pillar) => css`
     }
     p {
         padding: 0 0 12px;
-        ${textSans(5)};
+        ${body(2)};
         font-weight: 300;
         word-wrap: break-word;
         color: ${palette.neutral[7]};


### PR DESCRIPTION
## What does this change?

Tiny change based on @SiAdcock's [font change](https://github.com/guardian/dotcom-rendering/pull/357). Updates AMP pages with the body font instead of textSans.

## Why?
Visual parity(ish).

## Current AMP

![screen shot 2019-01-14 at 10 40 56](https://user-images.githubusercontent.com/638051/51108153-147bfe80-17e9-11e9-9dc5-277df1bfdc62.jpg)

## D-R AMP Before

![screen shot 2019-01-14 at 10 41 10](https://user-images.githubusercontent.com/638051/51108164-22ca1a80-17e9-11e9-9631-4f0be05d1c38.jpg)

## D-R AMP After

![screen shot 2019-01-14 at 10 38 43](https://user-images.githubusercontent.com/638051/51108177-2b225580-17e9-11e9-8fa4-8b81e28c6fde.jpg)
