### PR TITLE
⚡️ Remove section label above main image

### DIFF
--- a/packages/frontend/amp/components/MainBlock.tsx
+++ b/packages/frontend/amp/components/MainBlock.tsx
@@ -57,27 +57,10 @@ const header = css`
     margin: 0 -10px;
 `;
 
-const section = css`
-    @supports (display: grid) {
-        grid-template-areas: 'section';
-    }
-    ${headline(2)};
-    font-weight: 700;
-
-    padding: 0 10px;
-`;
-
 const profile = css`
     ${headline(2)};
     font-weight: 700;
     margin-bottom: 4px;
-`;
-
-const sectionLabelLink = css`
-    text-decoration: none;
-    :hover {
-        text-decoration: underline;
-    }
 `;
 
 const listStyles = css`
@@ -197,23 +180,6 @@ export const MainBlock: React.SFC<{
     articleData: ArticleModel;
 }> = ({ config, articleData }) => (
     <header className={header}>
-        {articleData.sectionLabel &&
-            articleData.sectionUrl && (
-                <div className={section}>
-                    <a
-                        className={cx(
-                            sectionLabelLink,
-                            pillarColours[articleData.pillar],
-                        )}
-                        href={`https:// www.theguardian.com/${
-                            articleData.sectionUrl
-                        }`}
-                        data-link-name="article section"
-                    >
-                        {articleData.sectionLabel}
-                    </a>
-                </div>
-            )}
         <Elements
             pillar={articleData.pillar}
             elements={articleData.mainMediaElements}


### PR DESCRIPTION
## What does this change?

Removes the section label from above the main image.

## Why?

This is not present in production AMP. I'm assuming at some point it was needed but if anyone has more info on this, or I've missed something, please shout.

![screenshot 2019-01-14 at 13 16 09](https://user-images.githubusercontent.com/858402/51114930-ab9f8100-17fe-11e9-9108-746ae3890826.png)
![screenshot 2019-01-14 at 13 16 18](https://user-images.githubusercontent.com/858402/51114932-ac381780-17fe-11e9-9a43-12892a8fef35.png)
