### PR TITLE
⚡️Add title

### DIFF
--- a/packages/frontend/amp/components/MainBlock.tsx
+++ b/packages/frontend/amp/components/MainBlock.tsx
@@ -57,27 +57,10 @@ const header = css`
     margin: 0 -10px;
 `;
 
-const section = css`
-    @supports (display: grid) {
-        grid-template-areas: 'section';
-    }
-    ${headline(2)};
-    font-weight: 700;
-
-    padding: 0 10px;
-`;
-
 const profile = css`
     ${headline(2)};
     font-weight: 700;
     margin-bottom: 4px;
-`;
-
-const sectionLabelLink = css`
-    text-decoration: none;
-    :hover {
-        text-decoration: underline;
-    }
 `;
 
 const listStyles = css`
@@ -197,23 +180,6 @@ export const MainBlock: React.SFC<{
     articleData: ArticleModel;
 }> = ({ config, articleData }) => (
     <header className={header}>
-        {articleData.sectionLabel &&
-            articleData.sectionUrl && (
-                <div className={section}>
-                    <a
-                        className={cx(
-                            sectionLabelLink,
-                            pillarColours[articleData.pillar],
-                        )}
-                        href={`https:// www.theguardian.com/${
-                            articleData.sectionUrl
-                        }`}
-                        data-link-name="article section"
-                    >
-                        {articleData.sectionLabel}
-                    </a>
-                </div>
-            )}
         <Elements
             pillar={articleData.pillar}
             elements={articleData.mainMediaElements}

--- a/packages/frontend/amp/server/document.test.tsx
+++ b/packages/frontend/amp/server/document.test.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 test('rejects invalid AMP doc (to test validator)', async () => {
     const v = await validator.getInstance();
     const result = v.validateString(
-        document({ scripts: [''], body: <img alt="foo" /> }),
+        document({ title: 'foo', scripts: [''], body: <img alt="foo" /> }),
     );
     expect(result.errors.length > 0).toBe(true);
 });

--- a/packages/frontend/amp/server/document.tsx
+++ b/packages/frontend/amp/server/document.tsx
@@ -12,9 +12,11 @@ interface RenderToStringResult {
 }
 
 export const document = ({
+    title,
     body,
     scripts,
 }: {
+    title: string;
     body: React.ReactElement<any>;
     scripts: string[];
 }) => {
@@ -27,6 +29,7 @@ export const document = ({
 <html ⚡>
     <head>
     <meta charset="utf-8">
+    <title>${title}</title>
     <link rel="canonical" href="self.html" />
     <meta name="viewport" content="width=device-width,minimum-scale=1">
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>

--- a/packages/frontend/amp/server/render.tsx
+++ b/packages/frontend/amp/server/render.tsx
@@ -28,6 +28,7 @@ export const render = ({ body }: express.Request, res: express.Response) => {
         ];
         const resp = document({
             scripts,
+            title: `${CAPI.headline} | ${CAPI.sectionLabel} | The Guardian`,
             body: (
                 <Article
                     articleData={CAPI}


### PR DESCRIPTION
## What does this change?

Adds title in the head.

## Why?

So that we have a title!

## Errata

The sectionLabel currently doesn't always return the actual section. E.g. 

https://www.theguardian.com/sport/2019/jan/14/andy-murray-out-first-round-australian-open-tennis-roberto-bautista-agut.json?guui

where Andy Murray is returned instead of the expected 'Sport'. This is a separate bug though - probably in the Scala side, so will fix separately.
