### PR TITLE
Use dark pillar colours

### DIFF
--- a/packages/frontend/amp/components/MainBlock.tsx
+++ b/packages/frontend/amp/components/MainBlock.tsx
@@ -141,7 +141,7 @@ const headlinePillarColours = pillarMap(pillar => {
     }
 
     return css`
-        color: ${pillarPalette[pillar].main};
+        color: ${pillarPalette[pillar].dark};
     `;
 });
 

--- a/packages/frontend/amp/components/Submeta.tsx
+++ b/packages/frontend/amp/components/Submeta.tsx
@@ -25,7 +25,7 @@ const linkStyle = (pillar: Pillar) => css`
     padding-left: 5px;
     padding-right: 6px;
     text-decoration: none;
-    color: ${pillarPalette[pillar].main};
+    color: ${pillarPalette[pillar].dark};
     ${textSans(4)};
     :after {
         content: '/';
@@ -60,7 +60,7 @@ const sectionLinkStyle = (pillar: Pillar) => css`
     padding-left: 5px;
     padding-right: 6px;
     text-decoration: none;
-    color: ${pillarPalette[pillar].main};
+    color: ${pillarPalette[pillar].dark};
     ${textSans(5)};
     :after {
         content: '/';

--- a/packages/frontend/amp/components/elements/RichLinkBlockComponent.tsx
+++ b/packages/frontend/amp/components/elements/RichLinkBlockComponent.tsx
@@ -16,7 +16,7 @@ const richLinkContainer = css`
 `;
 
 const pillarColour = (pillar: Pillar) => css`
-    color: ${pillarPalette[pillar].main};
+    color: ${pillarPalette[pillar].dark};
 `;
 
 const richLink = css`

--- a/packages/frontend/amp/components/elements/TextBlockComponent.tsx
+++ b/packages/frontend/amp/components/elements/TextBlockComponent.tsx
@@ -21,11 +21,11 @@ const style = (pillar: Pillar) => css`
         color: ${palette.neutral[7]};
     }
     a {
-        color: ${pillarPalette[pillar].main};
+        color: ${pillarPalette[pillar].dark};
         text-decoration: none;
         border-bottom: 1px solid #dcdcdc;
         :hover {
-            border-bottom: 1px solid ${pillarPalette[pillar].main};
+            border-bottom: 1px solid ${pillarPalette[pillar].dark};
         }
     }
     ${textSans(5)};


### PR DESCRIPTION
For visual parity, we need to use the dark pillar colours for links in AMP, not the main ones.
