### PR TITLE
Update expired local certificate

### DIFF
--- a/scripts/nginx/dotcom-rendering.conf
+++ b/scripts/nginx/dotcom-rendering.conf
@@ -12,8 +12,8 @@ server {
     server_name r.thegulocal.com;
 
     ssl on;
-    ssl_certificate wildcard-thegulocal-com-exp2019-01-09.crt; ## Supplied by https://github.com/guardian/identity-platform#setup-nginx-for-local-development
-    ssl_certificate_key wildcard-thegulocal-com-exp2019-01-09.key; ## ditto
+    ssl_certificate STAR_thegulocal_com_exp2020-01-09.crt; ## Supplied by https://github.com/guardian/identity-platform#setup-nginx-for-local-development
+    ssl_certificate_key STAR_thegulocal_com_exp2020-01-09.key; ## ditto
 
     ssl_session_timeout 5m;
 


### PR DESCRIPTION
## What does this change?
Updates a reference to an expired certificate used for running locally.  I haven't run dotcom rendering locally, so this is untested - but it's the same change we have made elsewhere.  You still need to re-run identity-platform setup script to download the necessary cert/key to get this to work.

## Why?
