### PR TITLE
⚡️ Add JSON-LD structured data to articles

### DIFF
--- a/packages/frontend/amp/server/document.test.tsx
+++ b/packages/frontend/amp/server/document.test.tsx
@@ -9,8 +9,14 @@ import { extract as extractModel } from '@frontend/model/extract-capi';
 
 test('rejects invalid AMP doc (to test validator)', async () => {
     const v = await validator.getInstance();
+    const linkedData = {};
     const result = v.validateString(
-        document({ title: 'foo', scripts: [''], body: <img alt="foo" /> }),
+        document({
+            linkedData,
+            title: 'foo',
+            scripts: [''],
+            body: <img alt="foo" />,
+        }),
     );
     expect(result.errors.length > 0).toBe(true);
 });
@@ -20,10 +26,16 @@ test('produces valid AMP doc', async () => {
     const config = extractConfig(data);
     const nav = extractNAV(data);
     const model = extractModel(data);
+    const linkedData = {};
 
     const body = <Article nav={nav} articleData={model} config={config} />;
     const result = v.validateString(
-        document({ body, title: 'foo', scripts: [] }),
+        document({
+            body,
+            linkedData,
+            title: 'foo',
+            scripts: [],
+        }),
     );
 
     if (result.errors.length > 0) {

--- a/packages/frontend/amp/server/document.tsx
+++ b/packages/frontend/amp/server/document.tsx
@@ -12,10 +12,12 @@ interface RenderToStringResult {
 }
 
 export const document = ({
+    linkedData,
     title,
     body,
     scripts,
 }: {
+    linkedData: object;
     title: string;
     body: React.ReactElement<any>;
     scripts: string[];
@@ -24,7 +26,6 @@ export const document = ({
         // TODO: CacheProvider can be removed when we've moved over to using @emotion/core
         renderToString(<CacheProvider value={cache}>{body}</CacheProvider>),
     );
-
     return `<!doctype html>
 <html ⚡>
     <head>
@@ -32,6 +33,11 @@ export const document = ({
     <title>${title}</title>
     <link rel="canonical" href="self.html" />
     <meta name="viewport" content="width=device-width,minimum-scale=1">
+    
+    <script type="application/ld+json">
+        ${JSON.stringify(linkedData)}
+    </script>
+
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <script async src="https://cdn.ampproject.org/v0.js"></script>
 

--- a/packages/frontend/amp/server/render.tsx
+++ b/packages/frontend/amp/server/render.tsx
@@ -6,11 +6,15 @@ import { extractScripts } from '@root/packages/frontend/amp/lib/scripts';
 import { extract as extractCAPI } from '@frontend/model/extract-capi';
 import { extract as extractNAV } from '@frontend/model/extract-nav';
 import { extract as extractConfig } from '@frontend/model/extract-config';
+import { extract as extractLinkedData } from '@frontend/model/extract-linked-data';
 import { analytics } from '../lib/analytics';
 
 export const render = ({ body }: express.Request, res: express.Response) => {
     try {
         const CAPI = extractCAPI(body);
+
+        const linkedData = extractLinkedData(body);
+
         const scripts = [
             ...extractScripts(CAPI.elements),
             ...analytics({
@@ -27,6 +31,7 @@ export const render = ({ body }: express.Request, res: express.Response) => {
             }),
         ];
         const resp = document({
+            linkedData,
             scripts,
             title: `${CAPI.headline} | ${CAPI.sectionLabel} | The Guardian`,
             body: (

--- a/packages/frontend/model/extract-linked-data.test.ts
+++ b/packages/frontend/model/extract-linked-data.test.ts
@@ -1,0 +1,30 @@
+import { extract as extractLinkedData } from '@frontend/model/extract-linked-data';
+
+describe('linked data', () => {
+    it('extracts data from config.page.linkedData', () => {
+        const input = {
+            config: {
+                page: {
+                    linkedData: {
+                        '@type': 'NewsArticle',
+                    },
+                },
+            },
+        };
+        const output = extractLinkedData(input);
+
+        expect(output).toEqual({
+            '@type': 'NewsArticle',
+        });
+    });
+
+    it('throws if it cannot find data from config.page.linkedData', () => {
+        const invaldInput = {
+            config: {},
+        };
+
+        expect(() => {
+            extractLinkedData(invaldInput);
+        }).toThrow();
+    });
+});

--- a/packages/frontend/model/extract-linked-data.ts
+++ b/packages/frontend/model/extract-linked-data.ts
@@ -1,0 +1,5 @@
+import { getObject } from '@frontend/model/validators';
+
+export const extract = (data: {}): object => {
+    return getObject(data, 'config.page.linkedData');
+};

--- a/packages/frontend/web/server/document.tsx
+++ b/packages/frontend/web/server/document.tsx
@@ -8,6 +8,7 @@ import htmlTemplate from './htmlTemplate';
 import Article from '../pages/Article';
 import assets from '@frontend/lib/assets';
 import { GADataType } from '@frontend/model/extract-ga';
+import { extract as extractLinkedData } from '@frontend/model/extract-linked-data';
 
 interface Props {
     data: {
@@ -37,6 +38,8 @@ export default ({ data }: Props) => {
             </CacheProvider>,
         ),
     );
+
+    const linkedData = extractLinkedData(data);
 
     /**
      * Preload the following woff2 font files
@@ -79,6 +82,7 @@ export default ({ data }: Props) => {
     ];
 
     return htmlTemplate({
+        linkedData,
         priorityScripts,
         lowPriorityScripts,
         css,

--- a/packages/frontend/web/server/htmlTemplate.ts
+++ b/packages/frontend/web/server/htmlTemplate.ts
@@ -4,6 +4,7 @@ import assets from '@frontend/lib/assets';
 
 export default ({
     title = 'The Guardian',
+    linkedData,
     priorityScripts,
     lowPriorityScripts,
     css,
@@ -14,6 +15,7 @@ export default ({
     fontFiles = [],
 }: {
     title?: string;
+    linkedData: object;
     priorityScripts: string[];
     lowPriorityScripts: string[];
     css: string;
@@ -30,6 +32,10 @@ export default ({
             <head>
                 <title>${title}</title>
                 <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+                <script type="application/ld+json">
+                    ${JSON.stringify(linkedData)}
+                </script>
+                
                 ${priorityScripts
                     .map(
                         url => `<link rel="preload" href="${url}" as="script">`,


### PR DESCRIPTION
NOTE: Merge this PR first: https://github.com/guardian/frontend/pull/20951

## What does this change?
* Render linked data from body data on amp and non-amp article templates

## Why?
* Add semantic meaning to article pages.
* Parity with existing `frontend` markup (social sharing etc. is likely to rely on this?).
* Required for the Subscribe with Google integration

## Differences to `frontend`'s existing markup
As per [recommendation from Google's docs](https://developers.google.com/news/subscribe/guides/structured-data-markup#example)
* `NewsArticle` replaces the broader `Webpage`
* The Guardian `Organization` is nested in the above as a `publisher`, instead of being a separate `Organization`.

**WARNING: Are these breaking changes?**

Existing:
<img width="1016" alt="screen shot 2019-01-17 at 14 59 37" src="https://user-images.githubusercontent.com/249676/51327185-a9d8f600-1a68-11e9-84e8-e39167a61384.png">

Proposed in this PR:
<img width="995" alt="screen shot 2019-01-17 at 15 09 32" src="https://user-images.githubusercontent.com/249676/51327787-f8d35b00-1a69-11e9-9c2e-2dbd87f542af.png">
