### PR TITLE
Get submeta links directly from CAPI

### DIFF
--- a/packages/frontend/model/extract-capi.test.ts
+++ b/packages/frontend/model/extract-capi.test.ts
@@ -504,30 +504,50 @@ describe('extract-capi', () => {
         });
     });
 
-    it('returns sectionData if keyword tag available', () => {
-        testData.tags.tags = [
+    it('returns submeta section labels if available', () => {
+        testData.config.page.subMetaLinks.sectionLabels = [
             {
-                properties: {
-                    id: 'money/money',
-                    tagType: 'Keyword',
-                    webTitle: 'Money',
-                },
+                link: '/football/chelsea',
+                text: 'Chelsea',
+                dataLinkName: 'article section',
             },
         ];
 
-        const { sectionLabel, sectionUrl } = extract(testData);
+        const { subMetaSectionLinks } = extract(testData);
+        const firstLink: SimpleLinkType = subMetaSectionLinks[0];
 
-        expect(sectionLabel).toEqual('Money');
-        expect(sectionUrl).toEqual('money/money');
+        expect(firstLink.url).toEqual('/football/chelsea');
+        expect(firstLink.title).toEqual('Chelsea');
     });
 
-    it('returns no sectionData if keyword tag unavailable', () => {
-        testData.tags.tags = [];
+    it('returns submeta keywords if available', () => {
+        testData.config.page.subMetaLinks.keywords = [
+            {
+                link: '/football/footballviolence',
+                text: 'Football violence',
+                dataLinkName: 'keyword: football/footballviolence',
+            },
+            {
+                link: '/world/race',
+                text: 'Race',
+                dataLinkName: 'keyword: world/race',
+            },
+            {
+                link: '/tone/news',
+                text: 'news',
+                dataLinkName: 'tone: news',
+            },
+        ];
 
-        const { sectionLabel, sectionUrl } = extract(testData);
+        const { subMetaKeywordLinks } = extract(testData);
+        const [firstLink, secondLink, thirdLink] = subMetaKeywordLinks;
 
-        expect(sectionLabel).toBeUndefined();
-        expect(sectionUrl).toBeUndefined();
+        expect(firstLink.url).toEqual('/football/footballviolence');
+        expect(firstLink.title).toEqual('Football violence');
+        expect(secondLink.url).toEqual('/world/race');
+        expect(secondLink.title).toEqual('Race');
+        expect(thirdLink.url).toEqual('/tone/news');
+        expect(thirdLink.title).toEqual('news');
     });
 
     it('returns contentType if contentType available', () => {

--- a/packages/frontend/model/extract-capi.ts
+++ b/packages/frontend/model/extract-capi.ts
@@ -85,27 +85,6 @@ const getAgeWarning = (
     }
 };
 
-// TODO this is a simple implementation of section data
-// and should be updated to matcch full implementation available at
-// https://github.com/guardian/frontend/blob/master/common/app/model/content.scala#L202
-const getSectionData: (
-    tags: TagType[],
-) => {
-    sectionLabel?: string;
-    sectionUrl?: string;
-} = tags => {
-    const keyWordTag = tags.find(tag => tag.type === 'Keyword');
-
-    if (keyWordTag) {
-        return {
-            sectionLabel: keyWordTag.title,
-            sectionUrl: keyWordTag.id,
-        };
-    }
-
-    return {};
-};
-
 const getSubMetaSectionLinks: (data: {}) => SimpleLinkType[] = data => {
     const subMetaSectionLinks = getArray<any>(
         data,
@@ -141,7 +120,6 @@ export const extract = (data: {}): CAPIType => {
     );
     const tags = getTags(data);
     const isImmersive = getBoolean(data, 'config.page.isImmersive', false);
-    const sectionData = getSectionData(tags);
     const sectionName = getNonEmptyString(data, 'config.page.section');
 
     const leadContributor: TagType = tags.filter(
@@ -208,7 +186,6 @@ export const extract = (data: {}): CAPIType => {
         ageWarning: getAgeWarning(tags, webPublicationDate),
         subMetaSectionLinks: getSubMetaSectionLinks(data),
         subMetaKeywordLinks: getSubMetaKeywordLinks(data),
-        ...sectionData,
         shouldHideAds: getBoolean(data, 'config.page.shouldHideAds', false),
         webURL: getNonEmptyString(data, 'config.page.webURL'),
         guardianBaseURL: getNonEmptyString(data, 'config.page.guardianBaseURL'),

--- a/packages/frontend/model/extract-capi.ts
+++ b/packages/frontend/model/extract-capi.ts
@@ -141,9 +141,6 @@ export const extract = (data: {}): CAPIType => {
     );
     const tags = getTags(data);
     const isImmersive = getBoolean(data, 'config.page.isImmersive', false);
-    const isArticle =
-        tags &&
-        tags.some(tag => tag.id === 'type/article' && tag.type === 'Type');
     const sectionData = getSectionData(tags);
     const sectionName = getNonEmptyString(data, 'config.page.section');
 

--- a/packages/frontend/model/extract-capi.ts
+++ b/packages/frontend/model/extract-capi.ts
@@ -106,64 +106,29 @@ const getSectionData: (
     return {};
 };
 
-const getSubMetaSectionLinks: (
-    data: {
-        tags: TagType[];
-        isImmersive: boolean;
-        isArticle: boolean;
-        sectionLabel?: string;
-        sectionUrl?: string;
-    },
-) => SimpleLinkType[] = data => {
-    const links: SimpleLinkType[] = [];
-    const { tags, isImmersive, isArticle, sectionLabel, sectionUrl } = data;
+const getSubMetaSectionLinks: (data: {}) => SimpleLinkType[] = data => {
+    const subMetaSectionLinks = getArray<any>(
+        data,
+        'config.page.subMetaLinks.sectionLabels',
+        [],
+    );
 
-    if (!(isImmersive && isArticle)) {
-        if (sectionLabel && sectionUrl) {
-            links.push({
-                url: `/${sectionUrl}`,
-                title: sectionLabel,
-            });
-        }
-
-        const blogOrSeriesTags = tags.filter(
-            tag => tag.type === 'Blog' || tag.type === 'Series',
-        );
-
-        blogOrSeriesTags.forEach(tag => {
-            links.push({
-                url: `/${tag.id}`,
-                title: tag.title,
-            });
-        });
-    }
-
-    return links;
+    return subMetaSectionLinks.map(({ link, text }) => ({
+        url: link,
+        title: text,
+    }));
 };
 
-const getSubMetaKeywordLinks: (
-    data: {
-        tags: TagType[];
-        sectionName: string;
-        sectionLabel?: string;
-        sectionUrl?: string;
-    },
-) => SimpleLinkType[] = data => {
-    const { tags, sectionName, sectionLabel } = data;
+const getSubMetaKeywordLinks: (data: {}) => SimpleLinkType[] = data => {
+    const subMetaKeywordLinks = getArray<any>(
+        data,
+        'config.page.subMetaLinks.keywords',
+        [],
+    );
 
-    const keywordTags = tags
-        .filter(
-            tag =>
-                tag.type === 'Keyword' &&
-                tag.id !== sectionLabel &&
-                tag.title.toLowerCase() !== sectionName.toLowerCase(),
-        )
-        .slice(1, 6);
-    const toneTags = tags.filter(tag => tag.type === 'Tone');
-
-    return [...keywordTags, ...toneTags].map(tag => ({
-        url: `/${tag.id}`,
-        title: tag.title,
+    return subMetaKeywordLinks.map(({ link, text }) => ({
+        url: link,
+        title: text,
     }));
 };
 
@@ -244,17 +209,8 @@ export const extract = (data: {}): CAPIType => {
         sharingUrls: getSharingUrls(data),
         pillar: findPillar(getString(data, 'config.page.pillar', '')) || 'news',
         ageWarning: getAgeWarning(tags, webPublicationDate),
-        subMetaSectionLinks: getSubMetaSectionLinks({
-            tags,
-            isImmersive,
-            isArticle,
-            ...sectionData,
-        }),
-        subMetaKeywordLinks: getSubMetaKeywordLinks({
-            tags,
-            sectionName,
-            ...sectionData,
-        }),
+        subMetaSectionLinks: getSubMetaSectionLinks(data),
+        subMetaKeywordLinks: getSubMetaKeywordLinks(data),
         ...sectionData,
         shouldHideAds: getBoolean(data, 'config.page.shouldHideAds', false),
         webURL: getNonEmptyString(data, 'config.page.webURL'),


### PR DESCRIPTION
## What does this change?

Get the submeta section label and keywords directly from the CAPI object, instead of deriving them from tag data. 

## Why?

These links are already [derived in frontend](https://github.com/guardian/frontend/blob/master/common/app/model/meta.scala#L665) (added in guardian/frontend#20654), and there's no reason to duplicate the logic in dotcom-rendering.