### PR TITLE
Always show section section

### DIFF
--- a/packages/frontend/web/components/ArticleBody.tsx
+++ b/packages/frontend/web/components/ArticleBody.tsx
@@ -492,8 +492,8 @@ const ArticleBody: React.SFC<{
     return (
         <div className={wrapper}>
             <header className={header}>
-                {CAPI.sectionLabel && CAPI.sectionUrl && (
-                    <div className={section}>
+                <div className={section}>
+                    {CAPI.sectionLabel && CAPI.sectionUrl && (
                         <a
                             className={cx(
                                 sectionLabelLink,
@@ -506,8 +506,8 @@ const ArticleBody: React.SFC<{
                         >
                             {CAPI.sectionLabel}
                         </a>
-                    </div>
-                )}
+                    )}
+                </div>
                 <div className={headlineCSS}>
                     <h1 className={headerStyle}>{CAPI.headline}</h1>
                     <div


### PR DESCRIPTION
## What does this change?

Always show the section section, even if section name and URL are not present

**Before**

![screen shot 2019-01-22 at 15 48 07](https://user-images.githubusercontent.com/5931528/51546979-37e42080-1e5d-11e9-877f-a053b6860eb3.png)

**After**

![screen shot 2019-01-22 at 15 48 30](https://user-images.githubusercontent.com/5931528/51546978-37e42080-1e5d-11e9-8f91-bf9a332944ce.png)

## Why?

Because if you don't, the layout of the main media / headline / meta area is completely broken

In frontend, it is perfectly acceptable for [these fields](https://github.com/guardian/frontend/blob/master/common/app/model/content.scala#L203-L217) to be empty strings