### PR TITLE
Extract section data from CAPI request

### DIFF
--- a/fixtures/article.ts
+++ b/fixtures/article.ts
@@ -10,6 +10,8 @@ export const data = {
             webPublicationDate: 1489173305000,
             webPublicationDateDisplay: 'Fri 10 Mar 2017 19.15 GMT',
             section: 'money',
+            sectionLabel: 'Ticket prices',
+            sectionUrl: 'money/ticket-prices',
             headline:
                 "Ticket touts face unlimited fines for using 'bots' to buy in bulk",
             webTitle:

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -94,8 +94,8 @@ interface CAPIType {
     tags: TagType[];
     pillar: Pillar;
     isImmersive: boolean;
-    sectionLabel?: string;
-    sectionUrl?: string;
+    sectionLabel: string;
+    sectionUrl: string;
     sectionName: string;
     subMetaSectionLinks: SimpleLinkType[];
     subMetaKeywordLinks: SimpleLinkType[];

--- a/packages/frontend/model/extract-capi.ts
+++ b/packages/frontend/model/extract-capi.ts
@@ -184,6 +184,8 @@ export const extract = (data: {}): CAPIType => {
         sharingUrls: getSharingUrls(data),
         pillar: findPillar(getString(data, 'config.page.pillar', '')) || 'news',
         ageWarning: getAgeWarning(tags, webPublicationDate),
+        sectionLabel: getString(data, 'config.page.sectionLabel'),
+        sectionUrl: getString(data, 'config.page.sectionUrl'),
         subMetaSectionLinks: getSubMetaSectionLinks(data),
         subMetaKeywordLinks: getSubMetaKeywordLinks(data),
         shouldHideAds: getBoolean(data, 'config.page.shouldHideAds', false),


### PR DESCRIPTION
## What does this change?

Adds `sectionUrl` and `sectionLabel` (added to DomComponents data model in frontend in guardian/frontend#20956)

## Why?

We need it for the top left bit

**Before**

![screen shot 2019-01-22 at 17 29 35](https://user-images.githubusercontent.com/5931528/51553666-50f3ce00-1e6b-11e9-83eb-933e1e3c0cf8.png)

**After**

![screen shot 2019-01-22 at 17 29 12](https://user-images.githubusercontent.com/5931528/51553628-3de0fe00-1e6b-11e9-8567-c175f6650558.png)

