### PR TITLE
 Add padding-bottom to share icons

### DIFF
--- a/packages/frontend/amp/components/ShareIcons.tsx
+++ b/packages/frontend/amp/components/ShareIcons.tsx
@@ -58,6 +58,10 @@ const shareIcon = (colour: string) => css`
     }
 `;
 
+const shareIconsList = css`
+    padding-bottom: 30px;
+`;
+
 interface ShareListItemType {
     id: SharePlatform;
     Icon: React.ComponentType;
@@ -110,7 +114,7 @@ export const ShareIcons: React.SFC<{
     }, []);
 
     return (
-        <ul className={cx([className])}>
+        <ul className={cx(shareIconsList, [className])}>
             {shareList.map(shareListItem => {
                 const { Icon, id, url, userMessage } = shareListItem;
 


### PR DESCRIPTION
## What does this change?

Add padding-bottom to share icons on AMP article
