### PR TITLE
⚡️RR links

### DIFF
--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -41,18 +41,18 @@ interface MoreType extends LinkType {
     more: true;
 }
 
-interface ReaderRevenueLink {
+interface ReaderRevenueCategories {
     contribute: string;
     subscribe: string;
     support: string;
 }
 
 interface ReaderRevenueLinks {
-    header: ReaderRevenueLink;
-    footer: ReaderRevenueLink;
-    sideMenu: ReaderRevenueLink;
-    ampHeader: ReaderRevenueLink;
-    ampFooter: ReaderRevenueLink;
+    header: ReaderRevenueCategories;
+    footer: ReaderRevenueCategories;
+    sideMenu: ReaderRevenueCategories;
+    ampHeader: ReaderRevenueCategories;
+    ampFooter: ReaderRevenueCategories;
 }
 
 interface NavType {

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -51,6 +51,8 @@ interface ReaderRevenueLinks {
     header: ReaderRevenueLink;
     footer: ReaderRevenueLink;
     sideMenu: ReaderRevenueLink;
+    ampHeader: string;
+    ampFooter: string;
 }
 
 interface NavType {

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -51,8 +51,8 @@ interface ReaderRevenueLinks {
     header: ReaderRevenueLink;
     footer: ReaderRevenueLink;
     sideMenu: ReaderRevenueLink;
-    ampHeader: string;
-    ampFooter: string;
+    ampHeader: ReaderRevenueLink;
+    ampFooter: ReaderRevenueLink;
 }
 
 interface NavType {

--- a/packages/frontend/model/extract-nav.ts
+++ b/packages/frontend/model/extract-nav.ts
@@ -26,9 +26,9 @@ const buildRRLinkCategories = (
     data: {},
     el: string,
     rrCategories: string[],
-): ReaderRevenueLink =>
+): ReaderRevenueCategories =>
     rrCategories.reduce(
-        (prevObj: ReaderRevenueLink, category: string) => ({
+        (prevObj: ReaderRevenueCategories, category: string) => ({
             ...prevObj,
             [category]: getString(
                 data,
@@ -36,7 +36,7 @@ const buildRRLinkCategories = (
                 '',
             ),
         }),
-        {} as ReaderRevenueLink,
+        {} as ReaderRevenueCategories,
     );
 
 const buildRRLinkModel = (

--- a/packages/frontend/model/extract-nav.ts
+++ b/packages/frontend/model/extract-nav.ts
@@ -28,14 +28,14 @@ const buildRRLinkCategories = (
     rrCategories: string[],
 ): ReaderRevenueLink =>
     rrCategories.reduce(
-        (prevObj: ReaderRevenueLink, category: string) =>
-            Object.assign(prevObj, {
-                [category]: getString(
-                    data,
-                    `config.readerRevenueLinks.${el}.${category}`,
-                    '',
-                ),
-            }),
+        (prevObj: ReaderRevenueLink, category: string) => ({
+            ...prevObj,
+            [category]: getString(
+                data,
+                `config.readerRevenueLinks.${el}.${category}`,
+                '',
+            ),
+        }),
         {} as ReaderRevenueLink,
     );
 

--- a/packages/frontend/model/extract-nav.ts
+++ b/packages/frontend/model/extract-nav.ts
@@ -2,12 +2,6 @@ import get from 'lodash.get';
 import { getString, getArray } from './validators';
 import { findPillar } from './find-pillar';
 
-// Reader revenue link name
-const readerRevenueConfig = {
-    rrElements: ['header', 'footer', 'sideMenu', 'ampHeader', 'ampFooter'],
-    rrCategories: ['contribute', 'subscribe', 'support'],
-};
-
 const getLink = (data: {}, { isPillar }: { isPillar: boolean }): LinkType => {
     const title = getString(data, 'title');
     return {
@@ -22,42 +16,23 @@ const getLink = (data: {}, { isPillar }: { isPillar: boolean }): LinkType => {
     };
 };
 
+const rrLinkConfig = 'config.readerRevenueLinks';
 const buildRRLinkCategories = (
     data: {},
     el: string,
-    rrCategories: string[],
-): ReaderRevenueCategories =>
-    rrCategories.reduce(
-        (prevObj: ReaderRevenueCategories, category: string) => ({
-            ...prevObj,
-            [category]: getString(
-                data,
-                `config.readerRevenueLinks.${el}.${category}`,
-                '',
-            ),
-        }),
-        {} as ReaderRevenueCategories,
-    );
+): ReaderRevenueCategories => ({
+    subscribe: getString(data, `${rrLinkConfig}.${el}.subscribe`, ''),
+    support: getString(data, `${rrLinkConfig}.${el}.support`, ''),
+    contribute: getString(data, `${rrLinkConfig}.${el}.contribute`, ''),
+});
 
-const buildRRLinkModel = (
-    data: {},
-    rrELementNames: string[],
-    rrCategoryNames: string[],
-): ReaderRevenueLinks =>
-    rrELementNames.reduce(
-        (prevObj: ReaderRevenueLinks, el: string) => ({
-            ...prevObj,
-            [el]: buildRRLinkCategories(data, el, rrCategoryNames),
-        }),
-        {} as ReaderRevenueLinks,
-    );
-
-const buildReaderRevenueLinks = (data: {}) =>
-    buildRRLinkModel(
-        data,
-        readerRevenueConfig.rrElements,
-        readerRevenueConfig.rrCategories,
-    );
+const buildRRLinkModel = (data: {}): ReaderRevenueLinks => ({
+    header: buildRRLinkCategories(data, 'header'),
+    footer: buildRRLinkCategories(data, 'footer'),
+    sideMenu: buildRRLinkCategories(data, 'sideMenu'),
+    ampHeader: buildRRLinkCategories(data, 'ampHeader'),
+    ampFooter: buildRRLinkCategories(data, 'ampFooter'),
+});
 
 export const extract = (data: {}): NavType => {
     let pillars = getArray<any>(data, 'config.nav.pillars');
@@ -93,6 +68,6 @@ export const extract = (data: {}): NavType => {
                   ),
               }
             : undefined,
-        readerRevenueLinks: buildReaderRevenueLinks(data),
+        readerRevenueLinks: buildRRLinkModel(data),
     };
 };

--- a/packages/frontend/model/extract-nav.ts
+++ b/packages/frontend/model/extract-nav.ts
@@ -2,6 +2,12 @@ import get from 'lodash.get';
 import { getString, getArray } from './validators';
 import { findPillar } from './find-pillar';
 
+// Reader revenue link name
+const readerRevenueConfig = {
+    rrElements: ['header', 'footer', 'sideMenu', 'ampHeader', 'ampFooter'],
+    rrCategories: ['contribute', 'subscribe', 'support'],
+};
+
 const getLink = (data: {}, { isPillar }: { isPillar: boolean }): LinkType => {
     const title = getString(data, 'title');
     return {
@@ -15,6 +21,43 @@ const getLink = (data: {}, { isPillar }: { isPillar: boolean }): LinkType => {
         mobileOnly: false,
     };
 };
+
+const buildRRLinkCategories = (
+    data: {},
+    el: string,
+    rrCategories: string[],
+): ReaderRevenueLink =>
+    rrCategories.reduce(
+        (prevObj: ReaderRevenueLink, category: string) =>
+            Object.assign(prevObj, {
+                [category]: getString(
+                    data,
+                    `config.readerRevenueLinks.${el}.${category}`,
+                    '',
+                ),
+            }),
+        {} as ReaderRevenueLink,
+    );
+
+const buildRRLinkModel = (
+    data: {},
+    rrELementNames: string[],
+    rrCategoryNames: string[],
+): ReaderRevenueLinks =>
+    rrELementNames.reduce(
+        (prevObj: ReaderRevenueLinks, el: string) => ({
+            ...prevObj,
+            [el]: buildRRLinkCategories(data, el, rrCategoryNames),
+        }),
+        {} as ReaderRevenueLinks,
+    );
+
+const buildReaderRevenueLinks = (data: {}) =>
+    buildRRLinkModel(
+        data,
+        readerRevenueConfig.rrElements,
+        readerRevenueConfig.rrCategories,
+    );
 
 export const extract = (data: {}): NavType => {
     let pillars = getArray<any>(data, 'config.nav.pillars');
@@ -50,92 +93,6 @@ export const extract = (data: {}): NavType => {
                   ),
               }
             : undefined,
-        readerRevenueLinks: {
-            header: {
-                contribute: getString(
-                    data,
-                    'config.readerRevenueLinks.header.contribute',
-                    '',
-                ),
-                subscribe: getString(
-                    data,
-                    'config.readerRevenueLinks.header.subscribe',
-                    '',
-                ),
-                support: getString(
-                    data,
-                    'config.readerRevenueLinks.header.support',
-                    '',
-                ),
-            },
-            footer: {
-                contribute: getString(
-                    data,
-                    'config.readerRevenueLinks.footer.contribute',
-                    '',
-                ),
-                subscribe: getString(
-                    data,
-                    'config.readerRevenueLinks.footer.subscribe',
-                    '',
-                ),
-                support: getString(
-                    data,
-                    'config.readerRevenueLinks.footer.support',
-                    '',
-                ),
-            },
-            sideMenu: {
-                contribute: getString(
-                    data,
-                    'config.readerRevenueLinks.sideMenu.contribute',
-                    '',
-                ),
-                subscribe: getString(
-                    data,
-                    'config.readerRevenueLinks.sideMenu.subscribe',
-                    '',
-                ),
-                support: getString(
-                    data,
-                    'config.readerRevenueLinks.sideMenu.support',
-                    '',
-                ),
-            },
-            ampHeader: {
-                contribute: getString(
-                    data,
-                    'config.readerRevenueLinks.ampHeader.contribute',
-                    '',
-                ),
-                subscribe: getString(
-                    data,
-                    'config.readerRevenueLinks.ampHeader.subscribe',
-                    '',
-                ),
-                support: getString(
-                    data,
-                    'config.readerRevenueLinks.ampHeader.support',
-                    '',
-                ),
-            },
-            ampFooter: {
-                contribute: getString(
-                    data,
-                    'config.readerRevenueLinks.ampFooter.contribute',
-                    '',
-                ),
-                subscribe: getString(
-                    data,
-                    'config.readerRevenueLinks.ampFooter.subscribe',
-                    '',
-                ),
-                support: getString(
-                    data,
-                    'config.readerRevenueLinks.ampFooter.support',
-                    '',
-                ),
-            },
-        },
+        readerRevenueLinks: buildReaderRevenueLinks(data),
     };
 };

--- a/packages/frontend/model/extract-nav.ts
+++ b/packages/frontend/model/extract-nav.ts
@@ -102,6 +102,40 @@ export const extract = (data: {}): NavType => {
                     '',
                 ),
             },
+            ampHeader: {
+                contribute: getString(
+                    data,
+                    'config.readerRevenueLinks.ampHeader.contribute',
+                    '',
+                ),
+                subscribe: getString(
+                    data,
+                    'config.readerRevenueLinks.ampHeader.subscribe',
+                    '',
+                ),
+                support: getString(
+                    data,
+                    'config.readerRevenueLinks.ampHeader.support',
+                    '',
+                ),
+            },
+            ampFooter: {
+                contribute: getString(
+                    data,
+                    'config.readerRevenueLinks.ampFooter.contribute',
+                    '',
+                ),
+                subscribe: getString(
+                    data,
+                    'config.readerRevenueLinks.ampFooter.subscribe',
+                    '',
+                ),
+                support: getString(
+                    data,
+                    'config.readerRevenueLinks.ampFooter.support',
+                    '',
+                ),
+            },
         },
     };
 };


### PR DESCRIPTION
## What does this change?

Adds the AMP reader revenue links from Frontend data model.

Requires: https://github.com/guardian/frontend/pull/20958

## Why?

One source of truth for RR links for use on all web platforms.