### PR TITLE
Add amp Subscribe with Google button (behind switch)

### DIFF
--- a/packages/frontend/amp/components/Header.tsx
+++ b/packages/frontend/amp/components/Header.tsx
@@ -6,6 +6,7 @@ import { headline, textSans } from '@guardian/pasteup/typography';
 import { pillarPalette } from '../../lib/pillars';
 import ArrowRight from '@guardian/pasteup/icons/arrow-right.svg';
 import { palette } from '@guardian/pasteup/palette';
+import { AmpSubscriptionGoogle } from '@frontend/amp/components/elements/AmpSubscriptionGoogle';
 
 const headerStyles = css`
     background-color: ${palette.brand.main};
@@ -174,10 +175,11 @@ const pillarLinks = (pillars: PillarType[], activePillar: Pillar) => (
 const supportLink =
     'https://support.theguardian.com/?INTCMP=header_support&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support%22%7D';
 
-const Header: React.SFC<{
+const Header: React.FunctionComponent<{
     nav: NavType;
     activePillar: Pillar;
-}> = ({ nav, activePillar }) => (
+    config: ConfigType;
+}> = ({ nav, activePillar, config }) => (
     <header className={headerStyles}>
         <div className={row}>
             <div className={supportStyles}>
@@ -186,6 +188,8 @@ const Header: React.SFC<{
                     <ArrowRight />
                 </a>
             </div>
+
+            {config.switches.subscribeWithGoogle && <AmpSubscriptionGoogle />}
 
             <a className={logoStyles} href="/">
                 <span

--- a/packages/frontend/amp/components/elements/AmpSubscriptionGoogle.tsx
+++ b/packages/frontend/amp/components/elements/AmpSubscriptionGoogle.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export const AmpSubscriptionGoogle: React.FunctionComponent = () => (
+    <section>
+        <button
+            subscriptions-action="subscribe"
+            subscriptions-service="subscribe.google.com"
+            subscriptions-display="true"
+        >
+            Subscribe
+        </button>
+    </section>
+);

--- a/packages/frontend/amp/lib/subscribe-with-google.ts
+++ b/packages/frontend/amp/lib/subscribe-with-google.ts
@@ -1,0 +1,23 @@
+const getServices = (apiUrl: string) => ({
+    services: [
+        {
+            authorizationUrl: `${apiUrl}/oauth`,
+            pingbackUrl: `${apiUrl}/pingback`,
+            actions: {
+                login: `${apiUrl}/login`,
+                subscribe: `${apiUrl}/subscribe#viewerUrl=https://google.com`,
+            },
+        },
+        {
+            serviceId: `subscribe.google.com`,
+        },
+    ],
+});
+
+export const getSubscribeWithGoogleExtensionScripts = (apiUrl: string) => [
+    `<script async custom-element="amp-subscriptions"
+src="https://cdn.ampproject.org/v0/amp-subscriptions-0.1.js"></script>`,
+    `<script async custom-element="amp-subscriptions-google" src="https://cdn.ampproject.org/v0/amp-subscriptions-google-0.1.js"></script>`,
+    `<script type="application/json" id="amp-subscriptions">
+${JSON.stringify(getServices(apiUrl))}</script>`,
+];

--- a/packages/frontend/amp/pages/Article.tsx
+++ b/packages/frontend/amp/pages/Article.tsx
@@ -62,7 +62,7 @@ export const Article: React.SFC<{
 
         <div key="main" className={backgroundColour}>
             <Container>
-                <Header nav={nav} activePillar={articleData.pillar} />
+                <Header nav={nav} activePillar={articleData.pillar} config={config} />
                 <Body
                     pillar={articleData.pillar}
                     data={articleData}

--- a/packages/frontend/amp/pages/Article.tsx
+++ b/packages/frontend/amp/pages/Article.tsx
@@ -62,7 +62,11 @@ export const Article: React.SFC<{
 
         <div key="main" className={backgroundColour}>
             <Container>
-                <Header nav={nav} activePillar={articleData.pillar} config={config} />
+                <Header
+                    nav={nav}
+                    activePillar={articleData.pillar}
+                    config={config}
+                />
                 <Body
                     pillar={articleData.pillar}
                     data={articleData}

--- a/packages/frontend/amp/server/render.tsx
+++ b/packages/frontend/amp/server/render.tsx
@@ -8,12 +8,23 @@ import { extract as extractNAV } from '@frontend/model/extract-nav';
 import { extract as extractConfig } from '@frontend/model/extract-config';
 import { extract as extractLinkedData } from '@frontend/model/extract-linked-data';
 import { AnalyticsModel } from '@frontend/amp/components/Analytics';
+import { getSubscribeWithGoogleExtensionScripts } from '@frontend/amp/lib/subscribe-with-google';
 
 export const render = ({ body }: express.Request, res: express.Response) => {
     try {
         const CAPI = extractCAPI(body);
         const linkedData = extractLinkedData(body);
-        const scripts = [...extractScripts(CAPI.elements)];
+
+        const config = extractConfig(body);
+
+        const scripts = [
+            ...extractScripts(CAPI.elements),
+            ...(config.switches.subscribeWithGoogle
+                ? getSubscribeWithGoogleExtensionScripts(
+                      config.subscribeWithGoogleApiUrl,
+                  )
+                : []),
+        ];
 
         const analytics: AnalyticsModel = {
             gaTracker: 'UA-78705427-1',
@@ -36,8 +47,8 @@ export const render = ({ body }: express.Request, res: express.Response) => {
                 <Article
                     articleData={CAPI}
                     nav={extractNAV(body)}
-                    config={extractConfig(body)}
                     analytics={analytics}
+                    config={config}
                 />
             ),
         });

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -128,6 +128,7 @@ interface ConfigType {
     ajaxUrl: string;
     sentryPublicApiKey: string;
     sentryHost: string;
+    subscribeWithGoogleApiUrl: string;
     isDev: boolean;
     switches: { [key: string]: boolean };
 }

--- a/packages/frontend/model/extract-config.ts
+++ b/packages/frontend/model/extract-config.ts
@@ -4,6 +4,11 @@ export const extract = (data: {}): ConfigType => ({
     ajaxUrl: getNonEmptyString(data, 'config.page.ajaxUrl'),
     sentryPublicApiKey: getString(data, 'config.page.sentryPublicApiKey', ''),
     sentryHost: getString(data, 'config.page.sentryHost', ''),
+    subscribeWithGoogleApiUrl: getString(
+        data,
+        'config.page.subscribeWithGoogleApiUrl',
+        '',
+    ),
     isDev: process.env.NODE_ENV === 'development',
     switches: getObject(data, 'config.page.switches', {}),
 });

--- a/packages/frontend/web/components/ShareCount.test.tsx
+++ b/packages/frontend/web/components/ShareCount.test.tsx
@@ -23,6 +23,7 @@ describe('ShareCount', () => {
         ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
         sentryHost: '',
         sentryPublicApiKey: '',
+        subscribeWithGoogleApiUrl: '',
         isDev: false,
         switches: {},
     };


### PR DESCRIPTION
## What does this change?
* Add amp Subscribe with Google button `<amp-subscription-google>`
* Behind `subscribeWithGoogle` feature switch
* Uses `config.page.subscribewithGoogleApiUrl`

## Why?
* To test Subscribe with Google integration

## Screenshot

This position isn't finalised (look at it!) - but allows us to test the integation.

<img width="628" alt="screen shot 2019-01-23 at 14 59 25" src="https://user-images.githubusercontent.com/249676/51620314-fe2d1b80-1f29-11e9-8464-08e849d453e0.png">
