### PR TITLE
⚡️�🚫

### DIFF
--- a/packages/frontend/amp/components/elements/EmbedBlockComponent.tsx
+++ b/packages/frontend/amp/components/elements/EmbedBlockComponent.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export const EmbedBlockComponent: React.SFC<{
+    element: EmbedBlockElement;
+}> = ({ element }) => {
+    if (element.isMandatory) {
+        throw new Error(
+            'This page cannot be rendered due to incompatible content that is marked as mandatory.',
+        );
+    }
+    return null;
+};

--- a/packages/frontend/amp/components/lib/Elements.tsx
+++ b/packages/frontend/amp/components/lib/Elements.tsx
@@ -8,6 +8,7 @@ import { CommentBlockComponent } from '@frontend/amp/components/elements/Comment
 import { RichLinkBlockComponent } from '@frontend/amp/components/elements/RichLinkBlockComponent';
 import { SoundcloudBlockComponent } from '@frontend/amp/components/elements/SoundcloudBlockComponent';
 import { findAdSlots } from '@frontend/amp/lib/find-adslots';
+import { EmbedBlockComponent } from '@frontend/amp/components/elements/EmbedBlockComponent';
 
 export const Elements: React.SFC<{
     elements: CAPIElement[];
@@ -43,9 +44,16 @@ export const Elements: React.SFC<{
                 return <CommentBlockComponent element={element} />;
             case 'model.dotcomrendering.pageElements.SoundcloudBlockElement':
                 return <SoundcloudBlockComponent element={element} />;
+            case 'model.dotcomrendering.pageElements.EmbedBlockElement':
+                return <EmbedBlockComponent element={element} />;
             default:
                 // tslint:disable-next-line:no-console
                 console.log('Unsupported Element', JSON.stringify(element));
+                if ((element as { isMandatory?: boolean }).isMandatory) {
+                    throw new Error(
+                        'This page cannot be rendered due to incompatible content that is marked as mandatory.',
+                    );
+                }
                 return null;
         }
     });

--- a/packages/frontend/lib/content.d.ts
+++ b/packages/frontend/lib/content.d.ts
@@ -82,6 +82,14 @@ interface SoundcloudBlockElement {
     isMandatory: boolean;
 }
 
+interface EmbedBlockElement {
+    _type: 'model.dotcomrendering.pageElements.EmbedBlockElement';
+    safe?: boolean;
+    alt?: string;
+    html: string;
+    isMandatory: boolean;
+}
+
 type CAPIElement =
     | TextBlockElement
     | ImageBlockElement
@@ -89,4 +97,5 @@ type CAPIElement =
     | TweetBlockElement
     | RichLinkBlockElement
     | CommentBlockElement
-    | SoundcloudBlockElement;
+    | SoundcloudBlockElement
+    | EmbedBlockElement;


### PR DESCRIPTION
## What does this change?
This causes amp to 500 when we hit a mandatory embed that won't¹ render.
## Why?
So we can finally respect `isMandatory`

## Todo
We probably should add logging now

1) Currently that is generic any embed.