### PR TITLE
Implement tslint rule no-default-export

### DIFF
--- a/packages/frontend/amp/components/Body.tsx
+++ b/packages/frontend/amp/components/Body.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
-import InnerContainer from '@frontend/amp/components/InnerContainer';
+import { InnerContainer } from '@frontend/amp/components/InnerContainer';
 import { Elements } from '@frontend/amp/components/lib/Elements';
 import { css } from 'emotion';
 import { ArticleModel } from '@frontend/amp/pages/Article';
 import { MainBlock } from '@frontend/amp/components/MainBlock';
-import Submeta from '@frontend/amp/components/Submeta';
+import { Submeta } from '@frontend/amp/components/Submeta';
 
 const body = css`
     background-color: white;
 `;
 
-const Body: React.SFC<{
+export const Body: React.SFC<{
     pillar: Pillar;
     data: ArticleModel;
     config: ConfigType;
@@ -27,5 +27,3 @@ const Body: React.SFC<{
         />
     </InnerContainer>
 );
-
-export default Body;

--- a/packages/frontend/amp/components/Container.tsx
+++ b/packages/frontend/amp/components/Container.tsx
@@ -6,7 +6,7 @@ const container = css`
     max-width: 600px;
 `;
 
-const Container: React.SFC<{
+export const Container: React.SFC<{
     className?: string;
     children: React.ReactNode;
 }> = ({ className, children, ...props }) => (
@@ -14,5 +14,3 @@ const Container: React.SFC<{
         {children}
     </div>
 );
-
-export default Container;

--- a/packages/frontend/amp/components/Footer.tsx
+++ b/packages/frontend/amp/components/Footer.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 import { body, textSans } from '@guardian/pasteup/typography';
 import { palette } from '@guardian/pasteup/palette';
-import InnerContainer from './InnerContainer';
+import { InnerContainer } from './InnerContainer';
 import { Link, footerLinksNew } from '@frontend/lib/footer-links';
 
 const footer = css`
@@ -133,7 +133,7 @@ const FooterLinks: React.SFC<{
     return <div className={footerList}>{linkGroups}</div>;
 };
 
-const Footer: React.SFC = () => (
+export const Footer: React.SFC = () => (
     <footer className={footer}>
         <InnerContainer>
             <div className={footerInner}>
@@ -154,5 +154,3 @@ const Footer: React.SFC = () => (
         </InnerContainer>
     </footer>
 );
-
-export default Footer;

--- a/packages/frontend/amp/components/Header.tsx
+++ b/packages/frontend/amp/components/Header.tsx
@@ -175,7 +175,7 @@ const pillarLinks = (pillars: PillarType[], activePillar: Pillar) => (
 const supportLink =
     'https://support.theguardian.com/?INTCMP=header_support&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support%22%7D';
 
-const Header: React.FunctionComponent<{
+export const Header: React.FunctionComponent<{
     nav: NavType;
     activePillar: Pillar;
     config: ConfigType;
@@ -213,5 +213,3 @@ const Header: React.FunctionComponent<{
         </div>
     </header>
 );
-
-export default Header;

--- a/packages/frontend/amp/components/InnerContainer.tsx
+++ b/packages/frontend/amp/components/InnerContainer.tsx
@@ -6,7 +6,7 @@ const style = css`
     padding-right: 10px;
 `;
 
-const InnerContainer: React.SFC<{
+export const InnerContainer: React.SFC<{
     className?: string;
     children: React.ReactNode;
 }> = ({ className, children, ...props }) => (
@@ -14,5 +14,3 @@ const InnerContainer: React.SFC<{
         {children}
     </div>
 );
-
-export default InnerContainer;

--- a/packages/frontend/amp/components/MainBlock.tsx
+++ b/packages/frontend/amp/components/MainBlock.tsx
@@ -3,7 +3,7 @@ import { headline, textSans, body } from '@guardian/pasteup/typography';
 import { css, cx } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
 import { pillarMap, pillarPalette } from '@frontend/lib/pillars';
-import Dateline from '@frontend/web/components/Dateline';
+import { Dateline } from '@frontend/web/components/Dateline';
 import { ShareCount } from '@frontend/web/components/ShareCount';
 import ClockIcon from '@guardian/pasteup/icons/clock.svg';
 import { ShareIcons } from '@frontend/amp/components/ShareIcons';

--- a/packages/frontend/amp/components/Onward.tsx
+++ b/packages/frontend/amp/components/Onward.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 import Plus from '@guardian/pasteup/icons/plus.svg';
-import InnerContainer from '@frontend/amp/components/InnerContainer';
+import { InnerContainer } from '@frontend/amp/components/InnerContainer';
 import { OnwardContainer } from '@frontend/amp/components/OnwardContainer';
 
 const wrapper = css`

--- a/packages/frontend/amp/components/Sidebar.tsx
+++ b/packages/frontend/amp/components/Sidebar.tsx
@@ -201,7 +201,7 @@ const template = `
 `;
 
 // tslint:disable:react-no-dangerous-html
-const Sidebar: React.SFC<{ nav: NavType }> = ({ nav }) => (
+export const Sidebar: React.SFC<{ nav: NavType }> = ({ nav }) => (
     <amp-sidebar class={sidebarStyles} layout="nodisplay" id="sidebar1">
         <amp-list
             layout="fill"
@@ -213,5 +213,3 @@ const Sidebar: React.SFC<{ nav: NavType }> = ({ nav }) => (
         </amp-list>
     </amp-sidebar>
 );
-
-export default Sidebar;

--- a/packages/frontend/amp/components/Submeta.tsx
+++ b/packages/frontend/amp/components/Submeta.tsx
@@ -93,7 +93,7 @@ const siteLinkStyle = css`
     line-height: 36px;
 `;
 
-const Submeta: React.SFC<{
+export const Submeta: React.SFC<{
     pillar: Pillar;
     sections: SimpleLinkType[];
     keywords: SimpleLinkType[];
@@ -157,5 +157,3 @@ const Submeta: React.SFC<{
         </>
     );
 };
-
-export default Submeta;

--- a/packages/frontend/amp/pages/Article.tsx
+++ b/packages/frontend/amp/pages/Article.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import Footer from '@frontend/amp/components/Footer';
-import Container from '@frontend/amp/components/Container';
-import Body from '@frontend/amp/components/Body';
-import Header from '@frontend/amp/components/Header';
+import { Footer } from '@frontend/amp/components/Footer';
+import { Container } from '@frontend/amp/components/Container';
+import { Body } from '@frontend/amp/components/Body';
+import { Header } from '@frontend/amp/components/Header';
 import { palette } from '@guardian/pasteup/palette';
 import { Onward } from '@frontend/amp/components/Onward';
 import { css } from 'emotion';
-import Sidebar from '@frontend/amp/components/Sidebar';
+import { Sidebar } from '@frontend/amp/components/Sidebar';
 import { Analytics, AnalyticsModel } from '@frontend/amp/components/Analytics';
 
 const backgroundColour = css`

--- a/packages/frontend/amp/server/document.tsx
+++ b/packages/frontend/amp/server/document.tsx
@@ -4,7 +4,7 @@ import { renderToString } from 'react-dom/server';
 import { CacheProvider } from '@emotion/core';
 import { cache } from 'emotion';
 import resetCSS from /* preval */ '@frontend/lib/reset-css';
-import fontsCss from '@frontend/lib/fonts-css';
+import { getFontsCss } from '@frontend/lib/fonts-css';
 
 interface RenderToStringResult {
     html: string;
@@ -33,7 +33,7 @@ export const document = ({
     <title>${title}</title>
     <link rel="canonical" href="self.html" />
     <meta name="viewport" content="width=device-width,minimum-scale=1">
-    
+
     <script type="application/ld+json">
         ${JSON.stringify(linkedData)}
     </script>
@@ -52,7 +52,7 @@ export const document = ({
     <!-- AMP elements that are optional dependending on content -->
     ${scripts.join(' ')}
 
-    <style amp-custom>${fontsCss}${resetCSS}${css}</style>
+    <style amp-custom>${getFontsCss()}${resetCSS}${css}</style>
     </head>
     <body>
     ${html}

--- a/packages/frontend/app/aws/metrics-baseline.ts
+++ b/packages/frontend/app/aws/metrics-baseline.ts
@@ -28,7 +28,7 @@ collectAndSendAWSMetrics(
 
 // records system metrics
 
-const recordBaselineCloudWatchMetrics = () => {
+export const recordBaselineCloudWatchMetrics = () => {
     disk.check('/', (err, diskinfo) => {
         if (err) {
             // tslint:disable-next-line:no-console
@@ -42,5 +42,3 @@ const recordBaselineCloudWatchMetrics = () => {
         }
     });
 };
-
-export default recordBaselineCloudWatchMetrics;

--- a/packages/frontend/app/server.ts
+++ b/packages/frontend/app/server.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import express from 'express';
 import compression from 'compression';
 
-import recordBaselineCloudWatchMetrics from './aws/metrics-baseline';
+import { recordBaselineCloudWatchMetrics } from './aws/metrics-baseline';
 import {
     getGuardianConfiguration,
     GuardianConfiguration,
@@ -13,6 +13,7 @@ import { render as renderAMPArticle } from '@frontend/amp/server/render';
 import { render as renderArticle } from '@frontend/web/server/render';
 
 // this export is the function used by webpackHotServerMiddleware in /scripts/frontend-dev-server
+// tslint:disable-next-line:no-default-export
 export default (options: any) => {
     if ('amp' in options) return renderAMPArticle;
     return renderArticle;

--- a/packages/frontend/lib/assets.ts
+++ b/packages/frontend/lib/assets.ts
@@ -23,8 +23,8 @@ const CDN = stage
     ? `//assets${stage === 'CODE' ? '-code' : ''}.guim.co.uk/guui/`
     : '/';
 
-export default {
-    dist: (path: string): string => `${CDN}assets/${assetHash[path] || path}`,
-    static: (path: string): string =>
-        `${CDN}static/frontend/${assetHash[path] || path}`,
-};
+export const getDist = (path: string): string =>
+    `${CDN}assets/${assetHash[path] || path}`;
+
+export const getStatic = (path: string): string =>
+    `${CDN}static/frontend/${assetHash[path] || path}`;

--- a/packages/frontend/lib/fonts-css.ts
+++ b/packages/frontend/lib/fonts-css.ts
@@ -1,5 +1,5 @@
 import { default as minifyCssString } from 'minify-css-string';
-import assets from './assets';
+import { getStatic } from './assets';
 
 type FontFamily =
     | 'GH Guardian Headline'
@@ -151,9 +151,9 @@ const template: (_: FontDisplay) => string = ({
 }) => `
     @font-face {
         font-family: "${family}";
-        src: url(${assets.static(woff2)}) format("woff2"),
-                url(${assets.static(woff)}) format("woff"),
-                url(${assets.static(ttf)}) format("truetype");
+        src: url(${getStatic(woff2)}) format("woff2"),
+                url(${getStatic(woff)}) format("woff"),
+                url(${getStatic(ttf)}) format("truetype");
         font-weight: ${weight};
         font-style: ${style};
         font-display: swap;
@@ -167,4 +167,4 @@ const getStyleString: () => string = () => {
     );
 };
 
-export default minifyCssString(getStyleString());
+export const getFontsCss = () => minifyCssString(getStyleString());

--- a/packages/frontend/model/clean.ts
+++ b/packages/frontend/model/clean.ts
@@ -6,7 +6,7 @@ import { minify } from 'html-minifier';
 const { window } = new JSDOM('');
 const DOMPurify = createDOMPurify(window);
 
-export default compose(
+export const clean = compose(
     (s: string) =>
         minify(s, {
             collapseWhitespace: true,

--- a/packages/frontend/model/extract-capi.test.ts
+++ b/packages/frontend/model/extract-capi.test.ts
@@ -1,6 +1,6 @@
 import cloneDeep from 'lodash.clonedeep';
 import { string as curly_ } from 'curlyquotes';
-import clean_ from './clean';
+import { clean as clean_ } from './clean';
 import { findPillar as findPillar_ } from './find-pillar';
 import { getSharingUrls as getSharingUrls_ } from './sharing-urls';
 import { extract } from './extract-capi';
@@ -17,7 +17,9 @@ jest.mock('./find-pillar', () => ({
 jest.mock('curlyquotes', () => ({
     string: jest.fn(),
 }));
-jest.mock('./clean', () => jest.fn());
+jest.mock('./clean', () => ({
+    clean: jest.fn(),
+}));
 jest.mock('./sharing-urls', () => ({
     getSharingUrls: jest.fn(),
 }));

--- a/packages/frontend/model/extract-capi.ts
+++ b/packages/frontend/model/extract-capi.ts
@@ -6,7 +6,7 @@ import {
     getBoolean,
     getArray,
 } from './validators';
-import clean from './clean';
+import { clean } from './clean';
 import { getSharingUrls } from './sharing-urls';
 import { findPillar } from './find-pillar';
 

--- a/packages/frontend/web/browser.ts
+++ b/packages/frontend/web/browser.ts
@@ -7,7 +7,7 @@ import {
     init as initGa,
     sendPageView as sendGaPageView,
 } from '@frontend/web/browser/ga';
-import Article from './pages/Article';
+import { Article } from './pages/Article';
 import { ReportedError } from '@frontend/web/browser/reportError';
 
 if (module.hot) {

--- a/packages/frontend/web/components/ArticleBody.tsx
+++ b/packages/frontend/web/components/ArticleBody.tsx
@@ -19,7 +19,7 @@ import { ArticleRenderer } from '@frontend/web/components/lib/ArticleRenderer';
 import { ShareCount } from './ShareCount';
 import { SharingIcons } from './ShareIcons';
 import { SubMetaLinksList } from './SubMetaLinksList';
-import Dateline from './Dateline';
+import { Dateline } from './Dateline';
 
 import { MainMedia } from './MainMedia';
 
@@ -482,7 +482,7 @@ const BylineContributor: React.SFC<{
     </a>
 );
 
-const ArticleBody: React.SFC<{
+export const ArticleBody: React.SFC<{
     CAPI: CAPIType;
     config: ConfigType;
 }> = ({ CAPI, config }) => {
@@ -614,5 +614,3 @@ const ArticleBody: React.SFC<{
         </div>
     );
 };
-
-export default ArticleBody;

--- a/packages/frontend/web/components/BackToTop.tsx
+++ b/packages/frontend/web/components/BackToTop.tsx
@@ -53,7 +53,7 @@ const link = css`
     color: ${palette.neutral[7]};
 `;
 
-const BackToTop: React.SFC = () => (
+export const BackToTop: React.SFC = () => (
     <a className={link} href="#top">
         <div className={outerWrapper}>
             <Container className={innerWrapper}>
@@ -65,5 +65,3 @@ const BackToTop: React.SFC = () => (
         </div>
     </a>
 );
-
-export default BackToTop;

--- a/packages/frontend/web/components/CookieBanner.test.tsx
+++ b/packages/frontend/web/components/CookieBanner.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, fireEvent } from 'react-testing-library';
-import CookieBanner from './CookieBanner';
+import { CookieBanner } from './CookieBanner';
 import {
     getCookie as getCookie_,
     addCookie as addCookie_,

--- a/packages/frontend/web/components/CookieBanner.tsx
+++ b/packages/frontend/web/components/CookieBanner.tsx
@@ -81,7 +81,7 @@ const actions = css`
 
 const consentCookie = 'GU_TK';
 
-export default class CookieBanner extends Component<{}, { show: boolean }> {
+export class CookieBanner extends Component<{}, { show: boolean }> {
     constructor(props: {}) {
         super(props);
 

--- a/packages/frontend/web/components/Dateline.tsx
+++ b/packages/frontend/web/components/Dateline.tsx
@@ -16,12 +16,10 @@ const dateline = css`
     margin-bottom: 6px;
 `;
 
-const Dateline: React.SFC<{
+export const Dateline: React.SFC<{
     dateDisplay: string;
 }> = ({ dateDisplay }) => (
     <>
         <div className={dateline}>{dateDisplay}</div>
     </>
 );
-
-export default Dateline;

--- a/packages/frontend/web/components/Footer.tsx
+++ b/packages/frontend/web/components/Footer.tsx
@@ -110,7 +110,7 @@ const FooterLinks: React.SFC<{
     return <div className={footerList}>{linkGroups}</div>;
 };
 
-const Footer: React.SFC = () => (
+export const Footer: React.SFC = () => (
     <footer className={footer}>
         <Container className={footerInner}>
             <iframe
@@ -133,5 +133,3 @@ const Footer: React.SFC = () => (
         </Container>
     </footer>
 );
-
-export default Footer;

--- a/packages/frontend/web/components/Header/Header.tsx
+++ b/packages/frontend/web/components/Header/Header.tsx
@@ -3,7 +3,7 @@ import { css } from 'emotion';
 
 import { tablet } from '@guardian/pasteup/breakpoints';
 
-import Nav from './Nav/Nav';
+import { Nav } from './Nav/Nav';
 import { palette } from '@guardian/pasteup/palette';
 
 const header = css`
@@ -15,7 +15,7 @@ const header = css`
     }
 `;
 
-const Header: React.SFC<{
+export const Header: React.SFC<{
     nav: NavType;
     pillar: Pillar;
     edition: Edition;
@@ -24,5 +24,3 @@ const Header: React.SFC<{
         <Nav nav={nav} pillar={pillar} edition={edition} />
     </header>
 );
-
-export default Header;

--- a/packages/frontend/web/components/Header/Nav/EditionDropdown.tsx
+++ b/packages/frontend/web/components/Header/Nav/EditionDropdown.tsx
@@ -63,7 +63,7 @@ const lookUpEditionLink = (edition: Edition): Link => {
     return mapping[edition];
 };
 
-const EditionDropdown: React.SFC<{
+export const EditionDropdown: React.SFC<{
     edition: Edition;
 }> = ({ edition }) => {
     const activeEditionLink = lookUpEditionLink(edition);
@@ -84,5 +84,3 @@ const EditionDropdown: React.SFC<{
         </div>
     );
 };
-
-export default EditionDropdown;

--- a/packages/frontend/web/components/Header/Nav/Links/Links.tsx
+++ b/packages/frontend/web/components/Header/Nav/Links/Links.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 
-import Dropdown, {
+import {
+    Dropdown,
     Link as DropdownLink,
 } from '@guardian/guui/components/Dropdown/Dropdown';
 import ProfileIcon from '@guardian/pasteup/icons/profile.svg';
@@ -174,7 +175,7 @@ const identityLinks: DropdownLink[] = [
     },
 ];
 
-const Links: React.SFC<{
+export const Links: React.SFC<{
     isSignedIn: boolean;
 }> = ({ isSignedIn }) => (
     <div className={links}>
@@ -216,5 +217,3 @@ const Links: React.SFC<{
         </Search>
     </div>
 );
-
-export default Links;

--- a/packages/frontend/web/components/Header/Nav/Links/SupportTheGuardian.tsx
+++ b/packages/frontend/web/components/Header/Nav/Links/SupportTheGuardian.tsx
@@ -87,7 +87,7 @@ const mobileSignInIcon = css`
     fill: ${palette.neutral[46]};
 `;
 
-const SupportTheGuardian: React.SFC<{
+export const SupportTheGuardian: React.SFC<{
     url: string;
 }> = ({ url }) => (
     <AsyncClientComponent f={shouldShow}>
@@ -140,5 +140,3 @@ const isRecentContributor: () => boolean = () => {
 const isPayingMember: () => boolean = () => {
     return getCookie('gu_paying_member') === 'true';
 };
-
-export default SupportTheGuardian;

--- a/packages/frontend/web/components/Header/Nav/Logo.tsx
+++ b/packages/frontend/web/components/Header/Nav/Logo.tsx
@@ -59,7 +59,7 @@ const style = css`
 
 const SVG = () => <TheGuardianLogoSVG className={style} />;
 
-const Logo: React.SFC = () => (
+export const Logo: React.SFC = () => (
     <a className={link} href="/">
         <span
             className={css`
@@ -71,4 +71,3 @@ const Logo: React.SFC = () => (
         <SVG />
     </a>
 );
-export default Logo;

--- a/packages/frontend/web/components/Header/Nav/MainMenuToggle/MainMenuToggle.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenuToggle/MainMenuToggle.tsx
@@ -77,7 +77,10 @@ interface Props {
     ariaControls: string;
 }
 
-class MainMenuToggle extends Component<Props, { enhanceCheckbox: boolean }> {
+export class MainMenuToggle extends Component<
+    Props,
+    { enhanceCheckbox: boolean }
+> {
     constructor(props: Props) {
         super(props);
 
@@ -158,5 +161,3 @@ class MainMenuToggle extends Component<Props, { enhanceCheckbox: boolean }> {
         ];
     }
 }
-
-export default MainMenuToggle;

--- a/packages/frontend/web/components/Header/Nav/Nav.tsx
+++ b/packages/frontend/web/components/Header/Nav/Nav.tsx
@@ -3,14 +3,14 @@ import { css } from 'emotion';
 import { clearFix } from '@guardian/pasteup/mixins';
 import { tablet, desktop, leftCol, wide } from '@guardian/pasteup/breakpoints';
 
-import Logo from './Logo';
-import EditionDropdown from './EditionDropdown';
-import Links from './Links/Links';
-import Pillars from './Pillars';
-import MainMenuToggle from './MainMenuToggle/MainMenuToggle';
+import { Logo } from './Logo';
+import { EditionDropdown } from './EditionDropdown';
+import { Links } from './Links/Links';
+import { Pillars } from './Pillars';
+import { MainMenuToggle } from './MainMenuToggle/MainMenuToggle';
 import { MainMenu } from './MainMenu/MainMenu';
-import SubNav from './SubNav/SubNav';
-import ReaderRevenueLinks from './ReaderRevenueLinks';
+import { SubNav } from './SubNav/SubNav';
+import { ReaderRevenueLinks } from './ReaderRevenueLinks';
 import { getCookie } from '@frontend/web/browser/cookie';
 
 const centered = css`
@@ -37,7 +37,7 @@ interface Props {
     edition: Edition;
 }
 
-export default class Nav extends Component<
+export class Nav extends Component<
     Props,
     { showMainMenu: boolean; isSignedIn: boolean }
 > {

--- a/packages/frontend/web/components/Header/Nav/Pillars.tsx
+++ b/packages/frontend/web/components/Header/Nav/Pillars.tsx
@@ -186,7 +186,7 @@ const forceUnderline = css`
     }
 `; // A11Y warning: this styling has no focus state for the selected pillar
 
-const Pillars: React.SFC<{
+export const Pillars: React.SFC<{
     showMainMenu: boolean;
     pillars: PillarType[];
     pillar: Pillar;
@@ -212,4 +212,3 @@ const Pillars: React.SFC<{
         ))}
     </ul>
 );
-export default Pillars;

--- a/packages/frontend/web/components/Header/Nav/ReaderRevenueLinks.test.tsx
+++ b/packages/frontend/web/components/Header/Nav/ReaderRevenueLinks.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, wait } from 'react-testing-library';
-import ReaderRevenueLinks from './ReaderRevenueLinks';
+import { ReaderRevenueLinks } from './ReaderRevenueLinks';
 import {
     getCookie as getCookie_,
     addCookie as addCookie_,

--- a/packages/frontend/web/components/Header/Nav/ReaderRevenueLinks.tsx
+++ b/packages/frontend/web/components/Header/Nav/ReaderRevenueLinks.tsx
@@ -108,7 +108,7 @@ const readerRevenueLinks = css`
     }
 `;
 
-const ReaderRevenueLinks: React.SFC<{
+export const ReaderRevenueLinks: React.SFC<{
     edition: Edition;
     urls: {
         subscribe: string;
@@ -183,5 +183,3 @@ const isRecentContributor: () => boolean = () => {
 const isPayingMember: () => boolean = () => {
     return getCookie('gu_paying_member') === 'true';
 };
-
-export default ReaderRevenueLinks;

--- a/packages/frontend/web/components/Header/Nav/SubNav/SubNav.tsx
+++ b/packages/frontend/web/components/Header/Nav/SubNav/SubNav.tsx
@@ -43,7 +43,7 @@ interface Props {
     currentNavLink: string;
 }
 
-export default class Subnav extends Component<
+export class SubNav extends Component<
     Props,
     {
         showMore: boolean;

--- a/packages/frontend/web/pages/Article.tsx
+++ b/packages/frontend/web/pages/Article.tsx
@@ -5,12 +5,12 @@ import { palette } from '@guardian/pasteup/palette';
 import { desktop, mobileLandscape } from '@guardian/pasteup/breakpoints';
 
 import { MostViewed } from '@frontend/web/components/MostViewed';
-import Header from '@frontend/web/components/Header/Header';
-import Footer from '@frontend/web/components/Footer';
-import ArticleBody from '@frontend/web/components/ArticleBody';
-import BackToTop from '@frontend/web/components/BackToTop';
-import SubNav from '@frontend/web/components/Header/Nav/SubNav/SubNav';
-import CookieBanner from '@frontend/web/components/CookieBanner';
+import { Header } from '@frontend/web/components/Header/Header';
+import { Footer } from '@frontend/web/components/Footer';
+import { ArticleBody } from '@frontend/web/components/ArticleBody';
+import { BackToTop } from '@frontend/web/components/BackToTop';
+import { SubNav } from '@frontend/web/components/Header/Nav/SubNav/SubNav';
+import { CookieBanner } from '@frontend/web/components/CookieBanner';
 
 // TODO: find a better of setting opacity
 const articleWrapper = css`
@@ -44,7 +44,7 @@ const articleContainer = css`
     }
 `;
 
-const Article: React.SFC<{
+export const Article: React.SFC<{
     data: ArticleProps;
 }> = ({ data }) => (
     <div>
@@ -75,5 +75,3 @@ const Article: React.SFC<{
         <CookieBanner />
     </div>
 );
-
-export default Article;

--- a/packages/frontend/web/server/document.tsx
+++ b/packages/frontend/web/server/document.tsx
@@ -4,9 +4,9 @@ import { renderToString } from 'react-dom/server';
 import { cache } from 'emotion';
 import { CacheProvider } from '@emotion/core';
 
-import htmlTemplate from './htmlTemplate';
-import Article from '../pages/Article';
-import assets from '@frontend/lib/assets';
+import { htmlTemplate } from './htmlTemplate';
+import { Article } from '../pages/Article';
+import { getDist } from '@frontend/lib/assets';
 import { GADataType } from '@frontend/model/extract-ga';
 
 interface Props {
@@ -27,7 +27,7 @@ interface RenderToStringResult {
     ids: string[];
 }
 
-export default ({ data }: Props) => {
+export const document = ({ data }: Props) => {
     const { page, site, CAPI, NAV, config, linkedData } = data;
     const title = `${CAPI.headline} | ${CAPI.sectionLabel} | The Guardian`;
     const { html, css, ids: cssIDs }: RenderToStringResult = extractCritical(
@@ -64,8 +64,8 @@ export default ({ data }: Props) => {
      * Please talk to the dotcom platform team before adding more.
      * Scripts will be executed in the order they appear in this array
      */
-    const bundleJS = assets.dist(`${site}.${page.toLowerCase()}.js`);
-    const vendorJS = assets.dist('vendor.js');
+    const bundleJS = getDist(`${site}.${page.toLowerCase()}.js`);
+    const vendorJS = getDist('vendor.js');
     const polyfillIO =
         'https://assets.guim.co.uk/polyfill.io/v2/polyfill.min.js?rum=0&features=es6,es7,es2017,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry&flags=gated&callback=guardianPolyfilled&unknown=polyfill';
     const priorityScripts = [polyfillIO, vendorJS, bundleJS];

--- a/packages/frontend/web/server/htmlTemplate.ts
+++ b/packages/frontend/web/server/htmlTemplate.ts
@@ -1,8 +1,8 @@
 import resetCSS from /* preval */ '@frontend/lib/reset-css';
-import fontsCSS from '@frontend/lib/fonts-css';
-import assets from '@frontend/lib/assets';
+import { getFontsCss } from '@frontend/lib/fonts-css';
+import { getStatic } from '@frontend/lib/assets';
 
-export default ({
+export const htmlTemplate = ({
     title = 'The Guardian',
     linkedData,
     priorityScripts,
@@ -35,7 +35,7 @@ export default ({
                 <script type="application/ld+json">
                     ${JSON.stringify(linkedData)}
                 </script>
-                
+
                 ${priorityScripts
                     .map(
                         url => `<link rel="preload" href="${url}" as="script">`,
@@ -44,12 +44,12 @@ export default ({
                 ${fontFiles
                     .map(
                         fontFile =>
-                            `<link rel="preload" href="${assets.static(
+                            `<link rel="preload" href="${getStatic(
                                 fontFile,
                             )}" as="font" crossorigin>`,
                     )
                     .join('\n')}
-                <style>${fontsCSS}${resetCSS}${css}</style>
+                <style>${getFontsCss()}${resetCSS}${css}</style>
                 <script>
                 window.guardian = ${JSON.stringify({
                     app: {

--- a/packages/frontend/web/server/render.ts
+++ b/packages/frontend/web/server/render.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 
-import document from '@frontend/web/server/document';
+import { document } from '@frontend/web/server/document';
 import { extract as extractCAPI } from '@frontend/model/extract-capi';
 import { extract as extractNAV } from '@frontend/model/extract-nav';
 import { extract as extractGA } from '@frontend/model/extract-ga';

--- a/packages/guui/components/BigNumber/BigNumber.tsx
+++ b/packages/guui/components/BigNumber/BigNumber.tsx
@@ -14,7 +14,7 @@ import Number10 from './10.svg';
 // tslint:disable:jsx-key
 // This file contains an array of elements, but only exposes one.
 
-const BigNumber = ({ index }: { index: number }) => {
+export const BigNumber = ({ index }: { index: number }) => {
     const numbers = [
         <Number0 />,
         <Number1 />,
@@ -31,5 +31,3 @@ const BigNumber = ({ index }: { index: number }) => {
 
     return numbers[index];
 };
-
-export default BigNumber;

--- a/packages/guui/components/CloseButton/CloseButton.tsx
+++ b/packages/guui/components/CloseButton/CloseButton.tsx
@@ -20,11 +20,9 @@ const closeButton = (foregroundColour: string, backgroundColour: string) => css`
     }
 `;
 
-const CloseButton: React.SFC<{
+export const CloseButton: React.SFC<{
     foregroundColour: string;
     backgroundColour: string;
 }> = ({ foregroundColour, backgroundColour }) => (
     <CloseIcon className={closeButton(foregroundColour, backgroundColour)} />
 );
-
-export default CloseButton;

--- a/packages/guui/components/Container/Container.tsx
+++ b/packages/guui/components/Container/Container.tsx
@@ -23,7 +23,7 @@ const container = css`
     }
 `;
 
-const Container: React.SFC<{
+export const Container: React.SFC<{
     className?: string;
     children: React.ReactNode;
 }> = ({ className, children, ...props }) => (
@@ -31,5 +31,3 @@ const Container: React.SFC<{
         {children}
     </div>
 );
-
-export default Container;

--- a/packages/guui/components/Dropdown/Dropdown.tsx
+++ b/packages/guui/components/Dropdown/Dropdown.tsx
@@ -138,7 +138,7 @@ const buttonExpanded = css`
     }
 `;
 
-export default class Dropdown extends React.Component<
+export class Dropdown extends React.Component<
     Props,
     { isExpanded: boolean; noJS: boolean }
 > {

--- a/packages/guui/index.ts
+++ b/packages/guui/index.ts
@@ -1,6 +1,6 @@
 // Components
-export { default as CloseButton } from './components/CloseButton/CloseButton';
-export { default as Dropdown } from './components/Dropdown/Dropdown';
-export { default as BigNumber } from './components/BigNumber/BigNumber';
-export { default as Container } from './components/Container/Container';
+export { CloseButton } from './components/CloseButton/CloseButton';
+export { Dropdown } from './components/Dropdown/Dropdown';
+export { BigNumber } from './components/BigNumber/BigNumber';
+export { Container } from './components/Container/Container';
 export { Cols as GridCols, Row as GridRow } from './components/Grid/Grid';

--- a/tslint.json
+++ b/tslint.json
@@ -33,16 +33,12 @@
             "allow-pascal-case",
             "allow-trailing-underscore"
         ],
-        // "no-default-export": {
-        //     "severity": "warning"
-        // },
-        "react-no-dangerous-html":true,
+        "no-default-export": true,
+        "react-no-dangerous-html": true,
         "prettier": true
     },
     "rulesDirectory": [],
     "linterOptions": {
-        "exclude": [
-            "packages/*/dist/**/*.js"
-        ]
+        "exclude": ["packages/*/dist/**/*.js"]
     }
 }


### PR DESCRIPTION
## What does this change?

We currently use named and default exports throughout our code with no convention in place. The team have spoken and agreed named exports are preferable. https://humanwhocodes.com/blog/2019/01/stop-using-default-exports-javascript-module/ is a good account of why this may be. 

This PR implements the `no-default-export` rule to `tslint` and converts the default exports we currently have to named.
