### PR TITLE
Reducing size of video icon and changing comment icon fill

### DIFF
--- a/packages/frontend/amp/components/OnwardContainer.tsx
+++ b/packages/frontend/amp/components/OnwardContainer.tsx
@@ -74,6 +74,17 @@ const iconCSS = css`
     svg {
         fill: ${palette.neutral[7]};
         padding-right: 2px;
+        height: 13px;
+        width: 16px;
+    }
+`;
+
+const quoteIconCSS = css`
+    svg {
+        fill: ${palette.neutral[60]};
+        padding-right: 2px;
+        height: 13px;
+        width: 16px;
     }
 `;
 
@@ -164,6 +175,8 @@ export const OnwardContainer: React.SFC<{
                                                 <MoustacheSection name="isAudio">
                                                     <VolumeHigh />
                                                 </MoustacheSection>
+                                            </span>
+                                            <span className={quoteIconCSS}>
                                                 <MoustacheSection name="isComment">
                                                     <Quote />
                                                 </MoustacheSection>


### PR DESCRIPTION
## What does this change?
Old: 
![screen shot 2019-01-25 at 16 23 06](https://user-images.githubusercontent.com/2051501/51760661-d1f8d280-20c2-11e9-95ba-5dbda8eab8ef.png)
New:
![screen shot 2019-01-25 at 17 01 26](https://user-images.githubusercontent.com/2051501/51760691-e89f2980-20c2-11e9-899b-aa7bd5303caf.png)
Live:
![screenshot_20190125-162136](https://user-images.githubusercontent.com/2051501/51760707-f785dc00-20c2-11e9-9c34-9d6b1e194a91.png)


## Why?
