### PR TITLE
Don't hydrate certain components in client

### DIFF
--- a/packages/frontend/web/components/Header/Nav/Nav.tsx
+++ b/packages/frontend/web/components/Header/Nav/Nav.tsx
@@ -12,6 +12,7 @@ import { MainMenu } from './MainMenu/MainMenu';
 import { SubNav } from './SubNav/SubNav';
 import { ReaderRevenueLinks } from './ReaderRevenueLinks';
 import { getCookie } from '@frontend/web/browser/cookie';
+import { Freeze } from '@frontend/web/components/lib/Freeze';
 
 const centered = css`
     ${tablet} {
@@ -80,13 +81,14 @@ export class Nav extends Component<
                     aria-label="Guardian sections"
                 >
                     <EditionDropdown edition={edition} />
-                    <Logo />
+                    <Freeze>
+                        <Logo />
+                    </Freeze>
                     {/*
                         TODO: The properties of the Links component
                         have been hardcoded to false. At some point
                         these need to be dynamic.
                     */}
-
                     <ReaderRevenueLinks
                         urls={nav.readerRevenueLinks.header}
                         edition={edition}
@@ -108,11 +110,13 @@ export class Nav extends Component<
                         nav={nav}
                     />
                 </nav>
-                <SubNav
-                    subnav={nav.subNavSections}
-                    currentNavLink={nav.currentNavLink}
-                    pillar={pillar}
-                />
+                <Freeze>
+                    <SubNav
+                        subnav={nav.subNavSections}
+                        currentNavLink={nav.currentNavLink}
+                        pillar={pillar}
+                    />
+                </Freeze>
             </div>
         );
     }

--- a/packages/frontend/web/components/lib/Freeze.tsx
+++ b/packages/frontend/web/components/lib/Freeze.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+interface Props {
+    children: React.ReactNode;
+}
+
+export class Freeze extends React.Component<Props> {
+    public render() {
+        const { children } = this.props;
+
+        return typeof window === 'undefined' ? (
+            <div>{children}</div>
+        ) : (
+            // tslint:disable-next-line:react-no-dangerous-html
+            <div
+                dangerouslySetInnerHTML={{
+                    __html: '',
+                }}
+                suppressHydrationWarning={true}
+            />
+        );
+    }
+}
+
+export default Freeze;

--- a/packages/frontend/web/components/lib/Freeze.tsx
+++ b/packages/frontend/web/components/lib/Freeze.tsx
@@ -21,5 +21,3 @@ export class Freeze extends React.Component<Props> {
         );
     }
 }
-
-export default Freeze;

--- a/packages/frontend/web/pages/Article.tsx
+++ b/packages/frontend/web/pages/Article.tsx
@@ -11,6 +11,7 @@ import { ArticleBody } from '@frontend/web/components/ArticleBody';
 import { BackToTop } from '@frontend/web/components/BackToTop';
 import { SubNav } from '@frontend/web/components/Header/Nav/SubNav/SubNav';
 import { CookieBanner } from '@frontend/web/components/CookieBanner';
+import { Freeze } from '@frontend/web/components/lib/Freeze';
 
 // TODO: find a better of setting opacity
 const articleWrapper = css`
@@ -53,10 +54,13 @@ export const Article: React.SFC<{
             pillar={data.CAPI.pillar}
             edition={data.CAPI.editionId}
         />
+
         <main className={articleWrapper}>
             <Container className={articleContainer}>
                 <article>
-                    <ArticleBody CAPI={data.CAPI} config={data.config} />
+                    <Freeze>
+                        <ArticleBody CAPI={data.CAPI} config={data.config} />
+                    </Freeze>
                     <div className={secondaryColumn} />
                 </article>
                 <MostViewed sectionName={data.CAPI.sectionName} />
@@ -68,10 +72,11 @@ export const Article: React.SFC<{
             pillar={data.CAPI.pillar}
             currentNavLink={data.NAV.currentNavLink}
         />
-        <BackToTop />
 
-        <Footer />
-
-        <CookieBanner />
+        <Freeze>
+            <BackToTop />
+            <Footer />
+            <CookieBanner />
+        </Freeze>
     </div>
 );

--- a/packages/frontend/web/pages/Article.tsx
+++ b/packages/frontend/web/pages/Article.tsx
@@ -57,12 +57,12 @@ export const Article: React.SFC<{
 
         <main className={articleWrapper}>
             <Container className={articleContainer}>
-                <article>
-                    <Freeze>
+                <Freeze>
+                    <article>
                         <ArticleBody CAPI={data.CAPI} config={data.config} />
-                    </Freeze>
-                    <div className={secondaryColumn} />
-                </article>
+                        <div className={secondaryColumn} />
+                    </article>
+                </Freeze>
                 <MostViewed sectionName={data.CAPI.sectionName} />
             </Container>
         </main>


### PR DESCRIPTION
 **This is an experimental feature!** 

We have a performance concern around React unnecessarily hydrating parts of our application which render exactly the same in the client as they do on the server. The same issues has been raised here https://github.com/facebook/react/issues/12617

One of the options put forward in this issue involves using "dangerouslySetInnerHTML with empty content" because React won't try to manipulate the tree of a dangerouslySetInnerHTML node on the client. 

This PR introduces a `<Freeze>` component. On the client the `render` function of `Freeze` returns an empty `div` with dangerouslySetInnerHTML set on it meaning React doesn't touch it, whilst on the server it renders the children nested within it. The idea is any children wrapped in this component will not be hydrated on the client by React, avoiding the processing overhead involved in hydrating these components.

To be wrapped by a `<Freeze>` a component must satisfy the following conditions:

1. Does not make use of any lifecycle methods
2. Does not have any nested descendant components that use lifecycle methods.
3. Does not accept any properties driven by a state change from an ancestor component.

At the moment the onus is entirely on the developer using `<Freeze>` to make sure these conditions are met, if they're not the only way you'd know there's an issue is via runtime bugs! 

I've tested this branch against `master` on `CODE` using https://www.webpagetest.org and have found the following:

**`gh-freeze-components` - Moto G4 - Chrome - 3GSlow - 18 runs**
First Interactive (Median) 12.8s

**`master` - Moto G4 - Chrome - 3GSlow - 18 runs**
First Interactive (Median) 14.8s

**To do**
An additional improvement (not applied here) of omitting certain components from the render cycle in the client is that we could remove the article data currently inline within the `<head> ` that's currently used during hydration. This should reduce the weight of the HTML document.

