### PR TITLE
Reduce cooldown on alarm

### DIFF
--- a/packages/frontend/cloudformation.yml
+++ b/packages/frontend/cloudformation.yml
@@ -244,7 +244,7 @@ Resources:
     Properties:
       AdjustmentType: ChangeInCapacity
       AutoScalingGroupName: !Ref AutoscalingGroup
-      Cooldown: '1200'
+      Cooldown: '120'
       ScalingAdjustment: '-1'
 
   ScaleUpPolicy:


### PR DESCRIPTION
## What does this change?

Adjust cooldown period on scale down alarms as 20 minutes is way too long! See equivalent (now old) PR in Platforms here:

https://github.com/guardian/platform/pull/1329

## Why?

The previous value (20 mins) is too long and prevents us from
adjusting in cases of spiky traffic.