### PR TITLE
Add favicon to AMP

### DIFF
--- a/packages/frontend/amp/server/document.tsx
+++ b/packages/frontend/amp/server/document.tsx
@@ -33,6 +33,7 @@ export const document = ({
     <title>${title}</title>
     <link rel="canonical" href="self.html" />
     <meta name="viewport" content="width=device-width,minimum-scale=1">
+    <link rel="icon" href="https://static.guim.co.uk/images/amp-favicon-32x32.ico">
 
     <script type="application/ld+json">
         ${JSON.stringify(linkedData)}


### PR DESCRIPTION
This is relatively unimportant as Google serves their own favicon for their AMP cache.

It's nice for development purposes though (local and remote).

@philmcmahon wasn't sure whether to comment on the S3 bucket source in the end as those can be sensitive, but let me know what you think as happy to include it.