### PR TITLE
Fix first-child and nth-child warnings

### DIFF
--- a/packages/frontend/amp/components/Header.tsx
+++ b/packages/frontend/amp/components/Header.tsx
@@ -69,7 +69,7 @@ const pillarListStyles = css`
 const pillarListItemStyle = css`
     display: inline-block;
 
-    :first-child {
+    :first-of-type {
         a {
             padding-left: 20px;
 

--- a/packages/frontend/web/components/Footer.tsx
+++ b/packages/frontend/web/components/Footer.tsx
@@ -54,22 +54,22 @@ const footerList = css`
         border-left: 1px solid ${palette.neutral[20]};
 
         ${until.tablet} {
-            :nth-child(odd) {
+            :nth-of-type(odd) {
                 border-left: 0px;
                 padding-left: 0px;
             }
 
-            :nth-child(3) {
+            :nth-of-type(3) {
                 padding-top: 0px;
             }
 
-            :nth-child(4) {
+            :nth-of-type(4) {
                 padding-top: 0px;
             }
         }
 
         ${until.leftCol} {
-            :nth-child(1) {
+            :nth-of-type(1) {
                 border-left: 0px;
                 padding-left: 0px;
             }

--- a/packages/frontend/web/components/Header/Nav/MainMenu/Column.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenu/Column.tsx
@@ -185,7 +185,7 @@ const columnStyle = css`
     ${leftCol} {
         width: 160px;
 
-        :first-child {
+        :first-of-type {
             width: 150px;
         }
     }

--- a/packages/frontend/web/components/Header/Nav/Pillars.tsx
+++ b/packages/frontend/web/components/Header/Nav/Pillars.tsx
@@ -68,7 +68,7 @@ const showMenuUnderline = css`
 `;
 
 const pillarStyle = css`
-    :first-child {
+    :first-of-type {
         margin-left: -20px;
         ${desktop} {
             width: 144px;

--- a/packages/frontend/web/components/MostViewed.tsx
+++ b/packages/frontend/web/components/MostViewed.tsx
@@ -100,7 +100,7 @@ const listItem = css`
         background-color: ${palette.neutral[86]};
     }
 
-    :first-child {
+    :first-of-type {
         &:before {
             display: none;
         }
@@ -123,7 +123,7 @@ const listItem = css`
         display: inline-block;
         width: 100%;
 
-        :nth-child(6) {
+        :nth-of-type(6) {
             &:before {
                 display: none;
             }


### PR DESCRIPTION
Remove these warnings:

![screenshot 2019-02-05 at 16 18 53](https://user-images.githubusercontent.com/858402/52287297-c7abc380-2961-11e9-8a62-405b786d002b.png)


Note, while I think these fixes work okay, nth-of-type is not completely equivalent to nth-child and the same for first-child.
