### PR TITLE
Update age warning on onward components

### DIFF
--- a/packages/frontend/amp/components/OnwardContainer.tsx
+++ b/packages/frontend/amp/components/OnwardContainer.tsx
@@ -70,6 +70,11 @@ const headlineCSS = css`
     ${headline(1)};
 `;
 
+const description = css`
+    ${headline(2)};
+    margin-bottom: 16px;
+`;
+
 const iconCSS = css`
     svg {
         fill: ${palette.neutral[7]};
@@ -151,7 +156,7 @@ export const OnwardContainer: React.SFC<{
                     </div>
                     <MoustacheSection name="description">
                         {/*  Don't show if there is not description WHAT STYLES HERE */}
-                        <div>
+                        <div className={description}>
                             <MoustacheVariable name="description" />
                         </div>
                     </MoustacheSection>

--- a/packages/frontend/amp/components/OnwardContainer.tsx
+++ b/packages/frontend/amp/components/OnwardContainer.tsx
@@ -64,7 +64,7 @@ const link = css`
 `;
 const headlineCSS = css`
     padding: 0;
-    margin: 1px 0 0;
+    margin: 1px 0 4px;
     font-weight: 500;
     word-wrap: break-word;
     ${headline(1)};
@@ -86,6 +86,12 @@ const quoteIconCSS = css`
         height: 13px;
         width: 16px;
     }
+`;
+
+const ageWarning = css`
+    color: ${palette.neutral[20]};
+    fill: ${palette.neutral[20]};
+    ${textSans(1)};
 `;
 
 const onward = css`
@@ -189,14 +195,11 @@ export const OnwardContainer: React.SFC<{
                                             </div>
                                         </MoustacheSection>
                                     </div>
-                                    <aside>
+                                    <aside className={ageWarning}>
                                         <time>
                                             <MoustacheSection name="showWebPublicationDate">
-                                                <Clock />
-                                                <span>
-                                                    <span>Published: </span>
-                                                    <MoustacheVariable name="webPublicationDate" />
-                                                </span>
+                                                <Clock />{' '}
+                                                <MoustacheVariable name="webPublicationDate" />
                                             </MoustacheSection>
                                         </time>
                                     </aside>


### PR DESCRIPTION
## What does this change?

Alters age warning on onward containers to be closer to prod.

![screenshot 2019-02-06 at 13 55 49](https://user-images.githubusercontent.com/858402/52346165-efa92e80-2a16-11e9-9bf9-6fdb88fcc00b.png)


To be honest, the PROD approach doesn't seem ideal - it's far too hard to read and not great for accessibility. So something to think about @rcrphillips perhaps.

## Why?

Go live.