### PR TITLE
⚡️Amp update RR links

### DIFF
--- a/packages/frontend/amp/components/Footer.tsx
+++ b/packages/frontend/amp/components/Footer.tsx
@@ -9,7 +9,7 @@ import { ReaderRevenueButton } from '@root/packages/frontend/amp/components/Read
 const footer = css`
     background-color: ${palette.brand.main};
     color: ${palette.neutral[86]};
-    ${textSans(3)};
+    ${textSans(5)};
     margin-top: 20px;
 `;
 

--- a/packages/frontend/amp/components/Footer.tsx
+++ b/packages/frontend/amp/components/Footer.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
 import { css } from 'emotion';
-import { textSans } from '@guardian/pasteup/typography';
+import { textSans, body } from '@guardian/pasteup/typography';
 import { palette } from '@guardian/pasteup/palette';
 import { InnerContainer } from './InnerContainer';
 import { Link, footerLinksNew } from '@frontend/lib/footer-links';
+import { ReaderRevenueButton } from '@root/packages/frontend/amp/components/ReaderRevenueButton';
 
 const footer = css`
     background-color: ${palette.brand.main};
     color: ${palette.neutral[86]};
-    ${textSans(5)};
+    ${textSans(3)};
     margin-top: 20px;
 `;
 
@@ -45,12 +46,12 @@ const footerList = css`
         display: block;
         background-color: rgba(255, 255, 255, 0.3);
     }
+`;
 
-    ul {
-        margin-right: 10px;
-        width: calc(50% - 10px);
-        margin-top: 0;
-    }
+const footerListBlock = css`
+    margin-right: 10px;
+    width: calc(50% - 10px);
+    margin-top: 0;
 `;
 
 const copyrightContainer = css`
@@ -112,11 +113,18 @@ const backToTopText = css`
     padding-top: 3px;
 `;
 
+const supportLink = css`
+    color: ${palette.highlight.main};
+    ${body(3)};
+    padding-bottom: 0.375rem;
+`;
+
 const year = new Date().getFullYear();
 
 const FooterLinks: React.FC<{
     links: Link[][];
-}> = ({ links }) => {
+    nav: NavType;
+}> = ({ links, nav }) => {
     const linkGroups = links.map(linkGroup => {
         const ls = linkGroup.map(l => (
             <li key={l.url}>
@@ -127,17 +135,38 @@ const FooterLinks: React.FC<{
         ));
         const key = linkGroup.reduce((acc, { title }) => `acc-${title}`, '');
 
-        return <ul key={key}>{ls}</ul>;
+        return (
+            <ul key={key} className={footerListBlock}>
+                {ls}
+            </ul>
+        );
     });
 
-    return <div className={footerList}>{linkGroups}</div>;
+    return (
+        <div className={footerList}>
+            {linkGroups}
+            <div className={footerListBlock}>
+                <div className={supportLink}>Support The&nbsp;Guardian</div>
+                <ReaderRevenueButton
+                    nav={nav}
+                    rrLink={'ampFooter'}
+                    rrCategory={'contribute'}
+                />
+                <ReaderRevenueButton
+                    nav={nav}
+                    rrLink={'ampFooter'}
+                    rrCategory={'subscribe'}
+                />
+            </div>
+        </div>
+    );
 };
 
-export const Footer: React.FC = () => (
+export const Footer: React.FC<{ nav: NavType }> = ({ nav }) => (
     <footer className={footer}>
         <InnerContainer>
             <div className={footerInner}>
-                <FooterLinks links={footerLinksNew} />
+                <FooterLinks links={footerLinksNew} nav={nav} />
             </div>
         </InnerContainer>
         <InnerContainer className={copyrightContainer}>

--- a/packages/frontend/amp/components/Footer.tsx
+++ b/packages/frontend/amp/components/Footer.tsx
@@ -152,12 +152,14 @@ const FooterLinks: React.FC<{
                     rrLink={'ampFooter'}
                     rrCategory={'contribute'}
                     rightAlignIcon={true}
+                    linkLabel={'Contribute'}
                 />
                 <ReaderRevenueButton
                     nav={nav}
                     rrLink={'ampFooter'}
                     rrCategory={'subscribe'}
                     rightAlignIcon={true}
+                    linkLabel={'Subscribe'}
                 />
             </div>
         </div>

--- a/packages/frontend/amp/components/Footer.tsx
+++ b/packages/frontend/amp/components/Footer.tsx
@@ -145,7 +145,7 @@ const FooterLinks: React.FC<{
     return (
         <div className={footerList}>
             {linkGroups}
-            <div className={footerListBlock}>
+            <div key="rrblock" className={footerListBlock}>
                 <div className={supportLink}>Support The&nbsp;Guardian</div>
                 <ReaderRevenueButton
                     nav={nav}

--- a/packages/frontend/amp/components/Footer.tsx
+++ b/packages/frontend/amp/components/Footer.tsx
@@ -151,11 +151,13 @@ const FooterLinks: React.FC<{
                     nav={nav}
                     rrLink={'ampFooter'}
                     rrCategory={'contribute'}
+                    rightAlignIcon={true}
                 />
                 <ReaderRevenueButton
                     nav={nav}
                     rrLink={'ampFooter'}
                     rrCategory={'subscribe'}
+                    rightAlignIcon={true}
                 />
             </div>
         </div>

--- a/packages/frontend/amp/components/Header.tsx
+++ b/packages/frontend/amp/components/Header.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { css, cx } from 'emotion';
 import Logo from '@guardian/pasteup/logos/the-guardian.svg';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';
-import { headline, textSans } from '@guardian/pasteup/typography';
+import { headline } from '@guardian/pasteup/typography';
 import { pillarPalette } from '../../lib/pillars';
-import ArrowRight from '@guardian/pasteup/icons/arrow-right.svg';
 import { palette } from '@guardian/pasteup/palette';
+import { ReaderRevenueButton } from '@root/packages/frontend/amp/components/ReaderRevenueButton';
 import { AmpSubscriptionGoogle } from '@frontend/amp/components/elements/AmpSubscriptionGoogle';
 import { mobileLandscape } from '@guardian/pasteup/breakpoints';
 
@@ -17,35 +17,6 @@ const row = css`
     display: flex;
     justify-content: space-between;
     position: relative;
-`;
-
-const supportStyles = css`
-    align-self: flex-start;
-    position: relative;
-    margin-left: 20px;
-    margin-top: 20px;
-    background-color: ${palette.highlight.main};
-    border-radius: 20px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    padding: 0 15px;
-    min-height: 30px;
-`;
-
-const supportLinkStyles = css`
-    position: relative;
-    color: ${palette.neutral[7]};
-    ${textSans(5)};
-    font-weight: 700;
-    display: block;
-    text-decoration: none;
-    padding-right: 20px;
-
-    svg {
-        position: absolute;
-        top: -6px;
-    }
 `;
 
 const logoStyles = css`
@@ -181,9 +152,6 @@ const pillarLinks = (pillars: PillarType[], activePillar: Pillar) => (
     </nav>
 );
 
-const supportLink =
-    'https://support.theguardian.com/?INTCMP=header_support&acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support%22%7D';
-
 export const Header: React.FC<{
     nav: NavType;
     activePillar: Pillar;
@@ -191,12 +159,11 @@ export const Header: React.FC<{
 }> = ({ nav, activePillar, config }) => (
     <header className={headerStyles}>
         <div className={row}>
-            <div className={supportStyles}>
-                <a className={supportLinkStyles} href={supportLink}>
-                    Support us
-                    <ArrowRight />
-                </a>
-            </div>
+            <ReaderRevenueButton
+                nav={nav}
+                rrLink={'ampHeader'}
+                rrCategory={'support'}
+            />
 
             {config.switches.subscribeWithGoogle && <AmpSubscriptionGoogle />}
 

--- a/packages/frontend/amp/components/Header.tsx
+++ b/packages/frontend/amp/components/Header.tsx
@@ -163,6 +163,7 @@ export const Header: React.FC<{
                 nav={nav}
                 rrLink={'ampHeader'}
                 rrCategory={'support'}
+                linkLabel={'Support Us'}
             />
 
             {config.switches.subscribeWithGoogle && <AmpSubscriptionGoogle />}

--- a/packages/frontend/amp/components/ReaderRevenueButton.tsx
+++ b/packages/frontend/amp/components/ReaderRevenueButton.tsx
@@ -54,8 +54,8 @@ const rightAlignedIcon = css`
 export const ReaderRevenueButton: React.SFC<{
     nav: NavType;
     linkLabel: string;
-    rrLink: ReaderRevenueLinkNames;
-    rrCategory: ReaderRevenueCategoryNames;
+    rrLink: ReaderRevenuePosition;
+    rrCategory: ReaderRevenueCategory;
     rightAlignIcon?: boolean;
 }> = ({ nav, linkLabel, rrLink, rrCategory, rightAlignIcon }) => {
     const url = nav.readerRevenueLinks[rrLink][rrCategory];

--- a/packages/frontend/amp/components/ReaderRevenueButton.tsx
+++ b/packages/frontend/amp/components/ReaderRevenueButton.tsx
@@ -35,6 +35,7 @@ const supportLinkStyles = css`
     line-height: 20px;
     text-decoration: none;
     padding-right: 20px;
+    width: 100%;
 
     svg {
         position: absolute;
@@ -42,11 +43,20 @@ const supportLinkStyles = css`
     }
 `;
 
+const rightAlignedIcon = css`
+    position: absolute;
+    height: 20px;
+    width: 20px;
+    right: 0;
+    top: 0;
+`;
+
 export const ReaderRevenueButton: React.SFC<{
     nav: NavType;
     rrLink: ReaderRevenueLinkNames;
     rrCategory: ReaderRevenueCategoryNames;
-}> = ({ nav, rrLink, rrCategory }) => {
+    rightAlignIcon?: boolean;
+}> = ({ nav, rrLink, rrCategory, rightAlignIcon }) => {
     const linkLabel =
         (rrCategory.toString() === 'support' && 'Support Us') ||
         (rrCategory.toString() === 'subscribe' && 'Subscribe') ||
@@ -68,7 +78,9 @@ export const ReaderRevenueButton: React.SFC<{
         >
             <a className={supportLinkStyles} href={url}>
                 {linkLabel}
-                <ArrowRight />
+                <span className={rightAlignIcon ? rightAlignedIcon : ''}>
+                    <ArrowRight />
+                </span>
             </a>
         </div>
     );

--- a/packages/frontend/amp/components/ReaderRevenueButton.tsx
+++ b/packages/frontend/amp/components/ReaderRevenueButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'emotion';
+import { css, cx } from 'emotion';
 
 import { textSans } from '@guardian/pasteup/typography';
 import ArrowRight from '@guardian/pasteup/icons/arrow-right.svg';
@@ -64,17 +64,21 @@ export const ReaderRevenueButton: React.SFC<{
         return null;
     }
 
+    const isAmpHeader = rrLink === 'ampHeader';
+
     return (
         <div
-            className={
-                rrLink === 'ampHeader'
-                    ? supportHeaderStyles
-                    : supportFooterStyles
-            }
+            className={cx([
+                isAmpHeader ? supportHeaderStyles : supportFooterStyles,
+            ])}
         >
             <a className={supportLinkStyles} href={url}>
                 {linkLabel}
-                <span className={rightAlignIcon ? rightAlignedIcon : ''}>
+                <span
+                    className={cx({
+                        [rightAlignedIcon]: !!rightAlignIcon,
+                    })}
+                >
                     <ArrowRight />
                 </span>
             </a>

--- a/packages/frontend/amp/components/ReaderRevenueButton.tsx
+++ b/packages/frontend/amp/components/ReaderRevenueButton.tsx
@@ -53,15 +53,11 @@ const rightAlignedIcon = css`
 
 export const ReaderRevenueButton: React.SFC<{
     nav: NavType;
+    linkLabel: string;
     rrLink: ReaderRevenueLinkNames;
     rrCategory: ReaderRevenueCategoryNames;
     rightAlignIcon?: boolean;
-}> = ({ nav, rrLink, rrCategory, rightAlignIcon }) => {
-    const linkLabel =
-        (rrCategory.toString() === 'support' && 'Support Us') ||
-        (rrCategory.toString() === 'subscribe' && 'Subscribe') ||
-        (rrCategory.toString() === 'contribute' && 'Contribute');
-
+}> = ({ nav, linkLabel, rrLink, rrCategory, rightAlignIcon }) => {
     const url = nav.readerRevenueLinks[rrLink][rrCategory];
 
     if (url === '') {

--- a/packages/frontend/amp/components/ReaderRevenueButton.tsx
+++ b/packages/frontend/amp/components/ReaderRevenueButton.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { textSans } from '@guardian/pasteup/typography';
+import ArrowRight from '@guardian/pasteup/icons/arrow-right.svg';
+import { palette } from '@guardian/pasteup/palette';
+
+const supportStyles = css`
+    align-self: flex-start;
+    background-color: ${palette.highlight.main};
+    border-radius: 20px;
+    display: flex;
+    align-items: center;
+    padding: 0 15px;
+    min-height: 30px;
+`;
+
+const supportHeaderStyles = css`
+    ${supportStyles}
+    justify-content: center;
+    margin-top: 20px;
+    margin-left: 20px;
+`;
+
+const supportFooterStyles = css`
+    ${supportStyles}
+    margin-bottom: 6px;
+`;
+
+const supportLinkStyles = css`
+    position: relative;
+    color: ${palette.neutral[7]};
+    ${textSans(5)};
+    display: block;
+    line-height: 20px;
+    text-decoration: none;
+    padding-right: 20px;
+
+    svg {
+        position: absolute;
+        top: -6px;
+    }
+`;
+
+export const ReaderRevenueButton: React.SFC<{
+    nav: NavType;
+    rrLink: ReaderRevenueLinkNames;
+    rrCategory: ReaderRevenueCategoryNames;
+}> = ({ nav, rrLink, rrCategory }) => {
+    const linkLabel =
+        (rrCategory.toString() === 'support' && 'Support Us') ||
+        (rrCategory.toString() === 'subscribe' && 'Subscribe') ||
+        (rrCategory.toString() === 'contribute' && 'Contribute');
+
+    const url = nav.readerRevenueLinks[rrLink][rrCategory];
+
+    if (url === '') {
+        return null;
+    }
+
+    return (
+        <div
+            className={
+                rrLink === 'ampHeader'
+                    ? supportHeaderStyles
+                    : supportFooterStyles
+            }
+        >
+            <a className={supportLinkStyles} href={url}>
+                {linkLabel}
+                <ArrowRight />
+            </a>
+        </div>
+    );
+};

--- a/packages/frontend/amp/pages/Article.tsx
+++ b/packages/frontend/amp/pages/Article.tsx
@@ -83,7 +83,7 @@ export const Article: React.FC<{
                     seriesTags={tagsOfType(articleData.tags, 'Series')}
                     guardianBaseURL={'https://amp.theguardian.com'}
                 />
-                <Footer />
+                <Footer nav={nav} />
             </Container>
         </div>
 

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -46,6 +46,7 @@ interface ReaderRevenueCategories {
     support: string;
 }
 
+type ReaderRevenueCategoryNames = 'contribute' | 'subscribe' | 'support';
 interface ReaderRevenueLinks {
     header: ReaderRevenueCategories;
     footer: ReaderRevenueCategories;
@@ -53,6 +54,13 @@ interface ReaderRevenueLinks {
     ampHeader: ReaderRevenueCategories;
     ampFooter: ReaderRevenueCategories;
 }
+
+type ReaderRevenueLinkNames =
+    | 'header'
+    | 'footer'
+    | 'sideMenu'
+    | 'ampHeader'
+    | 'ampFooter';
 
 interface NavType {
     pillars: PillarType[];

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -46,8 +46,8 @@ interface ReaderRevenueCategories {
     support: string;
 }
 
-type ReaderRevenueCategoryNames = 'contribute' | 'subscribe' | 'support';
-interface ReaderRevenueLinks {
+type ReaderRevenueCategory = 'contribute' | 'subscribe' | 'support';
+interface ReaderRevenuePositions {
     header: ReaderRevenueCategories;
     footer: ReaderRevenueCategories;
     sideMenu: ReaderRevenueCategories;
@@ -71,7 +71,7 @@ interface NavType {
         parent?: LinkType;
         links: LinkType[];
     };
-    readerRevenueLinks: ReaderRevenueLinks;
+    readerRevenueLinks: ReaderRevenuePositions;
 }
 
 interface AuthorType {

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -55,7 +55,7 @@ interface ReaderRevenueLinks {
     ampFooter: ReaderRevenueCategories;
 }
 
-type ReaderRevenueLinkNames =
+type ReaderRevenuePosition =
     | 'header'
     | 'footer'
     | 'sideMenu'

--- a/packages/frontend/model/extract-nav.ts
+++ b/packages/frontend/model/extract-nav.ts
@@ -26,7 +26,7 @@ const buildRRLinkCategories = (
     contribute: getString(data, `${rrLinkConfig}.${position}.contribute`, ''),
 });
 
-const buildRRLinkModel = (data: {}): ReaderRevenueLinks => ({
+const buildRRLinkModel = (data: {}): ReaderRevenuePositions => ({
     header: buildRRLinkCategories(data, 'header'),
     footer: buildRRLinkCategories(data, 'footer'),
     sideMenu: buildRRLinkCategories(data, 'sideMenu'),

--- a/packages/frontend/model/extract-nav.ts
+++ b/packages/frontend/model/extract-nav.ts
@@ -19,11 +19,11 @@ const getLink = (data: {}, { isPillar }: { isPillar: boolean }): LinkType => {
 const rrLinkConfig = 'config.readerRevenueLinks';
 const buildRRLinkCategories = (
     data: {},
-    el: ReaderRevenueLinkNames,
+    position: ReaderRevenuePosition,
 ): ReaderRevenueCategories => ({
-    subscribe: getString(data, `${rrLinkConfig}.${el}.subscribe`, ''),
-    support: getString(data, `${rrLinkConfig}.${el}.support`, ''),
-    contribute: getString(data, `${rrLinkConfig}.${el}.contribute`, ''),
+    subscribe: getString(data, `${rrLinkConfig}.${position}.subscribe`, ''),
+    support: getString(data, `${rrLinkConfig}.${position}.support`, ''),
+    contribute: getString(data, `${rrLinkConfig}.${position}.contribute`, ''),
 });
 
 const buildRRLinkModel = (data: {}): ReaderRevenueLinks => ({

--- a/packages/frontend/model/extract-nav.ts
+++ b/packages/frontend/model/extract-nav.ts
@@ -19,7 +19,7 @@ const getLink = (data: {}, { isPillar }: { isPillar: boolean }): LinkType => {
 const rrLinkConfig = 'config.readerRevenueLinks';
 const buildRRLinkCategories = (
     data: {},
-    el: string,
+    el: ReaderRevenueLinkNames,
 ): ReaderRevenueCategories => ({
     subscribe: getString(data, `${rrLinkConfig}.${el}.subscribe`, ''),
     support: getString(data, `${rrLinkConfig}.${el}.support`, ''),

--- a/packages/frontend/web/components/Header/Nav/MainMenu/Column.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenu/Column.tsx
@@ -192,7 +192,7 @@ const columnStyle = css`
 `;
 
 export const ReaderRevenueLinks: React.FC<{
-    readerRevenueLinks: ReaderRevenueLinks;
+    readerRevenueLinks: ReaderRevenuePositions;
 }> = ({ readerRevenueLinks }) => {
     const links: LinkType[] = [
         {


### PR DESCRIPTION
## What does this change?

There's still a couple of bits to fix but I wanted to get eyes on from @guardian/dotcom-platform early as it's my first component in Dotcom-rendering (and using emotion/typescript).

Please feel free to tear apart/question everything.

My own questions:

- There doesn't seem to be a standard 'button' component (usually the canonical example for building out a pattern library). Do these things fit in guui? How do we make things discoverable and easy to use?
- It felt weird add a new type of link and category names as strings, can I do that better?
- The footer isn't editionalised as it wasn't actually used anywhere, in the spirit of parity, it does what AMP does now

## Existing
![screen shot 2019-02-06 at 17 28 00](https://user-images.githubusercontent.com/638051/52400529-4bc38f80-2ab7-11e9-9b68-eba652ef3a87.jpg)


## New
Note, slightly different styling is because I tried to avoid changing typography styling?

![screen shot 2019-02-06 at 17 27 54](https://user-images.githubusercontent.com/638051/52400516-4403eb00-2ab7-11e9-8b25-437f98268eed.jpg)

Anyhoo, a lot of the questions are likely not blockers for go-live...
