### PR TITLE
Use dev favicon outside of prod

### DIFF
--- a/packages/frontend/amp/server/document.tsx
+++ b/packages/frontend/amp/server/document.tsx
@@ -26,6 +26,12 @@ export const document = ({
         // TODO: CacheProvider can be removed when we've moved over to using @emotion/core
         renderToString(<CacheProvider value={cache}>{body}</CacheProvider>),
     );
+
+    const favicon =
+        process.env.NODE_ENV === 'prod'
+            ? 'amp-favicon-32x32.ico'
+            : 'favicon-32x32-dev-yellow.ico';
+
     return `<!doctype html>
 <html ⚡>
     <head>
@@ -33,7 +39,7 @@ export const document = ({
     <title>${title}</title>
     <link rel="canonical" href="self.html" />
     <meta name="viewport" content="width=device-width,minimum-scale=1">
-    <link rel="icon" href="https://static.guim.co.uk/images/amp-favicon-32x32.ico">
+    <link rel="icon" href="https://static.guim.co.uk/images/${favicon}">
 
     <script type="application/ld+json">
         ${JSON.stringify(linkedData)}


### PR DESCRIPTION
## What does this change?

Use the red dev favicon for non-PROD as a visual aide.

## Why?

To help us know which environment we're on.

![screenshot 2019-02-07 at 11 03 58](https://user-images.githubusercontent.com/858402/52407428-2be89780-2ac8-11e9-9432-5e124a27f68f.png)

Update: OR YELLOW!?

![screenshot 2019-02-07 at 11 11 23](https://user-images.githubusercontent.com/858402/52407873-538c2f80-2ac9-11e9-9195-1fabb40e102d.png)

