### PR TITLE
Fix deprecated nginx ssl directive

### DIFF
--- a/scripts/nginx/dotcom-rendering.conf
+++ b/scripts/nginx/dotcom-rendering.conf
@@ -8,10 +8,9 @@ server {
 }
 
 server {
-    listen 443;
+    listen 443 ssl;
     server_name r.thegulocal.com;
 
-    ssl on;
     ssl_certificate STAR_thegulocal_com_exp2020-01-09.crt; ## Supplied by https://github.com/guardian/identity-platform#setup-nginx-for-local-development
     ssl_certificate_key STAR_thegulocal_com_exp2020-01-09.key; ## ditto
 


### PR DESCRIPTION
## What does this change?
Replace `ssl on;` with `listen 443 ssl;`

## Why?
<img width="1100" alt="screen shot 2019-02-08 at 10 28 50" src="https://user-images.githubusercontent.com/249676/52474537-af6dbb80-2b90-11e9-8a4b-795ae4b8a1cf.png">

The nginx template uses the `ssl on;` which was [made deprecated in version 1.15.0](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl):

> It is recommended to use the `ssl` parameter of the [listen](http://nginx.org/en/docs/http/ngx_http_core_module.html#listen) directive instead of this directive.