### PR TITLE
Remove amp SwG pingback url

### DIFF
--- a/packages/frontend/amp/lib/subscribe-with-google.ts
+++ b/packages/frontend/amp/lib/subscribe-with-google.ts
@@ -2,7 +2,6 @@ const getServices = (apiUrl: string) => ({
     services: [
         {
             authorizationUrl: `${apiUrl}/oauth`,
-            pingbackUrl: `${apiUrl}/pingback`,
             actions: {
                 login: `${apiUrl}/login`,
                 subscribe: `${apiUrl}/subscribe#viewerUrl=https://google.com`,


### PR DESCRIPTION
## What does this change?
Remove `pingbackUrl` from `amp-subscription-google` extension.

## Why?

It is not being used
