### PR TITLE
Fix prod(uction) favicons

### DIFF
--- a/packages/frontend/amp/server/document.tsx
+++ b/packages/frontend/amp/server/document.tsx
@@ -28,7 +28,7 @@ export const document = ({
     );
 
     const favicon =
-        process.env.NODE_ENV === 'prod'
+        process.env.NODE_ENV === 'production'
             ? 'favicon-32x32.ico'
             : 'favicon-32x32-dev-yellow.ico';
 

--- a/packages/frontend/web/server/htmlTemplate.ts
+++ b/packages/frontend/web/server/htmlTemplate.ts
@@ -29,7 +29,7 @@ export const htmlTemplate = ({
     fontFiles?: string[];
 }) => {
     const favicon =
-        process.env.NODE_ENV === 'prod'
+        process.env.NODE_ENV === 'production'
             ? 'favicon-32x32.ico'
             : 'favicon-32x32-dev-yellow.ico';
 


### PR DESCRIPTION
Detect prod properly.

I think this should work on prod okay!

In practice, Google serve their own favicon on AMP pages (grrr - though to be fair mobile it isn't so noticeable anyway) so the impact of a dev favicon on prod is pretty low here anyway.