### PR TITLE
Increase capacity for AMP go-live

### DIFF
--- a/packages/frontend/cloudformation.yml
+++ b/packages/frontend/cloudformation.yml
@@ -219,8 +219,8 @@ Resources:
         Ref: Subnets
       LaunchConfigurationName:
         Ref: LaunchConfig
-      MinSize: 1
-      MaxSize: 2
+      MinSize: 3
+      MaxSize: 12
       HealthCheckType: ELB
       HealthCheckGracePeriod: 120
       LoadBalancerNames:


### PR DESCRIPTION
## What does this change?

Increase min (to 3) and max (to 12) of ASG.

## Why?

To handle 'real' traffic once we go live. Note in practice we'll adjust these numbers once we see how it handles real traffic.