### PR TITLE
Pass guardian base URL where needed

### DIFF
--- a/packages/frontend/amp/components/Body.tsx
+++ b/packages/frontend/amp/components/Body.tsx
@@ -34,6 +34,7 @@ export const Body: React.FC<{
             sharingURLs={data.sharingUrls}
             pageID={data.pageId}
             isCommentable={data.isCommentable}
+            guardianBaseURL={data.guardianBaseURL}
         />
     </InnerContainer>
 );

--- a/packages/frontend/amp/components/SubMeta.tsx
+++ b/packages/frontend/amp/components/SubMeta.tsx
@@ -121,12 +121,21 @@ export const SubMeta: React.FC<{
     };
     pageID: string;
     isCommentable: boolean;
-}> = ({ pillar, sections, keywords, sharingURLs, pageID, isCommentable }) => {
+    guardianBaseURL: string;
+}> = ({
+    pillar,
+    sections,
+    keywords,
+    sharingURLs,
+    pageID,
+    isCommentable,
+    guardianBaseURL,
+}) => {
     const sectionListItems = sections.map(link => (
         <li className={itemStyle} key={link.url}>
             <a
                 className={sectionLinkStyle(pillar)}
-                href={`https://www.theguardian.com/${link.url}`}
+                href={`${guardianBaseURL}/${link.url}`}
             >
                 {link.title}
             </a>
@@ -137,7 +146,7 @@ export const SubMeta: React.FC<{
         <li className={itemStyle} key={link.url}>
             <a
                 className={linkStyle(pillar)}
-                href={`https://www.theguardian.com/${link.url}`}
+                href={`${guardianBaseURL}/${link.url}`}
             >
                 {link.title}
             </a>

--- a/packages/frontend/amp/components/TopMeta.tsx
+++ b/packages/frontend/amp/components/TopMeta.tsx
@@ -184,7 +184,8 @@ const Byline: React.FC<{
     byline: string;
     tags: TagType[];
     pillar: Pillar;
-}> = ({ byline, tags, pillar }) => {
+    guardianBaseURL: string;
+}> = ({ byline, tags, pillar, guardianBaseURL }) => {
     const contributorTags = tags.filter(tag => tag.type === 'Contributor');
     const tokens = bylineTokens(byline, contributorTags);
 
@@ -193,7 +194,7 @@ const Byline: React.FC<{
 
         if (matchedTag) {
             return (
-                <a href={`https://www.theguardian.com/${matchedTag.id}`}>
+                <a href={`${guardianBaseURL}/${matchedTag.id}`}>
                     {matchedTag.title}
                 </a>
             );
@@ -225,6 +226,7 @@ export const TopMeta: React.FC<{
                 byline={articleData.author.byline}
                 tags={articleData.tags}
                 pillar={articleData.pillar}
+                guardianBaseURL={articleData.guardianBaseURL}
             />
 
             {articleData.author.twitterHandle && (


### PR DESCRIPTION
To avoid hardcoding the value everywhere which will make testing on different environments difficult.

This is somewhat related to: https://github.com/guardian/dotcom-rendering/pull/424 but I didn't want to block that on fixing things everywhere.