### PR TITLE
Updates the H2 styling within the body as well as some standfirst changes

### DIFF
--- a/packages/frontend/amp/components/TopMeta.tsx
+++ b/packages/frontend/amp/components/TopMeta.tsx
@@ -94,13 +94,14 @@ const listStyles = (pillar: Pillar) => css`
 
 const standfirstCss = pillarMap(
     pillar => css`
-        ${body(2)};
-        font-weight: 700;
+        ${body(1)};
         color: ${palette.neutral[7]};
         margin-bottom: 12px;
         ${listStyles(pillar)};
         p {
             margin-bottom: 8px;
+            max-width: 80%;
+            line-height: 20px;
         }
     `,
 );

--- a/packages/frontend/amp/components/elements/TextBlockComponent.tsx
+++ b/packages/frontend/amp/components/elements/TextBlockComponent.tsx
@@ -10,12 +10,12 @@ const style = (pillar: Pillar) => css`
         font-weight: 700;
     }
     h2 {
-        margin-top: 24px;
-        ${textSans(6)};
+        ${body(3)};
+        font-weight: 600;
     }
     p {
         padding: 0 0 12px;
-        ${body(2)};
+        ${body(1)};
         font-weight: 300;
         word-wrap: break-word;
         color: ${palette.neutral[7]};

--- a/packages/pasteup/typography.ts
+++ b/packages/pasteup/typography.ts
@@ -32,7 +32,7 @@ const fontScaleMapping: any = {
         9: { fontSize: 44, lineHeight: 48 },
     },
     body: {
-        1: { fontSize: 14, lineHeight: 20 },
+        1: { fontSize: 16, lineHeight: 24 },
         2: { fontSize: 17, lineHeight: 24 },
         3: { fontSize: 18, lineHeight: 28 },
     },


### PR DESCRIPTION
## What does this change?
Old
<img width="612" alt="screen shot 2019-02-12 at 21 32 59" src="https://user-images.githubusercontent.com/2051501/52669386-d79d4780-2f0d-11e9-9f25-43e84377343d.png">

Live
<img width="614" alt="screen shot 2019-02-12 at 15 49 51" src="https://user-images.githubusercontent.com/2051501/52669449-04e9f580-2f0e-11e9-85cf-17be0465fa6d.png">

New
<img width="607" alt="screen shot 2019-02-12 at 15 50 02" src="https://user-images.githubusercontent.com/2051501/52669456-0a474000-2f0e-11e9-85f4-fab38a571f34.png">

## Why?
