### PR TITLE
⚡️ Add affiliate link notice

### DIFF
--- a/docs/elements/x-disclaimer.md
+++ b/docs/elements/x-disclaimer.md
@@ -1,0 +1,22 @@
+# Disclaimer Element
+
+An element which contains a contiguous block of marked up body text, intended as
+a disclaimer - typically placed at the bottom of a block.
+
+## CAPI representation
+
+This element does not exist in CAPI. It was originally introduced as part of
+supporting affiliate links, which requires a disclaimer at the bottom of the
+article body text.
+
+## Frontend Liveblog Representation
+
+This is represented in frontend by [DisclaimerBlockElement](https://github.com/guardian/frontend/blob/c796e4094bd66b5818458898602685a312dc68de/common/app/model/dotcomrendering/pageElements/PageElement.scala#L40). This has a single field `html` containing `Option[String]`.
+
+## CAPI HTML Output
+
+This is inserted raw into the document.
+
+## AMP Cleaned HTML
+
+This is run through the BodyCleaner and the AMP cleaners.

--- a/packages/frontend/amp/components/elements/DisclaimerBlockComponent.tsx
+++ b/packages/frontend/amp/components/elements/DisclaimerBlockComponent.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { css } from 'emotion';
+import { pillarPalette } from '@frontend/lib/pillars';
+import { textSans } from '@guardian/pasteup/typography';
+
+const style = (pillar: Pillar) => css`
+    ${textSans(2)};
+    line-height: 24px;
+
+    a {
+        color: ${pillarPalette[pillar].dark};
+    }
+`;
+
+export const DisclaimerBlockComponent: React.FC<{
+    html: string;
+    pillar: Pillar;
+}> = ({ html, pillar }) => (
+    // tslint:disable-next-line:react-no-dangerous-html
+    <span
+        className={style(pillar)}
+        dangerouslySetInnerHTML={{
+            __html: html,
+        }}
+    />
+);

--- a/packages/frontend/amp/components/lib/Elements.tsx
+++ b/packages/frontend/amp/components/lib/Elements.tsx
@@ -11,6 +11,7 @@ import { EmbedBlockComponent } from '@frontend/amp/components/elements/EmbedBloc
 import { findAdSlots } from '@frontend/amp/lib/find-adslots';
 import { AdComponent } from '@frontend/amp/components/elements/AdComponent';
 import { css } from 'emotion';
+import { DisclaimerBlockComponent } from '@frontend/amp/components/elements/DisclaimerBlockComponent';
 
 const clear = css`
     clear: both;
@@ -69,6 +70,14 @@ export const Elements: React.FC<{
                 return <SoundcloudBlockComponent key={i} element={element} />;
             case 'model.dotcomrendering.pageElements.EmbedBlockElement':
                 return <EmbedBlockComponent key={i} element={element} />;
+            case 'model.dotcomrendering.pageElements.DisclaimerBlockElement':
+                return (
+                    <DisclaimerBlockComponent
+                        key={i}
+                        html={element.html}
+                        pillar={pillar}
+                    />
+                );
             default:
                 // tslint:disable-next-line:no-console
                 console.log('Unsupported Element', JSON.stringify(element));
@@ -86,6 +95,7 @@ export const Elements: React.FC<{
         useKrux: switches.krux,
         usePrebid: switches['amp-prebid'],
     };
+
     const elementsWithAdverts = output.map((element, i) => (
         <>
             {element}

--- a/packages/frontend/lib/content.d.ts
+++ b/packages/frontend/lib/content.d.ts
@@ -7,6 +7,7 @@ type Weighting =
     | 'showcase'
     | 'halfwidth'
     | 'immersive';
+
 interface TextBlockElement {
     _type: 'model.dotcomrendering.pageElements.TextBlockElement';
     html: string;
@@ -92,6 +93,11 @@ interface EmbedBlockElement {
     isMandatory: boolean;
 }
 
+interface DisclaimerBlockElement {
+    _type: 'model.dotcomrendering.pageElements.DisclaimerBlockElement';
+    html: string;
+}
+
 type CAPIElement =
     | TextBlockElement
     | ImageBlockElement
@@ -100,4 +106,5 @@ type CAPIElement =
     | RichLinkBlockElement
     | CommentBlockElement
     | SoundcloudBlockElement
-    | EmbedBlockElement;
+    | EmbedBlockElement
+    | DisclaimerBlockElement;

--- a/yarn.lock
+++ b/yarn.lock
@@ -740,9 +740,6 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
-"@guardian/pasteup@1.0.0-alpha.5":
-  version "1.0.0-alpha.5"
-
 "@kossnocorp/desvg@^0.1.1":
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@kossnocorp/desvg/-/desvg-0.1.2.tgz#3d120b180d4dbb1f646603c3b9f2c89774c368dc"


### PR DESCRIPTION
**UPDATE: the description below is slightly out of date. We now pass the disclaimer as an element so the logic/code this side is much simpler as it doesn't require breaking out of the Elements model.**

Related to: https://github.com/guardian/frontend/pull/21084.

## What does this change?

Adds affiliate links notice on relevant articles.

![screenshot 2019-02-13 at 14 43 18](https://user-images.githubusercontent.com/858402/52719783-327e7f80-2f9e-11e9-84c6-f6bdf8ae74d0.png)

~~I'm not entirely convinced we should be putting styling/messing up the Elements file. It's already a bit confused from the ad stuff but there is probably a cleaner way of doing this that keeps the actual element transformations separate. That might be for another PR though depending on how strongly people feel, as this is currently affecting some of the newly-live AMP articles so keen to get live sooner rather than later.~~ (Update: no longer relevant.)

## Why?

Needed!