### PR TITLE
Update amp-twitter and fallback boolean attribute for React/TS and AMP compat

### DIFF
--- a/packages/frontend/amp/components/elements/TweetBlockComponent.tsx
+++ b/packages/frontend/amp/components/elements/TweetBlockComponent.tsx
@@ -23,7 +23,7 @@ export const TweetBlockComponent: React.FC<{
             data-tweetid={element.id}
         >
             {fallbackHTML && (
-                <div fallback={'true'}>
+                <div fallback={''}>
                     <blockquote
                         dangerouslySetInnerHTML={{ __html: fallbackHTML }}
                     />

--- a/packages/frontend/amp/components/lib/AMPAttributes.ts
+++ b/packages/frontend/amp/components/lib/AMPAttributes.ts
@@ -8,6 +8,6 @@ declare module 'react' {
     interface HTMLAttributes<T> extends DOMAttributes<T> {
         on?: string;
         overflow?: string;
-        fallback?: string;
+        fallback?: '';
     }
 }


### PR DESCRIPTION
## What does this change?

The fallback attribute must be 1. A boolean value for AMP and 2. An empty string to become a boolean value in JSX

## Why?

Currently fails AMP validation
