### PR TITLE
Fix some links

### DIFF
--- a/packages/frontend/amp/components/Header.tsx
+++ b/packages/frontend/amp/components/Header.tsx
@@ -145,7 +145,7 @@ const pillarLinks = (pillars: PillarType[], guardianBaseURL: string) => (
                 <li className={pillarListItemStyle} key={p.title}>
                     <a
                         className={pillarLinkStyle(p.pillar)}
-                        href={`${guardianBaseURL}/${p.url}`}
+                        href={`${guardianBaseURL}${p.url}`}
                     >
                         {p.title}
                     </a>
@@ -172,7 +172,7 @@ export const Header: React.FC<{
 
             {config.switches.subscribeWithGoogle && <AmpSubscriptionGoogle />}
 
-            <a className={logoStyles} href="/">
+            <a className={logoStyles} href={guardianBaseURL}>
                 <span
                     className={css`
                         ${screenReaderOnly};


### PR DESCRIPTION
* the logo should be to the non-amp homepage
* the pillar links shouldn't have a double-slash