### PR TITLE
Footer - Update to ampersand and get the correct year

### DIFF
--- a/packages/frontend/amp/components/Footer.tsx
+++ b/packages/frontend/amp/components/Footer.tsx
@@ -181,7 +181,7 @@ export const Footer: React.FC<{ nav: NavType }> = ({ nav }) => (
                 </span>
             </a>
             <div className={copyright}>
-                © {year} Guardian News and Media Limited or its affiliated
+                © {year} Guardian News & Media Limited or its affiliated
                 companies. All rights reserved.
             </div>
         </InnerContainer>

--- a/packages/frontend/web/components/Footer.tsx
+++ b/packages/frontend/web/components/Footer.tsx
@@ -110,6 +110,8 @@ const FooterLinks: React.FC<{
     return <div className={footerList}>{linkGroups}</div>;
 };
 
+const year = new Date().getFullYear();
+
 export const Footer: React.FC = () => (
     <footer className={footer}>
         <Container className={footerInner}>
@@ -127,7 +129,7 @@ export const Footer: React.FC = () => (
             />
             <FooterLinks links={footerLinks} />
             <div className={copyright}>
-                © 2018 Guardian News and Media Limited or its affiliated
+                © {year} Guardian News & Media Limited or its affiliated
                 companies. All rights reserved.
             </div>
         </Container>


### PR DESCRIPTION
## What does this change?
Updates the footer to use & instead of and. Also uses the getDate function for the dotcom footer.

## Why?
Parity