### PR TITLE
Up pasteup version & fix build scripts

### DIFF
--- a/makefile
+++ b/makefile
@@ -133,12 +133,12 @@ pre-publish-pasteup:
 	$(call log, "building pasteup")
 	@mkdir packages/pasteup/tmp
 	@NODE_ENV=production webpack --config scripts/webpack/pasteup
-	@mv packages/pasteup/*.js packages/pasteup/tmp
+	@mv packages/pasteup/*.ts packages/pasteup/tmp
 	@mv packages/pasteup/dist/*.js packages/pasteup
 
 post-publish-pasteup:
 	$(call log, "clean up after publishing pasteup")
-	@mv packages/pasteup/tmp/*.js packages/pasteup
+	@mv packages/pasteup/tmp/*.ts packages/pasteup
 
 publish-pasteup: clear clean-pasteup install
 	$(call log, "publishing pasteup")

--- a/makefile
+++ b/makefile
@@ -139,6 +139,8 @@ pre-publish-pasteup:
 post-publish-pasteup:
 	$(call log, "clean up after publishing pasteup")
 	@mv packages/pasteup/tmp/*.ts packages/pasteup
+	@mv packages/pasteup/*.js packages/pasteup/tmp
+	@make clean-pasteup
 
 publish-pasteup: clear clean-pasteup install
 	$(call log, "publishing pasteup")

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@emotion/core": "^10.0.5",
     "@guardian/guui": "2.0.0-alpha.1",
-    "@guardian/pasteup": "1.0.0-alpha.1",
+    "@guardian/pasteup": "1.0.0-alpha.5",
     "aws-sdk": "^2.340.0",
     "compose-function": "^3.0.3",
     "compression": "^1.7.3",

--- a/packages/guui/package.json
+++ b/packages/guui/package.json
@@ -7,7 +7,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@guardian/pasteup": "1.0.0-alpha.1",
+    "@guardian/pasteup": "1.0.0-alpha.5",
     "polished": "^1.9.2",
     "prop-types": "^15.6.1",
     "reset-css": "^3.0.0"

--- a/packages/pasteup/package.json
+++ b/packages/pasteup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/pasteup",
-  "version": "1.0.0-alpha.2",
+  "version": "1.0.0-alpha.5",
   "description": "Guardian design tokens",
   "repository": {
     "type": "git",

--- a/packages/pasteup/package.json
+++ b/packages/pasteup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/pasteup",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "description": "Guardian design tokens",
   "repository": {
     "type": "git",

--- a/scripts/webpack/pasteup.js
+++ b/scripts/webpack/pasteup.js
@@ -3,10 +3,10 @@ const path = require('path');
 module.exports = {
     mode: 'production',
     entry: {
-        breakpoints: './packages/pasteup/breakpoints.js',
-        fonts: './packages/pasteup/fonts.js',
-        mixins: './packages/pasteup/mixins.js',
-        palette: './packages/pasteup/palette.js',
+        breakpoints: './packages/pasteup/breakpoints.ts',
+        typography: './packages/pasteup/typography.ts',
+        mixins: './packages/pasteup/mixins.ts',
+        palette: './packages/pasteup/palette.ts',
     },
     output: {
         filename: '[name].js',
@@ -17,7 +17,7 @@ module.exports = {
     module: {
         rules: [
             {
-                test: /\.js$/,
+                test: /\.ts$/,
                 exclude: /node_modules/,
                 use: ['babel-loader'],
             },

--- a/yarn.lock
+++ b/yarn.lock
@@ -740,6 +740,9 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
+"@guardian/pasteup@1.0.0-alpha.5":
+  version "1.0.0-alpha.5"
+
 "@kossnocorp/desvg@^0.1.1":
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@kossnocorp/desvg/-/desvg-0.1.2.tgz#3d120b180d4dbb1f646603c3b9f2c89774c368dc"


### PR DESCRIPTION
## What does this change?

Updates the version of pasteup and makes the build scripts work with `.ts`

## Why?
We are importing it into `support-frontend` today 👀 