### PR TITLE
Render as static markup

### DIFF
--- a/packages/frontend/amp/server/document.tsx
+++ b/packages/frontend/amp/server/document.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { extractCritical } from 'emotion-server';
-import { renderToString } from 'react-dom/server';
+import { renderToStaticMarkup } from 'react-dom/server';
 import { CacheProvider } from '@emotion/core';
 import { cache } from 'emotion';
 import resetCSS from /* preval */ '@frontend/lib/reset-css';
@@ -24,7 +24,9 @@ export const document = ({
 }) => {
     const { html, css }: RenderToStringResult = extractCritical(
         // TODO: CacheProvider can be removed when we've moved over to using @emotion/core
-        renderToString(<CacheProvider value={cache}>{body}</CacheProvider>),
+        renderToStaticMarkup(
+            <CacheProvider value={cache}>{body}</CacheProvider>,
+        ),
     );
 
     const favicon =


### PR DESCRIPTION
This results in (marginally) smaller responses and also ensures we
aren't leaking React-specific stuff to the client. Probably we should do this for non-AMP too (once we've got some kind of client-side approach in place).

https://reactjs.org/docs/react-dom-server.html#rendertostaticmarkup

The size difference is *very* marginal:

![screenshot 2019-02-19 at 13 59 42](https://user-images.githubusercontent.com/858402/53023022-589b9800-3454-11e9-90cf-555b78d5f797.png)
