### PR TITLE
Add state colours to pasteup & up version

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@emotion/core": "^10.0.5",
     "@guardian/guui": "2.0.0-alpha.1",
-    "@guardian/pasteup": "1.0.0-alpha.5",
+    "@guardian/pasteup": "1.0.0-alpha.7",
     "aws-sdk": "^2.340.0",
     "compose-function": "^3.0.3",
     "compression": "^1.7.3",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@emotion/core": "^10.0.5",
     "@guardian/guui": "2.0.0-alpha.1",
-    "@guardian/pasteup": "~1.0.0",
+    "@guardian/pasteup": "^1.0.0",
     "aws-sdk": "^2.340.0",
     "compose-function": "^3.0.3",
     "compression": "^1.7.3",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@emotion/core": "^10.0.5",
     "@guardian/guui": "2.0.0-alpha.1",
-    "@guardian/pasteup": "^1.0.0",
+    "@guardian/pasteup": "1.0.0-alpha.7",
     "aws-sdk": "^2.340.0",
     "compose-function": "^3.0.3",
     "compression": "^1.7.3",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@emotion/core": "^10.0.5",
     "@guardian/guui": "2.0.0-alpha.1",
-    "@guardian/pasteup": "1.0.0-alpha.7",
+    "@guardian/pasteup": "~1.0.0",
     "aws-sdk": "^2.340.0",
     "compose-function": "^3.0.3",
     "compression": "^1.7.3",

--- a/packages/guui/package.json
+++ b/packages/guui/package.json
@@ -7,7 +7,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@guardian/pasteup": "1.0.0-alpha.7",
+    "@guardian/pasteup": "~1.0.0",
     "polished": "^1.9.2",
     "prop-types": "^15.6.1",
     "reset-css": "^3.0.0"

--- a/packages/guui/package.json
+++ b/packages/guui/package.json
@@ -7,7 +7,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@guardian/pasteup": "1.0.0-alpha.5",
+    "@guardian/pasteup": "1.0.0-alpha.7",
     "polished": "^1.9.2",
     "prop-types": "^15.6.1",
     "reset-css": "^3.0.0"

--- a/packages/guui/package.json
+++ b/packages/guui/package.json
@@ -7,7 +7,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@guardian/pasteup": "^1.0.0",
+    "@guardian/pasteup": "1.0.0-alpha.7",
     "polished": "^1.9.2",
     "prop-types": "^15.6.1",
     "reset-css": "^3.0.0"

--- a/packages/guui/package.json
+++ b/packages/guui/package.json
@@ -7,7 +7,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@guardian/pasteup": "~1.0.0",
+    "@guardian/pasteup": "^1.0.0",
     "polished": "^1.9.2",
     "prop-types": "^15.6.1",
     "reset-css": "^3.0.0"

--- a/packages/pasteup/package.json
+++ b/packages/pasteup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/pasteup",
-  "version": "1.0.0-alpha.5",
+  "version": "1.0.0-alpha.6",
   "description": "Guardian design tokens",
   "repository": {
     "type": "git",

--- a/packages/pasteup/package.json
+++ b/packages/pasteup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/pasteup",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "description": "Guardian design tokens",
   "repository": {
     "type": "git",

--- a/packages/pasteup/palette.ts
+++ b/packages/pasteup/palette.ts
@@ -25,74 +25,103 @@ export interface OtherColours {
         97: colour;
         100: colour;
     };
+    state: { success: colour; error: colour };
     specialReport: { dark: colour };
     labs: { dark: colour; main: colour };
     green: { dark: colour; main: colour };
     brand: { dark: colour; main: colour; pastel: colour };
 }
 
+const news: PillarColours = {
+    dark: '#ab0613',
+    main: '#c70000',
+    bright: '#ff4e36',
+    pastel: '#ffbac8',
+    faded: '#fff4f2',
+};
+
+const opinion: PillarColours = {
+    dark: '#bd5318',
+    main: '#e05e00',
+    bright: '#ff7f0f',
+    pastel: '#f9b376',
+    faded: '#fef9f5',
+};
+
+const sport: PillarColours = {
+    dark: '#005689',
+    main: '#0084c6',
+    bright: '#00b2ff',
+    pastel: '#90dcff',
+    faded: '#f1f8fc',
+};
+
+const culture: PillarColours = {
+    dark: '#6b5840',
+    main: '#a1845c',
+    bright: '#eacca0',
+    pastel: '#e7d4b9',
+    faded: '#fbf6ef',
+};
+
+const lifestyle: PillarColours = {
+    dark: '#7d0068',
+    main: '#bb3b80',
+    bright: '#ffabdb',
+    pastel: '#fec8d3',
+    faded: '#feeef7',
+};
+
+const green = {
+    dark: '#185E36',
+    main: '#22874D',
+};
+
+const brand = {
+    dark: '#041f4a',
+    main: '#052962',
+    pastel: '#506991',
+};
+
+const state = {
+    success: green.main,
+    error: news.main,
+};
+
+const highlight = {
+    main: '#ffe500',
+    dark: '#ffbb50',
+};
+
+const neutral = {
+    7: '#121212',
+    20: '#333333',
+    46: '#767676',
+    60: '#999999',
+    86: '#dcdcdc',
+    93: '#ededed',
+    97: '#f6f6f6',
+    100: '#ffffff',
+};
+
+const specialReport = { dark: '#3f464a' };
+
+const labs = {
+    dark: '#65a897',
+    main: '#69d1ca',
+};
+
 export const palette: AllPillarColours & OtherColours = {
-    news: {
-        dark: '#ab0613',
-        main: '#c70000',
-        bright: '#ff4e36',
-        pastel: '#ffbac8',
-        faded: '#fff4f2',
-    },
-    opinion: {
-        dark: '#bd5318',
-        main: '#e05e00',
-        bright: '#ff7f0f',
-        pastel: '#f9b376',
-        faded: '#fef9f5',
-    },
-    sport: {
-        dark: '#005689',
-        main: '#0084c6',
-        bright: '#00b2ff',
-        pastel: '#90dcff',
-        faded: '#f1f8fc',
-    },
-    culture: {
-        dark: '#6b5840',
-        main: '#a1845c',
-        bright: '#eacca0',
-        pastel: '#e7d4b9',
-        faded: '#fbf6ef',
-    },
-    lifestyle: {
-        dark: '#7d0068',
-        main: '#bb3b80',
-        bright: '#ffabdb',
-        pastel: '#fec8d3',
-        faded: '#feeef7',
-    },
-    highlight: {
-        main: '#ffe500',
-        dark: '#ffbb50',
-    },
-    neutral: {
-        7: '#121212',
-        20: '#333333',
-        46: '#767676',
-        60: '#999999',
-        86: '#dcdcdc',
-        93: '#ededed',
-        97: '#f6f6f6',
-        100: '#ffffff',
-    },
-    specialReport: { dark: '#3f464a' },
-    labs: {
-        dark: '#65a897',
-        main: '#69d1ca',
-    },
-    green: {
-        dark: '#185E36',
-        main: '#22874D',
-    },
-    brand: {
-        dark: '#041f4a',
-        main: '#052962',
-        pastel: '#506991',
-    },
+    news,
+    opinion,
+    sport,
+    culture,
+    lifestyle,
+    highlight,
+    neutral,
+    specialReport,
+    labs,
+    green,
+    brand,
+    state,
 };

--- a/packages/pasteup/palette.ts
+++ b/packages/pasteup/palette.ts
@@ -32,9 +32,19 @@ export interface OtherColours {
     brand: { dark: colour; main: colour; pastel: colour };
 }
 
-const news: PillarColours = {
+const green = {
+    dark: '#185E36',
+    main: '#22874D',
+};
+
+const red = {
     dark: '#ab0613',
     main: '#c70000',
+};
+
+const news: PillarColours = {
+    dark: red.dark,
+    main: red.main,
     bright: '#ff4e36',
     pastel: '#ffbac8',
     faded: '#fff4f2',
@@ -72,11 +82,6 @@ const lifestyle: PillarColours = {
     faded: '#feeef7',
 };
 
-const green = {
-    dark: '#185E36',
-    main: '#22874D',
-};
-
 const brand = {
     dark: '#041f4a',
     main: '#052962',
@@ -85,7 +90,7 @@ const brand = {
 
 const state = {
     success: green.main,
-    error: news.main,
+    error: red.main,
 };
 
 const highlight = {


### PR DESCRIPTION
Adds `state.success` and `state.error` to pasteup. This is because that way we prevent these states from being reimplemented using different colours or shades