### PR TITLE
Correct h2 and text relatively to each other

### DIFF
--- a/packages/frontend/amp/components/elements/TextBlockComponent.tsx
+++ b/packages/frontend/amp/components/elements/TextBlockComponent.tsx
@@ -11,7 +11,8 @@ const style = (pillar: Pillar) => css`
     }
     h2 {
         margin-top: 24px;
-        ${textSans(6)};
+        margin-bottom: 10px;
+        ${textSans(7)};
     }
     p {
         padding: 0 0 12px;

--- a/packages/frontend/amp/components/elements/TextBlockComponent.tsx
+++ b/packages/frontend/amp/components/elements/TextBlockComponent.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
 import { pillarPalette } from '@frontend/lib/pillars';
-import { textSans, body } from '@guardian/pasteup/typography';
+import { body, headline } from '@guardian/pasteup/typography';
 
 // tslint:disable:react-no-dangerous-html
 const style = (pillar: Pillar) => css`
@@ -12,7 +12,7 @@ const style = (pillar: Pillar) => css`
     h2 {
         margin-top: 24px;
         margin-bottom: 10px;
-        ${textSans(7)};
+        ${headline(3)};
     }
     p {
         padding: 0 0 12px;
@@ -29,7 +29,7 @@ const style = (pillar: Pillar) => css`
             border-bottom: 1px solid ${pillarPalette[pillar].dark};
         }
     }
-    ${textSans(5)};
+    ${body(3)};
 `;
 export const TextBlockComponent: React.FC<{
     html: string;


### PR DESCRIPTION
## What does this change?
Add `margin-bottom: 10px;` to h2 and increase the font size.

## Why?

*Currently PROD non dotcom rendering*

![screenshot 2019-02-20 at 12 14 34](https://user-images.githubusercontent.com/6035518/53091169-29932e00-3509-11e9-837b-569e63489d7c.png)

*Currently PROD dotcom rendering*

![screenshot 2019-02-20 at 12 15 19](https://user-images.githubusercontent.com/6035518/53091194-3b74d100-3509-11e9-92e5-82e87a8df221.png)

*Proposed change*

![screenshot 2019-02-20 at 14 57 25](https://user-images.githubusercontent.com/6035518/53100676-0b84f800-3520-11e9-8cd9-1e582933f893.png)


