### PR TITLE
Correct standfirst font-weight distribution

### DIFF
--- a/packages/frontend/amp/components/TopMeta.tsx
+++ b/packages/frontend/amp/components/TopMeta.tsx
@@ -67,12 +67,14 @@ const listStyles = (pillar: Pillar) => css`
 const standfirstCss = pillarMap(
     pillar => css`
         ${body(2)};
-        font-weight: 700;
         color: ${palette.neutral[7]};
         margin-bottom: 12px;
         ${listStyles(pillar)};
         p {
             margin-bottom: 8px;
+        }
+        strong {
+            font-weight: 700;
         }
     `,
 );


### PR DESCRIPTION
## What does this change?

Align the standfirst font-weight distribution to non amp articles

Article: https://www.theguardian.com/artanddesign/2019/feb/04/don-mccullin-tate-retrospective-review

*article (standard, non AMP)*

<img width="623" alt="screenshot 2019-02-21 at 16 08 20" src="https://user-images.githubusercontent.com/6035518/53183300-f4630a80-35f2-11e9-9f5e-435ddb80cc47.png">

*AMP (current)*

<img width="605" alt="screenshot 2019-02-21 at 16 09 17" src="https://user-images.githubusercontent.com/6035518/53183374-13fa3300-35f3-11e9-94ac-48a5f79cf69f.png">

*AMP (proposed change)*

<img width="633" alt="screenshot 2019-02-21 at 16 10 05" src="https://user-images.githubusercontent.com/6035518/53183434-2ffdd480-35f3-11e9-9e75-d0e28a47eb2f.png">



