### PR TITLE
Use correct experience dimension in GA

### DIFF
--- a/packages/frontend/amp/components/Analytics.tsx
+++ b/packages/frontend/amp/components/Analytics.tsx
@@ -54,7 +54,7 @@ export const Analytics: React.FC<{
                        "contentId": "${id}",
                        "isHostedFlag": "true",
                        "fullRequestUrl": "${domain}/${id}",
-                       "experience": "dotcom-platform"
+                       "experience": "dotcom-rendering"
                      }
                    }
                  }


### PR DESCRIPTION
## What does this change?

Updates the experience dimension from the meaningless `dotcom-platform` to the more useful `dotcom-rendering`. This matches what is happening in web.

## Why? 😓 

For parity with web, we should capture the same value in this dimension
