### PR TITLE
Add parameter to ad targeting to detect rendering platform

### DIFF
--- a/packages/frontend/amp/lib/ad-json.test.ts
+++ b/packages/frontend/amp/lib/ad-json.test.ts
@@ -74,6 +74,22 @@ describe('ampadslots', () => {
         expect(p.value).toBe('amp');
     });
 
+    it('should set rendering platform to dotcom-rendering', () => {
+        const edition = 'UK';
+        const targetings: EditionAdTargeting = {
+            paramSet,
+            edition,
+        };
+        const res = adJson(edition, [targetings]);
+        const renderingPlatform = res.targeting.find(
+            param => param.name === 'rp',
+        );
+        if (renderingPlatform === undefined) {
+            return fail();
+        }
+        expect(renderingPlatform.value).toBe('dotcom-rendering');
+    });
+
     it('should set values to a comma-separated string', () => {
         const edition = 'UK';
         const targetings: EditionAdTargeting = {

--- a/packages/frontend/amp/lib/ad-json.ts
+++ b/packages/frontend/amp/lib/ad-json.ts
@@ -25,6 +25,7 @@ export const adJson = (
 
     json = json.filter(p => p.name !== 'p');
     json.push({ name: 'p', value: 'amp' });
+    json.push({ name: 'rp', value: 'dotcom-rendering' });
 
     return { targeting: json };
 };


### PR DESCRIPTION
## What does this change?
This adds a `platform-rendering` parameter to the ad targeting so that we can detect which ad impressions came from frontend and which from dotcom-rendering.  The parameter corresponds to the `experience` parameter in GA and has the same values.

## Why?
So that we can easily detect the source rendering platform of ad impressions.

/cc @guardian/commercial-dev 
