### PR TITLE
Fix json attribute of amp-ad element

### DIFF
--- a/packages/frontend/amp/components/elements/AdComponent.tsx
+++ b/packages/frontend/amp/components/elements/AdComponent.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 import { until } from '@guardian/pasteup/breakpoints';
 import { palette } from '@guardian/pasteup/palette';
-import { adJson } from '@frontend/amp/lib/ad-json';
+import { adJson, stringify } from '@frontend/amp/lib/ad-json';
 
 const adStyle = css`
     background: ${palette.neutral[93]};
@@ -114,7 +114,9 @@ export const AdComponent: React.SFC<{
             data-loading-strategy={'prefer-viewability-over-views'}
             layout={'responsive'}
             type={'doubleclick'}
-            json={adJson(edition, commercialProperties.editionAdTargeting)}
+            json={stringify(
+                adJson(edition, commercialProperties.editionAdTargeting),
+            )}
             data-slot={ampData(section, contentType)}
             rtc-config={realTimeConfig(
                 edition,

--- a/packages/frontend/amp/lib/ad-json.test.ts
+++ b/packages/frontend/amp/lib/ad-json.test.ts
@@ -1,4 +1,4 @@
-import { adJson } from './ad-json';
+import { adJson, stringify } from './ad-json';
 
 const paramSet: AdTargetParam[] = [
     {
@@ -102,5 +102,33 @@ describe('ampadslots', () => {
             return fail();
         }
         expect(p.value).toBe('4,5,1,2,3');
+    });
+});
+
+describe('stringify', () => {
+    it('should generate the correct string value from an AdJson', () => {
+        const edition = 'AU';
+        const targetings: EditionAdTargeting = {
+            paramSet,
+            edition,
+        };
+        const res = adJson(edition, [targetings]);
+        const outputJson = {
+            targeting: {
+                su: '4,5,1,2,3',
+                url:
+                    '/business/2019/feb/07/no-deal-brexit-uk-exporters-risk-being-locked-out-of-world-harbours',
+                tn: 'news',
+                ct: 'article',
+                co: 'richard-partington',
+                k:
+                    'asia-pacific,politics,business,uk/uk,eu,newzealand,world,europe-news,internationaltrade,foreignpolicy,australia-news,eu-referendum,global-economy,japan,economics,south-korea',
+                edition: 'au',
+                sh: 'https://gu.com/p/akj3n',
+                p: 'amp',
+                rp: 'dotcom-rendering',
+            },
+        };
+        expect(stringify(res)).toBe(JSON.stringify(outputJson));
     });
 });

--- a/packages/frontend/amp/lib/ad-json.ts
+++ b/packages/frontend/amp/lib/ad-json.ts
@@ -31,9 +31,16 @@ export const adJson = (
 };
 
 export const stringify = (json: AdJson): string => {
-    const targeting = json.targeting.reduce((params, param) => {
-        params[param.name] = param.value;
-        return params;
-    }, {});
+    interface Map {
+        [key: string]: string;
+    }
+    const targeting = json.targeting.reduce(
+        (params, param) => {
+            params[param.name] = param.value;
+            return params;
+        },
+        {} as Map,
+    );
+
     return JSON.stringify({ targeting });
 };

--- a/packages/frontend/amp/lib/ad-json.ts
+++ b/packages/frontend/amp/lib/ad-json.ts
@@ -29,3 +29,11 @@ export const adJson = (
 
     return { targeting: json };
 };
+
+export const stringify = (json: AdJson): string => {
+    const targeting = json.targeting.reduce((params, param) => {
+        params[param.name] = param.value;
+        return params;
+    }, {});
+    return JSON.stringify({ targeting });
+};


### PR DESCRIPTION
## What does this change?
Fixes a bug in rendering of the json attribute.

Before:
<amp-ad ... **json="[object Object]"** ... >

After:
<amp-ad ... **json="{"targeting":{"edition":"uk","url":"/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software","tn":"news","sh":"`https://gu.com/p/64ak8`","su":"0","co":"rob-davies","ct":"article","k":"ticket-prices,consumer-affairs,internet,viagogo,money","p":"amp","rp":"dotcom-rendering"}}"** ... >

## Why?
Because otherwise ads will be untargeted.

/cc @guardian/commercial-dev 
