### PR TITLE
Strip HTML from trailtext

### DIFF
--- a/packages/frontend/model/clean.test.ts
+++ b/packages/frontend/model/clean.test.ts
@@ -1,4 +1,5 @@
 import { bigBullets } from './clean';
+
 describe('clean', () => {
     it('anotates bullet characters with spans', () => {
         const test = '<p>•</p>';

--- a/packages/frontend/model/extract-capi.ts
+++ b/packages/frontend/model/extract-capi.ts
@@ -8,6 +8,7 @@ import {
     optional,
 } from './validators';
 import { clean } from './clean';
+import { stripHTML } from './strip-html';
 import { string as curly } from 'curlyquotes';
 
 import { getSharingUrls } from './sharing-urls';
@@ -225,6 +226,9 @@ export const extract = (data: {}): CAPIType => {
         starRating: optional(
             getNumber.bind(null, data, 'config.page.starRating'),
         ),
-        trailText: getString(data, 'config.page.trailText', ''),
+        trailText: apply(
+            getString(data, 'config.page.trailText', ''),
+            stripHTML,
+        ),
     };
 };

--- a/packages/frontend/model/strip-html.test.ts
+++ b/packages/frontend/model/strip-html.test.ts
@@ -1,0 +1,9 @@
+import { stripHTML } from './strip-html';
+
+describe('stripHTML', () => {
+    it('removes all HTML tags', () => {
+        const test = '<p>foo <span>bar</span></p>';
+
+        expect(stripHTML(test)).toBe('foo bar');
+    });
+});

--- a/packages/frontend/model/strip-html.ts
+++ b/packages/frontend/model/strip-html.ts
@@ -1,0 +1,8 @@
+import createDOMPurify from 'dompurify';
+import { JSDOM } from 'jsdom';
+
+const { window } = new JSDOM('');
+const DOMPurify = createDOMPurify(window);
+
+export const stripHTML = (s: string): string =>
+    DOMPurify.sanitize(s, { ALLOWED_TAGS: [] });


### PR DESCRIPTION
## What does this change?

Strips HTML from trailtext field.

## Why?

It's unclear from the CAPI model if trailtext can contain markup but we currently strip HTML tags in Frontend so it seems prudent to do it here as well.

I also expect stripHTML to be a useful function generally.