### PR TITLE
Remove amp article model

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,6 @@
 {
     "recommendations": [
-        "eg2.tslint",
-        "esbenp.prettier-vscode",
+        "ms-vscode.vscode-typescript-tslint-plugin",
         "wix.vscode-import-cost",
         "eamodio.gitlens",
         "orta.vscode-jest"

--- a/packages/frontend/amp/components/Body.tsx
+++ b/packages/frontend/amp/components/Body.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { InnerContainer } from '@frontend/amp/components/InnerContainer';
 import { Elements } from '@frontend/amp/components/lib/Elements';
 import { css } from 'emotion';
-import { ArticleModel } from '@frontend/amp/pages/Article';
 import { TopMeta } from '@frontend/amp/components/TopMeta';
 import { SubMeta } from '@frontend/amp/components/SubMeta';
 import { pillarPalette } from '../../lib/pillars';
@@ -33,7 +32,7 @@ const bulletStyle = (pillar: Pillar) => css`
 
 export const Body: React.FC<{
     pillar: Pillar;
-    data: ArticleModel;
+    data: CAPIType;
     config: ConfigType;
 }> = ({ pillar, data, config }) => (
     <InnerContainer className={body(pillar)}>

--- a/packages/frontend/amp/components/TopMeta.tsx
+++ b/packages/frontend/amp/components/TopMeta.tsx
@@ -7,7 +7,6 @@ import { ShareCount } from '@frontend/web/components/ShareCount';
 import ClockIcon from '@guardian/pasteup/icons/clock.svg';
 import TwitterIcon from '@guardian/pasteup/icons/twitter.svg';
 import { ShareIcons } from '@frontend/amp/components/ShareIcons';
-import { ArticleModel } from '@frontend/amp/pages/Article';
 import { MainMedia } from '@frontend/amp/components/MainMedia';
 import Star from '@guardian/pasteup/icons/star.svg';
 import { Byline } from '@frontend/amp/components/Byline';
@@ -191,7 +190,7 @@ const Headline: React.FC<{
 
 export const TopMeta: React.FC<{
     config: ConfigType;
-    articleData: ArticleModel;
+    articleData: CAPIType;
 }> = ({ config, articleData }) => (
     <header className={header}>
         {articleData.mainMediaElements.map((element, i) => (

--- a/packages/frontend/amp/pages/Article.tsx
+++ b/packages/frontend/amp/pages/Article.tsx
@@ -13,41 +13,6 @@ const backgroundColour = css`
     background-color: ${palette.neutral[97]};
 `;
 
-export interface ArticleModel {
-    headline: string;
-    standfirst: string;
-    mainMediaElements: CAPIElement[];
-    elements: CAPIElement[];
-    author: AuthorType;
-    webPublicationDateDisplay: string;
-    pageId: string;
-    ageWarning?: string;
-    sharingUrls: {
-        [K in SharePlatform]?: {
-            url: string;
-            userMessage: string;
-        }
-    };
-    pillar: Pillar;
-    sectionLabel?: string;
-    sectionUrl?: string;
-    sectionName: string;
-    tags: TagType[];
-    subMetaSectionLinks: SimpleLinkType[];
-    subMetaKeywordLinks: SimpleLinkType[];
-    webURL: string;
-    shouldHideAds: boolean;
-    guardianBaseURL: string;
-    hasRelated: boolean;
-    hasStoryPackage: boolean;
-    isCommentable: boolean;
-    editionId: Edition;
-    contentType: string;
-    commercialProperties: CommercialProperties;
-    isImmersive: boolean;
-    starRating?: number;
-}
-
 // TODO move somewhere better
 const tagsOfType = (tags: TagType[], tagType: string): TagType[] => {
     return tags.filter(
@@ -59,7 +24,7 @@ const tagsOfType = (tags: TagType[], tagType: string): TagType[] => {
 
 export const Article: React.FC<{
     nav: NavType;
-    articleData: ArticleModel;
+    articleData: CAPIType;
     config: ConfigType;
     analytics: AnalyticsModel;
 }> = ({ nav, articleData, config, analytics }) => (


### PR DESCRIPTION
## What does this change?
This replaces `ArticleModel` with `CAPIType` in amp
Also upgrades tslint extension.
## Why?
Having the extra copy of `CAPIType` makes it difficult to reason about the data model, and not having a second copy of it will make the data model changes easier. 
