### PR TITLE
Add subheading element

### DIFF
--- a/docs/elements/x-subheading.md
+++ b/docs/elements/x-subheading.md
@@ -1,0 +1,12 @@
+# Subheading Element
+
+An element which contains a subheading.
+
+## CAPI representation
+
+This element does not exist in CAPI. Subheadings were originally treated as `TextBlockElement`s.
+This element was introduced to ensure ads were not inserted after subheadings.
+
+## CAPI HTML Output
+
+This is inserted raw into the document.

--- a/packages/frontend/amp/components/elements/SubheadingBlockElement.tsx
+++ b/packages/frontend/amp/components/elements/SubheadingBlockElement.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { css } from 'emotion';
+import { headline } from '@guardian/pasteup/typography';
+
+// tslint:disable:react-no-dangerous-html
+const style = css`
+    margin-top: 24px;
+    margin-bottom: 10px;
+    ${headline(3)};
+`;
+
+export const SubheadingBlockComponent: React.FC<{
+    html: string;
+}> = ({ html }) => (
+    <span
+        className={style}
+        dangerouslySetInnerHTML={{
+            __html: html,
+        }}
+    />
+);

--- a/packages/frontend/amp/components/lib/Elements.tsx
+++ b/packages/frontend/amp/components/lib/Elements.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { TextBlockComponent } from '@frontend/amp/components/elements/TextBlockComponent';
+import { SubheadingBlockComponent } from '@frontend/amp/components/elements/SubheadingBlockElement';
 import { ImageBlockComponent } from '@frontend/amp/components/elements/ImageBlockComponent';
 import { InstagramBlockComponent } from '@frontend/amp/components/elements/InstagramBlockComponent';
 import { TweetBlockComponent } from '@frontend/amp/components/elements/TweetBlockComponent';
@@ -51,6 +52,8 @@ export const Elements: React.FC<{
                         isImmersive={isImmersive}
                     />
                 );
+            case 'model.dotcomrendering.pageElements.SubheadingBlockElement':
+                return <SubheadingBlockComponent key={i} html={element.html} />;
             case 'model.dotcomrendering.pageElements.ImageBlockElement':
                 return (
                     <ImageBlockComponent

--- a/packages/frontend/lib/content.d.ts
+++ b/packages/frontend/lib/content.d.ts
@@ -13,6 +13,11 @@ interface TextBlockElement {
     html: string;
 }
 
+interface SubheadingBlockElement {
+    _type: 'model.dotcomrendering.pageElements.SubheadingBlockElement';
+    html: string;
+}
+
 interface RichLinkBlockElement {
     _type: 'model.dotcomrendering.pageElements.RichLinkBlockElement';
     url: string;
@@ -100,6 +105,7 @@ interface DisclaimerBlockElement {
 
 type CAPIElement =
     | TextBlockElement
+    | SubheadingBlockElement
     | ImageBlockElement
     | InstagramBlockElement
     | TweetBlockElement


### PR DESCRIPTION
## What does this change?

Adds a subheading element to represent subheadings inserted in Composer. Previously these were rendered as `TextBlockElement`s.

A companion to guardian/frontend#21210

## Why?

This ensures ads do not get added immediately after a subheading.