### PR TITLE
change default plugins

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,6 @@
 {
     "recommendations": [
-        "eg2.tslint",
-        "esbenp.prettier-vscode",
+        "ms-vscode.vscode-typescript-tslint-plugin",
         "wix.vscode-import-cost",
         "eamodio.gitlens",
         "orta.vscode-jest"


### PR DESCRIPTION
The tslint extension we use is deprecated, the new one is slightly better and works better with vscode. Prettier doesn't really work with autosave with this so have removed, tslint should do this now.