### PR TITLE
Move h2 styling to subheading component

### DIFF
--- a/packages/frontend/amp/components/elements/SubheadingBlockElement.tsx
+++ b/packages/frontend/amp/components/elements/SubheadingBlockElement.tsx
@@ -1,19 +1,42 @@
 import React from 'react';
-import { css } from 'emotion';
+import { css, cx } from 'emotion';
 import { headline } from '@guardian/pasteup/typography';
+import { pillarPalette } from '@frontend/lib/pillars';
 
 // tslint:disable:react-no-dangerous-html
-const style = css`
-    margin-top: 24px;
-    margin-bottom: 10px;
-    ${headline(3)};
+const style = (pillar: Pillar) => css`
+    h2 {
+        margin-top: 24px;
+        margin-bottom: 10px;
+        ${headline(3)};
+    }
+    strong {
+        font-weight: 700;
+    }
+    a {
+        color: ${pillarPalette[pillar].dark};
+        text-decoration: none;
+        border-bottom: 1px solid #dcdcdc;
+        :hover {
+            border-bottom: 1px solid ${pillarPalette[pillar].dark};
+        }
+    }
+`;
+
+const immersiveBodyStyle = css`
+    h2 {
+        ${headline(7)};
+        font-weight: 200;
+    }
 `;
 
 export const SubheadingBlockComponent: React.FC<{
     html: string;
-}> = ({ html }) => (
+    pillar: Pillar;
+    isImmersive: boolean;
+}> = ({ html, pillar, isImmersive }) => (
     <span
-        className={style}
+        className={cx(style(pillar), { [immersiveBodyStyle]: isImmersive })}
         dangerouslySetInnerHTML={{
             __html: html,
         }}

--- a/packages/frontend/amp/components/elements/TextBlockComponent.tsx
+++ b/packages/frontend/amp/components/elements/TextBlockComponent.tsx
@@ -1,18 +1,13 @@
 import React from 'react';
-import { css, cx } from 'emotion';
+import { css } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
 import { pillarPalette } from '@frontend/lib/pillars';
-import { body, headline } from '@guardian/pasteup/typography';
+import { body } from '@guardian/pasteup/typography';
 
 // tslint:disable:react-no-dangerous-html
 const style = (pillar: Pillar) => css`
     strong {
         font-weight: 700;
-    }
-    h2 {
-        margin-top: 24px;
-        margin-bottom: 10px;
-        ${headline(3)};
     }
     p {
         padding: 0 0 12px;
@@ -32,20 +27,12 @@ const style = (pillar: Pillar) => css`
     ${body(3)};
 `;
 
-const immersiveBodyStyle = css`
-    h2 {
-        ${headline(7)};
-        font-weight: 200;
-    }
-`;
-
 export const TextBlockComponent: React.FC<{
     html: string;
     pillar: Pillar;
-    isImmersive: boolean;
-}> = ({ html, pillar, isImmersive }) => (
+}> = ({ html, pillar }) => (
     <span
-        className={cx(style(pillar), { [immersiveBodyStyle]: isImmersive })}
+        className={style(pillar)}
         dangerouslySetInnerHTML={{
             __html: html,
         }}

--- a/packages/frontend/amp/components/lib/Elements.tsx
+++ b/packages/frontend/amp/components/lib/Elements.tsx
@@ -49,11 +49,17 @@ export const Elements: React.FC<{
                         key={i}
                         html={element.html}
                         pillar={pillar}
-                        isImmersive={isImmersive}
                     />
                 );
             case 'model.dotcomrendering.pageElements.SubheadingBlockElement':
-                return <SubheadingBlockComponent key={i} html={element.html} />;
+                return (
+                    <SubheadingBlockComponent
+                        key={i}
+                        html={element.html}
+                        pillar={pillar}
+                        isImmersive={isImmersive}
+                    />
+                );
             case 'model.dotcomrendering.pageElements.ImageBlockElement':
                 return (
                     <ImageBlockComponent


### PR DESCRIPTION
## What does this change?

Moves styling that is relevant to subheadings from Text to Subheading.

**Before**

![screen shot 2019-03-07 at 15 38 56](https://user-images.githubusercontent.com/5931528/53968558-39a53300-40ef-11e9-9e9f-5415485828e7.png)

**After**

![screen shot 2019-03-07 at 15 39 16](https://user-images.githubusercontent.com/5931528/53968557-390c9c80-40ef-11e9-832d-903007d773ab.png)

## Why?

Fixes some broken styling