### PR TITLE
Refactor commercialProperties as map of targeting params

### DIFF
--- a/fixtures/CAPI.ts
+++ b/fixtures/CAPI.ts
@@ -397,7 +397,10 @@ export const CAPI: CAPIType = {
     beaconURL: '//fake.url',
     isCommentable: false,
     commercialProperties: {
-        editionAdTargeting: [],
+        UK: { adTargeting: [] },
+        US: { adTargeting: [] },
+        AU: { adTargeting: [] },
+        INT: { adTargeting: [] },
     },
     starRating: 2,
     trailText:

--- a/packages/frontend/amp/components/elements/AdComponent.tsx
+++ b/packages/frontend/amp/components/elements/AdComponent.tsx
@@ -114,9 +114,7 @@ export const AdComponent: React.SFC<{
             data-loading-strategy={'prefer-viewability-over-views'}
             layout={'responsive'}
             type={'doubleclick'}
-            json={stringify(
-                adJson(edition, commercialProperties.editionAdTargeting),
-            )}
+            json={stringify(adJson(commercialProperties[edition].adTargeting))}
             data-slot={ampData(section, contentType)}
             rtc-config={realTimeConfig(
                 edition,

--- a/packages/frontend/amp/lib/ad-json.test.ts
+++ b/packages/frontend/amp/lib/ad-json.test.ts
@@ -3,33 +3,33 @@ import { adJson, stringify } from './ad-json';
 const paramSet: AdTargetParam[] = [
     {
         name: 'su',
-        values: ['4', '5', '1', '2', '3'],
+        value: ['4', '5', '1', '2', '3'],
     },
     {
         name: 'url',
-        values: [
+        value: [
             '/business/2019/feb/07/no-deal-brexit-uk-exporters-risk-being-locked-out-of-world-harbours',
         ],
     },
     {
         name: 'tn',
-        values: ['news'],
+        value: ['news'],
     },
     {
         name: 'ct',
-        values: ['article'],
+        value: ['article'],
     },
     {
         name: 'p',
-        values: ['ng'],
+        value: ['ng'],
     },
     {
         name: 'co',
-        values: ['richard-partington'],
+        value: ['richard-partington'],
     },
     {
         name: 'k',
-        values: [
+        value: [
             'asia-pacific',
             'politics',
             'business',
@@ -50,22 +50,17 @@ const paramSet: AdTargetParam[] = [
     },
     {
         name: 'edition',
-        values: ['au'],
+        value: ['au'],
     },
     {
         name: 'sh',
-        values: ['https://gu.com/p/akj3n'],
+        value: ['https://gu.com/p/akj3n'],
     },
 ];
 
 describe('ampadslots', () => {
     it('should set platform to amp', () => {
-        const edition = 'UK';
-        const targetings: EditionAdTargeting = {
-            paramSet,
-            edition: 'UK',
-        };
-        const res = adJson(edition, [targetings]);
+        const res = adJson(paramSet);
         const p = res.targeting.find(param => param.name === 'p');
         if (p === undefined) {
             return fail();
@@ -75,12 +70,7 @@ describe('ampadslots', () => {
     });
 
     it('should set rendering platform to dotcom-rendering', () => {
-        const edition = 'UK';
-        const targetings: EditionAdTargeting = {
-            paramSet,
-            edition,
-        };
-        const res = adJson(edition, [targetings]);
+        const res = adJson(paramSet);
         const renderingPlatform = res.targeting.find(
             param => param.name === 'rp',
         );
@@ -91,12 +81,7 @@ describe('ampadslots', () => {
     });
 
     it('should set values to a comma-separated string', () => {
-        const edition = 'UK';
-        const targetings: EditionAdTargeting = {
-            paramSet,
-            edition: 'UK',
-        };
-        const res = adJson(edition, [targetings]);
+        const res = adJson(paramSet);
         const p = res.targeting.find(param => param.name === 'su');
         if (p === undefined) {
             return fail();
@@ -107,12 +92,7 @@ describe('ampadslots', () => {
 
 describe('stringify', () => {
     it('should generate the correct string value from an AdJson', () => {
-        const edition = 'AU';
-        const targetings: EditionAdTargeting = {
-            paramSet,
-            edition,
-        };
-        const res = adJson(edition, [targetings]);
+        const res = adJson(paramSet);
         const outputJson = {
             targeting: {
                 su: '4,5,1,2,3',

--- a/packages/frontend/amp/lib/ad-json.ts
+++ b/packages/frontend/amp/lib/ad-json.ts
@@ -8,22 +8,17 @@ interface AdJson {
     targeting: KV[];
 }
 
-export const adJson = (
-    edition: Edition,
-    editionAdTargetings: EditionAdTargeting[],
-): AdJson => {
-    const targeting = editionAdTargetings.find(t => t.edition === edition);
-
+export const adJson = (targeting: AdTargetParam[]): AdJson => {
     if (!targeting) {
         return { targeting: [] };
     }
 
-    let json = targeting.paramSet.map(p => ({
-        name: p.name,
-        value: p.values.join(','),
-    }));
-
-    json = json.filter(p => p.name !== 'p');
+    const json = targeting
+        .filter(p => p.name !== 'p')
+        .map(({ name, value }) => ({
+            name,
+            value: Array.isArray(value) ? value.join(',') : value,
+        }));
     json.push({ name: 'p', value: 'amp' });
     json.push({ name: 'rp', value: 'dotcom-rendering' });
 

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -26,16 +26,28 @@ interface SimpleLinkType {
 
 interface AdTargetParam {
     name: string;
-    values: string[];
+    value: string | string[];
 }
 
-interface EditionAdTargeting {
-    edition: Edition;
-    paramSet: AdTargetParam[];
+interface EditionCommercialProperties {
+    adTargeting: AdTargetParam[];
+    branding?: Branding;
 }
 
-interface CommercialProperties {
-    editionAdTargeting: EditionAdTargeting[];
+type CommercialProperties = {
+    [E in Edition]: EditionCommercialProperties
+}
+
+interface Branding {
+    type: 'paid-content';
+    sponsorName: string;
+    logo: {
+        src: string;
+        width: number;
+        height: number;
+        link: string;
+    };
+    aboutThisLink: string;
 }
 
 interface LinkType extends SimpleLinkType {

--- a/packages/frontend/model/extract-capi.ts
+++ b/packages/frontend/model/extract-capi.ts
@@ -113,33 +113,11 @@ const getSubMetaKeywordLinks: (data: {}) => SimpleLinkType[] = data => {
 };
 
 const getCommercialProperties = (data: {}): CommercialProperties => {
-    const properties = getObject(
+    return getObject(
         data,
-        'page.commercial.commercialProperties',
+        'page.commercial.editionCommercialProperties',
         {},
-    );
-    const targeting = getArray<any>(properties, 'editionAdTargetings', []);
-    const editionAdTargeting: EditionAdTargeting[] = targeting.map(t => {
-        return {
-            edition: getEditionValue(getString(t, 'edition.id')),
-            paramSet: getArray<any>(t, 'paramSet', []).map(param => {
-                if (Array.isArray(param.value)) {
-                    return {
-                        name: param.name,
-                        values: param.value,
-                    };
-                }
-                return {
-                    name: param.name,
-                    values: [param.value],
-                };
-            }),
-        };
-    });
-
-    return {
-        editionAdTargeting,
-    };
+    ) as CommercialProperties;
 };
 
 // TODO really it would be nice if we passed just the data we needed and


### PR DESCRIPTION
## What does this change?

A refactor of commercial properties passed to AMP ads. Previously
this was an array of params, and we had to filter the array for the
correct edition.

This change supersedes #457, which was an attempt to implement this change and implement the paid content tone. 

**Old structure**

<img width="685" alt="Screen Shot 2019-03-13 at 16 25 11" src="https://user-images.githubusercontent.com/5931528/54296384-bda66180-45ac-11e9-9ac1-5ee265ac4c6b.png">

**New structure**

<img width="679" alt="Screen Shot 2019-03-13 at 16 26 04" src="https://user-images.githubusercontent.com/5931528/54296383-bda66180-45ac-11e9-95e5-d11949219c8f.png">


## Why?

This change restructures commercial properties as a map of edition
to targeting params, making it much easier to select the correct
params for the current edition. It simplifies our code and makes
it more efficient.

This corresponds to guardian/frontend#21208. We can remove the original
commercialProperties after this change is merged.

This provides the groundwork for paid content theming, as Branding is
easier to retrieve from the new editionalised map.
