### PR TITLE
228 consent banner for amp

### DIFF
--- a/packages/frontend/amp/components/AMPJSON.tsx
+++ b/packages/frontend/amp/components/AMPJSON.tsx
@@ -1,7 +1,7 @@
 // tslint:disable:react-no-dangerous-html
 import React from 'react';
 
-export const AMPJSON: React.FC<{ o: any }> = ({ o }) => {
+export const JsonScript: React.FC<{ o: any }> = ({ o }) => {
     const JSONString: string = JSON.stringify(o);
     return (
         <script

--- a/packages/frontend/amp/components/AMPJSON.tsx
+++ b/packages/frontend/amp/components/AMPJSON.tsx
@@ -1,0 +1,12 @@
+// tslint:disable:react-no-dangerous-html
+import React from 'react';
+
+export const AMPJSON: React.FC<{ o: any }> = ({ o }) => {
+    const JSONString: string = JSON.stringify(o);
+    return (
+        <script
+            type="application/json"
+            dangerouslySetInnerHTML={{ __html: JSONString }}
+        />
+    );
+};

--- a/packages/frontend/amp/components/AdConsent.tsx
+++ b/packages/frontend/amp/components/AdConsent.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { AMPJSON } from './AMPJSON';
+
+export const AdConsent: React.FC<{}> = ({}) => {
+    return (
+        <>
+            <amp-geo layout="nodisplay">
+                <AMPJSON
+                    o={{
+                        ISOCountryGroups: {
+                            eea: ['preset-eea'],
+                            us: ['us', 'ca'],
+                            au: ['au', 'nz'],
+                        },
+                    }}
+                />
+            </amp-geo>
+            <amp-consent layout="nodisplay" id="the-adconsent-element">
+                <AMPJSON
+                    o={{
+                        consents: {
+                            adconsent: {
+                                promptIfUnknownForGeoGroup: 'eea',
+                                promptUI: 'adconsent-ui',
+                            },
+                        },
+                        policy: {
+                            default: {
+                                waitFor: { adconsent: [] },
+                                timeout: {
+                                    seconds: 0,
+                                    fallbackAction: 'dismiss',
+                                },
+                            },
+                        },
+                    }}
+                />
+                <div
+                    id="adconsent-ui"
+                    className="with-uk-frame consent-ui main-body"
+                >
+                    <div className="adconsent-message">
+                        <p>
+                            We use cookies to improve your experience on our
+                            personalised advertising.
+                        </p>
+                        <p>
+                            To find out more, read our{' '}
+                            <a
+                                className="u-underline"
+                                href="https://www.theguardian.com/help/privacy-policy"
+                            >
+                                privacy policy
+                            </a>
+                            and{' '}
+                            <a
+                                className="u-underline"
+                                href="https://www.theguardian.com/info/cookies"
+                            >
+                                cookie policy
+                            </a>
+                            .
+                        </p>
+                    </div>
+                    <div className="adconsent-actions">
+                        <button
+                            on="tap:the-adconsent-element.accept"
+                            className="adconsent-accept"
+                            role="button"
+                        >
+                            I'm OK with that
+                        </button>
+                        <button
+                            on="tap:the-adconsent-element.reject"
+                            className="u-underline adconsent-reject"
+                            role="button"
+                        >
+                            I do not want to see personalised ads
+                        </button>
+                    </div>
+                </div>
+            </amp-consent>
+        </>
+    );
+};

--- a/packages/frontend/amp/components/AdConsent.tsx
+++ b/packages/frontend/amp/components/AdConsent.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { AMPJSON } from './AMPJSON';
 import { css, cx } from 'emotion';
+import Tick from '@guardian/pasteup/icons/tick.svg';
 
 const fontFamily =
-    "'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif";
+    'GuardianTextSans,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif';
 
 const consentUIStyle = css`
     font-family: ${fontFamily};
@@ -24,6 +25,11 @@ const containerDivStyle = css`
 const h2Style = css`
     margin-bottom: 1em;
     font-size: 1.5em;
+    font-weight: bold;
+`;
+
+const pStyle = css`
+    margin-bottom: 0.5em;
 `;
 
 const aStyle = css`
@@ -100,12 +106,12 @@ export const AdConsent: React.FC<{}> = ({}) => {
                 />
                 <div id="adconsent-ui" className={consentUIStyle}>
                     <div className={containerDivStyle}>
-                        <h2 className={h2Style}>Your pricacy</h2>
-                        <p>
+                        <h2 className={h2Style}>Your privacy</h2>
+                        <p className={pStyle}>
                             We use cookies to improve your experience on our
-                            personalised advertising.
+                            site and to show you personalised advertising.
                         </p>
-                        <p>
+                        <p className={pStyle}>
                             To find out more, read our{' '}
                             <a
                                 className={aStyle}
@@ -126,10 +132,10 @@ export const AdConsent: React.FC<{}> = ({}) => {
                     <div className={cx(actionsStyle, containerDivStyle)}>
                         <button
                             on="tap:the-adconsent-element.accept"
-                            className={cx(buttonStyle, acceptStyle, 'blabla')}
+                            className={cx(buttonStyle, acceptStyle)}
                             role="button"
                         >
-                            I'm OK with that
+                            <Tick /> I'm OK with that
                         </button>
                         <button
                             on="tap:the-adconsent-element.reject"

--- a/packages/frontend/amp/components/AdConsent.tsx
+++ b/packages/frontend/amp/components/AdConsent.tsx
@@ -6,9 +6,7 @@ import { palette } from '@guardian/pasteup/palette';
 import Tick from '@guardian/pasteup/icons/tick.svg';
 
 const consentUIStyle = css`
-    font-family: ${textSans(3)};
-    font-size: 16px;
-    line-height: 20px;
+    ${textSans(5)};
     color: ${palette.neutral[97]};
     background-color: ${palette.neutral[20]};
     max-width: 600px;

--- a/packages/frontend/amp/components/AdConsent.tsx
+++ b/packages/frontend/amp/components/AdConsent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { JsonScript } from './AMPJSON';
+import { JsonScript } from './JsonScript';
 import { css, cx } from 'emotion';
 import { textSans } from '@guardian/pasteup/typography';
 import { palette } from '@guardian/pasteup/palette';

--- a/packages/frontend/amp/components/AdConsent.tsx
+++ b/packages/frontend/amp/components/AdConsent.tsx
@@ -1,5 +1,61 @@
 import React from 'react';
 import { AMPJSON } from './AMPJSON';
+import { css, cx } from 'emotion';
+
+const consentUIStyle = css`
+    font-family: 'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
+    font-size: 1rem;
+    line-height: 1.25rem;
+    color: #f6f6f6;
+    background-color: rgb(51, 51, 51);
+
+    max-width: 37.5rem;
+    margin: 0 auto;
+    overflow-x: hidden;
+`;
+
+const containerDivStyle = css`
+    margin: 1em;
+`;
+
+const h2Style = css`
+    margin-bottom: 1em;
+    font-size: 1.5em;
+`;
+
+const aStyle = css`
+    color: #f6f6f6;
+    &:hover {
+        text-decoration: 0;
+    }
+`;
+
+const actionsStyle = css`
+    text-align: right;
+`;
+
+const buttonStyle = css`
+    font: inherit;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    display: block;
+    width: 100%;
+    margin-top: 1em;
+`;
+
+const acceptStyle = css`
+    border-radius: 20px;
+    border: .0625rem solid rgba(255, 255, 255, .3);
+    background: #ffe500;
+    color: #121212;
+    padding: 5px 20px;
+    font-weight: bold;
+`;
+
+const rejectStyle = css`
+    text-decoration: underline;
+`;
 
 export const AdConsent: React.FC<{}> = ({}) => {
     return (
@@ -15,7 +71,11 @@ export const AdConsent: React.FC<{}> = ({}) => {
                     }}
                 />
             </amp-geo>
-            <amp-consent layout="nodisplay" id="the-adconsent-element">
+            <amp-consent
+                layout="nodisplay"
+                id="the-adconsent-element"
+                style={{ background: 'none' }}
+            >
                 <AMPJSON
                     o={{
                         consents: {
@@ -35,11 +95,9 @@ export const AdConsent: React.FC<{}> = ({}) => {
                         },
                     }}
                 />
-                <div
-                    id="adconsent-ui"
-                    className="with-uk-frame consent-ui main-body"
-                >
-                    <div className="adconsent-message">
+                <div id="adconsent-ui" className={consentUIStyle}>
+                    <div className={containerDivStyle}>
+                        <h2 className={h2Style}>Your pricacy</h2>
                         <p>
                             We use cookies to improve your experience on our
                             personalised advertising.
@@ -47,14 +105,14 @@ export const AdConsent: React.FC<{}> = ({}) => {
                         <p>
                             To find out more, read our{' '}
                             <a
-                                className="u-underline"
+                                className={aStyle}
                                 href="https://www.theguardian.com/help/privacy-policy"
                             >
                                 privacy policy
                             </a>
-                            and{' '}
+                            {' '}and{' '}
                             <a
-                                className="u-underline"
+                                className={aStyle}
                                 href="https://www.theguardian.com/info/cookies"
                             >
                                 cookie policy
@@ -62,17 +120,17 @@ export const AdConsent: React.FC<{}> = ({}) => {
                             .
                         </p>
                     </div>
-                    <div className="adconsent-actions">
+                    <div className={cx(actionsStyle, containerDivStyle)}>
                         <button
                             on="tap:the-adconsent-element.accept"
-                            className="adconsent-accept"
+                            className={cx(buttonStyle,acceptStyle, 'blabla')}
                             role="button"
                         >
                             I'm OK with that
                         </button>
                         <button
                             on="tap:the-adconsent-element.reject"
-                            className="u-underline adconsent-reject"
+                            className={cx(buttonStyle,rejectStyle)}
                             role="button"
                         >
                             I do not want to see personalised ads

--- a/packages/frontend/amp/components/AdConsent.tsx
+++ b/packages/frontend/amp/components/AdConsent.tsx
@@ -2,8 +2,11 @@ import React from 'react';
 import { AMPJSON } from './AMPJSON';
 import { css, cx } from 'emotion';
 
+const fontFamily =
+    "'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif";
+
 const consentUIStyle = css`
-    font-family: 'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
+    font-family: ${fontFamily};
     font-size: 1rem;
     line-height: 1.25rem;
     color: #f6f6f6;
@@ -46,7 +49,7 @@ const buttonStyle = css`
 
 const acceptStyle = css`
     border-radius: 20px;
-    border: .0625rem solid rgba(255, 255, 255, .3);
+    border: 0.0625rem solid rgba(255, 255, 255, 0.3);
     background: #ffe500;
     color: #121212;
     padding: 5px 20px;
@@ -109,8 +112,8 @@ export const AdConsent: React.FC<{}> = ({}) => {
                                 href="https://www.theguardian.com/help/privacy-policy"
                             >
                                 privacy policy
-                            </a>
-                            {' '}and{' '}
+                            </a>{' '}
+                            and{' '}
                             <a
                                 className={aStyle}
                                 href="https://www.theguardian.com/info/cookies"
@@ -123,14 +126,14 @@ export const AdConsent: React.FC<{}> = ({}) => {
                     <div className={cx(actionsStyle, containerDivStyle)}>
                         <button
                             on="tap:the-adconsent-element.accept"
-                            className={cx(buttonStyle,acceptStyle, 'blabla')}
+                            className={cx(buttonStyle, acceptStyle, 'blabla')}
                             role="button"
                         >
                             I'm OK with that
                         </button>
                         <button
                             on="tap:the-adconsent-element.reject"
-                            className={cx(buttonStyle,rejectStyle)}
+                            className={cx(buttonStyle, rejectStyle)}
                             role="button"
                         >
                             I do not want to see personalised ads

--- a/packages/frontend/amp/components/AdConsent.tsx
+++ b/packages/frontend/amp/components/AdConsent.tsx
@@ -1,41 +1,42 @@
 import React from 'react';
-import { AMPJSON } from './AMPJSON';
+import { JsonScript } from './AMPJSON';
 import { css, cx } from 'emotion';
+import { textSans } from '@guardian/pasteup/typography';
+import { palette } from '@guardian/pasteup/palette';
 import Tick from '@guardian/pasteup/icons/tick.svg';
 
 const fontFamily =
     'GuardianTextSans,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif';
 
 const consentUIStyle = css`
-    font-family: ${fontFamily};
-    font-size: 1rem;
-    line-height: 1.25rem;
-    color: #f6f6f6;
-    background-color: rgb(51, 51, 51);
-
-    max-width: 37.5rem;
+    font-family: ${textSans(3)};
+    font-size: 16px;
+    line-height: 20px;
+    color: ${palette.neutral[97]};
+    background-color: ${palette.neutral[20]};
+    max-width: 600px;
     margin: 0 auto;
     overflow-x: hidden;
 `;
 
 const containerDivStyle = css`
-    margin: 1em;
+    margin: 16px;
 `;
 
 const h2Style = css`
-    margin-bottom: 1em;
-    font-size: 1.5em;
+    margin-bottom: 16px;
+    font-size: 24px;
     font-weight: bold;
 `;
 
 const pStyle = css`
-    margin-bottom: 0.5em;
+    margin-bottom: 8px;
 `;
 
 const aStyle = css`
-    color: #f6f6f6;
+    color: ${palette.neutral[97]};
     &:hover {
-        text-decoration: 0;
+        text-decoration: none;
     }
 `;
 
@@ -50,14 +51,14 @@ const buttonStyle = css`
     color: inherit;
     display: block;
     width: 100%;
-    margin-top: 1em;
+    margin-top: 16px;
 `;
 
 const acceptStyle = css`
     border-radius: 20px;
-    border: 0.0625rem solid rgba(255, 255, 255, 0.3);
-    background: #ffe500;
-    color: #121212;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    background: ${palette.highlight.main};
+    color: ${palette.neutral[7]};
     padding: 5px 20px;
     font-weight: bold;
 `;
@@ -70,7 +71,7 @@ export const AdConsent: React.FC<{}> = ({}) => {
     return (
         <>
             <amp-geo layout="nodisplay">
-                <AMPJSON
+                <JsonScript
                     o={{
                         ISOCountryGroups: {
                             eea: ['preset-eea'],
@@ -85,7 +86,7 @@ export const AdConsent: React.FC<{}> = ({}) => {
                 id="the-adconsent-element"
                 style={{ background: 'none' }}
             >
-                <AMPJSON
+                <JsonScript
                     o={{
                         consents: {
                             adconsent: {

--- a/packages/frontend/amp/components/AdConsent.tsx
+++ b/packages/frontend/amp/components/AdConsent.tsx
@@ -5,9 +5,6 @@ import { textSans } from '@guardian/pasteup/typography';
 import { palette } from '@guardian/pasteup/palette';
 import Tick from '@guardian/pasteup/icons/tick.svg';
 
-const fontFamily =
-    'GuardianTextSans,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif';
-
 const consentUIStyle = css`
     font-family: ${textSans(3)};
     font-size: 16px;

--- a/packages/frontend/amp/components/Footer.tsx
+++ b/packages/frontend/amp/components/Footer.tsx
@@ -3,7 +3,12 @@ import { css } from 'emotion';
 import { textSans, body } from '@guardian/pasteup/typography';
 import { palette } from '@guardian/pasteup/palette';
 import { InnerContainer } from './InnerContainer';
-import { Link, footerLinksNew } from '@frontend/lib/footer-links';
+import {
+    Link,
+    footerLinksNew,
+    LinkPlatform,
+    isOnPlatform,
+} from '@frontend/lib/footer-links';
 import { ReaderRevenueButton } from '@root/packages/frontend/amp/components/ReaderRevenueButton';
 
 const footer = css`
@@ -126,13 +131,15 @@ const FooterLinks: React.FC<{
     nav: NavType;
 }> = ({ links, nav }) => {
     const linkGroups = links.map(linkGroup => {
-        const ls = linkGroup.map(l => (
-            <li key={l.url}>
-                <a className={footerLink} href={l.url}>
-                    {l.title}
-                </a>
-            </li>
-        ));
+        const ls = linkGroup
+            .filter(l => isOnPlatform(l, LinkPlatform.Amp))
+            .map(l => (
+                <li key={l.url}>
+                    <a className={footerLink} href={l.url} on={l.on}>
+                        {l.title}
+                    </a>
+                </li>
+            ));
         const key = linkGroup.reduce((acc, { title }) => `acc-${title}`, '');
 
         return (

--- a/packages/frontend/amp/components/JsonScript.tsx
+++ b/packages/frontend/amp/components/JsonScript.tsx
@@ -1,4 +1,3 @@
-// tslint:disable:react-no-dangerous-html
 import React from 'react';
 
 export const JsonScript: React.FC<{ o: any }> = ({ o }) => {
@@ -6,7 +5,7 @@ export const JsonScript: React.FC<{ o: any }> = ({ o }) => {
     return (
         <script
             type="application/json"
-            dangerouslySetInnerHTML={{ __html: JSONString }}
+            dangerouslySetInnerHTML={{ __html: JSONString }} // tslint:disable-line
         />
     );
 };

--- a/packages/frontend/amp/components/JsonScript.tsx
+++ b/packages/frontend/amp/components/JsonScript.tsx
@@ -5,7 +5,7 @@ export const JsonScript: React.FC<{ o: any }> = ({ o }) => {
     return (
         <script
             type="application/json"
-            // tslint:disable-next-line react-no-dangerous-html
+            // tslint:disable-next-line:react-no-dangerous-html
             dangerouslySetInnerHTML={{ __html: JSONString }}
         />
     );

--- a/packages/frontend/amp/components/JsonScript.tsx
+++ b/packages/frontend/amp/components/JsonScript.tsx
@@ -5,7 +5,8 @@ export const JsonScript: React.FC<{ o: any }> = ({ o }) => {
     return (
         <script
             type="application/json"
-            dangerouslySetInnerHTML={{ __html: JSONString }} // tslint:disable-line
+            // tslint:disable-next-line react-no-dangerous-html
+            dangerouslySetInnerHTML={{ __html: JSONString }}
         />
     );
 };

--- a/packages/frontend/amp/components/JsonScript.tsx
+++ b/packages/frontend/amp/components/JsonScript.tsx
@@ -3,9 +3,9 @@ import React from 'react';
 export const JsonScript: React.FC<{ o: any }> = ({ o }) => {
     const JSONString: string = JSON.stringify(o);
     return (
+        // tslint:disable-next-line:react-no-dangerous-html
         <script
             type="application/json"
-            // tslint:disable-next-line:react-no-dangerous-html
             dangerouslySetInnerHTML={{ __html: JSONString }}
         />
     );

--- a/packages/frontend/amp/components/elements/AdComponent.tsx
+++ b/packages/frontend/amp/components/elements/AdComponent.tsx
@@ -108,6 +108,7 @@ export const AdComponent: React.SFC<{
 }> = ({ edition, section, contentType, config, commercialProperties }) => (
     <div className={adStyle}>
         <amp-ad
+            data-block-on-consent=""
             width={300}
             height={250}
             data-npa-on-unknown-consent={true}

--- a/packages/frontend/amp/pages/Article.tsx
+++ b/packages/frontend/amp/pages/Article.tsx
@@ -5,6 +5,7 @@ import { Body } from '@frontend/amp/components/Body';
 import { Header } from '@frontend/amp/components/Header';
 import { palette } from '@guardian/pasteup/palette';
 import { Onward } from '@frontend/amp/components/Onward';
+import { AdConsent } from '@frontend/amp/components/AdConsent';
 import { css } from 'emotion';
 import { Sidebar } from '@frontend/amp/components/Sidebar';
 import { Analytics, AnalyticsModel } from '@frontend/amp/components/Analytics';
@@ -65,6 +66,7 @@ export const Article: React.FC<{
 }> = ({ nav, articleData, config, analytics }) => (
     <>
         <Analytics key="analytics" analytics={analytics} />
+        <AdConsent />
 
         <div key="main" className={backgroundColour}>
             <Container>

--- a/packages/frontend/amp/server/document.tsx
+++ b/packages/frontend/amp/server/document.tsx
@@ -69,6 +69,8 @@ export const document = ({
     <script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
     <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
     <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
+    <script async custom-element="amp-geo" src="https://cdn.ampproject.org/v0/amp-geo-0.1.js"></script>
+    <script async custom-element="amp-consent" src="https://cdn.ampproject.org/v0/amp-consent-0.1.js"></script>
 
     <!-- AMP elements that are optional dependending on content -->
     ${scripts.join(' ')}

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -207,7 +207,12 @@ declare namespace JSX {
         'amp-analytics': any;
         'amp-pixel': any;
         'amp-ad': any;
+<<<<<<< HEAD
         'amp-youtube': any;
+=======
+        'amp-geo': any;
+        'amp-consent': any;
+>>>>>>> Added standard amp-consent component
         template: any;
     }
 }

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -207,12 +207,9 @@ declare namespace JSX {
         'amp-analytics': any;
         'amp-pixel': any;
         'amp-ad': any;
-<<<<<<< HEAD
         'amp-youtube': any;
-=======
         'amp-geo': any;
         'amp-consent': any;
->>>>>>> Added standard amp-consent component
         template: any;
     }
 }

--- a/packages/frontend/lib/footer-links.ts
+++ b/packages/frontend/lib/footer-links.ts
@@ -1,7 +1,18 @@
+export enum LinkPlatform {
+    Web,
+    Amp,
+}
+
 export interface Link {
     title: string;
-    url: string;
+    url?: string;
+    on?: string;
+    onlyOnPlatform?: LinkPlatform;
 }
+
+export const isOnPlatform = (l: Link, platform: LinkPlatform): boolean => {
+    return !l.onlyOnPlatform || l.onlyOnPlatform === platform;
+};
 
 export const footerLinks: Link[][] = [
     [
@@ -131,6 +142,11 @@ export const footerLinksNew: Link[][] = [
         {
             title: 'Cookie policy',
             url: '/info/cookies',
+        },
+        {
+            title: 'Your privacy',
+            on: 'tap:the-adconsent-element.prompt',
+            onlyOnPlatform: LinkPlatform.Amp,
         },
         {
             title: 'Terms & conditions',

--- a/packages/frontend/web/components/Footer.tsx
+++ b/packages/frontend/web/components/Footer.tsx
@@ -6,7 +6,12 @@ import { textSans } from '@guardian/pasteup/typography';
 
 import { Container } from '@guardian/guui';
 import { palette } from '@guardian/pasteup/palette';
-import { footerLinks, Link } from '@frontend/lib/footer-links';
+import {
+    footerLinks,
+    Link,
+    LinkPlatform,
+    isOnPlatform,
+} from '@frontend/lib/footer-links';
 
 const footer = css`
     background-color: ${palette.neutral[20]};
@@ -95,13 +100,15 @@ const FooterLinks: React.FC<{
     links: Link[][];
 }> = ({ links }) => {
     const linkGroups = links.map(linkGroup => {
-        const ls = linkGroup.map(l => (
-            <li key={l.url}>
-                <a className={footerLink} href={l.url}>
-                    {l.title}
-                </a>
-            </li>
-        ));
+        const ls = linkGroup
+            .filter(l => isOnPlatform(l, LinkPlatform.Web))
+            .map(l => (
+                <li key={l.url}>
+                    <a className={footerLink} href={l.url}>
+                        {l.title}
+                    </a>
+                </li>
+            ));
         const key = linkGroup.reduce((acc, { title }) => `acc-${title}`, '');
 
         return <ul key={key}>{ls}</ul>;


### PR DESCRIPTION
Before and After
![Picture 272](https://user-images.githubusercontent.com/19835654/54598539-9b8b6400-4a30-11e9-8011-fcb9dff19f3d.png)


## What does this change?

This replicates the Personalised Ads consent implementation on the new shiny platform.
