### PR TITLE
Support sponsored rich links

### DIFF
--- a/packages/frontend/amp/components/elements/RichLinkBlockComponent.tsx
+++ b/packages/frontend/amp/components/elements/RichLinkBlockComponent.tsx
@@ -40,18 +40,10 @@ const richLink = css`
 export const RichLinkBlockComponent: React.FC<{
     element: RichLinkBlockElement;
     pillar: Pillar;
-}> = ({ element, pillar }) => {
-    if (element.sponsorship) {
-        throw new Error('Sponsored rich links not supported');
-    }
-    return (
-        <aside className={richLinkContainer}>
-            <a
-                className={cx(richLink, pillarColour(pillar))}
-                href={element.url}
-            >
-                {element.text}
-            </a>
-        </aside>
-    );
-};
+}> = ({ element, pillar }) => (
+    <aside className={richLinkContainer}>
+        <a className={cx(richLink, pillarColour(pillar))} href={element.url}>
+            {element.text}
+        </a>
+    </aside>
+);


### PR DESCRIPTION
## What does this change?

Removes the error that is thrown when a sponsored rich link is detected.

## Why?

Currently a 500 response is sent to the user. The rich link is styled
mostly correctly, so sending a 500 response is overkill.

## Screenshots

**Before**

![Screen Shot 2019-03-14 at 10 46 10](https://user-images.githubusercontent.com/5931528/54351011-766caf00-4646-11e9-833c-ddf1f23dd36e.png)

**After** 

![Screen Shot 2019-03-14 at 10 46 39](https://user-images.githubusercontent.com/5931528/54351010-766caf00-4646-11e9-9dd0-b417ee59bde0.png)
