### PR TITLE
Consume the frontend commercial bundle

### DIFF
--- a/fixtures/article.ts
+++ b/fixtures/article.ts
@@ -3011,6 +3011,8 @@ export const data = {
                     'https://support.theguardian.com?INTCMP=footer_support&acquisitionData=%7B"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_FOOTER","componentId":"footer_support"%7D',
             },
         },
+        commercialUrl:
+            'https://assets.guim.co.uk/javascripts/3d3cbc5f29df7c0cdd65/graun.dotcom-rendering-commercial.js',
     },
     version: 2,
 };

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -172,6 +172,7 @@ interface ConfigType {
     isDev: boolean;
     switches: { [key: string]: boolean };
     dfpAccountId: string;
+    commercialUrl: string;
 }
 
 // 3rd party type declarations

--- a/packages/frontend/model/extract-config.test.ts
+++ b/packages/frontend/model/extract-config.test.ts
@@ -90,4 +90,22 @@ describe('extract-config', () => {
             expect(isDev).toBe(false);
         });
     });
+
+    it('returns commercialUrl if available', () => {
+        const testCommercialUrl = 'https://fetchMeSomething.com';
+
+        testData.site.commercialUrl = testCommercialUrl;
+
+        const { commercialUrl } = extract(testData);
+
+        expect(commercialUrl).toBe(testCommercialUrl);
+    });
+
+    it('throws error if commercialUrl unavailable', () => {
+        testData.site.commercialUrl = null;
+
+        expect(() => {
+            extract(testData);
+        }).toThrow();
+    });
 });

--- a/packages/frontend/model/extract-config.ts
+++ b/packages/frontend/model/extract-config.ts
@@ -1,5 +1,9 @@
 import { getNonEmptyString, getString, getObject } from './validators';
 
+const getCommercialUrl = (data: {}): string => {
+    return getNonEmptyString(data, 'site.commercialUrl');
+};
+
 export const extract = (data: {}): ConfigType => ({
     ajaxUrl: getNonEmptyString(data, 'site.ajaxUrl'),
     sentryPublicApiKey: getString(data, 'site.sentryPublicApiKey', ''),
@@ -12,4 +16,5 @@ export const extract = (data: {}): ConfigType => ({
     isDev: process.env.NODE_ENV === 'development',
     switches: getObject(data, 'site.switches', {}),
     dfpAccountId: getObject(data, 'site.dfpAccountId', ''), // TODO check and fix
+    commercialUrl: getCommercialUrl(data),
 });

--- a/packages/frontend/model/extract-config.ts
+++ b/packages/frontend/model/extract-config.ts
@@ -1,9 +1,5 @@
 import { getNonEmptyString, getString, getObject } from './validators';
 
-const getCommercialUrl = (data: {}): string => {
-    return getNonEmptyString(data, 'site.commercialUrl');
-};
-
 export const extract = (data: {}): ConfigType => ({
     ajaxUrl: getNonEmptyString(data, 'site.ajaxUrl'),
     sentryPublicApiKey: getString(data, 'site.sentryPublicApiKey', ''),
@@ -16,5 +12,5 @@ export const extract = (data: {}): ConfigType => ({
     isDev: process.env.NODE_ENV === 'development',
     switches: getObject(data, 'site.switches', {}),
     dfpAccountId: getObject(data, 'site.dfpAccountId', ''), // TODO check and fix
-    commercialUrl: getCommercialUrl(data),
+    commercialUrl: getNonEmptyString(data, 'site.commercialUrl'),
 });

--- a/packages/frontend/web/browser.ts
+++ b/packages/frontend/web/browser.ts
@@ -52,7 +52,13 @@ const initApp = (): void => {
         })
         .catch(err => {
             // If loadCommercial fails reportError and enhanceApp
-            reportError(err, {}, false);
+            reportError(
+                err,
+                {
+                    feature: 'commercial',
+                },
+                false,
+            );
             enhanceApp();
         });
 };

--- a/packages/frontend/web/browser/loadScript.test.ts
+++ b/packages/frontend/web/browser/loadScript.test.ts
@@ -1,0 +1,120 @@
+import { loadScript } from './loadScript';
+
+describe('loadScript', () => {
+    const script = document.createElement('script');
+
+    beforeAll(() => {
+        if (document.body) {
+            document.body.appendChild(script);
+        }
+    });
+
+    afterAll(() => {
+        script.remove();
+    });
+
+    test('does not add script if script with matching src already on page, and resolves promise', done => {
+        const existingScript = document.createElement('script');
+
+        existingScript.src = 'xxx';
+
+        if (document.body) {
+            document.body.appendChild(existingScript);
+        }
+
+        expect(document.querySelectorAll('script[src="xxx"]')).toHaveLength(1);
+
+        loadScript('xxx')
+            .then(() => {
+                expect(
+                    document.querySelectorAll('script[src="xxx"]'),
+                ).toHaveLength(1);
+
+                existingScript.remove();
+            })
+            .then(done);
+    });
+
+    test('adds script if it is not already on page, and resolves promise when script onload called', done => {
+        let scripts: NodeListOf<HTMLScriptElement> = document.querySelectorAll(
+            'script[src="xxx"]',
+        );
+
+        expect(scripts).toHaveLength(0);
+
+        loadScript('xxx')
+            .then(() => {
+                scripts = document.querySelectorAll('script[src="xxx"]');
+
+                expect(scripts).toHaveLength(1);
+
+                if (scripts[0]) {
+                    scripts[0].remove();
+                }
+            })
+            .then(done);
+
+        scripts = document.querySelectorAll('script[src="xxx"]');
+
+        expect(scripts).toHaveLength(1);
+
+        if (scripts[0] && scripts[0].onload) {
+            scripts[0].onload(new Event('load'));
+        }
+    });
+
+    test('adds script with attributes if it is not already on page, and resolves promise when script onload called', done => {
+        let scripts: NodeListOf<HTMLScriptElement> = document.querySelectorAll(
+            'script[src="xxx"]',
+        );
+
+        expect(scripts).toHaveLength(0);
+
+        loadScript('xxx', { async: true })
+            .then(() => {
+                scripts = document.querySelectorAll('script[src="xxx"]');
+
+                expect(scripts).toHaveLength(1);
+
+                if (scripts[0]) {
+                    expect(scripts[0].async).toBeTruthy();
+                    scripts[0].remove();
+                }
+            })
+            .then(done);
+
+        scripts = document.querySelectorAll('script[src="xxx"]');
+
+        expect(scripts).toHaveLength(1);
+
+        if (scripts[0] && scripts[0].onload) {
+            scripts[0].onload(new Event('load'));
+        }
+    });
+
+    test('rejects promise when script onerror called', done => {
+        let scripts: NodeListOf<HTMLScriptElement> = document.querySelectorAll(
+            'script[src="xxx"]',
+        );
+
+        expect(scripts).toHaveLength(0);
+
+        loadScript('xxx', {})
+            .catch(err => {
+                expect(err.message).toBe('Failed to load script xxx');
+
+                if (scripts[0]) {
+                    scripts[0].remove();
+                }
+            })
+            .then(done);
+
+        scripts = document.querySelectorAll('script[src="xxx"]');
+
+        expect(scripts).toHaveLength(1);
+
+        if (scripts[0] && scripts[0].onerror) {
+            scripts[0].onerror(new Event('fail'));
+        }
+    });
+});

--- a/packages/frontend/web/browser/loadScript.ts
+++ b/packages/frontend/web/browser/loadScript.ts
@@ -1,0 +1,21 @@
+const loadScript = (src: string): Promise<void> => {
+    if (document.querySelector(`script[src="${src}"]`)) {
+        return Promise.resolve();
+    }
+    return new Promise((resolve, reject) => {
+        const ref = document.scripts[0];
+        const script = document.createElement('script');
+        script.src = src;
+        script.onload = () => {
+            resolve();
+        };
+        script.onerror = () => {
+            reject(new Error(`Failed to load script ${src}`));
+        };
+        if (ref.parentNode) {
+            ref.parentNode.insertBefore(script, ref);
+        }
+    });
+};
+
+export { loadScript };

--- a/packages/frontend/web/browser/loadScript.ts
+++ b/packages/frontend/web/browser/loadScript.ts
@@ -1,4 +1,4 @@
-const loadScript = (src: string): Promise<void> => {
+const loadScript = (src: string, props?: object): Promise<void> => {
     if (document.querySelector(`script[src="${src}"]`)) {
         return Promise.resolve();
     }
@@ -6,6 +6,9 @@ const loadScript = (src: string): Promise<void> => {
         const ref = document.scripts[0];
         const script = document.createElement('script');
         script.src = src;
+        if (props) {
+            Object.assign(script, props);
+        }
         script.onload = () => {
             resolve();
         };

--- a/packages/frontend/web/browser/reportError.ts
+++ b/packages/frontend/web/browser/reportError.ts
@@ -15,7 +15,6 @@ export const reportError = (
 ): void => {
     getRaven().then(raven => {
         raven.captureException(err, { tags });
-
         if (shouldThrow) {
             // Flag to ensure it is not reported to Sentry again via global handlers
             const error = err;

--- a/packages/frontend/web/components/ShareCount.test.tsx
+++ b/packages/frontend/web/components/ShareCount.test.tsx
@@ -27,6 +27,7 @@ describe('ShareCount', () => {
         isDev: false,
         switches: {},
         dfpAccountId: '',
+        commercialUrl: '',
     };
 
     afterEach(() => {

--- a/packages/frontend/web/server/document.tsx
+++ b/packages/frontend/web/server/document.tsx
@@ -68,8 +68,8 @@ export const document = ({ data }: Props) => {
     const vendorJS = getDist('vendor.js');
     const polyfillIO =
         'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry&flags=gated&callback=guardianPolyfilled&unknown=polyfill';
-    const commercialBundle = config.commercialUrl;
-    const priorityScripts = [polyfillIO, commercialBundle, vendorJS, bundleJS];
+    // const commercialBundle = config.commercialUrl;
+    const priorityScripts = [polyfillIO, vendorJS, bundleJS];
 
     /**
      * Low priority scripts.

--- a/packages/frontend/web/server/document.tsx
+++ b/packages/frontend/web/server/document.tsx
@@ -68,8 +68,11 @@ export const document = ({ data }: Props) => {
     const vendorJS = getDist('vendor.js');
     const polyfillIO =
         'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry&flags=gated&callback=guardianPolyfilled&unknown=polyfill';
-    // const commercialBundle = config.commercialUrl;
+    const commercialBundle = config.commercialUrl;
     const priorityScripts = [polyfillIO, vendorJS, bundleJS];
+    const preloadScripts = [
+        ...new Set([commercialBundle].concat(priorityScripts)),
+    ];
 
     /**
      * Low priority scripts.
@@ -82,6 +85,7 @@ export const document = ({ data }: Props) => {
 
     return htmlTemplate({
         linkedData,
+        preloadScripts,
         priorityScripts,
         lowPriorityScripts,
         css,

--- a/packages/frontend/web/server/document.tsx
+++ b/packages/frontend/web/server/document.tsx
@@ -68,7 +68,8 @@ export const document = ({ data }: Props) => {
     const vendorJS = getDist('vendor.js');
     const polyfillIO =
         'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry&flags=gated&callback=guardianPolyfilled&unknown=polyfill';
-    const priorityScripts = [polyfillIO, vendorJS, bundleJS];
+    const commercialBundle = config.commercialUrl;
+    const priorityScripts = [polyfillIO, commercialBundle, vendorJS, bundleJS];
 
     /**
      * Low priority scripts.

--- a/packages/frontend/web/server/htmlTemplate.ts
+++ b/packages/frontend/web/server/htmlTemplate.ts
@@ -39,11 +39,9 @@ export const htmlTemplate = ({
                 <title>${title}</title>
                 <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
                 <link rel="icon" href="https://static.guim.co.uk/images/${favicon}">
-
                 <script type="application/ld+json">
                     ${JSON.stringify(linkedData)}
                 </script>
-
                 ${priorityScripts
                     .map(
                         url => `<link rel="preload" href="${url}" as="script">`,

--- a/packages/frontend/web/server/htmlTemplate.ts
+++ b/packages/frontend/web/server/htmlTemplate.ts
@@ -5,6 +5,7 @@ import { getStatic } from '@frontend/lib/assets';
 export const htmlTemplate = ({
     title = 'The Guardian',
     linkedData,
+    preloadScripts,
     priorityScripts,
     lowPriorityScripts,
     css,
@@ -16,6 +17,7 @@ export const htmlTemplate = ({
 }: {
     title?: string;
     linkedData: object;
+    preloadScripts: string[];
     priorityScripts: string[];
     lowPriorityScripts: string[];
     css: string;
@@ -42,7 +44,7 @@ export const htmlTemplate = ({
                 <script type="application/ld+json">
                     ${JSON.stringify(linkedData)}
                 </script>
-                ${priorityScripts
+                ${preloadScripts
                     .map(
                         url => `<link rel="preload" href="${url}" as="script">`,
                     )


### PR DESCRIPTION
## What does this change?

1. Introduce `loadScript`, stolen from front end. A convenient way to load external scripts by their URL. We introduce it to consume the commercial bundle introduced here: https://github.com/guardian/frontend/pull/21247

2. Otherwise the logic is simple. First we execute `run` script either once it's ready and if polyfill has finished its initialisation or left to be executed later. 

```
if (window.guardian.polyfilled) {
    run();
} else {
    window.guardian.onPolyfilled = run;
}
```

... and then, because we want the commercial bundle to run before our own initialisation script we define run to be

```
const run = () => {
    const { commercialUrl } = window.guardian.app.data.config;
    if(commercialUrl){
        loadScript(commercialUrl).then(() => {
            initApp();
        }).catch(() => {
            console.log("Something went wrong during loading commercial bundle");
            initApp();
        });
    } else {
        initApp();
    }
};
```

This gracefully allow ` initApp` to still run if `commercialUrl` is not defined or the commercial bundle failing to load. 

## Why?