### PR TITLE
Update README (Auto fix on save)

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
     "recommendations": [
-        "ms-vscode.vscode-typescript-tslint-plugin",
+        "esbenp.prettier-vscode",
         "wix.vscode-import-cost",
         "eamodio.gitlens",
         "orta.vscode-jest"

--- a/README.md
+++ b/README.md
@@ -76,12 +76,9 @@ You can also find these extensions by searching for `@recommended` in the extens
 
 ### Auto fix on save
 
-We recommend you update your workspace settings to automatically fix formatting errors on save:
+We recommend you update your workspace settings to automatically fix formatting errors on save, this prevent your commits from validating later on. Note. The current instruction work with the TSLint plugin `esbenp.prettier-vscode` and has been tested against the latest version of TSCode at the time of this writing
 
-1. Open the Command Palette (`shift + cmd + P`) and type `Preferences: Open Workspace Settings`
-2. Search for `tslint.autoFixOnSave`
-3. Update your `settings.json` with:
+1. Open the Command Palette (`shift + cmd + P`) and type `>Preferences: Open Settings (JSON)`
+2. Add the key value `"tslint.autoFixOnSave": true,`
 
-```json
-    "tslint.autoFixOnSave": true,
-```
+

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ You can also find these extensions by searching for `@recommended` in the extens
 
 ### Auto fix on save
 
-We recommend you update your workspace settings to automatically fix formatting errors on save, this prevent your commits from validating later on. Note. The current instruction work with the TSLint plugin `esbenp.prettier-vscode` and has been tested against the latest version of TSCode at the time of this writing
+We recommend you update your workspace settings to automatically fix formatting errors on save, this avoids code style validation failures. These instructions assume you have installed the `esbenp.prettier-vscode` VSCode plugin:
 
 1. Open the Command Palette (`shift + cmd + P`) and type `>Preferences: Open Settings (JSON)`
 2. Add the key value `"tslint.autoFixOnSave": true,`


### PR DESCRIPTION
Update the README's _auto fix on save section_, to match the latest version of VSCode settings. Note that it was necessary to revert to the previous TSLint plugin, because the new one doesn't actually support auto fix on save.
