### PR TITLE
Parameterise instance type, set default to t3.small.

### DIFF
--- a/packages/frontend/cloudformation.yml
+++ b/packages/frontend/cloudformation.yml
@@ -42,6 +42,10 @@ Parameters:
     Type: String
     Description: (Optional) Number of periods over which the latency is compared to the threshold before to send a notification
     Default: '5'
+  InstanceType:
+    Type: String
+    Description: EC2 Instance Type to use for dotcom-rendering
+    Default: t3.small
     
 Conditions:
     HasLatencyScalingAlarm: !Equals [!Ref Stage, 'PROD']
@@ -185,7 +189,7 @@ Resources:
         Ref: AMI
       SecurityGroups:
       - Ref: InstanceSecurityGroup
-      InstanceType: t3.medium
+      InstanceType: !Ref InstanceType
       IamInstanceProfile:
         Ref: InstanceProfile
       AssociatePublicIpAddress: true


### PR DESCRIPTION
## What does this change?
Moves instance type into a parameter so it can more easily be modified.

## Why?
CODE can run on a smaller instance to PROD, this makes it easy to sort that