### PR TITLE
Fix header issues on mobile breakpoint

### DIFF
--- a/packages/frontend/amp/components/Header.tsx
+++ b/packages/frontend/amp/components/Header.tsx
@@ -7,7 +7,7 @@ import { pillarPalette } from '../../lib/pillars';
 import { palette } from '@guardian/pasteup/palette';
 import { ReaderRevenueButton } from '@root/packages/frontend/amp/components/ReaderRevenueButton';
 import { AmpSubscriptionGoogle } from '@frontend/amp/components/elements/AmpSubscriptionGoogle';
-import { mobileLandscape } from '@guardian/pasteup/breakpoints';
+import { mobileLandscape, until } from '@guardian/pasteup/breakpoints';
 
 const headerStyles = css`
     background-color: ${palette.brand.main};
@@ -30,6 +30,14 @@ const logoStyles = css`
     path {
         fill: ${palette.neutral[100]};
     }
+
+    ${until.mobileMedium} {
+        height: 44px;
+        width: 135px;
+        margin-bottom: 24px;
+        margin-right: 52px;
+        margin-top: 9px;
+    }
 `;
 
 const pillarListStyles = css`
@@ -46,6 +54,12 @@ const pillarListItemStyle = css`
 
             :before {
                 display: none;
+            }
+        }
+
+        ${until.mobileLandscape} {
+            a {
+                padding-left: 10px;
             }
         }
     }
@@ -105,6 +119,14 @@ const veggieStyles = css`
     bottom: -3px;
     right: 20px;
     position: absolute;
+
+    ${until.mobileMedium} {
+        bottom: 50px;
+    }
+
+    ${until.mobileLandscape} {
+        right: 5px;
+    }
 `;
 
 const lineStyles = css`
@@ -180,7 +202,7 @@ export const Header: React.FC<{
                 >
                     The Guardian - Back to home
                 </span>
-                <Logo className={logoStyles} />
+                <Logo />
             </a>
         </div>
 

--- a/packages/frontend/amp/components/ReaderRevenueButton.tsx
+++ b/packages/frontend/amp/components/ReaderRevenueButton.tsx
@@ -19,7 +19,7 @@ const supportHeaderStyles = css`
     ${supportStyles}
     justify-content: center;
     margin-top: 20px;
-    margin-left: 20px;
+    margin-left: 10px;
 `;
 
 const supportFooterStyles = css`


### PR DESCRIPTION
Various styling fixes for the mobile breakpoint, relating to the support us link and veggie burger.

<img width="341" alt="Screenshot 2019-03-18 at 15 19 14" src="https://user-images.githubusercontent.com/858402/54541672-439e2000-4992-11e9-8142-2d409b833f98.png">
<img width="394" alt="Screenshot 2019-03-18 at 15 19 28" src="https://user-images.githubusercontent.com/858402/54541673-4436b680-4992-11e9-8999-d3174c9ccfa2.png">


**Previously (and currently live) is:**

<img width="327" alt="Screenshot 2019-03-18 at 15 28 28" src="https://user-images.githubusercontent.com/858402/54541793-8102ad80-4992-11e9-9d01-5eb168276d0b.png">
