### PR TITLE
Hide support arrow until mobile medium

### DIFF
--- a/packages/frontend/amp/components/ReaderRevenueButton.tsx
+++ b/packages/frontend/amp/components/ReaderRevenueButton.tsx
@@ -4,6 +4,7 @@ import { css, cx } from 'emotion';
 import { textSans } from '@guardian/pasteup/typography';
 import ArrowRight from '@guardian/pasteup/icons/arrow-right.svg';
 import { palette } from '@guardian/pasteup/palette';
+import { mobileMedium } from '@guardian/pasteup/breakpoints';
 
 const supportStyles = css`
     align-self: flex-start;
@@ -51,6 +52,14 @@ const rightAlignedIcon = css`
     top: 0;
 `;
 
+const arrowRight = css`
+    display: none;
+
+    ${mobileMedium} {
+        display: block;
+    }
+`;
+
 export const ReaderRevenueButton: React.SFC<{
     nav: NavType;
     linkLabel: string;
@@ -79,7 +88,7 @@ export const ReaderRevenueButton: React.SFC<{
                         [rightAlignedIcon]: !!rightAlignIcon,
                     })}
                 >
-                    <ArrowRight />
+                    <ArrowRight className={arrowRight} />
                 </span>
             </a>
         </div>


### PR DESCRIPTION
Remove support arrow until mobile medium:

**Before:**

<img width="320" alt="Screenshot 2019-03-19 at 11 38 00" src="https://user-images.githubusercontent.com/858402/54603146-8405a880-4a3b-11e9-81f6-81e9b0101fec.png">

**After:**

<img width="320" alt="Screenshot 2019-03-19 at 11 37 48" src="https://user-images.githubusercontent.com/858402/54603145-8405a880-4a3b-11e9-9b1d-007a507b3bca.png">

