### PR TITLE
test app client-side initialisation 

### DIFF
--- a/packages/frontend/web/browser/boot.test.ts
+++ b/packages/frontend/web/browser/boot.test.ts
@@ -1,0 +1,123 @@
+import { _ } from './boot';
+import { getRaven as getRaven_ } from '@frontend/web/browser/raven';
+import { loadScript as loadScript_ } from '@frontend/web/browser/loadScript';
+
+const getRaven: any = getRaven_;
+const loadScript: any = loadScript_;
+
+jest.mock('ophan-tracker-js', jest.fn());
+jest.mock('@frontend/web/browser/raven', () => ({
+    getRaven: jest.fn(),
+}));
+jest.mock('@frontend/web/browser/loadScript', () => ({
+    loadScript: jest.fn(),
+}));
+
+describe('boot', () => {
+    interface MockWindow extends Window {
+        addEventListener: jest.Mock<{}> & typeof window.addEventListener;
+        removeEventListener: jest.Mock<{}> & typeof window.removeEventListener;
+    }
+    interface MockRaven {
+        context: jest.Mock<{}>;
+        captureException: jest.Mock<{}>;
+    }
+    const mockWindow = (): MockWindow => {
+        window.addEventListener = jest.fn();
+        window.removeEventListener = jest.fn();
+        return window as MockWindow;
+    };
+    const mockRaven = (): MockRaven => {
+        const raven: MockRaven = {
+            context: jest.fn((config, callback) => {
+                callback();
+            }),
+            captureException: jest.fn(),
+        };
+
+        return raven;
+    };
+    let windowMock: MockWindow;
+    let ravenMock: MockRaven;
+    const commercialUrl = 'http://foo.bar';
+    const { onPolyfilled, polyfilled, app } = window.guardian;
+
+    beforeEach(() => {
+        windowMock = mockWindow();
+        ravenMock = mockRaven();
+
+        window.guardian = Object.assign({}, window.guardian, {
+            polyfilled: true,
+            app: {
+                data: {
+                    config: {
+                        commercialUrl,
+                    },
+                },
+            },
+        });
+
+        getRaven.mockImplementation(() => Promise.resolve(ravenMock));
+        loadScript.mockImplementation(() => Promise.resolve());
+    });
+
+    afterEach(() => {
+        windowMock.addEventListener.mockClear();
+
+        getRaven.mockReset();
+        loadScript.mockReset();
+
+        window.guardian = Object.assign({}, window.guardian, {
+            onPolyfilled,
+            polyfilled,
+            app,
+        });
+    });
+
+    test('does not call onPollyfilled when window.guardian.polyfilled is false', () => {
+        const onPolyfilledMock = jest.fn();
+
+        window.guardian.polyfilled = false;
+        window.guardian.onPolyfilled = onPolyfilledMock;
+
+        _.run();
+
+        expect(onPolyfilledMock).not.toBeCalled();
+    });
+
+    test('if getRaven successful initAppWithRaven', () => {
+        return _.onPolyfilled().then(() => {
+            expect(ravenMock.context).toHaveBeenCalled();
+            expect(ravenMock.context).toHaveBeenCalledWith(
+                {
+                    tags: {
+                        feature: 'initApp',
+                    },
+                },
+                expect.any(Function),
+            );
+            expect(loadScript).toHaveBeenCalledTimes(1);
+            expect(loadScript).toHaveBeenCalledWith(commercialUrl);
+            expect(windowMock.addEventListener).toHaveBeenCalledTimes(2);
+            expect(windowMock.addEventListener).toHaveBeenCalledWith(
+                'error',
+                expect.any(Function),
+            );
+            expect(windowMock.addEventListener).toHaveBeenCalledWith(
+                'unhandledrejection',
+                expect.any(Function),
+            );
+        });
+    });
+
+    test('if getRaven unsuccessful initApp without Raven', () => {
+        getRaven.mockReturnValueOnce(Promise.reject());
+
+        return _.onPolyfilled().then(() => {
+            expect(ravenMock.context).not.toHaveBeenCalled();
+            expect(loadScript).toHaveBeenCalledTimes(1);
+            expect(loadScript).toHaveBeenCalledWith(commercialUrl);
+            expect(windowMock.addEventListener).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/frontend/web/browser/boot.ts
+++ b/packages/frontend/web/browser/boot.ts
@@ -7,7 +7,7 @@ import {
     init as initGa,
     sendPageView as sendGaPageView,
 } from '@frontend/web/browser/ga';
-import { Article } from './pages/Article';
+import { Article } from '@frontend/web/pages/Article';
 import { ReportedError, reportError } from '@frontend/web/browser/reportError';
 import { loadScript } from '@frontend/web/browser/loadScript';
 import { RavenStatic } from 'raven-js';
@@ -48,18 +48,18 @@ const initApp = (): void => {
 
     loadCommercial()
         .then(() => {
-            enhanceApp();
+            // enhanceApp();
         })
         .catch(err => {
-            // If loadCommercial fails reportError and enhanceApp
-            reportError(
-                err,
-                {
-                    feature: 'commercial',
-                },
-                false,
-            );
-            enhanceApp();
+            // // If loadCommercial fails reportError and enhanceApp
+            // reportError(
+            //     err,
+            //     {
+            //         feature: 'commercial',
+            //     },
+            //     false,
+            // );
+            // enhanceApp();
         });
 };
 
@@ -86,6 +86,7 @@ const initAppWithRaven = (raven: RavenStatic) => {
 
     // Report unhandled promise rejections
     window.addEventListener('unhandledrejection', event => {
+        console.log('*** WAT ***');
         // Prevent error output on the console:
         event.preventDefault();
 
@@ -104,8 +105,8 @@ const initAppWithRaven = (raven: RavenStatic) => {
     );
 };
 
-const run = (): void => {
-    getRaven()
+const onPolyfilled = (): Promise<void> => {
+    return getRaven()
         .catch(err => {
             // If getRaven fails continue to initApp
             initApp();
@@ -126,14 +127,23 @@ const run = (): void => {
         });
 };
 
-/*
-    We want to run `run` only after polyfill.io has initialised
-    By the time this script runs, if `window.guardian.polyfilled` is true,
-    meaning that polyfill.io has initialised, then we run run(), otherwise
-    we stick it in window.guardian.onPolyfilled to be ran later.
-*/
-if (window.guardian.polyfilled) {
-    run();
-} else {
-    window.guardian.onPolyfilled = run;
-}
+const run = (): void => {
+    /*
+        We want to run `onPolyfilled` only after polyfill.io has initialised
+        By the time this script runs, if `window.guardian.polyfilled` is true,
+        meaning that polyfill.io has initialised, then we run onPolyfilled(), otherwise
+        we stick it in window.guardian.onPolyfilled to be ran later.
+    */
+    if (window.guardian.polyfilled) {
+        onPolyfilled();
+    } else {
+        window.guardian.onPolyfilled = onPolyfilled;
+    }
+};
+
+run();
+
+export const _ = {
+    run,
+    onPolyfilled,
+};

--- a/packages/frontend/web/browser/boot.ts
+++ b/packages/frontend/web/browser/boot.ts
@@ -51,15 +51,15 @@ const initApp = (): void => {
             enhanceApp();
         })
         .catch(err => {
-            // // If loadCommercial fails reportError and enhanceApp
-            // reportError(
-            //     err,
-            //     {
-            //         feature: 'commercial',
-            //     },
-            //     false,
-            // );
-            // enhanceApp();
+            // If loadCommercial fails reportError and enhanceApp
+            reportError(
+                err,
+                {
+                    feature: 'commercial',
+                },
+                false,
+            );
+            enhanceApp();
         });
 };
 
@@ -86,7 +86,6 @@ const initAppWithRaven = (raven: RavenStatic) => {
 
     // Report unhandled promise rejections
     window.addEventListener('unhandledrejection', event => {
-        console.log('*** WAT ***');
         // Prevent error output on the console:
         event.preventDefault();
 

--- a/packages/frontend/web/browser/boot.ts
+++ b/packages/frontend/web/browser/boot.ts
@@ -48,7 +48,7 @@ const initApp = (): void => {
 
     loadCommercial()
         .then(() => {
-            // enhanceApp();
+            enhanceApp();
         })
         .catch(err => {
             // // If loadCommercial fails reportError and enhanceApp

--- a/scripts/jest/setup.ts
+++ b/scripts/jest/setup.ts
@@ -9,7 +9,7 @@ window.guardian = {
         data: {},
         cssIDs: [],
     },
-    polyfilled: true,
+    polyfilled: false,
     onPolyfilled: () => {
         return undefined;
     },

--- a/scripts/webpack/browser.js
+++ b/scripts/webpack/browser.js
@@ -27,7 +27,7 @@ module.exports = ({ page }) => ({
         [`${siteName}.${page.toLowerCase()}`]: [
             DEV &&
                 'webpack-hot-middleware/client?name=browser&overlayWarnings=true',
-            './packages/frontend/web/browser.ts',
+            './packages/frontend/web/browser/boot.ts',
         ].filter(Boolean),
     },
     output: {


### PR DESCRIPTION
## What does this change?

- `web/browser.ts` becomes `web/browser/boot.ts`. I did this because `browser.ts` was the only file in the `web` directory and I felt it could be moved to sit alongside the other browser-only scripts in the `browser` directory - the server-side equivalent `render.ts` lives at `web/server/render.ts` for example.
- I've written a test suite using jest for `web/browser/boot.ts` that tests the logic that kicks off the app - this covers waiting for `Polyfill.io`, initialising `Raven`, loading `Commercial` and enhancing the `App`.

## Why?

- Tests verify the JS initialisation steps in the client are behaving as desired

