### PR TITLE
Render list of structured data as separate script tags instead of json array

### DIFF
--- a/packages/frontend/amp/server/document.test.tsx
+++ b/packages/frontend/amp/server/document.test.tsx
@@ -10,7 +10,7 @@ import { AnalyticsModel } from '@frontend/amp/components/Analytics';
 
 test('rejects invalid AMP doc (to test validator)', async () => {
     const v = await validator.getInstance();
-    const linkedData = [{}];
+    const linkedData = [{ '@type': 'WebPage' }];
     const metadata = { description: '', canonicalURL: '' };
     const result = v.validateString(
         document({
@@ -29,7 +29,7 @@ test('produces valid AMP doc', async () => {
     const config = extractConfig(data);
     const nav = extractNAV(data);
     const model = extractModel(data);
-    const linkedData = [{}];
+    const linkedData = [{ '@type': 'WebPage' }];
     const metadata = {
         description: model.trailText,
         canonicalURL: model.webURL,

--- a/packages/frontend/amp/server/document.test.tsx
+++ b/packages/frontend/amp/server/document.test.tsx
@@ -10,7 +10,7 @@ import { AnalyticsModel } from '@frontend/amp/components/Analytics';
 
 test('rejects invalid AMP doc (to test validator)', async () => {
     const v = await validator.getInstance();
-    const linkedData = [{ '@type': 'WebPage' }];
+    const linkedData = [{}];
     const metadata = { description: '', canonicalURL: '' };
     const result = v.validateString(
         document({
@@ -29,7 +29,7 @@ test('produces valid AMP doc', async () => {
     const config = extractConfig(data);
     const nav = extractNAV(data);
     const model = extractModel(data);
-    const linkedData = [{ '@type': 'WebPage' }];
+    const linkedData = [{}];
     const metadata = {
         description: model.trailText,
         canonicalURL: model.webURL,

--- a/packages/frontend/amp/server/document.tsx
+++ b/packages/frontend/amp/server/document.tsx
@@ -16,10 +16,6 @@ interface Metadata {
     canonicalURL: string;
 }
 
-interface LinkedDataEntity {
-    '@type': string;
-}
-
 export const document = ({
     linkedData,
     title,
@@ -27,7 +23,7 @@ export const document = ({
     scripts,
     metadata,
 }: {
-    linkedData: LinkedDataEntity[];
+    linkedData: object[];
     title: string;
     body: React.ReactElement<any>;
     scripts: string[];
@@ -60,9 +56,7 @@ export const document = ({
     
     ${linkedData.map(
         ld => `
-<script type="application/ld+json" data-schema="${
-            ld['@type']
-        }">${JSON.stringify(ld)}</script>`,
+<script type="application/ld+json">${JSON.stringify(ld)}</script>`,
     )}
 
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>

--- a/packages/frontend/amp/server/document.tsx
+++ b/packages/frontend/amp/server/document.tsx
@@ -16,6 +16,10 @@ interface Metadata {
     canonicalURL: string;
 }
 
+interface LinkedDataEntity {
+    '@type': string;
+}
+
 export const document = ({
     linkedData,
     title,
@@ -23,7 +27,7 @@ export const document = ({
     scripts,
     metadata,
 }: {
-    linkedData: object[];
+    linkedData: LinkedDataEntity[];
     title: string;
     body: React.ReactElement<any>;
     scripts: string[];
@@ -53,10 +57,13 @@ export const document = ({
     <link rel="canonical" href="${metadata.canonicalURL}" />
     <meta name="viewport" content="width=device-width,minimum-scale=1">
     <link rel="icon" href="https://static.guim.co.uk/images/${favicon}">
-
-    <script type="application/ld+json">
-        ${JSON.stringify(linkedData)}
-    </script>
+    
+    ${linkedData.map(
+        ld => `
+<script type="application/ld+json" data-schema="${
+            ld['@type']
+        }">${JSON.stringify(ld)}</script>`,
+    )}
 
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <script async src="https://cdn.ampproject.org/v0.js"></script>


### PR DESCRIPTION
## What does this change?
Render list of structured data as separate script tags instead of JSON array

## Why?
`amp-subscriptions-google` currently does not support an array or structured data.