### PR TITLE
Reduce number of dotcom rendering instances on CODE.

### DIFF
--- a/packages/frontend/cloudformation.yml
+++ b/packages/frontend/cloudformation.yml
@@ -55,6 +55,13 @@ Mappings:
       Value: frontend
     App:
       Value: rendering
+  StageMap:
+    PROD:
+      MinCapacity: 3
+      MaxCapacity: 6
+    CODE:
+      MinCapacity: 1
+      MaxCapacity: 2
 
 Resources:
   LoadBalancerSecurityGroup:
@@ -222,8 +229,8 @@ Resources:
         Ref: Subnets
       LaunchConfigurationName:
         Ref: LaunchConfig
-      MinSize: 3
-      MaxSize: 12
+      MinSize: !FindInMap [StageMap, !Ref Stage, MinCapacity]
+      MaxSize: !FindInMap [StageMap, !Ref Stage, MaxCapacity]
       HealthCheckType: ELB
       HealthCheckGracePeriod: 120
       LoadBalancerNames:


### PR DESCRIPTION
## What does this change?
On CODE there's no need to have high availability (we don't do this on frontend). This PR adds a mapping to allow different values for min/max capacity for CODE/PROD stacks.

## Why?
$$$