### PR TITLE
Changed timeout for consent to 5 secs and switched the fallBackAction…

### DIFF
--- a/packages/frontend/amp/components/AdConsent.tsx
+++ b/packages/frontend/amp/components/AdConsent.tsx
@@ -93,8 +93,8 @@ export const AdConsent: React.FC<{}> = ({}) => {
                             default: {
                                 waitFor: { adconsent: [] },
                                 timeout: {
-                                    seconds: 0,
-                                    fallbackAction: 'dismiss',
+                                    seconds: 5,
+                                    fallbackAction: 'reject',
                                 },
                             },
                         },


### PR DESCRIPTION
… to reject

## What does this change?
Adds a 5 seconds timeout to the consent form before it exdcutes fallBackAction.
Changes fallBackAction to rejected (was incorrectly set as dismiss)


## Why?
This change delays the ads loading by 5 seconds to allow time for the user to consent to having his data used and therefore potentially boost ad revenue for first time page visits.