### PR TITLE
Adding base url to direct users from amp to dotcom version of article

### DIFF
--- a/packages/frontend/amp/components/SubMeta.tsx
+++ b/packages/frontend/amp/components/SubMeta.tsx
@@ -177,11 +177,17 @@ export const SubMeta: React.FC<{
             {/* TODO link to actual (non-AMP) site here. Also handle comment count behaviour. */}
             <div className={cx(guardianLines, siteLinks)}>
                 {isCommentable && (
-                    <a className={siteLinkStyle} href={`/${pageID}#comments`}>
+                    <a
+                        className={siteLinkStyle}
+                        href={`${guardianBaseURL}/${pageID}#comments`}
+                    >
                         <CommentIcon className={commentIcon} /> View comments
                     </a>
                 )}
-                <a className={siteLinkStyle} href={`/${pageID}`}>
+                <a
+                    className={siteLinkStyle}
+                    href={`${guardianBaseURL}/${pageID}`}
+                >
                     View on theguardian.com
                 </a>
             </div>


### PR DESCRIPTION
## What does this change?
Takes users to the dotcom version of an article at the bottom of AMP pages

## Why?
Consistency