### PR TITLE
Better match article & footer w/ dotcom

### DIFF
--- a/packages/frontend/web/components/ArticleBody.tsx
+++ b/packages/frontend/web/components/ArticleBody.tsx
@@ -13,6 +13,7 @@ import {
     desktop,
     tablet,
 } from '@guardian/pasteup/breakpoints';
+import { clearFix } from '@guardian/pasteup/mixins';
 import { headline, textSans, body } from '@guardian/pasteup/typography';
 import { pillarMap, pillarPalette } from '@frontend/lib/pillars';
 import { ArticleRenderer } from '@frontend/web/components/lib/ArticleRenderer';
@@ -29,6 +30,7 @@ const wrapper = css`
     padding-top: 6px;
     margin-right: 0;
     margin-left: 0;
+    ${clearFix}
 
     ${desktop} {
         max-width: 620px;

--- a/packages/frontend/web/components/BackToTop.tsx
+++ b/packages/frontend/web/components/BackToTop.tsx
@@ -7,7 +7,8 @@ import { sans } from '@guardian/pasteup/typography';
 const iconContainer = css`
     position: relative;
     float: right;
-    margin-top: -6px;
+    margin-top: -3px;
+    margin-right: 4px;
     border-radius: 100%;
     background-color: ${palette.neutral[7]};
     cursor: pointer;
@@ -39,11 +40,6 @@ const text = css`
     padding-right: 10px;
 `;
 
-const outerWrapper = css`
-    border-top: 1px solid ${palette.neutral[86]};
-    background-color: ${palette.neutral[97]};
-`;
-
 const innerWrapper = css`
     text-align: right;
 `;
@@ -55,13 +51,11 @@ const link = css`
 
 export const BackToTop: React.FC = () => (
     <a className={link} href="#top">
-        <div className={outerWrapper}>
-            <Container className={innerWrapper}>
-                <span className={text}>back to top</span>
-                <span className={iconContainer}>
-                    <i className={icon} />
-                </span>
-            </Container>
-        </div>
+        <Container borders={true} className={innerWrapper}>
+            <span className={text}>back to top</span>
+            <span className={iconContainer}>
+                <i className={icon} />
+            </span>
+        </Container>
     </a>
 );

--- a/packages/frontend/web/components/Footer.tsx
+++ b/packages/frontend/web/components/Footer.tsx
@@ -14,9 +14,9 @@ import {
 } from '@frontend/lib/footer-links';
 
 const footer = css`
-    background-color: ${palette.neutral[20]};
-    color: ${palette.neutral[86]};
-    ${textSans(3)};
+    background-color: ${palette.brand.main};
+    color: ${palette.neutral[100]};
+    ${textSans(5)};
 `;
 
 const footerInner = css`
@@ -34,13 +34,14 @@ const emailSignup = css`
 `;
 
 const footerLink = css`
-    color: ${palette.neutral[86]};
+    color: inherit;
     text-decoration: none;
     padding-bottom: 12px;
     display: block;
 
     :hover {
         text-decoration: underline;
+        color: ${palette.highlight.main};
     }
 `;
 
@@ -48,7 +49,7 @@ const footerList = css`
     display: flex;
     flex-wrap: wrap;
     flex-direction: row;
-    border-top: 1px solid ${palette.neutral[20]};
+    border-top: 1px solid ${palette.brand.pastel};
 
     ${tablet} {
         border-top: none;
@@ -56,7 +57,7 @@ const footerList = css`
 
     ul {
         width: 50%;
-        border-left: 1px solid ${palette.neutral[20]};
+        border-left: 1px solid ${palette.brand.pastel};
 
         ${until.tablet} {
             :nth-of-type(odd) {
@@ -92,7 +93,7 @@ const footerList = css`
 const copyright = css`
     ${textSans(1)};
     padding: 6px 0 18px;
-    border-top: 1px solid ${palette.neutral[20]};
+    border-top: 1px solid ${palette.brand.pastel};
     margin-top: 12px;
 `;
 

--- a/packages/frontend/web/components/Header/Nav/SubNav/Inner.tsx
+++ b/packages/frontend/web/components/Header/Nav/SubNav/Inner.tsx
@@ -14,8 +14,6 @@ const wrapperCollapsed = css`
     overflow: hidden;
 
     ${tablet} {
-        border-left: 1px solid ${palette.neutral[86]};
-        border-right: 1px solid ${palette.neutral[86]};
         height: 42px;
     }
 `;

--- a/packages/frontend/web/components/Header/Nav/SubNav/SubNav.tsx
+++ b/packages/frontend/web/components/Header/Nav/SubNav/SubNav.tsx
@@ -3,7 +3,6 @@ import { css } from 'emotion';
 
 import { Container } from '@guardian/guui';
 import { palette } from '@guardian/pasteup/palette';
-import { tablet } from '@guardian/pasteup/breakpoints';
 import { Inner } from './Inner';
 
 const subnavWrapper = css`
@@ -27,11 +26,6 @@ const multiLine = css`
     clear: left;
     display: block;
     height: 13px;
-
-    ${tablet} {
-        border-left: 1px solid ${palette.neutral[86]};
-        border-right: 1px solid ${palette.neutral[86]};
-    }
 `;
 
 interface Props {
@@ -96,7 +90,7 @@ export class SubNav extends Component<
 
         return (
             <div className={subnavWrapper}>
-                <Container>
+                <Container borders={true}>
                     <Inner
                         links={this.props.subnav.links}
                         pillar={this.props.pillar}

--- a/packages/frontend/web/components/MostViewed.tsx
+++ b/packages/frontend/web/components/MostViewed.tsx
@@ -15,7 +15,6 @@ import { AsyncClientComponent } from './lib/AsyncClientComponent';
 import { reportError } from '@frontend/web/browser/reportError';
 
 const container = css`
-    border-top: 1px solid ${palette.neutral[86]};
     padding-top: 3px;
 
     ${desktop} {

--- a/packages/frontend/web/pages/Article.tsx
+++ b/packages/frontend/web/pages/Article.tsx
@@ -2,11 +2,7 @@ import React from 'react';
 import { Container } from '@guardian/guui';
 import { css, cx } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
-import {
-    desktop,
-    mobileLandscape,
-    tablet,
-} from '@guardian/pasteup/breakpoints';
+import { desktop, mobileLandscape } from '@guardian/pasteup/breakpoints';
 import { MostViewed } from '@frontend/web/components/MostViewed';
 import { Header } from '@frontend/web/components/Header/Header';
 import { Footer } from '@frontend/web/components/Footer';

--- a/packages/frontend/web/pages/Article.tsx
+++ b/packages/frontend/web/pages/Article.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import { Container } from '@guardian/guui';
-import { css } from 'emotion';
+import { css, cx } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
 import {
     desktop,
     mobileLandscape,
     tablet,
 } from '@guardian/pasteup/breakpoints';
-
 import { MostViewed } from '@frontend/web/components/MostViewed';
 import { Header } from '@frontend/web/components/Header/Header';
 import { Footer } from '@frontend/web/components/Footer';
@@ -38,6 +37,7 @@ const articleContainer = css`
     position: relative;
     background-color: ${palette.neutral[100]};
     padding: 0 10px;
+
     ${tablet} {
         border-left: 1px solid ${palette.neutral[86]};
         border-right: 1px solid ${palette.neutral[86]};
@@ -62,6 +62,15 @@ export const Article: React.FC<{
                     <ArticleBody CAPI={data.CAPI} config={data.config} />
                     <div className={secondaryColumn} />
                 </article>
+            </Container>
+            <Container
+                className={cx(
+                    articleContainer,
+                    css`
+                        border-top: 1px solid ${palette.neutral[86]};
+                    `,
+                )}
+            >
                 <MostViewed sectionName={data.CAPI.sectionName} />
             </Container>
         </main>

--- a/packages/frontend/web/pages/Article.tsx
+++ b/packages/frontend/web/pages/Article.tsx
@@ -38,10 +38,6 @@ const articleContainer = css`
     background-color: ${palette.neutral[100]};
     padding: 0 10px;
 
-    ${tablet} {
-        border-left: 1px solid ${palette.neutral[86]};
-        border-right: 1px solid ${palette.neutral[86]};
-    }
     ${mobileLandscape} {
         padding: 0 20px;
     }
@@ -57,13 +53,14 @@ export const Article: React.FC<{
             edition={data.CAPI.editionId}
         />
         <main>
-            <Container className={articleContainer}>
+            <Container borders={true} className={articleContainer}>
                 <article>
                     <ArticleBody CAPI={data.CAPI} config={data.config} />
                     <div className={secondaryColumn} />
                 </article>
             </Container>
             <Container
+                borders={true}
                 className={cx(
                     articleContainer,
                     css`

--- a/packages/frontend/web/pages/Article.tsx
+++ b/packages/frontend/web/pages/Article.tsx
@@ -2,7 +2,11 @@ import React from 'react';
 import { Container } from '@guardian/guui';
 import { css } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
-import { desktop, mobileLandscape } from '@guardian/pasteup/breakpoints';
+import {
+    desktop,
+    mobileLandscape,
+    tablet,
+} from '@guardian/pasteup/breakpoints';
 
 import { MostViewed } from '@frontend/web/components/MostViewed';
 import { Header } from '@frontend/web/components/Header/Header';
@@ -13,10 +17,6 @@ import { SubNav } from '@frontend/web/components/Header/Nav/SubNav/SubNav';
 import { CookieBanner } from '@frontend/web/components/CookieBanner';
 
 // TODO: find a better of setting opacity
-const articleWrapper = css`
-    background-color: rgba(18, 18, 18, 0.05);
-`;
-
 const secondaryColumn = css`
     position: absolute;
     top: 0;
@@ -38,7 +38,10 @@ const articleContainer = css`
     position: relative;
     background-color: ${palette.neutral[100]};
     padding: 0 10px;
-
+    ${tablet} {
+        border-left: 1px solid ${palette.neutral[86]};
+        border-right: 1px solid ${palette.neutral[86]};
+    }
     ${mobileLandscape} {
         padding: 0 20px;
     }
@@ -53,7 +56,7 @@ export const Article: React.FC<{
             pillar={data.CAPI.pillar}
             edition={data.CAPI.editionId}
         />
-        <main className={articleWrapper}>
+        <main>
             <Container className={articleContainer}>
                 <article>
                     <ArticleBody CAPI={data.CAPI} config={data.config} />

--- a/packages/guui/components/Container/Container.tsx
+++ b/packages/guui/components/Container/Container.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { css, cx } from 'emotion';
 
 import { tablet, desktop, leftCol, wide } from '@guardian/pasteup/breakpoints';
+import { palette } from '@guardian/pasteup/palette';
 
 const container = css`
     margin: auto;
@@ -23,11 +24,26 @@ const container = css`
     }
 `;
 
+const containerWithBorders = css`
+    ${tablet} {
+        border-left: 1px solid ${palette.neutral[86]};
+        border-right: 1px solid ${palette.neutral[86]};
+    }
+`;
+
 export const Container: React.SFC<{
     className?: string;
+    borders?: boolean;
     children: React.ReactNode;
-}> = ({ className, children, ...props }) => (
-    <div className={cx(container, className)} {...props}>
+}> = ({ className, borders, children, ...props }) => (
+    <div
+        className={cx(
+            container,
+            className,
+            borders ? containerWithBorders : null,
+        )}
+        {...props}
+    >
         {children}
     </div>
 );


### PR DESCRIPTION
## What does this change?

This tweaks some of the CSS to match the articles from gu.com a bit better since the last redesign:

- The side margins are transparent now, and the page has side borders.
- The footer is blue. It literally is the old footer but blue. It doesn't match the new footer but it looks closer so there's that.
- I've added a new `borders={true/false}` prop to `<Container>` to centralize the behavior of adding side borders only after tablet.

<img width="1552" alt="Screenshot 2019-04-09 at 16 50 20" src="https://user-images.githubusercontent.com/11539094/55815785-c9703f80-5ae8-11e9-9422-9659a5cd2731.png">

<img width="1552" alt="Screenshot 2019-04-09 at 16 50 17" src="https://user-images.githubusercontent.com/11539094/55815220-e48e7f80-5ae7-11e9-95aa-11557e7bc565.png">


## Why?

I wanted to get more familiar with the codebase and with emotion and with the overall process! Hope you like it