### PR TITLE
Remove design and pasteup from riffraff zip bundle

### DIFF
--- a/scripts/deploy/build-riffraff-bundle.js
+++ b/scripts/deploy/build-riffraff-bundle.js
@@ -53,7 +53,7 @@ const copyStatic = () => {
 const copyDist = () => {
     log(' - copying dist');
     return cpy(
-        ['**/*.!(html|json)'],
+        ['**/*.!(html|json)', '!**/design'],
         path.resolve(target, `${siteName}-static`, 'guui', 'assets'),
         {
             cwd: path.resolve(dist),
@@ -70,9 +70,21 @@ const copyRiffRaff = () => {
 
 const zipBundle = () => {
     log(' - zipping bundle');
-    return execa('zip', ['-r', 'rendering.zip', '.', '-x', '.git/**\\*'], {
-        shell: true,
-    }).then(() => {
+    return execa(
+        'zip',
+        [
+            '--recurse-paths',
+            'rendering.zip',
+            '.',
+            '--exclude',
+            '.git/**\\*',
+            '**/design/**\\*',
+            '**/pasteup/**\\*',
+        ],
+        {
+            shell: true,
+        },
+    ).then(() => {
         cpy(['rendering.zip'], path.resolve(target, 'rendering', 'dist'));
     });
 };

--- a/scripts/deploy/build-riffraff-bundle.js
+++ b/scripts/deploy/build-riffraff-bundle.js
@@ -53,7 +53,7 @@ const copyStatic = () => {
 const copyDist = () => {
     log(' - copying dist');
     return cpy(
-        ['**/*.!(html|json)', '!**/design'],
+        ['**/*.!(html|json)'],
         path.resolve(target, `${siteName}-static`, 'guui', 'assets'),
         {
             cwd: path.resolve(dist),

--- a/scripts/deploy/build-riffraff-bundle.js
+++ b/scripts/deploy/build-riffraff-bundle.js
@@ -80,6 +80,7 @@ const zipBundle = () => {
             '.git/**\\*',
             '**/design/**\\*',
             '**/pasteup/**\\*',
+            '**/guui/**\\*',
         ],
         {
             shell: true,


### PR DESCRIPTION
## What does this change?
This is an intermediary step I believe. This PR doesn't zip up new `design` and existing `pasteup` folders.

In this PR we started to zip up `node_modules` as a part of riffraff-bundle `zip` https://github.com/guardian/dotcom-rendering/pull/255/files#diff-2e8cfe06cb1e4b8080592c4e320373bcL80 as we wanted to remove `make start` - not running `make start` is right!

However, that causes memory issues as the project grows, so that we're now seeing `Error: stdout maxBuffer exceeded` on a 10mb stream to zip. 

I don't believe that we should be doing either a `make start` on the server nor do we need to ship `node_modules` and should instead be shipping a complete bundle, i.e : 

> Run Built Code, not Source Code

Which I *think* we're doing with the `dist` bundle that we're running, in which case we should be able to start that with pm2 without a need for `node_modules` being shipped?

Not my area of expertise at all so would like some eyes on as would prefer not to make AMP fall over!

I reasonably confident that this will work as I deleted `node_modules`, ran `pm2 start` against `dist/frontend.server.js` and then hit `9000/article` with the json of an article in Frontend in Postman and got a pretty article back:

![image](https://user-images.githubusercontent.com/638051/55819413-9b8ef900-5af0-11e9-9ad4-c1df220695d0.png)

## Why?
This intermediary step is required as  there's more investigation needed after `whatif` to make sure we do this correctly!
