### PR TITLE
Add Appearances and Contrasts Types to pasteup palette

### DIFF
--- a/packages/pasteup/palette.ts
+++ b/packages/pasteup/palette.ts
@@ -124,8 +124,8 @@ const labs = {
 };
 
 const contrasts = {
-    darkOnLight: { background: neutral[97], foreground: neutral[20] },
-    lightOnDark: { background: neutral[20], foreground: neutral[97] },
+    darkOnLight: { background: neutral[100], foreground: neutral[7] },
+    lightOnDark: { background: neutral[7], foreground: neutral[100] },
 };
 
 export const palette: AllPillarColours & OtherColours & Appearances = {

--- a/packages/pasteup/palette.ts
+++ b/packages/pasteup/palette.ts
@@ -32,6 +32,13 @@ export interface OtherColours {
     brand: { dark: colour; main: colour; pastel: colour };
 }
 
+export interface Appearances {
+    contrasts: {
+        darkOnLight: { background: colour; foreground: colour };
+        lightOnDark: { background: colour; foreground: colour };
+    };
+}
+
 const green = {
     dark: '#185E36',
     main: '#22874D',
@@ -116,7 +123,12 @@ const labs = {
     main: '#69d1ca',
 };
 
-export const palette: AllPillarColours & OtherColours = {
+const contrasts = {
+    darkOnLight: { background: neutral[97], foreground: neutral[20] },
+    lightOnDark: { background: neutral[20], foreground: neutral[97] },
+};
+
+export const palette: AllPillarColours & OtherColours & Appearances = {
     news,
     opinion,
     sport,
@@ -129,4 +141,5 @@ export const palette: AllPillarColours & OtherColours = {
     green,
     brand,
     state,
+    contrasts,
 };

--- a/packages/pasteup/palette.ts
+++ b/packages/pasteup/palette.ts
@@ -34,8 +34,13 @@ export interface OtherColours {
 
 export interface Appearances {
     contrasts: {
-        darkOnLight: { background: colour; foreground: colour };
-        lightOnDark: { background: colour; foreground: colour };
+        darkOnLight: { background: colour; foreground: colour; border: colour };
+        lightOnDark: { background: colour; foreground: colour; border: colour };
+        lightOnBrand: {
+            background: colour;
+            foreground: colour;
+            border: colour;
+        };
     };
 }
 
@@ -124,8 +129,21 @@ const labs = {
 };
 
 const contrasts = {
-    darkOnLight: { background: neutral[100], foreground: neutral[7] },
-    lightOnDark: { background: neutral[7], foreground: neutral[100] },
+    darkOnLight: {
+        background: neutral[100],
+        foreground: neutral[7],
+        border: neutral[86],
+    },
+    lightOnDark: {
+        background: neutral[7],
+        foreground: neutral[100],
+        border: neutral[20],
+    },
+    lightOnBrand: {
+        background: brand.main,
+        foreground: neutral[100],
+        border: brand.pastel,
+    },
 };
 
 export const palette: AllPillarColours & OtherColours & Appearances = {


### PR DESCRIPTION
## What does this change?
Adds Appearances and Contrasts as types to the pasteup palette. 

## Why?
Allows us to define consistent colour contrasts that can be used directly in the applications.

**Example**

This PR adds `darkOnLight` and `lightOnDark`, you can review the usage of the types in [closeButton pr](https://github.com/guardian/dotcom-rendering/pull/485/files) but it defines the contrast of this and it's opposite:

![image](https://user-images.githubusercontent.com/638051/55886698-25e46500-5ba4-11e9-8641-c45bd58c98eb.png)

