### PR TITLE
Update dateline with screenreader text and add story

### DIFF
--- a/packages/frontend/web/components/ArticleBody.tsx
+++ b/packages/frontend/web/components/ArticleBody.tsx
@@ -550,7 +550,10 @@ export const ArticleBody: React.FC<{
                             </a>
                         </div>
                     )}
-                    <Dateline dateDisplay={CAPI.webPublicationDateDisplay} />
+                    <Dateline
+                        dateDisplay={CAPI.webPublicationDateDisplay}
+                        descriptionText={'Published on'}
+                    />
                     <div className={metaExtras}>
                         <SharingIcons
                             sharingUrls={CAPI.sharingUrls}

--- a/packages/frontend/web/components/Dateline.stories.tsx
+++ b/packages/frontend/web/components/Dateline.stories.tsx
@@ -5,5 +5,10 @@ import { Dateline } from './Dateline';
 const stories = storiesOf('Frontend Web', module);
 
 stories.add('DateLine', () => {
-    return <Dateline dateDisplay={'1st January 1970'} />;
+    return (
+        <Dateline
+            dateDisplay={'Fri 10 Mar 2017 19.15 GMT'}
+            descriptionText={'Published on'}
+        />
+    );
 });

--- a/packages/frontend/web/components/Dateline.stories.tsx
+++ b/packages/frontend/web/components/Dateline.stories.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { Dateline } from './Dateline';
+
+const stories = storiesOf('Frontend Web', module);
+
+stories.add('DateLine', () => {
+    return <Dateline dateDisplay={'1st January 1970'} />;
+});

--- a/packages/frontend/web/components/Dateline.tsx
+++ b/packages/frontend/web/components/Dateline.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { css } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
 import { textSans } from '@guardian/pasteup/typography';
+import { screenReaderOnly } from '@guardian/pasteup/mixins';
 
 const captionFont = css`
     ${textSans(1)};
@@ -16,10 +17,18 @@ const dateline = css`
     margin-bottom: 6px;
 `;
 
+const description = css`
+    ${screenReaderOnly}
+`;
+
 export const Dateline: React.FC<{
     dateDisplay: string;
-}> = ({ dateDisplay }) => (
+    descriptionText: string;
+}> = ({ dateDisplay, descriptionText }) => (
     <>
-        <div className={dateline}>{dateDisplay}</div>
+        <div className={dateline}>
+            <span className={description}>{descriptionText} </span>
+            {dateDisplay}
+        </div>
     </>
 );


### PR DESCRIPTION
## What does this change?
Adds some 'screenReader' text as a required field for the dateline component to ensure that wherever the component is used there is context given for the date.

Also adds the storybook story for the component.

## Why?
Better context for screenreader users.