### PR TITLE
Move article age warning to above headline

### DIFF
--- a/packages/frontend/model/extract-capi.test.ts
+++ b/packages/frontend/model/extract-capi.test.ts
@@ -450,7 +450,7 @@ describe('extract-capi', () => {
             ];
         });
 
-        it('returns correct ageWarning if article over 2 years old', () => {
+        it('returns correct ageWarning if article more than 2 years old', () => {
             // set a publication date of 2 years ago
             publicationDate.setDate(publicationDate.getDate() - 365 * 2);
 
@@ -458,10 +458,10 @@ describe('extract-capi', () => {
 
             const { ageWarning } = extract(testData);
 
-            expect(ageWarning).toBe('This article is over 2 years old');
+            expect(ageWarning).toBe('2 years old');
         });
 
-        it('returns correct ageWarning if article over 1 year old', () => {
+        it('returns correct ageWarning if article more than 1 year old', () => {
             // set a publication date of 500 days ago
             publicationDate.setDate(publicationDate.getDate() - 500);
 
@@ -469,10 +469,10 @@ describe('extract-capi', () => {
 
             const { ageWarning } = extract(testData);
 
-            expect(ageWarning).toBe('This article is over 1 year old');
+            expect(ageWarning).toBe('1 year old');
         });
 
-        it('returns correct ageWarning if article over 2 months old', () => {
+        it('returns correct ageWarning if article more than 2 months old', () => {
             // set a publication date of 90 days ago
             publicationDate.setDate(publicationDate.getDate() - 90);
 
@@ -480,10 +480,10 @@ describe('extract-capi', () => {
 
             const { ageWarning } = extract(testData);
 
-            expect(ageWarning).toBe('This article is over 2 months old');
+            expect(ageWarning).toBe('2 months old');
         });
 
-        it('returns correct ageWarning if article over 1 month old', () => {
+        it('returns correct ageWarning if article more than 1 month old', () => {
             // set a publication date of 35 days ago
             publicationDate.setDate(publicationDate.getDate() - 35);
 
@@ -491,7 +491,7 @@ describe('extract-capi', () => {
 
             const { ageWarning } = extract(testData);
 
-            expect(ageWarning).toBe('This article is over 1 month old');
+            expect(ageWarning).toBe('1 month old');
         });
 
         it('returns no ageWarning if article is 1 week old', () => {

--- a/packages/frontend/model/extract-capi.ts
+++ b/packages/frontend/model/extract-capi.ts
@@ -66,22 +66,19 @@ const getAgeWarning = (
         const diffDays = diffHours / 24;
         const diffMonths = diffDays / 31;
         const diffYears = diffDays / 365;
+        let message;
 
         if (diffYears >= 2) {
-            return `${Math.floor(diffYears)} years old`;
+            message = `${Math.floor(diffYears)} years old`;
+        } else if (diffYears > 1) {
+            message = '1 year old';
+        } else if (diffMonths >= 2) {
+            message = `${Math.floor(diffMonths)} months old`;
+        } else if (diffMonths > 1) {
+            message = '1 month old';
         }
 
-        if (diffYears > 1) {
-            return '1 year old';
-        }
-
-        if (diffMonths >= 2) {
-            return `${Math.floor(diffMonths)} months old`;
-        }
-
-        if (diffMonths > 1) {
-            return '1 month old';
-        }
+        return message;
     }
 };
 

--- a/packages/frontend/model/extract-capi.ts
+++ b/packages/frontend/model/extract-capi.ts
@@ -67,22 +67,20 @@ const getAgeWarning = (
         const diffMonths = diffDays / 31;
         const diffYears = diffDays / 365;
 
-        const message = 'This article is over';
-
         if (diffYears >= 2) {
-            return `${message} ${Math.floor(diffYears)} years old`;
+            return `${Math.floor(diffYears)} years old`;
         }
 
         if (diffYears > 1) {
-            return `${message} 1 year old`;
+            return '1 year old';
         }
 
         if (diffMonths >= 2) {
-            return `${message} ${Math.floor(diffMonths)} months old`;
+            return `${Math.floor(diffMonths)} months old`;
         }
 
         if (diffMonths > 1) {
-            return `${message} 1 month old`;
+            return '1 month old';
         }
     }
 };

--- a/packages/frontend/web/components/ArticleBody.tsx
+++ b/packages/frontend/web/components/ArticleBody.tsx
@@ -12,8 +12,9 @@ import {
     leftCol,
     desktop,
     tablet,
+    mobileLandscape,
 } from '@guardian/pasteup/breakpoints';
-import { clearFix } from '@guardian/pasteup/mixins';
+import { clearFix, screenReaderOnly } from '@guardian/pasteup/mixins';
 import { headline, textSans, body } from '@guardian/pasteup/typography';
 import { pillarMap, pillarPalette } from '@frontend/lib/pillars';
 import { ArticleRenderer } from '@frontend/web/components/lib/ArticleRenderer';
@@ -86,12 +87,7 @@ const pillarColours = pillarMap(
             color: ${pillarPalette[pillar].main};
         `,
 );
-const pillarFill = pillarMap(
-    pillar =>
-        css`
-            fill: ${pillarPalette[pillar].main};
-        `,
-);
+
 const pillarFigCaptionIconColor = pillarMap(
     pillar =>
         css`
@@ -361,14 +357,36 @@ const bylineLink = css`
 `;
 
 const ageWarning = css`
-    ${textSans(1)};
+    ${textSans(5)};
+    color: ${palette.neutral[7]};
+    background-color: ${palette.highlight.main};
     display: inline-block;
-    margin-bottom: 12px;
-    width: 100%;
+    margin-bottom: 6px;
+
+    > strong {
+        font-weight: bold;
+    }
+
+    padding: 6px 10px;
+    margin-top: 6px;
+    margin-left: -10px;
+
+    ${mobileLandscape} {
+        padding-left: 12px;
+    }
+
+    ${tablet} {
+        margin-left: -20px;
+    }
 
     ${leftCol} {
-        margin-top: 6px;
-    }
+        margin-left: -10px;
+        margin-top: -6px;
+        padding-left: 10px;
+`;
+
+const ageWarningScreenReader = css`
+    ${screenReaderOnly};
 `;
 
 const twitterHandle = css`
@@ -520,7 +538,18 @@ export const ArticleBody: React.FC<{
                     )}
                 </div>
                 <div className={headlineCSS}>
+                    {CAPI.ageWarning && (
+                        <div className={ageWarning} aria-hidden="true">
+                            <ClockIcon /> This article is more than{' '}
+                            <strong>{CAPI.ageWarning}</strong>
+                        </div>
+                    )}
                     <h1 className={headerStyle}>{curly(CAPI.headline)}</h1>
+                    {CAPI.ageWarning && (
+                        <div className={ageWarningScreenReader}>
+                            This article is more than {` ${CAPI.ageWarning}`}
+                        </div>
+                    )}
                     <div
                         className={cx(standfirst, standfirstLinks[CAPI.pillar])}
                         dangerouslySetInnerHTML={{
@@ -561,17 +590,6 @@ export const ArticleBody: React.FC<{
                             displayIcons={['facebook', 'twitter', 'email']}
                         />
                         <ShareCount config={config} pageId={CAPI.pageId} />
-                        {CAPI.ageWarning && (
-                            <div
-                                className={cx(
-                                    ageWarning,
-                                    pillarColours[CAPI.pillar],
-                                    pillarFill[CAPI.pillar],
-                                )}
-                            >
-                                <ClockIcon /> {CAPI.ageWarning}
-                            </div>
-                        )}
                     </div>
                 </div>
                 <div


### PR DESCRIPTION
## What does this change?

Moves the content age warning to a more prominent position above the headline

## Screenshots

**Before**

![Screenshot 2019-04-11 at 13 41 14](https://user-images.githubusercontent.com/5931528/55957989-87b5d500-5c5f-11e9-8f61-01aa2e897995.png)

**After**

![Screenshot 2019-04-11 at 13 41 04](https://user-images.githubusercontent.com/5931528/55957988-87b5d500-5c5f-11e9-993f-a6626dff1781.png)

## Why?

Visual parity with frontend