### PR TITLE
Fix byline stories

### DIFF
--- a/packages/guui/components/Byline/Byline.stories.tsx
+++ b/packages/guui/components/Byline/Byline.stories.tsx
@@ -15,7 +15,7 @@ const radioOptions: { [s: string]: string } = {
     Opinion: 'Opinion',
 };
 
-stories.add('Close', () => {
+stories.add('Byline', () => {
     const selectedPillar = radios('Variants', radioOptions, 'News');
     const author: AuthorType = {
         byline: 'CP Scott',


### PR DESCRIPTION
## What does this change?

Fixes a copy-paste error that prevents the byline stories from rendering in storybook
