### PR TITLE
Announce dateline "published on" using aria-label

### DIFF
--- a/packages/frontend/web/components/Dateline.tsx
+++ b/packages/frontend/web/components/Dateline.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { css } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
 import { textSans } from '@guardian/pasteup/typography';
-import { screenReaderOnly } from '@guardian/pasteup/mixins';
 
 const captionFont = css`
     ${textSans(1)};
@@ -17,17 +16,15 @@ const dateline = css`
     margin-bottom: 6px;
 `;
 
-const description = css`
-    ${screenReaderOnly}
-`;
-
 export const Dateline: React.FC<{
     dateDisplay: string;
     descriptionText: string;
 }> = ({ dateDisplay, descriptionText }) => (
     <>
-        <div className={dateline}>
-            <span className={description}>{descriptionText} </span>
+        <div
+            className={dateline}
+            aria-label={`${descriptionText} ${dateDisplay}`}
+        >
             {dateDisplay}
         </div>
     </>


### PR DESCRIPTION
## What does this change?

Use `aria-label` to announced "Published on xx/yy/zz" instead of a separate screenreader-only span.

## Why?

Using a separate `<span>` announces "Published on" on its own, the user has to move to the next item to hear the date.

Using `aria-label`, the screen reader announces "Published on xx/yy/zz", which sounds and feels more natural.