### PR TITLE
Add background parameters to close button

### DIFF
--- a/packages/design/.storybook/addons.js
+++ b/packages/design/.storybook/addons.js
@@ -4,3 +4,4 @@ import '@storybook/addon-knobs/register';
 import '@storybook/addon-a11y/register';
 import '@storybook/addon-storysource/register';
 import '@storybook/addon-viewport/register';
+import '@storybook/addon-backgrounds/register';

--- a/packages/design/package.json
+++ b/packages/design/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@storybook/addon-a11y": "^5.0.6",
+    "@storybook/addon-backgrounds": "^5.0.6",
     "@storybook/addon-storysource": "^5.0.6",
     "@storybook/addon-viewport": "^5.0.6",
     "prettier": "^1.16.4"

--- a/packages/guui/components/CloseButton/CloseButton.stories.tsx
+++ b/packages/guui/components/CloseButton/CloseButton.stories.tsx
@@ -6,7 +6,14 @@ import { Appearances } from '@guardian/pasteup/palette';
 
 type contrastKeys = keyof Appearances['contrasts'];
 
-const stories = storiesOf('User Interface', module).addDecorator(withKnobs);
+const stories = storiesOf('User Interface', module)
+    .addDecorator(withKnobs)
+    .addParameters({
+        backgrounds: [
+            { name: 'Dark background', value: '#121212', default: true },
+            { name: 'Light background', value: '#fffff' },
+        ],
+    });
 const radioOptions: { [key: string]: contrastKeys } = {
     Light: 'darkOnLight',
     Dark: 'lightOnDark',

--- a/packages/guui/components/CloseButton/CloseButton.stories.tsx
+++ b/packages/guui/components/CloseButton/CloseButton.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withKnobs, radios } from '@storybook/addon-knobs';
 import { CloseButton } from './CloseButton';
-import { Appearances } from '@guardian/pasteup/palette';
+import { Appearances, palette } from '@guardian/pasteup/palette';
 
 type contrastKeys = keyof Appearances['contrasts'];
 
@@ -10,8 +10,15 @@ const stories = storiesOf('User Interface', module)
     .addDecorator(withKnobs)
     .addParameters({
         backgrounds: [
-            { name: 'Dark background', value: '#121212', default: true },
-            { name: 'Light background', value: '#fffff' },
+            {
+                name: 'Dark background',
+                value: palette.contrasts.lightOnDark.background,
+                default: true,
+            },
+            {
+                name: 'Light background',
+                value: palette.contrasts.darkOnLight.background,
+            },
         ],
     });
 const radioOptions: { [key: string]: contrastKeys } = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1475,6 +1475,21 @@
     react-inspector "^2.3.0"
     uuid "^3.3.2"
 
+"@storybook/addon-backgrounds@^5.0.6":
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-backgrounds/-/addon-backgrounds-5.0.6.tgz#34c41c2d85de43b96c7b92d935a1321ba91f57e8"
+  dependencies:
+    "@storybook/addons" "5.0.6"
+    "@storybook/client-logger" "5.0.6"
+    "@storybook/components" "5.0.6"
+    "@storybook/core-events" "5.0.6"
+    "@storybook/theming" "5.0.6"
+    core-js "^2.6.5"
+    global "^4.3.2"
+    memoizerific "^1.11.3"
+    react "^16.8.1"
+    util-deprecate "^1.0.2"
+
 "@storybook/addon-knobs@^5.0.6":
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/@storybook/addon-knobs/-/addon-knobs-5.0.6.tgz#f291d7e18d30ef65284dc424d1b7527f114183b6"


### PR DESCRIPTION
## What does this change?
Allows switching between the different backgrounds.

![image](https://user-images.githubusercontent.com/638051/56033238-04a68480-5d1c-11e9-9752-93381072dfa0.png)

## Why?
It allows us to test components against different tone or content backgrounds.