### PR TITLE
Remove forward slashes as redundant

### DIFF
--- a/packages/frontend/amp/components/SubMeta.tsx
+++ b/packages/frontend/amp/components/SubMeta.tsx
@@ -135,7 +135,7 @@ export const SubMeta: React.FC<{
         <li className={itemStyle} key={link.url}>
             <a
                 className={sectionLinkStyle(pillar)}
-                href={`${guardianBaseURL}/${link.url}`}
+                href={`${guardianBaseURL}${link.url}`}
             >
                 {link.title}
             </a>
@@ -146,7 +146,7 @@ export const SubMeta: React.FC<{
         <li className={itemStyle} key={link.url}>
             <a
                 className={linkStyle(pillar)}
-                href={`${guardianBaseURL}/${link.url}`}
+                href={`${guardianBaseURL}${link.url}`}
             >
                 {link.title}
             </a>


### PR DESCRIPTION
## What does this change?

At the moment we double the slash, which doesn't break links but does make them ugly/slightly incorrect.

## Why?

To fix this.