### PR TITLE
Remove `/` from Tag links on AMP articles

### DIFF
--- a/packages/frontend/amp/components/SubMeta.tsx
+++ b/packages/frontend/amp/components/SubMeta.tsx
@@ -135,7 +135,7 @@ export const SubMeta: React.FC<{
         <li className={itemStyle} key={link.url}>
             <a
                 className={sectionLinkStyle(pillar)}
-                href={`${guardianBaseURL}/${link.url}`}
+                href={`${guardianBaseURL}${link.url}`}
             >
                 {link.title}
             </a>
@@ -146,7 +146,7 @@ export const SubMeta: React.FC<{
         <li className={itemStyle} key={link.url}>
             <a
                 className={linkStyle(pillar)}
-                href={`${guardianBaseURL}/${link.url}`}
+                href={`${guardianBaseURL}${link.url}`}
             >
                 {link.title}
             </a>


### PR DESCRIPTION
## What does this change?

Removes duplicate forward `/` from Secondary tag links on AMP pages as these come in from Frontend

Relates to https://github.com/guardian/frontend/pull/21339

## Why?


