### PR TITLE
Add support for pullquote element

### DIFF
--- a/packages/frontend/amp/components/elements/PullquoteBlockComponent.tsx
+++ b/packages/frontend/amp/components/elements/PullquoteBlockComponent.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { css } from 'emotion';
+import Quote from '@guardian/pasteup/icons/quote.svg';
+import { pillarPalette } from '@frontend/lib/pillars';
+import { palette } from '@guardian/pasteup/palette';
+import { body } from '@guardian/pasteup/typography';
+
+const styles = (pillar: Pillar) => css`
+    background-color: ${palette.neutral[97]};
+    padding: 0.375rem 0.625rem 0.75rem;
+    margin-bottom: 0.75rem;
+    display: block;
+    color: ${pillarPalette[pillar].dark};
+    ${body(2)};
+
+    svg {
+        fill: ${pillarPalette[pillar].dark};
+    }
+`;
+
+export const PullquoteBlockComponent: React.FC<{
+    html: string;
+    pillar: Pillar;
+}> = ({ html, pillar }) => (
+    <aside className={styles(pillar)}>
+        <Quote />{' '}
+        <span // tslint:disable-line:react-no-dangerous-html
+            dangerouslySetInnerHTML={{
+                __html: html,
+            }}
+        />
+    </aside>
+);

--- a/packages/frontend/amp/components/lib/Elements.tsx
+++ b/packages/frontend/amp/components/lib/Elements.tsx
@@ -9,6 +9,7 @@ import { CommentBlockComponent } from '@frontend/amp/components/elements/Comment
 import { RichLinkBlockComponent } from '@frontend/amp/components/elements/RichLinkBlockComponent';
 import { SoundcloudBlockComponent } from '@frontend/amp/components/elements/SoundcloudBlockComponent';
 import { EmbedBlockComponent } from '@frontend/amp/components/elements/EmbedBlockComponent';
+import { PullquoteBlockComponent } from '@frontend/amp/components/elements/PullquoteBlockComponent';
 import { findAdSlots } from '@frontend/amp/lib/find-adslots';
 import { AdComponent } from '@frontend/amp/components/elements/AdComponent';
 import { css } from 'emotion';
@@ -89,6 +90,14 @@ export const Elements: React.FC<{
             case 'model.dotcomrendering.pageElements.DisclaimerBlockElement':
                 return (
                     <DisclaimerBlockComponent
+                        key={i}
+                        html={element.html}
+                        pillar={pillar}
+                    />
+                );
+            case 'model.dotcomrendering.pageElements.PullquoteBlockElement':
+                return (
+                    <PullquoteBlockComponent
                         key={i}
                         html={element.html}
                         pillar={pillar}

--- a/packages/frontend/lib/content.d.ts
+++ b/packages/frontend/lib/content.d.ts
@@ -1,4 +1,4 @@
-type Switches = { [key: string]: boolean }
+type Switches = { [key: string]: boolean };
 
 type Weighting =
     | 'inline'
@@ -29,7 +29,7 @@ interface RichLinkBlockElement {
 interface ImageBlockElement {
     _type: 'model.dotcomrendering.pageElements.ImageBlockElement';
     media: { allImages: Image[] };
-    data: { alt: string; credit: string; caption?: string; copyright?: string; };
+    data: { alt: string; credit: string; caption?: string; copyright?: string };
     imageSources: ImageSource[];
     displayCredit: boolean;
     role: string;
@@ -110,6 +110,12 @@ interface DisclaimerBlockElement {
     html: string;
 }
 
+interface PullquoteBlockElement {
+    _type: 'model.dotcomrendering.pageElements.PullquoteBlockElement';
+    html: string;
+    role: string;
+}
+
 type CAPIElement =
     | TextBlockElement
     | SubheadingBlockElement
@@ -121,4 +127,5 @@ type CAPIElement =
     | CommentBlockElement
     | SoundcloudBlockElement
     | EmbedBlockElement
-    | DisclaimerBlockElement;
+    | DisclaimerBlockElement
+    | PullquoteBlockElement;


### PR DESCRIPTION
## What does this change?

Adds support for pull quote elements.

Note, styling mirrors existing (old) AMP, but the typography is slightly different so as to use the newer font styles and colours that we use now.

www on mobile has prettier handling but ignoring that for now as want to speed migration!

## Why?

Parity with old AMP.

Old AMP:
<img width="601" alt="Screenshot 2019-04-17 at 16 56 36" src="https://user-images.githubusercontent.com/858402/56302498-cc46e200-6131-11e9-92ad-112c3d6901d1.png">

New AMP (i.e. with this PR):
<img width="601" alt="Screenshot 2019-04-17 at 16 51 55" src="https://user-images.githubusercontent.com/858402/56302448-b33e3100-6131-11e9-9034-80e531a71f39.png">

