### PR TITLE
Rename elements

### DIFF
--- a/packages/frontend/amp/components/GoogleSubscribeButton.tsx
+++ b/packages/frontend/amp/components/GoogleSubscribeButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export const AmpSubscriptionGoogle: React.FC = () => (
+export const GoogleSubscribeButton: React.FC = () => (
     <section>
         <button
             subscriptions-action="subscribe"

--- a/packages/frontend/amp/components/Header.tsx
+++ b/packages/frontend/amp/components/Header.tsx
@@ -6,7 +6,7 @@ import { headline } from '@guardian/pasteup/typography';
 import { pillarPalette } from '../../lib/pillars';
 import { palette } from '@guardian/pasteup/palette';
 import { ReaderRevenueButton } from '@root/packages/frontend/amp/components/ReaderRevenueButton';
-import { AmpSubscriptionGoogle } from '@frontend/amp/components/elements/AmpSubscriptionGoogle';
+import { GoogleSubscribeButton } from '@root/packages/frontend/amp/components/GoogleSubscribeButton';
 import { mobileLandscape, until } from '@guardian/pasteup/breakpoints';
 
 const headerStyles = css`
@@ -192,7 +192,7 @@ export const Header: React.FC<{
                 linkLabel={'Support Us'}
             />
 
-            {config.switches.subscribeWithGoogle && <AmpSubscriptionGoogle />}
+            {config.switches.subscribeWithGoogle && <GoogleSubscribeButton />}
 
             <a className={logoStyles} href={guardianBaseURL}>
                 <span

--- a/packages/frontend/amp/components/MainMedia.tsx
+++ b/packages/frontend/amp/components/MainMedia.tsx
@@ -5,7 +5,7 @@ import { css } from 'emotion';
 import { textSans } from '@guardian/pasteup/typography';
 import InfoIcon from '@guardian/pasteup/icons/info.svg';
 import { palette } from '@guardian/pasteup/palette';
-import { YoutubeBlockComponent } from '@frontend/amp/components/elements/YoutubeBlockComponent';
+import { YoutubeVideo } from '@frontend/amp/components/elements/YoutubeVideo';
 
 const figureStyle = css`
     margin: 0 0;
@@ -118,7 +118,7 @@ const asComponent = (
         case 'model.dotcomrendering.pageElements.ImageBlockElement':
             return mainImage(element);
         case 'model.dotcomrendering.pageElements.YoutubeBlockElement':
-            return <YoutubeBlockComponent element={element} pillar={pillar} />;
+            return <YoutubeVideo element={element} pillar={pillar} />;
         default:
             return null;
     }

--- a/packages/frontend/amp/components/elements/Ad.tsx
+++ b/packages/frontend/amp/components/elements/Ad.tsx
@@ -99,7 +99,7 @@ interface CommercialConfig {
     usePrebid: boolean;
 }
 
-export const AdComponent: React.SFC<{
+export const Ad: React.SFC<{
     edition: Edition;
     section: string;
     contentType: string;

--- a/packages/frontend/amp/components/elements/Comment.tsx
+++ b/packages/frontend/amp/components/elements/Comment.tsx
@@ -38,7 +38,7 @@ const bodyCSS = css`
     }
 `;
 
-export const CommentBlockComponent: React.FC<{
+export const Comment: React.FC<{
     element: CommentBlockElement;
 }> = ({ element }) => (
     <div className={wrapper}>

--- a/packages/frontend/amp/components/elements/Disclaimer.tsx
+++ b/packages/frontend/amp/components/elements/Disclaimer.tsx
@@ -12,7 +12,7 @@ const style = (pillar: Pillar) => css`
     }
 `;
 
-export const DisclaimerBlockComponent: React.FC<{
+export const Disclaimer: React.FC<{
     html: string;
     pillar: Pillar;
 }> = ({ html, pillar }) => (

--- a/packages/frontend/amp/components/elements/Embed.tsx
+++ b/packages/frontend/amp/components/elements/Embed.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export const EmbedBlockComponent: React.FC<{
+export const Embed: React.FC<{
     element: EmbedBlockElement;
 }> = ({ element }) => {
     if (element.isMandatory) {

--- a/packages/frontend/amp/components/elements/Image.tsx
+++ b/packages/frontend/amp/components/elements/Image.tsx
@@ -18,7 +18,7 @@ const captionStyle = css`
     color: ${palette.neutral[46]};
 `;
 
-export const ImageBlockComponent: React.FC<{
+export const Image: React.FC<{
     element: ImageBlockElement;
     pillar: Pillar;
 }> = ({ element, pillar }) => {

--- a/packages/frontend/amp/components/elements/InstagramEmbed.tsx
+++ b/packages/frontend/amp/components/elements/InstagramEmbed.tsx
@@ -22,7 +22,7 @@ The ig chrome is about 250px tall on a piece with caption excluding the text.
 So the aspect ratio is either going to be 1.5:1 or 2:1. With hope it reduces jank?
 
 */
-export const InstagramBlockComponent: React.FC<{
+export const InstagramEmbed: React.FC<{
     element: InstagramBlockElement;
 }> = ({ element }) => {
     const shortcode = getShortcode(element.url);

--- a/packages/frontend/amp/components/elements/PullQuote.tsx
+++ b/packages/frontend/amp/components/elements/PullQuote.tsx
@@ -18,7 +18,7 @@ const styles = (pillar: Pillar) => css`
     }
 `;
 
-export const PullquoteBlockComponent: React.FC<{
+export const PullQuote: React.FC<{
     html: string;
     pillar: Pillar;
 }> = ({ html, pillar }) => (

--- a/packages/frontend/amp/components/elements/RichLink.tsx
+++ b/packages/frontend/amp/components/elements/RichLink.tsx
@@ -37,7 +37,7 @@ const richLink = css`
     }
 `;
 
-export const RichLinkBlockComponent: React.FC<{
+export const RichLink: React.FC<{
     element: RichLinkBlockElement;
     pillar: Pillar;
 }> = ({ element, pillar }) => (

--- a/packages/frontend/amp/components/elements/SoundcloudEmbed.tsx
+++ b/packages/frontend/amp/components/elements/SoundcloudEmbed.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export const SoundcloudBlockComponent: React.FC<{
+export const SoundcloudEmbed: React.FC<{
     element: SoundcloudBlockElement;
 }> = ({ element }) => {
     return element.isTrack ? (

--- a/packages/frontend/amp/components/elements/Subheading.tsx
+++ b/packages/frontend/amp/components/elements/Subheading.tsx
@@ -30,7 +30,7 @@ const immersiveBodyStyle = css`
     }
 `;
 
-export const SubheadingBlockComponent: React.FC<{
+export const Subheading: React.FC<{
     html: string;
     pillar: Pillar;
     isImmersive: boolean;

--- a/packages/frontend/amp/components/elements/Text.tsx
+++ b/packages/frontend/amp/components/elements/Text.tsx
@@ -27,7 +27,7 @@ const style = (pillar: Pillar) => css`
     ${body(3)};
 `;
 
-export const TextBlockComponent: React.FC<{
+export const Text: React.FC<{
     html: string;
     pillar: Pillar;
 }> = ({ html, pillar }) => (

--- a/packages/frontend/amp/components/elements/TwitterEmbed.tsx
+++ b/packages/frontend/amp/components/elements/TwitterEmbed.tsx
@@ -10,7 +10,7 @@ const makeFallback = (html: string): string | null => {
 };
 
 // tslint:disable:react-no-dangerous-html
-export const TweetBlockComponent: React.FC<{
+export const TwitterEmbed: React.FC<{
     element: TweetBlockElement;
 }> = ({ element }) => {
     const fallbackHTML = makeFallback(element.html);

--- a/packages/frontend/amp/components/elements/YoutubeVideo.tsx
+++ b/packages/frontend/amp/components/elements/YoutubeVideo.tsx
@@ -15,7 +15,7 @@ const captionStyle = css`
     color: ${palette.neutral[46]};
 `;
 
-export const YoutubeBlockComponent: React.FC<{
+export const YoutubeVideo: React.FC<{
     element: YoutubeBlockElement;
     pillar: Pillar;
 }> = ({ element, pillar }) => {

--- a/packages/frontend/amp/components/lib/Elements.tsx
+++ b/packages/frontend/amp/components/lib/Elements.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { TextBlockComponent } from '@frontend/amp/components/elements/TextBlockComponent';
 import { SubheadingBlockComponent } from '@frontend/amp/components/elements/SubheadingBlockElement';
 import { Image } from '@root/packages/frontend/amp/components/elements/Image';
-import { InstagramBlockComponent } from '@frontend/amp/components/elements/InstagramBlockComponent';
+import { InstagramEmbed } from '@root/packages/frontend/amp/components/elements/InstagramEmbed';
 import { TweetBlockComponent } from '@frontend/amp/components/elements/TweetBlockComponent';
 import { Comment } from '@root/packages/frontend/amp/components/elements/Comment';
 import { RichLinkBlockComponent } from '@frontend/amp/components/elements/RichLinkBlockComponent';
@@ -64,7 +64,7 @@ export const Elements: React.FC<{
             case 'model.dotcomrendering.pageElements.ImageBlockElement':
                 return <Image key={i} element={element} pillar={pillar} />;
             case 'model.dotcomrendering.pageElements.InstagramBlockElement':
-                return <InstagramBlockComponent key={i} element={element} />;
+                return <InstagramEmbed key={i} element={element} />;
             case 'model.dotcomrendering.pageElements.TweetBlockElement':
                 return <TweetBlockComponent key={i} element={element} />;
             case 'model.dotcomrendering.pageElements.RichLinkBlockElement':

--- a/packages/frontend/amp/components/lib/Elements.tsx
+++ b/packages/frontend/amp/components/lib/Elements.tsx
@@ -6,7 +6,7 @@ import { Image } from '@root/packages/frontend/amp/components/elements/Image';
 import { InstagramEmbed } from '@root/packages/frontend/amp/components/elements/InstagramEmbed';
 import { TweetBlockComponent } from '@frontend/amp/components/elements/TweetBlockComponent';
 import { Comment } from '@root/packages/frontend/amp/components/elements/Comment';
-import { RichLinkBlockComponent } from '@frontend/amp/components/elements/RichLinkBlockComponent';
+import { RichLink } from '@root/packages/frontend/amp/components/elements/RichLink';
 import { SoundcloudBlockComponent } from '@frontend/amp/components/elements/SoundcloudBlockComponent';
 import { Embed } from '@root/packages/frontend/amp/components/elements/Embed';
 import { PullQuote } from '@root/packages/frontend/amp/components/elements/PullQuote';
@@ -68,13 +68,7 @@ export const Elements: React.FC<{
             case 'model.dotcomrendering.pageElements.TweetBlockElement':
                 return <TweetBlockComponent key={i} element={element} />;
             case 'model.dotcomrendering.pageElements.RichLinkBlockElement':
-                return (
-                    <RichLinkBlockComponent
-                        key={i}
-                        element={element}
-                        pillar={pillar}
-                    />
-                );
+                return <RichLink key={i} element={element} pillar={pillar} />;
             case 'model.dotcomrendering.pageElements.CommentBlockElement':
                 return <Comment key={i} element={element} />;
             case 'model.dotcomrendering.pageElements.SoundcloudBlockElement':

--- a/packages/frontend/amp/components/lib/Elements.tsx
+++ b/packages/frontend/amp/components/lib/Elements.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { TextBlockComponent } from '@frontend/amp/components/elements/TextBlockComponent';
-import { SubheadingBlockComponent } from '@frontend/amp/components/elements/SubheadingBlockElement';
+import { Subheading } from '@root/packages/frontend/amp/components/elements/Subheading';
 import { Image } from '@root/packages/frontend/amp/components/elements/Image';
 import { InstagramEmbed } from '@root/packages/frontend/amp/components/elements/InstagramEmbed';
 import { TweetBlockComponent } from '@frontend/amp/components/elements/TweetBlockComponent';
@@ -54,7 +54,7 @@ export const Elements: React.FC<{
                 );
             case 'model.dotcomrendering.pageElements.SubheadingBlockElement':
                 return (
-                    <SubheadingBlockComponent
+                    <Subheading
                         key={i}
                         html={element.html}
                         pillar={pillar}

--- a/packages/frontend/amp/components/lib/Elements.tsx
+++ b/packages/frontend/amp/components/lib/Elements.tsx
@@ -8,7 +8,7 @@ import { TweetBlockComponent } from '@frontend/amp/components/elements/TweetBloc
 import { Comment } from '@root/packages/frontend/amp/components/elements/Comment';
 import { RichLinkBlockComponent } from '@frontend/amp/components/elements/RichLinkBlockComponent';
 import { SoundcloudBlockComponent } from '@frontend/amp/components/elements/SoundcloudBlockComponent';
-import { EmbedBlockComponent } from '@frontend/amp/components/elements/EmbedBlockComponent';
+import { Embed } from '@root/packages/frontend/amp/components/elements/Embed';
 import { PullquoteBlockComponent } from '@frontend/amp/components/elements/PullquoteBlockComponent';
 import { findAdSlots } from '@frontend/amp/lib/find-adslots';
 import { Ad } from '@frontend/amp/components/elements/Ad';
@@ -86,7 +86,7 @@ export const Elements: React.FC<{
             case 'model.dotcomrendering.pageElements.SoundcloudBlockElement':
                 return <SoundcloudBlockComponent key={i} element={element} />;
             case 'model.dotcomrendering.pageElements.EmbedBlockElement':
-                return <EmbedBlockComponent key={i} element={element} />;
+                return <Embed key={i} element={element} />;
             case 'model.dotcomrendering.pageElements.DisclaimerBlockElement':
                 return (
                     <Disclaimer key={i} html={element.html} pillar={pillar} />

--- a/packages/frontend/amp/components/lib/Elements.tsx
+++ b/packages/frontend/amp/components/lib/Elements.tsx
@@ -5,7 +5,7 @@ import { SubheadingBlockComponent } from '@frontend/amp/components/elements/Subh
 import { ImageBlockComponent } from '@frontend/amp/components/elements/ImageBlockComponent';
 import { InstagramBlockComponent } from '@frontend/amp/components/elements/InstagramBlockComponent';
 import { TweetBlockComponent } from '@frontend/amp/components/elements/TweetBlockComponent';
-import { CommentBlockComponent } from '@frontend/amp/components/elements/CommentBlockComponent';
+import { Comment } from '@root/packages/frontend/amp/components/elements/Comment';
 import { RichLinkBlockComponent } from '@frontend/amp/components/elements/RichLinkBlockComponent';
 import { SoundcloudBlockComponent } from '@frontend/amp/components/elements/SoundcloudBlockComponent';
 import { EmbedBlockComponent } from '@frontend/amp/components/elements/EmbedBlockComponent';
@@ -82,7 +82,7 @@ export const Elements: React.FC<{
                     />
                 );
             case 'model.dotcomrendering.pageElements.CommentBlockElement':
-                return <CommentBlockComponent key={i} element={element} />;
+                return <Comment key={i} element={element} />;
             case 'model.dotcomrendering.pageElements.SoundcloudBlockElement':
                 return <SoundcloudBlockComponent key={i} element={element} />;
             case 'model.dotcomrendering.pageElements.EmbedBlockElement':

--- a/packages/frontend/amp/components/lib/Elements.tsx
+++ b/packages/frontend/amp/components/lib/Elements.tsx
@@ -4,7 +4,7 @@ import { Text } from '@root/packages/frontend/amp/components/elements/Text';
 import { Subheading } from '@root/packages/frontend/amp/components/elements/Subheading';
 import { Image } from '@root/packages/frontend/amp/components/elements/Image';
 import { InstagramEmbed } from '@root/packages/frontend/amp/components/elements/InstagramEmbed';
-import { TweetBlockComponent } from '@frontend/amp/components/elements/TweetBlockComponent';
+import { TwitterEmbed } from '@root/packages/frontend/amp/components/elements/TwitterEmbed';
 import { Comment } from '@root/packages/frontend/amp/components/elements/Comment';
 import { RichLink } from '@root/packages/frontend/amp/components/elements/RichLink';
 import { SoundcloudEmbed } from '@root/packages/frontend/amp/components/elements/SoundcloudEmbed';
@@ -60,7 +60,7 @@ export const Elements: React.FC<{
             case 'model.dotcomrendering.pageElements.InstagramBlockElement':
                 return <InstagramEmbed key={i} element={element} />;
             case 'model.dotcomrendering.pageElements.TweetBlockElement':
-                return <TweetBlockComponent key={i} element={element} />;
+                return <TwitterEmbed key={i} element={element} />;
             case 'model.dotcomrendering.pageElements.RichLinkBlockElement':
                 return <RichLink key={i} element={element} pillar={pillar} />;
             case 'model.dotcomrendering.pageElements.CommentBlockElement':

--- a/packages/frontend/amp/components/lib/Elements.tsx
+++ b/packages/frontend/amp/components/lib/Elements.tsx
@@ -11,7 +11,7 @@ import { SoundcloudBlockComponent } from '@frontend/amp/components/elements/Soun
 import { EmbedBlockComponent } from '@frontend/amp/components/elements/EmbedBlockComponent';
 import { PullquoteBlockComponent } from '@frontend/amp/components/elements/PullquoteBlockComponent';
 import { findAdSlots } from '@frontend/amp/lib/find-adslots';
-import { AdComponent } from '@frontend/amp/components/elements/AdComponent';
+import { Ad } from '@frontend/amp/components/elements/Ad';
 import { css } from 'emotion';
 import { DisclaimerBlockComponent } from '@frontend/amp/components/elements/DisclaimerBlockComponent';
 import { clean } from '@frontend/model/clean';
@@ -125,7 +125,7 @@ export const Elements: React.FC<{
         <>
             {element}
             {slotIndexes.includes(i) ? (
-                <AdComponent
+                <Ad
                     edition={edition}
                     section={section}
                     contentType={contentType}

--- a/packages/frontend/amp/components/lib/Elements.tsx
+++ b/packages/frontend/amp/components/lib/Elements.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { TextBlockComponent } from '@frontend/amp/components/elements/TextBlockComponent';
 import { SubheadingBlockComponent } from '@frontend/amp/components/elements/SubheadingBlockElement';
-import { ImageBlockComponent } from '@frontend/amp/components/elements/ImageBlockComponent';
+import { Image } from '@root/packages/frontend/amp/components/elements/Image';
 import { InstagramBlockComponent } from '@frontend/amp/components/elements/InstagramBlockComponent';
 import { TweetBlockComponent } from '@frontend/amp/components/elements/TweetBlockComponent';
 import { Comment } from '@root/packages/frontend/amp/components/elements/Comment';
@@ -62,13 +62,7 @@ export const Elements: React.FC<{
                     />
                 );
             case 'model.dotcomrendering.pageElements.ImageBlockElement':
-                return (
-                    <ImageBlockComponent
-                        key={i}
-                        element={element}
-                        pillar={pillar}
-                    />
-                );
+                return <Image key={i} element={element} pillar={pillar} />;
             case 'model.dotcomrendering.pageElements.InstagramBlockElement':
                 return <InstagramBlockComponent key={i} element={element} />;
             case 'model.dotcomrendering.pageElements.TweetBlockElement':

--- a/packages/frontend/amp/components/lib/Elements.tsx
+++ b/packages/frontend/amp/components/lib/Elements.tsx
@@ -13,7 +13,7 @@ import { PullquoteBlockComponent } from '@frontend/amp/components/elements/Pullq
 import { findAdSlots } from '@frontend/amp/lib/find-adslots';
 import { Ad } from '@frontend/amp/components/elements/Ad';
 import { css } from 'emotion';
-import { DisclaimerBlockComponent } from '@frontend/amp/components/elements/DisclaimerBlockComponent';
+import { Disclaimer } from '@root/packages/frontend/amp/components/elements/Disclaimer';
 import { clean } from '@frontend/model/clean';
 
 const clear = css`
@@ -89,11 +89,7 @@ export const Elements: React.FC<{
                 return <EmbedBlockComponent key={i} element={element} />;
             case 'model.dotcomrendering.pageElements.DisclaimerBlockElement':
                 return (
-                    <DisclaimerBlockComponent
-                        key={i}
-                        html={element.html}
-                        pillar={pillar}
-                    />
+                    <Disclaimer key={i} html={element.html} pillar={pillar} />
                 );
             case 'model.dotcomrendering.pageElements.PullquoteBlockElement':
                 return (

--- a/packages/frontend/amp/components/lib/Elements.tsx
+++ b/packages/frontend/amp/components/lib/Elements.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { TextBlockComponent } from '@frontend/amp/components/elements/TextBlockComponent';
+import { Text } from '@root/packages/frontend/amp/components/elements/Text';
 import { Subheading } from '@root/packages/frontend/amp/components/elements/Subheading';
 import { Image } from '@root/packages/frontend/amp/components/elements/Image';
 import { InstagramEmbed } from '@root/packages/frontend/amp/components/elements/InstagramEmbed';
@@ -45,13 +45,7 @@ export const Elements: React.FC<{
     const output = cleanedElements.map((element, i) => {
         switch (element._type) {
             case 'model.dotcomrendering.pageElements.TextBlockElement':
-                return (
-                    <TextBlockComponent
-                        key={i}
-                        html={element.html}
-                        pillar={pillar}
-                    />
-                );
+                return <Text key={i} html={element.html} pillar={pillar} />;
             case 'model.dotcomrendering.pageElements.SubheadingBlockElement':
                 return (
                     <Subheading

--- a/packages/frontend/amp/components/lib/Elements.tsx
+++ b/packages/frontend/amp/components/lib/Elements.tsx
@@ -9,7 +9,7 @@ import { Comment } from '@root/packages/frontend/amp/components/elements/Comment
 import { RichLinkBlockComponent } from '@frontend/amp/components/elements/RichLinkBlockComponent';
 import { SoundcloudBlockComponent } from '@frontend/amp/components/elements/SoundcloudBlockComponent';
 import { Embed } from '@root/packages/frontend/amp/components/elements/Embed';
-import { PullquoteBlockComponent } from '@frontend/amp/components/elements/PullquoteBlockComponent';
+import { PullQuote } from '@root/packages/frontend/amp/components/elements/PullQuote';
 import { findAdSlots } from '@frontend/amp/lib/find-adslots';
 import { Ad } from '@frontend/amp/components/elements/Ad';
 import { css } from 'emotion';
@@ -87,11 +87,7 @@ export const Elements: React.FC<{
                 );
             case 'model.dotcomrendering.pageElements.PullquoteBlockElement':
                 return (
-                    <PullquoteBlockComponent
-                        key={i}
-                        html={element.html}
-                        pillar={pillar}
-                    />
+                    <PullQuote key={i} html={element.html} pillar={pillar} />
                 );
             default:
                 // tslint:disable-next-line:no-console

--- a/packages/frontend/amp/components/lib/Elements.tsx
+++ b/packages/frontend/amp/components/lib/Elements.tsx
@@ -7,7 +7,7 @@ import { InstagramEmbed } from '@root/packages/frontend/amp/components/elements/
 import { TweetBlockComponent } from '@frontend/amp/components/elements/TweetBlockComponent';
 import { Comment } from '@root/packages/frontend/amp/components/elements/Comment';
 import { RichLink } from '@root/packages/frontend/amp/components/elements/RichLink';
-import { SoundcloudBlockComponent } from '@frontend/amp/components/elements/SoundcloudBlockComponent';
+import { SoundcloudEmbed } from '@root/packages/frontend/amp/components/elements/SoundcloudEmbed';
 import { Embed } from '@root/packages/frontend/amp/components/elements/Embed';
 import { PullQuote } from '@root/packages/frontend/amp/components/elements/PullQuote';
 import { findAdSlots } from '@frontend/amp/lib/find-adslots';
@@ -72,7 +72,7 @@ export const Elements: React.FC<{
             case 'model.dotcomrendering.pageElements.CommentBlockElement':
                 return <Comment key={i} element={element} />;
             case 'model.dotcomrendering.pageElements.SoundcloudBlockElement':
-                return <SoundcloudBlockComponent key={i} element={element} />;
+                return <SoundcloudEmbed key={i} element={element} />;
             case 'model.dotcomrendering.pageElements.EmbedBlockElement':
                 return <Embed key={i} element={element} />;
             case 'model.dotcomrendering.pageElements.DisclaimerBlockElement':


### PR DESCRIPTION
## What does this change?

Renaming of elements from:

    *Block[Component|Element] -> * 

E.g. 

    ImageBlockComponent -> Image

In addition, I moved the AmpGoogleSubscription component out of the elements folder.

## Why?

* for consistency (i.e. some used Element and some Component as suffix)
* for brevity - BlockComponent here is redundant as the folder structure (/elements/...) indicates the category here. It's also incorrect as these are not Blocks but Elements.


