### PR TITLE
Add metrics to pasteup

### DIFF
--- a/packages/design/package.json
+++ b/packages/design/package.json
@@ -17,7 +17,7 @@
     "@babel/core": "^7.4.3",
     "@guardian/frontend-rendering": "0.1.0-alpha.1",
     "@guardian/guui": "2.0.0-alpha.1",
-    "@guardian/pasteup": "1.0.0-alpha.7",
+    "@guardian/pasteup": "1.0.0-alpha.8",
     "@mdx-js/mdx": "^0.20.3",
     "@mdx-js/react": "^1.0.0-alpha.12",
     "@mdx-js/tag": "^0.20.3",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@emotion/core": "^10.0.5",
     "@guardian/guui": "2.0.0-alpha.1",
-    "@guardian/pasteup": "1.0.0-alpha.7",
+    "@guardian/pasteup": "1.0.0-alpha.8",
     "aws-sdk": "^2.340.0",
     "compose-function": "^3.0.3",
     "compression": "^1.7.3",

--- a/packages/guui/package.json
+++ b/packages/guui/package.json
@@ -7,7 +7,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@guardian/pasteup": "1.0.0-alpha.7",
+    "@guardian/pasteup": "1.0.0-alpha.8",
     "polished": "^1.9.2",
     "prop-types": "^15.6.1",
     "reset-css": "^3.0.0"

--- a/packages/pasteup/metrics.ts
+++ b/packages/pasteup/metrics.ts
@@ -1,0 +1,19 @@
+export type Metric = number;
+
+export interface LayoutMetrics {
+    gutter: Metric;
+    baseline: Metric;
+    column: Metric;
+}
+
+export interface Metrics {
+    layout: LayoutMetrics;
+}
+
+export const metrics: Metrics = {
+    layout: {
+        gutter: 20,
+        baseline: 12,
+        column: 60,
+    },
+};

--- a/packages/pasteup/package.json
+++ b/packages/pasteup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/pasteup",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "description": "Guardian design tokens",
   "repository": {
     "type": "git",
@@ -8,6 +8,7 @@
   },
   "files": [
     "breakpoints.js",
+    "metrics.js",
     "fonts.js",
     "mixins.js",
     "palette.js",

--- a/scripts/webpack/pasteup.js
+++ b/scripts/webpack/pasteup.js
@@ -4,6 +4,7 @@ module.exports = {
     mode: 'production',
     entry: {
         breakpoints: './packages/pasteup/breakpoints.ts',
+        metrics: './packages/pasteup/metrics.ts',
         typography: './packages/pasteup/typography.ts',
         mixins: './packages/pasteup/mixins.ts',
         palette: './packages/pasteup/palette.ts',


### PR DESCRIPTION
## What does this change?

Adds the 3 top pixel metrics we use in gu.com (gutter, baseline, column) to pasteup

## Why?

Editions