### PR TITLE
AMP atoms

### DIFF
--- a/packages/frontend/amp/components/Expandable.tsx
+++ b/packages/frontend/amp/components/Expandable.tsx
@@ -8,10 +8,8 @@ import { body, textSans, headline } from '@guardian/pasteup/typography';
 import { palette } from '@guardian/pasteup/palette';
 import { TextStyle } from '@frontend/amp/components/elements/Text';
 
-// TODO - check if we need to use a palette colour for background (neutral 93 is
-// closest) or incorporate this one into the palette?
 const wrapper = (pillar: Pillar) => css`
-    background: #f1f1f1;
+    background: ${palette.neutral[93]};
     position: relative;
     padding: 0 5px 6px;
     margin: 16px 0 36px;

--- a/packages/frontend/amp/components/Expandable.tsx
+++ b/packages/frontend/amp/components/Expandable.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+export const Expandable: React.FC<{
+    id: string;
+    type: string;
+    title: string;
+    img?: string;
+    html: string;
+    credit: string;
+}> = ({ id, type, title, img, html, credit }) => (
+    <aside>
+        <span>{type}</span>
+        <h1>{title}</h1>
+        {img && <amp-img src={img} alt={`Image for ${title} explainer`} />}
+        <div // tslint:disable-line:react-no-dangerous-html
+            id={id}
+            dangerouslySetInnerHTML={{
+                __html: html,
+            }}
+        />
+        <span>{credit}</span>
+        <button on={`tap:${id}.toggleVisibility`}>Toggle</button>
+    </aside>
+);

--- a/packages/frontend/amp/components/Expandable.tsx
+++ b/packages/frontend/amp/components/Expandable.tsx
@@ -1,4 +1,106 @@
 import React from 'react';
+import { css, cx } from 'emotion';
+import { pillarPalette } from '@frontend/lib/pillars';
+import InfoIcon from '@guardian/pasteup/icons/info.svg';
+import PlusIcon from '@guardian/pasteup/icons/plus.svg';
+
+import { body, textSans, headline } from '@guardian/pasteup/typography';
+import { palette } from '@guardian/pasteup/palette';
+
+const wrapper = (pillar: Pillar) => css`
+    background: ${palette.neutral[93]};
+    position: relative;
+    padding: 0 5px 6px;
+    margin: 16px 0 36px;
+
+    a {
+        color: ${pillarPalette[pillar].dark};
+    }
+
+    ${body(2)};
+`;
+
+const buttonStyles = css`
+    height: 32px;
+    background-color: ${palette.neutral[7]};
+    border-radius: 1600px;
+    color: ${palette.neutral[100]};
+    border: none;
+    ${textSans(2)};
+    font-weight: 700;
+    padding: 0 15px 0 7px;
+
+    display: inline-flex;
+    align-items: center;
+
+    position: absolute;
+    bottom: 0;
+    transform: translate(0, 50%);
+
+    span {
+        display: inline-flex;
+        align-items: center;
+    }
+
+    svg {
+        fill: ${palette.neutral[100]};
+        width: 20px;
+        height: 20px;
+        margin-right: 10px;
+    }
+`;
+
+const headerStyle = css`
+    ${headline(3)};
+`;
+
+const creditStyle = css`
+    ${textSans(2)};
+    display: block;
+    margin: 12px 0;
+`;
+
+const pillarColour = (pillar: Pillar) => css`
+    color: ${pillarPalette[pillar].main};
+`;
+
+const headers = css`
+    margin: 0 0 16px;
+`;
+
+const innerStyle = css`
+    padding-bottom: 24px;
+`;
+
+const iconStyle = css`
+    display: inline-flex;
+    background: ${palette.neutral[60]};
+    border-radius: 100%;
+    width: 16px;
+    height: 16px;
+    align-items: center;
+    justify-content: center;
+    margin-right: 5px;
+
+    svg {
+        height: 12px;
+        fill: ${palette.neutral[100]};
+    }
+`;
+
+const imageStyle = css`
+    width: 100px;
+    height: 100px;
+    display: block;
+    float: left;
+    margin-right: 10px;
+    margin-bottom: 6px;
+
+    img {
+        object-fit: cover;
+        border-radius: 50%;
+    }
+`;
 
 export const Expandable: React.FC<{
     id: string;
@@ -7,18 +109,49 @@ export const Expandable: React.FC<{
     img?: string;
     html: string;
     credit: string;
-}> = ({ id, type, title, img, html, credit }) => (
-    <aside>
-        <span>{type}</span>
-        <h1>{title}</h1>
-        {img && <amp-img src={img} alt={`Image for ${title} explainer`} />}
-        <div // tslint:disable-line:react-no-dangerous-html
-            id={id}
-            dangerouslySetInnerHTML={{
-                __html: html,
-            }}
-        />
-        <span>{credit}</span>
-        <button on={`tap:${id}.toggleVisibility`}>Toggle</button>
+    pillar: Pillar;
+}> = ({ id, type, title, img, html, credit, pillar }) => (
+    <aside className={wrapper(pillar)}>
+        <div className={headers}>
+            <span className={cx(headerStyle, pillarColour(pillar))}>
+                {type}
+            </span>
+            <h1 className={headerStyle}>{title}</h1>
+        </div>
+
+        <div className={innerStyle} hidden={true} id={id}>
+            {img && (
+                <amp-img
+                    class={imageStyle}
+                    src={img}
+                    alt={`Image for ${title} explainer`}
+                />
+            )}
+            <div // tslint:disable-line:react-no-dangerous-html
+                dangerouslySetInnerHTML={{
+                    __html: html,
+                }}
+            />
+            <span className={creditStyle}>
+                <span className={iconStyle}>
+                    <InfoIcon />
+                </span>{' '}
+                {credit}
+            </span>
+        </div>
+
+        <button
+            on={`tap:${id}.toggleVisibility,show-${id}.toggleVisibility,hide-${id}.toggleVisibility`}
+            className={buttonStyles}
+        >
+            <span id={`show-${id}`}>
+                <PlusIcon />
+                Show
+            </span>
+            <span hidden={true} id={`hide-${id}`}>
+                <PlusIcon />
+                Hide
+            </span>
+        </button>
     </aside>
 );

--- a/packages/frontend/amp/components/Expandable.tsx
+++ b/packages/frontend/amp/components/Expandable.tsx
@@ -6,6 +6,7 @@ import PlusIcon from '@guardian/pasteup/icons/plus.svg';
 
 import { body, textSans, headline } from '@guardian/pasteup/typography';
 import { palette } from '@guardian/pasteup/palette';
+import { TextStyle } from '@frontend/amp/components/elements/Text';
 
 // TODO - check if we need to use a palette colour for background (neutral 93 is
 // closest) or incorporate this one into the palette?
@@ -25,18 +26,7 @@ const wrapper = (pillar: Pillar) => css`
         )
         13;
 
-    a {
-        color: ${pillarPalette[pillar].dark};
-    }
-
-    p {
-        margin-bottom: 0.5rem;
-    }
-
-    b,
-    strong {
-        font-weight: bold;
-    }
+    ${TextStyle(pillar)}
 
     ${body(2)};
 `;
@@ -137,7 +127,7 @@ export const Expandable: React.FC<{
             <span className={cx(headerStyle, pillarColour(pillar))}>
                 {type}
             </span>
-            <h1 className={headerStyle}>{title}</h1>
+            <h2 className={headerStyle}>{title}</h2>
         </div>
 
         <div className={innerStyle} hidden={true} id={id}>

--- a/packages/frontend/amp/components/Expandable.tsx
+++ b/packages/frontend/amp/components/Expandable.tsx
@@ -17,6 +17,15 @@ const wrapper = (pillar: Pillar) => css`
         color: ${pillarPalette[pillar].dark};
     }
 
+    p {
+        margin-bottom: 0.5rem;
+    }
+
+    b,
+    strong {
+        font-weight: bold;
+    }
+
     ${body(2)};
 `;
 

--- a/packages/frontend/amp/components/Expandable.tsx
+++ b/packages/frontend/amp/components/Expandable.tsx
@@ -7,11 +7,23 @@ import PlusIcon from '@guardian/pasteup/icons/plus.svg';
 import { body, textSans, headline } from '@guardian/pasteup/typography';
 import { palette } from '@guardian/pasteup/palette';
 
+// TODO - check if we need to use a palette colour for background (neutral 93 is
+// closest) or incorporate this one into the palette?
 const wrapper = (pillar: Pillar) => css`
-    background: ${palette.neutral[93]};
+    background: #f1f1f1;
     position: relative;
     padding: 0 5px 6px;
     margin: 16px 0 36px;
+
+    border-top: 13px solid ${palette.neutral[7]};
+    border-image: repeating-linear-gradient(
+            to bottom,
+            #dcdcdc,
+            #dcdcdc 1px,
+            transparent 1px,
+            transparent 4px
+        )
+        13;
 
     a {
         color: ${pillarPalette[pillar].dark};
@@ -117,7 +129,7 @@ export const Expandable: React.FC<{
     title: string;
     img?: string;
     html: string;
-    credit: string;
+    credit?: string;
     pillar: Pillar;
 }> = ({ id, type, title, img, html, credit, pillar }) => (
     <aside className={wrapper(pillar)}>
@@ -141,12 +153,14 @@ export const Expandable: React.FC<{
                     __html: html,
                 }}
             />
-            <span className={creditStyle}>
-                <span className={iconStyle}>
-                    <InfoIcon />
-                </span>{' '}
-                {credit}
-            </span>
+            {credit && (
+                <span className={creditStyle}>
+                    <span className={iconStyle}>
+                        <InfoIcon />
+                    </span>{' '}
+                    {credit}
+                </span>
+            )}
         </div>
 
         <button

--- a/packages/frontend/amp/components/elements/Text.tsx
+++ b/packages/frontend/amp/components/elements/Text.tsx
@@ -4,8 +4,13 @@ import { palette } from '@guardian/pasteup/palette';
 import { pillarPalette } from '@frontend/lib/pillars';
 import { body } from '@guardian/pasteup/typography';
 
+// Note, this should only apply basic text styling. It is a case where we want
+// to re-use styling, but generally we should avoid this as it couples
+// components. Longer term we should probably put this in GUUI or somewhere else
+// which is easy to discover and re-use.
+
 // tslint:disable:react-no-dangerous-html
-const style = (pillar: Pillar) => css`
+export const TextStyle = (pillar: Pillar) => css`
     strong {
         font-weight: 700;
     }
@@ -32,7 +37,7 @@ export const Text: React.FC<{
     pillar: Pillar;
 }> = ({ html, pillar }) => (
     <span
-        className={style(pillar)}
+        className={TextStyle(pillar)}
         dangerouslySetInnerHTML={{
             __html: html,
         }}

--- a/packages/frontend/amp/components/elements/Timeline.tsx
+++ b/packages/frontend/amp/components/elements/Timeline.tsx
@@ -35,6 +35,10 @@ const eventIconStyle = css`
     }
 `;
 
+const headingStyle = css`
+    font-weight: bold;
+`;
+
 const getHTML = (events: TimelineEvent[], description?: string): string => {
     // TODO using ternary as && doesn't seem to work here - it prints out undefined
     const eventMarkup = events.map(e => (
@@ -47,7 +51,7 @@ const getHTML = (events: TimelineEvent[], description?: string): string => {
                 </>
             )}
             <div>
-                <b>{e.title}</b>
+                <h3 className={headingStyle}>{e.title}</h3>
                 <div // tslint:disable-line:react-no-dangerous-html
                     dangerouslySetInnerHTML={{
                         __html: e.body || '',

--- a/packages/frontend/amp/components/elements/Timeline.tsx
+++ b/packages/frontend/amp/components/elements/Timeline.tsx
@@ -40,7 +40,6 @@ const headingStyle = css`
 `;
 
 const getHTML = (events: TimelineEvent[], description?: string): string => {
-    // TODO using ternary as && doesn't seem to work here - it prints out undefined
     const eventMarkup = events.map(e => (
         <li className={eventStyle}>
             <time className={eventIconStyle}>{e.date}</time>

--- a/packages/frontend/amp/components/elements/Timeline.tsx
+++ b/packages/frontend/amp/components/elements/Timeline.tsx
@@ -53,7 +53,6 @@ const getHTML = (events: TimelineEvent[], description?: string): string => {
                         __html: e.body || '',
                     }}
                 />
-                <div />
             </div>
         </li>
     ));

--- a/packages/frontend/amp/components/elements/Timeline.tsx
+++ b/packages/frontend/amp/components/elements/Timeline.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { Expandable } from '@frontend/amp/components/Expandable';
+import { css } from 'emotion';
+import { palette } from '@guardian/pasteup/palette';
+
+const eventsWrapper = css`
+    margin-left: 8px;
+
+    li:not(:last-child) {
+        border-left: 1px solid rgba(220, 220, 220, 0.5);
+    }
+`;
+
+const eventStyle = css`
+    padding-left: 17px;
+    padding-bottom: 16px;
+`;
+
+const highlight = css`
+    background-color: ${palette.highlight.main};
+`;
+
+const eventIconStyle = css`
+    ${highlight}
+
+    :before {
+        content: '';
+        width: 16px;
+        height: 16px;
+        border-radius: 100%;
+        float: left;
+        margin-left: -25px;
+        background-color: ${palette.neutral[7]};
+    }
+`;
+
+const getHTML = (events: TimelineEvent[], description?: string): string => {
+    // TODO using ternary as && doesn't seem to work here - it prints out undefined
+    const eventMarkup = events.map(e => (
+        <li className={eventStyle}>
+            <time className={eventIconStyle}>{e.date}</time>
+            {e.toDate && (
+                <>
+                    {' '}
+                    - <time className={highlight}>{e.toDate}</time>
+                </>
+            )}
+            <div>
+                <b>{e.title}</b>
+                <div // tslint:disable-line:react-no-dangerous-html
+                    dangerouslySetInnerHTML={{
+                        __html: e.body || '',
+                    }}
+                />
+                <div />
+            </div>
+        </li>
+    ));
+
+    const eventString = renderToStaticMarkup(
+        <ul className={eventsWrapper}>{eventMarkup}</ul>,
+    );
+
+    return (description || '') + eventString;
+};
+
+export const Timeline: React.FC<{
+    id: string;
+    title: string;
+    description?: string;
+    events: TimelineEvent[];
+    pillar: Pillar;
+}> = ({ id, title, description, events, pillar }) => (
+    <Expandable
+        id={id}
+        type="Timeline"
+        title={title}
+        html={getHTML(events, description)}
+        pillar={pillar}
+    />
+);

--- a/packages/frontend/amp/components/lib/Elements.tsx
+++ b/packages/frontend/amp/components/lib/Elements.tsx
@@ -87,6 +87,7 @@ export const Elements: React.FC<{
                         html={element.html}
                         img={element.img}
                         credit={element.credit}
+                        pillar={pillar}
                     />
                 );
             default:

--- a/packages/frontend/amp/components/lib/Elements.tsx
+++ b/packages/frontend/amp/components/lib/Elements.tsx
@@ -16,6 +16,7 @@ import { css } from 'emotion';
 import { Disclaimer } from '@root/packages/frontend/amp/components/elements/Disclaimer';
 import { clean } from '@frontend/model/clean';
 import { Expandable } from '@frontend/amp/components/Expandable';
+import { Timeline } from '@frontend/amp/components/elements/Timeline';
 
 const clear = css`
     clear: both;
@@ -111,6 +112,16 @@ export const Elements: React.FC<{
                         html={element.html}
                         img={element.img}
                         credit={element.credit}
+                        pillar={pillar}
+                    />
+                );
+            case 'model.dotcomrendering.pageElements.TimelineBlockElement':
+                return (
+                    <Timeline
+                        id={element.id}
+                        title={element.title}
+                        description={element.description}
+                        events={element.events}
                         pillar={pillar}
                     />
                 );

--- a/packages/frontend/amp/components/lib/Elements.tsx
+++ b/packages/frontend/amp/components/lib/Elements.tsx
@@ -15,6 +15,7 @@ import { Ad } from '@frontend/amp/components/Ad';
 import { css } from 'emotion';
 import { Disclaimer } from '@root/packages/frontend/amp/components/elements/Disclaimer';
 import { clean } from '@frontend/model/clean';
+import { Expandable } from '@frontend/amp/components/Expandable';
 
 const clear = css`
     clear: both;
@@ -76,6 +77,17 @@ export const Elements: React.FC<{
             case 'model.dotcomrendering.pageElements.PullquoteBlockElement':
                 return (
                     <PullQuote key={i} html={element.html} pillar={pillar} />
+                );
+            case 'model.dotcomrendering.pageElements.QABlockElement':
+                return (
+                    <Expandable
+                        id={element.id}
+                        type="Q&A"
+                        title={element.title}
+                        html={element.html}
+                        img={element.img}
+                        credit={element.credit}
+                    />
                 );
             default:
                 // tslint:disable-next-line:no-console

--- a/packages/frontend/amp/components/lib/Elements.tsx
+++ b/packages/frontend/amp/components/lib/Elements.tsx
@@ -90,6 +90,30 @@ export const Elements: React.FC<{
                         pillar={pillar}
                     />
                 );
+            case 'model.dotcomrendering.pageElements.GuideBlockElement':
+                return (
+                    <Expandable
+                        id={element.id}
+                        type="Quick Guide"
+                        title={element.title}
+                        html={element.html}
+                        img={element.img}
+                        credit={element.credit}
+                        pillar={pillar}
+                    />
+                );
+            case 'model.dotcomrendering.pageElements.ProfileBlockElement':
+                return (
+                    <Expandable
+                        id={element.id}
+                        type="Profile"
+                        title={element.title}
+                        html={element.html}
+                        img={element.img}
+                        credit={element.credit}
+                        pillar={pillar}
+                    />
+                );
             default:
                 // tslint:disable-next-line:no-console
                 console.log('Unsupported Element', JSON.stringify(element));

--- a/packages/frontend/lib/content.d.ts
+++ b/packages/frontend/lib/content.d.ts
@@ -116,6 +116,15 @@ interface PullquoteBlockElement {
     role: string;
 }
 
+interface QABlockElement {
+    _type: 'model.dotcomrendering.pageElements.QABlockElement';
+    id: string;
+    title: string;
+    img?: string;
+    html: string;
+    credit: string;
+}
+
 type CAPIElement =
     | TextBlockElement
     | SubheadingBlockElement
@@ -128,4 +137,5 @@ type CAPIElement =
     | SoundcloudBlockElement
     | EmbedBlockElement
     | DisclaimerBlockElement
-    | PullquoteBlockElement;
+    | PullquoteBlockElement
+    | QABlockElement;

--- a/packages/frontend/lib/content.d.ts
+++ b/packages/frontend/lib/content.d.ts
@@ -143,6 +143,21 @@ interface ProfileBlockElement {
     credit: string;
 }
 
+interface TimelineEvent {
+    title: string;
+    date: string;
+    body?: string;
+    toDate?: string;
+}
+
+interface TimelineBlockElement {
+    _type: 'model.dotcomrendering.pageElements.TimelineBlockElement';
+    id: string;
+    title: string;
+    description?: string;
+    events: TimelineEvent[];
+}
+
 type CAPIElement =
     | TextBlockElement
     | SubheadingBlockElement
@@ -158,4 +173,5 @@ type CAPIElement =
     | PullquoteBlockElement
     | QABlockElement
     | GuideBlockElement
-    | ProfileBlockElement;
+    | ProfileBlockElement
+    | TimelineBlockElement;

--- a/packages/frontend/lib/content.d.ts
+++ b/packages/frontend/lib/content.d.ts
@@ -125,6 +125,24 @@ interface QABlockElement {
     credit: string;
 }
 
+interface GuideBlockElement {
+    _type: 'model.dotcomrendering.pageElements.GuideBlockElement';
+    id: string;
+    title: string;
+    img?: string;
+    html: string;
+    credit: string;
+}
+
+interface ProfileBlockElement {
+    _type: 'model.dotcomrendering.pageElements.ProfileBlockElement';
+    id: string;
+    title: string;
+    img?: string;
+    html: string;
+    credit: string;
+}
+
 type CAPIElement =
     | TextBlockElement
     | SubheadingBlockElement
@@ -138,4 +156,6 @@ type CAPIElement =
     | EmbedBlockElement
     | DisclaimerBlockElement
     | PullquoteBlockElement
-    | QABlockElement;
+    | QABlockElement
+    | GuideBlockElement
+    | ProfileBlockElement;


### PR DESCRIPTION
Note: requires https://github.com/guardian/frontend/pull/21357 to actually bear fruit (although can be merged before this).

## What does this change?

Adds support for a few atom types:

* guide
* profile
* q+a
* timeline

## Why?

AMP completion!

## Screenshots

<img width="606" alt="Screenshot 2019-04-23 at 11 31 14" src="https://user-images.githubusercontent.com/858402/56599270-217d6a80-65ee-11e9-92ec-40b49d2a3cf4.png">
<img width="606" alt="Screenshot 2019-04-23 at 12 25 35" src="https://user-images.githubusercontent.com/858402/56599271-22160100-65ee-11e9-856a-1d65f0a78dfb.png">
<img width="606" alt="Screenshot 2019-04-23 at 17 07 32" src="https://user-images.githubusercontent.com/858402/56599280-27734b80-65ee-11e9-890e-a1980a8f9418.png">

Note, again I've kind of adopted mostly mobile styling here as the AMP styling is a bit wacky/out of date - especially for the timeline atom.
