### PR TITLE
Add geolocation configuration to AMP ad slots

### DIFF
--- a/packages/frontend/amp/components/Ad.test.tsx
+++ b/packages/frontend/amp/components/Ad.test.tsx
@@ -18,7 +18,11 @@ describe('AdComponent', () => {
     };
     const kruxURL =
         'https://cdn.krxd.net/userdata/v2/amp/2196ddf0-947c-45ec-9b0d-0a82fb280cb8?segments_key=x&kuid_key=kuid';
-    const prebidURL =
+    const usPrebidURL =
+        'https://prebid.adnxs.com/pbs/v1/openrtb2/amp?tag_id=7&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF';
+    const auPrebidURL =
+        'https://prebid.adnxs.com/pbs/v1/openrtb2/amp?tag_id=6&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF';
+    const rowPrebidURL =
         'https://prebid.adnxs.com/pbs/v1/openrtb2/amp?tag_id=4&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF';
 
     beforeEach(() => {
@@ -26,7 +30,7 @@ describe('AdComponent', () => {
         commercialConfig.usePrebid = true;
     });
 
-    it('rtc-config returns Krux and PreBid URLs when useKrux and usePrebid flags are set to true', () => {
+    it('rtc-config returns correctly formed Krux and PreBid URLs when useKrux and usePrebid flags are set to true', () => {
         const { container } = render(
             <Ad
                 edition={edition}
@@ -37,25 +41,41 @@ describe('AdComponent', () => {
             />,
         );
 
-        const ampAdElement = container.querySelector('amp-ad');
+        const ampAdElement = container.querySelectorAll('amp-ad');
 
         expect(ampAdElement).not.toBeNull();
 
         if (ampAdElement) {
-            const rtcAttribute = ampAdElement.getAttribute('rtc-config');
+            const usRtcAttribute = ampAdElement[0].getAttribute('rtc-config');
+            const auRtcAttribute = ampAdElement[1].getAttribute('rtc-config');
+            const rowRtcAttribute = ampAdElement[2].getAttribute('rtc-config');
 
-            expect(rtcAttribute).not.toBeNull();
+            expect(usRtcAttribute).not.toBeNull();
+            expect(auRtcAttribute).not.toBeNull();
+            expect(rowRtcAttribute).not.toBeNull();
 
-            if (rtcAttribute) {
-                expect(JSON.parse(rtcAttribute).urls).toMatchObject([
+            if (usRtcAttribute) {
+                expect(JSON.parse(usRtcAttribute).urls).toMatchObject([
                     kruxURL,
-                    prebidURL,
+                    usPrebidURL,
+                ]);
+            }
+            if (auRtcAttribute) {
+                expect(JSON.parse(auRtcAttribute).urls).toMatchObject([
+                    kruxURL,
+                    auPrebidURL,
+                ]);
+            }
+            if (rowRtcAttribute) {
+                expect(JSON.parse(rowRtcAttribute).urls).toMatchObject([
+                    kruxURL,
+                    rowPrebidURL,
                 ]);
             }
         }
     });
 
-    it('rtc-config returns only the PreBid URL when useKrux flag is set to false and usePrebid flag is set to true', () => {
+    it('rtc-config returns only the correctly formed PreBid URL when useKrux flag is set to false and usePrebid flag is set to true', () => {
         commercialConfig.useKrux = false;
 
         const { container } = render(
@@ -68,18 +88,32 @@ describe('AdComponent', () => {
             />,
         );
 
-        const ampAdElement = container.querySelector('amp-ad');
+        const ampAdElement = container.querySelectorAll('amp-ad');
 
         expect(ampAdElement).not.toBeNull();
 
         if (ampAdElement) {
-            const rtcAttribute = ampAdElement.getAttribute('rtc-config');
+            const usRtcAttribute = ampAdElement[0].getAttribute('rtc-config');
+            const auRtcAttribute = ampAdElement[1].getAttribute('rtc-config');
+            const rowRtcAttribute = ampAdElement[2].getAttribute('rtc-config');
 
-            expect(rtcAttribute).not.toBeNull();
+            expect(usRtcAttribute).not.toBeNull();
+            expect(auRtcAttribute).not.toBeNull();
+            expect(rowRtcAttribute).not.toBeNull();
 
-            if (rtcAttribute) {
-                expect(JSON.parse(rtcAttribute).urls).toMatchObject([
-                    prebidURL,
+            if (usRtcAttribute) {
+                expect(JSON.parse(usRtcAttribute).urls).toMatchObject([
+                    usPrebidURL,
+                ]);
+            }
+            if (auRtcAttribute) {
+                expect(JSON.parse(auRtcAttribute).urls).toMatchObject([
+                    auPrebidURL,
+                ]);
+            }
+            if (rowRtcAttribute) {
+                expect(JSON.parse(rowRtcAttribute).urls).toMatchObject([
+                    rowPrebidURL,
                 ]);
             }
         }
@@ -98,17 +132,33 @@ describe('AdComponent', () => {
             />,
         );
 
-        const ampAdElement = container.querySelector('amp-ad');
+        const ampAdElement = container.querySelectorAll('amp-ad');
 
         expect(ampAdElement).not.toBeNull();
 
         if (ampAdElement) {
-            const rtcAttribute = ampAdElement.getAttribute('rtc-config');
+            const usRtcAttribute = ampAdElement[0].getAttribute('rtc-config');
+            const auRtcAttribute = ampAdElement[1].getAttribute('rtc-config');
+            const rowRtcAttribute = ampAdElement[2].getAttribute('rtc-config');
 
-            expect(rtcAttribute).not.toBeNull();
+            expect(usRtcAttribute).not.toBeNull();
+            expect(auRtcAttribute).not.toBeNull();
+            expect(rowRtcAttribute).not.toBeNull();
 
-            if (rtcAttribute) {
-                expect(JSON.parse(rtcAttribute).urls).toMatchObject([kruxURL]);
+            if (usRtcAttribute) {
+                expect(JSON.parse(usRtcAttribute).urls).toMatchObject([
+                    kruxURL,
+                ]);
+            }
+            if (auRtcAttribute) {
+                expect(JSON.parse(auRtcAttribute).urls).toMatchObject([
+                    kruxURL,
+                ]);
+            }
+            if (rowRtcAttribute) {
+                expect(JSON.parse(rowRtcAttribute).urls).toMatchObject([
+                    kruxURL,
+                ]);
             }
         }
     });
@@ -127,17 +177,27 @@ describe('AdComponent', () => {
             />,
         );
 
-        const ampAdElement = container.querySelector('amp-ad');
+        const ampAdElement = container.querySelectorAll('amp-ad');
 
         expect(ampAdElement).not.toBeNull();
 
         if (ampAdElement) {
-            const rtcAttribute = ampAdElement.getAttribute('rtc-config');
+            const usRtcAttribute = ampAdElement[0].getAttribute('rtc-config');
+            const auRtcAttribute = ampAdElement[1].getAttribute('rtc-config');
+            const rowRtcAttribute = ampAdElement[2].getAttribute('rtc-config');
 
-            expect(rtcAttribute).not.toBeNull();
+            expect(usRtcAttribute).not.toBeNull();
+            expect(auRtcAttribute).not.toBeNull();
+            expect(rowRtcAttribute).not.toBeNull();
 
-            if (rtcAttribute) {
-                expect(JSON.parse(rtcAttribute).urls).toMatchObject([]);
+            if (usRtcAttribute) {
+                expect(JSON.parse(usRtcAttribute).urls).toMatchObject([]);
+            }
+            if (auRtcAttribute) {
+                expect(JSON.parse(auRtcAttribute).urls).toMatchObject([]);
+            }
+            if (rowRtcAttribute) {
+                expect(JSON.parse(rowRtcAttribute).urls).toMatchObject([]);
             }
         }
     });

--- a/packages/frontend/amp/components/Ad.tsx
+++ b/packages/frontend/amp/components/Ad.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'emotion';
+import { css, cx } from 'emotion';
 import { until } from '@guardian/pasteup/breakpoints';
 import { palette } from '@guardian/pasteup/palette';
 import { adJson, stringify } from '@frontend/amp/lib/ad-json';
@@ -34,6 +34,28 @@ const adStyle = css`
         padding: 3px 10px;
         color: ${palette.neutral[46]};
         text-align: right;
+    }
+`;
+
+const adClass = css`
+    display: none;
+`;
+
+const usAdRegionClass = css`
+    .amp-geo-group-us & {
+        display: block;
+    }
+`;
+
+const auAdRegionClass = css`
+    .amp-geo-group-au & {
+        display: block;
+    }
+`;
+
+const rowAdRegionClass = css`
+    .amp-geo-group-eea & {
+        display: block;
     }
 `;
 
@@ -99,6 +121,34 @@ interface CommercialConfig {
     usePrebid: boolean;
 }
 
+const ampAdElem = (
+    adRegionClass: string,
+    edition: Edition,
+    section: string,
+    contentType: string,
+    config: CommercialConfig,
+    commercialProperties: CommercialProperties) => {
+
+    return <amp-ad
+        class={cx(adClass, adRegionClass)}
+        data-block-on-consent=""
+        width={300}
+        height={250}
+        data-npa-on-unknown-consent={true}
+        data-loading-strategy={'prefer-viewability-over-views'}
+        layout={'responsive'}
+        type={'doubleclick'}
+        json={stringify(adJson(commercialProperties[edition].adTargeting))}
+        data-slot={ampData(section, contentType)}
+        rtc-config={realTimeConfig(
+            edition,
+            config.useKrux,
+            config.usePrebid,
+        )}
+    />
+
+}
+
 export const Ad: React.SFC<{
     edition: Edition;
     section: string;
@@ -107,21 +157,8 @@ export const Ad: React.SFC<{
     commercialProperties: CommercialProperties;
 }> = ({ edition, section, contentType, config, commercialProperties }) => (
     <div className={adStyle}>
-        <amp-ad
-            data-block-on-consent=""
-            width={300}
-            height={250}
-            data-npa-on-unknown-consent={true}
-            data-loading-strategy={'prefer-viewability-over-views'}
-            layout={'responsive'}
-            type={'doubleclick'}
-            json={stringify(adJson(commercialProperties[edition].adTargeting))}
-            data-slot={ampData(section, contentType)}
-            rtc-config={realTimeConfig(
-                edition,
-                config.useKrux,
-                config.usePrebid,
-            )}
-        />
+        {ampAdElem(usAdRegionClass, edition, section, contentType, config, commercialProperties)}
+        {ampAdElem(auAdRegionClass, edition, section, contentType, config, commercialProperties)}
+        {ampAdElem(rowAdRegionClass, edition, section, contentType, config, commercialProperties)}
     </div>
 );

--- a/packages/frontend/amp/components/Ad.tsx
+++ b/packages/frontend/amp/components/Ad.tsx
@@ -59,6 +59,14 @@ const rowAdRegionClass = css`
     }
 `;
 
+const regionClasses = {
+    US: usAdRegionClass,
+    AU: auAdRegionClass,
+    ROW: rowAdRegionClass,
+};
+
+type Region = 'US' | 'AU' | 'ROW';
+
 const dfpAdUnitRoot = 'theguardian.com';
 
 const ampData = (section: string, contentType: string): string => {
@@ -71,8 +79,8 @@ const ampData = (section: string, contentType: string): string => {
     return `/${dfpAccountId}/${dfpAdUnitRoot}/amp`;
 };
 
-const getPlacementId = (edition: Edition): number => {
-    switch (edition) {
+const getPlacementId = (adRegion: Region): number => {
+    switch (adRegion) {
         case 'US':
             return 7;
         case 'AU':
@@ -83,11 +91,11 @@ const getPlacementId = (edition: Edition): number => {
 };
 
 const realTimeConfig = (
-    edition: Edition,
+    adRegion: Region,
     useKrux: boolean,
     usePrebid: boolean,
 ): any => {
-    const placementID = getPlacementId(edition);
+    const placementID = getPlacementId(adRegion);
     const preBidServerPrefix = 'https://prebid.adnxs.com/pbs/v1/openrtb2/amp';
     const kruxURL =
         'https://cdn.krxd.net/userdata/v2/amp/2196ddf0-947c-45ec-9b0d-0a82fb280cb8?segments_key=x&kuid_key=kuid';
@@ -122,7 +130,7 @@ interface CommercialConfig {
 }
 
 const ampAdElem = (
-    adRegionClass: string,
+    adRegion: Region,
     edition: Edition,
     section: string,
     contentType: string,
@@ -131,7 +139,7 @@ const ampAdElem = (
 ) => {
     return (
         <amp-ad
-            class={cx(adClass, adRegionClass)}
+            class={cx(adClass, regionClasses[adRegion])}
             data-block-on-consent=""
             width={300}
             height={250}
@@ -142,7 +150,7 @@ const ampAdElem = (
             json={stringify(adJson(commercialProperties[edition].adTargeting))}
             data-slot={ampData(section, contentType)}
             rtc-config={realTimeConfig(
-                edition,
+                adRegion,
                 config.useKrux,
                 config.usePrebid,
             )}
@@ -159,7 +167,7 @@ export const Ad: React.SFC<{
 }> = ({ edition, section, contentType, config, commercialProperties }) => (
     <div className={adStyle}>
         {ampAdElem(
-            usAdRegionClass,
+            'US',
             edition,
             section,
             contentType,
@@ -167,7 +175,7 @@ export const Ad: React.SFC<{
             commercialProperties,
         )}
         {ampAdElem(
-            auAdRegionClass,
+            'AU',
             edition,
             section,
             contentType,
@@ -175,7 +183,7 @@ export const Ad: React.SFC<{
             commercialProperties,
         )}
         {ampAdElem(
-            rowAdRegionClass,
+            'ROW',
             edition,
             section,
             contentType,

--- a/packages/frontend/amp/components/Ad.tsx
+++ b/packages/frontend/amp/components/Ad.tsx
@@ -59,13 +59,13 @@ const rowAdRegionClass = css`
     }
 `;
 
-const regionClasses = {
+const adRegionClasses = {
     US: usAdRegionClass,
     AU: auAdRegionClass,
     ROW: rowAdRegionClass,
 };
 
-type Region = 'US' | 'AU' | 'ROW';
+type AdRegion = 'US' | 'AU' | 'ROW';
 
 const dfpAdUnitRoot = 'theguardian.com';
 
@@ -79,7 +79,7 @@ const ampData = (section: string, contentType: string): string => {
     return `/${dfpAccountId}/${dfpAdUnitRoot}/amp`;
 };
 
-const getPlacementId = (adRegion: Region): number => {
+const getPlacementId = (adRegion: AdRegion): number => {
     switch (adRegion) {
         case 'US':
             return 7;
@@ -91,7 +91,7 @@ const getPlacementId = (adRegion: Region): number => {
 };
 
 const realTimeConfig = (
-    adRegion: Region,
+    adRegion: AdRegion,
     useKrux: boolean,
     usePrebid: boolean,
 ): any => {
@@ -130,7 +130,7 @@ interface CommercialConfig {
 }
 
 const ampAdElem = (
-    adRegion: Region,
+    adRegion: AdRegion,
     edition: Edition,
     section: string,
     contentType: string,
@@ -139,7 +139,7 @@ const ampAdElem = (
 ) => {
     return (
         <amp-ad
-            class={cx(adClass, regionClasses[adRegion])}
+            class={cx(adClass, adRegionClasses[adRegion])}
             data-block-on-consent=""
             width={300}
             height={250}

--- a/packages/frontend/amp/components/Ad.tsx
+++ b/packages/frontend/amp/components/Ad.tsx
@@ -127,27 +127,28 @@ const ampAdElem = (
     section: string,
     contentType: string,
     config: CommercialConfig,
-    commercialProperties: CommercialProperties) => {
-
-    return <amp-ad
-        class={cx(adClass, adRegionClass)}
-        data-block-on-consent=""
-        width={300}
-        height={250}
-        data-npa-on-unknown-consent={true}
-        data-loading-strategy={'prefer-viewability-over-views'}
-        layout={'responsive'}
-        type={'doubleclick'}
-        json={stringify(adJson(commercialProperties[edition].adTargeting))}
-        data-slot={ampData(section, contentType)}
-        rtc-config={realTimeConfig(
-            edition,
-            config.useKrux,
-            config.usePrebid,
-        )}
-    />
-
-}
+    commercialProperties: CommercialProperties,
+) => {
+    return (
+        <amp-ad
+            class={cx(adClass, adRegionClass)}
+            data-block-on-consent=""
+            width={300}
+            height={250}
+            data-npa-on-unknown-consent={true}
+            data-loading-strategy={'prefer-viewability-over-views'}
+            layout={'responsive'}
+            type={'doubleclick'}
+            json={stringify(adJson(commercialProperties[edition].adTargeting))}
+            data-slot={ampData(section, contentType)}
+            rtc-config={realTimeConfig(
+                edition,
+                config.useKrux,
+                config.usePrebid,
+            )}
+        />
+    );
+};
 
 export const Ad: React.SFC<{
     edition: Edition;
@@ -157,8 +158,29 @@ export const Ad: React.SFC<{
     commercialProperties: CommercialProperties;
 }> = ({ edition, section, contentType, config, commercialProperties }) => (
     <div className={adStyle}>
-        {ampAdElem(usAdRegionClass, edition, section, contentType, config, commercialProperties)}
-        {ampAdElem(auAdRegionClass, edition, section, contentType, config, commercialProperties)}
-        {ampAdElem(rowAdRegionClass, edition, section, contentType, config, commercialProperties)}
+        {ampAdElem(
+            usAdRegionClass,
+            edition,
+            section,
+            contentType,
+            config,
+            commercialProperties,
+        )}
+        {ampAdElem(
+            auAdRegionClass,
+            edition,
+            section,
+            contentType,
+            config,
+            commercialProperties,
+        )}
+        {ampAdElem(
+            rowAdRegionClass,
+            edition,
+            section,
+            contentType,
+            config,
+            commercialProperties,
+        )}
     </div>
 );


### PR DESCRIPTION
## What does this change?
Adds geolocation configuration to AMP ad slots.

Previously AMP ad slots considered edition rather than geolocation. This change will have each ad slot create 3 AMP ad elements but show only the one corresponding to geolocation determined by the amp-geo component.

Updates tests accordingly. Tests now fail when less than 3 amp-ad components are present, or if said components don't have a valid krux and/or prebid url (including checks for placementID) for each geolocation (US, AU and ROW).

## Why?
To allow us to target ads in AMP based on geolocation rather than on edition.

## How To Test It
To simulate being in a different country:
1. Switch on dev-channel at https://cdn.ampproject.org/experiments.html
1. Append #amp-geo=XX to URL, where XX is a country code, eg `nz`

The `amp-geo`element is documented [here](https://www.ampproject.org/docs/reference/components/amp-geo).