### PR TITLE
Adds Guardian legacy video format to AMP

### DIFF
--- a/packages/frontend/amp/components/elements/VideoGuardian.tsx
+++ b/packages/frontend/amp/components/elements/VideoGuardian.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export const VideoGuardian: React.FC<{
+    element: VideoGuardian;
+}> = ({ element }) => {
+    return (
+        <amp-video controls={''} width="16" height="9" layout="responsive">
+            <div fallback={''}>
+                Sorry, your browser is unable to play this video.
+                <br />
+                Please <a href="http://whatbrowser.org/">upgrade</a> to a modern
+                browser and try again.
+            </div>
+            {element.assets.map(
+                encoding =>
+                    encoding.mimeType.includes('video') && (
+                        <source src={encoding.url} type={encoding.mimeType} />
+                    ),
+            )}
+        </amp-video>
+    );
+};

--- a/packages/frontend/amp/components/lib/Elements.tsx
+++ b/packages/frontend/amp/components/lib/Elements.tsx
@@ -6,6 +6,7 @@ import { Image } from '@root/packages/frontend/amp/components/elements/Image';
 import { VideoYoutube } from '@frontend/amp/components/elements/VideoYoutube';
 import { VideoVimeo } from '@frontend/amp/components/elements/VideoVimeo';
 import { VideoFacebook } from '@frontend/amp/components/elements/VideoFacebook';
+import { VideoGuardian } from '@frontend/amp/components/elements/VideoGuardian';
 import { InstagramEmbed } from '@root/packages/frontend/amp/components/elements/InstagramEmbed';
 import { TwitterEmbed } from '@root/packages/frontend/amp/components/elements/TwitterEmbed';
 import { Comment } from '@root/packages/frontend/amp/components/elements/Comment';
@@ -69,6 +70,8 @@ export const Elements: React.FC<{
                 return <VideoVimeo key={i} element={element} />;
             case 'model.dotcomrendering.pageElements.VideoFacebookBlockElement':
                 return <VideoFacebook key={i} element={element} />;
+            case 'model.dotcomrendering.pageElements.GuVideoBlockElement':
+                return <VideoGuardian key={i} element={element} />;
             case 'model.dotcomrendering.pageElements.InstagramBlockElement':
                 return <InstagramEmbed key={i} element={element} />;
             case 'model.dotcomrendering.pageElements.TweetBlockElement':

--- a/packages/frontend/amp/lib/scripts.ts
+++ b/packages/frontend/amp/lib/scripts.ts
@@ -21,6 +21,8 @@ export const extractScripts: (
                     return `<script async custom-element="amp-vimeo" src="https://cdn.ampproject.org/v0/amp-vimeo-0.1.js"></script>`;
                 case 'model.dotcomrendering.pageElements.VideoFacebookBlockElement':
                     return `<script async custom-element="amp-facebook" src="https://cdn.ampproject.org/v0/amp-facebook-0.1.js"></script>`;
+                case 'model.dotcomrendering.pageElements.GuVideoBlockElement':
+                    return `<script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>`;
                 default:
                     return null;
             }

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -201,6 +201,7 @@ declare namespace JSX {
         'amp-list': any;
         'amp-vimeo': any;
         'amp-facebook': any;
+        'amp-video': any;
         'amp-instagram': any;
         'amp-soundcloud': any;
         'amp-iframe': any;

--- a/packages/frontend/lib/content.d.ts
+++ b/packages/frontend/lib/content.d.ts
@@ -66,6 +66,17 @@ interface VideoFacebook {
     width: number;
     caption: string;
 }
+
+interface VideoGuardian {
+    _type: 'model.dotcomrendering.pageElements.GuVideoBlockElement';
+    assets: VideoAssets[];
+    caption: string;
+}
+
+interface VideoAssets {
+    url: string;
+    mimeType: string;
+}
 interface InstagramBlockElement {
     _type: 'model.dotcomrendering.pageElements.InstagramBlockElement';
     html: string;
@@ -190,6 +201,7 @@ type CAPIElement =
     | VideoYoutube
     | VideoVimeo
     | VideoFacebook
+    | VideoGuardian
     | InstagramBlockElement
     | TweetBlockElement
     | RichLinkBlockElement


### PR DESCRIPTION
## What does this change?
The [old video format](https://amp.theguardian.com/politics/video/2017/apr/23/jeremy-corbyn-i-want-to-achieve-a-nuclear-free-world-video) passes sources from our CDN.

This adds the `amp-video` element for these videos in parity with existing AMP.

*Note:* Dependent on https://github.com/guardian/dotcom-rendering/pull/517

<img width="1098" alt="Screenshot 2019-04-25 at 09 59 23" src="https://user-images.githubusercontent.com/638051/56724643-50592500-6743-11e9-9d19-d344616d0780.png">

## Old AMP

![2019-04-25 10 18 02](https://user-images.githubusercontent.com/638051/56724782-90200c80-6743-11e9-8833-87db6ef11663.gif)

## New AMP

![2019-04-25 10 19 24](https://user-images.githubusercontent.com/638051/56724818-a1691900-6743-11e9-869a-94f063a3576a.gif)

