### PR TITLE
Support Youtube media atom

### DIFF
--- a/packages/frontend/amp/components/lib/Elements.tsx
+++ b/packages/frontend/amp/components/lib/Elements.tsx
@@ -17,6 +17,7 @@ import { Disclaimer } from '@root/packages/frontend/amp/components/elements/Disc
 import { clean } from '@frontend/model/clean';
 import { Expandable } from '@frontend/amp/components/Expandable';
 import { Timeline } from '@frontend/amp/components/elements/Timeline';
+import { YoutubeVideo } from '@frontend/amp/components/elements/YoutubeVideo';
 
 const clear = css`
     clear: both;
@@ -125,6 +126,8 @@ export const Elements: React.FC<{
                         pillar={pillar}
                     />
                 );
+            case 'model.dotcomrendering.pageElements.YoutubeBlockElement':
+                return <YoutubeVideo element={element} pillar={pillar} />;
             default:
                 // tslint:disable-next-line:no-console
                 console.log('Unsupported Element', JSON.stringify(element));


### PR DESCRIPTION
## What does this change?

Minimal PR to add support for Youtube media atoms (the model work has already been done :) ).

## Why?

AMP migration!

<img width="606" alt="Screenshot 2019-04-25 at 11 38 21" src="https://user-images.githubusercontent.com/858402/56730185-29a0eb80-674f-11e9-8171-0baf48199519.png">

(The sizing/proximity to the ad is a bug which we should fix separately - Trello card has been created.)
