### PR TITLE
Fixed bug where ads wouldn't show on no-group countries

### DIFF
--- a/packages/frontend/amp/components/Ad.tsx
+++ b/packages/frontend/amp/components/Ad.tsx
@@ -57,6 +57,9 @@ const rowAdRegionClass = css`
     .amp-geo-group-eea & {
         display: block;
     }
+    .amp-geo-no-group & {
+        display: block;
+    }
 `;
 
 const adRegionClasses = {


### PR DESCRIPTION
## What does this change?
Fixed a bug on a previous PR that made no-group countries get no ads on AMP.

## Why?
Ads were only showing up on AMP when the geolocation was US, AU or EEA.