### PR TITLE
Upgrade to yarn 1.15.2

### DIFF
--- a/scripts/env/check-yarn.js
+++ b/scripts/env/check-yarn.js
@@ -3,7 +3,7 @@ const exec = promisify(require('child_process').execFile);
 
 const ensure = require('./ensure');
 
-const YARN_VERSION = '1.9.4';
+const YARN_VERSION = '1.15.2';
 
 (async () => {
     try {


### PR DESCRIPTION
## What does this change?

Upgrades to latest version of yarn

## Why?

Among other things, gives us the ability to publish Pasteup with 2FA enabled.