### PR TITLE
Remove line break from caption

### DIFF
--- a/packages/frontend/amp/components/MainMedia.tsx
+++ b/packages/frontend/amp/components/MainMedia.tsx
@@ -97,9 +97,7 @@ const mainImage = (element: ImageBlockElement): JSX.Element | null => {
                         <InfoIcon />
                     </label>
                     <figcaption className={captionStyle}>
-                        {element.data.caption}
-                        <br />
-                        {element.data.credit}
+                        {element.data.caption} {element.data.credit}
                     </figcaption>
                 </>
             )}


### PR DESCRIPTION
## What does this change?
The caption shouldn't have a line break.

## Why?
@paperboyo said so https://github.com/guardian/dotcom-rendering/pull/531#issuecomment-487068425