### PR TITLE
Fix Branding interface in amp to include logo dimensions

### DIFF
--- a/packages/frontend/amp/components/TopMetaPaidContent.tsx
+++ b/packages/frontend/amp/components/TopMetaPaidContent.tsx
@@ -53,8 +53,8 @@ const PaidForByLogo: React.FC<{
             >
                 <amp-img
                     src={logo.src}
-                    width="280px"
-                    height="180px"
+                    width={`${logo.dimensions.width}px`}
+                    height={`${logo.dimensions.height}px`}
                     alt={sponsorName}
                 />
             </a>

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -40,9 +40,9 @@ interface Branding {
     sponsorName: string;
     logo: {
         src: string;
-        width: number;
-        height: number;
         link: string;
+        label: string;
+        dimensions: { width: number, height: number }
     };
     aboutThisLink: string;
 }


### PR DESCRIPTION
## What does this change?

- Updates the Branding interface in AMP to reflect logo data
- Displays AMP paid content sponsor in the image file's source dimensions rather than scaling up to hard-coded pixels

## Why?
Most logos coming through appear to be 280x180px but some are smaller so this was happening: 
![image](https://user-images.githubusercontent.com/32312712/57087184-6a70a580-6cf7-11e9-9403-c871be9f6266.png)
