### PR TITLE
Add guard for when no tone

### DIFF
--- a/packages/frontend/amp/lib/tag-utils.ts
+++ b/packages/frontend/amp/lib/tag-utils.ts
@@ -15,14 +15,19 @@ export type StyledTone =
     | 'default-tone';
 
 export const getToneType = (tags: TagType[]): StyledTone => {
-    const tone: string = filterForTagsOfType(tags, 'Tone')[0].id;
+    const defaultTone = 'default-tone';
+    const tone = filterForTagsOfType(tags, 'Tone')[0];
 
-    switch (tone) {
+    if (!tone) {
+        return defaultTone;
+    }
+
+    switch (tone.id) {
         case 'tone/advertisement-features':
             return 'tone/advertisement-features';
         case 'tone/comment':
             return 'tone/comment';
         default:
-            return 'default-tone';
+            return defaultTone;
     }
 };


### PR DESCRIPTION
## What does this change?

Fixes some 500s we've been getting that I noticed in the search console.

<img width="915" alt="Screenshot 2019-05-02 at 17 50 51" src="https://user-images.githubusercontent.com/858402/57092243-da385d80-6d02-11e9-9366-7f0b76f3c829.png">

## Why?

To stop the 500s!
