### PR TITLE
AMP Validation: Set fixed height and width for profile image in guide

### DIFF
--- a/packages/frontend/amp/components/Expandable.tsx
+++ b/packages/frontend/amp/components/Expandable.tsx
@@ -134,6 +134,9 @@ export const Expandable: React.FC<{
                     class={imageStyle}
                     src={img}
                     alt={`Image for ${title} explainer`}
+                    layout="fixed"
+                    width="100"
+                    height="100"
                 />
             )}
             <div // tslint:disable-line:react-no-dangerous-html


### PR DESCRIPTION
## What does this change?
Matches hardcoded CSS height and width.

## Why?
Ensure validation.