### PR TITLE
AMP Validation: Force https for video source

### DIFF
--- a/packages/frontend/amp/components/elements/VideoGuardian.tsx
+++ b/packages/frontend/amp/components/elements/VideoGuardian.tsx
@@ -18,7 +18,7 @@ export const VideoGuardian: React.FC<{
                     encoding =>
                         encoding.mimeType.includes('video') && (
                             <source
-                                src={encoding.url}
+                                src={encoding.url.replace('http:', 'https:')} // Force https as CAPI doesn't always send them
                                 type={encoding.mimeType}
                             />
                         ),


### PR DESCRIPTION
## What does this change?
Ensure we are requesting https sourced video.

## Why?
`http` invalidates AMP.