### PR TITLE
WIP Paid content sub meta styling amp

### DIFF
--- a/fixtures/CAPI.ts
+++ b/fixtures/CAPI.ts
@@ -361,6 +361,7 @@ export const CAPI: CAPIType = {
     },
     ageWarning: 'This article is over 1 year old',
     isImmersive: false,
+    isPaidContent: false,
     subMetaSectionLinks: [
         {
             url: '/money/ticket-prices',

--- a/packages/frontend/amp/components/Body.tsx
+++ b/packages/frontend/amp/components/Body.tsx
@@ -15,7 +15,7 @@ const body = (pillar: Pillar, tone: StyledTone) => {
     const bgColorMap = {
         'default-tone': palette.neutral[100],
         'tone/comment': palette.opinion.faded,
-        'tone/advertisement-features': palette.neutral[100],
+        'tone/advertisement-features': palette.neutral[85],
     };
     return css`
         background-color: ${bgColorMap[tone]};

--- a/packages/frontend/amp/components/Byline.tsx
+++ b/packages/frontend/amp/components/Byline.tsx
@@ -4,7 +4,6 @@ import { bylineTokens } from '@frontend/amp/lib/byline-tokens';
 export const Byline: React.FC<{
     byline: string;
     tags: TagType[];
-    pillar: Pillar;
     guardianBaseURL: string;
     className?: string;
 }> = ({ byline, tags, guardianBaseURL, className }) => {

--- a/packages/frontend/amp/components/PaidForBand.tsx
+++ b/packages/frontend/amp/components/PaidForBand.tsx
@@ -14,7 +14,7 @@ const headerStyle = css`
     margin: 0 -10px;
     padding: 0 10px;
     height: 58px;
-    background-color: ${palette.labs.main};
+    background-color: ${palette.labs.bright};
 
     ${mobileLandscape} {
         padding: 0 20px;
@@ -84,7 +84,7 @@ const logoStyle = css`
 
 const aStyle = css`
     display: inline-block;
-    color: ${palette.labs.main};
+    color: ${palette.labs.bright};
     text-decoration: none;
     margin-top: 10px;
     &:hover {
@@ -93,7 +93,7 @@ const aStyle = css`
 `;
 
 const iconStyle = css`
-    fill: ${palette.labs.main};
+    fill: ${palette.labs.bright};
     margin: 0 0;
     padding-right: 3px;
     vertical-align: middle;

--- a/packages/frontend/amp/components/ShareIcons.tsx
+++ b/packages/frontend/amp/components/ShareIcons.tsx
@@ -24,8 +24,9 @@ const shareIconsListItem = css`
     min-width: 32px;
 `;
 
-const shareIcon = (colour: string) => css`
-    border: 1px solid ${palette.neutral[86]};
+const shareIcon = (pillar: Pillar) => css`
+    border: 1px solid
+        ${pillar === 'labs' ? palette.neutral[60] : palette.neutral[86]};
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -51,8 +52,8 @@ const shareIcon = (colour: string) => css`
     }
 
     :hover {
-        background-color: ${colour};
-        border-color: ${colour};
+        background-color: ${pillarPalette[pillar].main};
+        border-color: ${pillarPalette[pillar].main};
         fill: white;
     }
 `;
@@ -124,7 +125,7 @@ export const ShareIcons: React.FC<{
                             </span>
                             <span
                                 className={cx(
-                                    shareIcon(pillarPalette[pillar].main),
+                                    shareIcon(pillar),
                                     pillarFill[pillar],
                                 )}
                             >

--- a/packages/frontend/amp/components/Standfirst.tsx
+++ b/packages/frontend/amp/components/Standfirst.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
-import { headline } from '@guardian/pasteup/typography';
+import { headline, textSans } from '@guardian/pasteup/typography';
 import { css, cx } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
 import { pillarPalette, pillarMap } from '@frontend/lib/pillars';
 
-// TODO - unclear if we need the list styles as well here
+// listStyles are used in paid content standfirsts, with a fallback for normal pillars
 const listStyles = (pillar: Pillar) => css`
     li {
         margin-bottom: 6px;
         padding-left: 20px;
-        ${headline(2)};
+        ${pillar === 'labs' ? textSans(7) : headline(2)};
+        ${pillar === 'labs' && 'font-weight: 700;'}
         p {
             display: inline;
         }
@@ -22,21 +23,23 @@ const listStyles = (pillar: Pillar) => css`
         height: 12px;
         width: 12px;
         margin-right: 8px;
-        background-color: ${palette.neutral[86]};
+        background-color: ${pillar === 'labs'
+            ? palette.neutral[60]
+            : palette.neutral[86]};
         margin-left: -20px;
     }
 `;
 
 const standfirstCss = pillarMap(
     pillar => css`
-        ${headline(2)};
+        ${pillar === 'labs' ? textSans(7) : headline(2)};
         font-weight: 100;
         color: ${palette.neutral[7]};
         margin-bottom: 12px;
         ${listStyles(pillar)};
         p {
             margin-bottom: 8px;
-            font-weight: 200;
+            ${pillar === 'labs' ? 'font-weight: 700;' : 'font-weight: 200;'}
         }
         strong {
             font-weight: 700;
@@ -48,9 +51,20 @@ const standfirstLinks = pillarMap(
     pillar =>
         css`
             a {
-                color: ${pillarPalette[pillar].dark};
+                color: ${pillar === 'labs'
+                    ? pillarPalette[pillar].main
+                    : pillarPalette[pillar].dark};
                 text-decoration: none;
-                border-bottom: 1px solid ${palette.neutral[86]};
+                border-bottom: 1px solid
+                    ${pillar === 'labs'
+                        ? palette.neutral[60]
+                        : palette.neutral[86]};
+            }
+            a:hover {
+                border-bottom: 1px solid
+                    ${pillar === 'labs'
+                        ? palette.neutral[7]
+                        : palette.neutral[86]};
             }
         `,
 );

--- a/packages/frontend/amp/components/TopMetaExtras.tsx
+++ b/packages/frontend/amp/components/TopMetaExtras.tsx
@@ -32,9 +32,11 @@ const metaExtras = css`
     margin-bottom: 6px;
 `;
 
-const borders = css`
-    border-top: 1px solid ${palette.neutral[86]};
-    border-bottom: 1px solid ${palette.neutral[86]};
+const borders = (pillar: Pillar) => css`
+    border-top: 1px solid
+        ${pillar === 'labs' ? palette.neutral[60] : palette.neutral[86]};
+    border-bottom: 1px solid
+        ${pillar === 'labs' ? palette.neutral[60] : palette.neutral[86]};
     display: flex;
     justify-content: space-between;
     flex-wrap: wrap;
@@ -120,7 +122,7 @@ export const TopMetaExtras: React.FC<{
         <TwitterHandle handle={twitterHandle} />
         <WebPublicationDate date={webPublicationDate} />
 
-        <div className={borders}>
+        <div className={borders(pillar)}>
             <ShareIcons
                 sharingUrls={sharingUrls}
                 pillar={pillar}

--- a/packages/frontend/amp/components/TopMetaPaidContent.tsx
+++ b/packages/frontend/amp/components/TopMetaPaidContent.tsx
@@ -9,19 +9,18 @@ import { Standfirst } from '@frontend/amp/components/Standfirst';
 import { PaidForBand } from '@frontend/amp/components/PaidForBand';
 
 import { palette } from '@guardian/pasteup/palette';
-import { headline, body } from '@guardian/pasteup/typography';
+import { textSans, body } from '@guardian/pasteup/typography';
 
-// TODO typography styling needs to be reviewed -> TextSans?
 const headerStyle = css`
-    ${headline(6)};
-    font-weight: 500;
-    padding-bottom: 24px;
+    ${textSans(8)};
+    font-weight: 400;
     padding-top: 3px;
+    padding-bottom: 40px;
     color: ${palette.neutral[7]};
 `;
 
-const bylineStyle = (pillar: Pillar) => css`
-    ${headline(2)};
+const bylineStyle = css`
+    ${body(2)};
     color: ${palette.neutral[7]};
     padding-bottom: 8px;
     font-style: italic;
@@ -32,18 +31,31 @@ const bylineStyle = (pillar: Pillar) => css`
         text-decoration: none;
         font-style: normal;
     }
+    a:hover {
+        text-decoration: underline;
+    }
 `;
 
 const paidForLogoLabelStyle = css`
-    ${body(1)};
+    ${textSans(2)};
+    font-weight: 700;
+    margin-bottom: 6px;
+    color: ${palette.neutral[46]};
+`;
+const paidForLogoStyle = css`
+    border-top: 1px solid ${palette.neutral[60]};
+    padding-top: 4px;
+    margin-top: 3px;
+    margin-bottom: 12px;
 `;
 
 const PaidForByLogo: React.FC<{
     branding: Branding;
 }> = ({ branding }) => {
     const { logo, sponsorName } = branding;
+
     return (
-        <div>
+        <div className={paidForLogoStyle}>
             <div className={paidForLogoLabelStyle}>Paid for by</div>
             {/* tslint:disable-next-line: react-a11y-anchors */}
             <a
@@ -53,8 +65,8 @@ const PaidForByLogo: React.FC<{
             >
                 <amp-img
                     src={logo.src}
-                    width={`${logo.dimensions.width}px`}
-                    height={`${logo.dimensions.height}px`}
+                    width={`140px`}
+                    height={`90px`}
                     alt={sponsorName}
                 />
             </a>
@@ -77,33 +89,25 @@ export const TopMetaPaidContent: React.FC<{
             <PaidForBand />
 
             {articleData.mainMediaElements.map((element, i) => (
-                <MainMedia
-                    key={i}
-                    element={element}
-                    pillar={articleData.pillar}
-                />
+                <MainMedia key={i} element={element} pillar="labs" />
             ))}
 
             <Headline headlineText={articleData.headline} />
 
             {!!branding && <PaidForByLogo branding={branding} />}
 
-            <Standfirst
-                text={articleData.standfirst}
-                pillar={articleData.pillar}
-            />
+            <Standfirst text={articleData.standfirst} pillar="labs" />
 
             <Byline
                 byline={articleData.author.byline}
                 tags={articleData.tags}
-                pillar={articleData.pillar}
                 guardianBaseURL={articleData.guardianBaseURL}
-                className={bylineStyle(articleData.pillar)}
+                className={bylineStyle}
             />
 
             <TopMetaExtras
                 sharingUrls={articleData.sharingUrls}
-                pillar={articleData.pillar} // pillar  defualt / none == black for paid?
+                pillar="labs" // pillar  defualt / none == black for paid?
                 ageWarning={articleData.ageWarning}
                 webPublicationDate={articleData.webPublicationDateDisplay}
                 twitterHandle={articleData.author.twitterHandle}

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -4,7 +4,7 @@ interface ArticleProps {
     config: ConfigType;
 }
 
-type Pillar = 'news' | 'opinion' | 'sport' | 'culture' | 'lifestyle';
+type Pillar = 'news' | 'opinion' | 'sport' | 'culture' | 'lifestyle' | 'labs';
 
 type Edition = 'UK' | 'US' | 'INT' | 'AU';
 

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -127,6 +127,7 @@ interface CAPIType {
     tags: TagType[];
     pillar: Pillar;
     isImmersive: boolean;
+    isPaidContent: boolean;
     sectionLabel: string;
     sectionUrl: string;
     sectionName?: string;

--- a/packages/frontend/lib/pillars.ts
+++ b/packages/frontend/lib/pillars.ts
@@ -14,6 +14,7 @@ export const pillarPalette: { [K in Pillar]: PillarColours } = {
     sport: palette.sport,
     culture: palette.culture,
     lifestyle: palette.lifestyle,
+    labs: palette.labs,
 };
 
 /*
@@ -28,6 +29,7 @@ export const pillarMap: <T>(
     sport: f('sport'),
     culture: f('culture'),
     lifestyle: f('lifestyle'),
+    labs: f('labs'),
 });
 /*
 Further notes on this function:

--- a/packages/frontend/model/extract-capi.test.ts
+++ b/packages/frontend/model/extract-capi.test.ts
@@ -197,6 +197,34 @@ describe('extract-capi', () => {
         expect(isImmersive).toBe(false);
     });
 
+    it('returns isPaidContent as true if paid content', () => {
+        testData.page.tags.all = [
+            {
+                properties: {
+                    id: 'money/ticket-prices',
+                    tagType: 'Keyword',
+                    webTitle: 'Ticket prices',
+                },
+            },
+            {
+                properties: {
+                    id: 'tone/advertisement-features',
+                    tagType: 'Tone',
+                    webTitle: 'Consumer affairs',
+                },
+            },
+        ];
+        const { isPaidContent } = extract(testData);
+
+        expect(isPaidContent).toBe(true);
+    });
+
+    it('returns isPaidContent as false if not paid content', () => {
+        const { isPaidContent } = extract(testData);
+
+        expect(isPaidContent).toBe(false);
+    });
+
     it('returns webPublicationDateDisplay if webPublicationDateDisplay available', () => {
         const testWebPublicationDateDisplay = 'Fri 10 Mar 2017 19.15 GMT';
 

--- a/packages/frontend/model/extract-capi.ts
+++ b/packages/frontend/model/extract-capi.ts
@@ -116,6 +116,11 @@ const getCommercialProperties = (data: {}): CommercialProperties => {
     ) as CommercialProperties;
 };
 
+// TODO do we need to account for (tag.type === 'paid-content')?
+const getIsPaidContent = (tags: TagType[]): boolean => tags.some(
+    tag => tag.type === 'Tone' && tag.id === 'tone/advertisement-features'
+);
+
 // TODO really it would be nice if we passed just the data we needed and
 // didn't have to do the transforms/lookups below. (While preserving the
 // validation on types.)
@@ -125,6 +130,7 @@ export const extract = (data: {}): CAPIType => {
     );
     const tags = getTags(data);
     const isImmersive = getBoolean(data, 'page.meta.isImmersive', false);
+    const isPaidContent = getIsPaidContent(tags);
     const sectionName = getString(data, 'page.section', '');
 
     const leadContributor: TagType = tags.filter(
@@ -146,6 +152,7 @@ export const extract = (data: {}): CAPIType => {
         editionLongForm,
         editionId,
         isImmersive,
+        isPaidContent,
         webPublicationDateDisplay: getNonEmptyString(
             data,
             'page.webPublicationDateDisplay',

--- a/packages/pasteup/palette.ts
+++ b/packages/pasteup/palette.ts
@@ -12,6 +12,7 @@ export interface AllPillarColours {
     sport: PillarColours;
     culture: PillarColours;
     lifestyle: PillarColours;
+    labs: PillarColours;
 }
 export interface OtherColours {
     highlight: { main: colour; dark: colour };
@@ -20,6 +21,7 @@ export interface OtherColours {
         20: colour;
         46: colour;
         60: colour;
+        85: colour;
         86: colour;
         93: colour;
         97: colour;
@@ -94,6 +96,7 @@ const lifestyle: PillarColours = {
     faded: '#feeef7',
 };
 
+
 const brand = {
     dark: '#041f4a',
     main: '#052962',
@@ -115,18 +118,23 @@ const neutral = {
     20: '#333333',
     46: '#767676',
     60: '#999999',
+    85: '#d9d9d9',
     86: '#dcdcdc',
     93: '#ededed',
     97: '#f6f6f6',
     100: '#ffffff',
 };
 
-const specialReport = { dark: '#3f464a' };
-
-const labs = {
+// Sort out Labs pillar colours - do we need to add more neutrals here?
+const labs: PillarColours & {} = {
     dark: '#65a897',
-    main: '#69d1ca',
+    main: neutral[7], // TODO
+    bright: '#69d1ca',
+    pastel: 'orange', // TODO
+    faded: 'pink', // TODO
 };
+
+const specialReport = { dark: '#3f464a' };
 
 const contrasts = {
     darkOnLight: {
@@ -152,10 +160,10 @@ export const palette: AllPillarColours & OtherColours & Appearances = {
     sport,
     culture,
     lifestyle,
+    labs,
     highlight,
     neutral,
     specialReport,
-    labs,
     green,
     brand,
     state,

--- a/packages/pasteup/typography.ts
+++ b/packages/pasteup/typography.ts
@@ -1,7 +1,7 @@
 type Category = 'headline' | 'body' | 'textSans';
 type HeadlineLevel = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
 type BodyLevel = 1 | 2 | 3 | 4;
-type TextSansLevel = 1 | 2 | 3 | 4 | 5 | 6 | 7;
+type TextSansLevel = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
 
 export const serif = {
     headline: ['GH Guardian Headline', 'Georgia', 'serif'].join(', '),
@@ -43,7 +43,8 @@ const fontScaleMapping: any = {
         4: { fontSize: 14, lineHeight: 22 },
         5: { fontSize: 16, lineHeight: 22 },
         6: { fontSize: 18, lineHeight: 18 },
-        7: { fontSize: 20, lineHeight: 20 },
+        7: { fontSize: 20, lineHeight: 22 },
+        8: { fontSize: 38, lineHeight: 42 },
     },
 };
 


### PR DESCRIPTION
## What does this change?

Adds styling to AMP paid content for Article **Top Meta** only.  (Working my way down from the top)

@zeftilldeath - Could you have a look at the styling and advise if ok? Converting to sansSerif per our chat this week to align the dotcom-rendering AMP styling closer to the current Frontend web look. 

## Why?

Roll out of Amp... 

## Thoughts

Guardian Labs articles share many sub-components with normal Pillar Articles that have all had CSS modelled around `pillar` variable and color palette. I've opted for now to create a fake Pillar color palette for `'labs'` so can hopefully handle Article Body styling with minimum conditional rendering in the CSS.

I was going to see how messy the CSS got as I apply styling to the rest of the article Body component but would love to chat through with anyone who has had thoughts on how best to handle. 

- Is it better to avoid conditional rendering inside CSS and  instead use standalone classes for Paid Content? 
- Is there a better way to do this using class composition pattern?
- I've hardcoded `pillar={'labs'}` in `TopMetaPaidContent` but for shared components this needs to be flagged at a higher level so thinking of adding `isPaidContent` to the `extract-capi` model instead maybe.

<img src="https://user-images.githubusercontent.com/32312712/57151438-de2eb300-6dc8-11e9-8dce-85cf9e22a923.png" width="300"/> <img src="https://user-images.githubusercontent.com/32312712/57151361-a889ca00-6dc8-11e9-91e9-8260caabc238.png" width="300"/>



