### PR TITLE
[Discuss] Add html sanitisation to text elements

### DIFF
--- a/packages/frontend/amp/components/elements/Text.tsx
+++ b/packages/frontend/amp/components/elements/Text.tsx
@@ -3,6 +3,7 @@ import { css } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
 import { pillarPalette } from '@frontend/lib/pillars';
 import { body } from '@guardian/pasteup/typography';
+import { sanitise } from '@frontend/amp/lib/sanitise-html';
 
 // Note, this should only apply basic text styling. It is a case where we want
 // to re-use styling, but generally we should avoid this as it couples
@@ -39,7 +40,7 @@ export const Text: React.FC<{
     <span
         className={TextStyle(pillar)}
         dangerouslySetInnerHTML={{
-            __html: html,
+            __html: sanitise(html),
         }}
     />
 );

--- a/packages/frontend/amp/lib/sanitise-html.test.ts
+++ b/packages/frontend/amp/lib/sanitise-html.test.ts
@@ -1,0 +1,19 @@
+import { sanitise } from '@frontend/amp/lib/sanitise-html';
+
+describe('sanitise-html', () => {
+    it('Remove rouge attributes', () => {
+        const badHtml =
+            '<p><a href="https://theguardian.com" not="allowed">Test</a></p>';
+        const goodHtml = '<p><a href="https://theguardian.com">Test</a></p>';
+
+        expect(sanitise(badHtml)).toEqual(goodHtml);
+    });
+
+    it('Fix malformed anchor', () => {
+        const badHtml =
+            '<p><a href="https://theguardian.com" not="allowed"">Test</a></p>';
+        const goodHtml = '<p><a href="https://theguardian.com">Test</a></p>';
+
+        expect(sanitise(badHtml)).toEqual(goodHtml);
+    });
+});

--- a/packages/frontend/amp/lib/sanitise-html.ts
+++ b/packages/frontend/amp/lib/sanitise-html.ts
@@ -1,0 +1,3 @@
+import sanitiszeHtml from 'sanitize-html';
+
+export const sanitise = (html: string): string => sanitiszeHtml(html);

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -9,6 +9,7 @@
     "@guardian/guui": "2.0.0-alpha.1",
     "@guardian/pasteup": "1.0.0-alpha.8",
     "@types/lodash.escape": "^4.0.6",
+    "@types/sanitize-html": "^1.18.3",
     "aws-sdk": "^2.340.0",
     "compose-function": "^3.0.3",
     "compression": "^1.7.3",
@@ -30,7 +31,8 @@
     "polished": "^1.9.2",
     "raven-js": "3.19.1",
     "react": "^16.4.0",
-    "react-dom": "^16.4.0"
+    "react-dom": "^16.4.0",
+    "sanitize-html": "^1.20.1"
   },
   "devDependencies": {
     "@types/amphtml-validator": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1959,9 +1959,21 @@
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-0.0.29.tgz#a1e514adfbd92f03a224ba54d693111dbf1f3754"
 
+"@types/domhandler@*":
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/@types/domhandler/-/domhandler-2.4.1.tgz#7b3b347f7762180fbcb1ece1ce3dd0ebbb8c64cf"
+  integrity sha512-cfBw6q6tT5sa1gSPFSRKzF/xxYrrmeiut7E0TxNBObiLSBTuFEHibcfEe3waQPEDbqBsq+ql/TOniw65EyDFMA==
+
 "@types/dompurify@^0.0.31":
   version "0.0.31"
   resolved "https://registry.yarnpkg.com/@types/dompurify/-/dompurify-0.0.31.tgz#f152d5a81f2b5625e29f11eb016cd9b301d0d4b4"
+
+"@types/domutils@*":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@types/domutils/-/domutils-1.7.2.tgz#89422e579c165994ad5c09ce90325da596cc105d"
+  integrity sha512-Nnwy1Ztwq42SSNSZSh9EXBJGrOZPR+PQ2sRT4VZy8hnsFXfCil7YlKO2hd2360HyrtFz2qwnKQ13ENrgXNxJbw==
+  dependencies:
+    "@types/domhandler" "*"
 
 "@types/events@*":
   version "1.2.0"
@@ -2020,6 +2032,15 @@
     "@types/clean-css" "*"
     "@types/relateurl" "*"
     "@types/uglify-js" "*"
+
+"@types/htmlparser2@*":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/@types/htmlparser2/-/htmlparser2-3.10.0.tgz#b94d3b08f813c9eec12990ac6a34d8b17a7aebc9"
+  integrity sha512-keXxWwpNOTvRTWTS4cdLHPp3p6gSzitTCmLNgPJinEvS95QzjkhbEMSaQO4XkEp4ctXJu8P0j4xqEVOPsLj3vg==
+  dependencies:
+    "@types/domhandler" "*"
+    "@types/domutils" "*"
+    "@types/node" "*"
 
 "@types/jest@^23.3.5":
   version "23.3.12"
@@ -2124,6 +2145,13 @@
 "@types/relateurl@*":
   version "0.2.28"
   resolved "https://registry.yarnpkg.com/@types/relateurl/-/relateurl-0.2.28.tgz#6bda7db8653fa62643f5ee69e9f69c11a392e3a6"
+
+"@types/sanitize-html@^1.18.3":
+  version "1.18.3"
+  resolved "https://registry.yarnpkg.com/@types/sanitize-html/-/sanitize-html-1.18.3.tgz#5916419bac4e68ed50fa20dfdec2e597a9f932ee"
+  integrity sha512-rc2QO3fudRfDckthQj4xJ9oFpbWV6g1bkjNG5NSXeYo89f3qvOwBiKnFk6I12c4d3y2Qjrpst5YPh8PrdEKJcg==
+  dependencies:
+    "@types/htmlparser2" "*"
 
 "@types/serve-static@*":
   version "1.13.2"
@@ -14327,6 +14355,22 @@ sane@^2.0.0:
 sanitize-html@^1.18.2:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-1.20.0.tgz#9a602beb1c9faf960fb31f9890f61911cc4d9156"
+  dependencies:
+    chalk "^2.4.1"
+    htmlparser2 "^3.10.0"
+    lodash.clonedeep "^4.5.0"
+    lodash.escaperegexp "^4.1.2"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.mergewith "^4.6.1"
+    postcss "^7.0.5"
+    srcset "^1.0.0"
+    xtend "^4.0.1"
+
+sanitize-html@^1.20.1:
+  version "1.20.1"
+  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-1.20.1.tgz#f6effdf55dd398807171215a62bfc21811bacf85"
+  integrity sha512-txnH8TQjaQvg2Q0HY06G6CDJLVYCpbnxrdO0WN8gjCKaU5J0KbyGYhZxx5QJg3WLZ1lB7XU9kDkfrCXUozqptA==
   dependencies:
     chalk "^2.4.1"
     htmlparser2 "^3.10.0"


### PR DESCRIPTION
## What does this change?

Discuss: AMP fails validation *lots* because someone has pasted in a random anchor and it contains dodgy attributes here and malformed markup there. This will likely fix a vast swathe of those AMP pages.

This adds the [`sanitize-html`](https://www.npmjs.com/package/sanitize-html) module to run over the text element html. It uses the defaults, [see tests here](https://github.com/punkave/sanitize-html/blob/master/test/test.js).

- Arguably, this should be done as a batch job on all existing articles and stored in CAPI... but is that likely? 
- It's also generally older articles we see issues, do we need the performance hit on newer articles?
- Do we trust the defaults? Looking at the tests, and *for AMP* I think I do...

I've not added massive amount of tests as they're already in the module and I've not added any custom filters.

## Why?

Protect against malformed stuff invalidating AMP.

## Examples

![image](https://user-images.githubusercontent.com/638051/57299724-36b5c700-70cd-11e9-9854-93917cdb2db4.png)

![image](https://user-images.githubusercontent.com/638051/57299738-4503e300-70cd-11e9-9345-adddb090871e.png)

(After is top...)
![image](https://user-images.githubusercontent.com/638051/57299776-5cdb6700-70cd-11e9-8683-12ed9f4fc66d.png)


@guardian/dotcom-platform 
