### PR TITLE
Add Labs as Pillar to Amp 

### DIFF
--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -4,7 +4,7 @@ interface ArticleProps {
     config: ConfigType;
 }
 
-type Pillar = 'news' | 'opinion' | 'sport' | 'culture' | 'lifestyle';
+type Pillar = 'news' | 'opinion' | 'sport' | 'culture' | 'lifestyle' | 'labs';
 
 type Edition = 'UK' | 'US' | 'INT' | 'AU';
 

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -4,6 +4,7 @@ interface ArticleProps {
     config: ConfigType;
 }
 
+// 'labs' is a fake pillar used to identify paid content (Guardian Labs) for rendering styling.
 type Pillar = 'news' | 'opinion' | 'sport' | 'culture' | 'lifestyle' | 'labs';
 
 type Edition = 'UK' | 'US' | 'INT' | 'AU';

--- a/packages/frontend/lib/pillars.ts
+++ b/packages/frontend/lib/pillars.ts
@@ -14,6 +14,7 @@ export const pillarPalette: { [K in Pillar]: PillarColours } = {
     sport: palette.sport,
     culture: palette.culture,
     lifestyle: palette.lifestyle,
+    labs: palette.labs,
 };
 
 /*
@@ -28,6 +29,7 @@ export const pillarMap: <T>(
     sport: f('sport'),
     culture: f('culture'),
     lifestyle: f('lifestyle'),
+    labs: f('labs'),
 });
 /*
 Further notes on this function:

--- a/packages/frontend/model/extract-capi.test.ts
+++ b/packages/frontend/model/extract-capi.test.ts
@@ -398,10 +398,10 @@ describe('extract-capi', () => {
 
         findPillar.mockReturnValueOnce(testPillar);
 
-        const { pillar } = extract(testData);
+        const { tags, pillar } = extract(testData);
 
         expect(pillar).toBe(testPillar);
-        expect(findPillar).toHaveBeenCalledWith(testPillar);
+        expect(findPillar).toHaveBeenCalledWith(testPillar, tags);
     });
 
     it('defaults pillar to "news" if not valid', () => {
@@ -411,10 +411,10 @@ describe('extract-capi', () => {
 
         findPillar.mockReturnValueOnce(undefined);
 
-        const { pillar } = extract(testData);
+        const { tags, pillar } = extract(testData);
 
         expect(pillar).toBe('news');
-        expect(findPillar).toHaveBeenCalledWith(testPillar);
+        expect(findPillar).toHaveBeenCalledWith(testPillar, tags);
     });
 
     it('returns ageWarning as undefined if article not in tone/news', () => {

--- a/packages/frontend/model/extract-capi.ts
+++ b/packages/frontend/model/extract-capi.ts
@@ -183,7 +183,7 @@ export const extract = (data: {}): CAPIType => {
         ),
         pageId: getNonEmptyString(data, 'page.pageId'),
         sharingUrls: getSharingUrls(data),
-        pillar: findPillar(getString(data, 'page.pillar', '')) || 'news',
+        pillar: findPillar(getString(data, 'page.pillar', ''), tags) || 'news',
         ageWarning: getAgeWarning(tags, webPublicationDate),
         sectionLabel: getString(data, 'page.sectionLabel'),
         sectionUrl: getString(data, 'page.sectionUrl'),

--- a/packages/frontend/model/find-pillar.test.ts
+++ b/packages/frontend/model/find-pillar.test.ts
@@ -1,7 +1,7 @@
 import { findPillar } from './find-pillar';
 
 jest.mock('@frontend/lib/pillars', () => ({
-    pillarNames: ['news', 'opinion', 'sport', 'culture', 'lifestyle'],
+    pillarNames: ['news', 'opinion', 'sport', 'culture', 'lifestyle', 'labs'],
 }));
 
 describe('findPillar', () => {
@@ -13,7 +13,24 @@ describe('findPillar', () => {
         expect(findPillar('foo')).toBeUndefined();
     });
 
-    it('returns "culture if "arts"', () => {
-        expect(findPillar('Arts')).toBe('culture');
+    it('returns "culture" if "arts"', () => {
+        expect(findPillar('Arts', [])).toBe('culture');
+    });
+
+    it('returns "labs" if paid content tagging exists', () => {
+        const tags = [
+            {
+                id: 'money/ticket-prices',
+                type: 'Keyword',
+                title: 'Ticket prices',
+            },
+            {
+                id: 'tone/advertisement-features',
+                type: 'Tone',
+                title: 'Consumer affairs',
+            },
+        ];
+
+        expect(findPillar('Arts', tags)).toBe('labs');
     });
 });

--- a/packages/frontend/model/find-pillar.ts
+++ b/packages/frontend/model/find-pillar.ts
@@ -1,6 +1,17 @@
 import { pillarNames } from '@frontend/lib/pillars';
 
-export const findPillar: (name: string) => Pillar | undefined = name => {
+export const findPillar: (
+    name: string,
+    tags?: TagType[],
+) => Pillar | undefined = (name, tags?) => {
+    // Flag paid content for Labs pillar (for styling purposes)
+    const isPaidContent = (tag: any) =>
+        tag.type === 'Tone' && tag.id === 'tone/advertisement-features';
+
+    if (tags && tags.some(isPaidContent)) {
+        return 'labs';
+    }
+
     const pillar: string = name.toLowerCase();
     // The pillar name is "arts" in CAPI, but "culture" everywhere else,
     // therefore we perform this substitution here.

--- a/packages/pasteup/palette.ts
+++ b/packages/pasteup/palette.ts
@@ -12,6 +12,7 @@ export interface AllPillarColours {
     sport: PillarColours;
     culture: PillarColours;
     lifestyle: PillarColours;
+    labs: PillarColours;
 }
 export interface OtherColours {
     highlight: { main: colour; dark: colour };
@@ -20,6 +21,7 @@ export interface OtherColours {
         20: colour;
         46: colour;
         60: colour;
+        85: colour;
         86: colour;
         93: colour;
         97: colour;
@@ -115,18 +117,22 @@ const neutral = {
     20: '#333333',
     46: '#767676',
     60: '#999999',
+    85: '#d9d9d9',
     86: '#dcdcdc',
     93: '#ededed',
     97: '#f6f6f6',
     100: '#ffffff',
 };
 
-const specialReport = { dark: '#3f464a' };
-
-const labs = {
-    dark: '#65a897',
-    main: '#69d1ca',
+const labs: PillarColours & {} = {
+    dark: neutral[7],
+    main: neutral[7],
+    bright: '#69d1ca', // bright teal
+    pastel: '', // TODO
+    faded: '#65a897', // dark teal
 };
+
+const specialReport = { dark: '#3f464a' };
 
 const contrasts = {
     darkOnLight: {
@@ -152,10 +158,10 @@ export const palette: AllPillarColours & OtherColours & Appearances = {
     sport,
     culture,
     lifestyle,
+    labs,
     highlight,
     neutral,
     specialReport,
-    labs,
     green,
     brand,
     state,

--- a/packages/pasteup/palette.ts
+++ b/packages/pasteup/palette.ts
@@ -124,7 +124,7 @@ const neutral = {
     100: '#ffffff',
 };
 
-const labs: PillarColours & {} = {
+const labs: PillarColours = {
     dark: neutral[7],
     main: neutral[7],
     bright: '#69d1ca', // bright teal


### PR DESCRIPTION
## What does this change?

- Adds a fifth **`'labs'`** pillar to the model and `pasteup/palette`
- Updated `findPillar` function in Model to flag any paid content (identified by tone/advertisement-feature tag) as part of the 'labs' pillar
- Adds tests for findPillar and impacted extractCapi functions

## Why?

The 'labs' pillar will be used for styling Guardian Labs (paid content) across amp components in a subsequent PR I am working on.

I opted for 'labs' for brevity but can change this pillar to 'paid-content' if people prefer? The hard-coded 'labs' string will only appear in these files, but css styles variable names in some components will reference 'Labs' for consistency. 
