### PR TITLE
Add lang attribute to html element

### DIFF
--- a/packages/frontend/amp/server/document.tsx
+++ b/packages/frontend/amp/server/document.tsx
@@ -43,7 +43,7 @@ export const document = ({
             : 'favicon-32x32-dev-yellow.ico';
 
     return `<!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
     <head>
     <meta charset="utf-8">
 

--- a/packages/frontend/web/server/htmlTemplate.ts
+++ b/packages/frontend/web/server/htmlTemplate.ts
@@ -36,7 +36,7 @@ export const htmlTemplate = ({
             : 'favicon-32x32-dev-yellow.ico';
 
     return `<!doctype html>
-        <html>
+        <html lang="en">
             <head>
                 <title>${title}</title>
                 <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">


### PR DESCRIPTION
## What does this change?

Adds language attribute to html tag in AMP and Web document: `<html lang="en">`

## Why?

A11y improvements