### PR TITLE
Publish pasteup typedefs

### DIFF
--- a/makefile
+++ b/makefile
@@ -126,22 +126,6 @@ clear: # private
 
 # packages #########################################
 
-clean-pasteup:
-	@rm -rf packages/pasteup/dist packages/pasteup/tmp
-
-pre-publish-pasteup:
-	$(call log, "building pasteup")
-	@mkdir packages/pasteup/tmp
-	@NODE_ENV=production webpack --config scripts/webpack/pasteup
-	@mv packages/pasteup/*.ts packages/pasteup/tmp
-	@mv packages/pasteup/dist/*.js packages/pasteup
-
-post-publish-pasteup:
-	$(call log, "clean up after publishing pasteup")
-	@mv packages/pasteup/tmp/*.ts packages/pasteup
-	@mv packages/pasteup/*.js packages/pasteup/tmp
-	@make clean-pasteup
-
-publish-pasteup: clear clean-pasteup install
+publish-pasteup: clear install
 	$(call log, "publishing pasteup")
 	@cd packages/pasteup && yarn publish

--- a/packages/pasteup/package.json
+++ b/packages/pasteup/package.json
@@ -1,23 +1,21 @@
 {
   "name": "@guardian/pasteup",
-  "version": "1.0.0-alpha.8",
+  "version": "1.0.0-alpha.10",
   "description": "Guardian design tokens",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/dotcom-rendering"
   },
   "files": [
-    "breakpoints.js",
-    "typography.js",
-    "mixins.js",
-    "palette.js",
+    "*.js",
+    "*.d.ts",
     "icons",
     "logos"
   ],
   "scripts": {
     "test": "jest",
-    "prepublish": "cd ../.. && make pre-publish-pasteup",
-    "postpublish": "cd ../.. && make post-publish-pasteup"
+    "postpublish": "rm -rf lib",
+    "prepublish": "tsc -p ."
   },
   "dependencies": {},
   "license": "Apache-2.0"

--- a/packages/pasteup/package.json
+++ b/packages/pasteup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/pasteup",
-  "version": "1.0.0-alpha.10",
+  "version": "1.0.0-alpha.10.1",
   "description": "Guardian design tokens",
   "repository": {
     "type": "git",
@@ -9,12 +9,13 @@
   "files": [
     "*.js",
     "*.d.ts",
+    "*.js.map",
+    "*.d.ts.map",
     "icons",
     "logos"
   ],
   "scripts": {
     "test": "jest",
-    "postpublish": "rm -rf lib",
     "prepublish": "tsc -p ."
   },
   "dependencies": {},

--- a/packages/pasteup/tsconfig.json
+++ b/packages/pasteup/tsconfig.json
@@ -1,0 +1,26 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+
+        "allowJs": false /* Allow javascript files to be compiled. */,
+        "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+        "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+        "sourceMap": true,                     /* Generates corresponding '.map' file. */
+        "outDir": "./",                        /* Redirect output structure to the directory. */
+        "noEmit": false /* Do not emit outputs. */,
+        "baseUrl": "./", /* Base directory to resolve non-absolute module names. */
+        /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+        "paths": {
+            /* Aliases should also be added to the webpack, babel and jest configurations */
+            "@root/*": [
+                "../../*"
+            ],
+            "@frontend/*": [
+                "../../packages/frontend/*"
+            ],
+        },
+    },
+    "exclude": [
+        "node_modules"
+    ],
+}


### PR DESCRIPTION
## What does this change?

Typescript type definitions when we publish pasteup.

## Why?

to consume pasteup

nb have published up to apha 10.10.1, will republish as alpha.11 on merge