### PR TITLE
A11y quick wins

### DIFF
--- a/packages/frontend/amp/components/Header.tsx
+++ b/packages/frontend/amp/components/Header.tsx
@@ -210,7 +210,11 @@ export const Header: React.FC<{
             {pillarLinks(nav.pillars, guardianBaseURL)}
 
             {/* Note, the actual sidebar lives directly in the body as AMP requires this :( */}
-            <button className={veggieStyles} on="tap:sidebar1.toggle">
+            <button
+                className={veggieStyles}
+                aria-label="Toggle main menu"
+                on="tap:sidebar1.toggle"
+            >
                 <span className={pattyStyles} />
             </button>
         </div>

--- a/packages/frontend/amp/components/MainMedia.tsx
+++ b/packages/frontend/amp/components/MainMedia.tsx
@@ -91,10 +91,10 @@ const mainImage = (element: ImageBlockElement): JSX.Element | null => {
                     <input
                         aria-checked={false}
                         type="checkbox"
-                        id="show-caption"
+                        aria-label="show-caption"
                         className={inputStyle}
                     />
-                    <label className={labelStyle} htmlFor="show-caption">
+                    <label className={labelStyle}>
                         <InfoIcon />
                     </label>
                     <figcaption className={captionStyle}>

--- a/packages/frontend/amp/components/TopMetaPaidContent.tsx
+++ b/packages/frontend/amp/components/TopMetaPaidContent.tsx
@@ -50,6 +50,7 @@ const PaidForByLogo: React.FC<{
                 href={logo.link}
                 data-sponsor={sponsorName.toLowerCase()}
                 rel="nofollow"
+                aria-label={`Visit the ${sponsorName} website`}
             >
                 <amp-img
                     src={logo.src}

--- a/packages/frontend/web/components/Dateline.tsx
+++ b/packages/frontend/web/components/Dateline.tsx
@@ -26,11 +26,7 @@ export const Dateline: React.FC<{
     descriptionText: string;
 }> = ({ dateDisplay, descriptionText }) => (
     <>
-        <div
-            className={dateline}
-            // tslint:disable-next-line:react-a11y-role
-            role="text"
-        >
+        <div className={dateline} role="textbox">
             <span className={description}>{descriptionText} </span>
             {dateDisplay}
         </div>

--- a/packages/frontend/web/components/Header/Nav/MainMenuToggle/VeggieBurger.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenuToggle/VeggieBurger.tsx
@@ -97,6 +97,7 @@ export const VeggieBurger: React.FC<{
                 className={veggieBurger({ showMainMenu })}
                 onClick={() => toggleMainMenu()}
                 aria-controls={ariaControls}
+                aria-label="Toggle main menu"
             >
                 <span className={veggieBurgerIcon({ showMainMenu })} />
             </button>
@@ -110,6 +111,7 @@ export const VeggieBurger: React.FC<{
             htmlFor={htmlFor}
             tabIndex={0}
             role="button"
+            aria-label="Toggle main menu"
         >
             <span className={veggieBurgerIcon({ showMainMenu })} />
         </label>


### PR DESCRIPTION
## What does this change?

Gets us here on Article and AMPArticle pages. Specifics in the commit history. 

The remaining errors are in the Onward content component which I did not have time to look into for the PR.  This does not include any manual checks which need to be looked at.

![image](https://user-images.githubusercontent.com/32312712/57531317-0cfcda00-7331-11e9-82e1-cdf1f363b262.png)
![image](https://user-images.githubusercontent.com/32312712/57531344-1ab25f80-7331-11e9-98c2-2be9fcf69cad.png)




## Why?

Hopefully the answer is obvious! 
