### PR TITLE
Use eslint instead of tslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,16 @@
+module.exports = {
+    "parser": '@typescript-eslint/parser',
+    "plugins": [
+        "@typescript-eslint/tslint"
+    ],
+    parserOptions: {
+        ecmaVersion: 6,
+        project: "./tsconfig.json",
+        sourceType: "module"
+    },
+    'rules': {
+        "@typescript-eslint/tslint/config": [1, {
+            "lintFile": "./tslint.json", // path to tslint.json of your project
+        }],
+    }
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ declare global {
     /*~ Here, declare things that go in the global namespace, or augment
      *~ existing declarations in the global namespace
      */
-    interface Window { 
+    interface Window {
         guardian: {
             app: {
                 data: any;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "packages/*"
     ],
     "scripts": {
-        "lint": "yarn tslint --project tsconfig.json -p . -t stylish",
+        "lint": "eslint . --ext .ts",
         "tsc": "tsc",
         "test": "jest",
         "postinstall": "./scripts/git-hooks/install.js"
@@ -34,6 +34,9 @@
         "@types/react-test-renderer": "^16.0.3",
         "@types/webpack": "^4.4.11",
         "@types/webpack-env": "^1.13.6",
+        "@typescript-eslint/eslint-plugin": "^1.7.0",
+        "@typescript-eslint/eslint-plugin-tslint": "^1.7.0",
+        "@typescript-eslint/parser": "^1.7.0",
         "babel-core": "^7.0.0-bridge.0",
         "babel-jest": "^23.6.0",
         "babel-loader": "^8.0.0",
@@ -42,6 +45,7 @@
         "babel-plugin-module-resolver": "^3.1.1",
         "babel-plugin-preval": "^3.0.0",
         "bundlesize": "^0.17.0",
+        "eslint": "^5.16.0",
         "friendly-errors-webpack-plugin": "^1.7.0",
         "jest": "^23.6.0",
         "jest-dom": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "packages/*"
     ],
     "scripts": {
-        "lint": "eslint . --ext .ts",
+        "lint": "eslint . --ext .ts,.tsx",
         "tsc": "tsc",
         "test": "jest",
         "postinstall": "./scripts/git-hooks/install.js"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,10 @@
 {
     "compilerOptions": {
         /* Basic Options */
-        "target":
-            "ESNEXT" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
-        "module":
-            "ESNext" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
-        "lib": ["esnext","es2015","dom"], /* Specify library files to be included in the compilation. */
+        "target": "ESNEXT" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
+        "module": "ESNext" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
+        "lib": ["esnext", "es2015", "dom"],
+        /* Specify library files to be included in the compilation. */
         "allowJs": true /* Allow javascript files to be compiled. */,
         // "checkJs": true,                       /* Report errors in .js files. */
         "jsx": "react" /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */,
@@ -22,7 +21,7 @@
         // "downlevelIteration": true,            /* Provide full suppotrt for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
         // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
         /* Strict Type-Checking Options */
-        "strict": true  /* Enable all strict type-checking options. */,
+        "strict": true /* Enable all strict type-checking options. */,
         // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
         // "strictNullChecks": true,              /* Enable strict null checks. */
         // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
@@ -31,25 +30,30 @@
         // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 
         /* Additional Checks */
-        "noUnusedLocals": true,                   /* Report errors on unused locals. */
+        "noUnusedLocals": true,
+        /* Report errors on unused locals. */
         // "noUnusedParameters": true,            /* Report errors on unused parameters. */
         // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
         // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
 
         /* Module Resolution Options */
-        "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-        "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+        "moduleResolution": "node",
+        /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+        "baseUrl": "./",
+        /* Base directory to resolve non-absolute module names. */
         /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
         "paths": {
             /* Aliases should also be added to the webpack, babel and jest configurations */
             "@root/*": ["./*"],
-            "@frontend/*": ["./packages/frontend/*"],
-         },
+            "@frontend/*": ["./packages/frontend/*"]
+        },
         // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
         // "typeRoots": [],                       /* List of folders to include type definitions from. */
         // "types": [],                           /* Type declaration files to be included in compilation. */
-        "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-        "esModuleInterop": true, /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+        "allowSyntheticDefaultImports": true,
+        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+        "esModuleInterop": true,
+        /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
         // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
 
         /* Source Map Options */
@@ -57,12 +61,9 @@
         // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
         // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
         // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-        "forceConsistentCasingInFileNames": true,
+        "forceConsistentCasingInFileNames": true
         /* Experimental Options */
         // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
         // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
-    },
-    "exclude": [
-        "node_modules"
-    ],
+    }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -35,10 +35,11 @@
         ],
         "no-default-export": true,
         "react-no-dangerous-html": true,
-        "prettier": true
+        "prettier": true,
+        "interface-over-type-literal": false
     },
     "rulesDirectory": [],
     "linterOptions": {
-        "exclude": ["packages/*/dist/**/*.js","coverage/*"]
+        "exclude": ["packages/*/dist/**/*.js", "coverage/*"]
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2234,6 +2234,42 @@
     "@types/uglify-js" "*"
     source-map "^0.6.0"
 
+"@typescript-eslint/eslint-plugin-tslint@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin-tslint/-/eslint-plugin-tslint-1.7.0.tgz#6787d32c80bcc539af4b446620ee90b461864438"
+  integrity sha512-lvz7hKqdQXE1cV+w00gWYrM3ChP2S01KrRKogsy6l+nDV2Bv7qAnRGAh+j8qxNQCEskJMf2litXR3g/e+yeCdA==
+  dependencies:
+    lodash.memoize "^4.1.2"
+
+"@typescript-eslint/eslint-plugin@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.7.0.tgz#570e45dc84fb97852e363f1e00f47e604a0b8bcc"
+  integrity sha512-NUSz1aTlIzzTjFFVFyzrbo8oFjHg3K/M9MzYByqbMCxeFdErhLAcGITVfXzSz+Yvp5OOpMu3HkIttB0NyKl54Q==
+  dependencies:
+    "@typescript-eslint/parser" "1.7.0"
+    "@typescript-eslint/typescript-estree" "1.7.0"
+    eslint-utils "^1.3.1"
+    regexpp "^2.0.1"
+    requireindex "^1.2.0"
+    tsutils "^3.7.0"
+
+"@typescript-eslint/parser@1.7.0", "@typescript-eslint/parser@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-1.7.0.tgz#c3ea0d158349ceefbb6da95b5b09924b75357851"
+  integrity sha512-1QFKxs2V940372srm12ovSE683afqc1jB6zF/f8iKhgLz1yoSjYeGHipasao33VXKI+0a/ob9okeogGdKGvvlg==
+  dependencies:
+    "@typescript-eslint/typescript-estree" "1.7.0"
+    eslint-scope "^4.0.0"
+    eslint-visitor-keys "^1.0.0"
+
+"@typescript-eslint/typescript-estree@1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-1.7.0.tgz#59ec02f5371964da1cc679dba7b878a417bc8c60"
+  integrity sha512-K5uedUxVmlYrVkFbyV3htDipvLqTE3QMOUQEHYJaKtgzxj6r7c5Ca/DG1tGgFxX+fsbi9nDIrf4arq7Ib7H/Yw==
+  dependencies:
+    lodash.unescape "4.0.1"
+    semver "5.5.0"
+
 "@webassemblyjs/ast@1.7.11":
   version "1.7.11"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.7.11.tgz#b988582cafbb2b095e8b556526f30c90d057cace"
@@ -6332,9 +6368,10 @@ eslint-visitor-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
 
-eslint@^5.6.0:
+eslint@^5.16.0, eslint@^5.6.0:
   version "5.16.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.16.0.tgz#a1e3ac1aae4a3fbd8296fcf8f7ab7314cbb6abea"
+  integrity sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     ajv "^6.9.1"
@@ -10245,6 +10282,11 @@ lodash.toarray@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
 
+lodash.unescape@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
+  integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
+
 lodash.union@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.union/-/lodash.union-4.6.0.tgz#48bb5088409f16f1821666641c44dd1aaae3cd88"
@@ -14153,6 +14195,11 @@ require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
 
+requireindex@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
+  integrity sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==
+
 requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
@@ -16023,6 +16070,13 @@ tsutils@^2.13.1, tsutils@^2.27.2, tsutils@^2.29.0:
 tsutils@^3.0.0, tsutils@^3.5.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.7.0.tgz#f97bdd2f109070bd1865467183e015b25734b477"
+  dependencies:
+    tslib "^1.8.1"
+
+tsutils@^3.7.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.10.0.tgz#6f1c95c94606e098592b0dff06590cf9659227d6"
+  integrity sha512-q20XSMq7jutbGB8luhKKsQldRKWvyBO2BGqni3p4yq8Ys9bEP/xQw3KepKmMRt9gJ4lvQSScrihJrcKdKoSU7Q==
   dependencies:
     tslib "^1.8.1"
 


### PR DESCRIPTION
## What does this change?

An experiment to see if we could easily use eslint instead of tslint because we want to write some linting rules but tslint is [getting deprecated](https://medium.com/palantir/tslint-in-2019-1a144c2317a9) in favour of focus on ESlint using [typescript-eslint](https://github.com/typescript-eslint/typescript-eslint) (worth reading the `.README` on that repo) and [eslint-plugin-tslint](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin-tslint) which allows us to use the existing tslint config.

This also allows us to use the more mature eslint for rules and plugins as well as making it easier to [write our own](https://trello.com/c/EcVAyY2j/527-enforcing-pasteup-%E2%97%8F%E2%97%8F%E2%97%8F%E2%97%8F%E2%97%8F%E2%97%8F%E2%97%8F%E2%97%8F%E2%97%8F) if needed..

It was fairly easy as eslint provided plugins to use tsconfig, the migration was:

- Add an `.eslintrc.js` and point it at the existing `tsconfig` and `tslint.json` and using the eslint-plugin-tslint
- Replace the `tslint` command from the `lint command` in `package.json` with `eslint` -> `eslint . --ext .ts,.tsx`
- Add an `.eslintignore` file with `node_modules` as it didn't seem to take into account the `excludes` param in `tsconfig`

## Future
It's almost possible to run *just run* [typescript-eslint](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin) instead of using the tslint configs. We should revisit the [roadmap](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin) periodically to see if everything is supported and we can fully migrate.
