### PR TITLE
Fix typing of pillarpallette

### DIFF
--- a/packages/frontend/lib/pillars.ts
+++ b/packages/frontend/lib/pillars.ts
@@ -8,7 +8,7 @@ export const pillarNames: Pillar[] = [
     'lifestyle',
 ];
 
-export const pillarPalette: { [K in Pillar]: PillarColours } = {
+export const pillarPalette: Record<Pillar, PillarColours> = {
     news: palette.news,
     opinion: palette.opinion,
     sport: palette.sport,

--- a/packages/pasteup/package.json
+++ b/packages/pasteup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/pasteup",
-  "version": "1.0.0-alpha.10.1",
+  "version": "1.0.0-alpha.11",
   "description": "Guardian design tokens",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What does this change?
This changes the typing of pillarpallete to be a record.
## Why?
https://github.com/Microsoft/TypeScript-Handbook/blob/master/pages/Utility%20Types.md