### PR TITLE
Added AMP prebid user sync

### DIFF
--- a/packages/frontend/amp/components/AdUserSync.tsx
+++ b/packages/frontend/amp/components/AdUserSync.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+const preBidSrc =
+    'https://cdn.jsdelivr.net/npm/prebid-universal-creative@latest/dist/load-cookie.html';
+
+const preBidImg =
+    'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==';
+
+export const AdUserSync: React.FC<{}> = () => {
+    return (
+        <>
+            <amp-iframe
+                data-block-on-consent=""
+                width={1}
+                title={'User Sync'}
+                height={1}
+                sandbox={'allow-scripts'}
+                frameborder={0}
+                src={preBidSrc}
+            >
+                <amp-img layout={'fill'} src={preBidImg} placeholder="" />
+            </amp-iframe>
+        </>
+    );
+};

--- a/packages/frontend/amp/components/AdUserSync.tsx
+++ b/packages/frontend/amp/components/AdUserSync.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { css } from 'emotion';
 
 const preBidSrc =
     'https://cdn.jsdelivr.net/npm/prebid-universal-creative@latest/dist/load-cookie.html';
@@ -6,13 +7,19 @@ const preBidSrc =
 const preBidImg =
     'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==';
 
+const iframeStyle = css`
+    position: fixed;
+    top: -1px;
+`;
+
 export const AdUserSync: React.FC<{}> = () => {
     return (
         <amp-iframe
+            class={iframeStyle}
             data-block-on-consent="_till_accepted"
-            width="1"
             title="User Sync"
             height="1"
+            width="1"
             sandbox="allow-scripts"
             frameborder="0"
             src={preBidSrc}

--- a/packages/frontend/amp/components/AdUserSync.tsx
+++ b/packages/frontend/amp/components/AdUserSync.tsx
@@ -9,7 +9,7 @@ const preBidImg =
 export const AdUserSync: React.FC<{}> = () => {
     return (
         <amp-iframe
-            data-block-on-consent=""
+            data-block-on-consent="_till_accepted"
             width="1"
             title="User Sync"
             height="1"

--- a/packages/frontend/amp/components/AdUserSync.tsx
+++ b/packages/frontend/amp/components/AdUserSync.tsx
@@ -8,16 +8,16 @@ const preBidImg =
 
 export const AdUserSync: React.FC<{}> = () => {
     return (
-            <amp-iframe
-                data-block-on-consent=""
-                width="1"
-                title="User Sync"
-                height="1"
-                sandbox="allow-scripts"
-                frameborder="0"
-                src={preBidSrc}
-            >
-                <amp-img layout="fill" src={preBidImg} placeholder="" />
-            </amp-iframe>
+        <amp-iframe
+            data-block-on-consent=""
+            width="1"
+            title="User Sync"
+            height="1"
+            sandbox="allow-scripts"
+            frameborder="0"
+            src={preBidSrc}
+        >
+            <amp-img layout="fill" src={preBidImg} placeholder="" />
+        </amp-iframe>
     );
 };

--- a/packages/frontend/amp/components/AdUserSync.tsx
+++ b/packages/frontend/amp/components/AdUserSync.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { css } from 'emotion';
 
-const preBidSrc =
+const prebidSrc =
     'https://cdn.jsdelivr.net/npm/prebid-universal-creative@latest/dist/load-cookie.html';
 
-const preBidImg =
+const prebidImg =
     'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==';
 
-const iframeStyle = css`
+const prebidIframeStyle = css`
     position: fixed;
     top: -1px;
 `;
@@ -15,16 +15,16 @@ const iframeStyle = css`
 export const AdUserSync: React.FC<{}> = () => {
     return (
         <amp-iframe
-            class={iframeStyle}
+            class={prebidIframeStyle}
             data-block-on-consent="_till_accepted"
             title="User Sync"
             height="1"
             width="1"
             sandbox="allow-scripts"
             frameborder="0"
-            src={preBidSrc}
+            src={prebidSrc}
         >
-            <amp-img layout="fill" src={preBidImg} placeholder="" />
+            <amp-img layout="fill" src={prebidImg} placeholder="" />
         </amp-iframe>
     );
 };

--- a/packages/frontend/amp/components/AdUserSync.tsx
+++ b/packages/frontend/amp/components/AdUserSync.tsx
@@ -8,18 +8,16 @@ const preBidImg =
 
 export const AdUserSync: React.FC<{}> = () => {
     return (
-        <>
             <amp-iframe
                 data-block-on-consent=""
-                width={1}
-                title={'User Sync'}
-                height={1}
-                sandbox={'allow-scripts'}
-                frameborder={0}
+                width="1"
+                title="User Sync"
+                height="1"
+                sandbox="allow-scripts"
+                frameborder="0"
                 src={preBidSrc}
             >
-                <amp-img layout={'fill'} src={preBidImg} placeholder="" />
+                <amp-img layout="fill" src={preBidImg} placeholder="" />
             </amp-iframe>
-        </>
     );
 };

--- a/packages/frontend/amp/components/Header.tsx
+++ b/packages/frontend/amp/components/Header.tsx
@@ -193,6 +193,7 @@ export const Header: React.FC<{
             />
 
             {config.switches.subscribeWithGoogle && <GoogleSubscribeButton />}
+
             <a className={logoStyles} href={guardianBaseURL}>
                 <span
                     className={css`
@@ -201,7 +202,6 @@ export const Header: React.FC<{
                 >
                     The Guardian - Back to home
                 </span>
-
                 <Logo />
             </a>
         </div>

--- a/packages/frontend/amp/components/Header.tsx
+++ b/packages/frontend/amp/components/Header.tsx
@@ -8,7 +8,6 @@ import { palette } from '@guardian/pasteup/palette';
 import { ReaderRevenueButton } from '@root/packages/frontend/amp/components/ReaderRevenueButton';
 import { GoogleSubscribeButton } from '@root/packages/frontend/amp/components/GoogleSubscribeButton';
 import { mobileLandscape, until } from '@guardian/pasteup/breakpoints';
-import { AdUserSync } from '@root/packages/frontend/amp/components/AdUserSync';
 
 const headerStyles = css`
     background-color: ${palette.brand.main};
@@ -194,14 +193,12 @@ export const Header: React.FC<{
             />
 
             {config.switches.subscribeWithGoogle && <GoogleSubscribeButton />}
-
             <a className={logoStyles} href={guardianBaseURL}>
                 <span
                     className={css`
                         ${screenReaderOnly};
                     `}
                 >
-                    <AdUserSync />
                     The Guardian - Back to home
                 </span>
 

--- a/packages/frontend/amp/components/Header.tsx
+++ b/packages/frontend/amp/components/Header.tsx
@@ -205,6 +205,7 @@ export const Header: React.FC<{
                 <Logo />
             </a>
         </div>
+
         <div className={cx(row, navRow)}>
             {pillarLinks(nav.pillars, guardianBaseURL)}
 

--- a/packages/frontend/amp/components/Header.tsx
+++ b/packages/frontend/amp/components/Header.tsx
@@ -8,6 +8,7 @@ import { palette } from '@guardian/pasteup/palette';
 import { ReaderRevenueButton } from '@root/packages/frontend/amp/components/ReaderRevenueButton';
 import { GoogleSubscribeButton } from '@root/packages/frontend/amp/components/GoogleSubscribeButton';
 import { mobileLandscape, until } from '@guardian/pasteup/breakpoints';
+import { AdUserSync } from '@root/packages/frontend/amp/components/AdUserSync';
 
 const headerStyles = css`
     background-color: ${palette.brand.main};
@@ -200,12 +201,13 @@ export const Header: React.FC<{
                         ${screenReaderOnly};
                     `}
                 >
+                    <AdUserSync />
                     The Guardian - Back to home
                 </span>
+
                 <Logo />
             </a>
         </div>
-
         <div className={cx(row, navRow)}>
             {pillarLinks(nav.pillars, guardianBaseURL)}
 

--- a/packages/frontend/amp/pages/Article.tsx
+++ b/packages/frontend/amp/pages/Article.tsx
@@ -11,6 +11,7 @@ import { css } from 'emotion';
 import { Sidebar } from '@frontend/amp/components/Sidebar';
 import { Analytics, AnalyticsModel } from '@frontend/amp/components/Analytics';
 import { filterForTagsOfType } from '@frontend/amp/lib/tag-utils';
+import { AdUserSync } from '@root/packages/frontend/amp/components/AdUserSync';
 
 const backgroundColour = css`
     background-color: ${palette.neutral[97]};
@@ -76,6 +77,7 @@ export const Article: React.FC<{
 }> = ({ nav, articleData, config, analytics }) => (
     <>
         <Analytics key="analytics" analytics={analytics} />
+        <AdUserSync />
         <AdConsent />
 
         {/* /TODO change to gray bgcolor */}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1312,6 +1312,11 @@
     signedsource "^1.0.0"
     yargs "^9.0.0"
 
+"@guardian/pasteup@1.0.0-alpha.8":
+  version "1.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/@guardian/pasteup/-/pasteup-1.0.0-alpha.8.tgz#340cc86207523adc71b5b6cb1d6693e3afeab217"
+  integrity sha512-ojTYoCRQxUx6axiwCLX26JKGmIah/MJix6AiPGIplQ/DiO4oJXS6RUC+HfYIEZC8V1g3woqXzmVF2lgCfDtyIA==
+
 "@icons/material@^0.2.4":
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/@icons/material/-/material-0.2.4.tgz#e90c9f71768b3736e76d7dd6783fc6c2afa88bc8"


### PR DESCRIPTION
## What does this change?
This change adds AMP prebid user syncing that respects the user's ad consent settings.

The user sync iframe has been "hidden" in the header of the page where it will load as soon as the user opens the webpage, if the user had consented to personalized ads.

For first time users the iframe will wait for an explicit yes on the ad consent banner until it triggers.  


## Why?
For the phat(er) stacks.