### PR TITLE
Extract and display basic pagination for AMP liveblogs

### DIFF
--- a/packages/frontend/amp/components/BodyLiveblog.tsx
+++ b/packages/frontend/amp/components/BodyLiveblog.tsx
@@ -104,6 +104,35 @@ const Blocks: React.SFC<{
     return <>{transformedBlocks}</>;
 };
 
+const Pagination: React.SFC<{
+    pagination?: Pagination;
+    guardianURL: string;
+}> = ({ pagination, guardianURL }) => {
+    const link = (url: string, suffix?: string): JSX.Element => {
+        if (!suffix) {
+            return <></>;
+        }
+
+        return <a href={url + suffix}>{suffix}</a>;
+    };
+
+    if (!pagination) {
+        return null;
+    }
+
+    return (
+        <div>
+            {link(guardianURL, pagination.newest)}
+            {link(guardianURL, pagination.newer)}
+            <div>
+                Page {pagination.currentPage} of {pagination.totalPages}
+            </div>
+            {link(guardianURL, pagination.older)}
+            {link(guardianURL, pagination.oldest)}
+        </div>
+    );
+};
+
 export const Body: React.FC<{
     pillar: Pillar;
     data: ArticleModel;
@@ -111,11 +140,17 @@ export const Body: React.FC<{
 }> = ({ pillar, data, config }) => {
     const tone = getToneType(data.tags);
     const url = `${data.guardianBaseURL}/${data.pageId}`;
+    const isFirstPage = data.pagination
+        ? data.pagination.currentPage === 1
+        : false;
 
     return (
         <InnerContainer className={body(pillar, tone)}>
             <TopMeta tone={tone} data={data} />
             <KeyEvents events={data.keyEvents} pillar={pillar} url={url} />
+            {!isFirstPage && (
+                <Pagination guardianURL={url} pagination={data.pagination} />
+            )}
             <Blocks
                 pillar={pillar}
                 blocks={data.blocks}
@@ -127,6 +162,7 @@ export const Body: React.FC<{
                 commercialProperties={data.commercialProperties}
                 url={url}
             />
+            <Pagination guardianURL={url} pagination={data.pagination} />
             <SubMeta
                 sections={data.subMetaSectionLinks}
                 keywords={data.subMetaKeywordLinks}

--- a/packages/frontend/amp/pages/Article.tsx
+++ b/packages/frontend/amp/pages/Article.tsx
@@ -21,6 +21,7 @@ export interface ArticleModel {
     standfirst: string;
     mainMediaElements: CAPIElement[];
     keyEvents: Block[]; // liveblog-specific
+    pagination?: Pagination;
     blocks: Block[];
     author: AuthorType;
     webPublicationDateDisplay: string;

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -113,6 +113,15 @@ interface Block {
     title?: string;
 }
 
+interface Pagination {
+    currentPage: number;
+    totalPages: number;
+    newest?: string;
+    newer?: string;
+    oldest?: string;
+    older?: string;
+}
+
 interface CAPIType {
     headline: string;
     standfirst: string;
@@ -121,6 +130,7 @@ interface CAPIType {
     body: string;
     keyEvents: Block[];
     blocks: Block[];
+    pagination?: Pagination;
     author: AuthorType;
     webPublicationDate: Date;
     webPublicationDateDisplay: string;

--- a/packages/frontend/model/extract-capi.ts
+++ b/packages/frontend/model/extract-capi.ts
@@ -116,6 +116,16 @@ const getCommercialProperties = (data: {}): CommercialProperties => {
     ) as CommercialProperties;
 };
 
+const getPagination = (data: {}): Pagination | undefined => {
+    const found = optional(getObject.bind(null, data, 'page.pagination'));
+
+    if (found) {
+        return found as Pagination;
+    }
+
+    return undefined;
+};
+
 // TODO really it would be nice if we passed just the data we needed and
 // didn't have to do the transforms/lookups below. (While preserving the
 // validation on types.)
@@ -139,6 +149,7 @@ export const extract = (data: {}): CAPIType => {
     const editionId = getEditionValue(getString(data, 'page.editionId', ''));
 
     if (editionId === undefined) throw new Error('edition id is undefined');
+
     return {
         webPublicationDate,
         tags,
@@ -179,6 +190,7 @@ export const extract = (data: {}): CAPIType => {
         keyEvents: getArray<any>(data, 'page.content.blocks.keyEvents').filter(
             Boolean,
         ),
+        pagination: getPagination(data),
         blocks: getArray<any>(data, 'page.content.blocks.body').filter(Boolean),
         pageId: getNonEmptyString(data, 'page.pageId'),
         sharingUrls: getSharingUrls(data),


### PR DESCRIPTION
## What does this change?

Adds the most rudimentary pagination support you can imagine. See also https://github.com/guardian/frontend/pull/21410, which it depends on for the data.

## Why?

Another step towards getting liveblogs ready!

![Screenshot 2019-05-14 at 17 14 58](https://user-images.githubusercontent.com/858402/57714653-deeb0300-766c-11e9-9bb2-5ecd9dcde558.png)

(literally no effort to style this yet - as I want others to be able to contribute to this/styling can be broken up)
