### PR TITLE
Use createdOnDisplay and lastUpdatedOnDisplay from model

### DIFF
--- a/packages/frontend/amp/components/BodyLiveblog.tsx
+++ b/packages/frontend/amp/components/BodyLiveblog.tsx
@@ -82,7 +82,9 @@ const Blocks: React.SFC<{
         return (
             <div key={block.id} className={blockStyle(pillar)}>
                 {block.createdOnDisplay && (
-                    <a href={blockLink(url, block.id)}>{block.createdOnDisplay}</a>
+                    <a href={blockLink(url, block.id)}>
+                        {block.createdOnDisplay}
+                    </a>
                 )}
                 {block.title && <h2>{block.title}</h2>}
                 <Elements
@@ -96,7 +98,9 @@ const Blocks: React.SFC<{
                     commercialProperties={commercialProperties}
                     isImmersive={false}
                 />
-                {block.lastUpdatedDisplay && <span>{block.lastUpdatedDisplay}</span>}
+                {block.lastUpdatedDisplay && (
+                    <span>{block.lastUpdatedDisplay}</span>
+                )}
             </div>
         );
     });

--- a/packages/frontend/amp/components/BodyLiveblog.tsx
+++ b/packages/frontend/amp/components/BodyLiveblog.tsx
@@ -81,8 +81,8 @@ const Blocks: React.SFC<{
     const transformedBlocks = blocks.map(block => {
         return (
             <div key={block.id} className={blockStyle(pillar)}>
-                {block.createdOn && (
-                    <a href={blockLink(url, block.id)}>{block.createdOn}</a>
+                {block.createdOnDisplay && (
+                    <a href={blockLink(url, block.id)}>{block.createdOnDisplay}</a>
                 )}
                 {block.title && <h2>{block.title}</h2>}
                 <Elements
@@ -96,7 +96,7 @@ const Blocks: React.SFC<{
                     commercialProperties={commercialProperties}
                     isImmersive={false}
                 />
-                {block.lastUpdate && <span>{block.lastUpdate}</span>}
+                {block.lastUpdatedDisplay && <span>{block.lastUpdatedDisplay}</span>}
             </div>
         );
     });

--- a/packages/frontend/amp/components/KeyEvents.tsx
+++ b/packages/frontend/amp/components/KeyEvents.tsx
@@ -74,7 +74,7 @@ export const KeyEvents: React.SFC<{
     const lis = events.map(event => (
         <li className={listItemStyle} key={event.id}>
             <a className={eventLinkStyle} href={blockLink(url, event.id)}>
-                <span className={timeStyle}>{event.createdOn}</span>
+                <span className={timeStyle}>{event.createdOnDisplay}</span>
                 <span className={listTitleStyle(pillar)}>
                     {event.title || ''}
                 </span>

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -108,8 +108,8 @@ interface AuthorType {
 interface Block {
     id: string;
     elements: CAPIElement[];
-    createdOn?: number;
-    lastUpdate?: number;
+    createdOnDisplay?: string;
+    lastUpdatedDisplay?: string;
     title?: string;
 }
 


### PR DESCRIPTION
## What does this change?

This is a companion pr for this one: https://github.com/guardian/frontend/pull/21417 

## Why?

We now have a better display of the time of a liveblog entry

<img width="496" alt="Screenshot 2019-05-15 at 16 39 00" src="https://user-images.githubusercontent.com/6035518/57789028-06ef6a80-7730-11e9-8278-bfe703377cfc.png">
