### PR TITLE
Add text underline on hover in header nav

### DIFF
--- a/packages/frontend/amp/components/Header.tsx
+++ b/packages/frontend/amp/components/Header.tsx
@@ -84,6 +84,10 @@ const pillarLinkStyle = (pillar: Pillar) => css`
         padding: 7px 4px 0;
     }
 
+    :hover {
+        text-decoration: underline;
+    }
+
     :before {
         border-left: 1px solid rgba(255, 255, 255, 0.3);
         top: 0;


### PR DESCRIPTION
## What does this change?

This correct a small visual parity discrepancy I am have noticed while doing the live blog migration. We did not have `text-decoration: underline;` on hover in the navigation.

Before:

![before](https://user-images.githubusercontent.com/6035518/57857472-21384f80-77e7-11e9-83e4-43d8cc34d59d.png)


After:

![after](https://user-images.githubusercontent.com/6035518/57857480-239aa980-77e7-11e9-8954-f55a0609b6d5.png)
