### PR TITLE
Implementation of amp-live-list

### DIFF
--- a/packages/frontend/amp/components/BodyLiveblog.tsx
+++ b/packages/frontend/amp/components/BodyLiveblog.tsx
@@ -155,17 +155,28 @@ export const Body: React.FC<{
             {!isFirstPage && (
                 <Pagination guardianURL={url} pagination={data.pagination} />
             )}
-            <Blocks
-                pillar={pillar}
-                blocks={data.blocks}
-                // stuff for ads
-                edition={data.editionId}
-                section={data.sectionName}
-                contentType={data.contentType}
-                switches={config.switches}
-                commercialProperties={data.commercialProperties}
-                url={url}
-            />
+            <amp-live-list
+                id="live-blog-entries"
+                data-poll-interval="15000"
+                data-max-items-per-page="20"
+            >
+                <button update="" on="tap:my-live-list.update">
+                    You have updates
+                </button>
+                <div items="">
+                    <Blocks
+                        pillar={pillar}
+                        blocks={data.blocks}
+                        // stuff for ads
+                        edition={data.editionId}
+                        section={data.sectionName}
+                        contentType={data.contentType}
+                        switches={config.switches}
+                        commercialProperties={data.commercialProperties}
+                        url={url}
+                    />
+                </div>
+            </amp-live-list>
             <Pagination guardianURL={url} pagination={data.pagination} />
             <SubMeta
                 sections={data.subMetaSectionLinks}

--- a/packages/frontend/amp/components/BodyLiveblog.tsx
+++ b/packages/frontend/amp/components/BodyLiveblog.tsx
@@ -80,7 +80,12 @@ const Blocks: React.SFC<{
     // TODO add last updated for blocks to show here
     const transformedBlocks = blocks.map(block => {
         return (
-            <div key={block.id} className={blockStyle(pillar)}>
+            <div
+                id={block.id}
+                data-sort-time={block.createdOn}
+                key={block.id}
+                className={blockStyle(pillar)}
+            >
                 {block.createdOnDisplay && (
                     <a href={blockLink(url, block.id)}>
                         {block.createdOnDisplay}
@@ -156,7 +161,7 @@ export const Body: React.FC<{
                 <Pagination guardianURL={url} pagination={data.pagination} />
             )}
             <amp-live-list
-                id="live-blog-entries"
+                id="live-blog-entries-7ea0dbef"
                 data-poll-interval="15000"
                 data-max-items-per-page="20"
             >

--- a/packages/frontend/amp/components/BodyLiveblog.tsx
+++ b/packages/frontend/amp/components/BodyLiveblog.tsx
@@ -162,7 +162,6 @@ export const Body: React.FC<{
             )}
             <amp-live-list
                 id="live-blog-entries-7ea0dbef"
-                data-poll-interval="15000"
                 data-max-items-per-page="20"
             >
                 <button update="" on="tap:my-live-list.update">

--- a/packages/frontend/amp/components/lib/AMPAttributes.ts
+++ b/packages/frontend/amp/components/lib/AMPAttributes.ts
@@ -9,5 +9,7 @@ declare module 'react' {
         on?: string;
         overflow?: string;
         fallback?: '';
+        update?: '';
+        items?: '';
     }
 }

--- a/packages/frontend/amp/server/document.tsx
+++ b/packages/frontend/amp/server/document.tsx
@@ -76,6 +76,9 @@ export const document = ({
     <script async custom-element="amp-geo" src="https://cdn.ampproject.org/v0/amp-geo-0.1.js"></script>
     <script async custom-element="amp-consent" src="https://cdn.ampproject.org/v0/amp-consent-0.1.js"></script>
 
+    <!-- AMP element which is specific to the live blog -->
+    <script async custom-element="amp-live-list" src="https://cdn.ampproject.org/v0/amp-live-list-0.1.js"></script>
+
     <!-- AMP elements that are optional dependending on content -->
     ${scripts.join(' ')}
 

--- a/packages/frontend/amp/server/render.tsx
+++ b/packages/frontend/amp/server/render.tsx
@@ -26,9 +26,6 @@ export const render = ({ body }: express.Request, res: express.Response) => {
                       config.subscribeWithGoogleApiUrl,
                   )
                 : []),
-            ...[
-                '<script async custom-element="amp-live-list" src="https://cdn.ampproject.org/v0/amp-live-list-0.1.js"></script>',
-            ],
         ];
 
         const analytics: AnalyticsModel = {

--- a/packages/frontend/amp/server/render.tsx
+++ b/packages/frontend/amp/server/render.tsx
@@ -26,6 +26,9 @@ export const render = ({ body }: express.Request, res: express.Response) => {
                       config.subscribeWithGoogleApiUrl,
                   )
                 : []),
+            ...[
+                '<script async custom-element="amp-live-list" src="https://cdn.ampproject.org/v0/amp-live-list-0.1.js"></script>',
+            ],
         ];
 
         const analytics: AnalyticsModel = {

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -231,6 +231,7 @@ declare namespace JSX {
         'amp-youtube': any;
         'amp-geo': any;
         'amp-consent': any;
+        'amp-live-list': any;
         template: any;
     }
 }

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -108,6 +108,7 @@ interface AuthorType {
 interface Block {
     id: string;
     elements: CAPIElement[];
+    createdOn?: number;
     createdOnDisplay?: string;
     lastUpdatedDisplay?: string;
     title?: string;

--- a/packages/frontend/lib/content.d.ts
+++ b/packages/frontend/lib/content.d.ts
@@ -1,4 +1,6 @@
-type Switches = { [key: string]: boolean };
+interface Switches {
+    [key: string]: boolean;
+}
 
 type Weighting =
     | 'inline'


### PR DESCRIPTION
## What does this change?

This adds an AMP wrapper ( https://amp.dev/documentation/components/amp-live-list ) around DCR's live blog's entries for automatic update. 

**Existing UI effect when updates are available**: 

<img width="622" alt="old" src="https://user-images.githubusercontent.com/6035518/58095314-a7c7a500-7bca-11e9-9758-ac3967744d1d.png">


**(Un-styled) Effects by amp-live-list**

<img width="646" alt="new" src="https://user-images.githubusercontent.com/6035518/58095376-ccbc1800-7bca-11e9-90ad-ee6d7eef4d05.png">

nb (1): The styling will come later.

nb (2): `live-blog-entries-7ea0dbef` is the unique id that the update process can look up for new contents. There is no special meaning to it, just that it's unique. 

nb (3): The `amp-live-list` script will be conditionally inserted in a future PR, for the moment it comes as default.

## Why?

To match the existing functionality of the AMP live blog.


 
