### PR TITLE
Lint usage of hex colours

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -7,6 +7,6 @@
   "rules": {
     "no-duplicate-selectors": null,
     "no-descending-specificity": null,
-    "color-no-hex": true
+    "color-no-hex": [true, { "message": "Please use the pasteup palette variables instead of hex values"}]
   }
 }

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -6,6 +6,7 @@
   ],
   "rules": {
     "no-duplicate-selectors": null,
-    "no-descending-specificity": null
+    "no-descending-specificity": null,
+    "color-no-hex": true
   }
 }

--- a/packages/frontend/amp/components/Expandable.tsx
+++ b/packages/frontend/amp/components/Expandable.tsx
@@ -17,8 +17,8 @@ const wrapper = (pillar: Pillar) => css`
     border-top: 13px solid ${palette.neutral[7]};
     border-image: repeating-linear-gradient(
             to bottom,
-            #dcdcdc,
-            #dcdcdc 1px,
+            ${palette.neutral[86]},
+            ${palette.neutral[86]} 1px,
             transparent 1px,
             transparent 4px
         )

--- a/packages/frontend/amp/components/KeyEvents.tsx
+++ b/packages/frontend/amp/components/KeyEvents.tsx
@@ -12,7 +12,7 @@ const headingStyle = css`
     padding: 0.375rem 0.625rem;
 
     span {
-        background-color: #767676;
+        background-color: ${palette.neutral[46]};
         float: right;
         position: relative;
     }
@@ -29,7 +29,7 @@ const listItemStyle = css`
     width: 100%;
     overflow: hidden;
     min-height: 2.5rem;
-    border-bottom: 0.0625rem solid #dcdcdc;
+    border-bottom: 0.0625rem solid ${palette.neutral[86]};
     padding: 0.125rem 0 0.375rem;
 `;
 
@@ -55,7 +55,7 @@ const wrapper = css`
 const eventLinkStyle = css`
     display: block;
     text-decoration: none;
-    color: #005689;
+    color: ${palette.sport.dark};
     :hover {
         text-decoration: underline;
     }

--- a/packages/frontend/amp/components/Sidebar.tsx
+++ b/packages/frontend/amp/components/Sidebar.tsx
@@ -29,7 +29,7 @@ const toggle = css`
         position: absolute;
 
         :before {
-            border: 2px solid #fff;
+            border: 2px solid ${palette.neutral[100]};
             border-top: 0;
             border-left: 0;
             content: '';
@@ -75,7 +75,7 @@ const link = css`
 `;
 
 const subLinks = css`
-    background-color: #041f4a;
+    background-color: ${palette.brand.dark};
     padding-bottom: 12px;
 
     a {
@@ -92,7 +92,7 @@ const otherLinks = css`
 const membershipLinks = css`
     a {
         font-weight: 700;
-        color: #ffe500;
+        color: ${palette.highlight.main};
     }
 `;
 

--- a/packages/frontend/amp/components/elements/Subheading.tsx
+++ b/packages/frontend/amp/components/elements/Subheading.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { css, cx } from 'emotion';
+import { palette } from '@guardian/pasteup/palette';
 import { headline } from '@guardian/pasteup/typography';
 import { pillarPalette } from '@frontend/lib/pillars';
 
@@ -16,7 +17,7 @@ const style = (pillar: Pillar) => css`
     a {
         color: ${pillarPalette[pillar].dark};
         text-decoration: none;
-        border-bottom: 1px solid #dcdcdc;
+        border-bottom: 1px solid ${palette.neutral[86]};
         :hover {
             border-bottom: 1px solid ${pillarPalette[pillar].dark};
         }

--- a/packages/frontend/amp/components/elements/Text.tsx
+++ b/packages/frontend/amp/components/elements/Text.tsx
@@ -25,7 +25,7 @@ export const TextStyle = (pillar: Pillar) => css`
     a {
         color: ${pillarPalette[pillar].dark};
         text-decoration: none;
-        border-bottom: 1px solid #dcdcdc;
+        border-bottom: 1px solid ${palette.neutral[86]};
         :hover {
             border-bottom: 1px solid ${pillarPalette[pillar].dark};
         }

--- a/packages/frontend/web/components/ArticleBody.tsx
+++ b/packages/frontend/web/components/ArticleBody.tsx
@@ -328,7 +328,7 @@ const linkColour = pillarMap(
     pillar => css`
         a {
             text-decoration: none;
-            border-bottom: 1px solid #dcdcdc;
+            border-bottom: 1px solid ${palette.neutral[86]};
             ${pillarColours[pillar]};
 
             :hover {


### PR DESCRIPTION
## What does this change?
Prevents the usage of hex values for `color: ` encouraging the palette.

![image](https://user-images.githubusercontent.com/638051/58187856-812f6a00-7caf-11e9-9cd3-58109c17bd2a.png)

## Why?
Enforces consistency.

Note: Doesn't handle the rgba cases which I'll review in a separate PR.
