### PR TITLE
AMP liveblog ads

### DIFF
--- a/packages/frontend/amp/components/Ad.test.tsx
+++ b/packages/frontend/amp/components/Ad.test.tsx
@@ -38,6 +38,7 @@ describe('AdComponent', () => {
                 contentType={contentType}
                 config={commercialConfig}
                 commercialProperties={commercialProperties}
+                className=""
             />,
         );
 
@@ -85,6 +86,7 @@ describe('AdComponent', () => {
                 contentType={contentType}
                 config={commercialConfig}
                 commercialProperties={commercialProperties}
+                className=""
             />,
         );
 
@@ -129,6 +131,7 @@ describe('AdComponent', () => {
                 contentType={contentType}
                 config={commercialConfig}
                 commercialProperties={commercialProperties}
+                className=""
             />,
         );
 
@@ -174,6 +177,7 @@ describe('AdComponent', () => {
                 contentType={contentType}
                 config={commercialConfig}
                 commercialProperties={commercialProperties}
+                className=""
             />,
         );
 

--- a/packages/frontend/amp/components/Ad.tsx
+++ b/packages/frontend/amp/components/Ad.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { css, cx } from 'emotion';
-import { until } from '@guardian/pasteup/breakpoints';
 import { palette } from '@guardian/pasteup/palette';
 import { adJson, stringify } from '@frontend/amp/lib/ad-json';
 
@@ -11,18 +10,11 @@ const adStyle = css`
     background-repeat: no-repeat;
     background-position: center;
     border-top: 1px solid ${palette.neutral[86]};
-    float: right;
     height: 272px;
     width: 300px;
-    margin: 4px 0 12px 20px;
-
-    ${until.phablet} {
-        clear: both;
-        float: none;
-        text-align: center;
-        margin-right: auto;
-        margin-left: auto;
-    }
+    clear: both;
+    text-align: center;
+    margin: 0 auto 12px;
 
     :before {
         content: 'Advertisement';

--- a/packages/frontend/amp/components/Ad.tsx
+++ b/packages/frontend/amp/components/Ad.tsx
@@ -141,10 +141,11 @@ const ampAdElem = (
     contentType: string,
     config: CommercialConfig,
     commercialProperties: CommercialProperties,
+    className: string,
 ) => {
     return (
         <amp-ad
-            class={cx(adClass, adRegionClasses[adRegion])}
+            class={cx(adClass, adRegionClasses[adRegion], className)}
             data-block-on-consent=""
             width={300}
             height={250}
@@ -169,7 +170,15 @@ export const Ad: React.SFC<{
     contentType: string;
     config: CommercialConfig;
     commercialProperties: CommercialProperties;
-}> = ({ edition, section, contentType, config, commercialProperties }) => (
+    className: string;
+}> = ({
+    edition,
+    section,
+    contentType,
+    config,
+    commercialProperties,
+    className,
+}) => (
     <div className={adStyle}>
         {ampAdElem(
             'US',
@@ -178,6 +187,7 @@ export const Ad: React.SFC<{
             contentType,
             config,
             commercialProperties,
+            className,
         )}
         {ampAdElem(
             'AU',
@@ -186,6 +196,7 @@ export const Ad: React.SFC<{
             contentType,
             config,
             commercialProperties,
+            className,
         )}
         {ampAdElem(
             'ROW',
@@ -194,6 +205,7 @@ export const Ad: React.SFC<{
             contentType,
             config,
             commercialProperties,
+            className,
         )}
     </div>
 );

--- a/packages/frontend/amp/components/Blocks.tsx
+++ b/packages/frontend/amp/components/Blocks.tsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import { Elements } from '@frontend/amp/components/Elements';
+import { css } from 'emotion';
+import { pillarPalette } from '@frontend/lib/pillars';
+import { palette } from '@guardian/pasteup/palette';
+import { blockLink } from '@frontend/amp/lib/block-link';
+import { Ad } from '@frontend/amp/components/Ad';
+import { findBlockAdSlots } from '@frontend/amp/lib/find-adslots';
+import { textSans } from '@guardian/pasteup/typography';
+
+const blockStyle = (pillar: Pillar) => css`
+    padding: 6px 10px 12px;
+    background-color: ${palette.neutral[100]};
+    border-top: 1px solid ${pillarPalette[pillar].dark};
+    border-bottom: 1px solid ${palette.neutral[93]};
+    margin-bottom: 12px;
+    blockquote {
+        margin-left: 40px;
+    }
+`;
+
+const blockCreatedOnStyle = css`
+    color: ${palette.neutral[7]};
+    line-height: 2rem;
+    margin-bottom: 10px;
+    text-decoration: none;
+    font-weight: bold;
+`;
+
+const lastUpdatedStyle = css`
+    ${textSans(1)};
+    color: ${palette.neutral[60]};
+    text-align: right;
+    padding-right: 15px;
+`;
+
+const withAds = (
+    blocks: JSX.Element[],
+    edition: Edition,
+    contentType: string,
+    commercialProperties: CommercialProperties,
+    switches: Switches,
+    section?: string,
+): JSX.Element[] => {
+    const commercialConfig = {
+        useKrux: switches.krux,
+        usePrebid: switches.ampPrebid,
+    };
+
+    const ad = (
+        <Ad
+            edition={edition}
+            section={section}
+            contentType={contentType}
+            config={commercialConfig}
+            commercialProperties={commercialProperties}
+        />
+    );
+
+    const adSlots = findBlockAdSlots(blocks);
+
+    return blocks.map((block, i) => {
+        if (adSlots.includes(i)) {
+            return (
+                <>
+                    {ad}
+                    {block}
+                </>
+            );
+        }
+
+        return block;
+    });
+};
+
+// TODO ad handling (currently done in elements, which is wrong, so let's lift
+// that out and have an Ad element type we match against
+export const Blocks: React.SFC<{
+    blocks: Block[];
+    pillar: Pillar;
+    edition: Edition;
+    section?: string;
+    contentType: string;
+    switches: Switches;
+    commercialProperties: CommercialProperties;
+    url: string;
+    shouldHideAds: boolean;
+}> = ({
+    blocks,
+    pillar,
+    edition,
+    section,
+    contentType,
+    switches,
+    commercialProperties,
+    url,
+    shouldHideAds,
+}) => {
+    // TODO add last updated for blocks to show here
+    const liveBlogBlocks = blocks.map(block => {
+        return (
+            <div
+                id={block.id}
+                data-sort-time={block.createdOn}
+                key={block.id}
+                className={blockStyle(pillar)}
+            >
+                {block.createdOnDisplay && (
+                    <a
+                        className={blockCreatedOnStyle}
+                        href={blockLink(url, block.id)}
+                    >
+                        {block.createdOnDisplay}
+                    </a>
+                )}
+                {block.title && <h2>{block.title}</h2>}
+                <Elements
+                    pillar={pillar}
+                    elements={block.elements}
+                    // stuff for ads
+                    edition={edition}
+                    section={section}
+                    contentType={contentType}
+                    switches={switches}
+                    commercialProperties={commercialProperties}
+                    isImmersive={false}
+                    shouldHideAds={false}
+                />
+                {block.lastUpdatedDisplay && (
+                    <div className={lastUpdatedStyle}>
+                        Updated at {block.lastUpdatedDisplay}
+                    </div>
+                )}
+            </div>
+        );
+    });
+
+    if (shouldHideAds) {
+        return <>{liveBlogBlocks}</>;
+    }
+
+    return (
+        <>
+            {withAds(
+                liveBlogBlocks,
+                edition,
+                contentType,
+                commercialProperties,
+                switches,
+                section,
+            )}
+        </>
+    );
+};

--- a/packages/frontend/amp/components/Blocks.tsx
+++ b/packages/frontend/amp/components/Blocks.tsx
@@ -4,9 +4,9 @@ import { css } from 'emotion';
 import { pillarPalette } from '@frontend/lib/pillars';
 import { palette } from '@guardian/pasteup/palette';
 import { blockLink } from '@frontend/amp/lib/block-link';
-import { Ad } from '@frontend/amp/components/Ad';
 import { findBlockAdSlots } from '@frontend/amp/lib/find-adslots';
 import { textSans } from '@guardian/pasteup/typography';
+import { WithAds } from '@frontend/amp/components/WithAds';
 
 const blockStyle = (pillar: Pillar) => css`
     padding: 6px 10px 12px;
@@ -33,45 +33,6 @@ const lastUpdatedStyle = css`
     text-align: right;
     padding-right: 15px;
 `;
-
-const withAds = (
-    blocks: JSX.Element[],
-    edition: Edition,
-    contentType: string,
-    commercialProperties: CommercialProperties,
-    switches: Switches,
-    section?: string,
-): JSX.Element[] => {
-    const commercialConfig = {
-        useKrux: switches.krux,
-        usePrebid: switches.ampPrebid,
-    };
-
-    const ad = (
-        <Ad
-            edition={edition}
-            section={section}
-            contentType={contentType}
-            config={commercialConfig}
-            commercialProperties={commercialProperties}
-        />
-    );
-
-    const adSlots = findBlockAdSlots(blocks);
-
-    return blocks.map((block, i) => {
-        if (adSlots.includes(i)) {
-            return (
-                <>
-                    {ad}
-                    {block}
-                </>
-            );
-        }
-
-        return block;
-    });
-};
 
 // TODO ad handling (currently done in elements, which is wrong, so let's lift
 // that out and have an Ad element type we match against
@@ -124,7 +85,7 @@ export const Blocks: React.SFC<{
                     switches={switches}
                     commercialProperties={commercialProperties}
                     isImmersive={false}
-                    shouldHideAds={false}
+                    shouldHideAds={true}
                 />
                 {block.lastUpdatedDisplay && (
                     <div className={lastUpdatedStyle}>
@@ -139,16 +100,23 @@ export const Blocks: React.SFC<{
         return <>{liveBlogBlocks}</>;
     }
 
+    const slotIndexes = findBlockAdSlots(liveBlogBlocks);
+    const adInfo = {
+        section,
+        edition,
+        contentType,
+        commercialProperties,
+        switches: { krux: switches.krux, ampPrebid: switches.prebid },
+    };
+
     return (
         <>
-            {withAds(
-                liveBlogBlocks,
-                edition,
-                contentType,
-                commercialProperties,
-                switches,
-                section,
-            )}
+            <WithAds
+                items={liveBlogBlocks}
+                adSlots={slotIndexes}
+                adClassName={''}
+                adInfo={adInfo}
+            />
         </>
     );
 };

--- a/packages/frontend/amp/components/BodyArticle.tsx
+++ b/packages/frontend/amp/components/BodyArticle.tsx
@@ -59,6 +59,7 @@ export const Body: React.FC<{
                 switches={config.switches}
                 commercialProperties={data.commercialProperties}
                 isImmersive={data.isImmersive}
+                shouldHideAds={data.shouldHideAds}
             />
             <SubMeta
                 sections={data.subMetaSectionLinks}

--- a/packages/frontend/amp/components/BodyLiveblog.tsx
+++ b/packages/frontend/amp/components/BodyLiveblog.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { InnerContainer } from '@frontend/amp/components/InnerContainer';
-import { Elements } from '@frontend/amp/components/Elements';
 import { css } from 'emotion';
 import { ArticleModel } from '@frontend/amp/pages/Article';
 import { TopMeta } from '@frontend/amp/components/TopMeta';
@@ -9,8 +8,8 @@ import { getToneType, StyledTone } from '@frontend/amp/lib/tag-utils';
 import { pillarPalette } from '@frontend/lib/pillars';
 import { palette } from '@guardian/pasteup/palette';
 import { KeyEvents } from '@frontend/amp/components/KeyEvents';
-import { headline, textSans } from '@guardian/pasteup/typography';
-import { blockLink } from '@frontend/amp/lib/block-link';
+import { headline } from '@guardian/pasteup/typography';
+import { Blocks } from '@frontend/amp/components/Blocks';
 
 // TODO check if liveblog background colours are more complex - like regular
 // article is
@@ -33,7 +32,7 @@ const body = (pillar: Pillar, tone: StyledTone) => css`
         margin-inline-end: 0px;
     }
 
-    ${listItemStyle(pillar)}
+    ${listItemStyle}
 `;
 
 // TODO move into shared place and also add list styling and blockquote etc.
@@ -55,7 +54,7 @@ const bulletStyle = (pillar: Pillar) => css`
     }
 `;
 
-const listItemStyle = (pillar: Pillar) => css`
+const listItemStyle = css`
     li {
         margin-bottom: 0.8em;
     }
@@ -69,94 +68,6 @@ const listItemStyle = (pillar: Pillar) => css`
         background-color: ${palette.neutral[60]};
     }
 `;
-
-const blockStyle = (pillar: Pillar) => css`
-    padding: 6px 10px 12px;
-    background-color: ${palette.neutral[100]};
-    border-top: 1px solid ${pillarPalette[pillar].dark};
-    border-bottom: 1px solid ${palette.neutral[93]};
-    margin-bottom: 12px;
-    blockquote {
-        margin-left: 40px;
-    }
-`;
-
-const blockCreatedOnStyle = (pillar: Pillar) => css`
-    color: ${palette.neutral[7]};
-    line-height: 2rem;
-    margin-bottom: 10px;
-    text-decoration: none;
-    font-weight: bold;
-`;
-
-const lastUpdatedStyle = css`
-    ${textSans(1)};
-    color: ${palette.neutral[60]};
-    text-align: right;
-    padding-right: 15px;
-`;
-
-// TODO ad handling (currently done in elements, which is wrong, so let's lift
-// that out and have an Ad element type we match against
-const Blocks: React.SFC<{
-    blocks: Block[];
-    pillar: Pillar;
-    edition: Edition;
-    section?: string;
-    contentType: string;
-    switches: Switches;
-    commercialProperties: CommercialProperties;
-    url: string;
-}> = ({
-    blocks,
-    pillar,
-    edition,
-    section,
-    contentType,
-    switches,
-    commercialProperties,
-    url,
-}) => {
-    // TODO add last updated for blocks to show here
-    const transformedBlocks = blocks.map(block => {
-        return (
-            <div
-                id={block.id}
-                data-sort-time={block.createdOn}
-                key={block.id}
-                className={blockStyle(pillar)}
-            >
-                {block.createdOnDisplay && (
-                    <a
-                        className={blockCreatedOnStyle(pillar)}
-                        href={blockLink(url, block.id)}
-                    >
-                        {block.createdOnDisplay}
-                    </a>
-                )}
-                {block.title && <h2>{block.title}</h2>}
-                <Elements
-                    pillar={pillar}
-                    elements={block.elements}
-                    // stuff for ads
-                    edition={edition}
-                    section={section}
-                    contentType={contentType}
-                    switches={switches}
-                    commercialProperties={commercialProperties}
-                    isImmersive={false}
-                />
-                {block.lastUpdatedDisplay && (
-                    <div className={lastUpdatedStyle}>
-                        Updated at {block.lastUpdatedDisplay}
-                    </div>
-                )}
-            </div>
-        );
-    });
-
-    return <>{transformedBlocks}</>;
-};
 
 const Pagination: React.SFC<{
     pagination?: Pagination;
@@ -202,12 +113,14 @@ export const Body: React.FC<{
         <InnerContainer className={body(pillar, tone)}>
             <TopMeta tone={tone} data={data} />
             <KeyEvents events={data.keyEvents} pillar={pillar} url={url} />
+
             {!isFirstPage && (
                 <Pagination guardianURL={url} pagination={data.pagination} />
             )}
+
             <amp-live-list
                 id="live-blog-entries-7ea0dbef"
-                data-max-items-per-page="20"
+                data-max-items-per-page="20" // TODO confirm if this should be dynamic
             >
                 <button update="" on="tap:my-live-list.update">
                     You have updates
@@ -223,10 +136,13 @@ export const Body: React.FC<{
                         switches={config.switches}
                         commercialProperties={data.commercialProperties}
                         url={url}
+                        shouldHideAds={data.shouldHideAds}
                     />
                 </div>
             </amp-live-list>
+
             <Pagination guardianURL={url} pagination={data.pagination} />
+
             <SubMeta
                 sections={data.subMetaSectionLinks}
                 keywords={data.subMetaKeywordLinks}

--- a/packages/frontend/amp/components/Elements.tsx
+++ b/packages/frontend/amp/components/Elements.tsx
@@ -31,6 +31,45 @@ const clear = css`
     clear: both;
 `;
 
+const withAds = (
+    elements: CAPIElement[],
+    components: any[],
+    edition: Edition,
+    contentType: string,
+    commercialProperties: CommercialProperties,
+    switches: Switches,
+    section?: string,
+): JSX.Element => {
+    const slotIndexes = findAdSlots(elements);
+    const commercialConfig = {
+        useKrux: switches.krux,
+        usePrebid: switches.ampPrebid,
+    };
+
+    // TODO lift out of here, and also check if ads required!
+    const elementsWithAdverts = components.map((element, i) => (
+        <>
+            {element}
+            {slotIndexes.includes(i) ? (
+                <Ad
+                    edition={edition}
+                    section={section}
+                    contentType={contentType}
+                    config={commercialConfig}
+                    commercialProperties={commercialProperties}
+                />
+            ) : null}
+        </>
+    ));
+
+    return (
+        <>
+            {elementsWithAdverts}
+            <div className={clear} />
+        </>
+    );
+};
+
 export const Elements: React.FC<{
     elements: CAPIElement[];
     pillar: Pillar;
@@ -40,6 +79,7 @@ export const Elements: React.FC<{
     switches: Switches;
     commercialProperties: CommercialProperties;
     isImmersive: boolean;
+    shouldHideAds: boolean;
 }> = ({
     elements,
     pillar,
@@ -49,6 +89,7 @@ export const Elements: React.FC<{
     switches,
     commercialProperties,
     isImmersive,
+    shouldHideAds,
 }) => {
     const cleanedElements = elements.map(element =>
         'html' in element ? { ...element, html: clean(element.html) } : element,
@@ -175,31 +216,21 @@ export const Elements: React.FC<{
         }
     });
 
-    const slotIndexes = findAdSlots(elements);
-    const commercialConfig = {
-        useKrux: switches.krux,
-        usePrebid: switches.ampPrebid,
-    };
-
-    const elementsWithAdverts = output.map((element, i) => (
-        <>
-            {element}
-            {slotIndexes.includes(i) ? (
-                <Ad
-                    edition={edition}
-                    section={section}
-                    contentType={contentType}
-                    config={commercialConfig}
-                    commercialProperties={commercialProperties}
-                />
-            ) : null}
-        </>
-    ));
+    if (shouldHideAds) {
+        return <>{output}</>;
+    }
 
     return (
         <>
-            {elementsWithAdverts}
-            <div className={clear} />
+            {withAds(
+                elements,
+                output,
+                edition,
+                contentType,
+                commercialProperties,
+                switches,
+                section,
+            )}
         </>
     );
 };

--- a/packages/frontend/amp/components/Elements.tsx
+++ b/packages/frontend/amp/components/Elements.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
-import { css } from 'emotion';
-import { clean } from '@frontend/model/clean';
 
 import { findAdSlots } from '@frontend/amp/lib/find-adslots';
-import { Ad } from '@frontend/amp/components/Ad';
 import { Expandable } from '@frontend/amp/components/Expandable';
 
 import { Disclaimer } from '@root/packages/frontend/amp/components/elements/Disclaimer';
@@ -21,54 +18,18 @@ import { RichLink } from '@root/packages/frontend/amp/components/elements/RichLi
 import { SoundcloudEmbed } from '@root/packages/frontend/amp/components/elements/SoundcloudEmbed';
 import { Embed } from '@root/packages/frontend/amp/components/elements/Embed';
 import { PullQuote } from '@root/packages/frontend/amp/components/elements/PullQuote';
+import { css } from 'emotion';
+import { clean } from '@frontend/model/clean';
 import { Timeline } from '@frontend/amp/components/elements/Timeline';
 import { YoutubeVideo } from '@frontend/amp/components/elements/YoutubeVideo';
 import { InteractiveUrl } from '@frontend/amp/components/elements/InteractiveUrl';
 import { InteractiveMarkup } from '@frontend/amp/components/elements/InteractiveMarkup';
 import { MapEmbed } from '@frontend/amp/components/elements/MapEmbed';
+import { WithAds } from '@frontend/amp/components/WithAds';
 
 const clear = css`
     clear: both;
 `;
-
-const withAds = (
-    elements: CAPIElement[],
-    components: any[],
-    edition: Edition,
-    contentType: string,
-    commercialProperties: CommercialProperties,
-    switches: Switches,
-    section?: string,
-): JSX.Element => {
-    const slotIndexes = findAdSlots(elements);
-    const commercialConfig = {
-        useKrux: switches.krux,
-        usePrebid: switches.ampPrebid,
-    };
-
-    // TODO lift out of here, and also check if ads required!
-    const elementsWithAdverts = components.map((element, i) => (
-        <>
-            {element}
-            {slotIndexes.includes(i) ? (
-                <Ad
-                    edition={edition}
-                    section={section}
-                    contentType={contentType}
-                    config={commercialConfig}
-                    commercialProperties={commercialProperties}
-                />
-            ) : null}
-        </>
-    ));
-
-    return (
-        <>
-            {elementsWithAdverts}
-            <div className={clear} />
-        </>
-    );
-};
 
 export const Elements: React.FC<{
     elements: CAPIElement[];
@@ -220,17 +181,24 @@ export const Elements: React.FC<{
         return <>{output}</>;
     }
 
+    const slotIndexes = findAdSlots(elements);
+    const adInfo = {
+        section,
+        edition,
+        contentType,
+        commercialProperties,
+        switches: { krux: switches.krux, ampPrebid: switches.prebid },
+    };
+
     return (
         <>
-            {withAds(
-                elements,
-                output,
-                edition,
-                contentType,
-                commercialProperties,
-                switches,
-                section,
-            )}
+            <WithAds
+                items={output}
+                adSlots={slotIndexes}
+                adClassName={''}
+                adInfo={adInfo}
+            />
+            <div className={clear} />
         </>
     );
 };

--- a/packages/frontend/amp/components/WithAds.tsx
+++ b/packages/frontend/amp/components/WithAds.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Ad } from '@frontend/amp/components/Ad';
+
+interface AdInfo {
+    edition: Edition;
+    contentType: string;
+    commercialProperties: CommercialProperties;
+    switches: {
+        krux: boolean;
+        ampPrebid: boolean;
+    };
+    section?: string;
+}
+
+export const WithAds: React.SFC<{
+    items: any[];
+    adSlots: number[];
+    adClassName: string;
+    adInfo: AdInfo;
+}> = ({ items, adSlots, adClassName, adInfo }) => {
+    const commercialConfig = {
+        useKrux: adInfo.switches.krux,
+        usePrebid: adInfo.switches.ampPrebid,
+    };
+
+    const ad = (
+        <Ad
+            className={adClassName}
+            edition={adInfo.edition}
+            section={adInfo.section}
+            contentType={adInfo.contentType}
+            config={commercialConfig}
+            commercialProperties={adInfo.commercialProperties}
+        />
+    );
+
+    const withAds = items.map((item, i) => {
+        if (adSlots.includes(i)) {
+            return (
+                <>
+                    {item}
+                    {ad}
+                </>
+            );
+        }
+
+        return item;
+    });
+
+    return <>{withAds}</>;
+};

--- a/packages/frontend/amp/lib/find-adslots.test.ts
+++ b/packages/frontend/amp/lib/find-adslots.test.ts
@@ -3,6 +3,7 @@ import {
     AD_LIMIT,
     SMALL_PARA_CHARS,
     MIN_CHAR_BUFFER,
+    findBlockAdSlots,
 } from './find-adslots';
 
 describe('ampadslots', () => {
@@ -95,6 +96,16 @@ describe('ampadslots', () => {
             ];
 
             expect(findAdSlots(data).length).toEqual(1);
+        });
+    });
+
+    describe('findBlockAdSlots', () => {
+        it('should intersperse ads every 5 blocks up to a maximum of 8', () => {
+            const blocks = Array(100).fill('foo');
+
+            const slots = findBlockAdSlots(blocks);
+
+            expect(slots).toEqual([5, 10, 15, 20, 25, 30, 35, 40]);
         });
     });
 });

--- a/packages/frontend/amp/lib/find-adslots.test.ts
+++ b/packages/frontend/amp/lib/find-adslots.test.ts
@@ -105,7 +105,7 @@ describe('ampadslots', () => {
 
             const slots = findBlockAdSlots(blocks);
 
-            expect(slots).toEqual([5, 10, 15, 20, 25, 30, 35, 40]);
+            expect(slots).toEqual([4, 9, 14, 19, 24, 29, 34, 39]);
         });
     });
 });

--- a/packages/frontend/amp/lib/find-adslots.ts
+++ b/packages/frontend/amp/lib/find-adslots.ts
@@ -145,6 +145,8 @@ export const findAdSlots = (elements: CAPIElement[]): number[] => {
 export const findBlockAdSlots = (blocks: any[]): number[] => {
     const maxAds = 8;
 
+    // Place slots every five elements, but not at the beginning. Limit to
+    // maxAds.
     return blocks
         .map((_, i) => i)
         .filter(i => i !== 0 && i % 5 === 0)

--- a/packages/frontend/amp/lib/find-adslots.ts
+++ b/packages/frontend/amp/lib/find-adslots.ts
@@ -141,12 +141,13 @@ export const findAdSlots = (elements: CAPIElement[]): number[] => {
     return adSlots;
 };
 
-// Returns index of items to place ads *before*
+// Returns index of items to place ads *after*
 export const findBlockAdSlots = (blocks: any[]): number[] => {
     const maxAds = 8;
 
     return blocks
         .map((_, i) => i)
         .filter(i => i !== 0 && i % 5 === 0)
+        .map(i => i - 1)
         .slice(0, maxAds);
 };

--- a/packages/frontend/amp/lib/find-adslots.ts
+++ b/packages/frontend/amp/lib/find-adslots.ts
@@ -119,6 +119,7 @@ const hasSpaceForAd = (
     );
 };
 
+// Returns index of items to place ads *after*
 export const findAdSlots = (elements: CAPIElement[]): number[] => {
     let charsScannedSinceLastAd = 0;
     const adSlots = [];
@@ -138,4 +139,14 @@ export const findAdSlots = (elements: CAPIElement[]): number[] => {
         }
     }
     return adSlots;
+};
+
+// Returns index of items to place ads *before*
+export const findBlockAdSlots = (blocks: any[]): number[] => {
+    const maxAds = 8;
+
+    return blocks
+        .map((_, i) => i)
+        .filter(i => i !== 0 && i % 5 === 0)
+        .slice(0, maxAds);
 };


### PR DESCRIPTION
## What does this change?

* Don't show ads if we shouldn't (this must be a regression as I'm sure we had this originally)
* support ads on liveblogs

As part of this I've had to do a lot of refactoring as there were a lot of assumptions in existing ad code that don't relate to liveblogs (positioning, styling are the big ones).

**Doesn't yet style ads for liveblogs properly!**