### PR TITLE
Correct styling for liveblog h2

### DIFF
--- a/packages/frontend/amp/components/BodyLiveblog.tsx
+++ b/packages/frontend/amp/components/BodyLiveblog.tsx
@@ -25,8 +25,7 @@ const body = (pillar: Pillar, tone: StyledTone) => css`
     }
 
     h2 {
-        ${headline(2)};
-        font-size: 1.5em;
+        ${headline(4)};
         font-weight: 500;
         margin-block-start: 0.83em;
         margin-block-end: 0.83em;


### PR DESCRIPTION
## What does this change?

This prevents the use of `font-size` for setting the style for `h2`. 

**Before**:

![before](https://user-images.githubusercontent.com/6035518/58331214-8536c580-7e30-11e9-9a1a-47bc4fe78715.png)


**After**:

![after](https://user-images.githubusercontent.com/6035518/58331222-8962e300-7e30-11e9-8736-37bf9379d72d.png)

