### PR TITLE
Adds support for Article in-body Map element in AMP

### DIFF
--- a/packages/frontend/amp/components/Elements.tsx
+++ b/packages/frontend/amp/components/Elements.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
+import { css } from 'emotion';
+import { clean } from '@frontend/model/clean';
 
+import { findAdSlots } from '@frontend/amp/lib/find-adslots';
+import { Ad } from '@frontend/amp/components/Ad';
+import { Expandable } from '@frontend/amp/components/Expandable';
+
+import { Disclaimer } from '@root/packages/frontend/amp/components/elements/Disclaimer';
 import { Text } from '@root/packages/frontend/amp/components/elements/Text';
 import { Subheading } from '@root/packages/frontend/amp/components/elements/Subheading';
 import { Image } from '@root/packages/frontend/amp/components/elements/Image';
@@ -14,16 +21,11 @@ import { RichLink } from '@root/packages/frontend/amp/components/elements/RichLi
 import { SoundcloudEmbed } from '@root/packages/frontend/amp/components/elements/SoundcloudEmbed';
 import { Embed } from '@root/packages/frontend/amp/components/elements/Embed';
 import { PullQuote } from '@root/packages/frontend/amp/components/elements/PullQuote';
-import { findAdSlots } from '@frontend/amp/lib/find-adslots';
-import { Ad } from '@frontend/amp/components/Ad';
-import { css } from 'emotion';
-import { Disclaimer } from '@root/packages/frontend/amp/components/elements/Disclaimer';
-import { clean } from '@frontend/model/clean';
-import { Expandable } from '@frontend/amp/components/Expandable';
 import { Timeline } from '@frontend/amp/components/elements/Timeline';
 import { YoutubeVideo } from '@frontend/amp/components/elements/YoutubeVideo';
 import { InteractiveUrl } from '@frontend/amp/components/elements/InteractiveUrl';
 import { InteractiveMarkup } from '@frontend/amp/components/elements/InteractiveMarkup';
+import { MapEmbed } from '@frontend/amp/components/elements/MapEmbed';
 
 const clear = css`
     clear: both;
@@ -93,6 +95,8 @@ export const Elements: React.FC<{
                 return <SoundcloudEmbed key={i} element={element} />;
             case 'model.dotcomrendering.pageElements.EmbedBlockElement':
                 return <Embed key={i} element={element} />;
+            case 'model.dotcomrendering.pageElements.MapBlockElement':
+                return <MapEmbed key={i} element={element} pillar={pillar} />;
             case 'model.dotcomrendering.pageElements.DisclaimerBlockElement':
                 return (
                     <Disclaimer key={i} html={element.html} pillar={pillar} />

--- a/packages/frontend/amp/components/elements/MapEmbed.tsx
+++ b/packages/frontend/amp/components/elements/MapEmbed.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { css } from 'emotion';
+import { Caption } from '@guardian/guui/components/Caption/Caption';
+
+const noCaptionStyle = css`
+    margin-bottom: 8px;
+`;
+
+export const MapEmbed: React.SFC<{
+    element: MapBlockElement;
+    pillar: Pillar;
+}> = ({ element, pillar }) => {
+    const attributes = {
+        src: `${element.url}`,
+        title: `${element.source}: ${element.title}`,
+        layout: 'responsive',
+        sandbox: 'allow-scripts allow-same-origin',
+        height: '1',
+        width: '1',
+        frameborder: '0',
+        'data-canonical-url': `${element.originalUrl}`,
+    };
+
+    return element.caption ? (
+        <Caption
+            captionText={element.caption}
+            pillar={pillar}
+            padCaption={true}
+            dirtyHtml={true}
+        >
+            <amp-iframe {...attributes} />
+        </Caption>
+    ) : (
+        <figure className={noCaptionStyle}>
+            <amp-iframe {...attributes} />
+        </figure>
+    );
+};

--- a/packages/frontend/lib/content.d.ts
+++ b/packages/frontend/lib/content.d.ts
@@ -208,6 +208,15 @@ interface InteractiveUrlElement {
     url: string;
 }
 
+interface MapBlockElement {
+    _type: 'model.dotcomrendering.pageElements.MapBlockElement';
+    url: string;
+    originalUrl: string;
+    source: string;
+    caption: string;
+    title: string;
+}
+
 type CAPIElement =
     | TextBlockElement
     | SubheadingBlockElement
@@ -230,4 +239,5 @@ type CAPIElement =
     | ProfileBlockElement
     | TimelineBlockElement
     | InteractiveMarkupBlockElement
-    | InteractiveUrlElement;
+    | InteractiveUrlElement
+    | MapBlockElement;


### PR DESCRIPTION
## What does this change?

Adds support for MapBlockElements in AMP. Requires update to frontend PageElements.scala in this Frontend PR: https://github.com/guardian/frontend/pull/21451

![image](https://user-images.githubusercontent.com/32312712/58337189-1dd34280-7e3d-11e9-972d-c19151defb61.png)


## Why?

AMP completion
