### PR TITLE
Correct atom title in AMP display

### DIFF
--- a/packages/frontend/amp/components/Elements.tsx
+++ b/packages/frontend/amp/components/Elements.tsx
@@ -133,7 +133,7 @@ export const Elements: React.FC<{
                 return (
                     <Expandable
                         id={element.id}
-                        type="Profile"
+                        type="Quick Guide"
                         title={element.title}
                         html={element.html}
                         img={element.img}


### PR DESCRIPTION
## What does this change?

Give the correct title to the Atom

**Before**

<img width="632" alt="Screenshot 2019-05-30 at 15 16 17" src="https://user-images.githubusercontent.com/6035518/58639472-e22df200-82ee-11e9-84a9-22766e1c58a0.png">


**After**

<img width="641" alt="Screenshot 2019-05-30 at 15 20 45" src="https://user-images.githubusercontent.com/6035518/58639482-e65a0f80-82ee-11e9-986d-3c9b9a7a3be6.png">
