### PR TITLE
AMP ad spacing bugfixes

### DIFF
--- a/packages/frontend/amp/lib/find-adslots.test.ts
+++ b/packages/frontend/amp/lib/find-adslots.test.ts
@@ -2,7 +2,6 @@ import {
     findAdSlots,
     AD_LIMIT,
     SMALL_PARA_CHARS,
-    MIN_CHAR_BUFFER,
     findBlockAdSlots,
 } from './find-adslots';
 
@@ -29,7 +28,6 @@ describe('ampadslots', () => {
         it('should have these values for ad spacing (or tests other than this one need updating)', () => {
             expect(AD_LIMIT).toEqual(8);
             expect(SMALL_PARA_CHARS).toEqual(50);
-            expect(MIN_CHAR_BUFFER).toEqual(700);
         });
 
         it('adds an advert after 700 chars', () => {

--- a/packages/frontend/amp/lib/find-adslots.test.ts
+++ b/packages/frontend/amp/lib/find-adslots.test.ts
@@ -3,28 +3,30 @@ import {
     AD_LIMIT,
     SMALL_PARA_CHARS,
     findBlockAdSlots,
+    getElementLength,
 } from './find-adslots';
 
+const getTextBlockElement = (length: number): TextBlockElement => {
+    return {
+        _type: 'model.dotcomrendering.pageElements.TextBlockElement',
+        html: `${'.'.repeat(length)}`,
+    };
+};
+
 describe('ampadslots', () => {
+    const imageBlockElement: ImageBlockElement = {
+        _type: 'model.dotcomrendering.pageElements.ImageBlockElement',
+        media: { allImages: [] },
+        data: { alt: 'img', credit: 'nobody' },
+        imageSources: [],
+        displayCredit: false,
+        role: 'lol',
+    };
+
+    const tenCharTextBlock = getTextBlockElement(10);
+    const fiveHundredCharTextBlock = getTextBlockElement(500);
+
     describe('findAdSlots', () => {
-        const getTextBlockElement = (length: number): TextBlockElement => {
-            return {
-                _type: 'model.dotcomrendering.pageElements.TextBlockElement',
-                html: `${'.'.repeat(length)}`,
-            };
-        };
-
-        const imageBlockElement: ImageBlockElement = {
-            _type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-            media: { allImages: [] },
-            data: { alt: 'img', credit: 'nobody' },
-            imageSources: [],
-            displayCredit: false,
-            role: 'lol',
-        };
-        const tenCharTextBlock = getTextBlockElement(10);
-        const fiveHundredCharTextBlock = getTextBlockElement(500);
-
         it('should have these values for ad spacing (or tests other than this one need updating)', () => {
             expect(AD_LIMIT).toEqual(8);
             expect(SMALL_PARA_CHARS).toEqual(50);
@@ -50,7 +52,7 @@ describe('ampadslots', () => {
         });
 
         it('does not add an advert after 699 chars', () => {
-            const data = [getTextBlockElement(699), getTextBlockElement(700)];
+            const data = [getTextBlockElement(300), getTextBlockElement(399)];
 
             expect(findAdSlots(data)).toEqual([]);
         });
@@ -105,5 +107,13 @@ describe('ampadslots', () => {
 
             expect(slots).toEqual([4, 9, 14, 19, 24, 29, 34, 39]);
         });
+    });
+});
+
+describe('getElementLength', () => {
+    it('should correctly calculate the length of a text block (stripping html chars)', () => {
+        const textBlock = getTextBlockElement(200);
+        textBlock.html = `<p>${textBlock.html}</p>`;
+        expect(getElementLength(textBlock)).toEqual(200);
     });
 });


### PR DESCRIPTION
This fixes issues outlined here https://trello.com/c/cPFhDtvt/512-amp-ad-behaviour-is-not-quite-the-same - basically we're adding too many ads on dotcom rendering.

This PR:
 - makes sure we remove HTML before calculating the length of a paragraph!
 - Adds an additional restriction that adverts should be at least 1 paragraph apart
 - Tidies some of the find adslots code a bit


## What does this change?

## Why?