### PR TITLE
Do not escape captions

### DIFF
--- a/packages/frontend/amp/components/elements/Image.tsx
+++ b/packages/frontend/amp/components/elements/Image.tsx
@@ -52,7 +52,7 @@ export const Image: React.FC<{
                     <span className={iconStyle}>
                         <TriangleIcon />
                     </span>
-
+// TODO - Move caption handling to use https://github.com/guardian/dotcom-rendering/blob/master/packages/guui/components/Caption/Caption.tsx
                     <span
                         // tslint:disable-line:react-no-dangerous-html
                         dangerouslySetInnerHTML={{

--- a/packages/frontend/amp/components/elements/Image.tsx
+++ b/packages/frontend/amp/components/elements/Image.tsx
@@ -52,7 +52,15 @@ export const Image: React.FC<{
                     <span className={iconStyle}>
                         <TriangleIcon />
                     </span>
-                    {element.data.caption}{' '}
+
+                    <span
+                        // tslint:disable-line:react-no-dangerous-html
+                        dangerouslySetInnerHTML={{
+                            __html: element.data.caption || '',
+                        }}
+                        key={'caption'}
+                    />
+
                     {element.displayCredit && element.data.credit}
                 </figcaption>
             )}


### PR DESCRIPTION
## What does this change?

Do not escape captions for images in AMP.

## Why?

As they can contain HTML.

## Trello

https://trello.com/c/iWPreh0b/514-html-in-captions-not-being-escaped-transformed