### PR TITLE
Read GuideBlockElement/ProfileBlockElement's type from DCR Object

### DIFF
--- a/packages/frontend/amp/components/Elements.tsx
+++ b/packages/frontend/amp/components/Elements.tsx
@@ -123,7 +123,7 @@ export const Elements: React.FC<{
                 return (
                     <Expandable
                         id={element.id}
-                        type="Quick Guide"
+                        type={element.label}
                         title={element.title}
                         html={element.html}
                         img={element.img}
@@ -135,7 +135,7 @@ export const Elements: React.FC<{
                 return (
                     <Expandable
                         id={element.id}
-                        type="Profile"
+                        type={element.label}
                         title={element.title}
                         html={element.html}
                         img={element.img}

--- a/packages/frontend/lib/content.d.ts
+++ b/packages/frontend/lib/content.d.ts
@@ -165,6 +165,7 @@ interface QABlockElement {
 interface GuideBlockElement {
     _type: 'model.dotcomrendering.pageElements.GuideBlockElement';
     id: string;
+    label: string;
     title: string;
     img?: string;
     html: string;
@@ -174,6 +175,7 @@ interface GuideBlockElement {
 interface ProfileBlockElement {
     _type: 'model.dotcomrendering.pageElements.ProfileBlockElement';
     id: string;
+    label: string;
     title: string;
     img?: string;
     html: string;


### PR DESCRIPTION
## What does this change?

This is the follow up of the front end change: https://github.com/guardian/frontend/pull/21478 . We can now read the correct value for `GuideBlockElement` and `ProfileBlockElement` types.

#-------------------------------
**DCR JSON Object**

![Screenshot 2019-06-04 at 15 49 24](https://user-images.githubusercontent.com/6035518/58889176-68c44400-86e0-11e9-8286-a9c8efd2e26d.png)

#-------------------------------
**Before Change**

![Screenshot 2019-06-04 at 15 48 59](https://user-images.githubusercontent.com/6035518/58889220-75e13300-86e0-11e9-9f8c-8cd86b8e44aa.png)

#-------------------------------
**After Change**

![Screenshot 2019-06-04 at 15 49 14](https://user-images.githubusercontent.com/6035518/58889278-8b565d00-86e0-11e9-993c-ba0c5fc64666.png)
