### PR TITLE
Fix alignment of ReaderRev button in Amp header for mobile

### DIFF
--- a/packages/frontend/amp/components/ReaderRevenueButton.tsx
+++ b/packages/frontend/amp/components/ReaderRevenueButton.tsx
@@ -14,13 +14,20 @@ const supportStyles = css`
     align-items: center;
     padding: 0 15px;
     min-height: 30px;
+    ${until.mobileMedium} {
+        padding: 0 10px;
+        min-height: 24px;
+    }
 `;
 
 const supportHeaderStyles = css`
     ${supportStyles}
     justify-content: center;
-    margin-top: 20px;
+    margin-top: 10px;
     margin-left: 10px;
+    ${until.mobileMedium} {
+        margin-top: 28px;
+    }
 `;
 
 const supportFooterStyles = css`
@@ -40,14 +47,17 @@ const supportLinkStyles = css`
 
     padding-right: 20px;
     ${until.mobileMedium} {
-        padding-right: 0px;
+        ${textSans(4)};
+        padding-right: 18px;
     }
 
     svg {
         position: absolute;
         top: -5px;
         ${until.mobileMedium} {
-            display: none;
+            top: -2px;
+            width: 26px;
+            height: 26px;
         }
     }
 `;


### PR DESCRIPTION
## What does this change?

Fixes alignment of ReaderRev button in Amp header for mobile per [Trello](https://trello.com/c/s0XMPRnl/552-bug-support-contribute-buttons-incorrectly-aligned-in-header)
![headersupport](https://user-images.githubusercontent.com/32312712/58950370-88ae4300-8786-11e9-94c3-86923e8fe833.gif)


## Why?
Making things prettier. 
