### PR TITLE
Add automatic Table of Contents generation to some docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Frontend rendering framework for theguardian.com. It uses [React](https://reactjs.org/), with [Emotion](https://emotion.sh) for styling.
 
+<!-- START doctoc -->
+<!-- END doctoc -->
+
 ## Chat
 
 Check out the [Digital/dotcom-rendering](https://chat.google.com/room/AAAA6yBswlI) channel on Chat. If you haven't already done so already, please ask the Dotcom Platform team for an invite.
@@ -34,7 +37,7 @@ If you're new to JavaScript projects, if you're trying to integrate with other a
 
 ### Feedback
 
-After completing this setup guide, we would greatly appreciate it if you could complete our [dotcom-rendering setup 
+After completing this setup guide, we would greatly appreciate it if you could complete our [dotcom-rendering setup
 questionnaire](https://docs.google.com/forms/d/e/1FAIpQLSdwFc05qejwW_Gtl3pyW4N22KqmY5zXoDKAUAjrkOwb2uXNcQ/viewform?vc=0&c=0&w=1). It should only take 3 minutes and will help us improve this documentation and the setup process in the future. Thank you! 🙏
 
 ## Code Quality
@@ -43,7 +46,7 @@ You can ensure your code passes code quality tests by running:
 
 ```
 $ make validate
-``` 
+```
 
 This runs our linting tool, the TypeScript compiler and our tests, before finally building the bundles.
 
@@ -70,7 +73,7 @@ We recommend using [VSCode](https://code.visualstudio.com/).
 
 ### Extensions
 
-VSCode should prompt you to install our recommended extensions when you open the project. 
+VSCode should prompt you to install our recommended extensions when you open the project.
 
 You can also find these extensions by searching for `@recommended` in the extensions pane.
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,23 @@
 
 Frontend rendering framework for theguardian.com. It uses [React](https://reactjs.org/), with [Emotion](https://emotion.sh) for styling.
 
-<!-- START doctoc -->
-<!-- END doctoc -->
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+<!-- Automatically created with yarn run createtoc and on push hook -->
+
+- [Chat](#chat)
+- [Quick start](#quick-start)
+  - [Install Node.js](#install-nodejs)
+  - [Running instructions](#running-instructions)
+  - [Detailed Setup](#detailed-setup)
+  - [Note on rebasing](#note-on-rebasing)
+  - [Feedback](#feedback)
+- [Other tasks](#other-tasks)
+- [IDE setup](#ide-setup)
+  - [Extensions](#extensions)
+  - [Auto fix on save](#auto-fix-on-save)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Chat
 

--- a/docs/contributing/code-style.md
+++ b/docs/contributing/code-style.md
@@ -1,8 +1,11 @@
 # Code style
 
+<!-- START doctoc -->
+<!-- END doctoc -->
+
 ## TypeScript
 
-We use TSlint and [Prettier](https://prettier.io/) to enforce our TypeScript code style. 
+We use TSlint and [Prettier](https://prettier.io/) to enforce our TypeScript code style.
 Running `make fix` after making any changes will fix most things.
 
 There are some styles the linter can't pick up. If you are unsure of anything, [Excel Micro's fork of AirBnB's style
@@ -19,7 +22,6 @@ export default () => <h1>My component</h1>;
 
 //Parent.tsx
 import MyComponent from './MyComponent';
-
 ```
 
 ```js
@@ -28,13 +30,13 @@ import MyComponent from './MyComponent';
 export const MyComponent = () => <h1>MyComponent</h1>;
 
 // Parent.tsx
-import {MyComponent} from './MyComponent';
+import { MyComponent } from './MyComponent';
 ```
 
 ### Never name a file `index.ts` or `index.tsx`
 
 > Why? There is a common Node.js idiom to give the name `index` to the module at the entry point to a directory. This leads to an adundance of files named `index.ts*`, which makes it
-harder to find a file in the IDE. When editing a number of files called `index.ts*` in an IDE, it is hard to see at a glance which one is which.
+> harder to find a file in the IDE. When editing a number of files called `index.ts*` in an IDE, it is hard to see at a glance which one is which.
 
 ```js
 // bad
@@ -61,24 +63,22 @@ We use [React](https://reactjs.org/) for our components, and [Emotion](https://e
 const MyComponent = styled('div')`
     color: red;
 `;
-render(
-    <MyComponent />
-);
+render(<MyComponent />);
 
 // bad
 render(
-    <div css={`
-        color: red;
-    `} />
+    <div
+        css={`
+            color: red;
+        `}
+    />,
 );
 
 // good
 const myComponent = css`
     color: red;
 `;
-render(
-    <div className={myComponent} />
-);
+render(<div className={myComponent} />);
 ```
 
 ### Extract CSS into a variable rather than defining it inline in a component
@@ -88,18 +88,18 @@ render(
 ```js
 // bad
 render(
-    <div className={css`
-        color: red;
-    `} />
-)
+    <div
+        className={css`
+            color: red;
+        `}
+    />,
+);
 
 // good
 const myComponent = css`
     color: red;
 `;
-render(
-    <div className={myComponent} />
-);
+render(<div className={myComponent} />);
 ```
 
 ### Extract dynamic styles into a function that takes `props`
@@ -108,17 +108,21 @@ render(
 
 ```js
 // bad
-const MyComponent = ({ fontColor }) =>
-    <div className={css`
-        color: ${fontColor};
-    `} />;
+const MyComponent = ({ fontColor }) => (
+    <div
+        className={css`
+            color: ${fontColor};
+        `}
+    />
+);
 
 // good
-const myComponent = (fontColor) => css`
+const myComponent = fontColor => css`
     color: ${fontColor};
 `;
-const MyComponent = ({ fontColor }) =>
-    <div className={myComponent(fontColor)} />;
+const MyComponent = ({ fontColor }) => (
+    <div className={myComponent(fontColor)} />
+);
 ```
 
 ### Define CSS using template literals rather than objects
@@ -144,18 +148,18 @@ const myComponent = css`
 ```js
 // bad
 const myList = css`
-  li {
-      a {
-          color: fuchsia;
-      }
-  }
+    li {
+        a {
+            color: fuchsia;
+        }
+    }
 `;
 render(
     <ul className={myList}>
         <li>
             <a href="#">Click me</a>
         </li>
-    </ul>
+    </ul>,
 );
 
 // good
@@ -165,9 +169,11 @@ const myLink = css`
 render(
     <ul>
         <li>
-            <a className={myLink} href="#">Click me</a>
+            <a className={myLink} href="#">
+                Click me
+            </a>
         </li>
-    </ul>
+    </ul>,
 );
 ```
 
@@ -185,8 +191,9 @@ const activeLink = css`
     ${link};
     color: red;
 `;
-const MyLink = ({ isActive }) =>
-    <a className={isActive ? activeLink : link}>Click me</a>;
+const MyLink = ({ isActive }) => (
+    <a className={isActive ? activeLink : link}>Click me</a>
+);
 
 // good
 const link = css`
@@ -196,10 +203,7 @@ const link = css`
 const activeLink = css`
     color: red;
 `;
-const MyLink = ({ isActive }) =>
-    <a className={cx(
-        { [activeLink]: isActive },
-        link
-    )}>Click Me</a>;
-
+const MyLink = ({ isActive }) => (
+    <a className={cx({ [activeLink]: isActive }, link)}>Click Me</a>
+);
 ```

--- a/docs/contributing/code-style.md
+++ b/docs/contributing/code-style.md
@@ -1,7 +1,21 @@
 # Code style
 
-<!-- START doctoc -->
-<!-- END doctoc -->
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+<!-- Automatically created with yarn run createtoc and on push hook -->
+
+- [TypeScript](#typescript)
+  - [Always used named exports](#always-used-named-exports)
+  - [Never name a file `index.ts` or `index.tsx`](#never-name-a-file-indexts-or-indextsx)
+- [Components](#components)
+  - [Use Emotion's `css` function to build a class name from styles](#use-emotions-css-function-to-build-a-class-name-from-styles)
+  - [Extract CSS into a variable rather than defining it inline in a component](#extract-css-into-a-variable-rather-than-defining-it-inline-in-a-component)
+  - [Extract dynamic styles into a function that takes `props`](#extract-dynamic-styles-into-a-function-that-takes-props)
+  - [Define CSS using template literals rather than objects](#define-css-using-template-literals-rather-than-objects)
+  - [Never define styles with more than one level of nesting](#never-define-styles-with-more-than-one-level-of-nesting)
+  - [Prefer `cx` for style composition](#prefer-cx-for-style-composition)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## TypeScript
 

--- a/docs/contributing/detailed-setup-guide.md
+++ b/docs/contributing/detailed-setup-guide.md
@@ -1,7 +1,34 @@
 # Detailed setup guide
 
+<<<<<<< HEAD
 -   [Developing](#developing)
 -   [Production](#production)
+=======
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+<!-- Automatically created with yarn run createtoc and on push hook -->
+
+- [Chat](#chat)
+- [Developing](#developing)
+  - [Setup](#setup)
+  - [Start](#start)
+  - [Running alongside identity](#running-alongside-identity)
+  - [Previewing article on local](#previewing-article-on-local)
+  - [Previewing AMP on local](#previewing-amp-on-local)
+  - [Debugging tools](#debugging-tools)
+- [Production](#production)
+- [Other tasks](#other-tasks)
+  - [Code quality](#code-quality)
+- [IDE setup](#ide-setup)
+  - [Extensions](#extensions)
+  - [Auto fix on save](#auto-fix-on-save)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Chat
+
+Check out the [Digital/dotcom-rendering](https://chat.google.com/room/AAAA6yBswlI) channel on Chat. If you haven't already done so already, please ask the Dotcom Platform team for an invite.
+>>>>>>> Add TOC update
 
 ## Developing
 

--- a/docs/contributing/detailed-setup-guide.md
+++ b/docs/contributing/detailed-setup-guide.md
@@ -57,6 +57,7 @@ For ease of development you may want to install:
 ### Running alongside identity
 
 You may want local identity cookies to be available in `dotcom-rendering`. To enable this:
+
 1. run `./scripts/nginx/setup.sh`
 1. access `dotcom-rendering` through https://r.thegulocal.com
 

--- a/docs/contributing/detailed-setup-guide.md
+++ b/docs/contributing/detailed-setup-guide.md
@@ -1,34 +1,29 @@
 # Detailed setup guide
 
-<<<<<<< HEAD
--   [Developing](#developing)
--   [Production](#production)
-=======
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 <!-- Automatically created with yarn run createtoc and on push hook -->
 
-- [Chat](#chat)
-- [Developing](#developing)
-  - [Setup](#setup)
-  - [Start](#start)
-  - [Running alongside identity](#running-alongside-identity)
-  - [Previewing article on local](#previewing-article-on-local)
-  - [Previewing AMP on local](#previewing-amp-on-local)
-  - [Debugging tools](#debugging-tools)
-- [Production](#production)
-- [Other tasks](#other-tasks)
-  - [Code quality](#code-quality)
-- [IDE setup](#ide-setup)
-  - [Extensions](#extensions)
-  - [Auto fix on save](#auto-fix-on-save)
+-   [Chat](#chat)
+-   [Developing](#developing)
+    -   [Setup](#setup)
+    -   [Start](#start)
+    -   [Running alongside identity](#running-alongside-identity)
+    -   [Previewing article on local](#previewing-article-on-local)
+    -   [Previewing AMP on local](#previewing-amp-on-local)
+    -   [Debugging tools](#debugging-tools)
+-   [Production](#production)
+-   [Other tasks](#other-tasks)
+    -   [Code quality](#code-quality)
+-   [IDE setup](#ide-setup)
+    -   [Extensions](#extensions)
+    -   [Auto fix on save](#auto-fix-on-save)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Chat
 
 Check out the [Digital/dotcom-rendering](https://chat.google.com/room/AAAA6yBswlI) channel on Chat. If you haven't already done so already, please ask the Dotcom Platform team for an invite.
->>>>>>> Add TOC update
 
 ## Developing
 

--- a/docs/contributing/where-should-my-code-live.md
+++ b/docs/contributing/where-should-my-code-live.md
@@ -1,7 +1,20 @@
 # Where should my code live?
 
-<!-- START doctoc -->
-<!-- END doctoc -->
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+<!-- Automatically created with yarn run createtoc and on push hook -->
+
+- [Scripts](#scripts)
+  - [Low priority scripts](#low-priority-scripts)
+  - [High priority scripts](#high-priority-scripts)
+- [Data extraction](#data-extraction)
+  - [Axiom 1](#axiom-1)
+  - [Axiom 2](#axiom-2)
+  - [Axiom 3](#axiom-3)
+  - [Architecture Decision Records](#architecture-decision-records)
+- [Components](#components)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Scripts
 

--- a/docs/contributing/where-should-my-code-live.md
+++ b/docs/contributing/where-should-my-code-live.md
@@ -1,5 +1,8 @@
 # Where should my code live?
 
+<!-- START doctoc -->
+<!-- END doctoc -->
+
 ## Scripts
 
 Externally hosted third party scripts should always be loaded asynchronously. If possible, they should be loaded conditionally using JavaScript by injecting a script element into the head of the document.
@@ -16,7 +19,7 @@ They can be added to the `lowPriorityScripts` array in the [`packages/frontend/w
 
 ### High priority scripts
 
-High priority scripts are injected by JavaScript running in the `<head>` of the document. They are loaded asynchronously and executed in the order they are requested. 
+High priority scripts are injected by JavaScript running in the `<head>` of the document. They are loaded asynchronously and executed in the order they are requested.
 
 Examples include the [polyfill.io](https://polyfill.io) response and the main application JavaScript bundles.
 
@@ -52,12 +55,12 @@ Data is passed between `frontend` and `dotcom-rendering` via a network request, 
 
 ### Architecture Decision Records
 
-- [New elements models in frontend](../architecture/013-new-elements-models-in-frontend.md)
-- [Client side computation](../architecture/016-client-side-computation.md)
+-   [New elements models in frontend](../architecture/013-new-elements-models-in-frontend.md)
+-   [Client side computation](../architecture/016-client-side-computation.md)
 
 ## Components
 
-Frontend-specific components live in `packages/frontend`. 
+Frontend-specific components live in `packages/frontend`.
 
 Note that [Frontend Web](../../packages/frontend/web) and [Frontend AMP](../../packages/frontend/amp) are separate applications that do not share code, including components. If you build a new component for the web, consider whether you need to build an analogous component for AMP too.
 

--- a/package.json
+++ b/package.json
@@ -5,15 +5,18 @@
     "workspaces": [
         "packages/*"
     ],
+    "tocList": "README.md packages/pasteup/README.md packages/pasteup/CONTRIBUTING.md packages/guui/README.md packages/design/CONTRIBUTING.md docs/contributing/**",
     "scripts": {
         "lint": "eslint . --ext .ts,.tsx",
         "tsc": "tsc",
         "test": "jest",
-        "postinstall": "./scripts/git-hooks/install.js"
+        "postinstall": "./scripts/git-hooks/install.js",
+        "createtoc": "doctoc $npm_package_tocList --github --title '<!-- Automatically created with yarn run createtoc and on push hook -->' ",
+        "addandcommittoc": "git add $npm_package_tocList && git commit -m 'Add TOC update'"
     },
     "husky": {
         "hooks": {
-            "pre-push": "make validate"
+            "pre-push": "make validate && createtoc && addandcommittoc"
         }
     },
     "bundlesize": [

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     },
     "husky": {
         "hooks": {
-            "pre-push": "make validate && createtoc && addandcommittoc"
+            "pre-push": "make validate && yarn run createtoc && yarn run addandcommittoc"
         }
     },
     "bundlesize": [

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
         "babel-plugin-preval": "^3.0.0",
         "babel-plugin-px-to-rem": "https://github.com/guardian/babel-plugin-px-to-rem#v0.1.0",
         "bundlesize": "^0.17.0",
+        "doctoc": "^1.4.0",
         "eslint": "^5.16.0",
         "friendly-errors-webpack-plugin": "^1.7.0",
         "husky": "^2.3.0",

--- a/packages/design/CONTRIBUTING.md
+++ b/packages/design/CONTRIBUTING.md
@@ -4,6 +4,9 @@ Paper is our design system and the code for its own documentation. We use `Gatsb
 
 All the content is inside `src/content` As we use `markdown` files you are welcome and encouraged to submit pull requests from Github itself to add content to the site.
 
+<!-- START doctoc -->
+<!-- END doctoc -->
+
 ## Running the docs
 
 If you want to run the docs locally, clone this repo. Then inside the `packages/design` directory, run `yarn develop` to run gatsby locally.

--- a/packages/design/CONTRIBUTING.md
+++ b/packages/design/CONTRIBUTING.md
@@ -4,8 +4,16 @@ Paper is our design system and the code for its own documentation. We use `Gatsb
 
 All the content is inside `src/content` As we use `markdown` files you are welcome and encouraged to submit pull requests from Github itself to add content to the site.
 
-<!-- START doctoc -->
-<!-- END doctoc -->
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+<!-- Automatically created with yarn run createtoc and on push hook -->
+
+- [Running the docs](#running-the-docs)
+- [Technical decision record](#technical-decision-record)
+  - [Component sharing](#component-sharing)
+  - [CSS Modules](#css-modules)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Running the docs
 

--- a/packages/guui/README.md
+++ b/packages/guui/README.md
@@ -1,1 +1,4 @@
 # 𝐆𝐔𝐔𝐈
+
+<!-- START doctoc -->
+<!-- END doctoc -->

--- a/packages/pasteup/CONTRIBUTING.md
+++ b/packages/pasteup/CONTRIBUTING.md
@@ -1,13 +1,19 @@
 # What goes in pasteup?
+
 Anything that either generates style primitives or can be used to generate style primitives and is plain javascript (including JSON). For the most part this is pretty unambiguous: Colours, sizes, grid, etc all fit the bill. Font mappings are a good candidate too. Do NOT use paste up for components (as of Feb ‘19).
 Think of pasteup as a base foundation you can use to build components with the tech stack of your choice.
 
+<!-- START doctoc -->
+<!-- END doctoc -->
+
 # Releasing pasteup
+
 After your PR gets approved, but before merging run
 
 ```
 make release-pasteup
 ```
+
 This will ask you to up the version of pasteup. We use (semver)[https://semver.org] and you can check a quick reference below.
 
 That's it! Pasteup is now in [NPM](https://www.npmjs.com/package/@guardian/pasteup). There's a couple loose ends we need to deal with to tidy everything up:
@@ -16,17 +22,19 @@ Your branch will have a commit with a change to pasteup's `package.json` reflect
 
 Your changes will ripple to dotcom-rendering immediately. For other projects you must notify other consumers of the library of the updated version. At the moment that includes:
 
-- support-frontend (reader revenue teams)
+-   support-frontend (reader revenue teams)
 
 TBD: Should we create an email address? Do we have one?
 TBD: Should we release via riffraff or travis? What are the downsides? How hard is this to set up?
 
-
 # Versioning rules of thumb
+
 Given the cross-cutting nature of this project, we are committed to avoiding breaking changes as that would erode trust from potential consumers:
-- PATCH for anything that tweaks the current value of a token (use common sense! If we rebrand green tomorrow that is bigger than a patch)
-- MINOR version for anything that adds a new token or function. 
-- MAJOR version for anything that will “break” the library in a way that will require consumers to do bigger changes than just upping the version, this includes severely changing metrics
+
+-   PATCH for anything that tweaks the current value of a token (use common sense! If we rebrand green tomorrow that is bigger than a patch)
+-   MINOR version for anything that adds a new token or function.
+-   MAJOR version for anything that will “break” the library in a way that will require consumers to do bigger changes than just upping the version, this includes severely changing metrics
 
 ## Migrations
+
 For things like renames & adding function parameters etc it is crucial that we are able to release those in a backwards compatible manner. A simple way to do this is keeping the old names around pointing to the new ones and logging deprecation warnings.

--- a/packages/pasteup/CONTRIBUTING.md
+++ b/packages/pasteup/CONTRIBUTING.md
@@ -3,8 +3,15 @@
 Anything that either generates style primitives or can be used to generate style primitives and is plain javascript (including JSON). For the most part this is pretty unambiguous: Colours, sizes, grid, etc all fit the bill. Font mappings are a good candidate too. Do NOT use paste up for components (as of Feb ‘19).
 Think of pasteup as a base foundation you can use to build components with the tech stack of your choice.
 
-<!-- START doctoc -->
-<!-- END doctoc -->
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+<!-- Automatically created with yarn run createtoc and on push hook -->
+
+- [Releasing pasteup](#releasing-pasteup)
+- [Versioning rules of thumb](#versioning-rules-of-thumb)
+  - [Migrations](#migrations)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 # Releasing pasteup
 

--- a/packages/pasteup/README.md
+++ b/packages/pasteup/README.md
@@ -2,8 +2,20 @@
 
 The Guardian Design Tokens are intended to be used in conjunction with a CSS-in-JS library such as [Emotion](https://emotion.sh).
 
-<!-- START doctoc -->
-<!-- END doctoc -->
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+<!-- Automatically created with yarn run createtoc and on push hook -->
+
+- [Motivation](#motivation)
+- [Usage](#usage)
+  - [Breakpoints](#breakpoints)
+    - [Example](#example)
+    - [Reference](#reference)
+  - [Fonts](#fonts)
+  - [Mixins](#mixins)
+  - [Palette](#palette)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 **Under construction 🚧**
 

--- a/packages/pasteup/README.md
+++ b/packages/pasteup/README.md
@@ -2,6 +2,9 @@
 
 The Guardian Design Tokens are intended to be used in conjunction with a CSS-in-JS library such as [Emotion](https://emotion.sh).
 
+<!-- START doctoc -->
+<!-- END doctoc -->
+
 **Under construction 🚧**
 
 This file documents the current version of Pasteup. This package is still under heavy construction, please do not install this in applications intended for use in production. The API may change significantly before it is out of alpha.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1910,6 +1910,24 @@
     "@svgr/plugin-svgo" "^4.0.3"
     loader-utils "^1.1.0"
 
+"@textlint/ast-node-types@^4.0.3":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@textlint/ast-node-types/-/ast-node-types-4.2.2.tgz#5042d0b3b16f18b9f2d16b96e6ee5356e6f3d37d"
+  integrity sha512-5VHykhxgUat7dvRWGw52Tk55SWjuZDpDO7PKDhfcLTFrD1cjbTtFFnWeJc0BfoqB2AUjfHXRoMdnqbFRGmnPVQ==
+
+"@textlint/markdown-to-ast@~6.0.9":
+  version "6.0.9"
+  resolved "https://registry.yarnpkg.com/@textlint/markdown-to-ast/-/markdown-to-ast-6.0.9.tgz#e7c89e5ad15d17dcd8e5a62758358936827658fa"
+  integrity sha512-hfAWBvTeUGh5t5kTn2U3uP3qOSM1BSrxzl1jF3nn0ywfZXpRBZr5yRjXnl4DzIYawCtZOshmRi/tI3/x4TE1jQ==
+  dependencies:
+    "@textlint/ast-node-types" "^4.0.3"
+    debug "^2.1.3"
+    remark-frontmatter "^1.2.0"
+    remark-parse "^5.0.0"
+    structured-source "^3.0.2"
+    traverse "^0.6.6"
+    unified "^6.1.6"
+
 "@types/amphtml-validator@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/amphtml-validator/-/amphtml-validator-1.0.0.tgz#9d4e0c879642938bbe5f363d49cafc8ae9f57c81"
@@ -2678,6 +2696,13 @@ amphtml-validator@^1.0.23:
     colors "1.1.2"
     commander "2.9.0"
     promise "7.1.1"
+
+anchor-markdown-header@^0.5.5:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/anchor-markdown-header/-/anchor-markdown-header-0.5.7.tgz#045063d76e6a1f9cd327a57a0126aa0fdec371a7"
+  integrity sha1-BFBj125qH5zTJ6V6ASaqD97Dcac=
+  dependencies:
+    emoji-regex "~6.1.0"
 
 ansi-align@^2.0.0:
   version "2.0.0"
@@ -3813,6 +3838,11 @@ bonjour@^3.5.0:
 boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+
+boundary@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/boundary/-/boundary-1.0.1.tgz#4d67dc2602c0cc16dd9bce7ebf87e948290f5812"
+  integrity sha1-TWfcJgLAzBbdm85+v4fpSCkPWBI=
 
 boxen@^1.2.1:
   version "1.3.0"
@@ -5492,7 +5522,7 @@ dateformat@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
 
-debug@2, debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.3, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9:
+debug@2, debug@2.6.9, debug@^2.1.2, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.3, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -5804,6 +5834,18 @@ dns-txt@^2.0.2:
   dependencies:
     buffer-indexof "^1.0.0"
 
+doctoc@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/doctoc/-/doctoc-1.4.0.tgz#3115aa61d0a92f0abb0672036918ea904f5b9e02"
+  integrity sha512-8IAq3KdMkxhXCUF+xdZxdJxwuz8N2j25sMgqiu4U4JWluN9tRKMlAalxGASszQjlZaBprdD2YfXpL3VPWUD4eg==
+  dependencies:
+    "@textlint/markdown-to-ast" "~6.0.9"
+    anchor-markdown-header "^0.5.5"
+    htmlparser2 "~3.9.2"
+    minimist "~1.2.0"
+    underscore "~1.8.3"
+    update-section "^0.3.0"
+
 doctrine@0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-0.7.2.tgz#7cb860359ba3be90e040b26b729ce4bfa654c523"
@@ -6046,6 +6088,11 @@ emitter-listener@^1.1.1:
 emoji-regex@^7.0.1, emoji-regex@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
+
+emoji-regex@~6.1.0:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.1.3.tgz#ec79a3969b02d2ecf2b72254279bf99bc7a83932"
+  integrity sha1-7HmjlpsC0uzytyJUJ5v5m8eoOTI=
 
 emojis-list@^2.0.0:
   version "2.1.0"
@@ -6770,6 +6817,13 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.4:
 fastparse@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.2.tgz#91728c5a5942eced8531283c79441ee4122c35a9"
+
+fault@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/fault/-/fault-1.0.3.tgz#4da88cf979b6b792b4e13c7ec836767725170b7e"
+  integrity sha512-sfFuP4X0hzrbGKjAUNXYvNqsZ5F6ohx/dZ9I0KQud/aiZNwg263r5L9yGB0clvXHCkzXh5W3t7RSHchggYIFmA==
+  dependencies:
+    format "^0.2.2"
 
 fault@^1.0.2:
   version "1.0.2"
@@ -8374,6 +8428,18 @@ htmlparser2@^3.9.2:
     entities "^1.1.1"
     inherits "^2.0.1"
     readable-stream "^3.0.6"
+
+htmlparser2@~3.9.2:
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
+  integrity sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=
+  dependencies:
+    domelementtype "^1.3.0"
+    domhandler "^2.3.0"
+    domutils "^1.5.1"
+    entities "^1.1.1"
+    inherits "^2.0.1"
+    readable-stream "^2.0.2"
 
 http-cache-semantics@^3.8.1:
   version "3.8.1"
@@ -10909,7 +10975,7 @@ minimist@1.1.x:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.1.3.tgz#3bedfd91a92d39016fcfaa1c681e8faa1a1efda8"
 
-minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
+minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -14134,6 +14200,14 @@ relay-runtime@2.0.0:
     "@babel/runtime" "^7.0.0"
     fbjs "^1.0.0"
 
+remark-frontmatter@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/remark-frontmatter/-/remark-frontmatter-1.3.1.tgz#bc28c0c913fa0b9dd26f17304bc47b856b2ea2de"
+  integrity sha512-Zj/fDMYnSVgMCeKp8fXIhtMoZq4G6E1dnwfMoO8fVXrm/+oVSiN8YMREtwN2cctgK9EsnYSeS1ExX2hcX/fE1A==
+  dependencies:
+    fault "^1.0.1"
+    xtend "^4.0.1"
+
 remark-parse@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-5.0.0.tgz#4c077f9e499044d1d5c13f80d7a98cf7b9285d95"
@@ -15480,6 +15554,13 @@ strip-markdown@^3.0.1:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/strip-markdown/-/strip-markdown-3.0.3.tgz#93b4526abe32a1d69e5ca943f4d9ba25c01a4d48"
 
+structured-source@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/structured-source/-/structured-source-3.0.2.tgz#dd802425e0f53dc4a6e7aca3752901a1ccda7af5"
+  integrity sha1-3YAkJeD1PcSm56yjdSkBoczaevU=
+  dependencies:
+    boundary "^1.0.1"
+
 style-loader@^0.21.0:
   version "0.21.0"
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.21.0.tgz#68c52e5eb2afc9ca92b6274be277ee59aea3a852"
@@ -16050,6 +16131,11 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
+traverse@^0.6.6:
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
+  integrity sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=
+
 trim-lines@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/trim-lines/-/trim-lines-1.1.1.tgz#da738ff58fa74817588455e30b11b85289f2a396"
@@ -16307,6 +16393,11 @@ underscore.string@^3.3.4, underscore.string@^3.3.5:
     sprintf-js "^1.0.3"
     util-deprecate "^1.0.2"
 
+underscore@~1.8.3:
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
+  integrity sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=
+
 unescape@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/unescape/-/unescape-0.2.0.tgz#b78b9b60c86f1629df181bf53eee3bc8d6367ddf"
@@ -16341,7 +16432,7 @@ unicode-property-aliases-ecmascript@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz#5a533f31b4317ea76f17d807fa0d116546111dd0"
 
-unified@^6.0.0, unified@^6.1.5:
+unified@^6.0.0, unified@^6.1.5, unified@^6.1.6:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/unified/-/unified-6.2.0.tgz#7fbd630f719126d67d40c644b7e3f617035f6dba"
   dependencies:
@@ -16521,6 +16612,11 @@ update-notifier@^2.3.0, update-notifier@^2.5.0:
     latest-version "^3.0.0"
     semver-diff "^2.0.0"
     xdg-basedir "^3.0.0"
+
+update-section@^0.3.0:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/update-section/-/update-section-0.3.3.tgz#458f17820d37820dc60e20b86d94391b00123158"
+  integrity sha1-RY8Xgg03gg3GDiC4bZQ5GwASMVg=
 
 upper-case-first@^1.1.0, upper-case-first@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
## What does this change?
I ❤️ tables of contents in documentation... but they're never kept up to date and easily forgotten about. 

This adds the npm `doctoc` module and relies on this PR https://github.com/guardian/dotcom-rendering/pull/591 to hook into the husky `pre-push` hook to create, add and commit changes to the tables of contents.

Most of the action is in [package.json](package.json) the rest being adding of TOC.

![image](https://user-images.githubusercontent.com/638051/58958086-00d23400-879a-11e9-951e-1dc184362db3.png)


## Why?
```javascript
'A+ documentation' === 'better devex'
``` 

@guardian/dotcom-platform 
