### PR TITLE
Add data model validation step to renderAMPArticle 

### DIFF
--- a/packages/frontend/amp/server/render.tsx
+++ b/packages/frontend/amp/server/render.tsx
@@ -8,8 +8,18 @@ import { extract as extractNAV } from '@frontend/model/extract-nav';
 import { extract as extractConfig } from '@frontend/model/extract-config';
 import { extract as extractLinkedData } from '@frontend/model/extract-linked-data';
 import { AnalyticsModel } from '@frontend/amp/components/Analytics';
+import { validateRequestData } from '@root/packages/frontend/model/validate';
 
-export const render = ({ body }: express.Request, res: express.Response) => {
+export const render = (
+    { body, path }: express.Request,
+    res: express.Response,
+) => {
+    try {
+        validateRequestData(body, path);
+    } catch (e) {
+        res.status(400).send(`<pre>${e.stack}</pre>`);
+    }
+
     try {
         const CAPI = extractCAPI(body);
         const linkedData = extractLinkedData(body);

--- a/packages/frontend/amp/server/render.tsx
+++ b/packages/frontend/amp/server/render.tsx
@@ -17,7 +17,7 @@ export const render = (
     try {
         validateRequestData(body, path);
     } catch (e) {
-        res.status(400).send(`<pre>${e.stack}</pre>`);
+        // TODO Add logging
     }
 
     try {

--- a/packages/frontend/model/validate.test.ts
+++ b/packages/frontend/model/validate.test.ts
@@ -1,0 +1,18 @@
+import { validateRequestData, ValidationError } from './validate';
+import { data } from '@root/fixtures/article';
+
+describe('JSON Schema request data validation', () => {
+    it('returns true if data is valid', () => {
+        expect(validateRequestData(data, '/AMPArticle')).toBe(true);
+    });
+
+    it('throws validation Error if data is invalid', () => {
+        const testData = {
+            ...data,
+            page: { content: { headline: 1 } },
+        };
+        expect(() => {
+            validateRequestData(testData, '/AMPArticle');
+        }).toThrowError(ValidationError);
+    });
+});

--- a/packages/frontend/model/validate.ts
+++ b/packages/frontend/model/validate.ts
@@ -1,0 +1,36 @@
+import Ajv from 'ajv';
+
+export class ValidationError extends Error { }
+
+// enpoint can be used to reference matching schema
+export const validateRequestData = (data: any, endpoint: string) => {
+    const schema = {
+        properties: {
+            page: {
+                type: 'object',
+                properties: {
+                    content: {
+                        type: 'object',
+                        properties: {
+                            headline: { type: 'string' },
+                        },
+                    },
+                },
+            },
+        },
+    };
+
+    const ajv = new Ajv();
+    const isValid = ajv.validate(schema, data);
+
+    if (!isValid) {
+        throw new ValidationError(
+            `Could not validate request from ${endpoint}.\n ${JSON.stringify(
+                ajv.errors,
+                null,
+                4,
+            )}`,
+        );
+    }
+    return isValid;
+};

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -10,6 +10,7 @@
     "@guardian/pasteup": "2.0.0-alpha.2",
     "@types/lodash.escape": "^4.0.6",
     "@types/sanitize-html": "^1.18.3",
+    "ajv": "^6.10.0",
     "aws-sdk": "^2.340.0",
     "compose-function": "^3.0.3",
     "compression": "^1.7.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2642,9 +2642,10 @@ ajv@^6.1.0, ajv@^6.5.5, ajv@^6.6.1:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^6.9.1:
+ajv@^6.10.0, ajv@^6.9.1:
   version "6.10.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.0.tgz#90d0d54439da587cd7e843bfb7045f50bd22bdf1"
+  integrity sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==
   dependencies:
     fast-deep-equal "^2.0.1"
     fast-json-stable-stringify "^2.0.0"


### PR DESCRIPTION
## What does this change?

- Adds a `validateRequestData` try/catch block to the top of `renderAMPArticle` in order to catch any data errors and fail fast with a 400 status code and helpful error message, leveraging JSON schema
- Adds `ajv` package to DCR for JSON schema validation

## Why?
This is first step to making data model validation and extraction type safe.

## Link to supporting Trello card
https://trello.com/c/qBNj8JJK/405-make-data-model-validation-and-extraction-type-safe

## Next Steps
- Build out JSON schema incrementally based on the Frontend DCR data model and DCR type requirements.
- Add appropriate logging of validation errors
