### PR TITLE
Validate AMP pages in prbuilds

### DIFF
--- a/.prbuilds/config.yml
+++ b/.prbuilds/config.yml
@@ -4,4 +4,6 @@ teardown:
   ansible: .prbuilds/cleanup.playbook.yml
 checks:
   lighthouse:
-    url: http://localhost:3030/Article
+    url: http://localhost:3030/AMPArticle
+  amp:
+    url: http://localhost:3030/AMPArticle


### PR DESCRIPTION
## What does this change?

I've built an AMP validator into prbuilds, this will configure dotcom-rendering to run this check. This PR will also verify that it actually works properly.

I also made the lighthouse check use the AMP page since that seems more useful right now. PRBuilds seems to be misbehaving on this repo anyway giving empty results so will be interesting to see what happens.

@gtrufitt 

## Why?

To prevent introducing breaking AMP changes at the PR level

## Link to supporting Trello card
