### PR TITLE
Fix update attribute to immediate child of amp-live-list

### DIFF
--- a/packages/frontend/amp/components/BodyLiveblog.tsx
+++ b/packages/frontend/amp/components/BodyLiveblog.tsx
@@ -118,8 +118,8 @@ export const Body: React.FC<{
                 id="live-blog-entries-7ea0dbef"
                 data-max-items-per-page="20" // TODO confirm if this should be dynamic
             >
-                <div className={updateButtonStyle}>
-                    <button update="" on="tap:my-live-list.update">
+                <div update="" className={updateButtonStyle}>
+                    <button on="tap:my-live-list.update">
                         <RefreshIcon />
                         <span>You have updates</span>
                     </button>


### PR DESCRIPTION
At the moment the update button always displays(!) as the update attribute is not on the direct descendant of the amp-live-list element - because I introduced a wrapper div for styling purposes.

Note: liveblogs are obviously not live yet so this issue is not urgent, but is something to fix before we can go live.
