### PR TITLE
Introduce AudioAtom rendering

### DIFF
--- a/packages/frontend/amp/components/Elements.tsx
+++ b/packages/frontend/amp/components/Elements.tsx
@@ -26,7 +26,7 @@ import { InteractiveUrl } from '@frontend/amp/components/elements/InteractiveUrl
 import { InteractiveMarkup } from '@frontend/amp/components/elements/InteractiveMarkup';
 import { MapEmbed } from '@frontend/amp/components/elements/MapEmbed';
 import { WithAds } from '@frontend/amp/components/WithAds';
-import { AudioAtom } from '@root/packages/frontend/amp/components/elements/AudioAtom';
+import { AudioAtom } from '@frontend/amp/components/elements/AudioAtom';
 
 const clear = css`
     clear: both;

--- a/packages/frontend/amp/components/Elements.tsx
+++ b/packages/frontend/amp/components/Elements.tsx
@@ -26,6 +26,7 @@ import { InteractiveUrl } from '@frontend/amp/components/elements/InteractiveUrl
 import { InteractiveMarkup } from '@frontend/amp/components/elements/InteractiveMarkup';
 import { MapEmbed } from '@frontend/amp/components/elements/MapEmbed';
 import { WithAds } from '@frontend/amp/components/WithAds';
+import { AudioAtom } from '@root/packages/frontend/amp/components/elements/AudioAtom';
 
 const clear = css`
     clear: both;
@@ -165,6 +166,8 @@ export const Elements: React.FC<{
                 );
             case 'model.dotcomrendering.pageElements.InteractiveUrlBlockElement':
                 return <InteractiveUrl url={element.url} />;
+            case 'model.dotcomrendering.pageElements.AudioAtomBlockElement':
+                return <AudioAtom element={element} />;
             default:
                 // tslint:disable-next-line:no-console
                 console.log('Unsupported Element', JSON.stringify(element));

--- a/packages/frontend/amp/components/elements/AudioAtom.tsx
+++ b/packages/frontend/amp/components/elements/AudioAtom.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export const AudioAtom: React.FC<{
+    element: AudioAtomElement;
+}> = ({ element }) => {
+    return (
+        <amp-audio src={element.trackUrl} title={element.kicker}>
+            <div fallback="">
+                <p>Your browser doesn’t support HTML5 audio</p>
+            </div>
+        </amp-audio>
+    );
+};

--- a/packages/frontend/amp/components/elements/AudioAtom.tsx
+++ b/packages/frontend/amp/components/elements/AudioAtom.tsx
@@ -6,7 +6,10 @@ export const AudioAtom: React.FC<{
     return (
         <amp-audio src={element.trackUrl} title={element.kicker}>
             <div fallback="">
-                <p>Your browser doesn’t support HTML5 audio</p>
+                <p>
+                    We're unable to serve this media because your browser does
+                    not support HTML 5 audio.
+                </p>
             </div>
         </amp-audio>
     );

--- a/packages/frontend/amp/server/document.tsx
+++ b/packages/frontend/amp/server/document.tsx
@@ -78,6 +78,7 @@ export const document = ({
 
     <!-- AMP element which is specific to the live blog -->
     <script async custom-element="amp-live-list" src="https://cdn.ampproject.org/v0/amp-live-list-0.1.js"></script>
+    <script async custom-element="amp-audio" src="https://cdn.ampproject.org/v0/amp-audio-0.1.js"></script>
 
     <!-- AMP elements that are optional dependending on content -->
     ${scripts.join(' ')}

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -232,6 +232,7 @@ declare namespace JSX {
         'amp-geo': any;
         'amp-consent': any;
         'amp-live-list': any;
+        'amp-audio': any;
         template: any;
     }
 }

--- a/packages/frontend/lib/content.d.ts
+++ b/packages/frontend/lib/content.d.ts
@@ -217,6 +217,15 @@ interface MapBlockElement {
     title: string;
 }
 
+interface AudioAtomElement {
+    _type: 'model.dotcomrendering.pageElements.AudioAtomBlockElement';
+    id: string;
+    kicker: string;
+    trackUrl: string;
+    duration: number;
+    coverUrl: string;
+}
+
 type CAPIElement =
     | TextBlockElement
     | SubheadingBlockElement
@@ -240,4 +249,5 @@ type CAPIElement =
     | TimelineBlockElement
     | InteractiveMarkupBlockElement
     | InteractiveUrlElement
-    | MapBlockElement;
+    | MapBlockElement
+    | AudioAtomElement;


### PR DESCRIPTION
This PR is the companion PR of https://github.com/guardian/frontend/pull/21492 and introduces support for the Audio atom rendering on dotcom-rendering.  Note that we are currently not offering audio on AMP, so this is specific to the dotcom-rendering.

We use the AMP `amp-audio` component ( https://amp.dev/documentation/components/amp-audio ). This is a preliminary implementation and we are not yet using the optional `artwork` attribute, even though the DCR `AudioAtomElement` type carries a correctly set `coverUrl`.

Article page: https://www.theguardian.com/business/2019/may/29/redcar-how-the-end-of-steel-left-a-tragic-legacy-in-a-proud-town

The below screenshoot was done with the mouse hovering over the component to show how the `title` shows up.

![Screenshot 2019-06-06 at 13 31 48](https://user-images.githubusercontent.com/6035518/59033515-c5e70380-8860-11e9-89d5-148684244763.png)


