### PR TITLE
Track component clicks on onward journeys

### DIFF
--- a/packages/frontend/amp/components/Onward.tsx
+++ b/packages/frontend/amp/components/Onward.tsx
@@ -90,40 +90,60 @@ export const Onward: React.FC<{
 }) => {
     const ampBaseURL = 'https://amp.theguardian.com';
 
-    const container = (path: string) => (
+    const container = (path: string, componentName: string) => (
         <OnwardContainer
             key={path}
+            componentName={componentName}
             guardianBaseURL={guardianBaseURL}
             path={path}
         />
     );
 
     const storyPackage = hasStoryPackage
-        ? [container(`${ampBaseURL}/story-package-mf2/${pageID}.json`)]
+        ? [
+              container(
+                  `${ampBaseURL}/story-package-mf2/${pageID}.json`,
+                  'more-on-this-story',
+              ),
+          ]
         : [];
 
     const series = seriesTags.map(tag =>
-        container(`${ampBaseURL}/series-mf2/${tag.id}.json`),
+        container(`${ampBaseURL}/series-mf2/${tag.id}.json`, 'series'),
     );
 
     const related =
         hasRelated && series.length < 1
-            ? [container(`${ampBaseURL}/related-mf2/${pageID}.json`)]
+            ? [
+                  container(
+                      `${ampBaseURL}/related-mf2/${pageID}.json`,
+                      'related-stories',
+                  ),
+              ]
             : [];
 
-    const mostRead = container(`${ampBaseURL}/most-read-mf2.json`);
+    // Frontend:
+    const mostRead = container(
+        `${ampBaseURL}/most-read-mf2.json`,
+        'most-popular',
+    );
 
     const hasSectionMostViewed = sectionID && sectionHasMostViewed(sectionID);
     const sectionMostViewed = hasSectionMostViewed
         ? container(
               `${ampBaseURL}/container/count/1/offset/0/section/${sectionID}/mf2.json`,
+              `most-viewed-in-${sectionID}`,
           )
-        : container(`${ampBaseURL}/container/count/1/offset/0/mf2.json`);
+        : container(
+              `${ampBaseURL}/container/count/1/offset/0/mf2.json`,
+              'most-viewed',
+          );
 
     const headlines = container(
         `${ampBaseURL}/container/count/3/offset/${
             hasSectionMostViewed ? 0 : 1 // TODO not entirely sure why this is needed
         }/mf2.json`,
+        'headlines',
     );
 
     // Outbrain is compliant if it appears in the top 2 containers

--- a/packages/frontend/amp/components/OnwardContainer.tsx
+++ b/packages/frontend/amp/components/OnwardContainer.tsx
@@ -111,18 +111,20 @@ const showMore = css`
 export const OnwardContainer: React.FC<{
     guardianBaseURL: string;
     path: string;
-}> = ({ guardianBaseURL, path }) => (
+    componentName: string;
+}> = ({ guardianBaseURL, path, componentName }) => (
     <amp-list
         layout="fixed-height"
         height="184px"
         src={path}
         credentials="include"
-        class="js-has-click-analytics"
-        data-component={componentName}
     >
         <MoustacheTemplate>
             <MoustacheSection name="showContent">
-                <div className={inner}>
+                <div
+                    className={`${header} js-has-click-event`}
+                    data-vars-component={componentName}
+                >
                     <div className={header}>
                         <MoustacheVariable name="displayName" />
                     </div>
@@ -197,7 +199,6 @@ export const OnwardContainer: React.FC<{
                 </div>
             </MoustacheSection>
         </MoustacheTemplate>
-
         <div overflow="" className={showMore}>
             <ShowMoreButton />
         </div>

--- a/packages/frontend/amp/components/OnwardContainer.tsx
+++ b/packages/frontend/amp/components/OnwardContainer.tsx
@@ -117,6 +117,8 @@ export const OnwardContainer: React.FC<{
         height="184px"
         src={path}
         credentials="include"
+        class="js-has-click-analytics"
+        data-component={componentName}
     >
         <MoustacheTemplate>
             <MoustacheSection name="showContent">

--- a/packages/frontend/amp/components/OnwardContainer.tsx
+++ b/packages/frontend/amp/components/OnwardContainer.tsx
@@ -122,7 +122,7 @@ export const OnwardContainer: React.FC<{
         <MoustacheTemplate>
             <MoustacheSection name="showContent">
                 <div
-                    className={`${header} js-has-click-event`}
+                    className={`${inner} js-has-click-event`}
                     data-vars-component={componentName}
                 >
                     <div className={header}>


### PR DESCRIPTION
## What does this change?

Alongside https://github.com/guardian/ophan/pull/3330 this adds tracking to onward journeys for Ophan.

## Why?

To ensure we have metrics 

## Link to supporting Trello card

https://trello.com/c/0VEP20Sn/343-m5-ensure-ophan-tracking-is-working-correctly-in-amp
