### PR TITLE
AMP ad placement

### DIFF
--- a/packages/frontend/amp/components/Ad.tsx
+++ b/packages/frontend/amp/components/Ad.tsx
@@ -133,11 +133,10 @@ const ampAdElem = (
     contentType: string,
     config: CommercialConfig,
     commercialProperties: CommercialProperties,
-    className: string,
 ) => {
     return (
         <amp-ad
-            class={cx(adClass, adRegionClasses[adRegion], className)}
+            class={cx(adClass, adRegionClasses[adRegion])}
             data-block-on-consent=""
             width={300}
             height={250}
@@ -171,7 +170,7 @@ export const Ad: React.SFC<{
     commercialProperties,
     className,
 }) => (
-    <div className={adStyle}>
+    <div className={cx(adStyle, className)}>
         {ampAdElem(
             'US',
             edition,
@@ -179,7 +178,6 @@ export const Ad: React.SFC<{
             contentType,
             config,
             commercialProperties,
-            className,
         )}
         {ampAdElem(
             'AU',
@@ -188,7 +186,6 @@ export const Ad: React.SFC<{
             contentType,
             config,
             commercialProperties,
-            className,
         )}
         {ampAdElem(
             'ROW',
@@ -197,7 +194,6 @@ export const Ad: React.SFC<{
             contentType,
             config,
             commercialProperties,
-            className,
         )}
     </div>
 );

--- a/packages/frontend/amp/components/Blocks.tsx
+++ b/packages/frontend/amp/components/Blocks.tsx
@@ -77,18 +77,7 @@ export const Blocks: React.SFC<{
                     </a>
                 )}
                 {block.title && <h2>{block.title}</h2>}
-                <Elements
-                    pillar={pillar}
-                    elements={block.elements}
-                    // stuff for ads
-                    edition={edition}
-                    section={section}
-                    contentType={contentType}
-                    switches={switches}
-                    commercialProperties={commercialProperties}
-                    isImmersive={false}
-                    shouldHideAds={true}
-                />
+                {Elements(block.elements, pillar, false)}
                 {/* Some elements float (e.g. rich links) */}
                 <div className={clearBoth} />{' '}
                 {block.lastUpdatedDisplay && (

--- a/packages/frontend/amp/components/BodyArticle.tsx
+++ b/packages/frontend/amp/components/BodyArticle.tsx
@@ -10,6 +10,7 @@ import { pillarPalette } from '@frontend/lib/pillars';
 import { palette } from '@guardian/pasteup/palette';
 import { WithAds } from '@frontend/amp/components/WithAds';
 import { findAdSlots } from '@frontend/amp/lib/find-adslots';
+import { until } from '@guardian/pasteup/breakpoints';
 
 const body = (pillar: Pillar, tone: StyledTone) => {
     const bgColorMap = {
@@ -41,6 +42,16 @@ const bulletStyle = (pillar: Pillar) => css`
     }
 `;
 
+const adStyle = css`
+    float: right;
+    margin: 4px 0 12px 20px;
+
+    ${until.phablet} {
+        float: none;
+        margin: 0 auto 12px;
+    }
+`;
+
 export const Body: React.FC<{
     pillar: Pillar;
     data: ArticleModel;
@@ -67,7 +78,7 @@ export const Body: React.FC<{
         <WithAds
             items={elementsWithoutAds}
             adSlots={slotIndexes}
-            adClassName={''}
+            adClassName={adStyle}
             adInfo={adInfo}
         />
     );

--- a/packages/frontend/amp/components/Elements.tsx
+++ b/packages/frontend/amp/components/Elements.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 
-import { findAdSlots } from '@frontend/amp/lib/find-adslots';
 import { Expandable } from '@frontend/amp/components/Expandable';
-
 import { Disclaimer } from '@frontend/amp/components/elements/Disclaimer';
 import { Text } from '@frontend/amp/components/elements/Text';
 import { Subheading } from '@frontend/amp/components/elements/Subheading';
@@ -18,41 +16,19 @@ import { RichLink } from '@frontend/amp/components/elements/RichLink';
 import { SoundcloudEmbed } from '@frontend/amp/components/elements/SoundcloudEmbed';
 import { Embed } from '@frontend/amp/components/elements/Embed';
 import { PullQuote } from '@frontend/amp/components/elements/PullQuote';
-import { css } from 'emotion';
 import { clean } from '@frontend/model/clean';
 import { Timeline } from '@frontend/amp/components/elements/Timeline';
 import { YoutubeVideo } from '@frontend/amp/components/elements/YoutubeVideo';
 import { InteractiveUrl } from '@frontend/amp/components/elements/InteractiveUrl';
 import { InteractiveMarkup } from '@frontend/amp/components/elements/InteractiveMarkup';
 import { MapEmbed } from '@frontend/amp/components/elements/MapEmbed';
-import { WithAds } from '@frontend/amp/components/WithAds';
 import { AudioAtom } from '@frontend/amp/components/elements/AudioAtom';
 
-const clear = css`
-    clear: both;
-`;
-
-export const Elements: React.FC<{
-    elements: CAPIElement[];
-    pillar: Pillar;
-    edition: Edition;
-    section?: string;
-    contentType: string;
-    switches: Switches;
-    commercialProperties: CommercialProperties;
-    isImmersive: boolean;
-    shouldHideAds: boolean;
-}> = ({
-    elements,
-    pillar,
-    edition,
-    section,
-    contentType,
-    switches,
-    commercialProperties,
-    isImmersive,
-    shouldHideAds,
-}) => {
+export const Elements = (
+    elements: CAPIElement[],
+    pillar: Pillar,
+    isImmersive: boolean,
+): JSX.Element[] => {
     const cleanedElements = elements.map(element =>
         'html' in element ? { ...element, html: clean(element.html) } : element,
     );
@@ -180,28 +156,5 @@ export const Elements: React.FC<{
         }
     });
 
-    if (shouldHideAds) {
-        return <>{output}</>;
-    }
-
-    const slotIndexes = findAdSlots(elements);
-    const adInfo = {
-        section,
-        edition,
-        contentType,
-        commercialProperties,
-        switches: { krux: switches.krux, ampPrebid: switches.prebid },
-    };
-
-    return (
-        <>
-            <WithAds
-                items={output}
-                adSlots={slotIndexes}
-                adClassName={''}
-                adInfo={adInfo}
-            />
-            <div className={clear} />
-        </>
-    );
+    return output.filter(el => el !== null) as JSX.Element[];
 };

--- a/packages/frontend/amp/components/WithAds.tsx
+++ b/packages/frontend/amp/components/WithAds.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
 import { Ad } from '@frontend/amp/components/Ad';
+import { css } from 'emotion';
+
+const clear = css`
+    clear: both;
+`;
 
 interface AdInfo {
     edition: Edition;
@@ -47,5 +52,10 @@ export const WithAds: React.SFC<{
         return item;
     });
 
-    return <>{withAds}</>;
+    return (
+        <>
+            {withAds}
+            <div className={clear} />
+        </>
+    );
 };


### PR DESCRIPTION
## What does this change?

Re-introduces right-float of ads on widest AMP breakpoints (phablet and up, which is 660px+).

## Why?

Looks better on wider devices.

## Link to supporting Trello card

https://trello.com/c/CVAPU74Y

![Screenshot 2019-06-10 at 15 56 56](https://user-images.githubusercontent.com/858402/59204588-dd8ff600-8b98-11e9-9977-bd5805ee66f1.png)

