### PR TITLE
Include hash in key event links

### DIFF
--- a/packages/frontend/amp/components/BodyLiveblog.tsx
+++ b/packages/frontend/amp/components/BodyLiveblog.tsx
@@ -75,7 +75,7 @@ export const Body: React.FC<{
     return (
         <InnerContainer className={bodyStyle}>
             <TopMeta tone={tone} data={data} />
-            <KeyEvents events={data.keyEvents} pillar={pillar} url={url} />
+            <KeyEvents events={data.keyEvents} url={url} />
 
             {!isFirstPage && (
                 <Pagination guardianURL={url} pagination={data.pagination} />

--- a/packages/frontend/amp/components/KeyEvents.tsx
+++ b/packages/frontend/amp/components/KeyEvents.tsx
@@ -64,9 +64,8 @@ const listStyle = css`
 
 export const KeyEvents: React.SFC<{
     events: Block[];
-    pillar: Pillar;
     url: string;
-}> = ({ events, pillar, url }) => {
+}> = ({ events, url }) => {
     if (!events || events.length < 1) {
         return null;
     }

--- a/packages/frontend/amp/lib/block-link.ts
+++ b/packages/frontend/amp/lib/block-link.ts
@@ -1,3 +1,3 @@
 export const blockLink = (url: string, blockID: string): string => {
-    return `${url}?page=with:block-${blockID}`;
+    return `${url}?page=with:block-${blockID}#block-${blockID}`;
 };


### PR DESCRIPTION
## What does this change?

Adds the hash to the key events links so that the link takes you to the exact block.

## Why?

Better UX.

## Link to supporting Trello card

https://trello.com/c/Wtnd5Ab2