### PR TITLE
Add Validation Error logging

### DIFF
--- a/packages/frontend/amp/server/render.tsx
+++ b/packages/frontend/amp/server/render.tsx
@@ -2,13 +2,15 @@ import React from 'react';
 import express from 'express';
 import { document } from '@frontend/amp/server/document';
 import { Article } from '@frontend/amp/pages/Article';
-import { extractScripts } from '@root/packages/frontend/amp/lib/scripts';
+import { extractScripts } from '@frontend/amp/lib/scripts';
 import { extract as extractCAPI } from '@frontend/model/extract-capi';
 import { extract as extractNAV } from '@frontend/model/extract-nav';
 import { extract as extractConfig } from '@frontend/model/extract-config';
 import { extract as extractLinkedData } from '@frontend/model/extract-linked-data';
 import { AnalyticsModel } from '@frontend/amp/components/Analytics';
-import { validateRequestData } from '@root/packages/frontend/model/validate';
+import { validateRequestData } from '@frontend/model/validate';
+import { logger } from '@frontend/app/logging';
+import { warn } from '@root/scripts/env/log';
 
 export const render = (
     { body, path }: express.Request,
@@ -16,8 +18,9 @@ export const render = (
 ) => {
     try {
         validateRequestData(body, path);
-    } catch (e) {
-        // TODO Add logging
+    } catch (err) {
+        logger.warn(err);
+        warn(err);
     }
 
     try {

--- a/packages/frontend/amp/server/render.tsx
+++ b/packages/frontend/amp/server/render.tsx
@@ -10,7 +10,6 @@ import { extract as extractLinkedData } from '@frontend/model/extract-linked-dat
 import { AnalyticsModel } from '@frontend/amp/components/Analytics';
 import { validateRequestData } from '@frontend/model/validate';
 import { logger } from '@frontend/app/logging';
-import { warn } from '@root/scripts/env/log';
 
 export const render = (
     { body, path }: express.Request,
@@ -20,7 +19,6 @@ export const render = (
         validateRequestData(body, path);
     } catch (err) {
         logger.warn(err);
-        warn(err);
     }
 
     try {

--- a/packages/frontend/app/logging.ts
+++ b/packages/frontend/app/logging.ts
@@ -39,7 +39,7 @@ configure({
     },
     categories: {
         default: { appenders: ['fileAppender'], level: 'info' },
-        development: { appenders: ['console'], level: 'warn' },
+        development: { appenders: ['console'], level: 'info' },
     },
     pm2: true,
 });

--- a/packages/frontend/app/logging.ts
+++ b/packages/frontend/app/logging.ts
@@ -27,6 +27,7 @@ addLayout('json', config => {
 
 configure({
     appenders: {
+        console: { type: 'console' },
         fileAppender: {
             type: 'file',
             filename: logLocation,
@@ -36,9 +37,15 @@ configure({
             layout: { type: 'json', separator: ',' },
         },
     },
-    categories: { default: { appenders: ['fileAppender'], level: 'info' } },
+    categories: {
+        default: { appenders: ['fileAppender'], level: 'info' },
+        development: { appenders: ['console'], level: 'warn' },
+    },
     pm2: true,
 });
 
-export const logger = getLogger();
+export const logger =
+    process.env.NODE_ENV === 'development'
+        ? getLogger('development')
+        : getLogger();
 logger.level = 'info';

--- a/packages/frontend/model/validate.ts
+++ b/packages/frontend/model/validate.ts
@@ -35,11 +35,9 @@ export const validateRequestData = (data: any, endpoint: string) => {
 
     if (!isValid) {
         throw new ValidationError(
-            `Could not validate request to ${endpoint}.\n ${JSON.stringify(
-                ajv.errors,
-                null,
-                2,
-            )}`,
+            `Could not validate ${endpoint} request for ${
+            data.page.pageId
+            }.\n ${JSON.stringify(ajv.errors, null, 2)}`,
         );
     }
     return isValid;

--- a/packages/frontend/model/validate.ts
+++ b/packages/frontend/model/validate.ts
@@ -1,6 +1,6 @@
 import Ajv from 'ajv';
 
-class ValidationError extends Error {
+export class ValidationError extends Error {
     constructor(message: string) {
         super(message);
         this.name = 'Validation Error';
@@ -25,7 +25,12 @@ export const validateRequestData = (data: any, endpoint: string) => {
         },
     };
 
-    const ajv = new Ajv();
+    const options = {
+        verbose: true,
+        allErrors: true,
+    };
+
+    const ajv = new Ajv(options);
     const isValid = ajv.validate(schema, data);
 
     if (!isValid) {

--- a/packages/frontend/model/validate.ts
+++ b/packages/frontend/model/validate.ts
@@ -1,6 +1,11 @@
 import Ajv from 'ajv';
 
-export class ValidationError extends Error { }
+class ValidationError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'Validation Error';
+    }
+}
 
 // enpoint can be used to reference matching schema
 export const validateRequestData = (data: any, endpoint: string) => {
@@ -25,10 +30,10 @@ export const validateRequestData = (data: any, endpoint: string) => {
 
     if (!isValid) {
         throw new ValidationError(
-            `Could not validate request from ${endpoint}.\n ${JSON.stringify(
+            `Could not validate request to ${endpoint}.\n ${JSON.stringify(
                 ajv.errors,
                 null,
-                4,
+                2,
             )}`,
         );
     }


### PR DESCRIPTION
## What does this change?

Adds logging of JSON Schema validation errors to Kibana and the console. 
Includes detailed error message from `ajv`, the schema validation package.
Errors will be observed to help verify robustness of JSON Schema, and eventually a 400 response will be added. 

Example error message:
```
Validation Error: Could not validate request to /AMPArticle.
 [
  {
    "keyword": "type",
    "dataPath": ".page.content.headline",
    "schemaPath": "#/properties/page/properties/content/properties/headline/type",
    "params": {
      "type": "string"
    },
    "message": "should be string",
    "schema": "string",
    "parentSchema": {
      "type": "string"
    },
    "data": 101
  }
]
```


## Why?
Incrementally roll out new data validation layer.  

## Link to supporting Trello card
https://trello.com/c/qBNj8JJK/405-make-data-model-validation-and-extraction-type-safe