### PR TITLE
Centre and fix update button positioning

### DIFF
--- a/packages/frontend/amp/components/BodyLiveblog.tsx
+++ b/packages/frontend/amp/components/BodyLiveblog.tsx
@@ -28,14 +28,17 @@ const bodyStyle = css`
     }
 `;
 
+// To override AMP styles we need to use nested and specific selectors here
+// unfortunately.
 const updateButtonStyle = css`
-    position: fixed;
-    top: 12px;
-    left: 0;
-    z-index: 1015;
+    &.amp-active[update] {
+        position: fixed;
+        left: 0;
+        top: 12px;
+        display: flex;
+        justify-content: center;
+    }
 
-    display: flex;
-    justify-content: center;
     width: 100%;
 
     button {


### PR DESCRIPTION
## What does this change?

Centers the update button and fixes it to within the viewport.

## Why?

So users can see it and it looks pretty.

## Link to supporting Trello card

final part of https://trello.com/c/mIVZxdAx

![Screenshot 2019-06-11 at 12 31 25](https://user-images.githubusercontent.com/858402/59268891-9b70be00-8c45-11e9-993a-b4ebbcb01f49.png)

