### PR TITLE
Add placeholder for tweets

### DIFF
--- a/packages/frontend/amp/components/Elements.tsx
+++ b/packages/frontend/amp/components/Elements.tsx
@@ -65,7 +65,9 @@ export const Elements = (
             case 'model.dotcomrendering.pageElements.InstagramBlockElement':
                 return <InstagramEmbed key={i} element={element} />;
             case 'model.dotcomrendering.pageElements.TweetBlockElement':
-                return <TwitterEmbed key={i} element={element} />;
+                return (
+                    <TwitterEmbed key={i} element={element} pillar={pillar} />
+                );
             case 'model.dotcomrendering.pageElements.RichLinkBlockElement':
                 return <RichLink key={i} element={element} pillar={pillar} />;
             case 'model.dotcomrendering.pageElements.CommentBlockElement':

--- a/packages/frontend/amp/components/elements/TwitterEmbed.tsx
+++ b/packages/frontend/amp/components/elements/TwitterEmbed.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { JSDOM } from 'jsdom';
+import { TextStyle } from '@frontend/amp/components/elements/Text';
 
 const makeFallback = (html: string): string | null => {
     const { window } = new JSDOM(html);
@@ -12,7 +13,8 @@ const makeFallback = (html: string): string | null => {
 // tslint:disable:react-no-dangerous-html
 export const TwitterEmbed: React.FC<{
     element: TweetBlockElement;
-}> = ({ element }) => {
+    pillar: Pillar;
+}> = ({ element, pillar }) => {
     const fallbackHTML = makeFallback(element.html);
 
     return (
@@ -23,7 +25,7 @@ export const TwitterEmbed: React.FC<{
             data-tweetid={element.id}
         >
             {fallbackHTML && (
-                <div fallback={''}>
+                <div placeholder={''} className={TextStyle(pillar)}>
                     <blockquote
                         dangerouslySetInnerHTML={{ __html: fallbackHTML }}
                     />


### PR DESCRIPTION
The advantage over simply a fallback is that it works for browsers that block twitter embeds because of tracking concerns.

This was a quick fix because I use ff with content blocking on quite a lot (it's part of vanilla FF now and doesn't require a plugin, although it is still opt-in). Note, that visually the height is still wrong in this case, but at least you get *something*!

Before on my FF: 

(blank space.)

Now:
![Screenshot 2019-06-11 at 17 00 05](https://user-images.githubusercontent.com/858402/59288939-d508ef80-8c6c-11e9-8797-b85ef1ce44f8.png)

(blank space *and* tweet text!)