### PR TITLE
Fix AMP Nielsen Tracking

### DIFF
--- a/fixtures/CAPI.ts
+++ b/fixtures/CAPI.ts
@@ -402,6 +402,7 @@ export const CAPI: CAPIType = {
         AU: { adTargeting: [] },
         INT: { adTargeting: [] },
     },
+    nielsenAPIID: 'ABC123',
     starRating: 2,
     trailText:
         'Ticket touts face unlimited fines for using ‘bots’ to buy in bulk',

--- a/packages/frontend/amp/server/render.tsx
+++ b/packages/frontend/amp/server/render.tsx
@@ -39,7 +39,7 @@ export const render = (
             contentType: CAPI.contentType,
             id: CAPI.pageId,
             beacon: `${CAPI.beaconURL}/count/pv.gif`,
-            neilsenAPIID: '66BEC53C-9890-477C-B639-60879EC4F762',
+            neilsenAPIID: CAPI.nielsenAPIID,
             domain: 'amp.theguardian.com',
         };
 

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -29,7 +29,7 @@ interface AdTargetParam {
     value: string | string[];
 }
 
-interface ArticleSection {
+interface SectionNielsenAPI {
     name: string;
     apiID: string;
 }

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -29,6 +29,12 @@ interface AdTargetParam {
     value: string | string[];
 }
 
+interface SectionAPIID {
+    section: string;
+    apiID: string;
+    subsections: string[];
+}
+
 interface EditionCommercialProperties {
     adTargeting: AdTargetParam[];
     branding?: Branding;
@@ -166,6 +172,7 @@ interface CAPIType {
     commercialProperties: CommercialProperties;
     starRating?: number;
     trailText: string;
+    nielsenAPIID: string;
 }
 
 interface TagType {

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -29,10 +29,10 @@ interface AdTargetParam {
     value: string | string[];
 }
 
-interface SectionAPIID {
-    section: string;
-    apiID: string;
+interface ArticleSection {
+    name: string;
     subsections: string[];
+    apiID: string;
 }
 
 interface EditionCommercialProperties {

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -31,7 +31,6 @@ interface AdTargetParam {
 
 interface ArticleSection {
     name: string;
-    subsections: string[];
     apiID: string;
 }
 

--- a/packages/frontend/model/article-sections.test.ts
+++ b/packages/frontend/model/article-sections.test.ts
@@ -1,0 +1,159 @@
+import { findBySubsection } from '@frontend/model/article-sections';
+
+describe('returns section for each subsection', () => {
+    it('returns Books section for all its subsections', () => {
+        const subsections = ['books', 'childrens-books-site'];
+        subsections.forEach(subsection => {
+            expect(findBySubsection(subsection).name).toEqual('Books');
+        });
+    });
+
+    it('returns Business section for all its subsections', () => {
+        const subsections = ['business', 'better-business', 'business-to-business', 'working-in-development'];
+        subsections.forEach(subsection => {
+            expect(findBySubsection(subsection).name).toEqual('Business');
+        });
+    });
+
+    it('return CommentIsFree section for all its subsections', () => {
+        const subsections = ['commentisfree'];
+        subsections.forEach(subsection => {
+            expect(findBySubsection(subsection).name).toEqual('CommentIsFree');
+        });
+    });
+
+    it('return Culture section for all its subsections', () => {
+        const subsections = ['culture', 'artanddesign', 'culture-network', 'culture-professionals-network', 'games', 'stage'];
+        subsections.forEach(subsection => {
+            expect(findBySubsection(subsection).name).toEqual('Culture');
+        });
+    });
+
+    it('return Education section for all its subsections', () => {
+        const subsections = ['education', 'higher-education-network', 'teacher-network'];
+        subsections.forEach(subsection => {
+            expect(findBySubsection(subsection).name).toEqual('Education');
+        });
+    });
+
+
+    it('return Environment section for all its subsections', () => {
+        const subsections = ['environment', 'animals-farmed'];
+        subsections.forEach(subsection => {
+            expect(findBySubsection(subsection).name).toEqual('Environment');
+        });
+    });
+
+    it('return Fashion section for all its subsections', () => {
+        const subsections = ['fashion'];
+        subsections.forEach(subsection => {
+            expect(findBySubsection(subsection).name).toEqual('Fashion');
+        });
+    });
+
+
+    it('return Film section for all its subsections', () => {
+        const subsections = ['film'];
+        subsections.forEach(subsection => {
+            expect(findBySubsection(subsection).name).toEqual('Film');
+        });
+    });
+
+    it('return LifeStyle section for all its subsections', () => {
+        const subsections = ['lifeandstyle'];
+        subsections.forEach(subsection => {
+            expect(findBySubsection(subsection).name).toEqual('LifeStyle');
+        });
+    });
+
+
+    it('return Media section for all its subsections', () => {
+        const subsections = ['media'];
+        subsections.forEach(subsection => {
+            expect(findBySubsection(subsection).name).toEqual('Media');
+        });
+    });
+
+    it('return Money section for all its subsections', () => {
+        const subsections = ['money'];
+        subsections.forEach(subsection => {
+            expect(findBySubsection(subsection).name).toEqual('Money');
+        });
+    });
+
+    it('return Music section for all its subsections', () => {
+        const subsections = ['music'];
+        subsections.forEach(subsection => {
+            expect(findBySubsection(subsection).name).toEqual('Music');
+        });
+    });
+
+    it('return News section for all its subsections', () => {
+        const subsections = ['news', 'australia-news', 'cardiff', 'cities', 'community', 'edinburgh', 'global-development', 'government-computing-network', 'law', 'leeds', 'local', 'local-government-network', 'media-network', 'uk-news', 'us-news', 'weather', 'world'];
+        subsections.forEach(subsection => {
+            expect(findBySubsection(subsection).name).toEqual('News');
+        });
+    });
+
+    it('return Politics section for all its subsections', () => {
+        const subsections = ['politics'];
+        subsections.forEach(subsection => {
+            expect(findBySubsection(subsection).name).toEqual('Politics');
+        });
+    });
+
+    it('return ProfessionalNetwork section for all its subsections', () => {
+        const subsections = ['guardian-professional', 'global-development-professionals-network', 'small-business-network'];
+        subsections.forEach(subsection => {
+            expect(findBySubsection(subsection).name).toEqual('ProfessionalNetwork');
+        });
+    });
+
+    it('return Science section for all its subsections', () => {
+        const subsections = ['science'];
+        subsections.forEach(subsection => {
+            expect(findBySubsection(subsection).name).toEqual('Science');
+        });
+    });
+
+
+    it('return Society section for all its subsections', () => {
+        const subsections = ['society', 'healthcare-network', 'housing-network', 'inequality', 'public-leaders-network', 'social-care-network', 'social-enterprise-network', 'society-professionals', 'women-in-leadership'];
+        subsections.forEach(subsection => {
+            expect(findBySubsection(subsection).name).toEqual('Society');
+        });
+    });
+
+    it('return Sport section for all its subsections', () => {
+        const subsections = ['sport', 'football'];
+        subsections.forEach(subsection => {
+            expect(findBySubsection(subsection).name).toEqual('Sport');
+        });
+    });
+
+
+    it('return Technology section for all its subsections', () => {
+        const subsections = ['technology'];
+        subsections.forEach(subsection => {
+            expect(findBySubsection(subsection).name).toEqual('Technology');
+        });
+    });
+
+    it('return Travel section for all its subsections', () => {
+        const subsections = ['travel', 'travel/offers'];
+        subsections.forEach(subsection => {
+            expect(findBySubsection(subsection).name).toEqual('Travel');
+        });
+    });
+
+    it('return TvRadio section for all its subsections', () => {
+        const subsections = ['tv-and-radio'];
+        subsections.forEach(subsection => {
+            expect(findBySubsection(subsection).name).toEqual('TvRadio');
+        });
+    });
+
+    it('return Guardian for empty subsections', () => {
+        expect(findBySubsection("").name).toEqual('Guardian');
+    });
+});

--- a/packages/frontend/model/article-sections.test.ts
+++ b/packages/frontend/model/article-sections.test.ts
@@ -1,159 +1,38 @@
 import { findBySubsection } from '@frontend/model/article-sections';
 
 describe('returns section for each subsection', () => {
-    it('returns Books section for all its subsections', () => {
-        const subsections = ['books', 'childrens-books-site'];
-        subsections.forEach(subsection => {
-            expect(findBySubsection(subsection).name).toEqual('Books');
+    const testCases = [
+        [[], 'Guardian'],
+        [['books', 'childrens-books-site'], 'Books'],
+        [['books', 'childrens-books-site'], 'Books'],
+        [['business', 'better-business', 'business-to-business', 'working-in-development'], 'Business'],
+        [['commentisfree'], 'CommentIsFree'],
+        [['culture', 'artanddesign', 'culture-network', 'culture-professionals-network', 'games', 'stage'], 'Culture'],
+        [['education', 'higher-education-network', 'teacher-network'], 'Education'],
+        [['environment', 'animals-farmed'], 'Environment'],
+        [['fashion'], 'Fashion'],
+        [['film'], 'Film'],
+        [['lifeandstyle'], 'LifeStyle'],
+        [['media'], 'Media'],
+        [['money'], 'Money'],
+        [['music'], 'Music'],
+        [['news', 'australia-news', 'cardiff', 'cities', 'community', 'edinburgh', 'global-development', 'government-computing-network', 'law', 'leeds', 'local', 'local-government-network', 'media-network', 'uk-news', 'us-news', 'weather', 'world'], 'News'],
+        [['politics'], 'Politics'],
+        [['guardian-professional', 'global-development-professionals-network', 'small-business-network'], 'ProfessionalNetwork'],
+        [['science'], 'Science'],
+        [['society', 'healthcare-network', 'housing-network', 'inequality', 'public-leaders-network', 'social-care-network', 'social-enterprise-network', 'society-professionals', 'women-in-leadership'], 'Society'],
+        [['sport', 'football'], 'Sport'],
+        [['technology'], 'Technology'],
+        [['travel', 'travel/offers'], 'Travel'],
+        [['tv-and-radio'], 'TvRadio']
+    ];
+
+    it('returns correct Section for each test case', () => {
+        testCases.forEach(testCase => {
+            for (const subsection of testCase[0]) {
+                expect(findBySubsection(subsection).name).toEqual(testCase[1]);
+            }
         });
     });
 
-    it('returns Business section for all its subsections', () => {
-        const subsections = ['business', 'better-business', 'business-to-business', 'working-in-development'];
-        subsections.forEach(subsection => {
-            expect(findBySubsection(subsection).name).toEqual('Business');
-        });
-    });
-
-    it('return CommentIsFree section for all its subsections', () => {
-        const subsections = ['commentisfree'];
-        subsections.forEach(subsection => {
-            expect(findBySubsection(subsection).name).toEqual('CommentIsFree');
-        });
-    });
-
-    it('return Culture section for all its subsections', () => {
-        const subsections = ['culture', 'artanddesign', 'culture-network', 'culture-professionals-network', 'games', 'stage'];
-        subsections.forEach(subsection => {
-            expect(findBySubsection(subsection).name).toEqual('Culture');
-        });
-    });
-
-    it('return Education section for all its subsections', () => {
-        const subsections = ['education', 'higher-education-network', 'teacher-network'];
-        subsections.forEach(subsection => {
-            expect(findBySubsection(subsection).name).toEqual('Education');
-        });
-    });
-
-
-    it('return Environment section for all its subsections', () => {
-        const subsections = ['environment', 'animals-farmed'];
-        subsections.forEach(subsection => {
-            expect(findBySubsection(subsection).name).toEqual('Environment');
-        });
-    });
-
-    it('return Fashion section for all its subsections', () => {
-        const subsections = ['fashion'];
-        subsections.forEach(subsection => {
-            expect(findBySubsection(subsection).name).toEqual('Fashion');
-        });
-    });
-
-
-    it('return Film section for all its subsections', () => {
-        const subsections = ['film'];
-        subsections.forEach(subsection => {
-            expect(findBySubsection(subsection).name).toEqual('Film');
-        });
-    });
-
-    it('return LifeStyle section for all its subsections', () => {
-        const subsections = ['lifeandstyle'];
-        subsections.forEach(subsection => {
-            expect(findBySubsection(subsection).name).toEqual('LifeStyle');
-        });
-    });
-
-
-    it('return Media section for all its subsections', () => {
-        const subsections = ['media'];
-        subsections.forEach(subsection => {
-            expect(findBySubsection(subsection).name).toEqual('Media');
-        });
-    });
-
-    it('return Money section for all its subsections', () => {
-        const subsections = ['money'];
-        subsections.forEach(subsection => {
-            expect(findBySubsection(subsection).name).toEqual('Money');
-        });
-    });
-
-    it('return Music section for all its subsections', () => {
-        const subsections = ['music'];
-        subsections.forEach(subsection => {
-            expect(findBySubsection(subsection).name).toEqual('Music');
-        });
-    });
-
-    it('return News section for all its subsections', () => {
-        const subsections = ['news', 'australia-news', 'cardiff', 'cities', 'community', 'edinburgh', 'global-development', 'government-computing-network', 'law', 'leeds', 'local', 'local-government-network', 'media-network', 'uk-news', 'us-news', 'weather', 'world'];
-        subsections.forEach(subsection => {
-            expect(findBySubsection(subsection).name).toEqual('News');
-        });
-    });
-
-    it('return Politics section for all its subsections', () => {
-        const subsections = ['politics'];
-        subsections.forEach(subsection => {
-            expect(findBySubsection(subsection).name).toEqual('Politics');
-        });
-    });
-
-    it('return ProfessionalNetwork section for all its subsections', () => {
-        const subsections = ['guardian-professional', 'global-development-professionals-network', 'small-business-network'];
-        subsections.forEach(subsection => {
-            expect(findBySubsection(subsection).name).toEqual('ProfessionalNetwork');
-        });
-    });
-
-    it('return Science section for all its subsections', () => {
-        const subsections = ['science'];
-        subsections.forEach(subsection => {
-            expect(findBySubsection(subsection).name).toEqual('Science');
-        });
-    });
-
-
-    it('return Society section for all its subsections', () => {
-        const subsections = ['society', 'healthcare-network', 'housing-network', 'inequality', 'public-leaders-network', 'social-care-network', 'social-enterprise-network', 'society-professionals', 'women-in-leadership'];
-        subsections.forEach(subsection => {
-            expect(findBySubsection(subsection).name).toEqual('Society');
-        });
-    });
-
-    it('return Sport section for all its subsections', () => {
-        const subsections = ['sport', 'football'];
-        subsections.forEach(subsection => {
-            expect(findBySubsection(subsection).name).toEqual('Sport');
-        });
-    });
-
-
-    it('return Technology section for all its subsections', () => {
-        const subsections = ['technology'];
-        subsections.forEach(subsection => {
-            expect(findBySubsection(subsection).name).toEqual('Technology');
-        });
-    });
-
-    it('return Travel section for all its subsections', () => {
-        const subsections = ['travel', 'travel/offers'];
-        subsections.forEach(subsection => {
-            expect(findBySubsection(subsection).name).toEqual('Travel');
-        });
-    });
-
-    it('return TvRadio section for all its subsections', () => {
-        const subsections = ['tv-and-radio'];
-        subsections.forEach(subsection => {
-            expect(findBySubsection(subsection).name).toEqual('TvRadio');
-        });
-    });
-
-    it('return Guardian for empty subsections', () => {
-        expect(findBySubsection("").name).toEqual('Guardian');
-    });
 });

--- a/packages/frontend/model/article-sections.ts
+++ b/packages/frontend/model/article-sections.ts
@@ -1,116 +1,158 @@
 export const sections: ArticleSection[] = [
     {
         name: 'Guardian',
-        subsections: [],
         apiID: '2879C1E1-7EF9-459B-9C5C-6F4D2BC9DD53'
     },
     {
         name: 'Books',
-        subsections: ['books', 'childrens-books-site'],
         apiID: '4994D04B-4279-4184-A2C5-E8BB1DD50AB9'
     },
     {
         name: 'Business',
-        subsections: ['business', 'better-business', 'business-to-business', 'working-in-development'],
         apiID: '163BF72C-72D0-4702-82A9-17A548A39D79'
     },
     {
         name: 'CommentIsFree',
-        subsections: ['commentisfree'],
         apiID: 'C962A2C3-C9E1-40DD-9B58-7B1095EDB16E'
     },
     {
         name: 'Culture',
-        subsections: ['culture', 'artanddesign', 'culture-network', 'culture-professionals-network', 'games', 'stage'],
         apiID: '87C0725C-D478-4567-967B-E3519ECD12E8'
     },{
         name: 'Education',
-        subsections: ['education', 'higher-education-network', 'teacher-network'],
         apiID: 'DD50B111-D493-4D25-8980-2B0752E16ED1'
     },
     {
         name: 'Environment',
-        subsections: ['environment', 'animals-farmed'],
         apiID: 'FEC0766C-C766-4A77-91B3-74C5525E680F'
     },
     {
         name: 'Fashion',
-        subsections: ['fashion'],
         apiID: '1639B19E-B581-491E-94B7-FBACB6823C43'
     },
     {
         name: 'Film',
-        subsections: ['film'],
         apiID: 'D5BB97FE-637C-4E9E-B972-C8EA88101CB7'
     },
     {
         name: 'LifeStyle',
-        subsections: ['lifeandstyle'],
         apiID: 'B32533F9-65CF-4261-8BB9-2A707F59712A'
     },
     {
         name: 'Media',
-        subsections: ['media'],
         apiID: '385AA13F-9B64-4927-9536-BE70F9AD54BD'
     },
     {
         name: 'Money',
-        subsections: ['money'],
         apiID: '10BE8096-BF69-4252-AC27-C4127D8631F6'
     },
     {
         name: 'Music',
-        subsections: ['music'],
         apiID: '9D928193-7B5C-45A9-89E4-C47F42B8FB73'
     },
     {
         name: 'News',
-        subsections: ['news', 'australia-news', 'cardiff', 'cities', 'community', 'edinburgh', 'global-development', 'government-computing-network', 'law', 'leeds', 'local', 'local-government-network', 'media-network', 'uk-news', 'us-news', 'weather', 'world'],
         apiID: '66BEC53C-9890-477C-B639-60879EC4F762'
     },
     {
         name: 'Politics',
-        subsections: ['politics'],
         apiID: 'C5C73A36-9E39-4D42-9049-2528DB5E998D'
     },
     {
         name: 'ProfessionalNetwork',
-        subsections: ['guardian-professional', 'global-development-professionals-network', 'small-business-network'],
         apiID: '9DFEFF7E-9D45-4676-82B3-F29A6BF05BE1'
     },
     {
         name: 'Science',
-        subsections: ['science'],
         apiID: 'F4867E05-4149-49F0-A9DE-9F3496930B8C'
     },
     {
         name: 'Society',
-        subsections: ['society', 'healthcare-network', 'housing-network', 'inequality', 'public-leaders-network', 'social-care-network', 'social-enterprise-network', 'society-professionals', 'women-in-leadership'],
         apiID: '617F9FB9-2D34-4C3A-A2E7-383AE877A35D'
     },
     {
         name: 'Sport',
-        subsections: ['sport', 'football'],
         apiID: '52A6516F-E323-449F-AA57-6A1B2386F8F6'
     },
     {
         name: 'Technology',
-        subsections: ['technology'],
         apiID: '4F448B55-305F-4203-B192-8534CB606C12'
     },
     {
         name: 'Travel',
-        subsections: ['travel', 'travel/offers'],
         apiID: '05A03097-D4CA-46BF-96AD-935252967239'
     },
     {
         name: 'TvRadio',
-        subsections: ['tv-and-radio'],
         apiID: '3277F0D0-9389-4A32-A4D6-516B49D87E45'
     }];
 
+const subsections = {
+  'books' :  sections[1],
+  'childrens-books-site' :  sections[1],
+    'business': sections[2],
+    'better-business': sections[2],
+    'business-to-business': sections[2],
+    'working-in-development': sections[2],
+    'commentisfree': sections[3],
+    'culture': sections[4],
+    'artanddesign': sections[4],
+    'culture-network': sections[4],
+    'culture-professionals-network': sections[4],
+    'games': sections[4],
+    'stage': sections[4],
+    'education': sections[5],
+    'higher-education-network': sections[5],
+    'teacher-network': sections[5],
+    'environment': sections[6],
+    'animals-farmed': sections[6],
+    'fashion': sections[7],
+    'film': sections[8],
+    'lifeandstyle': sections[9],
+    'media': sections[10],
+    'money': sections[11],
+    'music': sections[12],
+    'news': sections[13],
+    'australia-news': sections[13],
+    'cardiff': sections[13],
+    'cities': sections[13],
+    'community': sections[13],
+    'edinburgh': sections[13],
+    'global-development': sections[13],
+    'government-computing-network': sections[13],
+    'law': sections[13],
+    'leeds': sections[13],
+    'local': sections[13],
+    'local-government-network': sections[13],
+    'media-network': sections[13],
+    'uk-news': sections[13],
+    'us-news': sections[13],
+    'weather': sections[13],
+    'world': sections[13],
+    'politics': sections[14],
+    'guardian-professional': sections[15],
+    'global-development-professionals-network': sections[15],
+    'small-business-network': sections[15],
+    'science': sections[16],
+    'society': sections[17],
+    'healthcare-network': sections[17],
+    'housing-network': sections[17],
+    'inequality': sections[17],
+    'public-leaders-network': sections[17],
+    'social-care-network': sections[17],
+    'social-enterprise-network': sections[17],
+    'society-professionals': sections[17],
+    'women-in-leadership': sections[17],
+    'sport': sections[18],
+    'football': sections[18],
+    'technology': sections[19],
+    'travel': sections[20],
+    'travel/offers': sections[20],
+    'tv-and-radio': sections[21]
+};
+
 export const findBySubsection = (subsection: string): ArticleSection => {
-    const section = sections.find(section => section.subsections.some(_ => _ === subsection));
+    const section = (<any>subsections)[subsection];
 
     if (section) {
         return section;

--- a/packages/frontend/model/article-sections.ts
+++ b/packages/frontend/model/article-sections.ts
@@ -1,4 +1,4 @@
-export const sections: ArticleSection[] = [
+export const sections: SectionNielsenAPI[] = [
     {
         name: 'Guardian',
         apiID: '2879C1E1-7EF9-459B-9C5C-6F4D2BC9DD53'
@@ -151,7 +151,7 @@ const subsections = {
     'tv-and-radio': sections[21]
 };
 
-export const findBySubsection = (subsection: string): ArticleSection => {
+export const findBySubsection = (subsection: string): SectionNielsenAPI => {
     const section = (<any>subsections)[subsection];
 
     if (section) {

--- a/packages/frontend/model/article-sections.ts
+++ b/packages/frontend/model/article-sections.ts
@@ -1,0 +1,120 @@
+export const sections: ArticleSection[] = [
+    {
+        name: 'Guardian',
+        subsections: [],
+        apiID: '2879C1E1-7EF9-459B-9C5C-6F4D2BC9DD53'
+    },
+    {
+        name: 'Books',
+        subsections: ['books', 'childrens-books-site'],
+        apiID: '4994D04B-4279-4184-A2C5-E8BB1DD50AB9'
+    },
+    {
+        name: 'Business',
+        subsections: ['business', 'better-business', 'business-to-business', 'working-in-development'],
+        apiID: '163BF72C-72D0-4702-82A9-17A548A39D79'
+    },
+    {
+        name: 'CommentIsFree',
+        subsections: ['commentisfree'],
+        apiID: 'C962A2C3-C9E1-40DD-9B58-7B1095EDB16E'
+    },
+    {
+        name: 'Culture',
+        subsections: ['culture', 'artanddesign', 'culture-network', 'culture-professionals-network', 'games', 'stage'],
+        apiID: '87C0725C-D478-4567-967B-E3519ECD12E8'
+    },{
+        name: 'Education',
+        subsections: ['education', 'higher-education-network', 'teacher-network'],
+        apiID: 'DD50B111-D493-4D25-8980-2B0752E16ED1'
+    },
+    {
+        name: 'Environment',
+        subsections: ['environment', 'animals-farmed'],
+        apiID: 'FEC0766C-C766-4A77-91B3-74C5525E680F'
+    },
+    {
+        name: 'Fashion',
+        subsections: ['fashion'],
+        apiID: '1639B19E-B581-491E-94B7-FBACB6823C43'
+    },
+    {
+        name: 'Film',
+        subsections: ['film'],
+        apiID: 'D5BB97FE-637C-4E9E-B972-C8EA88101CB7'
+    },
+    {
+        name: 'LifeStyle',
+        subsections: ['lifeandstyle'],
+        apiID: 'B32533F9-65CF-4261-8BB9-2A707F59712A'
+    },
+    {
+        name: 'Media',
+        subsections: ['media'],
+        apiID: '385AA13F-9B64-4927-9536-BE70F9AD54BD'
+    },
+    {
+        name: 'Money',
+        subsections: ['money'],
+        apiID: '10BE8096-BF69-4252-AC27-C4127D8631F6'
+    },
+    {
+        name: 'Music',
+        subsections: ['music'],
+        apiID: '9D928193-7B5C-45A9-89E4-C47F42B8FB73'
+    },
+    {
+        name: 'News',
+        subsections: ['news', 'australia-news', 'cardiff', 'cities', 'community', 'edinburgh', 'global-development', 'government-computing-network', 'law', 'leeds', 'local', 'local-government-network', 'media-network', 'uk-news', 'us-news', 'weather', 'world'],
+        apiID: '66BEC53C-9890-477C-B639-60879EC4F762'
+    },
+    {
+        name: 'Politics',
+        subsections: ['politics'],
+        apiID: 'C5C73A36-9E39-4D42-9049-2528DB5E998D'
+    },
+    {
+        name: 'ProfessionalNetwork',
+        subsections: ['guardian-professional', 'global-development-professionals-network', 'small-business-network'],
+        apiID: '9DFEFF7E-9D45-4676-82B3-F29A6BF05BE1'
+    },
+    {
+        name: 'Science',
+        subsections: ['science'],
+        apiID: 'F4867E05-4149-49F0-A9DE-9F3496930B8C'
+    },
+    {
+        name: 'Society',
+        subsections: ['society', 'healthcare-network', 'housing-network', 'inequality', 'public-leaders-network', 'social-care-network', 'social-enterprise-network', 'society-professionals', 'women-in-leadership'],
+        apiID: '617F9FB9-2D34-4C3A-A2E7-383AE877A35D'
+    },
+    {
+        name: 'Sport',
+        subsections: ['sport', 'football'],
+        apiID: '52A6516F-E323-449F-AA57-6A1B2386F8F6'
+    },
+    {
+        name: 'Technology',
+        subsections: ['technology'],
+        apiID: '4F448B55-305F-4203-B192-8534CB606C12'
+    },
+    {
+        name: 'Travel',
+        subsections: ['travel', 'travel/offers'],
+        apiID: '05A03097-D4CA-46BF-96AD-935252967239'
+    },
+    {
+        name: 'TvRadio',
+        subsections: ['tv-and-radio'],
+        apiID: '3277F0D0-9389-4A32-A4D6-516B49D87E45'
+    }];
+
+export const findBySubsection = (subsection: string): ArticleSection => {
+    const section = sections.find(section => section.subsections.some(_ => _ === subsection));
+
+    if (section) {
+        return section;
+    }
+
+    return sections[0];
+};

--- a/packages/frontend/model/article-sections.ts
+++ b/packages/frontend/model/article-sections.ts
@@ -154,9 +154,7 @@ const subsections = {
 export const findBySubsection = (subsection: string): SectionNielsenAPI => {
     const section = (<any>subsections)[subsection];
 
-    if (section) {
-        return section;
-    }
+    if (section) return section;
 
     return sections[0];
 };

--- a/packages/frontend/model/article-sections.ts
+++ b/packages/frontend/model/article-sections.ts
@@ -88,8 +88,8 @@ export const sections: SectionNielsenAPI[] = [
     }];
 
 const subsections = {
-  'books' :  sections[1],
-  'childrens-books-site' :  sections[1],
+    'books' :  sections[1],
+    'childrens-books-site' :  sections[1],
     'business': sections[2],
     'better-business': sections[2],
     'business-to-business': sections[2],

--- a/packages/frontend/model/article-sections.ts
+++ b/packages/frontend/model/article-sections.ts
@@ -152,8 +152,8 @@ const subsections = {
 };
 
 export const findBySubsection = (subsection: string): SectionNielsenAPI => {
-    const section = (<any>subsections)[subsection];
-
+    // @ts-ignore
+    const section = subsections[subsection];
     if (section) return section;
 
     return sections[0];

--- a/packages/frontend/model/article-sections.ts
+++ b/packages/frontend/model/article-sections.ts
@@ -152,8 +152,7 @@ const subsections = {
 };
 
 export const findBySubsection = (subsection: string): SectionNielsenAPI => {
-    // @ts-ignore
-    const section = subsections[subsection];
+    const section = (subsections as any)[subsection];
     if (section) return section;
 
     return sections[0];

--- a/packages/frontend/model/extract-capi.test.ts
+++ b/packages/frontend/model/extract-capi.test.ts
@@ -589,5 +589,4 @@ describe('extract-capi', () => {
 
         expect(nielsenAPIID).toBe('2879C1E1-7EF9-459B-9C5C-6F4D2BC9DD53');
     });
-
 });

--- a/packages/frontend/model/extract-capi.test.ts
+++ b/packages/frontend/model/extract-capi.test.ts
@@ -573,4 +573,21 @@ describe('extract-capi', () => {
             extract(testData);
         }).toThrow();
     });
+
+    it('returns nielsenAPI based on section name', () => {
+        testData.page.section = 'books';
+
+        const { nielsenAPIID } = extract(testData);
+
+        expect(nielsenAPIID).toBe('4994D04B-4279-4184-A2C5-E8BB1DD50AB9');
+    });
+
+    it('returns empty nielsenAPI if section does not exist', () => {
+        testData.page.section = 'invalidSection';
+
+        const { nielsenAPIID } = extract(testData);
+
+        expect(nielsenAPIID).toBe('');
+    });
+
 });

--- a/packages/frontend/model/extract-capi.test.ts
+++ b/packages/frontend/model/extract-capi.test.ts
@@ -582,12 +582,12 @@ describe('extract-capi', () => {
         expect(nielsenAPIID).toBe('4994D04B-4279-4184-A2C5-E8BB1DD50AB9');
     });
 
-    it('returns empty nielsenAPI if section does not exist', () => {
+    it('returns the guardian nielsenAPI if section does not exist', () => {
         testData.page.section = 'invalidSection';
 
         const { nielsenAPIID } = extract(testData);
 
-        expect(nielsenAPIID).toBe('');
+        expect(nielsenAPIID).toBe('2879C1E1-7EF9-459B-9C5C-6F4D2BC9DD53');
     });
 
 });

--- a/packages/frontend/model/extract-capi.ts
+++ b/packages/frontend/model/extract-capi.ts
@@ -132,7 +132,6 @@ const getNielsenAPIID = (subsection: string): string => {
     return findBySubsection(subsection).apiID;
 };
 
-
 // TODO really it would be nice if we passed just the data we needed and
 // didn't have to do the transforms/lookups below. (While preserving the
 // validation on types.)
@@ -221,6 +220,6 @@ export const extract = (data: {}): CAPIType => {
             getString(data, 'page.content.trailText', ''),
             stripHTML,
         ),
-        nielsenAPIID: getNielsenAPIID(sectionName)
+        nielsenAPIID: getNielsenAPIID(sectionName),
     };
 };

--- a/packages/frontend/model/extract-capi.ts
+++ b/packages/frontend/model/extract-capi.ts
@@ -19,7 +19,7 @@ import { findPillar } from './find-pillar';
 const sectionsAPIs: SectionAPIID[] = [
     {
         section: 'Guardian',
-        apiID: '879C1E1-7EF9-459B-9C5C-6F4D2BC9DD53',
+        apiID: '2879C1E1-7EF9-459B-9C5C-6F4D2BC9DD53',
         subsections: []
     },
     {
@@ -29,7 +29,7 @@ const sectionsAPIs: SectionAPIID[] = [
     },
     {
         section: 'Business',
-        apiID: '2879C1E1-7EF9-459B-9C5C-6F4D2BC9DD53',
+        apiID: '163BF72C-72D0-4702-82A9-17A548A39D79',
         subsections: ['business', 'better-business', 'business-to-business', 'working-in-development']
     },
     {
@@ -244,7 +244,7 @@ const getNielsenAPIID = (subsection: string): string => {
         return APIID.apiID;
     }
 
-    return "";
+    return sectionsAPIs[0].apiID;
 };
 
 

--- a/packages/frontend/model/extract-capi.ts
+++ b/packages/frontend/model/extract-capi.ts
@@ -15,6 +15,118 @@ import { getSharingUrls } from './sharing-urls';
 import { findPillar } from './find-pillar';
 
 // tslint:disable:prefer-array-literal
+
+const sectionsAPIs: SectionAPIID[] = [
+    {
+        section: 'Guardian',
+        apiID: '879C1E1-7EF9-459B-9C5C-6F4D2BC9DD53',
+        subsections: []
+    },
+    {
+        section: 'Books',
+        apiID: '4994D04B-4279-4184-A2C5-E8BB1DD50AB9',
+        subsections: ['books', 'childrens-books-site']
+    },
+    {
+        section: 'Business',
+        apiID: '2879C1E1-7EF9-459B-9C5C-6F4D2BC9DD53',
+        subsections: ['business', 'better-business', 'business-to-business', 'working-in-development']
+    },
+    {
+        section: 'CommentIsFree',
+        apiID: 'C962A2C3-C9E1-40DD-9B58-7B1095EDB16E',
+        subsections: ['commentisfree']
+    },
+    {
+        section: 'Culture',
+        apiID: '87C0725C-D478-4567-967B-E3519ECD12E8',
+        subsections: ['culture', 'artanddesign', 'culture-network', 'culture-professionals-network', 'games', 'stage']
+    },{
+        section: 'Education',
+        apiID: 'DD50B111-D493-4D25-8980-2B0752E16ED1',
+        subsections: ['education', 'higher-education-network', 'teacher-network']
+    },
+    {
+        section: 'Environment',
+        apiID: 'FEC0766C-C766-4A77-91B3-74C5525E680F',
+        subsections: ['environment', 'animals-farmed']
+    },
+    {
+        section: 'Fashion',
+        apiID: '1639B19E-B581-491E-94B7-FBACB6823C43',
+        subsections: ['fashion']
+    },
+    {
+        section: 'Film',
+        apiID: 'D5BB97FE-637C-4E9E-B972-C8EA88101CB7',
+        subsections: ['film']
+    },
+    {
+        section: 'LifeStyle',
+        apiID: 'B32533F9-65CF-4261-8BB9-2A707F59712A',
+        subsections: ['lifeandstyle']
+    },
+    {
+        section: 'Media',
+        apiID: '385AA13F-9B64-4927-9536-BE70F9AD54BD',
+        subsections: ['media']
+    },
+    {
+        section: 'Money',
+        apiID: '10BE8096-BF69-4252-AC27-C4127D8631F6',
+        subsections: ['money']
+    },
+    {
+        section: 'Music',
+        apiID: '9D928193-7B5C-45A9-89E4-C47F42B8FB73',
+        subsections: ['music']
+    },
+    {
+        section: 'News',
+        apiID: '66BEC53C-9890-477C-B639-60879EC4F762',
+        subsections: ['news', 'australia-news', 'cardiff', 'cities', 'community', 'edinburgh', 'global-development', 'government-computing-network', 'law', 'leeds', 'local', 'local-government-network', 'media', 'media-network', 'uk-news', 'us-news', 'weather', 'world']
+    },
+    {
+        section: 'Politics',
+        apiID: 'C5C73A36-9E39-4D42-9049-2528DB5E998D',
+        subsections: ['politics']
+    },
+    {
+        section: 'ProfessionalNetwork',
+        apiID: '9DFEFF7E-9D45-4676-82B3-F29A6BF05BE1',
+        subsections: ['guardian-professional', 'global-development-professionals-network', 'small-business-network']
+    },
+    {
+        section: 'Science',
+        apiID: 'F4867E05-4149-49F0-A9DE-9F3496930B8C',
+        subsections: ['science']
+    },
+    {
+        section: 'Society',
+        apiID: '617F9FB9-2D34-4C3A-A2E7-383AE877A35D',
+        subsections: ['society', 'healthcare-network', 'housing-network', 'inequality', 'public-leaders-network', 'social-care-network', 'social-enterprise-network', 'society-professionals', 'women-in-leadership']
+    },
+    {
+        section: 'Sport',
+        apiID: '52A6516F-E323-449F-AA57-6A1B2386F8F6',
+        subsections: ['sport', 'football']
+    },
+    {
+        section: 'Technology',
+        apiID: '4F448B55-305F-4203-B192-8534CB606C12',
+        subsections: ['technology']
+    },
+    {
+        section: 'Travel',
+        apiID: '05A03097-D4CA-46BF-96AD-935252967239',
+        subsections: ['travel', 'travel/offers']
+    },
+    {
+        section: 'TvRadio',
+        apiID: '3277F0D0-9389-4A32-A4D6-516B49D87E45',
+        subsections: ['tv-and-radio']
+    }];
+
 const apply = (input: string, ...fns: Array<(_: string) => string>): string => {
     return fns.reduce((acc, fn) => fn(acc), input);
 };
@@ -126,6 +238,16 @@ const getPagination = (data: {}): Pagination | undefined => {
     return undefined;
 };
 
+const getNielsenAPIID = (subsection: string): string => {
+    const APIID = sectionsAPIs.find(section => section.subsections.some(_ => _ === subsection));
+    if (APIID) {
+        return APIID.apiID;
+    }
+
+    return "";
+};
+
+
 // TODO really it would be nice if we passed just the data we needed and
 // didn't have to do the transforms/lookups below. (While preserving the
 // validation on types.)
@@ -214,5 +336,6 @@ export const extract = (data: {}): CAPIType => {
             getString(data, 'page.content.trailText', ''),
             stripHTML,
         ),
+        nielsenAPIID: getNielsenAPIID(sectionName)
     };
 };

--- a/packages/frontend/model/extract-capi.ts
+++ b/packages/frontend/model/extract-capi.ts
@@ -13,119 +13,9 @@ import { string as curly } from 'curlyquotes';
 
 import { getSharingUrls } from './sharing-urls';
 import { findPillar } from './find-pillar';
+import { findBySubsection } from './article-sections';
 
 // tslint:disable:prefer-array-literal
-
-const sectionsAPIs: SectionAPIID[] = [
-    {
-        section: 'Guardian',
-        apiID: '2879C1E1-7EF9-459B-9C5C-6F4D2BC9DD53',
-        subsections: []
-    },
-    {
-        section: 'Books',
-        apiID: '4994D04B-4279-4184-A2C5-E8BB1DD50AB9',
-        subsections: ['books', 'childrens-books-site']
-    },
-    {
-        section: 'Business',
-        apiID: '163BF72C-72D0-4702-82A9-17A548A39D79',
-        subsections: ['business', 'better-business', 'business-to-business', 'working-in-development']
-    },
-    {
-        section: 'CommentIsFree',
-        apiID: 'C962A2C3-C9E1-40DD-9B58-7B1095EDB16E',
-        subsections: ['commentisfree']
-    },
-    {
-        section: 'Culture',
-        apiID: '87C0725C-D478-4567-967B-E3519ECD12E8',
-        subsections: ['culture', 'artanddesign', 'culture-network', 'culture-professionals-network', 'games', 'stage']
-    },{
-        section: 'Education',
-        apiID: 'DD50B111-D493-4D25-8980-2B0752E16ED1',
-        subsections: ['education', 'higher-education-network', 'teacher-network']
-    },
-    {
-        section: 'Environment',
-        apiID: 'FEC0766C-C766-4A77-91B3-74C5525E680F',
-        subsections: ['environment', 'animals-farmed']
-    },
-    {
-        section: 'Fashion',
-        apiID: '1639B19E-B581-491E-94B7-FBACB6823C43',
-        subsections: ['fashion']
-    },
-    {
-        section: 'Film',
-        apiID: 'D5BB97FE-637C-4E9E-B972-C8EA88101CB7',
-        subsections: ['film']
-    },
-    {
-        section: 'LifeStyle',
-        apiID: 'B32533F9-65CF-4261-8BB9-2A707F59712A',
-        subsections: ['lifeandstyle']
-    },
-    {
-        section: 'Media',
-        apiID: '385AA13F-9B64-4927-9536-BE70F9AD54BD',
-        subsections: ['media']
-    },
-    {
-        section: 'Money',
-        apiID: '10BE8096-BF69-4252-AC27-C4127D8631F6',
-        subsections: ['money']
-    },
-    {
-        section: 'Music',
-        apiID: '9D928193-7B5C-45A9-89E4-C47F42B8FB73',
-        subsections: ['music']
-    },
-    {
-        section: 'News',
-        apiID: '66BEC53C-9890-477C-B639-60879EC4F762',
-        subsections: ['news', 'australia-news', 'cardiff', 'cities', 'community', 'edinburgh', 'global-development', 'government-computing-network', 'law', 'leeds', 'local', 'local-government-network', 'media', 'media-network', 'uk-news', 'us-news', 'weather', 'world']
-    },
-    {
-        section: 'Politics',
-        apiID: 'C5C73A36-9E39-4D42-9049-2528DB5E998D',
-        subsections: ['politics']
-    },
-    {
-        section: 'ProfessionalNetwork',
-        apiID: '9DFEFF7E-9D45-4676-82B3-F29A6BF05BE1',
-        subsections: ['guardian-professional', 'global-development-professionals-network', 'small-business-network']
-    },
-    {
-        section: 'Science',
-        apiID: 'F4867E05-4149-49F0-A9DE-9F3496930B8C',
-        subsections: ['science']
-    },
-    {
-        section: 'Society',
-        apiID: '617F9FB9-2D34-4C3A-A2E7-383AE877A35D',
-        subsections: ['society', 'healthcare-network', 'housing-network', 'inequality', 'public-leaders-network', 'social-care-network', 'social-enterprise-network', 'society-professionals', 'women-in-leadership']
-    },
-    {
-        section: 'Sport',
-        apiID: '52A6516F-E323-449F-AA57-6A1B2386F8F6',
-        subsections: ['sport', 'football']
-    },
-    {
-        section: 'Technology',
-        apiID: '4F448B55-305F-4203-B192-8534CB606C12',
-        subsections: ['technology']
-    },
-    {
-        section: 'Travel',
-        apiID: '05A03097-D4CA-46BF-96AD-935252967239',
-        subsections: ['travel', 'travel/offers']
-    },
-    {
-        section: 'TvRadio',
-        apiID: '3277F0D0-9389-4A32-A4D6-516B49D87E45',
-        subsections: ['tv-and-radio']
-    }];
 
 const apply = (input: string, ...fns: Array<(_: string) => string>): string => {
     return fns.reduce((acc, fn) => fn(acc), input);
@@ -239,12 +129,7 @@ const getPagination = (data: {}): Pagination | undefined => {
 };
 
 const getNielsenAPIID = (subsection: string): string => {
-    const APIID = sectionsAPIs.find(section => section.subsections.some(_ => _ === subsection));
-    if (APIID) {
-        return APIID.apiID;
-    }
-
-    return sectionsAPIs[0].apiID;
+    return findBySubsection(subsection).apiID;
 };
 
 


### PR DESCRIPTION
## What does this change?
Changes to use specific API id for each article section
Added model for section and subsections

## Why?
Nielsen API id was always fixed to Guardian News instead of per section API id

## Link to supporting Trello card
https://trello.com/c/AQWKDSbM/10-fix-amp-neilsen-tracking