### PR TITLE
Introduce special styling/layout for liveblog top meta

### DIFF
--- a/packages/frontend/amp/components/BodyLiveblog.tsx
+++ b/packages/frontend/amp/components/BodyLiveblog.tsx
@@ -2,9 +2,8 @@ import React from 'react';
 import { InnerContainer } from '@frontend/amp/components/InnerContainer';
 import { css } from 'emotion';
 import { ArticleModel } from '@frontend/amp/pages/Article';
-import { TopMeta } from '@frontend/amp/components/TopMeta';
+import { TopMetaLiveblog } from '@frontend/amp/components/TopMetaLiveblog';
 import { SubMeta } from '@frontend/amp/components/SubMeta';
-import { getToneType } from '@frontend/amp/lib/tag-utils';
 import { palette } from '@guardian/pasteup/palette';
 import { KeyEvents } from '@frontend/amp/components/KeyEvents';
 import { Blocks } from '@frontend/amp/components/Blocks';
@@ -69,7 +68,6 @@ export const Body: React.FC<{
     data: ArticleModel;
     config: ConfigType;
 }> = ({ pillar, data, config }) => {
-    const tone = getToneType(data.tags);
     const url = `${data.guardianBaseURL}/${data.pageId}`;
     const isFirstPage = data.pagination
         ? data.pagination.currentPage === 1
@@ -77,7 +75,7 @@ export const Body: React.FC<{
 
     return (
         <InnerContainer className={bodyStyle}>
-            <TopMeta tone={tone} data={data} />
+            <TopMetaLiveblog articleData={data} />
             <KeyEvents events={data.keyEvents} url={url} />
 
             {!isFirstPage && (

--- a/packages/frontend/amp/components/Standfirst.tsx
+++ b/packages/frontend/amp/components/Standfirst.tsx
@@ -2,38 +2,16 @@ import React from 'react';
 import { headline, textSans } from '@guardian/pasteup/typography';
 import { css, cx } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
-import { pillarPalette, pillarMap } from '@frontend/lib/pillars';
+import { pillarPalette } from '@frontend/lib/pillars';
 import { composeLabsCSS } from '@frontend/amp/lib/compose-labs-css';
-
-// listStyles are used in paid content standfirsts, with a fallback for normal pillars
-const listStyle = (pillar: Pillar) => css`
-    li {
-        margin-bottom: 6px;
-        padding-left: 20px;
-        ${headline(2)};
-        p {
-            display: inline;
-        }
-    }
-
-    li:before {
-        display: inline-block;
-        content: '';
-        border-radius: 6px;
-        height: 12px;
-        width: 12px;
-        margin-right: 8px;
-        background-color: ${pillarPalette[pillar].neutral.border};
-        margin-left: -20px;
-    }
-`;
+import { ListStyle, LinkStyle } from '@frontend/amp/components/elements/Text';
 
 const standfirstCss = (pillar: Pillar) => css`
     ${headline(2)};
     font-weight: 100;
     color: ${palette.neutral[7]};
     margin-bottom: 12px;
-    ${listStyle(pillar)};
+
     p {
         margin-bottom: 8px;
         font-weight: 200;
@@ -41,21 +19,10 @@ const standfirstCss = (pillar: Pillar) => css`
     strong {
         font-weight: 700;
     }
-`;
 
-const standfirstLinks = pillarMap(
-    pillar =>
-        css`
-            a {
-                color: ${pillarPalette[pillar].dark};
-                text-decoration: none;
-                border-bottom: 1px solid ${pillarPalette[pillar].neutral.border};
-            }
-            a:hover {
-                border-bottom: 1px solid ${pillarPalette[pillar].dark};
-            }
-        `,
-);
+    ${ListStyle(pillarPalette[pillar].neutral.border)};
+    ${LinkStyle(pillar)};
+`;
 
 // Labs paid content only
 const labsStyle = css`
@@ -74,7 +41,7 @@ export const Standfirst: React.SFC<{
         <div // tslint:disable-line:react-no-dangerous-html
             className={composeLabsCSS(
                 pillar,
-                cx(standfirstCss(pillar), standfirstLinks[pillar]),
+                cx(standfirstCss(pillar)),
                 labsStyle,
             )}
             dangerouslySetInnerHTML={{

--- a/packages/frontend/amp/components/TopMeta.tsx
+++ b/packages/frontend/amp/components/TopMeta.tsx
@@ -9,6 +9,7 @@ export const TopMeta: React.SFC<{ data: ArticleModel; tone: StyledTone }> = ({
     data,
     tone,
 }) => {
+    // Note, liveblogs have a separate top meta - see TopMetaLiveblog
     const topMeta = {
         'default-tone': <TopMetaNews articleData={data} />,
         'tone/comment': <TopMetaOpinion articleData={data} />,

--- a/packages/frontend/amp/components/TopMetaLiveblog.tsx
+++ b/packages/frontend/amp/components/TopMetaLiveblog.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { headline } from '@guardian/pasteup/typography';
+import { css } from 'emotion';
+import { palette } from '@guardian/pasteup/palette';
+import { pillarPalette } from '@frontend/lib/pillars';
+import { ArticleModel } from '@frontend/amp/pages/Article';
+import { MainMedia } from '@frontend/amp/components/MainMedia';
+import { Byline } from '@frontend/amp/components/Byline';
+import { string as curly } from 'curlyquotes';
+import { TopMetaExtras } from '@frontend/amp/components/TopMetaExtras';
+import { ListStyle } from '@frontend/amp/components/elements/Text';
+
+const headerStyle = (pillar: Pillar) => css`
+    ${headline(5)};
+    font-weight: 500;
+    padding: 3px 10px 24px;
+    color: ${palette.neutral[100]};
+    background-color: ${pillarPalette[pillar].main};
+`;
+
+const bylineStyle = (pillar: Pillar) => css`
+    ${headline(2)};
+    color: ${pillarPalette[pillar].main};
+    padding-top: 3px;
+    padding-bottom: 8px;
+    font-style: italic;
+
+    a {
+        font-weight: 700;
+        color: ${pillarPalette[pillar].main};
+        text-decoration: none;
+        font-style: normal;
+    }
+`;
+
+const standfirstStyle = (pillar: Pillar) => css`
+    ${headline(2)};
+    color: ${palette.neutral[100]};
+    background-color: ${pillarPalette[pillar].dark};
+    font-weight: bold;
+    padding: 3px 10px 12px;
+
+    a {
+        color: ${palette.neutral[100]};
+    }
+
+    p {
+        margin-bottom: 8px;
+    }
+    strong {
+        font-weight: 700;
+    }
+
+    ${ListStyle(pillarPalette[pillar].neutral.border)};
+`;
+
+const fullWidth = css`
+    margin: 0 -10px;
+`;
+
+const Headline: React.FC<{
+    headlineText: string;
+    standfirst: string;
+    pillar: Pillar;
+    starRating?: number;
+}> = ({ headlineText, pillar, standfirst }) => {
+    return (
+        <div className={fullWidth}>
+            <h1 className={headerStyle(pillar)}>{curly(headlineText)}</h1>
+            <div // tslint:disable-line:react-no-dangerous-html
+                className={standfirstStyle(pillar)}
+                dangerouslySetInnerHTML={{
+                    __html: standfirst,
+                }}
+            />
+        </div>
+    );
+};
+
+export const TopMetaLiveblog: React.FC<{
+    articleData: ArticleModel;
+}> = ({ articleData }) => (
+    <header>
+        <Headline
+            headlineText={articleData.headline}
+            standfirst={articleData.standfirst}
+            pillar={articleData.pillar}
+            starRating={articleData.starRating}
+        />
+
+        {articleData.mainMediaElements.map((element, i) => (
+            <MainMedia key={i} element={element} pillar={articleData.pillar} />
+        ))}
+
+        <Byline
+            byline={articleData.author.byline}
+            tags={articleData.tags}
+            pillar={articleData.pillar}
+            guardianBaseURL={articleData.guardianBaseURL}
+            className={bylineStyle(articleData.pillar)}
+        />
+
+        <TopMetaExtras
+            sharingUrls={articleData.sharingUrls}
+            pillar={articleData.pillar}
+            ageWarning={articleData.ageWarning}
+            webPublicationDate={articleData.webPublicationDateDisplay}
+            twitterHandle={articleData.author.twitterHandle}
+        />
+    </header>
+);

--- a/packages/frontend/amp/components/elements/Text.tsx
+++ b/packages/frontend/amp/components/elements/Text.tsx
@@ -12,27 +12,8 @@ import { composeLabsCSS } from '@root/packages/frontend/amp/lib/compose-labs-css
 // which is easy to discover and re-use.
 
 // tslint:disable:react-no-dangerous-html
-export const TextStyle = (pillar: Pillar) => css`
-    strong {
-        font-weight: 700;
-    }
-    p {
-        padding: 0 0 12px;
-        ${body(2)};
-        font-weight: 300;
-        word-wrap: break-word;
-        color: ${palette.neutral[7]};
-    }
 
-    a {
-        color: ${pillarPalette[pillar].dark};
-        text-decoration: none;
-        border-bottom: 1px solid ${pillarPalette[pillar].neutral.border};
-        :hover {
-            border-bottom: 1px solid ${pillarPalette[pillar].dark};
-        }
-    }
-
+export const ListStyle = (iconColour: string) => css`
     li {
         margin-bottom: 6px;
         padding-left: 20px;
@@ -48,8 +29,32 @@ export const TextStyle = (pillar: Pillar) => css`
         height: 12px;
         width: 12px;
         margin-right: 8px;
-        background-color: ${pillarPalette[pillar].neutral.border};
+        background-color: ${iconColour};
         margin-left: -20px;
+    }
+`;
+
+export const LinkStyle = (pillar: Pillar) => css`
+    a {
+        color: ${pillarPalette[pillar].dark};
+        text-decoration: none;
+        border-bottom: 1px solid ${pillarPalette[pillar].neutral.border};
+        :hover {
+            border-bottom: 1px solid ${pillarPalette[pillar].dark};
+        }
+    }
+`;
+
+export const TextStyle = (pillar: Pillar) => css`
+    strong {
+        font-weight: 700;
+    }
+    p {
+        padding: 0 0 12px;
+        ${body(2)};
+        font-weight: 300;
+        word-wrap: break-word;
+        color: ${palette.neutral[7]};
     }
 
     blockquote {
@@ -58,6 +63,9 @@ export const TextStyle = (pillar: Pillar) => css`
     }
 
     ${body(2)};
+
+    ${LinkStyle(pillar)};
+    ${ListStyle(pillarPalette[pillar].neutral.border)};
 `;
 
 // Labs paid content only

--- a/packages/frontend/model/validate.ts
+++ b/packages/frontend/model/validate.ts
@@ -36,7 +36,7 @@ export const validateRequestData = (data: any, endpoint: string) => {
     if (!isValid) {
         throw new ValidationError(
             `Could not validate ${endpoint} request for ${
-            data.page.pageId
+                data.page.pageId
             }.\n ${JSON.stringify(ajv.errors, null, 2)}`,
         );
     }


### PR DESCRIPTION
## What does this change?

Adds appropriate styling for liveblog top meta section.

## Why?

Parity with mobile web.

## Link to supporting Trello card

https://trello.com/c/DFXynjxd

## Screenshots

![Screenshot 2019-06-12 at 12 26 52](https://user-images.githubusercontent.com/858402/59348304-a3e0fb80-8d0e-11e9-8f30-4563f21ddac9.png)

![Screenshot 2019-06-12 at 12 27 18](https://user-images.githubusercontent.com/858402/59348313-aa6f7300-8d0e-11e9-83d5-15318eb01569.png)
