### PR TITLE
Use correct switch name for prebid switch.

### DIFF
--- a/packages/frontend/amp/components/BodyArticle.tsx
+++ b/packages/frontend/amp/components/BodyArticle.tsx
@@ -68,7 +68,7 @@ export const Body: React.FC<{
         commercialProperties: data.commercialProperties,
         switches: {
             krux: config.switches.krux,
-            ampPrebid: config.switches.prebid,
+            ampPrebid: config.switches.ampPrebid,
         },
     };
 


### PR DESCRIPTION
The switch is called ampPrebid not prebid!
## What does this change?

## Why?
💰 💰 💰 💰 