### PR TITLE
Correctly name amp prebid switch

### DIFF
--- a/packages/frontend/amp/components/Blocks.tsx
+++ b/packages/frontend/amp/components/Blocks.tsx
@@ -99,7 +99,7 @@ export const Blocks: React.SFC<{
         edition,
         contentType,
         commercialProperties,
-        switches: { krux: switches.krux, ampPrebid: switches.prebid },
+        switches: { krux: switches.krux, ampPrebid: switches.ampPrebid },
     };
 
     return (


### PR DESCRIPTION
## What does this change?

## Why?

## Link to supporting Trello card