### PR TITLE
Add details for running PROD locally

### DIFF
--- a/docs/contributing/detailed-setup-guide.md
+++ b/docs/contributing/detailed-setup-guide.md
@@ -1,7 +1,7 @@
 # Detailed setup guide
 
-- [Developing](#developing)
-- [Production](#production)
+-   [Developing](#developing)
+-   [Production](#production)
 
 ## Developing
 
@@ -43,6 +43,7 @@ You can preview an AMP page similarly to an article, as follows
 http://localhost:3030/AMPArticle?url=https://amp.theguardian.com/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance
 
 ### Note on rebasing vs merging
+
 The dotcom-rendering github account is set up to merge PRs into master instead of rebase. Merge commits are useful to quickly revert things when there is a major incident - whereas with rebase you might have to revert a whole load of commits.
 
 However, if you are working on a feature branch and plan to make a PR, it's still recommended to rebase on `master` to avoid extranous merge commits in branches.
@@ -51,7 +52,7 @@ However, if you are working on a feature branch and plan to make a PR, it's stil
 
 For ease of development you may want to install:
 
-- [React Developer Tools](https://github.com/facebook/react-devtools)
+-   [React Developer Tools](https://github.com/facebook/react-devtools)
 
 ### Running alongside identity
 
@@ -64,7 +65,12 @@ You may want local identity cookies to be available in `dotcom-rendering`. To en
 
 ## Production
 
-- `make build` creates production-ready bundles.
-- `make start` starts the production server.
-- `make stop` stops the production server.
+-   `make build` creates production-ready bundles.
+-   `make start` starts the production server.
+-   `make stop` stops the production server.
 
+You may need to run these with `sudo`
+
+Production environment uses `pm2`. More scripts can be found in the `makefile` [scripts](https://github.com/guardian/dotcom-rendering/blob/e2c020f7e0ed24751ea729eec93f1271d37e3b50/makefile#L31)
+
+The production port default is 9000 for deployment, but to run locally alongside frontend, you will need to manually override in `scripts/frontend/config.js`. To hit the server, add `rendering.endpoint = "http://localhost:${port}/Article"` with the overide port number to `frontend.conf` and run frontend locally.


### PR DESCRIPTION
## What does this change?

Adds additional information about how to run PROD locally to `detailed-setup-guide.md`

## Why?

Information is power
