### PR TITLE
Fix logic for Onward Related content

### DIFF
--- a/packages/frontend/amp/components/Onward.tsx
+++ b/packages/frontend/amp/components/Onward.tsx
@@ -107,7 +107,7 @@ export const Onward: React.FC<{
     );
 
     const related =
-        hasRelated && series.length < 1
+        hasRelated && !hasStoryPackage && series.length < 1
             ? [container(`${ampBaseURL}/related-mf2/${pageID}.json`)]
             : [];
 


### PR DESCRIPTION
## What does this change?
Fixes the logic for finding Related content in Onward AMP component to match frontend logic in `/common/app/views/fragments/amp/onwardJourneys.scala.html`
```
  @if(content.showInRelated
        && !related.hasStoryPackage
        && content.tags.series.isEmpty) {
        @fragments.amp.onwardTemplateAmp("related-mf2/" + page.metadata.id + ".json")
    }
```

## Why?

Some articles were requesting Related content erroneously, receiving 404s and resulting in a gap in the onward journey containers. See the Trello card for link to example. 

## Link to supporting Trello card
https://trello.com/c/RWBgjbT1/515-incorrectly-trying-to-include-related-content-onward-for-some-articles-leaving-blank-space