### PR TITLE
Fix missing comment styling on Editorial articles

### DIFF
--- a/packages/frontend/amp/lib/tag-utils.test.ts
+++ b/packages/frontend/amp/lib/tag-utils.test.ts
@@ -84,7 +84,35 @@ describe('getToneType', () => {
             {
                 id: 'tone/comment',
                 type: 'Tone',
-                title: 'Advertisement features',
+                title: 'title',
+                twitterHandle: '',
+                bylineImageUrl: '',
+            },
+            {
+                id: 'tracking/commissioningdesk/uk-labs',
+                type: 'Tracking',
+                title: 'UK Labs',
+                twitterHandle: '',
+                bylineImageUrl: '',
+            },
+        ];
+        const tone = getToneType(tags);
+        expect(tone).toEqual('tone/comment');
+    });
+
+    it('should return "tone/comment" for editorial pieces correctly', () => {
+        const tags = [
+            {
+                id: 'tone/editorials',
+                type: 'Tone',
+                title: 'title',
+                twitterHandle: '',
+                bylineImageUrl: '',
+            },
+            {
+                id: 'tone/comment',
+                type: 'Tone',
+                title: 'title',
                 twitterHandle: '',
                 bylineImageUrl: '',
             },
@@ -105,7 +133,7 @@ describe('getToneType', () => {
             {
                 id: 'tone/something-else',
                 type: 'Tone',
-                title: 'Advertisement features',
+                title: 'title',
                 twitterHandle: '',
                 bylineImageUrl: '',
             },

--- a/packages/frontend/amp/lib/tag-utils.ts
+++ b/packages/frontend/amp/lib/tag-utils.ts
@@ -16,17 +16,23 @@ export type StyledTone =
 
 export const getToneType = (tags: TagType[]): StyledTone => {
     const defaultTone = 'default-tone';
-    const tone = filterForTagsOfType(tags, 'Tone')[0];
+    const tones = filterForTagsOfType(tags, 'Tone').map(tone => tone.id);
 
-    if (!tone) {
+    if (!tones) {
         return defaultTone;
     }
 
-    switch (tone.id) {
+    // Editorials have two tones - tone/editorials and tone/comment
+    // We defer to tone/comment for styling
+    if (tones.includes('tone/editorials')) {
+        return 'tone/comment';
+    }
+
+    switch (tones[0]) {
         case 'tone/advertisement-features':
-            return 'tone/advertisement-features';
+            return tones[0] as StyledTone;
         case 'tone/comment':
-            return 'tone/comment';
+            return tones[0] as StyledTone;
         default:
             return defaultTone;
     }

--- a/packages/frontend/amp/lib/tag-utils.ts
+++ b/packages/frontend/amp/lib/tag-utils.ts
@@ -22,17 +22,13 @@ export const getToneType = (tags: TagType[]): StyledTone => {
         return defaultTone;
     }
 
-    // Editorials have two tones - tone/editorials and tone/comment
-    // We defer to tone/comment for styling
-    if (tones.includes('tone/editorials')) {
-        return 'tone/comment';
-    }
-
     switch (tones[0]) {
         case 'tone/advertisement-features':
             return tones[0] as StyledTone;
         case 'tone/comment':
             return tones[0] as StyledTone;
+        case 'tone/editorials':
+            return 'tone/comment'
         default:
             return defaultTone;
     }


### PR DESCRIPTION
## What does this change?

Fixes `tag-utils` to account for editorial articles with more than one tone tag. 

Are there more cases of articles having multiple tone tags? What would be a way to verify this? The logic here could be more robust if there are more exceptional cases. 

## Why?

Editorial articles have two tones: `tone/editorials` and `tone/comment`. For styling, editorials should match other opinion pieces, so now any articles with `tone/editorials` will fallback to `tone/comment`

Top -> before
Bottom -> after
![image](https://user-images.githubusercontent.com/32312712/59515904-13deb580-8eb8-11e9-94e2-370cdc8410d5.png)

![image](https://user-images.githubusercontent.com/32312712/59515845-f873aa80-8eb7-11e9-8aeb-221a82c73c2b.png)


