### PR TITLE
Convert px to rems during babel compilation

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -14,6 +14,7 @@ module.exports = {
                 },
             },
         ],
+        'babel-plugin-px-to-rem',
     ],
     presets: [
         '@babel/preset-typescript',

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
         "babel-plugin-emotion": "^9.2.6",
         "babel-plugin-module-resolver": "^3.1.1",
         "babel-plugin-preval": "^3.0.0",
+        "babel-plugin-px-to-rem": "https://github.com/guardian/babel-plugin-px-to-rem#v0.1.0",
         "bundlesize": "^0.17.0",
         "eslint": "^5.16.0",
         "friendly-errors-webpack-plugin": "^1.7.0",
@@ -88,8 +89,8 @@
         "execa": "^0.10.0",
         "filesizegzip": "^2.0.0",
         "inquirer": "^5.2.0",
-        "pretty-bytes": "^4.0.2",
-        "log4js": "4.2.0"
+        "log4js": "4.2.0",
+        "pretty-bytes": "^4.0.2"
     },
     "jest": {
         "moduleFileExtensions": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3394,6 +3394,10 @@ babel-plugin-preval@^3.0.0:
     babel-plugin-macros "^2.2.2"
     require-from-string "^2.0.2"
 
+"babel-plugin-px-to-rem@https://github.com/guardian/babel-plugin-px-to-rem#v0.1.0":
+  version "0.1.0"
+  resolved "https://github.com/guardian/babel-plugin-px-to-rem#548c5f5bfdfdfc317b86103d27565868bd7d381c"
+
 babel-plugin-react-docgen@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-react-docgen/-/babel-plugin-react-docgen-2.0.2.tgz#3307e27414c370365710576b7fadbcaf8984d862"


### PR DESCRIPTION
## What does this change?

Converts px to rems at build time. Note, I assumed this was the right thing but I also just read https://hackernoon.com/rems-and-ems-and-why-you-probably-dont-need-them-664b9ce1e09f which argued otherwise. Would be great to get thoughts here @gtrufitt @SiAdcock @AWare and anyone else with accessibility knowledge!

See https://github.com/guardian/babel-plugin-px-to-rem for reference/actual babel plugin.

It only works on values within emotion css`..` calls.

This means at least the following don't work:

* inlined styles
* dynamically calculated px values

These shouldn't be things we do generally, but an important exception at the moment is font styling. We should be able to make this more build-time/declarative though to fix this.

## Why?

Accessibility.

## Link to supporting Trello card

https://trello.com/c/gGl76xdk