### PR TITLE
Add designType to the model and tests

### DIFF
--- a/fixtures/CAPI.ts
+++ b/fixtures/CAPI.ts
@@ -1,8 +1,10 @@
 const pillar: Pillar = 'lifestyle';
+const designType = 'Article';
 const editionId: Edition = 'UK';
 
 export const CAPI: CAPIType = {
     pillar,
+    designType,
     editionId,
     webPublicationDate: '2018-11-02T09:45:30.000Z',
     webPublicationDateDisplay: 'Fri 02 Mar 2018 09.45 GMT',

--- a/fixtures/article.ts
+++ b/fixtures/article.ts
@@ -1044,6 +1044,7 @@ export const data = {
                     },
                 },
             ],
+            designType: 'Comment',
         },
     },
     site: {

--- a/packages/frontend/amp/pages/Article.tsx
+++ b/packages/frontend/amp/pages/Article.tsx
@@ -30,6 +30,7 @@ export interface ArticleModel {
     webPublicationDateDisplay: string;
     pageId: string;
     pillar: Pillar;
+    designType: DesignType;
     sectionLabel?: string;
     sectionUrl?: string;
     sectionName?: string;

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -7,6 +7,24 @@ interface ArticleProps {
 // 'labs' is a fake pillar used to identify paid content (Guardian Labs) for rendering styling.
 type Pillar = 'news' | 'opinion' | 'sport' | 'culture' | 'lifestyle' | 'labs';
 
+// https://github.com/guardian/content-api-scala-client/blob/master/client/src/main/scala/com.gu.contentapi.client/utils/DesignType.scala
+type DesignType =
+    | 'Article'
+    | 'Immersive'
+    | 'Media'
+    | 'Review'
+    | 'Analysis'
+    | 'Comment'
+    | 'Feature'
+    | 'Live'
+    | 'SpecialReport'
+    | 'Recipe'
+    | 'MatchReport'
+    | 'Interview'
+    | 'GuardianView'
+    | 'GuardianLabs'
+    | 'Quiz';
+
 type Edition = 'UK' | 'US' | 'INT' | 'AU';
 
 type SharePlatform =
@@ -153,6 +171,7 @@ interface CAPIType {
     pageId: string;
     tags: TagType[];
     pillar: Pillar;
+    designType: DesignType;
     isImmersive: boolean;
     sectionLabel: string;
     sectionUrl: string;

--- a/packages/frontend/model/extract-capi.test.ts
+++ b/packages/frontend/model/extract-capi.test.ts
@@ -394,7 +394,23 @@ describe('extract-capi', () => {
         expect(findPillar).toHaveBeenCalledWith(testPillar, tags);
     });
 
-    /*     it('returns ageWarning as undefined if article not in tone/news', () => {
+    it('defaults designType to "Article" if not valid', () => {
+        testData.page.meta.designType = 'invalid';
+
+        const { designType } = extract(testData);
+
+        expect(designType).toBe('Article');
+    });
+
+    it('returns designType from data', () => {
+        testData.page.meta.designType = 'Comment';
+
+        const { designType } = extract(testData);
+
+        expect(designType).toBe('Comment');
+    });
+    /* it('returns ageWarning as undefined if article not in tone/news', () => {
+
         testData.page.tags.all = [
             {
                 properties: {
@@ -409,7 +425,7 @@ describe('extract-capi', () => {
 
         expect(ageWarning).toBeUndefined();
     }); */
-    /* 
+    /*
     describe('ageWarning', () => {
         let publicationDate: Date;
 

--- a/packages/frontend/model/extract-capi.ts
+++ b/packages/frontend/model/extract-capi.ts
@@ -26,6 +26,28 @@ const getEditionValue: (name: string) => Edition = name => {
     return edition === undefined ? 'UK' : edition;
 };
 
+const getDesignTypeValue: (name: string) => DesignType = name => {
+    const designType: DesignType[] = [
+        'Article',
+        'Immersive',
+        'Media',
+        'Review',
+        'Analysis',
+        'Comment',
+        'Feature',
+        'Live',
+        'SpecialReport',
+        'Recipe',
+        'MatchReport',
+        'Interview',
+        'GuardianView',
+        'GuardianLabs',
+        'Quiz',
+    ];
+
+    return designType.find(_ => _ === name) || 'Article';
+};
+
 const getTags: (data: any) => TagType[] = data => {
     const tags = getArray<any>(data, 'page.tags.all', []);
     return tags.map(tag => {
@@ -113,6 +135,10 @@ export const extract = (data: {}): CAPIType => {
     const navData = getObject(data, 'site.nav');
     navData.readerRevenueLinks = getObject(data, 'site.readerRevenueLinks');
 
+    const designType = getDesignTypeValue(
+        getString(data, 'page.meta.designType', 'Article'),
+    );
+
     return {
         tags,
         sectionName,
@@ -153,6 +179,7 @@ export const extract = (data: {}): CAPIType => {
         blocks: getArray<any>(data, 'page.content.blocks.body').filter(Boolean),
         pageId: getNonEmptyString(data, 'page.pageId'),
         pillar: findPillar(getString(data, 'page.pillar', ''), tags) || 'news',
+        designType,
         sectionLabel: getString(data, 'page.sectionLabel'),
         sectionUrl: getString(data, 'page.sectionUrl'),
         subMetaSectionLinks: getSubMetaSectionLinks(data),

--- a/packages/frontend/model/extract-capi.ts
+++ b/packages/frontend/model/extract-capi.ts
@@ -145,6 +145,7 @@ export const extract = (data: {}): CAPIType => {
         editionLongForm,
         editionId,
         isImmersive,
+        designType,
         webPublicationDate: webPublicationDate.toISOString(),
         webPublicationDateDisplay: getNonEmptyString(
             data,
@@ -179,7 +180,6 @@ export const extract = (data: {}): CAPIType => {
         blocks: getArray<any>(data, 'page.content.blocks.body').filter(Boolean),
         pageId: getNonEmptyString(data, 'page.pageId'),
         pillar: findPillar(getString(data, 'page.pillar', ''), tags) || 'news',
-        designType,
         sectionLabel: getString(data, 'page.sectionLabel'),
         sectionUrl: getString(data, 'page.sectionUrl'),
         subMetaSectionLinks: getSubMetaSectionLinks(data),

--- a/packages/frontend/modelV2/json-schema.json
+++ b/packages/frontend/modelV2/json-schema.json
@@ -141,6 +141,9 @@
         "pillar": {
             "$ref": "#/definitions/Pillar"
         },
+        "designType": {
+            "$ref": "#/definitions/DesignType"
+        },
         "isImmersive": {
             "type": "boolean"
         },
@@ -218,6 +221,7 @@
         "commercialProperties",
         "config",
         "contentType",
+        "designType",
         "editionId",
         "editionLongForm",
         "guardianBaseURL",
@@ -1317,6 +1321,26 @@
                 "news",
                 "opinion",
                 "sport"
+            ],
+            "type": "string"
+        },
+        "DesignType": {
+            "enum": [
+                "Analysis",
+                "Article",
+                "Comment",
+                "Feature",
+                "GuardianLabs",
+                "GuardianView",
+                "Immersive",
+                "Interview",
+                "Live",
+                "MatchReport",
+                "Media",
+                "Quiz",
+                "Recipe",
+                "Review",
+                "SpecialReport"
             ],
             "type": "string"
         },


### PR DESCRIPTION
## What does this change?

Adds designType to the dotcomponents model:

- [Frontend PR with more info](https://github.com/guardian/frontend/pull/21555) - Requires merge!

Note: I'm adding design type only in this PR but it may be that we can refactor out the tag lookup for opinion tone with this in place, but I need to document the usages and then see if it will work - separate PR!

## Why?

designType is used for styling.

## Link to supporting Trello card

https://trello.com/c/d4XhfFIX/597-difference-in-topic-colour-between-mobile-and-amp-version
