### PR TITLE
Shutdown logger before starting

### DIFF
--- a/packages/frontend/app/logging.ts
+++ b/packages/frontend/app/logging.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { configure, getLogger, addLayout } from 'log4js';
+import { configure, getLogger, addLayout, shutdown } from 'log4js';
 
 const logLocation =
     process.env.NODE_ENV === 'production'
@@ -44,8 +44,20 @@ configure({
     pm2: true,
 });
 
+// We do this to ensure no memory leaks during development as hot reloading
+// doesn't clear up old listeners.
+if (process.env.NODE_ENV === 'development') {
+    shutdown(e => {
+        if (e) {
+            // tslint:disable-next-line:no-console
+            console.log(e);
+        }
+    });
+}
+
 export const logger =
     process.env.NODE_ENV === 'development'
         ? getLogger('development')
         : getLogger();
+
 logger.level = 'info';


### PR DESCRIPTION
This is to solve max listener (memory leak) errors when hot-reloading in local development.

## What does this change?

Should avoid the process stopping with max listener errors after several local dev reloads.

## Why?

Dev experience.

## Link to supporting Trello card

https://trello.com/c/CzL27a3o/599-possible-memory-leak-with-log4js-logging
