### PR TITLE
Correct Outbrain compliance logic

### DIFF
--- a/packages/frontend/amp/components/Onward.tsx
+++ b/packages/frontend/amp/components/Onward.tsx
@@ -147,10 +147,10 @@ export const Onward: React.FC<{
     );
 
     // Outbrain is compliant if it appears in the top 2 containers
-    const outbrainIsNotCompliant = storyPackage.concat(series).length > 1;
+    const outbrainIsCompliant = storyPackage.concat(series).length <= 1;
     const outbrain = shouldHideAds
         ? []
-        : [outbrainContainer(webURL, !outbrainIsNotCompliant)];
+        : [outbrainContainer(webURL, outbrainIsCompliant)];
 
     // Note, if order changes, you may need to recalculate outbrain compliance
     const containers = storyPackage.concat(

--- a/packages/frontend/amp/components/Onward.tsx
+++ b/packages/frontend/amp/components/Onward.tsx
@@ -147,10 +147,10 @@ export const Onward: React.FC<{
     );
 
     // Outbrain is compliant if it appears in the top 2 containers
-    const outbrainIsCompliant = storyPackage.concat(series).length > 1;
+    const outbrainIsNotCompliant = storyPackage.concat(series).length > 1;
     const outbrain = shouldHideAds
         ? []
-        : [outbrainContainer(webURL, outbrainIsCompliant)];
+        : [outbrainContainer(webURL, !outbrainIsNotCompliant)];
 
     // Note, if order changes, you may need to recalculate outbrain compliance
     const containers = storyPackage.concat(


### PR DESCRIPTION
## What does this change?

Correct Outbrain compliance logic, following an email from Adam highlighting a problem.

"""
Here's the old logic in the frontend codebase:
https://github.com/guardian/frontend/blob/92342a471070f80d05c6eded5331735689cf8d4a/common/app/views/fragments/amp/onwardJourneys.scala.html#L20

Here's the new logic in dotcom-rendering:
https://github.com/guardian/dotcom-rendering/blob/e4cd5403acdacb32e45a33654b905ea93e94fee3/packages/frontend/amp/components/Onward.tsx#L150

As you can see, the logic is backwards. It uses the same predicate, which tests whether outbrain is *non* compliant, but assigns it to a value that called outbrainIsCompliant.
"""