### PR TITLE
Remove gitlens extension recommendation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,10 +2,9 @@
     "recommendations": [
         "esbenp.prettier-vscode",
         "wix.vscode-import-cost",
-        "eamodio.gitlens",
         "orta.vscode-jest",
         "shinnn.stylelint",
-        "editorconfig.editorconfig"
+        "editorconfig.editorconfig",
         "dbaeumer.vscode-eslint",
         "stkb.rewrap"
     ]


### PR DESCRIPTION
## What does this change?

Removes the gitlens recommendation. Fairly subjective as a PR.

## Why?

The other extensions are unambiguously useful and relate to code formatting/linting, testing, or performance concerns.

GitLens is something that doesn't directly affect the code produced and some people (me at least) find it annoying and don't want to use it. (But I still get pop-ups fairly frequently it seems in VS Code prodding me to install it.)

## Link to supporting Trello card

n/a
