### PR TITLE
visual parity with dotcom for submeta links

### DIFF
--- a/packages/frontend/amp/components/SubMeta.tsx
+++ b/packages/frontend/amp/components/SubMeta.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 import { pillarPalette } from '@frontend/lib/pillars';
-import { textSans } from '@guardian/pasteup/typography';
+import { textSans, body } from '@guardian/pasteup/typography';
 import { palette } from '@guardian/pasteup/palette';
 import { ShareIcons } from '@frontend/amp/components/ShareIcons';
 import CommentIcon from '@guardian/pasteup/icons/comment.svg';
@@ -26,16 +26,16 @@ const linkStyle = (pillar: Pillar) => css`
     padding-left: 5px;
     padding-right: 6px;
     text-decoration: none;
-    color: ${pillarPalette[pillar].dark};
-    ${textSans(4)};
+    color: ${pillarPalette[pillar].main};
+    ${textSans(3)};
     :after {
         content: '/';
-        ${textSans(5)};
+        ${textSans(3)};
         position: absolute;
         pointer-events: none;
         top: 0;
         right: -3px;
-        color: ${palette.neutral[46]};
+        color: ${palette.neutral[86]};
     }
 `;
 
@@ -61,16 +61,16 @@ const sectionLinkStyle = (pillar: Pillar) => css`
     padding-left: 5px;
     padding-right: 6px;
     text-decoration: none;
-    color: ${pillarPalette[pillar].dark};
-    ${textSans(5)};
+    color: ${pillarPalette[pillar].main};
+    ${body(3)};
     :after {
         content: '/';
-        ${textSans(8)};
+        ${body(3)};
         position: absolute;
         pointer-events: none;
         top: 0;
         right: -3px;
-        color: ${palette.neutral[46]};
+        color: ${palette.neutral[86]};
     }
 `;
 


### PR DESCRIPTION
## What does this change?
Before
![Screen Shot 2019-07-08 at 17 18 38](https://user-images.githubusercontent.com/2051501/60825848-859edc00-a1a4-11e9-9d5b-332d535d81d0.png)

Dotcom
![Screen Shot 2019-07-08 at 17 21 49](https://user-images.githubusercontent.com/2051501/60826028-ef1eea80-a1a4-11e9-9a3c-9eb7578b38e8.png)

After
![Screen Shot 2019-07-08 at 17 21 34](https://user-images.githubusercontent.com/2051501/60826059-fe9e3380-a1a4-11e9-8a67-af11af3dd0f5.png)

## Why?

## Link to supporting Trello card
https://trello.com/c/g4VVx5Rr