### PR TITLE
Make the byline font smaller

### DIFF
--- a/packages/frontend/web/components/ArticleBody.tsx
+++ b/packages/frontend/web/components/ArticleBody.tsx
@@ -420,20 +420,6 @@ const subMetaSharingIcons = css`
     }
 `;
 
-const bylineStyle = (pillar: Pillar) => css`
-    ${headline(2)};
-    color: ${pillarPalette[pillar].main};
-    padding-bottom: 8px;
-    font-style: italic;
-
-    a {
-        font-weight: 700;
-        color: ${pillarPalette[pillar].main};
-        text-decoration: none;
-        font-style: normal;
-    }
-`;
-
 export const ArticleBody: React.FC<{
     CAPI: CAPIType;
     config: ConfigType;
@@ -484,7 +470,7 @@ export const ArticleBody: React.FC<{
                     <Byline
                         author={CAPI.author}
                         tags={CAPI.tags}
-                        className={bylineStyle(CAPI.pillar)}
+                        pillar={CAPI.pillar}
                     />
                     <Dateline
                         dateDisplay={CAPI.webPublicationDateDisplay}

--- a/packages/frontend/web/components/ArticleBody.tsx
+++ b/packages/frontend/web/components/ArticleBody.tsx
@@ -420,6 +420,20 @@ const subMetaSharingIcons = css`
     }
 `;
 
+const bylineStyle = (pillar: Pillar) => css`
+    ${headline(2)};
+    color: ${pillarPalette[pillar].main};
+    padding-bottom: 8px;
+    font-style: italic;
+
+    a {
+        font-weight: 700;
+        color: ${pillarPalette[pillar].main};
+        text-decoration: none;
+        font-style: normal;
+    }
+`;
+
 export const ArticleBody: React.FC<{
     CAPI: CAPIType;
     config: ConfigType;
@@ -470,7 +484,7 @@ export const ArticleBody: React.FC<{
                     <Byline
                         author={CAPI.author}
                         tags={CAPI.tags}
-                        pillar={CAPI.pillar}
+                        className={bylineStyle(CAPI.pillar)}
                     />
                     <Dateline
                         dateDisplay={CAPI.webPublicationDateDisplay}

--- a/packages/guui/components/Byline/Byline.tsx
+++ b/packages/guui/components/Byline/Byline.tsx
@@ -1,38 +1,9 @@
 import React from 'react';
-import { css, cx } from 'emotion';
+import { css } from 'emotion';
 import TwitterIcon from '@guardian/pasteup/icons/twitter.svg';
 import { headline, textSans } from '@guardian/pasteup/typography';
 import { palette } from '@guardian/pasteup/palette';
-import { leftCol } from '@guardian/pasteup/breakpoints';
-
-const profile = css`
-    ${headline(2)};
-    font-weight: 700;
-    margin-bottom: 4px;
-`;
-
-const pillarColour = (pillar: Pillar) => css`
-    color: ${palette[pillar].main};
-`;
-
-const byline = css`
-    font-style: italic;
-`;
-
-const bylineLink = css`
-    ${headline(2)};
-    font-style: normal;
-    font-weight: 700;
-    text-decoration: none;
-    :hover {
-        text-decoration: underline;
-    }
-
-    ${leftCol} {
-        ${headline(3)};
-        line-height: 28px;
-    }
-`;
+import { pillarPalette } from '@frontend/lib/pillars';
 
 const twitterHandle = css`
     ${textSans(1)};
@@ -55,6 +26,23 @@ const twitterHandle = css`
     }
 `;
 
+const bylineStyle = (pillar: Pillar) => css`
+    ${headline(2)};
+    color: ${pillarPalette[pillar].main};
+    padding-bottom: 8px;
+    font-style: italic;
+
+    a {
+        font-weight: 700;
+        color: ${pillarPalette[pillar].main};
+        text-decoration: none;
+        font-style: normal;
+        :hover {
+            text-decoration: underline;
+        }
+    }
+`;
+
 // this crazy function aims to split bylines such as
 // 'Harry Potter in Hogwarts' to ['Harry Potter', 'in Hogwarts']
 const bylineAsTokens = (bylineText: string, tags: TagType[]): string[] => {
@@ -69,8 +57,8 @@ const bylineAsTokens = (bylineText: string, tags: TagType[]): string[] => {
 const RenderByline: React.FC<{
     bylineText: string;
     contributorTags: TagType[];
-    className?: string;
-}> = ({ bylineText, contributorTags, className }) => {
+    pillar: Pillar;
+}> = ({ bylineText, contributorTags, pillar }) => {
     const renderedTokens = bylineAsTokens(bylineText, contributorTags).map(
         (token, i) => {
             const associatedTags = contributorTags.filter(
@@ -89,7 +77,7 @@ const RenderByline: React.FC<{
         },
     );
 
-    return <div className={className}>{renderedTokens}</div>;
+    return <div className={bylineStyle(pillar)}>{renderedTokens}</div>;
 };
 
 const BylineContributor: React.FC<{
@@ -108,16 +96,14 @@ const BylineContributor: React.FC<{
 export const Byline: React.FC<{
     author: AuthorType;
     tags: TagType[];
-    className?: string;
-}> = ({ author, tags, className }) => (
+    pillar: Pillar;
+}> = ({ author, tags, pillar }) => (
     <address aria-label="Contributor info">
-        <span className={byline}>
-            <RenderByline
-                bylineText={author.byline}
-                contributorTags={tags}
-                className={className}
-            />
-        </span>
+        <RenderByline
+            bylineText={author.byline}
+            contributorTags={tags}
+            pillar={pillar}
+        />
         {author.twitterHandle && (
             <div className={twitterHandle}>
                 <TwitterIcon />

--- a/packages/guui/components/Byline/Byline.tsx
+++ b/packages/guui/components/Byline/Byline.tsx
@@ -69,8 +69,8 @@ const bylineAsTokens = (bylineText: string, tags: TagType[]): string[] => {
 const RenderByline: React.FC<{
     bylineText: string;
     contributorTags: TagType[];
-    pillar: Pillar;
-}> = ({ bylineText, contributorTags, pillar }) => {
+    className?: string;
+}> = ({ bylineText, contributorTags, className }) => {
     const renderedTokens = bylineAsTokens(bylineText, contributorTags).map(
         (token, i) => {
             const associatedTags = contributorTags.filter(
@@ -81,7 +81,6 @@ const RenderByline: React.FC<{
                     <BylineContributor
                         contributor={token}
                         contributorTagId={associatedTags[0].id}
-                        pillar={pillar}
                         key={i}
                     />
                 );
@@ -90,17 +89,15 @@ const RenderByline: React.FC<{
         },
     );
 
-    return <>{renderedTokens}</>;
+    return <div className={className}>{renderedTokens}</div>;
 };
 
 const BylineContributor: React.FC<{
     contributor: string;
     contributorTagId: string;
-    pillar: Pillar;
-}> = ({ contributor, contributorTagId, pillar }) => (
+}> = ({ contributor, contributorTagId }) => (
     <a
         rel="author"
-        className={cx(pillarColour(pillar), bylineLink)}
         data-link-name="auto tag link"
         href={`//www.theguardian.com/${contributorTagId}`}
     >
@@ -111,18 +108,16 @@ const BylineContributor: React.FC<{
 export const Byline: React.FC<{
     author: AuthorType;
     tags: TagType[];
-    pillar: Pillar;
-}> = ({ author, tags, pillar }) => (
+    className?: string;
+}> = ({ author, tags, className }) => (
     <address aria-label="Contributor info">
-        <div className={cx(pillarColour(pillar), profile)}>
-            <span className={byline}>
-                <RenderByline
-                    bylineText={author.byline}
-                    contributorTags={tags}
-                    pillar={pillar}
-                />
-            </span>
-        </div>
+        <span className={byline}>
+            <RenderByline
+                bylineText={author.byline}
+                contributorTags={tags}
+                className={className}
+            />
+        </span>
         {author.twitterHandle && (
             <div className={twitterHandle}>
                 <TwitterIcon />


### PR DESCRIPTION
## What does this change?
...and simplify a bit the byline component.
## Why?
Visual parity with the existing website

Now:
![Screenshot 2019-07-09 at 14 14 01](https://user-images.githubusercontent.com/3606555/60890753-de797d80-a253-11e9-9d89-2d095480faef.png)
Before:
![Screenshot 2019-07-09 at 14 14 14](https://user-images.githubusercontent.com/3606555/60890758-e0dbd780-a253-11e9-8448-0a2b4399fc69.png)


## Link to supporting Trello card
https://trello.com/c/kMy2TNbi/607-visual-parity