### PR TITLE
Force exit code of 0 if nothing to commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "test": "jest",
         "postinstall": "./scripts/git-hooks/install.js",
         "createtoc": "doctoc $npm_package_tocList --github --title '<!-- Automatically created with yarn run createtoc and on push hook -->' ",
-        "addandcommittoc": "git add $npm_package_tocList && git commit -m 'Add TOC update'"
+        "addandcommittoc": "git add $npm_package_tocList && git commit -m 'Add TOC update' || true"
     },
     "husky": {
         "hooks": {


### PR DESCRIPTION
## What does this change?

The prepush hook was preventing a push as if there is nothing to commit but you try (as we automatically do when trying to make sure docs are up to date) then you exit with code 1. We add a `|| true` here to ensure that we can exit with `0` and still push.

@nicl 
