### PR TITLE
Refactor Options types in ModelV2/validate

### DIFF
--- a/packages/frontend/modelV2/validate.ts
+++ b/packages/frontend/modelV2/validate.ts
@@ -1,11 +1,11 @@
 import Ajv from 'ajv';
 import schema from '@frontend/modelV2/json-schema.json';
 
-const options = {
+const options: Ajv.Options = {
     verbose: true,
     allErrors: true,
-    logger: (false as unknown) as false, // TODO ajv.d.ts
-    useDefaults: ('empty' as unknown) as boolean, // TODO add 'empty' to ajv.d.ts - PR pending https://github.com/epoberezkin/ajv/pull/1020
+    logger: false,
+    useDefaults: 'empty',
 };
 
 const ajv = new Ajv(options);

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -11,7 +11,7 @@
     "@types/ajv": "^1.0.0",
     "@types/lodash.escape": "^4.0.6",
     "@types/sanitize-html": "^1.18.3",
-    "ajv": "^6.10.0",
+    "ajv": "^6.10.1",
     "aws-sdk": "^2.340.0",
     "compose-function": "^3.0.3",
     "compression": "^1.7.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2663,7 +2663,7 @@ ajv-keywords@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.2.0.tgz#e86b819c602cf8821ad637413698f1dec021847a"
 
-ajv@*, ajv@^6.10.0, ajv@^6.9.1:
+ajv@*, ajv@^6.9.1:
   version "6.10.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.0.tgz#90d0d54439da587cd7e843bfb7045f50bd22bdf1"
   integrity sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==
@@ -2676,6 +2676,16 @@ ajv@*, ajv@^6.10.0, ajv@^6.9.1:
 ajv@^6.1.0, ajv@^6.5.5, ajv@^6.6.1:
   version "6.6.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.6.2.tgz#caceccf474bf3fc3ce3b147443711a24063cc30d"
+  dependencies:
+    fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^6.10.1:
+  version "6.10.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.1.tgz#ebf8d3af22552df9dd049bfbe50cc2390e823593"
+  integrity sha512-w1YQaVGNC6t2UCPjEawK/vo/dG8OOrVtUmhBT1uJJYxbl5kU2Tj3v6LGqBcsysN1yhuCStJCCA3GqdvKY8sqXQ==
   dependencies:
     fast-deep-equal "^2.0.1"
     fast-json-stable-stringify "^2.0.0"


### PR DESCRIPTION
## What does this change?
Update `ajv` library and Options type in Model/V2/validate

## Why?
Replaces hacky temp code waiting for library update. 

## Link to supporting Trello card
