### PR TITLE
Handle unknown element types without blowing up

### DIFF
--- a/fixtures/CAPI.ts
+++ b/fixtures/CAPI.ts
@@ -309,7 +309,7 @@ export const CAPI: CAPIType = {
                 },
             ],
             _type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-        },
+        } as GenericElement,
     ],
     editionLongForm: 'uk edition',
     author: {

--- a/packages/frontend/amp/components/BodyArticle.tsx
+++ b/packages/frontend/amp/components/BodyArticle.tsx
@@ -61,7 +61,7 @@ export const Body: React.FC<{
     const tone = getToneType(data.tags);
     const capiElements = data.blocks[0] ? data.blocks[0].elements : [];
     const elementsWithoutAds = Elements(capiElements, pillar, data.isImmersive);
-    const slotIndexes = findAdSlots(capiElements);
+    const slotIndexes = findAdSlots(capiElements as CAPIElement[]);
     const adInfo = {
         section: data.sectionName,
         edition: data.editionId,

--- a/packages/frontend/amp/components/Elements.tsx
+++ b/packages/frontend/amp/components/Elements.tsx
@@ -25,11 +25,15 @@ import { MapEmbed } from '@frontend/amp/components/elements/MapEmbed';
 import { AudioAtom } from '@frontend/amp/components/elements/AudioAtom';
 
 export const Elements = (
-    elements: CAPIElement[],
+    elements: GenericElement[],
     pillar: Pillar,
     isImmersive: boolean,
 ): JSX.Element[] => {
-    const cleanedElements = elements.map(element =>
+    // This is safe here as long as we have a default in the switch. See
+    // GenericElement definition for the rationale.
+    const capiElements = elements as CAPIElement[];
+
+    const cleanedElements = capiElements.map(element =>
         'html' in element ? { ...element, html: clean(element.html) } : element,
     );
     const output = cleanedElements.map((element, i) => {

--- a/packages/frontend/amp/components/MainMedia.tsx
+++ b/packages/frontend/amp/components/MainMedia.tsx
@@ -118,21 +118,23 @@ const expanded = css`
 `;
 
 const asComponent = (
-    element: CAPIElement,
+    element: GenericElement,
     pillar: Pillar,
 ): JSX.Element | null => {
-    switch (element._type) {
+    const capiElement = element as CAPIElement;
+
+    switch (capiElement._type) {
         case 'model.dotcomrendering.pageElements.ImageBlockElement':
-            return mainImage(element);
+            return mainImage(capiElement);
         case 'model.dotcomrendering.pageElements.YoutubeBlockElement':
-            return <YoutubeVideo element={element} pillar={pillar} />;
+            return <YoutubeVideo element={capiElement} pillar={pillar} />;
         default:
             return null;
     }
 };
 
 export const MainMedia: React.FC<{
-    element: CAPIElement;
+    element: GenericElement;
     pillar: Pillar;
 }> = ({ element, pillar }) => {
     return <div className={expanded}>{asComponent(element, pillar)}</div>;

--- a/packages/frontend/amp/lib/find-adslots.ts
+++ b/packages/frontend/amp/lib/find-adslots.ts
@@ -18,7 +18,7 @@
  */
 
 interface ElementWithLength {
-    element: CAPIElement;
+    element: GenericElement;
     length: number;
 }
 
@@ -27,23 +27,25 @@ export const SMALL_PARA_CHARS = 50;
 const NONTEXT_BUFFER_FORWARD = 300;
 const NONTEXT_BUFFER_BACKWARD = 200;
 
-const isTextElement = (e: CAPIElement): boolean => {
+const isTextElement = (e: GenericElement): boolean => {
     return e._type === 'model.dotcomrendering.pageElements.TextBlockElement';
 };
 
-export const getElementLength = (element: CAPIElement): number => {
+export const getElementLength = (element: GenericElement): number => {
     switch (element._type) {
         case 'model.dotcomrendering.pageElements.TextBlockElement':
             // we don't want to count html characters
             const htmlRegex = /(<([^>]+)>)/gi;
-            return element.html.replace(htmlRegex, '').length;
+            return (element as TextBlockElement).html.replace(htmlRegex, '')
+                .length;
+
         default:
             return 0; // for the purposes of ads we don't care how long other elements are
     }
 };
 
 const getElementsWithLength = (
-    elements: CAPIElement[],
+    elements: GenericElement[],
 ): ElementWithLength[] => {
     return elements.map(e => {
         return {
@@ -135,7 +137,7 @@ const hasSpaceForAd = (
 };
 
 // Returns index of items to place ads *after*
-export const findAdSlots = (elements: CAPIElement[]): number[] => {
+export const findAdSlots = (elements: GenericElement[]): number[] => {
     let charsSinceLastAd = 0;
     let paragraphsSinceLastAd = 0;
     let adCount = 0;

--- a/packages/frontend/amp/lib/scripts.ts
+++ b/packages/frontend/amp/lib/scripts.ts
@@ -1,10 +1,14 @@
 const notEmpty = (value: string | null): value is string => value !== null;
 
 export const extractScripts: (
-    elements: CAPIElement[],
-    mainMediaElements: CAPIElement[],
+    elements: GenericElement[],
+    mainMediaElements: GenericElement[],
 ) => string[] = (elements, mainMediaElements) => {
-    return [...new Set([...elements, ...mainMediaElements].map(e => e._type))]
+    const capiElements = elements as CAPIElement[];
+
+    return [
+        ...new Set([...capiElements, ...mainMediaElements].map(e => e._type)),
+    ]
         .map(t => {
             switch (t) {
                 case 'model.dotcomrendering.pageElements.TweetBlockElement':
@@ -28,6 +32,4 @@ export const extractScripts: (
             }
         })
         .filter(notEmpty) as string[];
-    // I have no idea why the type predicate isn't working here. I think it has something to do with the union type.
-    // It works with simpler arrays of type Array<string | null> but not this one.
 };

--- a/packages/frontend/amp/pages/Article.tsx
+++ b/packages/frontend/amp/pages/Article.tsx
@@ -21,7 +21,7 @@ export interface ArticleModel {
     headline: string;
     standfirst: string;
     webTitle: string;
-    mainMediaElements: CAPIElement[];
+    mainMediaElements: GenericElement[];
     keyEvents: Block[]; // liveblog-specific
     pagination?: Pagination;
     blocks: Block[];

--- a/packages/frontend/amp/server/render.tsx
+++ b/packages/frontend/amp/server/render.tsx
@@ -20,7 +20,7 @@ export const render = (
         const blockElements = CAPI.blocks.map(block => block.elements);
 
         // This is simply to flatten the elements
-        const elements = ([] as CAPIElement[]).concat(...blockElements);
+        const elements = ([] as GenericElement[]).concat(...blockElements);
 
         const scripts = [...extractScripts(elements, CAPI.mainMediaElements)];
 

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -111,7 +111,7 @@ interface AuthorType {
 
 interface Block {
     id: string;
-    elements: CAPIElement[];
+    elements: GenericElement[];
     createdOn?: number;
     createdOnDisplay?: string;
     lastUpdatedDisplay?: string;
@@ -135,7 +135,7 @@ interface CAPIType {
     headline: string;
     standfirst: string;
     webTitle: string;
-    mainMediaElements: CAPIElement[];
+    mainMediaElements: GenericElement[];
     main: string;
     keyEvents: Block[];
     blocks: Block[];

--- a/packages/frontend/lib/content.d.ts
+++ b/packages/frontend/lib/content.d.ts
@@ -262,3 +262,13 @@ type CAPIElement =
     | AudioAtomElement
     | AudioBlockElement
     | VideoBlockElement;
+
+// This is used at the validation stage as we don't want to fail validation on
+// unknown elements when checking our json-schema. Unfortunately it means we end
+// up casting this as CAPIElement in certain places. This is safe as long as:
+//
+//   a) element 'type' fields are unique (so values map to one interface)
+//   b) any switches include a default case
+interface GenericElement {
+    _type: string;
+}

--- a/packages/frontend/model/extract-capi.test.ts
+++ b/packages/frontend/model/extract-capi.test.ts
@@ -339,7 +339,7 @@ describe('extract-capi', () => {
         expect(blocks.length).toBe(2);
 
         const blockElements = blocks.map(block => block.elements);
-        const elems = ([] as CAPIElement[]).concat(...blockElements);
+        const elems = ([] as GenericElement[]).concat(...blockElements);
         expect(elems.length).toBe(4);
     });
 

--- a/packages/frontend/web/components/MainMedia.tsx
+++ b/packages/frontend/web/components/MainMedia.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
 import { ImageBlockComponent } from '@frontend/web/components/elements/ImageBlockComponent';
 
-export const MainMedia: React.FC<{ element: CAPIElement }> = ({ element }) => {
-    switch (element._type) {
+export const MainMedia: React.FC<{ element: GenericElement }> = ({
+    element,
+}) => {
+    const capiElement = element as CAPIElement;
+
+    switch (capiElement._type) {
         case 'model.dotcomrendering.pageElements.ImageBlockElement':
-            return <ImageBlockComponent element={element} />;
+            return <ImageBlockComponent element={capiElement} />;
         default:
             return null;
     }

--- a/packages/frontend/web/components/lib/ArticleRenderer.tsx
+++ b/packages/frontend/web/components/lib/ArticleRenderer.tsx
@@ -2,7 +2,7 @@ import { TextBlockComponent } from '@frontend/web/components/elements/TextBlockC
 import { ImageBlockComponent } from '@frontend/web/components/elements/ImageBlockComponent';
 import React from 'react';
 // import { clean } from '@frontend/model/clean';
-export const ArticleRenderer: React.FC<{ elements: CAPIElement[] }> = ({
+export const ArticleRenderer: React.FC<{ elements: GenericElement[] }> = ({
     elements,
 }) => {
     // const cleanedElements = elements.map(element =>
@@ -10,8 +10,9 @@ export const ArticleRenderer: React.FC<{ elements: CAPIElement[] }> = ({
     // );
     // ^^ Until we decide where to do the "isomorphism split" in this this code is not safe here.
     //    But should be soon.
+    const capiElements = elements as CAPIElement[];
 
-    const output = elements
+    const output = capiElements
         .map((element, i) => {
             switch (element._type) {
                 case 'model.dotcomrendering.pageElements.TextBlockElement':


### PR DESCRIPTION
**EDIT: ALTERNATIVE APPROACH HERE WHICH MIGHT BE BETTER: https://github.com/guardian/frontend/pull/21639.**

We want to accept unknown element types as it makes adding new ones easier and also is easier on clients.

Unfortunately, this complicates things because we also want to be typesafe. Previously we weren't.

*At the moment we are strict, but this causes errors on content with unsupported types, which is a problem!*

The 'solution' here is to introduce a separate `GenericElement` type which is used for model/input validation, and then to coerce that into `CAPIElement` when required in the code. So it should preserve/restore the same behavious as prior to schema validation. The downside is several `..as CAPIElement` in the code, all of which are potentially confusing and not typesafe.

I'm not overly-zealous on type safety here. This solution works but is a bit verbose/unclear.

Alternatives are:

* use the new GenericElement on CAPIType but immediately coerce
into a stricter type
* only send supported types from Frontend

None of these seem ideal!

## What does this change?

## Why?

## Link to supporting Trello card
