### PR TITLE
Add commercialConfiguration to CAPI data

### DIFF
--- a/fixtures/CAPI.ts
+++ b/fixtures/CAPI.ts
@@ -362,6 +362,15 @@ export const CAPI: CAPIType = {
         AU: { adTargeting: [] },
         INT: { adTargeting: [] },
     },
+    commercialConfiguration: {
+        hasShowcaseMainElement: false,
+        isFront: false,
+        isLiveblog: false,
+        isMinuteArticle: false,
+        isPaidContent: false,
+        isPreview: false,
+        isSensitive: false,
+    },
     starRating: 2,
     trailText:
         'Ticket touts face unlimited fines for using ‘bots’ to buy in bulk',

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -41,6 +41,16 @@ interface EditionCommercialProperties {
 
 type CommercialProperties = { [E in Edition]: EditionCommercialProperties };
 
+interface CommercialConfiguration {
+    hasShowcaseMainElement: boolean;
+    isFront: boolean;
+    isLiveblog: boolean;
+    isMinuteArticle: boolean;
+    isPaidContent: boolean;
+    isPreview: boolean;
+    isSensitive: boolean;
+}
+
 interface Branding {
     sponsorName: string;
     logo: {
@@ -174,6 +184,9 @@ interface CAPIType {
     commercialProperties: CommercialProperties;
     starRating?: number;
     trailText: string;
+
+    // Commercial
+    commercialConfiguration: CommercialConfiguration;
 
     nav: any; // as not extracting directly into NavType here for now (nav stuff is getting moved out)
 }

--- a/packages/frontend/model/extract-capi.ts
+++ b/packages/frontend/model/extract-capi.ts
@@ -73,6 +73,14 @@ const getCommercialProperties = (data: {}): CommercialProperties => {
     ) as CommercialProperties;
 };
 
+const getCommercialConfiguration = (data: {}): CommercialConfiguration => {
+    return getObject(
+        data,
+        'page.commercialConfiguration',
+        {},
+    ) as CommercialConfiguration;
+};
+
 const getPagination = (data: {}): Pagination | undefined => {
     const found = optional(getObject.bind(null, data, 'page.pagination'));
 
@@ -166,6 +174,7 @@ export const extract = (data: {}): CAPIType => {
         beaconURL: getNonEmptyString(data, 'site.beaconUrl'),
         isCommentable: getBoolean(data, 'page.meta.isCommentable', false),
         commercialProperties: getCommercialProperties(data),
+        commercialConfiguration: getCommercialConfiguration(data),
         starRating: optional(getNumber.bind(null, data, 'page.starRating')),
         trailText: apply(
             getString(data, 'page.content.trailText', ''),


### PR DESCRIPTION
## What does this change?

Add commercialConfiguration to CAPI data. 

Follow up of:
- https://github.com/guardian/frontend/pull/21623
- https://github.com/guardian/frontend/pull/21637
