### PR TITLE
Provide URL and reduce verbosity

### DIFF
--- a/packages/frontend/modelV2/validate.ts
+++ b/packages/frontend/modelV2/validate.ts
@@ -3,7 +3,7 @@ import schema from '@frontend/modelV2/json-schema.json';
 
 const options = {
     verbose: false,
-    allErrors: true,
+    allErrors: false,
     logger: (false as unknown) as false, // TODO ajv.d.ts
     useDefaults: ('empty' as unknown) as boolean, // TODO add 'empty' to ajv.d.ts - PR pending https://github.com/epoberezkin/ajv/pull/1020
 };
@@ -16,8 +16,10 @@ export const validateAsCAPIType = (data: any): CAPIType => {
     const isValid = validate(data);
 
     if (!isValid) {
+        const url = data.webUrl || 'unknown url';
+
         throw new TypeError(
-            `Unable to validate request body.\n
+            `Unable to validate request body for url ${url}.\n
             ${JSON.stringify(validate.errors, null, 2)}`,
         );
     }


### PR DESCRIPTION
## What does this change?

Improve error logging for model validation.

## Why?

The errors are still very verbose but lack context. This attempts to include the request URL and reduces the error logging as with the URL we can just test locally to replicate.

## Link to supporting Trello card

https://trello.com/c/qBNj8JJK
