### PR TITLE
Add captions to images

### DIFF
--- a/packages/frontend/web/components/ArticleBody.tsx
+++ b/packages/frontend/web/components/ArticleBody.tsx
@@ -430,7 +430,6 @@ export const ArticleBody: React.FC<{
     const hasSubMetaKeywordLinks = CAPI.subMetaKeywordLinks.length > 0;
     const sharingUrls = getSharingUrls(CAPI.pageId, CAPI.webTitle);
     const ageWarning = getAgeWarning(CAPI.tags, CAPI.webPublicationDate);
-
     return (
         <div className={wrapper}>
             <header className={header}>
@@ -496,7 +495,11 @@ export const ArticleBody: React.FC<{
                     )}
                 >
                     {CAPI.mainMediaElements.map((element, i) => (
-                        <MainMedia element={element} key={i} />
+                        <MainMedia
+                            element={element}
+                            key={i}
+                            pillar={CAPI.pillar}
+                        />
                     ))}
                 </div>
             </header>
@@ -509,6 +512,7 @@ export const ArticleBody: React.FC<{
                 >
                     <ArticleRenderer
                         elements={CAPI.blocks[0] ? CAPI.blocks[0].elements : []}
+                        pillar={CAPI.pillar}
                     />
                 </div>
                 <div className={cx(subMeta, guardianLines)}>

--- a/packages/frontend/web/components/ArticleBody.tsx
+++ b/packages/frontend/web/components/ArticleBody.tsx
@@ -90,7 +90,7 @@ const pillarColours = pillarMap(
         `,
 );
 
-//TODO refactor  to use in Caption.tsx
+// TODO refactor  to use in Caption.tsx
 // const pillarFigCaptionIconColor = pillarMap(
 //     pillar =>
 //         css`

--- a/packages/frontend/web/components/ArticleBody.tsx
+++ b/packages/frontend/web/components/ArticleBody.tsx
@@ -90,17 +90,18 @@ const pillarColours = pillarMap(
         `,
 );
 
-const pillarFigCaptionIconColor = pillarMap(
-    pillar =>
-        css`
-            figcaption {
-                &::before {
-                    border-color: transparent transparent
-                        ${pillarPalette[pillar].main} transparent;
-                }
-            }
-        `,
-);
+//TODO refactor  to use in Caption.tsx
+// const pillarFigCaptionIconColor = pillarMap(
+//     pillar =>
+//         css`
+//             figcaption {
+//                 &::before {
+//                     border-color: transparent transparent
+//                         ${pillarPalette[pillar].main} transparent;
+//                 }
+//             }
+//         `,
+// );
 
 const listStyles = css`
     li {
@@ -253,16 +254,6 @@ const mainMedia = css`
 
     figcaption {
         ${captionFont};
-
-        &::before {
-            content: '';
-            width: 0;
-            height: 0;
-            border-style: solid;
-            border-width: 0 5.5px 10px 5.5px;
-            display: inline-block;
-            margin-right: 2px;
-        }
     }
 `;
 
@@ -488,12 +479,7 @@ export const ArticleBody: React.FC<{
                         <ShareCount config={config} pageId={CAPI.pageId} />
                     </div>
                 </div>
-                <div
-                    className={cx(
-                        mainMedia,
-                        pillarFigCaptionIconColor[CAPI.pillar],
-                    )}
-                >
+                <div className={cx(mainMedia)}>
                     {CAPI.mainMediaElements.map((element, i) => (
                         <MainMedia
                             element={element}

--- a/packages/frontend/web/components/MainMedia.tsx
+++ b/packages/frontend/web/components/MainMedia.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import { ImageBlockComponent } from '@frontend/web/components/elements/ImageBlockComponent';
 
-export const MainMedia: React.FC<{ element: CAPIElement }> = ({ element }) => {
+export const MainMedia: React.FC<{ element: CAPIElement; pillar: Pillar }> = ({
+    element,
+    pillar,
+}) => {
     switch (element._type) {
         case 'model.dotcomrendering.pageElements.ImageBlockElement':
-            return <ImageBlockComponent element={element} />;
+            return <ImageBlockComponent element={element} pillar={pillar} />;
         default:
             return null;
     }

--- a/packages/frontend/web/components/Picture.tsx
+++ b/packages/frontend/web/components/Picture.tsx
@@ -34,7 +34,7 @@ export const Picture: React.FC<{
                 .map(forSource)
                 .join(
                     '',
-                )}<!--[if IE 9]></video><![endif]--><img itemprop="contentUrl" alt="${alt}" src="${src}/>`,
+                )}<!--[if IE 9]></video><![endif]--><img itemprop="contentUrl" alt="${alt}" src="${src}" />`,
         }}
     />
 );

--- a/packages/frontend/web/components/Picture.tsx
+++ b/packages/frontend/web/components/Picture.tsx
@@ -34,7 +34,7 @@ export const Picture: React.FC<{
                 .map(forSource)
                 .join(
                     '',
-                )}<!--[if IE 9]></video><![endif]--><img itemprop="contentUrl" alt="${alt}" src="${src}" />`,
+                )}<!--[if IE 9]></video><![endif]--><img itemprop="contentUrl" alt="${alt}" src="${src}/>`,
         }}
     />
 );

--- a/packages/frontend/web/components/elements/ImageBlockComponent.tsx
+++ b/packages/frontend/web/components/elements/ImageBlockComponent.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Picture, PictureSource } from '@frontend/web/components/Picture';
+import { Caption } from '@guardian/guui/components/Caption/Caption';
 
 const widths = [660, 480, 0];
 
@@ -57,16 +58,22 @@ const getFallback: (imageSources: ImageSource[]) => string = imageSources => {
     return bestFor(300, inlineSrcSets).src;
 };
 
-export const ImageBlockComponent: React.FC<{ element: ImageBlockElement }> = ({
-    element,
-}) => {
+export const ImageBlockComponent: React.FC<{
+    element: ImageBlockElement;
+    pillar: Pillar;
+}> = ({ element, pillar }) => {
     const sources = makeSources(element.imageSources);
-
     return (
-        <Picture
-            sources={sources}
-            alt={element.data.alt}
-            src={getFallback(element.imageSources)}
-        />
+        <Caption
+            captionText={element.data.caption}
+            pillar={pillar}
+            dirtyHtml={true}
+        >
+            <Picture
+                sources={sources}
+                alt={element.data.alt}
+                src={getFallback(element.imageSources)}
+            />
+        </Caption>
     );
 };

--- a/packages/frontend/web/components/lib/ArticleRenderer.tsx
+++ b/packages/frontend/web/components/lib/ArticleRenderer.tsx
@@ -2,9 +2,10 @@ import { TextBlockComponent } from '@frontend/web/components/elements/TextBlockC
 import { ImageBlockComponent } from '@frontend/web/components/elements/ImageBlockComponent';
 import React from 'react';
 // import { clean } from '@frontend/model/clean';
-export const ArticleRenderer: React.FC<{ elements: CAPIElement[] }> = ({
-    elements,
-}) => {
+export const ArticleRenderer: React.FC<{
+    elements: CAPIElement[];
+    pillar: Pillar;
+}> = ({ elements, pillar }) => {
     // const cleanedElements = elements.map(element =>
     //     'html' in element ? { ...element, html: clean(element.html) } : element,
     // );
@@ -17,7 +18,13 @@ export const ArticleRenderer: React.FC<{ elements: CAPIElement[] }> = ({
                 case 'model.dotcomrendering.pageElements.TextBlockElement':
                     return <TextBlockComponent key={i} html={element.html} />;
                 case 'model.dotcomrendering.pageElements.ImageBlockElement':
-                    return <ImageBlockComponent key={i} element={element} />;
+                    return (
+                        <ImageBlockComponent
+                            key={i}
+                            element={element}
+                            pillar={pillar}
+                        />
+                    );
                 default:
                     return null;
             }

--- a/packages/guui/components/Caption/Caption.tsx
+++ b/packages/guui/components/Caption/Caption.tsx
@@ -21,7 +21,7 @@ const captionPadding = css`
 `;
 
 export const Caption: React.FC<{
-    captionText: string;
+    captionText?: string;
     pillar: Pillar;
     padCaption?: boolean;
     dirtyHtml?: boolean;
@@ -57,7 +57,7 @@ export const Caption: React.FC<{
                     // tslint:disable-line:react-no-dangerous-html
                     className={captionLink}
                     dangerouslySetInnerHTML={{
-                        __html: captionText,
+                        __html: captionText || '',
                     }}
                     key={'caption'}
                 />


### PR DESCRIPTION
## What does this change?
Adds the caption field to images on dotcom-rendering articles.

<img width="788" alt="Screen Shot 2019-07-15 at 15 53 54" src="https://user-images.githubusercontent.com/2051501/61225610-d2406500-a718-11e9-9947-1bfeb6c16efe.png">

## Why?
Visual parity. Still need to add credit at a later point.

## Link to supporting Trello card
https://trello.com/c/97VCdoVc
