### PR TITLE
Introduce WindowGuardianObject

### DIFF
--- a/packages/frontend/model/window-guardian-object.ts
+++ b/packages/frontend/model/window-guardian-object.ts
@@ -1,0 +1,58 @@
+// This interface is currently a work in progress.
+// Not all attributes will remain and better types will be given as we go along
+interface WindowGuardianObjectConfig {
+    googleAnalytics: any;
+    images: any;
+    libs: any;
+    modules: any;
+    nav: any;
+    ophan: any;
+    page: any;
+    stylesheets: any;
+    switches: any;
+    tests: {
+        renderer: string;
+    };
+}
+
+export interface WindowGuardianObject {
+    app: {
+        data: {
+            page: string;
+            site: string;
+        };
+        cssIDs: string[];
+    };
+    config: WindowGuardianObjectConfig;
+}
+
+const config = {
+    googleAnalytics: null,
+    images: null,
+    libs: null,
+    modules: null,
+    nav: null,
+    ophan: null,
+    page: null,
+    stylesheets: null,
+    switches: null,
+    tests: {
+        renderer: 'new',
+    },
+};
+
+export const makeWindowGuardianObject = (
+    pageSite: {
+        page: string;
+        site: string;
+    },
+    cssIDs: string[],
+): WindowGuardianObject => {
+    return {
+        config,
+        app: {
+            cssIDs,
+            data: pageSite,
+        },
+    };
+};

--- a/packages/frontend/model/window-guardian.ts
+++ b/packages/frontend/model/window-guardian.ts
@@ -1,6 +1,6 @@
 // This interface is currently a work in progress.
 // Not all attributes will remain and better types will be given as we go along
-interface WindowGuardianObjectConfig {
+interface ClientSideConfig {
     googleAnalytics: any;
     images: any;
     libs: any;
@@ -15,7 +15,7 @@ interface WindowGuardianObjectConfig {
     };
 }
 
-export interface WindowGuardianObject {
+export interface WindowGuardian {
     app: {
         data: {
             page: string;
@@ -23,7 +23,7 @@ export interface WindowGuardianObject {
         };
         cssIDs: string[];
     };
-    config: WindowGuardianObjectConfig;
+    config: ClientSideConfig;
 }
 
 const config = {
@@ -41,13 +41,13 @@ const config = {
     },
 };
 
-export const makeWindowGuardianObject = (
+export const makeWindowGuardian = (
     pageSite: {
         page: string;
         site: string;
     },
     cssIDs: string[],
-): WindowGuardianObject => {
+): WindowGuardian => {
     return {
         config,
         app: {

--- a/packages/frontend/model/window-guardian.ts
+++ b/packages/frontend/model/window-guardian.ts
@@ -1,6 +1,6 @@
 // This interface is currently a work in progress.
 // Not all attributes will remain and better types will be given as we go along
-interface ClientSideConfig {
+export interface ClientSideConfig {
     googleAnalytics: any;
     images: any;
     libs: any;
@@ -10,23 +10,12 @@ interface ClientSideConfig {
     page: any;
     stylesheets: any;
     switches: any;
-    tests: {
-        renderer: string;
-    };
+    tests: any;
 }
 
-export interface WindowGuardian {
-    app: {
-        data: {
-            page: string;
-            site: string;
-        };
-        cssIDs: string[];
-    };
-    config: ClientSideConfig;
-}
-
-const config = {
+// Temporary
+// Currently exported, but will be replaced by a function call.
+export const clientSideConfig = {
     googleAnalytics: null,
     images: null,
     libs: null,
@@ -36,23 +25,15 @@ const config = {
     page: null,
     stylesheets: null,
     switches: null,
-    tests: {
-        renderer: 'new',
-    },
+    tests: null,
 };
 
+export interface WindowGuardian {
+    config: ClientSideConfig;
+}
+
 export const makeWindowGuardian = (
-    pageSite: {
-        page: string;
-        site: string;
-    },
-    cssIDs: string[],
+    config: ClientSideConfig,
 ): WindowGuardian => {
-    return {
-        config,
-        app: {
-            cssIDs,
-            data: pageSite,
-        },
-    };
+    return { config };
 };

--- a/packages/frontend/web/server/document.tsx
+++ b/packages/frontend/web/server/document.tsx
@@ -9,6 +9,8 @@ import { Article } from '../pages/Article';
 import { getDist } from '@frontend/lib/assets';
 import { GADataType } from '@frontend/model/extract-ga';
 
+import { makeWindowGuardianObject } from '@frontend/model/window-guardian-object';
+
 interface Props {
     data: {
         page: string;
@@ -83,6 +85,8 @@ export const document = ({ data }: Props) => {
         'https://www.google-analytics.com/analytics.js',
     ];
 
+    const windowGuardianObject = makeWindowGuardianObject(data, cssIDs);
+
     return htmlTemplate({
         linkedData,
         preloadScripts,
@@ -94,5 +98,6 @@ export const document = ({ data }: Props) => {
         fontFiles,
         data,
         title,
+        windowGuardianObject,
     });
 };

--- a/packages/frontend/web/server/document.tsx
+++ b/packages/frontend/web/server/document.tsx
@@ -9,7 +9,10 @@ import { Article } from '../pages/Article';
 import { getDist } from '@frontend/lib/assets';
 import { GADataType } from '@frontend/model/extract-ga';
 
-import { makeWindowGuardian } from '@frontend/model/window-guardian';
+import {
+    clientSideConfig,
+    makeWindowGuardian,
+} from '@frontend/model/window-guardian';
 
 interface Props {
     data: {
@@ -85,7 +88,7 @@ export const document = ({ data }: Props) => {
         'https://www.google-analytics.com/analytics.js',
     ];
 
-    const windowGuardian = makeWindowGuardian(data, cssIDs);
+    const windowGuardian = makeWindowGuardian(clientSideConfig);
 
     return htmlTemplate({
         linkedData,

--- a/packages/frontend/web/server/document.tsx
+++ b/packages/frontend/web/server/document.tsx
@@ -9,7 +9,7 @@ import { Article } from '../pages/Article';
 import { getDist } from '@frontend/lib/assets';
 import { GADataType } from '@frontend/model/extract-ga';
 
-import { makeWindowGuardianObject } from '@frontend/model/window-guardian-object';
+import { makeWindowGuardian } from '@frontend/model/window-guardian';
 
 interface Props {
     data: {
@@ -85,7 +85,7 @@ export const document = ({ data }: Props) => {
         'https://www.google-analytics.com/analytics.js',
     ];
 
-    const windowGuardianObject = makeWindowGuardianObject(data, cssIDs);
+    const windowGuardian = makeWindowGuardian(data, cssIDs);
 
     return htmlTemplate({
         linkedData,
@@ -98,6 +98,6 @@ export const document = ({ data }: Props) => {
         fontFiles,
         data,
         title,
-        windowGuardianObject,
+        windowGuardian,
     });
 };

--- a/packages/frontend/web/server/htmlTemplate.ts
+++ b/packages/frontend/web/server/htmlTemplate.ts
@@ -2,7 +2,7 @@ import resetCSS from /* preval */ '@frontend/lib/reset-css';
 import { getFontsCss } from '@frontend/lib/fonts-css';
 import { getStatic } from '@frontend/lib/assets';
 
-import { WindowGuardianObject } from '@frontend/model/window-guardian-object';
+import { WindowGuardian } from '@frontend/model/window-guardian';
 
 export const htmlTemplate = ({
     title = 'The Guardian',
@@ -14,9 +14,9 @@ export const htmlTemplate = ({
     html,
     data,
     cssIDs,
+    windowGuardian,
     nonBlockingJS = '',
     fontFiles = [],
-    windowGuardianObject,
 }: {
     title?: string;
     linkedData: object;
@@ -32,7 +32,7 @@ export const htmlTemplate = ({
     cssIDs: string[];
     nonBlockingJS?: string;
     fontFiles?: string[];
-    windowGuardianObject: WindowGuardianObject;
+    windowGuardian: WindowGuardian;
 }) => {
     const favicon =
         process.env.NODE_ENV === 'production'
@@ -63,7 +63,7 @@ export const htmlTemplate = ({
                     .join('\n')}
                 <style>${getFontsCss()}${resetCSS}${css}</style>
                 <script>
-                window.guardian = ${JSON.stringify(windowGuardianObject)};
+                window.guardian = ${JSON.stringify(windowGuardian)};
                 // this is a global that's called at the bottom of the pf.io response,
                 // once the polyfills have run. This may be useful for debugging.
                 // mainly to support browsers that don't support async=false or defer

--- a/packages/frontend/web/server/htmlTemplate.ts
+++ b/packages/frontend/web/server/htmlTemplate.ts
@@ -2,6 +2,8 @@ import resetCSS from /* preval */ '@frontend/lib/reset-css';
 import { getFontsCss } from '@frontend/lib/fonts-css';
 import { getStatic } from '@frontend/lib/assets';
 
+import { WindowGuardianObject } from '@frontend/model/window-guardian-object';
+
 export const htmlTemplate = ({
     title = 'The Guardian',
     linkedData,
@@ -14,6 +16,7 @@ export const htmlTemplate = ({
     cssIDs,
     nonBlockingJS = '',
     fontFiles = [],
+    windowGuardianObject,
 }: {
     title?: string;
     linkedData: object;
@@ -29,6 +32,7 @@ export const htmlTemplate = ({
     cssIDs: string[];
     nonBlockingJS?: string;
     fontFiles?: string[];
+    windowGuardianObject: WindowGuardianObject;
 }) => {
     const favicon =
         process.env.NODE_ENV === 'production'
@@ -59,17 +63,7 @@ export const htmlTemplate = ({
                     .join('\n')}
                 <style>${getFontsCss()}${resetCSS}${css}</style>
                 <script>
-                window.guardian = ${JSON.stringify({
-                    app: {
-                        data,
-                        cssIDs,
-                    },
-                    config: {
-                        tests: {
-                            renderer: 'new',
-                        },
-                    },
-                })};
+                window.guardian = ${JSON.stringify(windowGuardianObject)};
                 // this is a global that's called at the bottom of the pf.io response,
                 // once the polyfills have run. This may be useful for debugging.
                 // mainly to support browsers that don't support async=false or defer


### PR DESCRIPTION
This PR introduces a skeleton and separate helper functions for the `window.guardian` object. 

**dotcom-rendering before**:

<img width="392" alt="Screenshot 2019-07-16 at 14 26 56" src="https://user-images.githubusercontent.com/6035518/61298333-f3b35680-a7d5-11e9-937e-45ac98ea8dfa.png">


**dotcom-rendering after**:

<img width="333" alt="Screenshot 2019-07-16 at 15 19 59" src="https://user-images.githubusercontent.com/6035518/61302157-3593cb00-a7dd-11e9-81cf-d8f01a0cf1fd.png">



**current frontend**: 

<img width="709" alt="Screenshot 2019-07-16 at 14 30 01" src="https://user-images.githubusercontent.com/6035518/61298498-39701f00-a7d6-11e9-9b71-c612f93740bc.png">


