### PR TITLE
List testing articles on the landing page

### DIFF
--- a/scripts/frontend/dev-server.js
+++ b/scripts/frontend/dev-server.js
@@ -73,18 +73,8 @@ const go = async () => {
         }),
     );
 
-    app.get('/', (req, res) => {
-        res.send(`
-            <!DOCTYPE html>
-            <html>
-            <body>
-                <ul>
-                    <li><a href="/Article">Article</a></li>
-                    <li><a href="/AMPArticle">⚡️Article</a></li>
-                </ul>
-            </body>
-            </html>
-        `);
+    app.get('/',function(req,res) {
+        res.sendFile(path.join(root, 'scripts', 'frontend', 'landing', 'index.html'));
     });
 
     app.get('*', (req, res) => {

--- a/scripts/frontend/landing/index.html
+++ b/scripts/frontend/landing/index.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        html {
+            font-family: Arial, Helvetica, sans-serif;
+            padding-left: 2em;
+        }
+        h2 {
+            margin-top: 1.5em;
+        }
+        a {
+            color: #389ddc;
+        }
+        .test-articles-list span {
+            display: inline-block;
+            width: 8em;
+            line-height: 2em;
+        }
+        .test-article-header span {
+            font-weight: bold;
+        }
+        .test-article>span:nth-child(1), .test-article-header>span:nth-child(1) {
+            width: 14em !important;
+        }
+    </style>
+</head>
+<body>
+
+    <h2>Default Endpoints</h2>
+
+    <ul>
+        <li><a href="/Article">Article</a></li>
+        <li><a href="/AMPArticle">⚡️Article</a></li>
+    </ul>
+
+    <h2>Test Articles By Content Type</h2>
+
+    <div id="test-articles-by-content" class="test-articles-list">
+
+        <div class="test-article-header">
+            <span>type</span>
+            <span>local</span>
+            <span>local-amp</span>
+            <span>production</span>
+            <span>production-amp</span>
+        </div>
+
+    </div>
+
+    <h2>Test Articles By Element</h2>
+
+    <div id="test-articles-by-element" class="test-articles-list">
+
+        <div class="test-article-header">
+            <span>type</span>
+            <span>local</span>
+            <span>local-amp</span>
+            <span>production</span>
+            <span>production-amp</span>
+        </div>
+
+    </div>
+
+    <script>
+
+        var testContentTypes = [
+            { name: "Live Blog", article: "https://www.theguardian.com/football/live/2018/jul/03/world-cup-2018-england-v-colombia-switzerland-v-sweden-buildup-live" },
+            { name: "Opinion Piece", article: "https://www.theguardian.com/politics/2019/jul/15/it-will-be-boris-johnson-and-it-will-certainly-be-a-disaster" },
+            { name: "Review", article: "https://www.theguardian.com/music/2018/aug/31/eminem-kamikaze-album-review"}
+        ];
+
+        var testArticles = [
+            { name: "ImageBlockElement", article: "https://www.theguardian.com/environment/2018/dec/21/from-spectacular-orchids-to-towering-trees-2018s-top-new-plant-discoveries" },
+            { name: "ImageBlockElement (left)", article: "https://www.theguardian.com/film/2018/aug/30/damon-herriman-to-play-charles-manson-in-quentin-tarantino-film" },
+            { name: "TweetBlockElement", article: "https://www.theguardian.com/uk-news/reality-check/2015/sep/19/daily-mail-syrian-refugees-story-three-problems" },
+            { name: "RichLinkBlockElement", article: "https://www.theguardian.com/football/2019/jun/04/juventus-interested-paul-pogba-manchester-united" },
+            { name: "PullquoteBlockElement", article: "https://www.theguardian.com/world/2018/dec/28/south-koreas-sexist-sex-education" },
+            { name: "VideoBlockElement", article: "https://www.theguardian.com/us-news/2017/feb/23/los-angeles-police-officer-teen-gun-video-protests" },
+            { name: "AudioBlockElement", article: "https://www.theguardian.com/music/2018/nov/02/the-prodigy-no-tourists-review" },
+            { name: "EmbedBlockElement", article: "https://www.theguardian.com/australia-news/2018/jun/12/shorten-wants-more-aged-care-spending-but-wont-back-royal-commission" },
+            { name: "ContentAtomBlockElement", article: "https://www.theguardian.com/world/2018/jun/18/yemen-crisis-saudi-coalition-demands-houthis-unconditional-withdrawal-from-port" }
+        ];
+
+        var makeTestArticle = (a) => `
+            <div class="test-article">
+                <span>${a.name}</span>
+                <span><a href="/Article?url=${a.article}">example</a></span>
+                <span><a href="/AMPArticle?url=${a.article}">example</a></span>
+                <span><a href="${a.article}">example</a></span>
+                <span><a href="${a.article.replace("www.", "amp.")}">example</a></span>
+            </div>
+        `;
+
+        testArticles.forEach((a)=>{
+            document.getElementById("test-articles-by-element").innerHTML += makeTestArticle(a);
+        });
+
+        testContentTypes.forEach((a)=>{
+            document.getElementById("test-articles-by-content").innerHTML += makeTestArticle(a);
+        });
+
+    </script>
+
+</body>
+</html>

--- a/scripts/frontend/landing/index.html
+++ b/scripts/frontend/landing/index.html
@@ -67,7 +67,8 @@
         var testContentTypes = [
             { name: "Live Blog", article: "https://www.theguardian.com/football/live/2018/jul/03/world-cup-2018-england-v-colombia-switzerland-v-sweden-buildup-live" },
             { name: "Opinion Piece", article: "https://www.theguardian.com/politics/2019/jul/15/it-will-be-boris-johnson-and-it-will-certainly-be-a-disaster" },
-            { name: "Review", article: "https://www.theguardian.com/music/2018/aug/31/eminem-kamikaze-album-review"}
+            { name: "Review", article: "https://www.theguardian.com/music/2018/aug/31/eminem-kamikaze-album-review"},
+            { name: "Paid Content", article: "https://www.theguardian.com/bank-australia-clean-money/2019/feb/11/three-trillion-reasons-for-australians-to-join-the-clean-money-revolution"}
         ];
 
         var testArticles = [


### PR DESCRIPTION
## What does this change?

Changes the landing (/) page to this:

![image](https://user-images.githubusercontent.com/1218561/61306442-878c1f00-a7e4-11e9-8150-a40094965307.png)

The list of articles is not exhaustive, I just picked the most common ones, and the elements that we might aim to complete this quarter.

It's actually non-trivial to put react on the landing page since the project is set up with the whole serverside react bundle generation stuff, but I might investigate if this is possible. At the moment, this landing page is still just a static html page with embedded js/css. I tried to make it clean at least.

## Why?

I'm attempting to solve the specific problem of 'I'm working on X component, and I need to find an article that has it on it'. @rcrphillips thought it was a good idea to put it on the landing, and I agree! It should be useful this quarter as we need a write a bunch of these components.

## Link to supporting Trello card

https://trello.com/c/C5m0GYAh/625-make-and-centralise-a-list-of-test-articles-for-dcr
