### PR TITLE
Fix validation - displayCredit is optional

### DIFF
--- a/packages/frontend/lib/content.d.ts
+++ b/packages/frontend/lib/content.d.ts
@@ -32,7 +32,7 @@ interface ImageBlockElement {
     media: { allImages: Image[] };
     data: { alt: string; credit: string; caption?: string; copyright?: string };
     imageSources: ImageSource[];
-    displayCredit: boolean;
+    displayCredit?: boolean;
     role: string;
 }
 interface YoutubeBlockElement {

--- a/packages/frontend/modelV2/json-schema.json
+++ b/packages/frontend/modelV2/json-schema.json
@@ -369,7 +369,6 @@
             "required": [
                 "_type",
                 "data",
-                "displayCredit",
                 "imageSources",
                 "media",
                 "role"


### PR DESCRIPTION
## What does this change?

We're still getting some validation errors on AMP because the model doesn't align with reality in some cases. This fixes one such case.

## Why?

To ensure we serve content correctly on AMP.
