### PR TITLE
Adding optional display credit to caption

### DIFF
--- a/packages/frontend/amp/components/elements/Image.tsx
+++ b/packages/frontend/amp/components/elements/Image.tsx
@@ -73,8 +73,7 @@ export const Image: React.FC<{
                             __html: element.data.caption || '',
                         }}
                         key={'caption'}
-                    />
-
+                    />{' '}
                     {element.displayCredit && element.data.credit}
                 </figcaption>
             )}

--- a/packages/frontend/web/components/elements/ImageBlockComponent.tsx
+++ b/packages/frontend/web/components/elements/ImageBlockComponent.tsx
@@ -68,6 +68,8 @@ export const ImageBlockComponent: React.FC<{
             captionText={element.data.caption}
             pillar={pillar}
             dirtyHtml={true}
+            credit={element.data.credit}
+            displayCredit={true}
         >
             <Picture
                 sources={sources}

--- a/packages/guui/components/Caption/Caption.tsx
+++ b/packages/guui/components/Caption/Caption.tsx
@@ -25,11 +25,15 @@ export const Caption: React.FC<{
     pillar: Pillar;
     padCaption?: boolean;
     dirtyHtml?: boolean;
+    credit?: string;
+    displayCredit?: boolean;
 }> = ({
     captionText,
     pillar,
     padCaption = false,
     dirtyHtml = false,
+    credit,
+    displayCredit = true,
     children,
 }) => {
     const iconStyle = css`
@@ -79,7 +83,7 @@ export const Caption: React.FC<{
                         <span className={iconStyle}>
                             <TriangleIcon />
                         </span>
-                        {getCaptionHtml()}
+                        {getCaptionHtml()} {displayCredit && credit}
                     </figcaption>
                 </>
             )}


### PR DESCRIPTION
## What does this change?
Appends the the credit information to the caption display
Before
<img width="788" alt="Screen Shot 2019-07-16 at 17 19 46" src="https://user-images.githubusercontent.com/2051501/61311328-10f41f00-a7ee-11e9-945c-89bc3452ef9e.png">
After
<img width="788" alt="Screen Shot 2019-07-16 at 17 19 59" src="https://user-images.githubusercontent.com/2051501/61311329-10f41f00-a7ee-11e9-8256-82ad5a903fe3.png">

## Why?
Visual parity

## Link to supporting Trello card
https://trello.com/c/dND14lgM