### PR TITLE
Make data fields optional

### DIFF
--- a/packages/frontend/lib/content.d.ts
+++ b/packages/frontend/lib/content.d.ts
@@ -30,7 +30,12 @@ interface RichLinkBlockElement {
 interface ImageBlockElement {
     _type: 'model.dotcomrendering.pageElements.ImageBlockElement';
     media: { allImages: Image[] };
-    data: { alt: string; credit: string; caption?: string; copyright?: string };
+    data: {
+        alt?: string;
+        credit?: string;
+        caption?: string;
+        copyright?: string;
+    };
     imageSources: ImageSource[];
     displayCredit?: boolean;
     role: string;

--- a/packages/frontend/modelV2/json-schema.json
+++ b/packages/frontend/modelV2/json-schema.json
@@ -347,11 +347,7 @@
                         "copyright": {
                             "type": "string"
                         }
-                    },
-                    "required": [
-                        "alt",
-                        "credit"
-                    ]
+                    }
                 },
                 "imageSources": {
                     "type": "array",

--- a/packages/frontend/web/components/elements/ImageBlockComponent.tsx
+++ b/packages/frontend/web/components/elements/ImageBlockComponent.tsx
@@ -65,13 +65,13 @@ export const ImageBlockComponent: React.FC<{
     const sources = makeSources(element.imageSources);
     return (
         <Caption
-            captionText={element.data.caption}
+            captionText={element.data.caption || ''}
             pillar={pillar}
             dirtyHtml={true}
         >
             <Picture
                 sources={sources}
-                alt={element.data.alt}
+                alt={element.data.alt || ''}
                 src={getFallback(element.imageSources)}
             />
         </Caption>


### PR DESCRIPTION
Turns out none of these are guaranteed to be populated in the original models so we should reflect that here rather than erroring on validation as we currently do for some content in PROD.

