### PR TITLE
Add missing script tag for preloaded scripts

### DIFF
--- a/packages/frontend/web/server/htmlTemplate.ts
+++ b/packages/frontend/web/server/htmlTemplate.ts
@@ -100,6 +100,9 @@ export const htmlTemplate = ({
                     .map(script => `<script async src="${script}"></script>`)
                     .join('\n')}
                 <script>${nonBlockingJS}</script>
+                ${preloadScripts
+                    .map(url => `<script src="${url}"></script>`)
+                    .join('\n')}
             </body>
         </html>`;
 };


### PR DESCRIPTION
## What does this change?

Add missing script tag for preloaded scripts. This fixes the problem by which the commercial script wasn't firing up :)
