### PR TITLE
Ensure channel ID is optional

### DIFF
--- a/packages/frontend/amp/components/elements/YoutubeVideo.tsx
+++ b/packages/frontend/amp/components/elements/YoutubeVideo.tsx
@@ -7,17 +7,21 @@ export const YoutubeVideo: React.FC<{
 }> = ({ element, pillar }) => {
     // https://www.ampproject.org/docs/reference/components/amp-youtube
     // https://developers.google.com/youtube/player_parameters
-    const attributes = {
+    const attributes: any = {
         id: `gu-video-youtube-${element.id}`,
         'data-videoid': element.assetId,
         layout: 'responsive',
         width: '16',
         height: '9',
         'data-param-modestbranding': true, // Remove YouTube logo
-        'data-param-rel': '0', // Show the channel's related videos
-        'data-param-listType': 'playlist', // Related videos from playlist
-        'data-param-list': element.channelId, // Use specific channel ID for related videos
     };
+
+    if (element.channelId) {
+        // related videos metadata
+        attributes['data-param-rel'] = '0';
+        attributes['data-param-listType'] = 'playlist';
+        attributes['data-param-list'] = element.channelId;
+    }
 
     return (
         <Caption

--- a/packages/frontend/lib/content.d.ts
+++ b/packages/frontend/lib/content.d.ts
@@ -44,7 +44,7 @@ interface YoutubeBlockElement {
     _type: 'model.dotcomrendering.pageElements.YoutubeBlockElement';
     id: string;
     assetId: string;
-    channelId: string;
+    channelId?: string;
     mediaTitle: string;
 }
 

--- a/packages/frontend/model/json-schema.json
+++ b/packages/frontend/model/json-schema.json
@@ -485,7 +485,6 @@
             "required": [
                 "_type",
                 "assetId",
-                "channelId",
                 "id",
                 "mediaTitle"
             ]


### PR DESCRIPTION
Another one of these - this time around youtube videos which don't necessarily have a channel ID. E.g. see: 

https://www.theguardian.com/environment/2018/nov/21/swarming-sit-down-protests-aim-to-disrupt-london-traffic
