### PR TITLE
Structured data additions for non-AMP

### DIFF
--- a/packages/frontend/web/server/document.tsx
+++ b/packages/frontend/web/server/document.tsx
@@ -35,7 +35,7 @@ interface RenderToStringResult {
 export const document = ({ data }: Props) => {
     const { page, site, CAPI, NAV, config, linkedData } = data;
     const title = `${CAPI.headline} | ${CAPI.sectionLabel} | The Guardian`;
-    const { html, css, ids: cssIDs }: RenderToStringResult = extractCritical(
+    const { html, css }: RenderToStringResult = extractCritical(
         renderToString(
             // TODO: CacheProvider can be removed when we've moved over to using @emotion/core
             <CacheProvider value={cache}>
@@ -97,9 +97,7 @@ export const document = ({ data }: Props) => {
         lowPriorityScripts,
         css,
         html,
-        cssIDs,
         fontFiles,
-        data,
         title,
         windowGuardian,
     });

--- a/packages/frontend/web/server/document.tsx
+++ b/packages/frontend/web/server/document.tsx
@@ -90,6 +90,8 @@ export const document = ({ data }: Props) => {
 
     const windowGuardian = makeWindowGuardian(clientSideConfig);
 
+    const ampLink = `https://amp.theguardian.com/${data.CAPI.pageId}`;
+
     return htmlTemplate({
         linkedData,
         preloadScripts,
@@ -100,5 +102,6 @@ export const document = ({ data }: Props) => {
         fontFiles,
         title,
         windowGuardian,
+        ampLink,
     });
 };

--- a/packages/frontend/web/server/htmlTemplate.ts
+++ b/packages/frontend/web/server/htmlTemplate.ts
@@ -15,6 +15,7 @@ export const htmlTemplate = ({
     windowGuardian,
     nonBlockingJS = '',
     fontFiles = [],
+    ampLink,
 }: {
     title?: string;
     linkedData: object;
@@ -26,6 +27,7 @@ export const htmlTemplate = ({
     nonBlockingJS?: string;
     fontFiles?: string[];
     windowGuardian: WindowGuardian;
+    ampLink?: string;
 }) => {
     const favicon =
         process.env.NODE_ENV === 'production'
@@ -38,9 +40,11 @@ export const htmlTemplate = ({
                 <title>${title}</title>
                 <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
                 <link rel="icon" href="https://static.guim.co.uk/images/${favicon}">
+
                 <script type="application/ld+json">
                     ${JSON.stringify(linkedData)}
                 </script>
+
                 ${preloadScripts
                     .map(
                         url => `<link rel="preload" href="${url}" as="script">`,
@@ -54,6 +58,10 @@ export const htmlTemplate = ({
                             )}" as="font" crossorigin>`,
                     )
                     .join('\n')}
+
+                <!-- TODO make this conditional when we support more content types -->
+                ${ampLink ? `<link rel="amphtml" href="${ampLink}">` : ''}
+
                 <style>${getFontsCss()}${resetCSS}${css}</style>
                 <script>
                 window.guardian = ${JSON.stringify(windowGuardian)};

--- a/packages/frontend/web/server/htmlTemplate.ts
+++ b/packages/frontend/web/server/htmlTemplate.ts
@@ -12,8 +12,6 @@ export const htmlTemplate = ({
     lowPriorityScripts,
     css,
     html,
-    data,
-    cssIDs,
     windowGuardian,
     nonBlockingJS = '',
     fontFiles = [],
@@ -25,11 +23,6 @@ export const htmlTemplate = ({
     lowPriorityScripts: string[];
     css: string;
     html: string;
-    data: {
-        page: string;
-        site: string;
-    };
-    cssIDs: string[];
     nonBlockingJS?: string;
     fontFiles?: string[];
     windowGuardian: WindowGuardian;


### PR DESCRIPTION
## What does this change?

Adds an AMP rel link to the head of plain articles.

## Why?

So that we support AMP when we should.

## Link to supporting Trello card

https://trello.com/c/u7m2fnmD

This is the general card to track structured data stuff. It turns out we already do the core stuff from our AMP work, and also a lot of code in Frontend metadata is irrelevant for regular articles.
