### PR TITLE
Repair window.guardian by setting the correct object

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+import { WindowGuardianConfig } from '@frontend/model/window-guardian';
+
 declare global {
     /*~ Here, declare things that go in the global namespace, or augment
      *~ existing declarations in the global namespace
@@ -11,6 +13,7 @@ declare global {
             polyfilled: boolean;
             onPolyfilled: () => void;
         };
+        config: WindowGuardianConfig;
         GoogleAnalyticsObject: string;
         ga: UniversalAnalytics.ga;
     }

--- a/packages/frontend/model/window-guardian.ts
+++ b/packages/frontend/model/window-guardian.ts
@@ -1,6 +1,6 @@
 // This interface is currently a work in progress.
 // Not all attributes will remain and better types will be given as we go along
-export interface ClientSideConfig {
+export interface WindowGuardianConfig {
     googleAnalytics: any;
     images: any;
     libs: any;
@@ -15,7 +15,7 @@ export interface ClientSideConfig {
 
 // Temporary
 // Currently exported, but will be replaced by a function call.
-export const clientSideConfig = {
+export const windowGuardianConfig = {
     googleAnalytics: null,
     images: null,
     libs: null,
@@ -29,11 +29,27 @@ export const clientSideConfig = {
 };
 
 export interface WindowGuardian {
-    config: ClientSideConfig;
+    app: {
+        data: any;
+        cssIDs: string[];
+    };
+    polyfilled: boolean;
+    onPolyfilled: () => void;
+    config: WindowGuardianConfig;
 }
 
 export const makeWindowGuardian = (
-    config: ClientSideConfig,
+    config: WindowGuardianConfig,
+    data: any,
+    cssIDs: string[],
 ): WindowGuardian => {
-    return { config };
+    return {
+        config,
+        app: {
+            data,
+            cssIDs,
+        },
+        polyfilled: false,
+        onPolyfilled: () => null,
+    };
 };

--- a/packages/frontend/web/server/document.tsx
+++ b/packages/frontend/web/server/document.tsx
@@ -10,7 +10,7 @@ import { getDist } from '@frontend/lib/assets';
 // import { GADataType } from '@frontend/model/extract-ga';
 
 import {
-    clientSideConfig,
+    windowGuardianConfig,
     makeWindowGuardian,
 } from '@frontend/model/window-guardian';
 
@@ -88,7 +88,11 @@ export const document = ({ data }: Props) => {
         'https://www.google-analytics.com/analytics.js',
     ];
 
-    const windowGuardian = makeWindowGuardian(clientSideConfig);
+    const windowGuardian = makeWindowGuardian(
+        windowGuardianConfig,
+        data,
+        cssIDs,
+    );
 
     return htmlTemplate({
         linkedData,


### PR DESCRIPTION
## What does this change?

This repairs the the `window.guardian` object that I broke here ( https://github.com/guardian/dotcom-rendering/pull/657 ) when it wasn't apparent that `window.guardian.app` was being used and why. Turns out it is used on the client side and in particular carries the URL to the commercial bundle. 

Note this PR is not attempting to optimise its shape. Any improvement of the way it presents data will be done later.
