### PR TITLE
Reintroduce the correct value for cssIDs

### DIFF
--- a/packages/frontend/web/server/document.tsx
+++ b/packages/frontend/web/server/document.tsx
@@ -35,7 +35,7 @@ interface RenderToStringResult {
 export const document = ({ data }: Props) => {
     const { page, site, CAPI, NAV, config, linkedData } = data;
     const title = `${CAPI.headline} | ${CAPI.sectionLabel} | The Guardian`;
-    const { html, css }: RenderToStringResult = extractCritical(
+    const { html, css, ids: cssIDs }: RenderToStringResult = extractCritical(
         renderToString(
             // TODO: CacheProvider can be removed when we've moved over to using @emotion/core
             <CacheProvider value={cache}>
@@ -88,7 +88,11 @@ export const document = ({ data }: Props) => {
         'https://www.google-analytics.com/analytics.js',
     ];
 
-    const windowGuardian = makeWindowGuardian(windowGuardianConfig, data, []);
+    const windowGuardian = makeWindowGuardian(
+        windowGuardianConfig,
+        data,
+        cssIDs,
+    );
 
     const ampLink = `https://amp.theguardian.com/${data.CAPI.pageId}`;
 


### PR DESCRIPTION
## What does this change?

Reintroduce the correct value for cssIDs. This doesn't show up in type checking but is used on the client side here: https://github.com/guardian/dotcom-rendering/blob/17a5840606e381050d5c962486db5d6a649a5815/packages/frontend/web/browser/boot.ts#L36

