### PR TITLE
Remodel to use designType instead of tone tags directly in DCR

### DIFF
--- a/packages/frontend/amp/components/BodyArticle.tsx
+++ b/packages/frontend/amp/components/BodyArticle.tsx
@@ -5,8 +5,7 @@ import { css } from 'emotion';
 import { ArticleModel } from '@frontend/amp/pages/Article';
 import { TopMeta } from '@frontend/amp/components/topMeta/TopMeta';
 import { SubMeta } from '@frontend/amp/components/SubMeta';
-import { getToneType } from '@frontend/amp/lib/tag-utils';
-import { designTypes } from '@frontend/lib/designTypes';
+import { designTypeDefault } from '@frontend/lib/designTypes';
 import { pillarPalette } from '@frontend/lib/pillars';
 import { palette } from '@guardian/pasteup/palette';
 import { WithAds } from '@frontend/amp/components/WithAds';
@@ -15,21 +14,16 @@ import { until } from '@guardian/pasteup/breakpoints';
 import { getSharingUrls } from '@frontend/model/sharing-urls';
 
 const body = (pillar: Pillar, designType: DesignType) => {
-    type DesignTypeStyle = { [key in DesignType]: string };
-
-    const defaultStyles: DesignTypeStyle = designTypes.reduce(
-        (prev, curr) =>
-            Object.assign({}, prev, {
-                [curr]: palette.neutral[100],
-            }),
-        {} as DesignTypeStyle,
+    const defaultStyles: DesignTypesObj = designTypeDefault(
+        palette.neutral[100],
     );
 
     // Extend defaultStyles with custom styles for some designTypes
-    const designTypeStyle = Object.assign({}, defaultStyles, {
+    const designTypeStyle: DesignTypesObj = {
+        ...defaultStyles,
         Comment: palette.opinion.faded,
         AdvertismentFeature: palette.neutral[85],
-    });
+    };
 
     return css`
         background-color: ${designTypeStyle[designType]};
@@ -70,7 +64,6 @@ export const Body: React.FC<{
     data: ArticleModel;
     config: ConfigType;
 }> = ({ pillar, data, config }) => {
-    const tone = getToneType(data.tags);
     const designType = data.designType;
     const capiElements = data.blocks[0] ? data.blocks[0].elements : [];
     const elementsWithoutAds = Elements(capiElements, pillar, data.isImmersive);
@@ -99,7 +92,7 @@ export const Body: React.FC<{
 
     return (
         <InnerContainer className={body(pillar, designType)}>
-            <TopMeta designType={designType} tone={tone} data={data} />
+            <TopMeta designType={designType} data={data} />
 
             {elements}
 

--- a/packages/frontend/amp/components/BodyArticle.tsx
+++ b/packages/frontend/amp/components/BodyArticle.tsx
@@ -22,7 +22,7 @@ const body = (pillar: Pillar, designType: DesignType) => {
     const designTypeStyle: DesignTypesObj = {
         ...defaultStyles,
         Comment: palette.opinion.faded,
-        AdvertismentFeature: palette.neutral[85],
+        AdvertisementFeature: palette.neutral[85],
     };
 
     return css`

--- a/packages/frontend/amp/components/BodyArticle.tsx
+++ b/packages/frontend/amp/components/BodyArticle.tsx
@@ -5,7 +5,8 @@ import { css } from 'emotion';
 import { ArticleModel } from '@frontend/amp/pages/Article';
 import { TopMeta } from '@frontend/amp/components/topMeta/TopMeta';
 import { SubMeta } from '@frontend/amp/components/SubMeta';
-import { getToneType, StyledTone } from '@frontend/amp/lib/tag-utils';
+import { getToneType } from '@frontend/amp/lib/tag-utils';
+import { designTypes } from '@frontend/lib/designTypes';
 import { pillarPalette } from '@frontend/lib/pillars';
 import { palette } from '@guardian/pasteup/palette';
 import { WithAds } from '@frontend/amp/components/WithAds';
@@ -13,14 +14,25 @@ import { findAdSlots } from '@frontend/amp/lib/find-adslots';
 import { until } from '@guardian/pasteup/breakpoints';
 import { getSharingUrls } from '@frontend/model/sharing-urls';
 
-const body = (pillar: Pillar, tone: StyledTone) => {
-    const bgColorMap = {
-        'default-tone': palette.neutral[100],
-        'tone/comment': palette.opinion.faded,
-        'tone/advertisement-features': palette.neutral[85],
-    };
+const body = (pillar: Pillar, designType: DesignType) => {
+    type DesignTypeStyle = { [key in DesignType]: string };
+
+    const defaultStyles: DesignTypeStyle = designTypes.reduce(
+        (prev, curr) =>
+            Object.assign({}, prev, {
+                [curr]: palette.neutral[100],
+            }),
+        {} as DesignTypeStyle,
+    );
+
+    // Extend defaultStyles with custom styles for some designTypes
+    const designTypeStyle = Object.assign({}, defaultStyles, {
+        Comment: palette.opinion.faded,
+        AdvertismentFeature: palette.neutral[85],
+    });
+
     return css`
-        background-color: ${bgColorMap[tone]};
+        background-color: ${designTypeStyle[designType]};
         ${bulletStyle(pillar)}
     `;
 };
@@ -59,6 +71,7 @@ export const Body: React.FC<{
     config: ConfigType;
 }> = ({ pillar, data, config }) => {
     const tone = getToneType(data.tags);
+    const designType = data.designType;
     const capiElements = data.blocks[0] ? data.blocks[0].elements : [];
     const elementsWithoutAds = Elements(capiElements, pillar, data.isImmersive);
     const slotIndexes = findAdSlots(capiElements);
@@ -85,8 +98,8 @@ export const Body: React.FC<{
     );
 
     return (
-        <InnerContainer className={body(pillar, tone)}>
-            <TopMeta tone={tone} data={data} />
+        <InnerContainer className={body(pillar, designType)}>
+            <TopMeta designType={designType} tone={tone} data={data} />
 
             {elements}
 

--- a/packages/frontend/amp/components/topMeta/TopMeta.tsx
+++ b/packages/frontend/amp/components/topMeta/TopMeta.tsx
@@ -1,22 +1,25 @@
 import React from 'react';
-import { StyledTone } from '@frontend/amp/lib/tag-utils';
 import { ArticleModel } from '@frontend/amp/pages/Article';
 import { TopMetaNews } from '@frontend/amp/components/topMeta/TopMetaNews';
 import { TopMetaOpinion } from '@frontend/amp/components/topMeta/TopMetaOpinion';
 import { TopMetaPaidContent } from '@frontend/amp/components/topMeta/TopMetaPaidContent';
+import { designTypeDefault } from '@frontend/lib/designTypes';
 
-export const TopMeta: React.SFC<{ data: ArticleModel; tone: StyledTone }> = ({
-    data,
-    tone,
-}) => {
+export const TopMeta: React.SFC<{
+    data: ArticleModel;
+    designType: DesignType;
+}> = ({ data, designType }) => {
     // Note, liveblogs have a separate top meta - see TopMetaLiveblog
-    const topMeta = {
-        'default-tone': <TopMetaNews articleData={data} />,
-        'tone/comment': <TopMetaOpinion articleData={data} />,
-        'tone/advertisement-features': (
-            <TopMetaPaidContent articleData={data} />
-        ),
+    const defaultTopMeta: DesignTypesObj = designTypeDefault(
+        <TopMetaNews articleData={data} />,
+    );
+
+    // Extend defaultTopMeta with custom topMeta for some designTypes
+    const designTypeTopMeta: DesignTypesObj = {
+        ...defaultTopMeta,
+        Comment: <TopMetaOpinion articleData={data} />,
+        AdvertismentFeature: <TopMetaPaidContent articleData={data} />,
     };
 
-    return topMeta[tone];
+    return designTypeTopMeta[designType];
 };

--- a/packages/frontend/amp/components/topMeta/TopMeta.tsx
+++ b/packages/frontend/amp/components/topMeta/TopMeta.tsx
@@ -18,7 +18,7 @@ export const TopMeta: React.SFC<{
     const designTypeTopMeta: DesignTypesObj = {
         ...defaultTopMeta,
         Comment: <TopMetaOpinion articleData={data} />,
-        AdvertismentFeature: <TopMetaPaidContent articleData={data} />,
+        AdvertisementFeature: <TopMetaPaidContent articleData={data} />,
     };
 
     return designTypeTopMeta[designType];

--- a/packages/frontend/amp/lib/tag-utils.test.ts
+++ b/packages/frontend/amp/lib/tag-utils.test.ts
@@ -1,4 +1,4 @@
-import { filterForTagsOfType, getToneType } from './tag-utils';
+import { filterForTagsOfType } from './tag-utils';
 
 describe('filterForTagsOfType', () => {
     it('should extract tags of specified type from ArticleModel data', () => {
@@ -54,98 +54,5 @@ describe('filterForTagsOfType', () => {
                 bylineImageUrl: '',
             },
         ]);
-    });
-});
-
-describe('getToneType', () => {
-    it('should return "tone/advertisement-features" correctly', () => {
-        const tags = [
-            {
-                id: 'tone/advertisement-features',
-                type: 'Tone',
-                title: 'Advertisement features',
-                twitterHandle: '',
-                bylineImageUrl: '',
-            },
-            {
-                id: 'tracking/commissioningdesk/uk-labs',
-                type: 'Tracking',
-                title: 'UK Labs',
-                twitterHandle: '',
-                bylineImageUrl: '',
-            },
-        ];
-        const tone = getToneType(tags);
-        expect(tone).toEqual('tone/advertisement-features');
-    });
-
-    it('should return "tone/comment" correctly', () => {
-        const tags = [
-            {
-                id: 'tone/comment',
-                type: 'Tone',
-                title: 'title',
-                twitterHandle: '',
-                bylineImageUrl: '',
-            },
-            {
-                id: 'tracking/commissioningdesk/uk-labs',
-                type: 'Tracking',
-                title: 'UK Labs',
-                twitterHandle: '',
-                bylineImageUrl: '',
-            },
-        ];
-        const tone = getToneType(tags);
-        expect(tone).toEqual('tone/comment');
-    });
-
-    it('should return "tone/comment" for editorial pieces correctly', () => {
-        const tags = [
-            {
-                id: 'tone/editorials',
-                type: 'Tone',
-                title: 'title',
-                twitterHandle: '',
-                bylineImageUrl: '',
-            },
-            {
-                id: 'tone/comment',
-                type: 'Tone',
-                title: 'title',
-                twitterHandle: '',
-                bylineImageUrl: '',
-            },
-            {
-                id: 'tracking/commissioningdesk/uk-labs',
-                type: 'Tracking',
-                title: 'UK Labs',
-                twitterHandle: '',
-                bylineImageUrl: '',
-            },
-        ];
-        const tone = getToneType(tags);
-        expect(tone).toEqual('tone/comment');
-    });
-
-    it('should return "default-tone" correctly', () => {
-        const tags = [
-            {
-                id: 'tone/something-else',
-                type: 'Tone',
-                title: 'title',
-                twitterHandle: '',
-                bylineImageUrl: '',
-            },
-            {
-                id: 'tracking/commissioningdesk/uk-labs',
-                type: 'Tracking',
-                title: 'UK Labs',
-                twitterHandle: '',
-                bylineImageUrl: '',
-            },
-        ];
-        const tone = getToneType(tags);
-        expect(tone).toEqual('default-tone');
     });
 });

--- a/packages/frontend/amp/lib/tag-utils.ts
+++ b/packages/frontend/amp/lib/tag-utils.ts
@@ -8,28 +8,3 @@ export const filterForTagsOfType = (
             (tag.type === 'PaidContent' && tag.paidContentType === tagType),
     );
 };
-
-export type StyledTone =
-    | 'tone/advertisement-features'
-    | 'tone/comment'
-    | 'default-tone';
-
-export const getToneType = (tags: TagType[]): StyledTone => {
-    const defaultTone = 'default-tone';
-    const tones = filterForTagsOfType(tags, 'Tone').map(tone => tone.id);
-
-    if (!tones) {
-        return defaultTone;
-    }
-
-    switch (tones[0]) {
-        case 'tone/advertisement-features':
-            return tones[0] as StyledTone;
-        case 'tone/comment':
-            return tones[0] as StyledTone;
-        case 'tone/editorials':
-            return 'tone/comment';
-        default:
-            return defaultTone;
-    }
-};

--- a/packages/frontend/amp/pages/Article.tsx
+++ b/packages/frontend/amp/pages/Article.tsx
@@ -47,6 +47,7 @@ export interface ArticleModel {
     commercialProperties: CommercialProperties;
     isImmersive: boolean;
     starRating?: number;
+    designType: DesignType;
 }
 
 const Body: React.SFC<{

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -223,7 +223,8 @@ type DesignType =
     | 'Interview'
     | 'GuardianView'
     | 'GuardianLabs'
-    | 'Quiz';
+    | 'Quiz'
+    | 'AdvertismentFeature';
 
 // ----------------- //
 // General DataTypes //

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -224,7 +224,7 @@ type DesignType =
     | 'GuardianView'
     | 'GuardianLabs'
     | 'Quiz'
-    | 'AdvertismentFeature';
+    | 'AdvertisementFeature';
 
 type DesignTypesObj = { [key in DesignType]: any };
 

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -226,6 +226,9 @@ type DesignType =
     | 'Quiz'
     | 'AdvertisementFeature';
 
+// This is an object that allows you Type defaults of the designTypes.
+// The return type looks like: { Feature: any, Live: any, ...}
+// and can be used to add TypeSafety when needing to override a style in a designType
 type DesignTypesObj = { [key in DesignType]: any };
 
 // ----------------- //

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -226,6 +226,8 @@ type DesignType =
     | 'Quiz'
     | 'AdvertismentFeature';
 
+type DesignTypesObj = { [key in DesignType]: any };
+
 // ----------------- //
 // General DataTypes //
 // ----------------- //
@@ -247,7 +249,6 @@ interface Props {
 // ------------------------------
 // 3rd party type declarations //
 // ------------------------------
-
 declare module 'emotion-server' {
     export const extractCritical: any;
 }

--- a/packages/frontend/lib/designTypes.ts
+++ b/packages/frontend/lib/designTypes.ts
@@ -14,7 +14,7 @@ export const designTypes: Array<DesignType> = [
     'GuardianView',
     'GuardianLabs',
     'Quiz',
-    'AdvertismentFeature',
+    'AdvertisementFeature',
 ];
 
 // Return an object of all designTypes that uses the defaultVal

--- a/packages/frontend/lib/designTypes.ts
+++ b/packages/frontend/lib/designTypes.ts
@@ -1,4 +1,4 @@
-export const designTypes: Array<DesignType> = [
+export const designTypes: DesignType[] = [
     'Article',
     'Immersive',
     'Media',

--- a/packages/frontend/lib/designTypes.ts
+++ b/packages/frontend/lib/designTypes.ts
@@ -16,3 +16,14 @@ export const designTypes: Array<DesignType> = [
     'Quiz',
     'AdvertismentFeature',
 ];
+
+// Return an object of all designTypes that uses the defaultVal
+// Useful for extending overrides
+export const designTypeDefault = (defaultVal: any) =>
+    designTypes.reduce(
+        (prev, curr) =>
+            Object.assign({}, prev, {
+                [curr]: defaultVal,
+            }),
+        {} as DesignTypesObj,
+    );

--- a/packages/frontend/lib/designTypes.ts
+++ b/packages/frontend/lib/designTypes.ts
@@ -1,0 +1,18 @@
+export const designTypes: Array<DesignType> = [
+    'Article',
+    'Immersive',
+    'Media',
+    'Review',
+    'Analysis',
+    'Comment',
+    'Feature',
+    'Live',
+    'SpecialReport',
+    'Recipe',
+    'MatchReport',
+    'Interview',
+    'GuardianView',
+    'GuardianLabs',
+    'Quiz',
+    'AdvertismentFeature',
+];

--- a/packages/frontend/model/json-schema.json
+++ b/packages/frontend/model/json-schema.json
@@ -1370,6 +1370,7 @@
         },
         "DesignType": {
             "enum": [
+                "AdvertismentFeature",
                 "Analysis",
                 "Article",
                 "Comment",

--- a/packages/frontend/model/json-schema.json
+++ b/packages/frontend/model/json-schema.json
@@ -1370,7 +1370,7 @@
         },
         "DesignType": {
             "enum": [
-                "AdvertismentFeature",
+                "AdvertisementFeature",
                 "Analysis",
                 "Article",
                 "Comment",


### PR DESCRIPTION
## What does this change?
Remodels existing use of tones to use designType instead. In this case, where:

- We use `tone/comment` we remodel to use designType of `Comment`
- We use `tone/advertisement-feature` we remodel to use designType of `AdvertisementFeature`

## Why?
Clearer behaviour for the styling of behaviours, one source of truth for the styling of an article rather than some styling on Tone and some on DesignType. Removes confusion between Tones used to style and Tones used for Editorial purposes. DesignTypes can be *more* than tone tags.

## Link to supporting Trello card
https://trello.com/c/yXt9Tk0C/620-designtype-pillar-tone

@guardian/design-system @guardian/dotcom-platform 
