### PR TITLE
Apply the designType at component level to override pillar styling

### DIFF
--- a/packages/frontend/amp/components/BodyArticle.tsx
+++ b/packages/frontend/amp/components/BodyArticle.tsx
@@ -66,7 +66,12 @@ export const Body: React.FC<{
 }> = ({ pillar, data, config }) => {
     const designType = data.designType;
     const capiElements = data.blocks[0] ? data.blocks[0].elements : [];
-    const elementsWithoutAds = Elements(capiElements, pillar, data.isImmersive);
+    const elementsWithoutAds = Elements(
+        capiElements,
+        pillar,
+        data.isImmersive,
+        designType,
+    );
     const slotIndexes = findAdSlots(capiElements);
     const adInfo = {
         section: data.sectionName,
@@ -100,6 +105,7 @@ export const Body: React.FC<{
                 sections={data.subMetaSectionLinks}
                 keywords={data.subMetaKeywordLinks}
                 pillar={pillar}
+                designType={designType}
                 sharingURLs={getSharingUrls(data.pageId, data.webTitle)}
                 pageID={data.pageId}
                 isCommentable={data.isCommentable}

--- a/packages/frontend/amp/components/Elements.tsx
+++ b/packages/frontend/amp/components/Elements.tsx
@@ -28,6 +28,7 @@ export const Elements = (
     elements: CAPIElement[],
     pillar: Pillar,
     isImmersive: boolean,
+    designType?: MaybeDesignType,
 ): JSX.Element[] => {
     const cleanedElements = elements.map(element =>
         'html' in element ? { ...element, html: clean(element.html) } : element,
@@ -35,7 +36,14 @@ export const Elements = (
     const output = cleanedElements.map((element, i) => {
         switch (element._type) {
             case 'model.dotcomrendering.pageElements.TextBlockElement':
-                return <Text key={i} html={element.html} pillar={pillar} />;
+                return (
+                    <Text
+                        key={i}
+                        html={element.html}
+                        pillar={pillar}
+                        designType={designType}
+                    />
+                );
             case 'model.dotcomrendering.pageElements.SubheadingBlockElement':
                 return (
                     <Subheading

--- a/packages/frontend/amp/components/ShareIcons.tsx
+++ b/packages/frontend/amp/components/ShareIcons.tsx
@@ -8,14 +8,18 @@ import PinterestIcon from '@guardian/pasteup/icons/pinterest.svg';
 import WhatsAppIcon from '@guardian/pasteup/icons/whatsapp.svg';
 import MessengerIcon from '@guardian/pasteup/icons/messenger.svg';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';
-import { pillarMap, pillarPalette } from '@frontend/lib/pillars';
+import { pillarPalette } from '@frontend/lib/pillars';
 
-const pillarFill = pillarMap(
-    pillar =>
-        css`
-            fill: ${pillarPalette[pillar].main};
-        `,
-);
+const pillarOverride = (pillar: Pillar, isCommentDesignType: Boolean) => {
+    return isCommentDesignType
+        ? pillarPalette['opinion'].main
+        : pillarPalette[pillar].main;
+};
+
+const pillarFill = (pillar: Pillar, isCommentDesignType: Boolean) =>
+    css`
+        fill: ${pillarOverride(pillar, isCommentDesignType)};
+    `;
 
 const shareIconsListItem = css`
     padding: 0 3px 6px 0;
@@ -73,8 +77,15 @@ export const ShareIcons: React.FC<{
     };
     displayIcons: SharePlatform[];
     pillar: Pillar;
+    isCommentDesignType?: Boolean;
     className?: string;
-}> = ({ sharingUrls, displayIcons, pillar, className }) => {
+}> = ({
+    sharingUrls,
+    displayIcons,
+    pillar,
+    isCommentDesignType,
+    className,
+}) => {
     const icons: { [K in SharePlatform]?: React.ComponentType } = {
         facebook: FacebookIcon,
         twitter: TwitterIconPadded,
@@ -124,7 +135,7 @@ export const ShareIcons: React.FC<{
                             <span
                                 className={cx(
                                     shareIcon(pillar),
-                                    pillarFill[pillar],
+                                    pillarFill(pillar, isCommentDesignType),
                                 )}
                             >
                                 <Icon />

--- a/packages/frontend/amp/components/ShareIcons.tsx
+++ b/packages/frontend/amp/components/ShareIcons.tsx
@@ -10,15 +10,14 @@ import MessengerIcon from '@guardian/pasteup/icons/messenger.svg';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';
 import { pillarPalette } from '@frontend/lib/pillars';
 
-const pillarOverride = (pillar: Pillar, isCommentDesignType: Boolean) => {
-    return isCommentDesignType
-        ? pillarPalette['opinion'].main
+const pillarOverride = (pillar: Pillar, designType?: MaybeDesignType) =>
+    designType && pillar === 'news'
+        ? pillarPalette.opinion.main
         : pillarPalette[pillar].main;
-};
 
-const pillarFill = (pillar: Pillar, isCommentDesignType: Boolean) =>
+const pillarFill = (pillar: Pillar, designType?: DesignType) =>
     css`
-        fill: ${pillarOverride(pillar, isCommentDesignType)};
+        fill: ${pillarOverride(pillar, designType)};
     `;
 
 const shareIconsListItem = css`
@@ -27,7 +26,7 @@ const shareIconsListItem = css`
     min-width: 32px;
 `;
 
-const shareIcon = (pillar: Pillar) => css`
+const shareIcon = (pillar: Pillar, designType?: MaybeDesignType) => css`
     border: 1px solid ${pillarPalette[pillar].neutral.border};
     white-space: nowrap;
     overflow: hidden;
@@ -54,8 +53,8 @@ const shareIcon = (pillar: Pillar) => css`
     }
 
     :hover {
-        background-color: ${pillarPalette[pillar].main};
-        border-color: ${pillarPalette[pillar].main};
+        background-color: ${pillarOverride(pillar, designType)};
+        border-color: ${pillarOverride(pillar, designType)};
         fill: white;
     }
 `;
@@ -77,15 +76,9 @@ export const ShareIcons: React.FC<{
     };
     displayIcons: SharePlatform[];
     pillar: Pillar;
-    isCommentDesignType?: Boolean;
+    designType?: MaybeDesignType;
     className?: string;
-}> = ({
-    sharingUrls,
-    displayIcons,
-    pillar,
-    isCommentDesignType,
-    className,
-}) => {
+}> = ({ sharingUrls, displayIcons, pillar, designType, className }) => {
     const icons: { [K in SharePlatform]?: React.ComponentType } = {
         facebook: FacebookIcon,
         twitter: TwitterIconPadded,
@@ -134,8 +127,8 @@ export const ShareIcons: React.FC<{
                             </span>
                             <span
                                 className={cx(
-                                    shareIcon(pillar),
-                                    pillarFill(pillar, isCommentDesignType),
+                                    shareIcon(pillar, designType),
+                                    pillarFill(pillar, designType),
                                 )}
                             >
                                 <Icon />

--- a/packages/frontend/amp/components/SubMeta.tsx
+++ b/packages/frontend/amp/components/SubMeta.tsx
@@ -6,6 +6,11 @@ import { palette } from '@guardian/pasteup/palette';
 import { ShareIcons } from '@frontend/amp/components/ShareIcons';
 import CommentIcon from '@guardian/pasteup/icons/comment.svg';
 
+const pillarOverride = (pillar: Pillar, designType?: MaybeDesignType) =>
+    designType === 'Comment' && pillar === 'news'
+        ? pillarPalette.opinion.main
+        : pillarPalette[pillar].main;
+
 const guardianLines = (pillar: Pillar) => css`
     background-image: repeating-linear-gradient(
         to bottom,
@@ -21,12 +26,12 @@ const guardianLines = (pillar: Pillar) => css`
     margin-top: 12px;
 `;
 
-const linkStyle = (pillar: Pillar) => css`
+const linkStyle = (pillar: Pillar, designType?: MaybeDesignType) => css`
     position: relative;
     padding-left: 5px;
     padding-right: 6px;
     text-decoration: none;
-    color: ${pillarPalette[pillar].main};
+    color: ${pillarOverride(pillar, designType)};
     ${textSans(3)};
     :after {
         content: '/';
@@ -56,12 +61,12 @@ const keywordListStyle = (pillar: Pillar) => css`
     margin-bottom: 6px;
 `;
 
-const sectionLinkStyle = (pillar: Pillar) => css`
+const sectionLinkStyle = (pillar: Pillar, designType?: MaybeDesignType) => css`
     position: relative;
     padding-left: 5px;
     padding-right: 6px;
     text-decoration: none;
-    color: ${pillarPalette[pillar].main};
+    color: ${pillarOverride(pillar, designType)};
     ${body(3)};
     :after {
         content: '/';
@@ -122,6 +127,7 @@ export const SubMeta: React.FC<{
     pageID: string;
     isCommentable: boolean;
     guardianBaseURL: string;
+    designType?: MaybeDesignType;
 }> = ({
     pillar,
     sections,
@@ -130,11 +136,12 @@ export const SubMeta: React.FC<{
     pageID,
     isCommentable,
     guardianBaseURL,
+    designType,
 }) => {
     const sectionListItems = sections.map(link => (
         <li className={itemStyle} key={link.url}>
             <a
-                className={sectionLinkStyle(pillar)}
+                className={sectionLinkStyle(pillar, designType)}
                 href={`${guardianBaseURL}${link.url}`}
             >
                 {link.title}
@@ -145,7 +152,7 @@ export const SubMeta: React.FC<{
     const keywordListItems = keywords.map(link => (
         <li className={itemStyle} key={link.url}>
             <a
-                className={linkStyle(pillar)}
+                className={linkStyle(pillar, designType)}
                 href={`${guardianBaseURL}${link.url}`}
             >
                 {link.title}
@@ -164,6 +171,7 @@ export const SubMeta: React.FC<{
                 className={shareIcons}
                 sharingUrls={sharingURLs}
                 pillar={pillar}
+                designType={designType}
                 displayIcons={[
                     'facebook',
                     'twitter',

--- a/packages/frontend/amp/components/elements/Text.tsx
+++ b/packages/frontend/amp/components/elements/Text.tsx
@@ -13,6 +13,12 @@ import { composeLabsCSS } from '@root/packages/frontend/amp/lib/compose-labs-css
 
 // tslint:disable:react-no-dangerous-html
 
+const pillarOverride = (pillar: Pillar, designType?: MaybeDesignType) => {
+    return designType === 'Comment' && pillar === 'news'
+        ? pillarPalette.opinion.dark
+        : pillarPalette[pillar].dark;
+};
+
 export const ListStyle = (iconColour: string) => css`
     li {
         margin-bottom: 6px;
@@ -34,18 +40,18 @@ export const ListStyle = (iconColour: string) => css`
     }
 `;
 
-export const LinkStyle = (pillar: Pillar) => css`
+export const LinkStyle = (pillar: Pillar, designType?: MaybeDesignType) => css`
     a {
-        color: ${pillarPalette[pillar].dark};
+        color: ${pillarOverride(pillar, designType)};
         text-decoration: none;
         border-bottom: 1px solid ${pillarPalette[pillar].neutral.border};
         :hover {
-            border-bottom: 1px solid ${pillarPalette[pillar].dark};
+            border-bottom: 1px solid ${pillarOverride(pillar, designType)};
         }
     }
 `;
 
-export const TextStyle = (pillar: Pillar) => css`
+export const TextStyle = (pillar: Pillar, designType?: MaybeDesignType) => css`
     strong {
         font-weight: 700;
     }
@@ -64,7 +70,7 @@ export const TextStyle = (pillar: Pillar) => css`
 
     ${body(2)};
 
-    ${LinkStyle(pillar)};
+    ${LinkStyle(pillar, designType)};
     ${ListStyle(pillarPalette[pillar].neutral.border)};
 `;
 
@@ -78,9 +84,14 @@ const textStyleLabs = css`
 export const Text: React.FC<{
     html: string;
     pillar: Pillar;
-}> = ({ html, pillar }) => (
+    designType?: MaybeDesignType;
+}> = ({ html, pillar, designType }) => (
     <span
-        className={composeLabsCSS(pillar, TextStyle(pillar), textStyleLabs)}
+        className={composeLabsCSS(
+            pillar,
+            TextStyle(pillar, designType),
+            textStyleLabs,
+        )}
         dangerouslySetInnerHTML={{
             __html: sanitise(html),
         }}

--- a/packages/frontend/amp/components/topMeta/TopMetaExtras.tsx
+++ b/packages/frontend/amp/components/topMeta/TopMetaExtras.tsx
@@ -106,12 +106,14 @@ const TwitterHandle: React.FC<{
 export const TopMetaExtras: React.FC<{
     sharingUrls: SharingURLs;
     pillar: Pillar;
+    isCommentDesignType: Boolean;
     webPublicationDate: string;
     ageWarning?: string;
     twitterHandle?: string;
 }> = ({
     sharingUrls,
     pillar,
+    isCommentDesignType,
     webPublicationDate,
     ageWarning,
     twitterHandle,
@@ -125,6 +127,7 @@ export const TopMetaExtras: React.FC<{
                 sharingUrls={sharingUrls}
                 pillar={pillar}
                 displayIcons={['facebook', 'twitter', 'email']}
+                isCommentDesignType={isCommentDesignType}
             />
             <AgeWarning warning={ageWarning} pillar={pillar} />
         </div>

--- a/packages/frontend/amp/components/topMeta/TopMetaExtras.tsx
+++ b/packages/frontend/amp/components/topMeta/TopMetaExtras.tsx
@@ -106,17 +106,17 @@ const TwitterHandle: React.FC<{
 export const TopMetaExtras: React.FC<{
     sharingUrls: SharingURLs;
     pillar: Pillar;
-    isCommentDesignType: Boolean;
     webPublicationDate: string;
     ageWarning?: string;
     twitterHandle?: string;
+    designType?: MaybeDesignType;
 }> = ({
     sharingUrls,
     pillar,
-    isCommentDesignType,
     webPublicationDate,
     ageWarning,
     twitterHandle,
+    designType,
 }) => (
     <div className={metaExtras}>
         <TwitterHandle handle={twitterHandle} />
@@ -127,7 +127,7 @@ export const TopMetaExtras: React.FC<{
                 sharingUrls={sharingUrls}
                 pillar={pillar}
                 displayIcons={['facebook', 'twitter', 'email']}
-                isCommentDesignType={isCommentDesignType}
+                designType={designType}
             />
             <AgeWarning warning={ageWarning} pillar={pillar} />
         </div>

--- a/packages/frontend/amp/components/topMeta/TopMetaOpinion.tsx
+++ b/packages/frontend/amp/components/topMeta/TopMetaOpinion.tsx
@@ -25,7 +25,7 @@ const bylineStyle = (pillar: Pillar) => css`
     padding-top: 3px;
 
     a {
-        color: ${pillarPalette[pillar].main};
+        color: ${pillarPalette['opinion'].main};
         text-decoration: none;
         font-style: italic;
     }
@@ -119,6 +119,7 @@ export const TopMetaOpinion: React.FC<{
                 articleData.webTitle,
             )}
             pillar={articleData.pillar}
+            isCommentDesignType={true}
             ageWarning={getAgeWarning(
                 articleData.tags,
                 articleData.webPublicationDate,

--- a/packages/frontend/amp/components/topMeta/TopMetaOpinion.tsx
+++ b/packages/frontend/amp/components/topMeta/TopMetaOpinion.tsx
@@ -12,6 +12,12 @@ import { SeriesLink } from '@frontend/amp/components/topMeta/SeriesLink';
 import { getSharingUrls } from '@frontend/model/sharing-urls';
 import { getAgeWarning } from '@frontend/model/age-warning';
 
+const pillarOverride = (pillar: Pillar, designType?: MaybeDesignType) => {
+    return designType === 'Comment' && pillar === 'news'
+        ? pillarPalette.opinion.main
+        : pillarPalette[pillar].main;
+};
+
 const headerStyle = css`
     ${headline(5)};
     font-weight: 100;
@@ -25,7 +31,7 @@ const bylineStyle = (pillar: Pillar) => css`
     padding-top: 3px;
 
     a {
-        color: ${pillarPalette['opinion'].main};
+        color: ${pillarOverride(pillar, 'Comment')};
         text-decoration: none;
         font-style: italic;
     }
@@ -119,7 +125,7 @@ export const TopMetaOpinion: React.FC<{
                 articleData.webTitle,
             )}
             pillar={articleData.pillar}
-            isCommentDesignType={true}
+            designType={'Comment'}
             ageWarning={getAgeWarning(
                 articleData.tags,
                 articleData.webPublicationDate,

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -223,6 +223,7 @@ type DesignType =
     | 'AdvertisementFeature';
 
 type DesignTypesObj = { [key in DesignType]: any };
+type MaybeDesignType = DesignType | undefined;
 
 // 3rd party type declarations
 declare module 'emotion-server' {


### PR DESCRIPTION
## What does this change?
*Note*: I am not sure on this solution, I realised an alternative one here which I *think* I prefer but open to any and all suggestions.

---

This applies checks at the component level when we want to see whether the designType is 'Comment' and therefore, in the news pillar, apply comment styling.

## Why?

For Branding and trust purposes.

## Link to supporting Trello card

https://trello.com/c/yXt9Tk0C/620-designtype-pillar-tone

![Screenshot 2019-07-18 at 17 12 20](https://user-images.githubusercontent.com/638051/61526275-09ad5b00-aa12-11e9-81cd-f2fc71b7f587.png)
![Screenshot 2019-07-18 at 17 12 33](https://user-images.githubusercontent.com/638051/61526277-0a45f180-aa12-11e9-9bf4-5cf044cecb03.png)
![image](https://user-images.githubusercontent.com/638051/61526479-61e45d00-aa12-11e9-8df1-5e4ede3b92a2.png)


