### PR TITLE
Use designType to apply opinion tone to 'comment design type in news pillar' articles

### DIFF
--- a/packages/frontend/amp/components/BodyArticle.tsx
+++ b/packages/frontend/amp/components/BodyArticle.tsx
@@ -92,7 +92,7 @@ export const Body: React.FC<{
 
     return (
         <InnerContainer className={body(pillar, designType)}>
-            <TopMeta designType={designType} data={data} />
+            <TopMeta designType={designType} pillar={pillar} data={data} />
 
             {elements}
 

--- a/packages/frontend/amp/components/topMeta/TopMeta.tsx
+++ b/packages/frontend/amp/components/topMeta/TopMeta.tsx
@@ -4,6 +4,7 @@ import { TopMetaNews } from '@frontend/amp/components/topMeta/TopMetaNews';
 import { TopMetaOpinion } from '@frontend/amp/components/topMeta/TopMetaOpinion';
 import { TopMetaPaidContent } from '@frontend/amp/components/topMeta/TopMetaPaidContent';
 import { designTypeDefault } from '@frontend/lib/designTypes';
+import { getPillar } from '@frontend/lib/pillars';
 
 export const TopMeta: React.SFC<{
     data: ArticleModel;
@@ -17,7 +18,12 @@ export const TopMeta: React.SFC<{
     // Extend defaultTopMeta with custom topMeta for some designTypes
     const designTypeTopMeta: DesignTypesObj = {
         ...defaultTopMeta,
-        Comment: <TopMetaOpinion articleData={data} />,
+        Comment: (
+            <TopMetaOpinion
+                articleData={data}
+                pillar={getPillar(data.pillar, data.designType)}
+            />
+        ),
         AdvertisementFeature: <TopMetaPaidContent articleData={data} />,
     };
 

--- a/packages/frontend/amp/components/topMeta/TopMeta.tsx
+++ b/packages/frontend/amp/components/topMeta/TopMeta.tsx
@@ -4,12 +4,12 @@ import { TopMetaNews } from '@frontend/amp/components/topMeta/TopMetaNews';
 import { TopMetaOpinion } from '@frontend/amp/components/topMeta/TopMetaOpinion';
 import { TopMetaPaidContent } from '@frontend/amp/components/topMeta/TopMetaPaidContent';
 import { designTypeDefault } from '@frontend/lib/designTypes';
-import { getPillar } from '@frontend/lib/pillars';
 
 export const TopMeta: React.SFC<{
     data: ArticleModel;
     designType: DesignType;
-}> = ({ data, designType }) => {
+    pillar: Pillar;
+}> = ({ data, designType, pillar }) => {
     // Note, liveblogs have a separate top meta - see TopMetaLiveblog
     const defaultTopMeta: DesignTypesObj = designTypeDefault(
         <TopMetaNews articleData={data} />,
@@ -18,12 +18,7 @@ export const TopMeta: React.SFC<{
     // Extend defaultTopMeta with custom topMeta for some designTypes
     const designTypeTopMeta: DesignTypesObj = {
         ...defaultTopMeta,
-        Comment: (
-            <TopMetaOpinion
-                articleData={data}
-                pillar={getPillar(data.pillar, data.designType)}
-            />
-        ),
+        Comment: <TopMetaOpinion articleData={data} pillar={pillar} />,
         AdvertisementFeature: <TopMetaPaidContent articleData={data} />,
     };
 

--- a/packages/frontend/amp/components/topMeta/TopMetaOpinion.tsx
+++ b/packages/frontend/amp/components/topMeta/TopMetaOpinion.tsx
@@ -11,6 +11,7 @@ import { Standfirst } from '@frontend/amp/components/topMeta/Standfirst';
 import { SeriesLink } from '@frontend/amp/components/topMeta/SeriesLink';
 import { getSharingUrls } from '@frontend/model/sharing-urls';
 import { getAgeWarning } from '@frontend/model/age-warning';
+import { getPillar } from '@frontend/lib/pillars';
 
 const headerStyle = css`
     ${headline(5)};
@@ -66,15 +67,16 @@ const BylineMeta: React.SFC<{
     const bylineImageUrl = contributorTag
         ? contributorTag.bylineImageUrl
         : null;
+    const pillar = getPillar(articleData.pillar, articleData.designType);
 
     return (
         <div className={bylineWrapper}>
             <Byline
                 byline={articleData.author.byline}
                 tags={articleData.tags}
-                pillar={articleData.pillar}
+                pillar={pillar}
                 guardianBaseURL={articleData.guardianBaseURL}
-                className={cx(bylineStyle(articleData.pillar), {
+                className={cx(bylineStyle(pillar), {
                     [bottomPadding]: !bylineImageUrl,
                 })}
             />
@@ -94,37 +96,40 @@ const BylineMeta: React.SFC<{
 
 export const TopMetaOpinion: React.FC<{
     articleData: ArticleModel;
-}> = ({ articleData }) => (
-    <header>
-        {articleData.mainMediaElements.map((element, i) => (
-            <MainMedia key={i} element={element} pillar={articleData.pillar} />
-        ))}
+    pillar: Pillar;
+}> = ({ articleData, pillar }) => {
+    return (
+        <header>
+            {articleData.mainMediaElements.map((element, i) => (
+                <MainMedia key={i} element={element} pillar={pillar} />
+            ))}
 
-        <SeriesLink
-            baseURL={articleData.guardianBaseURL}
-            tags={articleData.tags}
-            pillar={articleData.pillar}
-            fallbackToSection={false}
-        />
+            <SeriesLink
+                baseURL={articleData.guardianBaseURL}
+                tags={articleData.tags}
+                pillar={pillar}
+                fallbackToSection={false}
+            />
 
-        <h1 className={headerStyle}>{articleData.headline}</h1>
+            <h1 className={headerStyle}>{articleData.headline}</h1>
 
-        <BylineMeta articleData={articleData} />
+            <BylineMeta articleData={articleData} />
 
-        <Standfirst text={articleData.standfirst} pillar={articleData.pillar} />
+            <Standfirst text={articleData.standfirst} pillar={pillar} />
 
-        <TopMetaExtras
-            sharingUrls={getSharingUrls(
-                articleData.pageId,
-                articleData.webTitle,
-            )}
-            pillar={articleData.pillar}
-            ageWarning={getAgeWarning(
-                articleData.tags,
-                articleData.webPublicationDate,
-            )}
-            webPublicationDate={articleData.webPublicationDateDisplay}
-            twitterHandle={articleData.author.twitterHandle}
-        />
-    </header>
-);
+            <TopMetaExtras
+                sharingUrls={getSharingUrls(
+                    articleData.pageId,
+                    articleData.webTitle,
+                )}
+                pillar={pillar}
+                ageWarning={getAgeWarning(
+                    articleData.tags,
+                    articleData.webPublicationDate,
+                )}
+                webPublicationDate={articleData.webPublicationDateDisplay}
+                twitterHandle={articleData.author.twitterHandle}
+            />
+        </header>
+    );
+};

--- a/packages/frontend/amp/components/topMeta/TopMetaOpinion.tsx
+++ b/packages/frontend/amp/components/topMeta/TopMetaOpinion.tsx
@@ -11,7 +11,6 @@ import { Standfirst } from '@frontend/amp/components/topMeta/Standfirst';
 import { SeriesLink } from '@frontend/amp/components/topMeta/SeriesLink';
 import { getSharingUrls } from '@frontend/model/sharing-urls';
 import { getAgeWarning } from '@frontend/model/age-warning';
-import { getPillar } from '@frontend/lib/pillars';
 
 const headerStyle = css`
     ${headline(5)};
@@ -62,12 +61,12 @@ const bottomPadding = css`
 
 const BylineMeta: React.SFC<{
     articleData: ArticleModel;
-}> = ({ articleData }) => {
+    pillar: Pillar;
+}> = ({ articleData, pillar }) => {
     const contributorTag = articleData.tags.find(t => t.type === 'Contributor');
     const bylineImageUrl = contributorTag
         ? contributorTag.bylineImageUrl
         : null;
-    const pillar = getPillar(articleData.pillar, articleData.designType);
 
     return (
         <div className={bylineWrapper}>
@@ -113,7 +112,7 @@ export const TopMetaOpinion: React.FC<{
 
             <h1 className={headerStyle}>{articleData.headline}</h1>
 
-            <BylineMeta articleData={articleData} />
+            <BylineMeta articleData={articleData} pillar={pillar} />
 
             <Standfirst text={articleData.standfirst} pillar={pillar} />
 

--- a/packages/frontend/amp/pages/Article.tsx
+++ b/packages/frontend/amp/pages/Article.tsx
@@ -12,6 +12,7 @@ import { Sidebar } from '@frontend/amp/components/Sidebar';
 import { Analytics, AnalyticsModel } from '@frontend/amp/components/Analytics';
 import { filterForTagsOfType } from '@frontend/amp/lib/tag-utils';
 import { AdUserSync } from '@root/packages/frontend/amp/components/AdUserSync';
+import { getPillar } from '@frontend/lib/pillars';
 
 const backgroundColour = css`
     background-color: ${palette.neutral[97]};
@@ -64,7 +65,13 @@ const Body: React.SFC<{
         );
     }
 
-    return <BodyArticle pillar={data.pillar} data={data} config={config} />;
+    return (
+        <BodyArticle
+            pillar={getPillar(data.pillar, data.designType)}
+            data={data}
+            config={config}
+        />
+    );
 };
 
 export const Article: React.FC<{

--- a/packages/frontend/amp/pages/Article.tsx
+++ b/packages/frontend/amp/pages/Article.tsx
@@ -53,25 +53,18 @@ export interface ArticleModel {
 
 const Body: React.SFC<{
     data: ArticleModel;
+    pillar: Pillar;
     config: ConfigType;
-}> = ({ data, config }) => {
+}> = ({ data, config, pillar }) => {
     // TODO check if there is a better way to determine if liveblog
     const isLiveBlog =
         data.tags.find(tag => tag.id === 'tone/minutebyminute') !== undefined;
 
     if (isLiveBlog) {
-        return (
-            <BodyLiveblog pillar={data.pillar} data={data} config={config} />
-        );
+        return <BodyLiveblog pillar={pillar} data={data} config={config} />;
     }
 
-    return (
-        <BodyArticle
-            pillar={getPillar(data.pillar, data.designType)}
-            data={data}
-            config={config}
-        />
-    );
+    return <BodyArticle pillar={pillar} data={data} config={config} />;
 };
 
 export const Article: React.FC<{
@@ -94,7 +87,14 @@ export const Article: React.FC<{
                     config={config}
                     guardianBaseURL={articleData.guardianBaseURL}
                 />
-                <Body data={articleData} config={config} />
+                <Body
+                    data={articleData}
+                    pillar={getPillar(
+                        articleData.pillar,
+                        articleData.designType,
+                    )}
+                    config={config}
+                />
                 <Onward
                     shouldHideAds={articleData.shouldHideAds}
                     pageID={articleData.pageId}

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -256,6 +256,10 @@ interface Props {
 // ------------------------------
 // 3rd party type declarations //
 // ------------------------------
+<<<<<<< HEAD
+=======
+
+>>>>>>> Add new schema
 declare module 'emotion-server' {
     export const extractCritical: any;
 }

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -256,10 +256,6 @@ interface Props {
 // ------------------------------
 // 3rd party type declarations //
 // ------------------------------
-<<<<<<< HEAD
-=======
-
->>>>>>> Add new schema
 declare module 'emotion-server' {
     export const extractCritical: any;
 }

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -8,8 +8,12 @@ interface ArticleProps {
     config: ConfigType;
 }
 
-// 'labs' is a fake pillar used to identify paid content (Guardian Labs) for rendering styling.
-type Pillar = 'news' | 'opinion' | 'sport' | 'culture' | 'lifestyle' | 'labs';
+// Pillars are used for styling
+// RealPillars have Pillar palette colours
+// FakePillars allow us to make modifications to style based on rules outside of the pillar of an article
+type RealPillars = 'news' | 'opinion' | 'sport' | 'culture' | 'lifestyle';
+type FakePillars = 'labs' | 'commentInNews';
+type Pillar = RealPillars | FakePillars;
 
 type Edition = 'UK' | 'US' | 'INT' | 'AU';
 

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -12,7 +12,7 @@ interface ArticleProps {
 // RealPillars have Pillar palette colours
 // FakePillars allow us to make modifications to style based on rules outside of the pillar of an article
 type RealPillars = 'news' | 'opinion' | 'sport' | 'culture' | 'lifestyle';
-type FakePillars = 'labs' | 'commentInNews';
+type FakePillars = 'labs';
 type Pillar = RealPillars | FakePillars;
 
 type Edition = 'UK' | 'US' | 'INT' | 'AU';

--- a/packages/frontend/lib/pillars.ts
+++ b/packages/frontend/lib/pillars.ts
@@ -6,6 +6,8 @@ export const pillarNames: Pillar[] = [
     'sport',
     'culture',
     'lifestyle',
+    'labs',
+    'commentInNews',
 ];
 
 export const pillarPalette: Record<Pillar, PillarColours> = {
@@ -15,6 +17,7 @@ export const pillarPalette: Record<Pillar, PillarColours> = {
     culture: palette.culture,
     lifestyle: palette.lifestyle,
     labs: palette.labs,
+    commentInNews: palette.commentInNews,
 };
 
 /*
@@ -30,6 +33,7 @@ export const pillarMap: <T>(
     culture: f('culture'),
     lifestyle: f('lifestyle'),
     labs: f('labs'),
+    commentInNews: f('commentInNews'),
 });
 /*
 Further notes on this function:
@@ -37,3 +41,13 @@ Further notes on this function:
     - Where the function parameter f returns type T, pillarMap will return an object with
       a key for each Pillar and values of type T.
  */
+
+export const getPillar = (pillar: Pillar, designType: DesignType): Pillar => {
+    console.log(designType, 'designType');
+    console.log(pillar, 'pillar');
+    if (designType === 'Comment' && pillar === 'news') {
+        return 'commentInNews';
+    }
+
+    return pillar;
+};

--- a/packages/frontend/lib/pillars.ts
+++ b/packages/frontend/lib/pillars.ts
@@ -7,7 +7,6 @@ export const pillarNames: Pillar[] = [
     'culture',
     'lifestyle',
     'labs',
-    'commentInNews',
 ];
 
 export const pillarPalette: Record<Pillar, PillarColours> = {
@@ -17,7 +16,6 @@ export const pillarPalette: Record<Pillar, PillarColours> = {
     culture: palette.culture,
     lifestyle: palette.lifestyle,
     labs: palette.labs,
-    commentInNews: palette.commentInNews,
 };
 
 /*

--- a/packages/frontend/lib/pillars.ts
+++ b/packages/frontend/lib/pillars.ts
@@ -33,7 +33,6 @@ export const pillarMap: <T>(
     culture: f('culture'),
     lifestyle: f('lifestyle'),
     labs: f('labs'),
-    commentInNews: f('commentInNews'),
 });
 /*
 Further notes on this function:
@@ -44,7 +43,7 @@ Further notes on this function:
 
 export const getPillar = (pillar: Pillar, designType: DesignType): Pillar => {
     if (designType === 'Comment' && pillar === 'news') {
-        return 'commentInNews';
+        return 'opinion';
     }
 
     return pillar;

--- a/packages/frontend/lib/pillars.ts
+++ b/packages/frontend/lib/pillars.ts
@@ -43,8 +43,6 @@ Further notes on this function:
  */
 
 export const getPillar = (pillar: Pillar, designType: DesignType): Pillar => {
-    console.log(designType, 'designType');
-    console.log(pillar, 'pillar');
     if (designType === 'Comment' && pillar === 'news') {
         return 'commentInNews';
     }

--- a/packages/frontend/model/json-schema.json
+++ b/packages/frontend/model/json-schema.json
@@ -1370,7 +1370,7 @@
         },
         "DesignType": {
             "enum": [
-                "AdvertismentFeature",
+                "AdvertisementFeature",
                 "Analysis",
                 "Article",
                 "Comment",

--- a/packages/pasteup/palette.ts
+++ b/packages/pasteup/palette.ts
@@ -18,7 +18,6 @@ export interface AllPillarColours {
     culture: PillarColours;
     lifestyle: PillarColours;
     labs: PillarColours;
-    commentInNews: PillarColours;
 }
 export interface OtherColours {
     highlight: { main: colour; dark: colour };
@@ -152,8 +151,6 @@ const labs: PillarColours = {
     neutral: darkTheme,
 };
 
-const commentInNews: PillarColours = opinion;
-
 const specialReport = { dark: '#3f464a' };
 
 const contrasts = {
@@ -181,7 +178,6 @@ export const palette: AllPillarColours & OtherColours & Appearances = {
     culture,
     lifestyle,
     labs,
-    commentInNews,
     highlight,
     neutral,
     specialReport,

--- a/packages/pasteup/palette.ts
+++ b/packages/pasteup/palette.ts
@@ -18,6 +18,7 @@ export interface AllPillarColours {
     culture: PillarColours;
     lifestyle: PillarColours;
     labs: PillarColours;
+    commentInNews: PillarColours;
 }
 export interface OtherColours {
     highlight: { main: colour; dark: colour };
@@ -151,6 +152,8 @@ const labs: PillarColours = {
     neutral: darkTheme,
 };
 
+const commentInNews: PillarColours = opinion;
+
 const specialReport = { dark: '#3f464a' };
 
 const contrasts = {
@@ -178,6 +181,7 @@ export const palette: AllPillarColours & OtherColours & Appearances = {
     culture,
     lifestyle,
     labs,
+    commentInNews,
     highlight,
     neutral,
     specialReport,


### PR DESCRIPTION
## What does this change?
Uses the designType to return the 'opinion' pillar for articles that live in the news pillar but have the 'comment' designType as per the #design.


## Link to supporting Trello card

https://trello.com/c/yXt9Tk0C/620-designtype-pillar-tone
