### PR TITLE
Adding Sentry data to window.guardian

### DIFF
--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -229,6 +229,18 @@ type DesignType =
 // General DataTypes //
 // ----------------- //
 
+interface Props {
+    data: {
+        page: string;
+        site: string;
+        CAPI: CAPIType;
+        NAV: NavType;
+        config: ConfigType;
+        GA: string; // TODO use GADataType again
+        linkedData: object;
+    };
+}
+
 // ------------------------------  //
 // window.guardian: WindowGuardian //
 // ------------------------------- //

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -243,10 +243,6 @@ interface Props {
     data: DCRDocumentData; // Do not fall to the tempation to rename 'data' into something else
 }
 
-// ------------------------------  //
-// window.guardian: WindowGuardian //
-// ------------------------------- //
-
 // ------------------------------
 // 3rd party type declarations //
 // ------------------------------

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -229,16 +229,18 @@ type DesignType =
 // General DataTypes //
 // ----------------- //
 
+interface DCRDocumentData {
+    page: string;
+    site: string;
+    CAPI: CAPIType;
+    NAV: NavType;
+    config: ConfigType;
+    GA: string; // TODO use GADataType again
+    linkedData: object;
+}
+
 interface Props {
-    data: {
-        page: string;
-        site: string;
-        CAPI: CAPIType;
-        NAV: NavType;
-        config: ConfigType;
-        GA: string; // TODO use GADataType again
-        linkedData: object;
-    };
+    data: DCRDocumentData;
 }
 
 // ------------------------------  //

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -240,7 +240,7 @@ interface DCRDocumentData {
 }
 
 interface Props {
-    data: DCRDocumentData;
+    data: DCRDocumentData; // Do not fall to the tempation to rename 'data' into something else
 }
 
 // ------------------------------  //

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -1,3 +1,7 @@
+// ------------------------  //
+// CAPIType and its subtypes //
+// ------------------------- //
+
 interface ArticleProps {
     CAPI: CAPIType;
     NAV: NavType;
@@ -221,7 +225,18 @@ type DesignType =
     | 'GuardianLabs'
     | 'Quiz';
 
-// 3rd party type declarations
+// ----------------- //
+// General DataTypes //
+// ----------------- //
+
+// ------------------------------  //
+// window.guardian: WindowGuardian //
+// ------------------------------- //
+
+// ------------------------------
+// 3rd party type declarations //
+// ------------------------------
+
 declare module 'emotion-server' {
     export const extractCritical: any;
 }
@@ -238,7 +253,10 @@ declare module 'minify-css-string' {
     export default minifyCSSString;
 }
 
-/* AMP types */
+// ------------------------------------- //
+// AMP types                             //
+// ------------------------------------- //
+
 // tslint:disable-next-line no-namespace
 declare namespace JSX {
     interface IntrinsicElements {

--- a/packages/frontend/model/window-guardian.ts
+++ b/packages/frontend/model/window-guardian.ts
@@ -36,24 +36,6 @@ const makeWindowGuardianConfig = (
     } as WindowGuardianConfig;
 };
 
-export const makeWindowGuardianConfigForTest = (): WindowGuardianConfig => {
-    return {
-        googleAnalytics: null,
-        images: null,
-        libs: null,
-        modules: null,
-        nav: null,
-        ophan: null,
-        page: {
-            sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
-            sentryHost: 'app.getsentry.com/35463',
-        },
-        stylesheets: null,
-        switches: null,
-        tests: null,
-    } as WindowGuardianConfig;
-};
-
 export interface WindowGuardian {
     app: {
         // The 'app' attribute of WindowGuardian doesn't exists in the regular frontend

--- a/packages/frontend/model/window-guardian.ts
+++ b/packages/frontend/model/window-guardian.ts
@@ -36,6 +36,24 @@ const makeWindowGuardianConfig = (
     } as WindowGuardianConfig;
 };
 
+export const makeWindowGuardianConfigForTest = (): WindowGuardianConfig => {
+    return {
+        googleAnalytics: null,
+        images: null,
+        libs: null,
+        modules: null,
+        nav: null,
+        ophan: null,
+        page: {
+            sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
+            sentryHost: 'app.getsentry.com/35463',
+        },
+        stylesheets: null,
+        switches: null,
+        tests: null,
+    } as WindowGuardianConfig;
+};
+
 export interface WindowGuardian {
     app: {
         // The 'app' attribute of WindowGuardian doesn't exists in the regular frontend

--- a/packages/frontend/model/window-guardian.ts
+++ b/packages/frontend/model/window-guardian.ts
@@ -36,6 +36,11 @@ export const windowGuardianConfig = {
 
 export interface WindowGuardian {
     app: {
+        // The 'app' attribute of WindowGuardian doesn't exists in the regular frontend
+        // I don't know why it was introduced in dotcom-rendering
+        // I would recommend not to invest in it and to use the config attribute instead
+        // Therefore I will be phasing it out.
+        // -- Pascal
         data: DCRDocumentData;
         cssIDs: string[];
     };

--- a/packages/frontend/model/window-guardian.ts
+++ b/packages/frontend/model/window-guardian.ts
@@ -16,7 +16,9 @@ export interface WindowGuardianConfig {
     tests: any;
 }
 
-const makeWindowGuardianConfig = (): WindowGuardianConfig => {
+const makeWindowGuardianConfig = (
+    dcrDocumentData: DCRDocumentData,
+): WindowGuardianConfig => {
     return {
         googleAnalytics: null,
         images: null,
@@ -25,8 +27,8 @@ const makeWindowGuardianConfig = (): WindowGuardianConfig => {
         nav: null,
         ophan: null,
         page: {
-            sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
-            sentryHost: 'app.getsentry.com/35463',
+            sentryPublicApiKey: dcrDocumentData.config.sentryPublicApiKey,
+            sentryHost: dcrDocumentData.config.sentryHost,
         },
         stylesheets: null,
         switches: null,
@@ -50,15 +52,15 @@ export interface WindowGuardian {
 }
 
 export const makeWindowGuardian = (
-    data: DCRDocumentData,
+    dcrDocumentData: DCRDocumentData,
     cssIDs: string[],
 ): WindowGuardian => {
     return {
         app: {
-            data,
             cssIDs,
+            data: dcrDocumentData,
         },
-        config: makeWindowGuardianConfig(),
+        config: makeWindowGuardianConfig(dcrDocumentData),
         polyfilled: false,
         onPolyfilled: () => null,
     };

--- a/packages/frontend/model/window-guardian.ts
+++ b/packages/frontend/model/window-guardian.ts
@@ -7,7 +7,10 @@ export interface WindowGuardianConfig {
     modules: any;
     nav: any;
     ophan: any;
-    page: any;
+    page: {
+        sentryHost: string;
+        sentryPublicApiKey: string;
+    };
     stylesheets: any;
     switches: any;
     tests: any;
@@ -22,7 +25,10 @@ export const windowGuardianConfig = {
     modules: null,
     nav: null,
     ophan: null,
-    page: null,
+    page: {
+        sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
+        sentryHost: 'app.getsentry.com/35463',
+    },
     stylesheets: null,
     switches: null,
     tests: null,
@@ -33,9 +39,9 @@ export interface WindowGuardian {
         data: any;
         cssIDs: string[];
     };
+    config: WindowGuardianConfig;
     polyfilled: boolean;
     onPolyfilled: () => void;
-    config: WindowGuardianConfig;
 }
 
 export const makeWindowGuardian = (

--- a/packages/frontend/model/window-guardian.ts
+++ b/packages/frontend/model/window-guardian.ts
@@ -1,6 +1,6 @@
-// This interface is currently a work in progress.
-// Not all attributes will remain and better types will be given as we go along
 export interface WindowGuardianConfig {
+    // This interface is currently a work in progress.
+    // Not all attributes will remain and better types will be given as we go along
     googleAnalytics: any;
     images: any;
     libs: any;
@@ -16,23 +16,23 @@ export interface WindowGuardianConfig {
     tests: any;
 }
 
-// Temporary
-// Currently exported, but will be replaced by a function call.
-export const windowGuardianConfig = {
-    googleAnalytics: null,
-    images: null,
-    libs: null,
-    modules: null,
-    nav: null,
-    ophan: null,
-    page: {
-        sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
-        sentryHost: 'app.getsentry.com/35463',
-    },
-    stylesheets: null,
-    switches: null,
-    tests: null,
-} as WindowGuardianConfig;
+const makeWindowGuardianConfig = (): WindowGuardianConfig => {
+    return {
+        googleAnalytics: null,
+        images: null,
+        libs: null,
+        modules: null,
+        nav: null,
+        ophan: null,
+        page: {
+            sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
+            sentryHost: 'app.getsentry.com/35463',
+        },
+        stylesheets: null,
+        switches: null,
+        tests: null,
+    } as WindowGuardianConfig;
+};
 
 export interface WindowGuardian {
     app: {
@@ -50,16 +50,15 @@ export interface WindowGuardian {
 }
 
 export const makeWindowGuardian = (
-    config: WindowGuardianConfig,
     data: DCRDocumentData,
     cssIDs: string[],
 ): WindowGuardian => {
     return {
-        config,
         app: {
             data,
             cssIDs,
         },
+        config: makeWindowGuardianConfig(),
         polyfilled: false,
         onPolyfilled: () => null,
     };

--- a/packages/frontend/model/window-guardian.ts
+++ b/packages/frontend/model/window-guardian.ts
@@ -36,7 +36,7 @@ export const windowGuardianConfig = {
 
 export interface WindowGuardian {
     app: {
-        data: any;
+        data: DCRDocumentData;
         cssIDs: string[];
     };
     config: WindowGuardianConfig;
@@ -46,7 +46,7 @@ export interface WindowGuardian {
 
 export const makeWindowGuardian = (
     config: WindowGuardianConfig,
-    data: any,
+    data: DCRDocumentData,
     cssIDs: string[],
 ): WindowGuardian => {
     return {

--- a/packages/frontend/web/server/document.tsx
+++ b/packages/frontend/web/server/document.tsx
@@ -14,18 +14,6 @@ import {
     makeWindowGuardian,
 } from '@frontend/model/window-guardian';
 
-interface Props {
-    data: {
-        page: string;
-        site: string;
-        CAPI: CAPIType;
-        NAV: NavType;
-        config: ConfigType;
-        GA: string; // TODO use GADataType again
-        linkedData: object;
-    };
-}
-
 interface RenderToStringResult {
     html: string;
     css: string;

--- a/packages/frontend/web/server/document.tsx
+++ b/packages/frontend/web/server/document.tsx
@@ -9,10 +9,7 @@ import { Article } from '../pages/Article';
 import { getDist } from '@frontend/lib/assets';
 // import { GADataType } from '@frontend/model/extract-ga';
 
-import {
-    windowGuardianConfig,
-    makeWindowGuardian,
-} from '@frontend/model/window-guardian';
+import { makeWindowGuardian } from '@frontend/model/window-guardian';
 
 interface RenderToStringResult {
     html: string;
@@ -76,11 +73,7 @@ export const document = ({ data }: Props) => {
         'https://www.google-analytics.com/analytics.js',
     ];
 
-    const windowGuardian = makeWindowGuardian(
-        windowGuardianConfig,
-        data,
-        cssIDs,
-    );
+    const windowGuardian = makeWindowGuardian(data, cssIDs);
 
     const ampLink = `https://amp.theguardian.com/${data.CAPI.pageId}`;
 

--- a/scripts/jest/setup.ts
+++ b/scripts/jest/setup.ts
@@ -5,8 +5,7 @@ import 'react-testing-library/cleanup-after-each';
 
 import { windowGuardianConfig } from '@frontend/model/window-guardian';
 
-// Stub global Guardian object
-window.guardian = {
+const windowGuardian = {
     app: {
         data: {},
         cssIDs: [],
@@ -17,3 +16,6 @@ window.guardian = {
         return undefined;
     },
 };
+
+// Stub global Guardian object
+window.guardian = windowGuardian;

--- a/scripts/jest/setup.ts
+++ b/scripts/jest/setup.ts
@@ -3,9 +3,23 @@ import 'jest-dom/extend-expect';
 // this is basically: afterEach(cleanup)
 import 'react-testing-library/cleanup-after-each';
 
-import { makeWindowGuardianConfigForTest } from '@frontend/model/window-guardian';
+import { WindowGuardianConfig } from '@frontend/model/window-guardian';
 
-const windowGuardianConfig = makeWindowGuardianConfigForTest();
+const windowGuardianConfig = {
+    googleAnalytics: null,
+    images: null,
+    libs: null,
+    modules: null,
+    nav: null,
+    ophan: null,
+    page: {
+        sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
+        sentryHost: 'app.getsentry.com/35463',
+    },
+    stylesheets: null,
+    switches: null,
+    tests: null,
+} as WindowGuardianConfig;
 
 const windowGuardian = {
     app: {

--- a/scripts/jest/setup.ts
+++ b/scripts/jest/setup.ts
@@ -3,7 +3,9 @@ import 'jest-dom/extend-expect';
 // this is basically: afterEach(cleanup)
 import 'react-testing-library/cleanup-after-each';
 
-import { windowGuardianConfig } from '@frontend/model/window-guardian';
+import { makeWindowGuardianConfigForTest } from '@frontend/model/window-guardian';
+
+const windowGuardianConfig = makeWindowGuardianConfigForTest();
 
 const windowGuardian = {
     app: {


### PR DESCRIPTION
## What does this change?

This change adds Sentry data to `window.guardian`.

While doing that the following happened:

- I introduced `DCRDocumentData` to get the type out of `Props`. This allow reference from other parts of the code, and in in particular gives proper structure to the `dcrDocumentData` argument of `makeWindowGuardian`, ensuring that changes in the data model will not result in un-intended consequences for the client side `window.guardian` and it's `config` attribute.

- Did various refactoring around `WindowGuardian`
