### PR TITLE
commercialBundleURL

### DIFF
--- a/packages/frontend/model/window-guardian.ts
+++ b/packages/frontend/model/window-guardian.ts
@@ -21,8 +21,7 @@ const makeWindowGuardianConfig = (
     dcrDocumentData: DCRDocumentData,
 ): WindowGuardianConfig => {
     return {
-        commercialBundleURL:
-            'http://localhost:9000/assets/javascripts/graun.dotcom-rendering-commercial.js',
+        commercialBundleURL: dcrDocumentData.CAPI.config.commercialUrl,
         googleAnalytics: null,
         images: null,
         libs: null,

--- a/packages/frontend/model/window-guardian.ts
+++ b/packages/frontend/model/window-guardian.ts
@@ -1,6 +1,7 @@
 export interface WindowGuardianConfig {
     // This interface is currently a work in progress.
     // Not all attributes will remain and better types will be given as we go along
+    commercialBundleURL: string;
     googleAnalytics: any;
     images: any;
     libs: any;
@@ -20,6 +21,8 @@ const makeWindowGuardianConfig = (
     dcrDocumentData: DCRDocumentData,
 ): WindowGuardianConfig => {
     return {
+        commercialBundleURL:
+            'http://localhost:9000/assets/javascripts/graun.dotcom-rendering-commercial.js',
         googleAnalytics: null,
         images: null,
         libs: null,

--- a/packages/frontend/web/browser/boot.test.ts
+++ b/packages/frontend/web/browser/boot.test.ts
@@ -72,7 +72,7 @@ describe('boot', () => {
     };
     let windowMock: MockWindow;
     let ravenMock: MockRaven;
-    const commercialUrl = 'http://foo.bar';
+    const commercialBundleURL = 'http://foo.bar';
     const { onPolyfilled, polyfilled, app } = window.guardian;
 
     beforeEach(() => {
@@ -83,11 +83,12 @@ describe('boot', () => {
             polyfilled: true,
             app: {
                 data: {
-                    config: {
-                        commercialUrl,
-                    },
+                    config: {},
                 },
                 cssIDs: ['foo', 'bar'],
+            },
+            config: {
+                commercialBundleURL,
             },
         });
 
@@ -136,7 +137,7 @@ describe('boot', () => {
                 expect.any(Function),
             );
             expect(loadScript).toHaveBeenCalledTimes(1);
-            expect(loadScript).toHaveBeenCalledWith(commercialUrl);
+            expect(loadScript).toHaveBeenCalledWith(commercialBundleURL);
             expect(windowMock.addEventListener).toHaveBeenCalledTimes(2);
             expect(windowMock.addEventListener).toHaveBeenCalledWith(
                 'error',
@@ -155,7 +156,7 @@ describe('boot', () => {
         return _.onPolyfilled().then(() => {
             expect(ravenMock.context).not.toHaveBeenCalled();
             expect(loadScript).toHaveBeenCalledTimes(1);
-            expect(loadScript).toHaveBeenCalledWith(commercialUrl);
+            expect(loadScript).toHaveBeenCalledWith(commercialBundleURL);
             expect(windowMock.addEventListener).not.toHaveBeenCalled();
         });
     });

--- a/packages/frontend/web/browser/boot.ts
+++ b/packages/frontend/web/browser/boot.ts
@@ -18,7 +18,7 @@ if (module.hot) {
 
 const initApp = (): void => {
     const { cssIDs, data } = window.guardian.app;
-    const { commercialUrl } = data.config;
+    const { commercialBundleURL } = window.guardian.config;
 
     const enhanceApp = () => {
         initGa();
@@ -43,7 +43,7 @@ const initApp = (): void => {
     };
 
     const loadCommercial = (): Promise<void> => {
-        return loadScript(commercialUrl);
+        return loadScript(commercialBundleURL);
     };
 
     loadCommercial()

--- a/scripts/jest/setup.ts
+++ b/scripts/jest/setup.ts
@@ -6,6 +6,7 @@ import 'react-testing-library/cleanup-after-each';
 import { WindowGuardianConfig } from '@frontend/model/window-guardian';
 
 const windowGuardianConfig = {
+    commercialBundleURL: 'http://foo.bar',
     googleAnalytics: null,
     images: null,
     libs: null,


### PR DESCRIPTION
## What does this change?

This renames `commercialUrl` into `commercialBundleURL` and reads it from `window.guardian.config` instead of `window.guardian.app.data.config`. 

This is part of eventually decommissioning `window.guardian.app.data`.
