### PR TITLE
Read commercialBundleURL from window.guardian.app.data.config

### DIFF
--- a/fixtures/CAPI.ts
+++ b/fixtures/CAPI.ts
@@ -436,7 +436,7 @@ export const CAPI: CAPIType = {
         sentryHost: 'app.getsentry.com/35463',
         switches: {},
         dfpAccountId: '',
-        commercialUrl:
+        commercialBundleUrl:
             'https://assets.guim.co.uk/javascripts/3d3cbc5f29df7c0cdd65/graun.dotcom-rendering-commercial.js',
     },
     webTitle: 'Foobar',

--- a/fixtures/article.ts
+++ b/fixtures/article.ts
@@ -3010,7 +3010,7 @@ export const data = {
                     'https://support.theguardian.com?INTCMP=footer_support&acquisitionData=%7B"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_FOOTER","componentId":"footer_support"%7D',
             },
         },
-        commercialUrl:
+        commercialBundleUrl:
             'https://assets.guim.co.uk/javascripts/3d3cbc5f29df7c0cdd65/graun.dotcom-rendering-commercial.js',
     },
     version: 2,

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -204,7 +204,7 @@ interface ConfigType {
     sentryHost: string;
     switches: { [key: string]: boolean };
     dfpAccountId: string;
-    commercialUrl: string;
+    commercialBundleUrl: string;
 }
 
 // https://github.com/guardian/content-api-scala-client/blob/master/client/src/main/scala/com.gu.contentapi.client/utils/DesignType.scala

--- a/packages/frontend/model/json-schema.json
+++ b/packages/frontend/model/json-schema.json
@@ -1356,13 +1356,13 @@
                 "dfpAccountId": {
                     "type": "string"
                 },
-                "commercialUrl": {
+                "commercialBundleUrl": {
                     "type": "string"
                 }
             },
             "required": [
                 "ajaxUrl",
-                "commercialUrl",
+                "commercialBundleUrl",
                 "dfpAccountId",
                 "sentryHost",
                 "sentryPublicApiKey",

--- a/packages/frontend/model/window-guardian.ts
+++ b/packages/frontend/model/window-guardian.ts
@@ -1,7 +1,6 @@
 export interface WindowGuardianConfig {
     // This interface is currently a work in progress.
     // Not all attributes will remain and better types will be given as we go along
-    commercialBundleURL: string;
     googleAnalytics: any;
     images: any;
     libs: any;
@@ -21,7 +20,6 @@ const makeWindowGuardianConfig = (
     dcrDocumentData: DCRDocumentData,
 ): WindowGuardianConfig => {
     return {
-        commercialBundleURL: dcrDocumentData.CAPI.config.commercialUrl,
         googleAnalytics: null,
         images: null,
         libs: null,

--- a/packages/frontend/web/browser/boot.test.ts
+++ b/packages/frontend/web/browser/boot.test.ts
@@ -72,7 +72,7 @@ describe('boot', () => {
     };
     let windowMock: MockWindow;
     let ravenMock: MockRaven;
-    const commercialBundleURL = 'http://foo.bar';
+    const commercialBundleUrl = 'http://foo.bar';
     const { onPolyfilled, polyfilled, app } = window.guardian;
 
     beforeEach(() => {
@@ -83,13 +83,13 @@ describe('boot', () => {
             polyfilled: true,
             app: {
                 data: {
-                    config: {},
+                    config: {
+                        commercialBundleUrl,
+                    },
                 },
                 cssIDs: ['foo', 'bar'],
             },
-            config: {
-                commercialBundleURL,
-            },
+            config: {},
         });
 
         getRaven.mockImplementation(() => Promise.resolve(ravenMock));
@@ -137,7 +137,7 @@ describe('boot', () => {
                 expect.any(Function),
             );
             expect(loadScript).toHaveBeenCalledTimes(1);
-            expect(loadScript).toHaveBeenCalledWith(commercialBundleURL);
+            expect(loadScript).toHaveBeenCalledWith(commercialBundleUrl);
             expect(windowMock.addEventListener).toHaveBeenCalledTimes(2);
             expect(windowMock.addEventListener).toHaveBeenCalledWith(
                 'error',
@@ -156,7 +156,7 @@ describe('boot', () => {
         return _.onPolyfilled().then(() => {
             expect(ravenMock.context).not.toHaveBeenCalled();
             expect(loadScript).toHaveBeenCalledTimes(1);
-            expect(loadScript).toHaveBeenCalledWith(commercialBundleURL);
+            expect(loadScript).toHaveBeenCalledWith(commercialBundleUrl);
             expect(windowMock.addEventListener).not.toHaveBeenCalled();
         });
     });

--- a/packages/frontend/web/browser/boot.ts
+++ b/packages/frontend/web/browser/boot.ts
@@ -18,7 +18,7 @@ if (module.hot) {
 
 const initApp = (): void => {
     const { cssIDs, data } = window.guardian.app;
-    const { commercialBundleURL } = window.guardian.config;
+    const commercialBundleUrl = data.config.commercialBundleUrl;
 
     const enhanceApp = () => {
         initGa();
@@ -43,7 +43,7 @@ const initApp = (): void => {
     };
 
     const loadCommercial = (): Promise<void> => {
-        return loadScript(commercialBundleURL);
+        return loadScript(commercialBundleUrl);
     };
 
     loadCommercial()

--- a/packages/frontend/web/components/ShareCount.test.tsx
+++ b/packages/frontend/web/components/ShareCount.test.tsx
@@ -25,7 +25,7 @@ describe('ShareCount', () => {
         sentryPublicApiKey: '',
         switches: {},
         dfpAccountId: '',
-        commercialUrl: '',
+        commercialBundleUrl: '',
     };
 
     afterEach(() => {

--- a/packages/frontend/web/server/document.tsx
+++ b/packages/frontend/web/server/document.tsx
@@ -58,7 +58,7 @@ export const document = ({ data }: Props) => {
     const vendorJS = getDist('vendor.js');
     const polyfillIO =
         'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry&flags=gated&callback=guardianPolyfilled&unknown=polyfill';
-    const commercialBundle = config.commercialUrl;
+    const commercialBundle = config.commercialBundleUrl;
     const priorityScripts = [polyfillIO, vendorJS, bundleJS];
     const preloadScripts = [
         ...new Set([commercialBundle].concat(priorityScripts)),

--- a/scripts/jest/setup.ts
+++ b/scripts/jest/setup.ts
@@ -6,7 +6,6 @@ import 'react-testing-library/cleanup-after-each';
 import { WindowGuardianConfig } from '@frontend/model/window-guardian';
 
 const windowGuardianConfig = {
-    commercialBundleURL: 'http://foo.bar',
     googleAnalytics: null,
     images: null,
     libs: null,


### PR DESCRIPTION
## What does this change?

This change performs two changes:

1. rename `commercialUrl` into `commercialBundleUrl`, including, reading it from the new JSON attribute from frontend, see https://github.com/guardian/frontend/pull/21669

2. Reads it from `window.guardian.app.data.config.commercialBundleUrl`, thereby reverting the decision I had taken here: https://github.com/guardian/dotcom-rendering/pull/676 ( that is because we now have a much better separation and purposes for `window.guardian.app` and `window.guardian.config` )

3. Remove the attribute from `WindowGuardianConfig`.
