### PR TITLE
Simplify WindowGuardianConfig

### DIFF
--- a/packages/frontend/model/window-guardian.ts
+++ b/packages/frontend/model/window-guardian.ts
@@ -1,52 +1,39 @@
 export interface WindowGuardianConfig {
-    // This interface is currently a work in progress.
-    // Not all attributes will remain and better types will be given as we go along
-    googleAnalytics: any;
-    images: any;
-    libs: any;
-    modules: any;
-    nav: any;
-    ophan: any;
     page: {
         sentryHost: string;
         sentryPublicApiKey: string;
     };
-    stylesheets: any;
-    switches: any;
-    tests: any;
 }
 
 const makeWindowGuardianConfig = (
     dcrDocumentData: DCRDocumentData,
 ): WindowGuardianConfig => {
     return {
-        googleAnalytics: null,
-        images: null,
-        libs: null,
-        modules: null,
-        nav: null,
-        ophan: null,
         page: {
             sentryPublicApiKey: dcrDocumentData.config.sentryPublicApiKey,
             sentryHost: dcrDocumentData.config.sentryHost,
         },
-        stylesheets: null,
-        switches: null,
-        tests: null,
     } as WindowGuardianConfig;
 };
 
 export interface WindowGuardian {
+    // At least until October 2019, do not modify this interface without checking with Pascal first.
+
+    // The 'app' attribute contains all the data that we decided to pass
+    // from frontend and the dotcom-rendering server side model
+    // to the client side.
     app: {
-        // The 'app' attribute of WindowGuardian doesn't exists in the regular frontend
-        // I don't know why it was introduced in dotcom-rendering
-        // I would recommend not to invest in it and to use the config attribute instead
-        // Therefore I will be phasing it out.
-        // -- Pascal
         data: DCRDocumentData;
         cssIDs: string[];
     };
+
+    // The 'config' attribute is derived from DCRDocumentData and contains
+    // all the data that, for legacy reasons, for instance compatibility
+    // with the frontend commercial stack, or other scripts, we want to find
+    // at window.guardian.config
     config: WindowGuardianConfig;
+
+    // Attributes 'polyfilled' and 'onPolyfilled' are positionned at window.guardian used by the client side's boot process.
     polyfilled: boolean;
     onPolyfilled: () => void;
 }

--- a/scripts/jest/setup.ts
+++ b/scripts/jest/setup.ts
@@ -6,19 +6,10 @@ import 'react-testing-library/cleanup-after-each';
 import { WindowGuardianConfig } from '@frontend/model/window-guardian';
 
 const windowGuardianConfig = {
-    googleAnalytics: null,
-    images: null,
-    libs: null,
-    modules: null,
-    nav: null,
-    ophan: null,
     page: {
         sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
         sentryHost: 'app.getsentry.com/35463',
     },
-    stylesheets: null,
-    switches: null,
-    tests: null,
 } as WindowGuardianConfig;
 
 const windowGuardian = {
@@ -28,9 +19,7 @@ const windowGuardian = {
     },
     config: windowGuardianConfig,
     polyfilled: false,
-    onPolyfilled: () => {
-        return undefined;
-    },
+    onPolyfilled: () => undefined,
 };
 
 // Stub global Guardian object


### PR DESCRIPTION
## What does this change?

This change simplifies `WindowGuardianConfig`, and, much more importantly, introduces a convention for the cohabitation of `window.guardian.app` and in particular `window.guardian.data` and `window.guardian.config`.
