### PR TITLE
Add adBlockers attribute to window.guardian

### DIFF
--- a/packages/frontend/model/window-guardian.ts
+++ b/packages/frontend/model/window-guardian.ts
@@ -36,6 +36,8 @@ export interface WindowGuardian {
     // Attributes 'polyfilled' and 'onPolyfilled' are positionned at window.guardian used by the client side's boot process.
     polyfilled: boolean;
     onPolyfilled: () => void;
+
+    adBlockers: any;
 }
 
 export const makeWindowGuardian = (
@@ -50,5 +52,9 @@ export const makeWindowGuardian = (
         config: makeWindowGuardianConfig(dcrDocumentData),
         polyfilled: false,
         onPolyfilled: () => null,
+        adBlockers: {
+            active: undefined,
+            onDetect: [],
+        },
     };
 };


### PR DESCRIPTION
## What does this change?

Add a template `adBlockers` attribute to `window.guardian` to prevent commercial script's imports from failing as it is expected. 
