### PR TITLE
Introduce flag window.guardian.config.isDotcomRendering

### DIFF
--- a/packages/frontend/model/window-guardian.ts
+++ b/packages/frontend/model/window-guardian.ts
@@ -1,4 +1,5 @@
 export interface WindowGuardianConfig {
+    isDotcomRendering: boolean;
     page: {
         sentryHost: string;
         sentryPublicApiKey: string;
@@ -10,6 +11,8 @@ const makeWindowGuardianConfig = (
     dcrDocumentData: DCRDocumentData,
 ): WindowGuardianConfig => {
     return {
+        // This indicates to the client side code that we are running a dotcom-rendering rendered page.
+        isDotcomRendering: true,
         page: {
             sentryPublicApiKey: dcrDocumentData.config.sentryPublicApiKey,
             sentryHost: dcrDocumentData.config.sentryHost,


### PR DESCRIPTION
## What does this change?

Introduce flag `window.guardian.config.isDotcomRendering`. On dotcom-rendering rendered pages will be true and on standard frontend pages, will be false. 

## Why?

To avoid duplicating code and maintain a sensible dev experience. 
