### PR TITLE
Add Google Analytics (again) using Data Model V3

### DIFF
--- a/fixtures/CAPI.ts
+++ b/fixtures/CAPI.ts
@@ -81,6 +81,11 @@ export const CAPI: CAPIType = {
             title: 'UK Business',
             twitterHandle: '',
         },
+        {
+            id: 'testseries',
+            type: 'Series',
+            title: 'This Series',
+        },
     ],
     sectionName: 'money',
     headline:

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -16,7 +16,6 @@ type FakePillars = 'labs';
 type Pillar = RealPillars | FakePillars;
 
 type Edition = 'UK' | 'US' | 'INT' | 'AU';
-type EditionLower = 'uk' | 'us' | 'int' | 'au'; // Is there a way to do this in typescript without duplication?
 
 type SharePlatform =
     | 'facebook'
@@ -226,7 +225,7 @@ interface GADataType {
     toneIds: string;
     seriesId: string;
     isHosted: string;
-    edition: EditionLower;
+    edition: Edition;
     beaconUrl: string;
 }
 

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -16,6 +16,7 @@ type FakePillars = 'labs';
 type Pillar = RealPillars | FakePillars;
 
 type Edition = 'UK' | 'US' | 'INT' | 'AU';
+type EditionLower = 'uk' | 'us' | 'int' | 'au'; // Is there a way to do this in typescript without duplication?
 
 type SharePlatform =
     | 'facebook'
@@ -213,6 +214,22 @@ interface ConfigType {
     isDev: boolean;
 }
 
+interface GADataType {
+    pillar: Pillar;
+    webTitle: string;
+    section: string;
+    contentType: string;
+    commissioningDesks: string;
+    contentId: string;
+    authorIds: string;
+    keywordIds: string;
+    toneIds: string;
+    seriesId: string;
+    isHosted: string;
+    edition: EditionLower;
+    beaconUrl: string;
+}
+
 // https://github.com/guardian/content-api-scala-client/blob/master/client/src/main/scala/com.gu.contentapi.client/utils/DesignType.scala
 type DesignType =
     | 'Article'
@@ -247,7 +264,7 @@ interface DCRDocumentData {
     CAPI: CAPIType;
     NAV: NavType;
     config: ConfigType;
-    GA: string; // TODO use GADataType again
+    GA: GADataType;
     linkedData: object;
 }
 

--- a/packages/frontend/model/extract-ga.test.ts
+++ b/packages/frontend/model/extract-ga.test.ts
@@ -23,23 +23,4 @@ describe('Google Analytics extracts and formats CAPI response correctly', () => 
     test('GA Extract returns correctly formatted GA response', () => {
         expect(extract(CAPI)).toEqual(base);
     });
-
-    test('GA extractn returns and formats Commissioning Desk from data', () => {
-        const testCAPI = { ...CAPI, ...{} };
-        testCAPI.tags.find(
-            o => o.title === 'UK Business' && (o.title = 'We ARE the Commish'),
-        );
-
-        expect(extract(testCAPI)).toEqual({
-            ...base,
-            ...{ commissioningDesks: 'wearethecommish' },
-        });
-    });
-
-    // TODO (implement)
-    // test('GA extract isHosted from data', () => {
-    //     const testCAPI = { ...CAPI, ...{ isHosted: true } };
-
-    //     expect(extract(testCAPI)).toEqual({ ...base, ...{ isHosted: 'true' } });
-    // });
 });

--- a/packages/frontend/model/extract-ga.test.ts
+++ b/packages/frontend/model/extract-ga.test.ts
@@ -1,0 +1,45 @@
+import { extract } from './extract-ga';
+import { CAPI } from '@root/fixtures/CAPI';
+
+const base = {
+    authorIds: 'profile/rob-davies',
+    beaconUrl: '//fake.url',
+    commissioningDesks: 'ukbusiness',
+    contentId:
+        'money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+    contentType: 'article',
+    edition: 'uk',
+    isHosted: 'false',
+    keywordIds:
+        'money/ticket-prices,money/consumer-affairs,money/money,technology/internet,money/viagogo',
+    pillar: 'lifestyle',
+    section: 'money',
+    seriesId: 'testseries',
+    toneIds: 'tone/news',
+    webTitle: 'Foobar',
+};
+
+describe('Google Analytics extracts and formats CAPI response correctly', () => {
+    test('GA Extract returns correctly formatted GA response', () => {
+        expect(extract(CAPI)).toEqual(base);
+    });
+
+    test('GA extractn returns and formats Commissioning Desk from data', () => {
+        const testCAPI = { ...CAPI, ...{} };
+        testCAPI.tags.find(
+            o => o.title === 'UK Business' && (o.title = 'We ARE the Commish'),
+        );
+
+        expect(extract(testCAPI)).toEqual({
+            ...base,
+            ...{ commissioningDesks: 'wearethecommish' },
+        });
+    });
+
+    // TODO (implement)
+    // test('GA extract isHosted from data', () => {
+    //     const testCAPI = { ...CAPI, ...{ isHosted: true } };
+
+    //     expect(extract(testCAPI)).toEqual({ ...base, ...{ isHosted: 'true' } });
+    // });
+});

--- a/packages/frontend/model/extract-ga.ts
+++ b/packages/frontend/model/extract-ga.ts
@@ -45,6 +45,6 @@ export const extract = (data: CAPIType): GADataType => ({
     toneIds: filterTags(data.tags, 'Tone'),
     seriesId: filterTags(data.tags, 'Series'),
     isHosted: 'false', // TODO - This is missing from the Frontend Data model
-    edition: data.editionId.toLowerCase() as EditionLower,
+    edition: data.editionId.toLowerCase() as Edition,
     beaconUrl: data.beaconURL,
 });

--- a/packages/frontend/model/extract-ga.ts
+++ b/packages/frontend/model/extract-ga.ts
@@ -1,43 +1,52 @@
-// export interface GADataType {
-//     pillar: string;
-//     webTitle: string;
-//     section: string;
-//     contentType: string;
-//     commissioningDesks: string;
-//     contentId: string;
-//     authorIds: string;
-//     keywordIds: string;
-//     toneIds: string;
-//     seriesId: string;
-//     isHosted: string;
-//     edition: string;
-//     beaconUrl: string;
-// }
+// All GA fields should  fall back to default values -
+import { findPillar } from './find-pillar';
 
-// // All GA fields should  fall back to default values -
-// import { getString, getBoolean } from './validators';
-// import { findPillar } from './find-pillar';
+const getMultipleTags = (
+    tags: CAPIType['tags'],
+    tagTypeIs: 'Contributor' | 'Keyword' | 'Tone' | 'Series', // Lets make a decision to keep this tag getter small and well defined, we don't really want to use tags
+): TagType['id'] | '' => {
+    const tagArr = tags.filter(tag => tag.type === tagTypeIs);
+    const arrOfvalues =
+        tagArr.length > 0 &&
+        tagArr.reduce(
+            (prev: Array<TagType['id']>, tag) => prev.concat(tag.id),
+            [],
+        );
 
-// // we should not bring down the website if a trackable field is missing!
-// export const extract = (data: {}): GADataType => {
-//     const edition = getString(data, 'page.edition', '').toLowerCase();
+    return (arrOfvalues && arrOfvalues.join(',')) || '';
+};
 
-//     return {
-//         webTitle: getString(data, 'page.webTitle', ''),
-//         pillar: findPillar(getString(data, 'page.pillar', '')) || 'news',
-//         section: getString(data, 'page.section', ''),
-//         contentType: getString(data, 'page.contentType', '')
-//             .toLowerCase()
-//             .split(' ')
-//             .join(''),
-//         commissioningDesks: getString(data, 'page.commissioningDesks', ''),
-//         contentId: getString(data, 'page.contentId', ''),
-//         authorIds: getString(data, 'page.authorIds', ''),
-//         keywordIds: getString(data, 'page.keywordIds', ''),
-//         toneIds: getString(data, 'page.toneIds', ''),
-//         seriesId: getString(data, 'page.seriesId', ''),
-//         isHosted: getBoolean(data, 'page.meta.isHosted', false).toString(),
-//         edition: edition === 'int' ? 'international' : edition,
-//         beaconUrl: getString(data, 'site.beaconUrl', ''),
-//     };
-// };
+// Annoyingly we ping GA with commissioningdesk as the title of the tag, not the id so handle that seprate
+const getCommissioningDesk = (
+    tags: CAPIType['tags'],
+): TagType['title'] | '' => {
+    const tag = tags.find(thisTag =>
+        thisTag.id.includes('tracking/commissioningdesk'),
+    );
+    return (tag && tag.title) || '';
+};
+
+// we should not bring down the website if a trackable field is missing!
+export const extract = (data: CAPIType): GADataType => {
+    return {
+        webTitle: data.webTitle,
+        pillar: findPillar(data.pillar) || 'news',
+        section: data.sectionName || '',
+        contentType: data.contentType
+            .toLowerCase()
+            .split(' ')
+            .join(''),
+        commissioningDesks: getCommissioningDesk(data.tags)
+            .toLowerCase()
+            .split(' ')
+            .join('-'),
+        contentId: data.pageId,
+        authorIds: getMultipleTags(data.tags, 'Contributor'),
+        keywordIds: getMultipleTags(data.tags, 'Keyword'),
+        toneIds: getMultipleTags(data.tags, 'Tone'),
+        seriesId: getMultipleTags(data.tags, 'Series'),
+        isHosted: 'false', // TODO - This is missing from the Frontend Data model
+        edition: data.editionId.toLowerCase() as EditionLower,
+        beaconUrl: data.beaconURL,
+    };
+};

--- a/packages/frontend/model/extract-ga.ts
+++ b/packages/frontend/model/extract-ga.ts
@@ -1,11 +1,11 @@
 // All GA fields should  fall back to default values -
 import { findPillar } from './find-pillar';
 
-const getMultipleTags = (
+const filterTags = (
     tags: CAPIType['tags'],
-    tagTypeIs: 'Contributor' | 'Keyword' | 'Tone' | 'Series', // Lets make a decision to keep this tag getter small and well defined, we don't really want to use tags
+    tagType: 'Contributor' | 'Keyword' | 'Tone' | 'Series', // Lets make a decision to keep this tag getter small and well defined, we don't really want to use tags
 ): TagType['id'] | '' => {
-    const tagArr = tags.filter(tag => tag.type === tagTypeIs);
+    const tagArr = tags.filter(tag => tag.type === tagType);
     const arrOfvalues =
         tagArr.length > 0 &&
         tagArr.reduce(
@@ -27,26 +27,24 @@ const getCommissioningDesk = (
 };
 
 // we should not bring down the website if a trackable field is missing!
-export const extract = (data: CAPIType): GADataType => {
-    return {
-        webTitle: data.webTitle,
-        pillar: findPillar(data.pillar) || 'news',
-        section: data.sectionName || '',
-        contentType: data.contentType
-            .toLowerCase()
-            .split(' ')
-            .join(''),
-        commissioningDesks: getCommissioningDesk(data.tags)
-            .toLowerCase()
-            .split(' ')
-            .join('-'),
-        contentId: data.pageId,
-        authorIds: getMultipleTags(data.tags, 'Contributor'),
-        keywordIds: getMultipleTags(data.tags, 'Keyword'),
-        toneIds: getMultipleTags(data.tags, 'Tone'),
-        seriesId: getMultipleTags(data.tags, 'Series'),
-        isHosted: 'false', // TODO - This is missing from the Frontend Data model
-        edition: data.editionId.toLowerCase() as EditionLower,
-        beaconUrl: data.beaconURL,
-    };
-};
+export const extract = (data: CAPIType): GADataType => ({
+    webTitle: data.webTitle,
+    pillar: findPillar(data.pillar) || 'news',
+    section: data.sectionName || '',
+    contentType: data.contentType
+        .toLowerCase()
+        .split(' ')
+        .join(''),
+    commissioningDesks: getCommissioningDesk(data.tags)
+        .toLowerCase()
+        .split(' ')
+        .join('-'),
+    contentId: data.pageId,
+    authorIds: filterTags(data.tags, 'Contributor'),
+    keywordIds: filterTags(data.tags, 'Keyword'),
+    toneIds: filterTags(data.tags, 'Tone'),
+    seriesId: filterTags(data.tags, 'Series'),
+    isHosted: 'false', // TODO - This is missing from the Frontend Data model
+    edition: data.editionId.toLowerCase() as EditionLower,
+    beaconUrl: data.beaconURL,
+});

--- a/packages/frontend/model/extract-ga.ts
+++ b/packages/frontend/model/extract-ga.ts
@@ -26,19 +26,19 @@ const getCommissioningDesk = (
     return (tag && tag.title) || '';
 };
 
+const formatStringForGa = (string: string): string =>
+    string
+        .toLowerCase()
+        .split(' ')
+        .join('');
+
 // we should not bring down the website if a trackable field is missing!
 export const extract = (data: CAPIType): GADataType => ({
     webTitle: data.webTitle,
     pillar: findPillar(data.pillar) || 'news',
     section: data.sectionName || '',
-    contentType: data.contentType
-        .toLowerCase()
-        .split(' ')
-        .join(''),
-    commissioningDesks: getCommissioningDesk(data.tags)
-        .toLowerCase()
-        .split(' ')
-        .join('-'),
+    contentType: formatStringForGa(data.contentType),
+    commissioningDesks: formatStringForGa(getCommissioningDesk(data.tags)),
     contentId: data.pageId,
     authorIds: filterTags(data.tags, 'Contributor'),
     keywordIds: filterTags(data.tags, 'Keyword'),

--- a/packages/frontend/web/browser/ga.ts
+++ b/packages/frontend/web/browser/ga.ts
@@ -71,7 +71,7 @@ export const sendPageView = (): void => {
     ga(set, 'dimension10', GA.toneIds);
     ga(set, 'dimension11', GA.seriesId);
     ga(set, 'dimension15', identityId);
-    ga(set, 'dimension16', !!identityId);
+    ga(set, 'dimension16', (identityId && 'true') || 'false');
     ga(set, 'dimension21', getQueryParam('INTCMP', window.location.search)); // internal campaign code
     ga(set, 'dimension22', getQueryParam('CMP_BUNIT', window.location.search)); // campaign business unit
     ga(set, 'dimension23', getQueryParam('CMP_TU', window.location.search)); // campaign team

--- a/packages/frontend/web/server/render.ts
+++ b/packages/frontend/web/server/render.ts
@@ -20,7 +20,7 @@ export const render = ({ body }: express.Request, res: express.Response) => {
                     { isDev: process.env.NODE_ENV !== 'production' },
                     CAPI.config,
                 ),
-                GA: extractGA(CAPI),, // TODO fixme with extractGA(body)
+                GA: extractGA(CAPI),
                 linkedData: CAPI.linkedData,
             },
         });

--- a/packages/frontend/web/server/render.ts
+++ b/packages/frontend/web/server/render.ts
@@ -3,6 +3,7 @@ import { extract as extractNAV } from '@frontend/model/extract-nav';
 
 import { document } from '@frontend/web/server/document';
 import { validateAsCAPIType } from '@frontend/model/validate';
+import { extract as extractGA } from '@frontend/model/extract-ga';
 
 export const render = ({ body }: express.Request, res: express.Response) => {
     try {
@@ -19,7 +20,7 @@ export const render = ({ body }: express.Request, res: express.Response) => {
                     { isDev: process.env.NODE_ENV !== 'production' },
                     CAPI.config,
                 ),
-                GA: '', // TODO fixme with extractGA(body)
+                GA: extractGA(CAPI),, // TODO fixme with extractGA(body)
                 linkedData: CAPI.linkedData,
             },
         });

--- a/tslint.json
+++ b/tslint.json
@@ -35,7 +35,8 @@
         "react-no-dangerous-html": true,
         "prettier": true,
         "interface-over-type-literal": false,
-        "curly": true
+        "curly": true,
+        "prefer-array-literal": [true, { "allow-type-parameters": true }]
     },
     "rulesDirectory": [],
     "linterOptions": {


### PR DESCRIPTION
## What does this change?

Google analytics was not functional and not applied in DCR and was still setup using model V2. This moves us to using model V3.

I am keen to move all tag based checking and string generation in [Frontend](https://github.com/guardian/frontend) [rather than in DCR (see Trello ticket)](https://trello.com/c/eFdDGQdG/632-move-all-data-derived-from-tags-or-strings-built-from-tags-to-the-frontend-model-build) but for now we build this in here.

## Why?

Tracking 📈 

## Link to supporting Trello card
https://trello.com/c/NWOYwTPu/611-tracking