### PR TITLE
Make non-linked bylines the right colour

### DIFF
--- a/packages/frontend/amp/components/topMeta/TopMetaOpinion.tsx
+++ b/packages/frontend/amp/components/topMeta/TopMetaOpinion.tsx
@@ -21,13 +21,14 @@ const headerStyle = css`
 
 const bylineStyle = (pillar: Pillar) => css`
     ${headline(5)};
+    color: ${pillarPalette[pillar].main};
+    font-style: italic;
     font-weight: 100;
     padding-top: 3px;
 
     a {
         color: ${pillarPalette[pillar].main};
         text-decoration: none;
-        font-style: italic;
     }
 `;
 


### PR DESCRIPTION
## What does this change?
As title

## Why?

From this 

![image](https://user-images.githubusercontent.com/638051/61786540-d568de80-ae05-11e9-964d-f12567551ba3.png)

to this

![image](https://user-images.githubusercontent.com/638051/61786556-dc8fec80-ae05-11e9-86e0-02b6b663ad41.png)



