### PR TITLE
Add contentType, edition and revisionNumber to window.guardian.config.page

### DIFF
--- a/fixtures/CAPI.ts
+++ b/fixtures/CAPI.ts
@@ -438,6 +438,7 @@ export const CAPI: CAPIType = {
         dfpAccountId: '',
         commercialBundleUrl:
             'https://assets.guim.co.uk/javascripts/3d3cbc5f29df7c0cdd65/graun.dotcom-rendering-commercial.js',
+        revisionNumber: '62cf0d6e4609276d37e09fd596430fbf8b629418',
     },
     webTitle: 'Foobar',
     nav: {

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -205,6 +205,7 @@ interface ConfigType {
     switches: { [key: string]: boolean };
     dfpAccountId: string;
     commercialBundleUrl: string;
+    revisionNumber: string;
 }
 
 // https://github.com/guardian/content-api-scala-client/blob/master/client/src/main/scala/com.gu.contentapi.client/utils/DesignType.scala

--- a/packages/frontend/model/window-guardian.ts
+++ b/packages/frontend/model/window-guardian.ts
@@ -1,6 +1,9 @@
 export interface WindowGuardianConfig {
     isDotcomRendering: boolean;
     page: {
+        contentType: string;
+        edition: Edition;
+        revisionNumber: string;
         sentryHost: string;
         sentryPublicApiKey: string;
     };
@@ -14,6 +17,9 @@ const makeWindowGuardianConfig = (
         // This indicates to the client side code that we are running a dotcom-rendering rendered page.
         isDotcomRendering: true,
         page: {
+            contentType: dcrDocumentData.CAPI.contentType,
+            edition: dcrDocumentData.CAPI.editionId,
+            revisionNumber: dcrDocumentData.config.revisionNumber,
             sentryPublicApiKey: dcrDocumentData.config.sentryPublicApiKey,
             sentryHost: dcrDocumentData.config.sentryHost,
         },

--- a/packages/frontend/web/components/ShareCount.test.tsx
+++ b/packages/frontend/web/components/ShareCount.test.tsx
@@ -26,6 +26,7 @@ describe('ShareCount', () => {
         switches: {},
         dfpAccountId: '',
         commercialBundleUrl: '',
+        revisionNumber: '',
     };
 
     afterEach(() => {


### PR DESCRIPTION
Add `contentType`, `edition` and `revisionNumber` to `window.guardian.config.page`, which are required by Sentry.

This is the follow up of: https://github.com/guardian/frontend/pull/21684