### PR TITLE
Add keywordIds attribute to config.page

### DIFF
--- a/packages/frontend/model/window-guardian.ts
+++ b/packages/frontend/model/window-guardian.ts
@@ -6,6 +6,7 @@ export interface WindowGuardianConfig {
         revisionNumber: string;
         sentryHost: string;
         sentryPublicApiKey: string;
+        keywordIds: [];
     };
     switches: { [key: string]: boolean };
 }
@@ -22,6 +23,7 @@ const makeWindowGuardianConfig = (
             revisionNumber: dcrDocumentData.config.revisionNumber,
             sentryPublicApiKey: dcrDocumentData.config.sentryPublicApiKey,
             sentryHost: dcrDocumentData.config.sentryHost,
+            keywordIds: [],
         },
         switches: dcrDocumentData.CAPI.config.switches,
     } as WindowGuardianConfig;


### PR DESCRIPTION
## What does this change?

Add keywordIds attribute to `window.guardian.config.page`, this is required for the last Ad Free commercial module. 