### PR TITLE
Add isDev to the config

### DIFF
--- a/fixtures/CAPI.ts
+++ b/fixtures/CAPI.ts
@@ -439,6 +439,7 @@ export const CAPI: CAPIType = {
         commercialBundleUrl:
             'https://assets.guim.co.uk/javascripts/3d3cbc5f29df7c0cdd65/graun.dotcom-rendering-commercial.js',
         revisionNumber: '62cf0d6e4609276d37e09fd596430fbf8b629418',
+        isDev: false,
     },
     webTitle: 'Foobar',
     nav: {

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -210,6 +210,7 @@ interface ConfigType {
     dfpAccountId: string;
     commercialBundleUrl: string;
     revisionNumber: string;
+    isDev: boolean;
 }
 
 // https://github.com/guardian/content-api-scala-client/blob/master/client/src/main/scala/com.gu.contentapi.client/utils/DesignType.scala

--- a/packages/frontend/web/components/ShareCount.test.tsx
+++ b/packages/frontend/web/components/ShareCount.test.tsx
@@ -27,6 +27,7 @@ describe('ShareCount', () => {
         dfpAccountId: '',
         commercialBundleUrl: '',
         revisionNumber: '',
+        isDev: false,
     };
 
     afterEach(() => {

--- a/packages/frontend/web/server/render.ts
+++ b/packages/frontend/web/server/render.ts
@@ -14,7 +14,12 @@ export const render = ({ body }: express.Request, res: express.Response) => {
                 site: 'frontend',
                 page: 'Article',
                 NAV: extractNAV(CAPI.nav),
-                config: CAPI.config,
+                config: Object.assign(
+                    {},
+                    { isDev: process.env.NODE_ENV !== 'production' },
+                    CAPI.config,
+                ),
+
                 GA: '', // TODO fixme with extractGA(body)
                 linkedData: CAPI.linkedData,
             },


### PR DESCRIPTION
## What does this change?

Adds the `isDev` field from Node Env to the config object so available from the client side. Some code uses this already, so not sure why it isn't there, maybe it got lost somewhere along the way.