### PR TITLE
Add onwards tracking to components

### DIFF
--- a/packages/frontend/amp/components/elements/Text.tsx
+++ b/packages/frontend/amp/components/elements/Text.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
 import { pillarPalette } from '@frontend/lib/pillars';
-import { sanitise } from '@frontend/amp/lib/sanitise-html';
+import { sanitise } from '@frontend/lib/sanitise-html';
 import { body, textSans } from '@guardian/pasteup/typography';
 import { composeLabsCSS } from '@root/packages/frontend/amp/lib/compose-labs-css';
 

--- a/packages/frontend/amp/lib/sanitise-html.test.ts
+++ b/packages/frontend/amp/lib/sanitise-html.test.ts
@@ -1,4 +1,4 @@
-import { sanitise } from '@frontend/amp/lib/sanitise-html';
+import { sanitise } from '@frontend/lib/sanitise-html';
 
 describe('sanitise-html', () => {
     it('Remove rouge attributes', () => {

--- a/packages/frontend/amp/lib/sanitise-html.ts
+++ b/packages/frontend/amp/lib/sanitise-html.ts
@@ -1,3 +1,0 @@
-import sanitiszeHtml from 'sanitize-html';
-
-export const sanitise = (html: string): string => sanitiszeHtml(html);

--- a/packages/frontend/lib/sanitise-html.ts
+++ b/packages/frontend/lib/sanitise-html.ts
@@ -1,0 +1,4 @@
+import sanitiszeHtml from 'sanitize-html';
+
+export const sanitise = (html: string, options: {} = {}): string =>
+    sanitiszeHtml(html, options);

--- a/packages/frontend/web/components/Header/Nav/Logo.tsx
+++ b/packages/frontend/web/components/Header/Nav/Logo.tsx
@@ -60,7 +60,7 @@ const style = css`
 const SVG = () => <TheGuardianLogoSVG className={style} />;
 
 export const Logo: React.FC = () => (
-    <a className={link} href="/">
+    <a className={link} href="/" data-link-name="nav2 : logo">
         <span
             className={css`
                 ${screenReaderOnly};

--- a/packages/frontend/web/components/Header/Nav/Nav.tsx
+++ b/packages/frontend/web/components/Header/Nav/Nav.tsx
@@ -78,6 +78,7 @@ export class Nav extends Component<
                     className={centered}
                     role="navigation"
                     aria-label="Guardian sections"
+                    data-component="nav2"
                 >
                     <EditionDropdown edition={edition} />
                     <Logo />

--- a/packages/frontend/web/components/elements/TextBlockComponent.tsx
+++ b/packages/frontend/web/components/elements/TextBlockComponent.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 import { body } from '@guardian/pasteup/typography';
+import { sanitise } from '@frontend/lib/sanitise-html';
 // tslint:disable:react-no-dangerous-html
 
 const para = css`
@@ -10,11 +11,28 @@ const para = css`
     }
 `;
 
+const sanitiserOptions = {
+    // Defaults: https://www.npmjs.com/package/sanitize-html#what-are-the-default-options
+    allowedTags: false, // Leave tags from CAPI alone
+    allowedAttributes: false, // Leave attributes from CAPI alone
+    transformTags: {
+        a: (tagName: string, attribs: {}) => ({
+            tagName, // Just return anchors as is
+            attribs: {
+                ...attribs, // Merge into the existing attributes
+                ...{
+                    'data-link-name': 'in body link', // Add the data-link-name for Ophan to anchors
+                },
+            },
+        }),
+    },
+};
+
 export const TextBlockComponent: React.FC<{ html: string }> = ({ html }) => (
     <span
         className={para}
         dangerouslySetInnerHTML={{
-            __html: html,
+            __html: sanitise(html, sanitiserOptions),
         }}
     />
 );


### PR DESCRIPTION
## What does this change?

*In Progress.*

Adding the tracking for onwards is fairly simple @guardian/dotcom-platform - here's an example, the ophan library does the rest, more to be added going forward.

[Some docs in Frontend.](https://github.com/guardian/frontend/blob/88cfa609c73545085c3e5f3921631ec344a3eb83/docs/03-dev-howtos/19-tracking-components-in-the-data-lake.md)

Depends on #112 

## Why?

Track onwards clicks.

## Link to supporting Trello card

https://trello.com/c/eagQlGEf/639-track-onward-journeys-in-ophan
