### PR TITLE
AMP supported by

### DIFF
--- a/packages/frontend/amp/components/topMeta/Branding.tsx
+++ b/packages/frontend/amp/components/topMeta/Branding.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { LinkStyle } from '@frontend/amp/components/elements/Text';
+import { textSans } from '@guardian/pasteup/typography';
+import { css } from 'emotion';
+
+const brandingStyle = (pillar: Pillar) => css`
+    padding: 10px 0;
+    ${LinkStyle(pillar)}
+
+    a, a:hover {
+        display: block;
+        border-bottom: none;
+        ${textSans(1)}
+    }
+`;
+
+const brandingLabelStyle = css`
+    ${textSans(1)};
+`;
+
+const brandingLogoStyle = css`
+    padding: 10px 0;
+`;
+
+export const Branding: React.FC<{
+    branding: Branding;
+    pillar: Pillar;
+}> = ({ branding, pillar }) => {
+    const { logo, sponsorName } = branding;
+
+    return (
+        <div className={brandingStyle(pillar)}>
+            <div className={brandingLabelStyle}>{branding.logo.label}</div>
+            {/* tslint:disable-next-line: react-a11y-anchors */}
+            <a
+                className={brandingLogoStyle}
+                href={logo.link}
+                data-sponsor={sponsorName.toLowerCase()}
+                rel="nofollow"
+                aria-label={`Visit the ${sponsorName} website`}
+            >
+                <amp-img
+                    src={logo.src}
+                    width={logo.dimensions.width}
+                    height={logo.dimensions.height}
+                    alt={sponsorName}
+                />
+            </a>
+            <a href={branding.aboutThisLink}>About this content</a>
+        </div>
+    );
+};

--- a/packages/frontend/amp/components/topMeta/TopMetaNews.tsx
+++ b/packages/frontend/amp/components/topMeta/TopMetaNews.tsx
@@ -13,6 +13,7 @@ import { Standfirst } from '@frontend/amp/components/topMeta/Standfirst';
 import { SeriesLink } from '@frontend/amp/components/topMeta/SeriesLink';
 import { getSharingUrls } from '@frontend/model/sharing-urls';
 import { getAgeWarning } from '@frontend/model/age-warning';
+import { Branding } from '@frontend/amp/components/topMeta/Branding';
 
 const headerStyle = css`
     ${headline(5)};
@@ -83,52 +84,68 @@ const Headline: React.FC<{
 
 export const TopMetaNews: React.FC<{ articleData: ArticleModel }> = ({
     articleData,
-}) => (
-    <header>
-        {articleData.mainMediaElements.map((element, i) => (
-            <MainMedia key={i} element={element} pillar={articleData.pillar} />
-        ))}
+}) => {
+    const branding =
+        articleData.commercialProperties[articleData.editionId].branding;
 
-        {!articleData.isImmersive && (
-            <SeriesLink
-                baseURL={articleData.guardianBaseURL}
+    return (
+        <header>
+            {articleData.mainMediaElements.map((element, i) => (
+                <MainMedia
+                    key={i}
+                    element={element}
+                    pillar={articleData.pillar}
+                />
+            ))}
+
+            {!articleData.isImmersive && (
+                <SeriesLink
+                    baseURL={articleData.guardianBaseURL}
+                    tags={articleData.tags}
+                    pillar={articleData.pillar}
+                    fallbackToSection={true}
+                    sectionLabel={articleData.sectionLabel}
+                    sectionUrl={articleData.sectionUrl}
+                />
+            )}
+
+            <Headline
+                headlineText={articleData.headline}
+                standfirst={articleData.standfirst}
+                pillar={articleData.pillar}
+                starRating={articleData.starRating}
+            />
+
+            <Standfirst
+                text={articleData.standfirst}
+                pillar={articleData.pillar}
+            />
+
+            {branding && (
+                <Branding branding={branding} pillar={articleData.pillar} />
+            )}
+
+            <Byline
+                byline={articleData.author.byline}
                 tags={articleData.tags}
                 pillar={articleData.pillar}
-                fallbackToSection={true}
-                sectionLabel={articleData.sectionLabel}
-                sectionUrl={articleData.sectionUrl}
+                guardianBaseURL={articleData.guardianBaseURL}
+                className={bylineStyle(articleData.pillar)}
             />
-        )}
 
-        <Headline
-            headlineText={articleData.headline}
-            standfirst={articleData.standfirst}
-            pillar={articleData.pillar}
-            starRating={articleData.starRating}
-        />
-
-        <Standfirst text={articleData.standfirst} pillar={articleData.pillar} />
-
-        <Byline
-            byline={articleData.author.byline}
-            tags={articleData.tags}
-            pillar={articleData.pillar}
-            guardianBaseURL={articleData.guardianBaseURL}
-            className={bylineStyle(articleData.pillar)}
-        />
-
-        <TopMetaExtras
-            sharingUrls={getSharingUrls(
-                articleData.pageId,
-                articleData.webTitle,
-            )}
-            pillar={articleData.pillar}
-            ageWarning={getAgeWarning(
-                articleData.tags,
-                articleData.webPublicationDate,
-            )}
-            webPublicationDate={articleData.webPublicationDateDisplay}
-            twitterHandle={articleData.author.twitterHandle}
-        />
-    </header>
-);
+            <TopMetaExtras
+                sharingUrls={getSharingUrls(
+                    articleData.pageId,
+                    articleData.webTitle,
+                )}
+                pillar={articleData.pillar}
+                ageWarning={getAgeWarning(
+                    articleData.tags,
+                    articleData.webPublicationDate,
+                )}
+                webPublicationDate={articleData.webPublicationDateDisplay}
+                twitterHandle={articleData.author.twitterHandle}
+            />
+        </header>
+    );
+};

--- a/packages/frontend/amp/components/topMeta/TopMetaOpinion.tsx
+++ b/packages/frontend/amp/components/topMeta/TopMetaOpinion.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { headline, textSans } from '@guardian/pasteup/typography';
+import { headline } from '@guardian/pasteup/typography';
 import { css, cx } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
 import { pillarPalette } from '@frontend/lib/pillars';
@@ -11,7 +11,7 @@ import { Standfirst } from '@frontend/amp/components/topMeta/Standfirst';
 import { SeriesLink } from '@frontend/amp/components/topMeta/SeriesLink';
 import { getSharingUrls } from '@frontend/model/sharing-urls';
 import { getAgeWarning } from '@frontend/model/age-warning';
-import { LinkStyle } from '../elements/Text';
+import { Branding } from '@frontend/amp/components/topMeta/Branding';
 
 const headerStyle = css`
     ${headline(5)};
@@ -91,54 +91,6 @@ const BylineMeta: React.SFC<{
                     height="150"
                 />
             )}
-        </div>
-    );
-};
-
-const brandingStyle = (pillar: Pillar) => css`
-    padding: 10px 0;
-    ${LinkStyle(pillar)}
-
-    a, a:hover {
-        display: block;
-        border-bottom: none;
-        ${textSans(1)}
-    }
-`;
-
-const brandingLabelStyle = css`
-    ${textSans(1)};
-`;
-
-const brandingLogoStyle = css`
-    padding: 10px 0;
-`;
-
-const Branding: React.FC<{
-    branding: Branding;
-    pillar: Pillar;
-}> = ({ branding, pillar }) => {
-    const { logo, sponsorName } = branding;
-
-    return (
-        <div className={brandingStyle(pillar)}>
-            <div className={brandingLabelStyle}>{branding.logo.label}</div>
-            {/* tslint:disable-next-line: react-a11y-anchors */}
-            <a
-                className={brandingLogoStyle}
-                href={logo.link}
-                data-sponsor={sponsorName.toLowerCase()}
-                rel="nofollow"
-                aria-label={`Visit the ${sponsorName} website`}
-            >
-                <amp-img
-                    src={logo.src}
-                    width={`140px`}
-                    height={`90px`}
-                    alt={sponsorName}
-                />
-            </a>
-            <a href={branding.aboutThisLink}>About this content</a>
         </div>
     );
 };

--- a/packages/frontend/amp/components/topMeta/TopMetaOpinion.tsx
+++ b/packages/frontend/amp/components/topMeta/TopMetaOpinion.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { headline } from '@guardian/pasteup/typography';
+import { headline, textSans } from '@guardian/pasteup/typography';
 import { css, cx } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
 import { pillarPalette } from '@frontend/lib/pillars';
@@ -11,6 +11,7 @@ import { Standfirst } from '@frontend/amp/components/topMeta/Standfirst';
 import { SeriesLink } from '@frontend/amp/components/topMeta/SeriesLink';
 import { getSharingUrls } from '@frontend/model/sharing-urls';
 import { getAgeWarning } from '@frontend/model/age-warning';
+import { LinkStyle } from '../elements/Text';
 
 const headerStyle = css`
     ${headline(5)};
@@ -94,10 +95,61 @@ const BylineMeta: React.SFC<{
     );
 };
 
+const brandingStyle = (pillar: Pillar) => css`
+    padding: 10px 0;
+    ${LinkStyle(pillar)}
+
+    a, a:hover {
+        display: block;
+        border-bottom: none;
+        ${textSans(1)}
+    }
+`;
+
+const brandingLabelStyle = css`
+    ${textSans(1)};
+`;
+
+const brandingLogoStyle = css`
+    padding: 10px 0;
+`;
+
+const Branding: React.FC<{
+    branding: Branding;
+    pillar: Pillar;
+}> = ({ branding, pillar }) => {
+    const { logo, sponsorName } = branding;
+
+    return (
+        <div className={brandingStyle(pillar)}>
+            <div className={brandingLabelStyle}>{branding.logo.label}</div>
+            {/* tslint:disable-next-line: react-a11y-anchors */}
+            <a
+                className={brandingLogoStyle}
+                href={logo.link}
+                data-sponsor={sponsorName.toLowerCase()}
+                rel="nofollow"
+                aria-label={`Visit the ${sponsorName} website`}
+            >
+                <amp-img
+                    src={logo.src}
+                    width={`140px`}
+                    height={`90px`}
+                    alt={sponsorName}
+                />
+            </a>
+            <a href={branding.aboutThisLink}>About this content</a>
+        </div>
+    );
+};
+
 export const TopMetaOpinion: React.FC<{
     articleData: ArticleModel;
     pillar: Pillar;
 }> = ({ articleData, pillar }) => {
+    const branding =
+        articleData.commercialProperties[articleData.editionId].branding;
+
     return (
         <header>
             {articleData.mainMediaElements.map((element, i) => (
@@ -112,6 +164,8 @@ export const TopMetaOpinion: React.FC<{
             />
 
             <h1 className={headerStyle}>{articleData.headline}</h1>
+
+            {branding && <Branding branding={branding} pillar={pillar} />}
 
             <BylineMeta articleData={articleData} pillar={pillar} />
 


### PR DESCRIPTION
## What does this change?

Add support for 'supported by' content - see https://amp.theguardian.com/info/2016/jan/25/content-funding.

![Screenshot 2019-07-30 at 11 46 35](https://user-images.githubusercontent.com/858402/62125361-cc27b800-b2c4-11e9-9d47-515767bd3ab7.png)
![Screenshot 2019-07-30 at 12 11 34](https://user-images.githubusercontent.com/858402/62125362-cc27b800-b2c4-11e9-9a11-9d300fa7b0be.png)

TODO: 
* fix image URLs to use the right source/check this.

## Why?

It was an omission from the AMP work.

## Link to supporting Trello card

https://trello.com/c/LxtlMUHN