### PR TITLE
Set sitespeed sample rate higher

### DIFF
--- a/packages/frontend/web/browser/ga.ts
+++ b/packages/frontend/web/browser/ga.ts
@@ -11,7 +11,7 @@ const tracker: TrackerConfig = {
     name: 'allEditorialPropertyTracker',
     id: 'UA-78705427-1',
     sampleRate: 100,
-    siteSpeedSampleRate: 1,
+    siteSpeedSampleRate: 100, // TODO Should be set to 1 when rolling out to wider audience
 };
 
 const getQueryParam = (


### PR DESCRIPTION
## What does this change?

Lets capture all the sitespeed requests in initial rollout.

## Why?

More data.

@guardian/dotcom-platform 


