### PR TITLE
Most popular onward journey tracking

### DIFF
--- a/packages/frontend/web/components/Header/Nav/Logo.tsx
+++ b/packages/frontend/web/components/Header/Nav/Logo.tsx
@@ -60,7 +60,7 @@ const style = css`
 const SVG = () => <TheGuardianLogoSVG className={style} />;
 
 export const Logo: React.FC = () => (
-    <a className={link} href="/">
+    <a className={link} href="/" data-link-name="nav2 : logo">
         <span
             className={css`
                 ${screenReaderOnly};

--- a/packages/frontend/web/components/Header/Nav/Nav.tsx
+++ b/packages/frontend/web/components/Header/Nav/Nav.tsx
@@ -78,6 +78,7 @@ export class Nav extends Component<
                     className={centered}
                     role="navigation"
                     aria-label="Guardian sections"
+                    data-component="nav2"
                 >
                     <EditionDropdown edition={edition} />
                     <Logo />

--- a/packages/frontend/web/components/MostViewed.tsx
+++ b/packages/frontend/web/components/MostViewed.tsx
@@ -254,7 +254,7 @@ export class MostViewed extends Component<Props, { selectedTabIndex: number }> {
         return (
             <div
                 className={container}
-                data-link-name={'most-viewed,dotcom-rendering'}
+                data-link-name={'most-viewed'}
                 data-component={'most-viewed'}
             >
                 <h2 className={heading}>Most viewed</h2>

--- a/packages/frontend/web/components/MostViewed.tsx
+++ b/packages/frontend/web/components/MostViewed.tsx
@@ -254,7 +254,7 @@ export class MostViewed extends Component<Props, { selectedTabIndex: number }> {
         return (
             <div
                 className={container}
-                data-link-name={'most-viewed'}
+                data-link-name={'most-viewed,dotcom-rendering'}
                 data-component={'most-viewed'}
             >
                 <h2 className={heading}>Most viewed</h2>

--- a/packages/frontend/web/components/MostViewed.tsx
+++ b/packages/frontend/web/components/MostViewed.tsx
@@ -252,7 +252,11 @@ export class MostViewed extends Component<Props, { selectedTabIndex: number }> {
 
     public render() {
         return (
-            <div className={container}>
+            <div
+                className={container}
+                data-link-name={'most-viewed'}
+                data-component={'most-viewed'}
+            >
                 <h2 className={heading}>Most viewed</h2>
                 <AsyncClientComponent f={this.fetchTrails}>
                     {({ data }) => (
@@ -309,11 +313,16 @@ export class MostViewed extends Component<Props, { selectedTabIndex: number }> {
                                     key={`tabs-popular-${i}`}
                                     role="tabpanel"
                                     aria-labelledby={`tabs-popular-${i}-tab`}
+                                    data-link-name={tab.heading}
+                                    data-link-context={`most-read/${
+                                        this.props.sectionName
+                                    }`}
                                 >
                                     {(tab.trails || []).map((trail, ii) => (
                                         <li
                                             className={listItem}
                                             key={trail.url}
+                                            data-link-name={`${ii + 1} | text`}
                                         >
                                             <span className={bigNumber}>
                                                 <BigNumber index={ii + 1} />
@@ -322,6 +331,7 @@ export class MostViewed extends Component<Props, { selectedTabIndex: number }> {
                                                 <a
                                                     className={headlineLink}
                                                     href={trail.url}
+                                                    data-link-name={'article'}
                                                 >
                                                     {trail.isLiveBlog && (
                                                         <span


### PR DESCRIPTION
## What does this change?

Adds:

### Navigation Logo Tracking
✔️ 

### Most Popular Tracking

Appears as:

```
* viewId: jyyll1fxk965kec6mxdg
* clickComponent: most-popular
* clickLinkNames: ["article","2 | text","Across The&nbsp;Guardian”,”most-viewed”]

Confirmed that it also appears in referringLinkNames and referringComponentName on the next pageview.
```

## Why?

Tracking on onwards journeys going into Ophan.

## Link to supporting Trello card
https://trello.com/c/eagQlGEf/639-track-onward-journeys-in-ophan