### PR TITLE
Add missing googletag to client side config object

### DIFF
--- a/fixtures/CAPI.ts
+++ b/fixtures/CAPI.ts
@@ -445,6 +445,7 @@ export const CAPI: CAPIType = {
             'https://assets.guim.co.uk/javascripts/3d3cbc5f29df7c0cdd65/graun.dotcom-rendering-commercial.js',
         revisionNumber: '62cf0d6e4609276d37e09fd596430fbf8b629418',
         isDev: false,
+        googletagUrl: '//www.googletagservices.com/tag/js/gpt.js',
     },
     webTitle: 'Foobar',
     nav: {

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -211,6 +211,7 @@ interface ConfigType {
     commercialBundleUrl: string;
     revisionNumber: string;
     isDev: boolean;
+    googletagUrl: string;
 }
 
 interface GADataType {

--- a/packages/frontend/model/window-guardian.ts
+++ b/packages/frontend/model/window-guardian.ts
@@ -8,6 +8,9 @@ export interface WindowGuardianConfig {
         sentryPublicApiKey: string;
         keywordIds: [];
     };
+    libs: {
+        googletag: string;
+    };
     switches: { [key: string]: boolean };
 }
 
@@ -24,6 +27,9 @@ const makeWindowGuardianConfig = (
             sentryPublicApiKey: dcrDocumentData.config.sentryPublicApiKey,
             sentryHost: dcrDocumentData.config.sentryHost,
             keywordIds: [],
+        },
+        libs: {
+            googletag: dcrDocumentData.config.googletagUrl,
         },
         switches: dcrDocumentData.CAPI.config.switches,
     } as WindowGuardianConfig;

--- a/packages/frontend/web/components/ShareCount.test.tsx
+++ b/packages/frontend/web/components/ShareCount.test.tsx
@@ -28,6 +28,7 @@ describe('ShareCount', () => {
         commercialBundleUrl: '',
         revisionNumber: '',
         isDev: false,
+        googletagUrl: '',
     };
 
     afterEach(() => {


### PR DESCRIPTION
## What does this change?

Add missing googletag to client side config object. Otherwise it's preventing commercial module `prepareGoogletag` from loading.
