### PR TITLE
Introduce dfpAccountId and adUnit on the client side

### DIFF
--- a/packages/frontend/model/window-guardian.ts
+++ b/packages/frontend/model/window-guardian.ts
@@ -7,6 +7,7 @@ export interface WindowGuardianConfig {
         sentryHost: string;
         sentryPublicApiKey: string;
         keywordIds: [];
+        dfpAccountId: string;
     };
     libs: {
         googletag: string;
@@ -27,6 +28,7 @@ const makeWindowGuardianConfig = (
             sentryPublicApiKey: dcrDocumentData.config.sentryPublicApiKey,
             sentryHost: dcrDocumentData.config.sentryHost,
             keywordIds: [],
+            dfpAccountId: dcrDocumentData.config.dfpAccountId,
         },
         libs: {
             googletag: dcrDocumentData.config.googletagUrl,

--- a/packages/frontend/model/window-guardian.ts
+++ b/packages/frontend/model/window-guardian.ts
@@ -8,6 +8,7 @@ export interface WindowGuardianConfig {
         sentryPublicApiKey: string;
         keywordIds: [];
         dfpAccountId: string;
+        adUnit: string;
     };
     libs: {
         googletag: string;
@@ -29,6 +30,7 @@ const makeWindowGuardianConfig = (
             sentryHost: dcrDocumentData.config.sentryHost,
             keywordIds: [],
             dfpAccountId: dcrDocumentData.config.dfpAccountId,
+            adUnit: '/59666047/theguardian.com/film/article/ng', // Hard coded for the moment, TODO: read the value from frontend
         },
         libs: {
             googletag: dcrDocumentData.config.googletagUrl,


### PR DESCRIPTION
## What does this change?

Report `dfpAccountId` to the clientside, and introduce `adUnit`, with a hardcoded value (for the moment). Both are required for ad display. Follow up PRs will include passing the ad unit from frontend to DCR, but this is not a problem for the moment. 


