### PR TITLE
Add data-link-names across all header

### DIFF
--- a/packages/frontend/web/components/Header/Nav/EditionDropdown.tsx
+++ b/packages/frontend/web/components/Header/Nav/EditionDropdown.tsx
@@ -32,25 +32,31 @@ const editionDropdown = css`
     }
 `;
 
+const editionPickerDataLinkName = 'nav2 : topbar : edition-picker: ';
+
 const ukEditionLink: Link = {
     url: '/preference/edition/uk',
     title: 'UK edition',
     isActive: true,
+    dataLinkName: `${editionPickerDataLinkName}UK`,
 };
 
 const usEditionLink: Link = {
     url: '/preference/edition/us',
     title: 'US edition',
+    dataLinkName: `${editionPickerDataLinkName}US`,
 };
 
 const auEditionLink: Link = {
     url: '/preference/edition/au',
     title: 'Australian edition',
+    dataLinkName: `${editionPickerDataLinkName}AU`,
 };
 
 const intEditionLink: Link = {
     url: '/preference/edition/int',
     title: 'International edition',
+    dataLinkName: `${editionPickerDataLinkName}INT`,
 };
 
 const lookUpEditionLink = (edition: Edition): Link => {
@@ -65,7 +71,8 @@ const lookUpEditionLink = (edition: Edition): Link => {
 
 export const EditionDropdown: React.FC<{
     edition: Edition;
-}> = ({ edition }) => {
+    dataLinkName: string;
+}> = ({ edition, dataLinkName }) => {
     const activeEditionLink = lookUpEditionLink(edition);
     const links = [
         ukEditionLink,
@@ -80,6 +87,7 @@ export const EditionDropdown: React.FC<{
                 label={activeEditionLink.title}
                 links={links}
                 id="edition"
+                dataLinkName={dataLinkName}
             />
         </div>
     );

--- a/packages/frontend/web/components/Header/Nav/Links/Links.tsx
+++ b/packages/frontend/web/components/Header/Nav/Links/Links.tsx
@@ -217,7 +217,7 @@ export const Links: React.FC<{
                     label="My account"
                     links={identityLinks}
                     id="my-account"
-                    data-link-name="nav2 : topbar: my account"
+                    dataLinkName="nav2 : topbar: my account"
                 />
             </div>
         ) : (

--- a/packages/frontend/web/components/Header/Nav/Links/Links.tsx
+++ b/packages/frontend/web/components/Header/Nav/Links/Links.tsx
@@ -150,34 +150,42 @@ const identityLinks: DropdownLink[] = [
     {
         url: `${profileSubdomain}/user/id/123`, // TODO use actual user ID once we have a user model
         title: 'Comments and replies',
+        dataLinkName: 'nav2 : topbar : comment activity',
     },
     {
         url: `${profileSubdomain}/public/edit`,
         title: 'Public profile',
+        dataLinkName: 'nav2 : topbar : edit profile',
     },
     {
         url: `${profileSubdomain}/account/edit`,
         title: 'Account details',
+        dataLinkName: 'nav2 : topbar : account details',
     },
     {
         url: `${profileSubdomain}/email-prefs`,
         title: 'Emails and marketing',
+        dataLinkName: 'nav2 : topbar : email prefs',
     },
     {
         url: `${profileSubdomain}/membership/edit`,
         title: 'Membership',
+        dataLinkName: 'nav2 : topbar : membership',
     },
     {
         url: `${profileSubdomain}/contribution/recurring/edit`,
         title: 'Contributions',
+        dataLinkName: 'nav2 : topbar : contributions',
     },
     {
         url: `${profileSubdomain}/digitalpack/edit`,
         title: 'Digital pack',
+        dataLinkName: 'nav2 : topbar : subscriptions',
     },
     {
         url: `${profileSubdomain}/signout`,
         title: 'Sign out',
+        dataLinkName: 'nav2 : topbar : sign out',
     },
 ];
 

--- a/packages/frontend/web/components/Header/Nav/Links/Links.tsx
+++ b/packages/frontend/web/components/Header/Nav/Links/Links.tsx
@@ -105,8 +105,14 @@ const seperatorHide = css`
 const Search: React.FC<{
     href: string;
     className?: string;
-}> = ({ className, children, href, ...props }) => (
-    <a href={href} className={cx(search, className)} {...props}>
+    dataLinkName: string;
+}> = ({ className, children, href, dataLinkName, ...props }) => (
+    <a
+        href={href}
+        className={cx(search, className)}
+        {...props}
+        data-link-name={dataLinkName}
+    >
         {children}
     </a>
 );
@@ -183,6 +189,7 @@ export const Links: React.FC<{
         <a
             href={jobsUrl}
             className={cx(linkTablet({ showAtTablet: false }), link)}
+            data-link-name="nav2 : job-cta"
         >
             Search jobs
         </a>
@@ -190,6 +197,7 @@ export const Links: React.FC<{
         <a
             href={datingUrl}
             className={cx(linkTablet({ showAtTablet: false }), link)}
+            data-link-name="nav2 : soulmates-cta"
         >
             Dating
         </a>
@@ -201,10 +209,15 @@ export const Links: React.FC<{
                     label="My account"
                     links={identityLinks}
                     id="my-account"
+                    data-link-name="nav2 : topbar: my account"
                 />
             </div>
         ) : (
-            <a className={link} href={signInUrl}>
+            <a
+                className={link}
+                href={signInUrl}
+                data-link-name="nav2 : topbar : signin"
+            >
                 <ProfileIcon /> Sign in
             </a>
         )}
@@ -212,6 +225,7 @@ export const Links: React.FC<{
         <Search
             className={cx(linkTablet({ showAtTablet: false }), link)}
             href="https://www.google.co.uk/advanced_search?q=site:www.theguardian.com"
+            dataLinkName={'nav2 : search'}
         >
             <SearchIcon /> Search
         </Search>

--- a/packages/frontend/web/components/Header/Nav/MainMenu/Column.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenu/Column.tsx
@@ -81,7 +81,12 @@ const ColumnLink: React.FC<{
         })}
         role="none"
     >
-        <a className={cx(columnLinkTitle)} href={link.url} role="menuitem">
+        <a
+            className={cx(columnLinkTitle)}
+            href={link.url}
+            role="menuitem"
+            data-link-name={`nav2 : secondary : ${link.longTitle}`}
+        >
             {link.longTitle}
         </a>
     </li>

--- a/packages/frontend/web/components/Header/Nav/MainMenu/Columns.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenu/Columns.tsx
@@ -125,6 +125,9 @@ export const Columns: React.FC<{
                             href={brandExtension.url}
                             key={brandExtension.title}
                             role="menuitem"
+                            data-link-name={`nav2 : brand extension : ${
+                                brandExtension.longTitle
+                            }`}
                         >
                             {brandExtension.longTitle}
                         </a>

--- a/packages/frontend/web/components/Header/Nav/MainMenuToggle/MainMenuToggle.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenuToggle/MainMenuToggle.tsx
@@ -120,6 +120,9 @@ export class MainMenuToggle extends Component<
                     onClick={() => toggleMainMenu()}
                     aria-controls={ariaControls}
                     key="OpenMainMenuButton"
+                    data-link-name={`nav2 : veggie-burger : ${
+                        showMainMenu ? 'show' : 'hide'
+                    }`}
                 >
                     <span className={screenReadable}>Show</span>
                     <span className={text({ showMainMenu })}>More</span>

--- a/packages/frontend/web/components/Header/Nav/MainMenuToggle/VeggieBurger.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenuToggle/VeggieBurger.tsx
@@ -98,6 +98,9 @@ export const VeggieBurger: React.FC<{
                 onClick={() => toggleMainMenu()}
                 aria-controls={ariaControls}
                 aria-label="Toggle main menu"
+                data-link-name={`nav2 : veggie-burger : ${
+                    showMainMenu ? 'hide' : 'show'
+                }`}
             >
                 <span className={veggieBurgerIcon({ showMainMenu })} />
             </button>

--- a/packages/frontend/web/components/Header/Nav/Nav.tsx
+++ b/packages/frontend/web/components/Header/Nav/Nav.tsx
@@ -79,7 +79,10 @@ export class Nav extends Component<
                     role="navigation"
                     aria-label="Guardian sections"
                 >
-                    <EditionDropdown edition={edition} />
+                    <EditionDropdown
+                        edition={edition}
+                        dataLinkName={'nav2 : topbar : edition-picker: toggle'}
+                    />
                     <Logo />
                     {/*
                         TODO: The properties of the Links component
@@ -90,6 +93,7 @@ export class Nav extends Component<
                     <ReaderRevenueLinks
                         urls={nav.readerRevenueLinks.header}
                         edition={edition}
+                        dataLinkNamePrefix={'nav2 : '}
                     />
                     <Links isSignedIn={isSignedIn} />
                     <Pillars

--- a/packages/frontend/web/components/Header/Nav/Pillars.tsx
+++ b/packages/frontend/web/components/Header/Nav/Pillars.tsx
@@ -204,6 +204,7 @@ export const Pillars: React.FC<{
                         },
                     )}
                     href={p.url}
+                    data-link-name={`nav2 : primary : ${p.title}`}
                 >
                     {p.title}
                 </a>

--- a/packages/frontend/web/components/Header/Nav/ReaderRevenueLinks.test.tsx
+++ b/packages/frontend/web/components/Header/Nav/ReaderRevenueLinks.test.tsx
@@ -38,7 +38,11 @@ describe('ReaderRevenueLinks', () => {
         getCookie.mockReturnValue(contributionDate);
 
         const { container } = render(
-            <ReaderRevenueLinks urls={urls} edition={edition} />,
+            <ReaderRevenueLinks
+                urls={urls}
+                edition={edition}
+                dataLinkNamePrefix={'nav2 : '}
+            />,
         );
 
         // expect nothing to be rendered
@@ -59,7 +63,11 @@ describe('ReaderRevenueLinks', () => {
             .mockReturnValueOnce('true');
 
         const { container } = render(
-            <ReaderRevenueLinks urls={urls} edition={edition} />,
+            <ReaderRevenueLinks
+                urls={urls}
+                edition={edition}
+                dataLinkNamePrefix={'nav2 : '}
+            />,
         );
 
         // expect nothing to be rendered
@@ -81,7 +89,11 @@ describe('ReaderRevenueLinks', () => {
             .mockReturnValueOnce('false');
 
         const { container, getByText } = render(
-            <ReaderRevenueLinks urls={urls} edition={edition} />,
+            <ReaderRevenueLinks
+                urls={urls}
+                edition={edition}
+                dataLinkNamePrefix={'nav2 : '}
+            />,
         );
 
         // expect something to be rendered

--- a/packages/frontend/web/components/Header/Nav/ReaderRevenueLinks.tsx
+++ b/packages/frontend/web/components/Header/Nav/ReaderRevenueLinks.tsx
@@ -113,7 +113,8 @@ export const ReaderRevenueLinks: React.FC<{
         support: string;
         contribute: string;
     };
-}> = ({ edition, urls }) => {
+    dataLinkNamePrefix: string;
+}> = ({ edition, urls, dataLinkNamePrefix }) => {
     return (
         <AsyncClientComponent f={shouldShow}>
             {({ data }) => (
@@ -127,12 +128,14 @@ export const ReaderRevenueLinks: React.FC<{
                                 <a
                                     className={cx(link, hiddenUntilTablet)}
                                     href={urls.contribute}
+                                    data-link-name={`${dataLinkNamePrefix}contribute-cta`}
                                 >
                                     Contribute <ArrowRightIcon />
                                 </a>
                                 <a
                                     className={cx(link, hiddenUntilTablet)}
                                     href={urls.subscribe}
+                                    data-link-name={`${dataLinkNamePrefix}subscribe-cta`}
                                 >
                                     Subscribe <ArrowRightIcon />
                                 </a>
@@ -141,6 +144,7 @@ export const ReaderRevenueLinks: React.FC<{
                                         [hidden]: edition !== 'UK',
                                     })}
                                     href={urls.support}
+                                    data-link-name={`${dataLinkNamePrefix}support-cta`}
                                 >
                                     Support us <ArrowRightIcon />
                                 </a>
@@ -149,6 +153,7 @@ export const ReaderRevenueLinks: React.FC<{
                                         [hidden]: edition === 'UK',
                                     })}
                                     href={urls.contribute}
+                                    data-link-name={`${dataLinkNamePrefix}contribute-cta`}
                                 >
                                     Contribute <ArrowRightIcon />
                                 </a>

--- a/packages/frontend/web/components/Header/Nav/SubNav/Inner.tsx
+++ b/packages/frontend/web/components/Header/Nav/SubNav/Inner.tsx
@@ -158,6 +158,7 @@ export const Inner: React.FC<{
                     [selected]: link.title === currentNavLink,
                 })}
                 href={link.url}
+                data-link-name={`nav2 : subnav : ${link.title}`}
             >
                 {link.title}
             </a>

--- a/packages/guui/components/Dropdown/Dropdown.tsx
+++ b/packages/guui/components/Dropdown/Dropdown.tsx
@@ -8,12 +8,14 @@ export interface Link {
     url: string;
     title: string;
     isActive?: boolean;
+    dataLinkName: string;
 }
 
 interface Props {
     id: string;
     label: string;
     links: Link[];
+    dataLinkName: string;
 }
 
 const input = css`
@@ -233,6 +235,7 @@ export class Dropdown extends React.Component<
                         })}
                         aria-controls={dropdownID}
                         aria-expanded={this.state.isExpanded ? 'true' : 'false'}
+                        data-link-name={this.props.dataLinkName}
                     >
                         {label}
                     </button>
@@ -254,6 +257,7 @@ export class Dropdown extends React.Component<
                                     [linkActive]: !!l.isActive,
                                     [linkFirst]: index === 0,
                                 })}
+                                data-link-name={l.dataLinkName}
                             >
                                 {l.title}
                             </a>


### PR DESCRIPTION
## What does this change?
As title


![Screenshot 2019-08-08 at 15 50 13](https://user-images.githubusercontent.com/638051/62717323-99d03600-b9fb-11e9-9f0b-67dceac3e470.png)
![Screenshot 2019-08-08 at 15 50 17](https://user-images.githubusercontent.com/638051/62717324-99d03600-b9fb-11e9-9908-e3a8da374bda.png)
![Screenshot 2019-08-08 at 15 50 32](https://user-images.githubusercontent.com/638051/62717325-99d03600-b9fb-11e9-8709-e50d9d808d8e.png)
![Screenshot 2019-08-08 at 15 50 44](https://user-images.githubusercontent.com/638051/62717327-9a68cc80-b9fb-11e9-9a06-db617e8ef10b.png)
![Screenshot 2019-08-08 at 15 51 57](https://user-images.githubusercontent.com/638051/62717328-9a68cc80-b9fb-11e9-83c2-c1041d0ee0d0.png)
![Screenshot 2019-08-08 at 15 55 12](https://user-images.githubusercontent.com/638051/62717329-9a68cc80-b9fb-11e9-9d31-3b07a200f9d1.png)

Also footer

![image](https://user-images.githubusercontent.com/638051/62764438-cd57a280-ba85-11e9-885d-7144b58ef960.png)

## Why?
Ophan tracking.

## Link to supporting Trello card
https://trello.com/c/eagQlGEf/639-track-onward-journeys-in-ophan
