### PR TITLE
Add subheading to Reader Revenue component

### DIFF
--- a/packages/frontend/web/components/Header/Nav/ReaderRevenueLinks.tsx
+++ b/packages/frontend/web/components/Header/Nav/ReaderRevenueLinks.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 
-import { serif, sans } from '@guardian/pasteup/typography';
+import { serif, sans, textSans, headline } from '@guardian/pasteup/typography';
 import ArrowRightIcon from '@guardian/pasteup/icons/arrow-right.svg';
 import { palette } from '@guardian/pasteup/palette';
 import {
@@ -23,18 +23,18 @@ const message = css`
     font-size: 20px;
     font-weight: 800;
     padding-top: 3px;
-    margin-bottom: 12px;
+    margin-bottom: 3px;
 
     ${tablet} {
         display: block;
     }
 
     ${desktop} {
-        font-size: 26px;
+        ${headline(4)}
     }
 
     ${leftCol} {
-        font-size: 32px;
+        ${headline(6)}
     }
 `;
 
@@ -106,6 +106,12 @@ const readerRevenueLinks = css`
     }
 `;
 
+const subMessage = css`
+    color: ${palette.neutral[100]};
+    ${textSans(5)};
+    margin-bottom: 9px;
+`;
+
 export const ReaderRevenueLinks: React.FC<{
     edition: Edition;
     urls: {
@@ -123,6 +129,14 @@ export const ReaderRevenueLinks: React.FC<{
                             <div className={readerRevenueLinks}>
                                 <div className={message}>
                                     Support The Guardian
+                                </div>
+                                <div
+                                    className={cx(
+                                        subMessage,
+                                        hiddenUntilTablet,
+                                    )}
+                                >
+                                    Available for everyone, funded by readers
                                 </div>
                                 <a
                                     className={cx(link, hiddenUntilTablet)}

--- a/packages/frontend/web/components/elements/TextBlockComponent.tsx
+++ b/packages/frontend/web/components/elements/TextBlockComponent.tsx
@@ -3,7 +3,7 @@ import { css } from 'emotion';
 import { body } from '@guardian/pasteup/typography';
 // tslint:disable:react-no-dangerous-html
 
-const para = css`
+export const para = css`
     p {
         margin-bottom: 16px;
         ${body(2)};

--- a/packages/frontend/web/components/elements/TweetBlockComponent.tsx
+++ b/packages/frontend/web/components/elements/TweetBlockComponent.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { css } from 'emotion';
+import { body } from '@guardian/pasteup/typography';
+
+// const makeFallback = (html: string): string | null => {
+//     const { window } = new JSDOM(html);
+//     const blockquotes = window.document.getElementsByTagName('blockquote');
+
+//     if (blockquotes.length !== 1) {
+//         return null;
+//     }
+
+//     const q = blockquotes[0];
+//     return q.innerHTML;
+// };
+
+export const tweetStyle = (pillar: Pillar) => css`
+    p {
+        ${body(3)};
+    }
+`;
+
+// tslint:disable:react-no-dangerous-html
+export const TweetBlockComponent: React.FC<{
+    element: TweetBlockElement;
+    pillar: Pillar;
+}> = ({ element, pillar }) => {
+    return <div dangerouslySetInnerHTML={{ __html: element.html }} />;
+};

--- a/packages/frontend/web/components/lib/ArticleRenderer.tsx
+++ b/packages/frontend/web/components/lib/ArticleRenderer.tsx
@@ -1,5 +1,6 @@
 import { TextBlockComponent } from '@frontend/web/components/elements/TextBlockComponent';
 import { ImageBlockComponent } from '@frontend/web/components/elements/ImageBlockComponent';
+import { TweetBlockComponent } from '@frontend/web/components/elements/TweetBlockComponent';
 import React from 'react';
 // import { clean } from '@frontend/model/clean';
 export const ArticleRenderer: React.FC<{
@@ -20,6 +21,14 @@ export const ArticleRenderer: React.FC<{
                 case 'model.dotcomrendering.pageElements.ImageBlockElement':
                     return (
                         <ImageBlockComponent
+                            key={i}
+                            element={element}
+                            pillar={pillar}
+                        />
+                    );
+                case 'model.dotcomrendering.pageElements.TweetBlockElement':
+                    return (
+                        <TweetBlockComponent
                             key={i}
                             element={element}
                             pillar={pillar}


### PR DESCRIPTION
## What does this change?
Brings the header component up to date with dotcom

DCR
![Screen Shot 2019-08-09 at 11 38 46](https://user-images.githubusercontent.com/2051501/62773845-27169780-ba9b-11e9-88f3-344316cdb40c.png)

Dotcom
![Screen Shot 2019-08-09 at 11 39 16](https://user-images.githubusercontent.com/2051501/62773846-27af2e00-ba9b-11e9-99bc-f7c8aaf9f791.png)

## Why?
Visual parity before we can go live


## Link to supporting Trello card
https://trello.com/c/ziOVEKjf