### PR TITLE
Reader revenue header update

### DIFF
--- a/packages/frontend/web/components/Header/Nav/ReaderRevenueLinks.tsx
+++ b/packages/frontend/web/components/Header/Nav/ReaderRevenueLinks.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 
-import { serif, sans } from '@guardian/pasteup/typography';
+import { serif, sans, textSans, headline } from '@guardian/pasteup/typography';
 import ArrowRightIcon from '@guardian/pasteup/icons/arrow-right.svg';
 import { palette } from '@guardian/pasteup/palette';
 import {
@@ -23,18 +23,18 @@ const message = css`
     font-size: 20px;
     font-weight: 800;
     padding-top: 3px;
-    margin-bottom: 12px;
+    margin-bottom: 3px;
 
     ${tablet} {
         display: block;
     }
 
     ${desktop} {
-        font-size: 26px;
+        ${headline(4)}
     }
 
     ${leftCol} {
-        font-size: 32px;
+        ${headline(6)}
     }
 `;
 
@@ -106,6 +106,12 @@ const readerRevenueLinks = css`
     }
 `;
 
+const subMessage = css`
+    color: ${palette.neutral[100]};
+    ${textSans(5)};
+    margin-bottom: 9px;
+`;
+
 export const ReaderRevenueLinks: React.FC<{
     edition: Edition;
     urls: {
@@ -123,6 +129,14 @@ export const ReaderRevenueLinks: React.FC<{
                             <div className={readerRevenueLinks}>
                                 <div className={message}>
                                     Support The Guardian
+                                </div>
+                                <div
+                                    className={cx(
+                                        subMessage,
+                                        hiddenUntilTablet,
+                                    )}
+                                >
+                                    Available for everyone, funded by readers
                                 </div>
                                 <a
                                     className={cx(link, hiddenUntilTablet)}


### PR DESCRIPTION
## What does this change?
Brings the header component up to date with dotcom

DCR
![Screen Shot 2019-08-09 at 11 38 46](https://user-images.githubusercontent.com/2051501/62773845-27169780-ba9b-11e9-88f3-344316cdb40c.png)

Dotcom
![Screen Shot 2019-08-09 at 11 39 16](https://user-images.githubusercontent.com/2051501/62773846-27af2e00-ba9b-11e9-99bc-f7c8aaf9f791.png)

## Why?
Visual parity before we can go live


## Link to supporting Trello card
https://trello.com/c/ziOVEKjf