### PR TITLE
Introduce component AdSlot

### DIFF
--- a/packages/frontend/web/components/AdSlot.test.tsx
+++ b/packages/frontend/web/components/AdSlot.test.tsx
@@ -1,0 +1,24 @@
+// tslint:disable:react-no-dangerous-html
+
+import { makeInternalSizeMappings, makeClassNames } from './AdSlot';
+
+describe('AdSlot', () => {
+    it('It should compute the internal size mappings correctly', () => {
+        const inputSizeMappings = {
+            mobile: ['1,1|2,2|300,250|300,274|300,600|fluid|300,1050'],
+        };
+        expect(
+            makeInternalSizeMappings(inputSizeMappings).mobile ===
+                '1,1|2,2|300,250|300,274|300,600|fluid|300,1050',
+        );
+    });
+    it('It should compute class names correctly', () => {
+        const name = 'right';
+        const adTypes = ['mpu-banner-ad', 'rendered'];
+        const optClassNames = ['js-sticky-mpu'];
+        expect(
+            makeClassNames(name, adTypes, optClassNames) ===
+                'js-ad-slot ad-slot ad-slot--right ad-slot--mpu-banner-ad ad-slot--rendered js-sticky-mpu ad-slot--gc',
+        );
+    });
+});

--- a/packages/frontend/web/components/AdSlot.tsx
+++ b/packages/frontend/web/components/AdSlot.tsx
@@ -2,12 +2,40 @@
 
 import React from 'react';
 
+export interface AdSlotInputSizeMappings {
+    [key: string]: string[];
+}
+
+export interface AdSlotInternalSizeMappings {
+    [key: string]: string;
+}
+
+export const makeInternalSizeMappings = (
+    inputSizeMapping: AdSlotInputSizeMappings,
+): AdSlotInternalSizeMappings => {
+    return Object.keys(inputSizeMapping).reduce(
+        (m: { [key: string]: string }, key) => {
+            m[`data-${key}`] = inputSizeMapping[key].join('|');
+            return m;
+        },
+        {},
+    );
+};
+
+export const makeClassNames = (
+    name: string,
+    adTypes: string[],
+    optClassNames: string[],
+): string => {
+    const baseClassNames = ['js-ad-slot', 'ad-slot', `ad-slot--${name}`];
+    const adTypeClassNames = adTypes.map(adType => `ad-slot--${adType}`);
+    return baseClassNames.concat(adTypeClassNames, optClassNames).join(' ');
+};
+
 export const AdSlot: React.FC<{
     name: string;
     adTypes: string[];
-    sizeMapping: {
-        [key: string]: string[];
-    };
+    sizeMapping: AdSlotInputSizeMappings;
     showLabel?: boolean;
     refresh?: boolean;
     outOfPage?: boolean;
@@ -23,43 +51,22 @@ export const AdSlot: React.FC<{
     optId,
     optClassNames,
 }) => {
-    const dataSizeMappings = Object.keys(sizeMapping).reduce(
-        (
-            mappings: {
-                [key: string]: string;
-            },
-            key,
-        ) => {
-            mappings[`data-${key}`] = sizeMapping[key].join('|');
-
-            return mappings;
-        },
-        {},
-    );
-
-    const getClassNames = (): string => {
-        const baseClassNames = ['js-ad-slot', 'ad-slot', `ad-slot--${name}`];
-        const adTypeClassNames = adTypes.map(adType => `ad-slot--${adType}`);
-
-        return baseClassNames
-            .concat(adTypeClassNames, optClassNames || [])
-            .join(' ');
-    };
-
+    // Will export `getOptionalProps` as a function if/when needed - Pascal.
     // const getOptionalProps = (): object => ({
     //     ...(showLabel && { 'data-label': true }),
     //     ...(refresh && { 'data-refresh': true }),
     //     ...(outOfPage && { 'data-out-of-page': true }),
     // });
 
+    const sizeMappings = makeInternalSizeMappings(sizeMapping);
     return (
         <div
             id={`dfp-ad--${optId || name}`}
-            className={getClassNames()}
+            className={makeClassNames(name, adTypes, optClassNames || [])}
             data-link-name={`ad slot ${name}`}
             data-name={name}
             // {...getOptionalProps()}
-            {...dataSizeMappings}
+            {...sizeMappings}
             aria-hidden="true"
         />
     );

--- a/packages/frontend/web/components/AdSlot.tsx
+++ b/packages/frontend/web/components/AdSlot.tsx
@@ -1,0 +1,66 @@
+// tslint:disable:react-no-dangerous-html
+
+import React from 'react';
+
+export const AdSlot: React.FC<{
+    name: string;
+    adTypes: string[];
+    sizeMapping: {
+        [key: string]: string[];
+    };
+    showLabel?: boolean;
+    refresh?: boolean;
+    outOfPage?: boolean;
+    optId?: string;
+    optClassNames?: string[];
+}> = ({
+    name,
+    adTypes,
+    sizeMapping,
+    showLabel = true,
+    refresh = true,
+    outOfPage = false,
+    optId,
+    optClassNames,
+}) => {
+    const dataSizeMappings = Object.keys(sizeMapping).reduce(
+        (
+            mappings: {
+                [key: string]: string;
+            },
+            key,
+        ) => {
+            mappings[`data-${key}`] = sizeMapping[key].join('|');
+
+            return mappings;
+        },
+        {},
+    );
+
+    const getClassNames = (): string => {
+        const baseClassNames = ['js-ad-slot', 'ad-slot', `ad-slot--${name}`];
+        const adTypeClassNames = adTypes.map(adType => `ad-slot--${adType}`);
+
+        return baseClassNames
+            .concat(adTypeClassNames, optClassNames || [])
+            .join(' ');
+    };
+
+    // const getOptionalProps = (): object => ({
+    //     ...(showLabel && { 'data-label': true }),
+    //     ...(refresh && { 'data-refresh': true }),
+    //     ...(outOfPage && { 'data-out-of-page': true }),
+    // });
+
+    return (
+        <div
+            id={`dfp-ad--${optId || name}`}
+            className={getClassNames()}
+            data-link-name={`ad slot ${name}`}
+            data-name={name}
+            // {...getOptionalProps()}
+            {...dataSizeMappings}
+            aria-hidden="true"
+        />
+    );
+};


### PR DESCRIPTION
## What does this change?

This PR simply introduces the AdSlot component that was made by @GHaberis 

We tested with on local with the following code

```
import React from 'react';
import { Container } from '@guardian/guui';
import { css, cx } from 'emotion';
import { palette } from '@guardian/pasteup/palette';
import { desktop, mobileLandscape } from '@guardian/pasteup/breakpoints';
import { MostViewed } from '@frontend/web/components/MostViewed';
import { Header } from '@frontend/web/components/Header/Header';
import { Footer } from '@frontend/web/components/Footer';
import { ArticleBody } from '@frontend/web/components/ArticleBody';
import { BackToTop } from '@frontend/web/components/BackToTop';
import { SubNav } from '@frontend/web/components/Header/Nav/SubNav/SubNav';
import { CookieBanner } from '@frontend/web/components/CookieBanner';
import { AdSlot } from '@frontend//web/components/AdSlot';

// TODO: find a better of setting opacity
const secondaryColumn = css`
    position: absolute;
    top: 0;
    right: 0;
    margin-right: 20px;
    width: 300px;
    margin-left: 20px;
    margin-top: 6px;

    min-height: 300px;
    display: none;

    ${desktop} {
        display: block;
    }
`;

const articleContainer = css`
    position: relative;
    background-color: ${palette.neutral[100]};
    padding: 0 10px;

    ${mobileLandscape} {
        padding: 0 20px;
    }
`;

interface AdSlotParameters {
    name: string;
    adTypes: string[];
    sizeMapping: {
        [key: string]: string[];
    };
    showLabel?: boolean;
    refresh?: boolean;
    outOfPage?: boolean;
    optId?: string;
    optClassNames?: string[];
}

export const Article: React.FC<{
    data: ArticleProps;
}> = ({ data }) => {
    // The current parameters have been taken from looking at an example of right MPU on an article.
    // regular article: js-ad-slot ad-slot ad-slot--right ad-slot--mpu-banner-ad js-sticky-mpu ad-slot--rendered
    // dotcom rendering: js-ad-slot ad-slot ad-slot--right ad-slot--mpu-banner-ad ad-slot--rendered js-sticky-mpu
    const adSlotParameters: AdSlotParameters = {
        name: 'right',
        adTypes: ['mpu-banner-ad', 'rendered'],
        sizeMapping: {
            mobile: ['1,1|2,2|300,250|300,274|300,600|fluid|300,1050'],
        },
        showLabel: true,
        refresh: false,
        outOfPage: false,
        optId: undefined,
        optClassNames: ['js-sticky-mpu'],
    };
    return (
        <div>
            <Header
                nav={data.NAV}
                pillar={data.CAPI.pillar}
                edition={data.CAPI.editionId}
            />
            <main>
                <Container borders={true} className={articleContainer}>
                    <article>
                        <ArticleBody CAPI={data.CAPI} config={data.config} />
                        <div className={secondaryColumn}>
                            <AdSlot
                                name={adSlotParameters.name}
                                adTypes={adSlotParameters.adTypes}
                                sizeMapping={adSlotParameters.sizeMapping}
                                showLabel={adSlotParameters.showLabel}
                                refresh={adSlotParameters.refresh}
                                outOfPage={adSlotParameters.outOfPage}
                                optId={adSlotParameters.optId}
                                optClassNames={adSlotParameters.optClassNames}
                            />
                        </div>
                    </article>
                </Container>
                <Container
                    borders={true}
                    className={cx(
                        articleContainer,
                        css`
                            border-top: 1px solid ${palette.neutral[86]};
                        `,
                    )}
                >
                    <MostViewed sectionName={data.CAPI.sectionName} />
                </Container>
            </main>
            <SubNav
                subnav={data.NAV.subNavSections}
                pillar={data.CAPI.pillar}
                currentNavLink={data.NAV.currentNavLink}
            />
            <BackToTop />
            <Footer />
            <CookieBanner />
        </div>
    );
};

```