### PR TITLE
AB test config

### DIFF
--- a/fixtures/CAPI.ts
+++ b/fixtures/CAPI.ts
@@ -440,6 +440,7 @@ export const CAPI: CAPIType = {
         sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
         sentryHost: 'app.getsentry.com/35463',
         switches: {},
+        abTests: {},
         dfpAccountId: '',
         commercialBundleUrl:
             'https://assets.guim.co.uk/javascripts/3d3cbc5f29df7c0cdd65/graun.dotcom-rendering-commercial.js',

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -208,10 +208,11 @@ interface ConfigType {
     sentryPublicApiKey: string;
     sentryHost: string;
     switches: { [key: string]: boolean };
+    abTests: { [key: string]: string };
     dfpAccountId: string;
     commercialBundleUrl: string;
     revisionNumber: string;
-    isDev: boolean;
+    isDev?: boolean;
     googletagUrl: string;
 }
 

--- a/packages/frontend/model/json-schema.json
+++ b/packages/frontend/model/json-schema.json
@@ -10,9 +10,6 @@
         "webTitle": {
             "type": "string"
         },
-        "showBottomSocialButtons": {
-            "type": "boolean"
-        },
         "mainMediaElements": {
             "type": "array",
             "items": {
@@ -188,6 +185,9 @@
         "designType": {
             "$ref": "#/definitions/DesignType"
         },
+        "showBottomSocialButtons": {
+            "type": "boolean"
+        },
         "guardianBaseURL": {
             "type": "string"
         },
@@ -243,6 +243,7 @@
         "sectionLabel",
         "sectionUrl",
         "shouldHideAds",
+        "showBottomSocialButtons",
         "standfirst",
         "subMetaKeywordLinks",
         "subMetaSectionLinks",
@@ -251,8 +252,7 @@
         "webPublicationDate",
         "webPublicationDateDisplay",
         "webTitle",
-        "webURL",
-        "showBottomSocialButtons"
+        "webURL"
     ],
     "definitions": {
         "TextBlockElement": {
@@ -268,7 +268,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "html"]
+            "required": [
+                "_type",
+                "html"
+            ]
         },
         "SubheadingBlockElement": {
             "type": "object",
@@ -283,7 +286,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "html"]
+            "required": [
+                "_type",
+                "html"
+            ]
         },
         "RichLinkBlockElement": {
             "type": "object",
@@ -304,7 +310,12 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "prefix", "text", "url"]
+            "required": [
+                "_type",
+                "prefix",
+                "text",
+                "url"
+            ]
         },
         "ImageBlockElement": {
             "type": "object",
@@ -325,7 +336,9 @@
                             }
                         }
                     },
-                    "required": ["allImages"]
+                    "required": [
+                        "allImages"
+                    ]
                 },
                 "data": {
                     "type": "object",
@@ -357,7 +370,13 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "data", "imageSources", "media", "role"]
+            "required": [
+                "_type",
+                "data",
+                "imageSources",
+                "media",
+                "role"
+            ]
         },
         "Image": {
             "type": "object",
@@ -378,7 +397,10 @@
                             "type": "string"
                         }
                     },
-                    "required": ["height", "width"]
+                    "required": [
+                        "height",
+                        "width"
+                    ]
                 },
                 "mediaType": {
                     "type": "string"
@@ -390,7 +412,13 @@
                     "type": "string"
                 }
             },
-            "required": ["fields", "index", "mediaType", "mimeType", "url"]
+            "required": [
+                "fields",
+                "index",
+                "mediaType",
+                "mimeType",
+                "url"
+            ]
         },
         "ImageSource": {
             "type": "object",
@@ -405,7 +433,10 @@
                     }
                 }
             },
-            "required": ["srcSet", "weighting"]
+            "required": [
+                "srcSet",
+                "weighting"
+            ]
         },
         "Weighting": {
             "enum": [
@@ -428,7 +459,10 @@
                     "type": "number"
                 }
             },
-            "required": ["src", "width"]
+            "required": [
+                "src",
+                "width"
+            ]
         },
         "YoutubeBlockElement": {
             "type": "object",
@@ -452,7 +486,12 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "assetId", "id", "mediaTitle"]
+            "required": [
+                "_type",
+                "assetId",
+                "id",
+                "mediaTitle"
+            ]
         },
         "VideoYoutube": {
             "type": "object",
@@ -476,7 +515,13 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "caption", "height", "url", "width"]
+            "required": [
+                "_type",
+                "caption",
+                "height",
+                "url",
+                "width"
+            ]
         },
         "VideoVimeo": {
             "type": "object",
@@ -500,7 +545,13 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "caption", "height", "url", "width"]
+            "required": [
+                "_type",
+                "caption",
+                "height",
+                "url",
+                "width"
+            ]
         },
         "VideoFacebook": {
             "type": "object",
@@ -524,7 +575,13 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "caption", "height", "url", "width"]
+            "required": [
+                "_type",
+                "caption",
+                "height",
+                "url",
+                "width"
+            ]
         },
         "VideoGuardian": {
             "type": "object",
@@ -545,7 +602,11 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "assets", "caption"]
+            "required": [
+                "_type",
+                "assets",
+                "caption"
+            ]
         },
         "VideoAssets": {
             "type": "object",
@@ -557,7 +618,10 @@
                     "type": "string"
                 }
             },
-            "required": ["mimeType", "url"]
+            "required": [
+                "mimeType",
+                "url"
+            ]
         },
         "InstagramBlockElement": {
             "type": "object",
@@ -578,7 +642,12 @@
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "hasCaption", "html", "url"]
+            "required": [
+                "_type",
+                "hasCaption",
+                "html",
+                "url"
+            ]
         },
         "TweetBlockElement": {
             "type": "object",
@@ -602,7 +671,13 @@
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "hasMedia", "html", "id", "url"]
+            "required": [
+                "_type",
+                "hasMedia",
+                "html",
+                "id",
+                "url"
+            ]
         },
         "CommentBlockElement": {
             "type": "object",
@@ -664,7 +739,13 @@
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "html", "id", "isMandatory", "isTrack"]
+            "required": [
+                "_type",
+                "html",
+                "id",
+                "isMandatory",
+                "isTrack"
+            ]
         },
         "EmbedBlockElement": {
             "type": "object",
@@ -688,7 +769,11 @@
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "html", "isMandatory"]
+            "required": [
+                "_type",
+                "html",
+                "isMandatory"
+            ]
         },
         "DisclaimerBlockElement": {
             "type": "object",
@@ -703,7 +788,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "html"]
+            "required": [
+                "_type",
+                "html"
+            ]
         },
         "PullquoteBlockElement": {
             "type": "object",
@@ -721,7 +809,11 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "html", "role"]
+            "required": [
+                "_type",
+                "html",
+                "role"
+            ]
         },
         "QABlockElement": {
             "type": "object",
@@ -748,7 +840,13 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "credit", "html", "id", "title"]
+            "required": [
+                "_type",
+                "credit",
+                "html",
+                "id",
+                "title"
+            ]
         },
         "GuideBlockElement": {
             "type": "object",
@@ -778,7 +876,14 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "credit", "html", "id", "label", "title"]
+            "required": [
+                "_type",
+                "credit",
+                "html",
+                "id",
+                "label",
+                "title"
+            ]
         },
         "ProfileBlockElement": {
             "type": "object",
@@ -808,7 +913,14 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "credit", "html", "id", "label", "title"]
+            "required": [
+                "_type",
+                "credit",
+                "html",
+                "id",
+                "label",
+                "title"
+            ]
         },
         "TimelineBlockElement": {
             "type": "object",
@@ -835,7 +947,12 @@
                     }
                 }
             },
-            "required": ["_type", "events", "id", "title"]
+            "required": [
+                "_type",
+                "events",
+                "id",
+                "title"
+            ]
         },
         "TimelineEvent": {
             "type": "object",
@@ -853,7 +970,10 @@
                     "type": "string"
                 }
             },
-            "required": ["date", "title"]
+            "required": [
+                "date",
+                "title"
+            ]
         },
         "InteractiveMarkupBlockElement": {
             "type": "object",
@@ -877,7 +997,9 @@
                     "type": "string"
                 }
             },
-            "required": ["_type"]
+            "required": [
+                "_type"
+            ]
         },
         "InteractiveUrlElement": {
             "type": "object",
@@ -892,7 +1014,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "url"]
+            "required": [
+                "_type",
+                "url"
+            ]
         },
         "MapBlockElement": {
             "type": "object",
@@ -972,7 +1097,9 @@
                     ]
                 }
             },
-            "required": ["_type"]
+            "required": [
+                "_type"
+            ]
         },
         "VideoBlockElement": {
             "type": "object",
@@ -984,7 +1111,9 @@
                     ]
                 }
             },
-            "required": ["_type"]
+            "required": [
+                "_type"
+            ]
         },
         "Block": {
             "type": "object",
@@ -1096,7 +1225,10 @@
                     "type": "string"
                 }
             },
-            "required": ["elements", "id"]
+            "required": [
+                "elements",
+                "id"
+            ]
         },
         "Pagination": {
             "type": "object",
@@ -1120,7 +1252,10 @@
                     "type": "string"
                 }
             },
-            "required": ["currentPage", "totalPages"]
+            "required": [
+                "currentPage",
+                "totalPages"
+            ]
         },
         "AuthorType": {
             "type": "object",
@@ -1135,10 +1270,17 @@
                     "type": "string"
                 }
             },
-            "required": ["byline"]
+            "required": [
+                "byline"
+            ]
         },
         "Edition": {
-            "enum": ["AU", "INT", "UK", "US"],
+            "enum": [
+                "AU",
+                "INT",
+                "UK",
+                "US"
+            ],
             "type": "string"
         },
         "TagType": {
@@ -1163,7 +1305,11 @@
                     "type": "string"
                 }
             },
-            "required": ["id", "title", "type"]
+            "required": [
+                "id",
+                "title",
+                "type"
+            ]
         },
         "Pillar": {
             "enum": [
@@ -1186,7 +1332,10 @@
                     "type": "string"
                 }
             },
-            "required": ["title", "url"]
+            "required": [
+                "title",
+                "url"
+            ]
         },
         "ConfigType": {
             "description": "the config model will contain useful app/site\nlevel data. Although currently derived from the config model\nconstructed in frontend and passed to dotcom-rendering\nthis data could eventually be defined in dotcom-rendering",
@@ -1207,17 +1356,35 @@
                         "type": "boolean"
                     }
                 },
+                "abTests": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
                 "dfpAccountId": {
                     "type": "string"
                 },
                 "commercialBundleUrl": {
                     "type": "string"
+                },
+                "revisionNumber": {
+                    "type": "string"
+                },
+                "isDev": {
+                    "type": "boolean"
+                },
+                "googletagUrl": {
+                    "type": "string"
                 }
             },
             "required": [
+                "abTests",
                 "ajaxUrl",
                 "commercialBundleUrl",
                 "dfpAccountId",
+                "googletagUrl",
+                "revisionNumber",
                 "sentryHost",
                 "sentryPublicApiKey",
                 "switches"
@@ -1260,7 +1427,12 @@
                     "$ref": "#/definitions/EditionCommercialProperties"
                 }
             },
-            "required": ["AU", "INT", "UK", "US"]
+            "required": [
+                "AU",
+                "INT",
+                "UK",
+                "US"
+            ]
         },
         "EditionCommercialProperties": {
             "type": "object",
@@ -1275,7 +1447,9 @@
                     "$ref": "#/definitions/Branding"
                 }
             },
-            "required": ["adTargeting"]
+            "required": [
+                "adTargeting"
+            ]
         },
         "AdTargetParam": {
             "type": "object",
@@ -1297,7 +1471,10 @@
                     ]
                 }
             },
-            "required": ["name", "value"]
+            "required": [
+                "name",
+                "value"
+            ]
         },
         "Branding": {
             "type": "object",
@@ -1327,16 +1504,28 @@
                                     "type": "number"
                                 }
                             },
-                            "required": ["height", "width"]
+                            "required": [
+                                "height",
+                                "width"
+                            ]
                         }
                     },
-                    "required": ["dimensions", "label", "link", "src"]
+                    "required": [
+                        "dimensions",
+                        "label",
+                        "link",
+                        "src"
+                    ]
                 },
                 "aboutThisLink": {
                     "type": "string"
                 }
             },
-            "required": ["aboutThisLink", "logo", "sponsorName"]
+            "required": [
+                "aboutThisLink",
+                "logo",
+                "sponsorName"
+            ]
         }
     },
     "$schema": "http://json-schema.org/draft-07/schema#"

--- a/packages/frontend/model/window-guardian.ts
+++ b/packages/frontend/model/window-guardian.ts
@@ -14,6 +14,7 @@ export interface WindowGuardianConfig {
         googletag: string;
     };
     switches: { [key: string]: boolean };
+    tests?: { [key: string]: string };
 }
 
 const makeWindowGuardianConfig = (
@@ -36,6 +37,7 @@ const makeWindowGuardianConfig = (
             googletag: dcrDocumentData.config.googletagUrl,
         },
         switches: dcrDocumentData.CAPI.config.switches,
+        tests: dcrDocumentData.CAPI.config.abTests || {},
     } as WindowGuardianConfig;
 };
 

--- a/packages/frontend/web/components/ShareCount.test.tsx
+++ b/packages/frontend/web/components/ShareCount.test.tsx
@@ -24,6 +24,7 @@ describe('ShareCount', () => {
         sentryHost: '',
         sentryPublicApiKey: '',
         switches: {},
+        abTests: {},
         dfpAccountId: '',
         commercialBundleUrl: '',
         revisionNumber: '',

--- a/packages/frontend/web/server/htmlTemplate.ts
+++ b/packages/frontend/web/server/htmlTemplate.ts
@@ -63,8 +63,10 @@ export const htmlTemplate = ({
                 ${ampLink ? `<link rel="amphtml" href="${ampLink}">` : ''}
 
                 <style>${getFontsCss()}${resetCSS}${css}</style>
+
                 <script>
                 window.guardian = ${JSON.stringify(windowGuardian)};
+
                 // this is a global that's called at the bottom of the pf.io response,
                 // once the polyfills have run. This may be useful for debugging.
                 // mainly to support browsers that don't support async=false or defer


### PR DESCRIPTION
## What does this change?

Adds test info to the client-side config to be read by the Ophan tracker. See also this related Scala change: https://github.com/guardian/frontend/pull/21726.

## Why?

To ensure our A/B test tracking works.

## Link to supporting Trello card

https://trello.com/c/ETBKHfia
