### PR TITLE
Make abTests property optional

### DIFF
--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -208,7 +208,7 @@ interface ConfigType {
     sentryPublicApiKey: string;
     sentryHost: string;
     switches: { [key: string]: boolean };
-    abTests: { [key: string]: string };
+    abTests?: { [key: string]: string };
     dfpAccountId: string;
     commercialBundleUrl: string;
     revisionNumber: string;

--- a/packages/frontend/model/json-schema.json
+++ b/packages/frontend/model/json-schema.json
@@ -1379,7 +1379,6 @@
                 }
             },
             "required": [
-                "abTests",
                 "ajaxUrl",
                 "commercialBundleUrl",
                 "dfpAccountId",


### PR DESCRIPTION
## What does this change?

This property should be optional.

## Why?

To decouple deploy from Frontend and reduce client burden when building model.