### PR TITLE
Record (Ophan) server-side experiment variants

### DIFF
--- a/packages/frontend/web/browser/ophan.test.ts
+++ b/packages/frontend/web/browser/ophan.test.ts
@@ -1,0 +1,18 @@
+import { abTestPayload } from './ophan';
+
+describe('abTestPayload', () => {
+    test('constructs payload correctly from config test data', () => {
+        const tests = {
+            MyTest: 'variant',
+        };
+
+        const actual = abTestPayload(tests);
+        const expected = {
+            abTestRegister: {
+                abMyTest: { variantName: 'variant', complete: false },
+            },
+        };
+
+        expect(actual).toEqual(expected);
+    });
+});

--- a/packages/frontend/web/browser/ophan.ts
+++ b/packages/frontend/web/browser/ophan.ts
@@ -1,3 +1,12 @@
+interface ABTestRecord {
+    variantName: string;
+    complete: string | boolean;
+}
+
+interface ABTestPayload {
+    abTestRegister: { [key: string]: ABTestRecord };
+}
+
 export const sendOphanPlatformRecord = () => {
     if (
         window.guardian &&
@@ -5,7 +14,27 @@ export const sendOphanPlatformRecord = () => {
         window.guardian.ophan.record
     ) {
         window.guardian.ophan.record({ platformVariant: 'dotcom-rendering' });
+
+        // Record server-side AB test variants (i.e. control or variant)
+        if (window.guardian.config.tests) {
+            const tests = window.guardian.config.tests;
+            window.guardian.ophan.record(abTestPayload(tests));
+        }
     } else {
         throw new Error("window.guardian.ophan.record doesn't exist");
     }
+};
+
+export const abTestPayload = (tests: {
+    [key: string]: string;
+}): ABTestPayload => {
+    const records: { [key: string]: ABTestRecord } = {};
+    Object.keys(tests).forEach(testName => {
+        records[`ab${testName}`] = {
+            variantName: tests[testName],
+            complete: false,
+        };
+    });
+
+    return { abTestRegister: records };
 };


### PR DESCRIPTION
## What does this change?

Sends tracking events to indicate which variant request is in for server-side AB tests.

## Why?

So that we can compare test variants in the Data Lake (in particular our beta DCR views vs regular site ones).

## Link to supporting Trello card

https://trello.com/c/ETBKHfia/627-a-b-test-for-audience-segmentation

![Screenshot 2019-08-13 at 16 40 31](https://user-images.githubusercontent.com/858402/62955706-6d485f80-bde9-11e9-91b7-bf6604afbd6c.png)

