### PR TITLE
Footer reader revenue links

### DIFF
--- a/packages/frontend/web/components/Footer.tsx
+++ b/packages/frontend/web/components/Footer.tsx
@@ -7,6 +7,7 @@ import {
     until,
     wide,
     desktop,
+    from,
 } from '@guardian/pasteup/breakpoints';
 import { textSans } from '@guardian/pasteup/typography';
 
@@ -127,8 +128,12 @@ const readerRevenueLinks = css`
         border-top: 1px solid ${palette.brand.pastel};
     }
 
-    ${tablet} {
+    ${from.tablet.until.desktop} {
         width: 218px;
+    }
+
+    ${from.desktop.until.leftCol} {
+        width: 458px;
     }
 `;
 

--- a/packages/frontend/web/components/Footer.tsx
+++ b/packages/frontend/web/components/Footer.tsx
@@ -51,7 +51,7 @@ const emailSignup = css`
 
     ${leftCol} {
         float: left;
-        width: 300px;
+        width: 258px;
         margin-right: 180px;
     }
 
@@ -78,7 +78,12 @@ const footerList = css`
     display: flex;
     flex-wrap: wrap;
     flex-direction: row;
-    border-top: 1px solid ${palette.brand.pastel};
+    justify-content: flex-end;
+    width: 100%;
+
+    ${until.leftCol} {
+        border-top: 1px solid ${palette.brand.pastel};
+    }
 
     ul {
         width: 50%;
@@ -110,7 +115,7 @@ const footerList = css`
 
         ${tablet} {
             margin: 0 10px 36px 0;
-            flex: 1 0 0;
+            width: 150px;
         }
 
         padding: 12px 0 0 10px;
@@ -120,11 +125,10 @@ const footerList = css`
 const readerRevenueLinks = css`
     border-left: 1px solid ${palette.brand.pastel};
     padding: 12px 0 0 10px;
-    margin: 0 10px 36px 0;
-
-    width: calc(50% - 10px);
+    margin: 0 0 36px 0;
 
     ${until.tablet} {
+        width: 50%;
         border-top: 1px solid ${palette.brand.pastel};
     }
 
@@ -134,6 +138,10 @@ const readerRevenueLinks = css`
 
     ${from.desktop.until.leftCol} {
         width: 458px;
+    }
+
+    ${leftCol} {
+        width: 300px;
     }
 `;
 
@@ -164,8 +172,10 @@ const copyright = css`
 const footerItemContainers = css`
     ${leftCol} {
         display: flex;
+        border-top: 1px solid ${palette.brand.pastel};
     }
 
+    width: 100%;
     padding: 0 19px;
 `;
 

--- a/packages/frontend/web/components/Footer.tsx
+++ b/packages/frontend/web/components/Footer.tsx
@@ -1,11 +1,18 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 
-import { leftCol, tablet, until } from '@guardian/pasteup/breakpoints';
+import {
+    leftCol,
+    tablet,
+    until,
+    wide,
+    desktop,
+} from '@guardian/pasteup/breakpoints';
 import { textSans } from '@guardian/pasteup/typography';
 
 import { Container } from '@guardian/guui';
 import { palette } from '@guardian/pasteup/palette';
+import { ReaderRevenueLinks } from './Header/Nav/ReaderRevenueLinks';
 
 const footer = css`
     background-color: ${palette.brand.main};
@@ -14,7 +21,27 @@ const footer = css`
 `;
 
 const footerInner = css`
+    margin: auto;
+
+    ${tablet} {
+        max-width: 740px;
+    }
+
+    ${desktop} {
+        max-width: 980px;
+    }
+
+    ${leftCol} {
+        max-width: 1140px;
+    }
+
+    ${wide} {
+        max-width: 1300px;
+    }
     padding-bottom: 6px;
+    display: block;
+    border: 0.0625rem solid ${palette.brand.pastel};
+    border-top: 0;
 `;
 
 const emailSignup = css`
@@ -24,6 +51,12 @@ const emailSignup = css`
         float: left;
         width: 300px;
         margin-right: 180px;
+    }
+
+    ${desktop} {
+        margin: 0 10px;
+        display: flex;
+        flex-direction: row;
     }
 `;
 
@@ -54,6 +87,8 @@ const footerList = css`
         border-left: 1px solid ${palette.brand.pastel};
 
         ${until.tablet} {
+            clear: left;
+
             :nth-of-type(odd) {
                 border-left: 0px;
                 padding-left: 0px;
@@ -84,11 +119,39 @@ const footerList = css`
     }
 `;
 
+const readerRevenueLinks = css`
+    border-left: 1px solid ${palette.brand.pastel};
+    padding: 12px 0 0 10px;
+    margin: 0 10px 36px 0;
+`;
+
 const copyright = css`
     ${textSans(1)};
-    padding: 6px 0 18px;
-    border-top: 1px solid ${palette.brand.pastel};
-    margin-top: 12px;
+    padding: 0 19px;
+    margin: 12px auto 0;
+
+    ${tablet} {
+        max-width: 740px;
+    }
+
+    ${desktop} {
+        max-width: 980px;
+    }
+
+    ${leftCol} {
+        max-width: 1140px;
+    }
+
+    ${wide} {
+        max-width: 1300px;
+    }
+
+    display: block;
+`;
+
+const footerItemContainers = css`
+    display: flex;
+    padding: 0 19px;
 `;
 
 const FooterLinks: React.FC<{
@@ -116,27 +179,38 @@ const FooterLinks: React.FC<{
 const year = new Date().getFullYear();
 
 export const Footer: React.FC<{
+    nav: NavType;
+    edition: Edition;
     pageFooter: FooterType;
-}> = ({ pageFooter }) => (
+}> = ({ nav, edition, pageFooter }) => (
     <footer className={footer}>
         <Container className={footerInner}>
-            <iframe
-                title="Guardian Email Sign-up Form"
-                src="https://www.theguardian.com/email/form/footer/today-uk"
-                scrolling="no"
-                seamless={true}
-                id="footer__email-form"
-                className={emailSignup}
-                data-form-success-desc="We will send you our picks of the most important headlines tomorrow morning."
-                data-node-uid="2"
-                height="100px"
-                frameBorder="0"
-            />
-            <FooterLinks pageFooter={pageFooter} />
-            <div className={copyright}>
-                © {year} Guardian News & Media Limited or its affiliated
-                companies. All rights reserved.
+            <div className={footerItemContainers}>
+                <iframe
+                    title="Guardian Email Sign-up Form"
+                    src="https://www.theguardian.com/email/form/footer/today-uk"
+                    scrolling="no"
+                    seamless={true}
+                    id="footer__email-form"
+                    className={emailSignup}
+                    data-form-success-desc="We will send you our picks of the most important headlines tomorrow morning."
+                    data-node-uid="2"
+                    height="100px"
+                    frameBorder="0"
+                />
+                <FooterLinks pageFooter={pageFooter} />
+                <div className={readerRevenueLinks}>
+                    <ReaderRevenueLinks
+                        urls={nav.readerRevenueLinks.footer}
+                        edition={edition}
+                        dataLinkNamePrefix={'footer : '}
+                    />
+                </div>
             </div>
         </Container>
+        <div className={copyright}>
+            © {year} Guardian News & Media Limited or its affiliated companies.
+            All rights reserved.
+        </div>
     </footer>
 );

--- a/packages/frontend/web/components/Footer.tsx
+++ b/packages/frontend/web/components/Footer.tsx
@@ -38,9 +38,10 @@ const footerInner = css`
     ${wide} {
         max-width: 1300px;
     }
+
     padding-bottom: 6px;
     display: block;
-    border: 0.0625rem solid ${palette.brand.pastel};
+    border: 1px solid ${palette.brand.pastel};
     border-top: 0;
 `;
 
@@ -77,10 +78,6 @@ const footerList = css`
     flex-wrap: wrap;
     flex-direction: row;
     border-top: 1px solid ${palette.brand.pastel};
-
-    ${tablet} {
-        border-top: none;
-    }
 
     ul {
         width: 50%;
@@ -123,6 +120,16 @@ const readerRevenueLinks = css`
     border-left: 1px solid ${palette.brand.pastel};
     padding: 12px 0 0 10px;
     margin: 0 10px 36px 0;
+
+    width: calc(50% - 10px);
+
+    ${until.tablet} {
+        border-top: 1px solid ${palette.brand.pastel};
+    }
+
+    ${tablet} {
+        width: 218px;
+    }
 `;
 
 const copyright = css`
@@ -150,13 +157,18 @@ const copyright = css`
 `;
 
 const footerItemContainers = css`
-    display: flex;
+    ${leftCol} {
+        display: flex;
+    }
+
     padding: 0 19px;
 `;
 
 const FooterLinks: React.FC<{
+    nav: NavType;
+    edition: Edition;
     pageFooter: FooterType;
-}> = ({ pageFooter }) => {
+}> = ({ pageFooter, nav, edition }) => {
     const linkGroups = pageFooter.footerLinks.map(linkGroup => {
         const linkList = linkGroup.map((l: FooterLink) => (
             <li key={l.url}>
@@ -173,7 +185,23 @@ const FooterLinks: React.FC<{
         return <ul key={key}>{linkList}</ul>;
     });
 
-    return <div className={footerList}>{linkGroups}</div>;
+    const rrLinks = (
+        <div className={readerRevenueLinks}>
+            <ReaderRevenueLinks
+                urls={nav.readerRevenueLinks.footer}
+                edition={edition}
+                dataLinkNamePrefix={'footer : '}
+                noResponsive={true}
+            />
+        </div>
+    );
+
+    return (
+        <div className={footerList}>
+            {linkGroups}
+            {rrLinks}
+        </div>
+    );
 };
 
 const year = new Date().getFullYear();
@@ -198,14 +226,12 @@ export const Footer: React.FC<{
                     height="100px"
                     frameBorder="0"
                 />
-                <FooterLinks pageFooter={pageFooter} />
-                <div className={readerRevenueLinks}>
-                    <ReaderRevenueLinks
-                        urls={nav.readerRevenueLinks.footer}
-                        edition={edition}
-                        dataLinkNamePrefix={'footer : '}
-                    />
-                </div>
+
+                <FooterLinks
+                    nav={nav}
+                    edition={edition}
+                    pageFooter={pageFooter}
+                />
             </div>
         </Container>
         <div className={copyright}>

--- a/packages/frontend/web/components/Footer.tsx
+++ b/packages/frontend/web/components/Footer.tsx
@@ -147,7 +147,7 @@ const readerRevenueLinks = css`
 
 const copyright = css`
     ${textSans(1)};
-    padding: 0 19px;
+    padding: 0 19px 12px;
     margin: 12px auto 0;
 
     ${tablet} {

--- a/packages/frontend/web/components/Header/Nav/Nav.tsx
+++ b/packages/frontend/web/components/Header/Nav/Nav.tsx
@@ -1,7 +1,13 @@
 import React, { Component } from 'react';
 import { css } from 'emotion';
 import { clearFix } from '@guardian/pasteup/mixins';
-import { tablet, desktop, leftCol, wide } from '@guardian/pasteup/breakpoints';
+import {
+    tablet,
+    desktop,
+    leftCol,
+    wide,
+    mobileLandscape,
+} from '@guardian/pasteup/breakpoints';
 
 import { Logo } from './Logo';
 import { EditionDropdown } from './EditionDropdown';
@@ -29,6 +35,20 @@ const centered = css`
     position: relative;
     margin: 0 auto;
     ${clearFix};
+`;
+
+const readerRevenueLinks = css`
+    position: absolute;
+    left: 10px;
+    top: 33px;
+
+    ${mobileLandscape} {
+        left: 20px;
+    }
+
+    ${tablet} {
+        top: 0;
+    }
 `;
 
 interface Props {
@@ -90,12 +110,13 @@ export class Nav extends Component<
                         have been hardcoded to false. At some point
                         these need to be dynamic.
                     */}
-
-                    <ReaderRevenueLinks
-                        urls={nav.readerRevenueLinks.header}
-                        edition={edition}
-                        dataLinkNamePrefix={'nav2 : '}
-                    />
+                    <div className={readerRevenueLinks}>
+                        <ReaderRevenueLinks
+                            urls={nav.readerRevenueLinks.header}
+                            edition={edition}
+                            dataLinkNamePrefix={'nav2 : '}
+                        />
+                    </div>
                     <Links isSignedIn={isSignedIn} />
                     <Pillars
                         showMainMenu={showMainMenu}

--- a/packages/frontend/web/components/Header/Nav/Nav.tsx
+++ b/packages/frontend/web/components/Header/Nav/Nav.tsx
@@ -115,6 +115,7 @@ export class Nav extends Component<
                             urls={nav.readerRevenueLinks.header}
                             edition={edition}
                             dataLinkNamePrefix={'nav2 : '}
+                            noResponsive={false}
                         />
                     </div>
                     <Links isSignedIn={isSignedIn} />

--- a/packages/frontend/web/components/Header/Nav/ReaderRevenueLinks.test.tsx
+++ b/packages/frontend/web/components/Header/Nav/ReaderRevenueLinks.test.tsx
@@ -42,6 +42,7 @@ describe('ReaderRevenueLinks', () => {
                 urls={urls}
                 edition={edition}
                 dataLinkNamePrefix={'nav2 : '}
+                noResponsive={false}
             />,
         );
 
@@ -67,6 +68,7 @@ describe('ReaderRevenueLinks', () => {
                 urls={urls}
                 edition={edition}
                 dataLinkNamePrefix={'nav2 : '}
+                noResponsive={false}
             />,
         );
 
@@ -93,6 +95,7 @@ describe('ReaderRevenueLinks', () => {
                 urls={urls}
                 edition={edition}
                 dataLinkNamePrefix={'nav2 : '}
+                noResponsive={false}
             />,
         );
 

--- a/packages/frontend/web/components/Header/Nav/ReaderRevenueLinks.tsx
+++ b/packages/frontend/web/components/Header/Nav/ReaderRevenueLinks.tsx
@@ -17,16 +17,11 @@ import { AsyncClientComponent } from '@frontend/web/components/lib/AsyncClientCo
 
 const message = css`
     color: ${palette.highlight.main};
-    display: none;
     ${serif.headline};
     font-size: 20px;
     font-weight: 800;
     padding-top: 3px;
     margin-bottom: 3px;
-
-    ${tablet} {
-        display: block;
-    }
 
     ${desktop} {
         ${headline(4)}
@@ -50,6 +45,7 @@ const link = css`
     padding: 7px 12px 0 12px;
     position: relative;
     margin-right: 10px;
+    margin-bottom: 6px;
 
     ${mobileMedium} {
         padding-right: 34px;
@@ -87,10 +83,6 @@ const hiddenFromTablet = css`
     }
 `;
 
-const hidden = css`
-    display: none;
-`;
-
 const subMessage = css`
     color: ${palette.neutral[100]};
     ${textSans(5)};
@@ -105,7 +97,10 @@ export const ReaderRevenueLinks: React.FC<{
         contribute: string;
     };
     dataLinkNamePrefix: string;
-}> = ({ edition, urls, dataLinkNamePrefix }) => {
+    noResponsive: boolean;
+}> = ({ edition, urls, dataLinkNamePrefix, noResponsive }) => {
+    const requiredLinkStyle = noResponsive ? link : cx(link, hiddenUntilTablet);
+
     return (
         <AsyncClientComponent f={shouldShow}>
             {({ data }) => (
@@ -113,44 +108,54 @@ export const ReaderRevenueLinks: React.FC<{
                     {data && (
                         <>
                             {/* <div className={readerRevenueLinks}> */}
-                            <div className={message}>
+                            <div
+                                className={cx(message, {
+                                    [hiddenUntilTablet]: !noResponsive,
+                                })}
+                            >
                                 Support The&nbsp;Guardian
                             </div>
-                            <div className={cx(subMessage, hiddenUntilTablet)}>
+                            <div
+                                className={cx(subMessage, {
+                                    [hiddenUntilTablet]: !noResponsive,
+                                })}
+                            >
                                 Available for everyone, funded by readers
                             </div>
                             <a
-                                className={cx(link, hiddenUntilTablet)}
+                                className={requiredLinkStyle}
                                 href={urls.contribute}
                                 data-link-name={`${dataLinkNamePrefix}contribute-cta`}
                             >
                                 Contribute <ArrowRightIcon />
                             </a>
                             <a
-                                className={cx(link, hiddenUntilTablet)}
+                                className={requiredLinkStyle}
                                 href={urls.subscribe}
                                 data-link-name={`${dataLinkNamePrefix}subscribe-cta`}
                             >
                                 Subscribe <ArrowRightIcon />
                             </a>
-                            <a
-                                className={cx(link, hiddenFromTablet, {
-                                    [hidden]: edition !== 'UK',
-                                })}
-                                href={urls.support}
-                                data-link-name={`${dataLinkNamePrefix}support-cta`}
-                            >
-                                Support us <ArrowRightIcon />
-                            </a>
-                            <a
-                                className={cx(link, hiddenFromTablet, {
-                                    [hidden]: edition === 'UK',
-                                })}
-                                href={urls.contribute}
-                                data-link-name={`${dataLinkNamePrefix}contribute-cta`}
-                            >
-                                Contribute <ArrowRightIcon />
-                            </a>
+
+                            {!noResponsive &&
+                                (edition === 'UK' ? (
+                                    <a
+                                        className={cx(link, hiddenFromTablet)}
+                                        href={urls.contribute}
+                                        data-link-name={`${dataLinkNamePrefix}contribute-cta`}
+                                    >
+                                        Contribute <ArrowRightIcon />
+                                    </a>
+                                ) : (
+                                    <a
+                                        className={cx(link, hiddenFromTablet)}
+                                        href={urls.support}
+                                        data-link-name={`${dataLinkNamePrefix}support-cta`}
+                                    >
+                                        Support us <ArrowRightIcon />
+                                    </a>
+                                ))}
+
                             {/* </div> */}
                         </>
                     )}

--- a/packages/frontend/web/components/Header/Nav/ReaderRevenueLinks.tsx
+++ b/packages/frontend/web/components/Header/Nav/ReaderRevenueLinks.tsx
@@ -89,6 +89,23 @@ const subMessage = css`
     margin-bottom: 9px;
 `;
 
+export const RRButton: React.FC<{
+    url: string;
+    dataLinkNamePrefix: string;
+    dataLinkNameSuffix: string;
+    linkText: string;
+}> = ({ url, dataLinkNamePrefix, dataLinkNameSuffix, linkText }) => {
+    return (
+        <a
+            className={link}
+            href={url}
+            data-link-name={`${dataLinkNamePrefix}${dataLinkNameSuffix}`}
+        >
+            {linkText} <ArrowRightIcon />
+        </a>
+    );
+};
+
 export const ReaderRevenueLinks: React.FC<{
     edition: Edition;
     urls: {
@@ -99,64 +116,54 @@ export const ReaderRevenueLinks: React.FC<{
     dataLinkNamePrefix: string;
     noResponsive: boolean;
 }> = ({ edition, urls, dataLinkNamePrefix, noResponsive }) => {
-    const requiredLinkStyle = noResponsive ? link : cx(link, hiddenUntilTablet);
-
     return (
         <AsyncClientComponent f={shouldShow}>
             {({ data }) => (
                 <>
                     {data && (
                         <>
-                            {/* <div className={readerRevenueLinks}> */}
                             <div
-                                className={cx(message, {
+                                className={cx({
                                     [hiddenUntilTablet]: !noResponsive,
                                 })}
                             >
-                                Support The&nbsp;Guardian
+                                <div className={message}>
+                                    Support The&nbsp;Guardian
+                                </div>
+                                <div className={subMessage}>
+                                    Available for everyone, funded by readers
+                                </div>
+                                <RRButton
+                                    url={urls.contribute}
+                                    dataLinkNamePrefix={dataLinkNamePrefix}
+                                    dataLinkNameSuffix={'contribute-cta'}
+                                    linkText={'Contribute'}
+                                />
+                                <RRButton
+                                    url={urls.subscribe}
+                                    dataLinkNamePrefix={dataLinkNamePrefix}
+                                    dataLinkNameSuffix={'subscribe-cta'}
+                                    linkText={'Subscribe'}
+                                />
                             </div>
-                            <div
-                                className={cx(subMessage, {
-                                    [hiddenUntilTablet]: !noResponsive,
-                                })}
-                            >
-                                Available for everyone, funded by readers
-                            </div>
-                            <a
-                                className={requiredLinkStyle}
-                                href={urls.contribute}
-                                data-link-name={`${dataLinkNamePrefix}contribute-cta`}
-                            >
-                                Contribute <ArrowRightIcon />
-                            </a>
-                            <a
-                                className={requiredLinkStyle}
-                                href={urls.subscribe}
-                                data-link-name={`${dataLinkNamePrefix}subscribe-cta`}
-                            >
-                                Subscribe <ArrowRightIcon />
-                            </a>
 
-                            {!noResponsive &&
-                                (edition === 'UK' ? (
-                                    <a
-                                        className={cx(link, hiddenFromTablet)}
-                                        href={urls.contribute}
-                                        data-link-name={`${dataLinkNamePrefix}contribute-cta`}
-                                    >
-                                        Contribute <ArrowRightIcon />
-                                    </a>
+                            <div className={hiddenFromTablet}>
+                                {edition === 'UK' ? (
+                                    <RRButton
+                                        url={urls.contribute}
+                                        dataLinkNamePrefix={dataLinkNamePrefix}
+                                        dataLinkNameSuffix={'contribute-cta'}
+                                        linkText={'Contribute'}
+                                    />
                                 ) : (
-                                    <a
-                                        className={cx(link, hiddenFromTablet)}
-                                        href={urls.support}
-                                        data-link-name={`${dataLinkNamePrefix}support-cta`}
-                                    >
-                                        Support us <ArrowRightIcon />
-                                    </a>
-                                ))}
-
-                            {/* </div> */}
+                                    <RRButton
+                                        url={urls.support}
+                                        dataLinkNamePrefix={dataLinkNamePrefix}
+                                        dataLinkNameSuffix={'support-cta'}
+                                        linkText={'Support us'}
+                                    />
+                                )}
+                            </div>
                         </>
                     )}
                 </>

--- a/packages/frontend/web/components/Header/Nav/ReaderRevenueLinks.tsx
+++ b/packages/frontend/web/components/Header/Nav/ReaderRevenueLinks.tsx
@@ -42,7 +42,7 @@ const link = css`
     font-weight: 700;
     height: 32px;
     text-decoration: none;
-    padding: 7px 12px 0 12px;
+    padding: 4px 12px 0 12px;
     position: relative;
     margin-right: 10px;
     margin-bottom: 6px;

--- a/packages/frontend/web/components/Header/Nav/ReaderRevenueLinks.tsx
+++ b/packages/frontend/web/components/Header/Nav/ReaderRevenueLinks.tsx
@@ -71,6 +71,10 @@ const link = css`
     }
 `;
 
+const hidden = css`
+    display: none;
+`;
+
 const hiddenUntilTablet = css`
     ${until.tablet} {
         display: none;
@@ -147,7 +151,12 @@ export const ReaderRevenueLinks: React.FC<{
                                 />
                             </div>
 
-                            <div className={hiddenFromTablet}>
+                            <div
+                                className={cx({
+                                    [hiddenFromTablet]: !noResponsive,
+                                    [hidden]: noResponsive,
+                                })}
+                            >
                                 {edition === 'UK' ? (
                                     <RRButton
                                         url={urls.contribute}

--- a/packages/frontend/web/components/Header/Nav/ReaderRevenueLinks.tsx
+++ b/packages/frontend/web/components/Header/Nav/ReaderRevenueLinks.tsx
@@ -5,7 +5,6 @@ import { serif, sans, textSans, headline } from '@guardian/pasteup/typography';
 import ArrowRightIcon from '@guardian/pasteup/icons/arrow-right.svg';
 import { palette } from '@guardian/pasteup/palette';
 import {
-    mobileLandscape,
     tablet,
     desktop,
     mobileMedium,
@@ -92,20 +91,6 @@ const hidden = css`
     display: none;
 `;
 
-const readerRevenueLinks = css`
-    position: absolute;
-    left: 10px;
-    top: 33px;
-
-    ${mobileLandscape} {
-        left: 20px;
-    }
-
-    ${tablet} {
-        top: 0;
-    }
-`;
-
 const subMessage = css`
     color: ${palette.neutral[100]};
     ${textSans(5)};
@@ -127,51 +112,46 @@ export const ReaderRevenueLinks: React.FC<{
                 <>
                     {data && (
                         <>
-                            <div className={readerRevenueLinks}>
-                                <div className={message}>
-                                    Support The Guardian
-                                </div>
-                                <div
-                                    className={cx(
-                                        subMessage,
-                                        hiddenUntilTablet,
-                                    )}
-                                >
-                                    Available for everyone, funded by readers
-                                </div>
-                                <a
-                                    className={cx(link, hiddenUntilTablet)}
-                                    href={urls.contribute}
-                                    data-link-name={`${dataLinkNamePrefix}contribute-cta`}
-                                >
-                                    Contribute <ArrowRightIcon />
-                                </a>
-                                <a
-                                    className={cx(link, hiddenUntilTablet)}
-                                    href={urls.subscribe}
-                                    data-link-name={`${dataLinkNamePrefix}subscribe-cta`}
-                                >
-                                    Subscribe <ArrowRightIcon />
-                                </a>
-                                <a
-                                    className={cx(link, hiddenFromTablet, {
-                                        [hidden]: edition !== 'UK',
-                                    })}
-                                    href={urls.support}
-                                    data-link-name={`${dataLinkNamePrefix}support-cta`}
-                                >
-                                    Support us <ArrowRightIcon />
-                                </a>
-                                <a
-                                    className={cx(link, hiddenFromTablet, {
-                                        [hidden]: edition === 'UK',
-                                    })}
-                                    href={urls.contribute}
-                                    data-link-name={`${dataLinkNamePrefix}contribute-cta`}
-                                >
-                                    Contribute <ArrowRightIcon />
-                                </a>
+                            {/* <div className={readerRevenueLinks}> */}
+                            <div className={message}>
+                                Support The&nbsp;Guardian
                             </div>
+                            <div className={cx(subMessage, hiddenUntilTablet)}>
+                                Available for everyone, funded by readers
+                            </div>
+                            <a
+                                className={cx(link, hiddenUntilTablet)}
+                                href={urls.contribute}
+                                data-link-name={`${dataLinkNamePrefix}contribute-cta`}
+                            >
+                                Contribute <ArrowRightIcon />
+                            </a>
+                            <a
+                                className={cx(link, hiddenUntilTablet)}
+                                href={urls.subscribe}
+                                data-link-name={`${dataLinkNamePrefix}subscribe-cta`}
+                            >
+                                Subscribe <ArrowRightIcon />
+                            </a>
+                            <a
+                                className={cx(link, hiddenFromTablet, {
+                                    [hidden]: edition !== 'UK',
+                                })}
+                                href={urls.support}
+                                data-link-name={`${dataLinkNamePrefix}support-cta`}
+                            >
+                                Support us <ArrowRightIcon />
+                            </a>
+                            <a
+                                className={cx(link, hiddenFromTablet, {
+                                    [hidden]: edition === 'UK',
+                                })}
+                                href={urls.contribute}
+                                data-link-name={`${dataLinkNamePrefix}contribute-cta`}
+                            >
+                                Contribute <ArrowRightIcon />
+                            </a>
+                            {/* </div> */}
                         </>
                     )}
                 </>

--- a/packages/frontend/web/pages/Article.tsx
+++ b/packages/frontend/web/pages/Article.tsx
@@ -75,7 +75,11 @@ export const Article: React.FC<{
         />
         <BackToTop />
 
-        <Footer pageFooter={data.CAPI.pageFooter} />
+        <Footer
+            nav={data.NAV}
+            edition={data.CAPI.editionId}
+            pageFooter={data.CAPI.pageFooter}
+        />
 
         <CookieBanner />
     </div>


### PR DESCRIPTION
In case anyone is able to pick this up in my absence.

It just needs to be tweaked to work at lower breakpoints.

<img width="1423" alt="Screen Shot 2019-08-13 at 22 09 37" src="https://user-images.githubusercontent.com/2051501/62977726-7d773380-be17-11e9-866e-eaee78214472.png">
## What does this change?
Adds the reader revenue CTAs to the footer
## Why?
Visual parity

## Link to supporting Trello card
