### PR TITLE
Fix links sitting above sidebar nav

### DIFF
--- a/packages/frontend/web/components/Header/Nav/Links/Links.tsx
+++ b/packages/frontend/web/components/Header/Nav/Links/Links.tsx
@@ -46,7 +46,6 @@ const link = css`
     transition: color 80ms ease-out;
     text-decoration: none;
     padding: 7px 0;
-    z-index: 1072;
 
     ${tablet} {
         padding: 7px 7px;


### PR DESCRIPTION
## What does this change?

Minor visual fix to prevent nav links overlaying the sidebar nav on lower breakpoints.

## Why?

Visual fix.

## Link to supporting Trello card

https://trello.com/c/sq0Af6vL
https://trello.com/c/bt7lMxJs

![Screenshot 2019-08-14 at 11 15 09](https://user-images.githubusercontent.com/858402/63013990-62430d00-be85-11e9-96bf-0a60d045cec2.png)

whereas previously was:

![z-index-issue](https://user-images.githubusercontent.com/858402/63014006-6f5ffc00-be85-11e9-8c32-c3697af0f432.png)

