### PR TITLE
Configure to AMP Validate a live blog

### DIFF
--- a/.prbuilds/config.yml
+++ b/.prbuilds/config.yml
@@ -6,4 +6,6 @@ checks:
   lighthouse:
     url: http://localhost:3030/AMPArticle
   amp:
-    url: http://localhost:3030/AMPArticle
+    urls: 
+      - http://localhost:3030/AMPArticle
+      - http://localhost:3030/AMPArticle?url=https://www.theguardian.com/football/live/2018/jul/03/world-cup-2018-england-v-colombia-switzerland-v-sweden-buildup-live


### PR DESCRIPTION
## What does this change?

Changes the PRBuilds configuration to validate against both a normal article and a live blog page.

## Why?

More coverage of amp validation

## Link to supporting Trello card

https://trello.com/c/ACqoRvOF/658-amp-validate-multiple-pages-on-prbuilds
