### PR TITLE
Better comment for window.guardian.config.page.adUnit

### DIFF
--- a/packages/frontend/model/window-guardian.ts
+++ b/packages/frontend/model/window-guardian.ts
@@ -31,7 +31,10 @@ const makeWindowGuardianConfig = (
             sentryHost: dcrDocumentData.config.sentryHost,
             keywordIds: [],
             dfpAccountId: dcrDocumentData.config.dfpAccountId,
-            adUnit: '/59666047/theguardian.com/film/article/ng', // Hard coded for the moment, TODO: read the value from frontend
+            // adUnit is currently present for consistency,
+            // ... but the value is not used on the master branch.
+            // TODO (Pascal): read the value from frontend.
+            adUnit: '/59666047/theguardian.com/film/article/ng',
         },
         libs: {
             googletag: dcrDocumentData.config.googletagUrl,


### PR DESCRIPTION
## What does this change?

Update the comment explaining the current (hardcoded) value of `window.guardian.config.page.adUnit`.

## Why?

Currently confusing.
