### PR TITLE
Introduce Outbrain Component

### DIFF
--- a/packages/frontend/web/components/Outbrain.tsx
+++ b/packages/frontend/web/components/Outbrain.tsx
@@ -1,0 +1,29 @@
+// tslint:disable:react-no-dangerous-html
+
+import React from 'react';
+import { Container } from '@guardian/guui';
+
+export const shouldDisplayOutbrain = (config: ConfigType): boolean => {
+    return config.switches.displayOutbrain;
+};
+
+export const OutbrainWidget: React.FC<{}> = ({}) => {
+    return (
+        <div className="js-outbrain">
+            <div className="js-outbrain-container" />
+        </div>
+    );
+};
+
+export const MaybeOutbrainContainer: React.FC<{
+    config: ConfigType;
+}> = ({ config }) => {
+    if (shouldDisplayOutbrain(config)) {
+        return (
+            <Container>
+                <OutbrainWidget />
+            </Container>
+        );
+    }
+    return <div />;
+};

--- a/packages/frontend/web/components/Outbrain.tsx
+++ b/packages/frontend/web/components/Outbrain.tsx
@@ -18,12 +18,12 @@ export const OutbrainWidget: React.FC<{}> = ({}) => {
 export const OutbrainContainer: React.FC<{
     config: ConfigType;
 }> = ({ config }) => {
-    if (shouldDisplayOutbrain(config)) {
-        return (
-            <Container>
-                <OutbrainWidget />
-            </Container>
-        );
+    if (!shouldDisplayOutbrain(config)) {
+        return null;
     }
-    return <div />;
+    return (
+        <Container>
+            <OutbrainWidget />
+        </Container>
+    );
 };

--- a/packages/frontend/web/components/Outbrain.tsx
+++ b/packages/frontend/web/components/Outbrain.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { Container } from '@guardian/guui';
 
 export const shouldDisplayOutbrain = (config: ConfigType): boolean => {
-    return config.switches.displayOutbrain;
+    return config.switches.outbrainDCRTest;
 };
 
 export const OutbrainWidget: React.FC<{}> = ({}) => {

--- a/packages/frontend/web/components/Outbrain.tsx
+++ b/packages/frontend/web/components/Outbrain.tsx
@@ -15,7 +15,7 @@ export const OutbrainWidget: React.FC<{}> = ({}) => {
     );
 };
 
-export const MaybeOutbrainContainer: React.FC<{
+export const OutbrainContainer: React.FC<{
     config: ConfigType;
 }> = ({ config }) => {
     if (shouldDisplayOutbrain(config)) {

--- a/packages/frontend/web/pages/Article.tsx
+++ b/packages/frontend/web/pages/Article.tsx
@@ -10,7 +10,7 @@ import { ArticleBody } from '@frontend/web/components/ArticleBody';
 import { BackToTop } from '@frontend/web/components/BackToTop';
 import { SubNav } from '@frontend/web/components/Header/Nav/SubNav/SubNav';
 import { CookieBanner } from '@frontend/web/components/CookieBanner';
-import { MaybeOutbrainContainer } from '@frontend/web/components/Outbrain';
+import { OutbrainContainer } from '@frontend/web/components/Outbrain';
 
 // TODO: find a better of setting opacity
 const secondaryColumn = css`
@@ -56,7 +56,7 @@ export const Article: React.FC<{
                     <div className={secondaryColumn} />
                 </article>
             </Container>
-            <MaybeOutbrainContainer config={data.config} />
+            <OutbrainContainer config={data.config} />
             <Container
                 borders={true}
                 className={cx(

--- a/packages/frontend/web/pages/Article.tsx
+++ b/packages/frontend/web/pages/Article.tsx
@@ -10,6 +10,7 @@ import { ArticleBody } from '@frontend/web/components/ArticleBody';
 import { BackToTop } from '@frontend/web/components/BackToTop';
 import { SubNav } from '@frontend/web/components/Header/Nav/SubNav/SubNav';
 import { CookieBanner } from '@frontend/web/components/CookieBanner';
+import { MaybeOutbrainContainer } from '@frontend/web/components/Outbrain';
 
 // TODO: find a better of setting opacity
 const secondaryColumn = css`
@@ -55,6 +56,7 @@ export const Article: React.FC<{
                     <div className={secondaryColumn} />
                 </article>
             </Container>
+            <MaybeOutbrainContainer config={data.config} />
             <Container
                 borders={true}
                 className={cx(


### PR DESCRIPTION
## What does this change?

Introduce the Outbrain component in DCR, and put it in position in `Article.tsx` to be tested in production (this because I cannot get it to display on local). The display will be controlled by a switch (which has not yet been put in frontend). 

Note: `config.switches.outbrainDCRTest` returns false for the moment.