### PR TITLE
Add comments with info about breakpoint for peek in VsCode

### DIFF
--- a/packages/pasteup/breakpoints.ts
+++ b/packages/pasteup/breakpoints.ts
@@ -20,14 +20,14 @@ const maxWidth = (until: number): string =>
 const minWidthMaxWidth = (from: number, until: number): string =>
     `@media (min-width: ${`${from}px`}) and (max-width: ${`${until - 1}px`})`;
 
-export const mobile = minWidth(breakpoints.mobile);
-export const mobileMedium = minWidth(breakpoints.mobileMedium);
-export const mobileLandscape = minWidth(breakpoints.mobileLandscape);
-export const phablet = minWidth(breakpoints.phablet);
-export const tablet = minWidth(breakpoints.tablet);
-export const desktop = minWidth(breakpoints.desktop);
-export const leftCol = minWidth(breakpoints.leftCol);
-export const wide = minWidth(breakpoints.wide);
+export const mobile = minWidth(breakpoints.mobile); // Mobile breakpoint is 320
+export const mobileMedium = minWidth(breakpoints.mobileMedium); // MobileMedium breakpoint is 360
+export const mobileLandscape = minWidth(breakpoints.mobileLandscape); // MobileLandscape breakpoint is 480
+export const phablet = minWidth(breakpoints.phablet); // Phablet breakpoint is 660
+export const tablet = minWidth(breakpoints.tablet); // Tablet breakpoint is 740
+export const desktop = minWidth(breakpoints.desktop); // Desktop breakpoint is 980
+export const leftCol = minWidth(breakpoints.leftCol); // leftCol breakpoint is 1140
+export const wide = minWidth(breakpoints.wide); // Wide breakpoint is 1300
 
 // e.g. until.*
 export const until = {


### PR DESCRIPTION
## What does this change?

![2019-08-16 17 03 23](https://user-images.githubusercontent.com/638051/63181677-7b47eb80-c048-11e9-9740-9ddb5c21a523.gif)


## Why?
It's useful for seeing the actual values 

@guardian/dotcom-platform 
