### PR TITLE
Introduce OutbrainSelectors

### DIFF
--- a/packages/frontend/web/components/Outbrain.tsx
+++ b/packages/frontend/web/components/Outbrain.tsx
@@ -3,14 +3,49 @@
 import React from 'react';
 import { Container } from '@guardian/guui';
 
-export const shouldDisplayOutbrain = (config: ConfigType): boolean => {
+interface OutbrainSelectors {
+    widget: string;
+    container: string;
+}
+
+const shouldDisplayOutbrain = (config: ConfigType): boolean => {
+    return true;
     return config.switches.outbrainDCRTest;
 };
 
-export const OutbrainWidget: React.FC<{}> = ({}) => {
+type OutbrainSelectorsType = 'outbrain' | 'merchandising' | 'nonCompliant';
+
+const outbrainSelectorsTypeMapping = {
+    outbrain: {
+        widget: '.js-outbrain',
+        container: '.js-outbrain-container',
+    },
+    merchandising: {
+        widget: '.js-container--commercial',
+        container: '.js-outbrain-container',
+    },
+    nonCompliant: {
+        widget: '.js-outbrain',
+        container: '.js-outbrain-container',
+    },
+};
+
+const getOutbrainSelectorsByType = (
+    type: OutbrainSelectorsType,
+): OutbrainSelectors => {
+    return outbrainSelectorsTypeMapping[type];
+};
+
+const getOutbrainSelectors = (): OutbrainSelectors => {
+    return getOutbrainSelectorsByType('outbrain');
+};
+
+const OutbrainWidget: React.FC<{
+    selectors: OutbrainSelectors;
+}> = ({ selectors }) => {
     return (
-        <div className="js-outbrain">
-            <div className="js-outbrain-container" />
+        <div className={selectors.widget}>
+            <div className={selectors.container} />
         </div>
     );
 };
@@ -21,9 +56,10 @@ export const OutbrainContainer: React.FC<{
     if (!shouldDisplayOutbrain(config)) {
         return null;
     }
+    const outbrainSelectors = getOutbrainSelectors();
     return (
         <Container>
-            <OutbrainWidget />
+            <OutbrainWidget selectors={outbrainSelectors} />
         </Container>
     );
 };

--- a/packages/frontend/web/components/Outbrain.tsx
+++ b/packages/frontend/web/components/Outbrain.tsx
@@ -9,7 +9,6 @@ interface OutbrainSelectors {
 }
 
 const shouldDisplayOutbrain = (config: ConfigType): boolean => {
-    return true;
     return config.switches.outbrainDCRTest;
 };
 

--- a/packages/frontend/web/components/Outbrain.tsx
+++ b/packages/frontend/web/components/Outbrain.tsx
@@ -39,9 +39,8 @@ const getOutbrainSelectors = (): OutbrainSelectors => {
     return getOutbrainSelectorsByType('outbrain');
 };
 
-const OutbrainWidget: React.FC<{
-    selectors: OutbrainSelectors;
-}> = ({ selectors }) => {
+const OutbrainWidget: React.FC<{}> = ({}) => {
+    const selectors = getOutbrainSelectors();
     return (
         <div className={selectors.widget}>
             <div className={selectors.container} />
@@ -55,10 +54,9 @@ export const OutbrainContainer: React.FC<{
     if (!shouldDisplayOutbrain(config)) {
         return null;
     }
-    const outbrainSelectors = getOutbrainSelectors();
     return (
         <Container>
-            <OutbrainWidget selectors={outbrainSelectors} />
+            <OutbrainWidget />
         </Container>
     );
 };

--- a/packages/frontend/web/components/Outbrain.tsx
+++ b/packages/frontend/web/components/Outbrain.tsx
@@ -16,16 +16,16 @@ type OutbrainSelectorsType = 'outbrain' | 'merchandising' | 'nonCompliant';
 
 const outbrainSelectorsTypeMapping = {
     outbrain: {
-        widget: '.js-outbrain',
-        container: '.js-outbrain-container',
+        widget: 'js-outbrain',
+        container: 'js-outbrain-container',
     },
     merchandising: {
-        widget: '.js-container--commercial',
-        container: '.js-outbrain-container',
+        widget: 'js-container--commercial',
+        container: 'js-outbrain-container',
     },
     nonCompliant: {
-        widget: '.js-outbrain',
-        container: '.js-outbrain-container',
+        widget: 'js-outbrain',
+        container: 'js-outbrain-container',
     },
 };
 


### PR DESCRIPTION
## What does this change?

This introduces the two other sets of selectors for Outbrain, bringing the widget on par with the commercial code expectations and the way it is currently being displayed on frontend. Note that even thought updated mechanics are introduced the function `getOutbrainSelectors` hardcodes the `outbrain` type, therefore the widget displays the same way as in the original PR: https://github.com/guardian/dotcom-rendering/pull/717 (this is until we are ready to implement the selection logic)

Note: the mapping `outbrainSelectorsTypeMapping` is taken from frontend. I am aware of the redundancy between `outbrain` and `nonCompliant` and the weird naming convention, but we initially want the frontend library to run unmodified. 
