### PR TITLE
Use defer for script loading

### DIFF
--- a/packages/frontend/model/window-guardian.ts
+++ b/packages/frontend/model/window-guardian.ts
@@ -60,11 +60,7 @@ export interface WindowGuardian {
     // with the frontend commercial stack, or other scripts, we want to find
     // at window.guardian.config
     config: WindowGuardianConfig;
-
-    // Attributes 'polyfilled' and 'onPolyfilled' are positionned at window.guardian used by the client side's boot process.
     polyfilled: boolean;
-    onPolyfilled: () => void;
-
     adBlockers: any;
 }
 
@@ -79,7 +75,6 @@ export const makeWindowGuardian = (
         },
         config: makeWindowGuardianConfig(dcrDocumentData),
         polyfilled: false,
-        onPolyfilled: () => null,
         adBlockers: {
             active: undefined,
             onDetect: [],

--- a/packages/frontend/web/browser/boot.test.ts
+++ b/packages/frontend/web/browser/boot.test.ts
@@ -78,7 +78,7 @@ describe('boot', () => {
     let windowMock: MockWindow;
     let ravenMock: MockRaven;
     const commercialBundleUrl = 'http://foo.bar';
-    const { onPolyfilled, polyfilled, app } = window.guardian;
+    const { app } = window.guardian;
 
     beforeEach(() => {
         windowMock = mockWindow();
@@ -114,21 +114,8 @@ describe('boot', () => {
         createElement.mockReset();
 
         window.guardian = Object.assign({}, window.guardian, {
-            onPolyfilled,
-            polyfilled,
             app,
         });
-    });
-
-    test('does not call onPollyfilled when window.guardian.polyfilled is false', () => {
-        const onPolyfilledMock = jest.fn();
-
-        window.guardian.polyfilled = false;
-        window.guardian.onPolyfilled = onPolyfilledMock;
-
-        _.run();
-
-        expect(onPolyfilledMock).not.toBeCalled();
     });
 
     test('if getRaven successful initAppWithRaven', () => {
@@ -195,7 +182,7 @@ describe('boot', () => {
         });
 
         test('if loadCommercial successful enhanceApp', () => {
-            return _.onPolyfilled();
+            return _.run();
         });
 
         test('if loadCommercial unsuccessful reportError and enhanceApp', () => {

--- a/packages/frontend/web/browser/boot.ts
+++ b/packages/frontend/web/browser/boot.ts
@@ -135,16 +135,15 @@ const onPolyfilled = (): Promise<void> => {
 };
 
 const run = (): void => {
-    /*
-        We want to run `onPolyfilled` only after polyfill.io has initialised
-        By the time this script runs, if `window.guardian.polyfilled` is true,
-        meaning that polyfill.io has initialised, then we run onPolyfilled(), otherwise
-        we stick it in window.guardian.onPolyfilled to be ran later.
-    */
+    // Expects polyfill to have run
     if (window.guardian.polyfilled) {
         onPolyfilled();
     } else {
-        window.guardian.onPolyfilled = onPolyfilled;
+        // (Should never happen)
+        // tslint:disable-next-line:no-console
+        console.log(
+            'Error: attempting to load boot before polyfills have loaded.',
+        );
     }
 };
 

--- a/packages/frontend/web/server/document.tsx
+++ b/packages/frontend/web/server/document.tsx
@@ -62,9 +62,11 @@ export const document = ({ data }: Props) => {
     const priorityScripts = [polyfillIO, vendorJS, bundleJS, commercialBundle];
 
     /**
-     * Low priority scripts.
-     * These scripts will be requested asynchronously after the main
-     * HTML has been parsed. Execution order is not guaranteed.
+     * Low priority scripts. These scripts will be requested
+     * asynchronously after the main HTML has been parsed. Execution
+     * order is not guaranteed. It is even possible that these execute
+     * *before* the high priority scripts, although this is very
+     * unlikely.
      */
     const lowPriorityScripts = [
         'https://www.google-analytics.com/analytics.js',

--- a/packages/frontend/web/server/document.tsx
+++ b/packages/frontend/web/server/document.tsx
@@ -74,6 +74,8 @@ export const document = ({ data }: Props) => {
 
     const ampLink = `https://amp.theguardian.com/${data.CAPI.pageId}`;
 
+    const description = `${CAPI.headline} | ${CAPI.sectionLabel} | The Guardian`;
+
     return htmlTemplate({
         linkedData,
         priorityScripts,
@@ -82,6 +84,7 @@ export const document = ({ data }: Props) => {
         html,
         fontFiles,
         title,
+        description,
         windowGuardian,
         ampLink,
     });

--- a/packages/frontend/web/server/document.tsx
+++ b/packages/frontend/web/server/document.tsx
@@ -59,11 +59,7 @@ export const document = ({ data }: Props) => {
         'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry&flags=gated&callback=guardianPolyfilled&unknown=polyfill';
     const commercialBundle = config.commercialBundleUrl;
 
-    const priorityScripts = [polyfillIO, vendorJS, bundleJS];
-
-    const preloadScripts = [
-        ...new Set([commercialBundle].concat(priorityScripts)),
-    ];
+    const priorityScripts = [polyfillIO, vendorJS, bundleJS, commercialBundle];
 
     /**
      * Low priority scripts.
@@ -80,7 +76,6 @@ export const document = ({ data }: Props) => {
 
     return htmlTemplate({
         linkedData,
-        preloadScripts,
         priorityScripts,
         lowPriorityScripts,
         css,

--- a/packages/frontend/web/server/htmlTemplate.ts
+++ b/packages/frontend/web/server/htmlTemplate.ts
@@ -74,9 +74,7 @@ export const htmlTemplate = ({
                     // once the polyfills have run. This may be useful for debugging.
                     // mainly to support browsers that don't support async=false or defer
                     function guardianPolyfilled() {
-                        try {
-                            window.guardian.polyfilled = true;
-                        } catch (e) {};
+                        window.guardian.polyfilled = true;
                     }
 
                     // We've got contracts to abide by with the Ophan tracker

--- a/packages/frontend/web/server/htmlTemplate.ts
+++ b/packages/frontend/web/server/htmlTemplate.ts
@@ -7,24 +7,20 @@ import { WindowGuardian } from '@frontend/model/window-guardian';
 export const htmlTemplate = ({
     title = 'The Guardian',
     linkedData,
-    preloadScripts,
     priorityScripts,
     lowPriorityScripts,
     css,
     html,
     windowGuardian,
-    nonBlockingJS = '',
     fontFiles = [],
     ampLink,
 }: {
     title?: string;
     linkedData: object;
-    preloadScripts: string[];
     priorityScripts: string[];
     lowPriorityScripts: string[];
     css: string;
     html: string;
-    nonBlockingJS?: string;
     fontFiles?: string[];
     windowGuardian: WindowGuardian;
     ampLink?: string;
@@ -33,6 +29,21 @@ export const htmlTemplate = ({
         process.env.NODE_ENV === 'production'
             ? 'favicon-32x32.ico'
             : 'favicon-32x32-dev-yellow.ico';
+
+    const priorityScriptTags = priorityScripts.map(
+        src => `<script defer src="${src}"></script>`,
+    );
+
+    const lowPriorityScriptTags = lowPriorityScripts.map(
+        src => `<script async src="${src}"></script>`,
+    );
+
+    const fontPreloadTags = fontFiles.map(
+        fontFile =>
+            `<link rel="preload" href="${getStatic(
+                fontFile,
+            )}" as="font" crossorigin>`,
+    );
 
     return `<!doctype html>
         <html lang="en">
@@ -45,78 +56,47 @@ export const htmlTemplate = ({
                     ${JSON.stringify(linkedData)}
                 </script>
 
-                ${preloadScripts
-                    .map(
-                        url => `<link rel="preload" href="${url}" as="script">`,
-                    )
-                    .join('\n')}
-                ${fontFiles
-                    .map(
-                        fontFile =>
-                            `<link rel="preload" href="${getStatic(
-                                fontFile,
-                            )}" as="font" crossorigin>`,
-                    )
-                    .join('\n')}
-
                 <!-- TODO make this conditional when we support more content types -->
                 ${ampLink ? `<link rel="amphtml" href="${ampLink}">` : ''}
 
-                <style>${getFontsCss()}${resetCSS}${css}</style>
+                ${fontPreloadTags.join('\n')}
 
                 <script>
-                window.guardian = ${JSON.stringify(windowGuardian)};
-
-                // this is a global that's called at the bottom of the pf.io response,
-                // once the polyfills have run. This may be useful for debugging.
-                // mainly to support browsers that don't support async=false or defer
-                function guardianPolyfilled() {
-                    try {
-                        window.guardian.polyfilled = true;
-                        window.guardian.onPolyfilled();
-                    } catch (e) {};
-                }
-
-                // We've got contracts to abide by with the Ophan tracker
-                // Setting pageViewId here ensures we're not getting race-conditions at all
-                window.guardian.config.ophan = {
-                    // This is duplicated from
-                    // https://github.com/guardian/ophan/blob/master/tracker-js/assets/coffee/ophan/transmit.coffee
-                    // Please do not change this without talking to the Ophan project first.
-                    pageViewId:
-                        new Date().getTime().toString(36) +
-                        'xxxxxxxxxxxx'.replace(/x/g, function() {
-                            return Math.floor(Math.random() * 36).toString(36);
-                        }),
-                };
-
-                (function() {
-                    var firstScript = document.scripts[0];
-                    [${priorityScripts.map(script =>
-                        JSON.stringify(script),
-                    )}].forEach(url => {
-                        if ('async' in firstScript) {
-                            // modern browsers
-                            var script = document.createElement('script');
-                            script.async = false;
-                            script.src = url;
-                            if (document.head) {
-                                document.head.appendChild(script);
-                            }
-                        } else {
-                            // fall back to defer
-                            document.write('<script src="' + url + '" defer></' + 'script>');
-                        }
-                    });
-                })();
+                    window.guardian = ${JSON.stringify(windowGuardian)};
                 </script>
+
+                <script>
+                    // this is a global that's called at the bottom of the pf.io response,
+                    // once the polyfills have run. This may be useful for debugging.
+                    // mainly to support browsers that don't support async=false or defer
+                    function guardianPolyfilled() {
+                        try {
+                            window.guardian.polyfilled = true;
+                        } catch (e) {};
+                    }
+
+                    // We've got contracts to abide by with the Ophan tracker
+                    // Setting pageViewId here ensures we're not getting race-conditions at all
+                    window.guardian.config.ophan = {
+                        // This is duplicated from
+                        // https://github.com/guardian/ophan/blob/master/tracker-js/assets/coffee/ophan/transmit.coffee
+                        // Please do not change this without talking to the Ophan project first.
+                        pageViewId:
+                            new Date().getTime().toString(36) +
+                            'xxxxxxxxxxxx'.replace(/x/g, function() {
+                                return Math.floor(Math.random() * 36).toString(36);
+                            }),
+                    };
+                </script>
+
+                ${priorityScriptTags.join('\n')}
+
+                <style>${getFontsCss()}${resetCSS}${css}</style>
             </head>
+
             <body>
                 <div id="app">${html}</div>
-                ${lowPriorityScripts
-                    .map(script => `<script async src="${script}"></script>`)
-                    .join('\n')}
-                <script>${nonBlockingJS}</script>
+                ${lowPriorityScriptTags.join('\n')}
             </body>
         </html>`;
 };

--- a/packages/frontend/web/server/htmlTemplate.ts
+++ b/packages/frontend/web/server/htmlTemplate.ts
@@ -6,6 +6,7 @@ import { WindowGuardian } from '@frontend/model/window-guardian';
 
 export const htmlTemplate = ({
     title = 'The Guardian',
+    description,
     linkedData,
     priorityScripts,
     lowPriorityScripts,
@@ -16,6 +17,7 @@ export const htmlTemplate = ({
     ampLink,
 }: {
     title?: string;
+    description: string;
     linkedData: object;
     priorityScripts: string[];
     lowPriorityScripts: string[];
@@ -49,6 +51,8 @@ export const htmlTemplate = ({
         <html lang="en">
             <head>
                 <title>${title}</title>
+                <meta name="description" content="${escape(description)}" />
+
                 <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
                 <link rel="icon" href="https://static.guim.co.uk/images/${favicon}">
 


### PR DESCRIPTION
## What does this change?

Use defer for script loading. Also simplify polyfill logic as we should always load polyfill io before other scripts.

## Why?

The async=false approach is not helpful for us as we want to wait for DomContentLoad anyway. And defer is simpler, and has better browser support.

Also removes some polyfill logic; we load polyfill first so do not need to do the callback behaviour/fallback.

See https://docs.google.com/document/d/1EnkowJ7BFumrqkpkRacRl-gSkiJs9fUgRCixQTLxBvo/edit#heading=h.66jd5ee5asei for fuller discussion.

## Link to supporting Trello card


