### PR TITLE
Align text centrally in reader revenue buttons.

### DIFF
--- a/packages/frontend/web/components/Header/Nav/ReaderRevenueLinks.tsx
+++ b/packages/frontend/web/components/Header/Nav/ReaderRevenueLinks.tsx
@@ -42,7 +42,8 @@ const link = css`
     font-weight: 700;
     height: 32px;
     text-decoration: none;
-    padding: 4px 12px 0 12px;
+    padding: 6px 12px 0 12px;
+    line-height: 1;
     position: relative;
     margin-right: 10px;
     margin-bottom: 6px;


### PR DESCRIPTION
## What does this change?
Fixes alignment of the reader revenue button text.

## Why?
It looks a bit off centre at the moment:

Before:

<img width="381" alt="Screenshot 2019-08-19 at 17 05 06" src="https://user-images.githubusercontent.com/3606555/63280916-9bbfb200-c2a3-11e9-9277-90f9cdc8357c.png">
**The bottom one actually doesn't have a problem at the moment: **
<img width="386" alt="Screenshot 2019-08-19 at 17 05 20" src="https://user-images.githubusercontent.com/3606555/63280917-9bbfb200-c2a3-11e9-93a0-3375648fc252.png">
After:
<img width="430" alt="Screenshot 2019-08-19 at 17 05 28" src="https://user-images.githubusercontent.com/3606555/63280918-9bbfb200-c2a3-11e9-88ec-1ae01d026299.png">
<img width="421" alt="Screenshot 2019-08-19 at 17 05 34" src="https://user-images.githubusercontent.com/3606555/63280920-9bbfb200-c2a3-11e9-880b-8cc023db2b98.png">

## Link to supporting Trello card
https://trello.com/c/3H8UVOtI/661-contribute-subscribe-vertical-alignment
