### PR TITLE
Add pillars to footer and other Footer and Header changes

### DIFF
--- a/packages/frontend/web/components/CookieBanner.tsx
+++ b/packages/frontend/web/components/CookieBanner.tsx
@@ -14,6 +14,7 @@ const banner = css`
     background-color: ${palette.neutral[20]};
     padding: 10px 0 24px;
     width: 100%;
+    z-index: 2;
 `;
 
 const inner = css`

--- a/packages/frontend/web/components/Footer.tsx
+++ b/packages/frontend/web/components/Footer.tsx
@@ -51,6 +51,11 @@ const footerInner = css`
 const pillarWrap = css`
     ${clearFix}
     border-bottom: 1px solid ${palette.brand.pastel};
+    padding-bottom: 12px;
+
+    > ul {
+        clear: none;
+    }
 `;
 
 const emailSignup = css`
@@ -237,6 +242,7 @@ export const Footer: React.FC<{
                     showMainMenu={false}
                     pillars={pillars}
                     pillar={pillar}
+                    showLastPillarDivider={false}
                 />
             </div>
             <div className={footerItemContainers}>
@@ -258,11 +264,6 @@ export const Footer: React.FC<{
                     edition={edition}
                     pageFooter={pageFooter}
                 />
-            </div>
-
-            <div className={copyright}>
-                © {year} Guardian News & Media Limited or its affiliated
-                companies. All rights reserved.
             </div>
         </Container>
         <div className={copyright}>

--- a/packages/frontend/web/components/Footer.tsx
+++ b/packages/frontend/web/components/Footer.tsx
@@ -7,7 +7,6 @@ import {
     until,
     wide,
     desktop,
-    from,
 } from '@guardian/pasteup/breakpoints';
 import { textSans } from '@guardian/pasteup/typography';
 import { clearFix } from '@guardian/pasteup/mixins';
@@ -104,53 +103,46 @@ const footerList = css`
     flex-wrap: wrap;
     flex-direction: row;
 
-    ${until.leftCol} {
+    ${until.desktop} {
         border-top: 1px solid ${palette.brand.pastel};
     }
 
     ul {
         width: 50%;
         border-left: 1px solid ${palette.brand.pastel};
+        padding: 12px 0 0 10px;
+
+        :nth-of-type(1) {
+            border-left: 0 none;
+        }
 
         ${until.tablet} {
             clear: left;
 
             :nth-of-type(odd) {
-                border-left: 0px;
-                padding-left: 0px;
+                border-left: 0;
+                padding-left: 0;
             }
 
             :nth-of-type(3) {
-                padding-top: 0px;
+                padding-top: 0;
             }
 
             :nth-of-type(4) {
-                padding-top: 0px;
+                padding-top: 0;
             }
         }
+
         ${tablet} {
             margin: 0 10px 36px 0;
             width: 150px;
-
-            :nth-of-type(1) {
-                border-left: none;
-                margin-left: 0;
-            }
         }
 
-        :nth-of-type(1) {
-            border-left: none;
-            padding-left: 0;
-        }
-
-        ${from.leftCol} {
+        ${desktop} {
             :nth-of-type(1) {
-                padding-left: 10px;
                 border-left: 1px solid ${palette.brand.pastel};
             }
         }
-
-        padding: 12px 0 0 10px;
     }
 `;
 

--- a/packages/frontend/web/components/Footer.tsx
+++ b/packages/frontend/web/components/Footer.tsx
@@ -133,7 +133,8 @@ const footerList = css`
 const readerRevenueLinks = css`
     border-left: 1px solid ${palette.brand.pastel};
     padding: 12px 0 0 10px;
-    margin: 0 0 36px 0;
+    margin: 0 10px 36px 0;
+    width: calc(50% - 10px);
 
     ${until.tablet} {
         width: 50%;
@@ -245,20 +246,27 @@ export const Footer: React.FC<{
                     pillar={pillar}
                 />
             </div>
-            <iframe
-                title="Guardian Email Sign-up Form"
-                src="https://www.theguardian.com/email/form/footer/today-uk"
-                scrolling="no"
-                seamless={true}
-                id="footer__email-form"
-                className={emailSignup}
-                data-form-success-desc="We will send you our picks of the most important headlines tomorrow morning."
-                data-node-uid="2"
-                height="100px"
-                frameBorder="0"
-            />
+            <div className={footerItemContainers}>
+                <iframe
+                    title="Guardian Email Sign-up Form"
+                    src="https://www.theguardian.com/email/form/footer/today-uk"
+                    scrolling="no"
+                    seamless={true}
+                    id="footer__email-form"
+                    className={emailSignup}
+                    data-form-success-desc="We will send you our picks of the most important headlines tomorrow morning."
+                    data-node-uid="2"
+                    height="100px"
+                    frameBorder="0"
+                />
 
-            <FooterLinks nav={nav} edition={edition} pageFooter={pageFooter} />
+                <FooterLinks
+                    nav={nav}
+                    edition={edition}
+                    pageFooter={pageFooter}
+                />
+            </div>
+
             <div className={copyright}>
                 © {year} Guardian News & Media Limited or its affiliated
                 companies. All rights reserved.

--- a/packages/frontend/web/components/Footer.tsx
+++ b/packages/frontend/web/components/Footer.tsx
@@ -13,10 +13,19 @@ import { textSans } from '@guardian/pasteup/typography';
 import { clearFix } from '@guardian/pasteup/mixins';
 
 import { Container } from '@guardian/guui';
-import { Pillars } from './Header/Nav/Pillars';
+import { Pillars, pillarWidth, firstPillarWidth } from './Header/Nav/Pillars';
 import { palette } from '@guardian/pasteup/palette';
 import { ReaderRevenueLinks } from './Header/Nav/ReaderRevenueLinks';
 
+// CSS vars
+const emailSignupSideMargins = 10;
+const footerItemContainerPadding = 19;
+const emailSignupWidth =
+    pillarWidth +
+    firstPillarWidth -
+    (emailSignupSideMargins * 2 + footerItemContainerPadding);
+
+// CSS
 const footer = css`
     background-color: ${palette.brand.main};
     color: ${palette.neutral[100]};
@@ -31,7 +40,7 @@ const footerInner = css`
     }
 
     ${desktop} {
-        max-width: 980px;
+        max-width: 100%;
     }
 
     ${leftCol} {
@@ -61,16 +70,20 @@ const pillarWrap = css`
 const emailSignup = css`
     padding-top: 12px;
 
-    ${leftCol} {
-        float: left;
-        width: 258px;
-        margin-right: 180px;
-    }
-
     ${desktop} {
-        margin: 0 10px;
+        margin: 0 ${emailSignupSideMargins}px;
         display: flex;
         flex-direction: row;
+        float: left;
+        width: ${emailSignupWidth}px;
+    }
+
+    ${wide} {
+        margin-right: ${pillarWidth * 2 +
+            firstPillarWidth -
+            (emailSignupWidth +
+                emailSignupSideMargins +
+                footerItemContainerPadding)}px;
     }
 `;
 
@@ -90,6 +103,10 @@ const footerList = css`
     display: flex;
     flex-wrap: wrap;
     flex-direction: row;
+
+    ${until.leftCol} {
+        border-top: 1px solid ${palette.brand.pastel};
+    }
 
     ul {
         width: 50%;
@@ -111,17 +128,26 @@ const footerList = css`
                 padding-top: 0px;
             }
         }
-
-        ${until.leftCol} {
-            :nth-of-type(1) {
-                border-left: 0px;
-                padding-left: 0px;
-            }
-        }
-
         ${tablet} {
             margin: 0 10px 36px 0;
             width: 150px;
+
+            :nth-of-type(1) {
+                border-left: none;
+                margin-left: 0;
+            }
+        }
+
+        :nth-of-type(1) {
+            border-left: none;
+            padding-left: 0;
+        }
+
+        ${from.leftCol} {
+            :nth-of-type(1) {
+                padding-left: 10px;
+                border-left: 1px solid ${palette.brand.pastel};
+            }
         }
 
         padding: 12px 0 0 10px;
@@ -130,6 +156,7 @@ const footerList = css`
 
 const readerRevenueLinks = css`
     border-left: 1px solid ${palette.brand.pastel};
+    flex: 1;
     padding: 12px 0 0 10px;
     margin: 0 10px 36px 0;
     width: calc(50% - 10px);
@@ -137,18 +164,6 @@ const readerRevenueLinks = css`
     ${until.tablet} {
         width: 50%;
         border-top: 1px solid ${palette.brand.pastel};
-    }
-
-    ${from.tablet.until.desktop} {
-        width: 218px;
-    }
-
-    ${from.desktop.until.leftCol} {
-        width: 458px;
-    }
-
-    ${leftCol} {
-        width: 300px;
     }
 `;
 
@@ -179,11 +194,10 @@ const copyright = css`
 const footerItemContainers = css`
     ${leftCol} {
         display: flex;
-        border-top: 1px solid ${palette.brand.pastel};
     }
 
     width: 100%;
-    padding: 0 19px;
+    padding: 0 ${footerItemContainerPadding}px;
 `;
 
 const FooterLinks: React.FC<{

--- a/packages/frontend/web/components/Footer.tsx
+++ b/packages/frontend/web/components/Footer.tsx
@@ -50,8 +50,7 @@ const footerInner = css`
 
 const pillarWrap = css`
     ${clearFix}
-    border: 1px solid ${palette.brand.pastel};
-    border-top: 0;
+    border-bottom: 1px solid ${palette.brand.pastel};
 `;
 
 const emailSignup = css`
@@ -86,12 +85,6 @@ const footerList = css`
     display: flex;
     flex-wrap: wrap;
     flex-direction: row;
-    justify-content: flex-end;
-    width: 100%;
-
-    ${until.leftCol} {
-        border-top: 1px solid ${palette.brand.pastel};
-    }
 
     ul {
         width: 50%;

--- a/packages/frontend/web/components/Footer.tsx
+++ b/packages/frontend/web/components/Footer.tsx
@@ -10,8 +10,10 @@ import {
     from,
 } from '@guardian/pasteup/breakpoints';
 import { textSans } from '@guardian/pasteup/typography';
+import { clearFix } from '@guardian/pasteup/mixins';
 
 import { Container } from '@guardian/guui';
+import { Pillars } from './Header/Nav/Pillars';
 import { palette } from '@guardian/pasteup/palette';
 import { ReaderRevenueLinks } from './Header/Nav/ReaderRevenueLinks';
 
@@ -42,6 +44,12 @@ const footerInner = css`
 
     padding-bottom: 6px;
     display: block;
+    border: 1px solid ${palette.brand.pastel};
+    border-top: 0;
+`;
+
+const pillarWrap = css`
+    ${clearFix}
     border: 1px solid ${palette.brand.pastel};
     border-top: 0;
 `;
@@ -222,31 +230,38 @@ const FooterLinks: React.FC<{
 const year = new Date().getFullYear();
 
 export const Footer: React.FC<{
+    pillars: PillarType[];
+    pillar: Pillar;
     nav: NavType;
     edition: Edition;
     pageFooter: FooterType;
-}> = ({ nav, edition, pageFooter }) => (
+}> = ({ pillars, pillar, nav, edition, pageFooter }) => (
     <footer className={footer}>
         <Container className={footerInner}>
-            <div className={footerItemContainers}>
-                <iframe
-                    title="Guardian Email Sign-up Form"
-                    src="https://www.theguardian.com/email/form/footer/today-uk"
-                    scrolling="no"
-                    seamless={true}
-                    id="footer__email-form"
-                    className={emailSignup}
-                    data-form-success-desc="We will send you our picks of the most important headlines tomorrow morning."
-                    data-node-uid="2"
-                    height="100px"
-                    frameBorder="0"
+            <div className={pillarWrap}>
+                <Pillars
+                    showMainMenu={false}
+                    pillars={pillars}
+                    pillar={pillar}
                 />
+            </div>
+            <iframe
+                title="Guardian Email Sign-up Form"
+                src="https://www.theguardian.com/email/form/footer/today-uk"
+                scrolling="no"
+                seamless={true}
+                id="footer__email-form"
+                className={emailSignup}
+                data-form-success-desc="We will send you our picks of the most important headlines tomorrow morning."
+                data-node-uid="2"
+                height="100px"
+                frameBorder="0"
+            />
 
-                <FooterLinks
-                    nav={nav}
-                    edition={edition}
-                    pageFooter={pageFooter}
-                />
+            <FooterLinks nav={nav} edition={edition} pageFooter={pageFooter} />
+            <div className={copyright}>
+                © {year} Guardian News & Media Limited or its affiliated
+                companies. All rights reserved.
             </div>
         </Container>
         <div className={copyright}>

--- a/packages/frontend/web/components/Header/Nav/MainMenu/Column.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenu/Column.tsx
@@ -179,12 +179,16 @@ const columnStyle = css`
     }
 
     ${desktop} {
-        width: 118px;
+        width: 134px;
         float: left;
         position: relative;
 
         :after {
             content: none;
+        }
+
+        :first-of-type {
+            width: 123px;
         }
     }
     ${leftCol} {

--- a/packages/frontend/web/components/Header/Nav/MainMenu/Columns.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenu/Columns.tsx
@@ -125,9 +125,7 @@ export const Columns: React.FC<{
                             href={brandExtension.url}
                             key={brandExtension.title}
                             role="menuitem"
-                            data-link-name={`nav2 : brand extension : ${
-                                brandExtension.longTitle
-                            }`}
+                            data-link-name={`nav2 : brand extension : ${brandExtension.longTitle}`}
                         >
                             {brandExtension.longTitle}
                         </a>

--- a/packages/frontend/web/components/Header/Nav/MainMenu/Columns.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenu/Columns.tsx
@@ -39,7 +39,7 @@ const desktopBrandExtensionColumn = css`
 `;
 
 const brandExtensionList = css`
-    width: 186px;
+    width: 131px;
     box-sizing: border-box;
     ${textSans(6)};
     flex-wrap: wrap;
@@ -125,7 +125,9 @@ export const Columns: React.FC<{
                             href={brandExtension.url}
                             key={brandExtension.title}
                             role="menuitem"
-                            data-link-name={`nav2 : brand extension : ${brandExtension.longTitle}`}
+                            data-link-name={`nav2 : brand extension : ${
+                                brandExtension.longTitle
+                            }`}
                         >
                             {brandExtension.longTitle}
                         </a>

--- a/packages/frontend/web/components/Header/Nav/Pillars.tsx
+++ b/packages/frontend/web/components/Header/Nav/Pillars.tsx
@@ -190,6 +190,9 @@ const forceUnderline = css`
     }
 `; // A11Y warning: this styling has no focus state for the selected pillar
 
+const isNotLastPillar = (i: number, noOfPillars: number): boolean =>
+    i !== noOfPillars - 1;
+
 export const Pillars: React.FC<{
     showMainMenu: boolean;
     pillars: PillarType[];
@@ -202,7 +205,8 @@ export const Pillars: React.FC<{
                 <a
                     className={cx(linkStyle, pillarUnderline[p.pillar], {
                         [pillarDivider]:
-                            showLastPillarDivider || i !== pillars.length - 1,
+                            showLastPillarDivider ||
+                            isNotLastPillar(i, pillars.length),
                         [showMenuUnderline]: showMainMenu,
                         [forceUnderline]: p.pillar === pillar,
                     })}

--- a/packages/frontend/web/components/Header/Nav/Pillars.tsx
+++ b/packages/frontend/web/components/Header/Nav/Pillars.tsx
@@ -15,6 +15,13 @@ import { headline } from '@guardian/pasteup/typography';
 import { pillarMap, pillarPalette } from '@frontend/lib/pillars';
 import { palette } from '@guardian/pasteup/palette';
 
+// CSS Vars
+
+export const firstPillarWidth = 171;
+export const pillarWidth = 160;
+
+// CSS
+
 const pillarsStyles = css`
     clear: right;
     margin: 0;
@@ -29,10 +36,7 @@ const pillarsStyles = css`
         display: block;
         position: relative;
         ${desktop} {
-            width: 134px;
-        }
-        ${leftCol} {
-            width: 160px;
+            width: ${pillarWidth}px;
         }
     }
 
@@ -71,10 +75,7 @@ const pillarStyle = css`
     :first-of-type {
         margin-left: -20px;
         ${desktop} {
-            width: 144px;
-        }
-        ${leftCol} {
-            width: 171px;
+            width: ${firstPillarWidth}px;
         }
         a {
             padding-left: 20px;

--- a/packages/frontend/web/components/Header/Nav/Pillars.tsx
+++ b/packages/frontend/web/components/Header/Nav/Pillars.tsx
@@ -189,20 +189,18 @@ export const Pillars: React.FC<{
     showMainMenu: boolean;
     pillars: PillarType[];
     pillar: Pillar;
-}> = ({ showMainMenu, pillars, pillar }) => (
+    showLastPillarDivider?: boolean;
+}> = ({ showMainMenu, pillars, pillar, showLastPillarDivider = true }) => (
     <ul className={pillarsStyles}>
         {pillars.map((p, i) => (
             <li key={p.title} className={pillarStyle}>
                 <a
-                    className={cx(
-                        pillarDivider,
-                        linkStyle,
-                        pillarUnderline[p.pillar],
-                        {
-                            [showMenuUnderline]: showMainMenu,
-                            [forceUnderline]: p.pillar === pillar,
-                        },
-                    )}
+                    className={cx(linkStyle, pillarUnderline[p.pillar], {
+                        [pillarDivider]:
+                            showLastPillarDivider || i !== pillars.length - 1,
+                        [showMenuUnderline]: showMainMenu,
+                        [forceUnderline]: p.pillar === pillar,
+                    })}
                     href={p.url}
                     data-link-name={`nav2 : primary : ${p.title}`}
                 >

--- a/packages/frontend/web/components/Header/Nav/Pillars.tsx
+++ b/packages/frontend/web/components/Header/Nav/Pillars.tsx
@@ -19,6 +19,8 @@ import { palette } from '@guardian/pasteup/palette';
 
 export const firstPillarWidth = 171;
 export const pillarWidth = 160;
+export const preLeftColFirstPillarWidth = 144;
+export const preLeftColPillarWidth = 134;
 
 // CSS
 
@@ -35,7 +37,8 @@ const pillarsStyles = css`
         float: left;
         display: block;
         position: relative;
-        ${desktop} {
+        width: ${preLeftColPillarWidth}px;
+        ${leftCol} {
             width: ${pillarWidth}px;
         }
     }
@@ -74,7 +77,8 @@ const showMenuUnderline = css`
 const pillarStyle = css`
     :first-of-type {
         margin-left: -20px;
-        ${desktop} {
+        width: ${preLeftColFirstPillarWidth}px;
+        ${leftCol} {
             width: ${firstPillarWidth}px;
         }
         a {

--- a/packages/frontend/web/pages/Article.tsx
+++ b/packages/frontend/web/pages/Article.tsx
@@ -81,6 +81,8 @@ export const Article: React.FC<{
             nav={data.NAV}
             edition={data.CAPI.editionId}
             pageFooter={data.CAPI.pageFooter}
+            pillar={data.CAPI.pillar}
+            pillars={data.NAV.pillars}
         />
 
         <CookieBanner />


### PR DESCRIPTION
## What does this change?

- Adds pillars to footer
- Small refactor to footer and pillars to parametrise some magic numbers and use them where they rely on each other
- Some fixes as per @zeftilldeath's review like lining up header nav with pillar lines

## Why?

Visual parity.

![2019-08-19 14 19 22](https://user-images.githubusercontent.com/638051/63282946-da576b80-c2a7-11e9-97b8-86da1c9480f6.gif)

![2019-08-19 14 19 51](https://user-images.githubusercontent.com/638051/63282953-dd525c00-c2a7-11e9-81a9-61f9bbc083a9.gif)


## Link to supporting Trello card
https://trello.com/c/kUFvDdqp/650-expanded-nav-breaks-outside-of-the-page-and-the-pillars-dont-match-the-content-beneath-them

https://trello.com/c/S8p3ku2l/648-%F0%9F%95%B5-footer-looking-wild-in-a-few-ways-we-have-since-added-pillars-here-too-not-sure-how-important-it-is-to-keep-up-with-changes-th

