### PR TITLE
Add initial document.test for web

### DIFF
--- a/fixtures/ga.ts
+++ b/fixtures/ga.ts
@@ -1,0 +1,18 @@
+const pillar: Pillar = 'lifestyle';
+const edition: Edition = 'UK';
+export const ga = {
+    pillar,
+    edition,
+    webTitle: "PC Andrew Harper: accused denies role in 'horrific murder'",
+    section: 'uk-news',
+    contentType: 'article',
+    commissioningDesks: 'ukhomenews',
+    contentId:
+        'uk-news/2019/aug/20/pc-andrew-harper-accused-jed-foster-denies-role-in-murder',
+    authorIds: '',
+    keywordIds: 'uk/uk',
+    toneIds: 'tone/news',
+    seriesId: '',
+    isHosted: 'false',
+    beaconUrl: '//phar.gu-web.net',
+};

--- a/packages/frontend/web/server/document.test.tsx
+++ b/packages/frontend/web/server/document.test.tsx
@@ -1,0 +1,33 @@
+import { document } from './document';
+import { CAPI } from '@root/fixtures/CAPI';
+import { ga } from '@root/fixtures/ga';
+import { extract as extractNAV } from '@frontend/model/extract-nav';
+
+const linkedData = [{}];
+const result = document({
+    data: {
+        linkedData,
+        CAPI,
+        page: 'article',
+        site: 'site',
+        NAV: extractNAV(CAPI.nav),
+        config: CAPI.config,
+        GA: ga,
+    },
+});
+
+test('that all the required meta SEO fields exist', async () => {
+    const names = ['description', 'viewport'];
+
+    names.map(name =>
+        expect(result.includes(`<meta name="${name}"`)).toBe(true),
+    );
+});
+
+test('that all the required links exist', async () => {
+    const names = ['amphtml'];
+
+    names.map(name =>
+        expect(result.includes(`<link rel="${name}" href="`)).toBe(true),
+    );
+});


### PR DESCRIPTION
## What does this change?
Very simple string `include` check on rendered html.

## Why?
Sanity check for web.

## Link to supporting Trello card
https://trello.com/c/hvhF3aS4/665-simple-doc-test-for-web
