### PR TITLE
Use ?dcr=true rather than ?guui to fetch data in dev mode.

### DIFF
--- a/packages/frontend/web/components/MostViewed.tsx
+++ b/packages/frontend/web/components/MostViewed.tsx
@@ -363,7 +363,7 @@ export class MostViewed extends Component<Props, { selectedTabIndex: number }> {
             hasSection ? `/${this.props.sectionName}` : ''
         }.json`;
         return new Promise((resolve, reject) => {
-            fetch(`https://api.nextgen.guardianapps.co.uk${endpoint}?guui`)
+            fetch(`https://api.nextgen.guardianapps.co.uk${endpoint}?dcr=true`)
                 .then(response => {
                     if (!response.ok) {
                         resolve([]);

--- a/scripts/frontend/dev-server.js
+++ b/scripts/frontend/dev-server.js
@@ -45,7 +45,7 @@ const go = async () => {
         async (req, res, next) => {
             const { html, ...config } = await fetch(
                 `${req.query.url ||
-                    'https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software'}.json?guui`,
+                    'https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software'}.json?dcr=true`,
             ).then(article => article.json());
 
             req.body = config;
@@ -61,7 +61,7 @@ const go = async () => {
         async (req, res, next) => {
             const { html, ...config } = await fetch(
                 `${req.query.url ||
-                    'https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software'}.json?guui`,
+                    'https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software'}.json?dcr=true`,
             ).then(article => article.json());
 
             req.body = config;
@@ -73,8 +73,10 @@ const go = async () => {
         }),
     );
 
-    app.get('/',function(req,res) {
-        res.sendFile(path.join(root, 'scripts', 'frontend', 'landing', 'index.html'));
+    app.get('/', function(req, res) {
+        res.sendFile(
+            path.join(root, 'scripts', 'frontend', 'landing', 'index.html'),
+        );
     });
 
     app.get('*', (req, res) => {


### PR DESCRIPTION
## What does this change?
Following from https://github.com/guardian/frontend/pull/21753 we'll need to update the endpoints that DCR hits in dev mode otherwise they'll break

## Why?
The original motivation for this was that `?guui=false` is currently broken, making it harder to compare pages with/without dotcom rendering.
