### PR TITLE
Gtrufitt/more footer tidy

### DIFF
--- a/packages/frontend/web/components/Header/Nav/MainMenu/Column.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenu/Column.tsx
@@ -47,8 +47,8 @@ const columnLinkTitle = css`
         padding-left: 60px;
     }
     ${desktop} {
+        ${textSans(6)};
         font-size: 16px;
-        ${headline(2)};
         padding: 6px 0;
     }
     :hover,

--- a/packages/frontend/web/components/Header/Nav/MainMenu/Column.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenu/Column.tsx
@@ -137,12 +137,6 @@ const pillarColumnLinks = css`
     }
 `;
 
-const firstColumn = css`
-    :after {
-        content: none;
-    }
-`;
-
 const hide = css`
     display: none;
 `;

--- a/packages/frontend/web/components/Header/Nav/MainMenu/Column.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenu/Column.tsx
@@ -6,6 +6,11 @@ import { desktop, tablet, leftCol, until } from '@guardian/pasteup/breakpoints';
 import { palette } from '@guardian/pasteup/palette';
 import { CollapseColumnButton } from './CollapseColumnButton';
 
+// CSS vars
+const pillarHeight = 42;
+
+// CSS
+
 export const hideDesktop = css`
     ${desktop} {
         display: none;
@@ -20,10 +25,18 @@ const pillarDivider = css`
             position: absolute;
             right: 0;
             top: 0;
-            bottom: -100px;
+            bottom: 0;
             width: 1px;
             background-color: ${palette.brand.pastel};
             z-index: 1;
+        }
+    }
+`;
+
+const pillarDividerExtended = css`
+    ${desktop} {
+        :before {
+            top: -${pillarHeight}px;
         }
     }
 `;
@@ -106,10 +119,10 @@ const columnLinks = css`
         flex-direction: column;
         flex-wrap: nowrap;
         order: 1;
+        height: 100%;
         width: 100%;
         padding: 0 9px;
     }
-    ${pillarDivider};
 `;
 
 const firstColumnLinks = css`
@@ -179,6 +192,11 @@ const columnStyle = css`
         right: 0;
     }
 
+    /* Remove the border from the top item on mobile */
+    :first-of-type:after {
+        content: none;
+    }
+
     ${desktop} {
         width: 134px;
         float: left;
@@ -245,7 +263,10 @@ export const More: React.FC<{
         ],
     };
     return (
-        <li className={cx(columnStyle)} role="none">
+        <li
+            className={cx(columnStyle, pillarDivider, pillarDividerExtended)}
+            role="none"
+        >
             <ColumnLinks column={more} showColumnLinks={true} id={subNavId} />
         </li>
     );
@@ -273,16 +294,7 @@ export class Column extends Component<
         const { column, index } = this.props;
         const subNavId = `${column.title.toLowerCase()}Links`;
         return (
-            <li
-                className={cx(
-                    columnStyle,
-                    {
-                        [pillarDivider]: index > 0,
-                    },
-                    { [firstColumn]: index === 0 },
-                )}
-                role="none"
-            >
+            <li className={cx(columnStyle, pillarDivider)} role="none">
                 <CollapseColumnButton
                     title={column.title}
                     showColumnLinks={showColumnLinks}

--- a/packages/frontend/web/components/Header/Nav/MainMenu/Column.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenu/Column.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { textSans, headline } from '@guardian/pasteup/typography';
+import { textSans } from '@guardian/pasteup/typography';
 import { css, cx } from 'emotion';
 
 import { desktop, tablet, leftCol, until } from '@guardian/pasteup/breakpoints';

--- a/packages/frontend/web/components/Header/Nav/MainMenu/Column.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenu/Column.tsx
@@ -165,6 +165,7 @@ const columnStyle = css`
     ${textSans(6)};
     list-style: none;
     margin: 0;
+    padding-bottom: 10px;
     position: relative;
 
     :after {

--- a/packages/frontend/web/components/Header/Nav/MainMenu/Columns.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenu/Columns.tsx
@@ -34,7 +34,7 @@ const desktopBrandExtensionColumn = css`
     display: none;
     position: absolute;
     right: 20px;
-    top: 6px;
+    top: -35px;
     bottom: 0;
 `;
 

--- a/packages/frontend/web/components/Header/Nav/MainMenu/Columns.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenu/Columns.tsx
@@ -34,7 +34,7 @@ const desktopBrandExtensionColumn = css`
     display: none;
     position: absolute;
     right: 20px;
-    top: -35px;
+    top: 4px;
     bottom: 0;
 `;
 

--- a/packages/frontend/web/components/Header/Nav/MainMenu/MainMenu.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenu/MainMenu.tsx
@@ -15,6 +15,7 @@ import { textSans } from '@guardian/pasteup/typography';
 const showMenu = css`
     ${desktop} {
         display: block;
+        overflow: visible;
     }
     ${until.desktop} {
         transform: translateX(0%);

--- a/packages/frontend/web/components/Header/Nav/Pillars.tsx
+++ b/packages/frontend/web/components/Header/Nav/Pillars.tsx
@@ -76,6 +76,10 @@ const showMenuUnderline = css`
     :hover {
         text-decoration: underline;
     }
+
+    :after {
+        transform: translateY(4px);
+    }
 `;
 
 const pillarStyle = css`

--- a/packages/frontend/web/components/Header/Nav/Pillars.tsx
+++ b/packages/frontend/web/components/Header/Nav/Pillars.tsx
@@ -21,7 +21,7 @@ export const firstPillarWidth = 171;
 export const pillarWidth = 160;
 export const preLeftColFirstPillarWidth = 144;
 export const preLeftColPillarWidth = 134;
-export const preTabletPillarWidth = 'auto';
+export const preDesktopPillarWidth = 'auto';
 
 // CSS
 
@@ -38,9 +38,9 @@ const pillarsStyles = css`
         float: left;
         display: block;
         position: relative;
-        width: ${preTabletPillarWidth};
-        ${tablet} {
-            width: ${preLeftColPillarWidth};
+        width: ${preDesktopPillarWidth};
+        ${desktop} {
+            width: ${preLeftColPillarWidth}px;
         }
         ${leftCol} {
             width: ${pillarWidth}px;
@@ -81,9 +81,9 @@ const showMenuUnderline = css`
 const pillarStyle = css`
     :first-of-type {
         margin-left: -20px;
-        width: ${preTabletPillarWidth};
+        width: ${preDesktopPillarWidth};
 
-        ${tablet} {
+        ${desktop} {
             width: ${preLeftColFirstPillarWidth}px;
         }
 

--- a/packages/frontend/web/pages/Article.tsx
+++ b/packages/frontend/web/pages/Article.tsx
@@ -40,10 +40,14 @@ const articleContainer = css`
     }
 `;
 
+const overflowHidden = css`
+    overflow: hidden;
+`;
+
 export const Article: React.FC<{
     data: ArticleProps;
 }> = ({ data }) => (
-    <div>
+    <div className={overflowHidden}>
         <Header
             nav={data.NAV}
             pillar={data.CAPI.pillar}


### PR DESCRIPTION
## What does this change?

More visual parity on header and footer.

- Uses the correct typography 📖 
- Fixes issues on some breakpoints 🚫 
- Adds the brand colour showing on dropdown 🎨 
- Makes the brand links float in space (get our dividers proper) 🗂 
- Fixes overflowing of nav 💧 
- Tweaks to layout 🏠 
- Some refactoring for clarity (Prefer CSS selectors of JS logic) 💡 

### Frontend `dcr=false`

![2019-08-22 08 02 59](https://user-images.githubusercontent.com/638051/63493615-e6b01400-c4b3-11e9-85f1-575b7d75b935.gif)

### DCR Prod Before

![2019-08-22 08 03 23](https://user-images.githubusercontent.com/638051/63493650-f4fe3000-c4b3-11e9-8fc3-7f1400eaf5bc.gif)


### DCR After

![2019-08-22 08 03 49](https://user-images.githubusercontent.com/638051/63493658-f891b700-c4b3-11e9-8f81-71c8e88b9d11.gif)


## Link to supporting Trello card

- https://trello.com/c/kUFvDdqp/650-expanded-nav-breaks-outside-of-the-page-and-the-pillars-dont-match-the-content-beneath-them
- https://trello.com/c/S8p3ku2l/648-%F0%9F%95%B5-footer-looking-wild-in-a-few-ways-we-have-since-added-pillars-here-too-not-sure-how-important-it-is-to-keep-up-with-changes-th
- https://trello.com/c/n4nr9zlu/649-sublinks-in-expanded-menu-should-be-text-sans-and-the-brand-extensions-are-floating-in-the-ether
