### PR TITLE
Baselines

### DIFF
--- a/packages/frontend/web/components/Header/Nav/MainMenuToggle/MainMenuToggle.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenuToggle/MainMenuToggle.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { css, cx } from 'emotion';
-import { desktop, wide } from '@guardian/pasteup/breakpoints';
+import { desktop } from '@guardian/pasteup/breakpoints';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';
 import { headline } from '@guardian/pasteup/typography';
 import { VeggieBurger } from './VeggieBurger';
@@ -10,7 +10,7 @@ const screenReadable = css`
     ${screenReaderOnly};
 `;
 const openMainMenu = css`
-    ${headline(3)};
+    ${headline(4)};
     font-weight: 300;
     color: ${palette.neutral[100]};
     cursor: pointer;
@@ -24,11 +24,8 @@ const openMainMenu = css`
     padding-right: 20px;
     ${desktop} {
         display: block;
-        padding-top: 7px;
+        padding-top: 5px;
         height: 42px;
-    }
-    ${wide} {
-        ${headline(4)};
     }
     :hover {
         color: ${palette.highlight.main};

--- a/packages/frontend/web/components/Header/Nav/Pillars.tsx
+++ b/packages/frontend/web/components/Header/Nav/Pillars.tsx
@@ -151,18 +151,21 @@ const linkStyle = css`
     }
     ${tablet} {
         font-size: 22px;
-        padding-top: 11px;
+        padding-top: 13px;
         height: 48px;
         padding-right: 20px;
         padding-left: 9px;
     }
     ${desktop} {
-        padding-top: 7px;
+        padding-top: 11px;
         height: 42px;
     }
+
     ${wide} {
+        padding-top: 9px;
         font-size: 24px;
     }
+
     :focus:after {
         transform: translateY(4px);
     }


### PR DESCRIPTION
## What does this change?
> Pillars vertical alignment, the baseline of the font should be level with the vertical lines, giving the impression of vertical centering

and 

> Baseline of More in nav should line up with baseline of pillars

![image](https://user-images.githubusercontent.com/638051/63496389-bd928200-c4b9-11e9-9bb3-23050bb60b97.png)

## Link to supporting Trello card
https://trello.com/c/99Omim3t/646-pillars-vertical-alignment-the-baseline-of-the-font-should-be-level-with-the-vertical-lines-giving-the-impression-of-vertical-ce

https://trello.com/c/exM73phs/660-baseline-of-more-in-nav-should-line-up-with-baseline-of-pillars