### PR TITLE
Add DCR import linting dependency

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,7 +26,8 @@ module.exports = {
                     "@frontend/lib/",
                     "@frontend/amp/lib/",
                     "@testing-library",
-                    "@root/packages/frontend/amp/lib/"
+                    "@root/packages/frontend/amp/lib/",
+                    "@guardian/src-foundations"
                 ]
             }
         ]

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
     parser: '@typescript-eslint/parser',
-    plugins: ['@typescript-eslint/tslint'],
+    plugins: ['@typescript-eslint/tslint', 'dcr'],
     parserOptions: {
         ecmaVersion: 6,
         project: './tsconfig.json',
@@ -13,5 +13,6 @@ module.exports = {
                 lintFile: './tslint.json', // path to tslint.json of your project
             },
         ],
+        'dcr/only-import-below': 1        
     },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,22 @@ module.exports = {
                 lintFile: './tslint.json', // path to tslint.json of your project
             },
         ],
-        'dcr/only-import-below': 1        
+        'dcr/only-import-below': [
+            'warn',            
+            {
+                allowedImports: [
+                    "react",
+                    "emotion",
+                    "jsdom",
+                    "curlyquotes",
+                    "react-dom",
+                    "@guardian/pasteup",
+                    "@frontend/lib/",
+                    "@frontend/amp/lib/",
+                    "@testing-library",
+                    "@root/packages/frontend/amp/lib/"
+                ]
+            }
+        ]
     },
 };

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
         "bundlesize": "^0.17.0",
         "doctoc": "^1.4.0",
         "eslint": "^5.16.0",
+        "eslint-plugin-dcr": "https://github.com/guardian/eslint-plugin-dcr",
         "friendly-errors-webpack-plugin": "^1.7.0",
         "husky": "^2.3.0",
         "jest": "^24.8.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "bundlesize": "^0.17.0",
         "doctoc": "^1.4.0",
         "eslint": "^5.16.0",
-        "eslint-plugin-dcr": "https://github.com/guardian/eslint-plugin-dcr",
+        "eslint-plugin-dcr": "https://github.com/guardian/eslint-plugin-dcr#v0.1.0",
         "friendly-errors-webpack-plugin": "^1.7.0",
         "husky": "^2.3.0",
         "jest": "^24.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7059,9 +7059,9 @@ eslint-module-utils@^2.4.0:
     debug "^2.6.8"
     pkg-dir "^2.0.0"
 
-"eslint-plugin-dcr@https://github.com/guardian/eslint-plugin-dcr":
+"eslint-plugin-dcr@https://github.com/guardian/eslint-plugin-dcr#v0.1.0":
   version "1.0.0"
-  resolved "https://github.com/guardian/eslint-plugin-dcr#a03d5a05e8f1e1b342ab5c5433fb0809d77e7b26"
+  resolved "https://github.com/guardian/eslint-plugin-dcr#9aff46e4ce196e57ea29e25ee5c0a3eb8d129964"
 
 eslint-plugin-flowtype@^2.46.1:
   version "2.50.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7059,6 +7059,10 @@ eslint-module-utils@^2.4.0:
     debug "^2.6.8"
     pkg-dir "^2.0.0"
 
+"eslint-plugin-dcr@https://github.com/guardian/eslint-plugin-dcr":
+  version "1.0.0"
+  resolved "https://github.com/guardian/eslint-plugin-dcr#a03d5a05e8f1e1b342ab5c5433fb0809d77e7b26"
+
 eslint-plugin-flowtype@^2.46.1:
   version "2.50.3"
   resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.50.3.tgz#61379d6dce1d010370acd6681740fd913d68175f"


### PR DESCRIPTION
## What does this change?

Adds a new eslint rule that restricts import statements usable in react components.

**Todo:**

- [x] Move hardcoded paths  and imports into rule config (other repo)
- [x] Decide if I need any form of packaging/transpilation (other repo)

[See the OTHER repo for the code, this PR just adds the dep](https://github.com/guardian/eslint-plugin-dcr)

## Why?

[trello card](https://trello.com/c/mEYb3T0r/521-ensuring-isolation-of-components-%E2%97%8F%E2%97%8F%E2%97%8F%E2%97%8F%E2%97%8F)

## Link to supporting Trello card

[trello card](https://trello.com/c/mEYb3T0r/521-ensuring-isolation-of-components-%E2%97%8F%E2%97%8F%E2%97%8F%E2%97%8F%E2%97%8F)
