### PR TITLE
Migrate colours from pasteup -> @guardian/src-foundations in AMP

### DIFF
--- a/packages/frontend/amp/components/Ad.tsx
+++ b/packages/frontend/amp/components/Ad.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css, cx } from 'emotion';
-import { palette } from '@guardian/pasteup/palette';
+import { palette } from '@guardian/src-foundations';
 import { textSans } from '@guardian/pasteup/typography';
 import { adJson, stringify } from '@frontend/amp/lib/ad-json';
 

--- a/packages/frontend/amp/components/AdConsent.tsx
+++ b/packages/frontend/amp/components/AdConsent.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { JsonScript } from './JsonScript';
 import { css, cx } from 'emotion';
 import { textSans } from '@guardian/pasteup/typography';
-import { palette } from '@guardian/pasteup/palette';
+import { palette } from '@guardian/src-foundations';
 import Tick from '@guardian/pasteup/icons/tick.svg';
 
 const consentUIStyle = css`
@@ -52,7 +52,7 @@ const buttonStyle = css`
 const acceptStyle = css`
     border-radius: 20px;
     border: 1px solid rgba(255, 255, 255, 0.3);
-    background: ${palette.highlight.main};
+    background: ${palette.yellow.main};
     color: ${palette.neutral[7]};
     padding: 5px 20px;
     font-weight: bold;

--- a/packages/frontend/amp/components/Blocks.tsx
+++ b/packages/frontend/amp/components/Blocks.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Elements } from '@frontend/amp/components/Elements';
 import { css } from 'emotion';
 import { pillarPalette } from '@frontend/lib/pillars';
-import { palette } from '@guardian/pasteup/palette';
+import { palette } from '@guardian/src-foundations';
 import { blockLink } from '@frontend/amp/lib/block-link';
 import { findBlockAdSlots } from '@frontend/amp/lib/find-adslots';
 import { textSans } from '@guardian/pasteup/typography';

--- a/packages/frontend/amp/components/BodyArticle.tsx
+++ b/packages/frontend/amp/components/BodyArticle.tsx
@@ -7,7 +7,7 @@ import { TopMeta } from '@frontend/amp/components/topMeta/TopMeta';
 import { SubMeta } from '@frontend/amp/components/SubMeta';
 import { designTypeDefault } from '@frontend/lib/designTypes';
 import { pillarPalette } from '@frontend/lib/pillars';
-import { palette } from '@guardian/pasteup/palette';
+import { palette } from '@guardian/src-foundations';
 import { WithAds } from '@frontend/amp/components/WithAds';
 import { findAdSlots } from '@frontend/amp/lib/find-adslots';
 import { until } from '@guardian/pasteup/breakpoints';

--- a/packages/frontend/amp/components/BodyLiveblog.tsx
+++ b/packages/frontend/amp/components/BodyLiveblog.tsx
@@ -4,7 +4,7 @@ import { css } from 'emotion';
 import { ArticleModel } from '@frontend/amp/pages/Article';
 import { TopMetaLiveblog } from '@frontend/amp/components/topMeta/TopMetaLiveblog';
 import { SubMeta } from '@frontend/amp/components/SubMeta';
-import { palette } from '@guardian/pasteup/palette';
+import { palette } from '@guardian/src-foundations';
 import { KeyEvents } from '@frontend/amp/components/KeyEvents';
 import { Blocks } from '@frontend/amp/components/Blocks';
 import RefreshIcon from '@guardian/pasteup/icons/refresh.svg';

--- a/packages/frontend/amp/components/Expandable.tsx
+++ b/packages/frontend/amp/components/Expandable.tsx
@@ -5,7 +5,7 @@ import InfoIcon from '@guardian/pasteup/icons/info.svg';
 import PlusIcon from '@guardian/pasteup/icons/plus.svg';
 
 import { body, textSans, headline } from '@guardian/pasteup/typography';
-import { palette } from '@guardian/pasteup/palette';
+import { palette } from '@guardian/src-foundations';
 import { TextStyle } from '@frontend/amp/components/elements/Text';
 
 const wrapper = (pillar: Pillar) => css`

--- a/packages/frontend/amp/components/Footer.tsx
+++ b/packages/frontend/amp/components/Footer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 import { textSans, body } from '@guardian/pasteup/typography';
-import { palette } from '@guardian/pasteup/palette';
+import { palette } from '@guardian/src-foundations';
 import { InnerContainer } from './InnerContainer';
 import {
     Link,
@@ -30,7 +30,7 @@ const footerLink = css`
     display: block;
 
     :hover {
-        color: ${palette.highlight.main};
+        color: ${palette.yellow.main};
     }
 `;
 
@@ -119,7 +119,7 @@ const backToTopText = css`
 `;
 
 const supportLink = css`
-    color: ${palette.highlight.main};
+    color: ${palette.yellow.main};
     ${body(3)};
     padding-bottom: 0.375rem;
 `;

--- a/packages/frontend/amp/components/Header.tsx
+++ b/packages/frontend/amp/components/Header.tsx
@@ -4,7 +4,7 @@ import Logo from '@guardian/pasteup/logos/the-guardian.svg';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';
 import { headline } from '@guardian/pasteup/typography';
 import { pillarPalette } from '../../lib/pillars';
-import { palette } from '@guardian/pasteup/palette';
+import { palette } from '@guardian/src-foundations';
 import { ReaderRevenueButton } from '@root/packages/frontend/amp/components/ReaderRevenueButton';
 import { mobileLandscape, until } from '@guardian/pasteup/breakpoints';
 
@@ -113,7 +113,7 @@ const pillarLinkStyle = (pillar: Pillar) => css`
 `;
 
 const veggieStyles = css`
-    background-color: ${palette.highlight.main};
+    background-color: ${palette.yellow.main};
     color: ${palette.neutral[97]};
     height: 42px;
     min-width: 42px;

--- a/packages/frontend/amp/components/KeyEvents.tsx
+++ b/packages/frontend/amp/components/KeyEvents.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 import { headline, textSans } from '@guardian/pasteup/typography';
-import { palette } from '@guardian/pasteup/palette';
+import { palette } from '@guardian/src-foundations';
 // import { pillarPalette } from '@frontend/lib/pillars';
 import DownArrow from '@guardian/pasteup/icons/down-arrow.svg';
 import { blockLink } from '@frontend/amp/lib/block-link';

--- a/packages/frontend/amp/components/MainMedia.tsx
+++ b/packages/frontend/amp/components/MainMedia.tsx
@@ -3,7 +3,7 @@ import { bestFitImage, heightEstimate } from '@frontend/amp/lib/image-fit';
 import { css } from 'emotion';
 import { textSans } from '@guardian/pasteup/typography';
 import InfoIcon from '@guardian/pasteup/icons/info.svg';
-import { palette } from '@guardian/pasteup/palette';
+import { palette } from '@guardian/src-foundations';
 import { YoutubeVideo } from '@frontend/amp/components/elements/YoutubeVideo';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';
 

--- a/packages/frontend/amp/components/OnwardContainer.tsx
+++ b/packages/frontend/amp/components/OnwardContainer.tsx
@@ -13,7 +13,7 @@ import Camera from '@guardian/pasteup/icons/camera.svg';
 import VolumeHigh from '@guardian/pasteup/icons/volume-high.svg';
 import Quote from '@guardian/pasteup/icons/quote.svg';
 import Clock from '@guardian/pasteup/icons/clock.svg';
-import { palette } from '@guardian/pasteup/palette';
+import { palette } from '@guardian/src-foundations';
 import { css } from 'emotion';
 import { ShowMoreButton } from '@frontend/amp/components/ShowMoreButton';
 

--- a/packages/frontend/amp/components/Pagination.tsx
+++ b/packages/frontend/amp/components/Pagination.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from 'emotion';
-import { palette } from '@guardian/pasteup/palette';
+import { palette } from '@guardian/src-foundations';
 import ChevronRightSingle from '@guardian/pasteup/icons/chevron-right-single.svg';
 import ChevronRightDouble from '@guardian/pasteup/icons/chevron-right-double.svg';
 import ChevronLeftSingle from '@guardian/pasteup/icons/chevron-left-single.svg';

--- a/packages/frontend/amp/components/ReaderRevenueButton.tsx
+++ b/packages/frontend/amp/components/ReaderRevenueButton.tsx
@@ -3,12 +3,12 @@ import { css, cx } from 'emotion';
 
 import { textSans } from '@guardian/pasteup/typography';
 import ArrowRight from '@guardian/pasteup/icons/arrow-right.svg';
-import { palette } from '@guardian/pasteup/palette';
+import { palette } from '@guardian/src-foundations';
 import { until } from '@guardian/pasteup/breakpoints';
 
 const supportStyles = css`
     align-self: flex-start;
-    background-color: ${palette.highlight.main};
+    background-color: ${palette.yellow.main};
     border-radius: 20px;
     display: flex;
     align-items: center;

--- a/packages/frontend/amp/components/ShowMoreButton.tsx
+++ b/packages/frontend/amp/components/ShowMoreButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from 'emotion';
-import { palette } from '@guardian/pasteup/palette';
+import { palette } from '@guardian/src-foundations';
 import { textSans } from '@guardian/pasteup/typography';
 import PlusIcon from '@guardian/pasteup/icons/plus.svg';
 

--- a/packages/frontend/amp/components/Sidebar.tsx
+++ b/packages/frontend/amp/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css, cx } from 'emotion';
-import { palette } from '@guardian/pasteup/palette';
+import { palette } from '@guardian/src-foundations';
 import { headline, textSans } from '@guardian/pasteup/typography';
 
 const sidebarStyles = css`
@@ -92,7 +92,7 @@ const otherLinks = css`
 const membershipLinks = css`
     a {
         font-weight: 700;
-        color: ${palette.highlight.main};
+        color: ${palette.yellow.main};
     }
 `;
 

--- a/packages/frontend/amp/components/SubMeta.tsx
+++ b/packages/frontend/amp/components/SubMeta.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css, cx } from 'emotion';
 import { pillarPalette } from '@frontend/lib/pillars';
 import { textSans, body } from '@guardian/pasteup/typography';
-import { palette } from '@guardian/pasteup/palette';
+import { palette } from '@guardian/src-foundations';
 import { ShareIcons } from '@frontend/amp/components/ShareIcons';
 import CommentIcon from '@guardian/pasteup/icons/comment.svg';
 

--- a/packages/frontend/amp/components/elements/Comment.tsx
+++ b/packages/frontend/amp/components/elements/Comment.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from 'emotion';
-import { palette } from '@guardian/pasteup/palette';
+import { palette } from '@guardian/src-foundations';
 import { textSans } from '@guardian/pasteup/typography';
 
 const wrapper = css`

--- a/packages/frontend/amp/components/elements/Image.tsx
+++ b/packages/frontend/amp/components/elements/Image.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { textSans } from '@guardian/pasteup/typography';
-import { palette } from '@guardian/pasteup/palette';
+import { palette } from '@guardian/src-foundations';
 import { css } from 'emotion';
 import { pillarPalette } from '@frontend/lib/pillars';
 import { bestFitImage, heightEstimate } from '@frontend/amp/lib/image-fit';

--- a/packages/frontend/amp/components/elements/PullQuote.tsx
+++ b/packages/frontend/amp/components/elements/PullQuote.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 import Quote from '@guardian/pasteup/icons/quote.svg';
 import { pillarPalette } from '@frontend/lib/pillars';
-import { palette } from '@guardian/pasteup/palette';
+import { palette } from '@guardian/src-foundations';
 import { body } from '@guardian/pasteup/typography';
 
 const styles = (pillar: Pillar) => css`

--- a/packages/frontend/amp/components/elements/RichLink.tsx
+++ b/packages/frontend/amp/components/elements/RichLink.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css, cx } from 'emotion';
-import { palette } from '@guardian/pasteup/palette';
+import { palette } from '@guardian/src-foundations';
 import { headline, textSans } from '@guardian/pasteup/typography';
 import { pillarPalette } from '@frontend/lib/pillars';
 

--- a/packages/frontend/amp/components/elements/Subheading.tsx
+++ b/packages/frontend/amp/components/elements/Subheading.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css, cx } from 'emotion';
-import { palette } from '@guardian/pasteup/palette';
+import { palette } from '@guardian/src-foundations';
 import { headline, textSans } from '@guardian/pasteup/typography';
 import { pillarPalette } from '@frontend/lib/pillars';
 import { composeLabsCSS } from '@root/packages/frontend/amp/lib/compose-labs-css';

--- a/packages/frontend/amp/components/elements/Text.tsx
+++ b/packages/frontend/amp/components/elements/Text.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from 'emotion';
-import { palette } from '@guardian/pasteup/palette';
+import { palette } from '@guardian/src-foundations';
 import { pillarPalette } from '@frontend/lib/pillars';
 import { sanitise } from '@frontend/amp/lib/sanitise-html';
 import { body, textSans } from '@guardian/pasteup/typography';

--- a/packages/frontend/amp/components/elements/Timeline.tsx
+++ b/packages/frontend/amp/components/elements/Timeline.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { Expandable } from '@frontend/amp/components/Expandable';
 import { css, cx } from 'emotion';
-import { palette } from '@guardian/pasteup/palette';
+import { palette } from '@guardian/src-foundations';
 
 const eventsWrapper = css`
     margin-left: 8px;
@@ -18,7 +18,7 @@ const eventStyle = css`
 `;
 
 const highlight = css`
-    background-color: ${palette.highlight.main};
+    background-color: ${palette.yellow.main};
 `;
 
 const eventIconStyle = css`

--- a/packages/frontend/amp/components/topMeta/PaidForBand.tsx
+++ b/packages/frontend/amp/components/topMeta/PaidForBand.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 
-import { palette } from '@guardian/pasteup/palette';
+import { palette } from '@guardian/src-foundations';
 import { textSans } from '@guardian/pasteup/typography';
 import { mobileLandscape } from '@guardian/pasteup/breakpoints';
 import LabsLogo from '@guardian/pasteup/logos/the-guardian-labs.svg';
@@ -22,7 +22,7 @@ const headerStyle = css`
 `;
 
 const focusColor = css`
-    outline-color: ${palette.highlight.main};
+    outline-color: ${palette.yellow.main};
 `;
 
 const metaStyle = css`

--- a/packages/frontend/amp/components/topMeta/Standfirst.tsx
+++ b/packages/frontend/amp/components/topMeta/Standfirst.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { headline, textSans } from '@guardian/pasteup/typography';
 import { css, cx } from 'emotion';
-import { palette } from '@guardian/pasteup/palette';
+import { palette } from '@guardian/src-foundations';
 import { pillarPalette } from '@frontend/lib/pillars';
 import { composeLabsCSS } from '@frontend/amp/lib/compose-labs-css';
 import { ListStyle, LinkStyle } from '@frontend/amp/components/elements/Text';

--- a/packages/frontend/amp/components/topMeta/TopMetaExtras.tsx
+++ b/packages/frontend/amp/components/topMeta/TopMetaExtras.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css, cx } from 'emotion';
 import ClockIcon from '@guardian/pasteup/icons/clock.svg';
 import { ShareIcons } from '@frontend/amp/components/ShareIcons';
-import { palette } from '@guardian/pasteup/palette';
+import { palette } from '@guardian/src-foundations';
 import { pillarMap, pillarPalette } from '@frontend/lib/pillars';
 import { textSans } from '@guardian/pasteup/typography';
 import TwitterIcon from '@guardian/pasteup/icons/twitter.svg';

--- a/packages/frontend/amp/components/topMeta/TopMetaLiveblog.tsx
+++ b/packages/frontend/amp/components/topMeta/TopMetaLiveblog.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { headline } from '@guardian/pasteup/typography';
 import { css } from 'emotion';
-import { palette } from '@guardian/pasteup/palette';
+import { palette } from '@guardian/src-foundations';
 import { pillarPalette } from '@frontend/lib/pillars';
 import { ArticleModel } from '@frontend/amp/pages/Article';
 import { MainMedia } from '@frontend/amp/components/MainMedia';

--- a/packages/frontend/amp/components/topMeta/TopMetaNews.tsx
+++ b/packages/frontend/amp/components/topMeta/TopMetaNews.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { headline } from '@guardian/pasteup/typography';
 import { css, cx } from 'emotion';
-import { palette } from '@guardian/pasteup/palette';
+import { palette } from '@guardian/src-foundations';
 import { pillarPalette } from '@frontend/lib/pillars';
 import { ArticleModel } from '@frontend/amp/pages/Article';
 import { MainMedia } from '@frontend/amp/components/MainMedia';
@@ -24,7 +24,7 @@ const headerStyle = css`
 `;
 
 const ratingsWrapper = css`
-    background-color: ${palette.highlight.main};
+    background-color: ${palette.yellow.main};
     display: inline-block;
     padding: 6px 10px;
     margin: 0 0 6px -10px;

--- a/packages/frontend/amp/components/topMeta/TopMetaOpinion.tsx
+++ b/packages/frontend/amp/components/topMeta/TopMetaOpinion.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { headline } from '@guardian/pasteup/typography';
 import { css, cx } from 'emotion';
-import { palette } from '@guardian/pasteup/palette';
+import { palette } from '@guardian/src-foundations';
 import { pillarPalette } from '@frontend/lib/pillars';
 import { ArticleModel } from '@frontend/amp/pages/Article';
 import { MainMedia } from '@frontend/amp/components/MainMedia';

--- a/packages/frontend/amp/components/topMeta/TopMetaPaidContent.tsx
+++ b/packages/frontend/amp/components/topMeta/TopMetaPaidContent.tsx
@@ -8,7 +8,7 @@ import { TopMetaExtras } from '@frontend/amp/components/topMeta/TopMetaExtras';
 import { Standfirst } from '@frontend/amp/components/topMeta/Standfirst';
 import { PaidForBand } from '@frontend/amp/components/topMeta/PaidForBand';
 
-import { palette } from '@guardian/pasteup/palette';
+import { palette } from '@guardian/src-foundations';
 import { textSans, body } from '@guardian/pasteup/typography';
 import { getSharingUrls } from '@frontend/model/sharing-urls';
 import { getAgeWarning } from '@frontend/model/age-warning';

--- a/packages/frontend/amp/pages/Article.tsx
+++ b/packages/frontend/amp/pages/Article.tsx
@@ -4,7 +4,6 @@ import { Container } from '@frontend/amp/components/Container';
 import { Body as BodyArticle } from '@frontend/amp/components/BodyArticle';
 import { Body as BodyLiveblog } from '@frontend/amp/components/BodyLiveblog';
 import { Header } from '@frontend/amp/components/Header';
-import { palette } from '@guardian/pasteup/palette';
 import { Onward } from '@frontend/amp/components/Onward';
 import { AdConsent } from '@frontend/amp/components/AdConsent';
 import { css } from 'emotion';
@@ -13,6 +12,7 @@ import { Analytics, AnalyticsModel } from '@frontend/amp/components/Analytics';
 import { filterForTagsOfType } from '@frontend/amp/lib/tag-utils';
 import { AdUserSync } from '@root/packages/frontend/amp/components/AdUserSync';
 import { getPillar } from '@frontend/lib/pillars';
+import { palette } from '@guardian/src-foundations';
 
 const backgroundColour = css`
     background-color: ${palette.neutral[97]};

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -8,6 +8,7 @@
     "@emotion/core": "^10.0.5",
     "@guardian/guui": "2.0.0-alpha.1",
     "@guardian/pasteup": "2.0.0-alpha.2",
+    "@guardian/src-foundations": "^0.0.9",
     "@types/ajv": "^1.0.0",
     "@types/lodash.escape": "^4.0.6",
     "@types/sanitize-html": "^1.18.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1175,6 +1175,11 @@
     signedsource "^1.0.0"
     yargs "^9.0.0"
 
+"@guardian/src-foundations@^0.0.9":
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.0.9.tgz#14946339deb8e0a80f4dc73661087ad22ad92ad4"
+  integrity sha512-6mek0gLh3NlWu+SnozZqnIyZmGKv8ZHDdJxLZG7Nfj2y79ptIR6L0D38uzY4hARKXO4/5fw6GJQ5OMRES8SGnw==
+
 "@hapi/address@2.x.x":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.0.0.tgz#9f05469c88cb2fd3dcd624776b54ee95c312126a"


### PR DESCRIPTION
## What does this change?

Migrates the colours in AMP from pasteup to [`@guardian/src-foundations`](https://github.com/guardian/source-components/blob/master/packages/foundations), the colours specified in **Source, the Guardian's new Design System** 🎉 

## Why?

- Source attempts to unify the design process across all Guardian digital products
- As it currently stands, Dotcom Rendering is assuming the responsibility for defining colours for all Guardian digital products! This is not a great precedent. We should aim to delete Pasteup and migrate projects that are using it over to `@guardian/src-foundations`
- This is a first pass at importing a Source package into a Guardian application, proving the concept and getting initial feedback on the process and API.

## Next steps

Please could you let me know if you have any feedback on this; actionable feedback is preferable! 😄 Specifically, it would be great to hear your thoughts on what it would take to get this PR merged?

## Link to supporting Trello card

https://trello.com/c/oM5SlFmW/80-migrate-dotcom-rendering-to-src-foundations-palette