### PR TITLE
Fix standfirst font

### DIFF
--- a/packages/frontend/web/components/ArticleBody.tsx
+++ b/packages/frontend/web/components/ArticleBody.tsx
@@ -138,6 +138,10 @@ const standfirst = css`
     p {
         margin-bottom: 8px;
     }
+
+    li {
+        ${headline(2)};
+    }
 `;
 
 const standfirstLinks = pillarMap(


### PR DESCRIPTION
## What does this change?

Before

![image](https://user-images.githubusercontent.com/638051/63756393-33c72800-c8b0-11e9-9f06-f2735f23f6bc.png)


After (Frontend vs DCR)

![2019-08-27 09 41 12](https://user-images.githubusercontent.com/638051/63756365-2873fc80-c8b0-11e9-99f8-604bb1eb0530.gif)

## Why?
Parity
