### PR TITLE
Make byline optional

### DIFF
--- a/packages/frontend/amp/components/topMeta/Byline.tsx
+++ b/packages/frontend/amp/components/topMeta/Byline.tsx
@@ -2,12 +2,16 @@ import React from 'react';
 import { bylineTokens } from '@frontend/amp/lib/byline-tokens';
 
 export const Byline: React.FC<{
-    byline: string;
+    byline?: string;
     tags: TagType[];
     pillar: Pillar;
     guardianBaseURL: string;
     className?: string;
 }> = ({ byline, tags, guardianBaseURL, className }) => {
+    if (!byline) {
+        return null;
+    }
+
     const contributorTags = tags.filter(tag => tag.type === 'Contributor');
     const tokens = bylineTokens(byline, contributorTags);
 

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -112,7 +112,7 @@ interface NavType {
 }
 
 interface AuthorType {
-    byline: string;
+    byline?: string;
     twitterHandle?: string;
     email?: string;
 }

--- a/packages/frontend/model/json-schema.json
+++ b/packages/frontend/model/json-schema.json
@@ -1273,10 +1273,7 @@
                 "email": {
                     "type": "string"
                 }
-            },
-            "required": [
-                "byline"
-            ]
+            }
         },
         "Edition": {
             "enum": [

--- a/packages/guui/components/Byline/Byline.tsx
+++ b/packages/guui/components/Byline/Byline.tsx
@@ -97,23 +97,29 @@ export const Byline: React.FC<{
     author: AuthorType;
     tags: TagType[];
     pillar: Pillar;
-}> = ({ author, tags, pillar }) => (
-    <address aria-label="Contributor info">
-        <RenderByline
-            bylineText={author.byline}
-            contributorTags={tags}
-            pillar={pillar}
-        />
-        {author.twitterHandle && (
-            <div className={twitterHandle}>
-                <TwitterIcon />
-                <a
-                    href={`https://www.twitter.com/${author.twitterHandle}`}
-                    aria-label={`@${author.twitterHandle} on Twitter`}
-                >
-                    @{author.twitterHandle}
-                </a>
-            </div>
-        )}
-    </address>
-);
+}> = ({ author, tags, pillar }) => {
+    if (!author.byline) {
+        return null;
+    }
+
+    return (
+        <address aria-label="Contributor info">
+            <RenderByline
+                bylineText={author.byline}
+                contributorTags={tags}
+                pillar={pillar}
+            />
+            {author.twitterHandle && (
+                <div className={twitterHandle}>
+                    <TwitterIcon />
+                    <a
+                        href={`https://www.twitter.com/${author.twitterHandle}`}
+                        aria-label={`@${author.twitterHandle} on Twitter`}
+                    >
+                        @{author.twitterHandle}
+                    </a>
+                </div>
+            )}
+        </address>
+    );
+};


### PR DESCRIPTION
## What does this change?

Makes `byline` optional, which allows Frontend to not send one if the field is empty.

## Why?

As some articles should have an empty byline. E.g. 

https://www.theguardian.com/football/2019/aug/23/liverpool-arsenal-match-preview?dcr=false

## Link to supporting Trello card

https://trello.com/c/va2zySpI