### PR TITLE
Outbrain behind 0% AB test

### DIFF
--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -220,7 +220,7 @@ interface ConfigType {
     sentryPublicApiKey: string;
     sentryHost: string;
     switches: { [key: string]: boolean };
-    abTests?: { [key: string]: string };
+    abTests: { [key: string]: string };
     dfpAccountId: string;
     commercialBundleUrl: string;
     revisionNumber: string;

--- a/packages/frontend/model/advertisement.ts
+++ b/packages/frontend/model/advertisement.ts
@@ -1,3 +1,5 @@
-export const shouldDisplayAdvertisements = () => {
-    return true;
+// We are using this function to control the activation of the commercial features
+// Currently it reports that the user has opted in to a 0% AB test.
+export const shouldDisplayAdvertisements = (config: ConfigType) => {
+    return config.abTests.dotcomRenderingAdvertisementsVariant === 'variant';
 };

--- a/packages/frontend/model/advertisement.ts
+++ b/packages/frontend/model/advertisement.ts
@@ -1,0 +1,3 @@
+export const shouldDisplayAdvertisements = () => {
+    return true;
+};

--- a/packages/frontend/model/json-schema.json
+++ b/packages/frontend/model/json-schema.json
@@ -1380,6 +1380,7 @@
                 }
             },
             "required": [
+                "abTests",
                 "ajaxUrl",
                 "commercialBundleUrl",
                 "dfpAccountId",

--- a/packages/frontend/web/components/Outbrain.tsx
+++ b/packages/frontend/web/components/Outbrain.tsx
@@ -10,7 +10,7 @@ interface OutbrainSelectors {
 }
 
 const shouldDisplayOutbrain = (config: ConfigType): boolean => {
-    return shouldDisplayAdvertisements();
+    return shouldDisplayAdvertisements(config);
 };
 
 type OutbrainSelectorsType = 'outbrain' | 'merchandising' | 'nonCompliant';

--- a/packages/frontend/web/components/Outbrain.tsx
+++ b/packages/frontend/web/components/Outbrain.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { Container } from '@guardian/guui';
+import { shouldDisplayAdvertisements } from '@frontend/model/advertisement';
 
 interface OutbrainSelectors {
     widget: string;
@@ -9,7 +10,7 @@ interface OutbrainSelectors {
 }
 
 const shouldDisplayOutbrain = (config: ConfigType): boolean => {
-    return config.switches.outbrainDCRTest;
+    return shouldDisplayAdvertisements();
 };
 
 type OutbrainSelectorsType = 'outbrain' | 'merchandising' | 'nonCompliant';


### PR DESCRIPTION
## What does this change?

1. The `abTest` attribute of `Config` is no longer optional. This matches the `frontend` code that generates the DCR object.

2. Introduces `advertisement.ts` which for the moment only contains one function `shouldDisplayAdvertisements`. This function listen to variant of the 0% AB test `dotcom-rendering-advertisements` ( https://github.com/guardian/frontend/pull/21765 )

ps: The switch `outbrainDCRTest` doesn't need to be decommissioned in `frontend` because it was never pushed to production.