### PR TITLE
AdSlot behind 0% AB Test

### DIFF
--- a/packages/frontend/model/advertisement.ts
+++ b/packages/frontend/model/advertisement.ts
@@ -1,5 +1,25 @@
+import { AdSlotParameters } from '@frontend//web/components/AdSlot';
+
 // We are using this function to control the activation of the commercial features
 // Currently it reports that the user has opted in to a 0% AB test.
 export const shouldDisplayAdvertisements = (config: ConfigType) => {
     return config.abTests.dotcomRenderingAdvertisementsVariant === 'variant';
+};
+
+export const adSlotParameters = () => {
+    // The current parameters have been taken from looking at an example of right MPU on an article.
+    // regular article: js-ad-slot ad-slot ad-slot--right ad-slot--mpu-banner-ad js-sticky-mpu ad-slot--rendered
+    // dotcom rendering: js-ad-slot ad-slot ad-slot--right ad-slot--mpu-banner-ad ad-slot--rendered js-sticky-mpu
+    return {
+        name: 'right',
+        adTypes: ['mpu-banner-ad', 'rendered'],
+        sizeMapping: {
+            mobile: ['1,1|2,2|300,250|300,274|300,600|fluid|300,1050'],
+        },
+        showLabel: true,
+        refresh: false,
+        outOfPage: false,
+        optId: undefined,
+        optClassNames: ['js-sticky-mpu'],
+    } as AdSlotParameters;
 };

--- a/packages/frontend/model/advertisement.ts
+++ b/packages/frontend/model/advertisement.ts
@@ -1,4 +1,4 @@
-import { AdSlotParameters } from '@frontend//web/components/AdSlot';
+import { AdSlotParameters } from '@frontend/web/components/AdSlot';
 
 // We are using this function to control the activation of the commercial features
 // Currently it reports that the user has opted in to a 0% AB test.

--- a/packages/frontend/web/components/AdSlot.tsx
+++ b/packages/frontend/web/components/AdSlot.tsx
@@ -1,6 +1,20 @@
 // tslint:disable:react-no-dangerous-html
 
 import React from 'react';
+import { shouldDisplayAdvertisements } from '@frontend/model/advertisement';
+
+export interface AdSlotParameters {
+    name: string;
+    adTypes: string[];
+    sizeMapping: {
+        [key: string]: string[];
+    };
+    showLabel?: boolean;
+    refresh?: boolean;
+    outOfPage?: boolean;
+    optId?: string;
+    optClassNames?: string[];
+}
 
 export interface AdSlotInputSizeMappings {
     [key: string]: string[];
@@ -32,7 +46,7 @@ export const makeClassNames = (
     return baseClassNames.concat(adTypeClassNames, optClassNames).join(' ');
 };
 
-export const AdSlot: React.FC<{
+export const AdSlotCore: React.FC<{
     name: string;
     adTypes: string[];
     sizeMapping: AdSlotInputSizeMappings;
@@ -68,6 +82,27 @@ export const AdSlot: React.FC<{
             // {...getOptionalProps()}
             {...sizeMappings}
             aria-hidden="true"
+        />
+    );
+};
+
+export const AdSlot: React.FC<{
+    asps: AdSlotParameters;
+    config: ConfigType;
+}> = ({ asps, config }) => {
+    if (!shouldDisplayAdvertisements(config)) {
+        return null;
+    }
+    return (
+        <AdSlotCore
+            name={asps.name}
+            adTypes={asps.adTypes}
+            sizeMapping={asps.sizeMapping}
+            showLabel={asps.showLabel}
+            refresh={asps.refresh}
+            outOfPage={asps.outOfPage}
+            optId={asps.optId}
+            optClassNames={asps.optClassNames}
         />
     );
 };

--- a/packages/frontend/web/components/AdSlot.tsx
+++ b/packages/frontend/web/components/AdSlot.tsx
@@ -93,16 +93,5 @@ export const AdSlot: React.FC<{
     if (!shouldDisplayAdvertisements(config)) {
         return null;
     }
-    return (
-        <AdSlotCore
-            name={asps.name}
-            adTypes={asps.adTypes}
-            sizeMapping={asps.sizeMapping}
-            showLabel={asps.showLabel}
-            refresh={asps.refresh}
-            outOfPage={asps.outOfPage}
-            optId={asps.optId}
-            optClassNames={asps.optClassNames}
-        />
-    );
+    return <AdSlotCore {...asps} />;
 };

--- a/packages/frontend/web/pages/Article.tsx
+++ b/packages/frontend/web/pages/Article.tsx
@@ -12,7 +12,7 @@ import { SubNav } from '@frontend/web/components/Header/Nav/SubNav/SubNav';
 import { CookieBanner } from '@frontend/web/components/CookieBanner';
 import { OutbrainContainer } from '@frontend/web/components/Outbrain';
 import { adSlotParameters } from '@frontend/model/advertisement';
-import { AdSlot } from '@frontend//web/components/AdSlot';
+import { AdSlot } from '@frontend/web/components/AdSlot';
 
 // TODO: find a better of setting opacity
 const secondaryColumn = css`

--- a/packages/frontend/web/pages/Article.tsx
+++ b/packages/frontend/web/pages/Article.tsx
@@ -11,6 +11,8 @@ import { BackToTop } from '@frontend/web/components/BackToTop';
 import { SubNav } from '@frontend/web/components/Header/Nav/SubNav/SubNav';
 import { CookieBanner } from '@frontend/web/components/CookieBanner';
 import { OutbrainContainer } from '@frontend/web/components/Outbrain';
+import { adSlotParameters } from '@frontend/model/advertisement';
+import { AdSlot } from '@frontend//web/components/AdSlot';
 
 // TODO: find a better of setting opacity
 const secondaryColumn = css`
@@ -46,49 +48,53 @@ const overflowHidden = css`
 
 export const Article: React.FC<{
     data: ArticleProps;
-}> = ({ data }) => (
-    <div className={overflowHidden}>
-        <Header
-            nav={data.NAV}
-            pillar={data.CAPI.pillar}
-            edition={data.CAPI.editionId}
-        />
-        <main>
-            <Container borders={true} className={articleContainer}>
-                <article>
-                    <ArticleBody CAPI={data.CAPI} config={data.config} />
-                    <div className={secondaryColumn} />
-                </article>
-            </Container>
-            <OutbrainContainer config={data.config} />
-            <Container
-                borders={true}
-                className={cx(
-                    articleContainer,
-                    css`
-                        border-top: 1px solid ${palette.neutral[86]};
-                    `,
-                )}
-            >
-                <MostViewed sectionName={data.CAPI.sectionName} />
-            </Container>
-        </main>
-
-        <SubNav
-            subnav={data.NAV.subNavSections}
-            pillar={data.CAPI.pillar}
-            currentNavLink={data.NAV.currentNavLink}
-        />
-        <BackToTop />
-
-        <Footer
-            nav={data.NAV}
-            edition={data.CAPI.editionId}
-            pageFooter={data.CAPI.pageFooter}
-            pillar={data.CAPI.pillar}
-            pillars={data.NAV.pillars}
-        />
-
-        <CookieBanner />
-    </div>
-);
+}> = ({ data }) => {
+    return (
+        <div className={overflowHidden}>
+            <Header
+                nav={data.NAV}
+                pillar={data.CAPI.pillar}
+                edition={data.CAPI.editionId}
+            />
+            <main>
+                <Container borders={true} className={articleContainer}>
+                    <article>
+                        <ArticleBody CAPI={data.CAPI} config={data.config} />
+                        <div className={secondaryColumn}>
+                            <AdSlot
+                                asps={adSlotParameters()}
+                                config={data.config}
+                            />
+                        </div>
+                    </article>
+                </Container>
+                <OutbrainContainer config={data.config} />
+                <Container
+                    borders={true}
+                    className={cx(
+                        articleContainer,
+                        css`
+                            border-top: 1px solid ${palette.neutral[86]};
+                        `,
+                    )}
+                >
+                    <MostViewed sectionName={data.CAPI.sectionName} />
+                </Container>
+            </main>
+            <SubNav
+                subnav={data.NAV.subNavSections}
+                pillar={data.CAPI.pillar}
+                currentNavLink={data.NAV.currentNavLink}
+            />
+            <BackToTop />
+            <Footer
+                nav={data.NAV}
+                edition={data.CAPI.editionId}
+                pageFooter={data.CAPI.pageFooter}
+                pillar={data.CAPI.pillar}
+                pillars={data.NAV.pillars}
+            />
+            <CookieBanner />
+        </div>
+    );
+};

--- a/packages/frontend/web/pages/Article.tsx
+++ b/packages/frontend/web/pages/Article.tsx
@@ -48,53 +48,51 @@ const overflowHidden = css`
 
 export const Article: React.FC<{
     data: ArticleProps;
-}> = ({ data }) => {
-    return (
-        <div className={overflowHidden}>
-            <Header
-                nav={data.NAV}
-                pillar={data.CAPI.pillar}
-                edition={data.CAPI.editionId}
-            />
-            <main>
-                <Container borders={true} className={articleContainer}>
-                    <article>
-                        <ArticleBody CAPI={data.CAPI} config={data.config} />
-                        <div className={secondaryColumn}>
-                            <AdSlot
-                                asps={adSlotParameters()}
-                                config={data.config}
-                            />
-                        </div>
-                    </article>
-                </Container>
-                <OutbrainContainer config={data.config} />
-                <Container
-                    borders={true}
-                    className={cx(
-                        articleContainer,
-                        css`
-                            border-top: 1px solid ${palette.neutral[86]};
-                        `,
-                    )}
-                >
-                    <MostViewed sectionName={data.CAPI.sectionName} />
-                </Container>
-            </main>
-            <SubNav
-                subnav={data.NAV.subNavSections}
-                pillar={data.CAPI.pillar}
-                currentNavLink={data.NAV.currentNavLink}
-            />
-            <BackToTop />
-            <Footer
-                nav={data.NAV}
-                edition={data.CAPI.editionId}
-                pageFooter={data.CAPI.pageFooter}
-                pillar={data.CAPI.pillar}
-                pillars={data.NAV.pillars}
-            />
-            <CookieBanner />
-        </div>
-    );
-};
+}> = ({ data }) => (
+    <div className={overflowHidden}>
+        <Header
+            nav={data.NAV}
+            pillar={data.CAPI.pillar}
+            edition={data.CAPI.editionId}
+        />
+        <main>
+            <Container borders={true} className={articleContainer}>
+                <article>
+                    <ArticleBody CAPI={data.CAPI} config={data.config} />
+                    <div className={secondaryColumn}>
+                        <AdSlot
+                            asps={adSlotParameters()}
+                            config={data.config}
+                        />
+                    </div>
+                </article>
+            </Container>
+            <OutbrainContainer config={data.config} />
+            <Container
+                borders={true}
+                className={cx(
+                    articleContainer,
+                    css`
+                        border-top: 1px solid ${palette.neutral[86]};
+                    `,
+                )}
+            >
+                <MostViewed sectionName={data.CAPI.sectionName} />
+            </Container>
+        </main>
+        <SubNav
+            subnav={data.NAV.subNavSections}
+            pillar={data.CAPI.pillar}
+            currentNavLink={data.NAV.currentNavLink}
+        />
+        <BackToTop />
+        <Footer
+            nav={data.NAV}
+            edition={data.CAPI.editionId}
+            pageFooter={data.CAPI.pageFooter}
+            pillar={data.CAPI.pillar}
+            pillars={data.NAV.pillars}
+        />
+        <CookieBanner />
+    </div>
+);


### PR DESCRIPTION
## What does this change?

We install the existing `AdSlot` prototype on the article right hand side behind a 0% AB test. This is the follow up of https://github.com/guardian/dotcom-rendering/pull/738 .