### PR TITLE
Use src-foundations for media queries

### DIFF
--- a/packages/frontend/amp/components/BodyArticle.tsx
+++ b/packages/frontend/amp/components/BodyArticle.tsx
@@ -7,10 +7,9 @@ import { TopMeta } from '@frontend/amp/components/topMeta/TopMeta';
 import { SubMeta } from '@frontend/amp/components/SubMeta';
 import { designTypeDefault } from '@frontend/lib/designTypes';
 import { pillarPalette } from '@frontend/lib/pillars';
-import { palette } from '@guardian/src-foundations';
+import { palette, mq } from '@guardian/src-foundations';
 import { WithAds } from '@frontend/amp/components/WithAds';
 import { findAdSlots } from '@frontend/amp/lib/find-adslots';
-import { until } from '@guardian/pasteup/breakpoints';
 import { getSharingUrls } from '@frontend/model/sharing-urls';
 
 const body = (pillar: Pillar, designType: DesignType) => {
@@ -53,7 +52,7 @@ const adStyle = css`
     float: right;
     margin: 4px 0 12px 20px;
 
-    ${until.phablet} {
+    ${mq({ until: 'phablet' })} {
         float: none;
         margin: 0 auto 12px;
     }

--- a/packages/frontend/amp/components/Header.tsx
+++ b/packages/frontend/amp/components/Header.tsx
@@ -4,9 +4,8 @@ import Logo from '@guardian/pasteup/logos/the-guardian.svg';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';
 import { headline } from '@guardian/pasteup/typography';
 import { pillarPalette } from '../../lib/pillars';
-import { palette } from '@guardian/src-foundations';
+import { palette, mq } from '@guardian/src-foundations';
 import { ReaderRevenueButton } from '@root/packages/frontend/amp/components/ReaderRevenueButton';
-import { mobileLandscape, until } from '@guardian/pasteup/breakpoints';
 
 const headerStyles = css`
     background-color: ${palette.brand.main};
@@ -30,7 +29,7 @@ const logoStyles = css`
         fill: ${palette.neutral[100]};
     }
 
-    ${until.mobileMedium} {
+    ${mq({ until: 'mobileMedium' })} {
         height: 44px;
         width: 135px;
         margin-bottom: 24px;
@@ -58,7 +57,7 @@ const pillarListItemStyle = css`
             }
         }
 
-        ${until.mobileLandscape} {
+        ${mq({ until: 'mobileLandscape' })} {
             a {
                 padding-left: 10px;
             }
@@ -80,7 +79,7 @@ const pillarLinkStyle = (pillar: Pillar) => css`
     font-weight: 900;
     font-size: 15.4px;
 
-    ${mobileLandscape} {
+    ${mq({ from: 'mobileLandscape' })} {
         font-size: 18px;
         padding: 7px 4px 0;
     }
@@ -125,11 +124,11 @@ const veggieStyles = css`
     right: 20px;
     position: absolute;
 
-    ${until.mobileMedium} {
+    ${mq({ until: 'mobileMedium' })} {
         bottom: 50px;
     }
 
-    ${until.mobileLandscape} {
+    ${mq({ until: 'mobileLandscape' })} {
         right: 5px;
     }
 `;

--- a/packages/frontend/amp/components/ReaderRevenueButton.tsx
+++ b/packages/frontend/amp/components/ReaderRevenueButton.tsx
@@ -3,8 +3,7 @@ import { css, cx } from 'emotion';
 
 import { textSans } from '@guardian/pasteup/typography';
 import ArrowRight from '@guardian/pasteup/icons/arrow-right.svg';
-import { palette } from '@guardian/src-foundations';
-import { until } from '@guardian/pasteup/breakpoints';
+import { palette, mq } from '@guardian/src-foundations';
 
 const supportStyles = css`
     align-self: flex-start;
@@ -14,7 +13,7 @@ const supportStyles = css`
     align-items: center;
     padding: 0 15px;
     min-height: 30px;
-    ${until.mobileMedium} {
+    ${mq({ until: 'mobileMedium' })} {
         padding: 0 10px;
         min-height: 24px;
     }
@@ -25,7 +24,7 @@ const supportHeaderStyles = css`
     justify-content: center;
     margin-top: 10px;
     margin-left: 10px;
-    ${until.mobileMedium} {
+    ${mq({ until: 'mobileMedium' })} {
         margin-top: 28px;
     }
 `;
@@ -45,7 +44,7 @@ const supportLinkStyles = css`
     width: 100%;
 
     padding-right: 20px;
-    ${until.mobileMedium} {
+    ${mq({ until: 'mobileMedium' })} {
         ${textSans(4)};
         padding-right: 18px;
     }
@@ -53,7 +52,7 @@ const supportLinkStyles = css`
     svg {
         position: absolute;
         top: -5px;
-        ${until.mobileMedium} {
+        ${mq({ until: 'mobileMedium' })} {
             top: -2px;
             width: 26px;
             height: 26px;

--- a/packages/frontend/amp/components/topMeta/PaidForBand.tsx
+++ b/packages/frontend/amp/components/topMeta/PaidForBand.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 
-import { palette } from '@guardian/src-foundations';
+import { palette, mq } from '@guardian/src-foundations';
 import { textSans } from '@guardian/pasteup/typography';
-import { mobileLandscape } from '@guardian/pasteup/breakpoints';
 import LabsLogo from '@guardian/pasteup/logos/the-guardian-labs.svg';
 import ArrowRightIcon from '@guardian/pasteup/icons/arrow-right.svg';
 
@@ -16,7 +15,7 @@ const headerStyle = css`
     height: 58px;
     background-color: ${palette.labs.bright};
 
-    ${mobileLandscape} {
+    ${mq({ from: 'mobileLandscape' })} {
         padding: 0 20px;
     }
 `;

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -8,7 +8,7 @@
     "@emotion/core": "^10.0.5",
     "@guardian/guui": "2.0.0-alpha.1",
     "@guardian/pasteup": "2.0.0-alpha.2",
-    "@guardian/src-foundations": "^0.0.9",
+    "@guardian/src-foundations": "^0.0.13",
     "@types/ajv": "^1.0.0",
     "@types/lodash.escape": "^4.0.6",
     "@types/sanitize-html": "^1.18.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1175,10 +1175,10 @@
     signedsource "^1.0.0"
     yargs "^9.0.0"
 
-"@guardian/src-foundations@^0.0.9":
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.0.9.tgz#14946339deb8e0a80f4dc73661087ad22ad92ad4"
-  integrity sha512-6mek0gLh3NlWu+SnozZqnIyZmGKv8ZHDdJxLZG7Nfj2y79ptIR6L0D38uzY4hARKXO4/5fw6GJQ5OMRES8SGnw==
+"@guardian/src-foundations@^0.0.13":
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.0.13.tgz#c5cd659e9f255712dae091ace091183371ab4a51"
+  integrity sha512-KlqcnMAl4lCMI9x/SkhlPWLuvk/VfBAqtfPsARJaD/7sjwh3JB+YfWLKaKmWJhQuGO2qB7Lwh9m+qcaesJRrAw==
 
 "@hapi/address@2.x.x":
   version "2.0.0"


### PR DESCRIPTION
## What does this change?

Builds on #733 to get media queries from the design system tokens

## Why?

Same as before, moves us towards deprecating pasteup and unifying the Guardian's design tokens across projects
