### PR TITLE
Activate Ad display on local

### DIFF
--- a/fixtures/CAPI.ts
+++ b/fixtures/CAPI.ts
@@ -447,6 +447,7 @@ export const CAPI: CAPIType = {
         revisionNumber: '62cf0d6e4609276d37e09fd596430fbf8b629418',
         isDev: false,
         googletagUrl: '//www.googletagservices.com/tag/js/gpt.js',
+        stage: 'DEV',
     },
     webTitle: 'Foobar',
     nav: {

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -226,6 +226,7 @@ interface ConfigType {
     revisionNumber: string;
     isDev?: boolean;
     googletagUrl: string;
+    stage: string;
 }
 
 interface GADataType {

--- a/packages/frontend/model/advertisement.ts
+++ b/packages/frontend/model/advertisement.ts
@@ -3,7 +3,10 @@ import { AdSlotParameters } from '@frontend/web/components/AdSlot';
 // We are using this function to control the activation of the commercial features
 // Currently it reports that the user has opted in to a 0% AB test.
 export const shouldDisplayAdvertisements = (config: ConfigType) => {
-    return config.abTests.dotcomRenderingAdvertisementsVariant === 'variant';
+    return (
+        config.stage === 'DEV' ||
+        config.abTests.dotcomRenderingAdvertisementsVariant === 'variant'
+    );
 };
 
 export const adSlotParameters = () => {

--- a/packages/frontend/web/components/ShareCount.test.tsx
+++ b/packages/frontend/web/components/ShareCount.test.tsx
@@ -30,6 +30,7 @@ describe('ShareCount', () => {
         revisionNumber: '',
         isDev: false,
         googletagUrl: '',
+        stage: 'DEV',
     };
 
     afterEach(() => {


### PR DESCRIPTION
## What does this change?

This enables the display of ads during development without relying on the AB testing framework. 

This works if the local instance of DCR talks to the local instance of frontend. If there is another way to detect a local run of DCR (so that the ad display works independently of which instance of frontend the local instance of DCR is talking to, we might implement it later).  
