### PR TITLE
Show series as well as section

### DIFF
--- a/packages/frontend/web/components/ArticleBody.tsx
+++ b/packages/frontend/web/components/ArticleBody.tsx
@@ -27,6 +27,7 @@ import { MainMedia } from './MainMedia';
 import { getSharingUrls } from '@frontend/model/sharing-urls';
 import { getAgeWarning } from '@frontend/model/age-warning';
 import { SyndicationButton } from './SyndicationButton';
+import { SeriesSectionLink } from './SeriesSectionLink';
 
 const curly = (x: any) => x;
 
@@ -163,23 +164,6 @@ const leftColWidth = css`
 
     ${wide} {
         width: 220px;
-    }
-`;
-
-const section = css`
-    ${leftColWidth};
-    @supports (display: grid) {
-        grid-template-areas: 'section';
-    }
-    ${headline(2)};
-    font-weight: 700;
-
-    ${leftCol} {
-        ${headline(3)};
-    }
-
-    ${until.phablet} {
-        padding: 0 10px;
     }
 `;
 
@@ -389,13 +373,6 @@ const header = css`
     }
 `;
 
-const sectionLabelLink = css`
-    text-decoration: none;
-    :hover {
-        text-decoration: underline;
-    }
-`;
-
 const subMeta = css`
     margin-top: 12px;
     padding-top: 18px;
@@ -426,20 +403,7 @@ export const ArticleBody: React.FC<{
     return (
         <div className={wrapper}>
             <header className={header}>
-                <div className={section}>
-                    {CAPI.sectionLabel && CAPI.sectionUrl && (
-                        <a
-                            className={cx(
-                                sectionLabelLink,
-                                pillarColours[CAPI.pillar],
-                            )}
-                            href={`https://www.theguardian.com/${CAPI.sectionUrl}`}
-                            data-link-name="article section"
-                        >
-                            {CAPI.sectionLabel}
-                        </a>
-                    )}
-                </div>
+                <SeriesSectionLink CAPI={CAPI} fallbackToSection={true} />
                 <div className={headlineCSS}>
                     {ageWarning && (
                         <div className={ageWarningStyle} aria-hidden="true">

--- a/packages/frontend/web/components/ArticleBody.tsx
+++ b/packages/frontend/web/components/ArticleBody.tsx
@@ -392,6 +392,16 @@ const subMetaSharingIcons = css`
     }
 `;
 
+const section = css`
+    ${leftColWidth};
+    @supports (display: grid) {
+        grid-template-areas: 'section';
+    }
+    ${until.phablet} {
+        padding: 0 10px;
+    }
+`;
+
 export const ArticleBody: React.FC<{
     CAPI: CAPIType;
     config: ConfigType;
@@ -403,7 +413,9 @@ export const ArticleBody: React.FC<{
     return (
         <div className={wrapper}>
             <header className={header}>
-                <SeriesSectionLink CAPI={CAPI} fallbackToSection={true} />
+                <div className={section}>
+                    <SeriesSectionLink CAPI={CAPI} fallbackToSection={true} />
+                </div>
                 <div className={headlineCSS}>
                     {ageWarning && (
                         <div className={ageWarningStyle} aria-hidden="true">

--- a/packages/frontend/web/components/SeriesSectionLink.tsx
+++ b/packages/frontend/web/components/SeriesSectionLink.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { css, cx } from 'emotion';
+import { pillarMap, pillarPalette } from '@frontend/lib/pillars';
+import { until, wide, leftCol } from '@guardian/pasteup/breakpoints';
+import { headline } from '@guardian/pasteup/typography';
+
+const leftColWidth = css`
+    ${leftCol} {
+        width: 140px;
+    }
+
+    ${wide} {
+        width: 220px;
+    }
+`;
+
+const section = css`
+    ${leftColWidth};
+    @supports (display: grid) {
+        grid-template-areas: 'section';
+    }
+    ${until.phablet} {
+        padding: 0 10px;
+    }
+`;
+
+const sectionLabelLink = css`
+    text-decoration: none;
+    :hover {
+        text-decoration: underline;
+    }
+`;
+
+const pillarColours = pillarMap(
+    pillar =>
+        css`
+            color: ${pillarPalette[pillar].main};
+        `,
+);
+
+const primaryStyle = css`
+    font-weight: 700;
+    ${headline(2)};
+
+    ${leftCol} {
+        ${headline(3)};
+    }
+`;
+
+const secondaryStyle = css`
+    ${headline(2)};
+    display: block;
+`;
+
+const TagLink: React.FC<{
+    pillar: Pillar;
+    guardianBaseURL: string;
+    tagTitle: string;
+    tagUrl: string;
+    dataLinkName: string;
+    weightingClass: string;
+}> = ({
+    pillar,
+    guardianBaseURL,
+    tagTitle,
+    tagUrl,
+    dataLinkName,
+    weightingClass,
+}) => {
+    return (
+        <a
+            href={`${guardianBaseURL}/${tagUrl}`}
+            className={cx(
+                sectionLabelLink,
+                pillarColours[pillar],
+                weightingClass,
+            )}
+            data-link-name={dataLinkName}
+        >
+            {tagTitle}
+        </a>
+    );
+};
+
+export const SeriesSectionLink: React.FC<{
+    CAPI: CAPIType;
+    fallbackToSection: boolean;
+}> = ({ CAPI, fallbackToSection }) => {
+    const tag = CAPI.tags.find(t => t.type === 'Blog' || t.type === 'Series');
+
+    if (!tag && !fallbackToSection) {
+        return null;
+    }
+
+    if (!tag && (CAPI.sectionLabel && CAPI.sectionUrl)) {
+        return (
+            <div className={section}>
+                <TagLink
+                    pillar={CAPI.pillar}
+                    guardianBaseURL={CAPI.guardianBaseURL}
+                    tagTitle={CAPI.sectionLabel}
+                    tagUrl={CAPI.sectionUrl}
+                    dataLinkName="article section"
+                    weightingClass={primaryStyle}
+                />
+            </div>
+        );
+    }
+
+    if (tag) {
+        return (
+            <div className={section}>
+                <TagLink
+                    pillar={CAPI.pillar}
+                    guardianBaseURL={CAPI.guardianBaseURL}
+                    tagTitle={tag.title}
+                    tagUrl={tag.id}
+                    dataLinkName="article series"
+                    weightingClass={primaryStyle}
+                />
+                <TagLink
+                    pillar={CAPI.pillar}
+                    guardianBaseURL={CAPI.guardianBaseURL}
+                    tagTitle={CAPI.sectionLabel}
+                    tagUrl={CAPI.sectionLabel}
+                    dataLinkName="article series"
+                    weightingClass={secondaryStyle}
+                />
+            </div>
+        );
+    }
+
+    return null;
+};

--- a/packages/frontend/web/components/SeriesSectionLink.tsx
+++ b/packages/frontend/web/components/SeriesSectionLink.tsx
@@ -1,28 +1,8 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 import { pillarMap, pillarPalette } from '@frontend/lib/pillars';
-import { until, wide, leftCol } from '@guardian/pasteup/breakpoints';
+import { leftCol } from '@guardian/pasteup/breakpoints';
 import { headline } from '@guardian/pasteup/typography';
-
-const leftColWidth = css`
-    ${leftCol} {
-        width: 140px;
-    }
-
-    ${wide} {
-        width: 220px;
-    }
-`;
-
-const section = css`
-    ${leftColWidth};
-    @supports (display: grid) {
-        grid-template-areas: 'section';
-    }
-    ${until.phablet} {
-        padding: 0 10px;
-    }
-`;
 
 const sectionLabelLink = css`
     text-decoration: none;
@@ -94,22 +74,20 @@ export const SeriesSectionLink: React.FC<{
 
     if (!tag && (CAPI.sectionLabel && CAPI.sectionUrl)) {
         return (
-            <div className={section}>
-                <TagLink
-                    pillar={CAPI.pillar}
-                    guardianBaseURL={CAPI.guardianBaseURL}
-                    tagTitle={CAPI.sectionLabel}
-                    tagUrl={CAPI.sectionUrl}
-                    dataLinkName="article section"
-                    weightingClass={primaryStyle}
-                />
-            </div>
+            <TagLink
+                pillar={CAPI.pillar}
+                guardianBaseURL={CAPI.guardianBaseURL}
+                tagTitle={CAPI.sectionLabel}
+                tagUrl={CAPI.sectionUrl}
+                dataLinkName="article section"
+                weightingClass={primaryStyle}
+            />
         );
     }
 
     if (tag) {
         return (
-            <div className={section}>
+            <>
                 <TagLink
                     pillar={CAPI.pillar}
                     guardianBaseURL={CAPI.guardianBaseURL}
@@ -123,10 +101,10 @@ export const SeriesSectionLink: React.FC<{
                     guardianBaseURL={CAPI.guardianBaseURL}
                     tagTitle={CAPI.sectionLabel}
                     tagUrl={CAPI.sectionLabel}
-                    dataLinkName="article series"
+                    dataLinkName="article section"
                     weightingClass={secondaryStyle}
                 />
-            </div>
+            </>
         );
     }
 


### PR DESCRIPTION
## What does this change?
Adds the series link where available at the top of an article

Before:
<img width="367" alt="Screenshot 2019-09-03 at 18 10 16" src="https://user-images.githubusercontent.com/3606555/64194138-517b2b00-ce76-11e9-8ef5-61e301ff6c7a.png">

After:
<img width="438" alt="Screenshot 2019-09-03 at 18 10 21" src="https://user-images.githubusercontent.com/3606555/64194106-3c9e9780-ce76-11e9-9fbf-6bcfaa51d86d.png">

## Why?
Visual parity!

## Link to supporting Trello card
