### PR TITLE
Visual parity: Most popular

### DIFF
--- a/packages/frontend/web/components/MostViewed.tsx
+++ b/packages/frontend/web/components/MostViewed.tsx
@@ -256,7 +256,7 @@ export class MostViewed extends Component<Props, { selectedTabIndex: number }> {
                 data-link-name={'most-viewed'}
                 data-component={'most-viewed'}
             >
-                <h2 className={heading}>Most viewed</h2>
+                <h2 className={heading}>Most popular</h2>
                 <AsyncClientComponent f={this.fetchTrails}>
                     {({ data }) => (
                         <div className={listContainer}>


### PR DESCRIPTION
## What does this change?

The "Most popular" container is currently incorrectly named "Most viewed". 
