### PR TITLE
Report stage information on client side

### DIFF
--- a/packages/frontend/model/window-guardian.ts
+++ b/packages/frontend/model/window-guardian.ts
@@ -1,5 +1,8 @@
+type stage = 'DEV' | 'CODE' | 'PROD';
+
 export interface WindowGuardianConfig {
     isDotcomRendering: boolean;
+    stage: stage;
     page: {
         contentType: string;
         edition: Edition;
@@ -32,6 +35,7 @@ const makeWindowGuardianConfig = (
     return {
         // This indicates to the client side code that we are running a dotcom-rendering rendered page.
         isDotcomRendering: true,
+        stage: dcrDocumentData.config.stage,
         page: {
             contentType: dcrDocumentData.CAPI.contentType,
             edition: dcrDocumentData.CAPI.editionId,


### PR DESCRIPTION
## What does this change?

Report stage information on client side. Generally useful, but for the moment will be used by the frontend generated DCR commercial bundle during ad stack implementation testing. 

![Screenshot 2019-09-04 at 14 11 56](https://user-images.githubusercontent.com/6035518/64257952-39f77d00-cf1e-11e9-88ab-b4747abac3b8.png)
