### PR TITLE
Marking article body with a specific classname

### DIFF
--- a/packages/frontend/web/components/lib/ArticleRenderer.tsx
+++ b/packages/frontend/web/components/lib/ArticleRenderer.tsx
@@ -35,5 +35,5 @@ export const ArticleRenderer: React.FC<{
             }
         })
         .filter(_ => _ != null);
-    return <>{output}</>;
+    return <div className="article-body-03f883b8">{output}</div>; // classname that space finder is going to target for in-body ads in DCR
 };


### PR DESCRIPTION
# What does this change?

Gives a specific class name to the parent of the article body elements. This will be used by Space Finder (more exactly will be part of the SpaceFinder rules for the DCR page structure).


![Screenshot 2019-09-04 at 15 46 37](https://user-images.githubusercontent.com/6035518/64265677-40402600-cf2b-11e9-8e49-d8a0d35d5165.png)
