### PR TITLE
Upgrade src-foundations: change to media query API

### DIFF
--- a/packages/frontend/amp/components/Header.tsx
+++ b/packages/frontend/amp/components/Header.tsx
@@ -4,7 +4,7 @@ import Logo from '@guardian/pasteup/logos/the-guardian.svg';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';
 import { headline } from '@guardian/pasteup/typography';
 import { pillarPalette } from '../../lib/pillars';
-import { palette, mobileLandscape, until } from '@guardian/src-foundations';
+import { palette, from, until } from '@guardian/src-foundations';
 import { ReaderRevenueButton } from '@root/packages/frontend/amp/components/ReaderRevenueButton';
 
 const headerStyles = css`
@@ -79,7 +79,7 @@ const pillarLinkStyle = (pillar: Pillar) => css`
     font-weight: 900;
     font-size: 15.4px;
 
-    ${mobileLandscape} {
+    ${from.mobileLandscape} {
         font-size: 18px;
         padding: 7px 4px 0;
     }

--- a/packages/frontend/amp/components/topMeta/PaidForBand.tsx
+++ b/packages/frontend/amp/components/topMeta/PaidForBand.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 
-import { palette, mobileLandscape } from '@guardian/src-foundations';
+import { palette, from } from '@guardian/src-foundations';
 import { textSans } from '@guardian/pasteup/typography';
 import LabsLogo from '@guardian/pasteup/logos/the-guardian-labs.svg';
 import ArrowRightIcon from '@guardian/pasteup/icons/arrow-right.svg';
@@ -15,7 +15,7 @@ const headerStyle = css`
     height: 58px;
     background-color: ${palette.labs.bright};
 
-    ${mobileLandscape} {
+    ${from.mobileLandscape} {
         padding: 0 20px;
     }
 `;

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -8,7 +8,7 @@
     "@emotion/core": "^10.0.5",
     "@guardian/guui": "2.0.0-alpha.1",
     "@guardian/pasteup": "2.0.0-alpha.2",
-    "@guardian/src-foundations": "^0.0.14",
+    "@guardian/src-foundations": "^0.1.0",
     "@types/ajv": "^1.0.0",
     "@types/lodash.escape": "^4.0.6",
     "@types/sanitize-html": "^1.18.3",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -8,7 +8,7 @@
     "@emotion/core": "^10.0.5",
     "@guardian/guui": "2.0.0-alpha.1",
     "@guardian/pasteup": "2.0.0-alpha.2",
-    "@guardian/src-foundations": "^0.1.0",
+    "@guardian/src-foundations": "^0.1.1",
     "@types/ajv": "^1.0.0",
     "@types/lodash.escape": "^4.0.6",
     "@types/sanitize-html": "^1.18.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1175,10 +1175,10 @@
     signedsource "^1.0.0"
     yargs "^9.0.0"
 
-"@guardian/src-foundations@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.1.0.tgz#ad1cd9f5f4e03858cc65bf1eb07a75a54b8a5b9a"
-  integrity sha512-vR2DYB6y3K/hsbumbdqJ5ATBXailm2jwjGH+SUBOy/0NdEXSQAK/PbQ+OyRHrjz4zlK8sXpr7hLSqEcl2s9KZg==
+"@guardian/src-foundations@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.1.1.tgz#902e4f17835646a5b2eed78960d247af173714a5"
+  integrity sha512-bZff9jZCqBjdgpN6STUYkOLbZ8+VdtYlgsv46q4uz9MQi8uQc67vh4J+euvxi1FpjVqWW3WBlW/XmM5m3VIudg==
 
 "@hapi/address@2.x.x":
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1175,10 +1175,10 @@
     signedsource "^1.0.0"
     yargs "^9.0.0"
 
-"@guardian/src-foundations@^0.0.14":
-  version "0.0.14"
-  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.0.14.tgz#863c5a5fec7e7c30ed387a4d901fb7173de64087"
-  integrity sha512-bnVnL5Jc34PnrEySP/dmfb6iG1Sx4dXEI27LcLT+OjCjbW7OU13Q4w9BLLIO/t9o4YskWMy6vZLqfippJtUzYw==
+"@guardian/src-foundations@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.1.0.tgz#ad1cd9f5f4e03858cc65bf1eb07a75a54b8a5b9a"
+  integrity sha512-vR2DYB6y3K/hsbumbdqJ5ATBXailm2jwjGH+SUBOy/0NdEXSQAK/PbQ+OyRHrjz4zlK8sXpr7hLSqEcl2s9KZg==
 
 "@hapi/address@2.x.x":
   version "2.0.0"


### PR DESCRIPTION
## What does this change?

The design system team have slightly changed the media query API. This change updates AMP to use the new API.

```js
// before
${mobileLandscape} {

}

// after
${from.mobileLandscape} {

}
```

## Why?

The new API has a smaller surface area and is more consistent

## Link to supporting Trello card
