### PR TITLE
Ad styling

### DIFF
--- a/packages/frontend/web/components/AdSlot.tsx
+++ b/packages/frontend/web/components/AdSlot.tsx
@@ -5,7 +5,7 @@ import { shouldDisplayAdvertisements } from '@frontend/model/advertisement';
 import { css } from 'emotion';
 import { textSans, palette } from '@guardian/src-foundations';
 
-const labelStyles = css`
+export const labelStyles = css`
     .ad-slot__label {
         ${textSans({ level: 1 })};
         position: relative;

--- a/packages/frontend/web/components/AdSlot.tsx
+++ b/packages/frontend/web/components/AdSlot.tsx
@@ -2,6 +2,26 @@
 
 import React from 'react';
 import { shouldDisplayAdvertisements } from '@frontend/model/advertisement';
+import { css } from 'emotion';
+import { textSans, palette } from '@guardian/src-foundations';
+
+const labelStyles = css`
+    .ad-slot__label {
+        ${textSans({ level: 1 })};
+        position: relative;
+        height: 24px;
+        background-color: ${palette.neutral[97]};
+        padding: 0 8px;
+        border-top: 1px solid ${palette.neutral[86]};
+        color: ${palette.neutral[46]};
+        text-align: left;
+        box-sizing: border-box;
+    }
+
+    .ad-slot__close-button {
+        display: none;
+    }
+`;
 
 export interface AdSlotParameters {
     name: string;
@@ -55,6 +75,7 @@ export const AdSlotCore: React.FC<{
     outOfPage?: boolean;
     optId?: string;
     optClassNames?: string[];
+    className: string;
 }> = ({
     name,
     adTypes,
@@ -64,6 +85,7 @@ export const AdSlotCore: React.FC<{
     outOfPage = false,
     optId,
     optClassNames,
+    className,
 }) => {
     // Will export `getOptionalProps` as a function if/when needed - Pascal.
     // const getOptionalProps = (): object => ({
@@ -76,7 +98,11 @@ export const AdSlotCore: React.FC<{
     return (
         <div
             id={`dfp-ad--${optId || name}`}
-            className={makeClassNames(name, adTypes, optClassNames || [])}
+            className={`${makeClassNames(
+                name,
+                adTypes,
+                optClassNames || [],
+            )} ${className} ${labelStyles}`}
             data-link-name={`ad slot ${name}`}
             data-name={name}
             // {...getOptionalProps()}
@@ -89,9 +115,10 @@ export const AdSlotCore: React.FC<{
 export const AdSlot: React.FC<{
     asps: AdSlotParameters;
     config: ConfigType;
-}> = ({ asps, config }) => {
+    className: string;
+}> = ({ asps, config, className }) => {
     if (!shouldDisplayAdvertisements(config)) {
         return null;
     }
-    return <AdSlotCore {...asps} />;
+    return <AdSlotCore {...asps} className={className} />;
 };

--- a/packages/frontend/web/components/MostViewed.tsx
+++ b/packages/frontend/web/components/MostViewed.tsx
@@ -371,6 +371,7 @@ export class MostViewed extends Component<Props, { selectedTabIndex: number }> {
                     <AdSlot
                         asps={namedAdSlotParameters('most-popular')}
                         config={this.props.config}
+                        className={''}
                     />
                 </div>
             </div>

--- a/packages/frontend/web/pages/Article.tsx
+++ b/packages/frontend/web/pages/Article.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import { Container } from '@guardian/guui';
 import { css, cx } from 'emotion';
-import { palette, until } from '@guardian/src-foundations';
-import { desktop, mobileLandscape } from '@guardian/pasteup/breakpoints';
+import {
+    palette,
+    until,
+    desktop,
+    mobileLandscape,
+    wide,
+} from '@guardian/src-foundations';
 import { MostViewed } from '@frontend/web/components/MostViewed';
 import { Header } from '@frontend/web/components/Header/Header';
 import { Footer } from '@frontend/web/components/Footer';
@@ -11,7 +16,7 @@ import { SubNav } from '@frontend/web/components/Header/Nav/SubNav/SubNav';
 import { CookieBanner } from '@frontend/web/components/CookieBanner';
 import { OutbrainContainer } from '@frontend/web/components/Outbrain';
 import { namedAdSlotParameters } from '@frontend/model/advertisement';
-import { AdSlot } from '@frontend/web/components/AdSlot';
+import { AdSlot, labelStyles } from '@frontend/web/components/AdSlot';
 
 // TODO: find a better of setting opacity
 const secondaryColumn = css`
@@ -81,6 +86,31 @@ const headerAd = css`
     width: 728px;
 `;
 
+// These are by selector as for dynamically-created ads
+const bodyAdStyles = css`
+    .ad-slot--inline {
+        background-color: ${palette.neutral[97]};
+        width: 320px;
+        margin: 12px auto;
+        min-width: 300px;
+        min-height: 274px;
+        text-align: center;
+
+        ${desktop} {
+            margin: 0;
+            width: auto;
+            float: right;
+            margin-right: -328px;
+        }
+
+        ${wide} {
+            margin-right: -408px;
+        }
+    }
+
+    ${labelStyles};
+`;
+
 export const Article: React.FC<{
     data: ArticleProps;
 }> = ({ data }) => (
@@ -103,7 +133,7 @@ export const Article: React.FC<{
 
         <main>
             <Container borders={true} className={articleContainer}>
-                <article>
+                <article className={bodyAdStyles}>
                     <ArticleBody CAPI={data.CAPI} config={data.config} />
                     <div className={secondaryColumn}>
                         <div className={adSlotWrapper}>

--- a/packages/frontend/web/pages/Article.tsx
+++ b/packages/frontend/web/pages/Article.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Container } from '@guardian/guui';
 import { css, cx } from 'emotion';
-import { palette } from '@guardian/pasteup/palette';
+import { palette, until } from '@guardian/src-foundations';
 import { desktop, mobileLandscape } from '@guardian/pasteup/breakpoints';
 import { MostViewed } from '@frontend/web/components/MostViewed';
 import { Header } from '@frontend/web/components/Header/Header';
@@ -41,34 +41,78 @@ const articleContainer = css`
     }
 `;
 
-const overflowHidden = css`
-    overflow: hidden;
+const adSlotWrapper = css`
+    position: static;
+    height: 1059px;
+`;
+
+const headerWrapper = css`
+    position: static;
+`;
+
+const stickyAdSlot = css`
+    position: sticky;
+    top: 0;
+`;
+
+const headerAdWrapper = css`
+    ${until.tablet} {
+        display: none;
+    }
+
+    margin: 0 auto;
+    min-height: 5.625rem;
+    padding-bottom: 1.125rem;
+    padding-top: 1.125rem;
+    text-align: left;
+    display: table;
+
+    z-index: 1080;
+
+    background-color: white;
+    width: 100%;
+    border-bottom: 0.0625rem solid ${palette.neutral[86]};
+
+    ${stickyAdSlot};
+`;
+
+const headerAd = css`
+    margin: 0 auto;
+    width: 728px;
 `;
 
 export const Article: React.FC<{
     data: ArticleProps;
 }> = ({ data }) => (
-    <div className={overflowHidden}>
-        <div>
-            <AdSlot
-                asps={namedAdSlotParameters('top-above-nav')}
-                config={data.config}
+    <div>
+        <div className={headerWrapper}>
+            <div className={headerAdWrapper}>
+                <AdSlot
+                    asps={namedAdSlotParameters('top-above-nav')}
+                    config={data.config}
+                    className={headerAd}
+                />
+            </div>
+
+            <Header
+                nav={data.NAV}
+                pillar={data.CAPI.pillar}
+                edition={data.CAPI.editionId}
             />
         </div>
-        <Header
-            nav={data.NAV}
-            pillar={data.CAPI.pillar}
-            edition={data.CAPI.editionId}
-        />
+
         <main>
             <Container borders={true} className={articleContainer}>
                 <article>
                     <ArticleBody CAPI={data.CAPI} config={data.config} />
                     <div className={secondaryColumn}>
-                        <AdSlot
-                            asps={namedAdSlotParameters('right')}
-                            config={data.config}
-                        />
+                        <div className={adSlotWrapper}>
+                            <AdSlot
+                                asps={namedAdSlotParameters('right')}
+                                config={data.config}
+                                className={stickyAdSlot}
+                            />
+                        </div>
                     </div>
                 </article>
             </Container>


### PR DESCRIPTION
## What does this change?

Add styling for ads. Note, there are almost certainly variants of the dynamic in-body ads that need different styling, which aren't yet handled.

## Why?

As part of static ad support.

## Link to supporting Trello card

https://trello.com/c/Ry9am7hl

![sticky-ads-dcr](https://user-images.githubusercontent.com/858402/64616171-ec728880-d3d3-11e9-808a-2d22a03aee9d.gif)

![Screenshot 2019-09-10 at 14 37 10](https://user-images.githubusercontent.com/858402/64619882-bdabe080-d3da-11e9-814d-8a83578448f0.png)
