### PR TITLE
Rename platform record to experiences

### DIFF
--- a/packages/frontend/web/browser/ophan/ophan.ts
+++ b/packages/frontend/web/browser/ophan/ophan.ts
@@ -13,7 +13,7 @@ export const sendOphanPlatformRecord = () => {
         window.guardian.ophan &&
         window.guardian.ophan.record
     ) {
-        window.guardian.ophan.record({ platformVariant: 'dotcom-rendering' });
+        window.guardian.ophan.record({ experiences: 'dotcom-rendering' });
 
         // Record server-side AB test variants (i.e. control or variant)
         if (window.guardian.config.tests) {


### PR DESCRIPTION
## What does this change?

Ophan expects the field 'experiences' (platformVariant never did nuffink)

## Why?

BETTER TRACKING.

![tenor-56223074](https://user-images.githubusercontent.com/638051/64703387-362aa400-d4a4-11e9-9399-3dd51721793e.gif)


## Link to supporting Trello card

https://trello.com/c/B86YrDpw/675-add-platform-to-page-view-ophan-data-lake-model

@guardian/dotcom-platform pls.