### PR TITLE
Fix height bug and units on banner ad

### DIFF
--- a/packages/frontend/web/pages/Article.tsx
+++ b/packages/frontend/web/pages/Article.tsx
@@ -66,9 +66,9 @@ const headerAdWrapper = css`
     }
 
     margin: 0 auto;
-    min-height: 5.625rem;
-    padding-bottom: 1.125rem;
-    padding-top: 1.125rem;
+    min-height: 151px;
+    padding-bottom: 18px;
+    padding-top: 18px;
     text-align: left;
     display: table;
 


### PR DESCRIPTION
## What does this change?

Fix the (min) height of the banner ad to prevent it being too small on an ad refresh (see Trello card for details).

## Why?

To fix the associated bug.

## Link to supporting Trello card

https://trello.com/c/9vDouO75/694-top-above-nav-static-add-refresh-is-not-smooth