### PR TITLE
Add window.guardian.config.page.showRelatedContent

### DIFF
--- a/packages/frontend/model/window-guardian.ts
+++ b/packages/frontend/model/window-guardian.ts
@@ -12,6 +12,7 @@ export interface WindowGuardianConfig {
         keywordIds: [];
         dfpAccountId: string;
         adUnit: string;
+        showRelatedContent: boolean;
     };
     libs: {
         googletag: string;
@@ -48,6 +49,7 @@ const makeWindowGuardianConfig = (
             // ... but the value is not used on the master branch.
             // TODO (Pascal): read the value from frontend.
             adUnit: '/59666047/theguardian.com/film/article/ng',
+            showRelatedContent: true,
         },
         libs: {
             googletag: dcrDocumentData.config.googletagUrl,


### PR DESCRIPTION
## What does this change?

Add the missing `window.guardian.config.page.showRelatedContent` boolean, currently hard coded to `true`. It is required to get Outbrain to show up ( see: https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/common/modules/commercial/commercial-features.js#L119 ). 

A later PR will set the value programatically. 