### PR TITLE
Ensure Raven is reporting correctly

### DIFF
--- a/packages/frontend/model/window-guardian.ts
+++ b/packages/frontend/model/window-guardian.ts
@@ -54,6 +54,7 @@ const makeWindowGuardianConfig = (
         },
         switches: dcrDocumentData.CAPI.config.switches,
         tests: dcrDocumentData.CAPI.config.abTests || {},
+        modules: {},
     } as WindowGuardianConfig;
 };
 

--- a/packages/frontend/web/browser/raven/init.ts
+++ b/packages/frontend/web/browser/raven/init.ts
@@ -13,7 +13,7 @@ const init = () => {
             setWIndowOnError(raven);
 
             // expose core function
-            window.guardian.modules.raven = { reportError };
+            window.guardian.config.modules.raven = { reportError };
         } catch {
             /**
              * Raven will have reported any unhandled promise

--- a/packages/frontend/web/browser/raven/init.ts
+++ b/packages/frontend/web/browser/raven/init.ts
@@ -2,8 +2,9 @@ import { getRaven, reportError, setWIndowOnError } from './raven';
 import { startup } from '@frontend/web/browser/startup';
 
 const init = () => {
-    return getRaven()
-        .then(raven => {
+    return Promise.resolve().then(() => {
+        const raven = getRaven();
+        try {
             if (!raven) {
                 return;
             }
@@ -13,14 +14,14 @@ const init = () => {
 
             // expose core function
             window.guardian.modules.raven = { reportError };
-        })
-        .catch(() => {
+        } catch {
             /**
              * Raven will have reported any unhandled promise
              * rejections from this chain so return here.
              */
             return;
-        });
+        }
+    });
 };
 
 startup('raven', null, init);

--- a/packages/frontend/web/browser/raven/raven.ts
+++ b/packages/frontend/web/browser/raven/raven.ts
@@ -61,9 +61,9 @@ const shouldSendCallback: (data: ShouldSendCallbackData) => boolean = data => {
         // Some environments don't support or don't always expose the console Object
         if (window.console && window.console.warn) {
             window.console.warn('Raven would send: ', {
+                isInSample,
                 'switches.enableSentryReporting':
                     switches.enableSentryReporting,
-                isInSample: isInSample,
                 '!isIgnored': !isIgnored,
                 '!adBlockInUse': !adBlockInUse,
                 '!isDev': !isDev,
@@ -119,7 +119,6 @@ export const reportError = (
 
 export const setWIndowOnError = (r: RavenStatic) => {
     const oldOnError = window.onerror;
-    console.log('error set');
     /**
      * Make sure global onerror doesn't report errors
      * already manually reported via reportError module


### PR DESCRIPTION
## What does this change?

Previously: Raven would wait until the Promise for 'AdBlockInUse' returned before initialising. This waits for a `requestAnimationFrame` by which time all other scripts have initialised and any errors are lost.

Now: Raven will initialise immediately but calls *after* we know an adblocker is on will be prevented.

Note: The new adblocker code is also async so can hook into the same mechanisms, so this is still relevant.

*Also*: 
- `Modules` was in the incorrect location, some adjustment made to fix that.
- More error logging for whether an error would be sent or not for local dev

## Testing

Tested by using `setTimeout` to fake async:

![Screenshot 2019-09-13 at 07 52 05](https://user-images.githubusercontent.com/638051/64875581-4f1e8b00-d645-11e9-92a7-2d4c3e528af3.png)


## Why?

We want to capture all errors.

## Link to supporting Trello card

https://trello.com/c/6eXzyRb5/706-fix-raven-reporting
