### PR TITLE
Replace interpolation with cx

### DIFF
--- a/packages/frontend/web/components/BackToTop.tsx
+++ b/packages/frontend/web/components/BackToTop.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'emotion';
+import { css, cx } from 'emotion';
 import { palette } from '@guardian/src-foundations';
 import { sans } from '@guardian/pasteup/typography';
 
@@ -24,7 +24,7 @@ const link = css`
     :hover {
         color: ${palette.yellow.main};
 
-        .${iconContainer} {
+        .icon-container {
             background-color: ${palette.yellow.main};
         }
     }
@@ -56,7 +56,7 @@ const text = css`
 export const BackToTop: React.FC = () => (
     <a className={link} href="#top">
         <span className={text}>Back to top</span>
-        <span className={iconContainer}>
+        <span className={cx('icon-container', iconContainer)}>
             <i className={icon} />
         </span>
     </a>


### PR DESCRIPTION
## What does this change?

In https://github.com/guardian/dotcom-rendering/pull/742/files I introduced the error:

```
Interpolating a className from css`` is not recommended and will cause problems with co
mposition.
    Interpolating a className from css`` will be completely unsupported in a future major version of Emotion
```

This fixes it following this: https://github.com/emotion-js/emotion/issues/1186

Namespaced to outer element.

## Why?

Errors are annoying.

## Link to supporting Trello card

https://trello.com/c/pSTQevpR/707-fix-interpolation-error

@guardian/dotcom-platform 
