### PR TITLE
Adds asset performance logging to Ophan

### DIFF
--- a/packages/frontend/model/window-guardian.ts
+++ b/packages/frontend/model/window-guardian.ts
@@ -20,8 +20,9 @@ export interface WindowGuardianConfig {
     switches: { [key: string]: boolean };
     tests?: { [key: string]: string };
     modules: {
+        started: string[];
         raven: {
-            reportError: (
+            reportError?: (
                 err: Error,
                 tags: { [key: string]: string },
                 shouldThrow: boolean,
@@ -56,7 +57,10 @@ const makeWindowGuardianConfig = (
         },
         switches: dcrDocumentData.CAPI.config.switches,
         tests: dcrDocumentData.CAPI.config.abTests || {},
-        modules: {},
+        modules: {
+            started: [],
+            raven: {},
+        },
     } as WindowGuardianConfig;
 };
 

--- a/packages/frontend/web/browser/ophan/init.ts
+++ b/packages/frontend/web/browser/ophan/init.ts
@@ -1,4 +1,4 @@
-import { sendOphanPlatformRecord } from './ophan';
+import { sendOphanPlatformRecord, recordPerformance } from './ophan';
 import { startup } from '@frontend/web/browser/startup';
 
 // side effect only
@@ -6,6 +6,12 @@ import 'ophan-tracker-js';
 
 const init = (): Promise<void> => {
     sendOphanPlatformRecord();
+    // We wait for the load event so that we can be sure our assetPerformance is reported as expected.
+    window.addEventListener('load', function load() {
+        recordPerformance();
+        window.removeEventListener('load', load, false);
+    });
+
     return Promise.resolve();
 };
 

--- a/packages/frontend/web/browser/startup.ts
+++ b/packages/frontend/web/browser/startup.ts
@@ -6,6 +6,8 @@ export interface Reporter {
     ) => void;
 }
 
+const modulesStarted = window.guardian.config.modules.started;
+
 const measure = (name: string, task: () => Promise<void>): void => {
     const perf = window.performance;
     const start = `${name}-start`;
@@ -16,6 +18,9 @@ const measure = (name: string, task: () => Promise<void>): void => {
     task().finally(() => {
         perf.mark(end);
         perf.measure(name, start, end);
+
+        // Keep track of the module names that have been initialised
+        modulesStarted.push(name);
 
         // tslint:disable-next-line:no-console
         console.log(JSON.stringify(perf.getEntriesByName(name)));


### PR DESCRIPTION
## What does this change?

Adds perf and asset logging to Ophan/Data Lake.

![Screenshot 2019-09-13 at 16 40 06](https://user-images.githubusercontent.com/638051/64877730-e5ed4680-d649-11e9-8d67-bc47e7031d02.png)

## Why?

Recording data on module start and end times.

## Link to supporting Trello card

https://trello.com/c/4fYygAWR/636-tracking-track-perf-in-ophan

@guardian/dotcom-platform 
