### PR TITLE
Styling the outbrain widget

### DIFF
--- a/packages/frontend/web/components/Outbrain.tsx
+++ b/packages/frontend/web/components/Outbrain.tsx
@@ -5,7 +5,14 @@ import { Container } from '@guardian/guui';
 import { shouldDisplayAdvertisements } from '@frontend/model/advertisement';
 import { css } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
-import { tablet, desktop, leftCol, wide } from '@guardian/src-foundations';
+import {
+    body,
+    textSans,
+    tablet,
+    desktop,
+    leftCol,
+    wide,
+} from '@guardian/src-foundations';
 
 interface OutbrainSelectors {
     widget: string;
@@ -87,8 +94,13 @@ const outbrainContainer = css`
         }
     }
 
+    .ob-widget-header {
+        ${body({ level: 2, lineHeight: 'regular', fontWeight: 'bold' })}
+    }
+
     .ob-rec-text {
         max-height: fit-content;
+        ${textSans({ level: 2, lineHeight: 'regular', fontWeight: 'bold' })}
     }
 `;
 

--- a/packages/frontend/web/components/Outbrain.tsx
+++ b/packages/frontend/web/components/Outbrain.tsx
@@ -5,6 +5,7 @@ import { Container } from '@guardian/guui';
 import { shouldDisplayAdvertisements } from '@frontend/model/advertisement';
 import { css } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
+import { tablet, desktop, leftCol, wide } from '@guardian/src-foundations';
 
 interface OutbrainSelectors {
     widget: string;
@@ -68,6 +69,22 @@ const outbrainContainer = css`
         border-right: 1px solid ${palette.neutral[86]};
         border-top: 1px solid ${palette.neutral[86]};
         padding: 20px;
+
+        ${tablet} {
+            max-width: 740px;
+        }
+
+        ${desktop} {
+            max-width: 980px;
+        }
+
+        ${leftCol} {
+            max-width: 1140px;
+        }
+
+        ${wide} {
+            max-width: 1300px;
+        }
     }
 
     .ob-rec-text {

--- a/packages/frontend/web/components/Outbrain.tsx
+++ b/packages/frontend/web/components/Outbrain.tsx
@@ -5,14 +5,8 @@ import { Container } from '@guardian/guui';
 import { shouldDisplayAdvertisements } from '@frontend/model/advertisement';
 import { css } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
-import {
-    body,
-    textSans,
-    tablet,
-    desktop,
-    leftCol,
-    wide,
-} from '@guardian/src-foundations';
+import { textSans, body } from '@guardian/pasteup/typography';
+import { tablet, desktop, leftCol, wide } from '@guardian/src-foundations';
 
 interface OutbrainSelectors {
     widget: string;
@@ -95,12 +89,12 @@ const outbrainContainer = css`
     }
 
     .ob-widget-header {
-        ${body({ level: 2, lineHeight: 'regular', fontWeight: 'bold' })}
+        ${body(3)};
     }
 
     .ob-rec-text {
         max-height: fit-content;
-        ${textSans({ level: 2, lineHeight: 'regular', fontWeight: 'bold' })}
+        ${textSans(5)};
     }
 `;
 

--- a/packages/frontend/web/components/Outbrain.tsx
+++ b/packages/frontend/web/components/Outbrain.tsx
@@ -3,6 +3,8 @@
 import React from 'react';
 import { Container } from '@guardian/guui';
 import { shouldDisplayAdvertisements } from '@frontend/model/advertisement';
+import { css } from 'emotion';
+import { palette } from '@guardian/pasteup/palette';
 
 interface OutbrainSelectors {
     widget: string;
@@ -49,6 +51,30 @@ const OutbrainWidget: React.FC<{}> = ({}) => {
     );
 };
 
+const outbrainContainer = css`
+    .js-outbrain {
+        width: 100vw;
+        position: relative;
+        left: 50%;
+        right: 50%;
+        margin-left: -50vw;
+        margin-right: -50vw;
+        background-color: ${palette.neutral[97]};
+    }
+
+    .js-outbrain-container {
+        margin: auto;
+        border-left: 1px solid ${palette.neutral[86]};
+        border-right: 1px solid ${palette.neutral[86]};
+        border-top: 1px solid ${palette.neutral[86]};
+        padding: 20px;
+    }
+
+    .ob-rec-text {
+        max-height: fit-content;
+    }
+`;
+
 export const OutbrainContainer: React.FC<{
     config: ConfigType;
 }> = ({ config }) => {
@@ -57,7 +83,9 @@ export const OutbrainContainer: React.FC<{
     }
     return (
         <Container>
-            <OutbrainWidget />
+            <div className={outbrainContainer}>
+                <OutbrainWidget />
+            </div>
         </Container>
     );
 };

--- a/packages/frontend/web/components/Outbrain.tsx
+++ b/packages/frontend/web/components/Outbrain.tsx
@@ -88,13 +88,22 @@ const outbrainContainer = css`
         }
     }
 
-    .ob-widget-header {
-        ${body(3)};
-    }
+    .ob-widget {
+        div.ob-widget-header {
+            ${body(3)};
+            span,
+            .ob_about_this_content {
+                ${body(1)};
+            }
+        }
+        div.ob-widget-section {
+            margin-top: 0px;
+        }
 
-    .ob-rec-text {
-        max-height: fit-content;
-        ${textSans(5)};
+        span.ob-rec-text {
+            max-height: fit-content;
+            ${textSans(5)};
+        }
     }
 `;
 

--- a/packages/frontend/web/components/Outbrain.tsx
+++ b/packages/frontend/web/components/Outbrain.tsx
@@ -92,8 +92,11 @@ const outbrainContainer = css`
         div.ob-widget-header {
             ${body(3)};
             span,
-            .ob_about_this_content {
+            .ob_about_this_content a {
                 ${body(1)};
+                text-decoration: none;
+                /* stylelint-disable-next-line color-no-hex */
+                color: #00456e;
             }
         }
         div.ob-widget-section {


### PR DESCRIPTION
## What does this change?
Before
![Screen Shot 2019-09-17 at 11 17 42](https://user-images.githubusercontent.com/2051501/65033484-01ec3300-d93d-11e9-9f3e-4e0eac120ef9.png)

After
<img width="1440" alt="Screen Shot 2019-09-17 at 11 31 10" src="https://user-images.githubusercontent.com/2051501/65034332-b9357980-d93e-11e9-9255-46938ac667eb.png">


Prod
![Screen Shot 2019-09-17 at 11 17 05](https://user-images.githubusercontent.com/2051501/65033501-09abd780-d93d-11e9-9cde-ab3b3528621e.png)

## Why?
Parity - although we lack the requisite font sizes/line-height/weight combinations to get complete parity

## Link to supporting Trello card
https://trello.com/c/ZQadWOXe
