### PR TITLE
Send performance metrics to Ophan 

### DIFF
--- a/packages/frontend/model/window-guardian.ts
+++ b/packages/frontend/model/window-guardian.ts
@@ -20,7 +20,6 @@ export interface WindowGuardianConfig {
     switches: { [key: string]: boolean };
     tests?: { [key: string]: string };
     modules: {
-        started: string[];
         raven: {
             reportError?: (
                 err: Error,
@@ -58,7 +57,6 @@ const makeWindowGuardianConfig = (
         switches: dcrDocumentData.CAPI.config.switches,
         tests: dcrDocumentData.CAPI.config.abTests || {},
         modules: {
-            started: [],
             raven: {},
         },
     } as WindowGuardianConfig;

--- a/packages/frontend/model/window-guardian.ts
+++ b/packages/frontend/model/window-guardian.ts
@@ -20,8 +20,9 @@ export interface WindowGuardianConfig {
     switches: { [key: string]: boolean };
     tests?: { [key: string]: string };
     modules: {
+        started: string[];
         raven: {
-            reportError: (
+            reportError?: (
                 err: Error,
                 tags: { [key: string]: string },
                 shouldThrow: boolean,
@@ -56,7 +57,10 @@ const makeWindowGuardianConfig = (
         },
         switches: dcrDocumentData.CAPI.config.switches,
         tests: dcrDocumentData.CAPI.config.abTests || {},
-        modules: {},
+        modules: {
+            started: [],
+            raven: {},
+        },
     } as WindowGuardianConfig;
 };
 

--- a/packages/frontend/model/window-guardian.ts
+++ b/packages/frontend/model/window-guardian.ts
@@ -19,15 +19,6 @@ export interface WindowGuardianConfig {
     };
     switches: { [key: string]: boolean };
     tests?: { [key: string]: string };
-    modules: {
-        raven: {
-            reportError?: (
-                err: Error,
-                tags: { [key: string]: string },
-                shouldThrow: boolean,
-            ) => void;
-        };
-    };
 }
 
 const makeWindowGuardianConfig = (
@@ -56,9 +47,6 @@ const makeWindowGuardianConfig = (
         },
         switches: dcrDocumentData.CAPI.config.switches,
         tests: dcrDocumentData.CAPI.config.abTests || {},
-        modules: {
-            raven: {},
-        },
     } as WindowGuardianConfig;
 };
 
@@ -80,6 +68,15 @@ export interface WindowGuardian {
     config: WindowGuardianConfig;
     polyfilled: boolean;
     adBlockers: any;
+    modules: {
+        raven: {
+            reportError?: (
+                err: Error,
+                tags: { [key: string]: string },
+                shouldThrow: boolean,
+            ) => void;
+        };
+    };
 }
 
 export const makeWindowGuardian = (
@@ -96,6 +93,9 @@ export const makeWindowGuardian = (
         adBlockers: {
             active: undefined,
             onDetect: [],
+        },
+        modules: {
+            raven: {},
         },
     };
 };

--- a/packages/frontend/web/browser/ophan/init.ts
+++ b/packages/frontend/web/browser/ophan/init.ts
@@ -1,4 +1,4 @@
-import { sendOphanPlatformRecord } from './ophan';
+import { sendOphanPlatformRecord, recordPerformance } from './ophan';
 import { startup } from '@frontend/web/browser/startup';
 
 // side effect only
@@ -6,6 +6,12 @@ import 'ophan-tracker-js';
 
 const init = (): Promise<void> => {
     sendOphanPlatformRecord();
+    // We wait for the load event so that we can be sure our assetPerformance is reported as expected.
+    window.addEventListener('load', function load() {
+        recordPerformance();
+        window.removeEventListener('load', load, false);
+    });
+
     return Promise.resolve();
 };
 

--- a/packages/frontend/web/browser/ophan/ophan.ts
+++ b/packages/frontend/web/browser/ophan/ophan.ts
@@ -52,18 +52,6 @@ export const recordPerformance = () => {
 
     const timing = performanceAPI.timing;
 
-    const allStartedModules = window.guardian.config.modules.started;
-    const marks = window.performance.getEntriesByType('mark').filter(mark => {
-        // We store our module marks as module-start and module-end
-        // and our startedModules as the module name. Lets split it
-        // out so that we can measure ours and only our marks.
-        const ourModuleMark = mark.name.split('-');
-        return (
-            allStartedModules.includes(ourModuleMark && ourModuleMark[0]) ||
-            mark.name.includes('commercial') // Commercial record is in a different format as from Frontend
-        );
-    });
-
     const performance = {
         dns: timing.domainLookupEnd - timing.domainLookupStart,
         connection: timing.connectEnd - timing.connectStart,
@@ -74,10 +62,6 @@ export const recordPerformance = () => {
         loadEvent: timing.loadEventStart - timing.domContentLoadedEventStart,
         navType: performanceAPI.navigation.type,
         redirectCount: performanceAPI.navigation.redirectCount,
-        assetsPerformance: marks.map(mark => ({
-            name: mark.name,
-            timing: Math.floor(mark.startTime),
-        })),
     };
 
     window.guardian.ophan.record({

--- a/packages/frontend/web/browser/raven/init.ts
+++ b/packages/frontend/web/browser/raven/init.ts
@@ -13,7 +13,7 @@ const init = () => {
             setWIndowOnError(raven);
 
             // expose core function
-            window.guardian.config.modules.raven = { reportError };
+            window.guardian.modules.raven = { reportError };
         } catch {
             /**
              * Raven will have reported any unhandled promise

--- a/packages/frontend/web/browser/startup.ts
+++ b/packages/frontend/web/browser/startup.ts
@@ -6,6 +6,8 @@ export interface Reporter {
     ) => void;
 }
 
+const modulesStarted = window.guardian.config.modules.started;
+
 const measure = (name: string, task: () => Promise<void>): void => {
     const perf = window.performance;
     const start = `${name}-start`;
@@ -16,6 +18,9 @@ const measure = (name: string, task: () => Promise<void>): void => {
     task().finally(() => {
         perf.mark(end);
         perf.measure(name, start, end);
+
+        // Keep track of the module names that have been initialised
+        modulesStarted.push(name);
 
         // tslint:disable-next-line:no-console
         console.log(JSON.stringify(perf.getEntriesByName(name)));

--- a/packages/frontend/web/browser/startup.ts
+++ b/packages/frontend/web/browser/startup.ts
@@ -6,8 +6,6 @@ export interface Reporter {
     ) => void;
 }
 
-const modulesStarted = window.guardian.config.modules.started;
-
 const measure = (name: string, task: () => Promise<void>): void => {
     const perf = window.performance;
     const start = `${name}-start`;
@@ -18,9 +16,6 @@ const measure = (name: string, task: () => Promise<void>): void => {
     task().finally(() => {
         perf.mark(end);
         perf.measure(name, start, end);
-
-        // Keep track of the module names that have been initialised
-        modulesStarted.push(name);
 
         // tslint:disable-next-line:no-console
         console.log(JSON.stringify(perf.getEntriesByName(name)));


### PR DESCRIPTION
## What does this change?

- Sends browser perf metrics to Ophan for use on the dashboard (note that this doesn't include `assetPerformance` at this time)
- The modules object was at the wrong level so adjusts that

## Why?

Data.

## Link to supporting Trello card

https://trello.com/c/4fYygAWR/636-tracking-track-perf-in-ophan
