### PR TITLE
Introduce frontendAssetsFullURL for prebid

### DIFF
--- a/fixtures/CAPI.ts
+++ b/fixtures/CAPI.ts
@@ -448,7 +448,7 @@ export const CAPI: CAPIType = {
         isDev: false,
         googletagUrl: '//www.googletagservices.com/tag/js/gpt.js',
         stage: 'DEV',
-        frontendAssetsFullURL: 'http://localhost:9000/assets/',
+        frontendAssetsFullURL: 'https://assets.guim.co.uk/',
     },
     webTitle: 'Foobar',
     nav: {

--- a/fixtures/CAPI.ts
+++ b/fixtures/CAPI.ts
@@ -448,6 +448,7 @@ export const CAPI: CAPIType = {
         isDev: false,
         googletagUrl: '//www.googletagservices.com/tag/js/gpt.js',
         stage: 'DEV',
+        frontendAssetsFullURL: 'http://localhost:9000/assets/',
     },
     webTitle: 'Foobar',
     nav: {

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -227,6 +227,7 @@ interface ConfigType {
     isDev?: boolean;
     googletagUrl: string;
     stage: string;
+    frontendAssetsFullURL: string;
 }
 
 interface GADataType {

--- a/packages/frontend/model/json-schema.json
+++ b/packages/frontend/model/json-schema.json
@@ -1377,6 +1377,9 @@
                 },
                 "googletagUrl": {
                     "type": "string"
+                },
+                "frontendAssetsFullURL": {
+                    "type": "string"
                 }
             },
             "required": [
@@ -1388,7 +1391,8 @@
                 "revisionNumber",
                 "sentryHost",
                 "sentryPublicApiKey",
-                "switches"
+                "switches",
+                "frontendAssetsFullURL"
             ]
         },
         "DesignType": {

--- a/packages/frontend/model/window-guardian.ts
+++ b/packages/frontend/model/window-guardian.ts
@@ -3,6 +3,7 @@ type stage = 'DEV' | 'CODE' | 'PROD';
 export interface WindowGuardianConfig {
     isDotcomRendering: boolean;
     stage: stage;
+    frontendAssetsFullURL: string;
     page: {
         contentType: string;
         edition: Edition;
@@ -37,6 +38,7 @@ const makeWindowGuardianConfig = (
         // This indicates to the client side code that we are running a dotcom-rendering rendered page.
         isDotcomRendering: true,
         stage: dcrDocumentData.config.stage,
+        frontendAssetsFullURL: dcrDocumentData.config.frontendAssetsFullURL,
         page: {
             contentType: dcrDocumentData.CAPI.contentType,
             edition: dcrDocumentData.CAPI.editionId,

--- a/packages/frontend/web/components/ShareCount.test.tsx
+++ b/packages/frontend/web/components/ShareCount.test.tsx
@@ -31,6 +31,7 @@ describe('ShareCount', () => {
         isDev: false,
         googletagUrl: '',
         stage: 'DEV',
+        frontendAssetsFullURL: 'http://localhost:9000/assets/',
     };
 
     afterEach(() => {


### PR DESCRIPTION
## What does this change?

Report the value of `frontendAssetsFullURL` into the client side window object. (This is going to be used to set up the correct webpack assets variable)

Comes after: https://github.com/guardian/frontend/pull/21834 and https://github.com/guardian/frontend/pull/21835
