### PR TITLE
Avoid wrapper span for text block elements

### DIFF
--- a/packages/frontend/web/components/elements/TextBlockComponent.tsx
+++ b/packages/frontend/web/components/elements/TextBlockComponent.tsx
@@ -4,17 +4,47 @@ import { body } from '@guardian/pasteup/typography';
 // tslint:disable:react-no-dangerous-html
 
 const para = css`
+    margin-bottom: 16px;
+    ${body(2)};
+`;
+
+const innerPara = css`
     p {
-        margin-bottom: 16px;
-        ${body(2)};
+        ${para}
     }
 `;
 
-export const TextBlockComponent: React.FC<{ html: string }> = ({ html }) => (
-    <span
-        className={para}
-        dangerouslySetInnerHTML={{
-            __html: html,
-        }}
-    />
-);
+export const TextBlockComponent: React.FC<{ html: string }> = ({ html }) => {
+    const prefix = '<p>';
+    const suffix = '</p>';
+
+    // Ideally we want to want to avoid an unnecessary 'span' wrapper,
+    // which also will cause issues with ads (spacefinder rules). React
+    // requires a wrapping element for dangerouslySetInnerHTML so we
+    // strip the original p markup and rewrap. The fallback case is
+    // added for safety but should never happen. If it does happen
+    // though it will cause issues with commercial JS which expects
+    // paras to be top-level.
+    if (html.startsWith(prefix) && html.endsWith(suffix)) {
+        return (
+            <p
+                className={para}
+                dangerouslySetInnerHTML={{
+                    __html: html.slice(
+                        prefix.length,
+                        html.length - suffix.length,
+                    ),
+                }}
+            />
+        );
+    }
+
+    return (
+        <span
+            className={innerPara}
+            dangerouslySetInnerHTML={{
+                __html: html,
+            }}
+        />
+    );
+};

--- a/packages/frontend/web/components/lib/ArticleRenderer.tsx
+++ b/packages/frontend/web/components/lib/ArticleRenderer.tsx
@@ -38,5 +38,5 @@ export const ArticleRenderer: React.FC<{
             }
         })
         .filter(_ => _ != null);
-    return <div className="article-body-03f883b8">{output}</div>; // classname that space finder is going to target for in-body ads in DCR
+    return <div className="article-body-commercial-selector">{output}</div>; // classname that space finder is going to target for in-body ads in DCR
 };

--- a/packages/frontend/web/pages/Article.tsx
+++ b/packages/frontend/web/pages/Article.tsx
@@ -88,18 +88,27 @@ const headerAd = css`
 
 // These are by selector as for dynamically-created ads
 const bodyAdStyles = css`
-    .ad-slot--inline {
+    .ad-slot {
         background-color: ${palette.neutral[97]};
         width: 320px;
         margin: 12px auto;
         min-width: 300px;
         min-height: 274px;
         text-align: center;
+    }
 
+    .ad-slot--inline {
         ${desktop} {
             margin: 0;
             width: auto;
             float: right;
+        }
+    }
+
+    .ad-slot--offset-right {
+        ${desktop} {
+            float: right;
+            width: auto;
             margin-right: -328px;
         }
 


### PR DESCRIPTION
This results in cleaner markup and avoids having to modify commercial.js which expects p's at the top-level rather than span elements.

The implementation itself feels quite messy though, but I'm not aware of a better way.

**WARNING: this will break DCR commercial code without corresponding changes there to revert our span handling.**
