### PR TITLE
Add hbImpl to window.guardian.config.page

### DIFF
--- a/packages/frontend/model/window-guardian.ts
+++ b/packages/frontend/model/window-guardian.ts
@@ -15,6 +15,7 @@ export interface WindowGuardianConfig {
         adUnit: string;
         showRelatedContent: boolean;
         ajaxUrl: string;
+        hbImpl: string;
     };
     libs: {
         googletag: string;
@@ -45,6 +46,7 @@ const makeWindowGuardianConfig = (
             adUnit: '/59666047/theguardian.com/film/article/ng',
             showRelatedContent: true,
             ajaxUrl: dcrDocumentData.config.ajaxUrl,
+            hbImpl: 'prebid',
         },
         libs: {
             googletag: dcrDocumentData.config.googletagUrl,


### PR DESCRIPTION
## What does this change?

Add `hbImpl` to `window.guardian.config.page` with an hardcoded value for the moment and the dynamic value will be set in a later PR.
