### PR TITLE
Move config from Frontend to config.page rather than config

### DIFF
--- a/packages/frontend/model/window-guardian.ts
+++ b/packages/frontend/model/window-guardian.ts
@@ -32,7 +32,7 @@ const makeWindowGuardianConfig = (
         isDotcomRendering: true,
         stage: dcrDocumentData.config.stage,
         frontendAssetsFullURL: dcrDocumentData.config.frontendAssetsFullURL,
-        page: {
+        page: Object.assign(dcrDocumentData.config, {
             contentType: dcrDocumentData.CAPI.contentType,
             edition: dcrDocumentData.CAPI.editionId,
             revisionNumber: dcrDocumentData.config.revisionNumber,
@@ -47,7 +47,7 @@ const makeWindowGuardianConfig = (
             showRelatedContent: true,
             ajaxUrl: dcrDocumentData.config.ajaxUrl,
             hbImpl: dcrDocumentData.config.hbImpl,
-        },
+        }),
         libs: {
             googletag: dcrDocumentData.config.googletagUrl,
         },
@@ -94,10 +94,7 @@ export const makeWindowGuardian = (
             cssIDs,
             data: dcrDocumentData,
         },
-        config: Object.assign(
-            dcrDocumentData.config,
-            makeWindowGuardianConfig(dcrDocumentData),
-        ),
+        config: makeWindowGuardianConfig(dcrDocumentData),
         polyfilled: false,
         adBlockers: {
             active: undefined,


### PR DESCRIPTION
## What does this change?

Moves the config (which is `config.page`) from Frontend from `config` to `config.page` on the DCR window object. 

![tenor-79436728](https://user-images.githubusercontent.com/638051/65314591-7ff34880-db8e-11e9-9ae6-14165b011827.gif)

Server params for ad targeting working locally:

![image](https://user-images.githubusercontent.com/638051/65314488-5a663f00-db8e-11e9-910e-cc7f315c87ac.png)

## Why?

I dunno, for fun I guess.

## Link to supporting Trello card
https://trello.com/c/X4W3aIQY/683-page-and-user-targeting
