### PR TITLE
Add __cmp as inline script before commercial

### DIFF
--- a/packages/frontend/web/browser/prepareCmp.ts
+++ b/packages/frontend/web/browser/prepareCmp.ts
@@ -1,0 +1,68 @@
+export const prepareCmpString = `
+try {
+    (function(document, window) {
+        if (!window.__cmp) {
+            window.__cmp = (function() {
+                var listen = window.attachEvent || window.addEventListener;
+                listen('message', function(event) {
+                    window.__cmp.receiveMessage(event);
+                }, false);
+
+                function addLocatorFrame() {
+                    if (!window.frames['__cmpLocator']) {
+                        if (document.body) {
+                            var frame = document.createElement('iframe');
+                            frame.style.display = 'none';
+                            frame.name = '__cmpLocator';
+                            frame.setAttribute('aria-hidden', true);
+                            document.body.appendChild(frame);
+                        } else {
+                            setTimeout(addLocatorFrame, 5);
+                        }
+                    }
+                }
+                addLocatorFrame();
+
+                var commandQueue = [];
+                var cmp = function(command, parameter, callback) {
+                    if (command === 'ping') {
+                        if (callback) {
+                            callback({
+                                gdprAppliesGlobally: !!(window.__cmp && window.__cmp.config && window.__cmp.config.storeConsentGlobally),
+                                cmpLoaded: false
+                            });
+                        }
+                    } else {
+                        commandQueue.push({
+                            command: command,
+                            parameter: parameter,
+                            callback: callback
+                        });
+                    }
+                }
+                cmp.commandQueue = commandQueue;
+                cmp.receiveMessage = function(event) {
+                    var data = event && event.data && event.data.__cmpCall;
+                    if (data) {
+                        commandQueue.push({
+                            callId: data.callId,
+                            command: data.command,
+                            parameter: data.parameter,
+                            event: event
+                        });
+                    }
+                };
+                cmp.config = {
+                    storeConsentGlobally: false,
+                    storePublisherData: false,
+                    logging: false,
+                    gdprApplies: true,
+                }
+                return cmp;
+            }());
+        }
+    })(document, window);
+} catch (e) {
+    // throw (e)
+}
+`;

--- a/packages/frontend/web/server/htmlTemplate.ts
+++ b/packages/frontend/web/server/htmlTemplate.ts
@@ -1,6 +1,7 @@
 import resetCSS from /* preval */ '@frontend/lib/reset-css';
 import { getFontsCss } from '@frontend/lib/fonts-css';
 import { getStatic } from '@frontend/lib/assets';
+import { prepareCmpString } from '@frontend/web/browser/prepareCmp';
 
 import { WindowGuardian } from '@frontend/model/window-guardian';
 
@@ -104,8 +105,9 @@ export const htmlTemplate = ({
                     };
                 </script>
 
-                ${priorityScriptTags.join('\n')}
+                <script>${prepareCmpString}</script>
 
+                ${priorityScriptTags.join('\n')}
                 <style>${getFontsCss()}${resetCSS}${css}</style>
             </head>
 


### PR DESCRIPTION
## What does this change?

Pastes the `__cmp` stub which preps for `__cmp` proper in commercial.

Note, that this is initially directly copied and stringified into the page, future PR will pull it out and type it.

Tested:

`getConsentData` for `essential` callback fires as expected. 

<img width="986" alt="Screenshot 2019-09-23 at 13 46 56" src="https://user-images.githubusercontent.com/638051/65427356-0e273300-de0a-11e9-8df6-6e5e31565903.png">
<img width="1184" alt="Screenshot 2019-09-23 at 13 47 08" src="https://user-images.githubusercontent.com/638051/65427357-0e273300-de0a-11e9-940b-91ce78f47abd.png">


## Why?

Hooking into the standard IAB API.

## Link to supporting Trello card

https://trello.com/c/4PqXGOTB/716-windowcmp-in-dcr
