### PR TITLE
Fix styling issue for right body ads

### DIFF
--- a/packages/frontend/web/pages/Article.tsx
+++ b/packages/frontend/web/pages/Article.tsx
@@ -89,12 +89,18 @@ const headerAd = css`
 // These are by selector as for dynamically-created ads
 const bodyAdStyles = css`
     .ad-slot {
-        background-color: ${palette.neutral[97]};
         width: 300px;
         margin: 12px auto;
         min-width: 300px;
         min-height: 274px;
         text-align: center;
+    }
+
+    .ad-slot--most-popular {
+        ${desktop} {
+            margin: 0;
+            width: auto;
+        }
     }
 
     .ad-slot--inline {
@@ -142,9 +148,9 @@ export const Article: React.FC<{
             />
         </div>
 
-        <main>
+        <main className={bodyAdStyles}>
             <Container borders={true} className={articleContainer}>
-                <article className={bodyAdStyles}>
+                <article>
                     <ArticleBody CAPI={data.CAPI} config={data.config} />
                     <div className={secondaryColumn}>
                         <div className={adSlotWrapper}>

--- a/packages/frontend/web/pages/Article.tsx
+++ b/packages/frontend/web/pages/Article.tsx
@@ -90,7 +90,7 @@ const headerAd = css`
 const bodyAdStyles = css`
     .ad-slot {
         background-color: ${palette.neutral[97]};
-        width: 320px;
+        width: 300px;
         margin: 12px auto;
         min-width: 300px;
         min-height: 274px;


### PR DESCRIPTION
## What does this change?

Fix border issue with some ads and also layout of most-popular ad on sub-desktop breakpoints.

## Why?

Fix.

## Link to supporting Trello card

https://trello.com/c/oYQXLTVU

Before:

![ad-style-padding-issue](https://user-images.githubusercontent.com/858402/65429575-4cbeec80-de0e-11e9-9cfc-c90d4107dcc7.png)

Now:

![Screenshot 2019-09-23 at 14 17 45](https://user-images.githubusercontent.com/858402/65429584-53e5fa80-de0e-11e9-90c1-332b82d92c78.png)

And for most-popular ad:

Before:

![Screenshot 2019-09-23 at 14 43 07](https://user-images.githubusercontent.com/858402/65430843-7aa53080-de10-11e9-8f25-88b3abaa382a.png)


Now:

![Screenshot 2019-09-23 at 14 41 58](https://user-images.githubusercontent.com/858402/65430783-619c7f80-de10-11e9-8782-3762f193ef38.png)

