### PR TITLE
Add initial .fast result

### DIFF
--- a/.fast
+++ b/.fast
@@ -1,0 +1,3 @@
+Format: [branch] [timestamp] [perf-score] [js size] [tti]
+
+master     2019-09-24T15:26:28.341009+01:00 0.56

--- a/scripts/perf/perf-test.js
+++ b/scripts/perf/perf-test.js
@@ -11,6 +11,7 @@ const run = async () => {
             'make stop',
             '--target-url',
             'http://localhost:9000/ArticlePerfTest',
+            '--append',
         ]);
 
         log(stdout);


### PR DESCRIPTION
## What does this change?

Record some .fast scores! :)

## Why?

See https://github.com/guardian/fast/commit/2507a5c83252ff87aca8b99cbc55f960a4569402
for relevant info on the format file and approach.

Note, the lighthouse scores do vary even when taking an average like here, but I still think this will be useful when working on larger changes and to track change over time.

## Link to supporting Trello card

https://trello.com/c/BIsVyCfJ