### PR TITLE
Add headerAdWrapperHidden class to hide on AdFree

### DIFF
--- a/fixtures/CAPI.ts
+++ b/fixtures/CAPI.ts
@@ -355,6 +355,7 @@ export const CAPI: CAPIType = {
     sectionLabel: 'Ticket prices',
     sectionUrl: 'money/ticket-prices',
     shouldHideAds: false,
+    isAdFreeUser: false,
     webURL:
         'https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
     guardianBaseURL: 'https://www.theguardian.com',

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -178,6 +178,7 @@ interface CAPIType {
     subMetaSectionLinks: SimpleLinkType[];
     subMetaKeywordLinks: SimpleLinkType[];
     shouldHideAds: boolean;
+    isAdFreeUser: boolean;
     webURL: string;
     linkedData: object[];
     config: ConfigType;

--- a/packages/frontend/model/json-schema.json
+++ b/packages/frontend/model/json-schema.json
@@ -168,6 +168,9 @@
         "shouldHideAds": {
             "type": "boolean"
         },
+        "isAdFreeUser": {
+            "type": "boolean"
+        },
         "webURL": {
             "type": "string"
         },
@@ -234,6 +237,7 @@
         "hasRelated",
         "hasStoryPackage",
         "headline",
+        "isAdFreeUser",
         "isCommentable",
         "isImmersive",
         "keyEvents",
@@ -811,10 +815,14 @@
                 },
                 "role": {
                     "type": "string"
+                },
+                "attribution": {
+                    "type": "string"
                 }
             },
             "required": [
                 "_type",
+                "attribution",
                 "html",
                 "role"
             ]
@@ -1378,6 +1386,9 @@
                 "googletagUrl": {
                     "type": "string"
                 },
+                "stage": {
+                    "type": "string"
+                },
                 "frontendAssetsFullURL": {
                     "type": "string"
                 },
@@ -1390,13 +1401,14 @@
                 "ajaxUrl",
                 "commercialBundleUrl",
                 "dfpAccountId",
+                "frontendAssetsFullURL",
                 "googletagUrl",
+                "hbImpl",
                 "revisionNumber",
                 "sentryHost",
                 "sentryPublicApiKey",
-                "switches",
-                "frontendAssetsFullURL",
-                "hbImpl"
+                "stage",
+                "switches"
             ]
         },
         "DesignType": {

--- a/packages/frontend/web/pages/Article.tsx
+++ b/packages/frontend/web/pages/Article.tsx
@@ -73,6 +73,10 @@ const headerAdWrapper = css`
     ${stickyAdSlot};
 `;
 
+const headerAdWrapperHidden = css`
+    display: none;
+`;
+
 const headerAd = css`
     margin: 0 auto;
     height: 151px;
@@ -144,7 +148,13 @@ export const Article: React.FC<{
 }> = ({ data }) => (
     <div>
         <div className={headerWrapper}>
-            <div className={headerAdWrapper}>
+            <div
+                className={cx({
+                    [headerAdWrapper]: true,
+                    [headerAdWrapperHidden]:
+                        data.CAPI.isAdFreeUser || data.CAPI.shouldHideAds,
+                })}
+            >
                 <AdSlot
                     asps={namedAdSlotParameters('top-above-nav')}
                     config={data.config}


### PR DESCRIPTION
## What does this change?

Adds `isAdFreeUser` to match https://github.com/guardian/frontend/pull/21865 and hide top ad slot for adfree users.

## Why?

Remove the whitespace.

![image](https://user-images.githubusercontent.com/638051/65527787-2a4ed100-deeb-11e9-9c90-871fd6354480.png)


## Link to supporting Trello card
