### PR TITLE
Make pullquote attribution optional

### DIFF
--- a/packages/frontend/lib/content.d.ts
+++ b/packages/frontend/lib/content.d.ts
@@ -155,7 +155,7 @@ interface PullquoteBlockElement {
     _type: 'model.dotcomrendering.pageElements.PullquoteBlockElement';
     html: string;
     role: string;
-    attribution: string;
+    attribution?: string;
 }
 
 interface QABlockElement {

--- a/packages/frontend/model/json-schema.json
+++ b/packages/frontend/model/json-schema.json
@@ -822,7 +822,6 @@
             },
             "required": [
                 "_type",
-                "attribution",
                 "html",
                 "role"
             ]

--- a/packages/frontend/web/components/elements/PullQuoteComponent.tsx
+++ b/packages/frontend/web/components/elements/PullQuoteComponent.tsx
@@ -34,7 +34,7 @@ const commonStyles = (pillar: Pillar) =>
         position: absolute;
         background-color: ${palette.neutral[97]};
     }
-    
+
     cite,
     svg {
         color: ${pillarPalette[pillar].main};
@@ -51,15 +51,15 @@ const supportingStyles = (pillar: Pillar) =>
         clear: left;
         float: left;
         ${body(4)};
-    
+
         ${leftCol} {
             margin-left: -${gutter / 2 + gsSpan(3) / 2}px;
         }
-    
+
         :after {
             left: ${gutter / 2};
             border-radius: 0 0 ${quoteTail}px;
-    
+
             ${leftCol} {
                 border-radius: 0 0 0 ${quoteTail}px;
                 left: 0rem;
@@ -75,7 +75,7 @@ const inlineStyles = (pillar: Pillar) =>
         margin-left: 0rem;
         display: block;
         ${body(4)};
-    
+
         ${mobileLandscape} {
             margin-left: -${gutter}px;
         }
@@ -85,11 +85,11 @@ const inlineStyles = (pillar: Pillar) =>
         ${leftCol} {
             margin-left: -3.5rem;
         }
-    
+
         :after {
             left: 0rem;
             border-radius: 0 0 ${quoteTail}px;
-    
+
             ${mobileLandscape} {
                 left: ${gutter}px;
             }
@@ -115,8 +115,8 @@ function getStyles(role: string, pillar: Pillar) {
 export const PullQuoteComponent: React.FC<{
     html: string;
     pillar: Pillar;
-    attribution: string;
     role: string;
+    attribution?: string;
 }> = ({ html, pillar, attribution, role }) => (
     <aside className={getStyles(role, pillar)}>
         <Quote />{' '}


### PR DESCRIPTION
DO NOT DEPLOY DCR without rolling this forward or reverting this https://github.com/guardian/dotcom-rendering/pull/786

---

## What does this change?

Pullquote attribution is not always on the dotcom data model (it is an option) and therefore caused errors when rolling out this change https://github.com/guardian/dotcom-rendering/pull/786 to DCR as `make gen-schema` had been missed. 

## Why?

Errors.

@guardian/dotcom-platform 

