### PR TITLE
Position article body

### DIFF
--- a/packages/frontend/web/components/lib/ArticleRenderer.tsx
+++ b/packages/frontend/web/components/lib/ArticleRenderer.tsx
@@ -4,7 +4,13 @@ import { ImageBlockComponent } from '@frontend/web/components/elements/ImageBloc
 import { TweetBlockComponent } from '@frontend/web/components/elements/TweetBlockComponent';
 import { PullQuoteComponent } from '@frontend/web/components/elements/PullQuoteComponent';
 import React from 'react';
-// import { clean } from '@frontend/model/clean';
+import { css } from 'emotion';
+
+// This is required for spacefinder to work!
+const commercialPosition = css`
+    position: relative;
+`;
+
 export const ArticleRenderer: React.FC<{
     elements: CAPIElement[];
     pillar: Pillar;
@@ -49,5 +55,12 @@ export const ArticleRenderer: React.FC<{
             }
         })
         .filter(_ => _ != null);
-    return <div className="article-body-commercial-selector">{output}</div>; // classname that space finder is going to target for in-body ads in DCR
+
+    return (
+        <div
+            className={`article-body-commercial-selector ${commercialPosition}`}
+        >
+            {output}
+        </div>
+    ); // classname that space finder is going to target for in-body ads in DCR
 };


### PR DESCRIPTION
Fixes at least a few of our spacefinder issues for dynamic ads.

Position relative is required by spacefinder as it calculates offsets using:

https://developer.mozilla.org/en-US/docs/Web/API/HTMLelement/offsetParent

which gives results relative to the immediate parent only if it is positioned. Otherwise it fallsback to the body which explains why we are seeing ad slots at the top of the body text.

To illustrate, these are the offsets on non-DCR (i.e. correct):
![Screenshot 2019-09-24 at 18 27 21](https://user-images.githubusercontent.com/858402/65535924-4c9c1b00-defa-11e9-92e5-2eca1de576a5.png)


And these are what DCR gets:
![Screenshot 2019-09-24 at 18 25 16](https://user-images.githubusercontent.com/858402/65535935-5291fc00-defa-11e9-90be-9867e1b8431b.png)


They don't have to be equal, but DCR should start nearer zero at least.