### PR TITLE
Add age labels to onward's journeys

### DIFF
--- a/packages/frontend/web/components/MostViewed.tsx
+++ b/packages/frontend/web/components/MostViewed.tsx
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import { css, cx } from 'emotion';
-import { headline } from '@guardian/pasteup/typography';
-import { palette } from '@guardian/pasteup/palette';
+import { textSans, headline, palette } from '@guardian/src-foundations';
 import {
     desktop,
     tablet,
@@ -31,14 +30,13 @@ const mostPopularBody = css`
 `;
 
 const heading = css`
-    ${headline(4)};
+    ${headline({ level: 2 })};
     color: ${palette.neutral[7]};
     font-weight: 900;
     padding-right: 5px;
     padding-bottom: 4px;
 
     ${leftCol} {
-        ${headline(3)};
         width: 140px;
         position: relative;
 
@@ -157,7 +155,7 @@ const headlineLink = css`
     text-decoration: none;
     color: ${palette.neutral[7]};
     font-weight: 500;
-    ${headline(2)};
+    ${headline({ level: 1 })};
 `;
 
 const tabsContainer = css`
@@ -194,7 +192,7 @@ const selectedListTab = css`
 `;
 
 const tabButton = css`
-    ${headline(1)};
+    ${headline({ level: 1 })};
     margin: 0;
     border: 0;
     background: transparent;
@@ -210,10 +208,6 @@ const tabButton = css`
 
     &:hover {
         cursor: pointer;
-    }
-
-    ${tablet} {
-        ${headline(2)};
     }
 `;
 

--- a/packages/frontend/web/components/MostViewed.tsx
+++ b/packages/frontend/web/components/MostViewed.tsx
@@ -252,12 +252,14 @@ const AgeWarning: React.FC<{
         return <></>;
     }
     return (
-        <div className={oldArticleMessage}>
-            <span className={oldClockWrapper}>
-                <ClockIcon />
-            </span>
-            This article is more than{' '}
-            <span className="embolden">{ageWarning} old</span>
+        <div>
+            <div className={oldArticleMessage}>
+                <span className={oldClockWrapper}>
+                    <ClockIcon />
+                </span>
+                This article is more than{' '}
+                <span className="embolden">{ageWarning} old</span>
+            </div>
         </div>
     );
 };

--- a/packages/frontend/web/components/MostViewed.tsx
+++ b/packages/frontend/web/components/MostViewed.tsx
@@ -13,6 +13,7 @@ import { BigNumber } from '@guardian/guui';
 import { AsyncClientComponent } from './lib/AsyncClientComponent';
 import { namedAdSlotParameters } from '@frontend/model/advertisement';
 import { AdSlot } from '@frontend/web/components/AdSlot';
+import ClockIcon from '@guardian/pasteup/icons/clock.svg';
 
 const container = css`
     padding-top: 3px;
@@ -223,10 +224,49 @@ const liveKicker = css`
     }
 `;
 
+const oldArticleMessage = css`
+    ${textSans({ level: 1 })}
+    background: ${palette.yellow.main};
+    display: inline-block;
+    color: ${palette.neutral[7]};
+    margin: 4px 0 6px;
+    padding: 3px 5px;
+
+    svg {
+        fill: currentColor;
+    }
+
+    .embolden {
+        font-weight: bold;
+    }
+`;
+
+const oldClockWrapper = css`
+    margin-right: 3px;
+`;
+
+const AgeWarning: React.FC<{
+    ageWarning?: string;
+}> = ({ ageWarning }) => {
+    if (!ageWarning) {
+        return <></>;
+    }
+    return (
+        <div className={oldArticleMessage}>
+            <span className={oldClockWrapper}>
+                <ClockIcon />
+            </span>
+            This article is more than{' '}
+            <span className="embolden">{ageWarning} old</span>
+        </div>
+    );
+};
+
 interface Trail {
     url: string;
     linkText: string;
     isLiveBlog: boolean;
+    ageWarning: string;
 }
 
 interface Tab {
@@ -353,6 +393,11 @@ export class MostViewed extends Component<Props, { selectedTabIndex: number }> {
                                                             </span>
                                                         )}
                                                         {trail.linkText}
+                                                        <AgeWarning
+                                                            ageWarning={
+                                                                trail.ageWarning
+                                                            }
+                                                        />
                                                     </a>
                                                 </h2>
                                             </li>


### PR DESCRIPTION
## What does this change?

Adds the ageWarning to the 'Most Popular' container.

(Also moves typography to `src-foundations` as a component to use DS tokens)

## Why?

Parity and integrity.

## Screenshots

### Frontend

<img width="904" alt="Screenshot 2019-09-26 at 12 34 05" src="https://user-images.githubusercontent.com/638051/65685748-9e5bb700-e05a-11e9-94de-d4f7572c2300.png">

### Dotcom Rendering Before

![image](https://user-images.githubusercontent.com/638051/65685827-d236dc80-e05a-11e9-9dc7-dce9ef648d05.png)


### Dotcom Rendering Now

<img width="904" alt="Screenshot 2019-09-26 at 12 33 45" src="https://user-images.githubusercontent.com/638051/65685761-a61b5b80-e05a-11e9-812e-2b6d141bb3e5.png">

## Link to supporting Trello card
https://trello.com/c/7qM2afgR/724-add-article-age-flags-to-onwards