### PR TITLE
Position images based on their role

### DIFF
--- a/packages/frontend/amp/lib/find-adslots.test.ts
+++ b/packages/frontend/amp/lib/find-adslots.test.ts
@@ -20,7 +20,7 @@ describe('ampadslots', () => {
         data: { alt: 'img', credit: 'nobody' },
         imageSources: [],
         displayCredit: false,
-        role: 'lol',
+        role: 'inline',
     };
 
     const tenCharTextBlock = getTextBlockElement(10);

--- a/packages/frontend/lib/content.d.ts
+++ b/packages/frontend/lib/content.d.ts
@@ -32,7 +32,8 @@ type RoleType =
     | 'supporting'
     | 'showcase'
     | 'inline'
-    | 'thumbnail';
+    | 'thumbnail'
+    | 'half-width';
 
 interface ImageBlockElement {
     _type: 'model.dotcomrendering.pageElements.ImageBlockElement';

--- a/packages/frontend/lib/content.d.ts
+++ b/packages/frontend/lib/content.d.ts
@@ -27,6 +27,13 @@ interface RichLinkBlockElement {
     prefix: string;
 }
 
+type RoleType =
+    | 'immersive'
+    | 'supporting'
+    | 'showcase'
+    | 'inline'
+    | 'thumbnail';
+
 interface ImageBlockElement {
     _type: 'model.dotcomrendering.pageElements.ImageBlockElement';
     media: { allImages: Image[] };
@@ -38,7 +45,7 @@ interface ImageBlockElement {
     };
     imageSources: ImageSource[];
     displayCredit?: boolean;
-    role: string;
+    role: RoleType;
 }
 interface YoutubeBlockElement {
     _type: 'model.dotcomrendering.pageElements.YoutubeBlockElement';

--- a/packages/frontend/web/components/elements/ImageBlockComponent.tsx
+++ b/packages/frontend/web/components/elements/ImageBlockComponent.tsx
@@ -61,89 +61,98 @@ const getFallback: (imageSources: ImageSource[]) => string = imageSources => {
     return bestFor(300, inlineSrcSets).src;
 };
 
+const imageCss = {
+    inline: css`
+        margin-top: 16px;
+        margin-bottom: 12px;
+    `,
+
+    supporting: css`
+        ${tablet} {
+            position: relative;
+            float: left;
+            width: 300px;
+            margin-top: 6px;
+            margin-bottom: 12px;
+            margin-right: 20px;
+            line-height: 0;
+        }
+        ${leftCol} {
+            margin-left: -160px;
+        }
+        ${wide} {
+            width: 380px;
+            margin-left: -240px;
+        }
+    `,
+
+    // TODO: immersive is pending review of different article types
+    immersive: css``,
+
+    // TODO: showcase is only a partial implementation as sometimes showcase images
+    //       appear differently based on where they appear in the article
+    //       See top image for: https://www.theguardian.com/stage/2019/oct/01/hammed-animashaun-nick-hytner-dream-master-harold-and-the-boys-national-theatre-london
+    showcase: css`
+        position: relative;
+        margin-top: 16px;
+        margin-bottom: 12px;
+        ${leftCol} {
+            position: relative;
+            margin-bottom: 16px;
+            margin-left: -160px;
+        }
+        ${wide} {
+            margin-left: -240px;
+        }
+    `,
+
+    thumbnail: css`
+        float: left;
+        clear: left;
+        margin-bottom: 0;
+        width: 120px;
+        margin-right: 20px;
+        margin-top: 6px;
+        ${tablet} {
+            margin-right: 20px;
+        }
+        ${wide} {
+            margin-left: -160px;
+        }
+        ${wide} {
+            margin-left: -240px;
+        }
+        ${leftCol} {
+            margin-left: -160px;
+        }
+        ${leftCol} {
+            position: relative;
+        }
+        ${tablet} {
+            width: 140px;
+        }
+    `,
+
+    // TODO:
+    'half-width': css``,
+};
+
 const decidePosition = (role: RoleType) => {
     switch (role) {
-        case 'immersive':
-            return css``; // TODO pending review of different article types
-            break;
-        case 'supporting':
-            return css`
-                ${tablet} {
-                    position: relative;
-                    float: left;
-                    width: 300px;
-                    margin-top: 6px;
-                    margin-bottom: 12px;
-                    margin-right: 20px;
-                    line-height: 0;
-                }
-                ${leftCol} {
-                    margin-left: -160px;
-                }
-                ${wide} {
-                    width: 380px;
-                    margin-left: -240px;
-                }
-            `;
-            break;
-        case 'showcase':
-            // TODO: This is only a partial implementation as sometimes showcase images
-            //       appear differently based on where they appear in the article
-            //       See top image for: https://www.theguardian.com/stage/2019/oct/01/hammed-animashaun-nick-hytner-dream-master-harold-and-the-boys-national-theatre-london
-            return css`
-                position: relative;
-                margin-top: 16px;
-                margin-bottom: 12px;
-                ${leftCol} {
-                    position: relative;
-                    margin-bottom: 16px;
-                    margin-left: -160px;
-                }
-                ${wide} {
-                    margin-left: -240px;
-                }
-            `;
-            break;
         case 'inline':
-            return css`
-                margin-top: 16px;
-                margin-bottom: 12px;
-            `;
-            break;
+            return imageCss.inline;
+        case 'supporting':
+            return imageCss.supporting;
+        case 'immersive':
+            return imageCss.immersive;
+        case 'showcase':
+            return imageCss.showcase;
         case 'thumbnail':
-            return css`
-                float: left;
-                clear: left;
-                margin-bottom: 0;
-                width: 120px;
-                margin-right: 20px;
-                margin-top: 6px;
-
-                ${tablet} {
-                    margin-right: 20px;
-                }
-                ${wide} {
-                    margin-left: -160px;
-                }
-                ${wide} {
-                    margin-left: -240px;
-                }
-                ${leftCol} {
-                    margin-left: -160px;
-                }
-                ${leftCol} {
-                    position: relative;
-                }
-                ${tablet} {
-                    width: 140px;
-                }
-            `;
-            break;
+            return imageCss.thumbnail;
         case 'half-width':
-            return css``; // TODO
-            break;
+            return imageCss['half-width'];
         default:
-            return css``;
+            return imageCss.inline;
     }
 };
 

--- a/packages/frontend/web/components/elements/ImageBlockComponent.tsx
+++ b/packages/frontend/web/components/elements/ImageBlockComponent.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
+import { css } from 'emotion';
 import { Picture, PictureSource } from '@frontend/web/components/Picture';
 import { Caption } from '@guardian/guui/components/Caption/Caption';
+
+import { wide, tablet, leftCol } from '@guardian/src-foundations';
 
 const widths = [660, 480, 0];
 
@@ -58,24 +61,110 @@ const getFallback: (imageSources: ImageSource[]) => string = imageSources => {
     return bestFor(300, inlineSrcSets).src;
 };
 
+const decidePosition = (role: RoleType) => {
+    switch (role) {
+        case 'immersive':
+            return css``; // TODO pending review of different article types
+            break;
+        case 'supporting':
+            return css`
+                ${tablet} {
+                    position: relative;
+                    float: left;
+                    width: 300px;
+                    margin-top: 6px;
+                    margin-bottom: 12px;
+                    margin-right: 20px;
+                    line-height: 0;
+                }
+                ${leftCol} {
+                    margin-left: -160px;
+                }
+                ${wide} {
+                    width: 380px;
+                    margin-left: -240px;
+                }
+            `;
+            break;
+        case 'showcase':
+            // TODO: This is only a partial implementation as sometimes showcase images
+            //       appear differently based on where they appear in the article
+            //       See top image for: https://www.theguardian.com/stage/2019/oct/01/hammed-animashaun-nick-hytner-dream-master-harold-and-the-boys-national-theatre-london
+            return css`
+                position: relative;
+                margin-top: 16px;
+                margin-bottom: 12px;
+                ${leftCol} {
+                    position: relative;
+                    margin-bottom: 16px;
+                    margin-left: -160px;
+                }
+                ${wide} {
+                    margin-left: -240px;
+                }
+            `;
+            break;
+        case 'inline':
+            return css`
+                margin-top: 16px;
+                margin-bottom: 12px;
+            `;
+            break;
+        case 'thumbnail':
+            return css`
+                float: left;
+                clear: left;
+                margin-bottom: 0;
+                width: 120px;
+                margin-right: 20px;
+                margin-top: 6px;
+
+                ${tablet} {
+                    margin-right: 20px;
+                }
+                ${wide} {
+                    margin-left: -160px;
+                }
+                ${wide} {
+                    margin-left: -240px;
+                }
+                ${leftCol} {
+                    margin-left: -160px;
+                }
+                ${leftCol} {
+                    position: relative;
+                }
+                ${tablet} {
+                    width: 140px;
+                }
+            `;
+            break;
+        default:
+            return css``;
+    }
+};
+
 export const ImageBlockComponent: React.FC<{
     element: ImageBlockElement;
     pillar: Pillar;
 }> = ({ element, pillar }) => {
     const sources = makeSources(element.imageSources);
+    const { role } = element;
     return (
-        <Caption
-            captionText={element.data.caption || ''}
-            pillar={pillar}
-            dirtyHtml={true}
-            credit={element.data.credit}
-            displayCredit={true}
-        >
-            <Picture
-                sources={sources}
-                alt={element.data.alt || ''}
-                src={getFallback(element.imageSources)}
-            />
-        </Caption>
+        <div className={decidePosition(role)}>
+            <Caption
+                captionText={element.data.caption || ''}
+                pillar={pillar}
+                dirtyHtml={true}
+                credit={element.data.credit}
+                displayCredit={true}
+            >
+                <Picture
+                    sources={sources}
+                    alt={element.data.alt || ''}
+                    src={getFallback(element.imageSources)}
+                />
+            </Caption>
+        </div>
     );
 };

--- a/packages/frontend/web/components/elements/ImageBlockComponent.tsx
+++ b/packages/frontend/web/components/elements/ImageBlockComponent.tsx
@@ -139,6 +139,9 @@ const decidePosition = (role: RoleType) => {
                 }
             `;
             break;
+        case 'half-width':
+            return css``; // TODO
+            break;
         default:
             return css``;
     }


### PR DESCRIPTION
## What does this change?
Images should be positioned within an article based on their role. This PR adds a function to wrap images with styling based on their role prop. It currentl works for `inline`, `thumbnail` and `supporting` roles.  `showcase` and `immersive` are pending because there are some variations on how these are shown based on article type which need to be reasoned through.

I've also added `RoleType` to the `ConfigType` object. 
```
type RoleType =
    | 'immersive'
    | 'supporting'
    | 'showcase'
    | 'inline'
    | 'thumbnail';
```
☝️  forces this property to conform to one of five values which is restrictive and could be a problem if this value is changeable - please shout if so - but if these types are fairly static then it feels like the right approach.

### `inline`
![image](https://user-images.githubusercontent.com/1336821/66033360-0436bb80-e4ff-11e9-99a3-51a98cfdc6b8.png)

### `supporting`
![image](https://user-images.githubusercontent.com/1336821/66033443-2f210f80-e4ff-11e9-99ba-fae05c6e8d7a.png)

### `thumbnail`
![image](https://user-images.githubusercontent.com/1336821/66035565-482bbf80-e503-11e9-9150-c29c7cce4c7c.png)

### `showcase`
_pending_

### `immersive`
_pending_

## Why is the top margin of each image incorrect?
There is this global css set in `ArticleBody`
```
    figure {
        margin-top: 16px;
        margin-bottom: 12px;
    }
```
Rather than over write this margin to 0, starting a new css war 😱, I think this css should be removed from here differing to the local css for each component. This can be done in a separate PR.

## Link to supporting Trello card
https://trello.com/c/ClRgypzM/738-support-various-image-styles-in-dcr

## Test article
http://localhost:3030/Article?url=https://www.theguardian.com/science/grrlscientist/2012/aug/07/3
