### PR TITLE
Correct hardcoding of adUnit at window.guardian.config.page

### DIFF
--- a/fixtures/CAPI.ts
+++ b/fixtures/CAPI.ts
@@ -451,6 +451,7 @@ export const CAPI: CAPIType = {
         stage: 'DEV',
         frontendAssetsFullURL: 'https://assets.guim.co.uk/',
         hbImpl: 'prebid',
+        adUnit: '/59666047/theguardian.com/film/article/ng',
     },
     webTitle: 'Foobar',
     nav: {

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -230,6 +230,7 @@ interface ConfigType {
     stage: string;
     frontendAssetsFullURL: string;
     hbImpl: string;
+    adUnit: string;
 }
 
 interface GADataType {

--- a/packages/frontend/model/window-guardian.ts
+++ b/packages/frontend/model/window-guardian.ts
@@ -40,9 +40,6 @@ const makeWindowGuardianConfig = (
             sentryHost: dcrDocumentData.config.sentryHost,
             keywordIds: [],
             dfpAccountId: dcrDocumentData.config.dfpAccountId,
-            // adUnit is currently present for consistency,
-            // ... but the value is not used on the master branch.
-            // TODO (Pascal): read the value from frontend.
             adUnit: dcrDocumentData.config.adUnit,
             showRelatedContent: true,
             ajaxUrl: dcrDocumentData.config.ajaxUrl,

--- a/packages/frontend/model/window-guardian.ts
+++ b/packages/frontend/model/window-guardian.ts
@@ -43,7 +43,7 @@ const makeWindowGuardianConfig = (
             // adUnit is currently present for consistency,
             // ... but the value is not used on the master branch.
             // TODO (Pascal): read the value from frontend.
-            adUnit: '/59666047/theguardian.com/film/article/ng',
+            adUnit: dcrDocumentData.config.adUnit,
             showRelatedContent: true,
             ajaxUrl: dcrDocumentData.config.ajaxUrl,
             hbImpl: dcrDocumentData.config.hbImpl,

--- a/packages/frontend/web/components/ShareCount.test.tsx
+++ b/packages/frontend/web/components/ShareCount.test.tsx
@@ -33,6 +33,7 @@ describe('ShareCount', () => {
         stage: 'DEV',
         frontendAssetsFullURL: 'http://localhost:9000/assets/',
         hbImpl: 'prebid',
+        adUnit: '/59666047/theguardian.com/film/article/ng',
     };
 
     afterEach(() => {


### PR DESCRIPTION
## What does this change?

When the AdSlots component was born I hard coded the `adUnit` value in the DCR code. This set the correct value using the data passed to DCR.
