### PR TITLE
Introduce merchandising-high

### DIFF
--- a/packages/frontend/model/advertisement.ts
+++ b/packages/frontend/model/advertisement.ts
@@ -9,7 +9,11 @@ export const shouldDisplayAdvertisements = (config: ConfigType): boolean => {
     );
 };
 
-type staticAdSlotNames = 'right' | 'top-above-nav' | 'most-popular';
+type staticAdSlotNames =
+    | 'right'
+    | 'top-above-nav'
+    | 'most-popular'
+    | 'merchandising-high';
 
 export const namedAdSlotParameters = (
     name: staticAdSlotNames,
@@ -53,6 +57,18 @@ export const namedAdSlotParameters = (
             outOfPage: false,
             optId: undefined,
             optClassNames: ['js-sticky-mpu'],
+        },
+        'merchandising-high': {
+            name: 'merchandising-high',
+            adTypes: [],
+            sizeMapping: {
+                mobile: ['1,1|2,2|88,87|fluid'],
+            },
+            showLabel: false,
+            refresh: false,
+            outOfPage: false,
+            optId: undefined,
+            optClassNames: [],
         },
     };
     return mapping[name];

--- a/packages/frontend/web/components/AdSlot.tsx
+++ b/packages/frontend/web/components/AdSlot.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { shouldDisplayAdvertisements } from '@frontend/model/advertisement';
 import { css } from 'emotion';
 import { textSans, palette } from '@guardian/src-foundations';
+import { Container } from '@guardian/guui';
 
 export const labelStyles = css`
     .ad-slot__label {
@@ -121,4 +122,19 @@ export const AdSlot: React.FC<{
         return null;
     }
     return <AdSlotCore {...asps} className={className} />;
+};
+
+export const AdSlotInContainer: React.FC<{
+    asps: AdSlotParameters;
+    config: ConfigType;
+    className: string;
+}> = ({ asps, config, className }) => {
+    if (!shouldDisplayAdvertisements(config)) {
+        return null;
+    }
+    return (
+        <Container>
+            <AdSlotCore {...asps} className={className} />
+        </Container>
+    );
 };

--- a/packages/frontend/web/pages/Article.tsx
+++ b/packages/frontend/web/pages/Article.tsx
@@ -17,7 +17,11 @@ import { SubNav } from '@frontend/web/components/Header/Nav/SubNav/SubNav';
 import { CookieBanner } from '@frontend/web/components/CookieBanner';
 import { OutbrainContainer } from '@frontend/web/components/Outbrain';
 import { namedAdSlotParameters } from '@frontend/model/advertisement';
-import { AdSlot, labelStyles } from '@frontend/web/components/AdSlot';
+import {
+    AdSlot,
+    AdSlotInContainer,
+    labelStyles,
+} from '@frontend/web/components/AdSlot';
 
 // TODO: find a better of setting opacity
 const secondaryColumn = css`
@@ -184,6 +188,11 @@ export const Article: React.FC<{
                     </div>
                 </article>
             </Container>
+            <AdSlotInContainer
+                asps={namedAdSlotParameters('merchandising-high')}
+                config={data.config}
+                className={''}
+            />
             <OutbrainContainer config={data.config} />
             <Container
                 borders={true}


### PR DESCRIPTION
## What does this change?

This adds a `merchandising-high` ad slot under the article body. Note that the logic for displaying them is more complex than currently implemented, but I need to debug something in prod before I do that part.

(Still behind the AB test)