### PR TITLE
Use Context to serve the `edition` prop

### DIFF
--- a/packages/frontend/web/components/Footer.tsx
+++ b/packages/frontend/web/components/Footer.tsx
@@ -197,9 +197,8 @@ const bttPosition = css`
 
 const FooterLinks: React.FC<{
     nav: NavType;
-    edition: Edition;
     pageFooter: FooterType;
-}> = ({ pageFooter, nav, edition }) => {
+}> = ({ pageFooter, nav }) => {
     const linkGroups = pageFooter.footerLinks.map(linkGroup => {
         const linkList = linkGroup.map((l: FooterLink, index: number) => (
             <li key={`${l.url}${index}`}>
@@ -220,7 +219,6 @@ const FooterLinks: React.FC<{
         <div className={readerRevenueLinks}>
             <ReaderRevenueLinks
                 urls={nav.readerRevenueLinks.footer}
-                edition={edition}
                 dataLinkNamePrefix={'footer : '}
                 noResponsive={true}
             />
@@ -241,9 +239,8 @@ export const Footer: React.FC<{
     pillars: PillarType[];
     pillar: Pillar;
     nav: NavType;
-    edition: Edition;
     pageFooter: FooterType;
-}> = ({ pillars, pillar, nav, edition, pageFooter }) => (
+}> = ({ pillars, pillar, nav, pageFooter }) => (
     <footer className={footer}>
         <Container className={footerInner}>
             <div className={pillarWrap}>
@@ -268,11 +265,7 @@ export const Footer: React.FC<{
                     frameBorder="0"
                 />
 
-                <FooterLinks
-                    nav={nav}
-                    edition={edition}
-                    pageFooter={pageFooter}
-                />
+                <FooterLinks nav={nav} pageFooter={pageFooter} />
                 <div className={bttPosition}>
                     <BackToTop />
                 </div>

--- a/packages/frontend/web/components/Header/Header.tsx
+++ b/packages/frontend/web/components/Header/Header.tsx
@@ -1,11 +1,10 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { css } from 'emotion';
 
 import { tablet } from '@guardian/pasteup/breakpoints';
 
 import { Nav } from './Nav/Nav';
 import { palette } from '@guardian/pasteup/palette';
-import { EditionContext } from '@frontend/web/context/EditionContext';
 
 const header = css`
     margin-bottom: 0;
@@ -19,12 +18,8 @@ const header = css`
 export const Header: React.FC<{
     nav: NavType;
     pillar: Pillar;
-}> = ({ nav, pillar }) => {
-    const edition = useContext(EditionContext);
-
-    return (
-        <header className={header}>
-            <Nav nav={nav} pillar={pillar} edition={edition} />
-        </header>
-    );
-};
+}> = ({ nav, pillar }) => (
+    <header className={header}>
+        <Nav nav={nav} pillar={pillar} />
+    </header>
+);

--- a/packages/frontend/web/components/Header/Header.tsx
+++ b/packages/frontend/web/components/Header/Header.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { css } from 'emotion';
 
 import { tablet } from '@guardian/pasteup/breakpoints';
 
 import { Nav } from './Nav/Nav';
 import { palette } from '@guardian/pasteup/palette';
+import { EditionContext } from '@frontend/web/context/EditionContext';
 
 const header = css`
     margin-bottom: 0;
@@ -18,9 +19,12 @@ const header = css`
 export const Header: React.FC<{
     nav: NavType;
     pillar: Pillar;
-    edition: Edition;
-}> = ({ nav, pillar, edition }) => (
-    <header className={header}>
-        <Nav nav={nav} pillar={pillar} edition={edition} />
-    </header>
-);
+}> = ({ nav, pillar }) => {
+    const edition = useContext(EditionContext);
+
+    return (
+        <header className={header}>
+            <Nav nav={nav} pillar={pillar} edition={edition} />
+        </header>
+    );
+};

--- a/packages/frontend/web/components/Header/Nav/EditionDropdown.tsx
+++ b/packages/frontend/web/components/Header/Nav/EditionDropdown.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { css } from 'emotion';
 
 import { Dropdown } from '@guardian/guui';
 import { desktop, wide } from '@guardian/pasteup/breakpoints';
 import { Link } from '@guardian/guui/components/Dropdown/Dropdown';
 import { palette } from '@guardian/pasteup/palette';
+import { EditionContext } from '@frontend/web/context/EditionContext';
 
 const editionDropdown = css`
     display: none;
@@ -71,9 +72,9 @@ const lookUpEditionLink = (edition: Edition): Link => {
 };
 
 export const EditionDropdown: React.FC<{
-    edition: Edition;
     dataLinkName: string;
-}> = ({ edition, dataLinkName }) => {
+}> = ({ dataLinkName }) => {
+    const edition = useContext(EditionContext);
     const activeEditionLink = lookUpEditionLink(edition);
     const links = [
         ukEditionLink,

--- a/packages/frontend/web/components/Header/Nav/Nav.tsx
+++ b/packages/frontend/web/components/Header/Nav/Nav.tsx
@@ -113,7 +113,6 @@ export class Nav extends Component<
                     <div className={readerRevenueLinks}>
                         <ReaderRevenueLinks
                             urls={nav.readerRevenueLinks.header}
-                            edition={edition}
                             dataLinkNamePrefix={'nav2 : '}
                             noResponsive={false}
                         />

--- a/packages/frontend/web/components/Header/Nav/Nav.tsx
+++ b/packages/frontend/web/components/Header/Nav/Nav.tsx
@@ -54,7 +54,6 @@ const readerRevenueLinks = css`
 interface Props {
     nav: NavType;
     pillar: Pillar;
-    edition: Edition;
 }
 
 export class Nav extends Component<
@@ -83,7 +82,7 @@ export class Nav extends Component<
     }
 
     public render() {
-        const { nav, pillar, edition } = this.props;
+        const { nav, pillar } = this.props;
         const toggleMainMenu = () => {
             this.toggleMainMenu();
         };
@@ -101,7 +100,6 @@ export class Nav extends Component<
                     data-component="nav2"
                 >
                     <EditionDropdown
-                        edition={edition}
                         dataLinkName={'nav2 : topbar : edition-picker: toggle'}
                     />
                     <Logo />

--- a/packages/frontend/web/components/Header/Nav/ReaderRevenueLinks.test.tsx
+++ b/packages/frontend/web/components/Header/Nav/ReaderRevenueLinks.test.tsx
@@ -5,6 +5,7 @@ import {
     getCookie as getCookie_,
     addCookie as addCookie_,
 } from '@frontend/web/browser/cookie';
+import { EditionContext } from '@frontend/web/context/EditionContext';
 
 const getCookie: any = getCookie_;
 const addCookie: any = addCookie_;
@@ -22,7 +23,6 @@ describe('ReaderRevenueLinks', () => {
         subscribe: 'https://www.theguardian.com/subscribe',
         support: 'https://www.theguardian.com/support',
     };
-    const edition: Edition = 'UK';
 
     beforeEach(() => {
         addCookie.mockReset();
@@ -38,12 +38,13 @@ describe('ReaderRevenueLinks', () => {
         getCookie.mockReturnValue(contributionDate);
 
         const { container } = render(
-            <ReaderRevenueLinks
-                urls={urls}
-                edition={edition}
-                dataLinkNamePrefix={'nav2 : '}
-                noResponsive={false}
-            />,
+            <EditionContext.Provider value={'UK'}>
+                <ReaderRevenueLinks
+                    urls={urls}
+                    dataLinkNamePrefix={'nav2 : '}
+                    noResponsive={false}
+                />
+            </EditionContext.Provider>,
         );
 
         // expect nothing to be rendered
@@ -64,12 +65,13 @@ describe('ReaderRevenueLinks', () => {
             .mockReturnValueOnce('true');
 
         const { container } = render(
-            <ReaderRevenueLinks
-                urls={urls}
-                edition={edition}
-                dataLinkNamePrefix={'nav2 : '}
-                noResponsive={false}
-            />,
+            <EditionContext.Provider value={'UK'}>
+                <ReaderRevenueLinks
+                    urls={urls}
+                    dataLinkNamePrefix={'nav2 : '}
+                    noResponsive={false}
+                />
+            </EditionContext.Provider>,
         );
 
         // expect nothing to be rendered
@@ -91,12 +93,13 @@ describe('ReaderRevenueLinks', () => {
             .mockReturnValueOnce('false');
 
         const { container, getByText } = render(
-            <ReaderRevenueLinks
-                urls={urls}
-                edition={edition}
-                dataLinkNamePrefix={'nav2 : '}
-                noResponsive={false}
-            />,
+            <EditionContext.Provider value={'UK'}>
+                <ReaderRevenueLinks
+                    urls={urls}
+                    dataLinkNamePrefix={'nav2 : '}
+                    noResponsive={false}
+                />
+            </EditionContext.Provider>,
         );
 
         // expect something to be rendered

--- a/packages/frontend/web/components/Header/Nav/ReaderRevenueLinks.tsx
+++ b/packages/frontend/web/components/Header/Nav/ReaderRevenueLinks.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { css, cx } from 'emotion';
 
 import { serif, sans, textSans, headline } from '@guardian/pasteup/typography';
@@ -14,6 +14,7 @@ import {
 
 import { getCookie } from '@frontend/web/browser/cookie';
 import { AsyncClientComponent } from '@frontend/web/components/lib/AsyncClientComponent';
+import { EditionContext } from '@frontend/web/context/EditionContext';
 
 const message = css`
     color: ${palette.highlight.main};
@@ -112,7 +113,6 @@ export const RRButton: React.FC<{
 };
 
 export const ReaderRevenueLinks: React.FC<{
-    edition: Edition;
     urls: {
         subscribe: string;
         support: string;
@@ -120,7 +120,9 @@ export const ReaderRevenueLinks: React.FC<{
     };
     dataLinkNamePrefix: string;
     noResponsive: boolean;
-}> = ({ edition, urls, dataLinkNamePrefix, noResponsive }) => {
+}> = ({ urls, dataLinkNamePrefix, noResponsive }) => {
+    const edition = useContext(EditionContext);
+
     return (
         <AsyncClientComponent f={shouldShow}>
             {({ data }) => (

--- a/packages/frontend/web/context/EditionContext.tsx
+++ b/packages/frontend/web/context/EditionContext.tsx
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export const EditionContext = React.createContext<Edition>('UK');

--- a/packages/frontend/web/pages/Article.tsx
+++ b/packages/frontend/web/pages/Article.tsx
@@ -162,11 +162,7 @@ export const Article: React.FC<{
                 />
             </div>
 
-            <Header
-                nav={data.NAV}
-                pillar={data.CAPI.pillar}
-                edition={data.CAPI.editionId}
-            />
+            <Header nav={data.NAV} pillar={data.CAPI.pillar} />
         </div>
 
         <main className={bodyAdStyles}>
@@ -208,7 +204,6 @@ export const Article: React.FC<{
 
         <Footer
             nav={data.NAV}
-            edition={data.CAPI.editionId}
             pageFooter={data.CAPI.pageFooter}
             pillar={data.CAPI.pillar}
             pillars={data.NAV.pillars}

--- a/packages/frontend/web/server/document.tsx
+++ b/packages/frontend/web/server/document.tsx
@@ -5,6 +5,7 @@ import { cache } from 'emotion';
 import { CacheProvider } from '@emotion/core';
 
 import { htmlTemplate } from './htmlTemplate';
+import { EditionContext } from '@frontend/web/context/EditionContext';
 import { Article } from '../pages/Article';
 import { getDist } from '@frontend/lib/assets';
 
@@ -23,7 +24,9 @@ export const document = ({ data }: Props) => {
         renderToString(
             // TODO: CacheProvider can be removed when we've moved over to using @emotion/core
             <CacheProvider value={cache}>
-                <Article data={{ CAPI, NAV, config }} />
+                <EditionContext.Provider value={data.CAPI.editionId}>
+                    <Article data={{ CAPI, NAV, config }} />
+                </EditionContext.Provider>
             </CacheProvider>,
         ),
     );


### PR DESCRIPTION
## What does this change?
Adds an `EditionContext` provider that removes the need to keep passing `edition` around through multiple levels and replaces it with the Provider / Consumer model so it can be accessed as and when required.

## Why?
> In a typical React application, data is passed top-down (parent to child) via props, but this can be cumbersome for certain types of props (e.g. locale preference, UI theme) that are required by many components within an application. Context provides a way to share values like these between components without having to explicitly pass a prop through every level of the tree.
https://reactjs.org/docs/context.html

## Note on Hooks
React Hooks were added in 16.8 and include the `useContext` hook which means the syntax for using context is now very clean and readable. There's no longer any need to wrap components in `<Providers>` and instead you can just use `const edition = useContext(EditionContext);` ❤️ 

## How to use
If your component wants to access the `edition` then you need 2 lines of code:

```
import { EditionContext } from '@frontend/web/context/EditionContext';
```

and then, in your function:
```
const edition = useContext(EditionContext);
```

Hooks allow classes to be replaced by functional components so ☝️ should always be sufficient but if you didn't want to migrate to hooks and needed to access `edition` from a class you can use the, still perfectly good, render props pattern:

```
<EditionContext.Consumer>
  {edition => /* render something based on the edition value */}
</EditionContext.Consumer>
```

## How to test context
If your test depends on the `edition` value then you can provide it to your test html stack in the same way as it's given to the actual app:

```
        const { container } = render(
            <EditionContext.Provider value={'AUS'}>
                {/* and now the useContext call inside ReaderRevenueLinks will return AUS */}
                <ReaderRevenueLinks
                    urls={urls}
                    dataLinkNamePrefix={'nav2 : '}
                    noResponsive={false}
                />
            </EditionContext.Provider>,
        );
```


## Link to supporting Trello card
https://trello.com/c/2C74DiyP/744-spike-react-context