### PR TITLE
Add `autoBreadcrumbs:{ console: false }` to raven options

### DIFF
--- a/packages/frontend/web/browser/raven/raven.ts
+++ b/packages/frontend/web/browser/raven/raven.ts
@@ -88,6 +88,9 @@ const setUpRaven: () => RavenStatic = () => {
             contentType,
             edition: editionLongForm,
         },
+        autoBreadcrumbs: {
+            console: false,
+        },
     };
 
     ravenConfig = raven.config(sentryUrl, sentryOptions).install();


### PR DESCRIPTION
## What does this change?

Adds an option to raven config to prevent `console.log` getting swallowed.

## Why?

From this:

<img width="618" alt="Screenshot 2019-10-04 at 10 28 57" src="https://user-images.githubusercontent.com/638051/66200177-6119a980-e698-11e9-83b8-1785516fcad5.png">

to this:

<img width="901" alt="Screenshot 2019-10-04 at 11 10 31" src="https://user-images.githubusercontent.com/638051/66200203-6d9e0200-e698-11e9-8c2e-59cd1d3623e1.png">

thanks to @faresite 