### PR TITLE
Better ad styles across the entire page

### DIFF
--- a/packages/frontend/web/pages/Article.tsx
+++ b/packages/frontend/web/pages/Article.tsx
@@ -81,20 +81,18 @@ const headerAdWrapperHidden = css`
     display: none;
 `;
 
-const headerAd = css`
+const adSlotAboveNav = css`
     margin: 0 auto;
     height: 151px;
     padding-bottom: 18px;
     padding-top: 18px;
     text-align: left;
     display: table;
-
     border-bottom: 0.0625rem solid ${palette.neutral[86]};
-
     width: 728px;
 `;
 
-const articleBodyAdStyles = css`
+const adSlot300px = css`
     .ad-slot {
         width: 300px;
         margin: 12px auto;
@@ -102,14 +100,25 @@ const articleBodyAdStyles = css`
         min-height: 274px;
         text-align: center;
     }
+`;
 
+const adSlotUnspecifiedWidth = css`
+    .ad-slot {
+        margin: 12px auto;
+        min-width: 300px;
+        min-height: 274px;
+        text-align: center;
+    }
+`;
+
+const articleBodyAdStyles = css`
+    ${adSlot300px}
     .ad-slot--most-popular {
         ${desktop} {
             margin: 0;
             width: auto;
         }
     }
-
     .ad-slot--inline {
         ${desktop} {
             margin: 0;
@@ -119,7 +128,6 @@ const articleBodyAdStyles = css`
             margin-left: 20px;
         }
     }
-
     .ad-slot--offset-right {
         ${desktop} {
             float: right;
@@ -131,7 +139,6 @@ const articleBodyAdStyles = css`
             margin-right: -408px;
         }
     }
-
     .ad-slot--outstream {
         ${tablet} {
             margin-left: 0;
@@ -146,14 +153,7 @@ const articleBodyAdStyles = css`
 `;
 
 const mostPopularAdStyle = css`
-    .ad-slot {
-        width: 300px;
-        margin: 12px auto;
-        min-width: 300px;
-        min-height: 274px;
-        text-align: center;
-    }
-
+    ${adSlot300px}
     .ad-slot--most-popular {
         ${desktop} {
             margin: 0;
@@ -161,15 +161,6 @@ const mostPopularAdStyle = css`
         }
     }
     ${labelStyles};
-`;
-
-const merchandisingHigh = css`
-    .ad-slot {
-        margin: 12px auto;
-        min-width: 300px;
-        min-height: 274px;
-        text-align: center;
-    }
 `;
 
 export const Article: React.FC<{
@@ -187,7 +178,7 @@ export const Article: React.FC<{
                 <AdSlot
                     asps={namedAdSlotParameters('top-above-nav')}
                     config={data.config}
-                    className={headerAd}
+                    className={adSlotAboveNav}
                 />
             </div>
 
@@ -217,7 +208,7 @@ export const Article: React.FC<{
         <AdSlotInContainer
             asps={namedAdSlotParameters('merchandising-high')}
             config={data.config}
-            className={merchandisingHigh}
+            className={adSlotUnspecifiedWidth}
         />
         <OutbrainContainer config={data.config} />
         <Container

--- a/packages/frontend/web/pages/Article.tsx
+++ b/packages/frontend/web/pages/Article.tsx
@@ -92,16 +92,6 @@ const adSlotAboveNav = css`
     width: 728px;
 `;
 
-const adSlot300px = css`
-    .ad-slot {
-        width: 300px;
-        margin: 12px auto;
-        min-width: 300px;
-        min-height: 274px;
-        text-align: center;
-    }
-`;
-
 const adSlotUnspecifiedWidth = css`
     .ad-slot {
         margin: 12px auto;
@@ -112,7 +102,13 @@ const adSlotUnspecifiedWidth = css`
 `;
 
 const articleBodyAdStyles = css`
-    ${adSlot300px}
+    .ad-slot {
+        width: 300px;
+        margin: 12px auto;
+        min-width: 300px;
+        min-height: 274px;
+        text-align: center;
+    }
     .ad-slot--most-popular {
         ${desktop} {
             margin: 0;
@@ -153,7 +149,13 @@ const articleBodyAdStyles = css`
 `;
 
 const mostPopularAdStyle = css`
-    ${adSlot300px}
+    .ad-slot {
+        width: 300px;
+        margin: 12px auto;
+        min-width: 300px;
+        min-height: 274px;
+        text-align: center;
+    }
     .ad-slot--most-popular {
         ${desktop} {
             margin: 0;

--- a/packages/frontend/web/pages/Article.tsx
+++ b/packages/frontend/web/pages/Article.tsx
@@ -188,23 +188,25 @@ export const Article: React.FC<{
                 edition={data.CAPI.editionId}
             />
         </div>
-        <Container
-            borders={true}
-            className={cx(articleContainer, articleBodyAdStyles)}
-        >
-            <article>
-                <ArticleBody CAPI={data.CAPI} config={data.config} />
-                <div className={secondaryColumn}>
-                    <div className={adSlotWrapper}>
-                        <AdSlot
-                            asps={namedAdSlotParameters('right')}
-                            config={data.config}
-                            className={stickyAdSlot}
-                        />
+        <main>
+            <Container
+                borders={true}
+                className={cx(articleContainer, articleBodyAdStyles)}
+            >
+                <article>
+                    <ArticleBody CAPI={data.CAPI} config={data.config} />
+                    <div className={secondaryColumn}>
+                        <div className={adSlotWrapper}>
+                            <AdSlot
+                                asps={namedAdSlotParameters('right')}
+                                config={data.config}
+                                className={stickyAdSlot}
+                            />
+                        </div>
                     </div>
-                </div>
-            </article>
-        </Container>
+                </article>
+            </Container>
+        </main>
         <AdSlotInContainer
             asps={namedAdSlotParameters('merchandising-high')}
             config={data.config}

--- a/packages/frontend/web/pages/Article.tsx
+++ b/packages/frontend/web/pages/Article.tsx
@@ -101,7 +101,7 @@ const adSlotUnspecifiedWidth = css`
     }
 `;
 
-const articleBodyAdStyles = css`
+const articleAdStyles = css`
     .ad-slot {
         width: 300px;
         margin: 12px auto;
@@ -191,11 +191,8 @@ export const Article: React.FC<{
             />
         </div>
         <main>
-            <Container
-                borders={true}
-                className={cx(articleContainer, articleBodyAdStyles)}
-            >
-                <article>
+            <Container borders={true} className={articleContainer}>
+                <article className={articleAdStyles}>
                     <ArticleBody CAPI={data.CAPI} config={data.config} />
                     <div className={secondaryColumn}>
                         <div className={adSlotWrapper}>

--- a/packages/frontend/web/pages/Article.tsx
+++ b/packages/frontend/web/pages/Article.tsx
@@ -94,8 +94,7 @@ const headerAd = css`
     width: 728px;
 `;
 
-// These are by selector as for dynamically-created ads
-const bodyAdStyles = css`
+const articleBodyAdStyles = css`
     .ad-slot {
         width: 300px;
         margin: 12px auto;
@@ -143,8 +142,34 @@ const bodyAdStyles = css`
             }
         }
     }
-
     ${labelStyles};
+`;
+
+const mostPopularAdStyle = css`
+    .ad-slot {
+        width: 300px;
+        margin: 12px auto;
+        min-width: 300px;
+        min-height: 274px;
+        text-align: center;
+    }
+
+    .ad-slot--most-popular {
+        ${desktop} {
+            margin: 0;
+            width: auto;
+        }
+    }
+    ${labelStyles};
+`;
+
+const merchandisingHigh = css`
+    .ad-slot {
+        margin: 12px auto;
+        min-width: 300px;
+        min-height: 274px;
+        text-align: center;
+    }
 `;
 
 export const Article: React.FC<{
@@ -172,43 +197,45 @@ export const Article: React.FC<{
                 edition={data.CAPI.editionId}
             />
         </div>
-
-        <main className={bodyAdStyles}>
-            <Container borders={true} className={articleContainer}>
-                <article>
-                    <ArticleBody CAPI={data.CAPI} config={data.config} />
-                    <div className={secondaryColumn}>
-                        <div className={adSlotWrapper}>
-                            <AdSlot
-                                asps={namedAdSlotParameters('right')}
-                                config={data.config}
-                                className={stickyAdSlot}
-                            />
-                        </div>
+        <Container
+            borders={true}
+            className={cx(articleContainer, articleBodyAdStyles)}
+        >
+            <article>
+                <ArticleBody CAPI={data.CAPI} config={data.config} />
+                <div className={secondaryColumn}>
+                    <div className={adSlotWrapper}>
+                        <AdSlot
+                            asps={namedAdSlotParameters('right')}
+                            config={data.config}
+                            className={stickyAdSlot}
+                        />
                     </div>
-                </article>
-            </Container>
-            <AdSlotInContainer
-                asps={namedAdSlotParameters('merchandising-high')}
+                </div>
+            </article>
+        </Container>
+        <AdSlotInContainer
+            asps={namedAdSlotParameters('merchandising-high')}
+            config={data.config}
+            className={merchandisingHigh}
+        />
+        <OutbrainContainer config={data.config} />
+        <Container
+            borders={true}
+            className={cx(
+                articleContainer,
+                mostPopularAdStyle,
+                css`
+                    border-top: 1px solid ${palette.neutral[86]};
+                `,
+            )}
+        >
+            <MostViewed
+                sectionName={data.CAPI.sectionName}
                 config={data.config}
-                className={''}
             />
-            <OutbrainContainer config={data.config} />
-            <Container
-                borders={true}
-                className={cx(
-                    articleContainer,
-                    css`
-                        border-top: 1px solid ${palette.neutral[86]};
-                    `,
-                )}
-            >
-                <MostViewed
-                    sectionName={data.CAPI.sectionName}
-                    config={data.config}
-                />
-            </Container>
-        </main>
+        </Container>
+
         <SubNav
             subnav={data.NAV.subNavSections}
             pillar={data.CAPI.pillar}


### PR DESCRIPTION
## What does this change?

Here we solves the little problem that was noticed when I introduced the merchandising-high ad slot: https://github.com/guardian/dotcom-rendering/pull/800

Turns out that `bodyAdStyles` had an incorrect scope. To solve this: 

1. We introduce better named ad slot styles: `adSlotAboveNav`, `adSlot300px`, `adSlotUnspecifiedWidth`,  `articleBodyAdStyles` (based on `adSlot300px`) and `mostPopularAdStyle`.

2. We give them better scopes.

Et voila!

ps: Note that in the process we lost `main`. 