### PR TITLE
Centralise api calls

### DIFF
--- a/packages/frontend/web/components/elements/RichLinkComponent.tsx
+++ b/packages/frontend/web/components/elements/RichLinkComponent.tsx
@@ -6,7 +6,7 @@ import Quote from '@guardian/pasteup/icons/quote.svg';
 import { palette, colour } from '@guardian/pasteup/palette';
 import { headline, textSans } from '@guardian/pasteup/typography';
 import { StarRating } from '@root/packages/frontend/web/components/StarRating';
-import { useApi } from '../lib/api';
+import { useApi } from '@frontend/web/components/lib/api';
 
 type CardStyle =
     | 'special-report'

--- a/packages/frontend/web/components/lib/api.tsx
+++ b/packages/frontend/web/components/lib/api.tsx
@@ -1,0 +1,42 @@
+import { useState, useEffect } from 'react';
+
+function checkForErrors(response: any) {
+    if (!response.ok) {
+        throw Error(response.statusText);
+    }
+    return response;
+}
+
+const callApi = (url: string) => {
+    return fetch(url)
+        .then(checkForErrors)
+        .then(response => response.json());
+};
+
+export function useApi<T>(url: string) {
+    const [request, setRequest] = useState<{
+        loading: boolean;
+        data?: T;
+        error?: Error;
+    }>({
+        loading: true,
+    });
+
+    useEffect(() => {
+        callApi(url)
+            .then(data => {
+                setRequest({
+                    data,
+                    loading: false,
+                });
+            })
+            .catch(error => {
+                setRequest({
+                    error,
+                    loading: false,
+                });
+            });
+    }, [url]);
+
+    return request;
+}


### PR DESCRIPTION
## What does this change?
This PR improves how we fetch data from an api by creating a centralised function that uses the `useEffect` hook.

## Why?
We currently use fetch is several places in the codebase, each place has it's own implementation for how an api call is made and if we wanted to change or improve this the code duplication would be wasteful.

By using `useEffect` we gain benefits in terms of code simplicity and readability but also in terms of features. I don't want to write a blog post about why hooks are a substantial step up from using the older lifecycle methods like `componentDidMount` and `componentDidUnmount` so here's some links for the curious:

https://reactjs.org/docs/hooks-intro.html
https://www.youtube.com/watch?v=1jWS7cCuUXw (this is really good)

## How does it work?
Currently components either use `fetch` directly, use it inside `componentDidMount` or use the `AsyncClientComponent` passing that a function that uses fetch. This PR replaces each of those patterns with:

```
import { useApi } from '@frontend/web/components/lib/api';

const export MyComponent = () => {
    const url = getMyUrl();
    // MyExpectedType is a generic passed in to be used to type `data` on the response
    const {data, loading, error} = useApi<MyExpectedType>(url);

    if (loading) { //maybe do nothing, maybe show a spinner }
    if (error) { // Handle error }
    return (
       <div>This is my data {data}</div>
    )
}

```

## How do you test it?
Rather than set a global mock for fetch, which is hard to mock because it's asynchronous, you can mock the `api.tsx` module itself:

```
import { useApi as useApi_ } from '@frontend/web/components/lib/api';

const useApi: any = useApi_;

jest.mock('@frontend/web/components/lib/api', () => ({
    useApi: jest.fn(),
}));

describe('MyTest', () => {
    beforeEach(() => {
        useApi.mockReset();
    });

    it('should call the api and render the response as expected', () => {
        useApi.mockReturnValue(someMockResponse);

        const { getByText } = render(
            <MyComponent />,
        );

        // Calls api once only
        expect(useApi).toHaveBeenCalledTimes(1);
    });
});

```

## If approved
If we're happy with this approach then the next step would be to replace all the raw, custom api calls with this `useApi` method. I think there's about 3 or 4 places to refactor - pretty straight forward.

## Link to supporting Trello card
https://trello.com/c/idYofvuI/399-revisit-current-client-side-components-and-see-whether-we-can-apply-client-side-principles-to-them
