### PR TITLE
Style trail items based on their pillar

### DIFF
--- a/packages/frontend/web/components/MostViewed.tsx
+++ b/packages/frontend/web/components/MostViewed.tsx
@@ -14,6 +14,8 @@ import { AsyncClientComponent } from './lib/AsyncClientComponent';
 import { namedAdSlotParameters } from '@frontend/model/advertisement';
 import { AdSlot } from '@frontend/web/components/AdSlot';
 import ClockIcon from '@guardian/pasteup/icons/clock.svg';
+import { QuoteIcon } from '@frontend/web/components/QuoteIcon';
+import { pillarPalette } from '@frontend/lib/pillars';
 
 const container = css`
     padding-top: 3px;
@@ -212,8 +214,8 @@ const tabButton = css`
     }
 `;
 
-const liveKicker = css`
-    color: ${palette.news.main};
+const liveKicker = (colour: string) => css`
+    color: ${colour};
     font-weight: 700;
 
     &::after {
@@ -223,6 +225,12 @@ const liveKicker = css`
         margin: 0 4px;
     }
 `;
+
+function getColour(pillar: Pillar) {
+    // Default to 'news' for now pending https://github.com/guardian/frontend/pull/21891. After
+    // this PR has been merged, remove this default
+    return pillarPalette[pillar || 'news'].main;
+}
 
 const oldArticleMessage = css`
     ${textSans({ level: 1 })}
@@ -269,6 +277,7 @@ interface Trail {
     linkText: string;
     isLiveBlog: boolean;
     ageWarning: string;
+    pillar: Pillar;
 }
 
 interface Tab {
@@ -387,12 +396,22 @@ export class MostViewed extends Component<Props, { selectedTabIndex: number }> {
                                                     >
                                                         {trail.isLiveBlog && (
                                                             <span
-                                                                className={
-                                                                    liveKicker
-                                                                }
+                                                                className={liveKicker(
+                                                                    getColour(
+                                                                        trail.pillar,
+                                                                    ),
+                                                                )}
                                                             >
                                                                 Live
                                                             </span>
+                                                        )}
+                                                        {trail.pillar ===
+                                                            'opinion' && (
+                                                            <QuoteIcon
+                                                                colour={getColour(
+                                                                    trail.pillar,
+                                                                )}
+                                                            />
                                                         )}
                                                         {trail.linkText}
                                                         <AgeWarning

--- a/packages/frontend/web/components/MostViewed.tsx
+++ b/packages/frontend/web/components/MostViewed.tsx
@@ -227,9 +227,7 @@ const liveKicker = (colour: string) => css`
 `;
 
 function getColour(pillar: Pillar) {
-    // Default to 'news' for now pending https://github.com/guardian/frontend/pull/21891. After
-    // this PR has been merged, remove this default
-    return pillarPalette[pillar || 'news'].main;
+    return pillarPalette[pillar].main;
 }
 
 const oldArticleMessage = css`


### PR DESCRIPTION
## What does this change?
Individual trail items in the MostViewed component were missing the `pillar` property against them. Now that this is included in the response, this PR adds the logic to style the 'Live' text and display the quote icons for opinion pieces.

## Relates to
https://github.com/guardian/frontend/pull/21891

## Link to supporting Trello card
https://trello.com/c/fACBoBtT/746-most-viewed-component-refactoring-to-improve-dev-ex-plus-fix-styling
