### PR TITLE
Enable the correct logic for high merchandising

### DIFF
--- a/packages/frontend/web/components/AdSlot.tsx
+++ b/packages/frontend/web/components/AdSlot.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 import { shouldDisplayAdvertisements } from '@frontend/model/advertisement';
 import { css } from 'emotion';
 import { textSans, palette } from '@guardian/src-foundations';
-import { Container } from '@guardian/guui';
 
 export const labelStyles = css`
     .ad-slot__label {
@@ -122,19 +121,4 @@ export const AdSlot: React.FC<{
         return null;
     }
     return <AdSlotCore {...asps} className={className} />;
-};
-
-export const AdSlotInContainer: React.FC<{
-    asps: AdSlotParameters;
-    config: ConfigType;
-    className: string;
-}> = ({ asps, config, className }) => {
-    if (!shouldDisplayAdvertisements(config)) {
-        return null;
-    }
-    return (
-        <Container>
-            <AdSlotCore {...asps} className={className} />
-        </Container>
-    );
 };

--- a/packages/frontend/web/pages/Article.tsx
+++ b/packages/frontend/web/pages/Article.tsx
@@ -17,11 +17,7 @@ import { SubNav } from '@frontend/web/components/Header/Nav/SubNav/SubNav';
 import { CookieBanner } from '@frontend/web/components/CookieBanner';
 import { OutbrainContainer } from '@frontend/web/components/Outbrain';
 import { namedAdSlotParameters } from '@frontend/model/advertisement';
-import {
-    AdSlot,
-    AdSlotInContainer,
-    labelStyles,
-} from '@frontend/web/components/AdSlot';
+import { AdSlot, labelStyles } from '@frontend/web/components/AdSlot';
 
 // TODO: find a better of setting opacity
 const secondaryColumn = css`
@@ -206,28 +202,24 @@ export const Article: React.FC<{
                 </article>
             </Container>
         </main>
-        <AdSlotInContainer
-            asps={namedAdSlotParameters('merchandising-high')}
-            config={data.config}
-            className={adSlotUnspecifiedWidth}
-        />
-        <OutbrainContainer config={data.config} />
-        <Container
-            borders={true}
-            className={cx(
-                articleContainer,
-                mostPopularAdStyle,
-                css`
-                    border-top: 1px solid ${palette.neutral[86]};
-                `,
-            )}
-        >
-            <MostViewed
-                sectionName={data.CAPI.sectionName}
-                config={data.config}
-            />
-        </Container>
-
+        <div className={`content-footer ${cx(adSlotUnspecifiedWidth)}`}>
+            <OutbrainContainer config={data.config} />
+            <Container
+                borders={true}
+                className={cx(
+                    articleContainer,
+                    mostPopularAdStyle,
+                    css`
+                        border-top: 1px solid ${palette.neutral[86]};
+                    `,
+                )}
+            >
+                <MostViewed
+                    sectionName={data.CAPI.sectionName}
+                    config={data.config}
+                />
+            </Container>
+        </div>
         <SubNav
             subnav={data.NAV.subNavSections}
             pillar={data.CAPI.pillar}


### PR DESCRIPTION
## What does this change?

This PR does three things:

1. Add some structure to the page by adding `content-footer` which sits between the article body and `SubNav`. This is the layout that we have in frontend and that is expected by the commercial code and in particular the module `cm-highMerch`. With this in place when the commercial code want to display the high merchandising ad slot, it puts it as first child of that node.

2. Remove the hardcoded `AdSlotInContainer / 'merchandising-high'` which I was using to display the high merchandising ad slot.

3. Actually get rid of `AdSlotInContainer` which I had introduced only to display the high merchandising (Can be back later if we need it one day).