### PR TITLE
Add tests to MostViewed component

### DIFF
--- a/packages/frontend/web/components/MostViewed/MostViewed.mocks.tsx
+++ b/packages/frontend/web/components/MostViewed/MostViewed.mocks.tsx
@@ -1,0 +1,350 @@
+export const responseWithTwoTabs = [
+    {
+        heading: 'Across The&nbsp;Guardian',
+        trails: [
+            {
+                url:
+                    'https://www.theguardian.com/politics/2019/sep/15/eu-officials-reject-boris-johnson-claim-huge-progress-brexit-talks',
+                linkText:
+                    "LINKTEXT EU officials reject Boris Johnson claim of 'huge progress' in Brexit talks",
+                showByline: false,
+                byline: 'Jennifer Rankin and Daniel Boffey',
+                image:
+                    'https://i.guim.co.uk/img/media/85377038aacd71b2c0e55b0a55478165fe6d3014/0_0_6000_3600/master/6000.jpg?width=300&quality=85&auto=format&fit=max&s=de2cecf52b21492f01daa4520c4f2a97',
+                isLiveBlog: false,
+            },
+            {
+                url:
+                    'https://www.theguardian.com/us-news/2019/sep/15/brett-kavanaugh-donald-trump-impeachment-supreme-court-justice',
+                linkText:
+                    'LINKTEXT Trump blasts calls for impeachment of Brett Kavanaugh after new allegations',
+                showByline: false,
+                byline: 'Martin Pengelly',
+                image:
+                    'https://i.guim.co.uk/img/media/579fd19481e46b9d6ed3c69c2a6992483df84478/0_0_6000_3600/master/6000.jpg?width=300&quality=85&auto=format&fit=max&s=63a6a5c13a8087e607a44ce5c7da2090',
+                isLiveBlog: false,
+            },
+            {
+                url:
+                    'https://www.theguardian.com/sport/2019/sep/15/ashes-cricket-series-drawn-england-beat-australia-fifth-test',
+                linkText:
+                    'LINKTEXT England win fifth Test to draw Ashes series but Australia keep urn',
+                showByline: false,
+                byline: 'Vic Marks at the Oval',
+                image:
+                    'https://i.guim.co.uk/img/media/0df1fc1a2b78aa1772b4b43c2e5ebfc7f43111a8/0_91_5445_3267/master/5445.jpg?width=300&quality=85&auto=format&fit=max&s=3da9f89b54b0126fec2677117e73487e',
+                isLiveBlog: false,
+            },
+            {
+                url:
+                    'https://www.theguardian.com/uk-news/2019/sep/15/boris-johnson-bonkers-plan-for-15bn-pound-bridge-derided-by-engineers',
+                linkText:
+                    "LINKTEXT Johnson's 'bonkers' plan for £15bn bridge derided by engineers",
+                showByline: false,
+                byline: 'Simon Murphy',
+                image:
+                    'https://i.guim.co.uk/img/media/57a9a1a56c7d319a8f57a9c8767793ae0481db4c/0_95_4950_2970/master/4950.jpg?width=300&quality=85&auto=format&fit=max&s=77949a713212b69499d0dc6b5bdb2faf',
+                isLiveBlog: false,
+            },
+            {
+                url:
+                    'https://www.theguardian.com/politics/2019/sep/15/five-things-we-learned-from-david-cameron-memoir-boris-johnson-michael-gove-referendum',
+                linkText:
+                    "LINKTEXT Five things we learned from David Cameron's memoirs",
+                howByline: false,
+                byline: 'Caroline Davies',
+                image:
+                    'https://i.guim.co.uk/img/media/e05185cce0a0c6953e666276caa98f6ea104c989/0_214_3600_2160/master/3600.jpg?width=300&quality=85&auto=format&fit=max&s=188a7a9ed42517b9462ae0788fe96a0a',
+                isLiveBlog: false,
+            },
+            {
+                url:
+                    'https://www.theguardian.com/sport/live/2019/sep/15/ashes-2019-england-v-australia-fifth-test-day-four-live',
+                linkText:
+                    'LINKTEXT Ashes 2019: England win fifth Test by 135 runs as series is drawn – as it happened',
+                showByline: false,
+                byline: 'Tanya Aldred,  Geoff Lemon  & Jonathan Howcroft',
+                image:
+                    'https://i.guim.co.uk/img/media/5792a3b971914e21bd04cb13eed54159463ce90e/0_128_4991_2994/master/4991.jpg?width=300&quality=85&auto=format&fit=max&s=6d4eab73546172d576a1022c29bdbcd2',
+                isLiveBlog: true,
+            },
+            {
+                url:
+                    'https://www.theguardian.com/lifeandstyle/2019/sep/15/how-six-weddings-in-one-year-made-me-love-being-single',
+                linkText:
+                    'LINKTEXT How six weddings in one year made me love being single',
+                showByline: false,
+                byline: 'Sarah Johnson',
+                image:
+                    'https://i.guim.co.uk/img/media/2e87f0ee5f1a6c292cfcfc5f6f99e9a54ba3cc05/0_139_4032_2419/master/4032.jpg?width=300&quality=85&auto=format&fit=max&s=e951b289eda050060201927e978d30ef',
+                isLiveBlog: false,
+            },
+            {
+                url:
+                    'https://www.theguardian.com/fashion/2019/sep/15/joani-johnson-model-fenty-career-began-at-65-ageing-interview',
+                linkText:
+                    'LINKTEXT JoAni Johnson: the sexagenarian model defying convention',
+                showByline: false,
+                byline: 'Aaron Hicklin',
+                image:
+                    'https://i.guim.co.uk/img/media/2d88f2493b6eff49b6b8d6dd35345f03fa2b4af2/0_721_3361_2017/master/3361.jpg?width=300&quality=85&auto=format&fit=max&s=8601a174c9dc594f75318da8e99932bf',
+                isLiveBlog: false,
+            },
+            {
+                url:
+                    'https://www.theguardian.com/fashion/2019/sep/15/victoria-beckham-announces-launch-of-own-makeup-brand',
+                linkText:
+                    'LINKTEXT Victoria Beckham launches makeup range and targets wellness market',
+                showByline: false,
+                byline: 'Jess Cartner-Morley',
+                image:
+                    'https://i.guim.co.uk/img/media/bceaab691b06c3f3830e7794d24c6ada2b301fad/847_177_2750_1650/master/2750.jpg?width=300&quality=85&auto=format&fit=max&s=3af893de9c01e38a8635c83883ef17ef',
+                isLiveBlog: false,
+            },
+            {
+                url:
+                    'https://www.theguardian.com/commentisfree/2019/sep/15/government-boris-johnson-incredible-hulk-sam-gyimah',
+                linkText:
+                    'LINKTEXT There’s nothing normal about this beast of a government | Matthew d’Ancona',
+                showByline: true,
+                byline: 'Matthew d’Ancona',
+                image:
+                    'https://i.guim.co.uk/img/media/bc4e5ed4448eafd6238656aefae98c832cacc148/32_13_1898_1139/master/1898.jpg?width=300&quality=85&auto=format&fit=max&s=a4b8c116c5e580482dfe727d126b57ae',
+                isLiveBlog: false,
+            },
+        ],
+    },
+    {
+        heading: 'in Music',
+        trails: [
+            {
+                url:
+                    'https://www.theguardian.com/music/2019/sep/15/bridget-christie-last-night-of-the-proms-jamie-barton-laura-mvula',
+                linkText:
+                    "LINKTEXT 'I thought I'd hate it': Bridget Christie on loving the Last Night of the Proms",
+                showByline: false,
+                byline: 'Bridget Christie',
+                image:
+                    'https://i.guim.co.uk/img/media/eef1ed43631aa9088f26fca4a138f6e4250d9319/0_297_5400_3240/master/5400.jpg?width=300&quality=85&auto=format&fit=max&s=90f779a1a1ca85348a47ff19ccc50b12',
+                isLiveBlog: false,
+            },
+            {
+                url:
+                    'https://www.theguardian.com/music/2019/sep/15/aphex-twin-review-printworks-london-electronic-music',
+                linkText:
+                    'LINKTEXT Aphex Twin review – wild lights, jungle buzzsaw and a boo for Boris',
+                showByline: false,
+                byline: 'Lauren Martin',
+                image:
+                    'https://i.guim.co.uk/img/media/ff131761ef56456073d4edfb52af4ec8b8b953c2/0_290_6355_3813/master/6355.jpg?width=300&quality=85&auto=format&fit=max&s=6f1d869f447a6389e1e4a05b457c2289',
+                isLiveBlog: false,
+            },
+            {
+                url:
+                    'https://www.theguardian.com/music/2019/sep/13/100-best-albums-of-the-21st-century',
+                linkText: 'LINKTEXT The 100 best albums of the 21st century',
+                howByline: false,
+                byline:
+                    'Ben Beaumont-Thomas (1-50); Laura Snapes and April Curtin (51-100)',
+                image:
+                    'https://i.guim.co.uk/img/media/1ce9e4ae33c1be975ab83fdabc267fc081c9d73c/0_0_4000_2400/master/4000.jpg?width=300&quality=85&auto=format&fit=max&s=16240604b766e11e7d5846fa13c43102',
+                isLiveBlog: false,
+            },
+            {
+                url:
+                    'https://www.theguardian.com/music/2019/sep/14/missy-elliott-interview-beyonce-vmas-katy-perry-misdemeanor',
+                linkText:
+                    "LINKTEXT Missy Elliott – Beyoncé said: ‘If I sound crazy, don’t put this out!'",
+                showByline: false,
+                byline: 'Dorian Lynskey',
+                image:
+                    'https://i.guim.co.uk/img/media/6de53bbc2260febc167488209afe81844c47ecaa/0_225_5352_3211/master/5352.jpg?width=300&quality=85&auto=format&fit=max&s=d7da55f1e5f9d6b3a11f0c97237f3992',
+                isLiveBlog: false,
+            },
+            {
+                url:
+                    'https://www.theguardian.com/music/2019/sep/14/beatles-paul-mccartney-ringo-starr-reunite-record-john-lennon-song',
+                linkText:
+                    'LINKTEXT Paul McCartney and Ringo Starr reunite to record John Lennon song',
+                showByline: false,
+                byline: 'Mattha Busby',
+                image:
+                    'https://i.guim.co.uk/img/media/5ee2bea12b92b28eff10b84d22e952c2681cb5f5/0_479_2239_1343/master/2239.jpg?width=300&quality=85&auto=format&fit=max&s=7b5cfb46f6a84b663d94a83c35acfe81',
+                isLiveBlog: false,
+            },
+            {
+                url:
+                    'https://www.theguardian.com/music/2019/sep/15/on-my-radar-gruff-rhys-interview',
+                linkText:
+                    'LINKTEXT On my radar: Gruff Rhys’s cultural highlights',
+                howByline: false,
+                byline: 'Killian Fox',
+                image:
+                    'https://i.guim.co.uk/img/media/981e17d90b401754aae355d2e56bfedbe5b359b5/0_1000_2480_1488/master/2480.jpg?width=300&quality=85&auto=format&fit=max&s=facd8591d83abd4b0019370b6031be6e',
+                isLiveBlog: false,
+            },
+            {
+                url:
+                    'https://www.theguardian.com/music/2019/sep/13/sam-smith-on-being-non-binary-im-changing-my-pronouns-to-theythem',
+                linkText:
+                    "LINKTEXT Sam Smith on being non-binary: 'I'm changing my pronouns to they/them'",
+                showByline: false,
+                byline: 'Laura Snapes',
+                image:
+                    'https://i.guim.co.uk/img/media/ff17da45e26064e2666106902a90655e4db49ea4/955_135_1467_880/master/1467.jpg?width=300&quality=85&auto=format&fit=max&s=f6c5f055f7614d73f65ec193bb30c054',
+                isLiveBlog: false,
+            },
+            {
+                url:
+                    'https://www.theguardian.com/music/2019/sep/15/pixies-beneath-the-eyrie-review',
+                linkText:
+                    'LINKTEXT Pixies: Beneath the Eyrie review – workaday once again',
+                showByline: false,
+                byline: 'Phil Mongredien',
+                image:
+                    'https://i.guim.co.uk/img/media/b819ca05b59cdbe5ee59684740d1d9fe181b5a22/0_69_3600_2160/master/3600.jpg?width=300&quality=85&auto=format&fit=max&s=2f001df53652440f4be489b695c03ad2',
+                isLiveBlog: false,
+            },
+            {
+                url:
+                    'https://www.theguardian.com/music/2019/sep/14/emeli-sande-interview-life-on-a-plate-i-loved-spaghetti-so-much',
+                linkText:
+                    'LINKTEXT Emeli Sandé: ‘I loved spaghetti so much as a child that I’d eat it from the garden drain’',
+                showByline: false,
+                byline: 'John Hind',
+                image:
+                    'https://i.guim.co.uk/img/media/1e518e0996861201a7350f91f46d1f573ed2ea9c/0_823_6206_3724/master/6206.jpg?width=300&quality=85&auto=format&fit=max&s=149bde7a6699e526903598c690c214d0',
+                isLiveBlog: false,
+            },
+            {
+                url:
+                    'https://www.theguardian.com/music/2019/sep/15/joyce-didonato-interview-agrippina-royal-opera-house',
+                linkText:
+                    'LINKTEXT Joyce DiDonato: ‘I’m trying to balance activism and joy’',
+                showByline: false,
+                byline: 'Fiona Maddocks',
+                image:
+                    'https://i.guim.co.uk/img/media/478dcff6eee2cbd753f1956e420c4caaf7b00fdd/0_1208_8095_4859/master/8095.jpg?width=300&quality=85&auto=format&fit=max&s=44effc5b2ab10b9a588be02c55a0620a',
+                isLiveBlog: false,
+            },
+        ],
+    },
+];
+
+export const responseWithOneTab = [
+    {
+        heading: 'Section header that should not appear',
+        trails: [
+            {
+                url:
+                    'https://www.theguardian.com/politics/2019/sep/15/eu-officials-reject-boris-johnson-claim-huge-progress-brexit-talks',
+                linkText:
+                    "LINKTEXT EU officials reject Boris Johnson claim of 'huge progress' in Brexit talks",
+                showByline: false,
+                byline: 'Jennifer Rankin and Daniel Boffey',
+                image:
+                    'https://i.guim.co.uk/img/media/85377038aacd71b2c0e55b0a55478165fe6d3014/0_0_6000_3600/master/6000.jpg?width=300&quality=85&auto=format&fit=max&s=de2cecf52b21492f01daa4520c4f2a97',
+                isLiveBlog: false,
+            },
+            {
+                url:
+                    'https://www.theguardian.com/us-news/2019/sep/15/brett-kavanaugh-donald-trump-impeachment-supreme-court-justice',
+                linkText:
+                    'LINKTEXT Trump blasts calls for impeachment of Brett Kavanaugh after new allegations',
+                showByline: false,
+                byline: 'Martin Pengelly',
+                image:
+                    'https://i.guim.co.uk/img/media/579fd19481e46b9d6ed3c69c2a6992483df84478/0_0_6000_3600/master/6000.jpg?width=300&quality=85&auto=format&fit=max&s=63a6a5c13a8087e607a44ce5c7da2090',
+                isLiveBlog: false,
+            },
+            {
+                url:
+                    'https://www.theguardian.com/sport/2019/sep/15/ashes-cricket-series-drawn-england-beat-australia-fifth-test',
+                linkText:
+                    'LINKTEXT England win fifth Test to draw Ashes series but Australia keep urn',
+                showByline: false,
+                byline: 'Vic Marks at the Oval',
+                image:
+                    'https://i.guim.co.uk/img/media/0df1fc1a2b78aa1772b4b43c2e5ebfc7f43111a8/0_91_5445_3267/master/5445.jpg?width=300&quality=85&auto=format&fit=max&s=3da9f89b54b0126fec2677117e73487e',
+                isLiveBlog: false,
+            },
+            {
+                url:
+                    'https://www.theguardian.com/uk-news/2019/sep/15/boris-johnson-bonkers-plan-for-15bn-pound-bridge-derided-by-engineers',
+                linkText:
+                    "LINKTEXT Johnson's 'bonkers' plan for £15bn bridge derided by engineers",
+                showByline: false,
+                byline: 'Simon Murphy',
+                image:
+                    'https://i.guim.co.uk/img/media/57a9a1a56c7d319a8f57a9c8767793ae0481db4c/0_95_4950_2970/master/4950.jpg?width=300&quality=85&auto=format&fit=max&s=77949a713212b69499d0dc6b5bdb2faf',
+                isLiveBlog: false,
+            },
+            {
+                url:
+                    'https://www.theguardian.com/politics/2019/sep/15/five-things-we-learned-from-david-cameron-memoir-boris-johnson-michael-gove-referendum',
+                linkText:
+                    "LINKTEXT Five things we learned from David Cameron's memoirs",
+                howByline: false,
+                byline: 'Caroline Davies',
+                image:
+                    'https://i.guim.co.uk/img/media/e05185cce0a0c6953e666276caa98f6ea104c989/0_214_3600_2160/master/3600.jpg?width=300&quality=85&auto=format&fit=max&s=188a7a9ed42517b9462ae0788fe96a0a',
+                isLiveBlog: false,
+            },
+            {
+                url:
+                    'https://www.theguardian.com/sport/live/2019/sep/15/ashes-2019-england-v-australia-fifth-test-day-four-live',
+                linkText:
+                    'LINKTEXT Ashes 2019: England win fifth Test by 135 runs as series is drawn – as it happened',
+                showByline: false,
+                byline: 'Tanya Aldred,  Geoff Lemon  & Jonathan Howcroft',
+                image:
+                    'https://i.guim.co.uk/img/media/5792a3b971914e21bd04cb13eed54159463ce90e/0_128_4991_2994/master/4991.jpg?width=300&quality=85&auto=format&fit=max&s=6d4eab73546172d576a1022c29bdbcd2',
+                isLiveBlog: true,
+            },
+            {
+                url:
+                    'https://www.theguardian.com/lifeandstyle/2019/sep/15/how-six-weddings-in-one-year-made-me-love-being-single',
+                linkText:
+                    'LINKTEXT How six weddings in one year made me love being single',
+                showByline: false,
+                byline: 'Sarah Johnson',
+                image:
+                    'https://i.guim.co.uk/img/media/2e87f0ee5f1a6c292cfcfc5f6f99e9a54ba3cc05/0_139_4032_2419/master/4032.jpg?width=300&quality=85&auto=format&fit=max&s=e951b289eda050060201927e978d30ef',
+                isLiveBlog: false,
+            },
+            {
+                url:
+                    'https://www.theguardian.com/fashion/2019/sep/15/joani-johnson-model-fenty-career-began-at-65-ageing-interview',
+                linkText:
+                    'LINKTEXT JoAni Johnson: the sexagenarian model defying convention',
+                showByline: false,
+                byline: 'Aaron Hicklin',
+                image:
+                    'https://i.guim.co.uk/img/media/2d88f2493b6eff49b6b8d6dd35345f03fa2b4af2/0_721_3361_2017/master/3361.jpg?width=300&quality=85&auto=format&fit=max&s=8601a174c9dc594f75318da8e99932bf',
+                isLiveBlog: false,
+            },
+            {
+                url:
+                    'https://www.theguardian.com/fashion/2019/sep/15/victoria-beckham-announces-launch-of-own-makeup-brand',
+                linkText:
+                    'LINKTEXT Victoria Beckham launches makeup range and targets wellness market',
+                showByline: false,
+                byline: 'Jess Cartner-Morley',
+                image:
+                    'https://i.guim.co.uk/img/media/bceaab691b06c3f3830e7794d24c6ada2b301fad/847_177_2750_1650/master/2750.jpg?width=300&quality=85&auto=format&fit=max&s=3af893de9c01e38a8635c83883ef17ef',
+                isLiveBlog: false,
+            },
+            {
+                url:
+                    'https://www.theguardian.com/commentisfree/2019/sep/15/government-boris-johnson-incredible-hulk-sam-gyimah',
+                linkText:
+                    'LINKTEXT There’s nothing normal about this beast of a government | Matthew d’Ancona',
+                showByline: true,
+                byline: 'Matthew d’Ancona',
+                image:
+                    'https://i.guim.co.uk/img/media/bc4e5ed4448eafd6238656aefae98c832cacc148/32_13_1898_1139/master/1898.jpg?width=300&quality=85&auto=format&fit=max&s=a4b8c116c5e580482dfe727d126b57ae',
+                isLiveBlog: false,
+            },
+        ],
+    },
+];

--- a/packages/frontend/web/components/MostViewed/MostViewed.mocks.tsx
+++ b/packages/frontend/web/components/MostViewed/MostViewed.mocks.tsx
@@ -12,6 +12,7 @@ export const responseWithTwoTabs = [
                 image:
                     'https://i.guim.co.uk/img/media/85377038aacd71b2c0e55b0a55478165fe6d3014/0_0_6000_3600/master/6000.jpg?width=300&quality=85&auto=format&fit=max&s=de2cecf52b21492f01daa4520c4f2a97',
                 isLiveBlog: false,
+                pillar: 'news',
             },
             {
                 url:
@@ -23,6 +24,7 @@ export const responseWithTwoTabs = [
                 image:
                     'https://i.guim.co.uk/img/media/579fd19481e46b9d6ed3c69c2a6992483df84478/0_0_6000_3600/master/6000.jpg?width=300&quality=85&auto=format&fit=max&s=63a6a5c13a8087e607a44ce5c7da2090',
                 isLiveBlog: false,
+                pillar: 'news',
             },
             {
                 url:
@@ -34,6 +36,7 @@ export const responseWithTwoTabs = [
                 image:
                     'https://i.guim.co.uk/img/media/0df1fc1a2b78aa1772b4b43c2e5ebfc7f43111a8/0_91_5445_3267/master/5445.jpg?width=300&quality=85&auto=format&fit=max&s=3da9f89b54b0126fec2677117e73487e',
                 isLiveBlog: false,
+                pillar: 'news',
             },
             {
                 url:
@@ -45,6 +48,7 @@ export const responseWithTwoTabs = [
                 image:
                     'https://i.guim.co.uk/img/media/57a9a1a56c7d319a8f57a9c8767793ae0481db4c/0_95_4950_2970/master/4950.jpg?width=300&quality=85&auto=format&fit=max&s=77949a713212b69499d0dc6b5bdb2faf',
                 isLiveBlog: false,
+                pillar: 'news',
             },
             {
                 url:
@@ -56,6 +60,7 @@ export const responseWithTwoTabs = [
                 image:
                     'https://i.guim.co.uk/img/media/e05185cce0a0c6953e666276caa98f6ea104c989/0_214_3600_2160/master/3600.jpg?width=300&quality=85&auto=format&fit=max&s=188a7a9ed42517b9462ae0788fe96a0a',
                 isLiveBlog: false,
+                pillar: 'opinion',
             },
             {
                 url:
@@ -67,6 +72,7 @@ export const responseWithTwoTabs = [
                 image:
                     'https://i.guim.co.uk/img/media/5792a3b971914e21bd04cb13eed54159463ce90e/0_128_4991_2994/master/4991.jpg?width=300&quality=85&auto=format&fit=max&s=6d4eab73546172d576a1022c29bdbcd2',
                 isLiveBlog: true,
+                pillar: 'news',
             },
             {
                 url:
@@ -78,6 +84,7 @@ export const responseWithTwoTabs = [
                 image:
                     'https://i.guim.co.uk/img/media/2e87f0ee5f1a6c292cfcfc5f6f99e9a54ba3cc05/0_139_4032_2419/master/4032.jpg?width=300&quality=85&auto=format&fit=max&s=e951b289eda050060201927e978d30ef',
                 isLiveBlog: false,
+                pillar: 'news',
             },
             {
                 url:
@@ -89,6 +96,7 @@ export const responseWithTwoTabs = [
                 image:
                     'https://i.guim.co.uk/img/media/2d88f2493b6eff49b6b8d6dd35345f03fa2b4af2/0_721_3361_2017/master/3361.jpg?width=300&quality=85&auto=format&fit=max&s=8601a174c9dc594f75318da8e99932bf',
                 isLiveBlog: false,
+                pillar: 'news',
             },
             {
                 url:
@@ -100,6 +108,7 @@ export const responseWithTwoTabs = [
                 image:
                     'https://i.guim.co.uk/img/media/bceaab691b06c3f3830e7794d24c6ada2b301fad/847_177_2750_1650/master/2750.jpg?width=300&quality=85&auto=format&fit=max&s=3af893de9c01e38a8635c83883ef17ef',
                 isLiveBlog: false,
+                pillar: 'news',
             },
             {
                 url:
@@ -111,6 +120,7 @@ export const responseWithTwoTabs = [
                 image:
                     'https://i.guim.co.uk/img/media/bc4e5ed4448eafd6238656aefae98c832cacc148/32_13_1898_1139/master/1898.jpg?width=300&quality=85&auto=format&fit=max&s=a4b8c116c5e580482dfe727d126b57ae',
                 isLiveBlog: false,
+                pillar: 'news',
             },
         ],
     },
@@ -127,6 +137,7 @@ export const responseWithTwoTabs = [
                 image:
                     'https://i.guim.co.uk/img/media/eef1ed43631aa9088f26fca4a138f6e4250d9319/0_297_5400_3240/master/5400.jpg?width=300&quality=85&auto=format&fit=max&s=90f779a1a1ca85348a47ff19ccc50b12',
                 isLiveBlog: false,
+                pillar: 'news',
             },
             {
                 url:
@@ -138,6 +149,7 @@ export const responseWithTwoTabs = [
                 image:
                     'https://i.guim.co.uk/img/media/ff131761ef56456073d4edfb52af4ec8b8b953c2/0_290_6355_3813/master/6355.jpg?width=300&quality=85&auto=format&fit=max&s=6f1d869f447a6389e1e4a05b457c2289',
                 isLiveBlog: false,
+                pillar: 'news',
             },
             {
                 url:
@@ -149,6 +161,7 @@ export const responseWithTwoTabs = [
                 image:
                     'https://i.guim.co.uk/img/media/1ce9e4ae33c1be975ab83fdabc267fc081c9d73c/0_0_4000_2400/master/4000.jpg?width=300&quality=85&auto=format&fit=max&s=16240604b766e11e7d5846fa13c43102',
                 isLiveBlog: false,
+                pillar: 'news',
             },
             {
                 url:
@@ -160,6 +173,7 @@ export const responseWithTwoTabs = [
                 image:
                     'https://i.guim.co.uk/img/media/6de53bbc2260febc167488209afe81844c47ecaa/0_225_5352_3211/master/5352.jpg?width=300&quality=85&auto=format&fit=max&s=d7da55f1e5f9d6b3a11f0c97237f3992',
                 isLiveBlog: false,
+                pillar: 'culture',
             },
             {
                 url:
@@ -171,6 +185,7 @@ export const responseWithTwoTabs = [
                 image:
                     'https://i.guim.co.uk/img/media/5ee2bea12b92b28eff10b84d22e952c2681cb5f5/0_479_2239_1343/master/2239.jpg?width=300&quality=85&auto=format&fit=max&s=7b5cfb46f6a84b663d94a83c35acfe81',
                 isLiveBlog: false,
+                pillar: 'news',
             },
             {
                 url:
@@ -182,6 +197,7 @@ export const responseWithTwoTabs = [
                 image:
                     'https://i.guim.co.uk/img/media/981e17d90b401754aae355d2e56bfedbe5b359b5/0_1000_2480_1488/master/2480.jpg?width=300&quality=85&auto=format&fit=max&s=facd8591d83abd4b0019370b6031be6e',
                 isLiveBlog: false,
+                pillar: 'news',
             },
             {
                 url:
@@ -193,6 +209,7 @@ export const responseWithTwoTabs = [
                 image:
                     'https://i.guim.co.uk/img/media/ff17da45e26064e2666106902a90655e4db49ea4/955_135_1467_880/master/1467.jpg?width=300&quality=85&auto=format&fit=max&s=f6c5f055f7614d73f65ec193bb30c054',
                 isLiveBlog: false,
+                pillar: 'news',
             },
             {
                 url:
@@ -204,6 +221,7 @@ export const responseWithTwoTabs = [
                 image:
                     'https://i.guim.co.uk/img/media/b819ca05b59cdbe5ee59684740d1d9fe181b5a22/0_69_3600_2160/master/3600.jpg?width=300&quality=85&auto=format&fit=max&s=2f001df53652440f4be489b695c03ad2',
                 isLiveBlog: false,
+                pillar: 'news',
             },
             {
                 url:
@@ -215,6 +233,7 @@ export const responseWithTwoTabs = [
                 image:
                     'https://i.guim.co.uk/img/media/1e518e0996861201a7350f91f46d1f573ed2ea9c/0_823_6206_3724/master/6206.jpg?width=300&quality=85&auto=format&fit=max&s=149bde7a6699e526903598c690c214d0',
                 isLiveBlog: false,
+                pillar: 'news',
             },
             {
                 url:
@@ -226,6 +245,7 @@ export const responseWithTwoTabs = [
                 image:
                     'https://i.guim.co.uk/img/media/478dcff6eee2cbd753f1956e420c4caaf7b00fdd/0_1208_8095_4859/master/8095.jpg?width=300&quality=85&auto=format&fit=max&s=44effc5b2ab10b9a588be02c55a0620a',
                 isLiveBlog: false,
+                pillar: 'news',
             },
         ],
     },
@@ -245,6 +265,7 @@ export const responseWithOneTab = [
                 image:
                     'https://i.guim.co.uk/img/media/85377038aacd71b2c0e55b0a55478165fe6d3014/0_0_6000_3600/master/6000.jpg?width=300&quality=85&auto=format&fit=max&s=de2cecf52b21492f01daa4520c4f2a97',
                 isLiveBlog: false,
+                pillar: 'news',
             },
             {
                 url:
@@ -256,6 +277,7 @@ export const responseWithOneTab = [
                 image:
                     'https://i.guim.co.uk/img/media/579fd19481e46b9d6ed3c69c2a6992483df84478/0_0_6000_3600/master/6000.jpg?width=300&quality=85&auto=format&fit=max&s=63a6a5c13a8087e607a44ce5c7da2090',
                 isLiveBlog: false,
+                pillar: 'news',
             },
             {
                 url:
@@ -267,6 +289,7 @@ export const responseWithOneTab = [
                 image:
                     'https://i.guim.co.uk/img/media/0df1fc1a2b78aa1772b4b43c2e5ebfc7f43111a8/0_91_5445_3267/master/5445.jpg?width=300&quality=85&auto=format&fit=max&s=3da9f89b54b0126fec2677117e73487e',
                 isLiveBlog: false,
+                pillar: 'news',
             },
             {
                 url:
@@ -278,6 +301,7 @@ export const responseWithOneTab = [
                 image:
                     'https://i.guim.co.uk/img/media/57a9a1a56c7d319a8f57a9c8767793ae0481db4c/0_95_4950_2970/master/4950.jpg?width=300&quality=85&auto=format&fit=max&s=77949a713212b69499d0dc6b5bdb2faf',
                 isLiveBlog: false,
+                pillar: 'news',
             },
             {
                 url:
@@ -289,6 +313,7 @@ export const responseWithOneTab = [
                 image:
                     'https://i.guim.co.uk/img/media/e05185cce0a0c6953e666276caa98f6ea104c989/0_214_3600_2160/master/3600.jpg?width=300&quality=85&auto=format&fit=max&s=188a7a9ed42517b9462ae0788fe96a0a',
                 isLiveBlog: false,
+                pillar: 'news',
             },
             {
                 url:
@@ -300,6 +325,7 @@ export const responseWithOneTab = [
                 image:
                     'https://i.guim.co.uk/img/media/5792a3b971914e21bd04cb13eed54159463ce90e/0_128_4991_2994/master/4991.jpg?width=300&quality=85&auto=format&fit=max&s=6d4eab73546172d576a1022c29bdbcd2',
                 isLiveBlog: true,
+                pillar: 'news',
             },
             {
                 url:
@@ -311,6 +337,7 @@ export const responseWithOneTab = [
                 image:
                     'https://i.guim.co.uk/img/media/2e87f0ee5f1a6c292cfcfc5f6f99e9a54ba3cc05/0_139_4032_2419/master/4032.jpg?width=300&quality=85&auto=format&fit=max&s=e951b289eda050060201927e978d30ef',
                 isLiveBlog: false,
+                pillar: 'sport',
             },
             {
                 url:
@@ -322,6 +349,7 @@ export const responseWithOneTab = [
                 image:
                     'https://i.guim.co.uk/img/media/2d88f2493b6eff49b6b8d6dd35345f03fa2b4af2/0_721_3361_2017/master/3361.jpg?width=300&quality=85&auto=format&fit=max&s=8601a174c9dc594f75318da8e99932bf',
                 isLiveBlog: false,
+                pillar: 'news',
             },
             {
                 url:
@@ -333,6 +361,7 @@ export const responseWithOneTab = [
                 image:
                     'https://i.guim.co.uk/img/media/bceaab691b06c3f3830e7794d24c6ada2b301fad/847_177_2750_1650/master/2750.jpg?width=300&quality=85&auto=format&fit=max&s=3af893de9c01e38a8635c83883ef17ef',
                 isLiveBlog: false,
+                pillar: 'news',
             },
             {
                 url:
@@ -344,6 +373,7 @@ export const responseWithOneTab = [
                 image:
                     'https://i.guim.co.uk/img/media/bc4e5ed4448eafd6238656aefae98c832cacc148/32_13_1898_1139/master/1898.jpg?width=300&quality=85&auto=format&fit=max&s=a4b8c116c5e580482dfe727d126b57ae',
                 isLiveBlog: false,
+                pillar: 'news',
             },
         ],
     },

--- a/packages/frontend/web/components/MostViewed/MostViewed.test.tsx
+++ b/packages/frontend/web/components/MostViewed/MostViewed.test.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { render, fireEvent, waitForElement } from '@testing-library/react';
+import { MostViewed } from './MostViewed';
+import { responseWithTwoTabs, responseWithOneTab } from './MostViewed.mocks';
+
+const VISIBLE = 'display: block';
+const HIDDEN = 'display: none';
+
+const mockFetchResponse = (response: any) => ({
+    ok: true,
+    json: () => response,
+});
+
+describe('MostViewed', () => {
+    const globalAny: any = global;
+    const config: ConfigType = {
+        ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
+        sentryHost: '',
+        sentryPublicApiKey: '',
+        switches: {},
+        abTests: {},
+        dfpAccountId: '',
+        commercialBundleUrl: '',
+        revisionNumber: '',
+        isDev: false,
+        googletagUrl: '',
+        stage: 'DEV',
+        frontendAssetsFullURL: '',
+        hbImpl: '',
+        adUnit: '',
+    };
+
+    it('should call the api and render the response as expected', async () => {
+        globalAny.fetch = jest.fn(async () =>
+            mockFetchResponse(responseWithTwoTabs),
+        );
+
+        const { getByText, getAllByText, getByTestId } = render(
+            <MostViewed config={config} sectionName="Section Name" />,
+        );
+
+        await waitForElement(() => getByTestId(responseWithTwoTabs[0].heading));
+
+        // Calls api once only
+        expect(globalAny.fetch).toHaveBeenCalledTimes(1);
+
+        // Renders all 20 items
+        expect(getAllByText(/LINKTEXT/).length).toBe(20);
+
+        // First tab defaults to visible
+        expect(getByTestId(responseWithTwoTabs[0].heading)).toHaveStyle(
+            VISIBLE,
+        );
+
+        // Prefixes live articles correctly
+        expect(getAllByText(/Live/).length).toBe(1);
+
+        // Handles &nbsp char
+        expect(getByText('Across The Guardian')).toBeInTheDocument();
+    });
+
+    it('should change the items shown when the associated tab is clicked', async () => {
+        globalAny.fetch = jest.fn(async () =>
+            mockFetchResponse(responseWithTwoTabs),
+        );
+
+        const { getByTestId, getByText } = render(
+            <MostViewed config={config} sectionName="Section Name" />,
+        );
+
+        await waitForElement(() => getByTestId(responseWithTwoTabs[0].heading));
+
+        const firstHeading = responseWithTwoTabs[0].heading;
+        const secondHeading = responseWithTwoTabs[1].heading;
+
+        expect(getByTestId(firstHeading)).toHaveStyle(VISIBLE);
+        expect(getByTestId(secondHeading)).toHaveStyle(HIDDEN);
+
+        fireEvent.click(getByText(secondHeading));
+
+        expect(getByTestId(firstHeading)).toHaveStyle(HIDDEN);
+        expect(getByTestId(secondHeading)).toHaveStyle(VISIBLE);
+
+        // Hardcode this text here because the actual raw data contains $nbsp; which is removed during rendering
+        fireEvent.click(getByText('Across The Guardian'));
+
+        expect(getByTestId(firstHeading)).toHaveStyle(VISIBLE);
+        expect(getByTestId(secondHeading)).toHaveStyle(HIDDEN);
+    });
+
+    it('should not show the tab menu when there is only one group of tabs', async () => {
+        globalAny.fetch = jest.fn(async () =>
+            mockFetchResponse(responseWithOneTab),
+        );
+
+        const { queryByText, getByTestId } = render(
+            <MostViewed config={config} sectionName="Section Name" />,
+        );
+
+        await waitForElement(() => getByTestId(responseWithOneTab[0].heading));
+
+        expect(
+            queryByText(responseWithOneTab[0].heading),
+        ).not.toBeInTheDocument();
+    });
+
+    // TODO: Restore this once the component has this feature added to it
+    it.skip('should show a byline when this property is set to true', async () => {
+        globalAny.fetch = jest.fn(async () =>
+            mockFetchResponse(responseWithTwoTabs),
+        );
+
+        const { getByText, getByTestId } = render(
+            <MostViewed config={config} sectionName="Section Name" />,
+        );
+
+        await waitForElement(() => getByTestId(responseWithTwoTabs[0].heading));
+
+        expect(
+            getByText(responseWithTwoTabs[0].trails[9].byline),
+        ).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/web/components/MostViewed/MostViewed.tsx
+++ b/packages/frontend/web/components/MostViewed/MostViewed.tsx
@@ -10,7 +10,7 @@ import {
 } from '@guardian/pasteup/breakpoints';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';
 import { BigNumber } from '@guardian/guui';
-import { AsyncClientComponent } from './lib/AsyncClientComponent';
+import { AsyncClientComponent } from '../lib/AsyncClientComponent';
 import { namedAdSlotParameters } from '@frontend/model/advertisement';
 import { AdSlot } from '@frontend/web/components/AdSlot';
 import ClockIcon from '@guardian/pasteup/icons/clock.svg';
@@ -366,6 +366,7 @@ export class MostViewed extends Component<Props, { selectedTabIndex: number }> {
                                         aria-labelledby={`tabs-popular-${i}-tab`}
                                         data-link-name={tab.heading}
                                         data-link-context={`most-read/${this.props.sectionName}`}
+                                        data-testid={tab.heading}
                                     >
                                         {(tab.trails || []).map((trail, ii) => (
                                             <li

--- a/packages/frontend/web/pages/Article.tsx
+++ b/packages/frontend/web/pages/Article.tsx
@@ -9,7 +9,7 @@ import {
     mobileLandscape,
     wide,
 } from '@guardian/src-foundations';
-import { MostViewed } from '@frontend/web/components/MostViewed';
+import { MostViewed } from '@frontend/web/components/MostViewed/MostViewed';
 import { Header } from '@frontend/web/components/Header/Header';
 import { Footer } from '@frontend/web/components/Footer';
 import { ArticleBody } from '@frontend/web/components/ArticleBody';


### PR DESCRIPTION
## What does this change?
This PR adds tests for the `MostViewed` component in preparation for refactoring it.

To accomodate the growing number of files (tests, mocks, etc.) a dedicated '/MostViewed' directory was created. This means you have to use slightly messier import statements, like:

```
import { MostViewed } from '@frontend/web/components/MostViewed/MostViewed';
```

But this seems a reasonable trade off for the win of more readable code.

## Link to supporting Trello card
https://trello.com/c/fACBoBtT/746-most-viewed-component-refactoring-to-improve-dev-ex-plus-fix-styling
