### PR TITLE
Refactor article layout

### DIFF
--- a/packages/frontend/web/components/ArticleAside.tsx
+++ b/packages/frontend/web/components/ArticleAside.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { desktop } from '@guardian/src-foundations';
+import { AdSlot } from '@frontend/web/components/AdSlot';
+import { namedAdSlotParameters } from '@frontend/model/advertisement';
+
+const secondaryColumn = css`
+    position: absolute;
+    top: 0;
+    right: 0;
+    margin-right: 20px;
+    width: 300px;
+    margin-left: 20px;
+    margin-top: 6px;
+
+    min-height: 300px;
+    display: none;
+
+    ${desktop} {
+        display: block;
+    }
+`;
+
+const adSlotWrapper = css`
+    position: static;
+    height: 1059px;
+`;
+
+const stickyAdSlot = css`
+    position: sticky;
+    top: 0;
+`;
+
+type Props = {
+    config: ConfigType;
+};
+export const ArticleAside = ({ config }: Props) => {
+    return (
+        <div className={secondaryColumn}>
+            <div className={adSlotWrapper}>
+                <AdSlot
+                    asps={namedAdSlotParameters('right')}
+                    config={config}
+                    className={stickyAdSlot}
+                />
+            </div>
+        </div>
+    );
+};

--- a/packages/frontend/web/components/ArticleBody.tsx
+++ b/packages/frontend/web/components/ArticleBody.tsx
@@ -161,7 +161,7 @@ export const ArticleBody: React.FC<{
     const hasSubMetaKeywordLinks = CAPI.subMetaKeywordLinks.length > 0;
     const sharingUrls = getSharingUrls(CAPI.pageId, CAPI.webTitle);
     return (
-        <>
+        <div>
             <div
                 className={cx(bodyStyle, linkColour[CAPI.pillar], {
                     [immersiveBodyStyle]: CAPI.isImmersive,
@@ -214,6 +214,6 @@ export const ArticleBody: React.FC<{
                     />
                 )}
             </div>
-        </>
+        </div>
     );
 };

--- a/packages/frontend/web/components/ArticleBody.tsx
+++ b/packages/frontend/web/components/ArticleBody.tsx
@@ -161,7 +161,7 @@ export const ArticleBody: React.FC<{
     const hasSubMetaKeywordLinks = CAPI.subMetaKeywordLinks.length > 0;
     const sharingUrls = getSharingUrls(CAPI.pageId, CAPI.webTitle);
     return (
-        <div>
+        <>
             <div
                 className={cx(bodyStyle, linkColour[CAPI.pillar], {
                     [immersiveBodyStyle]: CAPI.isImmersive,
@@ -214,6 +214,6 @@ export const ArticleBody: React.FC<{
                     />
                 )}
             </div>
-        </div>
+        </>
     );
 };

--- a/packages/frontend/web/components/ArticleBody.tsx
+++ b/packages/frontend/web/components/ArticleBody.tsx
@@ -34,29 +34,6 @@ const pillarColours = pillarMap(
 //         `,
 // );
 
-const listStyles = css`
-    li {
-        ${textSans(5)};
-        margin-bottom: 6px;
-        padding-left: 20px;
-
-        p {
-            display: inline;
-        }
-    }
-
-    li:before {
-        display: inline-block;
-        content: '';
-        border-radius: 6px;
-        height: 12px;
-        width: 12px;
-        margin-right: 8px;
-        background-color: ${palette.neutral[86]};
-        margin-left: -20px;
-    }
-`;
-
 const guardianLines = css`
     background-image: repeating-linear-gradient(
         to bottom,
@@ -114,7 +91,26 @@ const bodyStyle = css`
         }
     }
 
-    ${listStyles};
+    li {
+        ${textSans(5)};
+        margin-bottom: 6px;
+        padding-left: 20px;
+
+        p {
+            display: inline;
+        }
+    }
+
+    li:before {
+        display: inline-block;
+        content: '';
+        border-radius: 6px;
+        height: 12px;
+        width: 12px;
+        margin-right: 8px;
+        background-color: ${palette.neutral[86]};
+        margin-left: -20px;
+    }
 `;
 
 const immersiveBodyStyle = css`

--- a/packages/frontend/web/components/ArticleBody.tsx
+++ b/packages/frontend/web/components/ArticleBody.tsx
@@ -2,88 +2,17 @@
 
 import React from 'react';
 import { css, cx } from 'emotion';
+
 import { palette } from '@guardian/pasteup/palette';
-import ClockIcon from '@guardian/pasteup/icons/clock.svg';
-import {
-    from,
-    until,
-    wide,
-    leftCol,
-    desktop,
-    tablet,
-    mobileLandscape,
-} from '@guardian/pasteup/breakpoints';
-import { clearFix, screenReaderOnly } from '@guardian/pasteup/mixins';
-import { headline, textSans, body } from '@guardian/pasteup/typography';
-import { Byline } from '@guardian/guui/components/Byline/Byline';
+import { from, tablet } from '@guardian/pasteup/breakpoints';
+import { headline, textSans } from '@guardian/pasteup/typography';
 import { pillarMap, pillarPalette } from '@frontend/lib/pillars';
 import { ArticleRenderer } from '@frontend/web/components/lib/ArticleRenderer';
-import { ShareCount } from './ShareCount';
+import { getSharingUrls } from '@frontend/model/sharing-urls';
+
 import { SharingIcons } from './ShareIcons';
 import { SubMetaLinksList } from './SubMetaLinksList';
-import { Dateline } from './Dateline';
-
-import { MainMedia } from './MainMedia';
-import { getSharingUrls } from '@frontend/model/sharing-urls';
-import { getAgeWarning } from '@frontend/model/age-warning';
 import { SyndicationButton } from './SyndicationButton';
-import { SeriesSectionLink } from './SeriesSectionLink';
-
-const curly = (x: any) => x;
-
-const wrapper = css`
-    padding-top: 6px;
-    margin-right: 0;
-    margin-left: 0;
-    ${clearFix}
-
-    ${desktop} {
-        max-width: 620px;
-        margin-right: 310px;
-        padding-left: 10px;
-    }
-
-    ${leftCol} {
-        margin-left: 150px;
-        margin-right: 310px;
-        position: relative;
-        :before {
-            content: '';
-            position: absolute;
-            top: 0;
-            bottom: 0;
-            left: 0;
-            height: 100%;
-            width: 1px;
-            background: ${palette.neutral[86]};
-        }
-    }
-
-    ${wide} {
-        margin-left: 230px;
-    }
-
-    header {
-        display: flex;
-        flex-direction: column;
-
-        ${leftCol} {
-            @supports (display: grid) {
-                display: grid;
-                grid-template-areas: 'section headline' 'meta main-media';
-                grid-template-columns: 160px 1fr;
-                margin-left: -160px;
-            }
-        }
-
-        ${wide} {
-            @supports (display: grid) {
-                grid-template-columns: 240px 1fr;
-                margin-left: -240px;
-            }
-        }
-    }
-`;
 
 const pillarColours = pillarMap(
     pillar =>
@@ -128,69 +57,6 @@ const listStyles = css`
     }
 `;
 
-const standfirst = css`
-    ${body(2)};
-    font-weight: 700;
-    color: ${palette.neutral[7]};
-    margin-bottom: 12px;
-
-    ${listStyles};
-
-    p {
-        margin-bottom: 8px;
-    }
-
-    li {
-        ${headline(2)};
-    }
-`;
-
-const standfirstLinks = pillarMap(
-    pillar =>
-        css`
-            a {
-                color: ${pillarPalette[pillar].dark};
-                text-decoration: none;
-                border-bottom: 1px solid ${palette.neutral[86]};
-                transition: border-color 0.15s ease-out;
-            }
-        `,
-);
-
-const leftColWidth = css`
-    ${leftCol} {
-        width: 140px;
-    }
-
-    ${wide} {
-        width: 220px;
-    }
-`;
-
-const headlineCSS = css`
-    @supports (display: grid) {
-        grid-template-areas: 'headline';
-    }
-    ${until.phablet} {
-        padding: 0 10px;
-    }
-`;
-
-const meta = css`
-    ${leftColWidth};
-    @supports (display: grid) {
-        grid-template-areas: 'meta';
-    }
-    ${from.tablet.until.leftCol} {
-        order: 1;
-    }
-
-    ${until.phablet} {
-        padding-left: 10px;
-        padding-right: 10px;
-    }
-`;
-
 const guardianLines = css`
     background-image: repeating-linear-gradient(
         to bottom,
@@ -209,51 +75,6 @@ const guardianLines = css`
 const captionFont = css`
     ${textSans(1)};
     color: ${palette.neutral[46]};
-`;
-
-const mainMedia = css`
-    @supports (display: grid) {
-        grid-template-areas: 'main-media';
-    }
-
-    min-height: 1px;
-    /*
-    Thank you IE11, broken in stasis for all eternity.
-
-    https://github.com/philipwalton/flexbugs/issues/75#issuecomment-161800607
-    */
-
-    margin-bottom: 6px;
-
-    ${until.tablet} {
-        margin: 0;
-        order: -1;
-
-        figcaption {
-            display: none;
-        }
-    }
-
-    img {
-        flex: 0 0 auto; /* IE */
-        width: 100%;
-        height: 100%;
-    }
-
-    figcaption {
-        ${captionFont};
-    }
-`;
-
-const headerStyle = css`
-    ${headline(7)};
-    font-weight: 500;
-    padding-bottom: 24px;
-    padding-top: 3px;
-
-    ${tablet} {
-        padding-bottom: 36px;
-    }
 `;
 
 const bodyStyle = css`
@@ -317,62 +138,6 @@ const linkColour = pillarMap(
     `,
 );
 
-const ageWarningStyle = css`
-    ${textSans(5)};
-    color: ${palette.neutral[7]};
-    background-color: ${palette.highlight.main};
-    display: inline-block;
-    margin-bottom: 6px;
-
-    > strong {
-        font-weight: bold;
-    }
-
-    padding: 6px 10px;
-    margin-top: 6px;
-    margin-left: -10px;
-
-    ${mobileLandscape} {
-        padding-left: 12px;
-    }
-
-    ${tablet} {
-        margin-left: -20px;
-    }
-
-    ${leftCol} {
-        margin-left: -10px;
-        margin-top: -6px;
-        padding-left: 10px;
-    }
-`;
-
-const ageWarningScreenReader = css`
-    ${screenReaderOnly};
-`;
-
-const metaExtras = css`
-    border-top: 1px solid ${palette.neutral[86]};
-    padding-top: 6px;
-    margin-bottom: 6px;
-    display: flex;
-    justify-content: space-between;
-    flex-wrap: wrap;
-
-    ${until.phablet} {
-        margin-left: -10px;
-        margin-right: -10px;
-        padding-left: 10px;
-        padding-right: 10px;
-    }
-`;
-
-const header = css`
-    ${until.phablet} {
-        margin: 0 -10px;
-    }
-`;
-
 const subMeta = css`
     margin-top: 12px;
     padding-top: 18px;
@@ -392,16 +157,6 @@ const subMetaSharingIcons = css`
     }
 `;
 
-const section = css`
-    ${leftColWidth};
-    @supports (display: grid) {
-        grid-template-areas: 'section';
-    }
-    ${until.phablet} {
-        padding: 0 10px;
-    }
-`;
-
 export const ArticleBody: React.FC<{
     CAPI: CAPIType;
     config: ConfigType;
@@ -409,116 +164,59 @@ export const ArticleBody: React.FC<{
     const hasSubMetaSectionLinks = CAPI.subMetaSectionLinks.length > 0;
     const hasSubMetaKeywordLinks = CAPI.subMetaKeywordLinks.length > 0;
     const sharingUrls = getSharingUrls(CAPI.pageId, CAPI.webTitle);
-    const ageWarning = getAgeWarning(CAPI.tags, CAPI.webPublicationDate);
     return (
-        <div className={wrapper}>
-            <header className={header}>
-                <div className={section}>
-                    <SeriesSectionLink CAPI={CAPI} fallbackToSection={true} />
-                </div>
-                <div className={headlineCSS}>
-                    {ageWarning && (
-                        <div className={ageWarningStyle} aria-hidden="true">
-                            <ClockIcon /> This article is more than{' '}
-                            <strong>{ageWarning}</strong>
-                        </div>
-                    )}
-                    <h1 className={headerStyle}>{curly(CAPI.headline)}</h1>
-                    {ageWarning && (
-                        <div className={ageWarningScreenReader}>
-                            This article is more than {` ${ageWarning}`}
-                        </div>
-                    )}
-                    <div
-                        className={cx(standfirst, standfirstLinks[CAPI.pillar])}
-                        dangerouslySetInnerHTML={{
-                            __html: CAPI.standfirst,
-                        }}
-                    />
-                </div>
-                <div className={cx(meta, guardianLines)}>
-                    <Byline
-                        author={CAPI.author}
-                        tags={CAPI.tags}
+        <div>
+            <div
+                className={cx(bodyStyle, linkColour[CAPI.pillar], {
+                    [immersiveBodyStyle]: CAPI.isImmersive,
+                })}
+            >
+                <ArticleRenderer
+                    elements={CAPI.blocks[0] ? CAPI.blocks[0].elements : []}
+                    pillar={CAPI.pillar}
+                    config={CAPI.config}
+                />
+            </div>
+            <div className={cx(subMeta, guardianLines)}>
+                {(hasSubMetaSectionLinks || hasSubMetaKeywordLinks) && (
+                    <span className={subMetaLabel}>Topics</span>
+                )}
+                {hasSubMetaSectionLinks && (
+                    <SubMetaLinksList
+                        links={CAPI.subMetaSectionLinks}
+                        isSectionLinkList={true}
                         pillar={CAPI.pillar}
                     />
-                    <Dateline
-                        dateDisplay={CAPI.webPublicationDateDisplay}
-                        descriptionText={'Published on'}
-                    />
-                    <div className={metaExtras}>
-                        <SharingIcons
-                            sharingUrls={sharingUrls}
-                            pillar={CAPI.pillar}
-                            displayIcons={['facebook', 'twitter', 'email']}
-                        />
-                        <ShareCount config={config} pageId={CAPI.pageId} />
-                    </div>
-                </div>
-                <div className={cx(mainMedia)}>
-                    {CAPI.mainMediaElements.map((element, i) => (
-                        <MainMedia
-                            element={element}
-                            key={i}
-                            pillar={CAPI.pillar}
-                        />
-                    ))}
-                </div>
-            </header>
-
-            <div>
-                <div
-                    className={cx(bodyStyle, linkColour[CAPI.pillar], {
-                        [immersiveBodyStyle]: CAPI.isImmersive,
-                    })}
-                >
-                    <ArticleRenderer
-                        elements={CAPI.blocks[0] ? CAPI.blocks[0].elements : []}
+                )}
+                {hasSubMetaKeywordLinks && (
+                    <SubMetaLinksList
+                        links={CAPI.subMetaKeywordLinks}
+                        isSectionLinkList={false}
                         pillar={CAPI.pillar}
-                        config={CAPI.config}
                     />
-                </div>
-                <div className={cx(subMeta, guardianLines)}>
-                    {(hasSubMetaSectionLinks || hasSubMetaKeywordLinks) && (
-                        <span className={subMetaLabel}>Topics</span>
-                    )}
-                    {hasSubMetaSectionLinks && (
-                        <SubMetaLinksList
-                            links={CAPI.subMetaSectionLinks}
-                            isSectionLinkList={true}
-                            pillar={CAPI.pillar}
-                        />
-                    )}
-                    {hasSubMetaKeywordLinks && (
-                        <SubMetaLinksList
-                            links={CAPI.subMetaKeywordLinks}
-                            isSectionLinkList={false}
-                            pillar={CAPI.pillar}
-                        />
-                    )}
-                    {CAPI.showBottomSocialButtons && (
-                        <SharingIcons
-                            className={subMetaSharingIcons}
-                            sharingUrls={sharingUrls}
-                            pillar={CAPI.pillar}
-                            displayIcons={[
-                                'facebook',
-                                'twitter',
-                                'email',
-                                'linkedIn',
-                                'pinterest',
-                                'whatsApp',
-                                'messenger',
-                            ]}
-                        />
-                    )}
-                    {CAPI.showBottomSocialButtons && (
-                        <SyndicationButton
-                            webUrl={CAPI.webURL}
-                            internalPageCode={CAPI.pageId}
-                        />
-                    )}
-                </div>
+                )}
+                {CAPI.showBottomSocialButtons && (
+                    <SharingIcons
+                        className={subMetaSharingIcons}
+                        sharingUrls={sharingUrls}
+                        pillar={CAPI.pillar}
+                        displayIcons={[
+                            'facebook',
+                            'twitter',
+                            'email',
+                            'linkedIn',
+                            'pinterest',
+                            'whatsApp',
+                            'messenger',
+                        ]}
+                    />
+                )}
+                {CAPI.showBottomSocialButtons && (
+                    <SyndicationButton
+                        webUrl={CAPI.webURL}
+                        internalPageCode={CAPI.pageId}
+                    />
+                )}
             </div>
         </div>
     );

--- a/packages/frontend/web/components/ArticleHeader.tsx
+++ b/packages/frontend/web/components/ArticleHeader.tsx
@@ -26,7 +26,12 @@ import { SharingIcons } from './ShareIcons';
 
 const curly = (x: any) => x;
 
-const listStyles = css`
+const standfirst = css`
+    ${body(2)};
+    font-weight: 700;
+    color: ${palette.neutral[7]};
+    margin-bottom: 12px;
+
     li {
         ${textSans(5)};
         margin-bottom: 6px;
@@ -47,15 +52,6 @@ const listStyles = css`
         background-color: ${palette.neutral[86]};
         margin-left: -20px;
     }
-`;
-
-const standfirst = css`
-    ${body(2)};
-    font-weight: 700;
-    color: ${palette.neutral[7]};
-    margin-bottom: 12px;
-
-    ${listStyles};
 
     p {
         margin-bottom: 8px;

--- a/packages/frontend/web/components/ArticleHeader.tsx
+++ b/packages/frontend/web/components/ArticleHeader.tsx
@@ -223,13 +223,13 @@ const metaExtras = css`
     }
 `;
 
-const header = css`
+const headerStyles = css`
     ${until.phablet} {
         margin: 0 -10px;
     }
 `;
 
-const section = css`
+const sectionStyles = css`
     ${leftColWidth};
     @supports (display: grid) {
         grid-template-areas: 'section';
@@ -248,8 +248,8 @@ export const ArticleHeader = ({ CAPI, config }: Props) => {
     const ageWarning = getAgeWarning(CAPI.tags, CAPI.webPublicationDate);
     const sharingUrls = getSharingUrls(CAPI.pageId, CAPI.webTitle);
     return (
-        <header className={header}>
-            <div className={section}>
+        <header className={headerStyles}>
+            <div className={sectionStyles}>
                 <SeriesSectionLink CAPI={CAPI} fallbackToSection={true} />
             </div>
             <div className={headlineCSS}>

--- a/packages/frontend/web/components/ArticleHeader.tsx
+++ b/packages/frontend/web/components/ArticleHeader.tsx
@@ -1,0 +1,305 @@
+import React from 'react';
+import { css, cx } from 'emotion';
+
+import { palette } from '@guardian/pasteup/palette';
+import ClockIcon from '@guardian/pasteup/icons/clock.svg';
+import { Byline } from '@guardian/guui/components/Byline/Byline';
+import { getAgeWarning } from '@frontend/model/age-warning';
+import { pillarMap, pillarPalette } from '@frontend/lib/pillars';
+import { screenReaderOnly } from '@guardian/pasteup/mixins';
+import { headline, textSans, body } from '@guardian/pasteup/typography';
+import { getSharingUrls } from '@frontend/model/sharing-urls';
+import {
+    from,
+    until,
+    leftCol,
+    tablet,
+    mobileLandscape,
+    wide,
+} from '@guardian/pasteup/breakpoints';
+
+import { ShareCount } from './ShareCount';
+import { Dateline } from './Dateline';
+import { MainMedia } from './MainMedia';
+import { SeriesSectionLink } from './SeriesSectionLink';
+import { SharingIcons } from './ShareIcons';
+
+const curly = (x: any) => x;
+
+const listStyles = css`
+    li {
+        ${textSans(5)};
+        margin-bottom: 6px;
+        padding-left: 20px;
+
+        p {
+            display: inline;
+        }
+    }
+
+    li:before {
+        display: inline-block;
+        content: '';
+        border-radius: 6px;
+        height: 12px;
+        width: 12px;
+        margin-right: 8px;
+        background-color: ${palette.neutral[86]};
+        margin-left: -20px;
+    }
+`;
+
+const standfirst = css`
+    ${body(2)};
+    font-weight: 700;
+    color: ${palette.neutral[7]};
+    margin-bottom: 12px;
+
+    ${listStyles};
+
+    p {
+        margin-bottom: 8px;
+    }
+
+    li {
+        ${headline(2)};
+    }
+`;
+
+const standfirstLinks = pillarMap(
+    pillar =>
+        css`
+            a {
+                color: ${pillarPalette[pillar].dark};
+                text-decoration: none;
+                border-bottom: 1px solid ${palette.neutral[86]};
+                transition: border-color 0.15s ease-out;
+            }
+        `,
+);
+
+const guardianLines = css`
+    background-image: repeating-linear-gradient(
+        to bottom,
+        ${palette.neutral[86]},
+        ${palette.neutral[86]} 1px,
+        transparent 1px,
+        transparent 4px
+    );
+    background-repeat: repeat-x;
+    background-position: top;
+    background-size: 1px 13px;
+    padding-top: 15px;
+    margin-bottom: 6px;
+`;
+
+const captionFont = css`
+    ${textSans(1)};
+    color: ${palette.neutral[46]};
+`;
+
+const mainMedia = css`
+    @supports (display: grid) {
+        grid-template-areas: 'main-media';
+    }
+
+    min-height: 1px;
+    /*
+    Thank you IE11, broken in stasis for all eternity.
+
+    https://github.com/philipwalton/flexbugs/issues/75#issuecomment-161800607
+    */
+
+    margin-bottom: 6px;
+
+    ${until.tablet} {
+        margin: 0;
+        order: -1;
+
+        figcaption {
+            display: none;
+        }
+    }
+
+    img {
+        flex: 0 0 auto; /* IE */
+        width: 100%;
+        height: 100%;
+    }
+
+    figcaption {
+        ${captionFont};
+    }
+`;
+
+const headerStyle = css`
+    ${headline(7)};
+    font-weight: 500;
+    padding-bottom: 24px;
+    padding-top: 3px;
+
+    ${tablet} {
+        padding-bottom: 36px;
+    }
+`;
+
+const headlineCSS = css`
+    @supports (display: grid) {
+        grid-template-areas: 'headline';
+    }
+    ${until.phablet} {
+        padding: 0 10px;
+    }
+`;
+
+const leftColWidth = css`
+    ${leftCol} {
+        width: 140px;
+    }
+
+    ${wide} {
+        width: 220px;
+    }
+`;
+
+const meta = css`
+    ${leftColWidth};
+    @supports (display: grid) {
+        grid-template-areas: 'meta';
+    }
+    ${from.tablet.until.leftCol} {
+        order: 1;
+    }
+
+    ${until.phablet} {
+        padding-left: 10px;
+        padding-right: 10px;
+    }
+`;
+
+const ageWarningStyle = css`
+    ${textSans(5)};
+    color: ${palette.neutral[7]};
+    background-color: ${palette.highlight.main};
+    display: inline-block;
+    margin-bottom: 6px;
+
+    > strong {
+        font-weight: bold;
+    }
+
+    padding: 6px 10px;
+    margin-top: 6px;
+    margin-left: -10px;
+
+    ${mobileLandscape} {
+        padding-left: 12px;
+    }
+
+    ${tablet} {
+        margin-left: -20px;
+    }
+
+    ${leftCol} {
+        margin-left: -10px;
+        margin-top: -6px;
+        padding-left: 10px;
+    }
+`;
+
+const ageWarningScreenReader = css`
+    ${screenReaderOnly};
+`;
+
+const metaExtras = css`
+    border-top: 1px solid ${palette.neutral[86]};
+    padding-top: 6px;
+    margin-bottom: 6px;
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+
+    ${until.phablet} {
+        margin-left: -10px;
+        margin-right: -10px;
+        padding-left: 10px;
+        padding-right: 10px;
+    }
+`;
+
+const header = css`
+    ${until.phablet} {
+        margin: 0 -10px;
+    }
+`;
+
+const section = css`
+    ${leftColWidth};
+    @supports (display: grid) {
+        grid-template-areas: 'section';
+    }
+    ${until.phablet} {
+        padding: 0 10px;
+    }
+`;
+
+type Props = {
+    CAPI: CAPIType;
+    config: ConfigType;
+};
+
+export const ArticleHeader = ({ CAPI, config }: Props) => {
+    const ageWarning = getAgeWarning(CAPI.tags, CAPI.webPublicationDate);
+    const sharingUrls = getSharingUrls(CAPI.pageId, CAPI.webTitle);
+    return (
+        <header className={header}>
+            <div className={section}>
+                <SeriesSectionLink CAPI={CAPI} fallbackToSection={true} />
+            </div>
+            <div className={headlineCSS}>
+                {ageWarning && (
+                    <div className={ageWarningStyle} aria-hidden="true">
+                        <ClockIcon /> This article is more than{' '}
+                        <strong>{ageWarning}</strong>
+                    </div>
+                )}
+                <h1 className={headerStyle}>{curly(CAPI.headline)}</h1>
+                {ageWarning && (
+                    <div className={ageWarningScreenReader}>
+                        This article is more than {` ${ageWarning}`}
+                    </div>
+                )}
+                <div
+                    className={cx(standfirst, standfirstLinks[CAPI.pillar])}
+                    dangerouslySetInnerHTML={{
+                        __html: CAPI.standfirst,
+                    }}
+                />
+            </div>
+            <div className={cx(meta, guardianLines)}>
+                <Byline
+                    author={CAPI.author}
+                    tags={CAPI.tags}
+                    pillar={CAPI.pillar}
+                />
+                <Dateline
+                    dateDisplay={CAPI.webPublicationDateDisplay}
+                    descriptionText={'Published on'}
+                />
+                <div className={metaExtras}>
+                    <SharingIcons
+                        sharingUrls={sharingUrls}
+                        pillar={CAPI.pillar}
+                        displayIcons={['facebook', 'twitter', 'email']}
+                    />
+                    <ShareCount config={config} pageId={CAPI.pageId} />
+                </div>
+            </div>
+            <div className={cx(mainMedia)}>
+                {CAPI.mainMediaElements.map((element, i) => (
+                    <MainMedia element={element} key={i} pillar={CAPI.pillar} />
+                ))}
+            </div>
+        </header>
+    );
+};

--- a/packages/frontend/web/components/ArticleHeader.tsx
+++ b/packages/frontend/web/components/ArticleHeader.tsx
@@ -227,6 +227,25 @@ const headerStyles = css`
     ${until.phablet} {
         margin: 0 -10px;
     }
+
+    display: flex;
+    flex-direction: column;
+
+    ${leftCol} {
+        @supports (display: grid) {
+            display: grid;
+            grid-template-areas: 'section headline' 'meta main-media';
+            grid-template-columns: 160px 1fr;
+            margin-left: -160px;
+        }
+    }
+
+    ${wide} {
+        @supports (display: grid) {
+            grid-template-columns: 240px 1fr;
+            margin-left: -240px;
+        }
+    }
 `;
 
 const sectionStyles = css`

--- a/packages/frontend/web/components/ArticleHeader.tsx
+++ b/packages/frontend/web/components/ArticleHeader.tsx
@@ -284,7 +284,7 @@ export const ArticleHeader = ({ CAPI, config }: Props) => {
                         This article is more than {` ${ageWarning}`}
                     </div>
                 )}
-                <div
+                <div // tslint:disable-line:react-no-dangerous-html
                     className={cx(standfirst, standfirstLinks[CAPI.pillar])}
                     dangerouslySetInnerHTML={{
                         __html: CAPI.standfirst,

--- a/packages/frontend/web/components/Content.tsx
+++ b/packages/frontend/web/components/Content.tsx
@@ -12,8 +12,8 @@ import { clearFix } from '@guardian/pasteup/mixins';
 import { Container } from '@guardian/guui';
 import { ArticleBody } from '@frontend/web/components/ArticleBody';
 import { ArticleHeader } from '@frontend/web/components/ArticleHeader';
-import { AdSlot, labelStyles } from '@frontend/web/components/AdSlot';
-import { namedAdSlotParameters } from '@frontend/model/advertisement';
+import { labelStyles } from '@frontend/web/components/AdSlot';
+import { ArticleAside } from '@frontend/web/components/ArticleAside';
 
 const wrapper = css`
     padding-top: 6px;
@@ -46,33 +46,6 @@ const wrapper = css`
     ${wide} {
         margin-left: 230px;
     }
-`;
-
-const secondaryColumn = css`
-    position: absolute;
-    top: 0;
-    right: 0;
-    margin-right: 20px;
-    width: 300px;
-    margin-left: 20px;
-    margin-top: 6px;
-
-    min-height: 300px;
-    display: none;
-
-    ${desktop} {
-        display: block;
-    }
-`;
-
-const adSlotWrapper = css`
-    position: static;
-    height: 1059px;
-`;
-
-const stickyAdSlot = css`
-    position: sticky;
-    top: 0;
 `;
 
 const articleContainerStyles = css`
@@ -149,15 +122,7 @@ export const Content = ({ CAPI, config }: Props) => {
                         <ArticleHeader CAPI={CAPI} config={config} />
                         <ArticleBody CAPI={CAPI} config={config} />
                     </div>
-                    <div className={secondaryColumn}>
-                        <div className={adSlotWrapper}>
-                            <AdSlot
-                                asps={namedAdSlotParameters('right')}
-                                config={config}
-                                className={stickyAdSlot}
-                            />
-                        </div>
-                    </div>
+                    <ArticleAside config={config} />
                 </article>
             </Container>
         </main>

--- a/packages/frontend/web/components/Content.tsx
+++ b/packages/frontend/web/components/Content.tsx
@@ -12,7 +12,6 @@ import { ArticleBody } from '@frontend/web/components/ArticleBody';
 import { AdSlot, labelStyles } from '@frontend/web/components/AdSlot';
 import { namedAdSlotParameters } from '@frontend/model/advertisement';
 
-// TODO: find a better of setting opacity
 const secondaryColumn = css`
     position: absolute;
     top: 0;

--- a/packages/frontend/web/components/Content.tsx
+++ b/packages/frontend/web/components/Content.tsx
@@ -15,7 +15,7 @@ import { ArticleHeader } from '@frontend/web/components/ArticleHeader';
 import { labelStyles } from '@frontend/web/components/AdSlot';
 import { ArticleAside } from '@frontend/web/components/ArticleAside';
 
-const wrapper = css`
+const marginStyles = css`
     padding-top: 6px;
     margin-right: 0;
     margin-left: 0;
@@ -118,7 +118,7 @@ export const Content = ({ CAPI, config }: Props) => {
                 className={articleContainerStyles}
             >
                 <article className={articleAdStyles}>
-                    <div className={wrapper}>
+                    <div className={marginStyles}>
                         <ArticleHeader CAPI={CAPI} config={config} />
                         <ArticleBody CAPI={CAPI} config={config} />
                     </div>

--- a/packages/frontend/web/components/Content.tsx
+++ b/packages/frontend/web/components/Content.tsx
@@ -46,27 +46,6 @@ const wrapper = css`
     ${wide} {
         margin-left: 230px;
     }
-
-    header {
-        display: flex;
-        flex-direction: column;
-
-        ${leftCol} {
-            @supports (display: grid) {
-                display: grid;
-                grid-template-areas: 'section headline' 'meta main-media';
-                grid-template-columns: 160px 1fr;
-                margin-left: -160px;
-            }
-        }
-
-        ${wide} {
-            @supports (display: grid) {
-                grid-template-columns: 240px 1fr;
-                margin-left: -240px;
-            }
-        }
-    }
 `;
 
 const secondaryColumn = css`

--- a/packages/frontend/web/components/Content.tsx
+++ b/packages/frontend/web/components/Content.tsx
@@ -3,14 +3,71 @@ import { css } from 'emotion';
 import {
     tablet,
     desktop,
+    leftCol,
     wide,
     palette,
     mobileLandscape,
 } from '@guardian/src-foundations';
+import { clearFix } from '@guardian/pasteup/mixins';
 import { Container } from '@guardian/guui';
 import { ArticleBody } from '@frontend/web/components/ArticleBody';
+import { ArticleHeader } from '@frontend/web/components/ArticleHeader';
 import { AdSlot, labelStyles } from '@frontend/web/components/AdSlot';
 import { namedAdSlotParameters } from '@frontend/model/advertisement';
+
+const wrapper = css`
+    padding-top: 6px;
+    margin-right: 0;
+    margin-left: 0;
+    ${clearFix}
+
+    ${desktop} {
+        max-width: 620px;
+        margin-right: 310px;
+        padding-left: 10px;
+    }
+
+    ${leftCol} {
+        margin-left: 150px;
+        margin-right: 310px;
+        position: relative;
+        :before {
+            content: '';
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            left: 0;
+            height: 100%;
+            width: 1px;
+            background: ${palette.neutral[86]};
+        }
+    }
+
+    ${wide} {
+        margin-left: 230px;
+    }
+
+    header {
+        display: flex;
+        flex-direction: column;
+
+        ${leftCol} {
+            @supports (display: grid) {
+                display: grid;
+                grid-template-areas: 'section headline' 'meta main-media';
+                grid-template-columns: 160px 1fr;
+                margin-left: -160px;
+            }
+        }
+
+        ${wide} {
+            @supports (display: grid) {
+                grid-template-columns: 240px 1fr;
+                margin-left: -240px;
+            }
+        }
+    }
+`;
 
 const secondaryColumn = css`
     position: absolute;
@@ -109,7 +166,10 @@ export const Content = ({ CAPI, config }: Props) => {
                 className={articleContainerStyles}
             >
                 <article className={articleAdStyles}>
-                    <ArticleBody CAPI={CAPI} config={config} />
+                    <div className={wrapper}>
+                        <ArticleHeader CAPI={CAPI} config={config} />
+                        <ArticleBody CAPI={CAPI} config={config} />
+                    </div>
                     <div className={secondaryColumn}>
                         <div className={adSlotWrapper}>
                             <AdSlot


### PR DESCRIPTION
## What does this change?
This PR extracts out the main parts of an article into separate components, adding `ArticleHeader` and `ArticleAside`. As part of the process of creating these components, some css and variable names were rationalised.

## Why?
For readability, testability but also because by having separate elements it makes it much easier to reason about the page layout - which will be very useful as we look to support more article types.

## Link to supporting Trello card
https://trello.com/c/oSRTvZZ3/628-designtype-applied-to-web-rendering
