### PR TITLE
Support no flashing content accessibility flag

### DIFF
--- a/packages/frontend/web/components/PulsingDot.test.tsx
+++ b/packages/frontend/web/components/PulsingDot.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { PulsingDot, DISABLE_FLASHING_ELEMENTS_CLASS } from './PulsingDot';
+
+describe('PulsingDot', () => {
+    it('It should render pulsing dot as expected', () => {
+        const dotColour = 'blue';
+        const { container } = render(<PulsingDot colour={dotColour} />);
+        expect(container.firstChild).toHaveStyle(`color: ${dotColour}`);
+    });
+
+    it('It should not render pulsing dot if the no flashing class is present in the container', () => {
+        document.body.className += `${''} ${DISABLE_FLASHING_ELEMENTS_CLASS}`;
+        const { container } = render(<PulsingDot colour={'green'} />);
+        expect(container.firstChild).toBeNull();
+    });
+});

--- a/packages/frontend/web/components/PulsingDot.tsx
+++ b/packages/frontend/web/components/PulsingDot.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { css } from 'emotion';
 import { keyframes } from '@emotion/core';
 
+export const DISABLE_FLASHING_ELEMENTS_CLASS = 'disable-flashing-elements';
+
 const livePulse = keyframes`{
     0% {opacity: 1;}
     10% {opacity: .25;}
@@ -33,7 +35,7 @@ export const PulsingDot = ({ colour }: Props) => {
     // Respect the accessibility flag set here
     // https://www.theguardian.com/help/accessibility-help
     const flashingIsDisabled = !!document.getElementsByClassName(
-        'disable-flashing-elements',
+        DISABLE_FLASHING_ELEMENTS_CLASS,
     ).length;
     if (flashingIsDisabled) {
         return null;

--- a/packages/frontend/web/components/PulsingDot.tsx
+++ b/packages/frontend/web/components/PulsingDot.tsx
@@ -29,6 +29,15 @@ interface Props {
     colour: string;
 }
 
-export const PulsingDot = ({ colour }: Props) => (
-    <span className={pulsingDot(colour)} />
-);
+export const PulsingDot = ({ colour }: Props) => {
+    // Respect the accessibility flag set here
+    // https://www.theguardian.com/help/accessibility-help
+    const flashingIsDisabled = !!document.getElementsByClassName(
+        'disable-flashing-elements',
+    ).length;
+    if (flashingIsDisabled) {
+        return null;
+    }
+
+    return <span className={pulsingDot(colour)} />;
+};


### PR DESCRIPTION
## What does this change?
The recently added `PulsingDot` component was missing support for the the accessibility flag to prevent flashing elements on the page. This PR adds that support.

See: https://www.theguardian.com/help/accessibility-help

and the original PR: https://github.com/guardian/dotcom-rendering/pull/805
