### PR TITLE
Introduce MobileStickyContainer

### DIFF
--- a/packages/frontend/web/components/AdSlot.tsx
+++ b/packages/frontend/web/components/AdSlot.tsx
@@ -2,8 +2,8 @@
 
 import React from 'react';
 import { shouldDisplayAdvertisements } from '@frontend/model/advertisement';
-import { css } from 'emotion';
-import { textSans, palette } from '@guardian/src-foundations';
+import { css, cx } from 'emotion';
+import { textSans, palette, until } from '@guardian/src-foundations';
 
 export const labelStyles = css`
     .ad-slot__label {
@@ -20,6 +20,51 @@ export const labelStyles = css`
 
     .ad-slot__close-button {
         display: none;
+    }
+`;
+
+export const mobileStickyStyles = css`
+    .mobilesticky-container {
+        position: fixed;
+        bottom: 0;
+        width: 320px;
+        margin: 0 auto;
+        right: 0;
+        left: 0;
+        z-index: 1010;
+        ${until.phablet} {
+            display: none;
+        }
+    }
+    .ad-slot__close-button {
+        display: none;
+        position: absolute;
+        right: 3px;
+        top: 3px;
+        padding: 0;
+        border: 0;
+        height: 21px;
+        width: 21px;
+        background-color: transparent;
+    }
+    .ad-slot__close-button svg {
+        height: 6px;
+        width: 6px;
+        stroke: ${palette.neutral[7]};
+        fill: ${palette.neutral[7]};
+        stroke-linecap: round;
+        stroke-width: 0;
+        text-align: center;
+    }
+    .ad-slot--mobile-sticky .ad-slot__label .ad-slot__close-button {
+        display: block;
+    }
+    .ad-slot__close-button__x {
+        stroke: ${palette.neutral[7]};
+        fill: transparent;
+        stroke-linecap: round;
+        stroke-width: 2;
+        text-align: center;
     }
 `;
 
@@ -121,4 +166,10 @@ export const AdSlot: React.FC<{
         return null;
     }
     return <AdSlotCore {...asps} className={className} />;
+};
+
+export const MobileStickyContainer: React.FC<{}> = ({}) => {
+    return (
+        <div className={`mobilesticky-container ${cx(mobileStickyStyles)}`} />
+    );
 };

--- a/packages/frontend/web/pages/Article.tsx
+++ b/packages/frontend/web/pages/Article.tsx
@@ -5,6 +5,7 @@ import { Footer } from '@frontend/web/components/Footer';
 import { Content } from '@frontend/web/components/Content';
 import { SubNav } from '@frontend/web/components/Header/Nav/SubNav/SubNav';
 import { CookieBanner } from '@frontend/web/components/CookieBanner';
+import { MobileStickyContainer } from '@frontend/web/components/AdSlot';
 
 export const Article: React.FC<{
     data: ArticleProps;
@@ -18,17 +19,13 @@ export const Article: React.FC<{
             isAdFreeUser={data.CAPI.isAdFreeUser}
             shouldHideAds={data.CAPI.shouldHideAds}
         />
-
         <Content CAPI={data.CAPI} config={data.config} />
-
         <MostViewed sectionName={data.CAPI.sectionName} config={data.config} />
-
         <SubNav
             subnav={data.NAV.subNavSections}
             pillar={data.CAPI.pillar}
             currentNavLink={data.NAV.currentNavLink}
         />
-
         <Footer
             nav={data.NAV}
             edition={data.CAPI.editionId}
@@ -36,7 +33,7 @@ export const Article: React.FC<{
             pillar={data.CAPI.pillar}
             pillars={data.NAV.pillars}
         />
-
         <CookieBanner />
+        <MobileStickyContainer />
     </div>
 );


### PR DESCRIPTION
## What does this change?

This PR, introduces a component for hosting the mobile sticky ad. This is not an ad slot, but a target that the commercial code will put the ad in. This change will be followed by a frontend change to adapt the commercial code. (In frontend classic, the `div` is created, whereas here we create it and note that in essence this component only carries the styles required for the mobile sticky). 