### PR TITLE
Use lodash escape instead of default js

### DIFF
--- a/packages/frontend/web/server/htmlTemplate.ts
+++ b/packages/frontend/web/server/htmlTemplate.ts
@@ -2,6 +2,7 @@ import resetCSS from /* preval */ '@frontend/lib/reset-css';
 import { getFontsCss } from '@frontend/lib/fonts-css';
 import { getStatic } from '@frontend/lib/assets';
 import { prepareCmpString } from '@frontend/web/browser/prepareCmp';
+import escape from 'lodash.escape';
 
 import { WindowGuardian } from '@frontend/model/window-guardian';
 


### PR DESCRIPTION
## What does this change?

Lodash `escape` escapes to html entities (understood by browsesr and machnine readable things) whereas js `escape` escapes to `hexadecimal escape sequence.` which gives us garabage titles where spaces are converted, for example to `%20`.

https://lodash.com/docs/4.17.11#escape

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/escape


