### PR TITLE
Revert "Use lodash escape instead of default js"

### DIFF
--- a/packages/frontend/web/server/htmlTemplate.ts
+++ b/packages/frontend/web/server/htmlTemplate.ts
@@ -2,7 +2,6 @@ import resetCSS from /* preval */ '@frontend/lib/reset-css';
 import { getFontsCss } from '@frontend/lib/fonts-css';
 import { getStatic } from '@frontend/lib/assets';
 import { prepareCmpString } from '@frontend/web/browser/prepareCmp';
-import escape from 'lodash.escape';
 
 import { WindowGuardian } from '@frontend/model/window-guardian';
 


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#818