### PR TITLE
Remove the MobileStickyContainer

### DIFF
--- a/packages/frontend/web/pages/Article.tsx
+++ b/packages/frontend/web/pages/Article.tsx
@@ -5,7 +5,7 @@ import { Footer } from '@frontend/web/components/Footer';
 import { Content } from '@frontend/web/components/Content';
 import { SubNav } from '@frontend/web/components/Header/Nav/SubNav/SubNav';
 import { CookieBanner } from '@frontend/web/components/CookieBanner';
-import { MobileStickyContainer } from '@frontend/web/components/AdSlot';
+// import { MobileStickyContainer } from '@frontend/web/components/AdSlot';
 
 export const Article: React.FC<{
     data: ArticleProps;
@@ -34,6 +34,5 @@ export const Article: React.FC<{
             pillars={data.NAV.pillars}
         />
         <CookieBanner />
-        <MobileStickyContainer />
     </div>
 );


### PR DESCRIPTION
## What does this change?

This (temporarily) remove the MobileStickyContainer from the page. It was meant to come with a sister frontend PR, which turned out to be challenging.