### PR TITLE
Added escapeData to escape script tags

### DIFF
--- a/packages/frontend/web/components/MostViewed/MostViewed.tsx
+++ b/packages/frontend/web/components/MostViewed/MostViewed.tsx
@@ -19,6 +19,7 @@ import { PulsingDot } from '@frontend/web/components/PulsingDot';
 import { QuoteIcon } from '@frontend/web/components/QuoteIcon';
 import { pillarPalette } from '@frontend/lib/pillars';
 import { OutbrainContainer } from '@frontend/web/components/Outbrain';
+import { unescapeData } from '@frontend/web/server/escapeData';
 
 const container = css`
     padding-top: 3px;
@@ -409,8 +410,9 @@ export class MostViewed extends Component<Props, { selectedTabIndex: number }> {
                                                                     <span // tslint:disable-line:react-no-dangerous-html
                                                                         // "Across The Guardian" has a non-breaking space entity between "The" and "Guardian"
                                                                         dangerouslySetInnerHTML={{
-                                                                            __html:
+                                                                            __html: unescapeData(
                                                                                 tab.heading,
+                                                                            ),
                                                                         }}
                                                                     />
                                                                 </button>

--- a/packages/frontend/web/components/elements/PullQuoteComponent.tsx
+++ b/packages/frontend/web/components/elements/PullQuoteComponent.tsx
@@ -10,6 +10,7 @@ import {
     phablet,
     mobileLandscape,
 } from '@guardian/pasteup/breakpoints';
+import { unescapeData } from '@frontend/web/server/escapeData';
 
 const gutter = 20;
 const quoteTail = 25;
@@ -122,7 +123,7 @@ export const PullQuoteComponent: React.FC<{
         <Quote />{' '}
         <span // tslint:disable-line:react-no-dangerous-html
             dangerouslySetInnerHTML={{
-                __html: html,
+                __html: unescapeData(html),
             }}
         />
         <footer>

--- a/packages/frontend/web/components/elements/SubheadingBlockComponent.tsx
+++ b/packages/frontend/web/components/elements/SubheadingBlockComponent.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { unescapeData } from '@frontend/web/server/escapeData';
 // tslint:disable:react-no-dangerous-html
 
 export const SubheadingBlockComponent: React.FC<{ html: string }> = ({
@@ -10,7 +11,7 @@ export const SubheadingBlockComponent: React.FC<{ html: string }> = ({
     // to try to think of a workaround so that our ads will work properly.
     <div
         dangerouslySetInnerHTML={{
-            __html: html,
+            __html: unescapeData(html),
         }}
     />
 );

--- a/packages/frontend/web/components/elements/TextBlockComponent.tsx
+++ b/packages/frontend/web/components/elements/TextBlockComponent.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 import { body } from '@guardian/pasteup/typography';
+import { unescapeData } from '@frontend/web/server/escapeData';
 // tslint:disable:react-no-dangerous-html
 
 const para = css`
@@ -30,9 +31,8 @@ export const TextBlockComponent: React.FC<{ html: string }> = ({ html }) => {
             <p
                 className={para}
                 dangerouslySetInnerHTML={{
-                    __html: html.slice(
-                        prefix.length,
-                        html.length - suffix.length,
+                    __html: unescapeData(
+                        html.slice(prefix.length, html.length - suffix.length),
                     ),
                 }}
             />
@@ -43,7 +43,7 @@ export const TextBlockComponent: React.FC<{ html: string }> = ({ html }) => {
         <span
             className={innerPara}
             dangerouslySetInnerHTML={{
-                __html: html,
+                __html: unescapeData(html),
             }}
         />
     );

--- a/packages/frontend/web/components/elements/TweetBlockComponent.tsx
+++ b/packages/frontend/web/components/elements/TweetBlockComponent.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
 import { body } from '@guardian/pasteup/typography';
+import { unescapeData } from '@frontend/web/server/escapeData';
 
 // fallback styling for when JS is disabled
 const noJSStyling = css`
@@ -32,7 +33,7 @@ export const TweetBlockComponent: React.FC<{
         <div>
             <div
                 className={noJSStyling}
-                dangerouslySetInnerHTML={{ __html: element.html }}
+                dangerouslySetInnerHTML={{ __html: unescapeData(element.html) }}
             />
             <script
                 async={true}

--- a/packages/frontend/web/server/document.tsx
+++ b/packages/frontend/web/server/document.tsx
@@ -6,6 +6,7 @@ import { CacheProvider } from '@emotion/core';
 
 import { htmlTemplate } from './htmlTemplate';
 import { DecidePage } from './DecidePage';
+import { escapeData } from './escapeData';
 import { getDist } from '@frontend/lib/assets';
 
 import { makeWindowGuardian } from '@frontend/model/window-guardian';
@@ -80,7 +81,13 @@ export const document = ({ data }: Props) => {
         'https://www.google-analytics.com/analytics.js',
     ];
 
-    const windowGuardian = makeWindowGuardian(data, cssIDs);
+    /**
+     * We escape windowGuardian here to prevent errors when the data
+     * is placed in a script tag on the page
+     */
+    const windowGuardian = escapeData(
+        JSON.stringify(makeWindowGuardian(data, cssIDs)),
+    );
 
     const ampLink = `https://amp.theguardian.com/${data.CAPI.pageId}`;
 

--- a/packages/frontend/web/server/escapeData.test.tsx
+++ b/packages/frontend/web/server/escapeData.test.tsx
@@ -1,0 +1,21 @@
+import { escapeData, unescapeData } from './escapeData';
+
+describe('Escaping html', () => {
+    it('should escape script tags', () => {
+        const before =
+            '<script async src="//www.instagram.com/embed.js"></script>';
+        const after =
+            '<\\script async src="//www.instagram.com/embed.js"><\\/script>';
+
+        expect(escapeData(before)).toEqual(after);
+        expect(unescapeData(after)).toEqual(before);
+    });
+
+    it('should escape comments', () => {
+        const before = '<!-- Some comment -->';
+        const after = '<\\!-- Some comment -->';
+
+        expect(escapeData(before)).toEqual(after);
+        expect(unescapeData(after)).toEqual(before);
+    });
+});

--- a/packages/frontend/web/server/escapeData.tsx
+++ b/packages/frontend/web/server/escapeData.tsx
@@ -12,6 +12,7 @@
  * TODO: This could be extended
  */
 
+// See: https://stackoverflow.com/a/1144788
 function escapeRegExp(str: string): string {
     return str.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, '\\$1');
 }

--- a/packages/frontend/web/server/escapeData.tsx
+++ b/packages/frontend/web/server/escapeData.tsx
@@ -1,0 +1,37 @@
+/**
+ * Create an escapedData string that can be safely placed inside script tags on the page
+ *
+ * The level of sanitisation here is limited to escaping script tags to prevent
+ * errors when embedded html string contgain their own script tags.
+ *
+ * See: https://www.w3.org/TR/html52/semantics-scripting.html#restrictions-for-contents-of-script-elements
+ *
+ *  > The easiest and safest way to avoid the rather strange restrictions described in this section is to
+ *  > always escape "&lt;!--" as "&lt;\!--", "&lt;script" as "&lt;\script", and "&lt;/script" as "&lt;\/script"
+ *
+ * TODO: This could be extended
+ */
+
+function escapeRegExp(str: string): string {
+    return str.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, '\\$1');
+}
+
+function replaceAll(str: string, find: string, replace: string): string {
+    return str.replace(new RegExp(escapeRegExp(find), 'g'), replace);
+}
+
+export const escapeData = (data: string): string => {
+    let escaped = data;
+    escaped = replaceAll(escaped, '<!--', '<\\!--');
+    escaped = replaceAll(escaped, '<script', '<\\script');
+    escaped = replaceAll(escaped, '</script', '<\\/script');
+    return escaped;
+};
+
+export const unescapeData = (data: string): string => {
+    let unescaped = data;
+    unescaped = replaceAll(unescaped, '<\\!--', '<!--');
+    unescaped = replaceAll(unescaped, '<\\script', '<script');
+    unescaped = replaceAll(unescaped, '<\\/script', '</script');
+    return unescaped;
+};

--- a/packages/frontend/web/server/htmlTemplate.ts
+++ b/packages/frontend/web/server/htmlTemplate.ts
@@ -3,8 +3,6 @@ import { getFontsCss } from '@frontend/lib/fonts-css';
 import { getStatic } from '@frontend/lib/assets';
 import { prepareCmpString } from '@frontend/web/browser/prepareCmp';
 
-import { WindowGuardian } from '@frontend/model/window-guardian';
-
 export const htmlTemplate = ({
     title = 'The Guardian',
     description,
@@ -25,7 +23,7 @@ export const htmlTemplate = ({
     css: string;
     html: string;
     fontFiles?: string[];
-    windowGuardian: WindowGuardian;
+    windowGuardian: string;
     ampLink?: string;
 }) => {
     const favicon =
@@ -67,7 +65,7 @@ export const htmlTemplate = ({
                 ${fontPreloadTags.join('\n')}
 
                 <script>
-                    window.guardian = ${JSON.stringify(windowGuardian)};
+                    window.guardian = ${windowGuardian};
                     window.guardian.queue = []; // Queue for functions to be fired by polyfill.io callback
                 </script>
 


### PR DESCRIPTION
## What does this change?
This PR fixes the Lewis problem where a large portion of `window.guardian` was being printed to the page. The elements data for this article contained a html string that included a closing script tag, this tag terminated the containing script tag that the string existed inside too early, corrupting the page.

The solution given here is to escape the string before it is placed on the page. And then unescape it when used inside `dangerouslySetInnerHtml()`

### The 'Lewis' article that triggered the problem
http://localhost:3030/Article?url=https://www.theguardian.com/music/2019/oct/10/lewis-capaldi-theyre-screaming-americas-sweetheart-at-me-its-wild

## Relevant section of the W3 specification
https://www.w3.org/TR/html52/semantics-scripting.html#restrictions-for-contents-of-script-elements

## Question
Should this escape code live at '@frontend/web/server/escapeData'? I didn't see an obvious one but could be maybe have a `/lib` folder somewhere higher up?



