### PR TITLE
Add `useApi` call to ShareCount

### DIFF
--- a/packages/frontend/web/components/ShareCount.test.tsx
+++ b/packages/frontend/web/components/ShareCount.test.tsx
@@ -1,24 +1,17 @@
 import React from 'react';
-import { render, wait, waitForElement } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { ShareCount } from './ShareCount';
 import { CAPI } from '@root/fixtures/CAPI';
 
-const fetchResult: (
-    shareCount: number,
-) => {
-    ok: boolean;
-    json: () => {
-        share_count: number;
-    };
-} = shareCount => ({
-    ok: true,
-    json: () => ({
-        share_count: shareCount,
-    }),
-});
+import { useApi as useApi_ } from '@frontend/web/components/lib/api';
+
+const useApi: any = useApi_;
+
+jest.mock('@frontend/web/components/lib/api', () => ({
+    useApi: jest.fn(),
+}));
 
 describe('ShareCount', () => {
-    const globalAny: any = global;
     const config: ConfigType = {
         ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
         sentryHost: '',
@@ -36,47 +29,67 @@ describe('ShareCount', () => {
         adUnit: '/59666047/theguardian.com/film/article/ng',
     };
 
-    afterEach(() => {
-        const { pageId } = CAPI;
-        const { ajaxUrl } = config;
+    const { pageId } = CAPI;
+    const { ajaxUrl } = config;
 
-        expect(globalAny.fetch).toHaveBeenCalledWith(
-            `${ajaxUrl}/sharecount/${pageId}.json`,
-        );
+    beforeEach(() => {
+        useApi.mockReset();
     });
 
-    it('It should render null if state.shareCount is falsy', async () => {
-        globalAny.fetch = jest.fn(async () => fetchResult(0));
+    it('It should render null if share_count is falsy', () => {
+        useApi.mockReturnValue({ data: { share_count: 0 } });
 
         const { container } = render(
             <ShareCount config={config} pageId={CAPI.pageId} />,
         );
 
-        await wait(() => expect(container.firstChild).toBeNull());
+        expect(useApi).toHaveBeenCalledWith(
+            `${ajaxUrl}/sharecount/${pageId}.json`,
+        );
+
+        expect(container.firstChild).toBeNull();
     });
 
-    it('It should render if state.shareCount is truthy', async () => {
-        globalAny.fetch = jest.fn(async () => fetchResult(100));
+    it('It should render null if there is an error', () => {
+        useApi.mockReturnValue({ error: { message: 'Bad' } });
+
+        const { container } = render(
+            <ShareCount config={config} pageId={CAPI.pageId} />,
+        );
+
+        expect(useApi).toHaveBeenCalledWith(
+            `${ajaxUrl}/sharecount/${pageId}.json`,
+        );
+
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('It should render if share_count is truthy', () => {
+        useApi.mockReturnValue({ data: { share_count: 100 } });
 
         const { container, getByTestId } = render(
             <ShareCount config={config} pageId={CAPI.pageId} />,
         );
 
-        await waitForElement(() => getByTestId('countFull'));
+        expect(useApi).toHaveBeenCalledWith(
+            `${ajaxUrl}/sharecount/${pageId}.json`,
+        );
 
         expect(container.firstChild).not.toBeNull();
         expect(getByTestId('countFull').innerHTML).toBe('100');
         expect(getByTestId('countShort').innerHTML).toBe('100');
     });
 
-    it('It should format long shareCount correctly', async () => {
-        globalAny.fetch = jest.fn(async () => fetchResult(25000));
+    it('It should format long shareCount correctly', () => {
+        useApi.mockReturnValue({ data: { share_count: 25000 } });
 
         const { container, getByTestId } = render(
             <ShareCount config={config} pageId={CAPI.pageId} />,
         );
 
-        await waitForElement(() => getByTestId('countFull'));
+        expect(useApi).toHaveBeenCalledWith(
+            `${ajaxUrl}/sharecount/${pageId}.json`,
+        );
 
         expect(container.firstChild).not.toBeNull();
         expect(getByTestId('countFull').innerHTML).toBe('25,000');

--- a/packages/frontend/web/components/ShareCount.tsx
+++ b/packages/frontend/web/components/ShareCount.tsx
@@ -87,6 +87,8 @@ export const ShareCount = ({ config, pageId }: Props) => {
             },
             true,
         );
+
+        return null;
     }
 
     if (!data || !data.share_count) {

--- a/packages/frontend/web/components/ShareCount.tsx
+++ b/packages/frontend/web/components/ShareCount.tsx
@@ -1,10 +1,11 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { css } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
 import ShareIcon from '@guardian/pasteup/icons/share.svg';
 import { textSans } from '@guardian/pasteup/typography';
 import { from, wide, leftCol } from '@guardian/pasteup/breakpoints';
 import { integerCommas } from '@frontend/lib/formatters';
+import { useApi } from '@frontend/web/components/lib/api';
 
 const shareCount = css`
     ${textSans(6)};
@@ -65,75 +66,61 @@ interface Props {
     pageId: string;
 }
 
-export class ShareCount extends Component<Props, { shareCount?: number }> {
-    constructor(props: Props) {
-        super(props);
-        this.state = {};
-    }
+interface ShareCountType {
+    path: string;
+    share_count: number;
+    refreshStatus: boolean;
+}
+function buildUrl(ajaxUrl: string, pageId: string) {
+    return `${ajaxUrl}/sharecount/${pageId}.json`;
+}
 
-    public componentDidMount() {
-        const { config, pageId } = this.props;
-        const url = `${config.ajaxUrl}/sharecount/${pageId}.json`;
+export const ShareCount = ({ config, pageId }: Props) => {
+    const url = buildUrl(config.ajaxUrl, pageId);
+    const { data, error } = useApi<ShareCountType>(url);
 
-        fetch(url)
-            .then(resp => {
-                if (resp.ok) {
-                    return resp.json();
-                }
-            })
-            .then(data => {
-                this.setState({
-                    shareCount: data.share_count,
-                });
-            })
-            .catch(err => {
-                // window.guardian.modules.raven.reportError(
-                //     err,
-                //     {
-                //         feature: 'share-count',
-                //     },
-                //     true,
-                // );
-            });
-    }
-
-    public render() {
-        if (!this.state.shareCount) {
-            return null;
-        }
-
-        const displayCount = parseInt(this.state.shareCount.toFixed(0), 10);
-        const formattedDisplayCount = integerCommas(displayCount);
-        const shortDisplayCount =
-            displayCount > 10000
-                ? `${Math.round(displayCount / 1000)}k`
-                : displayCount;
-
-        return (
-            <div
-                className={shareCount}
-                aria-label={`${shortDisplayCount} Shares`}
-            >
-                <div className={shareCountContainer}>
-                    <div className={shareCountHeader}>
-                        <ShareIcon className={shareCountIcon} />
-                    </div>
-                    <div
-                        data-testid={'countFull'}
-                        className={countFull}
-                        aria-hidden="true"
-                    >
-                        {formattedDisplayCount}
-                    </div>
-                    <div
-                        data-testid={'countShort'}
-                        className={countShort}
-                        aria-hidden="true"
-                    >
-                        {shortDisplayCount}
-                    </div>
-                </div>
-            </div>
+    if (error) {
+        window.guardian.modules.raven.reportError(
+            error,
+            {
+                feature: 'share-count',
+            },
+            true,
         );
     }
-}
+
+    if (!data || !data.share_count) {
+        return null;
+    }
+
+    const displayCount = parseInt(data.share_count.toFixed(0), 10);
+    const formattedDisplayCount = integerCommas(displayCount);
+    const shortDisplayCount =
+        displayCount > 10000
+            ? `${Math.round(displayCount / 1000)}k`
+            : displayCount;
+
+    return (
+        <div className={shareCount} aria-label={`${shortDisplayCount} Shares`}>
+            <div className={shareCountContainer}>
+                <div className={shareCountHeader}>
+                    <ShareIcon className={shareCountIcon} />
+                </div>
+                <div
+                    data-testid={'countFull'}
+                    className={countFull}
+                    aria-hidden="true"
+                >
+                    {formattedDisplayCount}
+                </div>
+                <div
+                    data-testid={'countShort'}
+                    className={countShort}
+                    aria-hidden="true"
+                >
+                    {shortDisplayCount}
+                </div>
+            </div>
+        </div>
+    );
+};


### PR DESCRIPTION
## What does this change?
Brings the ShareCount component inline with the other components that call the api by adding the `useApi` method and converting it into a functional component.

## Why?
For consistency and centralisation of fetch logic

## Link to supporting Trello card
https://trello.com/c/Z03z5QtW/761-100-coverage-for-centralised-fetch-api-module
