### PR TITLE
Refactor components using @root and direct import paths

### DIFF
--- a/packages/frontend/amp/components/Footer.tsx
+++ b/packages/frontend/amp/components/Footer.tsx
@@ -9,7 +9,7 @@ import {
     LinkPlatform,
     isOnPlatform,
 } from '@frontend/lib/footer-links';
-import { ReaderRevenueButton } from '@root/packages/frontend/amp/components/ReaderRevenueButton';
+import { ReaderRevenueButton } from '@frontend/amp/components/ReaderRevenueButton';
 
 const footer = css`
     background-color: ${palette.brand.main};

--- a/packages/frontend/amp/components/Header.tsx
+++ b/packages/frontend/amp/components/Header.tsx
@@ -3,9 +3,9 @@ import { css, cx } from 'emotion';
 import Logo from '@guardian/pasteup/logos/the-guardian.svg';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';
 import { headline } from '@guardian/pasteup/typography';
-import { pillarPalette } from '../../lib/pillars';
+import { pillarPalette } from '@frontend/lib/pillars';
 import { palette, mobileLandscape, until } from '@guardian/src-foundations';
-import { ReaderRevenueButton } from '@root/packages/frontend/amp/components/ReaderRevenueButton';
+import { ReaderRevenueButton } from '@frontend/amp/components/ReaderRevenueButton';
 
 const headerStyles = css`
     background-color: ${palette.brand.main};


### PR DESCRIPTION
## What does this change?

Standardises some imports that use ```@root``` or a direct import where they could have used ```@frontend ```

## Why?

Standardisation, fixing lint warnings.

## Link to supporting Trello card

https://trello.com/c/rqv3fChq/751-fix-some-of-the-component-lint-warnings-in-dcr
