### PR TITLE
Move sharing urls into lib

### DIFF
--- a/packages/frontend/amp/components/BodyArticle.tsx
+++ b/packages/frontend/amp/components/BodyArticle.tsx
@@ -10,7 +10,7 @@ import { pillarPalette } from '@frontend/lib/pillars';
 import { palette, until } from '@guardian/src-foundations';
 import { WithAds } from '@frontend/amp/components/WithAds';
 import { findAdSlots } from '@frontend/amp/lib/find-adslots';
-import { getSharingUrls } from '@frontend/model/sharing-urls';
+import { getSharingUrls } from '@frontend/lib/sharing-urls';
 
 const body = (pillar: Pillar, designType: DesignType) => {
     const defaultStyles: DesignTypesObj = designTypeDefault(

--- a/packages/frontend/amp/components/BodyLiveblog.tsx
+++ b/packages/frontend/amp/components/BodyLiveblog.tsx
@@ -10,7 +10,7 @@ import { Blocks } from '@frontend/amp/components/Blocks';
 import RefreshIcon from '@guardian/pasteup/icons/refresh.svg';
 import { Pagination } from '@frontend/amp/components/Pagination';
 import { headline, textSans } from '@guardian/pasteup/typography';
-import { getSharingUrls } from '@frontend/model/sharing-urls';
+import { getSharingUrls } from '@frontend/lib/sharing-urls';
 
 // TODO check if liveblog background colours are more complex - like regular
 // article is

--- a/packages/frontend/amp/components/topMeta/TopMetaLiveblog.tsx
+++ b/packages/frontend/amp/components/topMeta/TopMetaLiveblog.tsx
@@ -9,7 +9,7 @@ import { Byline } from '@frontend/amp/components/topMeta/Byline';
 import { string as curly } from 'curlyquotes';
 import { TopMetaExtras } from '@frontend/amp/components/topMeta/TopMetaExtras';
 import { ListStyle } from '@frontend/amp/components/elements/Text';
-import { getSharingUrls } from '@frontend/model/sharing-urls';
+import { getSharingUrls } from '@frontend/lib/sharing-urls';
 import { getAgeWarning } from '@frontend/model/age-warning';
 
 const headerStyle = (pillar: Pillar) => css`

--- a/packages/frontend/amp/components/topMeta/TopMetaNews.tsx
+++ b/packages/frontend/amp/components/topMeta/TopMetaNews.tsx
@@ -10,7 +10,7 @@ import { string as curly } from 'curlyquotes';
 import { TopMetaExtras } from '@frontend/amp/components/topMeta/TopMetaExtras';
 import { Standfirst } from '@frontend/amp/components/topMeta/Standfirst';
 import { SeriesLink } from '@frontend/amp/components/topMeta/SeriesLink';
-import { getSharingUrls } from '@frontend/model/sharing-urls';
+import { getSharingUrls } from '@frontend/lib/sharing-urls';
 import { getAgeWarning } from '@frontend/model/age-warning';
 import { Branding } from '@frontend/amp/components/topMeta/Branding';
 import { StarRating } from '../StarRating';

--- a/packages/frontend/amp/components/topMeta/TopMetaOpinion.tsx
+++ b/packages/frontend/amp/components/topMeta/TopMetaOpinion.tsx
@@ -9,7 +9,7 @@ import { Byline } from '@frontend/amp/components/topMeta/Byline';
 import { TopMetaExtras } from '@frontend/amp/components/topMeta/TopMetaExtras';
 import { Standfirst } from '@frontend/amp/components/topMeta/Standfirst';
 import { SeriesLink } from '@frontend/amp/components/topMeta/SeriesLink';
-import { getSharingUrls } from '@frontend/model/sharing-urls';
+import { getSharingUrls } from '@frontend/lib/sharing-urls';
 import { getAgeWarning } from '@frontend/model/age-warning';
 import { Branding } from '@frontend/amp/components/topMeta/Branding';
 

--- a/packages/frontend/amp/components/topMeta/TopMetaPaidContent.tsx
+++ b/packages/frontend/amp/components/topMeta/TopMetaPaidContent.tsx
@@ -10,7 +10,7 @@ import { PaidForBand } from '@frontend/amp/components/topMeta/PaidForBand';
 
 import { palette } from '@guardian/src-foundations';
 import { textSans, body } from '@guardian/pasteup/typography';
-import { getSharingUrls } from '@frontend/model/sharing-urls';
+import { getSharingUrls } from '@frontend/lib/sharing-urls';
 import { getAgeWarning } from '@frontend/model/age-warning';
 
 const headerStyle = css`

--- a/packages/frontend/lib/sharing-urls.ts
+++ b/packages/frontend/lib/sharing-urls.ts
@@ -12,7 +12,6 @@ const appendParamsToBaseUrl: (
         )}=${encodeURIComponent(params[param])}`;
     }, baseUrl);
 
-// TODO move to ./lib
 export const getSharingUrls = (
     pageId: string,
     title: string,

--- a/packages/frontend/web/components/ArticleBody.tsx
+++ b/packages/frontend/web/components/ArticleBody.tsx
@@ -8,7 +8,7 @@ import { from, tablet } from '@guardian/pasteup/breakpoints';
 import { headline, textSans } from '@guardian/pasteup/typography';
 import { pillarMap, pillarPalette } from '@frontend/lib/pillars';
 import { ArticleRenderer } from '@frontend/web/components/lib/ArticleRenderer';
-import { getSharingUrls } from '@frontend/model/sharing-urls';
+import { getSharingUrls } from '@frontend/lib/sharing-urls';
 
 import { SharingIcons } from './ShareIcons';
 import { SubMetaLinksList } from './SubMetaLinksList';

--- a/packages/frontend/web/components/ArticleHeader.tsx
+++ b/packages/frontend/web/components/ArticleHeader.tsx
@@ -8,7 +8,7 @@ import { getAgeWarning } from '@frontend/model/age-warning';
 import { pillarMap, pillarPalette } from '@frontend/lib/pillars';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';
 import { headline, textSans, body } from '@guardian/pasteup/typography';
-import { getSharingUrls } from '@frontend/model/sharing-urls';
+import { getSharingUrls } from '@frontend/lib/sharing-urls';
 import {
     from,
     until,


### PR DESCRIPTION
## What does this change?

moves the sharing-urls utility into frontend/lib from frontend/models

## Why?

models should be used for utilities to parse data from capi. This code doesn't belong in there, and many components use it as a library, so we're putting it into lib. @nicl had a code comment in the file already that this should be done at some point.

Fixes some lint warnings as a side  effect.

## Link to supporting Trello card
