### PR TITLE
Fix lint warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,8 +26,8 @@ module.exports = {
                     "@frontend/lib/",
                     "@frontend/amp/lib/",
                     "@testing-library",
-                    "@root/packages/frontend/amp/lib/",
-                    "@guardian/src-foundations"
+                    "@guardian/src-foundations",
+                    "@guardian/guui/components"
                 ]
             }
         ]

--- a/packages/frontend/amp/components/elements/Subheading.tsx
+++ b/packages/frontend/amp/components/elements/Subheading.tsx
@@ -3,7 +3,7 @@ import { css, cx } from 'emotion';
 import { palette } from '@guardian/src-foundations';
 import { headline, textSans } from '@guardian/pasteup/typography';
 import { pillarPalette } from '@frontend/lib/pillars';
-import { composeLabsCSS } from '@root/packages/frontend/amp/lib/compose-labs-css';
+import { composeLabsCSS } from '@frontend/amp/lib/compose-labs-css';
 
 // tslint:disable:react-no-dangerous-html
 const style = (pillar: Pillar) => css`

--- a/packages/frontend/amp/components/elements/Text.tsx
+++ b/packages/frontend/amp/components/elements/Text.tsx
@@ -4,7 +4,7 @@ import { palette } from '@guardian/src-foundations';
 import { pillarPalette } from '@frontend/lib/pillars';
 import { sanitise } from '@frontend/amp/lib/sanitise-html';
 import { body, textSans } from '@guardian/pasteup/typography';
-import { composeLabsCSS } from '@root/packages/frontend/amp/lib/compose-labs-css';
+import { composeLabsCSS } from '@frontend/amp/lib/compose-labs-css';
 
 // Note, this should only apply basic text styling. It is a case where we want
 // to re-use styling, but generally we should avoid this as it couples

--- a/packages/frontend/amp/components/topMeta/TopMetaNews.tsx
+++ b/packages/frontend/amp/components/topMeta/TopMetaNews.tsx
@@ -13,7 +13,7 @@ import { SeriesLink } from '@frontend/amp/components/topMeta/SeriesLink';
 import { getSharingUrls } from '@frontend/lib/sharing-urls';
 import { getAgeWarning } from '@frontend/lib/age-warning';
 import { Branding } from '@frontend/amp/components/topMeta/Branding';
-import { StarRating } from '../StarRating';
+import { StarRating } from '@frontend/amp/components/StarRating';
 
 const headerStyle = css`
     ${headline(5)};


### PR DESCRIPTION
## What does this change?

* **Removed** ```@root/packages/frontend/amp/lib/``` as a valid import for DCR components because it's just a duplicate of ```@frontend/amp/lib/```
* **Adds** ```@guardian/guui/components``` as a valid import import for DCR components because these seem to be common/reusable components so they are a valid library
* Refactors a few more files that were using ```@root``` or ```../``` where they could be using ```@frontend```

## Why?

Standardisation, fixes lint warnings

## Link to supporting Trello card
