### PR TITLE
Extract ArticleModel interface into own file

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,7 @@ module.exports = {
                     '@frontend/amp/lib/',
                     '@testing-library',
                     '@guardian/frontend/static/',
+                    "@guardian/guui/components"
                 ],
             },
         ],

--- a/packages/frontend/amp/components/BodyArticle.tsx
+++ b/packages/frontend/amp/components/BodyArticle.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { InnerContainer } from '@frontend/amp/components/InnerContainer';
 import { Elements } from '@frontend/amp/components/Elements';
 import { css } from 'emotion';
-import { ArticleModel } from '@frontend/amp/pages/Article';
+import { ArticleModel } from '@frontend/amp/types/ArticleModel';
 import { TopMeta } from '@frontend/amp/components/topMeta/TopMeta';
 import { SubMeta } from '@frontend/amp/components/SubMeta';
 import { designTypeDefault } from '@frontend/lib/designTypes';

--- a/packages/frontend/amp/components/BodyLiveblog.tsx
+++ b/packages/frontend/amp/components/BodyLiveblog.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { InnerContainer } from '@frontend/amp/components/InnerContainer';
 import { css } from 'emotion';
-import { ArticleModel } from '@frontend/amp/pages/Article';
+import { ArticleModel } from '@frontend/amp/types/ArticleModel';
 import { TopMetaLiveblog } from '@frontend/amp/components/topMeta/TopMetaLiveblog';
 import { SubMeta } from '@frontend/amp/components/SubMeta';
 import { palette, headline, textSans } from '@guardian/src-foundations';

--- a/packages/frontend/amp/components/topMeta/TopMeta.tsx
+++ b/packages/frontend/amp/components/topMeta/TopMeta.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ArticleModel } from '@frontend/amp/pages/Article';
+import { ArticleModel } from '@frontend/amp/types/ArticleModel';
 import { TopMetaNews } from '@frontend/amp/components/topMeta/TopMetaNews';
 import { TopMetaOpinion } from '@frontend/amp/components/topMeta/TopMetaOpinion';
 import { TopMetaPaidContent } from '@frontend/amp/components/topMeta/TopMetaPaidContent';

--- a/packages/frontend/amp/components/topMeta/TopMetaLiveblog.tsx
+++ b/packages/frontend/amp/components/topMeta/TopMetaLiveblog.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { headline, palette } from '@guardian/src-foundations';
 import { css } from 'emotion';
 import { pillarPalette } from '@frontend/lib/pillars';
-import { ArticleModel } from '@frontend/amp/pages/Article';
+import { ArticleModel } from '@frontend/amp/types/ArticleModel';
 import { MainMedia } from '@frontend/amp/components/MainMedia';
 import { Byline } from '@frontend/amp/components/topMeta/Byline';
 import { string as curly } from 'curlyquotes';

--- a/packages/frontend/amp/components/topMeta/TopMetaNews.tsx
+++ b/packages/frontend/amp/components/topMeta/TopMetaNews.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css, cx } from 'emotion';
 import { palette, headline } from '@guardian/src-foundations';
 import { pillarPalette } from '@frontend/lib/pillars';
-import { ArticleModel } from '@frontend/amp/pages/Article';
+import { ArticleModel } from '@frontend/amp/types/ArticleModel';
 import { MainMedia } from '@frontend/amp/components/MainMedia';
 import { Byline } from '@frontend/amp/components/topMeta/Byline';
 import { string as curly } from 'curlyquotes';

--- a/packages/frontend/amp/components/topMeta/TopMetaOpinion.tsx
+++ b/packages/frontend/amp/components/topMeta/TopMetaOpinion.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { headline, palette } from '@guardian/src-foundations';
 import { css, cx } from 'emotion';
 import { pillarPalette } from '@frontend/lib/pillars';
-import { ArticleModel } from '@frontend/amp/pages/Article';
+import { ArticleModel } from '@frontend/amp/types/ArticleModel';
 import { MainMedia } from '@frontend/amp/components/MainMedia';
 import { Byline } from '@frontend/amp/components/topMeta/Byline';
 import { TopMetaExtras } from '@frontend/amp/components/topMeta/TopMetaExtras';

--- a/packages/frontend/amp/components/topMeta/TopMetaPaidContent.tsx
+++ b/packages/frontend/amp/components/topMeta/TopMetaPaidContent.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 
-import { ArticleModel } from '@frontend/amp/pages/Article';
+import { ArticleModel } from '@frontend/amp/types/ArticleModel';
 import { MainMedia } from '@frontend/amp/components/MainMedia';
 import { Byline } from '@frontend/amp/components/topMeta/Byline';
 import { TopMetaExtras } from '@frontend/amp/components/topMeta/TopMetaExtras';

--- a/packages/frontend/amp/pages/Article.tsx
+++ b/packages/frontend/amp/pages/Article.tsx
@@ -13,43 +13,11 @@ import { filterForTagsOfType } from '@frontend/amp/lib/tag-utils';
 import { AdUserSync } from '@root/packages/frontend/amp/components/AdUserSync';
 import { getPillar } from '@frontend/lib/pillars';
 import { palette } from '@guardian/src-foundations';
+import { ArticleModel } from '@frontend/amp/types/ArticleModel';
 
 const backgroundColour = css`
     background-color: ${palette.neutral[97]};
 `;
-
-export interface ArticleModel {
-    headline: string;
-    standfirst: string;
-    webTitle: string;
-    mainMediaElements: CAPIElement[];
-    keyEvents: Block[]; // liveblog-specific
-    pagination?: Pagination;
-    blocks: Block[];
-    author: AuthorType;
-    webPublicationDate: string;
-    webPublicationDateDisplay: string;
-    pageId: string;
-    pillar: Pillar;
-    sectionLabel?: string;
-    sectionUrl?: string;
-    sectionName?: string;
-    tags: TagType[];
-    subMetaSectionLinks: SimpleLinkType[];
-    subMetaKeywordLinks: SimpleLinkType[];
-    webURL: string;
-    shouldHideAds: boolean;
-    guardianBaseURL: string;
-    hasRelated: boolean;
-    hasStoryPackage: boolean;
-    isCommentable: boolean;
-    editionId: Edition;
-    contentType: string;
-    commercialProperties: CommercialProperties;
-    isImmersive: boolean;
-    starRating?: number;
-    designType: DesignType;
-}
 
 const Body: React.SFC<{
     data: ArticleModel;

--- a/packages/frontend/amp/types/ArticleModel.tsx
+++ b/packages/frontend/amp/types/ArticleModel.tsx
@@ -1,0 +1,32 @@
+export interface ArticleModel {
+    headline: string;
+    standfirst: string;
+    webTitle: string;
+    mainMediaElements: CAPIElement[];
+    keyEvents: Block[]; // liveblog-specific
+    pagination?: Pagination;
+    blocks: Block[];
+    author: AuthorType;
+    webPublicationDate: string;
+    webPublicationDateDisplay: string;
+    pageId: string;
+    pillar: Pillar;
+    sectionLabel?: string;
+    sectionUrl?: string;
+    sectionName?: string;
+    tags: TagType[];
+    subMetaSectionLinks: SimpleLinkType[];
+    subMetaKeywordLinks: SimpleLinkType[];
+    webURL: string;
+    shouldHideAds: boolean;
+    guardianBaseURL: string;
+    hasRelated: boolean;
+    hasStoryPackage: boolean;
+    isCommentable: boolean;
+    editionId: Edition;
+    contentType: string;
+    commercialProperties: CommercialProperties;
+    isImmersive: boolean;
+    starRating?: number;
+    designType: DesignType;
+}


### PR DESCRIPTION
## What does this change?

Refactors the definition of ArticleModel out of ```Article.tsx``` and into it's own file at ```amp/types/ArticleModel.tsx```. the ```amp/types``` package is introduced in this pr

## Why?

We want to move ArticleModel interface out of this file, because it's used as an import in a bunch of components, and components having to import the page probably isn't quite right. Doing this will also fix a sizeable chunk of our lint warnings.

*It's an open question as to where the most appropriate place for this interface actually is however*. 

Two existing options are to pull it into the ```index.d.ts``` definitions, and another option is to bring it into the ```amp/lib``` package. I do not like the former option because I'd prefer these types to be tightly scoped to the amp package. And I don't like the latter because this isn't library code, it is a type. 

Thus, I have tentatively introduced the ```amp/types``` package. I'm not a client side dev so many people may disagree with me here!

### prior art

I thought I'd look around and find some prior art as well, so I looked at the past months top trending typescript repos on github to see how they handle it.

* [vscode uses a typings directory](https://github.com/microsoft/vscode/tree/master/src/typings)

* [angular has types.ts under packages](https://github.com/angular/angular/tree/f6e88cd65945d8abead74d322caf0d93b9743062/packages/language-service/src)

* [Graphana has a types directory](https://github.com/grafana/grafana/tree/3c61b563c3e51caf0d0b6334bf5ab06d746dfe1a/public/app/types)

* [Nestjs has an interfaces directory](https://github.com/nestjs/nest/tree/6fc41cab7212dbc5c2527b4d1d127693e3ec93f9/packages/common/interfaces)


## Link to supporting Trello card
