### PR TITLE
Productionise percy

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,6 @@
 {
     "viewportWidth": 1500,
     "viewportHeight": 860,
-    "baseUrl": "http://localhost:3030/"
+    "baseUrl": "http://localhost:3030/",
+    "video": false
 }

--- a/cypress.json
+++ b/cypress.json
@@ -1,1 +1,4 @@
-{}
+{
+    "viewportWidth": 1500,
+    "viewportHeight": 860
+}

--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,5 @@
 {
     "viewportWidth": 1500,
-    "viewportHeight": 860
+    "viewportHeight": 860,
+    "baseUrl": "http://localhost:3030/"
 }

--- a/cypress/fixtures/mostRead.json
+++ b/cypress/fixtures/mostRead.json
@@ -4,7 +4,7 @@
         "trails": [
             {
                 "url": "https://www.theguardian.com/politics/live/2019/oct/16/brexit-boris-johnson-races-the-clock-as-deadline-for-deal-looms-politics-live",
-                "linkText": "Brexshit: Irish PM hints extra EU summit  might be needed because 'many issues' still to be resolved– live news",
+                "linkText": "Brexit: Irish PM hints extra EU summit  might be needed because 'many issues' still to be resolved– live news",
                 "showByline": false,
                 "byline": "Andrew Sparrow (now);  Sarah Marsh and Kate Lyons (earlier)",
                 "image": "https://i.guim.co.uk/img/media/2623bdff1d63a85d76c8a86231b0dbeda59649c4/87_0_3325_1996/master/3325.jpg?width=300&quality=85&auto=format&fit=max&s=a0881e9682459be5acf622916ce20f29",

--- a/cypress/fixtures/mostRead.json
+++ b/cypress/fixtures/mostRead.json
@@ -1,0 +1,192 @@
+[
+    {
+        "heading": "Across The&nbsp;Guardian",
+        "trails": [
+            {
+                "url": "https://www.theguardian.com/politics/live/2019/oct/16/brexit-boris-johnson-races-the-clock-as-deadline-for-deal-looms-politics-live",
+                "linkText": "Brexshit: Irish PM hints extra EU summit  might be needed because 'many issues' still to be resolved– live news",
+                "showByline": false,
+                "byline": "Andrew Sparrow (now);  Sarah Marsh and Kate Lyons (earlier)",
+                "image": "https://i.guim.co.uk/img/media/2623bdff1d63a85d76c8a86231b0dbeda59649c4/87_0_3325_1996/master/3325.jpg?width=300&quality=85&auto=format&fit=max&s=a0881e9682459be5acf622916ce20f29",
+                "isLiveBlog": true,
+                "pillar": "news"
+            },
+            {
+                "url": "https://www.theguardian.com/us-news/2019/oct/15/harry-dunn-parents-trump-white-house-anne-sacoolas",
+                "linkText": "Harry Dunn parents: Trump shocked us by revealing Sacoolas was in next room",
+                "showByline": false,
+                "byline": "David Smith in Washington",
+                "image": "https://i.guim.co.uk/img/media/e7636de4a7f92973965f780869ab51a653ce0f6c/0_0_5010_3007/master/5010.jpg?width=300&quality=85&auto=format&fit=max&s=e2f72ae40f776ebbfce3a2dfb8bab428",
+                "isLiveBlog": false,
+                "pillar": "news"
+            },
+            {
+                "url": "https://www.theguardian.com/politics/2019/oct/16/brexit-talks-continue-after-boris-johnson-makes-concessions-on-irish-border",
+                "linkText": "Brexit talks continue after Boris Johnson makes concessions on Irish border",
+                "showByline": false,
+                "byline": "Daniel Boffey in Brussels",
+                "image": "https://i.guim.co.uk/img/media/937596849031d67dea0dd34e8043b5ecf139c3cf/0_76_2117_1270/master/2117.jpg?width=300&quality=85&auto=format&fit=max&s=bbfcb659e272cfc6a2a6b8d3088abc75",
+                "isLiveBlog": false,
+                "pillar": "news"
+            },
+            {
+                "url": "https://www.theguardian.com/education/2019/oct/16/oxford-professor-dirk-obbink-ancient-bible-fragments-hobby-lobby",
+                "linkText": "Oxford professor accused of selling ancient Bible fragments",
+                "showByline": false,
+                "byline": "Peter Beaumont",
+                "image": "https://i.guim.co.uk/img/media/4f578aaef55d9adb75bc8d9d18d48f2a6f96556e/0_67_5413_3248/master/5413.jpg?width=300&quality=85&auto=format&fit=max&s=26b0dcc7213c5bf95f17ef6977388518",
+                "isLiveBlog": false,
+                "pillar": "news"
+            },
+            {
+                "url": "https://www.theguardian.com/us-news/2019/oct/15/democratic-debate-joe-biden-elizabeth-warren-bernie-sanders",
+                "linkText": "Warren under attack as Democrats spar in largest primary debate in US history",
+                "showByline": false,
+                "byline": "Lauren Gambino in Westerville, Ohio",
+                "image": "https://i.guim.co.uk/img/media/da0fae452159c3de9a13a97b51c55a705db77d2a/174_547_4770_2861/master/4770.jpg?width=300&quality=85&auto=format&fit=max&s=83a4bcad510dee0a6235980e747b535c",
+                "isLiveBlog": false,
+                "pillar": "news"
+            },
+            {
+                "url": "https://www.theguardian.com/politics/2019/oct/15/boris-johnson-close-to-brexit-deal-after-border-concessions",
+                "linkText": "Boris Johnson 'on brink of Brexit deal' after border concessions",
+                "showByline": false,
+                "byline": "Daniel Boffey in Luxembourg Jon Henley in Paris, Lisa O'Carroll and Rowena Mason",
+                "image": "https://i.guim.co.uk/img/media/937596849031d67dea0dd34e8043b5ecf139c3cf/0_96_2117_1270/master/2117.jpg?width=300&quality=85&auto=format&fit=max&s=4b6e623d7242c6b6303667e44525a7f1",
+                "isLiveBlog": false,
+                "pillar": "news"
+            },
+            {
+                "url": "https://www.theguardian.com/world/2019/oct/15/six-freed-after-years-living-in-dutch-cellar-waiting-for-end-of-time",
+                "linkText": "Six freed after years living in Dutch cellar 'waiting for end of time'",
+                "showByline": false,
+                "byline": "Jon Henley Europe correspondent",
+                "image": "https://i.guim.co.uk/img/media/d96284ece6ab5f8ea750f91a374a1d90c62367bc/128_0_3736_2242/master/3736.jpg?width=300&quality=85&auto=format&fit=max&s=0d43667605d2336ad82ea6643a919e6d",
+                "isLiveBlog": false,
+                "pillar": "news"
+            },
+            {
+                "url": "https://www.theguardian.com/books/2019/oct/16/me-elton-john-autobiography-review",
+                "linkText": "Me by Elton John review – hilariously self-lacerating",
+                "showByline": false,
+                "byline": "Hadley Freeman",
+                "image": "https://i.guim.co.uk/img/media/a7b7c5de6b16c53c52520ff54d4432787be9caa7/109_0_3281_1969/master/3281.jpg?width=300&quality=85&auto=format&fit=max&s=9e35a9aed3ef36887361a5fec9ef63b2",
+                "isLiveBlog": false,
+                "pillar": "culture"
+            },
+            {
+                "url": "https://www.theguardian.com/us-news/2019/oct/15/twitter-explains-how-it-handles-world-leaders-amid-pressure-to-rein-in-trump",
+                "linkText": "Twitter lays out rules for world leaders amid pressure to rein in Trump",
+                "showByline": false,
+                "byline": "Julia Carrie Wong in San Francisco",
+                "image": "https://i.guim.co.uk/img/media/47977c2eda35081186798f13247ca3352a7df663/0_58_3617_2170/master/3617.jpg?width=300&quality=85&auto=format&fit=max&s=77c0920357a1aa6efc6014e14d23bb71",
+                "isLiveBlog": false,
+                "pillar": "news"
+            },
+            {
+                "url": "https://www.theguardian.com/film/2019/oct/15/jennifer-anistons-instagram-debut-sends-platform-crashing",
+                "linkText": "Jennifer Aniston’s Instagram debut sends platform crashing",
+                "showByline": false,
+                "byline": "Martha Brennan",
+                "image": "https://i.guim.co.uk/img/media/fb8b96b9bac6df0e8992b4016c3baea8831e70fa/0_241_640_384/master/640.jpg?width=300&quality=85&auto=format&fit=max&s=1c704f506904ac8a8ffe300ba79eff46",
+                "isLiveBlog": false,
+                "pillar": "culture"
+            }
+        ]
+    },
+    {
+        "heading": "in UK news",
+        "trails": [
+            {
+                "url": "https://www.theguardian.com/uk-news/2019/oct/15/rise-in-homophobic-attacks-in-birmingham-after-lgbt-teaching-protests",
+                "linkText": "'Rise in homophobic attacks' in Birmingham after LGBT teaching protests",
+                "showByline": false,
+                "byline": "Nazia Parveen",
+                "image": "https://i.guim.co.uk/img/media/e6b385f294bb6fb2d2e5bc2f9ea77c20dda82804/386_279_2746_1648/master/2746.jpg?width=300&quality=85&auto=format&fit=max&s=b2d17b2b3c052f42e2d8d0ca3737f9e4",
+                "isLiveBlog": false,
+                "pillar": "news"
+            },
+            {
+                "url": "https://www.theguardian.com/uk-news/2019/oct/15/uk-family-arrested-in-us-for-inadvertently-crossing-border",
+                "linkText": "UK family arrested in US for 'inadvertently crossing border'",
+                "showByline": false,
+                "byline": "Matthew Weaver",
+                "image": "https://i.guim.co.uk/img/media/72fc8c71fd78e3ecb42a06ae6008965a57d75262/0_79_6000_3600/master/6000.jpg?width=300&quality=85&auto=format&fit=max&s=7173b04013b8e2a31973c05e42406249",
+                "isLiveBlog": false,
+                "pillar": "news"
+            },
+            {
+                "url": "https://www.theguardian.com/uk-news/2019/oct/15/infected-blood-inquiry-hears-evidence-from-woman-who-lost-two-husbands",
+                "linkText": "Infected blood inquiry hears evidence from woman who lost two husbands",
+                "showByline": false,
+                "byline": "Simon Hattenstone",
+                "image": "https://i.guim.co.uk/img/media/222f8ec0e7d30dd9765580bbf3bb9d5010f83cd5/0_343_2400_1440/master/2400.jpg?width=300&quality=85&auto=format&fit=max&s=e3343c0b2dbdc575a97d2cad56cd68fb",
+                "isLiveBlog": false,
+                "pillar": "news"
+            },
+            {
+                "url": "https://www.theguardian.com/uk-news/2019/oct/16/northern-powerhouse-seeks-more-control-of-hs2-rail-scheme",
+                "linkText": "Northern Powerhouse seeks more control of HS2 rail scheme",
+                "showByline": false,
+                "byline": "Gwyn Topham  Transport correspondent",
+                "image": "https://i.guim.co.uk/img/media/10aeb219e009f9c34668824ee1aa89415e2eb4db/0_273_6720_4032/master/6720.jpg?width=300&quality=85&auto=format&fit=max&s=98c3ad0909f16413f4e1c664eefcf524",
+                "isLiveBlog": false,
+                "pillar": "news"
+            },
+            {
+                "url": "https://www.theguardian.com/uk-news/2019/oct/15/red-poppy-used-remember-civilian-victims-for-first-time",
+                "linkText": "Red poppy to be used to remember civilian victims for first time",
+                "showByline": false,
+                "byline": "Robert Booth Social affairs correspondent",
+                "image": "https://i.guim.co.uk/img/media/c4fe99a4b35d0389c6ec9c7aaf4c31bd399369ec/0_196_3000_1800/master/3000.jpg?width=300&quality=85&auto=format&fit=max&s=5439363cb9478990f509024bce8ff424",
+                "isLiveBlog": false,
+                "pillar": "news"
+            },
+            {
+                "url": "https://www.theguardian.com/uk-news/2019/oct/15/i-kissed-woman-to-boost-her-confidence-paul-gascoigne-tells-assault-trial",
+                "linkText": "I kissed woman to boost her confidence, Paul Gascoigne tells assault trial",
+                "showByline": false,
+                "byline": "Josh Halliday North of England correspondent",
+                "image": "https://i.guim.co.uk/img/media/8a8d569ce20e000492d427d02a5df4c15af42bfd/265_22_2832_1700/master/2832.jpg?width=300&quality=85&auto=format&fit=max&s=71b1d21b1524d9d50e0871cbe3c47f79",
+                "isLiveBlog": false,
+                "pillar": "news"
+            },
+            {
+                "url": "https://www.theguardian.com/uk-news/2019/oct/14/paedophile-richard-huckle-found-dead-in-prison",
+                "linkText": "Paedophile Richard Huckle 'murdered' in prison",
+                "showByline": false,
+                "byline": "Haroon Siddique",
+                "image": "https://i.guim.co.uk/img/media/7fd33243e8f3a4a425500ff5f1acf6552b449376/0_717_1596_957/master/1596.jpg?width=300&quality=85&auto=format&fit=max&s=02e09a68290db3246281d6f3e197da51",
+                "isLiveBlog": false,
+                "pillar": "news"
+            },
+            {
+                "url": "https://www.theguardian.com/uk-news/2019/oct/15/home-office-infiltrating-safe-havens-to-deport-rough-sleepers",
+                "linkText": "Home Office 'infiltrating' safe havens to deport rough sleepers",
+                "showByline": false,
+                "byline": "Diane Taylor",
+                "image": "https://i.guim.co.uk/img/media/d92d9a245622672ffbeeb7e0eb01e8340605289c/0_326_5170_3103/master/5170.jpg?width=300&quality=85&auto=format&fit=max&s=f986524939a690e752428117c55cac51",
+                "isLiveBlog": false,
+                "pillar": "news"
+            },
+            {
+                "url": "https://www.theguardian.com/uk-news/2019/oct/13/harry-dunn-anne-sacoolas-driver-who-fled-uk-devastated-by-fatal-crash",
+                "linkText": "Diplomatic immunity no longer applies to Anne Sacoolas, says Foreign Office",
+                "showByline": false,
+                "byline": "Amy Walker",
+                "image": "https://i.guim.co.uk/img/media/d852d107d85aaafe214e0b0b2b23180548e6e00d/0_1137_2169_1300/master/2169.jpg?width=300&quality=85&auto=format&fit=max&s=3454cf37a4eb3f5bad3f14b86948d58b",
+                "isLiveBlog": false,
+                "pillar": "news"
+            },
+            {
+                "url": "https://www.theguardian.com/uk-news/2019/oct/14/snp-women-close-to-quitting-gender-recognition-proposals-trans-rights-scotland",
+                "linkText": "Several women 'close to quitting SNP over gender recognition plans'",
+                "showByline": false,
+                "byline": "Libby Brooks",
+                "image": "https://i.guim.co.uk/img/media/1efb6afd339acbd8863c89faafb043faa5ff7cb4/0_547_2874_1724/master/2874.jpg?width=300&quality=85&auto=format&fit=max&s=6337bc9b481112ce0f348f758b0ddf1f",
+                "isLiveBlog": false,
+                "pillar": "news"
+            }
+        ]
+    }
+]

--- a/cypress/fixtures/richLink.json
+++ b/cypress/fixtures/richLink.json
@@ -1,0 +1,50 @@
+{
+    "tags": [
+        {
+            "id": "football/transfer-window",
+            "type": "Keyword",
+            "title": "Transfer window"
+        },
+        {
+            "id": "football/football",
+            "type": "Keyword",
+            "title": "Football"
+        },
+        {
+            "id": "sport/sport",
+            "type": "Keyword",
+            "title": "Sport"
+        },
+        {
+            "id": "type/interactive",
+            "type": "Type",
+            "title": "Interactive"
+        },
+        {
+            "id": "profile/niall-mcveigh",
+            "type": "Contributor",
+            "title": "Niall McVeigh"
+        },
+        {
+            "id": "profile/marcuschristenson",
+            "type": "Contributor",
+            "title": "Marcus Christenson"
+        },
+        {
+            "id": "profile/garry-blight",
+            "type": "Contributor",
+            "title": "Garry Blight"
+        },
+        {
+            "id": "tracking/commissioningdesk/uk-sport",
+            "type": "Tracking",
+            "title": "UK Sport"
+        }
+    ],
+    "cardStyle": "news",
+    "thumbnailUrl": "https://i.guim.co.uk/img/media/169a4d018cf7d86cbbf9bed80d5215f8dcd8780f/0_10_1008_605/master/1008.jpg?width=460&quality=85&auto=format&fit=max&s=d50247642b8e2fc8f4296de25530ccc9",
+    "headline": "Summer transfer window recap – every deal from Europe's top five leagues",
+    "contentType": "Interactive",
+    "url": "/football/ng-interactive/2019/jun/04/football-transfer-window-2019-every-summer-deal-from-europe-top-five-leagues",
+    "pillar": "sport"
+}

--- a/cypress/fixtures/shareCount.json
+++ b/cypress/fixtures/shareCount.json
@@ -1,0 +1,5 @@
+{
+    "path": "football/2019/jun/04/juventus-interested-paul-pogba-manchester-united",
+    "refreshStatus": true,
+    "share_count": 46
+}

--- a/cypress/integration/article.amp.spec.js
+++ b/cypress/integration/article.amp.spec.js
@@ -1,0 +1,18 @@
+import { getPolyfill } from '../lib/polyfill';
+import { fixTime } from '../lib/time';
+import { visitOptions } from '../lib/config';
+import { AMPArticles } from '../lib/articles.js';
+
+describe('Page rendering', function() {
+    beforeEach(getPolyfill);
+    beforeEach(fixTime);
+
+    it('should load AMP articles', function() {
+        AMPArticles.map((article, index) => {
+            cy.visit(`AMPArticle?url=${article.url}`, visitOptions);
+            cy.percySnapshot(
+                `AMP-${article.pillar}-${article.designType}-${index}`,
+            );
+        });
+    });
+});

--- a/cypress/integration/article.spec.js
+++ b/cypress/integration/article.spec.js
@@ -1,17 +1,31 @@
 import { getPolyfill } from '../lib/polyfill';
 import { visitOptions } from '../lib/config';
-import { articles } from '../lib/articles.js';
+import { articles, AMPArticles } from '../lib/articles.js';
 
 describe('Page rendering', function() {
     beforeEach(getPolyfill);
 
-    it('should load a basic article', function() {
-        articles.map(article => {
+    it('should load WEB articles', function() {
+        articles.map((article, index) => {
             cy.visit(
-                `http://localhost:3030/Article?url=${article.url}#noads`,
+                `http://localhost:3030/Article?url=${article.url}`,
                 visitOptions,
             );
-            cy.percySnapshot();
+            cy.percySnapshot(
+                `WEB-${article.pillar}-${article.designType}-${index}`,
+            );
+        });
+    });
+
+    it('should load AMP articles', function() {
+        AMPArticles.map((article, index) => {
+            cy.visit(
+                `http://localhost:3030/AMPArticle?url=${article.url}`,
+                visitOptions,
+            );
+            cy.percySnapshot(
+                `AMP-${article.pillar}-${article.designType}-${index}`,
+            );
         });
     });
 });

--- a/cypress/integration/article.spec.js
+++ b/cypress/integration/article.spec.js
@@ -9,10 +9,7 @@ describe('Page rendering', function() {
 
     it('should load WEB articles', function() {
         articles.map((article, index) => {
-            cy.visit(
-                `http://localhost:3030/Article?url=${article.url}`,
-                visitOptions,
-            );
+            cy.visit(`Article?url=${article.url}`, visitOptions);
             cy.percySnapshot(
                 `WEB-${article.pillar}-${article.designType}-${index}`,
             );
@@ -21,10 +18,7 @@ describe('Page rendering', function() {
 
     it('should load AMP articles', function() {
         AMPArticles.map((article, index) => {
-            cy.visit(
-                `http://localhost:3030/AMPArticle?url=${article.url}`,
-                visitOptions,
-            );
+            cy.visit(`AMPArticle?url=${article.url}`, visitOptions);
             cy.percySnapshot(
                 `AMP-${article.pillar}-${article.designType}-${index}`,
             );

--- a/cypress/integration/article.spec.js
+++ b/cypress/integration/article.spec.js
@@ -1,9 +1,11 @@
 import { getPolyfill } from '../lib/polyfill';
+import { fixTime } from '../lib/time';
 import { visitOptions } from '../lib/config';
 import { articles, AMPArticles } from '../lib/articles.js';
 
 describe('Page rendering', function() {
     beforeEach(getPolyfill);
+    beforeEach(fixTime);
 
     it('should load WEB articles', function() {
         articles.map((article, index) => {

--- a/cypress/integration/article.spec.js
+++ b/cypress/integration/article.spec.js
@@ -1,9 +1,17 @@
-describe('Page rendering', function() {
-    it('should load a basic article', function() {
-        cy.visit(
-            'http://localhost:3030/Article?url=https://www.theguardian.com/football/2019/jun/04/juventus-interested-paul-pogba-manchester-united',
-        );
+import { getPolyfill } from '../lib/polyfill';
+import { visitOptions } from '../lib/config';
+import { articles } from '../lib/articles.js';
 
-        cy.percySnapshot();
+describe('Page rendering', function() {
+    beforeEach(getPolyfill);
+
+    it('should load a basic article', function() {
+        articles.map(article => {
+            cy.visit(
+                `http://localhost:3030/Article?url=${article.url}#noads`,
+                visitOptions,
+            );
+            cy.percySnapshot();
+        });
     });
 });

--- a/cypress/integration/article.web.spec.js
+++ b/cypress/integration/article.web.spec.js
@@ -1,7 +1,7 @@
 import { getPolyfill } from '../lib/polyfill';
 import { fixTime } from '../lib/time';
 import { visitOptions } from '../lib/config';
-import { articles, AMPArticles } from '../lib/articles.js';
+import { articles } from '../lib/articles.js';
 
 describe('Page rendering', function() {
     beforeEach(getPolyfill);
@@ -12,15 +12,6 @@ describe('Page rendering', function() {
             cy.visit(`Article?url=${article.url}`, visitOptions);
             cy.percySnapshot(
                 `WEB-${article.pillar}-${article.designType}-${index}`,
-            );
-        });
-    });
-
-    it('should load AMP articles', function() {
-        AMPArticles.map((article, index) => {
-            cy.visit(`AMPArticle?url=${article.url}`, visitOptions);
-            cy.percySnapshot(
-                `AMP-${article.pillar}-${article.designType}-${index}`,
             );
         });
     });

--- a/cypress/lib/articles.js
+++ b/cypress/lib/articles.js
@@ -1,0 +1,8 @@
+export const articles = [
+    {
+        url:
+            'https://www.theguardian.com/commentisfree/2019/oct/16/impostor-syndrome-class-unfairness',
+        pillar: 'opinion',
+        designType: 'Comment',
+    },
+];

--- a/cypress/lib/articles.js
+++ b/cypress/lib/articles.js
@@ -5,4 +5,219 @@ export const articles = [
         pillar: 'opinion',
         designType: 'Comment',
     },
+    {
+        url:
+            'https://www.theguardian.com/football/2019/oct/15/thomas-tuchel-interview-neymar-truth-consequences',
+        pillar: 'sport',
+        designType: 'Interview',
+    },
+    {
+        url:
+            'https://www.theguardian.com/media/2019/sep/18/dorothy-byrne-on-calling-boris-johnson-a-liar-nobody-has-said-that-isnt-true',
+        pillar: 'news',
+        designType: 'Interview',
+    },
+    {
+        url:
+            'https://www.theguardian.com/tv-and-radio/2019/oct/16/regina-king-beale-street-watchmen-superhero-hbo-dc-comics-oscar-actor',
+        pillar: 'culture',
+        designType: 'Interview',
+    },
+    {
+        url:
+            'https://www.theguardian.com/football/2019/oct/06/southampton-chelsea-premier-league-match-report',
+        pillar: 'sport',
+        designType: 'MatchReport',
+    },
+    {
+        url:
+            'https://www.theguardian.com/football/2019/apr/13/tottenham-huddersfield-premier-league-match-report',
+        pillar: 'sport',
+        designType: 'MatchReport',
+    },
+    {
+        url:
+            'https://www.theguardian.com/travel/2019/oct/16/car-free-break-cheshire-chester-roman-treasures-industrial-heritage',
+        pillar: 'lifestyle',
+        designType: 'Feature',
+    },
+    {
+        url:
+            'https://www.theguardian.com/travel/2019/oct/12/20-best-alps-ski-resorts-by-train-rail-france-switzerland-austria-italy',
+        pillar: 'lifestyle',
+        designType: 'Immersive',
+    },
+    {
+        url:
+            'https://www.theguardian.com/commentisfree/2019/jan/17/the-guardian-view-on-the-brexit-impasse-extend-article-50-now',
+        pillar: 'opinion',
+        designType: 'GuardianView',
+    },
+    {
+        url:
+            'https://www.theguardian.com/commentisfree/2019/aug/07/the-guardian-view-on-british-foreign-policy-the-lost-art-of-diplomacy',
+        pillar: 'opinion',
+        designType: 'GuardianView',
+    },
+    {
+        url:
+            'https://www.theguardian.com/environment/2019/oct/16/ivory-coast-law-could-see-chocolate-industry-wipe-out-protected-forests',
+        pillar: 'news',
+        designType: 'Article',
+    },
+    {
+        url:
+            'https://www.theguardian.com/food/2019/may/10/anna-jones-chickpea-recipes',
+        pillar: 'lifestyle',
+        designType: 'Recipes',
+    },
+    {
+        url:
+            'https://www.theguardian.com/food/2019/feb/22/seed-recipes-anna-jones-sesame-sunflower-snack-bhaji-raita',
+        pillar: 'lifestyle',
+        designType: 'Recipes',
+    },
+    {
+        url:
+            'https://www.theguardian.com/music/2019/jul/29/chance-the-rapper-the-big-day-review',
+        pillar: 'culture',
+        designType: 'Review',
+    },
+    {
+        url:
+            'https://www.theguardian.com/music/2018/nov/23/laibach-the-sound-of-music-review-glorious-silly-covers-are-bright-as-a-copper-kettle',
+        pillar: 'culture',
+        designType: 'Review',
+    },
+    {
+        url:
+            'https://www.theguardian.com/politics/2019/mar/20/theresa-may-short-brexit-delay-what-happens-next-explainer',
+        pillar: 'news',
+        designType: 'Analysis',
+    },
+    {
+        url:
+            'https://www.theguardian.com/sport/2019/feb/14/hakeem-al-araibi-power-politics-football-and-the-will-of-the-people',
+        pillar: 'sport',
+        designType: 'Analysis',
+    },
+    {
+        url:
+            'https://www.theguardian.com/football/blog/2019/oct/10/iran-women-watching-football-not-enough-world-cup-qualifer-cambodia',
+        pillar: 'sport',
+        designType: 'Comment',
+    },
 ];
+
+export const AMPArticles = [
+    {
+        url:
+            'https://amp.theguardian.com/commentisfree/2019/oct/16/impostor-syndrome-class-unfairness',
+        pillar: 'opinion',
+        designType: 'Comment',
+    },
+    {
+        url:
+            'https://amp.theguardian.com/football/2019/oct/15/thomas-tuchel-interview-neymar-truth-consequences',
+        pillar: 'sport',
+        designType: 'Interview',
+    },
+    {
+        url:
+            'https://amp.theguardian.com/media/2019/sep/18/dorothy-byrne-on-calling-boris-johnson-a-liar-nobody-has-said-that-isnt-true',
+        pillar: 'news',
+        designType: 'Interview',
+    },
+    {
+        url:
+            'https://amp.theguardian.com/tv-and-radio/2019/oct/16/regina-king-beale-street-watchmen-superhero-hbo-dc-comics-oscar-actor',
+        pillar: 'culture',
+        designType: 'Interview',
+    },
+    {
+        url:
+            'https://amp.theguardian.com/football/2019/oct/06/southampton-chelsea-premier-league-match-report',
+        pillar: 'sport',
+        designType: 'MatchReport',
+    },
+    {
+        url:
+            'https://amp.theguardian.com/football/2019/apr/13/tottenham-huddersfield-premier-league-match-report',
+        pillar: 'sport',
+        designType: 'MatchReport',
+    },
+    {
+        url:
+            'https://amp.theguardian.com/travel/2019/oct/16/car-free-break-cheshire-chester-roman-treasures-industrial-heritage',
+        pillar: 'lifestyle',
+        designType: 'Feature',
+    },
+    {
+        url:
+            'https://amp.theguardian.com/travel/2019/oct/12/20-best-alps-ski-resorts-by-train-rail-france-switzerland-austria-italy',
+        pillar: 'lifestyle',
+        designType: 'Immersive',
+    },
+    {
+        url:
+            'https://amp.theguardian.com/commentisfree/2019/jan/17/the-guardian-view-on-the-brexit-impasse-extend-article-50-now',
+        pillar: 'opinion',
+        designType: 'GuardianView',
+    },
+    {
+        url:
+            'https://amp.theguardian.com/commentisfree/2019/aug/07/the-guardian-view-on-british-foreign-policy-the-lost-art-of-diplomacy',
+        pillar: 'opinion',
+        designType: 'GuardianView',
+    },
+    {
+        url:
+            'https://amp.theguardian.com/environment/2019/oct/16/ivory-coast-law-could-see-chocolate-industry-wipe-out-protected-forests',
+        pillar: 'news',
+        designType: 'Article',
+    },
+    {
+        url:
+            'https://amp.theguardian.com/food/2019/may/10/anna-jones-chickpea-recipes',
+        pillar: 'lifestyle',
+        designType: 'Recipes',
+    },
+    {
+        url:
+            'https://amp.theguardian.com/food/2019/feb/22/seed-recipes-anna-jones-sesame-sunflower-snack-bhaji-raita',
+        pillar: 'lifestyle',
+        designType: 'Recipes',
+    },
+    {
+        url:
+            'https://amp.theguardian.com/music/2019/jul/29/chance-the-rapper-the-big-day-review',
+        pillar: 'culture',
+        designType: 'Review',
+    },
+    {
+        url:
+            'https://amp.theguardian.com/music/2018/nov/23/laibach-the-sound-of-music-review-glorious-silly-covers-are-bright-as-a-copper-kettle',
+        pillar: 'culture',
+        designType: 'Review',
+    },
+    {
+        url:
+            'https://amp.theguardian.com/politics/2019/mar/20/theresa-may-short-brexit-delay-what-happens-next-explainer',
+        pillar: 'news',
+        designType: 'Analysis',
+    },
+    {
+        url:
+            'https://amp.theguardian.com/sport/2019/feb/14/hakeem-al-araibi-power-politics-football-and-the-will-of-the-people',
+        pillar: 'sport',
+        designType: 'Analysis',
+    },
+    {
+        url:
+            'https://amp.theguardian.com/football/blog/2019/oct/10/iran-women-watching-football-not-enough-world-cup-qualifer-cambodia',
+        pillar: 'sport',
+        designType: 'Comment',
+    },
+];
+
+// live blogs

--- a/cypress/lib/config.js
+++ b/cypress/lib/config.js
@@ -1,0 +1,7 @@
+import { polyfillFetch } from '../lib/polyfill';
+
+export const visitOptions = {
+    onBeforeLoad(win) {
+        polyfillFetch(win);
+    },
+};

--- a/cypress/lib/polyfill.js
+++ b/cypress/lib/polyfill.js
@@ -1,0 +1,16 @@
+let polyfill;
+
+export const getPolyfill = () => {
+    const polyfillUrl = 'https://unpkg.com/unfetch/dist/unfetch.umd.js';
+    cy.request(polyfillUrl).then(response => {
+        polyfill = response.body;
+    });
+};
+
+export const polyfillFetch = win => {
+    delete win.fetch;
+    // since the application code does not ship with a polyfill
+    // load a polyfilled "fetch" from the test
+    win.eval(polyfill);
+    win.fetch = win.unfetch;
+};

--- a/cypress/lib/time.js
+++ b/cypress/lib/time.js
@@ -1,0 +1,4 @@
+export const fixTime = () => {
+    const now = new Date(2019, 10, 1);
+    cy.clock(now);
+};

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -14,7 +14,29 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
-import './commands'
+import './commands';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
+
+beforeEach(() => {
+    cy.server();
+    // Mock share count
+    cy.route({
+        method: 'GET',
+        url: '/sharecount/**',
+        response: 'fixture:shareCount.json',
+    });
+    // Mock most-read
+    cy.route({
+        method: 'GET',
+        url: '/most-read/**',
+        response: 'fixture:mostRead.json',
+    });
+    // Mock most-read
+    cy.route({
+        method: 'GET',
+        url: '/embed/card/**',
+        response: 'fixture:richLink.json',
+    });
+});


### PR DESCRIPTION
## What does this change?
Improves our Percy/Cypress setup by:

- Adding AMP tests
- Adding tests for various article types
- Making time static (to prevent age warnings suddenly failing snapshots)
- Mocking the endpoints we currently use to fetch data

## This PR does not integrate Percy into our CI flow
This PR doesn't include adding the build step to include the execution of these steps in our CI flow. In order to have a soft start with Percy I'm holding back from this for now in favour of manually running Percy snapshots. This way we don't annoy the rest of the team with spurious problems on their PRs until we can be sure that they really _are_ problems.

## Link to supporting Trello card
https://trello.com/c/O8K2cxnu/763-productionise-percy