### PR TITLE
Building Blocks

### DIFF
--- a/packages/frontend/web/components/ArticleLeft.tsx
+++ b/packages/frontend/web/components/ArticleLeft.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { css } from 'emotion';
-import { from, wide, until } from '@guardian/src-foundations';
+import { css, cx } from 'emotion';
+import { from, wide, until, palette } from '@guardian/src-foundations';
 
 const leftWidth = css`
+    padding-right: 10px;
     ${until.leftCol} {
         /* below 1140 */
         display: none;
@@ -23,10 +24,24 @@ const leftWidth = css`
     }
 `;
 
+const rightBorder = (colour: string) => css`
+    border-right: 1px solid ${colour};
+`;
+
 type Props = {
     children: JSX.Element | JSX.Element[];
+    showRightBorder?: boolean;
+    borderColour?: string;
 };
 
-export const ArticleLeft = ({ children }: Props) => (
-    <section className={leftWidth}>{children}</section>
+export const ArticleLeft = ({
+    children,
+    showRightBorder = true,
+    borderColour = palette.neutral[86],
+}: Props) => (
+    <section
+        className={cx(leftWidth, showRightBorder && rightBorder(borderColour))}
+    >
+        {children}
+    </section>
 );

--- a/packages/frontend/web/components/ArticleMeta.tsx
+++ b/packages/frontend/web/components/ArticleMeta.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { css, cx } from 'emotion';
+import { from, until, palette } from '@guardian/src-foundations';
+
+import { ShareCount } from './ShareCount';
+import { Dateline } from './Dateline';
+import { SharingIcons } from './ShareIcons';
+import { Byline } from '@frontend/web/components/Byline';
+import { getSharingUrls } from '@frontend/lib/sharing-urls';
+
+const guardianLines = css`
+    background-image: repeating-linear-gradient(
+        to bottom,
+        ${palette.neutral[86]},
+        ${palette.neutral[86]} 1px,
+        transparent 1px,
+        transparent 4px
+    );
+    background-repeat: repeat-x;
+    background-position: top;
+    background-size: 1px 13px;
+    padding-top: 15px;
+    margin-bottom: 6px;
+`;
+
+const meta = css`
+    ${from.tablet.until.leftCol} {
+        order: 1;
+    }
+
+    ${until.phablet} {
+        padding-left: 10px;
+        padding-right: 10px;
+    }
+`;
+
+const metaExtras = css`
+    border-top: 1px solid ${palette.neutral[86]};
+    padding-top: 6px;
+    margin-bottom: 6px;
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+
+    ${until.phablet} {
+        margin-left: -10px;
+        margin-right: -10px;
+        padding-left: 10px;
+        padding-right: 10px;
+    }
+`;
+
+type Props = {
+    CAPI: CAPIType;
+    config: ConfigType;
+};
+
+export const ArticleMeta = ({ CAPI, config }: Props) => {
+    const sharingUrls = getSharingUrls(CAPI.pageId, CAPI.webTitle);
+
+    return (
+        <div className={cx(meta, guardianLines)}>
+            <Byline
+                author={CAPI.author}
+                tags={CAPI.tags}
+                pillar={CAPI.pillar}
+            />
+            <Dateline
+                dateDisplay={CAPI.webPublicationDateDisplay}
+                descriptionText={'Published on'}
+            />
+            <div className={metaExtras}>
+                <SharingIcons
+                    sharingUrls={sharingUrls}
+                    pillar={CAPI.pillar}
+                    displayIcons={['facebook', 'twitter', 'email']}
+                />
+                <ShareCount config={config} pageId={CAPI.pageId} />
+            </div>
+        </div>
+    );
+};

--- a/packages/frontend/web/components/ArticleTitle.tsx
+++ b/packages/frontend/web/components/ArticleTitle.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { SeriesSectionLink } from './SeriesSectionLink';
+
+const sectionStyles = css`
+    height: 157px;
+    padding-top: 8px;
+`;
+
+type Props = {
+    CAPI: CAPIType;
+    fallbackToSection: boolean;
+};
+
+export const ArticleTitle = ({ CAPI, fallbackToSection }: Props) => (
+    <div className={sectionStyles}>
+        <SeriesSectionLink CAPI={CAPI} fallbackToSection={fallbackToSection} />
+    </div>
+);


### PR DESCRIPTION
## What does this change?
This PR creates the `ArticleTitle` and `ArticleMeta` components. It also adds a `showLeftBorder` prop to the `ArticleLeft` component.

These 2 components contain the code for the elements that are included in the article left column (ArticleLeft).

### ArticleTitle
![image](https://user-images.githubusercontent.com/1336821/67095131-1bd39c80-f1ad-11e9-898c-c853df7e19a1.png)

### ArticleMeta
![image](https://user-images.githubusercontent.com/1336821/67095157-2a21b880-f1ad-11e9-917a-493295531786.png)

## Why?
To make refactoring the layout easier.

## Link to supporting Trello card
https://trello.com/c/A2UsILGE/764-review-article-layout
