### PR TITLE
Add opengraph and twitter meta tags.

### DIFF
--- a/fixtures/CAPI.ts
+++ b/fixtures/CAPI.ts
@@ -374,8 +374,50 @@ export const CAPI: CAPIType = {
     trailText:
         'Ticket touts face unlimited fines for using ‘bots’ to buy in bulk',
     keyEvents: [],
-    twitterData: {},
-    openGraphData: {},
+    twitterData: {
+        'twitter:app:id:iphone': '409128287',
+        'twitter:app:name:googleplay': 'The Guardian',
+        'twitter:app:name:ipad': 'The Guardian',
+        'twitter:image':
+            'https://i.guim.co.uk/img/media/6787bd3346264fdf786495e079523f9ae7b1a126/1649_294_1820_1092/master/1820.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctYWdlLTIwMTgucG5n&s=d3dd838e1b6ef5a72abc846f0fd783a2',
+        'twitter:site': '@guardian',
+        'twitter:app:url:ipad':
+            'gnmguardian://money/2018/jul/05/ticket-touts-face-unlimited-fines-for-using-bots?contenttype=Article&source=twitter',
+        'twitter:card': 'summary_large_image',
+        'twitter:app:name:iphone': 'The Guardian',
+        'twitter:creator': '@ByRobDavies',
+        'twitter:app:id:ipad': '409128287',
+        'twitter:app:id:googleplay': 'com.guardian',
+        'twitter:app:url:googleplay':
+            'guardian://www.theguardian.com/money/2018/jul/05/ticket-touts-face-unlimited-fines-for-using-bots',
+        'twitter:app:url:iphone':
+            'gnmguardian://money/2018/jul/05/ticket-touts-face-unlimited-fines-for-using-bots?contenttype=Article&source=twitter',
+    },
+    openGraphData: {
+        'og:url':
+            'http://www.theguardian.com/money/2018/jul/05/ticket-touts-face-unlimited-fines-for-using-bots',
+        'article:author': 'https://www.theguardian.com/profile/rob-davies',
+        'og:image:height': '720',
+        'og:description':
+            'Music industry groups hails law, part of wider effort to crack down on ‘secondary ticketing’',
+        'og:image:width': '1200',
+        'og:image':
+            'https://i.guim.co.uk/img/media/6787bd3346264fdf786495e079523f9ae7b1a126/1649_294_1820_1092/master/1820.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctYWdlLTIwMTgucG5n&enable=upscale&s=a1303790ad17807b9c68053d0226ace4',
+        'al:ios:url':
+            'gnmguardian://money/2018/jul/05/ticket-touts-face-unlimited-fines-for-using-bots?contenttype=Article&source=applinks',
+        'article:publisher': 'https://www.facebook.com/theguardian',
+        'og:type': 'article',
+        'al:ios:app_store_id': '409128287',
+        'article:section': 'Money',
+        'article:published_time': '2018-07-05T05:01:22.000Z',
+        'og:title': 'Ticket touts face unlimited fines for using bots',
+        'fb:app_id': '180444840287',
+        'article:tag':
+            'Ticket prices,Viagogo,Taylor Swift,Consumer affairs,Retail industry,Culture,Money,Ed Sheeran,Music',
+        'al:ios:app_name': 'The Guardian',
+        'og:site_name': 'the Guardian',
+        'article:modified_time': '2018-07-05T17:23:09.000Z',
+    },
     linkedData: [
         {
             '@type': 'NewsArticle',

--- a/fixtures/CAPI.ts
+++ b/fixtures/CAPI.ts
@@ -374,6 +374,8 @@ export const CAPI: CAPIType = {
     trailText:
         'Ticket touts face unlimited fines for using ‘bots’ to buy in bulk',
     keyEvents: [],
+    twitterData: {},
+    openGraphData: {},
     linkedData: [
         {
             '@type': 'NewsArticle',

--- a/packages/frontend/index.d.ts
+++ b/packages/frontend/index.d.ts
@@ -196,6 +196,8 @@ interface CAPIType {
     subMetaKeywordLinks: SimpleLinkType[];
     shouldHideAds: boolean;
     isAdFreeUser: boolean;
+    openGraphData: { [key: string]: string };
+    twitterData: { [key: string]: string };
     webURL: string;
     linkedData: object[];
     config: ConfigType;

--- a/packages/frontend/web/server/document.tsx
+++ b/packages/frontend/web/server/document.tsx
@@ -93,6 +93,9 @@ export const document = ({ data }: Props) => {
 
     const description = `${CAPI.headline} | ${CAPI.sectionLabel} | The Guardian`;
 
+    const openGraphData = CAPI.openGraphData;
+    const twitterData = CAPI.twitterData;
+
     return htmlTemplate({
         linkedData,
         priorityScripts,
@@ -104,5 +107,7 @@ export const document = ({ data }: Props) => {
         description,
         windowGuardian,
         ampLink,
+        openGraphData,
+        twitterData,
     });
 };

--- a/packages/frontend/web/server/htmlTemplate.ts
+++ b/packages/frontend/web/server/htmlTemplate.ts
@@ -82,10 +82,6 @@ export const htmlTemplate = ({
 
                 ${twitterMetaTags}
 
-                <meta name="twitter:image" content="${
-                    twitterData['twitter:image']
-                }"/>
-
                 <script>
                     window.guardian = ${windowGuardian};
                     window.guardian.queue = []; // Queue for functions to be fired by polyfill.io callback

--- a/packages/frontend/web/server/htmlTemplate.ts
+++ b/packages/frontend/web/server/htmlTemplate.ts
@@ -51,9 +51,12 @@ export const htmlTemplate = ({
     );
 
     const generateMetaTags = (dataObject: { [key: string]: string }) => {
-        return Object.entries(dataObject)
-            .map(([id, value]) => `<meta name="${id}" content="${value}"/>`)
-            .join('\n');
+        if (dataObject) {
+            return Object.entries(dataObject)
+                .map(([id, value]) => `<meta name="${id}" content="${value}"/>`)
+                .join('\n');
+        }
+        return '';
     };
 
     const openGraphMetaTags = generateMetaTags(openGraphData);

--- a/packages/frontend/web/server/htmlTemplate.ts
+++ b/packages/frontend/web/server/htmlTemplate.ts
@@ -14,6 +14,8 @@ export const htmlTemplate = ({
     windowGuardian,
     fontFiles = [],
     ampLink,
+    openGraphData,
+    twitterData,
 }: {
     title?: string;
     description: string;
@@ -25,6 +27,8 @@ export const htmlTemplate = ({
     fontFiles?: string[];
     windowGuardian: string;
     ampLink?: string;
+    openGraphData: { [key: string]: string };
+    twitterData: { [key: string]: string };
 }) => {
     const favicon =
         process.env.NODE_ENV === 'production'
@@ -46,6 +50,16 @@ export const htmlTemplate = ({
             )}" as="font" crossorigin>`,
     );
 
+    const generateMetaTags = (dataObject: { [key: string]: string }) => {
+        return Object.entries(dataObject)
+            .map(([id, value]) => `<meta name="${id}" content="${value}"/>`)
+            .join('\n');
+    };
+
+    const openGraphMetaTags = generateMetaTags(openGraphData);
+
+    const twitterMetaTags = generateMetaTags(twitterData);
+
     return `<!doctype html>
         <html lang="en">
             <head>
@@ -63,6 +77,14 @@ export const htmlTemplate = ({
                 ${ampLink ? `<link rel="amphtml" href="${ampLink}">` : ''}
 
                 ${fontPreloadTags.join('\n')}
+
+                ${openGraphMetaTags}
+
+                ${twitterMetaTags}
+
+                <meta name="twitter:image" content="${
+                    twitterData['twitter:image']
+                }"/>
 
                 <script>
                     window.guardian = ${windowGuardian};


### PR DESCRIPTION
## What does this change?
Adds twitter and open graph meta tags to DCR, fixing issues with e.g. twitter cards not generating properly for pages using DCR.

Before:
![Screenshot 2019-10-18 at 14 32 26](https://user-images.githubusercontent.com/3606555/67098457-26456480-f1b4-11e9-85ee-2991df22c355.png)
After:


![Screenshot 2019-10-18 at 14 32 13](https://user-images.githubusercontent.com/3606555/67098465-29405500-f1b4-11e9-9ff8-d2b12b02dc1b.png)


## Link to supporting Trello card
https://trello.com/c/peBr8qB3/775-fix-twitter-cards