### PR TITLE
ArticleMain

### DIFF
--- a/packages/frontend/web/components/ArticleMain.tsx
+++ b/packages/frontend/web/components/ArticleMain.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import { css, cx } from 'emotion';
-import { from, until, desktop, wide, tablet } from '@guardian/src-foundations';
+import {
+    phablet,
+    until,
+    desktop,
+    wide,
+    tablet,
+} from '@guardian/src-foundations';
 import { labelStyles } from '@frontend/web/components/AdSlot';
 
 const articleContainer = css`
@@ -10,7 +16,7 @@ const articleContainer = css`
         padding-left: 10px;
     }
 
-    ${from.phablet} {
+    ${phablet} {
         padding-left: 20px;
     }
 

--- a/packages/frontend/web/components/ArticleMain.tsx
+++ b/packages/frontend/web/components/ArticleMain.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { css, cx } from 'emotion';
+import { from, until, desktop, wide, tablet } from '@guardian/src-foundations';
+import { labelStyles } from '@frontend/web/components/AdSlot';
+
+const articleContainer = css`
+    padding-right: 20px;
+
+    ${until.phablet} {
+        padding-left: 10px;
+    }
+
+    ${from.phablet} {
+        padding-left: 20px;
+    }
+
+    flex-grow: 1;
+`;
+
+const maxWidth = css`
+    max-width: 630px;
+`;
+
+const articleAdStyles = css`
+    .ad-slot  {
+        width: 300px;
+        margin: 12px auto;
+        min-width: 300px;
+        min-height: 274px;
+        text-align: center;
+    }
+    .ad-slot--mostpop  {
+        ${desktop}  {
+            margin: 0;
+            width: auto;
+        }
+    }
+    .ad-slot--inline  {
+        ${desktop}  {
+            margin: 0;
+            width: auto;
+            float: right;
+            margin-top: 4px;
+            margin-left: 20px;
+        }
+    }
+    .ad-slot--offset-right  {
+        ${desktop}  {
+            float: right;
+            width: auto;
+            margin-right: -328px;
+        }
+
+        ${wide}  {
+            margin-right: -408px;
+        }
+    }
+    .ad-slot--outstream  {
+        ${tablet}  {
+            margin-left: 0;
+
+            .ad-slot__label  {
+                margin-left: 35px;
+                margin-right: 35px;
+            }
+        }
+    }
+    ${labelStyles};
+`;
+
+type Props = {
+    children: JSX.Element | JSX.Element[];
+};
+
+export const ArticleMain = ({ children }: Props) => {
+    return (
+        <main className={cx(articleContainer, articleAdStyles)}>
+            <div className={maxWidth}>{children}</div>
+        </main>
+    );
+};


### PR DESCRIPTION
## What does this change?
Adds `ArticleMain`, a wrapper component for the main article content.

This component is responsible for:

- Setting responsive padding
- Holding the maximum width of the article text to 630px
- Ensuring the article container grows to fit the available space (using `flex-grow: 1;`)

## Link to supporting Trello card
https://trello.com/c/A2UsILGE/764-review-article-layout