### PR TITLE
Cypress API Tests

### DIFF
--- a/cypress/integration/e2e/article.e2e.spec.js
+++ b/cypress/integration/e2e/article.e2e.spec.js
@@ -1,15 +1,42 @@
 import { getPolyfill } from '../../lib/polyfill';
 import { visitOptions } from '../../lib/config';
 import { articles } from '../../lib/articles.js';
+import { setupApiRoutes } from '../../lib/apiRoutes.js';
 
 describe('E2E Page rendering', function() {
     beforeEach(getPolyfill);
+    beforeEach(setupApiRoutes);
 
     articles.map((article, index) => {
         const { url, pillar, designType } = article;
         it(`It should load ${designType} articles under the ${pillar} pillar`, function() {
             cy.visit(`Article?url=${url}`, visitOptions);
             cy.contains('Sign in');
+
+            cy.wait('@getMostRead').then(xhr => {
+                expect(xhr.response.body.length).to.be.at.least(1);
+                expect(xhr.response.body.length).to.be.at.least(2);
+                expect(xhr.status).to.be.equal(200);
+
+                cy.contains('Most popular');
+                cy.contains('Across The');
+            });
+
+            cy.wait('@getShareCount').then(xhr => {
+                expect(xhr.status).to.be.equal(200);
+                expect(xhr.response.body).to.have.property('path');
+                expect(xhr.response.body).to.have.property('refreshStatus');
+                expect(xhr.response.body)
+                    .to.have.property('share_count')
+                    .that.is.a('number');
+            });
+
+            if (article.hasRichLinks) {
+                cy.wait('@getRichLinks').then(xhr => {
+                    expect(xhr.status).to.be.equal(200);
+                    cy.contains('Read more');
+                });
+            }
         });
     });
 });

--- a/cypress/lib/apiRoutes.js
+++ b/cypress/lib/apiRoutes.js
@@ -1,0 +1,18 @@
+export const setupApiRoutes = () => {
+    cy.server();
+    // Listen for share count call
+    cy.route({
+        method: 'GET',
+        url: '/sharecount/**',
+    }).as('getShareCount');
+    // Listen for most-read call
+    cy.route({
+        method: 'GET',
+        url: '/most-read/**',
+    }).as('getMostRead');
+    // Listen for most-read call
+    cy.route({
+        method: 'GET',
+        url: '/embed/card/**',
+    }).as('getRichLinks');
+};

--- a/cypress/lib/articles.js
+++ b/cypress/lib/articles.js
@@ -4,108 +4,126 @@ export const articles = [
             'https://www.theguardian.com/commentisfree/2019/oct/16/impostor-syndrome-class-unfairness',
         pillar: 'opinion',
         designType: 'Comment',
+        hasRichLinks: true,
     },
     {
         url:
             'https://www.theguardian.com/football/2019/oct/15/thomas-tuchel-interview-neymar-truth-consequences',
         pillar: 'sport',
         designType: 'Interview',
+        hasRichLinks: true,
     },
     {
         url:
             'https://www.theguardian.com/media/2019/sep/18/dorothy-byrne-on-calling-boris-johnson-a-liar-nobody-has-said-that-isnt-true',
         pillar: 'news',
         designType: 'Interview',
+        hasRichLinks: false,
     },
     {
         url:
             'https://www.theguardian.com/tv-and-radio/2019/oct/16/regina-king-beale-street-watchmen-superhero-hbo-dc-comics-oscar-actor',
         pillar: 'culture',
         designType: 'Interview',
+        hasRichLinks: true,
     },
     {
         url:
             'https://www.theguardian.com/football/2019/oct/06/southampton-chelsea-premier-league-match-report',
         pillar: 'sport',
         designType: 'MatchReport',
+        hasRichLinks: true,
     },
     {
         url:
             'https://www.theguardian.com/football/2019/apr/13/tottenham-huddersfield-premier-league-match-report',
         pillar: 'sport',
         designType: 'MatchReport',
+        hasRichLinks: true,
     },
     {
         url:
             'https://www.theguardian.com/travel/2019/oct/16/car-free-break-cheshire-chester-roman-treasures-industrial-heritage',
         pillar: 'lifestyle',
         designType: 'Feature',
+        hasRichLinks: false,
     },
     {
         url:
             'https://www.theguardian.com/travel/2019/oct/12/20-best-alps-ski-resorts-by-train-rail-france-switzerland-austria-italy',
         pillar: 'lifestyle',
         designType: 'Immersive',
+        hasRichLinks: false,
     },
     {
         url:
             'https://www.theguardian.com/commentisfree/2019/jan/17/the-guardian-view-on-the-brexit-impasse-extend-article-50-now',
         pillar: 'opinion',
         designType: 'GuardianView',
+        hasRichLinks: false,
     },
     {
         url:
             'https://www.theguardian.com/commentisfree/2019/aug/07/the-guardian-view-on-british-foreign-policy-the-lost-art-of-diplomacy',
         pillar: 'opinion',
         designType: 'GuardianView',
+        hasRichLinks: false,
     },
     {
         url:
             'https://www.theguardian.com/environment/2019/oct/16/ivory-coast-law-could-see-chocolate-industry-wipe-out-protected-forests',
         pillar: 'news',
         designType: 'Article',
+        hasRichLinks: true,
     },
     {
         url:
             'https://www.theguardian.com/food/2019/may/10/anna-jones-chickpea-recipes',
         pillar: 'lifestyle',
         designType: 'Recipes',
+        hasRichLinks: false,
     },
     {
         url:
             'https://www.theguardian.com/food/2019/feb/22/seed-recipes-anna-jones-sesame-sunflower-snack-bhaji-raita',
         pillar: 'lifestyle',
         designType: 'Recipes',
+        hasRichLinks: false,
     },
     {
         url:
             'https://www.theguardian.com/music/2019/jul/29/chance-the-rapper-the-big-day-review',
         pillar: 'culture',
         designType: 'Review',
+        hasRichLinks: false,
     },
     {
         url:
             'https://www.theguardian.com/music/2018/nov/23/laibach-the-sound-of-music-review-glorious-silly-covers-are-bright-as-a-copper-kettle',
         pillar: 'culture',
         designType: 'Review',
+        hasRichLinks: false,
     },
     {
         url:
             'https://www.theguardian.com/politics/2019/mar/20/theresa-may-short-brexit-delay-what-happens-next-explainer',
         pillar: 'news',
         designType: 'Analysis',
+        hasRichLinks: true,
     },
     {
         url:
             'https://www.theguardian.com/sport/2019/feb/14/hakeem-al-araibi-power-politics-football-and-the-will-of-the-people',
         pillar: 'sport',
         designType: 'Analysis',
+        hasRichLinks: true,
     },
     {
         url:
             'https://www.theguardian.com/football/blog/2019/oct/10/iran-women-watching-football-not-enough-world-cup-qualifer-cambodia',
         pillar: 'sport',
         designType: 'Comment',
+        hasRichLinks: true,
     },
 ];
 


### PR DESCRIPTION
## What does this change?
Adds additional assertions to our existing E2E tests to verify that the page is making api calls and getting and using the responses as expected.

The following calls are tested:
- Most Read
- Share Count
- Rich Links (where present)

**Note: If an additional api call is placed on the page these tests should be extended to include it**

## Why?
For coverage but also in response to a recent issue where it was noted that api calls were not being made

