### PR TITLE
Never use CODE assets environment. Remove /guui from path.

### DIFF
--- a/packages/frontend/lib/assets.ts
+++ b/packages/frontend/lib/assets.ts
@@ -19,9 +19,7 @@ const stage =
         ? process.env.GU_STAGE.toUpperCase()
         : process.env.GU_STAGE;
 
-const CDN = stage
-    ? `//assets${stage === 'CODE' ? '-code' : ''}.guim.co.uk/guui/`
-    : '/';
+const CDN = stage ? `//assets.guim.co.uk/` : '/';
 
 export const getDist = (path: string): string =>
     `${CDN}assets/${assetHash[path] || path}`;


### PR DESCRIPTION
## What does this change?
Removes the fork we were doing to decide whether to hit assets.guim code or prod. 

Also, remove the /guui bit of the path following from https://github.com/guardian/dotcom-rendering/pull/840 

## Why?
We want CODE to be as close to PROD as possible so we should use the same fastly service (behind the scenes they point to the same S3 bucket)
## Link to supporting Trello card
