### PR TITLE
Correct font weight of section label text

### DIFF
--- a/packages/frontend/web/components/SeriesSectionLink.tsx
+++ b/packages/frontend/web/components/SeriesSectionLink.tsx
@@ -4,6 +4,10 @@ import { pillarMap, pillarPalette } from '@frontend/lib/pillars';
 import { leftCol } from '@guardian/pasteup/breakpoints';
 import { headline } from '@guardian/src-foundations';
 
+const sectionLabelText = css`
+    font-weight: 700;
+`;
+
 const sectionLabelLink = css`
     text-decoration: none;
     :hover {
@@ -21,7 +25,6 @@ const pillarColours = pillarMap(
 const primaryStyle = css`
     font-weight: 700;
     ${headline({ level: 1 })};
-
     ${leftCol} {
         ${headline({ level: 2 })};
     }
@@ -57,7 +60,7 @@ const TagLink: React.FC<{
             )}
             data-link-name={dataLinkName}
         >
-            {tagTitle}
+            <span className={sectionLabelText}>{tagTitle}</span>
         </a>
     );
 };


### PR DESCRIPTION
## What does this change?

Align the style of the section link text style to that of frontend classic.


Before: 

![Screenshot 2019-10-21 at 16 49 17](https://user-images.githubusercontent.com/6035518/67221473-69593f00-f423-11e9-98a0-5c88f5b7cf4d.png)


After:

![Screenshot 2019-10-21 at 16 49 08](https://user-images.githubusercontent.com/6035518/67221461-64948b00-f423-11e9-9e51-a1ad6beca208.png)

