### PR TITLE
Split out main image and content images, ready to treat them differently

### DIFF
--- a/packages/frontend/web/components/MainMedia.tsx
+++ b/packages/frontend/web/components/MainMedia.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ImageBlockComponent } from '@frontend/web/components/elements/ImageBlockComponent';
+import { MainImageComponent } from '@frontend/web/components/elements/MainImageComponent';
 
 export const MainMedia: React.FC<{ element: CAPIElement; pillar: Pillar }> = ({
     element,
@@ -7,7 +7,7 @@ export const MainMedia: React.FC<{ element: CAPIElement; pillar: Pillar }> = ({
 }) => {
     switch (element._type) {
         case 'model.dotcomrendering.pageElements.ImageBlockElement':
-            return <ImageBlockComponent element={element} pillar={pillar} />;
+            return <MainImageComponent element={element} pillar={pillar} />;
         default:
             return null;
     }

--- a/packages/frontend/web/components/elements/ImageBlockComponent.tsx
+++ b/packages/frontend/web/components/elements/ImageBlockComponent.tsx
@@ -1,65 +1,8 @@
 import React from 'react';
 import { css } from 'emotion';
-import { Picture, PictureSource } from '@frontend/web/components/Picture';
-import { Caption } from '@frontend/web/components/Caption';
+import { ImageComponent } from '@frontend/web/components/elements/ImageComponent';
 
 import { wide, tablet, leftCol } from '@guardian/src-foundations';
-
-const widths = [660, 480, 0];
-
-const bestFor = (desiredWidth: number, inlineSrcSets: SrcSet[]): SrcSet => {
-    const sorted = inlineSrcSets.sort((a, b) => b.width - a.width);
-
-    return sorted.reduce((best, current) => {
-        if (current.width < best.width && current.width >= desiredWidth) {
-            return current;
-        }
-
-        return best;
-    });
-};
-
-const getSrcSetsForWeighting = (
-    imageSources: ImageSource[],
-    forWeighting: Weighting,
-): SrcSet[] =>
-    imageSources.filter(({ weighting }) => weighting === forWeighting)[0]
-        .srcSet;
-
-const makeSources = (imageSources: ImageSource[]): PictureSource[] => {
-    const inlineSrcSets = getSrcSetsForWeighting(imageSources, 'inline');
-    const sources: PictureSource[] = [];
-
-    // TODO: ideally the imageSources array will come from frontend with prebaked URLs for
-    // hidpi images.
-    // Until that happens, here we're manually injecting (inadequate) <source> elements for
-    // those images, albeit without the necessary query params for hidpi images :(
-    widths.forEach(width => {
-        sources.push(makeSource(true, width, bestFor(width, inlineSrcSets)));
-        sources.push(makeSource(false, width, bestFor(width, inlineSrcSets)));
-    });
-
-    return sources;
-};
-
-const makeSource = (
-    hidpi: boolean,
-    minWidth: number,
-    srcSet: SrcSet,
-): PictureSource => {
-    return {
-        hidpi,
-        minWidth,
-        width: srcSet.width,
-        srcset: `${srcSet.src} ${hidpi ? srcSet.width * 2 : srcSet.width}w`,
-    };
-};
-
-const getFallback: (imageSources: ImageSource[]) => string = imageSources => {
-    const inlineSrcSets = getSrcSetsForWeighting(imageSources, 'inline');
-
-    return bestFor(300, inlineSrcSets).src;
-};
 
 const imageCss = {
     inline: css`
@@ -160,23 +103,10 @@ export const ImageBlockComponent: React.FC<{
     element: ImageBlockElement;
     pillar: Pillar;
 }> = ({ element, pillar }) => {
-    const sources = makeSources(element.imageSources);
     const { role } = element;
     return (
         <div className={decidePosition(role)}>
-            <Caption
-                captionText={element.data.caption || ''}
-                pillar={pillar}
-                dirtyHtml={true}
-                credit={element.data.credit}
-                displayCredit={true}
-            >
-                <Picture
-                    sources={sources}
-                    alt={element.data.alt || ''}
-                    src={getFallback(element.imageSources)}
-                />
-            </Caption>
+            <ImageComponent element={element} pillar={pillar} />
         </div>
     );
 };

--- a/packages/frontend/web/components/elements/ImageComponent.tsx
+++ b/packages/frontend/web/components/elements/ImageComponent.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { Picture, PictureSource } from '@frontend/web/components/Picture';
+import { Caption } from '@frontend/web/components/Caption';
+
+const widths = [660, 480, 0];
+
+const bestFor = (desiredWidth: number, inlineSrcSets: SrcSet[]): SrcSet => {
+    const sorted = inlineSrcSets.sort((a, b) => b.width - a.width);
+
+    return sorted.reduce((best, current) => {
+        if (current.width < best.width && current.width >= desiredWidth) {
+            return current;
+        }
+
+        return best;
+    });
+};
+
+const getSrcSetsForWeighting = (
+    imageSources: ImageSource[],
+    forWeighting: Weighting,
+): SrcSet[] =>
+    imageSources.filter(({ weighting }) => weighting === forWeighting)[0]
+        .srcSet;
+
+const makeSources = (imageSources: ImageSource[]): PictureSource[] => {
+    const inlineSrcSets = getSrcSetsForWeighting(imageSources, 'inline');
+    const sources: PictureSource[] = [];
+
+    // TODO: ideally the imageSources array will come from frontend with prebaked URLs for
+    // hidpi images.
+    // Until that happens, here we're manually injecting (inadequate) <source> elements for
+    // those images, albeit without the necessary query params for hidpi images :(
+    widths.forEach(width => {
+        sources.push(makeSource(true, width, bestFor(width, inlineSrcSets)));
+        sources.push(makeSource(false, width, bestFor(width, inlineSrcSets)));
+    });
+
+    return sources;
+};
+
+const makeSource = (
+    hidpi: boolean,
+    minWidth: number,
+    srcSet: SrcSet,
+): PictureSource => {
+    return {
+        hidpi,
+        minWidth,
+        width: srcSet.width,
+        srcset: `${srcSet.src} ${hidpi ? srcSet.width * 2 : srcSet.width}w`,
+    };
+};
+
+const getFallback: (imageSources: ImageSource[]) => string = imageSources => {
+    const inlineSrcSets = getSrcSetsForWeighting(imageSources, 'inline');
+
+    return bestFor(300, inlineSrcSets).src;
+};
+
+export const ImageComponent: React.FC<{
+    element: ImageBlockElement;
+    pillar: Pillar;
+}> = ({ element, pillar }) => {
+    const sources = makeSources(element.imageSources);
+    return (
+        <Caption
+            captionText={element.data.caption || ''}
+            pillar={pillar}
+            dirtyHtml={true}
+            credit={element.data.credit}
+            displayCredit={true}
+        >
+            <Picture
+                sources={sources}
+                alt={element.data.alt || ''}
+                src={getFallback(element.imageSources)}
+            />
+        </Caption>
+    );
+};

--- a/packages/frontend/web/components/elements/MainImageComponent.tsx
+++ b/packages/frontend/web/components/elements/MainImageComponent.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { ImageComponent } from '@frontend/web/components/elements/ImageComponent';
+
+export const MainImageComponent: React.FC<{
+    element: ImageBlockElement;
+    pillar: Pillar;
+}> = ({ element, pillar }) => {
+    return <ImageComponent element={element} pillar={pillar} />;
+};


### PR DESCRIPTION
## What does this change?
This PR creates a dedicated component for rendering the Main image component. Instead of using the generic `ImageBlockComponent` used by all images in an article, this lets has have a dedicated route.

In addition, to prevent duplication, I've broken out the core image rendering into `ImageComponent` which is shared between `ImageBlockComponent` and `MainImageComponent`.

### Does MainImageComponent do anything?
No, not at this time, we could just render `ImageComponent` directly. But this is a placeholder file for when we do want to apply special styles to the main image element.

## Why?
Parity and also to fix a problem that we have currently with rendering showcase images.

## Link to supporting Trello card
https://trello.com/c/A2UsILGE/764-review-article-layout
