### PR TITLE
Refactor Article Layout

### DIFF
--- a/packages/frontend/web/components/ArticleBody.tsx
+++ b/packages/frontend/web/components/ArticleBody.tsx
@@ -153,6 +153,10 @@ const subMetaSharingIcons = css`
     }
 `;
 
+const maxWidth = css`
+    max-width: 630px;
+`;
+
 export const ArticleBody: React.FC<{
     CAPI: CAPIType;
     config: ConfigType;
@@ -161,7 +165,7 @@ export const ArticleBody: React.FC<{
     const hasSubMetaKeywordLinks = CAPI.subMetaKeywordLinks.length > 0;
     const sharingUrls = getSharingUrls(CAPI.pageId, CAPI.webTitle);
     return (
-        <div>
+        <main className={maxWidth}>
             <div
                 className={cx(bodyStyle, linkColour[CAPI.pillar], {
                     [immersiveBodyStyle]: CAPI.isImmersive,
@@ -214,6 +218,6 @@ export const ArticleBody: React.FC<{
                     />
                 )}
             </div>
-        </div>
+        </main>
     );
 };

--- a/packages/frontend/web/components/ArticleContainer.tsx
+++ b/packages/frontend/web/components/ArticleContainer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 import {
-    phablet,
+    leftCol,
     until,
     desktop,
     wide,
@@ -10,21 +10,17 @@ import {
 import { labelStyles } from '@frontend/web/components/AdSlot';
 
 const articleContainer = css`
-    padding-right: 20px;
+    ${until.leftCol} {
+        /* below 1140 */
+        padding-left: 0;
+    }
 
-    ${until.phablet} {
+    ${leftCol} {
+        /* above 1140 */
         padding-left: 10px;
     }
 
-    ${phablet} {
-        padding-left: 20px;
-    }
-
     flex-grow: 1;
-`;
-
-const maxWidth = css`
-    max-width: 630px;
 `;
 
 const articleAdStyles = css`
@@ -78,10 +74,10 @@ type Props = {
     children: JSX.Element | JSX.Element[];
 };
 
-export const ArticleMain = ({ children }: Props) => {
+export const ArticleContainer = ({ children }: Props) => {
     return (
         <main className={cx(articleContainer, articleAdStyles)}>
-            <div className={maxWidth}>{children}</div>
+            {children}
         </main>
     );
 };

--- a/packages/frontend/web/components/ArticleHeader.tsx
+++ b/packages/frontend/web/components/ArticleHeader.tsx
@@ -3,26 +3,18 @@ import { css, cx } from 'emotion';
 
 import { palette } from '@guardian/pasteup/palette';
 import ClockIcon from '@frontend/static/icons/clock.svg';
-import { Byline } from '@frontend/web/components/Byline';
 import { getAgeWarning } from '@frontend/lib/age-warning';
 import { pillarMap, pillarPalette } from '@frontend/lib/pillars';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';
 import { headline, textSans, body } from '@guardian/src-foundations';
-import { getSharingUrls } from '@frontend/lib/sharing-urls';
 import {
-    from,
     until,
     leftCol,
     tablet,
     mobileLandscape,
-    wide,
 } from '@guardian/pasteup/breakpoints';
 
-import { ShareCount } from './ShareCount';
-import { Dateline } from './Dateline';
 import { MainMedia } from './MainMedia';
-import { SeriesSectionLink } from './SeriesSectionLink';
-import { SharingIcons } from './ShareIcons';
 
 const curly = (x: any) => x;
 
@@ -73,21 +65,6 @@ const standfirstLinks = pillarMap(
             }
         `,
 );
-
-const guardianLines = css`
-    background-image: repeating-linear-gradient(
-        to bottom,
-        ${palette.neutral[86]},
-        ${palette.neutral[86]} 1px,
-        transparent 1px,
-        transparent 4px
-    );
-    background-repeat: repeat-x;
-    background-position: top;
-    background-size: 1px 13px;
-    padding-top: 15px;
-    margin-bottom: 6px;
-`;
 
 const captionFont = css`
     ${textSans({ level: 1 })};
@@ -140,36 +117,9 @@ const headerStyle = css`
 `;
 
 const headlineCSS = css`
-    @supports (display: grid) {
-        grid-template-areas: 'headline';
-    }
+    max-width: 630px;
     ${until.phablet} {
         padding: 0 10px;
-    }
-`;
-
-const leftColWidth = css`
-    ${leftCol} {
-        width: 140px;
-    }
-
-    ${wide} {
-        width: 220px;
-    }
-`;
-
-const meta = css`
-    ${leftColWidth};
-    @supports (display: grid) {
-        grid-template-areas: 'meta';
-    }
-    ${from.tablet.until.leftCol} {
-        order: 1;
-    }
-
-    ${until.phablet} {
-        padding-left: 10px;
-        padding-right: 10px;
     }
 `;
 
@@ -207,22 +157,6 @@ const ageWarningScreenReader = css`
     ${screenReaderOnly};
 `;
 
-const metaExtras = css`
-    border-top: 1px solid ${palette.neutral[86]};
-    padding-top: 6px;
-    margin-bottom: 6px;
-    display: flex;
-    justify-content: space-between;
-    flex-wrap: wrap;
-
-    ${until.phablet} {
-        margin-left: -10px;
-        margin-right: -10px;
-        padding-left: 10px;
-        padding-right: 10px;
-    }
-`;
-
 const headerStyles = css`
     ${until.phablet} {
         margin: 0 -10px;
@@ -230,32 +164,6 @@ const headerStyles = css`
 
     display: flex;
     flex-direction: column;
-
-    ${leftCol} {
-        @supports (display: grid) {
-            display: grid;
-            grid-template-areas: 'section headline' 'meta main-media';
-            grid-template-columns: 160px 1fr;
-            margin-left: -160px;
-        }
-    }
-
-    ${wide} {
-        @supports (display: grid) {
-            grid-template-columns: 240px 1fr;
-            margin-left: -240px;
-        }
-    }
-`;
-
-const sectionStyles = css`
-    ${leftColWidth};
-    @supports (display: grid) {
-        grid-template-areas: 'section';
-    }
-    ${until.phablet} {
-        padding: 0 10px;
-    }
 `;
 
 type Props = {
@@ -265,12 +173,8 @@ type Props = {
 
 export const ArticleHeader = ({ CAPI, config }: Props) => {
     const ageWarning = getAgeWarning(CAPI.tags, CAPI.webPublicationDate);
-    const sharingUrls = getSharingUrls(CAPI.pageId, CAPI.webTitle);
     return (
         <header className={headerStyles}>
-            <div className={sectionStyles}>
-                <SeriesSectionLink CAPI={CAPI} fallbackToSection={true} />
-            </div>
             <div className={headlineCSS}>
                 {ageWarning && (
                     <div className={ageWarningStyle} aria-hidden="true">
@@ -290,25 +194,6 @@ export const ArticleHeader = ({ CAPI, config }: Props) => {
                         __html: CAPI.standfirst,
                     }}
                 />
-            </div>
-            <div className={cx(meta, guardianLines)}>
-                <Byline
-                    author={CAPI.author}
-                    tags={CAPI.tags}
-                    pillar={CAPI.pillar}
-                />
-                <Dateline
-                    dateDisplay={CAPI.webPublicationDateDisplay}
-                    descriptionText={'Published on'}
-                />
-                <div className={metaExtras}>
-                    <SharingIcons
-                        sharingUrls={sharingUrls}
-                        pillar={CAPI.pillar}
-                        displayIcons={['facebook', 'twitter', 'email']}
-                    />
-                    <ShareCount config={config} pageId={CAPI.pageId} />
-                </div>
             </div>
             <div className={cx(mainMedia)}>
                 {CAPI.mainMediaElements.map((element, i) => (

--- a/packages/frontend/web/components/ArticleRight.tsx
+++ b/packages/frontend/web/components/ArticleRight.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'emotion';
+import { css, cx } from 'emotion';
 import { until, desktop } from '@guardian/src-foundations';
 
 const hideBelowDesktop = css`
@@ -17,10 +17,18 @@ const hideBelowDesktop = css`
     }
 `;
 
+const topPadding = css`
+    padding-top: 6px;
+`;
+
 type Props = {
     children: JSX.Element | JSX.Element[];
 };
 
 export const ArticleRight = ({ children }: Props) => {
-    return <section className={hideBelowDesktop}>{children}</section>;
+    return (
+        <section className={cx(hideBelowDesktop, topPadding)}>
+            {children}
+        </section>
+    );
 };

--- a/packages/frontend/web/components/ArticleRight.tsx
+++ b/packages/frontend/web/components/ArticleRight.tsx
@@ -17,8 +17,9 @@ const hideBelowDesktop = css`
     }
 `;
 
-const topPadding = css`
+const padding = css`
     padding-top: 6px;
+    padding-left: 10px;
 `;
 
 type Props = {
@@ -27,8 +28,6 @@ type Props = {
 
 export const ArticleRight = ({ children }: Props) => {
     return (
-        <section className={cx(hideBelowDesktop, topPadding)}>
-            {children}
-        </section>
+        <section className={cx(hideBelowDesktop, padding)}>{children}</section>
     );
 };

--- a/packages/frontend/web/components/Content.tsx
+++ b/packages/frontend/web/components/Content.tsx
@@ -1,112 +1,33 @@
 import React from 'react';
-import { css } from 'emotion';
-import {
-    tablet,
-    desktop,
-    leftCol,
-    wide,
-    palette,
-} from '@guardian/src-foundations';
-import { clearFix } from '@guardian/pasteup/mixins';
+import { Flex } from '@frontend/web/components/Flex';
+import { StickyAd } from '@frontend/web/components/StickyAd';
 import { ArticleBody } from '@frontend/web/components/ArticleBody';
 import { ArticleHeader } from '@frontend/web/components/ArticleHeader';
-import { labelStyles } from '@frontend/web/components/AdSlot';
-import { ArticleAside } from '@frontend/web/components/ArticleAside';
-
-const marginStyles = css`
-    padding-top: 6px;
-    margin-right: 0;
-    margin-left: 0;
-    ${clearFix}
-
-    ${desktop} {
-        max-width: 620px;
-        margin-right: 310px;
-        padding-left: 10px;
-    }
-
-    ${leftCol} {
-        margin-left: 150px;
-        margin-right: 310px;
-        position: relative;
-        :before {
-            content: '';
-            position: absolute;
-            top: 0;
-            bottom: 0;
-            left: 0;
-            height: 100%;
-            width: 1px;
-            background: ${palette.neutral[86]};
-        }
-    }
-
-    ${wide} {
-        margin-left: 230px;
-    }
-`;
-
-const articleAdStyles = css`
-    .ad-slot {
-        width: 300px;
-        margin: 12px auto;
-        min-width: 300px;
-        min-height: 274px;
-        text-align: center;
-    }
-    .ad-slot--mostpop {
-        ${desktop} {
-            margin: 0;
-            width: auto;
-        }
-    }
-    .ad-slot--inline {
-        ${desktop} {
-            margin: 0;
-            width: auto;
-            float: right;
-            margin-top: 4px;
-            margin-left: 20px;
-        }
-    }
-    .ad-slot--offset-right {
-        ${desktop} {
-            float: right;
-            width: auto;
-            margin-right: -328px;
-        }
-
-        ${wide} {
-            margin-right: -408px;
-        }
-    }
-    .ad-slot--outstream {
-        ${tablet} {
-            margin-left: 0;
-
-            .ad-slot__label {
-                margin-left: 35px;
-                margin-right: 35px;
-            }
-        }
-    }
-    ${labelStyles};
-`;
+import { ArticleLeft } from '@frontend/web/components/ArticleLeft';
+import { ArticleRight } from '@frontend/web/components/ArticleRight';
+import { ArticleTitle } from '@frontend/web/components/ArticleTitle';
+import { ArticleContainer } from '@frontend/web/components/ArticleContainer';
+import { ArticleMeta } from '@frontend/web/components/ArticleMeta';
 
 interface Props {
     CAPI: CAPIType;
     config: ConfigType;
 }
+
 export const Content = ({ CAPI, config }: Props) => {
     return (
-        <main>
-            <article className={articleAdStyles}>
-                <div className={marginStyles}>
-                    <ArticleHeader CAPI={CAPI} config={config} />
-                    <ArticleBody CAPI={CAPI} config={config} />
-                </div>
-                <ArticleAside config={config} />
-            </article>
-        </main>
+        <Flex>
+            <ArticleLeft>
+                <ArticleTitle CAPI={CAPI} fallbackToSection={true} />
+                <ArticleMeta CAPI={CAPI} config={config} />
+            </ArticleLeft>
+            <ArticleContainer>
+                <ArticleHeader CAPI={CAPI} config={config} />
+                <ArticleBody CAPI={CAPI} config={config} />
+            </ArticleContainer>
+            <ArticleRight>
+                <StickyAd config={config} />
+            </ArticleRight>
+        </Flex>
     );
 };

--- a/packages/frontend/web/components/Flex.tsx
+++ b/packages/frontend/web/components/Flex.tsx
@@ -9,6 +9,7 @@ export const Flex = ({ children }: Props) => (
     <div
         className={css`
             display: flex;
+            justify-content: space-between;
         `}
     >
         {children}


### PR DESCRIPTION
## What does this change?
This PR builds upon recent work adding building block components. These blocks are used here to reconstruct the article with the styling and business logic kept out of the layout.

## Before
```
        <main>
            <article className={articleAdStyles}>
                <div className={marginStyles}>
                    <ArticleHeader CAPI={CAPI} config={config} />
                    <ArticleBody CAPI={CAPI} config={config} />
                </div>
                <ArticleAside config={config} />
            </article>
        </main>
```

## After
```
        <Flex>
            <ArticleLeft>
                <ArticleTitle CAPI={CAPI} fallbackToSection={true} />
                <ArticleMeta CAPI={CAPI} config={config} />
            </ArticleLeft>
            <ArticleContainer>
                <ArticleHeader CAPI={CAPI} config={config} />
                <ArticleBody CAPI={CAPI} config={config} />
            </ArticleContainer>
            <ArticleRight>
                <StickyAd config={config} />
            </ArticleRight>
        </Flex>
```

So there's nothing wrong with the before code above, but once we begin the pending work to start supporting different article layouts, then the new code structure in this PR will hopefully make that easier.

There should be no visual diffs with this change, it is purely code restructuring.

## Why?
To help with future work expanding the list of supported articles.

## Link to supporting Trello card
https://trello.com/c/A2UsILGE/764-review-article-layout
