### PR TITLE
Migrate breakpoints

### DIFF
--- a/packages/frontend/web/components/ArticleBody.tsx
+++ b/packages/frontend/web/components/ArticleBody.tsx
@@ -4,8 +4,7 @@ import React from 'react';
 import { css, cx } from 'emotion';
 
 import { palette } from '@guardian/pasteup/palette';
-import { from, tablet } from '@guardian/pasteup/breakpoints';
-import { headline, textSans } from '@guardian/src-foundations';
+import { from, tablet, headline, textSans } from '@guardian/src-foundations';
 import { pillarMap, pillarPalette } from '@frontend/lib/pillars';
 import { ArticleRenderer } from '@frontend/web/components/lib/ArticleRenderer';
 import { getSharingUrls } from '@frontend/lib/sharing-urls';

--- a/packages/frontend/web/components/ArticleHeader.tsx
+++ b/packages/frontend/web/components/ArticleHeader.tsx
@@ -6,13 +6,15 @@ import ClockIcon from '@frontend/static/icons/clock.svg';
 import { getAgeWarning } from '@frontend/lib/age-warning';
 import { pillarMap, pillarPalette } from '@frontend/lib/pillars';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';
-import { headline, textSans, body } from '@guardian/src-foundations';
 import {
     until,
     leftCol,
     tablet,
     mobileLandscape,
-} from '@guardian/pasteup/breakpoints';
+    headline,
+    textSans,
+    body,
+} from '@guardian/src-foundations';
 
 import { MainMedia } from './MainMedia';
 

--- a/packages/frontend/web/components/CookieBanner.tsx
+++ b/packages/frontend/web/components/CookieBanner.tsx
@@ -1,11 +1,10 @@
 import React, { Component } from 'react';
 import { css } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
-import { headline, textSans, body } from '@guardian/src-foundations';
+import { headline, textSans, body, until } from '@guardian/src-foundations';
 import TickIcon from '@frontend/static/icons/tick.svg';
 import RoundelIcon from '@frontend/static/icons/the-guardian-roundel.svg';
 import { getCookie, addCookie } from '@frontend/web/browser/cookie';
-import { until } from '@guardian/pasteup/breakpoints';
 
 const banner = css`
     position: fixed;

--- a/packages/frontend/web/components/Dropdown.tsx
+++ b/packages/frontend/web/components/Dropdown.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
-import { textSans } from '@guardian/src-foundations';
+import { textSans, until, tablet } from '@guardian/src-foundations';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';
-import { until, tablet } from '@guardian/pasteup/breakpoints';
 
 export interface Link {
     url: string;

--- a/packages/frontend/web/components/Footer.tsx
+++ b/packages/frontend/web/components/Footer.tsx
@@ -7,8 +7,8 @@ import {
     until,
     wide,
     desktop,
-} from '@guardian/pasteup/breakpoints';
-import { textSans } from '@guardian/src-foundations';
+    textSans,
+} from '@guardian/src-foundations';
 import { clearFix } from '@guardian/pasteup/mixins';
 
 import { Pillars, pillarWidth, firstPillarWidth } from './Header/Nav/Pillars';

--- a/packages/frontend/web/components/Header/Nav/EditionDropdown.tsx
+++ b/packages/frontend/web/components/Header/Nav/EditionDropdown.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 import { Dropdown, Link } from '@frontend/web/components/Dropdown';
-import { desktop, wide } from '@guardian/pasteup/breakpoints';
+import { desktop, wide } from '@guardian/src-foundations';
 import { palette } from '@guardian/pasteup/palette';
 
 const editionDropdown = css`

--- a/packages/frontend/web/components/Header/Nav/Links/Links.tsx
+++ b/packages/frontend/web/components/Header/Nav/Links/Links.tsx
@@ -7,13 +7,13 @@ import {
 import ProfileIcon from '@frontend/static/icons/profile.svg';
 import SearchIcon from '@frontend/static/icons/search.svg';
 import { palette } from '@guardian/pasteup/palette';
-import { textSans } from '@guardian/src-foundations';
 import {
     tablet,
     desktop,
     mobileLandscape,
     wide,
-} from '@guardian/pasteup/breakpoints';
+    textSans,
+} from '@guardian/src-foundations';
 
 const search = css`
     :after {

--- a/packages/frontend/web/components/Header/Nav/Links/SupportTheGuardian.tsx
+++ b/packages/frontend/web/components/Header/Nav/Links/SupportTheGuardian.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { css } from 'emotion';
 
-import { headline } from '@guardian/src-foundations';
 import { palette } from '@guardian/pasteup/palette';
 import {
     mobileLandscape,
     tablet,
     mobileMedium,
-} from '@guardian/pasteup/breakpoints';
+    headline,
+} from '@guardian/src-foundations';
 import ProfileIcon from '@frontend/static/icons/profile.svg';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';
 

--- a/packages/frontend/web/components/Header/Nav/Logo.tsx
+++ b/packages/frontend/web/components/Header/Nav/Logo.tsx
@@ -7,7 +7,7 @@ import {
     tablet,
     desktop,
     wide,
-} from '@guardian/pasteup/breakpoints';
+} from '@guardian/src-foundations';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';
 
 import { palette } from '@guardian/pasteup/palette';

--- a/packages/frontend/web/components/Header/Nav/MainMenu/Column.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenu/Column.tsx
@@ -1,8 +1,13 @@
 import React, { Component } from 'react';
-import { textSans } from '@guardian/src-foundations';
 import { css, cx } from 'emotion';
 
-import { desktop, tablet, leftCol, until } from '@guardian/pasteup/breakpoints';
+import {
+    desktop,
+    tablet,
+    leftCol,
+    until,
+    textSans,
+} from '@guardian/src-foundations';
 import { palette } from '@guardian/pasteup/palette';
 import { CollapseColumnButton } from './CollapseColumnButton';
 

--- a/packages/frontend/web/components/Header/Nav/MainMenu/Columns.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenu/Columns.tsx
@@ -1,8 +1,14 @@
 import React from 'react';
 import { css } from 'emotion';
 
-import { tablet, desktop, leftCol, wide } from '@guardian/pasteup/breakpoints';
-import { headline, textSans } from '@guardian/src-foundations';
+import {
+    tablet,
+    desktop,
+    leftCol,
+    wide,
+    headline,
+    textSans,
+} from '@guardian/src-foundations';
 
 import { Column, More, ReaderRevenueLinks } from './Column';
 import { palette } from '@guardian/pasteup/palette';

--- a/packages/frontend/web/components/Header/Nav/MainMenu/MainMenu.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenu/MainMenu.tsx
@@ -7,10 +7,10 @@ import {
     mobileLandscape,
     desktop,
     tablet,
-} from '@guardian/pasteup/breakpoints';
+    textSans,
+} from '@guardian/src-foundations';
 import { Columns } from './Columns';
 import { palette } from '@guardian/pasteup/palette';
-import { textSans } from '@guardian/src-foundations';
 
 const showMenu = css`
     ${desktop} {

--- a/packages/frontend/web/components/Header/Nav/MainMenuToggle/MainMenuToggle.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenuToggle/MainMenuToggle.tsx
@@ -1,8 +1,7 @@
 import React, { Component } from 'react';
 import { css, cx } from 'emotion';
-import { desktop } from '@guardian/pasteup/breakpoints';
+import { desktop, headline } from '@guardian/src-foundations';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';
-import { headline } from '@guardian/src-foundations';
 import { VeggieBurger } from './VeggieBurger';
 import { palette } from '@guardian/pasteup/palette';
 

--- a/packages/frontend/web/components/Header/Nav/MainMenuToggle/VeggieBurger.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenuToggle/VeggieBurger.tsx
@@ -6,7 +6,7 @@ import {
     mobileMedium,
     mobileLandscape,
     tablet,
-} from '@guardian/pasteup/breakpoints';
+} from '@guardian/src-foundations';
 import { palette } from '@guardian/pasteup/palette';
 
 const veggieBurger = ({ showMainMenu }: { showMainMenu: boolean }) => css`

--- a/packages/frontend/web/components/Header/Nav/Pillars.tsx
+++ b/packages/frontend/web/components/Header/Nav/Pillars.tsx
@@ -9,9 +9,9 @@ import {
     mobileMedium,
     wide,
     until,
-} from '@guardian/pasteup/breakpoints';
+    headline,
+} from '@guardian/src-foundations';
 
-import { headline } from '@guardian/src-foundations';
 import { pillarMap, pillarPalette } from '@frontend/lib/pillars';
 import { palette } from '@guardian/pasteup/palette';
 

--- a/packages/frontend/web/components/Header/Nav/ReaderRevenueLinks.tsx
+++ b/packages/frontend/web/components/Header/Nav/ReaderRevenueLinks.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 
-import { textSans, headline } from '@guardian/src-foundations';
 import ArrowRightIcon from '@frontend/static/icons/arrow-right.svg';
 import { palette } from '@guardian/pasteup/palette';
 import {
@@ -10,7 +9,9 @@ import {
     mobileMedium,
     until,
     leftCol,
-} from '@guardian/pasteup/breakpoints';
+    textSans,
+    headline,
+} from '@guardian/src-foundations';
 
 import { getCookie } from '@frontend/web/browser/cookie';
 import { AsyncClientComponent } from '@frontend/web/components/lib/AsyncClientComponent';

--- a/packages/frontend/web/components/Header/Nav/SubNav/Inner.tsx
+++ b/packages/frontend/web/components/Header/Nav/SubNav/Inner.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
-import { textSans } from '@guardian/src-foundations';
 import {
     desktop,
     tablet,
     mobileLandscape,
-} from '@guardian/pasteup/breakpoints';
+    textSans,
+} from '@guardian/src-foundations';
 import { pillarPalette, pillarMap } from '@frontend/lib/pillars';
 
 const wrapperCollapsed = css`

--- a/packages/frontend/web/components/SeriesSectionLink.tsx
+++ b/packages/frontend/web/components/SeriesSectionLink.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 import { pillarMap, pillarPalette } from '@frontend/lib/pillars';
-import { leftCol } from '@guardian/pasteup/breakpoints';
-import { headline } from '@guardian/src-foundations';
+import { leftCol, headline } from '@guardian/src-foundations';
 
 const sectionLabelText = css`
     font-weight: 700;

--- a/packages/frontend/web/components/ShareCount.tsx
+++ b/packages/frontend/web/components/ShareCount.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 import { palette } from '@guardian/pasteup/palette';
 import ShareIcon from '@frontend/static/icons/share.svg';
-import { textSans } from '@guardian/src-foundations';
-import { from, wide, leftCol } from '@guardian/pasteup/breakpoints';
+import { from, wide, leftCol, textSans } from '@guardian/src-foundations';
 import { integerCommas } from '@frontend/lib/formatters';
 import { useApi } from '@frontend/web/components/lib/api';
 

--- a/packages/frontend/web/components/ShareIcons.tsx
+++ b/packages/frontend/web/components/ShareIcons.tsx
@@ -8,7 +8,7 @@ import LinkedInIcon from '@frontend/static/icons/linked-in.svg';
 import PinterestIcon from '@frontend/static/icons/pinterest.svg';
 import WhatsAppIcon from '@frontend/static/icons/whatsapp.svg';
 import MessengerIcon from '@frontend/static/icons/messenger.svg';
-import { phablet, wide } from '@guardian/pasteup/breakpoints';
+import { phablet, wide } from '@guardian/src-foundations';
 import { pillarMap, pillarPalette } from '@frontend/lib/pillars';
 
 const pillarFill = pillarMap(

--- a/packages/frontend/web/components/SyndicationButton.tsx
+++ b/packages/frontend/web/components/SyndicationButton.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { desktop } from '@guardian/pasteup/breakpoints';
+import { desktop, textSans } from '@guardian/src-foundations';
 import { css } from 'emotion';
-import { textSans } from '@guardian/src-foundations';
 import { palette } from '@guardian/pasteup/palette';
 
 export const SyndicationButton: React.FC<{

--- a/packages/frontend/web/components/elements/PullQuoteComponent.tsx
+++ b/packages/frontend/web/components/elements/PullQuoteComponent.tsx
@@ -2,13 +2,14 @@ import React from 'react';
 import { css } from 'emotion';
 import Quote from '@frontend/static/icons/quote.svg';
 import { pillarPalette } from '@frontend/lib/pillars';
-import { palette, body } from '@guardian/src-foundations';
 import {
+    palette,
+    body,
     desktop,
     leftCol,
     phablet,
     mobileLandscape,
-} from '@guardian/pasteup/breakpoints';
+} from '@guardian/src-foundations';
 import { unescapeData } from '@frontend/lib/escapeData';
 
 const gutter = 20;


### PR DESCRIPTION
## What does this change?

Migrate breakpoints from pasteup to src-foundations.

## Why?

To help complete the migration.

## Link to supporting Trello card

https://trello.com/c/psXEfcWL