### PR TITLE
Migrate mixins from pasteup

### DIFF
--- a/packages/frontend/amp/components/Header.tsx
+++ b/packages/frontend/amp/components/Header.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 import Logo from '@frontend/static/logos/the-guardian.svg';
-import { screenReaderOnly } from '@guardian/pasteup/mixins';
 import { pillarPalette } from '@frontend/lib/pillars';
 import {
     headline,
     palette,
     mobileLandscape,
     until,
+    visuallyHidden,
 } from '@guardian/src-foundations';
 import { ReaderRevenueButton } from '@frontend/amp/components/ReaderRevenueButton';
 
@@ -203,7 +203,7 @@ export const Header: React.FC<{
             <a className={logoStyles} href={guardianBaseURL}>
                 <span
                     className={css`
-                        ${screenReaderOnly};
+                        ${visuallyHidden};
                     `}
                 >
                     The Guardian - Back to home

--- a/packages/frontend/amp/components/MainMedia.tsx
+++ b/packages/frontend/amp/components/MainMedia.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import { bestFitImage, heightEstimate } from '@frontend/amp/lib/image-fit';
 import { css } from 'emotion';
-import { textSans, palette } from '@guardian/src-foundations';
+import { textSans, palette, visuallyHidden } from '@guardian/src-foundations';
 import InfoIcon from '@frontend/static/icons/info.svg';
 import { YoutubeVideo } from '@frontend/amp/components/elements/YoutubeVideo';
-import { screenReaderOnly } from '@guardian/pasteup/mixins';
 
 const figureStyle = css`
     margin: 0 0;
@@ -59,10 +58,6 @@ const labelStyle = css`
         position: absolute;
         fill: ${palette.neutral[100]};
     }
-`;
-
-const visuallyHidden = css`
-    ${screenReaderOnly}
 `;
 
 const mainImage = (element: ImageBlockElement): JSX.Element | null => {

--- a/packages/frontend/amp/components/ShareIcons.tsx
+++ b/packages/frontend/amp/components/ShareIcons.tsx
@@ -7,7 +7,7 @@ import LinkedInIcon from '@frontend/static/icons/linked-in.svg';
 import PinterestIcon from '@frontend/static/icons/pinterest.svg';
 import WhatsAppIcon from '@frontend/static/icons/whatsapp.svg';
 import MessengerIcon from '@frontend/static/icons/messenger.svg';
-import { screenReaderOnly } from '@guardian/pasteup/mixins';
+import { visuallyHidden } from '@guardian/src-foundations';
 import { pillarMap, pillarPalette, neutralBorder } from '@frontend/lib/pillars';
 
 const pillarFill = pillarMap(
@@ -116,7 +116,7 @@ export const ShareIcons: React.FC<{
                         <a href={url} role="button">
                             <span
                                 className={css`
-                                    ${screenReaderOnly};
+                                    ${visuallyHidden};
                                 `}
                             >
                                 {userMessage}

--- a/packages/frontend/lib/mixins.ts
+++ b/packages/frontend/lib/mixins.ts
@@ -1,0 +1,7 @@
+export const clearFix = `
+    :after {
+        content: '';
+        display: table;
+        clear: both;
+    }
+`;

--- a/packages/frontend/web/components/ArticleHeader.tsx
+++ b/packages/frontend/web/components/ArticleHeader.tsx
@@ -4,7 +4,6 @@ import { css, cx } from 'emotion';
 import ClockIcon from '@frontend/static/icons/clock.svg';
 import { getAgeWarning } from '@frontend/lib/age-warning';
 import { pillarMap, pillarPalette } from '@frontend/lib/pillars';
-import { screenReaderOnly } from '@guardian/pasteup/mixins';
 import {
     until,
     leftCol,
@@ -14,6 +13,7 @@ import {
     textSans,
     body,
     palette,
+    visuallyHidden,
 } from '@guardian/src-foundations';
 
 import { MainMedia } from './MainMedia';
@@ -156,7 +156,7 @@ const ageWarningStyle = css`
 `;
 
 const ageWarningScreenReader = css`
-    ${screenReaderOnly};
+    ${visuallyHidden};
 `;
 
 const headerStyles = css`

--- a/packages/frontend/web/components/Dateline.tsx
+++ b/packages/frontend/web/components/Dateline.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
 import { css } from 'emotion';
-import { palette, textSans } from '@guardian/src-foundations';
-import { screenReaderOnly } from '@guardian/pasteup/mixins';
+import { textSans, visuallyHidden, palette } from '@guardian/src-foundations';
 
 const captionFont = css`
     ${textSans({ level: 1 })};
@@ -17,7 +16,7 @@ const dateline = css`
 `;
 
 const description = css`
-    ${screenReaderOnly}
+    ${visuallyHidden}
 `;
 
 export const Dateline: React.FC<{

--- a/packages/frontend/web/components/Dropdown.tsx
+++ b/packages/frontend/web/components/Dropdown.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import { css, cx } from 'emotion';
-import { textSans, palette, until, tablet } from '@guardian/src-foundations';
-import { screenReaderOnly } from '@guardian/pasteup/mixins';
+import {
+    textSans,
+    visuallyHidden,
+    palette,
+    until,
+    tablet,
+} from '@guardian/src-foundations';
 
 export interface Link {
     url: string;
@@ -18,7 +23,7 @@ interface Props {
 }
 
 const input = css`
-    ${screenReaderOnly};
+    ${visuallyHidden};
     :checked + ul {
         display: block;
     }

--- a/packages/frontend/web/components/Footer.tsx
+++ b/packages/frontend/web/components/Footer.tsx
@@ -10,8 +10,8 @@ import {
     textSans,
     palette,
 } from '@guardian/src-foundations';
-import { clearFix } from '@guardian/pasteup/mixins';
 
+import { clearFix } from '@frontend/lib/mixins';
 import { Pillars, pillarWidth, firstPillarWidth } from './Header/Nav/Pillars';
 import { ReaderRevenueLinks } from './Header/Nav/ReaderRevenueLinks';
 import { BackToTop } from './BackToTop';

--- a/packages/frontend/web/components/Header/Nav/Links/SupportTheGuardian.tsx
+++ b/packages/frontend/web/components/Header/Nav/Links/SupportTheGuardian.tsx
@@ -6,9 +6,9 @@ import {
     mobileMedium,
     headline,
     palette,
+    visuallyHidden,
 } from '@guardian/src-foundations';
 import ProfileIcon from '@frontend/static/icons/profile.svg';
-import { screenReaderOnly } from '@guardian/pasteup/mixins';
 
 import { getCookie } from '@frontend/web/browser/cookie';
 import { AsyncClientComponent } from '@frontend/web/components/lib/AsyncClientComponent';
@@ -104,7 +104,7 @@ export const SupportTheGuardian: React.FC<{
                                 <ProfileIcon className={mobileSignInIcon} />
                                 <span
                                     className={css`
-                                        ${screenReaderOnly};
+                                        ${visuallyHidden};
                                     `}
                                 >
                                     Sign in

--- a/packages/frontend/web/components/Header/Nav/Logo.tsx
+++ b/packages/frontend/web/components/Header/Nav/Logo.tsx
@@ -8,8 +8,9 @@ import {
     desktop,
     wide,
     palette,
+    visuallyHidden,
 } from '@guardian/src-foundations';
-import { screenReaderOnly } from '@guardian/pasteup/mixins';
+
 import TheGuardianLogoSVG from '@frontend/static/logos/the-guardian.svg';
 
 const link = css`
@@ -62,7 +63,7 @@ export const Logo: React.FC = () => (
     <a className={link} href="/" data-link-name="nav2 : logo">
         <span
             className={css`
-                ${screenReaderOnly};
+                ${visuallyHidden};
             `}
         >
             The Guardian - Back to home

--- a/packages/frontend/web/components/Header/Nav/MainMenuToggle/MainMenuToggle.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenuToggle/MainMenuToggle.tsx
@@ -1,11 +1,15 @@
 import React, { Component } from 'react';
 import { css, cx } from 'emotion';
-import { desktop, headline, palette } from '@guardian/src-foundations';
-import { screenReaderOnly } from '@guardian/pasteup/mixins';
+import {
+    headline,
+    visuallyHidden,
+    desktop,
+    palette,
+} from '@guardian/src-foundations';
 import { VeggieBurger } from './VeggieBurger';
 
 const screenReadable = css`
-    ${screenReaderOnly};
+    ${visuallyHidden};
 `;
 const openMainMenu = css`
     ${headline({ level: 3 })};

--- a/packages/frontend/web/components/Header/Nav/Nav.tsx
+++ b/packages/frontend/web/components/Header/Nav/Nav.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { css } from 'emotion';
-import { clearFix } from '@guardian/pasteup/mixins';
+import { clearFix } from '@frontend/lib/mixins';
 import {
     tablet,
     desktop,

--- a/packages/frontend/web/components/MostViewed/MostViewedGrid.tsx
+++ b/packages/frontend/web/components/MostViewed/MostViewedGrid.tsx
@@ -1,7 +1,12 @@
 import React, { useState } from 'react';
 import { css, cx } from 'emotion';
-import { headline, palette, tablet, until } from '@guardian/src-foundations';
-import { screenReaderOnly } from '@guardian/pasteup/mixins';
+import {
+    visuallyHidden,
+    headline,
+    palette,
+    tablet,
+    until,
+} from '@guardian/src-foundations';
 
 import { TabType, TrailType } from './MostViewed';
 import { MostViewedItem } from './MostViewedItem';
@@ -124,7 +129,7 @@ export const MostViewedGrid = ({ data, sectionName, pillar }: Props) => {
                             >
                                 <span
                                     className={css`
-                                        ${screenReaderOnly};
+                                        ${visuallyHidden};
                                     `}
                                 >
                                     Most viewed{' '}


### PR DESCRIPTION
## What does this change?

Migrates mixins out of pasteup.

## Why?

We are removing pasteup.

## Link to supporting Trello card

https://trello.com/c/psXEfcWL
