### PR TITLE
Migrate remaining palette uses

### DIFF
--- a/packages/frontend/amp/components/Caption.tsx
+++ b/packages/frontend/amp/components/Caption.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { textSans } from '@guardian/src-foundations';
-import { palette } from '@guardian/pasteup/palette';
+import { textSans, palette } from '@guardian/src-foundations';
 import { css, cx } from 'emotion';
 import { pillarPalette } from '@guardian/frontend-rendering/lib/pillars';
 import TriangleIcon from '@frontend/static/icons/triangle.svg';

--- a/packages/frontend/amp/components/ShareIcons.tsx
+++ b/packages/frontend/amp/components/ShareIcons.tsx
@@ -8,7 +8,7 @@ import PinterestIcon from '@frontend/static/icons/pinterest.svg';
 import WhatsAppIcon from '@frontend/static/icons/whatsapp.svg';
 import MessengerIcon from '@frontend/static/icons/messenger.svg';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';
-import { pillarMap, pillarPalette } from '@frontend/lib/pillars';
+import { pillarMap, pillarPalette, neutralBorder } from '@frontend/lib/pillars';
 
 const pillarFill = pillarMap(
     pillar =>
@@ -24,7 +24,7 @@ const shareIconsListItem = css`
 `;
 
 const shareIcon = (pillar: Pillar) => css`
-    border: 1px solid ${pillarPalette[pillar].neutral.border};
+    border: 1px solid ${neutralBorder(pillar)};
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/packages/frontend/amp/components/SubMeta.tsx
+++ b/packages/frontend/amp/components/SubMeta.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css, cx } from 'emotion';
-import { pillarPalette } from '@frontend/lib/pillars';
+import { pillarPalette, neutralBorder } from '@frontend/lib/pillars';
 import { palette, textSans, body } from '@guardian/src-foundations';
 import { ShareIcons } from '@frontend/amp/components/ShareIcons';
 import CommentIcon from '@frontend/static/icons/comment.svg';
@@ -8,8 +8,8 @@ import CommentIcon from '@frontend/static/icons/comment.svg';
 const guardianLines = (pillar: Pillar) => css`
     background-image: repeating-linear-gradient(
         to bottom,
-        ${pillarPalette[pillar].neutral.border},
-        ${pillarPalette[pillar].neutral.border} 1px,
+        ${neutralBorder(pillar)},
+        ${neutralBorder(pillar)} 1px,
         transparent 1px,
         transparent 4px
     );
@@ -51,7 +51,7 @@ const keywordListStyle = (pillar: Pillar) => css`
     margin-left: -6px;
     padding-top: 6px;
     padding-bottom: 12px;
-    border-bottom: 1px solid ${pillarPalette[pillar].neutral.border};
+    border-bottom: 1px solid ${neutralBorder(pillar)};
     margin-bottom: 6px;
 `;
 

--- a/packages/frontend/amp/components/elements/Text.tsx
+++ b/packages/frontend/amp/components/elements/Text.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 import { palette, body, textSans } from '@guardian/src-foundations';
-import { pillarPalette } from '@frontend/lib/pillars';
+import { pillarPalette, neutralBorder } from '@frontend/lib/pillars';
 import { sanitise } from '@frontend/amp/lib/sanitise-html';
 import { composeLabsCSS } from '@frontend/amp/lib/compose-labs-css';
 
@@ -36,7 +36,7 @@ export const LinkStyle = (pillar: Pillar) => css`
     a {
         color: ${pillarPalette[pillar].dark};
         text-decoration: none;
-        border-bottom: 1px solid ${pillarPalette[pillar].neutral.border};
+        border-bottom: 1px solid ${neutralBorder(pillar)};
         :hover {
             border-bottom: 1px solid ${pillarPalette[pillar].dark};
         }
@@ -63,7 +63,7 @@ export const TextStyle = (pillar: Pillar) => css`
     ${body({ level: 2 })};
 
     ${LinkStyle(pillar)};
-    ${ListStyle(pillarPalette[pillar].neutral.border)};
+    ${ListStyle(neutralBorder(pillar))};
 `;
 
 // Labs paid content only

--- a/packages/frontend/amp/components/topMeta/PaidForBand.tsx
+++ b/packages/frontend/amp/components/topMeta/PaidForBand.tsx
@@ -4,6 +4,7 @@ import { css, cx } from 'emotion';
 import { palette, mobileLandscape, textSans } from '@guardian/src-foundations';
 import LabsLogo from '@frontend/static/logos/the-guardian-labs.svg';
 import ArrowRightIcon from '@frontend/static/icons/arrow-right.svg';
+import { augmentedLabs } from '@frontend/lib/pillars';
 
 const headerStyle = css`
     display: flex;
@@ -12,7 +13,7 @@ const headerStyle = css`
     margin: 0 -10px;
     padding: 0 10px;
     height: 58px;
-    background-color: ${palette.labs.bright};
+    background-color: ${augmentedLabs.bright};
 
     ${mobileLandscape} {
         padding: 0 20px;
@@ -42,8 +43,8 @@ const aboutButtonStyle = css`
     margin-left: 10px;
     padding: 10px;
     border: 0;
-    border-left: solid 1px ${palette.labs.faded};
-    border-right: solid 1px ${palette.labs.faded};
+    border-left: solid 1px ${augmentedLabs.faded};
+    border-right: solid 1px ${augmentedLabs.faded};
     background: transparent;
     color: inherit;
     cursor: pointer;
@@ -82,7 +83,7 @@ const logoStyle = css`
 
 const aStyle = css`
     display: inline-block;
-    color: ${palette.labs.bright};
+    color: ${augmentedLabs.bright};
     text-decoration: none;
     margin-top: 10px;
     &:hover {
@@ -91,7 +92,7 @@ const aStyle = css`
 `;
 
 const iconStyle = css`
-    fill: ${palette.labs.bright};
+    fill: ${augmentedLabs.bright};
     margin: 0 0;
     padding-right: 3px;
     vertical-align: middle;

--- a/packages/frontend/amp/components/topMeta/Standfirst.tsx
+++ b/packages/frontend/amp/components/topMeta/Standfirst.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 import { palette, headline, textSans } from '@guardian/src-foundations';
-import { pillarPalette } from '@frontend/lib/pillars';
+import { neutralBorder } from '@frontend/lib/pillars';
 import { composeLabsCSS } from '@frontend/amp/lib/compose-labs-css';
 import { ListStyle, LinkStyle } from '@frontend/amp/components/elements/Text';
 
@@ -19,7 +19,7 @@ const standfirstCss = (pillar: Pillar) => css`
         font-weight: 700;
     }
 
-    ${ListStyle(pillarPalette[pillar].neutral.border)};
+    ${ListStyle(neutralBorder(pillar))};
     ${LinkStyle(pillar)};
 `;
 

--- a/packages/frontend/amp/components/topMeta/TopMetaExtras.tsx
+++ b/packages/frontend/amp/components/topMeta/TopMetaExtras.tsx
@@ -3,7 +3,7 @@ import { css, cx } from 'emotion';
 import ClockIcon from '@frontend/static/icons/clock.svg';
 import { ShareIcons } from '@frontend/amp/components/ShareIcons';
 import { palette, textSans } from '@guardian/src-foundations';
-import { pillarMap, pillarPalette } from '@frontend/lib/pillars';
+import { pillarMap, pillarPalette, neutralBorder } from '@frontend/lib/pillars';
 import TwitterIcon from '@frontend/static/icons/twitter.svg';
 
 const pillarColours = pillarMap(
@@ -32,8 +32,8 @@ const metaExtras = css`
 `;
 
 const borders = (pillar: Pillar) => css`
-    border-top: 1px solid ${pillarPalette[pillar].neutral.border};
-    border-bottom: 1px solid ${pillarPalette[pillar].neutral.border};
+    border-top: 1px solid ${neutralBorder(pillar)};
+    border-bottom: 1px solid ${neutralBorder(pillar)};
     display: flex;
     justify-content: space-between;
     flex-wrap: wrap;

--- a/packages/frontend/amp/components/topMeta/TopMetaLiveblog.tsx
+++ b/packages/frontend/amp/components/topMeta/TopMetaLiveblog.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { headline, palette } from '@guardian/src-foundations';
 import { css } from 'emotion';
-import { pillarPalette } from '@frontend/lib/pillars';
+import { pillarPalette, neutralBorder } from '@frontend/lib/pillars';
 import { ArticleModel } from '@frontend/amp/types/ArticleModel';
 import { MainMedia } from '@frontend/amp/components/MainMedia';
 import { Byline } from '@frontend/amp/components/topMeta/Byline';
@@ -52,7 +52,7 @@ const standfirstStyle = (pillar: Pillar) => css`
         font-weight: 700;
     }
 
-    ${ListStyle(pillarPalette[pillar].neutral.border)};
+    ${ListStyle(neutralBorder(pillar))};
 `;
 
 const fullWidth = css`

--- a/packages/frontend/lib/pillars.ts
+++ b/packages/frontend/lib/pillars.ts
@@ -1,4 +1,14 @@
-import { PillarColours, palette } from '@guardian/pasteup/palette';
+import { palette } from '@guardian/src-foundations';
+
+type colour = string;
+
+interface PillarColours {
+    dark: colour;
+    main: colour;
+    bright: colour;
+    pastel: colour;
+    faded: colour;
+}
 
 export const pillarNames: Pillar[] = [
     'news',
@@ -9,13 +19,21 @@ export const pillarNames: Pillar[] = [
     'labs',
 ];
 
+export const augmentedLabs: PillarColours = {
+    dark: palette.labs.dark,
+    main: palette.labs.main,
+    bright: '#69d1ca', // bright teal
+    pastel: '', // TODO
+    faded: '#65a897', // dark teal
+};
+
 export const pillarPalette: Record<Pillar, PillarColours> = {
     news: palette.news,
     opinion: palette.opinion,
     sport: palette.sport,
     culture: palette.culture,
     lifestyle: palette.lifestyle,
-    labs: palette.labs,
+    labs: augmentedLabs,
 };
 
 /*
@@ -45,4 +63,13 @@ export const getPillar = (pillar: Pillar, designType: DesignType): Pillar => {
     }
 
     return pillar;
+};
+
+export const neutralBorder = (pillar: Pillar): colour => {
+    switch (pillar) {
+        case 'labs':
+            return palette.neutral[60]; // 'dark' theme
+        default:
+            return palette.neutral[86];
+    }
 };

--- a/packages/frontend/web/components/ArticleBody.tsx
+++ b/packages/frontend/web/components/ArticleBody.tsx
@@ -3,8 +3,13 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 
-import { palette } from '@guardian/pasteup/palette';
-import { from, tablet, headline, textSans } from '@guardian/src-foundations';
+import {
+    from,
+    tablet,
+    headline,
+    textSans,
+    palette,
+} from '@guardian/src-foundations';
 import { pillarMap, pillarPalette } from '@frontend/lib/pillars';
 import { ArticleRenderer } from '@frontend/web/components/lib/ArticleRenderer';
 import { getSharingUrls } from '@frontend/lib/sharing-urls';

--- a/packages/frontend/web/components/ArticleHeader.tsx
+++ b/packages/frontend/web/components/ArticleHeader.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 
-import { palette } from '@guardian/pasteup/palette';
 import ClockIcon from '@frontend/static/icons/clock.svg';
 import { getAgeWarning } from '@frontend/lib/age-warning';
 import { pillarMap, pillarPalette } from '@frontend/lib/pillars';
@@ -14,6 +13,7 @@ import {
     headline,
     textSans,
     body,
+    palette,
 } from '@guardian/src-foundations';
 
 import { MainMedia } from './MainMedia';
@@ -128,7 +128,7 @@ const headlineCSS = css`
 const ageWarningStyle = css`
     ${textSans({ level: 3 })};
     color: ${palette.neutral[7]};
-    background-color: ${palette.highlight.main};
+    background-color: ${palette.yellow.main};
     display: inline-block;
     margin-bottom: 6px;
 

--- a/packages/frontend/web/components/Byline.tsx
+++ b/packages/frontend/web/components/Byline.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 import TwitterIcon from '@frontend/static/icons/twitter.svg';
-import { headline, textSans } from '@guardian/src-foundations';
-import { palette } from '@guardian/pasteup/palette';
+import { headline, textSans, palette } from '@guardian/src-foundations';
 import { pillarPalette } from '@frontend/lib/pillars';
 
 const twitterHandle = css`

--- a/packages/frontend/web/components/Caption.tsx
+++ b/packages/frontend/web/components/Caption.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { textSans } from '@guardian/src-foundations';
-import { palette } from '@guardian/pasteup/palette';
+import { textSans, palette } from '@guardian/src-foundations';
 import { css, cx } from 'emotion';
 import { pillarPalette } from '@guardian/frontend-rendering/lib/pillars';
 import TriangleIcon from '@frontend/static/icons/triangle.svg';

--- a/packages/frontend/web/components/CookieBanner.tsx
+++ b/packages/frontend/web/components/CookieBanner.tsx
@@ -1,7 +1,12 @@
 import React, { Component } from 'react';
 import { css } from 'emotion';
-import { palette } from '@guardian/pasteup/palette';
-import { headline, textSans, body, until } from '@guardian/src-foundations';
+import {
+    headline,
+    textSans,
+    body,
+    until,
+    palette,
+} from '@guardian/src-foundations';
 import TickIcon from '@frontend/static/icons/tick.svg';
 import RoundelIcon from '@frontend/static/icons/the-guardian-roundel.svg';
 import { getCookie, addCookie } from '@frontend/web/browser/cookie';
@@ -72,7 +77,7 @@ const button = css`
     ${textSans({ level: 3 })};
     border-radius: 1000px;
     height: 42px;
-    background: ${palette.highlight.main};
+    background: ${palette.yellow.main};
     color: ${palette.neutral[7]};
     padding: 0 25px 0 46px;
     align-items: flex-start;

--- a/packages/frontend/web/components/Dateline.tsx
+++ b/packages/frontend/web/components/Dateline.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
 import { css } from 'emotion';
-import { palette } from '@guardian/pasteup/palette';
-import { textSans } from '@guardian/src-foundations';
+import { palette, textSans } from '@guardian/src-foundations';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';
 
 const captionFont = css`

--- a/packages/frontend/web/components/Dropdown.tsx
+++ b/packages/frontend/web/components/Dropdown.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { css, cx } from 'emotion';
-import { palette } from '@guardian/pasteup/palette';
-import { textSans, until, tablet } from '@guardian/src-foundations';
+import { textSans, palette, until, tablet } from '@guardian/src-foundations';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';
 
 export interface Link {
@@ -125,7 +124,7 @@ const button = css`
     text-decoration: none;
 
     :hover {
-        color: ${palette.highlight.main};
+        color: ${palette.yellow.main};
 
         :after {
             transform: translateY(0) rotate(45deg);

--- a/packages/frontend/web/components/Footer.tsx
+++ b/packages/frontend/web/components/Footer.tsx
@@ -8,11 +8,11 @@ import {
     wide,
     desktop,
     textSans,
+    palette,
 } from '@guardian/src-foundations';
 import { clearFix } from '@guardian/pasteup/mixins';
 
 import { Pillars, pillarWidth, firstPillarWidth } from './Header/Nav/Pillars';
-import { palette } from '@guardian/pasteup/palette';
 import { ReaderRevenueLinks } from './Header/Nav/ReaderRevenueLinks';
 import { BackToTop } from './BackToTop';
 
@@ -78,7 +78,7 @@ const footerLink = css`
 
     :hover {
         text-decoration: underline;
-        color: ${palette.highlight.main};
+        color: ${palette.yellow.main};
     }
 `;
 

--- a/packages/frontend/web/components/Header/Nav/EditionDropdown.tsx
+++ b/packages/frontend/web/components/Header/Nav/EditionDropdown.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 import { Dropdown, Link } from '@frontend/web/components/Dropdown';
-import { desktop, wide } from '@guardian/src-foundations';
-import { palette } from '@guardian/pasteup/palette';
+import { palette, desktop, wide } from '@guardian/src-foundations';
 
 const editionDropdown = css`
     display: none;

--- a/packages/frontend/web/components/Header/Nav/Links/Links.tsx
+++ b/packages/frontend/web/components/Header/Nav/Links/Links.tsx
@@ -6,13 +6,13 @@ import {
 } from '@frontend/web/components/Dropdown';
 import ProfileIcon from '@frontend/static/icons/profile.svg';
 import SearchIcon from '@frontend/static/icons/search.svg';
-import { palette } from '@guardian/pasteup/palette';
 import {
     tablet,
     desktop,
     mobileLandscape,
     wide,
     textSans,
+    palette,
 } from '@guardian/src-foundations';
 
 const search = css`
@@ -52,7 +52,7 @@ const link = css`
 
     :hover,
     :focus {
-        color: ${palette.highlight.main};
+        color: ${palette.yellow.main};
     }
 
     svg {

--- a/packages/frontend/web/components/Header/Nav/Links/SupportTheGuardian.tsx
+++ b/packages/frontend/web/components/Header/Nav/Links/SupportTheGuardian.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import { css } from 'emotion';
-
-import { palette } from '@guardian/pasteup/palette';
 import {
     mobileLandscape,
     tablet,
     mobileMedium,
     headline,
+    palette,
 } from '@guardian/src-foundations';
 import ProfileIcon from '@frontend/static/icons/profile.svg';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';

--- a/packages/frontend/web/components/Header/Nav/Logo.tsx
+++ b/packages/frontend/web/components/Header/Nav/Logo.tsx
@@ -7,10 +7,9 @@ import {
     tablet,
     desktop,
     wide,
+    palette,
 } from '@guardian/src-foundations';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';
-
-import { palette } from '@guardian/pasteup/palette';
 import TheGuardianLogoSVG from '@frontend/static/logos/the-guardian.svg';
 
 const link = css`

--- a/packages/frontend/web/components/Header/Nav/MainMenu/CollapseColumnButton.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenu/CollapseColumnButton.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import { headline } from '@guardian/src-foundations';
+import { headline, palette } from '@guardian/src-foundations';
 import { css, cx } from 'emotion';
 import { hideDesktop } from './Column';
-import { palette } from '@guardian/pasteup/palette';
 
 const showColumnLinksStyle = css`
     :before {

--- a/packages/frontend/web/components/Header/Nav/MainMenu/Column.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenu/Column.tsx
@@ -1,14 +1,13 @@
 import React, { Component } from 'react';
 import { css, cx } from 'emotion';
-
 import {
     desktop,
     tablet,
     leftCol,
     until,
     textSans,
+    palette,
 } from '@guardian/src-foundations';
-import { palette } from '@guardian/pasteup/palette';
 import { CollapseColumnButton } from './CollapseColumnButton';
 
 // CSS vars
@@ -73,7 +72,7 @@ const columnLinkTitle = css`
 
     :hover,
     :focus {
-        color: ${palette.highlight.main};
+        color: ${palette.yellow.main};
         text-decoration: underline;
     }
 

--- a/packages/frontend/web/components/Header/Nav/MainMenu/Columns.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenu/Columns.tsx
@@ -8,10 +8,10 @@ import {
     wide,
     headline,
     textSans,
+    palette,
 } from '@guardian/src-foundations';
 
 import { Column, More, ReaderRevenueLinks } from './Column';
-import { palette } from '@guardian/pasteup/palette';
 
 const ColumnsStyle = css`
     box-sizing: border-box;
@@ -95,7 +95,7 @@ const brandExtensionLink = css`
     }
     :hover,
     :focus {
-        color: ${palette.highlight.main};
+        color: ${palette.yellow.main};
     }
     > * {
         pointer-events: none;

--- a/packages/frontend/web/components/Header/Nav/MainMenu/MainMenu.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenu/MainMenu.tsx
@@ -8,9 +8,9 @@ import {
     desktop,
     tablet,
     textSans,
+    palette,
 } from '@guardian/src-foundations';
 import { Columns } from './Columns';
-import { palette } from '@guardian/pasteup/palette';
 
 const showMenu = css`
     ${desktop} {

--- a/packages/frontend/web/components/Header/Nav/MainMenuToggle/MainMenuToggle.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenuToggle/MainMenuToggle.tsx
@@ -1,9 +1,8 @@
 import React, { Component } from 'react';
 import { css, cx } from 'emotion';
-import { desktop, headline } from '@guardian/src-foundations';
+import { desktop, headline, palette } from '@guardian/src-foundations';
 import { screenReaderOnly } from '@guardian/pasteup/mixins';
 import { VeggieBurger } from './VeggieBurger';
-import { palette } from '@guardian/pasteup/palette';
 
 const screenReadable = css`
     ${screenReaderOnly};
@@ -27,10 +26,10 @@ const openMainMenu = css`
         height: 42px;
     }
     :hover {
-        color: ${palette.highlight.main};
+        color: ${palette.yellow.main};
     }
     :focus {
-        color: ${palette.highlight.main};
+        color: ${palette.yellow.main};
     }
 `;
 const checkbox = css`

--- a/packages/frontend/web/components/Header/Nav/MainMenuToggle/VeggieBurger.tsx
+++ b/packages/frontend/web/components/Header/Nav/MainMenuToggle/VeggieBurger.tsx
@@ -6,11 +6,11 @@ import {
     mobileMedium,
     mobileLandscape,
     tablet,
+    palette,
 } from '@guardian/src-foundations';
-import { palette } from '@guardian/pasteup/palette';
 
 const veggieBurger = ({ showMainMenu }: { showMainMenu: boolean }) => css`
-    background-color: ${palette.highlight.main};
+    background-color: ${palette.yellow.main};
     color: ${palette.neutral[7]};
     cursor: pointer;
     height: 42px;

--- a/packages/frontend/web/components/Header/Nav/Pillars.tsx
+++ b/packages/frontend/web/components/Header/Nav/Pillars.tsx
@@ -10,10 +10,10 @@ import {
     wide,
     until,
     headline,
+    palette,
 } from '@guardian/src-foundations';
 
 import { pillarMap, pillarPalette } from '@frontend/lib/pillars';
-import { palette } from '@guardian/pasteup/palette';
 
 // CSS Vars
 

--- a/packages/frontend/web/components/Header/Nav/ReaderRevenueLinks.tsx
+++ b/packages/frontend/web/components/Header/Nav/ReaderRevenueLinks.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { css, cx } from 'emotion';
 
 import ArrowRightIcon from '@frontend/static/icons/arrow-right.svg';
-import { palette } from '@guardian/pasteup/palette';
 import {
     tablet,
     desktop,
@@ -11,13 +10,14 @@ import {
     leftCol,
     textSans,
     headline,
+    palette,
 } from '@guardian/src-foundations';
 
 import { getCookie } from '@frontend/web/browser/cookie';
 import { AsyncClientComponent } from '@frontend/web/components/lib/AsyncClientComponent';
 
 const message = css`
-    color: ${palette.highlight.main};
+    color: ${palette.yellow.main};
     ${headline({ level: 2 })};
     padding-top: 3px;
     margin-bottom: 3px;
@@ -32,7 +32,7 @@ const message = css`
 `;
 
 const link = css`
-    background: ${palette.highlight.main};
+    background: ${palette.yellow.main};
     border-radius: 16px;
     box-sizing: border-box;
     color: ${palette.neutral[7]};

--- a/packages/frontend/web/components/Header/Nav/SubNav/Inner.tsx
+++ b/packages/frontend/web/components/Header/Nav/SubNav/Inner.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { css, cx } from 'emotion';
-import { palette } from '@guardian/pasteup/palette';
 import {
     desktop,
     tablet,
     mobileLandscape,
     textSans,
+    palette,
 } from '@guardian/src-foundations';
 import { pillarPalette, pillarMap } from '@frontend/lib/pillars';
 

--- a/packages/frontend/web/components/Header/Nav/SubNav/SubNav.tsx
+++ b/packages/frontend/web/components/Header/Nav/SubNav/SubNav.tsx
@@ -1,7 +1,7 @@
 import React, { Component, createRef } from 'react';
 import { css } from 'emotion';
 
-import { palette } from '@guardian/pasteup/palette';
+import { palette } from '@guardian/src-foundations';
 import { Inner } from './Inner';
 
 const subnavWrapper = css`

--- a/packages/frontend/web/components/Outbrain.tsx
+++ b/packages/frontend/web/components/Outbrain.tsx
@@ -3,7 +3,6 @@
 import React from 'react';
 import { shouldDisplayAdvertisements } from '@frontend/model/advertisement';
 import { css } from 'emotion';
-import { palette } from '@guardian/pasteup/palette';
 import {
     textSans,
     body,
@@ -11,6 +10,7 @@ import {
     desktop,
     leftCol,
     wide,
+    palette,
 } from '@guardian/src-foundations';
 
 interface OutbrainSelectors {

--- a/packages/frontend/web/components/ShareCount.tsx
+++ b/packages/frontend/web/components/ShareCount.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import { css } from 'emotion';
-import { palette } from '@guardian/pasteup/palette';
 import ShareIcon from '@frontend/static/icons/share.svg';
-import { from, wide, leftCol, textSans } from '@guardian/src-foundations';
+import {
+    from,
+    wide,
+    leftCol,
+    textSans,
+    palette,
+} from '@guardian/src-foundations';
 import { integerCommas } from '@frontend/lib/formatters';
 import { useApi } from '@frontend/web/components/lib/api';
 

--- a/packages/frontend/web/components/ShareIcons.tsx
+++ b/packages/frontend/web/components/ShareIcons.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { css, cx } from 'emotion';
-import { palette } from '@guardian/pasteup/palette';
 import TwitterIconPadded from '@frontend/static/icons/twitter-padded.svg';
 import FacebookIcon from '@frontend/static/icons/facebook.svg';
 import EmailIcon from '@frontend/static/icons/email.svg';
@@ -8,7 +7,7 @@ import LinkedInIcon from '@frontend/static/icons/linked-in.svg';
 import PinterestIcon from '@frontend/static/icons/pinterest.svg';
 import WhatsAppIcon from '@frontend/static/icons/whatsapp.svg';
 import MessengerIcon from '@frontend/static/icons/messenger.svg';
-import { phablet, wide } from '@guardian/src-foundations';
+import { phablet, wide, palette } from '@guardian/src-foundations';
 import { pillarMap, pillarPalette } from '@frontend/lib/pillars';
 
 const pillarFill = pillarMap(

--- a/packages/frontend/web/components/SubMetaLinksList.tsx
+++ b/packages/frontend/web/components/SubMetaLinksList.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { css, cx } from 'emotion';
-import { palette } from '@guardian/pasteup/palette';
-import { headline, textSans } from '@guardian/src-foundations';
+import { headline, textSans, palette } from '@guardian/src-foundations';
 
 import { pillarMap, pillarPalette } from '@frontend/lib/pillars';
 

--- a/packages/frontend/web/components/SyndicationButton.tsx
+++ b/packages/frontend/web/components/SyndicationButton.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { desktop, textSans } from '@guardian/src-foundations';
 import { css } from 'emotion';
-import { palette } from '@guardian/pasteup/palette';
+import { textSans, palette, desktop } from '@guardian/src-foundations';
 
 export const SyndicationButton: React.FC<{
     webUrl: string;

--- a/packages/frontend/web/components/elements/RichLinkComponent.tsx
+++ b/packages/frontend/web/components/elements/RichLinkComponent.tsx
@@ -3,10 +3,11 @@ import { css, cx } from 'emotion';
 import { pillarPalette } from '@frontend/lib/pillars';
 import ArrowInCircle from '@frontend/static/icons/arrow-in-circle.svg';
 import Quote from '@frontend/static/icons/quote.svg';
-import { palette, colour } from '@guardian/pasteup/palette';
-import { headline, textSans } from '@guardian/src-foundations';
+import { headline, textSans, palette } from '@guardian/src-foundations';
 import { StarRating } from '@root/packages/frontend/web/components/StarRating';
 import { useApi } from '@frontend/web/components/lib/api';
+
+type colour = string;
 
 type CardStyle =
     | 'special-report'

--- a/packages/frontend/web/components/elements/TweetBlockComponent.tsx
+++ b/packages/frontend/web/components/elements/TweetBlockComponent.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { css } from 'emotion';
-import { palette } from '@guardian/pasteup/palette';
-import { body } from '@guardian/src-foundations';
+import { palette, body } from '@guardian/src-foundations';
 import { unescapeData } from '@frontend/lib/escapeData';
 
 // fallback styling for when JS is disabled


### PR DESCRIPTION
## What does this change?

Migrates palette use to src-foundations.

Mostly, this is like for like. An exception is labs as src-foundations doesn't quite support all that we need, so I've added `augmentedLabs` in the `pillars.ts` file here.

## Why?

Part of the pasteup goodbye.

## Link to supporting Trello card

https://trello.com/c/psXEfcWL
