### PR TITLE
Added Hide component

### DIFF
--- a/packages/frontend/web/components/Hide.tsx
+++ b/packages/frontend/web/components/Hide.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { css } from 'emotion';
+import {
+    until,
+    mobileMedium,
+    mobileLandscape,
+    phablet,
+    tablet,
+    desktop,
+    leftCol,
+    wide,
+} from '@guardian/src-foundations';
+
+const breakpoints = {
+    mobileMedium,
+    mobileLandscape,
+    phablet,
+    tablet,
+    desktop,
+    leftCol,
+    wide,
+};
+
+type Props = {
+    children: JSX.Element | JSX.Element[];
+    when: 'above' | 'below';
+    breakpoint:
+        | 'mobileMedium'
+        | 'mobileLandscape'
+        | 'phablet'
+        | 'tablet'
+        | 'desktop'
+        | 'leftCol'
+        | 'wide';
+};
+
+export const Hide = ({ children, when, breakpoint }: Props) => {
+    let whenToHide;
+    if (when === 'below') {
+        whenToHide = css`
+            ${until[breakpoint]} {
+                display: none;
+            }
+        `;
+    } else {
+        whenToHide = css`
+            ${breakpoints[breakpoint]} {
+                display: none;
+            }
+        `;
+    }
+    return <div className={whenToHide}>{children}</div>;
+};


### PR DESCRIPTION
## What does this change?
Adds a utility component to allow dom nodes to be hidden based on media breakpoints.

## Props
```
type Props = {
    children: JSX.Element | JSX.Element[];
    when: 'above' | 'below';
    breakpoint:
        | 'mobileMedium'
        | 'mobileLandscape'
        | 'phablet'
        | 'tablet'
        | 'desktop'
        | 'leftCol'
        | 'wide';
};
```

## Usage
```
    import { Hide } from '@frontend/web/components/Hide';

    ...
    <Hide when='above' breakpoint='desktop`>
        <p>I will be hidden above desktop widths</p>
    </Hide>

    <Hide when='below' breakpoint='leftCol`>
        <p>I will be hidden below leftCol</p>
    </Hide>
    ...
```

## Why?
For readability