### PR TITLE
Re-enable amphtml-validator tests

### DIFF
--- a/packages/frontend/amp/server/document.test.tsx
+++ b/packages/frontend/amp/server/document.test.tsx
@@ -6,7 +6,7 @@ import { Article } from '@frontend/amp/pages/Article';
 import { extract as extractNAV } from '@frontend/model/extract-nav';
 import { AnalyticsModel } from '@frontend/amp/components/Analytics';
 
-test.skip('rejects invalid AMP doc (to test validator)', async () => {
+test('rejects invalid AMP doc (to test validator)', async () => {
     const v = await validator.getInstance();
     const linkedData = [{}];
     const metadata = { description: '', canonicalURL: '' };
@@ -25,7 +25,7 @@ test.skip('rejects invalid AMP doc (to test validator)', async () => {
 // TODO failing because fixture still models blocks as nested array of elements
 // rather than a list of Block(s) - that are objects with 'id' and 'elements'
 // fields. This then errors in Elements.tsx.
-test.skip('produces valid AMP doc', async () => {
+test('produces valid AMP doc', async () => {
     const v = await validator.getInstance();
     const config = CAPI.config;
     const nav = extractNAV(CAPI.nav);

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -53,6 +53,6 @@
         "@types/raven-js": "^3.10.0",
         "@types/react": "^16.4.11",
         "@types/react-dom": "^16.0.7",
-        "amphtml-validator": "^1.0.23"
+        "amphtml-validator": "^1.0.28"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2054,14 +2054,14 @@ amp@0.3.1, amp@~0.3.1:
   resolved "https://registry.yarnpkg.com/amp/-/amp-0.3.1.tgz#6adf8d58a74f361e82c1fa8d389c079e139fc47d"
   integrity sha1-at+NWKdPNh6CwfqNOJwHnhOfxH0=
 
-amphtml-validator@^1.0.23:
-  version "1.0.23"
-  resolved "https://registry.yarnpkg.com/amphtml-validator/-/amphtml-validator-1.0.23.tgz#dba0c3854289563c0adaac292cd4d6096ee4d7c8"
-  integrity sha1-26DDhUKJVjwK2qwpLNTWCW7k18g=
+amphtml-validator@^1.0.28:
+  version "1.0.28"
+  resolved "https://registry.yarnpkg.com/amphtml-validator/-/amphtml-validator-1.0.28.tgz#ae32bb0e9f75a26921b98ad8922d1b449fd2e33b"
+  integrity sha512-tnRKsOZ3St8SuaJ+pKkHmbOMkD4YMj4pKzjL0NayhcqzNsB4IwMSEhrpD6OQ+fNg+lDoo8vcdpaWSv9oOp1+Vg==
   dependencies:
-    colors "1.1.2"
-    commander "2.9.0"
-    promise "7.1.1"
+    colors "1.2.5"
+    commander "2.15.1"
+    promise "8.0.1"
 
 anchor-markdown-header@^0.5.5:
   version "0.5.7"
@@ -3362,10 +3362,10 @@ colornames@^1.1.1:
   resolved "https://registry.yarnpkg.com/colornames/-/colornames-1.1.1.tgz#f8889030685c7c4ff9e2a559f5077eb76a816f96"
   integrity sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y=
 
-colors@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
-  integrity sha1-FopHAXVran9RoSzgyXv6KMCE7WM=
+colors@1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.2.5.tgz#89c7ad9a374bc030df8013241f68136ed8835afc"
+  integrity sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==
 
 colors@^1.2.1, colors@^1.3.2:
   version "1.4.0"
@@ -3404,13 +3404,6 @@ commander@2.17.x:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
   integrity sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
-
-commander@2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
-  integrity sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=
-  dependencies:
-    graceful-readlink ">= 1.0.0"
 
 commander@^2.11.0, commander@^2.12.1, commander@^2.18.0, commander@^2.20.0, commander@~2.20.0:
   version "2.20.0"
@@ -5491,11 +5484,6 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.0.tgz#8d8fdc73977cb04104721cb53666c1ca64cd328b"
   integrity sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==
-
-"graceful-readlink@>= 1.0.0":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
-  integrity sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=
 
 growly@^1.3.0:
   version "1.3.0"
@@ -9175,10 +9163,10 @@ promise-inflight@^1.0.1:
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
 
-promise@7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
-  integrity sha1-SJZUxpJha4qlWwck+oCbt9tJxb8=
+promise@8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-8.0.1.tgz#e45d68b00a17647b6da711bf85ed6ed47208f450"
+  integrity sha1-5F1osAoXZHttpxG/he1u1HII9FA=
   dependencies:
     asap "~2.0.3"
 


### PR DESCRIPTION
## What does this change?
This PR bumps `amphtml-validator` to v1.0.28 and re-enables the AMP document tests following the fix that was implemented for [this issue](https://github.com/ampproject/amphtml/issues/25188).

