### PR TITLE
Use margin to prevent image resize on load

### DIFF
--- a/packages/frontend/web/components/ArticleRight.tsx
+++ b/packages/frontend/web/components/ArticleRight.tsx
@@ -19,7 +19,9 @@ const hideBelowDesktop = css`
 
 const padding = css`
     padding-top: 6px;
-    padding-left: 10px;
+    /* Use margin here to the prevent flicker on load that you get
+       with padding (because the header section has flex-grow: 1) */
+    margin-left: 10px;
 `;
 
 type Props = {


### PR DESCRIPTION
## What does this change?
Because we're using a 3 column flex layout with the central column having `flex-grow: 1`, the image slightly resizes itself on page load causing a flicker. Using `margin` in place of `padding` prevents this.

## Why?
The flicker distracts a user's attention