### PR TITLE
Added a way to branch on showcase

### DIFF
--- a/packages/frontend/web/components/Content.tsx
+++ b/packages/frontend/web/components/Content.tsx
@@ -9,12 +9,45 @@ import { ArticleTitle } from '@frontend/web/components/ArticleTitle';
 import { ArticleContainer } from '@frontend/web/components/ArticleContainer';
 import { ArticleMeta } from '@frontend/web/components/ArticleMeta';
 
+function hasShowcase(elements: CAPIElement[]) {
+    function isShowcase(element: CAPIElement) {
+        switch (element._type) {
+            case 'model.dotcomrendering.pageElements.ImageBlockElement':
+                return element.role === 'showcase';
+            default:
+                return false;
+        }
+    }
+
+    // Return true is any element in the array is an ImageBlockElement
+    // with the 'showcase' role
+    return elements.find(isShowcase);
+}
 interface Props {
     CAPI: CAPIType;
     config: ConfigType;
 }
 
 export const Content = ({ CAPI, config }: Props) => {
+    if (hasShowcase(CAPI.mainMediaElements)) {
+        // TODO: This layout should be updated to support showcase images
+        return (
+            <Flex>
+                <ArticleLeft>
+                    <ArticleTitle CAPI={CAPI} fallbackToSection={true} />
+                    <ArticleMeta CAPI={CAPI} config={config} />
+                </ArticleLeft>
+                <ArticleContainer>
+                    <ArticleHeader CAPI={CAPI} config={config} />
+                    <ArticleBody CAPI={CAPI} config={config} />
+                </ArticleContainer>
+                <ArticleRight>
+                    <StickyAd config={config} />
+                </ArticleRight>
+            </Flex>
+        );
+    }
+
     return (
         <Flex>
             <ArticleLeft>


### PR DESCRIPTION
## What does this change?
This adds a way to decide if an article's main media elements contain any showcase items.

I've written this to support multiple items because the `mainMediaElements` property is an array but in reality I am not aware of any cases where this feature is used and I understand the CMS does not easily allow multiple main media elements. Nonetheless, this code will return true if any item is of type `showcase`.

## Why?
This function will be used to branch the layout and support showcase articles.

## Link to supporting Trello card
https://trello.com/c/b3aVtAh3/778-support-showcase-article-type
