### PR TITLE
Update reader revenue button text and link in nav for amp

### DIFF
--- a/packages/frontend/amp/components/Header.tsx
+++ b/packages/frontend/amp/components/Header.tsx
@@ -196,8 +196,9 @@ export const Header: React.FC<{
             <ReaderRevenueButton
                 nav={nav}
                 rrLink={'ampHeader'}
-                rrCategory={'support'}
-                linkLabel={'Support us'}
+                rrCategory={'subscribe'}
+                linkLabel={'Subscribe'}
+                showArrow={false}
             />
 
             <a className={logoStyles} href={guardianBaseURL}>

--- a/packages/frontend/amp/components/ReaderRevenueButton.tsx
+++ b/packages/frontend/amp/components/ReaderRevenueButton.tsx
@@ -89,7 +89,7 @@ export const ReaderRevenueButton: React.SFC<{
     rrLink,
     rrCategory,
     rightAlignIcon,
-    showArrow = true
+    showArrow = true,
 }) => {
     const url = nav.readerRevenueLinks[rrLink][rrCategory];
 
@@ -112,13 +112,15 @@ export const ReaderRevenueButton: React.SFC<{
                 href={url}
             >
                 {linkLabel}
-                {showArrow && (<span
-                    className={cx({
-                        [rightAlignedIcon]: !!rightAlignIcon,
-                    })}
-                >
-                    <ArrowRight />
-                </span>)}
+                {showArrow && (
+                    <span
+                        className={cx({
+                            [rightAlignedIcon]: !!rightAlignIcon,
+                        })}
+                    >
+                        <ArrowRight />
+                    </span>
+                )}
             </a>
         </div>
     );

--- a/packages/frontend/amp/components/ReaderRevenueButton.tsx
+++ b/packages/frontend/amp/components/ReaderRevenueButton.tsx
@@ -59,6 +59,15 @@ const supportLinkStyles = css`
     }
 `;
 
+const supportLinkStylesNoArrow = css`
+    ${supportLinkStyles}
+    padding-right: 0px;
+
+    ${until.mobileMedium} {
+        padding-right: 0px;
+    }
+`
+
 const rightAlignedIcon = css`
     position: absolute;
     height: 20px;
@@ -73,7 +82,8 @@ export const ReaderRevenueButton: React.SFC<{
     rrLink: ReaderRevenuePosition;
     rrCategory: ReaderRevenueCategory;
     rightAlignIcon?: boolean;
-}> = ({ nav, linkLabel, rrLink, rrCategory, rightAlignIcon }) => {
+    showArrow?: boolean;
+}> = ({ nav, linkLabel, rrLink, rrCategory, rightAlignIcon, showArrow = true }) => {
     const url = nav.readerRevenueLinks[rrLink][rrCategory];
 
     if (url === '') {
@@ -88,15 +98,15 @@ export const ReaderRevenueButton: React.SFC<{
                 isAmpHeader ? supportHeaderStyles : supportFooterStyles,
             ])}
         >
-            <a className={supportLinkStyles} href={url}>
+            <a className={showArrow ? supportLinkStyles : supportLinkStylesNoArrow} href={url}>
                 {linkLabel}
-                <span
+                {showArrow && (<span
                     className={cx({
                         [rightAlignedIcon]: !!rightAlignIcon,
                     })}
                 >
                     <ArrowRight />
-                </span>
+                </span>)}
             </a>
         </div>
     );

--- a/packages/frontend/amp/components/ReaderRevenueButton.tsx
+++ b/packages/frontend/amp/components/ReaderRevenueButton.tsx
@@ -66,7 +66,7 @@ const supportLinkStylesNoArrow = css`
     ${until.mobileMedium} {
         padding-right: 0px;
     }
-`
+`;
 
 const rightAlignedIcon = css`
     position: absolute;
@@ -83,7 +83,14 @@ export const ReaderRevenueButton: React.SFC<{
     rrCategory: ReaderRevenueCategory;
     rightAlignIcon?: boolean;
     showArrow?: boolean;
-}> = ({ nav, linkLabel, rrLink, rrCategory, rightAlignIcon, showArrow = true }) => {
+}> = ({
+    nav,
+    linkLabel,
+    rrLink,
+    rrCategory,
+    rightAlignIcon,
+    showArrow = true
+}) => {
     const url = nav.readerRevenueLinks[rrLink][rrCategory];
 
     if (url === '') {
@@ -98,7 +105,12 @@ export const ReaderRevenueButton: React.SFC<{
                 isAmpHeader ? supportHeaderStyles : supportFooterStyles,
             ])}
         >
-            <a className={showArrow ? supportLinkStyles : supportLinkStylesNoArrow} href={url}>
+            <a
+                className={
+                    showArrow ? supportLinkStyles : supportLinkStylesNoArrow
+                }
+                href={url}
+            >
                 {linkLabel}
                 {showArrow && (<span
                     className={cx({


### PR DESCRIPTION
## What does this change?
This changes the Reader Revenue button in the nav for AMP to say 'Subscribe' rather than 'Support us' and the link goes to the subscription landing page rather than the support showcase.

## Why?
This is part of a big push in the RR team to push traffic to digital subscriptions. The page where this link goes features the digital subscription. We have already made this change for non-AMP pages.

## Link to supporting Trello card
Here's the card in [Trello](https://trello.com/c/wP6dEaYs/2606-implement-amp-header-link-change-as-we-already-did-for-normal-mobile).