### PR TITLE
Resurrect allowed component libs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,8 @@ module.exports = {
                     '@guardian/src-foundations',
                     '@frontend/lib/',
                     '@frontend/amp/lib/',
+                    '@frontend/amp/types',
+                    '@frontend/static/icons',
                     '@testing-library',
                     '@guardian/frontend/static/',
                     '@guardian/guui/components',


### PR DESCRIPTION
## What does this change?

Adds two more entries to the allowed component libs to prevent lint warnings.

## Why?

## Link to supporting Trello card
