### PR TITLE
Support Showcase Images

### DIFF
--- a/packages/frontend/web/components/ArticleBody.tsx
+++ b/packages/frontend/web/components/ArticleBody.tsx
@@ -14,9 +14,11 @@ import { pillarMap, pillarPalette } from '@frontend/lib/pillars';
 import { ArticleRenderer } from '@frontend/web/components/lib/ArticleRenderer';
 import { getSharingUrls } from '@frontend/lib/sharing-urls';
 
-import { SharingIcons } from './ShareIcons';
-import { SubMetaLinksList } from './SubMetaLinksList';
-import { SyndicationButton } from './SyndicationButton';
+import { SharingIcons } from '@frontend/web/components/ShareIcons';
+import { SubMetaLinksList } from '@frontend/web/components/SubMetaLinksList';
+import { SyndicationButton } from '@frontend/web/components/SyndicationButton';
+import { ArticleStandfirst } from '@frontend/web/components/ArticleStandfirst';
+import { Hide } from '@frontend/web/components/Hide';
 
 const pillarColours = pillarMap(
     pillar =>
@@ -164,7 +166,8 @@ const maxWidth = css`
 export const ArticleBody: React.FC<{
     CAPI: CAPIType;
     config: ConfigType;
-}> = ({ CAPI, config }) => {
+    isShowcase?: boolean;
+}> = ({ CAPI, config, isShowcase }) => {
     const hasSubMetaSectionLinks = CAPI.subMetaSectionLinks.length > 0;
     const hasSubMetaKeywordLinks = CAPI.subMetaKeywordLinks.length > 0;
     const sharingUrls = getSharingUrls(CAPI.pageId, CAPI.webTitle);
@@ -175,6 +178,16 @@ export const ArticleBody: React.FC<{
                     [immersiveBodyStyle]: CAPI.isImmersive,
                 })}
             >
+                {isShowcase && (
+                    // For articles with main media set as showcase, the standfirst sometimes
+                    // sits inside here so that the right column advert does not get pushed down
+                    <Hide when="below" breakpoint="leftCol">
+                        <ArticleStandfirst
+                            pillar={CAPI.pillar}
+                            standfirst={CAPI.standfirst}
+                        />
+                    </Hide>
+                )}
                 <ArticleRenderer
                     elements={CAPI.blocks[0] ? CAPI.blocks[0].elements : []}
                     pillar={CAPI.pillar}

--- a/packages/frontend/web/components/ArticleTitle.tsx
+++ b/packages/frontend/web/components/ArticleTitle.tsx
@@ -10,11 +10,10 @@ const sectionStyles = css`
 
 type Props = {
     CAPI: CAPIType;
-    fallbackToSection: boolean;
 };
 
-export const ArticleTitle = ({ CAPI, fallbackToSection }: Props) => (
+export const ArticleTitle = ({ CAPI }: Props) => (
     <div className={sectionStyles}>
-        <SeriesSectionLink CAPI={CAPI} fallbackToSection={fallbackToSection} />
+        <SeriesSectionLink CAPI={CAPI} fallbackToSection={true} />
     </div>
 );

--- a/packages/frontend/web/components/Content.tsx
+++ b/packages/frontend/web/components/Content.tsx
@@ -8,21 +8,8 @@ import { ArticleRight } from '@frontend/web/components/ArticleRight';
 import { ArticleTitle } from '@frontend/web/components/ArticleTitle';
 import { ArticleContainer } from '@frontend/web/components/ArticleContainer';
 import { ArticleMeta } from '@frontend/web/components/ArticleMeta';
-
-function hasShowcase(elements: CAPIElement[]) {
-    function isShowcase(element: CAPIElement) {
-        switch (element._type) {
-            case 'model.dotcomrendering.pageElements.ImageBlockElement':
-                return element.role === 'showcase';
-            default:
-                return false;
-        }
-    }
-
-    // Return true is any element in the array is an ImageBlockElement
-    // with the 'showcase' role
-    return elements.find(isShowcase);
-}
+import { Hide } from '@frontend/web/components/Hide';
+import { hasShowcase } from '@frontend/web/components/lib/layoutHelpers';
 interface Props {
     CAPI: CAPIType;
     config: ConfigType;
@@ -30,20 +17,38 @@ interface Props {
 
 export const Content = ({ CAPI, config }: Props) => {
     if (hasShowcase(CAPI.mainMediaElements)) {
-        // TODO: This layout should be updated to support showcase images
         return (
             <Flex>
                 <ArticleLeft>
-                    <ArticleTitle CAPI={CAPI} fallbackToSection={true} />
+                    <ArticleTitle CAPI={CAPI} />
                     <ArticleMeta CAPI={CAPI} config={config} />
                 </ArticleLeft>
                 <ArticleContainer>
-                    <ArticleHeader CAPI={CAPI} config={config} />
-                    <ArticleBody CAPI={CAPI} config={config} />
+                    {/* When BELOW leftCol we display the header in this position, at the top of the page */}
+                    <Hide when="below" breakpoint="leftCol">
+                        <ArticleHeader
+                            CAPI={CAPI}
+                            config={config}
+                            isShowcase={true}
+                        />
+                    </Hide>
+                    <Flex>
+                        <div>
+                            {/* When ABOVE leftCol we display the header in this position, above the article body, underneath the full width image */}
+                            <Hide when="above" breakpoint="leftCol">
+                                <ArticleHeader CAPI={CAPI} config={config} />
+                            </Hide>
+                            <ArticleBody
+                                CAPI={CAPI}
+                                config={config}
+                                isShowcase={true}
+                            />
+                        </div>
+                        <ArticleRight>
+                            <StickyAd config={config} />
+                        </ArticleRight>
+                    </Flex>
                 </ArticleContainer>
-                <ArticleRight>
-                    <StickyAd config={config} />
-                </ArticleRight>
             </Flex>
         );
     }

--- a/packages/frontend/web/components/Content.tsx
+++ b/packages/frontend/web/components/Content.tsx
@@ -51,7 +51,7 @@ export const Content = ({ CAPI, config }: Props) => {
     return (
         <Flex>
             <ArticleLeft>
-                <ArticleTitle CAPI={CAPI} fallbackToSection={true} />
+                <ArticleTitle CAPI={CAPI} />
                 <ArticleMeta CAPI={CAPI} config={config} />
             </ArticleLeft>
             <ArticleContainer>

--- a/packages/frontend/web/components/elements/ImageBlockComponent.tsx
+++ b/packages/frontend/web/components/elements/ImageBlockComponent.tsx
@@ -32,9 +32,6 @@ const imageCss = {
     // TODO: immersive is pending review of different article types
     immersive: css``,
 
-    // TODO: showcase is only a partial implementation as sometimes showcase images
-    //       appear differently based on where they appear in the article
-    //       See top image for: https://www.theguardian.com/stage/2019/oct/01/hammed-animashaun-nick-hytner-dream-master-harold-and-the-boys-national-theatre-london
     showcase: css`
         position: relative;
         margin-top: 16px;

--- a/packages/frontend/web/components/lib/layoutHelpers.ts
+++ b/packages/frontend/web/components/lib/layoutHelpers.ts
@@ -1,0 +1,14 @@
+export const hasShowcase = (elements: CAPIElement[]) => {
+    function isShowcase(element: CAPIElement) {
+        switch (element._type) {
+            case 'model.dotcomrendering.pageElements.ImageBlockElement':
+                return element.role === 'showcase';
+            default:
+                return false;
+        }
+    }
+
+    // Return true is any element in the array is an ImageBlockElement
+    // with the 'showcase' role
+    return elements.find(isShowcase);
+};


### PR DESCRIPTION
## What does this change?
This adds support for showcase images in main media. This is not related to showcase images as article body content.

### Before
![image](https://user-images.githubusercontent.com/1336821/67413688-858ee480-f5b9-11e9-8054-d2e050cb2d14.png)


### After
![Screenshot 2019-10-23 at 17 20 16](https://user-images.githubusercontent.com/1336821/67413644-75770500-f5b9-11e9-87dd-0cbb9abd8a2b.jpg)

## The approach
There are 2 dynamic elements to showcase images.

1. The image itself becomes full width inside the article column, but only at certain viewport widths
2. The header items (headline, standfirst, image) change order, again based on viewport

I was keen to keep the code clean and simple but this was a relatively complicated layout to support and the logic needed to exist somewhere.

For point 1, this is achieved by showing and hiding elements on the page (see the `isShowcase` flag in ArticleBody and the use of `Hide` helpers around `ArticleHeader` in Content).

Point 2 is done using the css property `order` (see `positionMainImage` function in ArticleHeader).


## Link to supporting Trello card
https://trello.com/c/b3aVtAh3/778-support-showcase-article-type
