### PR TITLE
Fix image halfWidth type issue

### DIFF
--- a/packages/frontend/lib/content.d.ts
+++ b/packages/frontend/lib/content.d.ts
@@ -33,7 +33,7 @@ type RoleType =
     | 'showcase'
     | 'inline'
     | 'thumbnail'
-    | 'half-width';
+    | 'halfWidth';
 
 interface ImageBlockElement {
     _type: 'model.dotcomrendering.pageElements.ImageBlockElement';

--- a/packages/frontend/model/json-schema.json
+++ b/packages/frontend/model/json-schema.json
@@ -171,6 +171,18 @@
         "isAdFreeUser": {
             "type": "boolean"
         },
+        "openGraphData": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "string"
+            }
+        },
+        "twitterData": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "string"
+            }
+        },
         "webURL": {
             "type": "string"
         },
@@ -245,6 +257,7 @@
         "main",
         "mainMediaElements",
         "nav",
+        "openGraphData",
         "pageFooter",
         "pageId",
         "pillar",
@@ -257,6 +270,7 @@
         "subMetaSectionLinks",
         "tags",
         "trailText",
+        "twitterData",
         "webPublicationDate",
         "webPublicationDateDisplay",
         "webTitle",
@@ -474,7 +488,7 @@
         },
         "RoleType": {
             "enum": [
-                "half-width",
+                "halfWidth",
                 "immersive",
                 "inline",
                 "showcase",

--- a/packages/frontend/web/components/elements/ImageBlockComponent.tsx
+++ b/packages/frontend/web/components/elements/ImageBlockComponent.tsx
@@ -77,7 +77,7 @@ const imageCss = {
     `,
 
     // TODO:
-    'half-width': css``,
+    halfWidth: css``,
 };
 
 const decidePosition = (role: RoleType) => {
@@ -92,8 +92,8 @@ const decidePosition = (role: RoleType) => {
             return imageCss.showcase;
         case 'thumbnail':
             return imageCss.thumbnail;
-        case 'half-width':
-            return imageCss['half-width'];
+        case 'halfWidth':
+            return imageCss.halfWidth;
         default:
             return imageCss.inline;
     }


### PR DESCRIPTION
## What does this change?

An immediate for for an image validation issue. Separately, we should relax type checking at the edge a bit to prevent total failure on small errors like this one.

See also https://github.com/guardian/frontend/blob/master/common/app/model/dotcomrendering/pageElements/Role.scala#L38 for the relevant Frontend behaviour (which uses `halfWidth`).

## Why?

To stop affected articles 5xxing on prod. E.g. see:

https://amp.theguardian.com/fashion/2018/mar/26/virgil-abloh-named-artistic-director-of-louis-vuitton-menswear

## Link to supporting Trello card

n/a .
