### PR TITLE
Don't throw on validation errors

### DIFF
--- a/packages/frontend/model/validate.test.ts
+++ b/packages/frontend/model/validate.test.ts
@@ -2,9 +2,28 @@ import { validateAsCAPIType } from './validate';
 import { CAPI } from '@root/fixtures/CAPI';
 
 describe('validate', () => {
-    it('does not throw an error on invalid data', () => {
+    const OLD_ENV = process.env;
+
+    beforeEach(() => {
+        jest.resetModules(); // Clear cache
+        process.env = { ...OLD_ENV };
+        delete process.env.NODE_ENV;
+    });
+
+    afterEach(() => {
+        process.env = OLD_ENV;
+    });
+
+    it('does not throw an error in production on invalid data', () => {
+        process.env.NODE_ENV = 'production';
         const data = { foo: 'bar' };
         expect(() => validateAsCAPIType(data)).not.toThrowError(TypeError);
+    });
+
+    it('does throw an error in development on invalid data', () => {
+        process.env.NODE_ENV = 'development';
+        const data = { foo: 'bar' };
+        expect(() => validateAsCAPIType(data)).toThrowError(TypeError);
     });
 
     it('confirm valid data', () => {

--- a/packages/frontend/model/validate.test.ts
+++ b/packages/frontend/model/validate.test.ts
@@ -2,9 +2,9 @@ import { validateAsCAPIType } from './validate';
 import { CAPI } from '@root/fixtures/CAPI';
 
 describe('validate', () => {
-    it('throws on invalid data', () => {
+    it('does not throw an error on invalid data', () => {
         const data = { foo: 'bar' };
-        expect(() => validateAsCAPIType(data)).toThrowError(TypeError);
+        expect(() => validateAsCAPIType(data)).not.toThrowError(TypeError);
     });
 
     it('confirm valid data', () => {

--- a/packages/frontend/model/validate.ts
+++ b/packages/frontend/model/validate.ts
@@ -18,9 +18,17 @@ export const validateAsCAPIType = (data: any): CAPIType => {
 
     if (!isValid) {
         const url = data.webURL || 'unknown url';
+        const errorMessage = `Unable to validate request body for url ${url}.\n${JSON.stringify(
+            validate.errors,
+            null,
+            2,
+        )}`;
 
-        logger.error(`Unable to validate request body for url ${url}.\n
-        ${JSON.stringify(validate.errors, null, 2)}`);
+        if (process.env.NODE_ENV === 'development') {
+            throw new TypeError(errorMessage);
+        } else {
+            logger.error(errorMessage);
+        }
     }
 
     return data as CAPIType;

--- a/packages/frontend/model/validate.ts
+++ b/packages/frontend/model/validate.ts
@@ -1,5 +1,6 @@
 import Ajv from 'ajv';
 import schema from '@frontend/model/json-schema.json';
+import { logger } from '../app/logging';
 
 const options: Ajv.Options = {
     verbose: false,
@@ -18,10 +19,8 @@ export const validateAsCAPIType = (data: any): CAPIType => {
     if (!isValid) {
         const url = data.webURL || 'unknown url';
 
-        throw new TypeError(
-            `Unable to validate request body for url ${url}.\n
-            ${JSON.stringify(validate.errors, null, 2)}`,
-        );
+        logger.error(`Unable to validate request body for url ${url}.\n
+        ${JSON.stringify(validate.errors, null, 2)}`);
     }
 
     return data as CAPIType;

--- a/packages/frontend/model/validate.ts
+++ b/packages/frontend/model/validate.ts
@@ -24,7 +24,7 @@ export const validateAsCAPIType = (data: any): CAPIType => {
             2,
         )}`;
 
-        if (process.env.NODE_ENV === 'development') {
+        if (process.env.NODE_ENV !== 'production') {
             throw new TypeError(errorMessage);
         } else {
             logger.error(errorMessage);


### PR DESCRIPTION
## What does this change?
This prevents the validation code throwing an error causing the request to be served a 500 error.

## Why?
500 errors are bad and should only happen when all else fails, unhandled exceptions basically. But in this case we have caught the error and are able to handle it, so we should.
