### PR TITLE
Desktop breakpoint rich links

### DIFF
--- a/packages/frontend/web/components/StarRating.tsx
+++ b/packages/frontend/web/components/StarRating.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 import Star from '@frontend/static/icons/star.svg';
-import { palette } from '@guardian/src-foundations';
+import { palette, desktop } from '@guardian/src-foundations';
 
 const ratingsWrapper = css`
     background-color: ${palette.yellow.main};
@@ -23,6 +23,14 @@ const smallSize = css`
     svg {
         width: 15px;
         height: 15px;
+    }
+
+    ${desktop} {
+        padding: 2px;
+        svg {
+            width: 23px;
+            height: 23px;
+        }
     }
 `;
 

--- a/packages/frontend/web/components/StarRating.tsx
+++ b/packages/frontend/web/components/StarRating.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 import Star from '@frontend/static/icons/star.svg';
-import { palette, desktop } from '@guardian/src-foundations';
+import { palette, wide } from '@guardian/src-foundations';
 
 const ratingsWrapper = css`
     background-color: ${palette.yellow.main};
@@ -25,7 +25,7 @@ const smallSize = css`
         height: 15px;
     }
 
-    ${desktop} {
+    ${wide} {
         padding: 2px;
         svg {
             width: 23px;

--- a/packages/frontend/web/components/StarRating.tsx
+++ b/packages/frontend/web/components/StarRating.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 import Star from '@frontend/static/icons/star.svg';
-import { palette, wide } from '@guardian/src-foundations';
+import { palette } from '@guardian/src-foundations';
+import { from } from '@guardian/src-utilities';
 
 const ratingsWrapper = css`
     background-color: ${palette.yellow.main};
@@ -25,7 +26,7 @@ const smallSize = css`
         height: 15px;
     }
 
-    ${wide} {
+    ${from.wide} {
         padding: 2px;
         svg {
             width: 23px;

--- a/packages/frontend/web/components/elements/RichLinkComponent.tsx
+++ b/packages/frontend/web/components/elements/RichLinkComponent.tsx
@@ -3,14 +3,8 @@ import { css, cx } from 'emotion';
 import { pillarPalette } from '@frontend/lib/pillars';
 import ArrowInCircle from '@frontend/static/icons/arrow-in-circle.svg';
 import Quote from '@frontend/static/icons/quote.svg';
-import {
-    headline,
-    textSans,
-    palette,
-    until,
-    from,
-    wide,
-} from '@guardian/src-foundations';
+import { headline, textSans, palette } from '@guardian/src-foundations';
+import { from, until, between } from '@guardian/src-utilities';
 import { StarRating } from '@root/packages/frontend/web/components/StarRating';
 import { useApi } from '@frontend/web/components/lib/api';
 
@@ -53,16 +47,16 @@ const richLinkPillarColour: (pillar: Pillar) => colour = pillar => {
 
 const richLinkContainer = css`
     ${until.wide} {
-        width: 130px;
+        width: 140px;
     }
     float: left;
     margin-right: 20px;
     margin-bottom: 5px;
     margin-left: 0px;
-    ${from.leftCol.until.wide} {
-        margin-left: -150px;
+    ${between.leftCol.and.wide} {
+        margin-left: -160px;
     }
-    ${wide} {
+    ${from.wide} {
         margin-left: -240px;
         width: 220px;
     }
@@ -98,7 +92,7 @@ const richLinkTitle = css`
     padding-top: 1px;
     padding-bottom: 1px;
     font-weight: 400;
-    ${wide} {
+    ${from.wide} {
         ${headline({ level: 2 })};
         padding-bottom: 5px;
     }
@@ -115,7 +109,7 @@ const richLinkReadMore: (pillar: Pillar) => colour = pillar => {
 const readMoreTextStyle = css`
     ${headline({ level: 1 })};
     font-size: 14px;
-    ${wide} {
+    ${from.wide} {
         ${headline({ level: 1 })}
     }
     display: inline-block;
@@ -131,7 +125,7 @@ const byline = css`
     ${headline({ level: 1 })};
     font-size: 14px;
     font-style: italic;
-    ${wide} {
+    ${from.wide} {
         ${headline({ level: 2 })};
     }
 `;
@@ -149,7 +143,7 @@ const contributorImageWrapper = css`
     height: 5rem;
     margin-left: auto;
     margin-right: 0.3rem;
-    ${wide} {
+    ${from.wide} {
         width: 8.5rem;
         height: 8.5rem;
     }

--- a/packages/frontend/web/components/elements/RichLinkComponent.tsx
+++ b/packages/frontend/web/components/elements/RichLinkComponent.tsx
@@ -7,7 +7,10 @@ import {
     headline,
     textSans,
     palette,
-    desktop,
+    until,
+    from,
+    wide,
+    body,
 } from '@guardian/src-foundations';
 import { StarRating } from '@root/packages/frontend/web/components/StarRating';
 import { useApi } from '@frontend/web/components/lib/api';
@@ -50,11 +53,17 @@ const richLinkPillarColour: (pillar: Pillar) => colour = pillar => {
 };
 
 const richLinkContainer = css`
-    width: 130px;
+    ${until.wide} {
+        width: 130px;
+    }
     float: left;
     margin-right: 20px;
     margin-bottom: 5px;
-    ${desktop} {
+    margin-left: 0px;
+    ${from.leftCol.until.wide} {
+        margin-left: -150px;
+    }
+    ${wide} {
         margin-left: -240px;
         width: 220px;
     }
@@ -85,11 +94,11 @@ const quote: (pillar: Pillar) => colour = pillar => {
 };
 
 const richLinkTitle = css`
-    ${headline({ level: 1 })};
-    font-weight: 400;
+    ${body({ level: 1 })};
     padding-top: 1px;
     padding-bottom: 1px;
-    ${desktop} {
+    font-weight: 400;
+    ${wide} {
         ${headline({ level: 2 })};
         padding-bottom: 5px;
     }
@@ -104,7 +113,10 @@ const richLinkReadMore: (pillar: Pillar) => colour = pillar => {
 };
 
 const readMoreTextStyle = css`
-    ${headline({ level: 1 })};
+    ${body({ level: 1 })};
+    ${wide} {
+        ${headline({ level: 1 })}
+    }
     display: inline-block;
     height: 30px;
     line-height: 26px;
@@ -115,9 +127,9 @@ const readMoreTextStyle = css`
 `;
 
 const byline = css`
-    ${headline({ level: 1 })};
+    ${body({ level: 1 })};
     font-style: italic;
-    ${desktop} {
+    ${wide} {
         ${headline({ level: 2 })};
     }
 `;
@@ -135,7 +147,7 @@ const contributorImageWrapper = css`
     height: 5rem;
     margin-left: auto;
     margin-right: 0.3rem;
-    ${desktop} {
+    ${wide} {
         width: 8.5rem;
         height: 8.5rem;
     }

--- a/packages/frontend/web/components/elements/RichLinkComponent.tsx
+++ b/packages/frontend/web/components/elements/RichLinkComponent.tsx
@@ -10,7 +10,6 @@ import {
     until,
     from,
     wide,
-    body,
 } from '@guardian/src-foundations';
 import { StarRating } from '@root/packages/frontend/web/components/StarRating';
 import { useApi } from '@frontend/web/components/lib/api';
@@ -94,7 +93,8 @@ const quote: (pillar: Pillar) => colour = pillar => {
 };
 
 const richLinkTitle = css`
-    ${body({ level: 1 })};
+    ${headline({ level: 1 })};
+    font-size: 14px;
     padding-top: 1px;
     padding-bottom: 1px;
     font-weight: 400;
@@ -113,7 +113,8 @@ const richLinkReadMore: (pillar: Pillar) => colour = pillar => {
 };
 
 const readMoreTextStyle = css`
-    ${body({ level: 1 })};
+    ${headline({ level: 1 })};
+    font-size: 14px;
     ${wide} {
         ${headline({ level: 1 })}
     }
@@ -127,7 +128,8 @@ const readMoreTextStyle = css`
 `;
 
 const byline = css`
-    ${body({ level: 1 })};
+    ${headline({ level: 1 })};
+    font-size: 14px;
     font-style: italic;
     ${wide} {
         ${headline({ level: 2 })};

--- a/packages/frontend/web/components/elements/RichLinkComponent.tsx
+++ b/packages/frontend/web/components/elements/RichLinkComponent.tsx
@@ -3,7 +3,12 @@ import { css, cx } from 'emotion';
 import { pillarPalette } from '@frontend/lib/pillars';
 import ArrowInCircle from '@frontend/static/icons/arrow-in-circle.svg';
 import Quote from '@frontend/static/icons/quote.svg';
-import { headline, textSans, palette } from '@guardian/src-foundations';
+import {
+    headline,
+    textSans,
+    palette,
+    desktop,
+} from '@guardian/src-foundations';
 import { StarRating } from '@root/packages/frontend/web/components/StarRating';
 import { useApi } from '@frontend/web/components/lib/api';
 
@@ -45,10 +50,14 @@ const richLinkPillarColour: (pillar: Pillar) => colour = pillar => {
 };
 
 const richLinkContainer = css`
-    width: 8.125rem;
+    width: 130px;
     float: left;
     margin-right: 20px;
     margin-bottom: 5px;
+    ${desktop} {
+        margin-left: -240px;
+        width: 220px;
+    }
 `;
 
 const richLinkTopBorder: (pillar: Pillar) => colour = pillar => {
@@ -80,6 +89,10 @@ const richLinkTitle = css`
     font-weight: 400;
     padding-top: 1px;
     padding-bottom: 1px;
+    ${desktop} {
+        ${headline({ level: 2 })};
+        padding-bottom: 5px;
+    }
 `;
 
 const richLinkReadMore: (pillar: Pillar) => colour = pillar => {
@@ -104,6 +117,9 @@ const readMoreTextStyle = css`
 const byline = css`
     ${headline({ level: 1 })};
     font-style: italic;
+    ${desktop} {
+        ${headline({ level: 2 })};
+    }
 `;
 
 // !important is used here to override the default inline body image styling
@@ -119,6 +135,10 @@ const contributorImageWrapper = css`
     height: 5rem;
     margin-left: auto;
     margin-right: 0.3rem;
+    ${desktop} {
+        width: 8.5rem;
+        height: 8.5rem;
+    }
 `;
 
 const neutralBackground = css`


### PR DESCRIPTION
## What does this change?
Adds css for rich links for the desktop breakpoint. 

## Why?
They look weird at the moment and interfere with adverts. This PR pulls them out to the left of content and brings them into visual parity (ish) with frontend.

Before:
![Screenshot 2019-10-25 at 18 15 53](https://user-images.githubusercontent.com/3606555/67590645-80fe3380-f753-11e9-8fc0-cea50bbc0b86.png)

After:
![Screenshot 2019-10-25 at 18 14 16](https://user-images.githubusercontent.com/3606555/67590625-72b01780-f753-11e9-9f60-258d70b39b45.png)


## Link to supporting Trello card
https://trello.com/c/WWVPX2lV/788-fix-rich-links-on-desktop-breakpoint