### PR TITLE
Show byline in article body when above leftCol

### DIFF
--- a/packages/frontend/web/components/Content.tsx
+++ b/packages/frontend/web/components/Content.tsx
@@ -37,6 +37,7 @@ export const Content = ({ CAPI, config }: Props) => {
                             {/* When ABOVE leftCol we display the header in this position, above the article body, underneath the full width image */}
                             <Hide when="above" breakpoint="leftCol">
                                 <ArticleHeader CAPI={CAPI} config={config} />
+                                <ArticleMeta CAPI={CAPI} config={config} />
                             </Hide>
                             <ArticleBody
                                 CAPI={CAPI}
@@ -61,6 +62,9 @@ export const Content = ({ CAPI, config }: Props) => {
             </ArticleLeft>
             <ArticleContainer>
                 <ArticleHeader CAPI={CAPI} config={config} />
+                <Hide when="above" breakpoint="leftCol">
+                    <ArticleMeta CAPI={CAPI} config={config} />
+                </Hide>
                 <ArticleBody CAPI={CAPI} config={config} />
             </ArticleContainer>
             <ArticleRight>


### PR DESCRIPTION
## What does this change?
Shows the article byline (ArticleMeta) in the article body when page width is below `leftCol`.

## Before
<img width="742" alt="image" src="https://user-images.githubusercontent.com/1336821/67615420-3b2d8380-f7c4-11e9-8677-23f767c5b638.png">


## After
<img width="742" alt="image" src="https://user-images.githubusercontent.com/1336821/67615424-4d0f2680-f7c4-11e9-9d18-1d4e83a31678.png">


## Why?
Parity

