### PR TITLE
Oliver/cypress improvements

### DIFF
--- a/cypress/integration/e2e/article.e2e.spec.js
+++ b/cypress/integration/e2e/article.e2e.spec.js
@@ -1,40 +1,57 @@
 import { getPolyfill } from '../../lib/polyfill';
 import { visitOptions } from '../../lib/config';
-import { articles } from '../../lib/articles.js';
+import { articles, AMPArticles } from '../../lib/articles.js';
 import { setupApiRoutes } from '../../lib/apiRoutes.js';
 
 describe('E2E Page rendering', function() {
     beforeEach(getPolyfill);
     beforeEach(setupApiRoutes);
 
-    articles.map((article, index) => {
-        const { url, pillar, designType } = article;
-        it(`It should load ${designType} articles under the ${pillar} pillar`, function() {
-            cy.visit(`Article?url=${url}`, visitOptions);
-            cy.contains('Sign in');
+    describe('for WEB', function() {
+        articles.map((article, index) => {
+            const { url, pillar, designType } = article;
 
-            cy.wait('@getMostRead').then(xhr => {
-                expect(xhr.response.body.length).to.be.at.least(1);
-                expect(xhr.status).to.be.equal(200);
+            it(`It should load ${designType} articles under the ${pillar} pillar`, function() {
+                cy.visit(`Article?url=${url}`, visitOptions);
+                cy.contains('Sign in');
 
-                cy.contains('Most popular');
-            });
-
-            cy.wait('@getShareCount').then(xhr => {
-                expect(xhr.status).to.be.equal(200);
-                expect(xhr.response.body).to.have.property('path');
-                expect(xhr.response.body).to.have.property('refreshStatus');
-                expect(xhr.response.body)
-                    .to.have.property('share_count')
-                    .that.is.a('number');
-            });
-
-            if (article.hasRichLinks) {
-                cy.wait('@getRichLinks').then(xhr => {
+                cy.wait('@getMostRead').then(xhr => {
+                    expect(xhr.response.body.length).to.be.at.least(1);
                     expect(xhr.status).to.be.equal(200);
-                    cy.contains('Read more');
+
+                    cy.contains('Most popular');
                 });
-            }
+
+                cy.wait('@getShareCount').then(xhr => {
+                    expect(xhr.status).to.be.equal(200);
+                    expect(xhr.response.body).to.have.property('path');
+                    expect(xhr.response.body).to.have.property('refreshStatus');
+                    expect(xhr.response.body)
+                        .to.have.property('share_count')
+                        .that.is.a('number');
+                });
+
+                if (article.hasRichLinks) {
+                    cy.wait('@getRichLinks').then(xhr => {
+                        expect(xhr.status).to.be.equal(200);
+                        cy.contains('Read more');
+                    });
+                }
+            });
+        });
+    });
+
+    describe('for AMP', function() {
+        AMPArticles.map((article, index) => {
+            const { url, pillar, designType } = article;
+
+            it(`It should load ${designType} articles under the ${pillar} pillar`, function() {
+                // Prevent the Privacy consent banner from obscuring snapshots
+                cy.setCookie('GU_TK', 'true');
+
+                cy.visit(`AMPArticle?url=${url}`, visitOptions);
+                cy.contains('Opinion');
+            });
         });
     });
 });

--- a/cypress/integration/percy/article.amp.spec.js
+++ b/cypress/integration/percy/article.amp.spec.js
@@ -13,6 +13,8 @@ describe('For AMP', function() {
         const { url, pillar, designType } = article;
         it(`It should load ${designType} articles under the ${pillar} pillar`, function() {
             cy.visit(`AMPArticle?url=${url}`, visitOptions);
+            // Don't include the privacy banner in snapshots
+            cy.contains('OK with that').click();
             cy.percySnapshot(`AMP-${pillar}-${designType}-${index}`);
         });
     });

--- a/cypress/integration/percy/article.web.spec.js
+++ b/cypress/integration/percy/article.web.spec.js
@@ -12,6 +12,8 @@ describe('For WEB', function() {
     articles.map((article, index) => {
         const { url, pillar, designType } = article;
         it(`It should load ${designType} articles under the ${pillar} pillar`, function() {
+            // Prevent the Privacy consent banner from obscuring snapshots
+            cy.setCookie('GU_TK', 'true');
             cy.visit(`Article?url=${url}`, visitOptions);
             cy.percySnapshot(`WEB-${pillar}-${designType}-${index}`);
         });


### PR DESCRIPTION
## What does this change?
This PR:

1. Removes the Privacy banner from our Percy snapshots as it was annoying and obscured content we wanted to see.

2. Adds AMP tests to the set of end to end cypress tests run by `make cypress` in the build.

## Why?
1. For a better dev ex.
2. For coverage.

## Link to supporting Trello card
https://trello.com/c/qYy3VPDT/792-remove-privacy-banner-from-percy-snapshots
