### PR TITLE
Remove Privacy click step for AMP tests

### DIFF
--- a/cypress/integration/percy/article.amp.spec.js
+++ b/cypress/integration/percy/article.amp.spec.js
@@ -13,8 +13,6 @@ describe('For AMP', function() {
         const { url, pillar, designType } = article;
         it(`It should load ${designType} articles under the ${pillar} pillar`, function() {
             cy.visit(`AMPArticle?url=${url}`, visitOptions);
-            // Don't include the privacy banner in snapshots
-            cy.contains('OK with that').click();
             cy.percySnapshot(`AMP-${pillar}-${designType}-${index}`);
         });
     });


### PR DESCRIPTION
## What does this change?
Removes the Cypress test step of clicking on the Privacy banner

## Why?
Because sometimes it isn't there so we'd need to implement conditional logic in the Cypress test so on balance, potentially having the banner in the snapshot for AMP views seems a better option.
