### PR TITLE
Snapshot across all relevant widths

### DIFF
--- a/cypress/integration/percy/article.amp.spec.js
+++ b/cypress/integration/percy/article.amp.spec.js
@@ -13,7 +13,9 @@ describe('For AMP', function() {
         const { url, pillar, designType } = article;
         it(`It should load ${designType} articles under the ${pillar} pillar`, function() {
             cy.visit(`AMPArticle?url=${url}`, visitOptions);
-            cy.percySnapshot(`AMP-${pillar}-${designType}-${index}`);
+            cy.percySnapshot(`AMP-${pillar}-${designType}-${index}`, {
+                widths: [375],
+            });
         });
     });
 });

--- a/cypress/integration/percy/article.web.spec.js
+++ b/cypress/integration/percy/article.web.spec.js
@@ -15,7 +15,9 @@ describe('For WEB', function() {
             // Prevent the Privacy consent banner from obscuring snapshots
             cy.setCookie('GU_TK', 'true');
             cy.visit(`Article?url=${url}`, visitOptions);
-            cy.percySnapshot(`WEB-${pillar}-${designType}-${index}`);
+            cy.percySnapshot(`WEB-${pillar}-${designType}-${index}`, {
+                widths: [739, 979, 1139, 1299, 1400],
+            });
         });
     });
 });


### PR DESCRIPTION
## What does this change?
Replaces Percy's default screen widths with an array that means we're now testing across the full spectrum of how a page can be rendered.

Based on this code`const breakpoints = [740, 980, 1140, 1300]` in `theme.ts` in `src-utilities`.

## Why?
Coverage
