### PR TITLE
Add encoding tag to document head

### DIFF
--- a/packages/frontend/web/server/htmlTemplate.ts
+++ b/packages/frontend/web/server/htmlTemplate.ts
@@ -68,6 +68,7 @@ export const htmlTemplate = ({
             <head>
                 <title>${title}</title>
                 <meta name="description" content="${escape(description)}" />
+                <meta charset="utf-8">
 
                 <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
                 <link rel="icon" href="https://static.guim.co.uk/images/${favicon}">


### PR DESCRIPTION
## What does this change?
Adds `<meta charset="utf-8">` to the head

## Why?
So browsers have a default when deciding how content might be encoded
