### PR TITLE
Bump src-foundations version

### DIFF
--- a/packages/frontend/amp/components/MainMedia.tsx
+++ b/packages/frontend/amp/components/MainMedia.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { bestFitImage, heightEstimate } from '@frontend/amp/lib/image-fit';
 import { css } from 'emotion';
-import { textSans, palette, visuallyHidden } from '@guardian/src-foundations';
+import { textSans, palette } from '@guardian/src-foundations';
+import { visuallyHidden } from '@guardian/src-utilities';
 import InfoIcon from '@frontend/static/icons/info.svg';
 import { YoutubeVideo } from '@frontend/amp/components/elements/YoutubeVideo';
 

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -6,8 +6,8 @@
     "license": "Apache-2.0",
     "dependencies": {
         "@emotion/core": "^10.0.5",
-        "@guardian/src-foundations": "^0.2.4",
-        "@guardian/src-utilities": "^0.1.2",
+        "@guardian/src-foundations": "^0.3.2",
+        "@guardian/src-utilities": "^0.1.5",
         "@types/ajv": "^1.0.0",
         "@types/lodash.escape": "^4.0.6",
         "@types/sanitize-html": "^1.18.3",

--- a/packages/frontend/web/components/Hide.tsx
+++ b/packages/frontend/web/components/Hide.tsx
@@ -1,37 +1,11 @@
 import React from 'react';
 import { css } from 'emotion';
-import {
-    until,
-    mobileMedium,
-    mobileLandscape,
-    phablet,
-    tablet,
-    desktop,
-    leftCol,
-    wide,
-} from '@guardian/src-foundations';
-
-const breakpoints = {
-    mobileMedium,
-    mobileLandscape,
-    phablet,
-    tablet,
-    desktop,
-    leftCol,
-    wide,
-};
+import { until, from, Breakpoint } from '@guardian/src-utilities';
 
 type Props = {
     children: JSX.Element | JSX.Element[];
     when: 'above' | 'below';
-    breakpoint:
-        | 'mobileMedium'
-        | 'mobileLandscape'
-        | 'phablet'
-        | 'tablet'
-        | 'desktop'
-        | 'leftCol'
-        | 'wide';
+    breakpoint: Breakpoint;
 };
 
 export const Hide = ({ children, when, breakpoint }: Props) => {
@@ -44,7 +18,7 @@ export const Hide = ({ children, when, breakpoint }: Props) => {
         `;
     } else {
         whenToHide = css`
-            ${breakpoints[breakpoint]} {
+            ${from[breakpoint]} {
                 display: none;
             }
         `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -869,15 +869,15 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
-"@guardian/src-foundations@^0.2.4":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.2.4.tgz#a2dc8267be6efb19c684b1bb27099ad58d887c3b"
-  integrity sha512-SYijZJndBv6bvoFHaWgAo2iOSkZgi4pLQWKB2GYOf5wzN1R/DOl3UUjNUHSF7vKVDzNnsChfiopl4WSx2gIH8g==
+"@guardian/src-foundations@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.3.2.tgz#8b7b7bfc25fcdaddc10c6f540167e6633c86e948"
+  integrity sha512-+bycGwCoBZYyKgO4+C3v66KdLDcVPHu+E3ZUoyVaNGY84HjFwakh2FVgAfyvthwhLzsgcKF3SiY/xukPZkjTEw==
 
-"@guardian/src-utilities@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@guardian/src-utilities/-/src-utilities-0.1.2.tgz#7647e9aef7cd1f0b69e9fa436ec2e211d70580c8"
-  integrity sha512-vCyQrFaa/TtwUtzw6rpl005Un+2GfrJVYxLAqJQsblxX2mNGcDvdQl97+PAE1LYMPdvLezrcR7poD7gT0+/hxw==
+"@guardian/src-utilities@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@guardian/src-utilities/-/src-utilities-0.1.5.tgz#80c9b4353999b239d49461441cc975a275fc2759"
+  integrity sha512-BtcgblFxBdkEHw8d5Fcs73MP9Mrr7UNgSTb/+iTGr5lfJpKh6uvyZTjDis/jQeY121zZ/ETT2e4OFrgF1qu57w==
 
 "@hapi/address@2.x.x":
   version "2.1.2"


### PR DESCRIPTION
## What does this change?

Bumps the versions of src-foundations and src-utilities. 

## Why?

This removes the old media queries API and `visuallyHidden` from src-foundations. Going forward, this functionality should be imported from src-utilities.

Note that this is likely to change at least one more time 😖 
