### PR TITLE
Article widths

### DIFF
--- a/packages/frontend/web/components/ArticleStandfirst.tsx
+++ b/packages/frontend/web/components/ArticleStandfirst.tsx
@@ -5,6 +5,7 @@ import { headline, textSans, body, palette } from '@guardian/src-foundations';
 
 const standfirstStyles = css`
     ${body({ level: 2 })};
+    max-width: 550px;
     font-weight: 700;
     color: ${palette.neutral[7]};
     margin-bottom: 12px;

--- a/packages/frontend/web/layouts/StandardHeader.tsx
+++ b/packages/frontend/web/layouts/StandardHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'emotion';
+import { css, cx } from 'emotion';
 
 import { from, until } from '@guardian/src-utilities';
 
@@ -38,6 +38,10 @@ const headerStyles = css`
     flex-direction: column;
 `;
 
+const maxWidth = css`
+    max-width: 620px;
+`;
+
 type Props = {
     CAPI: CAPIType;
 };
@@ -69,7 +73,7 @@ export const StandardHeader = ({ CAPI }: Props) => {
             <HeaderItem order={3}>
                 <ArticleStandfirst pillar={pillar} standfirst={standfirst} />
             </HeaderItem>
-            <div className={positionMainImage}>
+            <div className={cx(positionMainImage, maxWidth)}>
                 <MainMedia elements={mainMediaElements} pillar={pillar} />
             </div>
         </header>


### PR DESCRIPTION
## What does this change?
Sets a max width on the main image and standfirst

## Before
![image](https://user-images.githubusercontent.com/1336821/67755574-51d81280-fa30-11e9-8d1d-05f7fcf52424.png)


## After
![image](https://user-images.githubusercontent.com/1336821/67755526-3a008e80-fa30-11e9-85ee-7c949c3c8658.png)

## Frontend
![image](https://user-images.githubusercontent.com/1336821/67755739-8cda4600-fa30-11e9-8c06-085b5c95e146.png)



## Why?
Parity


## Trello
https://trello.com/c/XY5ZI4xb/806-article-widths
