### PR TITLE
Abolish #d9d9d9

### DIFF
--- a/packages/frontend/amp/components/BodyArticle.tsx
+++ b/packages/frontend/amp/components/BodyArticle.tsx
@@ -23,7 +23,7 @@ const body = (pillar: Pillar, designType: DesignType) => {
     const designTypeStyle: DesignTypesObj = {
         ...defaultStyles,
         Comment: palette.opinion.faded,
-        AdvertisementFeature: palette.neutral[85],
+        AdvertisementFeature: palette.neutral[86],
     };
 
     return css`

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -6,7 +6,7 @@
     "license": "Apache-2.0",
     "dependencies": {
         "@emotion/core": "^10.0.5",
-        "@guardian/src-foundations": "^0.3.2",
+        "@guardian/src-foundations": "^0.4.0",
         "@guardian/src-utilities": "^0.1.5",
         "@types/ajv": "^1.0.0",
         "@types/lodash.escape": "^4.0.6",

--- a/packages/frontend/web/components/SyndicationButton.tsx
+++ b/packages/frontend/web/components/SyndicationButton.tsx
@@ -23,7 +23,7 @@ export const SyndicationButton: React.FC<{
     const syndicationButton = css`
         color: ${palette.neutral[46]};
         background-color: transparent;
-        border-color: ${palette.neutral[85]};
+        border-color: ${palette.neutral[86]};
         border-radius: 62.5rem;
         border-width: 0.0625rem;
         border-style: solid;

--- a/yarn.lock
+++ b/yarn.lock
@@ -869,10 +869,10 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
-"@guardian/src-foundations@^0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.3.2.tgz#8b7b7bfc25fcdaddc10c6f540167e6633c86e948"
-  integrity sha512-+bycGwCoBZYyKgO4+C3v66KdLDcVPHu+E3ZUoyVaNGY84HjFwakh2FVgAfyvthwhLzsgcKF3SiY/xukPZkjTEw==
+"@guardian/src-foundations@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.4.0.tgz#bdf77ed6e7f36d8a4aed0a69dde8351108699325"
+  integrity sha512-E19YNqyPlQG9RZW+uEIx51GJdlrC36ZaEvjFsRC98uh9FPFLu6tJj4fWoIB0/kbSZopouW21pb4kqva5iy1mlA==
 
 "@guardian/src-utilities@^0.1.5":
   version "0.1.5"


### PR DESCRIPTION
## What does this change?

An upgrade to src-foundations that removes the colour `#d9d9d9` (`neutral[85]`) 

## Why?

Because it is very similar to `#dcdcdc` (`neutral[86]`)

