### PR TITLE
Add hideCaption prop for images

### DIFF
--- a/packages/frontend/web/components/MainMedia.tsx
+++ b/packages/frontend/web/components/MainMedia.tsx
@@ -39,11 +39,21 @@ const mainMedia = css`
     }
 `;
 
-function renderElement(element: CAPIElement, pillar: Pillar, i: number) {
+function renderElement(
+    element: CAPIElement,
+    pillar: Pillar,
+    i: number,
+    hideCaption?: boolean,
+) {
     switch (element._type) {
         case 'model.dotcomrendering.pageElements.ImageBlockElement':
             return (
-                <MainImageComponent key={i} element={element} pillar={pillar} />
+                <MainImageComponent
+                    key={i}
+                    element={element}
+                    pillar={pillar}
+                    hideCaption={hideCaption}
+                />
             );
         default:
             return null;
@@ -53,8 +63,11 @@ function renderElement(element: CAPIElement, pillar: Pillar, i: number) {
 export const MainMedia: React.FC<{
     elements: CAPIElement[];
     pillar: Pillar;
-}> = ({ elements, pillar }) => (
+    hideCaption?: boolean;
+}> = ({ elements, pillar, hideCaption }) => (
     <div className={mainMedia}>
-        {elements.map((element, i) => renderElement(element, pillar, i))}
+        {elements.map((element, i) =>
+            renderElement(element, pillar, i, hideCaption),
+        )}
     </div>
 );

--- a/packages/frontend/web/components/elements/ImageBlockComponent.tsx
+++ b/packages/frontend/web/components/elements/ImageBlockComponent.tsx
@@ -99,11 +99,16 @@ const decidePosition = (role: RoleType) => {
 export const ImageBlockComponent: React.FC<{
     element: ImageBlockElement;
     pillar: Pillar;
-}> = ({ element, pillar }) => {
+    hideCaption?: boolean;
+}> = ({ element, pillar, hideCaption }) => {
     const { role } = element;
     return (
         <div className={decidePosition(role)}>
-            <ImageComponent element={element} pillar={pillar} />
+            <ImageComponent
+                element={element}
+                pillar={pillar}
+                hideCaption={hideCaption}
+            />
         </div>
     );
 };

--- a/packages/frontend/web/components/elements/ImageComponent.tsx
+++ b/packages/frontend/web/components/elements/ImageComponent.tsx
@@ -61,8 +61,18 @@ const getFallback: (imageSources: ImageSource[]) => string = imageSources => {
 export const ImageComponent: React.FC<{
     element: ImageBlockElement;
     pillar: Pillar;
-}> = ({ element, pillar }) => {
+    hideCaption?: boolean;
+}> = ({ element, pillar, hideCaption }) => {
     const sources = makeSources(element.imageSources);
+    if (hideCaption) {
+        return (
+            <Picture
+                sources={sources}
+                alt={element.data.alt || ''}
+                src={getFallback(element.imageSources)}
+            />
+        );
+    }
     return (
         <Caption
             captionText={element.data.caption || ''}

--- a/packages/frontend/web/components/elements/MainImageComponent.tsx
+++ b/packages/frontend/web/components/elements/MainImageComponent.tsx
@@ -4,6 +4,13 @@ import { ImageComponent } from '@frontend/web/components/elements/ImageComponent
 export const MainImageComponent: React.FC<{
     element: ImageBlockElement;
     pillar: Pillar;
-}> = ({ element, pillar }) => {
-    return <ImageComponent element={element} pillar={pillar} />;
+    hideCaption?: boolean;
+}> = ({ element, pillar, hideCaption }) => {
+    return (
+        <ImageComponent
+            element={element}
+            pillar={pillar}
+            hideCaption={hideCaption}
+        />
+    );
 };


### PR DESCRIPTION
## What does this change?
Adds the `hideCaption` prop for images. Image props now read as:

```
{
    element: ImageBlockElement;
    pillar: Pillar;
    hideCaption?: boolean;
}
```

## Why?
This will be useful for both `Immersive` and `PhotoEssay` views

## Link to supporting Trello card
https://trello.com/c/zi1EudDh/807-immersive-articles
