### PR TITLE
Put all the layout into each layout file

### DIFF
--- a/packages/frontend/web/layouts/DecideLayout.tsx
+++ b/packages/frontend/web/layouts/DecideLayout.tsx
@@ -10,16 +10,17 @@ type Props = {
     designType: DesignType;
     CAPI: CAPIType;
     config: ConfigType;
+    NAV: NavType;
 };
 
-export const DecideLayout = ({ designType, CAPI, config }: Props) => {
+export const DecideLayout = ({ designType, CAPI, config, NAV }: Props) => {
     if (hasShowcase(CAPI.mainMediaElements)) {
-        return <ShowcaseLayout CAPI={CAPI} config={config} />;
+        return <ShowcaseLayout CAPI={CAPI} config={config} NAV={NAV} />;
     }
 
     // Otherwise, switch based on designType
     const designTypeContent: DesignTypesObj = designTypeDefault(
-        <StandardLayout CAPI={CAPI} config={config} />,
+        <StandardLayout CAPI={CAPI} config={config} NAV={NAV} />,
     );
 
     return designTypeContent[designType];

--- a/packages/frontend/web/layouts/ShowcaseLayout.tsx
+++ b/packages/frontend/web/layouts/ShowcaseLayout.tsx
@@ -9,41 +9,127 @@ import { ArticleContainer } from '@frontend/web/components/ArticleContainer';
 import { ArticleMeta } from '@frontend/web/components/ArticleMeta';
 import { Hide } from '@frontend/web/components/Hide';
 
+import { palette } from '@guardian/src-foundations';
+import { MostViewed } from '@frontend/web/components/MostViewed/MostViewed';
+import { Header } from '@root/packages/frontend/web/components/Header/Header';
+import { Footer } from '@frontend/web/components/Footer';
+import { SubNav } from '@root/packages/frontend/web/components/SubNav/SubNav';
+import { CookieBanner } from '@frontend/web/components/CookieBanner';
+import { OutbrainContainer } from '@frontend/web/components/Outbrain';
+import { Section } from '@frontend/web/components/Section';
+import { Nav } from '@frontend/web/components/Nav/Nav';
+import { HeaderAdSlot } from '@root/packages/frontend/web/components/HeaderAdSlot';
+
 import { ShowcaseHeader } from './ShowcaseHeader';
 
 interface Props {
     CAPI: CAPIType;
     config: ConfigType;
+    NAV: NavType;
 }
 
-export const ShowcaseLayout = ({ CAPI, config }: Props) => (
-    <Flex>
-        <ArticleLeft>
-            <ArticleTitle CAPI={CAPI} />
-            <ArticleMeta CAPI={CAPI} config={config} />
-        </ArticleLeft>
-        <ArticleContainer>
-            {/* When BELOW leftCol we display the header in this position, at the top of the page */}
-            <Hide when="below" breakpoint="leftCol">
-                <ShowcaseHeader CAPI={CAPI} />
-            </Hide>
+export const ShowcaseLayout = ({ CAPI, config, NAV }: Props) => (
+    <>
+        <Section showTopBorder={false} showSideBorders={false} padded={false}>
+            <HeaderAdSlot
+                config={config}
+                isAdFreeUser={CAPI.isAdFreeUser}
+                shouldHideAds={CAPI.shouldHideAds}
+            />
+        </Section>
+        <Section
+            showTopBorder={false}
+            showSideBorders={false}
+            padded={false}
+            backgroundColour={palette.brand.main}
+        >
+            <Header nav={NAV} pillar={CAPI.pillar} edition={CAPI.editionId} />
+        </Section>
+
+        <Section
+            showSideBorders={true}
+            borderColour={palette.brand.pastel}
+            showTopBorder={false}
+            padded={false}
+            backgroundColour={palette.brand.main}
+        >
+            <Nav pillar={CAPI.pillar} nav={NAV} />
+        </Section>
+
+        <Section backgroundColour={palette.neutral[100]} padded={false}>
+            <SubNav
+                subnav={NAV.subNavSections}
+                currentNavLink={NAV.currentNavLink}
+                pillar={CAPI.pillar}
+            />
+        </Section>
+
+        <Section showTopBorder={false}>
             <Flex>
-                <div>
-                    {/* When ABOVE leftCol we display the header in this position, above the article body, underneath the full width image */}
-                    <Hide when="above" breakpoint="leftCol">
+                <ArticleLeft>
+                    <ArticleTitle CAPI={CAPI} />
+                    <ArticleMeta CAPI={CAPI} config={config} />
+                </ArticleLeft>
+                <ArticleContainer>
+                    {/* When BELOW leftCol we display the header in this position, at the top of the page */}
+                    <Hide when="below" breakpoint="leftCol">
                         <ShowcaseHeader CAPI={CAPI} />
-                        <ArticleMeta CAPI={CAPI} config={config} />
                     </Hide>
-                    <ArticleBody
-                        CAPI={CAPI}
-                        config={config}
-                        isShowcase={true}
-                    />
-                </div>
-                <ArticleRight>
-                    <StickyAd config={config} />
-                </ArticleRight>
+                    <Flex>
+                        <div>
+                            {/* When ABOVE leftCol we display the header in this position, above the article body, underneath the full width image */}
+                            <Hide when="above" breakpoint="leftCol">
+                                <ShowcaseHeader CAPI={CAPI} />
+                                <ArticleMeta CAPI={CAPI} config={config} />
+                            </Hide>
+                            <ArticleBody
+                                CAPI={CAPI}
+                                config={config}
+                                isShowcase={true}
+                            />
+                        </div>
+                        <ArticleRight>
+                            <StickyAd config={config} />
+                        </ArticleRight>
+                    </Flex>
+                </ArticleContainer>
             </Flex>
-        </ArticleContainer>
-    </Flex>
+        </Section>
+
+        <Section showTopBorder={false}>
+            <OutbrainContainer config={config} />
+        </Section>
+
+        <Section>
+            <MostViewed
+                sectionName={CAPI.sectionName}
+                config={config}
+                pillar={CAPI.pillar}
+            />
+        </Section>
+
+        <Section padded={false}>
+            <SubNav
+                subnav={NAV.subNavSections}
+                pillar={CAPI.pillar}
+                currentNavLink={NAV.currentNavLink}
+            />
+        </Section>
+
+        <Section
+            padded={false}
+            backgroundColour={palette.brand.main}
+            borderColour={palette.brand.pastel}
+        >
+            <Footer
+                nav={NAV}
+                edition={CAPI.editionId}
+                pageFooter={CAPI.pageFooter}
+                pillar={CAPI.pillar}
+                pillars={NAV.pillars}
+            />
+        </Section>
+
+        <CookieBanner />
+    </>
 );

--- a/packages/frontend/web/layouts/StandardLayout.tsx
+++ b/packages/frontend/web/layouts/StandardLayout.tsx
@@ -9,28 +9,114 @@ import { ArticleContainer } from '@frontend/web/components/ArticleContainer';
 import { ArticleMeta } from '@frontend/web/components/ArticleMeta';
 import { Hide } from '@frontend/web/components/Hide';
 
+import { palette } from '@guardian/src-foundations';
+import { MostViewed } from '@frontend/web/components/MostViewed/MostViewed';
+import { Header } from '@root/packages/frontend/web/components/Header/Header';
+import { Footer } from '@frontend/web/components/Footer';
+import { SubNav } from '@root/packages/frontend/web/components/SubNav/SubNav';
+import { CookieBanner } from '@frontend/web/components/CookieBanner';
+import { OutbrainContainer } from '@frontend/web/components/Outbrain';
+import { Section } from '@frontend/web/components/Section';
+import { Nav } from '@frontend/web/components/Nav/Nav';
+import { HeaderAdSlot } from '@root/packages/frontend/web/components/HeaderAdSlot';
+
 import { StandardHeader } from './StandardHeader';
 
 interface Props {
     CAPI: CAPIType;
     config: ConfigType;
+    NAV: NavType;
 }
 
-export const StandardLayout = ({ CAPI, config }: Props) => (
-    <Flex>
-        <ArticleLeft>
-            <ArticleTitle CAPI={CAPI} />
-            <ArticleMeta CAPI={CAPI} config={config} />
-        </ArticleLeft>
-        <ArticleContainer>
-            <StandardHeader CAPI={CAPI} />
-            <Hide when="above" breakpoint="leftCol">
-                <ArticleMeta CAPI={CAPI} config={config} />
-            </Hide>
-            <ArticleBody CAPI={CAPI} config={config} />
-        </ArticleContainer>
-        <ArticleRight>
-            <StickyAd config={config} />
-        </ArticleRight>
-    </Flex>
+export const StandardLayout = ({ CAPI, config, NAV }: Props) => (
+    <>
+        <Section showTopBorder={false} showSideBorders={false} padded={false}>
+            <HeaderAdSlot
+                config={config}
+                isAdFreeUser={CAPI.isAdFreeUser}
+                shouldHideAds={CAPI.shouldHideAds}
+            />
+        </Section>
+        <Section
+            showTopBorder={false}
+            showSideBorders={false}
+            padded={false}
+            backgroundColour={palette.brand.main}
+        >
+            <Header nav={NAV} pillar={CAPI.pillar} edition={CAPI.editionId} />
+        </Section>
+
+        <Section
+            showSideBorders={true}
+            borderColour={palette.brand.pastel}
+            showTopBorder={false}
+            padded={false}
+            backgroundColour={palette.brand.main}
+        >
+            <Nav pillar={CAPI.pillar} nav={NAV} />
+        </Section>
+
+        <Section backgroundColour={palette.neutral[100]} padded={false}>
+            <SubNav
+                subnav={NAV.subNavSections}
+                currentNavLink={NAV.currentNavLink}
+                pillar={CAPI.pillar}
+            />
+        </Section>
+
+        <Section showTopBorder={false}>
+            <Flex>
+                <ArticleLeft>
+                    <ArticleTitle CAPI={CAPI} />
+                    <ArticleMeta CAPI={CAPI} config={config} />
+                </ArticleLeft>
+                <ArticleContainer>
+                    <StandardHeader CAPI={CAPI} />
+                    <Hide when="above" breakpoint="leftCol">
+                        <ArticleMeta CAPI={CAPI} config={config} />
+                    </Hide>
+                    <ArticleBody CAPI={CAPI} config={config} />
+                </ArticleContainer>
+                <ArticleRight>
+                    <StickyAd config={config} />
+                </ArticleRight>
+            </Flex>
+        </Section>
+
+        <Section showTopBorder={false}>
+            <OutbrainContainer config={config} />
+        </Section>
+
+        <Section>
+            <MostViewed
+                sectionName={CAPI.sectionName}
+                config={config}
+                pillar={CAPI.pillar}
+            />
+        </Section>
+
+        <Section padded={false}>
+            <SubNav
+                subnav={NAV.subNavSections}
+                pillar={CAPI.pillar}
+                currentNavLink={NAV.currentNavLink}
+            />
+        </Section>
+
+        <Section
+            padded={false}
+            backgroundColour={palette.brand.main}
+            borderColour={palette.brand.pastel}
+        >
+            <Footer
+                nav={NAV}
+                edition={CAPI.editionId}
+                pageFooter={CAPI.pageFooter}
+                pillar={CAPI.pillar}
+                pillars={NAV.pillars}
+            />
+        </Section>
+
+        <CookieBanner />
+    </>
 );

--- a/packages/frontend/web/pages/Article.tsx
+++ b/packages/frontend/web/pages/Article.tsx
@@ -1,102 +1,16 @@
 import React from 'react';
-import { palette } from '@guardian/src-foundations';
-import { MostViewed } from '@frontend/web/components/MostViewed/MostViewed';
-import { Header } from '@root/packages/frontend/web/components/Header/Header';
-import { Footer } from '@frontend/web/components/Footer';
-import { SubNav } from '@root/packages/frontend/web/components/SubNav/SubNav';
-import { CookieBanner } from '@frontend/web/components/CookieBanner';
-import { OutbrainContainer } from '@frontend/web/components/Outbrain';
-import { Section } from '@frontend/web/components/Section';
-import { Nav } from '@frontend/web/components/Nav/Nav';
-import { HeaderAdSlot } from '@root/packages/frontend/web/components/HeaderAdSlot';
 
 import { DecideLayout } from '../layouts/DecideLayout';
-import { CAPI } from '@root/fixtures/CAPI';
 
 export const Article: React.FC<{
     data: ArticleProps;
-}> = ({ data }) => (
-    <div>
-        <Section showTopBorder={false} showSideBorders={false} padded={false}>
-            <HeaderAdSlot
-                config={data.config}
-                isAdFreeUser={data.CAPI.isAdFreeUser}
-                shouldHideAds={data.CAPI.shouldHideAds}
-            />
-        </Section>
-        <Section
-            showTopBorder={false}
-            showSideBorders={false}
-            padded={false}
-            backgroundColour={palette.brand.main}
-        >
-            <Header
-                nav={data.NAV}
-                pillar={data.CAPI.pillar}
-                edition={data.CAPI.editionId}
-            />
-        </Section>
-
-        <Section
-            showSideBorders={true}
-            borderColour={palette.brand.pastel}
-            showTopBorder={false}
-            padded={false}
-            backgroundColour={palette.brand.main}
-        >
-            <Nav pillar={data.CAPI.pillar} nav={data.NAV} />
-        </Section>
-
-        <Section backgroundColour={palette.neutral[100]} padded={false}>
-            <SubNav
-                subnav={data.NAV.subNavSections}
-                currentNavLink={data.NAV.currentNavLink}
-                pillar={data.CAPI.pillar}
-            />
-        </Section>
-
-        <Section showTopBorder={false}>
-            <DecideLayout
-                designType={CAPI.designType}
-                CAPI={data.CAPI}
-                config={data.config}
-            />
-        </Section>
-
-        <Section showTopBorder={false}>
-            <OutbrainContainer config={data.config} />
-        </Section>
-
-        <Section>
-            <MostViewed
-                sectionName={data.CAPI.sectionName}
-                config={data.config}
-                pillar={data.CAPI.pillar}
-            />
-        </Section>
-
-        <Section padded={false}>
-            <SubNav
-                subnav={data.NAV.subNavSections}
-                pillar={data.CAPI.pillar}
-                currentNavLink={data.NAV.currentNavLink}
-            />
-        </Section>
-
-        <Section
-            padded={false}
-            backgroundColour={palette.brand.main}
-            borderColour={palette.brand.pastel}
-        >
-            <Footer
-                nav={data.NAV}
-                edition={data.CAPI.editionId}
-                pageFooter={data.CAPI.pageFooter}
-                pillar={data.CAPI.pillar}
-                pillars={data.NAV.pillars}
-            />
-        </Section>
-
-        <CookieBanner />
-    </div>
-);
+}> = ({ data }) => {
+    return (
+        <DecideLayout
+            designType={data.CAPI.designType}
+            CAPI={data.CAPI}
+            config={data.config}
+            NAV={data.NAV}
+        />
+    );
+};


### PR DESCRIPTION
## What does this change?
This moves the shared layout code that was sitting in `DecideLayout` and pulls it into each separate layout file.

## Why?
This does create duplication but it makes branching the layout later much easier. Instead of sprinkling the shared code with if statements and terniaries we can can be explicit in what we want for each type of article layout.

## Link to supporting Trello card
https://trello.com/c/zi1EudDh/807-immersive-articles
