### PR TITLE
Use a timestamp to fix Cypress time

### DIFF
--- a/cypress/lib/time.js
+++ b/cypress/lib/time.js
@@ -1,4 +1,4 @@
 export const fixTime = () => {
-    const now = new Date(2019, 10, 1);
+    const now = new Date(2019, 10, 1).getTime();
     cy.clock(now);
 };


### PR DESCRIPTION
## What does this change?
Passes a timestamp to `cy.clock()` instead of a date string.

## Why?
Matches [documented example](https://docs.cypress.io/api/commands/clock.html#Specify-a-now-timestamp)

