### PR TITLE
Use sectionUrl, not label, to build link

### DIFF
--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -103,7 +103,7 @@ export const SeriesSectionLink: React.FC<{
                     pillar={CAPI.pillar}
                     guardianBaseURL={CAPI.guardianBaseURL}
                     tagTitle={CAPI.sectionLabel}
-                    tagUrl={CAPI.sectionLabel}
+                    tagUrl={CAPI.sectionUrl}
                     dataLinkName="article section"
                     weightingClass={secondaryStyle}
                 />


### PR DESCRIPTION
## What does this change?
Fixes an issue raised by editorial where the series section link was returning a 404

Replaces the use of `sectionLabel` to build the link, with `sectionUrl`

## Trello
https://trello.com/c/McnAbeEz/836-wrong-tag-link
