### PR TITLE
Upgrade src-foundations to v0.5

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,7 +23,6 @@ module.exports = {
                     'curlyquotes',
                     'react-dom',
                     '@guardian/src-foundations',
-                    '@guardian/src-utilities',
                     '@frontend/lib/',
                     '@frontend/amp/lib/',
                     '@frontend/amp/types',

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     ],
     "dependencies": {
         "@emotion/core": "^10.0.5",
-        "@guardian/src-foundations": "^0.4.0",
-        "@guardian/src-utilities": "^0.1.5",
+        "@guardian/src-foundations": "^0.5.0",
         "@sentry/browser": "^5.7.1",
         "@types/ajv": "^1.0.0",
         "@types/lodash.escape": "^4.0.6",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     ],
     "dependencies": {
         "@emotion/core": "^10.0.5",
-        "@guardian/src-foundations": "^0.5.0",
+        "@guardian/src-foundations": "^0.5.6",
         "@sentry/browser": "^5.7.1",
         "@types/ajv": "^1.0.0",
         "@types/lodash.escape": "^4.0.6",

--- a/package.json
+++ b/package.json
@@ -173,9 +173,6 @@
         "transform": {
             "^.+\\.(ts|tsx)$": "ts-jest"
         },
-        "transformIgnorePatterns": [
-            "node_modules/(?!(@guardian/src-foundations)/)"
-        ],
         "globals": {
             "ts-jest": {
                 "diagnostics": false,

--- a/package.json
+++ b/package.json
@@ -173,6 +173,9 @@
         "transform": {
             "^.+\\.(ts|tsx)$": "ts-jest"
         },
+        "transformIgnorePatterns": [
+            "node_modules/(?!(@guardian/src-foundations)/)"
+        ],
         "globals": {
             "ts-jest": {
                 "diagnostics": false,

--- a/src/amp/components/BodyArticle.tsx
+++ b/src/amp/components/BodyArticle.tsx
@@ -8,7 +8,7 @@ import { SubMeta } from '@root/src/amp/components/SubMeta';
 import { designTypeDefault } from '@root/src/lib/designTypes';
 import { pillarPalette } from '@root/src/lib/pillars';
 import { palette } from '@guardian/src-foundations';
-import { until } from '@guardian/src-utilities';
+import { until } from '@guardian/src-foundations/mq';
 import { WithAds } from '@root/src/amp/components/WithAds';
 import { findAdSlots } from '@root/src/amp/lib/find-adslots';
 import { getSharingUrls } from '@root/src/lib/sharing-urls';

--- a/src/amp/components/Header.tsx
+++ b/src/amp/components/Header.tsx
@@ -3,7 +3,8 @@ import { css, cx } from 'emotion';
 import Logo from '@frontend/static/logos/the-guardian.svg';
 import { pillarPalette } from '@root/src/lib/pillars';
 import { headline, palette } from '@guardian/src-foundations';
-import { from, until, visuallyHidden } from '@guardian/src-utilities';
+import { from, until } from '@guardian/src-foundations/mq';
+import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 import { ReaderRevenueButton } from '@root/src/amp/components/ReaderRevenueButton';
 
 const headerStyles = css`

--- a/src/amp/components/MainMedia.tsx
+++ b/src/amp/components/MainMedia.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { bestFitImage, heightEstimate } from '@root/src/amp/lib/image-fit';
 import { css } from 'emotion';
 import { textSans, palette } from '@guardian/src-foundations';
-import { visuallyHidden } from '@guardian/src-utilities';
+import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 import InfoIcon from '@frontend/static/icons/info.svg';
 import { YoutubeVideo } from '@root/src/amp/components/elements/YoutubeVideo';
 

--- a/src/amp/components/ReaderRevenueButton.tsx
+++ b/src/amp/components/ReaderRevenueButton.tsx
@@ -3,7 +3,7 @@ import { css, cx } from 'emotion';
 
 import ArrowRight from '@frontend/static/icons/arrow-right.svg';
 import { palette, textSans } from '@guardian/src-foundations';
-import { until } from '@guardian/src-utilities';
+import { until } from '@guardian/src-foundations/mq';
 
 const supportStyles = css`
     align-self: flex-start;

--- a/src/amp/components/ShareIcons.tsx
+++ b/src/amp/components/ShareIcons.tsx
@@ -7,7 +7,7 @@ import LinkedInIcon from '@frontend/static/icons/linked-in.svg';
 import PinterestIcon from '@frontend/static/icons/pinterest.svg';
 import WhatsAppIcon from '@frontend/static/icons/whatsapp.svg';
 import MessengerIcon from '@frontend/static/icons/messenger.svg';
-import { visuallyHidden } from '@guardian/src-utilities';
+import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 import { pillarMap, pillarPalette, neutralBorder } from '@root/src/lib/pillars';
 
 const pillarFill = pillarMap(

--- a/src/amp/components/topMeta/PaidForBand.tsx
+++ b/src/amp/components/topMeta/PaidForBand.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css, cx } from 'emotion';
 
 import { palette, textSans } from '@guardian/src-foundations';
-import { from } from '@guardian/src-utilities';
+import { from } from '@guardian/src-foundations/mq';
 import LabsLogo from '@frontend/static/logos/the-guardian-labs.svg';
 import ArrowRightIcon from '@frontend/static/icons/arrow-right.svg';
 import { augmentedLabs } from '@root/src/lib/pillars';

--- a/src/web/components/AdSlot.tsx
+++ b/src/web/components/AdSlot.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { css } from 'emotion';
 import { textSans, palette } from '@guardian/src-foundations';
-import { from } from '@guardian/src-utilities';
+import { from } from '@guardian/src-foundations/mq';
 
 export const labelStyles = css`
     .ad-slot__label {

--- a/src/web/components/ArticleBody.tsx
+++ b/src/web/components/ArticleBody.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { css, cx } from 'emotion';
 
 import { textSans, headline, palette } from '@guardian/src-foundations';
-import { from, between } from '@guardian/src-utilities';
+import { from, between } from '@guardian/src-foundations/mq';
 import { pillarMap, pillarPalette } from '@root/src/lib/pillars';
 import { ArticleRenderer } from '@root/src/web/components/lib/ArticleRenderer';
 import { getSharingUrls } from '@root/src/lib/sharing-urls';

--- a/src/web/components/ArticleContainer.tsx
+++ b/src/web/components/ArticleContainer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css, cx } from 'emotion';
-import { from, until } from '@guardian/src-utilities';
+import { from, until } from '@guardian/src-foundations/mq';
 import { labelStyles } from '@root/src/web/components/AdSlot';
 
 const articleContainer = css`

--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -5,7 +5,8 @@ import ClockIcon from '@frontend/static/icons/clock.svg';
 import { getAgeWarning } from '@root/src/lib/age-warning';
 
 import { headline, textSans, palette } from '@guardian/src-foundations';
-import { from, visuallyHidden } from '@guardian/src-utilities';
+import { from } from '@guardian/src-foundations/mq';
+import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 
 const curly = (x: any) => x;
 

--- a/src/web/components/ArticleLeft.tsx
+++ b/src/web/components/ArticleLeft.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 import { palette } from '@guardian/src-foundations';
-import { from, between, until } from '@guardian/src-utilities';
+import { from, between, until } from '@guardian/src-foundations/mq';
 
 const leftWidth = css`
     padding-right: 10px;

--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 import { palette } from '@guardian/src-foundations';
-import { between, until } from '@guardian/src-utilities';
+import { between, until } from '@guardian/src-foundations/mq';
 
 import { ShareCount } from './ShareCount';
 import { Dateline } from './Dateline';

--- a/src/web/components/ArticleRight.tsx
+++ b/src/web/components/ArticleRight.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css, cx } from 'emotion';
-import { from, until } from '@guardian/src-utilities';
+import { from, until } from '@guardian/src-foundations/mq';
 
 const hideBelowDesktop = css`
     ${until.desktop} {

--- a/src/web/components/CookieBanner.tsx
+++ b/src/web/components/CookieBanner.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { css } from 'emotion';
 import { headline, textSans, body, palette } from '@guardian/src-foundations';
-import { until } from '@guardian/src-utilities';
+import { until } from '@guardian/src-foundations/mq';
 import TickIcon from '@frontend/static/icons/tick.svg';
 import RoundelIcon from '@frontend/static/icons/the-guardian-roundel.svg';
 import { getCookie, addCookie } from '@root/src/web/browser/cookie';

--- a/src/web/components/Dateline.tsx
+++ b/src/web/components/Dateline.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { css } from 'emotion';
 import { textSans, palette } from '@guardian/src-foundations';
-import { visuallyHidden } from '@guardian/src-utilities';
+import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 
 const captionFont = css`
     ${textSans({ level: 1 })};

--- a/src/web/components/Dropdown.tsx
+++ b/src/web/components/Dropdown.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 import { textSans, palette } from '@guardian/src-foundations';
-import { from, until, visuallyHidden } from '@guardian/src-utilities';
+import { from, until } from '@guardian/src-foundations/mq';
+import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 
 export interface Link {
     url: string;

--- a/src/web/components/Footer.tsx
+++ b/src/web/components/Footer.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css, cx } from 'emotion';
 
 import { textSans, palette } from '@guardian/src-foundations';
-import { from, until } from '@guardian/src-utilities';
+import { from, until } from '@guardian/src-foundations/mq';
 
 import { clearFix } from '@root/src/lib/mixins';
 import { ReaderRevenueLinks } from '@root/src/web/components/ReaderRevenueLinks';

--- a/src/web/components/Header/EditionDropdown.tsx
+++ b/src/web/components/Header/EditionDropdown.tsx
@@ -3,7 +3,7 @@ import { css } from 'emotion';
 
 import { Dropdown, Link } from '@root/src/web/components/Dropdown';
 import { palette } from '@guardian/src-foundations';
-import { from } from '@guardian/src-utilities';
+import { from } from '@guardian/src-foundations/mq';
 
 const editionDropdown = css`
     position: absolute;

--- a/src/web/components/Header/Links/Links.tsx
+++ b/src/web/components/Header/Links/Links.tsx
@@ -8,7 +8,7 @@ import {
 import ProfileIcon from '@frontend/static/icons/profile.svg';
 import SearchIcon from '@frontend/static/icons/search.svg';
 import { textSans, palette } from '@guardian/src-foundations';
-import { from } from '@guardian/src-utilities';
+import { from } from '@guardian/src-foundations/mq';
 
 const search = css`
     :after {

--- a/src/web/components/Header/Links/SupportTheGuardian.tsx
+++ b/src/web/components/Header/Links/SupportTheGuardian.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { css } from 'emotion';
 import { headline, palette } from '@guardian/src-foundations';
-import { from, visuallyHidden } from '@guardian/src-utilities';
+import { from } from '@guardian/src-foundations/mq';
+import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 import ProfileIcon from '@frontend/static/icons/profile.svg';
 import { getCookie } from '@root/src/web/browser/cookie';
 import { AsyncClientComponent } from '@root/src/web/components/lib/AsyncClientComponent';

--- a/src/web/components/Header/Logo.tsx
+++ b/src/web/components/Header/Logo.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { css } from 'emotion';
 
 import { palette } from '@guardian/src-foundations';
-import { from, visuallyHidden } from '@guardian/src-utilities';
+import { from } from '@guardian/src-foundations/mq';
+import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 
 import TheGuardianLogoSVG from '@frontend/static/logos/the-guardian.svg';
 

--- a/src/web/components/HeaderItem.tsx
+++ b/src/web/components/HeaderItem.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css, cx } from 'emotion';
-import { until } from '@guardian/src-utilities';
+import { until } from '@guardian/src-foundations/mq';
 
 const maxWidth = css`
     max-width: 630px;

--- a/src/web/components/Hide.tsx
+++ b/src/web/components/Hide.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from 'emotion';
-import { until, from, Breakpoint } from '@guardian/src-utilities';
+import { until, from, Breakpoint } from '@guardian/src-foundations/mq';
 
 type Props = {
     children: JSX.Element | JSX.Element[];

--- a/src/web/components/MainMedia.tsx
+++ b/src/web/components/MainMedia.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 import { textSans, palette } from '@guardian/src-foundations';
-import { until } from '@guardian/src-utilities';
+import { until } from '@guardian/src-foundations/mq';
 import { MainImageComponent } from '@root/src/web/components/elements/MainImageComponent';
 
 const captionFont = css`

--- a/src/web/components/MostViewed/MostViewed.tsx
+++ b/src/web/components/MostViewed/MostViewed.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 import { headline, palette } from '@guardian/src-foundations';
-import { from, between, Breakpoint } from '@guardian/src-utilities';
+import { from, between, Breakpoint } from '@guardian/src-foundations/mq';
 import { namedAdSlotParameters } from '@root/src/model/advertisement';
 import { AdSlot, labelStyles } from '@root/src/web/components/AdSlot';
 import { useApi } from '@root/src/web/components/lib/api';

--- a/src/web/components/MostViewed/MostViewedGrid.tsx
+++ b/src/web/components/MostViewed/MostViewedGrid.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
 import { css, cx } from 'emotion';
 import { headline, palette } from '@guardian/src-foundations';
-import { from, until, visuallyHidden } from '@guardian/src-utilities';
+import { from, until } from '@guardian/src-foundations/mq';
+import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 
 import { TabType, TrailType } from './MostViewed';
 import { MostViewedItem } from './MostViewedItem';

--- a/src/web/components/MostViewed/MostViewedItem.tsx
+++ b/src/web/components/MostViewed/MostViewedItem.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 import { textSans, headline, palette } from '@guardian/src-foundations';
-import { until } from '@guardian/src-utilities';
+import { until } from '@guardian/src-foundations/mq';
 import { BigNumber } from '@root/src/web/components/BigNumber/BigNumber';
 import { PulsingDot } from '@root/src/web/components/PulsingDot';
 import { QuoteIcon } from '@root/src/web/components/QuoteIcon';

--- a/src/web/components/Nav/ExpandedMenu/Column.tsx
+++ b/src/web/components/Nav/ExpandedMenu/Column.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { css, cx } from 'emotion';
 import { textSans, palette } from '@guardian/src-foundations';
-import { from, until } from '@guardian/src-utilities';
+import { from, until } from '@guardian/src-foundations/mq';
 import { CollapseColumnButton } from './CollapseColumnButton';
 
 // CSS vars

--- a/src/web/components/Nav/ExpandedMenu/Columns.tsx
+++ b/src/web/components/Nav/ExpandedMenu/Columns.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 import { headline, textSans, palette } from '@guardian/src-foundations';
-import { from } from '@guardian/src-utilities';
+import { from } from '@guardian/src-foundations/mq';
 
 import { Column, More, ReaderRevenueLinks } from './Column';
 

--- a/src/web/components/Nav/ExpandedMenu/ExpandedMenu.tsx
+++ b/src/web/components/Nav/ExpandedMenu/ExpandedMenu.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css, cx } from 'emotion';
 
 import { textSans, palette } from '@guardian/src-foundations';
-import { from, until } from '@guardian/src-utilities';
+import { from, until } from '@guardian/src-foundations/mq';
 
 import { ExpandedMenuToggle } from './ExpandedMenuToggle/ExpandedMenuToggle';
 import { Columns } from './Columns';

--- a/src/web/components/Nav/ExpandedMenu/ExpandedMenuToggle/ExpandedMenuToggle.tsx
+++ b/src/web/components/Nav/ExpandedMenu/ExpandedMenuToggle/ExpandedMenuToggle.tsx
@@ -1,7 +1,8 @@
 import React, { Component } from 'react';
 import { css, cx } from 'emotion';
 import { headline, palette } from '@guardian/src-foundations';
-import { from, visuallyHidden } from '@guardian/src-utilities';
+import { from } from '@guardian/src-foundations/mq';
+import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 import { VeggieBurger } from './VeggieBurger';
 
 const screenReadable = css`

--- a/src/web/components/Nav/ExpandedMenu/ExpandedMenuToggle/VeggieBurger.tsx
+++ b/src/web/components/Nav/ExpandedMenu/ExpandedMenuToggle/VeggieBurger.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 import { palette } from '@guardian/src-foundations';
-import { from } from '@guardian/src-utilities';
+import { from } from '@guardian/src-foundations/mq';
 
 const veggieBurger = ({
     showExpandedMenu,

--- a/src/web/components/Outbrain.tsx
+++ b/src/web/components/Outbrain.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { css } from 'emotion';
 import { textSans, body, palette } from '@guardian/src-foundations';
-import { from } from '@guardian/src-utilities';
+import { from } from '@guardian/src-foundations/mq';
 
 interface OutbrainSelectors {
     widget: string;

--- a/src/web/components/Pillars.tsx
+++ b/src/web/components/Pillars.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css, cx } from 'emotion';
 
 import { headline, palette } from '@guardian/src-foundations';
-import { from, until } from '@guardian/src-utilities';
+import { from, until } from '@guardian/src-foundations/mq';
 
 import { pillarMap, pillarPalette } from '@root/src/lib/pillars';
 

--- a/src/web/components/ReaderRevenueLinks.tsx
+++ b/src/web/components/ReaderRevenueLinks.tsx
@@ -3,7 +3,7 @@ import { css, cx } from 'emotion';
 
 import ArrowRightIcon from '@frontend/static/icons/arrow-right.svg';
 import { textSans, headline, palette } from '@guardian/src-foundations';
-import { from, until } from '@guardian/src-utilities';
+import { from, until } from '@guardian/src-foundations/mq';
 
 import { getCookie } from '@root/src/web/browser/cookie';
 import { AsyncClientComponent } from '@root/src/web/components/lib/AsyncClientComponent';

--- a/src/web/components/Section.tsx
+++ b/src/web/components/Section.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css, cx } from 'emotion';
 
 import { palette } from '@guardian/src-foundations';
-import { from } from '@guardian/src-utilities';
+import { from } from '@guardian/src-foundations/mq';
 
 const center = css`
     position: relative;

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css, cx } from 'emotion';
 import { pillarMap, pillarPalette } from '@root/src/lib/pillars';
 import { headline } from '@guardian/src-foundations';
-import { from } from '@guardian/src-utilities';
+import { from } from '@guardian/src-foundations/mq';
 
 const sectionLabelText = css`
     font-weight: 700;

--- a/src/web/components/ShareCount.tsx
+++ b/src/web/components/ShareCount.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 import ShareIcon from '@frontend/static/icons/share.svg';
 import { textSans, palette } from '@guardian/src-foundations';
-import { from, between } from '@guardian/src-utilities';
+import { from, between } from '@guardian/src-foundations/mq';
 import { integerCommas } from '@root/src/lib/formatters';
 import { useApi } from '@root/src/web/components/lib/api';
 

--- a/src/web/components/ShareIcons.tsx
+++ b/src/web/components/ShareIcons.tsx
@@ -8,7 +8,7 @@ import PinterestIcon from '@frontend/static/icons/pinterest.svg';
 import WhatsAppIcon from '@frontend/static/icons/whatsapp.svg';
 import MessengerIcon from '@frontend/static/icons/messenger.svg';
 import { palette } from '@guardian/src-foundations';
-import { from } from '@guardian/src-utilities';
+import { from } from '@guardian/src-foundations/mq';
 import { pillarMap, pillarPalette } from '@root/src/lib/pillars';
 
 const pillarFill = pillarMap(

--- a/src/web/components/StarRating.tsx
+++ b/src/web/components/StarRating.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css, cx } from 'emotion';
 import Star from '@frontend/static/icons/star.svg';
 import { palette } from '@guardian/src-foundations';
-import { from } from '@guardian/src-utilities';
+import { from } from '@guardian/src-foundations/mq';
 
 const ratingsWrapper = css`
     background-color: ${palette.yellow.main};

--- a/src/web/components/SubNav/Inner.tsx
+++ b/src/web/components/SubNav/Inner.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 import { textSans, palette } from '@guardian/src-foundations';
-import { from } from '@guardian/src-utilities';
+import { from } from '@guardian/src-foundations/mq';
 import { pillarPalette, pillarMap } from '@root/src/lib/pillars';
 
 const wrapperCollapsed = css`

--- a/src/web/components/SyndicationButton.tsx
+++ b/src/web/components/SyndicationButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 import { textSans, palette } from '@guardian/src-foundations';
-import { from } from '@guardian/src-utilities';
+import { from } from '@guardian/src-foundations/mq';
 
 export const SyndicationButton: React.FC<{
     webUrl: string;

--- a/src/web/components/elements/ImageBlockComponent.tsx
+++ b/src/web/components/elements/ImageBlockComponent.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 import { ImageComponent } from '@root/src/web/components/elements/ImageComponent';
 
-import { from } from '@guardian/src-utilities';
+import { from } from '@guardian/src-foundations/mq';
 
 const imageCss = {
     inline: css`

--- a/src/web/components/elements/PullQuoteComponent.tsx
+++ b/src/web/components/elements/PullQuoteComponent.tsx
@@ -3,7 +3,7 @@ import { css } from 'emotion';
 import Quote from '@frontend/static/icons/quote.svg';
 import { pillarPalette } from '@root/src/lib/pillars';
 import { palette, body } from '@guardian/src-foundations';
-import { from } from '@guardian/src-utilities';
+import { from } from '@guardian/src-foundations/mq';
 import { unescapeData } from '@root/src/lib/escapeData';
 
 const gutter = 20;

--- a/src/web/components/elements/RichLinkComponent.tsx
+++ b/src/web/components/elements/RichLinkComponent.tsx
@@ -5,7 +5,7 @@ import ArrowInCircle from '@frontend/static/icons/arrow-in-circle.svg';
 import Quote from '@frontend/static/icons/quote.svg';
 import { headline, textSans, palette } from '@guardian/src-foundations';
 import { StarRating } from '@root/src/web/components/StarRating';
-import { from, until, between } from '@guardian/src-utilities';
+import { from, until, between } from '@guardian/src-foundations/mq';
 import { useApi } from '@frontend/web/components/lib/api';
 
 type colour = string;

--- a/src/web/layouts/ShowcaseHeader.tsx
+++ b/src/web/layouts/ShowcaseHeader.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 
-import { from, until, between } from '@guardian/src-utilities';
+import { from, until, between } from '@guardian/src-foundations/mq';
 
 import { MainMedia } from '@root/src/web/components/MainMedia';
 import { ArticleHeadline } from '@root/src/web/components/ArticleHeadline';

--- a/src/web/layouts/StandardHeader.tsx
+++ b/src/web/layouts/StandardHeader.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 
-import { from, until } from '@guardian/src-utilities';
+import { from, until } from '@guardian/src-foundations/mq';
 
 import { MainMedia } from '@root/src/web/components/MainMedia';
 import { ArticleHeadline } from '@root/src/web/components/ArticleHeadline';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1342,10 +1342,10 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
-"@guardian/src-foundations@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.5.0.tgz#654fabebaec2ccbc2095c9404725a7afe6c43dcd"
-  integrity sha512-YrddBXTiyBzuz5l67B0ucfSkxpkgFLEmGth9jtYZE+3NuaOR5qarFDf2vWPcraITbzc/w7LgvAYLi2Uul/KWuQ==
+"@guardian/src-foundations@^0.5.6":
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.5.6.tgz#139e7d78fe1f2133cad2ba6a5095e0cd4c5a9985"
+  integrity sha512-rSPUzNXUANPbWeIzG9djpKDuIll/YN6SJriW344kj22mFk3xmRCQaxyMFvkrUkaTdyR1piDg51dG7afqCwEA4w==
 
 "@hapi/address@2.x.x":
   version "2.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1342,15 +1342,10 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
-"@guardian/src-foundations@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.4.0.tgz#bdf77ed6e7f36d8a4aed0a69dde8351108699325"
-  integrity sha512-E19YNqyPlQG9RZW+uEIx51GJdlrC36ZaEvjFsRC98uh9FPFLu6tJj4fWoIB0/kbSZopouW21pb4kqva5iy1mlA==
-
-"@guardian/src-utilities@^0.1.5":
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/@guardian/src-utilities/-/src-utilities-0.1.5.tgz#80c9b4353999b239d49461441cc975a275fc2759"
-  integrity sha512-BtcgblFxBdkEHw8d5Fcs73MP9Mrr7UNgSTb/+iTGr5lfJpKh6uvyZTjDis/jQeY121zZ/ETT2e4OFrgF1qu57w==
+"@guardian/src-foundations@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.5.0.tgz#654fabebaec2ccbc2095c9404725a7afe6c43dcd"
+  integrity sha512-YrddBXTiyBzuz5l67B0ucfSkxpkgFLEmGth9jtYZE+3NuaOR5qarFDf2vWPcraITbzc/w7LgvAYLi2Uul/KWuQ==
 
 "@hapi/address@2.x.x":
   version "2.1.2"


### PR DESCRIPTION
## What does this change?

- Upgrades to v0.5 of src-foundations
- Removes src-utilities

See [CHANGELOG](https://github.com/guardian/source-components/blob/master/CHANGELOG.md#1st-november-2019) for details

## Why?

As mentioned in guardian/source-components#70, src-utilities was just adding noise. However, we're still keen to keep the top-level API of src-foundations as tokens. This change moves these helpful utility functions into folders under src-foundations.