### PR TITLE
Manually added fonts to Storybook

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,357 @@
+<style>
+    /* BEGIN HEADLINE */
+
+    @font-face {
+        font-family: 'GH Guardian Headline';
+        src: url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Light.woff2')
+                format('woff2'),
+            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Light.woff')
+                format('woff'),
+            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Light.ttf')
+                format('truetype');
+        font-weight: 300;
+        font-style: normal;
+    }
+
+    @font-face {
+        font-family: 'GH Guardian Headline';
+        src: url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-LightItalic.woff2')
+                format('woff2'),
+            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-LightItalic.woff')
+                format('woff'),
+            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-LightItalic.ttf')
+                format('truetype');
+        font-weight: 300;
+        font-style: italic;
+    }
+
+    @font-face {
+        font-family: 'GH Guardian Headline';
+        src: url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Regular.woff2')
+                format('woff2'),
+            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Regular.woff')
+                format('woff'),
+            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Regular.ttf')
+                format('truetype');
+        font-weight: 400;
+        font-style: normal;
+    }
+
+    @font-face {
+        font-family: 'GH Guardian Headline';
+        src: url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-RegularItalic.woff2')
+                format('woff2'),
+            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-RegularItalic.woff')
+                format('woff'),
+            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-RegularItalic.ttf')
+                format('truetype');
+        font-weight: 400;
+        font-style: italic;
+    }
+
+    @font-face {
+        font-family: 'GH Guardian Headline';
+        src: url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Medium.woff2')
+                format('woff2'),
+            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Medium.woff')
+                format('woff'),
+            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Medium.ttf')
+                format('truetype');
+        font-weight: 500;
+        font-style: normal;
+    }
+
+    @font-face {
+        font-family: 'GH Guardian Headline';
+        src: url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-MediumItalic.woff2')
+                format('woff2'),
+            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-MediumItalic.woff')
+                format('woff'),
+            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-MediumItalic.ttf')
+                format('truetype');
+        font-weight: 500;
+        font-style: italic;
+    }
+
+    @font-face {
+        font-family: 'GH Guardian Headline';
+        src: url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Semibold.woff2')
+                format('woff2'),
+            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Semibold.woff')
+                format('woff'),
+            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Semibold.ttf')
+                format('truetype');
+        font-weight: 600;
+        font-style: normal;
+    }
+
+    @font-face {
+        font-family: 'GH Guardian Headline';
+        src: url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-SemiboldItalic.woff2')
+                format('woff2'),
+            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-SemiboldItalic.woff')
+                format('woff'),
+            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-SemiboldItalic.ttf')
+                format('truetype');
+        font-weight: 600;
+        font-style: italic;
+    }
+
+    @font-face {
+        font-family: 'GH Guardian Headline';
+        src: url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Bold.woff2')
+                format('woff2'),
+            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Bold.woff')
+                format('woff'),
+            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Bold.ttf')
+                format('truetype');
+        font-weight: 700;
+        font-style: normal;
+    }
+
+    @font-face {
+        font-family: 'GH Guardian Headline';
+        src: url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-BoldItalic.woff2')
+                format('woff2'),
+            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-BoldItalic.woff')
+                format('woff'),
+            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-BoldItalic.ttf')
+                format('truetype');
+        font-weight: 700;
+        font-style: italic;
+    }
+
+    @font-face {
+        font-family: 'GH Guardian Headline';
+        src: url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Black.woff2')
+                format('woff2'),
+            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Black.woff')
+                format('woff'),
+            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Black.ttf')
+                format('truetype');
+        font-weight: 900;
+        font-style: normal;
+    }
+
+    @font-face {
+        font-family: 'GH Guardian Headline';
+        src: url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-BlackItalic.woff2')
+                format('woff2'),
+            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-BlackItalic.woff')
+                format('woff'),
+            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-BlackItalic.ttf')
+                format('truetype');
+        font-weight: 900;
+        font-style: italic;
+    }
+
+    /* BEGIN TEXT SANS */
+
+    @font-face {
+        font-family: 'GuardianTextSans';
+        src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-Regular.woff2')
+                format('woff2'),
+            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-Regular.woff')
+                format('woff'),
+            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-Regular.ttf')
+                format('truetype');
+        font-weight: 400;
+        font-style: normal;
+    }
+
+    @font-face {
+        font-family: 'GuardianTextSans';
+        src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-RegularItalic.woff2')
+                format('woff2'),
+            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-RegularItalic.woff')
+                format('woff'),
+            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-RegularItalic.ttf')
+                format('truetype');
+        font-weight: 400;
+        font-style: italic;
+    }
+
+    @font-face {
+        font-family: 'GuardianTextSans';
+        src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-Medium.woff2')
+                format('woff2'),
+            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-Medium.woff')
+                format('woff'),
+            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-Medium.ttf')
+                format('truetype');
+        font-weight: 500;
+        font-style: normal;
+    }
+
+    @font-face {
+        font-family: 'GuardianTextSans';
+        src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-MediumItalic.woff2')
+                format('woff2'),
+            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-MediumItalic.woff')
+                format('woff'),
+            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-MediumItalic.ttf')
+                format('truetype');
+        font-weight: 500;
+        font-style: italic;
+    }
+
+    @font-face {
+        font-family: 'GuardianTextSans';
+        src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-Bold.woff2')
+                format('woff2'),
+            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-Bold.woff')
+                format('woff'),
+            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-Bold.ttf')
+                format('truetype');
+        font-weight: 700;
+        font-style: normal;
+    }
+
+    @font-face {
+        font-family: 'GuardianTextSans';
+        src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-BoldItalic.woff2')
+                format('woff2'),
+            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-BoldItalic.woff')
+                format('woff'),
+            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-BoldItalic.ttf')
+                format('truetype');
+        font-weight: 700;
+        font-style: italic;
+    }
+
+    @font-face {
+        font-family: 'GuardianTextSans';
+        src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-Black.woff2')
+                format('woff2'),
+            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-Black.woff')
+                format('woff'),
+            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-Black.ttf')
+                format('truetype');
+        font-weight: 900;
+        font-style: normal;
+    }
+
+    @font-face {
+        font-family: 'GuardianTextSans';
+        src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-BlackItalic.woff2')
+                format('woff2'),
+            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-BlackItalic.woff')
+                format('woff'),
+            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-BlackItalic.ttf')
+                format('truetype');
+        font-weight: 900;
+        font-style: italic;
+    }
+
+    /* BEGIN TEXT EGYPTIAN */
+
+    @font-face {
+        font-family: 'GuardianTextEgyptian';
+        src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Regular.woff2')
+                format('woff2'),
+            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Regular.woff')
+                format('woff'),
+            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Regular.ttf')
+                format('truetype');
+        font-weight: 400;
+        font-style: normal;
+    }
+
+    @font-face {
+        font-family: 'GuardianTextEgyptian';
+        src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-RegularItalic.woff2')
+                format('woff2'),
+            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-RegularItalic.woff')
+                format('woff'),
+            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-RegularItalic.ttf')
+                format('truetype');
+        font-weight: 400;
+        font-style: italic;
+    }
+
+    @font-face {
+        font-family: 'GuardianTextEgyptian';
+        src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Medium.woff2')
+                format('woff2'),
+            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Medium.woff')
+                format('woff'),
+            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Medium.ttf')
+                format('truetype');
+        font-weight: 500;
+        font-style: normal;
+    }
+
+    @font-face {
+        font-family: 'GuardianTextEgyptian';
+        src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-MediumItalic.woff2')
+                format('woff2'),
+            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-MediumItalic.woff')
+                format('woff'),
+            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-MediumItalic.ttf')
+                format('truetype');
+        font-weight: 500;
+        font-style: italic;
+    }
+
+    @font-face {
+        font-family: 'GuardianTextEgyptian';
+        src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Bold.woff2')
+                format('woff2'),
+            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Bold.woff')
+                format('woff'),
+            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Bold.ttf')
+                format('truetype');
+        font-weight: 700;
+        font-style: normal;
+    }
+
+    @font-face {
+        font-family: 'GuardianTextEgyptian';
+        src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-BoldItalic.woff2')
+                format('woff2'),
+            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-BoldItalic.woff')
+                format('woff'),
+            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-BoldItalic.ttf')
+                format('truetype');
+        font-weight: 700;
+        font-style: italic;
+    }
+
+    @font-face {
+        font-family: 'GuardianTextEgyptian';
+        src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Black.woff2')
+                format('woff2'),
+            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Black.woff')
+                format('woff'),
+            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Black.ttf')
+                format('truetype');
+        font-weight: 900;
+        font-style: normal;
+    }
+
+    @font-face {
+        font-family: 'GuardianTextEgyptian';
+        src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-BlackItalic.woff2')
+                format('woff2'),
+            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-BlackItalic.woff')
+                format('woff'),
+            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-BlackItalic.ttf')
+                format('truetype');
+        font-weight: 900;
+        font-style: italic;
+    }
+
+    /* BEGIN TITLEPIECE */
+
+    @font-face {
+        font-family: 'GT Guardian Titlepiece';
+        src: url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GTGuardianTitlepiece-Bold.woff2')
+                format('woff2'),
+            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GTGuardianTitlepiece-Bold.woff')
+                format('woff'),
+            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GTGuardianTitlepiece-Bold.ttf')
+                format('truetype');
+        font-weight: 700;
+        font-style: normal;
+    }
+</style>


### PR DESCRIPTION
## What does this change?
In line with `source-foundation`, this adds our list of fonts to Storybook. Previously we were missing certain fonts.

See: https://github.com/guardian/source-components/blob/master/.storybook/preview-head.html

## Why?
Storybook ❤️ 

## Link to supporting Trello card
https://trello.com/c/4walsXYD/838-fix-storybook-fonts
