### PR TITLE
Fix inverted headline styles

### DIFF
--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -168,35 +168,33 @@ const renderHeadline = (
         case 'light':
         case 'underlined': {
             return (
-                <>
-                    <h1
-                        className={cx(
-                            standardFont,
-                            standardPadding,
-                            type === 'underlined' && underlinedStyles,
-                            type === 'bold' && boldFont,
-                            type === 'bold' && boldPadding,
-                            type === 'light' && lightFont,
-                            options && colourStyles(options.colour),
-                        )}
-                    >
-                        {curly(headlineString)}
-                    </h1>
-                </>
+                <h1
+                    className={cx(
+                        standardFont,
+                        standardPadding,
+                        type === 'underlined' && underlinedStyles,
+                        type === 'bold' && boldFont,
+                        type === 'bold' && boldPadding,
+                        type === 'light' && lightFont,
+                        options && colourStyles(options.colour),
+                    )}
+                >
+                    {curly(headlineString)}
+                </h1>
             );
         }
         case 'inverted': {
             return (
                 // Inverted headlines have a wrapper div for positioning
                 // and a black background (only for the text)
-                <div
+                <h1
                     className={cx(
                         invertedWrapper,
                         shiftPosition('down'),
                         maxWidth,
                     )}
                 >
-                    <h1
+                    <span
                         className={cx(
                             invertedFont,
                             blackBackground,
@@ -206,15 +204,15 @@ const renderHeadline = (
                         )}
                     >
                         {curly(headlineString)}
-                    </h1>
-                </div>
+                    </span>
+                </h1>
             );
         }
         case 'jumbo': {
             return (
                 // Jumbo headlines are large and inverted and have their black background
                 // extended to the right
-                <div
+                <h1
                     className={cx(
                         invertedWrapper,
                         shiftPosition('up'),
@@ -222,7 +220,7 @@ const renderHeadline = (
                         options && colourStyles(options.colour),
                     )}
                 >
-                    <h1
+                    <span
                         className={cx(
                             jumboFont,
                             maxWidth,
@@ -232,8 +230,8 @@ const renderHeadline = (
                         )}
                     >
                         {curly(headlineString)}
-                    </h1>
-                </div>
+                    </span>
+                </h1>
             );
         }
     }

--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -99,8 +99,8 @@ const invertedStyles = css`
     color: white;
     display: 'inline';
     white-space: pre-wrap;
-    padding: 5px;
-    padding-left: 0px;
+    padding-bottom: 5px;
+    padding-right: 5px;
     box-shadow: -6px 0 0 black;
 `;
 

--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -189,6 +189,7 @@ const renderHeadline = (
                 // and a black background (only for the text)
                 <h1
                     className={cx(
+                        invertedFont,
                         invertedWrapper,
                         shiftPosition('down'),
                         maxWidth,
@@ -196,7 +197,6 @@ const renderHeadline = (
                 >
                     <span
                         className={cx(
-                            invertedFont,
                             blackBackground,
                             invertedStyles,
                             displayInline,

--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -39,6 +39,11 @@ const jumboFont = css`
     line-height: 56px;
 `;
 
+const invertedFont = css`
+    ${headline({ level: 5, fontWeight: 'bold' })};
+    line-height: 42px;
+`;
+
 const lightFont = css`
     font-weight: normal;
     font-weight: 300;
@@ -193,7 +198,7 @@ const renderHeadline = (
                 >
                     <h1
                         className={cx(
-                            standardFont,
+                            invertedFont,
                             blackBackground,
                             invertedStyles,
                             displayInline,
@@ -219,11 +224,10 @@ const renderHeadline = (
                 >
                     <h1
                         className={cx(
-                            standardFont,
+                            jumboFont,
                             maxWidth,
                             invertedStyles,
                             displayBlock,
-                            jumboFont,
                             options && colourStyles(options.colour),
                         )}
                     >


### PR DESCRIPTION
## What does this change?
This is a quick follow on PR from https://github.com/guardian/dotcom-rendering/pull/908. I noticed that we were very slightly chopping off the bottom of 'g's in `inverted` headlines. This PR fixes that.

It also better applies how we set the `h1` tag, which matters.

Finally, in the same code, I refactored things very slightly to be clearer.

