### PR TITLE
Update typography API

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     ],
     "dependencies": {
         "@emotion/core": "^10.0.5",
-        "@guardian/src-foundations": "^0.6.0-alpha.1",
+        "@guardian/src-foundations": "^0.6.0-alpha.2",
         "@sentry/browser": "^5.7.1",
         "@types/ajv": "^1.0.0",
         "@types/lodash.escape": "^4.0.6",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     ],
     "dependencies": {
         "@emotion/core": "^10.0.5",
-        "@guardian/src-foundations": "^0.5.6",
+        "@guardian/src-foundations": "^0.6.0-alpha.1",
         "@sentry/browser": "^5.7.1",
         "@types/ajv": "^1.0.0",
         "@types/lodash.escape": "^4.0.6",

--- a/src/amp/components/topMeta/TopMetaNews.tsx
+++ b/src/amp/components/topMeta/TopMetaNews.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
-import { palette, headline } from '@guardian/src-foundations';
+import { palette } from '@guardian/src-foundations';
+import { headline } from '@guardian/src-foundations/__experimental__typography';
 import { pillarPalette } from '@root/src/lib/pillars';
 import { ArticleModel } from '@root/src/amp/types/ArticleModel';
 import { MainMedia } from '@root/src/amp/components/MainMedia';
@@ -15,14 +16,14 @@ import { Branding } from '@root/src/amp/components/topMeta/Branding';
 import { StarRating } from '@root/src/amp/components/StarRating';
 
 const headerStyle = css`
-    ${headline({ level: 4 })};
+    ${headline.small()};
     font-weight: 500;
     padding-bottom: 24px;
     padding-top: 3px;
     color: ${palette.neutral[7]};
 `;
 const bylineStyle = (pillar: Pillar) => css`
-    ${headline({ level: 1 })};
+    ${headline.tiny()};
     color: ${pillarPalette[pillar].main};
     padding-bottom: 8px;
     font-style: italic;

--- a/src/web/components/AdSlot.tsx
+++ b/src/web/components/AdSlot.tsx
@@ -2,12 +2,13 @@
 
 import React from 'react';
 import { css } from 'emotion';
-import { textSans, palette } from '@guardian/src-foundations';
+import { palette } from '@guardian/src-foundations';
+import { textSans } from '@guardian/src-foundations/__experimental__typography';
 import { from } from '@guardian/src-foundations/mq';
 
 export const labelStyles = css`
     .ad-slot__label {
-        ${textSans({ level: 1 })};
+        ${textSans.xsmall()};
         position: relative;
         height: 24px;
         background-color: ${palette.neutral[97]};
@@ -74,7 +75,7 @@ const mobileStickyAdStyles = css`
         color: ${palette.neutral[60]};
         text-align: left;
         box-sizing: border-box;
-        ${textSans({ level: 1 })};
+        ${textSans.xsmall()};
     }
 `;
 export interface AdSlotParameters {

--- a/src/web/components/ArticleBody.tsx
+++ b/src/web/components/ArticleBody.tsx
@@ -3,7 +3,11 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 
-import { textSans, headline, palette } from '@guardian/src-foundations';
+import { palette } from '@guardian/src-foundations';
+import {
+    textSans,
+    headline,
+} from '@guardian/src-foundations/__experimental__typography';
 import { from, between } from '@guardian/src-foundations/mq';
 import { pillarMap, pillarPalette } from '@root/src/lib/pillars';
 import { ArticleRenderer } from '@root/src/web/components/lib/ArticleRenderer';
@@ -37,7 +41,7 @@ const pillarColours = pillarMap(
 // );
 
 const captionFont = css`
-    ${textSans({ level: 1 })};
+    ${textSans.xsmall()};
     color: ${palette.neutral[46]};
 `;
 
@@ -47,7 +51,7 @@ const bodyStyle = css`
     }
 
     h2 {
-        ${headline({ level: 2 })};
+        ${headline.xxsmall()};
     }
 
     strong {
@@ -79,7 +83,7 @@ const bodyStyle = css`
     }
 
     li {
-        ${textSans({ level: 3 })};
+        ${textSans.medium()};
         margin-bottom: 6px;
         padding-left: 20px;
 
@@ -102,7 +106,7 @@ const bodyStyle = css`
 
 const immersiveBodyStyle = css`
     h2 {
-        ${headline({ level: 5 })};
+        ${headline.medium()};
         font-weight: 200;
     }
 `;
@@ -122,7 +126,7 @@ const linkColour = pillarMap(
 );
 
 const subMetaLabel = css`
-    ${textSans({ level: 1 })};
+    ${textSans.xsmall()};
     display: block;
     color: ${palette.neutral[60]};
 `;

--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -5,7 +5,10 @@ import ClockIcon from '@frontend/static/icons/clock.svg';
 import { getAgeWarning } from '@root/src/lib/age-warning';
 
 import { palette } from '@guardian/src-foundations';
-import { headline, textSans } from '@guardian/src-foundations/__typography';
+import {
+    headline,
+    textSans,
+} from '@guardian/src-foundations/__experimental__typography';
 import { from } from '@guardian/src-foundations/mq';
 import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 

--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -4,7 +4,8 @@ import { css, cx } from 'emotion';
 import ClockIcon from '@frontend/static/icons/clock.svg';
 import { getAgeWarning } from '@root/src/lib/age-warning';
 
-import { headline, textSans, palette } from '@guardian/src-foundations';
+import { palette } from '@guardian/src-foundations';
+import { headline, textSans } from '@guardian/src-foundations/__typography';
 import { from } from '@guardian/src-foundations/mq';
 import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 
@@ -27,20 +28,20 @@ type Props = {
 const curly = (x: any) => x;
 
 const standardFont = css`
-    ${headline({ level: 5, fontWeight: 'medium' })};
+    ${headline.medium()};
 `;
 
 const boldFont = css`
-    ${headline({ level: 5, fontWeight: 'bold' })};
+    ${headline.medium({ fontWeight: 'bold' })};
 `;
 
 const jumboFont = css`
-    ${headline({ level: 7, fontWeight: 'bold' })};
+    ${headline.xlarge({ fontWeight: 'bold' })};
     line-height: 56px;
 `;
 
 const invertedFont = css`
-    ${headline({ level: 5, fontWeight: 'bold' })};
+    ${headline.medium({ fontWeight: 'bold' })};
     line-height: 42px;
 `;
 
@@ -122,7 +123,7 @@ const invertedWrapper = css`
 `;
 
 const ageWarningStyle = css`
-    ${textSans({ level: 3 })};
+    ${textSans.medium()};
     color: ${palette.neutral[7]};
     background-color: ${palette.yellow.main};
     display: inline-block;

--- a/src/web/components/ArticleStandfirst.tsx
+++ b/src/web/components/ArticleStandfirst.tsx
@@ -1,17 +1,22 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 import { pillarMap, pillarPalette } from '@root/src/lib/pillars';
-import { headline, textSans, body, palette } from '@guardian/src-foundations';
+import { palette } from '@guardian/src-foundations';
+import {
+    body,
+    headline,
+    textSans,
+} from '@guardian/src-foundations/__experimental__typography';
 
 const standfirstStyles = css`
-    ${body({ level: 2 })};
+    ${body.medium()};
     max-width: 550px;
     font-weight: 700;
     color: ${palette.neutral[7]};
     margin-bottom: 12px;
 
     li {
-        ${textSans({ level: 3 })};
+        ${textSans.medium()};
         margin-bottom: 6px;
         padding-left: 20px;
 
@@ -36,7 +41,7 @@ const standfirstStyles = css`
     }
 
     li {
-        ${headline({ level: 1 })};
+        ${headline.tiny()};
     }
 `;
 

--- a/src/web/components/BackToTop.tsx
+++ b/src/web/components/BackToTop.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
-import { palette, textSans } from '@guardian/src-foundations';
+import { palette } from '@guardian/src-foundations';
+import { textSans } from '@guardian/src-foundations/__experimental__typography';
 
 const iconHeight = '42px';
 
@@ -48,7 +49,7 @@ const icon = css`
 `;
 
 const text = css`
-    ${textSans({ level: 2 })};
+    ${textSans.small()};
     padding-right: 5px;
 `;
 

--- a/src/web/components/Byline.tsx
+++ b/src/web/components/Byline.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
 import { css } from 'emotion';
 import TwitterIcon from '@frontend/static/icons/twitter.svg';
-import { headline, textSans, palette } from '@guardian/src-foundations';
+import { palette } from '@guardian/src-foundations';
+import {
+    headline,
+    textSans,
+} from '@guardian/src-foundations/__experimental__typography';
 import { pillarPalette } from '@root/src/lib/pillars';
 
 const twitterHandle = css`
-    ${textSans({ level: 1 })};
+    ${textSans.xsmall()};
     font-weight: bold;
     color: ${palette.neutral[46]};
 
@@ -26,7 +30,7 @@ const twitterHandle = css`
 `;
 
 const bylineStyle = (pillar: Pillar) => css`
-    ${headline({ level: 1 })};
+    ${headline.xxsmall()};
     color: ${pillarPalette[pillar].main};
     padding-bottom: 8px;
     font-style: italic;

--- a/src/web/components/Byline.tsx
+++ b/src/web/components/Byline.tsx
@@ -30,7 +30,7 @@ const twitterHandle = css`
 `;
 
 const bylineStyle = (pillar: Pillar) => css`
-    ${headline.xxsmall()};
+    ${headline.tiny()};
     color: ${pillarPalette[pillar].main};
     padding-bottom: 8px;
     font-style: italic;

--- a/src/web/components/Caption.tsx
+++ b/src/web/components/Caption.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { textSans, palette } from '@guardian/src-foundations';
+import { palette } from '@guardian/src-foundations';
+import { textSans } from '@guardian/src-foundations/__experimental__typography';
 import { css, cx } from 'emotion';
 import { pillarPalette } from '@root/src/lib/pillars';
 import TriangleIcon from '@frontend/static/icons/triangle.svg';
@@ -9,7 +10,7 @@ const figureStyle = css`
 `;
 const captionStyle = css`
     padding-top: 10px;
-    ${textSans({ level: 1 })};
+    ${textSans.xsmall()};
     word-wrap: break-word;
     color: ${palette.neutral[46]};
 `;

--- a/src/web/components/CookieBanner.tsx
+++ b/src/web/components/CookieBanner.tsx
@@ -1,6 +1,11 @@
 import React, { Component } from 'react';
 import { css } from 'emotion';
-import { headline, textSans, body, palette } from '@guardian/src-foundations';
+import { palette } from '@guardian/src-foundations';
+import {
+    headline,
+    textSans,
+    body,
+} from '@guardian/src-foundations/__experimental__typography';
 import { until } from '@guardian/src-foundations/mq';
 import TickIcon from '@frontend/static/icons/tick.svg';
 import RoundelIcon from '@frontend/static/icons/the-guardian-roundel.svg';
@@ -21,7 +26,7 @@ const inner = css`
     position: relative;
     margin: 0 20%;
     p {
-        ${body({ level: 2 })};
+        ${body.medium()};
         margin-top: 0;
         color: ${palette.neutral[100]};
         margin-bottom: 8px;
@@ -41,13 +46,13 @@ const inner = css`
         margin: auto;
         padding: 0;
         p {
-            ${body({ level: 1 })};
+            ${body.small()};
         }
     }
 `;
 
 const header = css`
-    ${headline({ level: 5 })};
+    ${headline.medium()};
     font-weight: bold;
     padding-bottom: 12px;
     color: ${palette.neutral[100]};
@@ -55,7 +60,7 @@ const header = css`
 
 const more = css`
     margin-left: 12px;
-    ${textSans({ level: 2 })};
+    ${textSans.small()};
     font-weight: bold;
 `;
 
@@ -69,7 +74,7 @@ const iconCss = css`
 `;
 
 const button = css`
-    ${textSans({ level: 3 })};
+    ${textSans.medium()};
     border-radius: 1000px;
     height: 42px;
     background: ${palette.yellow.main};

--- a/src/web/components/Dateline.tsx
+++ b/src/web/components/Dateline.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 
 import { css } from 'emotion';
-import { textSans, palette } from '@guardian/src-foundations';
+import { palette } from '@guardian/src-foundations';
+import { textSans } from '@guardian/src-foundations/__experimental__typography';
 import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 
 const captionFont = css`
-    ${textSans({ level: 1 })};
+    ${textSans.xsmall()};
     color: ${palette.neutral[46]};
 `;
 

--- a/src/web/components/Dropdown.tsx
+++ b/src/web/components/Dropdown.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
-import { textSans, palette } from '@guardian/src-foundations';
+import { palette } from '@guardian/src-foundations';
+import { textSans } from '@guardian/src-foundations/__experimental__typography';
 import { from, until } from '@guardian/src-foundations/mq';
 import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 
@@ -57,7 +58,7 @@ const ulExpanded = css`
 `;
 
 const link = css`
-    ${textSans({ level: 2 })};
+    ${textSans.small()};
     color: ${palette.neutral[7]};
     position: relative;
     transition: color 80ms ease-out;
@@ -110,7 +111,7 @@ const linkFirst = css`
 `;
 
 const button = css`
-    ${textSans({ level: 3 })};
+    ${textSans.medium()};
     display: block;
     cursor: pointer;
     background: none;

--- a/src/web/components/Footer.tsx
+++ b/src/web/components/Footer.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 
-import { textSans, palette } from '@guardian/src-foundations';
+import { palette } from '@guardian/src-foundations';
+import { textSans } from '@guardian/src-foundations/__experimental__typography';
 import { from, until } from '@guardian/src-foundations/mq';
 
 import { clearFix } from '@root/src/lib/mixins';
@@ -22,7 +23,7 @@ const footer = css`
     background-color: ${palette.brand.main};
     color: ${palette.neutral[100]};
     padding-bottom: 6px;
-    ${textSans({ level: 3 })};
+    ${textSans.medium()};
 `;
 
 const pillarWrap = css`
@@ -136,7 +137,7 @@ const readerRevenueLinks = css`
 `;
 
 const copyright = css`
-    ${textSans({ level: 1 })};
+    ${textSans.xsmall()};
     padding: 12px;
 
     ${until.tablet} {

--- a/src/web/components/Header/Links/Links.tsx
+++ b/src/web/components/Header/Links/Links.tsx
@@ -7,7 +7,8 @@ import {
 } from '@root/src/web/components/Dropdown';
 import ProfileIcon from '@frontend/static/icons/profile.svg';
 import SearchIcon from '@frontend/static/icons/search.svg';
-import { textSans, palette } from '@guardian/src-foundations';
+import { palette } from '@guardian/src-foundations';
+import { textSans } from '@guardian/src-foundations/__experimental__typography';
 import { from } from '@guardian/src-foundations/mq';
 
 const search = css`
@@ -33,7 +34,7 @@ const search = css`
 `;
 
 const link = css`
-    ${textSans({ level: 3 })};
+    ${textSans.medium()};
     color: ${palette.neutral[100]};
     float: left;
     position: relative;

--- a/src/web/components/Header/Links/SupportTheGuardian.tsx
+++ b/src/web/components/Header/Links/SupportTheGuardian.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
-import { headline, palette } from '@guardian/src-foundations';
+import { palette } from '@guardian/src-foundations';
+import { headline } from '@guardian/src-foundations/__experimental__typography';
 import { from } from '@guardian/src-foundations/mq';
 import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 import ProfileIcon from '@frontend/static/icons/profile.svg';
@@ -41,14 +42,14 @@ const style = css`
 
 const text = css`
     color: ${palette.neutral[97]};
-    ${headline({ level: 1 })};
+    ${headline.tiny()};
     font-weight: 700;
     text-align: center;
     padding: 6px 20px 3px;
     position: relative;
 
     ${from.tablet} {
-        ${headline({ level: 1 })};
+        ${headline.tiny()};
     }
 `;
 

--- a/src/web/components/MainMedia.tsx
+++ b/src/web/components/MainMedia.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { css } from 'emotion';
-import { textSans, palette } from '@guardian/src-foundations';
+import { palette } from '@guardian/src-foundations';
+import { textSans } from '@guardian/src-foundations/__experimental__typography';
 import { until } from '@guardian/src-foundations/mq';
 import { MainImageComponent } from '@root/src/web/components/elements/MainImageComponent';
 
 const captionFont = css`
-    ${textSans({ level: 1 })};
+    ${textSans.xsmall()};
     color: ${palette.neutral[46]};
 `;
 

--- a/src/web/components/MostViewed/MostViewed.tsx
+++ b/src/web/components/MostViewed/MostViewed.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
-import { headline, palette } from '@guardian/src-foundations';
+import { palette } from '@guardian/src-foundations';
+import { headline } from '@guardian/src-foundations/__experimental__typography';
 import { from, between, Breakpoint } from '@guardian/src-foundations/mq';
 import { namedAdSlotParameters } from '@root/src/model/advertisement';
 import { AdSlot, labelStyles } from '@root/src/web/components/AdSlot';
@@ -34,7 +35,7 @@ const asideWidth = css`
 `;
 
 const headingStyles = css`
-    ${headline({ level: 3 })};
+    ${headline.xsmall()};
     color: ${palette.neutral[7]};
     font-weight: 900;
     padding-right: 5px;
@@ -42,7 +43,7 @@ const headingStyles = css`
     padding-top: 3px;
 
     ${from.leftCol} {
-        ${headline({ level: 3 })};
+        ${headline.xsmall()};
         font-weight: 900;
     }
 

--- a/src/web/components/MostViewed/MostViewedGrid.tsx
+++ b/src/web/components/MostViewed/MostViewedGrid.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { css, cx } from 'emotion';
-import { headline, palette } from '@guardian/src-foundations';
+import { palette } from '@guardian/src-foundations';
+import { headline } from '@guardian/src-foundations/__experimental__typography';
 import { from, until } from '@guardian/src-foundations/mq';
 import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 
@@ -55,7 +56,7 @@ const unselectedListTab = css`
 `;
 
 const tabButton = css`
-    ${headline({ level: 1 })};
+    ${headline.tiny()};
     margin: 0;
     border: 0;
     background: transparent;

--- a/src/web/components/MostViewed/MostViewedItem.tsx
+++ b/src/web/components/MostViewed/MostViewedItem.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { css } from 'emotion';
 
-import { textSans, headline, palette } from '@guardian/src-foundations';
+import { palette } from '@guardian/src-foundations';
+import {
+    textSans,
+    headline,
+} from '@guardian/src-foundations/__experimental__typography';
 import { until } from '@guardian/src-foundations/mq';
 import { BigNumber } from '@root/src/web/components/BigNumber/BigNumber';
 import { PulsingDot } from '@root/src/web/components/PulsingDot';
@@ -54,7 +58,7 @@ const headlineLink = css`
     text-decoration: none;
     color: ${palette.neutral[7]};
     font-weight: 500;
-    ${headline({ level: 1 })};
+    ${headline.tiny()};
 `;
 
 const liveKicker = (colour: string) => css`
@@ -93,7 +97,7 @@ const AgeWarning: React.FC<{
 };
 
 const oldArticleMessage = css`
-    ${textSans({ level: 1 })}
+    ${textSans.xsmall()}
     background: ${palette.yellow.main};
     display: inline-block;
     color: ${palette.neutral[7]};

--- a/src/web/components/Nav/ExpandedMenu/CollapseColumnButton.tsx
+++ b/src/web/components/Nav/ExpandedMenu/CollapseColumnButton.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 
-import { headline, palette } from '@guardian/src-foundations';
+import { palette } from '@guardian/src-foundations';
+import { headline } from '@guardian/src-foundations/__experimental__typography';
 
 import { hideDesktop } from './Column';
 
@@ -18,7 +19,7 @@ const collapseColumnButton = css`
     cursor: pointer;
     color: ${palette.neutral[100]};
     display: block;
-    ${headline({ level: 3 })};
+    ${headline.xsmall()};
     font-weight: 700;
     outline: none;
     padding: 6px 34px 18px 50px;

--- a/src/web/components/Nav/ExpandedMenu/Column.tsx
+++ b/src/web/components/Nav/ExpandedMenu/Column.tsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { css, cx } from 'emotion';
-import { textSans, palette } from '@guardian/src-foundations';
+import { palette } from '@guardian/src-foundations';
+import { textSans } from '@guardian/src-foundations/__experimental__typography';
 import { from, until } from '@guardian/src-foundations/mq';
 import { CollapseColumnButton } from './CollapseColumnButton';
 
@@ -40,7 +41,7 @@ const pillarDividerExtended = css`
 `;
 
 const columnLinkTitle = css`
-    ${textSans({ level: 3, lineHeight: 'tight' })};
+    ${textSans.medium({ lineHeight: 'tight' })};
     background-color: transparent;
     text-decoration: none;
     border: 0;
@@ -106,7 +107,7 @@ const ColumnLink: React.FC<{
 );
 
 const columnLinks = css`
-    ${textSans({ level: 3 })};
+    ${textSans.medium()};
     box-sizing: border-box;
     display: flex;
     flex-wrap: wrap;
@@ -169,7 +170,7 @@ const ColumnLinks: React.FC<{
 };
 
 const columnStyle = css`
-    ${textSans({ level: 3 })};
+    ${textSans.medium()};
     list-style: none;
     margin: 0;
     padding-bottom: 10px;

--- a/src/web/components/Nav/ExpandedMenu/Columns.tsx
+++ b/src/web/components/Nav/ExpandedMenu/Columns.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { css } from 'emotion';
 
-import { headline, textSans, palette } from '@guardian/src-foundations';
+import { palette } from '@guardian/src-foundations';
+import {
+    headline,
+    textSans,
+} from '@guardian/src-foundations/__experimental__typography';
 import { from } from '@guardian/src-foundations/mq';
 
 import { Column, More, ReaderRevenueLinks } from './Column';
@@ -40,7 +44,7 @@ const desktopBrandExtensionColumn = css`
 const brandExtensionList = css`
     width: 131px;
     box-sizing: border-box;
-    ${textSans({ level: 3 })};
+    ${textSans.medium()};
     flex-wrap: wrap;
     list-style: none;
     margin: 0;
@@ -63,7 +67,7 @@ const brandExtensionListItem = css`
 `;
 
 const brandExtensionLink = css`
-    ${headline({ level: 2 })};
+    ${headline.xxsmall()};
     font-weight: 700;
     background-color: transparent;
     border: 0;

--- a/src/web/components/Nav/ExpandedMenu/ExpandedMenu.tsx
+++ b/src/web/components/Nav/ExpandedMenu/ExpandedMenu.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 
-import { textSans, palette } from '@guardian/src-foundations';
+import { palette } from '@guardian/src-foundations';
+import { textSans } from '@guardian/src-foundations/__experimental__typography';
 import { from, until } from '@guardian/src-foundations/mq';
 
 import { ExpandedMenuToggle } from './ExpandedMenuToggle/ExpandedMenuToggle';
@@ -20,7 +21,7 @@ const showExpandedMenuStyles = css`
 const mainMenu = css`
     background-color: ${palette.brand.main};
     box-sizing: border-box;
-    ${textSans({ level: 4 })};
+    ${textSans.large()};
     left: 0;
     margin-right: 29px;
     padding-bottom: 24px;

--- a/src/web/components/Nav/ExpandedMenu/ExpandedMenuToggle/ExpandedMenuToggle.tsx
+++ b/src/web/components/Nav/ExpandedMenu/ExpandedMenuToggle/ExpandedMenuToggle.tsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { css, cx } from 'emotion';
-import { headline, palette } from '@guardian/src-foundations';
+import { palette } from '@guardian/src-foundations';
+import { headline } from '@guardian/src-foundations/__experimental__typography';
 import { from } from '@guardian/src-foundations/mq';
 import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 import { VeggieBurger } from './VeggieBurger';
@@ -9,7 +10,7 @@ const screenReadable = css`
     ${visuallyHidden};
 `;
 const openExpandedMenu = css`
-    ${headline({ level: 3 })};
+    ${headline.xsmall()};
     font-weight: 300;
     color: ${palette.neutral[100]};
     cursor: pointer;

--- a/src/web/components/Outbrain.tsx
+++ b/src/web/components/Outbrain.tsx
@@ -2,7 +2,11 @@
 
 import React from 'react';
 import { css } from 'emotion';
-import { textSans, body, palette } from '@guardian/src-foundations';
+import { palette } from '@guardian/src-foundations';
+import {
+    textSans,
+    body,
+} from '@guardian/src-foundations/__experimental__typography';
 import { from } from '@guardian/src-foundations/mq';
 
 interface OutbrainSelectors {
@@ -83,10 +87,10 @@ const outbrainContainer = css`
 
     .ob-widget {
         div.ob-widget-header {
-            ${body({ level: 2 })};
+            ${body.medium()};
             span,
             .ob_about_this_content a {
-                ${body({ level: 1 })};
+                ${body.small()};
                 text-decoration: none;
                 /* stylelint-disable-next-line color-no-hex */
                 color: #00456e;
@@ -98,7 +102,7 @@ const outbrainContainer = css`
 
         span.ob-rec-text {
             max-height: fit-content;
-            ${textSans({ level: 3 })};
+            ${textSans.medium()};
         }
     }
 `;

--- a/src/web/components/Pillars.tsx
+++ b/src/web/components/Pillars.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 
-import { headline, palette } from '@guardian/src-foundations';
+import { palette } from '@guardian/src-foundations';
+import { headline } from '@guardian/src-foundations/__experimental__typography';
 import { from, until } from '@guardian/src-foundations/mq';
 
 import { pillarMap, pillarPalette } from '@root/src/lib/pillars';
@@ -118,7 +119,7 @@ const pillarDivider = css`
 `;
 
 const linkStyle = css`
-    ${headline({ level: 1 })};
+    ${headline.tiny()};
     box-sizing: border-box;
     font-weight: 900;
     color: ${palette.neutral[100]};

--- a/src/web/components/ReaderRevenueLinks.tsx
+++ b/src/web/components/ReaderRevenueLinks.tsx
@@ -2,7 +2,11 @@ import React from 'react';
 import { css, cx } from 'emotion';
 
 import ArrowRightIcon from '@frontend/static/icons/arrow-right.svg';
-import { textSans, headline, palette } from '@guardian/src-foundations';
+import { palette } from '@guardian/src-foundations';
+import {
+    textSans,
+    headline,
+} from '@guardian/src-foundations/__experimental__typography';
 import { from, until } from '@guardian/src-foundations/mq';
 
 import { getCookie } from '@root/src/web/browser/cookie';
@@ -22,16 +26,16 @@ const padded = css`
 
 const message = css`
     color: ${palette.yellow.main};
-    ${headline({ level: 2, fontWeight: 'bold' })};
+    ${headline.xxsmall({ fontWeight: 'bold' })};
     padding-top: 3px;
     margin-bottom: 3px;
 
     ${from.desktop} {
-        ${headline({ level: 3, fontWeight: 'bold' })}
+        ${headline.xsmall({ fontWeight: 'bold' })}
     }
 
     ${from.leftCol} {
-        ${headline({ level: 5, fontWeight: 'bold' })}
+        ${headline.medium({ fontWeight: 'bold' })}
     }
 `;
 
@@ -41,7 +45,7 @@ const link = css`
     box-sizing: border-box;
     color: ${palette.neutral[7]};
     float: left;
-    ${textSans({ level: 2 })};
+    ${textSans.small()};
     font-weight: 700;
     height: 32px;
     text-decoration: none;
@@ -93,7 +97,7 @@ const hiddenFromTablet = css`
 
 const subMessage = css`
     color: ${palette.neutral[100]};
-    ${textSans({ level: 3 })};
+    ${textSans.medium()};
     margin-bottom: 9px;
 `;
 

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 import { pillarMap, pillarPalette } from '@root/src/lib/pillars';
-import { headline } from '@guardian/src-foundations';
+import { headline } from '@guardian/src-foundations/__experimental__typography';
 import { from } from '@guardian/src-foundations/mq';
 
 const sectionLabelText = css`
@@ -24,14 +24,14 @@ const pillarColours = pillarMap(
 
 const primaryStyle = css`
     font-weight: 700;
-    ${headline({ level: 1 })};
+    ${headline.tiny()};
     ${from.leftCol} {
-        ${headline({ level: 2 })};
+        ${headline.xxsmall()};
     }
 `;
 
 const secondaryStyle = css`
-    ${headline({ level: 1 })};
+    ${headline.tiny()};
     display: block;
 `;
 

--- a/src/web/components/ShareCount.tsx
+++ b/src/web/components/ShareCount.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import { css } from 'emotion';
 import ShareIcon from '@frontend/static/icons/share.svg';
-import { textSans, palette } from '@guardian/src-foundations';
+import { palette } from '@guardian/src-foundations';
+import { textSans } from '@guardian/src-foundations/__experimental__typography';
 import { from, between } from '@guardian/src-foundations/mq';
 import { integerCommas } from '@root/src/lib/formatters';
 import { useApi } from '@root/src/web/components/lib/api';
 
 const shareCount = css`
-    ${textSans({ level: 3 })};
+    ${textSans.medium()};
     font-weight: bold;
     color: ${palette.neutral[46]};
 

--- a/src/web/components/SubMetaLinksList.tsx
+++ b/src/web/components/SubMetaLinksList.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { css, cx } from 'emotion';
-import { headline, textSans, palette } from '@guardian/src-foundations';
+import { palette } from '@guardian/src-foundations';
+import {
+    headline,
+    textSans,
+} from '@guardian/src-foundations/__experimental__typography';
 
 import { pillarMap, pillarPalette } from '@root/src/lib/pillars';
 
@@ -51,11 +55,11 @@ const subMetaLink = css`
 `;
 
 const subMetaSectionLink = css`
-    ${headline({ level: 1 })};
+    ${headline.tiny()};
 `;
 
 const subMetaKeywordLink = css`
-    ${textSans({ level: 2 })};
+    ${textSans.small()};
 `;
 
 const hideSlash = css`

--- a/src/web/components/SubNav/Inner.tsx
+++ b/src/web/components/SubNav/Inner.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
-import { textSans, palette } from '@guardian/src-foundations';
+import { palette } from '@guardian/src-foundations';
+import { textSans } from '@guardian/src-foundations/__experimental__typography';
 import { from } from '@guardian/src-foundations/mq';
 import { pillarPalette, pillarMap } from '@root/src/lib/pillars';
 
@@ -41,7 +42,7 @@ const subnavCollapsed = css`
 `;
 
 const fontStyle = css`
-    ${textSans({ level: 3 })};
+    ${textSans.medium()};
     font-weight: 500;
     color: ${palette.neutral[7]};
     padding: 0 5px;

--- a/src/web/components/SyndicationButton.tsx
+++ b/src/web/components/SyndicationButton.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
-import { textSans, palette } from '@guardian/src-foundations';
+import { palette } from '@guardian/src-foundations';
+import { textSans } from '@guardian/src-foundations/__experimental__typography';
 import { from } from '@guardian/src-foundations/mq';
 
 export const SyndicationButton: React.FC<{
@@ -11,7 +12,7 @@ export const SyndicationButton: React.FC<{
         display: none;
 
         ${from.desktop} {
-            ${textSans({ level: 1 })};
+            ${textSans.xsmall()};
             display: inline-block;
             float: right;
         }

--- a/src/web/components/elements/PullQuoteComponent.tsx
+++ b/src/web/components/elements/PullQuoteComponent.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { css } from 'emotion';
 import Quote from '@frontend/static/icons/quote.svg';
 import { pillarPalette } from '@root/src/lib/pillars';
-import { palette, body } from '@guardian/src-foundations';
+import { palette } from '@guardian/src-foundations';
+import { body } from '@guardian/src-foundations/__experimental__typography';
 import { from } from '@guardian/src-foundations/mq';
 import { unescapeData } from '@root/src/lib/escapeData';
 
@@ -45,7 +46,7 @@ const supportingStyles = (pillar: Pillar) =>
         margin-right: 0.6rem;
         clear: left;
         float: left;
-        ${body({ level: 2 })};
+        ${body.medium()};
 
         ${from.leftCol} {
             margin-left: -${gutter / 2 + gsSpan(3) / 2}px;
@@ -69,7 +70,7 @@ const inlineStyles = (pillar: Pillar) =>
         `
         margin-left: 0rem;
         display: block;
-        ${body({ level: 2 })};
+        ${body.medium()};
 
         ${from.mobileLandscape} {
             margin-left: -${gutter}px;

--- a/src/web/components/elements/RichLinkComponent.tsx
+++ b/src/web/components/elements/RichLinkComponent.tsx
@@ -3,8 +3,12 @@ import { css, cx } from 'emotion';
 import { pillarPalette } from '@frontend/lib/pillars';
 import ArrowInCircle from '@frontend/static/icons/arrow-in-circle.svg';
 import Quote from '@frontend/static/icons/quote.svg';
-import { headline, textSans, palette } from '@guardian/src-foundations';
+import { palette } from '@guardian/src-foundations';
 import { StarRating } from '@root/src/web/components/StarRating';
+import {
+    headline,
+    textSans,
+} from '@guardian/src-foundations/__experimental__typography';
 import { from, until, between } from '@guardian/src-foundations/mq';
 import { useApi } from '@frontend/web/components/lib/api';
 
@@ -87,13 +91,13 @@ const quote: (pillar: Pillar) => colour = pillar => {
 };
 
 const richLinkTitle = css`
-    ${headline({ level: 1 })};
+    ${headline.tiny()};
     font-size: 14px;
     padding-top: 1px;
     padding-bottom: 1px;
     font-weight: 400;
     ${from.wide} {
-        ${headline({ level: 2 })};
+        ${headline.xxsmall()};
         padding-bottom: 5px;
     }
 `;
@@ -107,10 +111,10 @@ const richLinkReadMore: (pillar: Pillar) => colour = pillar => {
 };
 
 const readMoreTextStyle = css`
-    ${headline({ level: 1 })};
+    ${headline.tiny()};
     font-size: 14px;
     ${from.wide} {
-        ${headline({ level: 1 })}
+        ${headline.tiny()}
     }
     display: inline-block;
     height: 30px;
@@ -122,11 +126,11 @@ const readMoreTextStyle = css`
 `;
 
 const byline = css`
-    ${headline({ level: 1 })};
+    ${headline.tiny()};
     font-size: 14px;
     font-style: italic;
     ${from.wide} {
-        ${headline({ level: 2 })};
+        ${headline.xxsmall()};
     }
 `;
 
@@ -172,7 +176,7 @@ const textColour: (pillar: Pillar) => colour = pillar => {
 };
 
 const paidForBranding = css`
-    ${textSans({ level: 1 })};
+    ${textSans.xsmall()};
     font-weight: bold;
     color: ${palette.neutral[46]};
 `;

--- a/src/web/components/elements/TextBlockComponent.tsx
+++ b/src/web/components/elements/TextBlockComponent.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { css } from 'emotion';
-import { body } from '@guardian/src-foundations';
+import { body } from '@guardian/src-foundations/__typography';
 import { unescapeData } from '@root/src/lib/escapeData';
 // tslint:disable:react-no-dangerous-html
 
 const para = css`
     margin-bottom: 16px;
-    ${body({ level: 2 })};
+    ${body.medium()};
 `;
 
 const innerPara = css`

--- a/src/web/components/elements/TextBlockComponent.tsx
+++ b/src/web/components/elements/TextBlockComponent.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from 'emotion';
-import { body } from '@guardian/src-foundations/__typography';
+import { body } from '@guardian/src-foundations/__experimental__typography';
 import { unescapeData } from '@root/src/lib/escapeData';
 // tslint:disable:react-no-dangerous-html
 

--- a/src/web/components/elements/TweetBlockComponent.tsx
+++ b/src/web/components/elements/TweetBlockComponent.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
-import { palette, body } from '@guardian/src-foundations';
+import { palette } from '@guardian/src-foundations';
+import { body } from '@guardian/src-foundations/__experimental__typography';
 import { unescapeData } from '@root/src/lib/escapeData';
 
 // fallback styling for when JS is disabled
@@ -11,7 +12,7 @@ const noJSStyling = css`
         padding: 20px;
         width: 100%;
         margin-bottom: 16px;
-        ${body({ level: 1 })};
+        ${body.small()};
     }
 
     .twitter-tweet p {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1342,10 +1342,10 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
-"@guardian/src-foundations@^0.5.6":
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.5.6.tgz#139e7d78fe1f2133cad2ba6a5095e0cd4c5a9985"
-  integrity sha512-rSPUzNXUANPbWeIzG9djpKDuIll/YN6SJriW344kj22mFk3xmRCQaxyMFvkrUkaTdyR1piDg51dG7afqCwEA4w==
+"@guardian/src-foundations@^0.6.0-alpha.1":
+  version "0.6.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.6.0-alpha.1.tgz#cda9cf441fd21d7779489af70a3f5890af46c859"
+  integrity sha512-O/B4bB7PEUMU0J2YvjiW0+D3o8Acia/VzEnv3BdO5ofhg1pTyBiy/21uKpc9tqq12dqky8qYvvZB8fCVEMtiOQ==
 
 "@hapi/address@2.x.x":
   version "2.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1342,10 +1342,10 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
-"@guardian/src-foundations@^0.6.0-alpha.1":
-  version "0.6.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.6.0-alpha.1.tgz#cda9cf441fd21d7779489af70a3f5890af46c859"
-  integrity sha512-O/B4bB7PEUMU0J2YvjiW0+D3o8Acia/VzEnv3BdO5ofhg1pTyBiy/21uKpc9tqq12dqky8qYvvZB8fCVEMtiOQ==
+"@guardian/src-foundations@^0.6.0-alpha.2":
+  version "0.6.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.6.0-alpha.2.tgz#08e78f2d37d3a542d4a6fc61305c7a53f8b52167"
+  integrity sha512-PNJrf7sz03TWsdxrFAA+1W9RO2Tna9FuTLX9bVKrfWN3XrzbuasjAVS5F6Tn/luPvdikRbXcS29pR9lo8A3ItA==
 
 "@hapi/address@2.x.x":
   version "2.1.2"


### PR DESCRIPTION
## What does this change?

Updates src-foundations and uses the new typography API (guardian/source-components#77)

If we like this, I can migrate all of web (or all of amp) to support the new API.

Comments welcome!

## Why?

- `level` was not a very descriptive concept. However, it was always a necessary option. In that respect, it's not really an "option". This API pulls it out into an executable.
- levels as numbers was difficult to decode at a glance.
- specifying `fontWeight` and `lineHeight` as options is still readable and extensible.

This change also outputs font size as rems to support user-specified browser settings.

## Transformations


### Headline

old level | new level | px
| ------------- |:-------------:| -----:|
1 | tiny | 17
2 | xxsmall | 20
3 | xsmall | 24
4 | small | 28
5 | medium | 34
6 | large | 42
7 | xlarge | 50
8 | jumbo | 70

### Text Sans

old level | new level | px
| ------------- |:-------------:| -----:|
1 | xsmall | 12
2 | small | 15
3 | medium | 17
4 | large | 20
5 | xlarge | 24
6 | xxlarge | 28

### Body

old level | new level | px
| ------------- |:-------------:| -----:|
1 | small | 15
2 | medium | 17


