### PR TITLE
Fix Twitter embed width overflow

### DIFF
--- a/src/web/components/ArticleContainer.tsx
+++ b/src/web/components/ArticleContainer.tsx
@@ -4,6 +4,12 @@ import { from, until } from '@guardian/src-foundations/mq';
 import { labelStyles } from '@root/src/web/components/AdSlot';
 
 const articleContainer = css`
+    /* Set min-width: 0 here to prevent flex children breaking out of the
+    containing parent. This ws happening for embedded tweets which have
+    a width: 500px property.
+    See: https://stackoverflow.com/a/47457331 */
+    min-width: 0;
+
     ${until.leftCol} {
         /* below 1140 */
         padding-left: 0;


### PR DESCRIPTION
## What does this change?
Fixes an issue where embedded tweets were overflowing their parent container at widths <500px.

Twitter's embedded js script applies it's own styles, with various width settings, one of which is a `width: 500px` property. This width is _not_ respected when the viewport is reduced and the content shrinks correctly. However, when a parent has a `display: flex` property (as we do), then the rules change and the width: 500px property is absolute. This can be worked around by setting `min-width: 0;` as [discussed here](https://stackoverflow.com/a/47457331).

## Before
![Screenshot 2019-11-10 at 22 20 43](https://user-images.githubusercontent.com/1336821/68551809-853f7780-0408-11ea-8983-fdcab8f66170.jpg)


## After
![Screenshot 2019-11-10 at 22 21 22](https://user-images.githubusercontent.com/1336821/68551806-81abf080-0408-11ea-80c4-3546d64bba72.jpg)


## Link to supporting Trello card
https://trello.com/c/jt7bhjS4/849-tweet-embeds-overflow-article-container