### PR TITLE
Fixes #911 Use visiblyHidden correctly

### DIFF
--- a/src/amp/components/MainMedia.tsx
+++ b/src/amp/components/MainMedia.tsx
@@ -93,7 +93,13 @@ const mainImage = (element: ImageBlockElement): JSX.Element | null => {
                         className={inputStyle}
                     />
                     <label className={labelStyle} htmlFor="show-caption">
-                        <span className={visuallyHidden}>Show caption</span>
+                        <span
+                            className={css`
+                                ${visuallyHidden}
+                            `}
+                        >
+                            Show caption
+                        </span>
                         <InfoIcon />
                     </label>
                     <figcaption className={captionStyle}>


### PR DESCRIPTION
## What does this change?
Fixes #911 Show Caption text was visible when it should be hidden.

The `visuallyHidden` style mixin from `src-foundation` needs to be wrapped in an `emotion` css wrapper but it was missing here.

## Before
![Screenshot 2019-11-10 at 23 13 04](https://user-images.githubusercontent.com/1336821/68552555-2847bf80-0410-11ea-925d-2c0986271c9c.jpg)

## After
![Screenshot 2019-11-10 at 23 13 39](https://user-images.githubusercontent.com/1336821/68552554-25e56580-0410-11ea-99a8-0dac209ccdc6.jpg)

## Link to supporting Trello card
https://trello.com/c/i7IANt2s/850-show-caption-text-showing-on-amp
