### PR TITLE
Upgrade to src-foundations 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     ],
     "dependencies": {
         "@emotion/core": "^10.0.5",
-        "@guardian/src-foundations": "^0.6.0-alpha.2",
+        "@guardian/src-foundations": "^0.6.0",
         "@sentry/browser": "^5.7.1",
         "@types/ajv": "^1.0.0",
         "@types/lodash.escape": "^4.0.6",

--- a/src/amp/components/Ad.tsx
+++ b/src/amp/components/Ad.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 import { palette } from '@guardian/src-foundations';
-import { textSans } from '@guardian/src-foundations/__experimental__typography';
+import { textSans } from '@guardian/src-foundations/typography';
 import { adJson, stringify } from '@root/src/amp/lib/ad-json';
 
 const adStyle = css`

--- a/src/amp/components/AdConsent.tsx
+++ b/src/amp/components/AdConsent.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { JsonScript } from './JsonScript';
 import { css, cx } from 'emotion';
 import { palette } from '@guardian/src-foundations';
-import { textSans } from '@guardian/src-foundations/__experimental__typography';
+import { textSans } from '@guardian/src-foundations/typography';
 import Tick from '@frontend/static/icons/tick.svg';
 
 const consentUIStyle = css`

--- a/src/amp/components/Blocks.tsx
+++ b/src/amp/components/Blocks.tsx
@@ -3,7 +3,7 @@ import { Elements } from '@root/src/amp/components/Elements';
 import { css } from 'emotion';
 import { pillarPalette } from '@root/src/lib/pillars';
 import { palette } from '@guardian/src-foundations';
-import { textSans } from '@guardian/src-foundations/__experimental__typography';
+import { textSans } from '@guardian/src-foundations/typography';
 import { blockLink } from '@root/src/amp/lib/block-link';
 import { findBlockAdSlots } from '@root/src/amp/lib/find-adslots';
 import { WithAds } from '@root/src/amp/components/WithAds';

--- a/src/amp/components/BodyLiveblog.tsx
+++ b/src/amp/components/BodyLiveblog.tsx
@@ -5,10 +5,7 @@ import { ArticleModel } from '@root/src/amp/types/ArticleModel';
 import { TopMetaLiveblog } from '@root/src/amp/components/topMeta/TopMetaLiveblog';
 import { SubMeta } from '@root/src/amp/components/SubMeta';
 import { palette } from '@guardian/src-foundations';
-import {
-    headline,
-    textSans,
-} from '@guardian/src-foundations/__experimental__typography';
+import { headline, textSans } from '@guardian/src-foundations/typography';
 import { KeyEvents } from '@root/src/amp/components/KeyEvents';
 import { Blocks } from '@root/src/amp/components/Blocks';
 import RefreshIcon from '@frontend/static/icons/refresh.svg';

--- a/src/amp/components/Caption.tsx
+++ b/src/amp/components/Caption.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { palette } from '@guardian/src-foundations';
-import { textSans } from '@guardian/src-foundations/__experimental__typography';
+import { textSans } from '@guardian/src-foundations/typography';
 import { css, cx } from 'emotion';
 import { pillarPalette } from '@root/src/lib/pillars';
 import TriangleIcon from '@frontend/static/icons/triangle.svg';

--- a/src/amp/components/Expandable.tsx
+++ b/src/amp/components/Expandable.tsx
@@ -5,11 +5,7 @@ import InfoIcon from '@frontend/static/icons/info.svg';
 import PlusIcon from '@frontend/static/icons/plus.svg';
 
 import { palette } from '@guardian/src-foundations';
-import {
-    body,
-    textSans,
-    headline,
-} from '@guardian/src-foundations/__experimental__typography';
+import { body, textSans, headline } from '@guardian/src-foundations/typography';
 import { TextStyle } from '@root/src/amp/components/elements/Text';
 
 const wrapper = (pillar: Pillar) => css`

--- a/src/amp/components/Footer.tsx
+++ b/src/amp/components/Footer.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 import { palette } from '@guardian/src-foundations';
-import {
-    textSans,
-    body,
-} from '@guardian/src-foundations/__experimental__typography';
+import { textSans, body } from '@guardian/src-foundations/typography';
 import { InnerContainer } from './InnerContainer';
 import {
     Link,

--- a/src/amp/components/Header.tsx
+++ b/src/amp/components/Header.tsx
@@ -3,7 +3,7 @@ import { css, cx } from 'emotion';
 import Logo from '@frontend/static/logos/the-guardian.svg';
 import { pillarPalette } from '@root/src/lib/pillars';
 import { palette } from '@guardian/src-foundations';
-import { headline } from '@guardian/src-foundations/__experimental__typography';
+import { headline } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
 import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 import { ReaderRevenueButton } from '@root/src/amp/components/ReaderRevenueButton';

--- a/src/amp/components/KeyEvents.tsx
+++ b/src/amp/components/KeyEvents.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 import { palette } from '@guardian/src-foundations';
-import {
-    headline,
-    textSans,
-} from '@guardian/src-foundations/__experimental__typography';
+import { headline, textSans } from '@guardian/src-foundations/typography';
 import DownArrow from '@frontend/static/icons/down-arrow.svg';
 import { blockLink } from '@root/src/amp/lib/block-link';
 

--- a/src/amp/components/MainMedia.tsx
+++ b/src/amp/components/MainMedia.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { bestFitImage, heightEstimate } from '@root/src/amp/lib/image-fit';
 import { css } from 'emotion';
 import { palette } from '@guardian/src-foundations';
-import { textSans } from '@guardian/src-foundations/__experimental__typography';
+import { textSans } from '@guardian/src-foundations/typography';
 import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 import InfoIcon from '@frontend/static/icons/info.svg';
 import { YoutubeVideo } from '@root/src/amp/components/elements/YoutubeVideo';

--- a/src/amp/components/OnwardContainer.tsx
+++ b/src/amp/components/OnwardContainer.tsx
@@ -7,10 +7,7 @@ import {
     moustacheVariable,
 } from '@root/src/amp/components/moustache';
 import { palette } from '@guardian/src-foundations';
-import {
-    headline,
-    textSans,
-} from '@guardian/src-foundations/__experimental__typography';
+import { headline, textSans } from '@guardian/src-foundations/typography';
 
 import VideoIcon from '@frontend/static/icons/video-icon.svg';
 import Camera from '@frontend/static/icons/camera.svg';

--- a/src/amp/components/Pagination.tsx
+++ b/src/amp/components/Pagination.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 import { palette } from '@guardian/src-foundations';
-import { textSans } from '@guardian/src-foundations/__experimental__typography';
+import { textSans } from '@guardian/src-foundations/typography';
 import ChevronRightSingle from '@frontend/static/icons/chevron-right-single.svg';
 import ChevronRightDouble from '@frontend/static/icons/chevron-right-double.svg';
 import ChevronLeftSingle from '@frontend/static/icons/chevron-left-single.svg';

--- a/src/amp/components/ReaderRevenueButton.tsx
+++ b/src/amp/components/ReaderRevenueButton.tsx
@@ -3,7 +3,7 @@ import { css, cx } from 'emotion';
 
 import ArrowRight from '@frontend/static/icons/arrow-right.svg';
 import { palette } from '@guardian/src-foundations';
-import { textSans } from '@guardian/src-foundations/__experimental__typography';
+import { textSans } from '@guardian/src-foundations/typography';
 import { until } from '@guardian/src-foundations/mq';
 
 const supportStyles = css`

--- a/src/amp/components/ShowMoreButton.tsx
+++ b/src/amp/components/ShowMoreButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 import { palette } from '@guardian/src-foundations';
-import { textSans } from '@guardian/src-foundations/__experimental__typography';
+import { textSans } from '@guardian/src-foundations/typography';
 import PlusIcon from '@frontend/static/icons/plus.svg';
 
 const showMore = css`

--- a/src/amp/components/Sidebar.tsx
+++ b/src/amp/components/Sidebar.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 import { palette } from '@guardian/src-foundations';
-import {
-    headline,
-    textSans,
-} from '@guardian/src-foundations/__experimental__typography';
+import { headline, textSans } from '@guardian/src-foundations/typography';
 
 const sidebarStyles = css`
     width: 80vh;

--- a/src/amp/components/SubMeta.tsx
+++ b/src/amp/components/SubMeta.tsx
@@ -2,10 +2,7 @@ import React from 'react';
 import { css, cx } from 'emotion';
 import { pillarPalette, neutralBorder } from '@root/src/lib/pillars';
 import { palette } from '@guardian/src-foundations';
-import {
-    textSans,
-    body,
-} from '@guardian/src-foundations/__experimental__typography';
+import { textSans, body } from '@guardian/src-foundations/typography';
 import { ShareIcons } from '@root/src/amp/components/ShareIcons';
 import CommentIcon from '@frontend/static/icons/comment.svg';
 

--- a/src/amp/components/elements/Comment.tsx
+++ b/src/amp/components/elements/Comment.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 import { palette } from '@guardian/src-foundations';
-import { textSans } from '@guardian/src-foundations/__experimental__typography';
+import { textSans } from '@guardian/src-foundations/typography';
 
 const wrapper = css`
     overflow: hidden;

--- a/src/amp/components/elements/Disclaimer.tsx
+++ b/src/amp/components/elements/Disclaimer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 import { pillarPalette } from '@root/src/lib/pillars';
-import { textSans } from '@guardian/src-foundations/__experimental__typography';
+import { textSans } from '@guardian/src-foundations/typography';
 
 const style = (pillar: Pillar) => css`
     ${textSans.small()};

--- a/src/amp/components/elements/Image.tsx
+++ b/src/amp/components/elements/Image.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { palette } from '@guardian/src-foundations';
-import { textSans } from '@guardian/src-foundations/__experimental__typography';
+import { textSans } from '@guardian/src-foundations/typography';
 import { css } from 'emotion';
 import { pillarPalette } from '@root/src/lib/pillars';
 import { bestFitImage, heightEstimate } from '@root/src/amp/lib/image-fit';

--- a/src/amp/components/elements/PullQuote.tsx
+++ b/src/amp/components/elements/PullQuote.tsx
@@ -3,7 +3,7 @@ import { css } from 'emotion';
 import Quote from '@frontend/static/icons/quote.svg';
 import { pillarPalette } from '@root/src/lib/pillars';
 import { palette } from '@guardian/src-foundations';
-import { body } from '@guardian/src-foundations/__experimental__typography';
+import { body } from '@guardian/src-foundations/typography';
 
 const styles = (pillar: Pillar) => css`
     background-color: ${palette.neutral[97]};

--- a/src/amp/components/elements/RichLink.tsx
+++ b/src/amp/components/elements/RichLink.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 import { palette } from '@guardian/src-foundations';
-import {
-    headline,
-    textSans,
-} from '@guardian/src-foundations/__experimental__typography';
+import { headline, textSans } from '@guardian/src-foundations/typography';
 import { pillarPalette } from '@root/src/lib/pillars';
 
 const richLinkContainer = css`

--- a/src/amp/components/elements/Subheading.tsx
+++ b/src/amp/components/elements/Subheading.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 import { palette } from '@guardian/src-foundations';
-import {
-    headline,
-    textSans,
-} from '@guardian/src-foundations/__experimental__typography';
+import { headline, textSans } from '@guardian/src-foundations/typography';
 import { pillarPalette } from '@root/src/lib/pillars';
 import { composeLabsCSS } from '@root/src/amp/lib/compose-labs-css';
 

--- a/src/amp/components/elements/Text.tsx
+++ b/src/amp/components/elements/Text.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 import { palette } from '@guardian/src-foundations';
-import {
-    body,
-    textSans,
-} from '@guardian/src-foundations/__experimental__typography';
+import { body, textSans } from '@guardian/src-foundations/typography';
 import { pillarPalette, neutralBorder } from '@root/src/lib/pillars';
 import { sanitise } from '@root/src/amp/lib/sanitise-html';
 import { composeLabsCSS } from '@root/src/amp/lib/compose-labs-css';

--- a/src/amp/components/topMeta/Branding.tsx
+++ b/src/amp/components/topMeta/Branding.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { LinkStyle } from '@root/src/amp/components/elements/Text';
-import { textSans } from '@guardian/src-foundations/__experimental__typography';
+import { textSans } from '@guardian/src-foundations/typography';
 import { css } from 'emotion';
 
 const brandingStyle = (pillar: Pillar) => css`

--- a/src/amp/components/topMeta/PaidForBand.tsx
+++ b/src/amp/components/topMeta/PaidForBand.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css, cx } from 'emotion';
 
 import { palette } from '@guardian/src-foundations';
-import { textSans } from '@guardian/src-foundations/__experimental__typography';
+import { textSans } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 import LabsLogo from '@frontend/static/logos/the-guardian-labs.svg';
 import ArrowRightIcon from '@frontend/static/icons/arrow-right.svg';

--- a/src/amp/components/topMeta/SeriesLink.tsx
+++ b/src/amp/components/topMeta/SeriesLink.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { headline } from '@guardian/src-foundations/__experimental__typography';
+import { headline } from '@guardian/src-foundations/typography';
 import { css } from 'emotion';
 import { pillarPalette } from '@root/src/lib/pillars';
 

--- a/src/amp/components/topMeta/Standfirst.tsx
+++ b/src/amp/components/topMeta/Standfirst.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 import { palette } from '@guardian/src-foundations';
-import {
-    headline,
-    textSans,
-} from '@guardian/src-foundations/__experimental__typography';
+import { headline, textSans } from '@guardian/src-foundations/typography';
 import { neutralBorder } from '@root/src/lib/pillars';
 import { composeLabsCSS } from '@root/src/amp/lib/compose-labs-css';
 import { ListStyle, LinkStyle } from '@root/src/amp/components/elements/Text';

--- a/src/amp/components/topMeta/TopMetaExtras.tsx
+++ b/src/amp/components/topMeta/TopMetaExtras.tsx
@@ -3,7 +3,7 @@ import { css, cx } from 'emotion';
 import ClockIcon from '@frontend/static/icons/clock.svg';
 import { ShareIcons } from '@root/src/amp/components/ShareIcons';
 import { palette } from '@guardian/src-foundations';
-import { textSans } from '@guardian/src-foundations/__experimental__typography';
+import { textSans } from '@guardian/src-foundations/typography';
 import { pillarMap, pillarPalette, neutralBorder } from '@root/src/lib/pillars';
 import TwitterIcon from '@frontend/static/icons/twitter.svg';
 

--- a/src/amp/components/topMeta/TopMetaLiveblog.tsx
+++ b/src/amp/components/topMeta/TopMetaLiveblog.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { palette } from '@guardian/src-foundations';
-import { headline } from '@guardian/src-foundations/__experimental__typography';
+import { headline } from '@guardian/src-foundations/typography';
 import { css } from 'emotion';
 import { pillarPalette, neutralBorder } from '@root/src/lib/pillars';
 import { ArticleModel } from '@root/src/amp/types/ArticleModel';

--- a/src/amp/components/topMeta/TopMetaNews.tsx
+++ b/src/amp/components/topMeta/TopMetaNews.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 import { palette } from '@guardian/src-foundations';
-import { headline } from '@guardian/src-foundations/__experimental__typography';
+import { headline } from '@guardian/src-foundations/typography';
 import { pillarPalette } from '@root/src/lib/pillars';
 import { ArticleModel } from '@root/src/amp/types/ArticleModel';
 import { MainMedia } from '@root/src/amp/components/MainMedia';

--- a/src/amp/components/topMeta/TopMetaOpinion.tsx
+++ b/src/amp/components/topMeta/TopMetaOpinion.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { palette } from '@guardian/src-foundations';
-import { headline } from '@guardian/src-foundations/__experimental__typography';
+import { headline } from '@guardian/src-foundations/typography';
 import { css, cx } from 'emotion';
 import { pillarPalette } from '@root/src/lib/pillars';
 import { ArticleModel } from '@root/src/amp/types/ArticleModel';

--- a/src/amp/components/topMeta/TopMetaPaidContent.tsx
+++ b/src/amp/components/topMeta/TopMetaPaidContent.tsx
@@ -9,10 +9,7 @@ import { Standfirst } from '@root/src/amp/components/topMeta/Standfirst';
 import { PaidForBand } from '@root/src/amp/components/topMeta/PaidForBand';
 
 import { palette } from '@guardian/src-foundations';
-import {
-    textSans,
-    body,
-} from '@guardian/src-foundations/__experimental__typography';
+import { textSans, body } from '@guardian/src-foundations/typography';
 import { getSharingUrls } from '@root/src/lib/sharing-urls';
 import { getAgeWarning } from '@root/src/lib/age-warning';
 

--- a/src/web/components/AdSlot.tsx
+++ b/src/web/components/AdSlot.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { css } from 'emotion';
 import { palette } from '@guardian/src-foundations';
-import { textSans } from '@guardian/src-foundations/__experimental__typography';
+import { textSans } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 
 export const labelStyles = css`

--- a/src/web/components/ArticleBody.tsx
+++ b/src/web/components/ArticleBody.tsx
@@ -4,10 +4,7 @@ import React from 'react';
 import { css, cx } from 'emotion';
 
 import { palette } from '@guardian/src-foundations';
-import {
-    textSans,
-    headline,
-} from '@guardian/src-foundations/__experimental__typography';
+import { textSans, headline } from '@guardian/src-foundations/typography';
 import { from, between } from '@guardian/src-foundations/mq';
 import { pillarMap, pillarPalette } from '@root/src/lib/pillars';
 import { ArticleRenderer } from '@root/src/web/components/lib/ArticleRenderer';

--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -5,10 +5,7 @@ import ClockIcon from '@frontend/static/icons/clock.svg';
 import { getAgeWarning } from '@root/src/lib/age-warning';
 
 import { palette } from '@guardian/src-foundations';
-import {
-    headline,
-    textSans,
-} from '@guardian/src-foundations/__experimental__typography';
+import { headline, textSans } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 

--- a/src/web/components/ArticleStandfirst.tsx
+++ b/src/web/components/ArticleStandfirst.tsx
@@ -2,11 +2,7 @@ import React from 'react';
 import { css, cx } from 'emotion';
 import { pillarMap, pillarPalette } from '@root/src/lib/pillars';
 import { palette } from '@guardian/src-foundations';
-import {
-    body,
-    headline,
-    textSans,
-} from '@guardian/src-foundations/__experimental__typography';
+import { body, headline, textSans } from '@guardian/src-foundations/typography';
 
 const standfirstStyles = css`
     ${body.medium()};

--- a/src/web/components/BackToTop.tsx
+++ b/src/web/components/BackToTop.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 import { palette } from '@guardian/src-foundations';
-import { textSans } from '@guardian/src-foundations/__experimental__typography';
+import { textSans } from '@guardian/src-foundations/typography';
 
 const iconHeight = '42px';
 

--- a/src/web/components/Byline.tsx
+++ b/src/web/components/Byline.tsx
@@ -2,10 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 import TwitterIcon from '@frontend/static/icons/twitter.svg';
 import { palette } from '@guardian/src-foundations';
-import {
-    headline,
-    textSans,
-} from '@guardian/src-foundations/__experimental__typography';
+import { headline, textSans } from '@guardian/src-foundations/typography';
 import { pillarPalette } from '@root/src/lib/pillars';
 
 const twitterHandle = css`

--- a/src/web/components/Caption.tsx
+++ b/src/web/components/Caption.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { palette } from '@guardian/src-foundations';
-import { textSans } from '@guardian/src-foundations/__experimental__typography';
+import { textSans } from '@guardian/src-foundations/typography';
 import { css, cx } from 'emotion';
 import { pillarPalette } from '@root/src/lib/pillars';
 import TriangleIcon from '@frontend/static/icons/triangle.svg';

--- a/src/web/components/CookieBanner.tsx
+++ b/src/web/components/CookieBanner.tsx
@@ -1,11 +1,7 @@
 import React, { Component } from 'react';
 import { css } from 'emotion';
 import { palette } from '@guardian/src-foundations';
-import {
-    headline,
-    textSans,
-    body,
-} from '@guardian/src-foundations/__experimental__typography';
+import { headline, textSans, body } from '@guardian/src-foundations/typography';
 import { until } from '@guardian/src-foundations/mq';
 import TickIcon from '@frontend/static/icons/tick.svg';
 import RoundelIcon from '@frontend/static/icons/the-guardian-roundel.svg';

--- a/src/web/components/Dateline.tsx
+++ b/src/web/components/Dateline.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { css } from 'emotion';
 import { palette } from '@guardian/src-foundations';
-import { textSans } from '@guardian/src-foundations/__experimental__typography';
+import { textSans } from '@guardian/src-foundations/typography';
 import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 
 const captionFont = css`

--- a/src/web/components/Dropdown.tsx
+++ b/src/web/components/Dropdown.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 import { palette } from '@guardian/src-foundations';
-import { textSans } from '@guardian/src-foundations/__experimental__typography';
+import { textSans } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
 import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 

--- a/src/web/components/Footer.tsx
+++ b/src/web/components/Footer.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css, cx } from 'emotion';
 
 import { palette } from '@guardian/src-foundations';
-import { textSans } from '@guardian/src-foundations/__experimental__typography';
+import { textSans } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
 
 import { clearFix } from '@root/src/lib/mixins';

--- a/src/web/components/Header/Links/Links.tsx
+++ b/src/web/components/Header/Links/Links.tsx
@@ -8,7 +8,7 @@ import {
 import ProfileIcon from '@frontend/static/icons/profile.svg';
 import SearchIcon from '@frontend/static/icons/search.svg';
 import { palette } from '@guardian/src-foundations';
-import { textSans } from '@guardian/src-foundations/__experimental__typography';
+import { textSans } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 
 const search = css`

--- a/src/web/components/Header/Links/SupportTheGuardian.tsx
+++ b/src/web/components/Header/Links/SupportTheGuardian.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 import { palette } from '@guardian/src-foundations';
-import { headline } from '@guardian/src-foundations/__experimental__typography';
+import { headline } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 import ProfileIcon from '@frontend/static/icons/profile.svg';

--- a/src/web/components/MainMedia.tsx
+++ b/src/web/components/MainMedia.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 import { palette } from '@guardian/src-foundations';
-import { textSans } from '@guardian/src-foundations/__experimental__typography';
+import { textSans } from '@guardian/src-foundations/typography';
 import { until } from '@guardian/src-foundations/mq';
 import { MainImageComponent } from '@root/src/web/components/elements/MainImageComponent';
 

--- a/src/web/components/MostViewed/MostViewed.tsx
+++ b/src/web/components/MostViewed/MostViewed.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 import { palette } from '@guardian/src-foundations';
-import { headline } from '@guardian/src-foundations/__experimental__typography';
+import { headline } from '@guardian/src-foundations/typography';
 import { from, between, Breakpoint } from '@guardian/src-foundations/mq';
 import { namedAdSlotParameters } from '@root/src/model/advertisement';
 import { AdSlot, labelStyles } from '@root/src/web/components/AdSlot';

--- a/src/web/components/MostViewed/MostViewedGrid.tsx
+++ b/src/web/components/MostViewed/MostViewedGrid.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { css, cx } from 'emotion';
 import { palette } from '@guardian/src-foundations';
-import { headline } from '@guardian/src-foundations/__experimental__typography';
+import { headline } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
 import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 

--- a/src/web/components/MostViewed/MostViewedItem.tsx
+++ b/src/web/components/MostViewed/MostViewedItem.tsx
@@ -2,10 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 import { palette } from '@guardian/src-foundations';
-import {
-    textSans,
-    headline,
-} from '@guardian/src-foundations/__experimental__typography';
+import { textSans, headline } from '@guardian/src-foundations/typography';
 import { until } from '@guardian/src-foundations/mq';
 import { BigNumber } from '@root/src/web/components/BigNumber/BigNumber';
 import { PulsingDot } from '@root/src/web/components/PulsingDot';

--- a/src/web/components/Nav/ExpandedMenu/CollapseColumnButton.tsx
+++ b/src/web/components/Nav/ExpandedMenu/CollapseColumnButton.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css, cx } from 'emotion';
 
 import { palette } from '@guardian/src-foundations';
-import { headline } from '@guardian/src-foundations/__experimental__typography';
+import { headline } from '@guardian/src-foundations/typography';
 
 import { hideDesktop } from './Column';
 

--- a/src/web/components/Nav/ExpandedMenu/Column.tsx
+++ b/src/web/components/Nav/ExpandedMenu/Column.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { css, cx } from 'emotion';
 import { palette } from '@guardian/src-foundations';
-import { textSans } from '@guardian/src-foundations/__experimental__typography';
+import { textSans } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
 import { CollapseColumnButton } from './CollapseColumnButton';
 

--- a/src/web/components/Nav/ExpandedMenu/Columns.tsx
+++ b/src/web/components/Nav/ExpandedMenu/Columns.tsx
@@ -2,10 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 import { palette } from '@guardian/src-foundations';
-import {
-    headline,
-    textSans,
-} from '@guardian/src-foundations/__experimental__typography';
+import { headline, textSans } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 
 import { Column, More, ReaderRevenueLinks } from './Column';

--- a/src/web/components/Nav/ExpandedMenu/ExpandedMenu.tsx
+++ b/src/web/components/Nav/ExpandedMenu/ExpandedMenu.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css, cx } from 'emotion';
 
 import { palette } from '@guardian/src-foundations';
-import { textSans } from '@guardian/src-foundations/__experimental__typography';
+import { textSans } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
 
 import { ExpandedMenuToggle } from './ExpandedMenuToggle/ExpandedMenuToggle';

--- a/src/web/components/Nav/ExpandedMenu/ExpandedMenuToggle/ExpandedMenuToggle.tsx
+++ b/src/web/components/Nav/ExpandedMenu/ExpandedMenuToggle/ExpandedMenuToggle.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { css, cx } from 'emotion';
 import { palette } from '@guardian/src-foundations';
-import { headline } from '@guardian/src-foundations/__experimental__typography';
+import { headline } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 import { VeggieBurger } from './VeggieBurger';

--- a/src/web/components/Outbrain.tsx
+++ b/src/web/components/Outbrain.tsx
@@ -3,10 +3,7 @@
 import React from 'react';
 import { css } from 'emotion';
 import { palette } from '@guardian/src-foundations';
-import {
-    textSans,
-    body,
-} from '@guardian/src-foundations/__experimental__typography';
+import { textSans, body } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 
 interface OutbrainSelectors {

--- a/src/web/components/Pillars.tsx
+++ b/src/web/components/Pillars.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css, cx } from 'emotion';
 
 import { palette } from '@guardian/src-foundations';
-import { headline } from '@guardian/src-foundations/__experimental__typography';
+import { headline } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
 
 import { pillarMap, pillarPalette } from '@root/src/lib/pillars';

--- a/src/web/components/ReaderRevenueLinks.tsx
+++ b/src/web/components/ReaderRevenueLinks.tsx
@@ -3,10 +3,7 @@ import { css, cx } from 'emotion';
 
 import ArrowRightIcon from '@frontend/static/icons/arrow-right.svg';
 import { palette } from '@guardian/src-foundations';
-import {
-    textSans,
-    headline,
-} from '@guardian/src-foundations/__experimental__typography';
+import { textSans, headline } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
 
 import { getCookie } from '@root/src/web/browser/cookie';

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 import { pillarMap, pillarPalette } from '@root/src/lib/pillars';
-import { headline } from '@guardian/src-foundations/__experimental__typography';
+import { headline } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 
 const sectionLabelText = css`

--- a/src/web/components/ShareCount.tsx
+++ b/src/web/components/ShareCount.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 import ShareIcon from '@frontend/static/icons/share.svg';
 import { palette } from '@guardian/src-foundations';
-import { textSans } from '@guardian/src-foundations/__experimental__typography';
+import { textSans } from '@guardian/src-foundations/typography';
 import { from, between } from '@guardian/src-foundations/mq';
 import { integerCommas } from '@root/src/lib/formatters';
 import { useApi } from '@root/src/web/components/lib/api';

--- a/src/web/components/SubMetaLinksList.tsx
+++ b/src/web/components/SubMetaLinksList.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 import { palette } from '@guardian/src-foundations';
-import {
-    headline,
-    textSans,
-} from '@guardian/src-foundations/__experimental__typography';
+import { headline, textSans } from '@guardian/src-foundations/typography';
 
 import { pillarMap, pillarPalette } from '@root/src/lib/pillars';
 

--- a/src/web/components/SubNav/Inner.tsx
+++ b/src/web/components/SubNav/Inner.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 import { palette } from '@guardian/src-foundations';
-import { textSans } from '@guardian/src-foundations/__experimental__typography';
+import { textSans } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 import { pillarPalette, pillarMap } from '@root/src/lib/pillars';
 

--- a/src/web/components/SyndicationButton.tsx
+++ b/src/web/components/SyndicationButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 import { palette } from '@guardian/src-foundations';
-import { textSans } from '@guardian/src-foundations/__experimental__typography';
+import { textSans } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 
 export const SyndicationButton: React.FC<{

--- a/src/web/components/elements/PullQuoteComponent.tsx
+++ b/src/web/components/elements/PullQuoteComponent.tsx
@@ -3,7 +3,7 @@ import { css } from 'emotion';
 import Quote from '@frontend/static/icons/quote.svg';
 import { pillarPalette } from '@root/src/lib/pillars';
 import { palette } from '@guardian/src-foundations';
-import { body } from '@guardian/src-foundations/__experimental__typography';
+import { body } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 import { unescapeData } from '@root/src/lib/escapeData';
 

--- a/src/web/components/elements/RichLinkComponent.tsx
+++ b/src/web/components/elements/RichLinkComponent.tsx
@@ -5,10 +5,7 @@ import ArrowInCircle from '@frontend/static/icons/arrow-in-circle.svg';
 import Quote from '@frontend/static/icons/quote.svg';
 import { palette } from '@guardian/src-foundations';
 import { StarRating } from '@root/src/web/components/StarRating';
-import {
-    headline,
-    textSans,
-} from '@guardian/src-foundations/__experimental__typography';
+import { headline, textSans } from '@guardian/src-foundations/typography';
 import { from, until, between } from '@guardian/src-foundations/mq';
 import { useApi } from '@frontend/web/components/lib/api';
 

--- a/src/web/components/elements/TextBlockComponent.tsx
+++ b/src/web/components/elements/TextBlockComponent.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from 'emotion';
-import { body } from '@guardian/src-foundations/__experimental__typography';
+import { body } from '@guardian/src-foundations/typography';
 import { unescapeData } from '@root/src/lib/escapeData';
 // tslint:disable:react-no-dangerous-html
 

--- a/src/web/components/elements/TweetBlockComponent.tsx
+++ b/src/web/components/elements/TweetBlockComponent.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 import { palette } from '@guardian/src-foundations';
-import { body } from '@guardian/src-foundations/__experimental__typography';
+import { body } from '@guardian/src-foundations/typography';
 import { unescapeData } from '@root/src/lib/escapeData';
 
 // fallback styling for when JS is disabled

--- a/yarn.lock
+++ b/yarn.lock
@@ -1342,10 +1342,10 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
-"@guardian/src-foundations@^0.6.0-alpha.2":
-  version "0.6.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.6.0-alpha.2.tgz#08e78f2d37d3a542d4a6fc61305c7a53f8b52167"
-  integrity sha512-PNJrf7sz03TWsdxrFAA+1W9RO2Tna9FuTLX9bVKrfWN3XrzbuasjAVS5F6Tn/luPvdikRbXcS29pR9lo8A3ItA==
+"@guardian/src-foundations@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.6.0.tgz#a5fc783faedb62686756c7ca92b4e851227e3710"
+  integrity sha512-zuU5VSexP/qZoku3/Tq+3YeeeCCU+f2Sx+mGjZQK7ltE0dBBFlXk204JzSM6iCd9QAvQvn4gTwXOT12NQk/J8g==
 
 "@hapi/address@2.x.x":
   version "2.1.2"


### PR DESCRIPTION
## What does this change?

Upgrades to v0.6.0 of `src-foundations`

## Why?

Keeps everything up to date. 

- launch new typography API (and deletes old one)
- make hex colour casing consistent

[CHANGELOG](https://github.com/guardian/source-components/blob/master/CHANGELOG.md#guardiansrc-foundations-060)

