### PR TITLE
Add HeadlineTag story & component

### DIFF
--- a/src/web/components/HeadlineTag.stories.tsx
+++ b/src/web/components/HeadlineTag.stories.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+// import { Section } from './Section';
+
+import { HeadlineTag } from './HeadlineTag';
+// import { Flex } from './Flex';
+// import { ArticleLeft } from './ArticleLeft';
+// import { ArticleContainer } from './ArticleContainer';
+
+/* tslint:disable */
+export default {
+    component: HeadlineTag,
+    title: 'Components/HeadlineTag',
+};
+/* tslint:enable */
+
+export const defaultStory = () => {
+    return <HeadlineTag tagText="Tag name" pillar="culture" />;
+};
+defaultStory.story = { name: 'default' };
+
+export const longTagNameStory = () => {
+    return <HeadlineTag tagText="Slightly longer tag name" pillar="news" />;
+};
+longTagNameStory.story = { name: 'With a longer tag name' };
+
+export const wrappedTagNameStory = () => {
+    return (
+        <HeadlineTag
+            tagText="Very long tag name with enough text to wrap to a second line"
+            pillar="labs"
+        />
+    );
+};
+wrappedTagNameStory.story = { name: 'With wrapped tag name' };

--- a/src/web/components/HeadlineTag.tsx
+++ b/src/web/components/HeadlineTag.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { css } from 'emotion';
+import { pillarPalette } from '@root/src/lib/pillars';
+import { palette } from '@guardian/src-foundations';
+import { headline } from '@guardian/src-foundations/__experimental__typography';
+
+const headlineTagWrapper = css`
+    margin-left: 6px;
+`;
+
+const headlineTagStyles = (pillar: Pillar) => css`
+    background-color: ${pillarPalette[pillar].dark};
+    color: ${palette.neutral[100]};
+    ${headline.xxsmall({ fontWeight: 'bold', lineHeight: 'loose' })}
+    box-shadow: 0.25rem 0 0 ${pillarPalette[pillar].dark}, -0.375rem 0 0 ${
+    pillarPalette[pillar].dark
+};
+    display: inline-block;
+    box-decoration-break: clone;
+`;
+
+type Props = {
+    tagText: string;
+    pillar: Pillar;
+};
+
+export const HeadlineTag = ({ tagText, pillar }: Props) => (
+    <div className={headlineTagWrapper}>
+        <div className={headlineTagStyles(pillar)}>{tagText}</div>
+    </div>
+);


### PR DESCRIPTION
## What does this change?
Adds a new component to render a headline tag. Takes two required props, `tagText` and `pillar`. `tagText` is the text to be rendered inside the tag and `pillar` is the name of the pillar serving as context for the HeadlineTag instance.

Supports multiline tag names, as unusual as they might be.

## Screenshots
![Screenshot 2019-11-11 at 12 29 25](https://user-images.githubusercontent.com/1692169/68587494-249f5180-047f-11ea-827f-e736fb400e07.png)
![Screenshot 2019-11-11 at 12 29 45](https://user-images.githubusercontent.com/1692169/68587495-249f5180-047f-11ea-8064-78e849a6fccb.png)
![Screenshot 2019-11-11 at 12 30 02](https://user-images.githubusercontent.com/1692169/68587496-249f5180-047f-11ea-8f7e-19882e0c1cc7.png)

## Link to supporting Trello card
https://trello.com/c/WVHiclQR/826-headlinetag