### PR TITLE
Migrate HeadlineTag to use new typography API

### DIFF
--- a/src/web/components/HeadlineTag.tsx
+++ b/src/web/components/HeadlineTag.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 import { pillarPalette } from '@root/src/lib/pillars';
 import { palette } from '@guardian/src-foundations';
-import { headline } from '@guardian/src-foundations/__experimental__typography';
+import { headline } from '@guardian/src-foundations/typography';
 
 const headlineTagWrapper = css`
     margin-left: 6px;


### PR DESCRIPTION
## What does this change?

Migrates the new `HeadlineTag` component to use new typography API

## Why?

This component is currently using the experimental API that was deleted in v0.6.0 (see #917)

## Link to supporting Trello card
