### PR TITLE
Cleaning up commented out code from  HeadlineTag story

### DIFF
--- a/src/web/components/HeadlineTag.stories.tsx
+++ b/src/web/components/HeadlineTag.stories.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 
 import { HeadlineTag } from './HeadlineTag';
 
+/* tslint:disable */
 export default {
     component: HeadlineTag,
     title: 'Components/HeadlineTag',
 };
+/* tslint:enable */
 
 export const defaultStory = () => {
     return <HeadlineTag tagText="Tag name" pillar="culture" />;

--- a/src/web/components/HeadlineTag.stories.tsx
+++ b/src/web/components/HeadlineTag.stories.tsx
@@ -1,18 +1,11 @@
 import React from 'react';
 
-// import { Section } from './Section';
-
 import { HeadlineTag } from './HeadlineTag';
-// import { Flex } from './Flex';
-// import { ArticleLeft } from './ArticleLeft';
-// import { ArticleContainer } from './ArticleContainer';
 
-/* tslint:disable */
 export default {
     component: HeadlineTag,
     title: 'Components/HeadlineTag',
 };
-/* tslint:enable */
 
 export const defaultStory = () => {
     return <HeadlineTag tagText="Tag name" pillar="culture" />;


### PR DESCRIPTION
## What does this change?
Improves readability of the component story by deleting some commented out code that was unintentionally merged earlier.

## Why?
We should avoid merging in unused/commented out code.