### PR TITLE
SubMeta

### DIFF
--- a/src/web/components/ArticleBody.tsx
+++ b/src/web/components/ArticleBody.tsx
@@ -8,13 +8,9 @@ import { textSans, headline } from '@guardian/src-foundations/typography';
 import { from, between } from '@guardian/src-foundations/mq';
 import { pillarMap, pillarPalette } from '@root/src/lib/pillars';
 import { ArticleRenderer } from '@root/src/web/components/lib/ArticleRenderer';
-import { getSharingUrls } from '@root/src/lib/sharing-urls';
-
-import { SharingIcons } from '@root/src/web/components/ShareIcons';
-import { SubMetaLinksList } from '@root/src/web/components/SubMetaLinksList';
-import { SyndicationButton } from '@root/src/web/components/SyndicationButton';
 import { ArticleStandfirst } from '@root/src/web/components/ArticleStandfirst';
 import { GuardianLines } from '@root/src/web/components/GuardianLines';
+import { SubMeta } from '@root/src/web/components/SubMeta';
 import { Hide } from '@root/src/web/components/Hide';
 
 const pillarColours = pillarMap(
@@ -122,20 +118,6 @@ const linkColour = pillarMap(
     `,
 );
 
-const subMetaLabel = css`
-    ${textSans.xsmall()};
-    display: block;
-    color: ${palette.neutral[60]};
-`;
-
-const subMetaSharingIcons = css`
-    :after {
-        content: '';
-        display: block;
-        clear: left;
-    }
-`;
-
 const maxWidth = css`
     max-width: 630px;
 `;
@@ -145,9 +127,6 @@ export const ArticleBody: React.FC<{
     config: ConfigType;
     isShowcase?: boolean;
 }> = ({ CAPI, config, isShowcase }) => {
-    const hasSubMetaSectionLinks = CAPI.subMetaSectionLinks.length > 0;
-    const hasSubMetaKeywordLinks = CAPI.subMetaKeywordLinks.length > 0;
-    const sharingUrls = getSharingUrls(CAPI.pageId, CAPI.webTitle);
     return (
         <main className={maxWidth}>
             <div
@@ -172,47 +151,15 @@ export const ArticleBody: React.FC<{
                 />
             </div>
             <GuardianLines pillar={CAPI.pillar} />
-            <>
-                {(hasSubMetaSectionLinks || hasSubMetaKeywordLinks) && (
-                    <span className={subMetaLabel}>Topics</span>
-                )}
-                {hasSubMetaSectionLinks && (
-                    <SubMetaLinksList
-                        links={CAPI.subMetaSectionLinks}
-                        isSectionLinkList={true}
-                        pillar={CAPI.pillar}
-                    />
-                )}
-                {hasSubMetaKeywordLinks && (
-                    <SubMetaLinksList
-                        links={CAPI.subMetaKeywordLinks}
-                        isSectionLinkList={false}
-                        pillar={CAPI.pillar}
-                    />
-                )}
-                {CAPI.showBottomSocialButtons && (
-                    <SharingIcons
-                        className={subMetaSharingIcons}
-                        sharingUrls={sharingUrls}
-                        pillar={CAPI.pillar}
-                        displayIcons={[
-                            'facebook',
-                            'twitter',
-                            'email',
-                            'linkedIn',
-                            'pinterest',
-                            'whatsApp',
-                            'messenger',
-                        ]}
-                    />
-                )}
-                {CAPI.showBottomSocialButtons && (
-                    <SyndicationButton
-                        webUrl={CAPI.webURL}
-                        internalPageCode={CAPI.pageId}
-                    />
-                )}
-            </>
+            <SubMeta
+                pillar={CAPI.pillar}
+                subMetaKeywordLinks={CAPI.subMetaKeywordLinks}
+                subMetaSectionLinks={CAPI.subMetaSectionLinks}
+                pageId={CAPI.pageId}
+                webUrl={CAPI.webURL}
+                webTitle={CAPI.webTitle}
+                showBottomSocialButtons={CAPI.showBottomSocialButtons}
+            />
         </main>
     );
 };

--- a/src/web/components/SubMeta.tsx
+++ b/src/web/components/SubMeta.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { textSans } from '@guardian/src-foundations/typography';
+import { palette } from '@guardian/src-foundations';
+
+import { SharingIcons } from '@frontend/web/components/ShareIcons';
+import { SubMetaLinksList } from '@frontend/web/components/SubMetaLinksList';
+import { SyndicationButton } from '@frontend/web/components/SyndicationButton';
+import { getSharingUrls } from '@frontend/lib/sharing-urls';
+
+const subMetaLabel = css`
+    ${textSans.xsmall()};
+    display: block;
+    color: ${palette.neutral[60]};
+`;
+
+const subMetaSharingIcons = css`
+    :after {
+        content: '';
+        display: block;
+        clear: left;
+    }
+`;
+
+type Props = {
+    pillar: Pillar;
+    subMetaSectionLinks: SimpleLinkType[];
+    subMetaKeywordLinks: SimpleLinkType[];
+    pageId: string;
+    webUrl: string;
+    webTitle: string;
+    showBottomSocialButtons: boolean;
+};
+
+export const SubMeta = ({
+    pillar,
+    subMetaKeywordLinks,
+    subMetaSectionLinks,
+    pageId,
+    webUrl,
+    webTitle,
+    showBottomSocialButtons,
+}: Props) => {
+    const hasSubMetaSectionLinks = subMetaSectionLinks.length > 0;
+    const hasSubMetaKeywordLinks = subMetaKeywordLinks.length > 0;
+    const sharingUrls = getSharingUrls(pageId, webTitle);
+    return (
+        <>
+            {(hasSubMetaSectionLinks || hasSubMetaKeywordLinks) && (
+                <span className={subMetaLabel}>Topics</span>
+            )}
+            {hasSubMetaSectionLinks && (
+                <SubMetaLinksList
+                    links={subMetaSectionLinks}
+                    isSectionLinkList={true}
+                    pillar={pillar}
+                />
+            )}
+            {hasSubMetaKeywordLinks && (
+                <SubMetaLinksList
+                    links={subMetaKeywordLinks}
+                    isSectionLinkList={false}
+                    pillar={pillar}
+                />
+            )}
+            {showBottomSocialButtons && (
+                <SharingIcons
+                    className={subMetaSharingIcons}
+                    sharingUrls={sharingUrls}
+                    pillar={pillar}
+                    displayIcons={[
+                        'facebook',
+                        'twitter',
+                        'email',
+                        'linkedIn',
+                        'pinterest',
+                        'whatsApp',
+                        'messenger',
+                    ]}
+                />
+            )}
+            {showBottomSocialButtons && (
+                <SyndicationButton webUrl={webUrl} internalPageCode={pageId} />
+            )}
+        </>
+    );
+};


### PR DESCRIPTION
## What does this change?
This PR extracts the html and styles for the article sub meta elements from `ArticleBody` and puts them into their own compoent: `SubMeta`.

I also refactored the props to remove blunt use of `CAPI` in favour of more explicit props, so we only pass in what the component needs.

```
type Props = {
    pillar: Pillar;
    subMetaSectionLinks: SimpleLinkType[];
    subMetaKeywordLinks: SimpleLinkType[];
    pageId: string;
    webUrl: string;
    webTitle: string;
    showBottomSocialButtons: boolean;
};
```

## Why?
This is useful both in terms of readability and for scalability

## Link to supporting Trello card
https://trello.com/c/ck2kpsdc/855-submeta
