### PR TITLE
Adding Badge component & stories

### DIFF
--- a/src/web/components/Badge.stories.tsx
+++ b/src/web/components/Badge.stories.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import { Badge } from './Badge';
+
+/* tslint:disable */
+export default {
+    component: Badge,
+    title: 'Components/Badge',
+};
+/* tslint:enable */
+
+export const defaultStory = () => {
+    return (
+        <Badge
+            altText="General Election 2019"
+            imgSrc="https://assets.guim.co.uk/images/badges/21574e2295169b4a72ba9d78733fc2ed/ge2019-badge.svg"
+        />
+    );
+};
+defaultStory.story = { name: 'default' };
+
+export const withClickThruStory = () => {
+    return (
+        <Badge
+            altText="General Election 2019"
+            imgSrc="https://assets.guim.co.uk/images/badges/21574e2295169b4a72ba9d78733fc2ed/ge2019-badge.svg"
+            linkTo="https://www.theguardian.com/politics/general-election-2019"
+        />
+    );
+};
+withClickThruStory.story = { name: 'With a click thru link' };

--- a/src/web/components/Badge.tsx
+++ b/src/web/components/Badge.tsx
@@ -3,18 +3,23 @@ import { css } from 'emotion';
 import { palette } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 
+const badgeSizingStyles = css`
+    height: 42px;
+    ${from.wide} {
+        height: 54px;
+    }
+`;
+
 const badgeWrapper = css`
     float: left;
     background-color: ${palette.neutral[100]};
+    ${badgeSizingStyles}
 `;
 
 const badgeImg = css`
     display: block;
     width: auto;
-    height: 42px;
-    ${from.wide} {
-        height: 54px;
-    }
+    ${badgeSizingStyles}
 `;
 
 const badgeLink = css`

--- a/src/web/components/Badge.tsx
+++ b/src/web/components/Badge.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { css } from 'emotion';
+import { palette } from '@guardian/src-foundations';
+import { from } from '@guardian/src-foundations/mq';
+
+const badgeWrapper = css`
+    float: left;
+    background-color: ${palette.neutral[100]};
+`;
+
+const badgeImg = css`
+    display: block;
+    width: auto;
+    height: 42px;
+    ${from.wide} {
+        height: 54px;
+    }
+`;
+
+const badgeLink = css`
+    text-decoration: none;
+`;
+
+type Props = {
+    altText: string;
+    imgSrc: string;
+    linkTo?: string;
+};
+
+export const Badge = ({ altText, imgSrc, linkTo }: Props) => {
+    if (linkTo) {
+        return (
+            <div className={badgeWrapper}>
+                <a href={linkTo} className={badgeLink}>
+                    <img src={imgSrc} alt={altText} className={badgeImg} />
+                </a>
+            </div>
+        );
+    }
+
+    return (
+        <div className={badgeWrapper}>
+            <img src={imgSrc} alt={altText} className={badgeImg} />
+        </div>
+    );
+};


### PR DESCRIPTION
## What does this change?
Adds a Badge component that renders an image with an alt text, optionally wrapped in an anchor element if click thru link provided.

## Why?
Because some articles should render a Badge and we want to centralise the styles and logic for them.

## Trello card
https://trello.com/c/WpfdQCOq/856-support-badges

## Screenshot
![Screenshot 2019-11-12 at 10 48 41](https://user-images.githubusercontent.com/1692169/68665539-224dfd80-053a-11ea-9eeb-9200606fd03d.png)
