### PR TITLE
Add Avatar component

### DIFF
--- a/src/web/components/Avatar.stories.tsx
+++ b/src/web/components/Avatar.stories.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { Avatar } from './Avatar';
+
+/* tslint:disable */
+export default {
+    component: Avatar,
+    title: 'Components/Avatar',
+};
+/* tslint:enable */
+
+const imageSrc173 =
+    'https://i.guim.co.uk/img/uploads/2017/10/06/George-Monbiot,-L.png?width=173&quality=85&auto=format&fit=max&s=be5b0d3f3aa55682e4930057fc3929a3';
+const imageSrc300 =
+    'https://i.guim.co.uk/img/uploads/2017/10/06/Leah-Harper,-L.png?width=300&quality=85&auto=format&fit=max&s=4530b8769ac9f0b655d77a155ea13852';
+const imageSrc300Sport =
+    'https://i.guim.co.uk/img/uploads/2018/05/25/Sid_Lowe,_L.png?width=300&quality=85&auto=format&fit=max&s=4e058df05bd09dd029abe3d23bddb27c';
+
+export const defaultStory = () => (
+    <div style={{ width: '136px', height: '136px' }}>
+        <Avatar
+            imageSrc={imageSrc173}
+            imageAlt="The alt of the image"
+            pillar={'opinion'}
+        />
+    </div>
+);
+defaultStory.story = { name: 'Medium, Opinion (Rich Links)' };
+
+export const largeStory = () => (
+    <div style={{ width: '140px', height: '140px' }}>
+        <Avatar
+            imageSrc={imageSrc300}
+            imageAlt="The alt of the image"
+            pillar={'lifestyle'}
+        />
+    </div>
+);
+largeStory.story = { name: 'Large, Lifestyle (Byline image - Desktop)' };
+
+export const largeStoryNews = () => (
+    <div style={{ width: '140px', height: '140px' }}>
+        <Avatar
+            imageSrc={imageSrc300}
+            imageAlt="The alt of the image"
+            pillar={'news'}
+        />
+    </div>
+);
+largeStoryNews.story = { name: 'Large, News (Byline image - Desktop)' };
+
+export const largeStoryCulture = () => (
+    <div style={{ width: '140px', height: '140px' }}>
+        <Avatar
+            imageSrc={imageSrc300}
+            imageAlt="The alt of the image"
+            pillar={'culture'}
+        />
+    </div>
+);
+largeStoryCulture.story = { name: 'Large, Culture (Byline image - Desktop)' };
+
+export const smallStory = () => (
+    <div style={{ width: '60px', height: '60px' }}>
+        <Avatar
+            imageSrc={imageSrc300Sport}
+            imageAlt="The alt of the image"
+            pillar={'sport'}
+        />
+    </div>
+);
+smallStory.story = { name: 'Small, Sport (Byline image - Mobile)' };

--- a/src/web/components/Avatar.tsx
+++ b/src/web/components/Avatar.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { css, cx } from 'emotion';
+import { from } from '@guardian/src-foundations/mq';
+
+const contributorImage = css`
+    border-radius: 100%;
+    object-fit: cover;
+`;
+
+const contributorImageWrapper = css`
+    width: 5rem;
+    height: 5rem;
+    margin-left: auto;
+    margin-right: 0.3rem;
+    ${from.wide} {
+        width: 8.5rem;
+        height: 8.5rem;
+    }
+
+    /* TODO remove the default img styling in ArticleBody.tsx - do we need direct element styling? */
+    img {
+        width: 100%;
+        height: 100%;
+    }
+`;
+
+const pillarBackground: (pillarColour: string) => string = pillarColour => css`
+    background-color: ${pillarColour};
+`;
+
+export const Avatar: React.FC<{
+    imageSrc: string;
+    imageAlt: string;
+    pillarColour: string;
+}> = ({ imageSrc, imageAlt, pillarColour }) => {
+    return (
+        <div className={contributorImageWrapper}>
+            <img
+                src={imageSrc}
+                alt={imageAlt}
+                className={cx(pillarBackground(pillarColour), contributorImage)}
+            />
+        </div>
+    );
+};

--- a/src/web/components/Avatar.tsx
+++ b/src/web/components/Avatar.tsx
@@ -9,9 +9,10 @@ const contributorImage = css`
     width: 100%;
 `;
 
-const pillarBackground: (pillar: Pillar) => string = pillar => css`
-    background-color: ${pillarPalette[pillar ? pillar : 'opinion'].main};
-`;
+const pillarBackground = (pillar: Pillar = 'opinion') =>
+    css`
+        background-color: ${pillarPalette[pillar].main};
+    `;
 
 export const Avatar: React.FC<{
     imageSrc: string;

--- a/src/web/components/Avatar.tsx
+++ b/src/web/components/Avatar.tsx
@@ -1,45 +1,28 @@
 import React from 'react';
 import { css, cx } from 'emotion';
-import { from } from '@guardian/src-foundations/mq';
+import { pillarPalette } from '@frontend/lib/pillars';
 
 const contributorImage = css`
     border-radius: 100%;
     object-fit: cover;
+    height: 100%;
+    width: 100%;
 `;
 
-const contributorImageWrapper = css`
-    width: 5rem;
-    height: 5rem;
-    margin-left: auto;
-    margin-right: 0.3rem;
-    ${from.wide} {
-        width: 8.5rem;
-        height: 8.5rem;
-    }
-
-    /* TODO remove the default img styling in ArticleBody.tsx - do we need direct element styling? */
-    img {
-        width: 100%;
-        height: 100%;
-    }
-`;
-
-const pillarBackground: (pillarColour: string) => string = pillarColour => css`
-    background-color: ${pillarColour};
+const pillarBackground: (pillar: Pillar) => string = pillar => css`
+    background-color: ${pillarPalette[pillar ? pillar : 'opinion'].main};
 `;
 
 export const Avatar: React.FC<{
     imageSrc: string;
     imageAlt: string;
-    pillarColour: string;
-}> = ({ imageSrc, imageAlt, pillarColour }) => {
+    pillar: Pillar;
+}> = ({ imageSrc, imageAlt, pillar }) => {
     return (
-        <div className={contributorImageWrapper}>
-            <img
-                src={imageSrc}
-                alt={imageAlt}
-                className={cx(pillarBackground(pillarColour), contributorImage)}
-            />
-        </div>
+        <img
+            src={imageSrc}
+            alt={imageAlt}
+            className={cx(pillarBackground(pillar), contributorImage)}
+        />
     );
 };

--- a/src/web/components/elements/RichLinkComponent.tsx
+++ b/src/web/components/elements/RichLinkComponent.tsx
@@ -88,7 +88,7 @@ const quote: (pillar: Pillar) => colour = pillar => {
     `;
 };
 
-const rickLinkHeader = css`
+const richLinkHeader = css`
     padding-bottom: 10px;
 `;
 
@@ -227,7 +227,7 @@ const RichLinkBody: React.FC<{ richLink: RichLink }> = ({ richLink }) => {
                 </div>
             )}
             <div className={richLinkElements}>
-                <div className={rickLinkHeader}>
+                <div className={richLinkHeader}>
                     <div className={richLinkTitle}>
                         {isOpinion && (
                             <div className={quote(richLink.pillar)}>

--- a/src/web/components/elements/RichLinkComponent.tsx
+++ b/src/web/components/elements/RichLinkComponent.tsx
@@ -5,6 +5,7 @@ import ArrowInCircle from '@frontend/static/icons/arrow-in-circle.svg';
 import Quote from '@frontend/static/icons/quote.svg';
 import { palette } from '@guardian/src-foundations';
 import { StarRating } from '@root/src/web/components/StarRating';
+import { Avatar } from '@frontend/web/components/Avatar';
 import { headline, textSans } from '@guardian/src-foundations/typography';
 import { from, until, between } from '@guardian/src-foundations/mq';
 import { useApi } from '@frontend/web/components/lib/api';
@@ -87,6 +88,10 @@ const quote: (pillar: Pillar) => colour = pillar => {
     `;
 };
 
+const rickLinkHeader = css`
+    padding-bottom: 10px;
+`;
+
 const richLinkTitle = css`
     ${headline.tiny()};
     font-size: 14px;
@@ -128,25 +133,6 @@ const byline = css`
     font-style: italic;
     ${from.wide} {
         ${headline.xxsmall()};
-    }
-`;
-
-// !important is used here to override the default inline body image styling
-const contributorImage = css`
-    border-radius: 100%;
-    object-fit: cover;
-    width: 100%;
-    height: 100% !important ;
-`;
-
-const contributorImageWrapper = css`
-    width: 5rem;
-    height: 5rem;
-    margin-left: auto;
-    margin-right: 0.3rem;
-    ${from.wide} {
-        width: 8.5rem;
-        height: 8.5rem;
     }
 `;
 
@@ -224,38 +210,40 @@ const RichLinkBody: React.FC<{ richLink: RichLink }> = ({ richLink }) => {
                 </div>
             )}
             <div className={richLinkElements}>
-                <div className={richLinkTitle}>
+                <div className={rickLinkHeader}>
+                    <div className={richLinkTitle}>
+                        {isOpinion && (
+                            <div className={quote(richLink.pillar)}>
+                                <Quote />
+                            </div>
+                        )}
+                        {linkText}
+                    </div>
                     {isOpinion && (
-                        <div className={quote(richLink.pillar)}>
-                            <Quote />
+                        <div
+                            className={cx(byline, textColour(richLink.pillar))}
+                        >
+                            {mainContributor}
                         </div>
                     )}
-                    {linkText}
-                </div>
-                {isOpinion && (
-                    <div className={cx(byline, textColour(richLink.pillar))}>
-                        {mainContributor}
-                    </div>
-                )}
-                {richLink.starRating && richLink.starRating > 0 && (
-                    <StarRating rating={richLink.starRating} size={'small'} />
-                )}
-                {isPaidContent && richLink.sponsorName && (
-                    <div className={paidForBranding}>
-                        Paid for by {richLink.sponsorName}
-                    </div>
-                )}
-                {isOpinion && richLink.contributorImage && (
-                    <div className={contributorImageWrapper}>
-                        <img
-                            src={richLink.contributorImage}
-                            alt={mainContributor}
-                            className={cx(
-                                pillarBackground(richLink.pillar),
-                                contributorImage,
-                            )}
+                    {richLink.starRating && richLink.starRating > 0 && (
+                        <StarRating
+                            rating={richLink.starRating}
+                            size={'small'}
                         />
-                    </div>
+                    )}
+                    {isPaidContent && richLink.sponsorName && (
+                        <div className={paidForBranding}>
+                            Paid for by {richLink.sponsorName}
+                        </div>
+                    )}
+                </div>
+                {isOpinion && richLink.contributorImage && (
+                    <Avatar
+                        imageSrc={richLink.contributorImage}
+                        imageAlt={mainContributor}
+                        pillarColour={richLinkPillarColour(richLink.pillar)}
+                    />
                 )}
                 <div className={richLinkReadMore(richLink.pillar)}>
                     <ArrowInCircle />

--- a/src/web/components/elements/RichLinkComponent.tsx
+++ b/src/web/components/elements/RichLinkComponent.tsx
@@ -136,6 +136,23 @@ const byline = css`
     }
 `;
 
+const contributorImageWrapper = css`
+    width: 5rem;
+    height: 5rem;
+    margin-left: auto;
+    margin-right: 0.3rem;
+    ${from.wide} {
+        width: 8.5rem;
+        height: 8.5rem;
+    }
+
+    /* TODO remove the default img styling in ArticleBody.tsx - do we need direct element styling? */
+    img {
+        width: 100%;
+        height: 100%;
+    }
+`;
+
 const neutralBackground = css`
     background-color: ${palette.neutral[97]};
     a {
@@ -239,11 +256,13 @@ const RichLinkBody: React.FC<{ richLink: RichLink }> = ({ richLink }) => {
                     )}
                 </div>
                 {isOpinion && richLink.contributorImage && (
-                    <Avatar
-                        imageSrc={richLink.contributorImage}
-                        imageAlt={mainContributor}
-                        pillarColour={richLinkPillarColour(richLink.pillar)}
-                    />
+                    <div className={contributorImageWrapper}>
+                        <Avatar
+                            imageSrc={richLink.contributorImage}
+                            imageAlt={mainContributor}
+                            pillar={richLink.pillar}
+                        />
+                    </div>
                 )}
                 <div className={richLinkReadMore(richLink.pillar)}>
                     <ArrowInCircle />


### PR DESCRIPTION
## What does this change?

![2019-11-12 15 13 49](https://user-images.githubusercontent.com/638051/68683982-a2d32500-055f-11ea-8929-d76ae58f3664.gif)


Splits `Avatar` into a component for use in RichLinks, Onwards etc.

Differs from Trello ticket, in that it doesn't take a size prop but relies on the including element to define a containing size because it seems highly likely that the including component will describe to the avatar what its size should be from a design perspective. 

Lets see what falls out of implementing this going forward as it might make sense to shift that.

## Why?

People in circles.

## Link to supporting Trello card
https://trello.com/c/OhIZYkB2/824-avatar

