### PR TITLE
Ensure isDev is set

### DIFF
--- a/src/web/server/render.ts
+++ b/src/web/server/render.ts
@@ -16,11 +16,10 @@ export const render = ({ body }: express.Request, res: express.Response) => {
                 site: 'frontend',
                 page: 'Article',
                 NAV: extractNAV(CAPI.nav),
-                config: Object.assign(
-                    {},
-                    { isDev: process.env.NODE_ENV !== 'production' },
-                    CAPI.config,
-                ),
+                config: {
+                    ...CAPI.config,
+                    isDev: process.env.NODE_ENV !== 'production',
+                },
                 GA: extractGA(CAPI),
                 linkedData: CAPI.linkedData,
             },


### PR DESCRIPTION
## What does this change?
This PR ensures that the `isDev` property is set as expected.

## Why?
To stop Sentry sending lots of errors from our local machines 😱 

## Link to supporting Trello card
https://trello.com/c/B24LHrQf/854-filter-local-sentry-errors
