### PR TITLE
SmallHeadline

### DIFF
--- a/src/web/components/QuoteIcon.tsx
+++ b/src/web/components/QuoteIcon.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { css } from 'emotion';
 
 const quoteStyles = (colour?: string) => css`
-    height: 1.0625rem;
-    width: 0.57375rem;
+    height: 17px;
+    width: 9px;
     margin-right: 12px;
-    transform: translateY(-0.0625rem);
+    transform: translateY(-1px);
     overflow: visible;
     fill: ${colour && colour};
 `;
@@ -15,31 +15,31 @@ const sizeStyles = (size: 'tiny' | 'xxsmall' | 'xsmall') => {
         case 'tiny':
             return css`
                 svg {
-                    height: 1rem;
-                    width: 0.5rem;
+                    height: 16px;
+                    width: 8px;
                 }
             `;
         case 'xxsmall':
             return css`
-                margin-right: 0.25rem;
+                margin-right: 4px;
                 svg {
-                    height: 1.25rem;
-                    width: 0.675rem;
+                    height: 20px;
+                    width: 11px;
                 }
             `;
         case 'xsmall':
             return css`
-                margin-right: 0.5rem;
+                margin-right: 8px;
                 svg {
-                    height: 1.5rem;
-                    width: 0.81rem;
+                    height: 24px;
+                    width: 13px;
                 }
             `;
         default:
             return css`
                 svg {
-                    height: 1.25rem;
-                    width: 0.675rem;
+                    height: 20px;
+                    width: 11px;
                 }
             `;
     }

--- a/src/web/components/QuoteIcon.tsx
+++ b/src/web/components/QuoteIcon.tsx
@@ -10,12 +10,48 @@ const quoteStyles = (colour?: string) => css`
     fill: ${colour && colour};
 `;
 
-type Props = {
-    colour?: string;
+const sizeStyles = (size: 'tiny' | 'xxsmall' | 'xsmall') => {
+    switch (size) {
+        case 'tiny':
+            return css`
+                svg {
+                    height: 1rem;
+                    width: 0.5rem;
+                }
+            `;
+        case 'xxsmall':
+            return css`
+                margin-right: 0.25rem;
+                svg {
+                    height: 1.25rem;
+                    width: 0.675rem;
+                }
+            `;
+        case 'xsmall':
+            return css`
+                margin-right: 0.5rem;
+                svg {
+                    height: 1.5rem;
+                    width: 0.81rem;
+                }
+            `;
+        default:
+            return css`
+                svg {
+                    height: 1.25rem;
+                    width: 0.675rem;
+                }
+            `;
+    }
 };
 
-export const QuoteIcon = ({ colour }: Props) => (
-    <>
+type Props = {
+    colour?: string;
+    size?: 'tiny' | 'xxsmall' | 'xsmall';
+};
+
+export const QuoteIcon = ({ colour, size = 'xxsmall' }: Props) => (
+    <span className={sizeStyles(size)}>
         <svg
             width="70"
             height="49"
@@ -25,5 +61,5 @@ export const QuoteIcon = ({ colour }: Props) => (
         >
             <path d="M69.587.9c-1.842 15.556-3.89 31.316-4.708 48.1H37.043c3.07-16.784 8.391-32.544 17.602-48.1h14.942zM32.949.9c-2.047 15.556-4.094 31.316-4.912 48.1H.2C3.066 32.216 8.592 16.456 17.598.9h15.35z" />
         </svg>
-    </>
+    </span>
 );

--- a/src/web/components/SmallHeadline.stories.tsx
+++ b/src/web/components/SmallHeadline.stories.tsx
@@ -234,19 +234,19 @@ export const Busy = () => (
 );
 Busy.story = { name: 'Lifestyle opinion' };
 
-export const UnderlineOnHover = () => (
+export const InUnderlinedState = () => (
     <Section showTopBorder={false} showSideBorders={false}>
         <SmallHeadline
-            headlineString="If you hover me an underline will show"
+            headlineString="This is the underlined state when showUnderline is true"
             pillar="news"
-            underlineOnHover={true}
+            showUnderline={true}
             size="tiny"
             prefix={{
-                text: 'I am not underlined',
+                text: 'I am never underlined',
                 pillar: 'news',
                 showSlash: true,
             }}
         />
     </Section>
 );
-UnderlineOnHover.story = { name: 'Underline on hover' };
+InUnderlinedState.story = { name: 'With showUnderline true' };

--- a/src/web/components/SmallHeadline.stories.tsx
+++ b/src/web/components/SmallHeadline.stories.tsx
@@ -1,0 +1,252 @@
+import React from 'react';
+
+import { Section } from '@frontend/web/components/Section';
+
+import { SmallHeadline } from '@frontend/web/components/SmallHeadline';
+
+/* tslint:disable */
+export default {
+    component: SmallHeadline,
+    title: 'Components/SmallHeadline',
+};
+/* tslint:enable */
+
+export const tinyStory = () => (
+    <Section showTopBorder={false} showSideBorders={false}>
+        <SmallHeadline
+            headlineString="This is how a tiny headline link looks"
+            pillar="news"
+            size="tiny"
+        />
+    </Section>
+);
+tinyStory.story = { name: 'Size | tiny' };
+
+export const defaultStory = () => (
+    <Section showTopBorder={false} showSideBorders={false}>
+        <SmallHeadline
+            headlineString="This is how a default headline link looks"
+            pillar="news"
+        />
+    </Section>
+);
+defaultStory.story = { name: 'Size | xxsmall (default)' };
+
+export const xsmallStory = () => (
+    <Section showTopBorder={false} showSideBorders={false}>
+        <SmallHeadline
+            headlineString="This is how a xsmall headline link looks"
+            pillar="news"
+            size="xsmall"
+        />
+    </Section>
+);
+xsmallStory.story = { name: 'Size | xsmall' };
+
+export const liveStory = () => (
+    <Section showTopBorder={false} showSideBorders={false}>
+        <SmallHeadline
+            headlineString="This is how a headline with a live prefix looks"
+            pillar="news"
+            prefix={{
+                text: 'Live',
+                pillar: 'news',
+            }}
+        />
+    </Section>
+);
+liveStory.story = { name: 'With Live prefix' };
+
+export const noSlash = () => (
+    <Section showTopBorder={false} showSideBorders={false}>
+        <SmallHeadline
+            headlineString="This is how a headline with no prefix slash looks"
+            pillar="news"
+            prefix={{
+                text: 'Live',
+                pillar: 'news',
+                showSlash: false,
+            }}
+        />
+    </Section>
+);
+noSlash.story = { name: 'With Live prefix but no slash' };
+
+export const pulsingDot = () => (
+    <Section showTopBorder={false} showSideBorders={false}>
+        <SmallHeadline
+            headlineString="This is how a headline with a pulsing dot looks"
+            pillar="news"
+            prefix={{
+                text: 'Live',
+                pillar: 'news',
+                showPulsingDot: true,
+            }}
+        />
+    </Section>
+);
+pulsingDot.story = { name: 'With pulsing dot' };
+
+export const cultureVariant = () => (
+    <Section showTopBorder={false} showSideBorders={false}>
+        <SmallHeadline
+            headlineString="This is how a headline with a culture prefix looks"
+            pillar="news"
+            prefix={{
+                text: 'Art and stuff',
+                pillar: 'culture',
+            }}
+        />
+    </Section>
+);
+cultureVariant.story = { name: 'With a culture prefix' };
+
+export const underlinedTiny = () => (
+    <Section showTopBorder={false} showSideBorders={false}>
+        <SmallHeadline
+            headlineString="Sometimes tiny headline links are underlined"
+            pillar="news"
+            size="tiny"
+            underlined={true}
+        />
+    </Section>
+);
+underlinedTiny.story = { name: 'Underlined | tiny' };
+
+export const underlinedXXSmall = () => (
+    <Section showTopBorder={false} showSideBorders={false}>
+        <SmallHeadline
+            headlineString="Sometimes xxsmall headline links are underlined"
+            pillar="news"
+            size="xxsmall"
+            underlined={true}
+        />
+    </Section>
+);
+underlinedXXSmall.story = { name: 'Underlined | xxsmall' };
+
+export const underlinedXSmall = () => (
+    <Section showTopBorder={false} showSideBorders={false}>
+        <SmallHeadline
+            headlineString="Sometimes xsmall headline links are underlined"
+            pillar="news"
+            size="xsmall"
+            underlined={true}
+        />
+    </Section>
+);
+underlinedXSmall.story = { name: 'Underlined | xsmall' };
+
+export const opinionTiny = () => (
+    <Section showTopBorder={false} showSideBorders={false}>
+        <SmallHeadline
+            headlineString="This is how tiny links to opinion articles look"
+            pillar="opinion"
+            showQuotes={true}
+            size="tiny"
+        />
+    </Section>
+);
+opinionTiny.story = { name: 'Quotes | tiny' };
+
+export const opinionXXSmall = () => (
+    <Section showTopBorder={false} showSideBorders={false}>
+        <SmallHeadline
+            headlineString="This is how xxsmall links to opinion articles look"
+            pillar="opinion"
+            showQuotes={true}
+            size="xxsmall"
+        />
+    </Section>
+);
+opinionXXSmall.story = { name: 'Quotes | xxsmall' };
+
+export const opinionXSmall = () => (
+    <Section showTopBorder={false} showSideBorders={false}>
+        <SmallHeadline
+            headlineString="This is how xsmall links to opinion articles look"
+            pillar="opinion"
+            showQuotes={true}
+            size="xsmall"
+        />
+    </Section>
+);
+opinionXSmall.story = { name: 'Quotes | xsmall' };
+
+export const colouredStory = () => (
+    <Section showTopBorder={false} showSideBorders={false}>
+        <SmallHeadline
+            headlineString="This is how a coloured headline link looks"
+            pillar="sport"
+            coloured={true}
+        />
+    </Section>
+);
+colouredStory.story = { name: 'Coloured' };
+
+export const colouredWithPrefix = () => (
+    <Section showTopBorder={false} showSideBorders={false}>
+        <SmallHeadline
+            headlineString="Coloured headline with a prefix"
+            pillar="sport"
+            coloured={true}
+            prefix={{
+                text: 'England 0 - 8 USA',
+                pillar: 'sport',
+                showPulsingDot: true,
+                showSlash: true,
+            }}
+        />
+    </Section>
+);
+colouredWithPrefix.story = { name: 'Coloured with prefix' };
+
+export const OpinionPrefix = () => (
+    <Section showTopBorder={false} showSideBorders={false}>
+        <SmallHeadline
+            headlineString="This is how an opinion headline with a prefix looks"
+            pillar="opinion"
+            showQuotes={true}
+            prefix={{
+                text: 'George Monbiot',
+                pillar: 'opinion',
+                showSlash: true,
+            }}
+        />
+    </Section>
+);
+OpinionPrefix.story = { name: 'With a culture prefix' };
+
+export const Busy = () => (
+    <Section showTopBorder={false} showSideBorders={false}>
+        <SmallHeadline
+            headlineString="I look life a buffoon. I feel incredible. And then I vomit"
+            pillar="lifestyle"
+            showQuotes={true}
+            coloured={true}
+            prefix={{
+                text: 'Aerial Yoga',
+                pillar: 'lifestyle',
+                showSlash: true,
+            }}
+        />
+    </Section>
+);
+Busy.story = { name: 'Lifestyle opinion' };
+
+export const UnderlineOnHover = () => (
+    <Section showTopBorder={false} showSideBorders={false}>
+        <SmallHeadline
+            headlineString="If you hover me an underline will show"
+            pillar="news"
+            underlineOnHover={true}
+            size="tiny"
+            prefix={{
+                text: 'I am not underlined',
+                pillar: 'news',
+                showSlash: true,
+            }}
+        />
+    </Section>
+);
+UnderlineOnHover.story = { name: 'Underline on hover' };

--- a/src/web/components/SmallHeadline.tsx
+++ b/src/web/components/SmallHeadline.tsx
@@ -136,11 +136,9 @@ const Prefix = ({
 }: PrefixType) => {
     const prefixColour = palette[pillar].main;
     return (
-        <>
-            <span className={prefixStyles(prefixColour)}>
-                {showPulsingDot && <PulsingDot colour={prefixColour} />}
-                <span className={cx(showSlash && slashStyles)}>{text}</span>
-            </span>
-        </>
+        <span className={prefixStyles(prefixColour)}>
+            {showPulsingDot && <PulsingDot colour={prefixColour} />}
+            <span className={cx(showSlash && slashStyles)}>{text}</span>
+        </span>
     );
 };

--- a/src/web/components/SmallHeadline.tsx
+++ b/src/web/components/SmallHeadline.tsx
@@ -11,10 +11,8 @@ const fontStyles = (size: HeadlineLinkSize) => css`
     ${headline[size]()};
 `;
 
-const hoverStyles = css`
-    :hover {
-        text-decoration: underline;
-    }
+const textDecorationUnderline = css`
+    text-decoration: underline;
 `;
 
 const underlinedStyles = (size: HeadlineLinkSize) => {
@@ -76,7 +74,7 @@ type Props = {
     headlineString: string; // The text shown
     pillar: Pillar; // Used to colour the headline (dark) and the prefix (main)
     underlined?: boolean; // Some headlines have an underlined style
-    underlineOnHover?: boolean; // Some headlines have text-decoration underlined
+    showUnderline?: boolean; // Some headlines have text-decoration underlined when hovered
     prefix?: PrefixType;
     showQuotes?: boolean; // When true the QuoteIcon is shown
     size?: HeadlineLinkSize;
@@ -87,7 +85,7 @@ export const SmallHeadline = ({
     headlineString,
     pillar,
     underlined = false,
-    underlineOnHover = false,
+    showUnderline = false,
     prefix,
     showQuotes = false,
     size = 'xxsmall',
@@ -111,7 +109,7 @@ export const SmallHeadline = ({
                     className={cx(
                         underlined && underlinedStyles(size),
                         coloured && colourStyles(palette[pillar].dark),
-                        underlineOnHover && hoverStyles,
+                        showUnderline && textDecorationUnderline,
                     )}
                 >
                     {headlineString}
@@ -120,7 +118,7 @@ export const SmallHeadline = ({
                 <span
                     className={cx(
                         coloured && colourStyles(palette[pillar].dark),
-                        underlineOnHover && hoverStyles,
+                        showUnderline && textDecorationUnderline,
                     )}
                 >
                     {headlineString}

--- a/src/web/components/SmallHeadline.tsx
+++ b/src/web/components/SmallHeadline.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import { css, cx } from 'emotion';
+
+import { headline } from '@guardian/src-foundations/typography';
+import { palette } from '@guardian/src-foundations';
+
+import { PulsingDot } from '@root/src/web/components/PulsingDot';
+import { QuoteIcon } from '@root/src/web/components/QuoteIcon';
+
+const fontStyles = (size: HeadlineLinkSize) => css`
+    ${headline[size]()};
+`;
+
+const hoverStyles = css`
+    :hover {
+        text-decoration: underline;
+    }
+`;
+
+const underlinedStyles = (size: HeadlineLinkSize) => {
+    function generateUnderlinedCss(baseSize: number) {
+        return css`
+            display: inline;
+            background-image: linear-gradient(
+                to bottom,
+                transparent,
+                transparent ${baseSize - 1}px,
+                rgba(199, 0, 0, 0.5)
+            );
+            line-height: ${baseSize}px;
+            background-size: 1px ${baseSize}px;
+            background-origin: content-box;
+            background-clip: content-box;
+        `;
+    }
+    switch (size) {
+        case 'tiny':
+            return generateUnderlinedCss(20);
+        case 'xxsmall':
+            return generateUnderlinedCss(23);
+        case 'xsmall':
+            return generateUnderlinedCss(28);
+        default:
+            return generateUnderlinedCss(23);
+    }
+};
+
+const colourStyles = (colour: string) => css`
+    color: ${colour};
+`;
+
+const prefixStyles = (colour: string) => css`
+    color: ${colour};
+    font-weight: 700;
+    margin-right: 4px;
+`;
+
+const slashStyles = css`
+    &::after {
+        content: '/';
+        display: inline-block;
+        margin-left: 4px;
+    }
+`;
+
+type PrefixType = {
+    text: string;
+    pillar?: Pillar;
+    showPulsingDot?: boolean;
+    showSlash?: boolean;
+};
+
+type HeadlineLinkSize = 'tiny' | 'xxsmall' | 'xsmall';
+
+type Props = {
+    headlineString: string; // The text shown
+    pillar: Pillar; // Used to colour the headline (dark) and the prefix (main)
+    underlined?: boolean; // Some headlines have an underlined style
+    underlineOnHover?: boolean; // Some headlines have text-decoration underlined
+    prefix?: PrefixType;
+    showQuotes?: boolean; // When true the QuoteIcon is shown
+    size?: HeadlineLinkSize;
+    coloured?: boolean; // When coloured, the headline takes the dark pillar colour
+};
+
+export const SmallHeadline = ({
+    headlineString,
+    pillar,
+    underlined = false,
+    underlineOnHover = false,
+    prefix,
+    showQuotes = false,
+    size = 'xxsmall',
+    coloured = false,
+}: Props) => {
+    return (
+        <h4 className={fontStyles(size)}>
+            {prefix && (
+                <Prefix
+                    text={prefix.text}
+                    pillar={prefix.pillar}
+                    showPulsingDot={prefix.showPulsingDot}
+                    showSlash={prefix.showSlash}
+                />
+            )}
+            {showQuotes && (
+                <QuoteIcon colour={palette[pillar].main} size={size} />
+            )}
+            {underlined ? (
+                <div
+                    className={cx(
+                        underlined && underlinedStyles(size),
+                        coloured && colourStyles(palette[pillar].dark),
+                        underlineOnHover && hoverStyles,
+                    )}
+                >
+                    {headlineString}
+                </div>
+            ) : (
+                <span
+                    className={cx(
+                        coloured && colourStyles(palette[pillar].dark),
+                        underlineOnHover && hoverStyles,
+                    )}
+                >
+                    {headlineString}
+                </span>
+            )}
+        </h4>
+    );
+};
+
+const Prefix = ({
+    text,
+    pillar = 'news',
+    showPulsingDot,
+    showSlash = true,
+}: PrefixType) => {
+    const prefixColour = palette[pillar].main;
+    return (
+        <>
+            <span className={prefixStyles(prefixColour)}>
+                {showPulsingDot && <PulsingDot colour={prefixColour} />}
+                <span className={cx(showSlash && slashStyles)}>{text}</span>
+            </span>
+        </>
+    );
+};


### PR DESCRIPTION
## What does this change?
This adds a new `SmallHeadline` component to centralise the various ways an article heading can be shown as a link to the main content.

```typescript
type PrefixType = {
    text: string;
    pillar?: Pillar;
    showPulsingDot?: boolean;
    showSlash?: boolean;
};

type HeadlineLinkSize = 'tiny' | 'xxsmall' | 'xsmall';

type Props = {
    headlineString: string; // The text shown
    pillar: Pillar; // Used to colour the headline (dark) and the prefix (main)
    underlined?: boolean; // Some headlines have an underlined style
    underlineOnHover?: boolean; // Some headlines have text-decoration underlined
    prefix?: PrefixType;
    showQuotes?: boolean; // When true the QuoteIcon is shown
    size?: HeadlineLinkSize;
    coloured?: boolean; // When coloured, the headline takes the dark pillar colour
};
```

![2019-11-13 16 52 29](https://user-images.githubusercontent.com/1336821/68785939-ccab4b00-0636-11ea-914b-5eeea7fea924.gif)

## Steps to verify
1.`git checkout oliver/headline-link-text`
2.`yarn storybook`
3. http://localhost:6006/?path=/story/components-smallheadline--tiny-story

## Why?
To prevent duplication of code. To document the site. To make the lives of future developers easier.

## Link to supporting Trello card
https://trello.com/c/Cw2LYEWo/864-headlinelinktext
