### PR TITLE
Added basic front card

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -239,6 +239,13 @@ interface BadgeType {
     svgSrc: () => JSX.Element;
 }
 
+interface PrefixType {
+    text: string;
+    pillar?: Pillar;
+    showPulsingDot?: boolean;
+    showSlash?: boolean;
+}
+
 /**
  * the config model will contain useful app/site
  * level data. Although currently derived from the config model

--- a/src/web/components/Card/Card.stories.tsx
+++ b/src/web/components/Card/Card.stories.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { Card } from '@frontend/web/components/Card/Card';
+
+const Container = ({
+    children,
+    direction = 'column',
+}: {
+    children: JSX.Element | JSX.Element[];
+    direction?: 'row' | 'column';
+}) => (
+    <ul
+        className={css`
+            display: flex;
+            flex-direction: ${direction};
+            height: 300px;
+            border: 3px dashed;
+        `}
+    >
+        {children}
+    </ul>
+);
+
+/* tslint:disable */
+export default {
+    component: Card,
+    title: 'Components/Card',
+};
+/* tslint:enable */
+
+export const defaultStory = () => (
+    <Card
+        linkTo="/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse"
+        pillar="news"
+        headlineString="This is the most basic card view for the news pillar"
+    />
+);
+defaultStory.story = { name: 'default' };
+
+export const VerticalSpacing = () => (
+    <Container>
+        <Card
+            linkTo="/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse"
+            pillar="news"
+            headlineString="Johnson heckled on tour"
+            prefix={{
+                text: 'Election 2019',
+                pillar: 'news',
+            }}
+        />
+        <Card
+            linkTo="/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse"
+            pillar="news"
+            headlineString="Johnson shouted at on tour"
+            prefix={{
+                text: 'Election 2019',
+                pillar: 'news',
+            }}
+        />
+        <Card
+            linkTo="/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse"
+            pillar="news"
+            headlineString="Johnson ignored on tour"
+            prefix={{
+                text: 'Election 2019',
+                pillar: 'news',
+            }}
+        />
+    </Container>
+);
+VerticalSpacing.story = { name: 'with equal height vertically' };
+
+export const HorizontalSpacing = () => (
+    <Container direction="row">
+        <Card
+            linkTo="/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse"
+            pillar="news"
+            headlineString="Johnson heckled on tour"
+            prefix={{
+                text: 'Election 2019',
+                pillar: 'news',
+            }}
+        />
+        <Card
+            linkTo="/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse"
+            pillar="news"
+            headlineString="Johnson shouted at on tour"
+            prefix={{
+                text: 'Election 2019',
+                pillar: 'news',
+            }}
+        />
+        <Card
+            linkTo="/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse"
+            pillar="news"
+            headlineString="Johnson ignored on tour"
+            prefix={{
+                text: 'Election 2019',
+                pillar: 'news',
+            }}
+        />
+    </Container>
+);
+HorizontalSpacing.story = { name: 'with equal width horizontally' };

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { palette } from '@guardian/src-foundations';
+// import { visuallyHidden } from '@guardian/src-foundations/accessibility';
+
+import { CardWrapper } from './CardWrapper';
+import { SmallHeadline } from '@frontend/web/components/SmallHeadline';
+
+const linkStyles = ({
+    backgroundColour,
+    backgroundOnHover,
+}: {
+    backgroundColour: string;
+    backgroundOnHover: string;
+}) => css`
+    /* a tag specific styles */
+    color: inherit;
+    text-decoration: none;
+
+    /* The whole card is one link so we card level styles here */
+    margin-left: 10px;
+    margin-right: 10px;
+    margin-bottom: 12px;
+    width: 100%;
+    background-color: ${backgroundColour};
+    :hover {
+        background-color: ${backgroundOnHover};
+    }
+
+    /* We aboslute position the 1 pixel top bar in
+       the card so this is required here */
+    position: relative;
+`;
+
+const listStyles = css`
+    /* Here we ensure the card stretches to fill the containing space */
+    flex-basis: 100%;
+    display: flex;
+`;
+
+type Props = {
+    linkTo: string;
+    pillar: Pillar;
+    headlineString: string;
+    prefix?: PrefixType;
+};
+
+export const Card = ({ linkTo, pillar, headlineString, prefix }: Props) => {
+    return (
+        <li className={listStyles}>
+            {/* tslint:disable-next-line:react-a11y-anchors */}
+            <a
+                href={linkTo}
+                className={linkStyles({
+                    backgroundColour: palette.neutral[93],
+                    backgroundOnHover: palette.neutral[86],
+                })}
+            >
+                <CardWrapper topBarColour={palette[pillar].main}>
+                    <SmallHeadline
+                        pillar={pillar}
+                        headlineString={headlineString}
+                        prefix={prefix}
+                    />
+                </CardWrapper>
+            </a>
+        </li>
+    );
+};

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -27,7 +27,7 @@ const linkStyles = ({
         background-color: ${backgroundOnHover};
     }
 
-    /* We aboslute position the 1 pixel top bar in
+    /* We absolutely position the 1 pixel top bar in
        the card so this is required here */
     position: relative;
 `;

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { css } from 'emotion';
 
 import { palette } from '@guardian/src-foundations';
-// import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 
 import { CardWrapper } from './CardWrapper';
 import { SmallHeadline } from '@frontend/web/components/SmallHeadline';

--- a/src/web/components/Card/CardWrapper.tsx
+++ b/src/web/components/Card/CardWrapper.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { css } from 'emotion';
+
+type Props = {
+    children: JSX.Element | JSX.Element[];
+    topBarColour: string;
+};
+
+export const CardWrapper = ({ children, topBarColour }: Props) => (
+    <div
+        className={css`
+            padding-left: 5px;
+            padding-right: 5px;
+            padding-bottom: 8px;
+
+            /* Styling for top bar */
+            :before {
+                background-color: ${topBarColour};
+                content: '';
+                position: absolute;
+                top: 0;
+                left: 0;
+                right: 0;
+                height: 1px;
+                z-index: 2;
+            }
+        `}
+    >
+        {children}
+    </div>
+);

--- a/src/web/components/SmallHeadline.tsx
+++ b/src/web/components/SmallHeadline.tsx
@@ -61,13 +61,6 @@ const slashStyles = css`
     }
 `;
 
-type PrefixType = {
-    text: string;
-    pillar?: Pillar;
-    showPulsingDot?: boolean;
-    showSlash?: boolean;
-};
-
 type HeadlineLinkSize = 'tiny' | 'xxsmall' | 'xsmall';
 
 type Props = {


### PR DESCRIPTION
## What does this change?
In order to support Related Stories, we need to display an article card. There are several variations on how these cards show, this PR introduces the most basic of these

```typescript
type Props = {
    linkTo: string;
    pillar: Pillar;
    headlineString: string;
    prefix?: PrefixType;
};
```

![2019-11-14 16 14 13](https://user-images.githubusercontent.com/1336821/68874891-d944a780-06f9-11ea-8e3e-d2cc474824e0.gif)

## Usage
For accessibility, cards use `<li>` tags and expect to be nested in `<ul>` or `<ol>` tags

For layout, cards use flex to stretch and fill the space within a container. Container's should have `display: flex;`


## Why?
Because we want parity on articles

## Link to supporting Trello card
https://trello.com/c/sK1BBqZ5/863-card-component
