### PR TITLE
figcaption width

### DIFF
--- a/src/web/components/Caption.tsx
+++ b/src/web/components/Caption.tsx
@@ -15,8 +15,11 @@ const captionStyle = (role?: RoleType) => css`
     word-wrap: break-word;
     color: ${palette.neutral[46]};
     ${from.leftCol} {
-        width: ${role && role === 'showcase' && '200px'};
+        width: ${role && (role === 'showcase' || role === 'supporting') && '140px'};
         position: ${role && (role === 'showcase' || role === 'supporting') && 'absolute'}
+    }
+    ${from.wide} {
+        width: ${role && (role === 'showcase' || role === 'supporting') && '220px'};
     }
 `;
 

--- a/src/web/components/Caption.tsx
+++ b/src/web/components/Caption.tsx
@@ -14,12 +14,15 @@ const captionStyle = (role?: RoleType) => css`
     ${textSans.xsmall()};
     word-wrap: break-word;
     color: ${palette.neutral[46]};
+`;
+
+const limitedWidth = css`
     ${from.leftCol} {
-        width: ${role && (role === 'showcase' || role === 'supporting') && '140px'};
-        position: ${role && (role === 'showcase' || role === 'supporting') && 'absolute'};
+        width: 140px;
+        position: absolute;
     }
     ${from.wide} {
-        width: ${role && (role === 'showcase' || role === 'supporting') && '220px'};
+        width: 220px;
     }
 `;
 
@@ -80,15 +83,20 @@ export const Caption: React.FC<{
         return captionText;
     };
 
+    const shouldLimitWidth =
+        role && (role === 'showcase' || role === 'supporting');
+
     return (
         <figure className={figureStyle}>
             {children}
             {captionText && (
                 <>
                     <figcaption
-                        className={cx(captionStyle(role), {
-                            [captionPadding]: padCaption,
-                        })}
+                        className={cx(
+                            captionStyle(role),
+                            shouldLimitWidth && limitedWidth,
+                            { [captionPadding]: padCaption },
+                        )}
                     >
                         <span className={iconStyle}>
                             <TriangleIcon />

--- a/src/web/components/Caption.tsx
+++ b/src/web/components/Caption.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { palette } from '@guardian/src-foundations';
+import { from } from '@guardian/src-foundations/mq';
 import { textSans } from '@guardian/src-foundations/typography';
 import { css, cx } from 'emotion';
 import { pillarPalette } from '@root/src/lib/pillars';
@@ -8,11 +9,14 @@ import TriangleIcon from '@frontend/static/icons/triangle.svg';
 const figureStyle = css`
     margin-bottom: 8px;
 `;
-const captionStyle = css`
+const captionStyle = (role?: RoleType) => css`
     padding-top: 10px;
     ${textSans.xsmall()};
     word-wrap: break-word;
     color: ${palette.neutral[46]};
+    ${from.leftCol} {
+        width: ${role && role === 'showcase' && '200px'};
+    }
 `;
 
 const captionPadding = css`
@@ -27,6 +31,7 @@ export const Caption: React.FC<{
     dirtyHtml?: boolean;
     credit?: string;
     displayCredit?: boolean;
+    role?: RoleType;
 }> = ({
     captionText,
     pillar,
@@ -35,6 +40,7 @@ export const Caption: React.FC<{
     credit,
     displayCredit = true,
     children,
+    role,
 }) => {
     const iconStyle = css`
         fill: ${pillarPalette[pillar].main};
@@ -76,7 +82,7 @@ export const Caption: React.FC<{
             {captionText && (
                 <>
                     <figcaption
-                        className={cx(captionStyle, {
+                        className={cx(captionStyle(role), {
                             [captionPadding]: padCaption,
                         })}
                     >

--- a/src/web/components/Caption.tsx
+++ b/src/web/components/Caption.tsx
@@ -16,6 +16,7 @@ const captionStyle = (role?: RoleType) => css`
     color: ${palette.neutral[46]};
     ${from.leftCol} {
         width: ${role && role === 'showcase' && '200px'};
+        position: ${role && (role === 'showcase' || role === 'supporting') && 'absolute'}
     }
 `;
 

--- a/src/web/components/Caption.tsx
+++ b/src/web/components/Caption.tsx
@@ -16,7 +16,7 @@ const captionStyle = (role?: RoleType) => css`
     color: ${palette.neutral[46]};
     ${from.leftCol} {
         width: ${role && (role === 'showcase' || role === 'supporting') && '140px'};
-        position: ${role && (role === 'showcase' || role === 'supporting') && 'absolute'}
+        position: ${role && (role === 'showcase' || role === 'supporting') && 'absolute'};
     }
     ${from.wide} {
         width: ${role && (role === 'showcase' || role === 'supporting') && '220px'};
@@ -46,12 +46,12 @@ export const Caption: React.FC<{
     children,
     role,
 }) => {
-    const iconStyle = css`
+        const iconStyle = css`
         fill: ${pillarPalette[pillar].main};
         padding-right: 3px;
     `;
 
-    const captionLink = css`
+        const captionLink = css`
         a {
             color: ${pillarPalette[pillar].main};
             text-decoration: none;
@@ -64,39 +64,39 @@ export const Caption: React.FC<{
         }
     `;
 
-    const getCaptionHtml = () => {
-        if (dirtyHtml) {
-            return (
-                <span
-                    // tslint:disable-line:react-no-dangerous-html
-                    className={captionLink}
-                    dangerouslySetInnerHTML={{
-                        __html: captionText || '',
-                    }}
-                    key={'caption'}
-                />
-            );
-        }
-        return captionText;
-    };
+        const getCaptionHtml = () => {
+            if (dirtyHtml) {
+                return (
+                    <span
+                        // tslint:disable-line:react-no-dangerous-html
+                        className={captionLink}
+                        dangerouslySetInnerHTML={{
+                            __html: captionText || '',
+                        }}
+                        key={'caption'}
+                    />
+                );
+            }
+            return captionText;
+        };
 
-    return (
-        <figure className={figureStyle}>
-            {children}
-            {captionText && (
-                <>
-                    <figcaption
-                        className={cx(captionStyle(role), {
-                            [captionPadding]: padCaption,
-                        })}
-                    >
-                        <span className={iconStyle}>
-                            <TriangleIcon />
-                        </span>
-                        {getCaptionHtml()} {displayCredit && credit}
-                    </figcaption>
-                </>
-            )}
-        </figure>
-    );
-};
+        return (
+            <figure className={figureStyle}>
+                {children}
+                {captionText && (
+                    <>
+                        <figcaption
+                            className={cx(captionStyle(role), {
+                                [captionPadding]: padCaption,
+                            })}
+                        >
+                            <span className={iconStyle}>
+                                <TriangleIcon />
+                            </span>
+                            {getCaptionHtml()} {displayCredit && credit}
+                        </figcaption>
+                    </>
+                )}
+            </figure>
+        );
+    };

--- a/src/web/components/Caption.tsx
+++ b/src/web/components/Caption.tsx
@@ -16,7 +16,7 @@ const captionStyle = (role?: RoleType) => css`
     color: ${palette.neutral[46]};
     ${from.leftCol} {
         width: ${role && (role === 'showcase' || role === 'supporting') && '140px'};
-        position: ${role && (role === 'showcase' || role === 'supporting') && 'absolute'}
+        position: ${role && (role === 'showcase' || role === 'supporting') && 'absolute'};
     }
     ${from.wide} {
         width: ${role && (role === 'showcase' || role === 'supporting') && '220px'};

--- a/src/web/components/Caption.tsx
+++ b/src/web/components/Caption.tsx
@@ -16,7 +16,7 @@ const captionStyle = (role?: RoleType) => css`
     color: ${palette.neutral[46]};
     ${from.leftCol} {
         width: ${role && (role === 'showcase' || role === 'supporting') && '140px'};
-        position: ${role && (role === 'showcase' || role === 'supporting') && 'absolute'};
+        position: ${role && (role === 'showcase' || role === 'supporting') && 'absolute'}
     }
     ${from.wide} {
         width: ${role && (role === 'showcase' || role === 'supporting') && '220px'};
@@ -46,12 +46,12 @@ export const Caption: React.FC<{
     children,
     role,
 }) => {
-        const iconStyle = css`
+    const iconStyle = css`
         fill: ${pillarPalette[pillar].main};
         padding-right: 3px;
     `;
 
-        const captionLink = css`
+    const captionLink = css`
         a {
             color: ${pillarPalette[pillar].main};
             text-decoration: none;
@@ -64,39 +64,39 @@ export const Caption: React.FC<{
         }
     `;
 
-        const getCaptionHtml = () => {
-            if (dirtyHtml) {
-                return (
-                    <span
-                        // tslint:disable-line:react-no-dangerous-html
-                        className={captionLink}
-                        dangerouslySetInnerHTML={{
-                            __html: captionText || '',
-                        }}
-                        key={'caption'}
-                    />
-                );
-            }
-            return captionText;
-        };
-
-        return (
-            <figure className={figureStyle}>
-                {children}
-                {captionText && (
-                    <>
-                        <figcaption
-                            className={cx(captionStyle(role), {
-                                [captionPadding]: padCaption,
-                            })}
-                        >
-                            <span className={iconStyle}>
-                                <TriangleIcon />
-                            </span>
-                            {getCaptionHtml()} {displayCredit && credit}
-                        </figcaption>
-                    </>
-                )}
-            </figure>
-        );
+    const getCaptionHtml = () => {
+        if (dirtyHtml) {
+            return (
+                <span
+                    // tslint:disable-line:react-no-dangerous-html
+                    className={captionLink}
+                    dangerouslySetInnerHTML={{
+                        __html: captionText || '',
+                    }}
+                    key={'caption'}
+                />
+            );
+        }
+        return captionText;
     };
+
+    return (
+        <figure className={figureStyle}>
+            {children}
+            {captionText && (
+                <>
+                    <figcaption
+                        className={cx(captionStyle(role), {
+                            [captionPadding]: padCaption,
+                        })}
+                    >
+                        <span className={iconStyle}>
+                            <TriangleIcon />
+                        </span>
+                        {getCaptionHtml()} {displayCredit && credit}
+                    </figcaption>
+                </>
+            )}
+        </figure>
+    );
+};

--- a/src/web/components/elements/ImageBlockComponent.tsx
+++ b/src/web/components/elements/ImageBlockComponent.tsx
@@ -108,6 +108,7 @@ export const ImageBlockComponent: React.FC<{
                 element={element}
                 pillar={pillar}
                 hideCaption={hideCaption}
+                role={element.role}
             />
         </div>
     );

--- a/src/web/components/elements/ImageComponent.tsx
+++ b/src/web/components/elements/ImageComponent.tsx
@@ -62,7 +62,8 @@ export const ImageComponent: React.FC<{
     element: ImageBlockElement;
     pillar: Pillar;
     hideCaption?: boolean;
-}> = ({ element, pillar, hideCaption }) => {
+    role?: RoleType;
+}> = ({ element, pillar, hideCaption, role }) => {
     const sources = makeSources(element.imageSources);
     if (hideCaption) {
         return (
@@ -80,6 +81,7 @@ export const ImageComponent: React.FC<{
             dirtyHtml={true}
             credit={element.data.credit}
             displayCredit={true}
+            role={role}
         >
             <Picture
                 sources={sources}


### PR DESCRIPTION
## What does this change?

Sets a width for captions at showcase and supporting weights

## Why?

Matches frontend + full-width captions were hard to read as they were crossing a vertical line.

Before:
<img width="1521" alt="Before" src="https://user-images.githubusercontent.com/4561/68935039-2aa37400-0798-11ea-973d-6f0f136fad13.png">


After:
<img width="1521" alt="After" src="https://user-images.githubusercontent.com/4561/68935034-28411a00-0798-11ea-864f-0fd2a3c62749.png">



## Link to supporting Trello card
https://trello.com/c/XPTBNAJt/870-fix-caption-width