### PR TITLE
Nested Links

### DIFF
--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -18,9 +18,6 @@ const linkStyles = ({
     text-decoration: none;
 
     /* The whole card is one link so we card level styles here */
-    margin-left: 10px;
-    margin-right: 10px;
-    margin-bottom: 12px;
     width: 100%;
     background-color: ${backgroundColour};
     :hover {
@@ -36,6 +33,11 @@ const listStyles = css`
     /* Here we ensure the card stretches to fill the containing space */
     flex-basis: 100%;
     display: flex;
+
+    /* Set spacing margins on the li element */
+    margin-left: 10px;
+    margin-right: 10px;
+    margin-bottom: 12px;
 `;
 
 type Props = {

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -24,15 +24,27 @@ const linkStyles = ({
         background-color: ${backgroundOnHover};
     }
 
-    /* We absolutely position the 1 pixel top bar in
-       the card so this is required here */
-    position: relative;
+    /* Sometimes a headline contains it's own link so we use the
+       approach described below to deal with nested links
+       See: https://css-tricks.com/nested-links/ */
+    :before {
+        content: '';
+        position: absolute;
+        left: 0;
+        top: 0;
+        right: 0;
+        bottom: 0;
+    }
 `;
 
 const listStyles = css`
     /* Here we ensure the card stretches to fill the containing space */
     flex-basis: 100%;
     display: flex;
+
+    /* We absolutely position the 1 pixel top bar in
+       the card so this is required here */
+    position: relative;
 
     /* Set spacing margins on the li element */
     margin-left: 10px;

--- a/src/web/components/SmallHeadline.stories.tsx
+++ b/src/web/components/SmallHeadline.stories.tsx
@@ -250,3 +250,20 @@ export const InUnderlinedState = () => (
     </Section>
 );
 InUnderlinedState.story = { name: 'With showUnderline true' };
+
+export const linkStory = () => (
+    <Section showTopBorder={false} showSideBorders={false}>
+        <SmallHeadline
+            headlineString="This is how a headline looks as a link"
+            pillar="sport"
+            prefix={{
+                text: 'I am not a link',
+                pillar: 'sport',
+                showSlash: true,
+            }}
+            coloured={true}
+            linkTo="some/path/to/link/to"
+        />
+    </Section>
+);
+linkStory.story = { name: 'With linkTo provided' };

--- a/src/web/components/SmallHeadline.tsx
+++ b/src/web/components/SmallHeadline.tsx
@@ -61,6 +61,20 @@ const slashStyles = css`
     }
 `;
 
+const linkStyles = css`
+    position: relative;
+
+    color: inherit;
+    :active :hover :visited {
+        color: inherit;
+    }
+
+    text-decoration: none;
+    :hover {
+        text-decoration: underline;
+    }
+`;
+
 type HeadlineLinkSize = 'tiny' | 'xxsmall' | 'xsmall';
 
 type Props = {
@@ -72,6 +86,7 @@ type Props = {
     showQuotes?: boolean; // When true the QuoteIcon is shown
     size?: HeadlineLinkSize;
     coloured?: boolean; // When coloured, the headline takes the dark pillar colour
+    linkTo?: string; // If provided, this turns the headlineString into an a tag
 };
 
 export const SmallHeadline = ({
@@ -83,7 +98,9 @@ export const SmallHeadline = ({
     showQuotes = false,
     size = 'xxsmall',
     coloured = false,
+    linkTo,
 }: Props) => {
+    const Headline = linkTo ? 'a' : 'span';
     return (
         <h4 className={fontStyles(size)}>
             {prefix && (
@@ -97,26 +114,18 @@ export const SmallHeadline = ({
             {showQuotes && (
                 <QuoteIcon colour={palette[pillar].main} size={size} />
             )}
-            {underlined ? (
-                <div
-                    className={cx(
-                        underlined && underlinedStyles(size),
-                        coloured && colourStyles(palette[pillar].dark),
-                        showUnderline && textDecorationUnderline,
-                    )}
-                >
-                    {headlineString}
-                </div>
-            ) : (
-                <span
-                    className={cx(
-                        coloured && colourStyles(palette[pillar].dark),
-                        showUnderline && textDecorationUnderline,
-                    )}
-                >
-                    {headlineString}
-                </span>
-            )}
+            <Headline
+                href={linkTo}
+                className={cx(
+                    // Composed styles - order matters for colours
+                    linkTo && linkStyles,
+                    underlined && underlinedStyles(size),
+                    showUnderline && textDecorationUnderline,
+                    coloured && colourStyles(palette[pillar].dark),
+                )}
+            >
+                {headlineString}
+            </Headline>
         </h4>
     );
 };

--- a/src/web/components/SmallHeadline.tsx
+++ b/src/web/components/SmallHeadline.tsx
@@ -65,9 +65,6 @@ const linkStyles = css`
     position: relative;
 
     color: inherit;
-    :active :hover :visited {
-        color: inherit;
-    }
 
     text-decoration: none;
     :hover {


### PR DESCRIPTION
## What does this change?
Some components have links inside links. This isn't supported in html but there are [several workarounds](https://css-tricks.com/nested-links/) which let you achieve this.

This PR introduces [one of those workarounds](https://heydon.github.io/Inclusive-Components/cards-pseudo-content-author-link/) to the SmallHeading and Card component.

## Usage
The calling, container, component should apply the following css to the link that it wants to cover itself with:

```css
    :before {
        content: '';
        position: absolute;
        left: 0;
        top: 0;
        right: 0;
        bottom: 0;
    }
```

Because this css is using absolute positioning, it's parent should have `position: relative;`.

Then, by passing the prop `linkTo` to `SmallHeading` the 2 will work together. You can also now just pass `linkTo` to `SmallHeading` without it being nested, this will also work in isolation.

## Link to supporting Trello card
https://trello.com/c/I5qJxOPH/869-nested-links
