### PR TITLE
Support Card standfirst

### DIFF
--- a/src/web/components/ArticleStandfirst.tsx
+++ b/src/web/components/ArticleStandfirst.tsx
@@ -2,12 +2,16 @@ import React from 'react';
 import { css, cx } from 'emotion';
 import { pillarMap, pillarPalette } from '@root/src/lib/pillars';
 import { palette } from '@guardian/src-foundations';
-import { body, headline, textSans } from '@guardian/src-foundations/typography';
+import { headline, textSans } from '@guardian/src-foundations/typography';
+
+import { Standfirst } from '@frontend/web/components/Standfirst';
 
 const standfirstStyles = css`
-    ${body.medium()};
+    ${headline.tiny({
+        fontWeight: 'bold',
+    })};
+    line-height: 20px;
     max-width: 550px;
-    font-weight: 700;
     color: ${palette.neutral[7]};
     margin-bottom: 12px;
 
@@ -55,14 +59,11 @@ const standfirstLinks = pillarMap(
 
 type Props = {
     pillar: Pillar;
-    standfirst: string;
+    standfirst: string; // Can be html
 };
 
 export const ArticleStandfirst = ({ pillar, standfirst }: Props) => (
-    <div // tslint:disable-line:react-no-dangerous-html
-        className={cx(standfirstStyles, standfirstLinks[pillar])}
-        dangerouslySetInnerHTML={{
-            __html: standfirst,
-        }}
-    />
+    <div className={cx(standfirstStyles, standfirstLinks[pillar])}>
+        <Standfirst pillar={pillar} standfirst={standfirst} />
+    </div>
 );

--- a/src/web/components/Card/Card.stories.tsx
+++ b/src/web/components/Card/Card.stories.tsx
@@ -217,3 +217,32 @@ export const ImageRight = () => (
     </Container>
 );
 ImageRight.story = { name: 'with large image to the right' };
+
+export const Standfirst = () => (
+    <Container direction="row" height="100%">
+        <Card
+            linkTo="/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse"
+            pillar="sport"
+            headlineString="Johnson heckled on tour"
+            prefix={{
+                text: 'World Cup 2019',
+                pillar: 'sport',
+            }}
+            image={{ element: imageElement, position: 'left', size: 'large' }}
+            standfirst="This is the standfirst text. This is more standfirst text to show how it looks when wrapped"
+        />
+        <Card
+            linkTo="/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse"
+            pillar="sport"
+            headlineString="Johnson shouted at on tour"
+            prefix={{
+                text: 'World Cup 2019',
+                showPulsingDot: true,
+                showSlash: true,
+                pillar: 'sport',
+            }}
+            image={{ element: imageElement, position: 'left', size: 'large' }}
+        />
+    </Container>
+);
+Standfirst.story = { name: 'with standfirst' };

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -2,15 +2,18 @@ import React from 'react';
 
 import { palette } from '@guardian/src-foundations';
 
+import { ContentWrapper } from './ContentWrapper';
 import { HeadlineWrapper } from './HeadlineWrapper';
 import { ImageLeftLayout } from './ImageLeftLayout';
 import { ImageRightLayout } from './ImageRightLayout';
 import { ImageWrapper } from './ImageWrapper';
+import { StandfirstWrapper } from './StandfirstWrapper';
 import { TopBar } from './TopBar';
 import { CardLink } from './CardLink';
 import { CardListItem } from './CardListItem';
 
 import { SmallHeadline } from '@frontend/web/components/SmallHeadline';
+import { Standfirst } from '@frontend/web/components/Standfirst';
 import { ImageComponent } from '@frontend/web/components/elements/ImageComponent';
 
 const decideLayout = (image?: CardImageType) => {
@@ -35,7 +38,7 @@ type CoveragesType = {
         medium: CardCoverageType;
         large: CardCoverageType;
     };
-    headline: {
+    content: {
         small: CardCoverageType;
         medium: CardCoverageType;
         large: CardCoverageType;
@@ -51,7 +54,7 @@ const coverages: CoveragesType = {
         medium: '50%',
         large: '67%',
     },
-    headline: {
+    content: {
         small: '75%',
         medium: '50%',
         large: '33%',
@@ -70,6 +73,7 @@ type Props = {
     headlineString: string;
     prefix?: PrefixType;
     image?: CardImageType;
+    standfirst?: string;
 };
 
 export const Card = ({
@@ -78,6 +82,7 @@ export const Card = ({
     headlineString,
     prefix,
     image,
+    standfirst,
 }: Props) => {
     // The choice of layout affects where any image is placed
     const Layout = decideLayout(image);
@@ -85,8 +90,8 @@ export const Card = ({
     // If there was no image given or image size was not set, coverage is null and
     // no flex-basis property is set in the wrappers, so content flows normally
     const imageCoverage = image && image.size && coverages.image[image.size];
-    const headlineCoverage =
-        image && image.size && coverages.headline[image.size];
+    const contentCoverage =
+        image && image.size && coverages.content[image.size];
 
     return (
         <CardListItem>
@@ -107,13 +112,25 @@ export const Card = ({
                                     />
                                 </ImageWrapper>
                             )}
-                            <HeadlineWrapper coverage={headlineCoverage}>
-                                <SmallHeadline
-                                    pillar={pillar}
-                                    headlineString={headlineString}
-                                    prefix={prefix}
-                                />
-                            </HeadlineWrapper>
+                            <ContentWrapper coverage={contentCoverage}>
+                                <>
+                                    <HeadlineWrapper>
+                                        <SmallHeadline
+                                            pillar={pillar}
+                                            headlineString={headlineString}
+                                            prefix={prefix}
+                                        />
+                                    </HeadlineWrapper>
+                                    {standfirst && (
+                                        <StandfirstWrapper>
+                                            <Standfirst
+                                                pillar={pillar}
+                                                standfirst={standfirst}
+                                            />
+                                        </StandfirstWrapper>
+                                    )}
+                                </>
+                            </ContentWrapper>
                         </>
                     </Layout>
                 </TopBar>

--- a/src/web/components/Card/ContentWrapper.tsx
+++ b/src/web/components/Card/ContentWrapper.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { css } from 'emotion';
+
+type Props = {
+    children: JSX.Element | JSX.Element[];
+    coverage?: CardCoverageType;
+};
+
+export const ContentWrapper = ({ children, coverage }: Props) => (
+    <div
+        className={css`
+            display: flex;
+            flex-direction: column;
+            justify-content: space-between;
+            flex-basis: ${coverage && coverage};
+
+            padding-left: 5px;
+            padding-right: 5px;
+        `}
+    >
+        {children}
+    </div>
+);

--- a/src/web/components/Card/HeadlineWrapper.tsx
+++ b/src/web/components/Card/HeadlineWrapper.tsx
@@ -3,16 +3,11 @@ import { css } from 'emotion';
 
 type Props = {
     children: JSX.Element | JSX.Element[];
-    coverage?: CardCoverageType;
 };
 
-export const HeadlineWrapper = ({ children, coverage }: Props) => (
+export const HeadlineWrapper = ({ children }: Props) => (
     <div
         className={css`
-            flex-basis: ${coverage && coverage};
-
-            padding-left: 5px;
-            padding-right: 5px;
             padding-bottom: 8px;
         `}
     >

--- a/src/web/components/Card/StandfirstWrapper.tsx
+++ b/src/web/components/Card/StandfirstWrapper.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { body } from '@guardian/src-foundations/typography';
+
+type Props = {
+    children: JSX.Element | JSX.Element[];
+};
+
+export const StandfirstWrapper = ({ children }: Props) => (
+    <div
+        className={css`
+            display: flex;
+            flex-direction: column;
+            justify-content: space-between;
+
+            ${body.small({
+                fontWeight: 'light',
+            })};
+            line-height: 20px;
+
+            padding-right: 5px;
+            padding-bottom: 6px;
+        `}
+    >
+        {children}
+    </div>
+);

--- a/src/web/components/Standfirst.tsx
+++ b/src/web/components/Standfirst.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { css } from 'emotion';
+import { palette } from '@guardian/src-foundations';
+import { headline, textSans } from '@guardian/src-foundations/typography';
+
+const standfirstStyles = css`
+    li {
+        ${textSans.medium()};
+        margin-bottom: 6px;
+        padding-left: 20px;
+
+        p {
+            display: inline;
+        }
+    }
+
+    li:before {
+        display: inline-block;
+        content: '';
+        border-radius: 6px;
+        height: 12px;
+        width: 12px;
+        margin-right: 8px;
+        background-color: ${palette.neutral[86]};
+        margin-left: -20px;
+    }
+
+    p {
+        margin-bottom: 8px;
+    }
+
+    li {
+        ${headline.tiny()};
+    }
+`;
+
+// type SizeType = 'tiny' | 'small' | 'medium';
+// type WeightType = 'light' | 'regular' | 'medium' | 'bold';
+
+type Props = {
+    pillar: Pillar;
+    standfirst: string;
+};
+
+export const Standfirst = ({ pillar, standfirst }: Props) => (
+    <div // tslint:disable-line:react-no-dangerous-html
+        className={standfirstStyles}
+        dangerouslySetInnerHTML={{
+            __html: standfirst,
+        }}
+    />
+);


### PR DESCRIPTION
## What does this change?
This PR refactors the `ArticleStandfirst` component breaking it out into `ArticleStandfirst` & `Standfirst` to allow us to separate context specific styling.

With this change, this PR also adds the `Standfirst` inside the `Card` component.

## Why?
Parity

## Link to supporting Trello card
https://trello.com/c/FJmcsAPk/874-card-standfirst
