### PR TITLE
Card Age

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
         "jest-teamcity-reporter": "^0.9.0",
         "lighthouse": "^5.2.0",
         "lodash.clonedeep": "^4.5.0",
+        "mockdate": "^2.0.5",
         "node-fetch": "^2.2.1",
         "prettier": "^1.18.2",
         "regenerator-runtime": "^0.12.1",

--- a/src/web/components/Card/Card.stories.tsx
+++ b/src/web/components/Card/Card.stories.tsx
@@ -45,6 +45,7 @@ export const defaultStory = () => (
             linkTo="/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse"
             pillar="news"
             headlineString="This is the most basic card view. Cards expand to fit the height and width of their container."
+            webPublicationDate="2019-11-16T09:45:30.000Z"
         />
     </Container>
 );
@@ -56,6 +57,7 @@ export const VerticalSpacing = () => (
             linkTo="/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse"
             pillar="news"
             headlineString="Johnson heckled on tour"
+            webPublicationDate="2019-11-15T09:45:30.000Z"
             prefix={{
                 text: 'Election 2019',
                 pillar: 'news',
@@ -65,6 +67,7 @@ export const VerticalSpacing = () => (
             linkTo="/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse"
             pillar="news"
             headlineString="Johnson shouted at on tour"
+            webPublicationDate="2019-11-14T09:45:30.000Z"
             prefix={{
                 text: 'Election 2019',
                 pillar: 'news',
@@ -74,6 +77,7 @@ export const VerticalSpacing = () => (
             linkTo="/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse"
             pillar="news"
             headlineString="Johnson ignored on tour"
+            webPublicationDate="2019-11-16T09:45:30.000Z"
             prefix={{
                 text: 'Election 2019',
                 pillar: 'news',
@@ -89,6 +93,7 @@ export const HorizontalSpacing = () => (
             linkTo="/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse"
             pillar="news"
             headlineString="Johnson heckled on tour"
+            webPublicationDate="2019-11-12T09:45:30.000Z"
             prefix={{
                 text: 'Election 2019',
                 pillar: 'news',
@@ -98,6 +103,7 @@ export const HorizontalSpacing = () => (
             linkTo="/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse"
             pillar="news"
             headlineString="Johnson shouted at on tour"
+            webPublicationDate="2019-10-16T09:45:30.000Z"
             prefix={{
                 text: 'Election 2019',
                 pillar: 'news',
@@ -107,6 +113,7 @@ export const HorizontalSpacing = () => (
             linkTo="/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse"
             pillar="news"
             headlineString="Johnson ignored on tour"
+            webPublicationDate="2019-11-16T22:45:30.000Z"
             prefix={{
                 text: 'Election 2019',
                 pillar: 'news',
@@ -122,6 +129,7 @@ export const ImageAbove = () => (
             linkTo="/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse"
             pillar="news"
             headlineString="Johnson heckled on tour"
+            webPublicationDate="2019-11-16T09:45:30.000Z"
             prefix={{
                 text: 'Election 2019',
                 pillar: 'news',
@@ -132,6 +140,7 @@ export const ImageAbove = () => (
             linkTo="/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse"
             pillar="news"
             headlineString="Johnson shouted at on tour"
+            webPublicationDate="2019-11-16T09:45:30.000Z"
             prefix={{
                 text: 'Election 2019',
                 pillar: 'news',
@@ -142,6 +151,7 @@ export const ImageAbove = () => (
             linkTo="/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse"
             pillar="news"
             headlineString="Johnson ignored on tour"
+            webPublicationDate="2019-11-16T09:45:30.000Z"
             prefix={{
                 text: 'Election 2019',
                 pillar: 'news',
@@ -224,6 +234,7 @@ export const Standfirst = () => (
             linkTo="/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse"
             pillar="sport"
             headlineString="Johnson heckled on tour"
+            webPublicationDate="2019-11-16T09:45:30.000Z"
             prefix={{
                 text: 'World Cup 2019',
                 pillar: 'sport',
@@ -235,6 +246,7 @@ export const Standfirst = () => (
             linkTo="/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse"
             pillar="sport"
             headlineString="Johnson shouted at on tour"
+            webPublicationDate="2019-11-16T09:45:30.000Z"
             prefix={{
                 text: 'World Cup 2019',
                 showPulsingDot: true,

--- a/src/web/components/Card/Card.stories.tsx
+++ b/src/web/components/Card/Card.stories.tsx
@@ -84,7 +84,7 @@ export const VerticalSpacing = () => (
 VerticalSpacing.story = { name: 'with equal height vertically' };
 
 export const HorizontalSpacing = () => (
-    <Container direction="row" height="100px">
+    <Container direction="row" height="100%">
         <Card
             linkTo="/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse"
             pillar="news"
@@ -126,7 +126,7 @@ export const ImageAbove = () => (
                 text: 'Election 2019',
                 pillar: 'news',
             }}
-            image={{ element: imageElement }}
+            image={{ element: imageElement, position: 'top', size: 'large' }}
         />
         <Card
             linkTo="/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse"
@@ -136,7 +136,7 @@ export const ImageAbove = () => (
                 text: 'Election 2019',
                 pillar: 'news',
             }}
-            image={{ element: imageElement }}
+            image={{ element: imageElement, position: 'top', size: 'large' }}
         />
         <Card
             linkTo="/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse"
@@ -146,7 +146,7 @@ export const ImageAbove = () => (
                 text: 'Election 2019',
                 pillar: 'news',
             }}
-            image={{ element: imageElement }}
+            image={{ element: imageElement, position: 'top', size: 'large' }}
         />
     </Container>
 );

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -16,6 +16,7 @@ import { StandfirstWrapper } from './components/StandfirstWrapper';
 import { TopBar } from './components/TopBar';
 import { CardLink } from './components/CardLink';
 import { CardListItem } from './components/CardListItem';
+import { CardAge } from './components/CardAge';
 
 const decideLayout = (image?: CardImageType) => {
     if (!image) {
@@ -72,6 +73,7 @@ type Props = {
     linkTo: string;
     pillar: Pillar;
     headlineString: string;
+    webPublicationDate?: string;
     prefix?: PrefixType;
     image?: CardImageType;
     standfirst?: string;
@@ -81,6 +83,7 @@ export const Card = ({
     linkTo,
     pillar,
     headlineString,
+    webPublicationDate,
     prefix,
     image,
     standfirst,
@@ -135,6 +138,13 @@ export const Card = ({
                                                 standfirst={standfirst}
                                             />
                                         </StandfirstWrapper>
+                                    )}
+                                    {webPublicationDate && (
+                                        <CardAge
+                                            webPublicationDate={
+                                                webPublicationDate
+                                            }
+                                        />
                                     )}
                                 </div>
                             </ContentWrapper>

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -8,6 +8,7 @@ import { ImageComponent } from '@frontend/web/components/elements/ImageComponent
 
 import { ContentWrapper } from './components/ContentWrapper';
 import { HeadlineWrapper } from './components/HeadlineWrapper';
+import { ImageTopLayout } from './components/ImageTopLayout';
 import { ImageLeftLayout } from './components/ImageLeftLayout';
 import { ImageRightLayout } from './components/ImageRightLayout';
 import { ImageWrapper } from './components/ImageWrapper';
@@ -18,17 +19,17 @@ import { CardListItem } from './components/CardListItem';
 
 const decideLayout = (image?: CardImageType) => {
     if (!image) {
-        return 'div';
+        return ImageTopLayout;
     }
     switch (image.position) {
         case 'top':
-            return 'div';
+            return ImageTopLayout;
         case 'left':
             return ImageLeftLayout;
         case 'right':
             return ImageRightLayout;
         default:
-            return 'div';
+            return ImageTopLayout;
     }
 };
 
@@ -89,9 +90,12 @@ export const Card = ({
 
     // If there was no image given or image size was not set, coverage is null and
     // no flex-basis property is set in the wrappers, so content flows normally
-    const imageCoverage = image && image.size && coverages.image[image.size];
+    const imageCoverage =
+        (image && image.size && coverages.image[image.size]) || '50%';
     const contentCoverage =
-        image && image.size && coverages.content[image.size];
+        (image && image.size && coverages.content[image.size]) || '50%';
+
+    const spaceContent = !image || (image && image.position === 'top');
 
     return (
         <CardListItem>
@@ -112,15 +116,18 @@ export const Card = ({
                                     />
                                 </ImageWrapper>
                             )}
-                            <ContentWrapper coverage={contentCoverage}>
-                                <>
-                                    <HeadlineWrapper>
-                                        <SmallHeadline
-                                            pillar={pillar}
-                                            headlineString={headlineString}
-                                            prefix={prefix}
-                                        />
-                                    </HeadlineWrapper>
+                            <ContentWrapper
+                                coverage={contentCoverage}
+                                spaceContent={spaceContent}
+                            >
+                                <HeadlineWrapper>
+                                    <SmallHeadline
+                                        pillar={pillar}
+                                        headlineString={headlineString}
+                                        prefix={prefix}
+                                    />
+                                </HeadlineWrapper>
+                                <div>
                                     {standfirst && (
                                         <StandfirstWrapper>
                                             <Standfirst
@@ -129,7 +136,7 @@ export const Card = ({
                                             />
                                         </StandfirstWrapper>
                                     )}
-                                </>
+                                </div>
                             </ContentWrapper>
                         </>
                     </Layout>

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -97,8 +97,8 @@ export const Card = ({
         <CardListItem>
             <CardLink
                 linkTo={linkTo}
-                backgroundColour={palette.neutral[93]}
-                backgroundOnHover={palette.neutral[86]}
+                backgroundColour={palette.neutral[97]}
+                backgroundOnHover={palette.neutral[93]}
             >
                 <TopBar topBarColour={palette[pillar].main}>
                     <Layout>

--- a/src/web/components/Card/components/CardAge.tsx
+++ b/src/web/components/Card/components/CardAge.tsx
@@ -39,7 +39,7 @@ export const CardAge = ({ webPublicationDate }: Props) => {
     return (
         <span className={ageStyles}>
             <ClockIcon />
-            <span>{displayString}</span>
+            <time dateTime={webPublicationDate}>{displayString}</time>
         </span>
     );
 };

--- a/src/web/components/Card/components/CardAge.tsx
+++ b/src/web/components/Card/components/CardAge.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { palette } from '@guardian/src-foundations';
+import { textSans } from '@guardian/src-foundations/typography';
+
+import ClockIcon from '@frontend/static/icons/clock.svg';
+
+import { makeRelativeDate } from '@frontend/web/components/lib/dateTime';
+
+const ageStyles = css`
+    ${textSans.xsmall()};
+    color: ${palette.neutral[60]};
+    svg {
+        fill: ${palette.neutral[46]};
+        margin-bottom: -1px;
+        height: 11px;
+        width: 11px;
+        margin-right: 2px;
+    }
+`;
+
+type Props = {
+    webPublicationDate: string;
+};
+
+export const CardAge = ({ webPublicationDate }: Props) => {
+    const displayString = makeRelativeDate(
+        new Date(webPublicationDate).getTime(),
+        {
+            format: 'short',
+        },
+    );
+
+    if (!displayString) {
+        return null;
+    }
+
+    return (
+        <span className={ageStyles}>
+            <ClockIcon />
+            <span>{displayString}</span>
+        </span>
+    );
+};

--- a/src/web/components/Card/components/CardLink.tsx
+++ b/src/web/components/Card/components/CardLink.tsx
@@ -8,6 +8,7 @@ const linkStyles = ({
     backgroundColour: string;
     backgroundOnHover: string;
 }) => css`
+    display: flex;
     /* a tag specific styles */
     color: inherit;
     text-decoration: none;

--- a/src/web/components/Card/components/ContentWrapper.tsx
+++ b/src/web/components/Card/components/ContentWrapper.tsx
@@ -1,22 +1,40 @@
 import React from 'react';
-import { css } from 'emotion';
+import { css, cx } from 'emotion';
+
+const sizingStyles = css`
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+`;
+
+const coverageStyles = (coverage: string) => css`
+    flex-basis: ${coverage && coverage};
+`;
+
+const paddingStyles = css`
+    padding-left: 5px;
+    padding-right: 5px;
+`;
+
+const spacingStyles = css`
+    flex-grow: 1;
+    flex-shrink: 0;
+`;
 
 type Props = {
     children: JSX.Element | JSX.Element[];
     coverage?: CardCoverageType;
+    spaceContent?: boolean;
 };
 
-export const ContentWrapper = ({ children, coverage }: Props) => (
+export const ContentWrapper = ({ children, coverage, spaceContent }: Props) => (
     <div
-        className={css`
-            display: flex;
-            flex-direction: column;
-            justify-content: space-between;
-            flex-basis: ${coverage && coverage};
-
-            padding-left: 5px;
-            padding-right: 5px;
-        `}
+        className={cx(
+            sizingStyles,
+            coverage && coverageStyles(coverage),
+            paddingStyles,
+            spaceContent && spacingStyles,
+        )}
     >
         {children}
     </div>

--- a/src/web/components/Card/components/ImageRightLayout.tsx
+++ b/src/web/components/Card/components/ImageRightLayout.tsx
@@ -10,7 +10,6 @@ export const ImageRightLayout = ({ children }: Props) => (
         className={css`
             display: flex;
             flex-direction: row-reverse;
-            height: 100%;
         `}
     >
         {children}

--- a/src/web/components/Card/components/ImageTopLayout.tsx
+++ b/src/web/components/Card/components/ImageTopLayout.tsx
@@ -5,11 +5,12 @@ type Props = {
     children: JSX.Element | JSX.Element[];
 };
 
-export const ImageLeftLayout = ({ children }: Props) => (
+export const ImageTopLayout = ({ children }: Props) => (
     <div
         className={css`
             display: flex;
-            flex-direction: row;
+            flex-direction: column;
+            width: 100%;
         `}
     >
         {children}

--- a/src/web/components/Card/components/TopBar.tsx
+++ b/src/web/components/Card/components/TopBar.tsx
@@ -9,6 +9,9 @@ type Props = {
 export const TopBar = ({ children, topBarColour }: Props) => (
     <div
         className={css`
+            display: flex;
+            width: 100%;
+
             /* Styling for top bar */
             :before {
                 background-color: ${topBarColour};

--- a/src/web/components/lib/dateTime.test.tsx
+++ b/src/web/components/lib/dateTime.test.tsx
@@ -1,0 +1,95 @@
+import { makeRelativeDate } from './dateTime';
+import MockDate from 'mockdate';
+
+describe('makeRelativeDate', () => {
+    beforeAll(() => {
+        MockDate.set('Sun Nov 17 2019 12:00:00 GMT+0000 (Greenwich Mean Time)');
+    });
+
+    afterAll(() => {
+        MockDate.reset();
+    });
+
+    it('returns a short date string for older dates', () => {
+        const older = new Date(Date.UTC(2019, 1, 1)).getTime();
+        expect(makeRelativeDate(older)).toBe('1 Feb 2019');
+    });
+
+    it('returns seconds for very recent dates', () => {
+        const secondsAgo = new Date(
+            Date.UTC(2019, 10, 17, 11, 59, 30),
+        ).getTime();
+        expect(makeRelativeDate(secondsAgo)).toBe('30s');
+    });
+
+    it('returns minutes for slightly recent dates', () => {
+        const fiveMinutesAgo = new Date(
+            Date.UTC(2019, 10, 17, 11, 55, 0),
+        ).getTime();
+        expect(makeRelativeDate(fiveMinutesAgo)).toBe('5m');
+    });
+
+    it('returns hours for dates within the last 24 hours', () => {
+        const twoHoursAgo = new Date(
+            Date.UTC(2019, 10, 17, 10, 0, 0),
+        ).getTime();
+        expect(makeRelativeDate(twoHoursAgo)).toBe('2h');
+    });
+
+    it('returns days for dates within one week when short option is passed', () => {
+        const twoDaysAgo = new Date(Date.UTC(2019, 10, 15, 13, 0, 0)).getTime();
+        expect(
+            makeRelativeDate(twoDaysAgo, {
+                format: 'short',
+            }),
+        ).toBe('2d');
+    });
+
+    it('returns days with the "ago" text when med option is passed', () => {
+        const twoDaysAgo = new Date(Date.UTC(2019, 10, 15, 13, 0, 0)).getTime();
+
+        expect(
+            makeRelativeDate(twoDaysAgo, {
+                format: 'med',
+            }),
+        ).toBe('2d ago');
+    });
+
+    it('returns "yesterday" correctly', () => {
+        const yesterday = new Date(Date.UTC(2019, 10, 16, 13, 0, 0)).getTime();
+
+        expect(makeRelativeDate(yesterday)).toBe('Yesterday 13:00');
+    });
+
+    it('returns long format for dates within one week when long option given', () => {
+        const twoDaysAgo = new Date(Date.UTC(2019, 10, 15, 13, 0, 0)).getTime();
+        expect(
+            makeRelativeDate(twoDaysAgo, {
+                format: 'long',
+            }),
+        ).toBe('Friday 15 Nov 2019');
+    });
+
+    it('returns short format dates for dates over one week ago, regardless of options', () => {
+        const oneMonthAgo = new Date(Date.UTC(2019, 9, 17, 13, 0, 0)).getTime();
+        expect(makeRelativeDate(oneMonthAgo)).toBe('17 Oct 2019');
+        expect(makeRelativeDate(oneMonthAgo, { format: 'med' })).toBe(
+            '17 Oct 2019',
+        );
+        expect(makeRelativeDate(oneMonthAgo, { format: 'long' })).toBe(
+            '17 Oct 2019',
+        );
+    });
+
+    it('returns false when past any cutoff value given', () => {
+        const twoYearsAgo = new Date(
+            Date.UTC(2017, 10, 17, 10, 0, 0),
+        ).getTime();
+        const oneYearInSeconds = 60 * 60 * 24 * 365;
+        expect(
+            makeRelativeDate(twoYearsAgo, {
+                notAfter: oneYearInSeconds,
+            }),
+        ).toBeFalsy();
+    });
+});

--- a/src/web/components/lib/dateTime.ts
+++ b/src/web/components/lib/dateTime.ts
@@ -125,30 +125,37 @@ export const makeRelativeDate = (
         return false;
     }
 
+    // delta is the number of seconds since the article was published and now
     delta = Math.floor((now.getTime() - then.getTime()) / 1000);
 
     // tslint:disable no-else-after-return because I think
     // the intention reads better with the else statements here
     if (delta < 0) {
+        // Publication dates in the future are not supported
         return false;
     } else if (opts.notAfter && delta > opts.notAfter) {
+        // If article was published before the cutoff (notAfter) bail out
         return false;
     } else if (delta < 55) {
+        // Seconds
         return delta + getSuffix('s', format, delta);
     } else if (delta < 55 * 60) {
+        // Minutes
         minutes = Math.round(delta / 60);
         return minutes + getSuffix('m', format, minutes);
     } else if (isToday(then) || (extendedFormatting && isWithin24Hours(then))) {
+        // Hours
         hours = Math.round(delta / 3600);
         return hours + getSuffix('h', format, hours);
     } else if (extendedFormatting && isWithinPastWeek(then)) {
+        // Days
         days = Math.round(delta / 3600 / 24);
         return days + getSuffix('d', format, days);
     } else if (isYesterday(then)) {
-        // yesterday
+        // Yesterday
         return `Yesterday${withTime(then)}`;
     } else if (delta < 5 * 24 * 60 * 60) {
-        // less than 5 days
+        // Less than 5 days (and *not* extendedFormatting)
         return (
             [
                 dayOfWeek(then.getDay()),
@@ -159,6 +166,7 @@ export const makeRelativeDate = (
         );
     }
     return (
+        // Default: long description + optional time
         [then.getDate(), monthAbbr(then.getMonth()), then.getFullYear()].join(
             ' ',
         ) + (opts.showTime ? withTime(then) : '')

--- a/src/web/components/lib/dateTime.ts
+++ b/src/web/components/lib/dateTime.ts
@@ -1,0 +1,167 @@
+type RelativeDateOptions = {
+    notAfter?: number;
+    format?: FormatType;
+    showTime?: boolean;
+};
+
+type FormatType = 'short' | 'med' | 'long';
+type PeriodType = 's' | 'm' | 'h' | 'd';
+
+const dayOfWeek = (day: number): string =>
+    [
+        'Sunday',
+        'Monday',
+        'Tuesday',
+        'Wednesday',
+        'Thursday',
+        'Friday',
+        'Saturday',
+    ][day];
+
+const monthAbbr = (month: number): string =>
+    [
+        'Jan',
+        'Feb',
+        'Mar',
+        'Apr',
+        'May',
+        'Jun',
+        'Jul',
+        'Aug',
+        'Sep',
+        'Oct',
+        'Nov',
+        'Dec',
+    ][month];
+
+const pad = (n: number): number | string => (n < 10 ? `0${n}` : n);
+
+const isToday = (date: Date): boolean => {
+    const today = new Date();
+    return date && date.toDateString() === today.toDateString();
+};
+
+const isWithin24Hours = (date: Date): boolean => {
+    const today = new Date();
+    return date && date.valueOf() > today.valueOf() - 24 * 60 * 60 * 1000;
+};
+
+const isYesterday = (relative: Date): boolean => {
+    const today = new Date();
+    const yesterday = new Date();
+    yesterday.setDate(today.getDate() - 1);
+    return relative.toDateString() === yesterday.toDateString();
+};
+
+const isWithinPastWeek = (date: Date): boolean => {
+    const weekAgo = new Date().valueOf() - 7 * 24 * 60 * 60 * 1000;
+    return date.valueOf() >= weekAgo;
+};
+
+const isValidDate = (date: Date): boolean => {
+    if (Object.prototype.toString.call(date) !== '[object Date]') {
+        return false;
+    }
+    return !Number.isNaN(date.getTime());
+};
+
+const getSuffix = (
+    type: PeriodType,
+    format: FormatType,
+    value: number,
+): string => {
+    let strs;
+
+    const units = {
+        s: {
+            short: ['s'],
+            med: ['s ago'],
+            long: [' second ago', ' seconds ago'],
+        },
+        m: {
+            short: ['m'],
+            med: ['m ago'],
+            long: [' minute ago', ' minutes ago'],
+        },
+        h: {
+            short: ['h'],
+            med: ['h ago'],
+            long: [' hour ago', ' hours ago'],
+        },
+        d: {
+            short: ['d'],
+            med: ['d ago'],
+            long: [' day ago', ' days ago'],
+        },
+    };
+
+    if (units[type]) {
+        strs = units[type][format];
+        if (value === 1) {
+            return strs[0];
+        }
+        return strs[strs.length - 1];
+    }
+    return '';
+};
+
+const withTime = (date: Date): string =>
+    ` ${date.getHours()}:${pad(date.getMinutes())}`;
+
+export const makeRelativeDate = (
+    epoch: number,
+    opts: RelativeDateOptions = {},
+): false | string => {
+    let minutes;
+    let hours;
+    let days;
+    let delta = 0;
+    const then = new Date(Number(epoch));
+    const now = new Date();
+    const format = opts.format || 'short';
+    const extendedFormatting = opts.format === 'short' || opts.format === 'med';
+
+    if (!isValidDate(then)) {
+        return false;
+    }
+
+    delta = Math.floor((now.getTime() - then.getTime()) / 1000);
+
+    // tslint:disable no-else-after-return because I think
+    // the intention reads better with the else statements here
+    if (delta < 0) {
+        return false;
+    } else if (opts.notAfter && delta > opts.notAfter) {
+        return false;
+    } else if (delta < 55) {
+        return delta + getSuffix('s', format, delta);
+    } else if (delta < 55 * 60) {
+        minutes = Math.round(delta / 60);
+        return minutes + getSuffix('m', format, minutes);
+    } else if (isToday(then) || (extendedFormatting && isWithin24Hours(then))) {
+        hours = Math.round(delta / 3600);
+        return hours + getSuffix('h', format, hours);
+    } else if (extendedFormatting && isWithinPastWeek(then)) {
+        days = Math.round(delta / 3600 / 24);
+        return days + getSuffix('d', format, days);
+    } else if (isYesterday(then)) {
+        // yesterday
+        return `Yesterday${withTime(then)}`;
+    } else if (delta < 5 * 24 * 60 * 60) {
+        // less than 5 days
+        return (
+            [
+                dayOfWeek(then.getDay()),
+                then.getDate(),
+                monthAbbr(then.getMonth()),
+                then.getFullYear(),
+            ].join(' ') + (opts.showTime ? withTime(then) : '')
+        );
+    }
+    return (
+        [then.getDate(), monthAbbr(then.getMonth()), then.getFullYear()].join(
+            ' ',
+        ) + (opts.showTime ? withTime(then) : '')
+    );
+    // tslint:enable no-else-after-return
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -10366,6 +10366,11 @@ mkdirp@0.5.1, mkdirp@0.x, mkdirp@^0.5, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5
   dependencies:
     minimist "0.0.8"
 
+mockdate@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-2.0.5.tgz#70c6abf9ed4b2dae65c81dfc170dd1a5cec53620"
+  integrity sha512-ST0PnThzWKcgSLyc+ugLVql45PvESt3Ul/wrdV/OPc/6Pr8dbLAIJsN1cIp41FLzbN+srVTNIRn+5Cju0nyV6A==
+
 module-details-from-path@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/module-details-from-path/-/module-details-from-path-1.0.3.tgz#114c949673e2a8a35e9d35788527aa37b679da2b"


### PR DESCRIPTION
## What does this change?
Some cards have an age tag at the bottom and this PR adds support for that tag. If the `webPublicationDate` is given to the card, then the tag is calculated and shown with formatting age and option dependent.

Making this element stick to the bottom of the card required a refactor of the layout.

![Screenshot 2019-11-18 at 10 28 51](https://user-images.githubusercontent.com/1336821/69045172-3f794500-09ee-11ea-87a6-7f1dd8f97369.jpg)
![Screenshot 2019-11-18 at 10 28 08](https://user-images.githubusercontent.com/1336821/69045175-4011db80-09ee-11ea-8719-42abe77fc630.jpg)


The decision logic is mostly lifted from the frontend repo [here](https://github.com/guardian/frontend/blob/05614058dc3b3d44ec1e6fd1eff50a2926b4ffed/static/src/javascripts/projects/common/modules/ui/relativedates.js).

I also snuck in a change to the shade of grey used as the default background.

## Why?
To support Related Stories.

## Link to supporting Trello card
https://trello.com/c/RMKKQ69a/876-card-age-tag
