### PR TITLE
Convert CookieBanner to an island

### DIFF
--- a/src/web/browser/cookie.ts
+++ b/src/web/browser/cookie.ts
@@ -6,6 +6,11 @@ const isValidCookieValue = (name: string): boolean =>
 
 const getShortDomain = (isCrossSubdomain = false): string => {
     const domain = document.domain || '';
+
+    if (domain === 'localhost') {
+        return domain;
+    }
+
     // Trim any possible subdomain (will be shared with supporter, identity, etc)
     if (isCrossSubdomain) {
         return ['', ...domain.split('.').slice(-2)].join('.');

--- a/src/web/components/CookieBanner.tsx
+++ b/src/web/components/CookieBanner.tsx
@@ -10,6 +10,7 @@ import { getCookie, addCookie } from '@root/src/web/browser/cookie';
 const banner = css`
     position: fixed;
     bottom: 0;
+    left: 0;
     background-color: ${palette.neutral[20]};
     padding: 10px 0 24px;
     width: 100%;

--- a/src/web/islands/islands.tsx
+++ b/src/web/islands/islands.tsx
@@ -8,6 +8,7 @@ import { MostViewedRight } from '@frontend/web/components/MostViewed/MostViewedR
 import { ShareCount } from '@frontend/web/components/ShareCount';
 import { RichLinkComponent } from '@frontend/web/components/elements/RichLinkComponent';
 import { ReaderRevenueLinks } from '@frontend/web/components/ReaderRevenueLinks';
+import { CookieBanner } from '@frontend/web/components/CookieBanner';
 
 type IslandProps =
     | {
@@ -123,6 +124,11 @@ export const hydrateIslands = (
                 inHeader: false,
             },
             root: 'reader-revenue-links-footer',
+        },
+        {
+            component: CookieBanner,
+            props: {},
+            root: 'cookie-banner',
         },
     ];
 

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -16,7 +16,6 @@ import { palette } from '@guardian/src-foundations';
 import { Header } from '@root/src/web/components/Header/Header';
 import { Footer } from '@root/src/web/components/Footer';
 import { SubNav } from '@root/src/web/components/SubNav/SubNav';
-import { CookieBanner } from '@root/src/web/components/CookieBanner';
 import { OutbrainContainer } from '@root/src/web/components/Outbrain';
 import { Section } from '@root/src/web/components/Section';
 import { Nav } from '@root/src/web/components/Nav/Nav';
@@ -150,6 +149,6 @@ export const ShowcaseLayout = ({ CAPI, config, NAV }: Props) => (
             />
         </Section>
 
-        <CookieBanner />
+        <div data-island="cookie-banner" />
     </>
 );

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -18,7 +18,6 @@ import { palette } from '@guardian/src-foundations';
 import { Header } from '@root/src/web/components/Header/Header';
 import { Footer } from '@root/src/web/components/Footer';
 import { SubNav } from '@root/src/web/components/SubNav/SubNav';
-import { CookieBanner } from '@root/src/web/components/CookieBanner';
 import { OutbrainContainer } from '@root/src/web/components/Outbrain';
 import { Section } from '@root/src/web/components/Section';
 import { Nav } from '@root/src/web/components/Nav/Nav';
@@ -161,7 +160,7 @@ export const StandardLayout = ({ CAPI, config, NAV }: Props) => {
                 />
             </Section>
 
-            <CookieBanner />
+            <Section islandId="cookie-banner" />
         </>
     );
 };

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -160,7 +160,7 @@ export const StandardLayout = ({ CAPI, config, NAV }: Props) => {
                 />
             </Section>
 
-            <Section islandId="cookie-banner" />
+            <div data-island="cookie-banner" />
         </>
     );
 };


### PR DESCRIPTION
## What does this change?

Whilst working on the new CMP (consent management platform) I noticed the current CMP (aka the "Cookie Banner") isn't showing on DCR pages.

The "Cookie Banner" component should be displayed to any users viewing the Guardian who haven't granted consent (users who haven't set the `GU_TK` cookie). 

Currently there's a `<CookieBanner>` component, but the code for it isn't running in the client because it hasn't been converted to an "island". Therefore user's viewing a DCR page never see the banner, even if they should. This PR fixes that.

## Why?

Get user's consent state for third party tracking and personalised ads.

## Screenshot (mobile)

![cmp-dcr](https://user-images.githubusercontent.com/1590704/69072425-87668f00-0a23-11ea-8e96-bc66e24adca9.gif)
