### PR TITLE
Adding MostViewedRight to Standard and Showcase layouts

### DIFF
--- a/cypress/fixtures/mostReadGeo.json
+++ b/cypress/fixtures/mostReadGeo.json
@@ -1,0 +1,96 @@
+{
+    "heading": "Across The&nbsp;Guardian",
+    "trails": [
+        {
+            "url": "https://www.theguardian.com/politics/live/2019/oct/16/brexit-boris-johnson-races-the-clock-as-deadline-for-deal-looms-politics-live",
+            "linkText": "Brexit: Irish PM hints extra EU summit  might be needed because 'many issues' still to be resolved– live news",
+            "showByline": false,
+            "byline": "Andrew Sparrow (now);  Sarah Marsh and Kate Lyons (earlier)",
+            "image": "https://i.guim.co.uk/img/media/2623bdff1d63a85d76c8a86231b0dbeda59649c4/87_0_3325_1996/master/3325.jpg?width=300&quality=85&auto=format&fit=max&s=a0881e9682459be5acf622916ce20f29",
+            "isLiveBlog": true,
+            "pillar": "news"
+        },
+        {
+            "url": "https://www.theguardian.com/us-news/2019/oct/15/harry-dunn-parents-trump-white-house-anne-sacoolas",
+            "linkText": "Harry Dunn parents: Trump shocked us by revealing Sacoolas was in next room",
+            "showByline": false,
+            "byline": "David Smith in Washington",
+            "image": "https://i.guim.co.uk/img/media/e7636de4a7f92973965f780869ab51a653ce0f6c/0_0_5010_3007/master/5010.jpg?width=300&quality=85&auto=format&fit=max&s=e2f72ae40f776ebbfce3a2dfb8bab428",
+            "isLiveBlog": false,
+            "pillar": "news",
+            "ageWarning": "5 months"
+        },
+        {
+            "url": "https://www.theguardian.com/politics/2019/oct/16/brexit-talks-continue-after-boris-johnson-makes-concessions-on-irish-border",
+            "linkText": "Brexit talks continue after Boris Johnson makes concessions on Irish border",
+            "showByline": false,
+            "byline": "Daniel Boffey in Brussels",
+            "image": "https://i.guim.co.uk/img/media/937596849031d67dea0dd34e8043b5ecf139c3cf/0_76_2117_1270/master/2117.jpg?width=300&quality=85&auto=format&fit=max&s=bbfcb659e272cfc6a2a6b8d3088abc75",
+            "isLiveBlog": false,
+            "pillar": "news"
+        },
+        {
+            "url": "https://www.theguardian.com/education/2019/oct/16/oxford-professor-dirk-obbink-ancient-bible-fragments-hobby-lobby",
+            "linkText": "Oxford professor accused of selling ancient Bible fragments",
+            "showByline": false,
+            "byline": "Peter Beaumont",
+            "image": "https://i.guim.co.uk/img/media/4f578aaef55d9adb75bc8d9d18d48f2a6f96556e/0_67_5413_3248/master/5413.jpg?width=300&quality=85&auto=format&fit=max&s=26b0dcc7213c5bf95f17ef6977388518",
+            "isLiveBlog": false,
+            "pillar": "news"
+        },
+        {
+            "url": "https://www.theguardian.com/us-news/2019/oct/15/democratic-debate-joe-biden-elizabeth-warren-bernie-sanders",
+            "linkText": "Warren under attack as Democrats spar in largest primary debate in US history",
+            "showByline": false,
+            "byline": "Lauren Gambino in Westerville, Ohio",
+            "image": "https://i.guim.co.uk/img/media/da0fae452159c3de9a13a97b51c55a705db77d2a/174_547_4770_2861/master/4770.jpg?width=300&quality=85&auto=format&fit=max&s=83a4bcad510dee0a6235980e747b535c",
+            "isLiveBlog": false,
+            "pillar": "news"
+        },
+        {
+            "url": "https://www.theguardian.com/politics/2019/oct/15/boris-johnson-close-to-brexit-deal-after-border-concessions",
+            "linkText": "Boris Johnson 'on brink of Brexit deal' after border concessions",
+            "showByline": false,
+            "byline": "Daniel Boffey in Luxembourg Jon Henley in Paris, Lisa O'Carroll and Rowena Mason",
+            "image": "https://i.guim.co.uk/img/media/937596849031d67dea0dd34e8043b5ecf139c3cf/0_96_2117_1270/master/2117.jpg?width=300&quality=85&auto=format&fit=max&s=4b6e623d7242c6b6303667e44525a7f1",
+            "isLiveBlog": false,
+            "pillar": "news"
+        },
+        {
+            "url": "https://www.theguardian.com/world/2019/oct/15/six-freed-after-years-living-in-dutch-cellar-waiting-for-end-of-time",
+            "linkText": "Six freed after years living in Dutch cellar 'waiting for end of time'",
+            "showByline": false,
+            "byline": "Jon Henley Europe correspondent",
+            "image": "https://i.guim.co.uk/img/media/d96284ece6ab5f8ea750f91a374a1d90c62367bc/128_0_3736_2242/master/3736.jpg?width=300&quality=85&auto=format&fit=max&s=0d43667605d2336ad82ea6643a919e6d",
+            "isLiveBlog": false,
+            "pillar": "news"
+        },
+        {
+            "url": "https://www.theguardian.com/books/2019/oct/16/me-elton-john-autobiography-review",
+            "linkText": "Me by Elton John review – hilariously self-lacerating",
+            "showByline": false,
+            "byline": "Hadley Freeman",
+            "image": "https://i.guim.co.uk/img/media/a7b7c5de6b16c53c52520ff54d4432787be9caa7/109_0_3281_1969/master/3281.jpg?width=300&quality=85&auto=format&fit=max&s=9e35a9aed3ef36887361a5fec9ef63b2",
+            "isLiveBlog": false,
+            "pillar": "culture"
+        },
+        {
+            "url": "https://www.theguardian.com/us-news/2019/oct/15/twitter-explains-how-it-handles-world-leaders-amid-pressure-to-rein-in-trump",
+            "linkText": "Twitter lays out rules for world leaders amid pressure to rein in Trump",
+            "showByline": false,
+            "byline": "Julia Carrie Wong in San Francisco",
+            "image": "https://i.guim.co.uk/img/media/47977c2eda35081186798f13247ca3352a7df663/0_58_3617_2170/master/3617.jpg?width=300&quality=85&auto=format&fit=max&s=77c0920357a1aa6efc6014e14d23bb71",
+            "isLiveBlog": false,
+            "pillar": "news"
+        },
+        {
+            "url": "https://www.theguardian.com/film/2019/oct/15/jennifer-anistons-instagram-debut-sends-platform-crashing",
+            "linkText": "Jennifer Aniston’s Instagram debut sends platform crashing",
+            "showByline": false,
+            "byline": "Martha Brennan",
+            "image": "https://i.guim.co.uk/img/media/fb8b96b9bac6df0e8992b4016c3baea8831e70fa/0_241_640_384/master/640.jpg?width=300&quality=85&auto=format&fit=max&s=1c704f506904ac8a8ffe300ba79eff46",
+            "isLiveBlog": false,
+            "pillar": "culture"
+        }
+    ]
+}

--- a/cypress/integration/e2e/article.e2e.spec.js
+++ b/cypress/integration/e2e/article.e2e.spec.js
@@ -22,6 +22,13 @@ describe('E2E Page rendering', function() {
                     cy.contains('Most popular');
                 });
 
+                cy.wait('@getMostReadGeo').then(xhr => {
+                    expect(xhr.response.body).to.have.property('heading');
+                    expect(xhr.status).to.be.equal(200);
+
+                    cy.contains('most viewed');
+                });
+
                 cy.wait('@getShareCount').then(xhr => {
                     expect(xhr.status).to.be.equal(200);
                     expect(xhr.response.body).to.have.property('path');

--- a/cypress/lib/mocks.js
+++ b/cypress/lib/mocks.js
@@ -15,6 +15,12 @@ export const mockApi = () => {
     // Mock most-read
     cy.route({
         method: 'GET',
+        url: '**/most-read-geo**',
+        response: 'fixture:mostReadGeo.json',
+    });
+    // Mock most-read
+    cy.route({
+        method: 'GET',
         url: '/embed/card/**',
         response: 'fixture:richLink.json',
     });

--- a/src/web/components/MostViewed/MostViewedRight/MostViewedRight.tsx
+++ b/src/web/components/MostViewed/MostViewedRight/MostViewedRight.tsx
@@ -34,7 +34,7 @@ export const MostViewedRight = ({ limitItems = 5 }: Props) => {
             <div className={wrapperStyles}>
                 <GuardianLines count={4} />
                 <h3 className={headingStyles}>most viewed</h3>
-                <div>
+                <ul>
                     {(data.trails || [])
                         .slice(0, limitItems)
                         .map((trail: TrailType, ii: number) => (
@@ -43,7 +43,7 @@ export const MostViewedRight = ({ limitItems = 5 }: Props) => {
                                 trail={trail}
                             />
                         ))}
-                </div>
+                </ul>
             </div>
         );
     }

--- a/src/web/components/MostViewed/MostViewedRight/MostViewedRightItem.tsx
+++ b/src/web/components/MostViewed/MostViewedRight/MostViewedRightItem.tsx
@@ -20,6 +20,7 @@ const listItemStyles = css`
 `;
 
 const linkTagStyles = css`
+    display: flex;
     text-decoration: none;
     font-weight: 500;
     ${headline.tiny()};
@@ -30,11 +31,8 @@ const linkTagStyles = css`
     }
 `;
 
-const textWrapperStyles = css`
-    display: flex;
-`;
-
 const headlineWrapperStyles = css`
+    width: calc(100% - 82px);
     display: flex;
     flex-direction: column;
 `;
@@ -58,8 +56,6 @@ const imageTagStyles = css`
     left: -24px;
     clip-path: circle(36% at 50% 50%);
 `;
-
-const ageWarningStyles = css``;
 
 type Props = {
     trail: TrailType;
@@ -89,37 +85,30 @@ export const MostViewedRightItem = ({ trail }: Props) => {
                 data-link-name={'article'}
                 ref={hoverRef}
             >
-                <div className={textWrapperStyles}>
-                    <div className={imageWrapperStyles}>
-                        <img
-                            src={trail.image}
-                            role="presentation"
-                            alt=""
-                            className={imageTagStyles}
-                        />
-                    </div>
-                    <div className={headlineWrapperStyles}>
-                        <SmallHeadline
-                            headlineString={trail.linkText}
-                            pillar={trail.pillar}
-                            size="tiny"
-                            showUnderline={isHovered}
-                            {...itemProps}
-                            link={{
-                                to: trail.url,
-                                visitedColour: palette.neutral[46],
-                                preventFocus: true,
-                            }}
-                        />
-                        {trail.ageWarning && (
-                            <div className={ageWarningStyles}>
-                                <AgeWarning
-                                    age={trail.ageWarning}
-                                    size="small"
-                                />
-                            </div>
-                        )}
-                    </div>
+                <div className={imageWrapperStyles}>
+                    <img
+                        src={trail.image}
+                        role="presentation"
+                        alt=""
+                        className={imageTagStyles}
+                    />
+                </div>
+                <div className={headlineWrapperStyles}>
+                    <SmallHeadline
+                        headlineString={trail.linkText}
+                        pillar={trail.pillar}
+                        size="tiny"
+                        showUnderline={isHovered}
+                        {...itemProps}
+                        link={{
+                            to: trail.url,
+                            visitedColour: palette.neutral[46],
+                            preventFocus: true,
+                        }}
+                    />
+                    {trail.ageWarning && (
+                        <AgeWarning age={trail.ageWarning} size="small" />
+                    )}
                 </div>
             </a>
         </li>

--- a/src/web/components/MostViewed/MostViewedRight/MostViewedRightItem.tsx
+++ b/src/web/components/MostViewed/MostViewedRight/MostViewedRightItem.tsx
@@ -20,7 +20,6 @@ const listItemStyles = css`
 `;
 
 const linkTagStyles = css`
-    display: flex;
     text-decoration: none;
     font-weight: 500;
     ${headline.tiny()};
@@ -29,6 +28,10 @@ const linkTagStyles = css`
     &:active {
         color: ${palette.neutral[7]};
     }
+`;
+
+const lineWrapperStyles = css`
+    display: flex;
 `;
 
 const headlineWrapperStyles = css`
@@ -85,30 +88,32 @@ export const MostViewedRightItem = ({ trail }: Props) => {
                 data-link-name={'article'}
                 ref={hoverRef}
             >
-                <div className={imageWrapperStyles}>
-                    <img
-                        src={trail.image}
-                        role="presentation"
-                        alt=""
-                        className={imageTagStyles}
-                    />
-                </div>
-                <div className={headlineWrapperStyles}>
-                    <SmallHeadline
-                        headlineString={trail.linkText}
-                        pillar={trail.pillar}
-                        size="tiny"
-                        showUnderline={isHovered}
-                        {...itemProps}
-                        link={{
-                            to: trail.url,
-                            visitedColour: palette.neutral[46],
-                            preventFocus: true,
-                        }}
-                    />
-                    {trail.ageWarning && (
-                        <AgeWarning age={trail.ageWarning} size="small" />
-                    )}
+                <div className={lineWrapperStyles}>
+                    <div className={imageWrapperStyles}>
+                        <img
+                            src={trail.image}
+                            role="presentation"
+                            alt=""
+                            className={imageTagStyles}
+                        />
+                    </div>
+                    <div className={headlineWrapperStyles}>
+                        <SmallHeadline
+                            headlineString={trail.linkText}
+                            pillar={trail.pillar}
+                            size="tiny"
+                            showUnderline={isHovered}
+                            {...itemProps}
+                            link={{
+                                to: trail.url,
+                                visitedColour: palette.neutral[46],
+                                preventFocus: true,
+                            }}
+                        />
+                        {trail.ageWarning && (
+                            <AgeWarning age={trail.ageWarning} size="small" />
+                        )}
+                    </div>
                 </div>
             </a>
         </li>

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -115,6 +115,7 @@ export const ShowcaseLayout = ({ CAPI, config, NAV }: Props) => (
                         </div>
                         <ArticleRight>
                             <StickyAd config={config} />
+                            <div data-island="most-viewed-right" />
                         </ArticleRight>
                     </Flex>
                 </ArticleContainer>

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -128,6 +128,7 @@ export const StandardLayout = ({ CAPI, config, NAV }: Props) => {
                     </ArticleContainer>
                     <ArticleRight>
                         <StickyAd config={config} />
+                        <div data-island="most-viewed-right" />
                     </ArticleRight>
                 </Flex>
             </Section>


### PR DESCRIPTION
##  What does this change?
Adds the `MostViewedRight` component to the desktop sidebar of both StandardLayout and ShowcaseLayout, below the Sticky Ad.

## Why?
Because we now have a MostViewedRight component that fully supports the design requirements and we want to render it in both article layouts for parity with `frontend`.

## Link to supporting Trello card
https://trello.com/c/S9IJVSa7/884-add-mostviewed-component-to-standard-and-showcase-layouts

## Screenshots
![Screenshot 2019-11-19 at 13 11 21](https://user-images.githubusercontent.com/1692169/69149325-247e0200-0ace-11ea-8335-00484e6cafd5.png)
![2019-11-19 13 05 27](https://user-images.githubusercontent.com/1692169/69149359-3790d200-0ace-11ea-994d-d2180ef332c9.gif)

