### PR TITLE
Hotfix - Removes MostViewedSide from Standard & Showcase layouts while we work on a fix

### DIFF
--- a/cypress/integration/e2e/article.e2e.spec.js
+++ b/cypress/integration/e2e/article.e2e.spec.js
@@ -22,13 +22,6 @@ describe('E2E Page rendering', function() {
                     cy.contains('Most popular');
                 });
 
-                cy.wait('@getMostReadGeo').then(xhr => {
-                    expect(xhr.response.body).to.have.property('heading');
-                    expect(xhr.status).to.be.equal(200);
-
-                    cy.contains('most viewed');
-                });
-
                 cy.wait('@getShareCount').then(xhr => {
                     expect(xhr.status).to.be.equal(200);
                     expect(xhr.response.body).to.have.property('path');

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -115,7 +115,6 @@ export const ShowcaseLayout = ({ CAPI, config, NAV }: Props) => (
                         </div>
                         <ArticleRight>
                             <StickyAd config={config} />
-                            <div data-island="most-viewed-right" />
                         </ArticleRight>
                     </Flex>
                 </ArticleContainer>

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -128,7 +128,6 @@ export const StandardLayout = ({ CAPI, config, NAV }: Props) => {
                     </ArticleContainer>
                     <ArticleRight>
                         <StickyAd config={config} />
-                        <div data-island="most-viewed-right" />
                     </ArticleRight>
                 </Flex>
             </Section>


### PR DESCRIPTION
## What does this change?
Safely removes MostViewedRight from the article layouts where it's being used.

## Why?
To give us time to properly investigate all the conditions we need to ensure the component is only rendered when the article is long enough to accommodate all the components in the sidebar.

## Link to supporting Trello card
https://trello.com/c/hiPN7kGv/893-remove-mostviewedright-from-standard-showcase-layouts