### PR TITLE
Add W3 validation logo

### DIFF
--- a/src/web/components/Footer.tsx
+++ b/src/web/components/Footer.tsx
@@ -240,5 +240,15 @@ export const Footer: React.FC<{
             © {year} Guardian News & Media Limited or its affiliated companies.
             All rights reserved. (beta)
         </div>
+        <p>
+            <a href="http://validator.w3.org/check?uri=referer">
+                <img
+                    src="http://www.w3.org/Icons/valid-xhtml10"
+                    alt="Valid XHTML 1.0 Transitional"
+                    height="31"
+                    width="88"
+                />
+            </a>
+        </p>
     </footer>
 );


### PR DESCRIPTION
## What does this change?

W3 suggests adding a validation logo to valid sites:

<img width="1391" alt="Screenshot 2019-11-20 at 17 06 46" src="https://user-images.githubusercontent.com/858402/69261657-e100c200-0bb9-11ea-9658-cc4f3a69eb1c.png">

I noticed this when checking how valid we are. (There are some issues we should fix.)

Therefore, I've added:

<img width="1391" alt="Screenshot 2019-11-20 at 17 09 16" src="https://user-images.githubusercontent.com/858402/69261684-f1b13800-0bb9-11ea-910b-981475f40c88.png">

cc'ing @rcrphillips for final approval but guessing we want this.

## Why?

Appeal to authority.

## Link to supporting Trello card

n/a
