### PR TITLE
Create JSXElements type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -357,7 +357,7 @@ interface Props {
     data: DCRDocumentData; // Do not fall to the tempation to rename 'data' into something else
 }
 
-type ChildrenType = JSX.Element | JSX.Element[];
+type JSXElements = JSX.Element | JSX.Element[];
 
 interface TrailType {
     url: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -356,6 +356,8 @@ interface Props {
     data: DCRDocumentData; // Do not fall to the tempation to rename 'data' into something else
 }
 
+type ChildrenType = JSX.Element | JSX.Element[];
+
 // ------------------------------
 // 3rd party type declarations //
 // ------------------------------

--- a/src/web/components/ArticleContainer.tsx
+++ b/src/web/components/ArticleContainer.tsx
@@ -71,7 +71,7 @@ const articleAdStyles = css`
 `;
 
 type Props = {
-    children: JSX.Element | JSX.Element[];
+    children: ChildrenType;
 };
 
 export const ArticleContainer = ({ children }: Props) => {

--- a/src/web/components/ArticleContainer.tsx
+++ b/src/web/components/ArticleContainer.tsx
@@ -71,7 +71,7 @@ const articleAdStyles = css`
 `;
 
 type Props = {
-    children: ChildrenType;
+    children: JSXElements;
 };
 
 export const ArticleContainer = ({ children }: Props) => {

--- a/src/web/components/ArticleLeft.tsx
+++ b/src/web/components/ArticleLeft.tsx
@@ -30,7 +30,7 @@ const rightBorder = (colour: string) => css`
 `;
 
 type Props = {
-    children: ChildrenType;
+    children: JSXElements;
     showRightBorder?: boolean;
     borderColour?: string;
 };

--- a/src/web/components/ArticleLeft.tsx
+++ b/src/web/components/ArticleLeft.tsx
@@ -30,7 +30,7 @@ const rightBorder = (colour: string) => css`
 `;
 
 type Props = {
-    children: JSX.Element | JSX.Element[];
+    children: ChildrenType;
     showRightBorder?: boolean;
     borderColour?: string;
 };

--- a/src/web/components/ArticleRight.tsx
+++ b/src/web/components/ArticleRight.tsx
@@ -25,7 +25,7 @@ const padding = css`
 `;
 
 type Props = {
-    children: ChildrenType;
+    children: JSXElements;
 };
 
 export const ArticleRight = ({ children }: Props) => {

--- a/src/web/components/ArticleRight.tsx
+++ b/src/web/components/ArticleRight.tsx
@@ -25,7 +25,7 @@ const padding = css`
 `;
 
 type Props = {
-    children: JSX.Element | JSX.Element[];
+    children: ChildrenType;
 };
 
 export const ArticleRight = ({ children }: Props) => {

--- a/src/web/components/Cards/Card/components/CardLink.tsx
+++ b/src/web/components/Cards/Card/components/CardLink.tsx
@@ -34,7 +34,7 @@ const linkStyles = ({
 `;
 
 type Props = {
-    children: JSX.Element | JSX.Element[];
+    children: ChildrenType;
     linkTo: string;
     backgroundColour: string;
     backgroundOnHover: string;

--- a/src/web/components/Cards/Card/components/CardLink.tsx
+++ b/src/web/components/Cards/Card/components/CardLink.tsx
@@ -34,7 +34,7 @@ const linkStyles = ({
 `;
 
 type Props = {
-    children: ChildrenType;
+    children: JSXElements;
     linkTo: string;
     backgroundColour: string;
     backgroundOnHover: string;

--- a/src/web/components/Cards/Card/components/CardListItem.tsx
+++ b/src/web/components/Cards/Card/components/CardListItem.tsx
@@ -19,7 +19,7 @@ const listStyles = (percentage?: CardPercentageType) => css`
 `;
 
 type Props = {
-    children: ChildrenType;
+    children: JSXElements;
     percentage?: CardPercentageType;
 };
 

--- a/src/web/components/Cards/Card/components/CardListItem.tsx
+++ b/src/web/components/Cards/Card/components/CardListItem.tsx
@@ -19,7 +19,7 @@ const listStyles = (percentage?: CardPercentageType) => css`
 `;
 
 type Props = {
-    children: JSX.Element | JSX.Element[];
+    children: ChildrenType;
     percentage?: CardPercentageType;
 };
 

--- a/src/web/components/Cards/Card/components/ContentWrapper.tsx
+++ b/src/web/components/Cards/Card/components/ContentWrapper.tsx
@@ -22,7 +22,7 @@ const spacingStyles = css`
 `;
 
 type Props = {
-    children: JSX.Element | JSX.Element[];
+    children: ChildrenType;
     percentage?: CardPercentageType;
     spaceContent?: boolean;
 };

--- a/src/web/components/Cards/Card/components/ContentWrapper.tsx
+++ b/src/web/components/Cards/Card/components/ContentWrapper.tsx
@@ -22,7 +22,7 @@ const spacingStyles = css`
 `;
 
 type Props = {
-    children: ChildrenType;
+    children: JSXElements;
     percentage?: CardPercentageType;
     spaceContent?: boolean;
 };

--- a/src/web/components/Cards/Card/components/HeadlineWrapper.tsx
+++ b/src/web/components/Cards/Card/components/HeadlineWrapper.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 type Props = {
-    children: ChildrenType;
+    children: JSXElements;
 };
 
 export const HeadlineWrapper = ({ children }: Props) => (

--- a/src/web/components/Cards/Card/components/HeadlineWrapper.tsx
+++ b/src/web/components/Cards/Card/components/HeadlineWrapper.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 type Props = {
-    children: JSX.Element | JSX.Element[];
+    children: ChildrenType;
 };
 
 export const HeadlineWrapper = ({ children }: Props) => (

--- a/src/web/components/Cards/Card/components/ImageLeftLayout.tsx
+++ b/src/web/components/Cards/Card/components/ImageLeftLayout.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 type Props = {
-    children: ChildrenType;
+    children: JSXElements;
 };
 
 export const ImageLeftLayout = ({ children }: Props) => (

--- a/src/web/components/Cards/Card/components/ImageLeftLayout.tsx
+++ b/src/web/components/Cards/Card/components/ImageLeftLayout.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 type Props = {
-    children: JSX.Element | JSX.Element[];
+    children: ChildrenType;
 };
 
 export const ImageLeftLayout = ({ children }: Props) => (

--- a/src/web/components/Cards/Card/components/ImageRightLayout.tsx
+++ b/src/web/components/Cards/Card/components/ImageRightLayout.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 type Props = {
-    children: ChildrenType;
+    children: JSXElements;
 };
 
 export const ImageRightLayout = ({ children }: Props) => (

--- a/src/web/components/Cards/Card/components/ImageRightLayout.tsx
+++ b/src/web/components/Cards/Card/components/ImageRightLayout.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 type Props = {
-    children: JSX.Element | JSX.Element[];
+    children: ChildrenType;
 };
 
 export const ImageRightLayout = ({ children }: Props) => (

--- a/src/web/components/Cards/Card/components/ImageTopLayout.tsx
+++ b/src/web/components/Cards/Card/components/ImageTopLayout.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 type Props = {
-    children: JSX.Element | JSX.Element[];
+    children: ChildrenType;
 };
 
 export const ImageTopLayout = ({ children }: Props) => (

--- a/src/web/components/Cards/Card/components/ImageTopLayout.tsx
+++ b/src/web/components/Cards/Card/components/ImageTopLayout.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 type Props = {
-    children: ChildrenType;
+    children: JSXElements;
 };
 
 export const ImageTopLayout = ({ children }: Props) => (

--- a/src/web/components/Cards/Card/components/ImageWrapper.tsx
+++ b/src/web/components/Cards/Card/components/ImageWrapper.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 type Props = {
-    children: ChildrenType;
+    children: JSXElements;
     percentage?: CardPercentageType;
 };
 

--- a/src/web/components/Cards/Card/components/ImageWrapper.tsx
+++ b/src/web/components/Cards/Card/components/ImageWrapper.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 type Props = {
-    children: JSX.Element | JSX.Element[];
+    children: ChildrenType;
     percentage?: CardPercentageType;
 };
 

--- a/src/web/components/Cards/Card/components/StandfirstWrapper.tsx
+++ b/src/web/components/Cards/Card/components/StandfirstWrapper.tsx
@@ -4,7 +4,7 @@ import { css } from 'emotion';
 import { body } from '@guardian/src-foundations/typography';
 
 type Props = {
-    children: JSX.Element | JSX.Element[];
+    children: ChildrenType;
 };
 
 export const StandfirstWrapper = ({ children }: Props) => (

--- a/src/web/components/Cards/Card/components/StandfirstWrapper.tsx
+++ b/src/web/components/Cards/Card/components/StandfirstWrapper.tsx
@@ -4,7 +4,7 @@ import { css } from 'emotion';
 import { body } from '@guardian/src-foundations/typography';
 
 type Props = {
-    children: ChildrenType;
+    children: JSXElements;
 };
 
 export const StandfirstWrapper = ({ children }: Props) => (

--- a/src/web/components/Cards/Card/components/TopBar.tsx
+++ b/src/web/components/Cards/Card/components/TopBar.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 type Props = {
-    children: JSX.Element | JSX.Element[];
+    children: ChildrenType;
     topBarColour: string;
 };
 

--- a/src/web/components/Cards/Card/components/TopBar.tsx
+++ b/src/web/components/Cards/Card/components/TopBar.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 type Props = {
-    children: ChildrenType;
+    children: JSXElements;
     topBarColour: string;
 };
 

--- a/src/web/components/Flex.tsx
+++ b/src/web/components/Flex.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 type Props = {
-    children: JSX.Element | JSX.Element[];
+    children: ChildrenType;
     direction?: 'row' | 'column';
     justify?: 'space-between'; // Extend as required
 };

--- a/src/web/components/Flex.tsx
+++ b/src/web/components/Flex.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 type Props = {
-    children: ChildrenType;
+    children: JSXElements;
     direction?: 'row' | 'column';
     justify?: 'space-between'; // Extend as required
 };

--- a/src/web/components/HeaderItem.tsx
+++ b/src/web/components/HeaderItem.tsx
@@ -14,7 +14,7 @@ const setOrder = (order: number) => css`
 `;
 
 type Props = {
-    children: ChildrenType;
+    children: JSXElements;
     order: number;
 };
 

--- a/src/web/components/HeaderItem.tsx
+++ b/src/web/components/HeaderItem.tsx
@@ -14,7 +14,7 @@ const setOrder = (order: number) => css`
 `;
 
 type Props = {
-    children: JSX.Element | JSX.Element[];
+    children: ChildrenType;
     order: number;
 };
 

--- a/src/web/components/Hide.tsx
+++ b/src/web/components/Hide.tsx
@@ -3,7 +3,7 @@ import { css } from 'emotion';
 import { until, from, Breakpoint } from '@guardian/src-foundations/mq';
 
 type Props = {
-    children: ChildrenType;
+    children: JSXElements;
     when: 'above' | 'below';
     breakpoint: Breakpoint;
 };

--- a/src/web/components/Hide.tsx
+++ b/src/web/components/Hide.tsx
@@ -3,7 +3,7 @@ import { css } from 'emotion';
 import { until, from, Breakpoint } from '@guardian/src-foundations/mq';
 
 type Props = {
-    children: JSX.Element | JSX.Element[];
+    children: ChildrenType;
     when: 'above' | 'below';
     breakpoint: Breakpoint;
 };

--- a/src/web/components/LI.tsx
+++ b/src/web/components/LI.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 type Props = {
-    children: ChildrenType;
+    children: JSXElements;
     percentage?: CardPercentageType;
 };
 

--- a/src/web/components/LI.tsx
+++ b/src/web/components/LI.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 type Props = {
-    children: JSX.Element | JSX.Element[];
+    children: ChildrenType;
     percentage?: CardPercentageType;
 };
 

--- a/src/web/components/UL.tsx
+++ b/src/web/components/UL.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 type Props = {
-    children: ChildrenType;
+    children: JSXElements;
     direction?: 'row' | 'column';
 };
 

--- a/src/web/components/UL.tsx
+++ b/src/web/components/UL.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 type Props = {
-    children: JSX.Element | JSX.Element[];
+    children: ChildrenType;
     direction?: 'row' | 'column';
 };
 


### PR DESCRIPTION
## What does this change?
This replaces the often repeated pattern of using `JSX.Element | JSX.Element[];` with a central type of `type JSXElements = JSX.Element | JSX.Element[];`

## Why?
For brevity

## Link to supporting Trello card
https://trello.com/c/5X6W6yg7/885-create-childrentype-type
