### PR TITLE
Implement window.guardian.config.page.dcrCouldRender

### DIFF
--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -5,6 +5,7 @@ export interface WindowGuardianConfig {
     stage: stage;
     frontendAssetsFullURL: string;
     page: {
+        dcrCouldRender: boolean;
         contentType: string;
         edition: Edition;
         revisionNumber: string;
@@ -34,6 +35,7 @@ const makeWindowGuardianConfig = (
         stage: dcrDocumentData.config.stage,
         frontendAssetsFullURL: dcrDocumentData.config.frontendAssetsFullURL,
         page: Object.assign(dcrDocumentData.config, {
+            dcrCouldRender: true,
             contentType: dcrDocumentData.CAPI.contentType,
             edition: dcrDocumentData.CAPI.editionId,
             revisionNumber: dcrDocumentData.config.revisionNumber,


### PR DESCRIPTION
## What does this change?

Hardcode an expected `window.guardian.config.page.dcrCouldRender` (the value is always `true` when the page was rendered by DCR).
