### PR TITLE
Code Snippets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ node_modules
 .idea
 .vscode/*
 !.vscode/extensions.json
+!.vscode/dcr.code-snippets
 
 # System files
 .DS_Store

--- a/.vscode/dcr.code-snippets
+++ b/.vscode/dcr.code-snippets
@@ -1,0 +1,34 @@
+{
+    // Place your dotcom-rendering workspace snippets here. Each snippet is defined under a snippet name and has a scope, prefix, body and
+    // description. Add comma separated ids of the languages where the snippet is applicable in the scope field. If scope
+    // is left empty or omitted, the snippet gets applied to all languages. The prefix is what is
+    // used to trigger the snippet and the body will be expanded and inserted. Possible variables are:
+    // $1, $2 for tab stops, $0 for the final cursor position, and ${1:label}, ${2:another} for placeholders.
+    // Placeholders with the same ids are connected.
+    // Example:
+    // "Print to console": {
+    // 	"scope": "javascript,typescript",
+    // 	"prefix": "log",
+    // 	"body": [
+    // 		"console.log('$1');",
+    // 		"$2"
+    // 	],
+    // 	"description": "Log output to console"
+    // }
+
+    "React wrapper component": {
+        "prefix": "rw",
+        "body": [
+            "import React from 'react';",
+            "",
+            "type Props = {",
+            "  children: JSX.Element | JSX.Element[];",
+            "}",
+            "",
+            "export const $TM_FILENAME_BASE = ({ children }: Props) => ($1",
+            "  <div>{children}</div>",
+            ");"
+        ],
+        "description": "React wrapper component"
+    }
+}


### PR DESCRIPTION
## What does this change?
Adds a file to contain code snippets for use in VSCode

If you type `rw` in a new file it will generate boilerplate for a standard react wrapper component.

[This site](https://snippet-generator.app/) is good for generating new ones.

![2019-11-22 09 55 02](https://user-images.githubusercontent.com/1336821/69416545-c2f8a600-0d0e-11ea-9e38-bf8e6dace46e.gif)


## Why?
To improve the developer experience

## Link to supporting Trello card
https://trello.com/c/WmlXfWWF/904-code-snippets
