### PR TITLE
Simplify ShareCount Props

### DIFF
--- a/src/web/components/ShareCount.test.tsx
+++ b/src/web/components/ShareCount.test.tsx
@@ -12,31 +12,9 @@ jest.mock('@frontend/web/components/lib/api', () => ({
 }));
 
 describe('ShareCount', () => {
-    const config: ConfigType = {
-        ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
-        sentryHost: '',
-        sentryPublicApiKey: '',
-        dcrSentryDsn: '',
-        switches: {},
-        abTests: {},
-        dfpAccountId: '',
-        commercialBundleUrl: '',
-        revisionNumber: '',
-        isDev: false,
-        googletagUrl: '',
-        stage: 'DEV',
-        frontendAssetsFullURL: 'http://localhost:9000/assets/',
-        hbImpl: 'prebid',
-        adUnit: '/59666047/theguardian.com/film/article/ng',
-        isSensitive: '',
-        videoDuration: 0,
-        edition: '',
-        section: '',
-        sharedAdTargeting: {},
-    };
+    const ajaxUrl = 'https://api.nextgen.guardianapps.co.uk';
 
     const { pageId } = CAPI;
-    const { ajaxUrl } = config;
 
     beforeEach(() => {
         useApi.mockReset();
@@ -46,7 +24,7 @@ describe('ShareCount', () => {
         useApi.mockReturnValue({ data: { share_count: 0 } });
 
         const { container } = render(
-            <ShareCount config={config} pageId={CAPI.pageId} />,
+            <ShareCount ajaxUrl={ajaxUrl} pageId={CAPI.pageId} />,
         );
 
         expect(useApi).toHaveBeenCalledWith(
@@ -60,7 +38,7 @@ describe('ShareCount', () => {
         useApi.mockReturnValue({ error: { message: 'Bad' } });
 
         const { container } = render(
-            <ShareCount config={config} pageId={CAPI.pageId} />,
+            <ShareCount ajaxUrl={ajaxUrl} pageId={CAPI.pageId} />,
         );
 
         expect(useApi).toHaveBeenCalledWith(
@@ -74,7 +52,7 @@ describe('ShareCount', () => {
         useApi.mockReturnValue({ data: { share_count: 100 } });
 
         const { container, getByTestId } = render(
-            <ShareCount config={config} pageId={CAPI.pageId} />,
+            <ShareCount ajaxUrl={ajaxUrl} pageId={CAPI.pageId} />,
         );
 
         expect(useApi).toHaveBeenCalledWith(
@@ -90,7 +68,7 @@ describe('ShareCount', () => {
         useApi.mockReturnValue({ data: { share_count: 25000 } });
 
         const { container, getByTestId } = render(
-            <ShareCount config={config} pageId={CAPI.pageId} />,
+            <ShareCount ajaxUrl={ajaxUrl} pageId={CAPI.pageId} />,
         );
 
         expect(useApi).toHaveBeenCalledWith(

--- a/src/web/components/ShareCount.tsx
+++ b/src/web/components/ShareCount.tsx
@@ -62,7 +62,7 @@ const countShort = css`
 `;
 
 interface Props {
-    config: ConfigType;
+    ajaxUrl: string;
     pageId: string;
 }
 
@@ -75,8 +75,8 @@ function buildUrl(ajaxUrl: string, pageId: string) {
     return `${ajaxUrl}/sharecount/${pageId}.json`;
 }
 
-export const ShareCount = ({ config, pageId }: Props) => {
-    const url = buildUrl(config.ajaxUrl, pageId);
+export const ShareCount = ({ ajaxUrl, pageId }: Props) => {
+    const url = buildUrl(ajaxUrl, pageId);
     const { data, error } = useApi<ShareCountType>(url);
 
     if (error) {

--- a/src/web/islands/islands.tsx
+++ b/src/web/islands/islands.tsx
@@ -28,7 +28,7 @@ type IslandProps =
           limitItems?: number;
       }
     | {
-          config: ConfigType;
+          ajaxUrl: string;
           pageId: string;
       }
     | {
@@ -61,6 +61,7 @@ export const hydrateIslands = (
     NAV: NavType,
 ) => {
     const { pillar, editionId, sectionName, pageId } = CAPI;
+    const { ajaxUrl } = config;
 
     // Define the list of islands we intend to hydrate. Each island should have a
     // corresponding root element that exists on the DOM with the id value equal to the root property
@@ -100,7 +101,7 @@ export const hydrateIslands = (
         {
             component: ShareCount,
             props: {
-                config,
+                ajaxUrl,
                 pageId,
             },
             root: 'share-count',


### PR DESCRIPTION
## What does this change?
Removes the usage of `config` as a prop on `ShareCount` replacing it with `ajaxUrl`, which is all that's needed.

## Why?
Simple is good

## Link to supporting Trello card
https://trello.com/c/eQO3h1Hn/906-refactor-sharecount-props
