### PR TITLE
Delete config from AdSlot

### DIFF
--- a/src/web/components/AdSlot.tsx
+++ b/src/web/components/AdSlot.tsx
@@ -169,9 +169,8 @@ export const AdSlotCore: React.FC<{
 
 export const AdSlot: React.FC<{
     asps: AdSlotParameters;
-    config: ConfigType;
     className: string;
-}> = ({ asps, config, className }) => {
+}> = ({ asps, className }) => {
     return <AdSlotCore {...asps} className={className} />;
 };
 

--- a/src/web/components/HeaderAdSlot.tsx
+++ b/src/web/components/HeaderAdSlot.tsx
@@ -34,10 +34,9 @@ const adSlotAboveNav = css`
 `;
 
 export const HeaderAdSlot: React.FC<{
-    config: ConfigType;
     isAdFreeUser: boolean;
     shouldHideAds: boolean;
-}> = ({ config, isAdFreeUser, shouldHideAds }) => (
+}> = ({ isAdFreeUser, shouldHideAds }) => (
     <div className={headerWrapper}>
         <Hide when="below" breakpoint="tablet">
             <div
@@ -48,7 +47,6 @@ export const HeaderAdSlot: React.FC<{
             >
                 <AdSlot
                     asps={namedAdSlotParameters('top-above-nav')}
-                    config={config}
                     className={adSlotAboveNav}
                 />
             </div>

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.stories.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.stories.tsx
@@ -9,29 +9,6 @@ import {
     responseWithOneTab,
 } from './MostViewedFooter.mocks';
 
-const config: ConfigType = {
-    ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
-    sentryHost: '',
-    sentryPublicApiKey: '',
-    dcrSentryDsn: '',
-    switches: {},
-    abTests: {},
-    dfpAccountId: '',
-    commercialBundleUrl: '',
-    revisionNumber: '',
-    isDev: false,
-    googletagUrl: '',
-    stage: 'DEV',
-    frontendAssetsFullURL: '',
-    hbImpl: '',
-    adUnit: '',
-    isSensitive: '',
-    videoDuration: 0,
-    edition: '',
-    section: '',
-    sharedAdTargeting: {},
-};
-
 /* tslint:disable */
 export default {
     component: MostViewedFooter,
@@ -47,12 +24,7 @@ export const withTwoTabs = () => {
 
     return (
         <Section>
-            <MostViewedFooter
-                pillar="news"
-                config={config}
-                sectionName="politics"
-            />
-            ;
+            <MostViewedFooter pillar="news" sectionName="politics" />;
         </Section>
     );
 };
@@ -66,7 +38,7 @@ export const withOneTabs = () => {
 
     return (
         <Section>
-            <MostViewedFooter pillar="news" config={config} />;
+            <MostViewedFooter pillar="news" />;
         </Section>
     );
 };

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.test.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.test.tsx
@@ -18,29 +18,6 @@ const VISIBLE = 'display: grid';
 const HIDDEN = 'display: none';
 
 describe('MostViewedFooter', () => {
-    const config: ConfigType = {
-        ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
-        sentryHost: '',
-        sentryPublicApiKey: '',
-        dcrSentryDsn: '',
-        switches: {},
-        abTests: {},
-        dfpAccountId: '',
-        commercialBundleUrl: '',
-        revisionNumber: '',
-        isDev: false,
-        googletagUrl: '',
-        stage: 'DEV',
-        frontendAssetsFullURL: '',
-        hbImpl: '',
-        adUnit: '',
-        isSensitive: '',
-        videoDuration: 0,
-        edition: '',
-        section: '',
-        sharedAdTargeting: {},
-    };
-
     beforeEach(() => {
         useApi.mockReset();
     });
@@ -49,11 +26,7 @@ describe('MostViewedFooter', () => {
         useApi.mockReturnValue(responseWithTwoTabs);
 
         const { getByText, getAllByText, getByTestId } = render(
-            <MostViewedFooter
-                config={config}
-                sectionName="Section Name"
-                pillar="news"
-            />,
+            <MostViewedFooter sectionName="Section Name" pillar="news" />,
         );
 
         // Calls api once only
@@ -81,11 +54,7 @@ describe('MostViewedFooter', () => {
         useApi.mockReturnValue(responseWithTwoTabs);
 
         const { getByTestId, getByText } = render(
-            <MostViewedFooter
-                config={config}
-                sectionName="Section Name"
-                pillar="news"
-            />,
+            <MostViewedFooter sectionName="Section Name" pillar="news" />,
         );
 
         const firstHeading = responseWithTwoTabs.data[0].heading;
@@ -110,11 +79,7 @@ describe('MostViewedFooter', () => {
         useApi.mockReturnValue(responseWithOneTab);
 
         const { queryByText } = render(
-            <MostViewedFooter
-                config={config}
-                sectionName="Section Name"
-                pillar="news"
-            />,
+            <MostViewedFooter sectionName="Section Name" pillar="news" />,
         );
 
         expect(
@@ -127,11 +92,7 @@ describe('MostViewedFooter', () => {
         useApi.mockReturnValue(responseWithTwoTabs);
 
         const { getByText } = render(
-            <MostViewedFooter
-                config={config}
-                sectionName="Section Name"
-                pillar="news"
-            />,
+            <MostViewedFooter sectionName="Section Name" pillar="news" />,
         );
 
         expect(
@@ -160,11 +121,7 @@ describe('MostViewedFooter', () => {
         });
 
         const { getByText } = render(
-            <MostViewedFooter
-                config={config}
-                sectionName="Section Name"
-                pillar="news"
-            />,
+            <MostViewedFooter sectionName="Section Name" pillar="news" />,
         );
 
         expect(getByText('Live')).toBeInTheDocument();
@@ -191,11 +148,7 @@ describe('MostViewedFooter', () => {
         });
 
         const { queryByText } = render(
-            <MostViewedFooter
-                config={config}
-                sectionName="Section Name"
-                pillar="news"
-            />,
+            <MostViewedFooter sectionName="Section Name" pillar="news" />,
         );
 
         expect(queryByText('Live')).not.toBeInTheDocument();

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.tsx
@@ -82,7 +82,6 @@ export interface TabType {
 
 interface Props {
     sectionName?: string;
-    config: ConfigType;
     pillar: Pillar;
 }
 
@@ -97,7 +96,7 @@ function buildSectionUrl(sectionName?: string) {
     return `https://api.nextgen.guardianapps.co.uk${endpoint}?dcr=true`;
 }
 
-export const MostViewedFooter = ({ config, sectionName, pillar }: Props) => {
+export const MostViewedFooter = ({ sectionName, pillar }: Props) => {
     const url = buildSectionUrl(sectionName);
     const { data, error } = useApi<TabType[]>(url);
 
@@ -130,7 +129,6 @@ export const MostViewedFooter = ({ config, sectionName, pillar }: Props) => {
                         >
                             <AdSlot
                                 asps={namedAdSlotParameters('mostpop')}
-                                config={config}
                                 className={''}
                             />
                         </div>

--- a/src/web/components/StickyAd.tsx
+++ b/src/web/components/StickyAd.tsx
@@ -14,15 +14,10 @@ const stickyAdSlot = css`
     top: 0;
 `;
 
-type Props = {
-    config: ConfigType;
-};
-
-export const StickyAd = ({ config }: Props) => (
+export const StickyAd = () => (
     <div className={adSlotWrapper}>
         <AdSlot
             asps={namedAdSlotParameters('right')}
-            config={config}
             className={stickyAdSlot}
         />
     </div>

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -34,7 +34,6 @@ export const ShowcaseLayout = ({ CAPI, config, NAV }: Props) => (
     <>
         <Section showTopBorder={false} showSideBorders={false} padded={false}>
             <HeaderAdSlot
-                config={config}
                 isAdFreeUser={CAPI.isAdFreeUser}
                 shouldHideAds={CAPI.shouldHideAds}
             />
@@ -115,7 +114,7 @@ export const ShowcaseLayout = ({ CAPI, config, NAV }: Props) => (
                             </main>
                         </div>
                         <ArticleRight>
-                            <StickyAd config={config} />
+                            <StickyAd />
                             <MostViewedRightIsland />
                         </ArticleRight>
                     </Flex>

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -54,7 +54,6 @@ export const StandardLayout = ({ CAPI, config, NAV }: Props) => {
                 padded={false}
             >
                 <HeaderAdSlot
-                    config={config}
                     isAdFreeUser={CAPI.isAdFreeUser}
                     shouldHideAds={CAPI.shouldHideAds}
                 />
@@ -128,7 +127,7 @@ export const StandardLayout = ({ CAPI, config, NAV }: Props) => {
                         </main>
                     </ArticleContainer>
                     <ArticleRight>
-                        <StickyAd config={config} />
+                        <StickyAd />
                         <MostViewedRightIsland />
                     </ArticleRight>
                 </Flex>


### PR DESCRIPTION
## What does this change?
This PR removes the unused prop `config` from the component `AdSlot` and then cleans up the dependency stack above it.

## Why?
Less code

## Link to supporting Trello card
https://trello.com/c/pZFGxSnb/907-refactor-adslot-props
