### PR TITLE
Clean up ArticleMeta Props

### DIFF
--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -39,10 +39,9 @@ const metaExtras = css`
 
 type Props = {
     CAPI: CAPIType;
-    config: ConfigType;
 };
 
-export const ArticleMeta = ({ CAPI, config }: Props) => {
+export const ArticleMeta = ({ CAPI }: Props) => {
     const sharingUrls = getSharingUrls(CAPI.pageId, CAPI.webTitle);
 
     return (

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -71,7 +71,7 @@ export const ShowcaseLayout = ({ CAPI, config, NAV }: Props) => (
             <Flex>
                 <ArticleLeft>
                     <ArticleTitle CAPI={CAPI} inLeftCol={true} />
-                    <ArticleMeta CAPI={CAPI} config={config} />
+                    <ArticleMeta CAPI={CAPI} />
                 </ArticleLeft>
                 <ArticleContainer>
                     {/* When BELOW leftCol we display the header in this position, at the top of the page */}
@@ -83,7 +83,7 @@ export const ShowcaseLayout = ({ CAPI, config, NAV }: Props) => (
                             {/* When ABOVE leftCol we display the header in this position, above the article body, underneath the full width image */}
                             <Hide when="above" breakpoint="leftCol">
                                 <ShowcaseHeader CAPI={CAPI} />
-                                <ArticleMeta CAPI={CAPI} config={config} />
+                                <ArticleMeta CAPI={CAPI} />
                             </Hide>
 
                             <main

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -99,12 +99,12 @@ export const StandardLayout = ({ CAPI, config, NAV }: Props) => {
                             badge={GE2019Badge}
                             inLeftCol={true}
                         />
-                        <ArticleMeta CAPI={CAPI} config={config} />
+                        <ArticleMeta CAPI={CAPI} />
                     </ArticleLeft>
                     <ArticleContainer>
                         <StandardHeader CAPI={CAPI} badge={GE2019Badge} />
                         <Hide when="above" breakpoint="leftCol">
-                            <ArticleMeta CAPI={CAPI} config={config} />
+                            <ArticleMeta CAPI={CAPI} />
                         </Hide>
                         <main
                             className={css`


### PR DESCRIPTION
## What does this change?
Removes the `config` prop from `ArticleMeta`

## Why?
Less code

## Link to supporting Trello card
https://trello.com/c/0YfNXRND/908-delete-config-from-articlemeta
