### PR TITLE
Remove use of config prop

### DIFF
--- a/src/web/components/ArticleBody.tsx
+++ b/src/web/components/ArticleBody.tsx
@@ -118,9 +118,8 @@ const linkColour = pillarMap(
 
 export const ArticleBody: React.FC<{
     CAPI: CAPIType;
-    config: ConfigType;
     isShowcase?: boolean;
-}> = ({ CAPI, config, isShowcase }) => {
+}> = ({ CAPI, isShowcase }) => {
     return (
         <div
             className={cx(bodyStyle, linkColour[CAPI.pillar], {

--- a/src/web/components/ArticleBody.tsx
+++ b/src/web/components/ArticleBody.tsx
@@ -139,7 +139,6 @@ export const ArticleBody: React.FC<{
             <ArticleRenderer
                 elements={CAPI.blocks[0] ? CAPI.blocks[0].elements : []}
                 pillar={CAPI.pillar}
-                config={CAPI.config}
             />
         </div>
     );

--- a/src/web/components/Outbrain.tsx
+++ b/src/web/components/Outbrain.tsx
@@ -104,9 +104,7 @@ const outbrainContainer = css`
     }
 `;
 
-export const OutbrainContainer: React.FC<{
-    config: ConfigType;
-}> = ({ config }) => {
+export const OutbrainContainer: React.FC<{}> = () => {
     return (
         <div className={outbrainContainer}>
             <OutbrainWidget />

--- a/src/web/components/lib/ArticleRenderer.tsx
+++ b/src/web/components/lib/ArticleRenderer.tsx
@@ -14,8 +14,7 @@ const commercialPosition = css`
 export const ArticleRenderer: React.FC<{
     elements: CAPIElement[];
     pillar: Pillar;
-    config: ConfigType;
-}> = ({ elements, pillar, config }) => {
+}> = ({ elements, pillar }) => {
     // const cleanedElements = elements.map(element =>
     //     'html' in element ? { ...element, html: clean(element.html) } : element,
     // );

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -120,7 +120,7 @@ export const ShowcaseLayout = ({ CAPI, config, NAV }: Props) => (
         </Section>
 
         <Section showTopBorder={false}>
-            <OutbrainContainer config={config} />
+            <OutbrainContainer />
         </Section>
 
         <Section islandId="most-viewed-footer" />

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -91,11 +91,7 @@ export const ShowcaseLayout = ({ CAPI, config, NAV }: Props) => (
                                     max-width: 630px;
                                 `}
                             >
-                                <ArticleBody
-                                    CAPI={CAPI}
-                                    config={config}
-                                    isShowcase={true}
-                                />
+                                <ArticleBody CAPI={CAPI} isShowcase={true} />
                                 <GuardianLines pillar={CAPI.pillar} />
                                 <SubMeta
                                     pillar={CAPI.pillar}

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -111,7 +111,7 @@ export const StandardLayout = ({ CAPI, config, NAV }: Props) => {
                                 max-width: 630px;
                             `}
                         >
-                            <ArticleBody CAPI={CAPI} config={config} />
+                            <ArticleBody CAPI={CAPI} />
                             <GuardianLines pillar={CAPI.pillar} />
                             <SubMeta
                                 pillar={CAPI.pillar}

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -135,7 +135,7 @@ export const StandardLayout = ({ CAPI, config, NAV }: Props) => {
             </Section>
 
             <Section showTopBorder={false}>
-                <OutbrainContainer config={config} />
+                <OutbrainContainer />
             </Section>
 
             <Section islandId="most-viewed-footer" />


### PR DESCRIPTION
## What does this change?
Removes the `config` prop from `ArticleBody`, `ArticleRenderer` and `OutbrainContainer`.

## Why?
Less code

## Link to supporting Trello card
https://trello.com/c/NVcFzRth/909-remove-config-from-remaining-components
