### PR TITLE
Adjust spacing on header for parity

### DIFF
--- a/src/web/components/Header/EditionDropdown.tsx
+++ b/src/web/components/Header/EditionDropdown.tsx
@@ -10,7 +10,6 @@ const editionDropdown = css`
     right: 11px;
     z-index: 1072;
     transform: translateX(100%);
-    padding-top: 7px;
 
     :before {
         content: '';
@@ -81,12 +80,18 @@ export const EditionDropdown: React.FC<{
     links.unshift(activeEditionLink);
     return (
         <div className={editionDropdown}>
-            <Dropdown
-                label={activeEditionLink.title}
-                links={links}
-                id="edition"
-                dataLinkName={dataLinkName}
-            />
+            <div
+                className={css`
+                    padding-top: 7px;
+                `}
+            >
+                <Dropdown
+                    label={activeEditionLink.title}
+                    links={links}
+                    id="edition"
+                    dataLinkName={dataLinkName}
+                />
+            </div>
         </div>
     );
 };

--- a/src/web/components/Header/Links/Links.tsx
+++ b/src/web/components/Header/Links/Links.tsx
@@ -43,7 +43,7 @@ const link = css`
     padding: 7px 0;
 
     ${from.tablet} {
-        padding: 7px 7px;
+        padding: 5px 7px;
     }
 
     :hover,
@@ -56,7 +56,7 @@ const link = css`
         float: left;
         height: 18px;
         width: 18px;
-        margin: 1px 4px 0 0;
+        margin: 3px 4px 0 0;
     }
 `;
 

--- a/src/web/components/Pillars.tsx
+++ b/src/web/components/Pillars.tsx
@@ -142,18 +142,18 @@ const linkStyle = css`
     }
     ${from.tablet} {
         font-size: 22px;
-        padding-top: 13px;
+        padding-top: 9px;
         height: 48px;
         padding-right: 20px;
         padding-left: 9px;
     }
     ${from.desktop} {
-        padding-top: 11px;
+        padding-top: 5px;
         height: 42px;
     }
 
     ${from.wide} {
-        padding-top: 9px;
+        padding-top: 7px;
         font-size: 24px;
     }
 

--- a/src/web/components/ReaderRevenueLinks.tsx
+++ b/src/web/components/ReaderRevenueLinks.tsx
@@ -47,7 +47,7 @@ const link = css`
     height: 32px;
     text-decoration: none;
     padding: 6px 12px 0 12px;
-    line-height: 1;
+    line-height: 18px;
     position: relative;
     margin-right: 10px;
     margin-bottom: 6px;
@@ -95,7 +95,7 @@ const hiddenFromTablet = css`
 const subMessage = css`
     color: ${palette.neutral[100]};
     ${textSans.medium()};
-    margin-bottom: 9px;
+    margin-bottom: 5px;
 `;
 
 export const RRButton: React.FC<{


### PR DESCRIPTION
## What does this change?
This PR tidies up some of the spacing in the header and pillar nav to bring us more in line with frontend.

Please review [the Percy snapshots ](https://percy.io/The-Guardian/dotcom/builds/3226828?utm_campaign=The-Guardian&utm_content=dotcom&utm_source=github_status_private)for a visual overview of the changes

## Why?
Parity

## Link to supporting Trello card
https://trello.com/c/rYZQ7mWt/910-fix-header-spacing
