### PR TITLE
Article Spacing

### DIFF
--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -108,7 +108,9 @@ const blackBackground = css`
 `;
 
 const maxWidth = css`
-    max-width: 620px;
+    ${from.desktop} {
+        max-width: 620px;
+    }
 `;
 
 const invertedWrapper = css`

--- a/src/web/components/HeaderItem.tsx
+++ b/src/web/components/HeaderItem.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { css, cx } from 'emotion';
-import { until } from '@guardian/src-foundations/mq';
+import { from, until } from '@guardian/src-foundations/mq';
 
 const maxWidth = css`
-    max-width: 630px;
+    ${from.desktop} {
+        max-width: 630px;
+    }
     ${until.phablet} {
         padding: 0 10px;
     }

--- a/src/web/layouts/ShowcaseHeader.tsx
+++ b/src/web/layouts/ShowcaseHeader.tsx
@@ -88,11 +88,11 @@ export const ShowcaseHeader = ({ CAPI, badge }: Props) => {
                     />
                 </Hide>
             </HeaderItem>
-            <Hide when="below" breakpoint="tablet">
-                <div className={positionMainImage}>
+            <div className={positionMainImage}>
+                <Hide when="below" breakpoint="tablet">
                     <MainMedia elements={mainMediaElements} pillar={pillar} />
-                </div>
-            </Hide>
+                </Hide>
+            </div>
         </header>
     );
 };

--- a/src/web/layouts/ShowcaseHeader.tsx
+++ b/src/web/layouts/ShowcaseHeader.tsx
@@ -88,9 +88,11 @@ export const ShowcaseHeader = ({ CAPI, badge }: Props) => {
                     />
                 </Hide>
             </HeaderItem>
-            <div className={positionMainImage}>
-                <MainMedia elements={mainMediaElements} pillar={pillar} />
-            </div>
+            <Hide when="below" breakpoint="tablet">
+                <div className={positionMainImage}>
+                    <MainMedia elements={mainMediaElements} pillar={pillar} />
+                </div>
+            </Hide>
         </header>
     );
 };

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -12,6 +12,7 @@ import { Hide } from '@root/src/web/components/Hide';
 import { GuardianLines } from '@root/src/web/components/GuardianLines';
 import { MostViewedRightIsland } from '@root/src/web/components/MostViewedRightIsland';
 import { SubMeta } from '@root/src/web/components/SubMeta';
+import { MainMedia } from '@root/src/web/components/MainMedia';
 
 import { palette } from '@guardian/src-foundations';
 import { Header } from '@root/src/web/components/Header/Header';
@@ -65,6 +66,16 @@ export const ShowcaseLayout = ({ CAPI, config, NAV }: Props) => (
                 pillar={CAPI.pillar}
             />
         </Section>
+
+        <Hide when="above" breakpoint="tablet">
+            {/* When below tablet, show the main article image in a full width container */}
+            <Section showTopBorder={false} padded={false}>
+                <MainMedia
+                    elements={CAPI.mainMediaElements}
+                    pillar={CAPI.pillar}
+                />
+            </Section>
+        </Hide>
 
         <Section showTopBorder={false}>
             <Flex>

--- a/src/web/layouts/StandardHeader.tsx
+++ b/src/web/layouts/StandardHeader.tsx
@@ -81,11 +81,11 @@ export const StandardHeader = ({ CAPI, badge }: Props) => {
             <HeaderItem order={3}>
                 <ArticleStandfirst pillar={pillar} standfirst={standfirst} />
             </HeaderItem>
-            <Hide when="below" breakpoint="tablet">
-                <div className={cx(positionMainImage, maxWidth)}>
+            <div className={cx(positionMainImage, maxWidth)}>
+                <Hide when="below" breakpoint="tablet">
                     <MainMedia elements={mainMediaElements} pillar={pillar} />
-                </div>
-            </Hide>
+                </Hide>
+            </div>
         </header>
     );
 };

--- a/src/web/layouts/StandardHeader.tsx
+++ b/src/web/layouts/StandardHeader.tsx
@@ -39,7 +39,9 @@ const headerStyles = css`
 `;
 
 const maxWidth = css`
-    max-width: 620px;
+    ${from.desktop} {
+        max-width: 620px;
+    }
 `;
 
 type Props = {
@@ -79,9 +81,11 @@ export const StandardHeader = ({ CAPI, badge }: Props) => {
             <HeaderItem order={3}>
                 <ArticleStandfirst pillar={pillar} standfirst={standfirst} />
             </HeaderItem>
-            <div className={cx(positionMainImage, maxWidth)}>
-                <MainMedia elements={mainMediaElements} pillar={pillar} />
-            </div>
+            <Hide when="below" breakpoint="tablet">
+                <div className={cx(positionMainImage, maxWidth)}>
+                    <MainMedia elements={mainMediaElements} pillar={pillar} />
+                </div>
+            </Hide>
         </header>
     );
 };

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -13,6 +13,7 @@ import { Hide } from '@root/src/web/components/Hide';
 import { GuardianLines } from '@root/src/web/components/GuardianLines';
 import { MostViewedRightIsland } from '@root/src/web/components/MostViewedRightIsland';
 import { SubMeta } from '@root/src/web/components/SubMeta';
+import { MainMedia } from '@root/src/web/components/MainMedia';
 
 import { palette } from '@guardian/src-foundations';
 
@@ -89,6 +90,16 @@ export const StandardLayout = ({ CAPI, config, NAV }: Props) => {
                     pillar={CAPI.pillar}
                 />
             </Section>
+
+            <Hide when="above" breakpoint="tablet">
+                {/* When below tablet, show the main article image in a full width container */}
+                <Section showTopBorder={false} padded={false}>
+                    <MainMedia
+                        elements={CAPI.mainMediaElements}
+                        pillar={CAPI.pillar}
+                    />
+                </Section>
+            </Hide>
 
             <Section showTopBorder={false}>
                 <Flex>


### PR DESCRIPTION
## What does this change?
This PR fixes some spacing inconsistencies around the article header and main image. The two main changes are:

- Remove the max width property when below `desktop` because the content should be full width at this point

- Make the main image full width below `tablet`

For the main image change, my first approach was to set negative side margins on the image, like:

```
    ${until.tablet} {
        margin: 0 -20px;
    }
```

But this creates a magic dependency between the Section padding and this code. So instead, I updated the layout to make the image appear outside of the padded section at the correct breakpoint and hide the other image (the one inside the padded section) at the same point.

Check out [the Percy snapshots](https://percy.io/The-Guardian/dotcom/builds/3227333?utm_campaign=The-Guardian&utm_content=dotcom&utm_source=github_status_private) for a visual demonstration of the changes

## Why?
Parity

## Link to supporting Trello card
https://trello.com/c/5BjRWs1l/911-fix-article-spacing