### PR TITLE
Refactor Headline API

### DIFF
--- a/src/web/components/ArticleHeadline.stories.tsx
+++ b/src/web/components/ArticleHeadline.stories.tsx
@@ -6,6 +6,7 @@ import { Flex } from './Flex';
 import { ArticleLeft } from './ArticleLeft';
 import { ArticleContainer } from './ArticleContainer';
 import { MainMedia } from './MainMedia';
+import { Standfirst } from './Standfirst';
 import { mainMediaElements } from './ArticleHeadline.mocks';
 
 /* tslint:disable */
@@ -82,6 +83,32 @@ export const Feature = () => (
 );
 Feature.story = { name: 'Feature' };
 
+export const ShowcaseInterview = () => (
+    <Section>
+        <Flex>
+            <ArticleLeft>
+                <></>
+            </ArticleLeft>
+            <ArticleContainer>
+                <ArticleHeadline
+                    headlineString="This is an Interview headline. It has a black background, white text and overlays the image below it (as a sibling)"
+                    designType="Interview"
+                    pillar="culture"
+                    webPublicationDate=""
+                    tags={[]}
+                    isShowcase={true}
+                />
+                <MainMedia
+                    hideCaption={true}
+                    elements={mainMediaElements}
+                    pillar="news"
+                />
+            </ArticleContainer>
+        </Flex>
+    </Section>
+);
+ShowcaseInterview.story = { name: 'Interview (with showcase)' };
+
 export const Interview = () => (
     <Section>
         <Flex>
@@ -96,6 +123,10 @@ export const Interview = () => (
                     webPublicationDate=""
                     tags={[]}
                 />
+                <Standfirst
+                    pillar="culture"
+                    standfirst="This is the standfirst text. We include here to demonstrate spacing in this case where we have a Interview type article that does not have a showcase main media element"
+                />
                 <MainMedia
                     hideCaption={true}
                     elements={mainMediaElements}
@@ -105,7 +136,7 @@ export const Interview = () => (
         </Flex>
     </Section>
 );
-Interview.story = { name: 'Interview' };
+Interview.story = { name: 'Interview (without showcase)' };
 
 export const Comment = () => (
     <Section>

--- a/src/web/components/ArticleHeadline.stories.tsx
+++ b/src/web/components/ArticleHeadline.stories.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
 
 import { Section } from './Section';
-
 import { ArticleHeadline } from './ArticleHeadline';
 import { Flex } from './Flex';
 import { ArticleLeft } from './ArticleLeft';
 import { ArticleContainer } from './ArticleContainer';
 import { MainMedia } from './MainMedia';
-
 import { mainMediaElements } from './ArticleHeadline.mocks';
 
 /* tslint:disable */
@@ -17,7 +15,7 @@ export default {
 };
 /* tslint:enable */
 
-export const defaultStory = () => (
+export const ArticleStory = () => (
     <Section>
         <Flex>
             <ArticleLeft>
@@ -26,6 +24,8 @@ export const defaultStory = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is how the default headline looks"
+                    designType="Article"
+                    pillar="news"
                     webPublicationDate=""
                     tags={[]}
                 />
@@ -33,7 +33,7 @@ export const defaultStory = () => (
         </Flex>
     </Section>
 );
-defaultStory.story = { name: 'type: basic, with defaults' };
+ArticleStory.story = { name: 'Article' };
 
 export const oldHeadline = () => (
     <Section>
@@ -44,6 +44,8 @@ export const oldHeadline = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is an old headline"
+                    designType="Article"
+                    pillar="news"
                     webPublicationDate="2014-07-13T18:46:01.933Z"
                     tags={[
                         // Age warnings only show for old articles when the tone/news tag is present
@@ -58,9 +60,9 @@ export const oldHeadline = () => (
         </Flex>
     </Section>
 );
-oldHeadline.story = { name: 'type: basic, with age warning' };
+oldHeadline.story = { name: 'Article, with age warning' };
 
-export const Bold = () => (
+export const Feature = () => (
     <Section>
         <Flex>
             <ArticleLeft>
@@ -68,19 +70,19 @@ export const Bold = () => (
             </ArticleLeft>
             <ArticleContainer>
                 <ArticleHeadline
-                    headlineString="This is a bold headline with colour applied"
-                    webPublicationDate="2014-07-13T18:46:01.933Z"
+                    headlineString="This is a Feature headline, it has colour applied based on pillar"
+                    designType="Feature"
+                    pillar="lifestyle"
+                    webPublicationDate=""
                     tags={[]}
-                    colour="#7d0068"
-                    type="bold"
                 />
             </ArticleContainer>
         </Flex>
     </Section>
 );
-Bold.story = { name: 'type: bold, with colour' };
+Feature.story = { name: 'Feature' };
 
-export const inverted = () => (
+export const Interview = () => (
     <Section>
         <Flex>
             <ArticleLeft>
@@ -88,10 +90,11 @@ export const inverted = () => (
             </ArticleLeft>
             <ArticleContainer>
                 <ArticleHeadline
-                    headlineString="This is an inverted headline. It has a black background, white text and overlays the image below it (as a sibling)"
-                    webPublicationDate="2014-07-13T18:46:01.933Z"
+                    headlineString="This is an Interview headline. It has a black background, white text and overlays the image below it (as a sibling)"
+                    designType="Interview"
+                    pillar="culture"
+                    webPublicationDate=""
                     tags={[]}
-                    type="inverted"
                 />
                 <MainMedia
                     hideCaption={true}
@@ -102,9 +105,9 @@ export const inverted = () => (
         </Flex>
     </Section>
 );
-inverted.story = { name: 'type: inverted' };
+Interview.story = { name: 'Interview' };
 
-export const light = () => (
+export const Comment = () => (
     <Section>
         <Flex>
             <ArticleLeft>
@@ -113,17 +116,18 @@ export const light = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="Yes, the billionaire club is one we really need to shut down"
-                    webPublicationDate="2014-07-13T18:46:01.933Z"
+                    designType="Comment"
+                    pillar="opinion"
+                    webPublicationDate=""
                     tags={[]}
-                    type="light"
                 />
             </ArticleContainer>
         </Flex>
     </Section>
 );
-light.story = { name: 'type: light' };
+Comment.story = { name: 'Comment' };
 
-export const underlined = () => (
+export const Analysis = () => (
     <Section>
         <Flex>
             <ArticleLeft>
@@ -131,18 +135,219 @@ export const underlined = () => (
             </ArticleLeft>
             <ArticleContainer>
                 <ArticleHeadline
-                    headlineString="This headline is underlined. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor"
-                    webPublicationDate="2014-07-13T18:46:01.933Z"
+                    headlineString="This is an Analysis headline, it's underlined. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor"
+                    designType="Analysis"
+                    pillar="news"
+                    webPublicationDate=""
                     tags={[]}
-                    type="underlined"
                 />
             </ArticleContainer>
         </Flex>
     </Section>
 );
-underlined.story = { name: 'type: underlined' };
+Analysis.story = { name: 'Analysis' };
 
-export const Jumbo = () => (
+export const Media = () => (
+    <Section>
+        <Flex>
+            <ArticleLeft>
+                <></>
+            </ArticleLeft>
+            <ArticleContainer>
+                <ArticleHeadline
+                    headlineString="This is the headline you see when design type is Media"
+                    designType="Media"
+                    pillar="news"
+                    webPublicationDate=""
+                    tags={[]}
+                />
+            </ArticleContainer>
+        </Flex>
+    </Section>
+);
+Media.story = { name: 'Media' };
+
+export const Review = () => (
+    <Section>
+        <Flex>
+            <ArticleLeft>
+                <></>
+            </ArticleLeft>
+            <ArticleContainer>
+                <ArticleHeadline
+                    headlineString="This is the headline you see when design type is Review"
+                    designType="Review"
+                    pillar="news"
+                    webPublicationDate=""
+                    tags={[]}
+                />
+            </ArticleContainer>
+        </Flex>
+    </Section>
+);
+Review.story = { name: 'Review' };
+
+export const AdvertisementFeature = () => (
+    <Section>
+        <Flex>
+            <ArticleLeft>
+                <></>
+            </ArticleLeft>
+            <ArticleContainer>
+                <ArticleHeadline
+                    headlineString="This is the headline you see when design type is AdvertisementFeature"
+                    designType="AdvertisementFeature"
+                    pillar="news"
+                    webPublicationDate=""
+                    tags={[]}
+                />
+            </ArticleContainer>
+        </Flex>
+    </Section>
+);
+AdvertisementFeature.story = { name: 'AdvertisementFeature' };
+
+export const Quiz = () => (
+    <Section>
+        <Flex>
+            <ArticleLeft>
+                <></>
+            </ArticleLeft>
+            <ArticleContainer>
+                <ArticleHeadline
+                    headlineString="This is the headline you see when design type is Quiz"
+                    designType="Quiz"
+                    pillar="news"
+                    webPublicationDate=""
+                    tags={[]}
+                />
+            </ArticleContainer>
+        </Flex>
+    </Section>
+);
+Quiz.story = { name: 'Quiz' };
+
+export const GuardianLabs = () => (
+    <Section>
+        <Flex>
+            <ArticleLeft>
+                <></>
+            </ArticleLeft>
+            <ArticleContainer>
+                <ArticleHeadline
+                    headlineString="This is the headline you see when design type is GuardianLabs"
+                    designType="GuardianLabs"
+                    pillar="news"
+                    webPublicationDate=""
+                    tags={[]}
+                />
+            </ArticleContainer>
+        </Flex>
+    </Section>
+);
+GuardianLabs.story = { name: 'GuardianLabs' };
+
+export const Recipe = () => (
+    <Section>
+        <Flex>
+            <ArticleLeft>
+                <></>
+            </ArticleLeft>
+            <ArticleContainer>
+                <ArticleHeadline
+                    headlineString="This is the headline you see when design type is Recipe"
+                    designType="Recipe"
+                    pillar="news"
+                    webPublicationDate=""
+                    tags={[]}
+                />
+            </ArticleContainer>
+        </Flex>
+    </Section>
+);
+Recipe.story = { name: 'Recipe' };
+
+export const GuardianView = () => (
+    <Section>
+        <Flex>
+            <ArticleLeft>
+                <></>
+            </ArticleLeft>
+            <ArticleContainer>
+                <ArticleHeadline
+                    headlineString="This is the headline you see when design type is GuardianView"
+                    designType="GuardianView"
+                    pillar="news"
+                    webPublicationDate=""
+                    tags={[]}
+                />
+            </ArticleContainer>
+        </Flex>
+    </Section>
+);
+GuardianView.story = { name: 'GuardianView' };
+
+export const MatchReport = () => (
+    <Section>
+        <Flex>
+            <ArticleLeft>
+                <></>
+            </ArticleLeft>
+            <ArticleContainer>
+                <ArticleHeadline
+                    headlineString="This is the headline you see when design type is MatchReport"
+                    designType="MatchReport"
+                    pillar="news"
+                    webPublicationDate=""
+                    tags={[]}
+                />
+            </ArticleContainer>
+        </Flex>
+    </Section>
+);
+MatchReport.story = { name: 'MatchReport' };
+
+export const SpecialReport = () => (
+    <Section>
+        <Flex>
+            <ArticleLeft>
+                <></>
+            </ArticleLeft>
+            <ArticleContainer>
+                <ArticleHeadline
+                    headlineString="This is the headline you see when design type is SpecialReport"
+                    designType="SpecialReport"
+                    pillar="news"
+                    webPublicationDate=""
+                    tags={[]}
+                />
+            </ArticleContainer>
+        </Flex>
+    </Section>
+);
+SpecialReport.story = { name: 'SpecialReport' };
+
+export const Live = () => (
+    <Section>
+        <Flex>
+            <ArticleLeft>
+                <></>
+            </ArticleLeft>
+            <ArticleContainer>
+                <ArticleHeadline
+                    headlineString="This is the headline you see when design type is Live"
+                    designType="Live"
+                    pillar="news"
+                    webPublicationDate=""
+                    tags={[]}
+                />
+            </ArticleContainer>
+        </Flex>
+    </Section>
+);
+Live.story = { name: 'Live' };
+
+export const Immersive = () => (
     <>
         <MainMedia
             hideCaption={true}
@@ -162,13 +367,14 @@ export const Jumbo = () => (
                 <ArticleContainer>
                     <ArticleHeadline
                         headlineString="Here the headline overlays the image above it, the text is larger and the black background should extend to the right"
-                        webPublicationDate="2014-07-13T18:46:01.933Z"
+                        designType="Immersive"
+                        pillar="culture"
+                        webPublicationDate=""
                         tags={[]}
-                        type="jumbo"
                     />
                 </ArticleContainer>
             </Flex>
         </Section>
     </>
 );
-Jumbo.story = { name: 'type: jumbo' };
+Immersive.story = { name: 'Immersive' };

--- a/src/web/components/ArticleHeadline.stories.tsx
+++ b/src/web/components/ArticleHeadline.stories.tsx
@@ -161,7 +161,7 @@ export const Jumbo = () => (
                 </ArticleLeft>
                 <ArticleContainer>
                     <ArticleHeadline
-                        headlineString="Here the headling overlays the image above it, the text is larger and the black background should extend to the right"
+                        headlineString="Here the headline overlays the image above it, the text is larger and the black background should extend to the right"
                         webPublicationDate="2014-07-13T18:46:01.933Z"
                         tags={[]}
                         type="jumbo"

--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -1,26 +1,18 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 
+import { pillarPalette } from '@root/src/lib/pillars';
 import { getAgeWarning } from '@root/src/lib/age-warning';
-
 import { AgeWarning } from '@root/src/web/components/AgeWarning';
 import { headline } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 
-type HeadlineType =
-    | 'basic'
-    | 'underlined'
-    | 'light'
-    | 'jumbo'
-    | 'inverted'
-    | 'bold';
-
 type Props = {
     headlineString: string;
-    type?: HeadlineType; // Defaults to basic
+    designType: DesignType;
+    pillar: Pillar;
     webPublicationDate: string; // Used for age warning
     tags: TagType[]; // Used for age warning
-    colour?: string; // pass in pillar colour for features, etc.
 };
 
 const curly = (x: any) => x;
@@ -44,6 +36,7 @@ const invertedFont = css`
 `;
 
 const lightFont = css`
+    ${headline.medium()};
     font-weight: normal;
     font-weight: 300;
     font-size: 2.125rem;
@@ -56,11 +49,6 @@ const standardPadding = css`
     ${from.tablet} {
         padding-bottom: 36px;
     }
-`;
-
-const boldPadding = css`
-    padding-bottom: 24px;
-    padding-top: 3px;
 `;
 
 const underlinedStyles = css`
@@ -101,6 +89,8 @@ const invertedStyles = css`
     padding-bottom: 5px;
     padding-right: 5px;
     box-shadow: -6px 0 0 black;
+    /* Box decoration is required to push the box shadow out on Firefox */
+    box-decoration-break: clone;
 `;
 
 const blackBackground = css`
@@ -136,34 +126,64 @@ const ageWarningMargins = css`
 `;
 
 const renderHeadline = (
-    type: HeadlineType,
+    designType: DesignType,
     headlineString: string,
     options?: {
         colour?: string;
     },
 ) => {
-    switch (type) {
-        case 'basic':
-        case 'bold':
-        case 'light':
-        case 'underlined': {
+    switch (designType) {
+        case 'Article':
+        case 'Media':
+        case 'Review':
+        case 'Live':
+        case 'SpecialReport':
+        case 'Recipe':
+        case 'MatchReport':
+        case 'GuardianView':
+        case 'GuardianLabs':
+        case 'Quiz':
+        case 'AdvertisementFeature':
+            return (
+                <h1 className={cx(standardFont, standardPadding)}>
+                    {curly(headlineString)}
+                </h1>
+            );
+
+        case 'Feature':
             return (
                 <h1
                     className={cx(
-                        standardFont,
+                        boldFont,
                         standardPadding,
-                        type === 'underlined' && underlinedStyles,
-                        type === 'bold' && boldFont,
-                        type === 'bold' && boldPadding,
-                        type === 'light' && lightFont,
-                        options && colourStyles(options.colour),
+                        colourStyles(options && options.colour),
                     )}
                 >
                     {curly(headlineString)}
                 </h1>
             );
-        }
-        case 'inverted': {
+
+        case 'Comment':
+            return (
+                <h1 className={cx(lightFont, standardPadding)}>
+                    {curly(headlineString)}
+                </h1>
+            );
+
+        case 'Analysis':
+            return (
+                <h1
+                    className={cx(
+                        standardFont,
+                        standardPadding,
+                        underlinedStyles,
+                    )}
+                >
+                    {curly(headlineString)}
+                </h1>
+            );
+
+        case 'Interview':
             return (
                 // Inverted headlines have a wrapper div for positioning
                 // and a black background (only for the text)
@@ -180,24 +200,22 @@ const renderHeadline = (
                             blackBackground,
                             invertedStyles,
                             displayInline,
-                            options && colourStyles(options.colour),
                         )}
                     >
                         {curly(headlineString)}
                     </span>
                 </h1>
             );
-        }
-        case 'jumbo': {
+
+        case 'Immersive':
             return (
-                // Jumbo headlines are large and inverted and have their black background
+                // Immersive headlines are large and inverted and have their black background
                 // extended to the right
                 <h1
                     className={cx(
                         invertedWrapper,
                         shiftPosition('up'),
                         blackBackground,
-                        options && colourStyles(options.colour),
                     )}
                 >
                     <span
@@ -206,23 +224,21 @@ const renderHeadline = (
                             maxWidth,
                             invertedStyles,
                             displayBlock,
-                            options && colourStyles(options.colour),
                         )}
                     >
                         {curly(headlineString)}
                     </span>
                 </h1>
             );
-        }
     }
 };
 
 export const ArticleHeadline = ({
     headlineString,
+    designType,
+    pillar,
     webPublicationDate,
     tags,
-    colour,
-    type = 'basic',
 }: Props) => {
     const age = getAgeWarning(tags, webPublicationDate);
     return (
@@ -232,8 +248,8 @@ export const ArticleHeadline = ({
                     <AgeWarning age={age} />
                 </div>
             )}
-            {renderHeadline(type, headlineString, {
-                colour,
+            {renderHeadline(designType, headlineString, {
+                colour: pillarPalette[pillar].dark,
             })}
             {age && <AgeWarning age={age} isScreenReader={true} />}
         </>

--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -9,11 +9,11 @@ import { from } from '@guardian/src-foundations/mq';
 
 type Props = {
     headlineString: string;
-    designType: DesignType;
-    pillar: Pillar;
+    designType: DesignType; // Decides headline appearance
+    pillar: Pillar; // Decides headline colour when relevant
     webPublicationDate: string; // Used for age warning
     tags: TagType[]; // Used for age warning
-    isShowcase?: boolean;
+    isShowcase?: boolean; // Used for Interviews to change headline position
 };
 
 const curly = (x: any) => x;

--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -13,6 +13,7 @@ type Props = {
     pillar: Pillar;
     webPublicationDate: string; // Used for age warning
     tags: TagType[]; // Used for age warning
+    isShowcase?: boolean;
 };
 
 const curly = (x: any) => x;
@@ -81,6 +82,10 @@ const shiftPosition = (shift?: 'up' | 'down') => css`
     margin-bottom: ${shift && shift === 'down' && '-50px'};
 `;
 
+const shiftSlightly = css`
+    margin-bottom: 16px;
+`;
+
 const invertedStyles = css`
     position: relative;
     color: white;
@@ -127,6 +132,7 @@ const ageWarningMargins = css`
 
 const renderHeadline = (
     designType: DesignType,
+    isShowcase: boolean,
     headlineString: string,
     options?: {
         colour?: string;
@@ -191,7 +197,8 @@ const renderHeadline = (
                     className={cx(
                         invertedFont,
                         invertedWrapper,
-                        shiftPosition('down'),
+                        // We only shift the inverted headline down when main media is showcase
+                        isShowcase ? shiftPosition('down') : shiftSlightly,
                         maxWidth,
                     )}
                 >
@@ -239,6 +246,7 @@ export const ArticleHeadline = ({
     pillar,
     webPublicationDate,
     tags,
+    isShowcase = false,
 }: Props) => {
     const age = getAgeWarning(tags, webPublicationDate);
     return (
@@ -248,7 +256,7 @@ export const ArticleHeadline = ({
                     <AgeWarning age={age} />
                 </div>
             )}
-            {renderHeadline(designType, headlineString, {
+            {renderHeadline(designType, isShowcase, headlineString, {
                 colour: pillarPalette[pillar].dark,
             })}
             {age && <AgeWarning age={age} isScreenReader={true} />}

--- a/src/web/components/GuardianLines.stories.tsx
+++ b/src/web/components/GuardianLines.stories.tsx
@@ -36,6 +36,8 @@ export const defaultStory = () => {
                             headlineString="Headline text"
                             webPublicationDate=""
                             tags={[]}
+                            designType="Article"
+                            pillar="news"
                         />
                     </ArticleContainer>
                 </Flex>
@@ -65,6 +67,8 @@ export const eightLines = () => {
                             headlineString="Headline text"
                             webPublicationDate=""
                             tags={[]}
+                            designType="Article"
+                            pillar="news"
                         />
                     </ArticleContainer>
                 </Flex>
@@ -100,6 +104,8 @@ export const paddedLines = () => {
                             headlineString="Headline text"
                             webPublicationDate=""
                             tags={[]}
+                            designType="Article"
+                            pillar="news"
                         />
                     </ArticleContainer>
                 </Flex>
@@ -135,6 +141,8 @@ export const squigglyLines = () => {
                             headlineString="Headline text"
                             webPublicationDate=""
                             tags={[]}
+                            designType="Article"
+                            pillar="news"
                         />
                     </ArticleContainer>
                 </Flex>

--- a/src/web/layouts/ShowcaseHeader.tsx
+++ b/src/web/layouts/ShowcaseHeader.tsx
@@ -77,6 +77,7 @@ export const ShowcaseHeader = ({ CAPI, badge }: Props) => {
                     pillar={pillar}
                     webPublicationDate={webPublicationDate}
                     tags={tags}
+                    isShowcase={true}
                 />
             </HeaderItem>
             <HeaderItem order={3}>

--- a/src/web/layouts/ShowcaseHeader.tsx
+++ b/src/web/layouts/ShowcaseHeader.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { css } from 'emotion';
 
-import { pillarPalette } from '@root/src/lib/pillars';
 import { from, until, between } from '@guardian/src-foundations/mq';
 
 import { MainMedia } from '@root/src/web/components/MainMedia';
@@ -74,10 +73,10 @@ export const ShowcaseHeader = ({ CAPI, badge }: Props) => {
             <HeaderItem order={2}>
                 <ArticleHeadline
                     headlineString={headline}
-                    tags={tags}
+                    designType={CAPI.designType}
+                    pillar={pillar}
                     webPublicationDate={webPublicationDate}
-                    type="bold"
-                    colour={pillarPalette[pillar].dark}
+                    tags={tags}
                 />
             </HeaderItem>
             <HeaderItem order={3}>

--- a/src/web/layouts/StandardHeader.tsx
+++ b/src/web/layouts/StandardHeader.tsx
@@ -72,8 +72,10 @@ export const StandardHeader = ({ CAPI, badge }: Props) => {
             <HeaderItem order={2}>
                 <ArticleHeadline
                     headlineString={headline}
-                    tags={tags}
+                    designType={CAPI.designType}
+                    pillar={pillar}
                     webPublicationDate={webPublicationDate}
+                    tags={tags}
                 />
             </HeaderItem>
             <HeaderItem order={3}>


### PR DESCRIPTION
## What does this change?
Replaces the usage of a custom `type` from the Headline api with the `designType` value.

## Before

```typescript
type HeadlineType =
    | 'basic'
    | 'underlined'
    | 'light'
    | 'jumbo'
    | 'inverted'
    | 'bold';

type Props = {
    headlineString: string;
    type?: HeadlineType; // Defaults to basic
    webPublicationDate: string; // Used for age warning
    tags: TagType[]; // Used for age warning
    colour?: string; // pass in pillar colour for features, etc.
};
```

## After

```typescript
type Props = {
    headlineString: string;
    designType: DesignType;
    pillar: Pillar;
    webPublicationDate: string; // Used for age warning
    tags: TagType[]; // Used for age warning
    isShowcase?: boolean; // Used for Interviews to change headline position
};
```

This has the effect of adding support for the various headline styles. Please review [the snapshots](https://percy.io/The-Guardian/dotcom/builds/3233423?utm_campaign=The-Guardian&utm_content=dotcom&utm_source=github_status_private) to see these changes.

## Why?
Using `type` with our own custom names for the different ways a headline can be styled creates an additional cognitive burden as it's a new term to learn and forces a mapping to be maintained between the different `designType`s and this value. By removing `type` and directly using `designType` the language of the component is standardised and easier to reason about.

## Why not?
One impact to this change is it brings the logic to decide what type of headline to show into the `ArticleHeadline` component itself, rather than having it in the calling component. This has the effect of distributing decisions rather than keeping them in one place but this seems to be worth it to keep the code readable.

## Link to supporting Trello card
https://trello.com/c/bdpbd7nm/912-refactor-headline-props