### PR TITLE
Remove unused card props

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -261,7 +261,6 @@ interface CardType {
     linkTo: string;
     pillar: Pillar;
     headline: SmallHeadlineType;
-    showDivider?: boolean;
     webPublicationDate?: string;
     image?: CardImageType;
     standfirst?: string;

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -52,7 +52,6 @@ export const Card = ({
     linkTo,
     pillar,
     headline,
-    showDivider = false,
     webPublicationDate,
     image,
     standfirst,


### PR DESCRIPTION
## What does this change?
There's a `showDivider` prop on `Card` not being used, this removes it


## Link to supporting Trello card
https://trello.com/c/rBVYuYZr/914-remove-unused-card-prop
