### PR TITLE
Upgrade to src-foundations v0.8.0

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -255,7 +255,7 @@ type CardImageType = {
     size?: ImageSizeType;
 };
 
-type SmallHeadlineSize = 'tiny' | 'xxsmall' | 'xsmall';
+type SmallHeadlineSize = 'xxxsmall' | 'xxsmall' | 'xsmall';
 
 interface CardType {
     linkTo: string;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     ],
     "dependencies": {
         "@emotion/core": "^10.0.5",
-        "@guardian/src-foundations": "^0.6.0",
+        "@guardian/src-foundations": "^0.8.0",
         "@sentry/browser": "^5.7.1",
         "@types/ajv": "^1.0.0",
         "@types/lodash.escape": "^4.0.6",

--- a/src/amp/components/Header.tsx
+++ b/src/amp/components/Header.tsx
@@ -70,7 +70,7 @@ const pillarLinkStyle = (pillar: Pillar) => css`
     text-decoration: none;
     cursor: pointer;
     display: block;
-    ${headline.tiny()};
+    ${headline.xxxsmall()};
     height: 36px;
     padding: 9px 4px;
     color: ${palette.neutral[100]};

--- a/src/amp/components/OnwardContainer.tsx
+++ b/src/amp/components/OnwardContainer.tsx
@@ -67,11 +67,11 @@ const headlineCSS = css`
     margin: 1px 0 4px;
     font-weight: 500;
     word-wrap: break-word;
-    ${headline.tiny()};
+    ${headline.xxxsmall()};
 `;
 
 const description = css`
-    ${headline.tiny()};
+    ${headline.xxxsmall()};
     margin-bottom: 16px;
 `;
 

--- a/src/amp/components/elements/RichLink.tsx
+++ b/src/amp/components/elements/RichLink.tsx
@@ -23,7 +23,7 @@ const richLink = css`
     font-weight: 500;
     border: 0;
     text-decoration: none;
-    ${headline.tiny()};
+    ${headline.xxxsmall()};
     word-wrap: break-word;
     :hover {
         text-decoration: underline;

--- a/src/amp/components/topMeta/SeriesLink.tsx
+++ b/src/amp/components/topMeta/SeriesLink.tsx
@@ -5,7 +5,7 @@ import { pillarPalette } from '@root/src/lib/pillars';
 
 const seriesStyle = (pillar: Pillar) => css`
     color: ${pillarPalette[pillar].main};
-    ${headline.tiny()};
+    ${headline.xxxsmall()};
     font-weight: 900;
     text-decoration: none;
     margin-top: 10px;

--- a/src/amp/components/topMeta/Standfirst.tsx
+++ b/src/amp/components/topMeta/Standfirst.tsx
@@ -7,7 +7,7 @@ import { composeLabsCSS } from '@root/src/amp/lib/compose-labs-css';
 import { ListStyle, LinkStyle } from '@root/src/amp/components/elements/Text';
 
 const standfirstCss = (pillar: Pillar) => css`
-    ${headline.tiny()};
+    ${headline.xxxsmall()};
     font-weight: 100;
     color: ${palette.neutral[7]};
     margin-bottom: 12px;

--- a/src/amp/components/topMeta/TopMetaLiveblog.tsx
+++ b/src/amp/components/topMeta/TopMetaLiveblog.tsx
@@ -21,7 +21,7 @@ const headerStyle = (pillar: Pillar) => css`
 `;
 
 const bylineStyle = (pillar: Pillar) => css`
-    ${headline.tiny()};
+    ${headline.xxxsmall()};
     color: ${pillarPalette[pillar].main};
     padding-top: 3px;
     padding-bottom: 8px;
@@ -36,7 +36,7 @@ const bylineStyle = (pillar: Pillar) => css`
 `;
 
 const standfirstStyle = (pillar: Pillar) => css`
-    ${headline.tiny()};
+    ${headline.xxxsmall()};
     color: ${palette.neutral[100]};
     background-color: ${pillarPalette[pillar].dark};
     font-weight: bold;

--- a/src/amp/components/topMeta/TopMetaNews.tsx
+++ b/src/amp/components/topMeta/TopMetaNews.tsx
@@ -23,7 +23,7 @@ const headerStyle = css`
     color: ${palette.neutral[7]};
 `;
 const bylineStyle = (pillar: Pillar) => css`
-    ${headline.tiny()};
+    ${headline.xxxsmall()};
     color: ${pillarPalette[pillar].main};
     padding-bottom: 8px;
     font-style: italic;

--- a/src/web/components/ArticleStandfirst.tsx
+++ b/src/web/components/ArticleStandfirst.tsx
@@ -7,7 +7,7 @@ import { headline, textSans } from '@guardian/src-foundations/typography';
 import { Standfirst } from '@frontend/web/components/Standfirst';
 
 const standfirstStyles = css`
-    ${headline.tiny({
+    ${headline.xxxsmall({
         fontWeight: 'bold',
     })};
     line-height: 20px;
@@ -41,7 +41,7 @@ const standfirstStyles = css`
     }
 
     li {
-        ${headline.tiny()};
+        ${headline.xxxsmall()};
     }
 `;
 

--- a/src/web/components/Byline.tsx
+++ b/src/web/components/Byline.tsx
@@ -27,7 +27,7 @@ const twitterHandle = css`
 `;
 
 const bylineStyle = (pillar: Pillar) => css`
-    ${headline.tiny()};
+    ${headline.xxxsmall()};
     color: ${pillarPalette[pillar].main};
     padding-bottom: 8px;
     font-style: italic;

--- a/src/web/components/Card/Card.stories.tsx
+++ b/src/web/components/Card/Card.stories.tsx
@@ -145,7 +145,7 @@ export const News = () => (
                                             headlineString:
                                                 'Listen. Strange women lying in ponds distributing swords is no basis for a system of government',
                                             pillar: 'news',
-                                            size: 'tiny',
+                                            size: 'xxxsmall',
                                         },
                                     }}
                                 />
@@ -160,7 +160,7 @@ export const News = () => (
                                             headlineString:
                                                 'Supreme executive power derives from a mandate from the masses, not from some farcical aquatic ceremony',
                                             pillar: 'news',
-                                            size: 'tiny',
+                                            size: 'xxxsmall',
                                             kicker: {
                                                 text: 'Monty Python',
                                                 pillar: 'news',
@@ -183,7 +183,7 @@ export const News = () => (
                                             headlineString:
                                                 'Are you suggesting that coconuts migrate?',
                                             pillar: 'news',
-                                            size: 'tiny',
+                                            size: 'xxxsmall',
                                             kicker: {
                                                 text: 'Run Away!',
                                                 pillar: 'sport',
@@ -202,7 +202,7 @@ export const News = () => (
                                             headlineString:
                                                 "On second thoughts, let's not go there. It is a silly place",
                                             pillar: 'news',
-                                            size: 'tiny',
+                                            size: 'xxxsmall',
                                             kicker: {
                                                 text: 'Monty Python!',
                                                 pillar: 'news',
@@ -221,7 +221,7 @@ export const News = () => (
                                             headlineString:
                                                 'Let us ride to Camelot',
                                             pillar: 'news',
-                                            size: 'tiny',
+                                            size: 'xxxsmall',
                                             kicker: {
                                                 text: 'Monty Python!',
                                                 pillar: 'news',
@@ -240,7 +240,7 @@ export const News = () => (
                                             headlineString:
                                                 "Where'd you get the coconuts?",
                                             pillar: 'news',
-                                            size: 'tiny',
+                                            size: 'xxxsmall',
                                             kicker: {
                                                 text: 'Monty Python!',
                                                 pillar: 'news',
@@ -259,7 +259,7 @@ export const News = () => (
                                             headlineString:
                                                 'Now, look here, my good man',
                                             pillar: 'news',
-                                            size: 'tiny',
+                                            size: 'xxxsmall',
                                             kicker: {
                                                 text: 'Terry Gillingham',
                                                 pillar: 'lifestyle',
@@ -278,7 +278,7 @@ export const News = () => (
                                             headlineString:
                                                 "We shall say 'Ni' again to you, if you do not appease us",
                                             pillar: 'news',
-                                            size: 'tiny',
+                                            size: 'xxxsmall',
                                             kicker: {
                                                 text: 'Monty Python',
                                                 pillar: 'news',
@@ -339,7 +339,7 @@ export const InDepth = () => (
                                         headline: {
                                             headlineString:
                                                 'Now, look here, my good man',
-                                            size: 'tiny',
+                                            size: 'xxxsmall',
                                             pillar: 'news',
                                             kicker: {
                                                 text: 'Holy Grail',
@@ -363,7 +363,7 @@ export const InDepth = () => (
                                         headline: {
                                             headlineString:
                                                 "Where'd you get the coconuts",
-                                            size: 'tiny',
+                                            size: 'xxxsmall',
                                             pillar: 'news',
                                             kicker: {
                                                 text: 'Holy Grail',
@@ -387,7 +387,7 @@ export const InDepth = () => (
                                         headline: {
                                             headlineString:
                                                 'Let us ride to Camelot!',
-                                            size: 'tiny',
+                                            size: 'xxxsmall',
                                             pillar: 'news',
                                             kicker: {
                                                 text: 'Holy Grail',
@@ -411,7 +411,7 @@ export const InDepth = () => (
                                         headline: {
                                             headlineString:
                                                 'How do you know she is a witch? Burn her!',
-                                            size: 'tiny',
+                                            size: 'xxxsmall',
                                             pillar: 'news',
                                             kicker: {
                                                 text: 'Holy Grail',
@@ -553,7 +553,7 @@ export const Related = () => (
                                 headline: {
                                     headlineString:
                                         'Go and boil your bottoms, sons of a silly person!',
-                                    size: 'tiny',
+                                    size: 'xxxsmall',
                                     pillar: 'news',
                                     kicker: {
                                         text: 'Monty Python',
@@ -572,7 +572,7 @@ export const Related = () => (
                                 pillar: 'sport',
                                 headline: {
                                     headlineString: 'Let us ride to Camelot!',
-                                    size: 'tiny',
+                                    size: 'xxxsmall',
                                     pillar: 'news',
                                     kicker: {
                                         text: 'Monty Python',
@@ -591,7 +591,7 @@ export const Related = () => (
                                 pillar: 'sport',
                                 headline: {
                                     headlineString: 'Let us ride to Camelot!',
-                                    size: 'tiny',
+                                    size: 'xxxsmall',
                                     pillar: 'news',
                                     kicker: {
                                         text: 'Monty Python',
@@ -611,7 +611,7 @@ export const Related = () => (
                                 headline: {
                                     headlineString:
                                         'How do you know she is a witch? Burn her!',
-                                    size: 'tiny',
+                                    size: 'xxxsmall',
                                     pillar: 'news',
                                     kicker: {
                                         text: 'Holy Grail',

--- a/src/web/components/Header/Links/SupportTheGuardian.tsx
+++ b/src/web/components/Header/Links/SupportTheGuardian.tsx
@@ -42,14 +42,14 @@ const style = css`
 
 const text = css`
     color: ${palette.neutral[97]};
-    ${headline.tiny()};
+    ${headline.xxxsmall()};
     font-weight: 700;
     text-align: center;
     padding: 6px 20px 3px;
     position: relative;
 
     ${from.tablet} {
-        ${headline.tiny()};
+        ${headline.xxxsmall()};
     }
 `;
 

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterGrid.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterGrid.tsx
@@ -56,7 +56,7 @@ const unselectedListTab = css`
 `;
 
 const tabButton = css`
-    ${headline.tiny()};
+    ${headline.xxxsmall()};
     margin: 0;
     border: 0;
     background: transparent;

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterItem.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterItem.tsx
@@ -53,7 +53,7 @@ const headlineLink = css`
     text-decoration: none;
     color: ${palette.neutral[7]};
     font-weight: 500;
-    ${headline.tiny()};
+    ${headline.xxxsmall()};
 `;
 
 const ageWarningStyles = css`
@@ -79,7 +79,7 @@ export const MostViewedFooterItem = ({ trail, position }: Props) => (
                     <SmallHeadline
                         headlineString={trail.linkText}
                         pillar={trail.pillar}
-                        size="tiny"
+                        size="xxxsmall"
                         kicker={{
                             text: 'Live',
                             pillar: trail.pillar,
@@ -91,7 +91,7 @@ export const MostViewedFooterItem = ({ trail, position }: Props) => (
                     <SmallHeadline
                         headlineString={trail.linkText}
                         pillar={trail.pillar}
-                        size="tiny"
+                        size="xxxsmall"
                     />
                 )}
             </div>

--- a/src/web/components/MostViewed/MostViewedRight/MostViewedRight.tsx
+++ b/src/web/components/MostViewed/MostViewedRight/MostViewedRight.tsx
@@ -11,7 +11,7 @@ const wrapperStyles = css`
 `;
 
 const headingStyles = css`
-    ${headline.tiny({ fontWeight: 'bold' })}
+    ${headline.xxxsmall({ fontWeight: 'bold' })}
     margin-bottom: 8px;
 `;
 

--- a/src/web/components/MostViewed/MostViewedRight/MostViewedRightItem.tsx
+++ b/src/web/components/MostViewed/MostViewedRight/MostViewedRightItem.tsx
@@ -22,7 +22,7 @@ const listItemStyles = css`
 const linkTagStyles = css`
     text-decoration: none;
     font-weight: 500;
-    ${headline.tiny()};
+    ${headline.xxxsmall()};
 
     &:link,
     &:active {
@@ -101,7 +101,7 @@ export const MostViewedRightItem = ({ trail }: Props) => {
                         <SmallHeadline
                             headlineString={trail.linkText}
                             pillar={trail.pillar}
-                            size="tiny"
+                            size="xxxsmall"
                             showUnderline={isHovered}
                             {...itemProps}
                             link={{

--- a/src/web/components/Pillars.tsx
+++ b/src/web/components/Pillars.tsx
@@ -119,7 +119,7 @@ const pillarDivider = css`
 `;
 
 const linkStyle = css`
-    ${headline.tiny()};
+    ${headline.xxxsmall()};
     box-sizing: border-box;
     font-weight: 900;
     color: ${palette.neutral[100]};

--- a/src/web/components/QuoteIcon.tsx
+++ b/src/web/components/QuoteIcon.tsx
@@ -10,9 +10,9 @@ const quoteStyles = (colour?: string) => css`
     fill: ${colour && colour};
 `;
 
-const sizeStyles = (size: 'tiny' | 'xxsmall' | 'xsmall') => {
+const sizeStyles = (size: 'xxxsmall' | 'xxsmall' | 'xsmall') => {
     switch (size) {
-        case 'tiny':
+        case 'xxxsmall':
             return css`
                 svg {
                     height: 16px;
@@ -47,7 +47,7 @@ const sizeStyles = (size: 'tiny' | 'xxsmall' | 'xsmall') => {
 
 type Props = {
     colour?: string;
-    size?: 'tiny' | 'xxsmall' | 'xsmall';
+    size?: 'xxxsmall' | 'xxsmall' | 'xsmall';
 };
 
 export const QuoteIcon = ({ colour, size = 'xxsmall' }: Props) => (

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -24,14 +24,14 @@ const pillarColours = pillarMap(
 
 const primaryStyle = css`
     font-weight: 700;
-    ${headline.tiny()};
+    ${headline.xxxsmall()};
     ${from.leftCol} {
         ${headline.xxsmall()};
     }
 `;
 
 const secondaryStyle = css`
-    ${headline.tiny()};
+    ${headline.xxxsmall()};
     display: block;
 `;
 

--- a/src/web/components/SmallHeadline.stories.tsx
+++ b/src/web/components/SmallHeadline.stories.tsx
@@ -12,16 +12,16 @@ export default {
 };
 /* tslint:enable */
 
-export const tinyStory = () => (
+export const xxxsmallStory = () => (
     <Section showTopBorder={false} showSideBorders={false}>
         <SmallHeadline
-            headlineString="This is how a tiny headline link looks"
+            headlineString="This is how a xxxsmall headline link looks"
             pillar="news"
-            size="tiny"
+            size="xxxsmall"
         />
     </Section>
 );
-tinyStory.story = { name: 'Size | tiny' };
+xxxsmallStory.story = { name: 'Size | xxxsmall' };
 
 export const defaultStory = () => (
     <Section showTopBorder={false} showSideBorders={false}>
@@ -102,17 +102,17 @@ export const cultureVariant = () => (
 );
 cultureVariant.story = { name: 'With a culture kicker' };
 
-export const underlinedTiny = () => (
+export const underlinedxxxsmall = () => (
     <Section showTopBorder={false} showSideBorders={false}>
         <SmallHeadline
-            headlineString="Sometimes tiny headline links are underlined"
+            headlineString="Sometimes xxxsmall headline links are underlined"
             pillar="news"
-            size="tiny"
+            size="xxxsmall"
             underlined={true}
         />
     </Section>
 );
-underlinedTiny.story = { name: 'Underlined | tiny' };
+underlinedxxxsmall.story = { name: 'Underlined | xxxsmall' };
 
 export const underlinedXXSmall = () => (
     <Section showTopBorder={false} showSideBorders={false}>
@@ -138,17 +138,17 @@ export const underlinedXSmall = () => (
 );
 underlinedXSmall.story = { name: 'Underlined | xsmall' };
 
-export const opinionTiny = () => (
+export const opinionxxxsmall = () => (
     <Section showTopBorder={false} showSideBorders={false}>
         <SmallHeadline
-            headlineString="This is how tiny links to opinion articles look"
+            headlineString="This is how xxxsmall links to opinion articles look"
             pillar="opinion"
             showQuotes={true}
-            size="tiny"
+            size="xxxsmall"
         />
     </Section>
 );
-opinionTiny.story = { name: 'Quotes | tiny' };
+opinionxxxsmall.story = { name: 'Quotes | xxxsmall' };
 
 export const opinionXXSmall = () => (
     <Section showTopBorder={false} showSideBorders={false}>
@@ -241,7 +241,7 @@ export const InUnderlinedState = () => (
             headlineString="This is the underlined state when showUnderline is true"
             pillar="news"
             showUnderline={true}
-            size="tiny"
+            size="xxxsmall"
             kicker={{
                 text: 'I am never underlined',
                 pillar: 'news',

--- a/src/web/components/SmallHeadline.tsx
+++ b/src/web/components/SmallHeadline.tsx
@@ -32,7 +32,7 @@ const underlinedStyles = (size: SmallHeadlineSize) => {
         `;
     }
     switch (size) {
-        case 'tiny':
+        case 'xxxsmall':
             return generateUnderlinedCss(20);
         case 'xxsmall':
             return generateUnderlinedCss(23);

--- a/src/web/components/Standfirst.tsx
+++ b/src/web/components/Standfirst.tsx
@@ -30,11 +30,11 @@ const standfirstStyles = css`
     }
 
     li {
-        ${headline.tiny()};
+        ${headline.xxxsmall()};
     }
 `;
 
-// type SizeType = 'tiny' | 'small' | 'medium';
+// type SizeType = 'xxxsmall' | 'small' | 'medium';
 // type WeightType = 'light' | 'regular' | 'medium' | 'bold';
 
 type Props = {

--- a/src/web/components/SubMetaLinksList.tsx
+++ b/src/web/components/SubMetaLinksList.tsx
@@ -52,7 +52,7 @@ const subMetaLink = css`
 `;
 
 const subMetaSectionLink = css`
-    ${headline.tiny()};
+    ${headline.xxxsmall()};
 `;
 
 const subMetaKeywordLink = css`

--- a/src/web/components/elements/RichLinkComponent.tsx
+++ b/src/web/components/elements/RichLinkComponent.tsx
@@ -93,7 +93,7 @@ const richLinkHeader = css`
 `;
 
 const richLinkTitle = css`
-    ${headline.tiny()};
+    ${headline.xxxsmall()};
     font-size: 14px;
     padding-top: 1px;
     padding-bottom: 1px;
@@ -113,10 +113,10 @@ const richLinkReadMore: (pillar: Pillar) => colour = pillar => {
 };
 
 const readMoreTextStyle = css`
-    ${headline.tiny()};
+    ${headline.xxxsmall()};
     font-size: 14px;
     ${from.wide} {
-        ${headline.tiny()}
+        ${headline.xxxsmall()}
     }
     display: inline-block;
     height: 30px;
@@ -128,7 +128,7 @@ const readMoreTextStyle = css`
 `;
 
 const byline = css`
-    ${headline.tiny()};
+    ${headline.xxxsmall()};
     font-size: 14px;
     font-style: italic;
     ${from.wide} {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1342,10 +1342,10 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
-"@guardian/src-foundations@^0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.6.0.tgz#a5fc783faedb62686756c7ca92b4e851227e3710"
-  integrity sha512-zuU5VSexP/qZoku3/Tq+3YeeeCCU+f2Sx+mGjZQK7ltE0dBBFlXk204JzSM6iCd9QAvQvn4gTwXOT12NQk/J8g==
+"@guardian/src-foundations@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.8.0.tgz#c8d422324522540c502070845318dad183a336bc"
+  integrity sha512-n0E8BV5wpdZomH6vXesh2gfHbrlTlIUTcGfLuur+xN3WJ//nangJsI1jckf9X6y+XnUiQeFUclrQEgNYFPPIrw==
 
 "@hapi/address@2.x.x":
   version "2.1.2"


### PR DESCRIPTION
## What does this change?

Upgrades Foundations to v0.8.0. The most impactful change is a rename of `headline.tiny` to `headline.xxxsmall`, for consistency. 

Note that this also changes our spacing system from 6px-based to 4px-based, but I don't think you're using the `space` foundation anywhere?

## Why?

[CHANGELOG](https://github.com/guardian/source-components/blob/master/CHANGELOG.md)
