### PR TITLE
Disable Percy for Storybook for now

### DIFF
--- a/makefile
+++ b/makefile
@@ -60,8 +60,8 @@ dev: clear clean-dist install
 # cypress #####################################
 
 percy: clear clean-dist install
-	$(call log, "taking snapshots from storybook")
-	@yarn storybook:snapshot
+	# $(call log, "taking snapshots from storybook")
+	# @yarn storybook:snapshot
 	$(call log, "starting frontend DEV server for Cypress")
 	@NODE_ENV=development start-server-and-test 'node scripts/frontend/dev-server' 3030 'percy exec -- cypress run --spec "cypress/integration/percy/**/*"'
 


### PR DESCRIPTION
## What does this change?
Disables taking snapshots from Storybook because we can currently only have one set of snapshots per build, Cypress or Storybook, so this make the choice for Cypress while we work on a solution.

## Trello
https://trello.com/c/CDKNDdH5/937-disable-storybook-snapshots