### PR TITLE
Use EU for edition, not UK

### DIFF
--- a/cypress/integration/percy/article.web.spec.js
+++ b/cypress/integration/percy/article.web.spec.js
@@ -15,7 +15,7 @@ describe('For WEB', function() {
             // Prevent the Privacy consent banner from obscuring snapshots
             cy.setCookie('GU_TK', 'true');
             // Fix the location to UK (for edition)
-            cy.setCookie('GU_EDITION', 'UK');
+            cy.setCookie('GU_EDITION', 'EU');
             cy.visit(`Article?url=${url}`, fetchPolyfill);
             cy.percySnapshot(`WEB-${pillar}-${designType}-${index}`, {
                 widths: [739, 979, 1139, 1299, 1400],


### PR DESCRIPTION
## What does this change?
Replace `UK` with `EU` when trying to fix the edition that gets served for Percy tests.

## Why?
Because we still sometimes get served the international edition, failing snapshots.

## Trello
https://trello.com/c/s25cC1BZ/936-eu-not-uk