### PR TITLE
Added snapshot cmd for second percy project

### DIFF
--- a/makefile
+++ b/makefile
@@ -60,10 +60,10 @@ dev: clear clean-dist install
 # cypress #####################################
 
 percy: clear clean-dist install
-	$(call log, "taking snapshots from storybook")
-	@yarn storybook:snapshot
-	$(call log, "starting frontend DEV server for Cypress")
-	@NODE_ENV=development start-server-and-test 'node scripts/frontend/dev-server' 3030 'percy exec -- cypress run --spec "cypress/integration/percy/**/*"'
+	$(call log, "starting frontend DEV server for Cypress to take snapshots")
+	@PERCY_TOKEN=${PERCY_PAGES_TOKEN} NODE_ENV=development start-server-and-test 'node scripts/frontend/dev-server' 3030 'percy exec -- cypress run --spec "cypress/integration/percy/**/*"'
+	$(call log, "taking snapshots from Storybook")
+	@PERCY_TOKEN=${PERCY_COMPONENTS_TOKEN} yarn storybook:snapshot
 
 cypress: clear clean-dist install
 	$(call log, "starting frontend DEV server for Cypress")


### PR DESCRIPTION
## What does this change?
In order to capture snapshots from both Cypress (pages) and Storybook (components), we need a second Percy project to bucket things.

## Why?
Better test coverage

## Link to supporting Trello card
https://trello.com/c/oc0q4nxw/938-create-second-percy-project