### PR TITLE
Force edition header

### DIFF
--- a/cypress/integration/percy/article.web.spec.js
+++ b/cypress/integration/percy/article.web.spec.js
@@ -9,14 +9,22 @@ describe('For WEB', function() {
     beforeEach(fixTime);
     beforeEach(mockApi);
 
+    const EDITION = 'UK';
+
     articles.map((article, index) => {
         const { url, pillar, designType } = article;
         it(`It should load ${designType} articles under the ${pillar} pillar`, function() {
             // Prevent the Privacy consent banner from obscuring snapshots
             cy.setCookie('GU_TK', 'true');
             // Fix the location to UK (for edition)
-            cy.setCookie('GU_EDITION', 'UK');
-            cy.visit(`Article?url=${url}`, fetchPolyfill);
+            cy.setCookie('GU_EDITION', EDITION);
+            cy.visit(`Article?url=${url}`, {
+                ...fetchPolyfill,
+                // In addition to the GU_EDITION cookie above, we're also setting this header here
+                headers: {
+                    'X-Gu-Edition': EDITION,
+                },
+            });
             cy.percySnapshot(`WEB-${pillar}-${designType}-${index}`, {
                 widths: [739, 979, 1139, 1299, 1400],
             });


### PR DESCRIPTION
## What does this change?
We've been using the `GU_EDITION` cookie to for the UK edition on out cypress snapshots but this hasn't always worked. It's possible fastly is overriding this cookie. This PR also mocks the `X-Gu-Edition`.

If this proves to be reliable over time then we'll look to rationalise things by removing the cookie. If not, then we have a deeper issue and we may need to look at things further.

## Why?
To prevent the edition changing between snapshots

## Link to supporting Trello card
https://trello.com/c/a6qF46TD/941-fix-cypress-edition
