### PR TITLE
Mock edition

### DIFF
--- a/cypress/integration/percy/article.web.spec.js
+++ b/cypress/integration/percy/article.web.spec.js
@@ -14,9 +14,8 @@ describe('For WEB', function() {
         it(`It should load ${designType} articles under the ${pillar} pillar`, function() {
             // Prevent the Privacy consent banner from obscuring snapshots
             cy.setCookie('GU_TK', 'true');
-            // Fix the location to UK (for edition)
-            cy.setCookie('GU_EDITION', 'UK');
-            cy.visit(`Article?url=${url}`, fetchPolyfill);
+            // Make the request, forcing the location to UK (for edition)
+            cy.visit(`Article?url=${url}?_edition=UK`, fetchPolyfill);
             cy.percySnapshot(`WEB-${pillar}-${designType}-${index}`, {
                 widths: [739, 979, 1139, 1299, 1400],
             });

--- a/scripts/frontend/dev-server.js
+++ b/scripts/frontend/dev-server.js
@@ -13,8 +13,11 @@ function buildUrl(req) {
     const DEFAULT_URL =
         'https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software';
     const url = new URL(req.query.url || DEFAULT_URL);
+    // searchParams will only work for the first set of query params because 'url' is already a query param itself
+    const searchparams = url.searchParams && url.searchParams.toString();
     // Reconstruct the parsed url adding .json?dcr which we need to force dcr to return json
-    return `${url.origin}${url.pathname}.json?dcr=true${url.search}`;
+    return `${url.origin}${url.pathname}.json?dcr=true${searchparams &&
+        '&' + searchparams}`;
 }
 
 function ampifyUrl(url) {

--- a/scripts/frontend/dev-server.js
+++ b/scripts/frontend/dev-server.js
@@ -16,8 +16,7 @@ function buildUrl(req) {
     // searchParams will only work for the first set of query params because 'url' is already a query param itself
     const searchparams = url.searchParams && url.searchParams.toString();
     // Reconstruct the parsed url adding .json?dcr which we need to force dcr to return json
-    return `${url.origin}${url.pathname}.json?dcr=true${searchparams &&
-        '&' + searchparams}`;
+    return `${url.origin}${url.pathname}.json?dcr=true&${searchparams}`;
 }
 
 function ampifyUrl(url) {


### PR DESCRIPTION
## What does this change?
Previous attempts to mock edition were failing because our local dev server did not pass query params through. This PR fixes this and then amends the cypress tests to use the `_edition` query param to force the UK edition.

## Why?
To prevent our cypress snapshots being rendered with different editions, causing false negatives.

## Link to supporting Trello card
https://trello.com/c/a6qF46TD/941-fix-cypress-edition
