### PR TITLE
Take fewer snapshots

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "cypress:run:e2e": "cypress run --spec 'cypress/integration/e2e/**/*'",
         "storybook": "start-storybook -s ./src/static -p 6006",
         "storybook:build": "build-storybook",
-        "storybook:snapshot": "build-storybook && percy-storybook --widths=320,1139"
+        "storybook:snapshot": "build-storybook && percy-storybook --widths=1139"
     },
     "husky": {
         "hooks": {


### PR DESCRIPTION
## What does this change?
This reduces the number of viewports we take Storybook snapshots over from 2 to 1.

## Why?
This halves our count of snapshots and speeds up the build. We already have viewport coverage when taking article level snapshots which is more useful

## Link to supporting Trello card
https://trello.com/c/KTVNGjlu/943-reduce-storybook-snapshots