### PR TITLE
Percy in Github Actions

### DIFF
--- a/.github/percy.yml
+++ b/.github/percy.yml
@@ -1,0 +1,19 @@
+name: Percy Snapshots
+
+on: [push]
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v1
+            - name: Use Node.js 10.15
+              uses: actions/setup-node@v1
+              with:
+                  node-version: 10.15
+            - name: Run Percy
+              run: make percy
+              env:
+                  PERCY_PAGES_TOKEN: ${{ secrets.PERCY_PAGES_TOKEN }}
+                  PERCY_COMPONENTS_TOKEN: ${{ secrets.PERCY_COMPONENTS_TOKEN }}


### PR DESCRIPTION
## What does this change?
Adds `percy.yml` a file used by Github to integrate Actions to this repo for running the Percy tests.

## Why?
To make the build faster

## Link to supporting Trello card
https://trello.com/c/9WRm5pYx/944-use-github-actions-for-percy