### PR TITLE
Remove root config prop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,6 @@
 interface ArticleProps {
     CAPI: CAPIType;
     NAV: NavType;
-    config: ConfigType;
 }
 
 // Pillars are used for styling
@@ -371,7 +370,6 @@ interface DCRDocumentData {
     site: string;
     CAPI: CAPIType;
     NAV: NavType;
-    config: ConfigType;
     GA: GADataType;
     linkedData: object;
 }

--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -29,32 +29,33 @@ export interface WindowGuardianConfig {
 const makeWindowGuardianConfig = (
     dcrDocumentData: DCRDocumentData,
 ): WindowGuardianConfig => {
+    const { config } = dcrDocumentData.CAPI;
     return {
         // This indicates to the client side code that we are running a dotcom-rendering rendered page.
         isDotcomRendering: true,
-        stage: dcrDocumentData.config.stage,
-        frontendAssetsFullURL: dcrDocumentData.config.frontendAssetsFullURL,
-        page: Object.assign(dcrDocumentData.config, {
+        stage: config.stage,
+        frontendAssetsFullURL: config.frontendAssetsFullURL,
+        page: Object.assign(config, {
             dcrCouldRender: true,
             contentType: dcrDocumentData.CAPI.contentType,
             edition: dcrDocumentData.CAPI.editionId,
-            revisionNumber: dcrDocumentData.config.revisionNumber,
+            revisionNumber: config.revisionNumber,
             dcrSentryDsn:
                 'https://1937ab71c8804b2b8438178dfdd6468f@sentry.io/1377847',
-            sentryPublicApiKey: dcrDocumentData.config.sentryPublicApiKey,
-            sentryHost: dcrDocumentData.config.sentryHost,
+            sentryPublicApiKey: config.sentryPublicApiKey,
+            sentryHost: config.sentryHost,
             keywordIds: [],
-            dfpAccountId: dcrDocumentData.config.dfpAccountId,
-            adUnit: dcrDocumentData.config.adUnit,
+            dfpAccountId: config.dfpAccountId,
+            adUnit: config.adUnit,
             showRelatedContent: true,
-            ajaxUrl: dcrDocumentData.config.ajaxUrl,
-            hbImpl: dcrDocumentData.config.hbImpl,
+            ajaxUrl: config.ajaxUrl,
+            hbImpl: config.hbImpl,
         }),
         libs: {
-            googletag: dcrDocumentData.config.googletagUrl,
+            googletag: config.googletagUrl,
         },
-        switches: dcrDocumentData.CAPI.config.switches,
-        tests: dcrDocumentData.CAPI.config.abTests || {},
+        switches: config.switches,
+        tests: config.abTests || {},
     } as WindowGuardianConfig;
 };
 

--- a/src/web/browser/react/init.ts
+++ b/src/web/browser/react/init.ts
@@ -6,7 +6,7 @@ import { hydrateIslands } from '@frontend/web/islands/islands';
 const init = (): Promise<void> => {
     const {
         cssIDs,
-        data: { CAPI, config, NAV },
+        data: { CAPI, NAV },
     } = window.guardian.app;
 
     /**
@@ -19,7 +19,7 @@ const init = (): Promise<void> => {
         hydrateCSS(cssIDs);
     }
 
-    hydrateIslands(CAPI, config, NAV);
+    hydrateIslands(CAPI, NAV);
 
     return Promise.resolve();
 };

--- a/src/web/browser/sentry/sentry.tsx
+++ b/src/web/browser/sentry/sentry.tsx
@@ -24,12 +24,15 @@ const ignoreErrors = [
 ];
 
 export const initialiseSentry = (adBlockInUse: boolean) => {
-    const { editionLongForm, contentType } = window.guardian.app.data.CAPI;
     const {
-        isDev,
-        switches: { enableSentryReporting },
-        dcrSentryDsn,
-    } = window.guardian.app.data.config;
+        editionLongForm,
+        contentType,
+        config: {
+            isDev,
+            switches: { enableSentryReporting },
+            dcrSentryDsn,
+        },
+    } = window.guardian.app.data.CAPI;
 
     Sentry.init({
         ignoreErrors,

--- a/src/web/islands/islands.tsx
+++ b/src/web/islands/islands.tsx
@@ -20,7 +20,6 @@ type IslandProps =
           dataLinkName: string;
       }
     | {
-          config: ConfigType;
           pillar: Pillar;
           sectionName?: string;
       }
@@ -55,13 +54,14 @@ type IslandType = {
     root: string;
 };
 
-export const hydrateIslands = (
-    CAPI: CAPIType,
-    config: ConfigType,
-    NAV: NavType,
-) => {
-    const { pillar, editionId, sectionName, pageId } = CAPI;
-    const { ajaxUrl } = config;
+export const hydrateIslands = (CAPI: CAPIType, NAV: NavType) => {
+    const {
+        pillar,
+        editionId,
+        sectionName,
+        pageId,
+        config: { ajaxUrl },
+    } = CAPI;
 
     // Define the list of islands we intend to hydrate. Each island should have a
     // corresponding root element that exists on the DOM with the id value equal to the root property
@@ -109,7 +109,6 @@ export const hydrateIslands = (
         {
             component: MostViewedFooter,
             props: {
-                config,
                 pillar,
                 sectionName,
             },
@@ -147,7 +146,7 @@ export const hydrateIslands = (
                 props: {
                     element,
                     pillar,
-                    ajaxEndpoint: config.ajaxUrl,
+                    ajaxEndpoint: ajaxUrl,
                 },
                 root: `rich-link-${i}`,
             });

--- a/src/web/layouts/DecideLayout.tsx
+++ b/src/web/layouts/DecideLayout.tsx
@@ -9,18 +9,17 @@ import { hasShowcase } from './layoutHelpers';
 type Props = {
     designType: DesignType;
     CAPI: CAPIType;
-    config: ConfigType;
     NAV: NavType;
 };
 
-export const DecideLayout = ({ designType, CAPI, config, NAV }: Props) => {
+export const DecideLayout = ({ designType, CAPI, NAV }: Props) => {
     if (hasShowcase(CAPI.mainMediaElements)) {
-        return <ShowcaseLayout CAPI={CAPI} config={config} NAV={NAV} />;
+        return <ShowcaseLayout CAPI={CAPI} NAV={NAV} />;
     }
 
     // Otherwise, switch based on designType
     const designTypeContent: DesignTypesObj = designTypeDefault(
-        <StandardLayout CAPI={CAPI} config={config} NAV={NAV} />,
+        <StandardLayout CAPI={CAPI} NAV={NAV} />,
     );
 
     return designTypeContent[designType];

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -27,11 +27,10 @@ import { ShowcaseHeader } from './ShowcaseHeader';
 
 interface Props {
     CAPI: CAPIType;
-    config: ConfigType;
     NAV: NavType;
 }
 
-export const ShowcaseLayout = ({ CAPI, config, NAV }: Props) => (
+export const ShowcaseLayout = ({ CAPI, NAV }: Props) => (
     <>
         <Section showTopBorder={false} showSideBorders={false} padded={false}>
             <HeaderAdSlot

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -41,11 +41,10 @@ function checkForGE2019Badge(tags: TagType[]) {
 
 interface Props {
     CAPI: CAPIType;
-    config: ConfigType;
     NAV: NavType;
 }
 
-export const StandardLayout = ({ CAPI, config, NAV }: Props) => {
+export const StandardLayout = ({ CAPI, NAV }: Props) => {
     const GE2019Badge = checkForGE2019Badge(CAPI.tags);
     return (
         <>

--- a/src/web/pages/Article.tsx
+++ b/src/web/pages/Article.tsx
@@ -9,7 +9,6 @@ export const Article: React.FC<{
         <DecideLayout
             designType={data.CAPI.designType}
             CAPI={data.CAPI}
-            config={data.config}
             NAV={data.NAV}
         />
     );

--- a/src/web/server/document.test.tsx
+++ b/src/web/server/document.test.tsx
@@ -11,7 +11,6 @@ const result = document({
         page: 'article',
         site: 'site',
         NAV: extractNAV(CAPI.nav),
-        config: CAPI.config,
         GA: ga,
     },
 });

--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -18,13 +18,13 @@ interface RenderToStringResult {
 }
 
 export const document = ({ data }: Props) => {
-    const { CAPI, NAV, config, linkedData } = data;
+    const { CAPI, NAV, linkedData } = data;
     const title = `${CAPI.headline} | ${CAPI.sectionLabel} | The Guardian`;
     const { html, css, ids: cssIDs }: RenderToStringResult = extractCritical(
         renderToString(
             // TODO: CacheProvider can be removed when we've moved over to using @emotion/core
             <CacheProvider value={cache}>
-                <Article data={{ CAPI, NAV, config }} />
+                <Article data={{ CAPI, NAV }} />
             </CacheProvider>,
         ),
     );
@@ -61,7 +61,7 @@ export const document = ({ data }: Props) => {
         polyfillIO,
         getDist('sentry.js'),
         getDist('react.js'),
-        config.commercialBundleUrl,
+        CAPI.config && CAPI.config.commercialBundleUrl,
     ];
 
     /**

--- a/src/web/server/render.ts
+++ b/src/web/server/render.ts
@@ -12,14 +12,16 @@ export const render = ({ body }: express.Request, res: express.Response) => {
 
         const resp = document({
             data: {
-                CAPI,
+                CAPI: {
+                    ...CAPI,
+                    config: {
+                        ...CAPI.config,
+                        isDev: process.env.NODE_ENV !== 'production',
+                    },
+                },
                 site: 'frontend',
                 page: 'Article',
                 NAV: extractNAV(CAPI.nav),
-                config: {
-                    ...CAPI.config,
-                    isDev: process.env.NODE_ENV !== 'production',
-                },
                 GA: extractGA(CAPI),
                 linkedData: CAPI.linkedData,
             },


### PR DESCRIPTION
## What does this change?
This refactors out the root `config` prop in favour of the same value which already exists on `CAPI.config`.

## Why?
To simplify

## Link to supporting Trello card
https://trello.com/c/rciiuNPU/768-refactor-how-we-manage-and-pass-config
