### PR TITLE
Partial Right Border

### DIFF
--- a/src/web/components/ArticleLeft.stories.tsx
+++ b/src/web/components/ArticleLeft.stories.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+
+import { Flex } from '@root/src/web/components/Flex';
+import { ArticleRight } from '@root/src/web/components/ArticleRight';
+import { ArticleContainer } from '@root/src/web/components/ArticleContainer';
+import { Section } from '@frontend/web/components/Section';
+
+import { ArticleLeft } from './ArticleLeft';
+
+/* tslint:disable */
+export default {
+    component: ArticleLeft,
+    title: 'Components/ArticleLeft',
+};
+/* tslint:enable */
+
+export const PartialRightBorder = () => {
+    return (
+        <Section>
+            <Flex>
+                <ArticleLeft
+                    showPartialRightBorder={true}
+                    showRightBorder={false}
+                >
+                    <>
+                        The border to my right is only partial, it does not
+                        stretch the whole height
+                    </>
+                </ArticleLeft>
+                <ArticleContainer>
+                    <img
+                        src="https://www.fillmurray.com/g/300/450"
+                        alt="Bill"
+                    />
+                </ArticleContainer>
+                <ArticleRight>
+                    <>Right column content</>
+                </ArticleRight>
+            </Flex>
+        </Section>
+    );
+};
+PartialRightBorder.story = { name: 'Partial right border' };
+
+export const RightBorder = () => {
+    return (
+        <Section>
+            <Flex>
+                <ArticleLeft>
+                    <>The border to my right should stretch the whole height</>
+                </ArticleLeft>
+                <ArticleContainer>
+                    <img
+                        src="https://www.fillmurray.com/g/600/500"
+                        alt="Bill"
+                    />
+                </ArticleContainer>
+                <ArticleRight>
+                    <>Right column content</>
+                </ArticleRight>
+            </Flex>
+        </Section>
+    );
+};
+RightBorder.story = { name: 'Full right border' };

--- a/src/web/components/ArticleLeft.stories.tsx
+++ b/src/web/components/ArticleLeft.stories.tsx
@@ -29,7 +29,7 @@ export const PartialRightBorder = () => {
                 </ArticleLeft>
                 <ArticleContainer>
                     <img
-                        src="https://www.fillmurray.com/g/300/450"
+                        src="https://www.fillmurray.com/g/600/500"
                         alt="Bill"
                     />
                 </ArticleContainer>

--- a/src/web/components/ArticleLeft.tsx
+++ b/src/web/components/ArticleLeft.tsx
@@ -58,20 +58,27 @@ export const ArticleLeft = ({
     showRightBorder = true,
     borderColour = palette.neutral[86],
     showPartialRightBorder = false,
-}: Props) => (
-    <section
-        className={cx(
-            positionRelative,
-            leftWidth,
-            showRightBorder && rightBorder(borderColour),
-        )}
-    >
-        <div
+}: Props) => {
+    // Make sure we can never have both borders at the same time
+    const shouldShowPartialBorder = showRightBorder
+        ? false
+        : showPartialRightBorder;
+
+    return (
+        <section
             className={cx(
-                showPartialRightBorder && partialRightBorder(borderColour),
+                positionRelative,
+                leftWidth,
+                showRightBorder && rightBorder(borderColour),
             )}
         >
-            {children}
-        </div>
-    </section>
-);
+            <div
+                className={cx(
+                    shouldShowPartialBorder && partialRightBorder(borderColour),
+                )}
+            >
+                {children}
+            </div>
+        </section>
+    );
+};

--- a/src/web/components/ArticleLeft.tsx
+++ b/src/web/components/ArticleLeft.tsx
@@ -25,6 +25,23 @@ const leftWidth = css`
     }
 `;
 
+const positionRelative = css`
+    position: relative;
+`;
+
+const partialRightBorder = (colour: string) => css`
+    :before {
+        content: '';
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        right: 0;
+        height: 30px;
+        width: 1px;
+        background: ${colour};
+    }
+`;
+
 const rightBorder = (colour: string) => css`
     border-right: 1px solid ${colour};
 `;
@@ -33,16 +50,28 @@ type Props = {
     children: JSXElements;
     showRightBorder?: boolean;
     borderColour?: string;
+    showPartialRightBorder?: boolean;
 };
 
 export const ArticleLeft = ({
     children,
     showRightBorder = true,
     borderColour = palette.neutral[86],
+    showPartialRightBorder = false,
 }: Props) => (
     <section
-        className={cx(leftWidth, showRightBorder && rightBorder(borderColour))}
+        className={cx(
+            positionRelative,
+            leftWidth,
+            showRightBorder && rightBorder(borderColour),
+        )}
     >
-        {children}
+        <div
+            className={cx(
+                showPartialRightBorder && partialRightBorder(borderColour),
+            )}
+        >
+            {children}
+        </div>
     </section>
 );

--- a/src/web/components/ArticleLeft.tsx
+++ b/src/web/components/ArticleLeft.tsx
@@ -49,8 +49,8 @@ const rightBorder = (colour: string) => css`
 type Props = {
     children: JSXElements;
     showRightBorder?: boolean;
-    borderColour?: string;
     showPartialRightBorder?: boolean;
+    borderColour?: string;
 };
 
 export const ArticleLeft = ({

--- a/src/web/components/MostViewed/MostViewedRight/MostViewedRight.stories.tsx
+++ b/src/web/components/MostViewed/MostViewedRight/MostViewedRight.stories.tsx
@@ -26,7 +26,10 @@ export const defaultStory = () => {
     return (
         <Section>
             <Flex>
-                <ArticleLeft>
+                <ArticleLeft
+                    showPartialRightBorder={true}
+                    showRightBorder={false}
+                >
                     <></>
                 </ArticleLeft>
                 <ArticleContainer>


### PR DESCRIPTION
## What does this change?
Added the ability to have a partial right border on ArticleLeft

![2019-11-28 17 19 47](https://user-images.githubusercontent.com/1336821/69824332-57797180-1203-11ea-9c10-306bc2fae20a.gif)


## Props
```typescript
type Props = {
    children: JSXElements;
    showRightBorder?: boolean;
    showPartialRightBorder?: boolean;
    borderColour?: string;
};
```

## Why?
This adds support for onwards containers that don't stretch the right border full height

## Link to supporting Trello card
https://trello.com/c/Xg7LzlbO/790-implement-related-journey-components