### PR TITLE
Rename ArticleLeft > LeftColumn

### DIFF
--- a/src/web/components/ArticleHeadline.stories.tsx
+++ b/src/web/components/ArticleHeadline.stories.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Section } from './Section';
 import { ArticleHeadline } from './ArticleHeadline';
 import { Flex } from './Flex';
-import { ArticleLeft } from './ArticleLeft';
+import { LeftColumn } from './LeftColumn';
 import { ArticleContainer } from './ArticleContainer';
 import { MainMedia } from './MainMedia';
 import { Standfirst } from './Standfirst';
@@ -19,9 +19,9 @@ export default {
 export const ArticleStory = () => (
     <Section>
         <Flex>
-            <ArticleLeft>
+            <LeftColumn>
                 <></>
-            </ArticleLeft>
+            </LeftColumn>
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is how the default headline looks"
@@ -39,9 +39,9 @@ ArticleStory.story = { name: 'Article' };
 export const oldHeadline = () => (
     <Section>
         <Flex>
-            <ArticleLeft>
+            <LeftColumn>
                 <></>
-            </ArticleLeft>
+            </LeftColumn>
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is an old headline"
@@ -66,9 +66,9 @@ oldHeadline.story = { name: 'Article, with age warning' };
 export const Feature = () => (
     <Section>
         <Flex>
-            <ArticleLeft>
+            <LeftColumn>
                 <></>
-            </ArticleLeft>
+            </LeftColumn>
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is a Feature headline, it has colour applied based on pillar"
@@ -86,9 +86,9 @@ Feature.story = { name: 'Feature' };
 export const ShowcaseInterview = () => (
     <Section>
         <Flex>
-            <ArticleLeft>
+            <LeftColumn>
                 <></>
-            </ArticleLeft>
+            </LeftColumn>
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is an Interview headline. It has a black background, white text and overlays the image below it (as a sibling)"
@@ -112,9 +112,9 @@ ShowcaseInterview.story = { name: 'Interview (with showcase)' };
 export const Interview = () => (
     <Section>
         <Flex>
-            <ArticleLeft>
+            <LeftColumn>
                 <></>
-            </ArticleLeft>
+            </LeftColumn>
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is an Interview headline. It has a black background, white text and overlays the image below it (as a sibling)"
@@ -141,9 +141,9 @@ Interview.story = { name: 'Interview (without showcase)' };
 export const Comment = () => (
     <Section>
         <Flex>
-            <ArticleLeft>
+            <LeftColumn>
                 <></>
-            </ArticleLeft>
+            </LeftColumn>
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="Yes, the billionaire club is one we really need to shut down"
@@ -161,9 +161,9 @@ Comment.story = { name: 'Comment' };
 export const Analysis = () => (
     <Section>
         <Flex>
-            <ArticleLeft>
+            <LeftColumn>
                 <></>
-            </ArticleLeft>
+            </LeftColumn>
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is an Analysis headline, it's underlined. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor"
@@ -181,9 +181,9 @@ Analysis.story = { name: 'Analysis' };
 export const Media = () => (
     <Section>
         <Flex>
-            <ArticleLeft>
+            <LeftColumn>
                 <></>
-            </ArticleLeft>
+            </LeftColumn>
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is the headline you see when design type is Media"
@@ -201,9 +201,9 @@ Media.story = { name: 'Media' };
 export const Review = () => (
     <Section>
         <Flex>
-            <ArticleLeft>
+            <LeftColumn>
                 <></>
-            </ArticleLeft>
+            </LeftColumn>
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is the headline you see when design type is Review"
@@ -221,9 +221,9 @@ Review.story = { name: 'Review' };
 export const AdvertisementFeature = () => (
     <Section>
         <Flex>
-            <ArticleLeft>
+            <LeftColumn>
                 <></>
-            </ArticleLeft>
+            </LeftColumn>
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is the headline you see when design type is AdvertisementFeature"
@@ -241,9 +241,9 @@ AdvertisementFeature.story = { name: 'AdvertisementFeature' };
 export const Quiz = () => (
     <Section>
         <Flex>
-            <ArticleLeft>
+            <LeftColumn>
                 <></>
-            </ArticleLeft>
+            </LeftColumn>
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is the headline you see when design type is Quiz"
@@ -261,9 +261,9 @@ Quiz.story = { name: 'Quiz' };
 export const GuardianLabs = () => (
     <Section>
         <Flex>
-            <ArticleLeft>
+            <LeftColumn>
                 <></>
-            </ArticleLeft>
+            </LeftColumn>
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is the headline you see when design type is GuardianLabs"
@@ -281,9 +281,9 @@ GuardianLabs.story = { name: 'GuardianLabs' };
 export const Recipe = () => (
     <Section>
         <Flex>
-            <ArticleLeft>
+            <LeftColumn>
                 <></>
-            </ArticleLeft>
+            </LeftColumn>
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is the headline you see when design type is Recipe"
@@ -301,9 +301,9 @@ Recipe.story = { name: 'Recipe' };
 export const GuardianView = () => (
     <Section>
         <Flex>
-            <ArticleLeft>
+            <LeftColumn>
                 <></>
-            </ArticleLeft>
+            </LeftColumn>
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is the headline you see when design type is GuardianView"
@@ -321,9 +321,9 @@ GuardianView.story = { name: 'GuardianView' };
 export const MatchReport = () => (
     <Section>
         <Flex>
-            <ArticleLeft>
+            <LeftColumn>
                 <></>
-            </ArticleLeft>
+            </LeftColumn>
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is the headline you see when design type is MatchReport"
@@ -341,9 +341,9 @@ MatchReport.story = { name: 'MatchReport' };
 export const SpecialReport = () => (
     <Section>
         <Flex>
-            <ArticleLeft>
+            <LeftColumn>
                 <></>
-            </ArticleLeft>
+            </LeftColumn>
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is the headline you see when design type is SpecialReport"
@@ -361,9 +361,9 @@ SpecialReport.story = { name: 'SpecialReport' };
 export const Live = () => (
     <Section>
         <Flex>
-            <ArticleLeft>
+            <LeftColumn>
                 <></>
-            </ArticleLeft>
+            </LeftColumn>
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is the headline you see when design type is Live"
@@ -392,9 +392,9 @@ export const Immersive = () => (
             shouldCenter={false}
         >
             <Flex>
-                <ArticleLeft showRightBorder={false}>
+                <LeftColumn showRightBorder={false}>
                     <></>
-                </ArticleLeft>
+                </LeftColumn>
                 <ArticleContainer>
                     <ArticleHeadline
                         headlineString="Here the headline overlays the image above it, the text is larger and the black background should extend to the right"

--- a/src/web/components/ArticleStandfirst.stories.tsx
+++ b/src/web/components/ArticleStandfirst.stories.tsx
@@ -4,7 +4,7 @@ import { Section } from './Section';
 
 import { ArticleStandfirst } from './ArticleStandfirst';
 import { Flex } from './Flex';
-import { ArticleLeft } from './ArticleLeft';
+import { LeftColumn } from './LeftColumn';
 import { ArticleContainer } from './ArticleContainer';
 
 /* tslint:disable */
@@ -18,9 +18,9 @@ export const defaultStory = () => {
     return (
         <Section>
             <Flex>
-                <ArticleLeft>
+                <LeftColumn>
                     <></>
-                </ArticleLeft>
+                </LeftColumn>
                 <ArticleContainer>
                     <ArticleStandfirst
                         standfirst="This the default standfirst text. Aut explicabo officia delectus omnis repellendus voluptas"

--- a/src/web/components/Card/Card.stories.tsx
+++ b/src/web/components/Card/Card.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Section } from '@frontend/web/components/Section';
 import { Flex } from '@frontend/web/components/Flex';
-import { ArticleLeft } from '@frontend/web/components/ArticleLeft';
+import { LeftColumn } from '@frontend/web/components/LeftColumn';
 import { ArticleContainer } from '@frontend/web/components/ArticleContainer';
 
 import { Card } from './Card';
@@ -26,9 +26,9 @@ export default {
 export const News = () => (
     <Section>
         <Flex>
-            <ArticleLeft showRightBorder={false}>
+            <LeftColumn showRightBorder={false}>
                 <></>
-            </ArticleLeft>
+            </LeftColumn>
             <ArticleContainer>
                 <UL direction="row" bottomMargin={true}>
                     <LI percentage="75%" showDivider={false} padSides={true}>
@@ -310,9 +310,9 @@ News.story = { name: 'News' };
 export const InDepth = () => (
     <Section>
         <Flex>
-            <ArticleLeft showRightBorder={false}>
+            <LeftColumn showRightBorder={false}>
                 <></>
-            </ArticleLeft>
+            </LeftColumn>
             <ArticleContainer>
                 <UL direction="row">
                     <LI percentage="50%" padSides={true}>
@@ -479,9 +479,9 @@ InDepth.story = { name: 'In Depth' };
 export const Related = () => (
     <Section>
         <Flex>
-            <ArticleLeft showRightBorder={false}>
+            <LeftColumn showRightBorder={false}>
                 <></>
-            </ArticleLeft>
+            </LeftColumn>
             <ArticleContainer>
                 <UL direction="row" bottomMargin={true}>
                     <LI padSides={true}>
@@ -655,9 +655,9 @@ Related.story = { name: 'Related Stories' };
 export const Spotlight = () => (
     <Section>
         <Flex>
-            <ArticleLeft showRightBorder={false}>
+            <LeftColumn showRightBorder={false}>
                 <></>
-            </ArticleLeft>
+            </LeftColumn>
             <ArticleContainer>
                 <Card
                     {...{
@@ -692,9 +692,9 @@ Spotlight.story = { name: 'Spotlight' };
 export const Quad = () => (
     <Section>
         <Flex>
-            <ArticleLeft showRightBorder={false}>
+            <LeftColumn showRightBorder={false}>
                 <></>
-            </ArticleLeft>
+            </LeftColumn>
             <ArticleContainer>
                 <UL direction="row">
                     <LI padSides={true}>

--- a/src/web/components/GuardianLines.stories.tsx
+++ b/src/web/components/GuardianLines.stories.tsx
@@ -4,7 +4,7 @@ import { Section } from './Section';
 
 import { GuardianLines } from './GuardianLines';
 import { Flex } from './Flex';
-import { ArticleLeft } from './ArticleLeft';
+import { LeftColumn } from './LeftColumn';
 import { ArticleContainer } from './ArticleContainer';
 import { ArticleHeadline } from './ArticleHeadline';
 import { Byline } from './Byline';
@@ -28,9 +28,9 @@ export const defaultStory = () => {
             </Section>
             <Section showTopBorder={false}>
                 <Flex>
-                    <ArticleLeft>
+                    <LeftColumn>
                         <></>
-                    </ArticleLeft>
+                    </LeftColumn>
                     <ArticleContainer>
                         <ArticleHeadline
                             headlineString="Headline text"
@@ -59,9 +59,9 @@ export const eightLines = () => {
             </Section>
             <Section showTopBorder={false}>
                 <Flex>
-                    <ArticleLeft>
+                    <LeftColumn>
                         <></>
-                    </ArticleLeft>
+                    </LeftColumn>
                     <ArticleContainer>
                         <ArticleHeadline
                             headlineString="Headline text"
@@ -90,7 +90,7 @@ export const paddedLines = () => {
             </Section>
             <Section showTopBorder={false}>
                 <Flex>
-                    <ArticleLeft>
+                    <LeftColumn>
                         <div style={{ marginTop: '30px' }} />
                         <GuardianLines />
                         <Byline
@@ -98,7 +98,7 @@ export const paddedLines = () => {
                             tags={[]}
                             pillar="news"
                         />
-                    </ArticleLeft>
+                    </LeftColumn>
                     <ArticleContainer>
                         <ArticleHeadline
                             headlineString="Headline text"
@@ -127,7 +127,7 @@ export const squigglyLines = () => {
             </Section>
             <Section showTopBorder={false}>
                 <Flex>
-                    <ArticleLeft>
+                    <LeftColumn>
                         <div style={{ marginTop: '30px' }} />
                         <GuardianLines squiggly={true} />
                         <Byline
@@ -135,7 +135,7 @@ export const squigglyLines = () => {
                             tags={[]}
                             pillar="news"
                         />
-                    </ArticleLeft>
+                    </LeftColumn>
                     <ArticleContainer>
                         <ArticleHeadline
                             headlineString="Headline text"

--- a/src/web/components/LeftColumn.stories.tsx
+++ b/src/web/components/LeftColumn.stories.tsx
@@ -5,12 +5,12 @@ import { ArticleRight } from '@root/src/web/components/ArticleRight';
 import { ArticleContainer } from '@root/src/web/components/ArticleContainer';
 import { Section } from '@frontend/web/components/Section';
 
-import { ArticleLeft } from './ArticleLeft';
+import { LeftColumn } from './LeftColumn';
 
 /* tslint:disable */
 export default {
-    component: ArticleLeft,
-    title: 'Components/ArticleLeft',
+    component: LeftColumn,
+    title: 'Components/LeftColumn',
 };
 /* tslint:enable */
 
@@ -18,7 +18,7 @@ export const PartialRightBorder = () => {
     return (
         <Section>
             <Flex>
-                <ArticleLeft
+                <LeftColumn
                     showPartialRightBorder={true}
                     showRightBorder={false}
                 >
@@ -26,7 +26,7 @@ export const PartialRightBorder = () => {
                         The border to my right is only partial, it does not
                         stretch the whole height
                     </>
-                </ArticleLeft>
+                </LeftColumn>
                 <ArticleContainer>
                     <img
                         src="https://www.fillmurray.com/g/600/500"
@@ -46,9 +46,9 @@ export const RightBorder = () => {
     return (
         <Section>
             <Flex>
-                <ArticleLeft>
+                <LeftColumn>
                     <>The border to my right should stretch the whole height</>
-                </ArticleLeft>
+                </LeftColumn>
                 <ArticleContainer>
                     <img
                         src="https://www.fillmurray.com/g/600/500"

--- a/src/web/components/LeftColumn.tsx
+++ b/src/web/components/LeftColumn.tsx
@@ -53,7 +53,7 @@ type Props = {
     borderColour?: string;
 };
 
-export const ArticleLeft = ({
+export const LeftColumn = ({
     children,
     showRightBorder = true,
     borderColour = palette.neutral[86],

--- a/src/web/components/MostViewed/MostViewedRight/MostViewedRight.stories.tsx
+++ b/src/web/components/MostViewed/MostViewedRight/MostViewedRight.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import fetchMock from 'fetch-mock';
 
 import { Flex } from '@root/src/web/components/Flex';
-import { ArticleLeft } from '@root/src/web/components/ArticleLeft';
+import { LeftColumn } from '@root/src/web/components/LeftColumn';
 import { ArticleRight } from '@root/src/web/components/ArticleRight';
 import { ArticleContainer } from '@root/src/web/components/ArticleContainer';
 import { Section } from '@frontend/web/components/Section';
@@ -26,12 +26,12 @@ export const defaultStory = () => {
     return (
         <Section>
             <Flex>
-                <ArticleLeft
+                <LeftColumn
                     showPartialRightBorder={true}
                     showRightBorder={false}
                 >
                     <></>
-                </ArticleLeft>
+                </LeftColumn>
                 <ArticleContainer>
                     <></>
                 </ArticleContainer>
@@ -59,9 +59,9 @@ export const limitItemsStory = () => {
     return (
         <Section>
             <Flex>
-                <ArticleLeft>
+                <LeftColumn>
                     <></>
-                </ArticleLeft>
+                </LeftColumn>
                 <ArticleContainer>
                     <></>
                 </ArticleContainer>

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -3,7 +3,7 @@ import { css } from 'emotion';
 import { Flex } from '@root/src/web/components/Flex';
 import { StickyAd } from '@root/src/web/components/StickyAd';
 import { ArticleBody } from '@root/src/web/components/ArticleBody';
-import { ArticleLeft } from '@root/src/web/components/ArticleLeft';
+import { LeftColumn } from '@root/src/web/components/LeftColumn';
 import { ArticleRight } from '@root/src/web/components/ArticleRight';
 import { ArticleTitle } from '@root/src/web/components/ArticleTitle';
 import { ArticleContainer } from '@root/src/web/components/ArticleContainer';
@@ -78,10 +78,10 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => (
 
         <Section showTopBorder={false}>
             <Flex>
-                <ArticleLeft>
+                <LeftColumn>
                     <ArticleTitle CAPI={CAPI} inLeftCol={true} />
                     <ArticleMeta CAPI={CAPI} />
-                </ArticleLeft>
+                </LeftColumn>
                 <ArticleContainer>
                     {/* When BELOW leftCol we display the header in this position, at the top of the page */}
                     <Hide when="below" breakpoint="leftCol">

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -4,7 +4,7 @@ import { css } from 'emotion';
 import { Flex } from '@root/src/web/components/Flex';
 import { StickyAd } from '@root/src/web/components/StickyAd';
 import { ArticleBody } from '@root/src/web/components/ArticleBody';
-import { ArticleLeft } from '@root/src/web/components/ArticleLeft';
+import { LeftColumn } from '@root/src/web/components/LeftColumn';
 import { ArticleRight } from '@root/src/web/components/ArticleRight';
 import { ArticleTitle } from '@root/src/web/components/ArticleTitle';
 import { ArticleContainer } from '@root/src/web/components/ArticleContainer';
@@ -102,14 +102,14 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
 
             <Section showTopBorder={false}>
                 <Flex>
-                    <ArticleLeft>
+                    <LeftColumn>
                         <ArticleTitle
                             CAPI={CAPI}
                             badge={GE2019Badge}
                             inLeftCol={true}
                         />
                         <ArticleMeta CAPI={CAPI} />
-                    </ArticleLeft>
+                    </LeftColumn>
                     <ArticleContainer>
                         <StandardHeader CAPI={CAPI} badge={GE2019Badge} />
                         <Hide when="above" breakpoint="leftCol">


### PR DESCRIPTION
## What does this change?
Renames `ArticleLeft` > `LeftColumn`

## Why?
Because ArticleLeft could be used outside the context of an article

## Link to supporting Trello card
https://trello.com/c/4pZnBF9T/947-rename-articleleft-articleright