### PR TITLE
ArticleRight > RightColumn

### DIFF
--- a/src/web/components/ArticleLeft.stories.tsx
+++ b/src/web/components/ArticleLeft.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Flex } from '@root/src/web/components/Flex';
-import { ArticleRight } from '@root/src/web/components/ArticleRight';
+import { RightColumn } from '@root/src/web/components/RightColumn';
 import { ArticleContainer } from '@root/src/web/components/ArticleContainer';
 import { Section } from '@frontend/web/components/Section';
 
@@ -33,9 +33,9 @@ export const PartialRightBorder = () => {
                         alt="Bill"
                     />
                 </ArticleContainer>
-                <ArticleRight>
+                <RightColumn>
                     <>Right column content</>
-                </ArticleRight>
+                </RightColumn>
             </Flex>
         </Section>
     );
@@ -55,9 +55,9 @@ export const RightBorder = () => {
                         alt="Bill"
                     />
                 </ArticleContainer>
-                <ArticleRight>
+                <RightColumn>
                     <>Right column content</>
-                </ArticleRight>
+                </RightColumn>
             </Flex>
         </Section>
     );

--- a/src/web/components/MostViewed/MostViewedRight/MostViewedRight.stories.tsx
+++ b/src/web/components/MostViewed/MostViewedRight/MostViewedRight.stories.tsx
@@ -3,7 +3,7 @@ import fetchMock from 'fetch-mock';
 
 import { Flex } from '@root/src/web/components/Flex';
 import { ArticleLeft } from '@root/src/web/components/ArticleLeft';
-import { ArticleRight } from '@root/src/web/components/ArticleRight';
+import { RightColumn } from '@root/src/web/components/RightColumn';
 import { ArticleContainer } from '@root/src/web/components/ArticleContainer';
 import { Section } from '@frontend/web/components/Section';
 
@@ -35,7 +35,7 @@ export const defaultStory = () => {
                 <ArticleContainer>
                     <></>
                 </ArticleContainer>
-                <ArticleRight>
+                <RightColumn>
                     <Section
                         showSideBorders={false}
                         showTopBorder={false}
@@ -43,7 +43,7 @@ export const defaultStory = () => {
                     >
                         <MostViewedRight />
                     </Section>
-                </ArticleRight>
+                </RightColumn>
             </Flex>
         </Section>
     );
@@ -65,7 +65,7 @@ export const limitItemsStory = () => {
                 <ArticleContainer>
                     <></>
                 </ArticleContainer>
-                <ArticleRight>
+                <RightColumn>
                     <Section
                         showSideBorders={false}
                         showTopBorder={false}
@@ -73,7 +73,7 @@ export const limitItemsStory = () => {
                     >
                         <MostViewedRight limitItems={3} />
                     </Section>
-                </ArticleRight>
+                </RightColumn>
             </Flex>
         </Section>
     );

--- a/src/web/components/RightColumn.tsx
+++ b/src/web/components/RightColumn.tsx
@@ -28,7 +28,7 @@ type Props = {
     children: JSXElements;
 };
 
-export const ArticleRight = ({ children }: Props) => {
+export const RightColumn = ({ children }: Props) => {
     return (
         <section className={cx(hideBelowDesktop, padding)}>{children}</section>
     );

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -4,7 +4,7 @@ import { Flex } from '@root/src/web/components/Flex';
 import { StickyAd } from '@root/src/web/components/StickyAd';
 import { ArticleBody } from '@root/src/web/components/ArticleBody';
 import { ArticleLeft } from '@root/src/web/components/ArticleLeft';
-import { ArticleRight } from '@root/src/web/components/ArticleRight';
+import { RightColumn } from '@root/src/web/components/RightColumn';
 import { ArticleTitle } from '@root/src/web/components/ArticleTitle';
 import { ArticleContainer } from '@root/src/web/components/ArticleContainer';
 import { ArticleMeta } from '@root/src/web/components/ArticleMeta';
@@ -119,10 +119,10 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => (
                                 />
                             </main>
                         </div>
-                        <ArticleRight>
+                        <RightColumn>
                             <StickyAd />
                             <MostViewedRightIsland />
-                        </ArticleRight>
+                        </RightColumn>
                     </Flex>
                 </ArticleContainer>
             </Flex>

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -5,7 +5,7 @@ import { Flex } from '@root/src/web/components/Flex';
 import { StickyAd } from '@root/src/web/components/StickyAd';
 import { ArticleBody } from '@root/src/web/components/ArticleBody';
 import { ArticleLeft } from '@root/src/web/components/ArticleLeft';
-import { ArticleRight } from '@root/src/web/components/ArticleRight';
+import { RightColumn } from '@root/src/web/components/RightColumn';
 import { ArticleTitle } from '@root/src/web/components/ArticleTitle';
 import { ArticleContainer } from '@root/src/web/components/ArticleContainer';
 import { ArticleMeta } from '@root/src/web/components/ArticleMeta';
@@ -136,10 +136,10 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                             />
                         </main>
                     </ArticleContainer>
-                    <ArticleRight>
+                    <RightColumn>
                         <StickyAd />
                         <MostViewedRightIsland />
-                    </ArticleRight>
+                    </RightColumn>
                 </Flex>
             </Section>
 


### PR DESCRIPTION
## What does this change?
Renames `ArticleRight` > `RightColumn`

## Why?
To be consistent with LeftColumn

## Link to supporting Trello card
https://trello.com/c/4pZnBF9T/947-rename-articleleft-articleright