### PR TITLE
Decommission AMP Caption's dirtyHtml attribute (1000 🎉)

### DIFF
--- a/src/amp/components/Caption.tsx
+++ b/src/amp/components/Caption.tsx
@@ -24,14 +24,12 @@ export const Caption: React.FC<{
     captionText?: string;
     pillar: Pillar;
     padCaption?: boolean;
-    dirtyHtml?: boolean;
     credit?: string;
     displayCredit?: boolean;
 }> = ({
     captionText,
     pillar,
     padCaption = false,
-    dirtyHtml = false,
     credit,
     displayCredit = true,
     children,
@@ -55,19 +53,16 @@ export const Caption: React.FC<{
     `;
 
     const getCaptionHtml = () => {
-        if (dirtyHtml) {
-            return (
-                <span
-                    // tslint:disable-line:react-no-dangerous-html
-                    className={captionLink}
-                    dangerouslySetInnerHTML={{
-                        __html: captionText || '',
-                    }}
-                    key="caption"
-                />
-            );
-        }
-        return captionText;
+        return (
+            <span
+                // tslint:disable-line:react-no-dangerous-html
+                className={captionLink}
+                dangerouslySetInnerHTML={{
+                    __html: captionText || '',
+                }}
+                key="caption"
+            />
+        );
     };
 
     return (

--- a/src/amp/components/elements/MapEmbed.tsx
+++ b/src/amp/components/elements/MapEmbed.tsx
@@ -26,7 +26,6 @@ export const MapEmbed: React.SFC<{
             captionText={element.caption}
             pillar={pillar}
             padCaption={true}
-            dirtyHtml={true}
         >
             <amp-iframe {...attributes} />
         </Caption>

--- a/src/amp/components/elements/VideoGuardian.tsx
+++ b/src/amp/components/elements/VideoGuardian.tsx
@@ -6,7 +6,7 @@ export const VideoGuardian: React.FC<{
     pillar: Pillar;
 }> = ({ element, pillar }) => {
     return (
-        <Caption captionText={element.caption} pillar={pillar} dirtyHtml={true}>
+        <Caption captionText={element.caption} pillar={pillar}>
             <amp-video controls="" width="16" height="9" layout="responsive">
                 <div fallback="">
                     Sorry, your browser is unable to play this video.

--- a/src/amp/components/elements/VideoYoutube.tsx
+++ b/src/amp/components/elements/VideoYoutube.tsx
@@ -13,7 +13,7 @@ export const VideoYoutube: React.FC<{
         'v',
     );
     return (
-        <Caption captionText={element.caption} pillar={pillar} dirtyHtml={true}>
+        <Caption captionText={element.caption} pillar={pillar}>
             <amp-youtube
                 data-videoid={youtubeId}
                 layout="responsive"

--- a/src/web/components/Caption.tsx
+++ b/src/web/components/Caption.tsx
@@ -34,7 +34,6 @@ export const Caption: React.FC<{
     captionText?: string;
     pillar: Pillar;
     padCaption?: boolean;
-    dirtyHtml?: boolean;
     credit?: string;
     displayCredit?: boolean;
     role?: RoleType;
@@ -43,7 +42,6 @@ export const Caption: React.FC<{
     captionText,
     pillar,
     padCaption = false,
-    dirtyHtml = false,
     credit,
     displayCredit = true,
     children,
@@ -69,19 +67,16 @@ export const Caption: React.FC<{
     `;
 
     const getCaptionHtml = () => {
-        if (dirtyHtml) {
-            return (
-                <span
-                    className={captionLink}
-                    // eslint-disable-next-line react/no-danger
-                    dangerouslySetInnerHTML={{
-                        __html: captionText || '',
-                    }}
-                    key="caption"
-                />
-            );
-        }
-        return captionText;
+        return (
+            <span
+                className={captionLink}
+                // eslint-disable-next-line react/no-danger
+                dangerouslySetInnerHTML={{
+                    __html: captionText || '',
+                }}
+                key="caption"
+            />
+        );
     };
 
     const shouldLimitWidth =

--- a/src/web/components/elements/ImageComponent.tsx
+++ b/src/web/components/elements/ImageComponent.tsx
@@ -131,7 +131,6 @@ export const ImageComponent: React.FC<{
         <Caption
             captionText={element.data.caption || ''}
             pillar={pillar}
-            dirtyHtml={true}
             credit={element.data.credit}
             displayCredit={true}
             role={role}

--- a/src/web/components/elements/YouTubeComponent.tsx
+++ b/src/web/components/elements/YouTubeComponent.tsx
@@ -34,7 +34,6 @@ export const YouTubeComponent = ({
         <Caption
             captionText={element.mediaTitle || ''}
             pillar={pillar}
-            dirtyHtml={true}
             displayCredit={false}
             role={role}
         >


### PR DESCRIPTION
## What does this change?

Tiny follow up https://github.com/guardian/dotcom-rendering/pull/1177 . Remove the `dirtyHtml` of `Caption` both in amp and web. 

## Why?

Simplicity
