### PR TITLE
Reinstate arrow on reader revenue button

### DIFF
--- a/src/amp/components/Header.tsx
+++ b/src/amp/components/Header.tsx
@@ -193,7 +193,6 @@ export const Header: React.FC<{
                 rrLink="ampHeader"
                 rrCategory="subscribe"
                 linkLabel="Subscribe"
-                showArrow={false}
             />
 
             <a className={logoStyles} href={guardianBaseURL}>

--- a/src/amp/components/ReaderRevenueButton.tsx
+++ b/src/amp/components/ReaderRevenueButton.tsx
@@ -61,15 +61,6 @@ const supportLinkStyles = css`
     }
 `;
 
-const supportLinkStylesNoArrow = css`
-    ${supportLinkStyles}
-    padding-right: 0px;
-
-    ${until.mobileMedium} {
-        padding-right: 0px;
-    }
-`;
-
 const rightAlignedIcon = css`
     position: absolute;
     height: 20px;
@@ -84,13 +75,7 @@ export const ReaderRevenueButton: React.SFC<{
     rrLink: ReaderRevenuePosition;
     rrCategory: ReaderRevenueCategory;
     rightAlignIcon?: boolean;
-}> = ({
-    nav,
-    linkLabel,
-    rrLink,
-    rrCategory,
-    rightAlignIcon,
-}) => {
+}> = ({ nav, linkLabel, rrLink, rrCategory, rightAlignIcon }) => {
     const url = nav.readerRevenueLinks[rrLink][rrCategory];
 
     if (url === '') {

--- a/src/amp/components/ReaderRevenueButton.tsx
+++ b/src/amp/components/ReaderRevenueButton.tsx
@@ -52,9 +52,9 @@ const supportLinkStyles = css`
 
     svg {
         position: absolute;
-        top: -5px;
+        top: -3px;
+
         ${until.mobileMedium} {
-            top: -2px;
             width: 26px;
             height: 26px;
         }
@@ -84,14 +84,12 @@ export const ReaderRevenueButton: React.SFC<{
     rrLink: ReaderRevenuePosition;
     rrCategory: ReaderRevenueCategory;
     rightAlignIcon?: boolean;
-    showArrow?: boolean;
 }> = ({
     nav,
     linkLabel,
     rrLink,
     rrCategory,
     rightAlignIcon,
-    showArrow = true,
 }) => {
     const url = nav.readerRevenueLinks[rrLink][rrCategory];
 
@@ -107,22 +105,15 @@ export const ReaderRevenueButton: React.SFC<{
                 isAmpHeader ? supportHeaderStyles : supportFooterStyles,
             ])}
         >
-            <a
-                className={
-                    showArrow ? supportLinkStyles : supportLinkStylesNoArrow
-                }
-                href={url}
-            >
+            <a className={supportLinkStyles} href={url}>
                 {linkLabel}
-                {showArrow && (
-                    <span
-                        className={cx({
-                            [rightAlignedIcon]: !!rightAlignIcon,
-                        })}
-                    >
-                        <ArrowRight />
-                    </span>
-                )}
+                <span
+                    className={cx({
+                        [rightAlignedIcon]: !!rightAlignIcon,
+                    })}
+                >
+                    <ArrowRight />
+                </span>
             </a>
         </div>
     );


### PR DESCRIPTION
## What does this change?
This reinstates the arrow on the reader revenue button (which I erroneously removed a while back 😬 )

## Link to supporting Trello card
https://trello.com/c/Jm2mUDD9/2708-add-an-arrow-into-amp-header-subscribe-button

## Screenshot
![Screen Shot 2019-12-02 at 16 30 12](https://user-images.githubusercontent.com/16781258/69976539-0d550080-1521-11ea-8df7-b043afa4c4db.png)
