### PR TITLE
Card & Link Bylines

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -288,6 +288,7 @@ interface LinkHeadlineType {
     showQuotes?: boolean; // When true the QuoteIcon is shown
     size?: SmallHeadlineSize;
     link?: HeadlineLink; // An optional link object configures if/how the component renders an anchor tag
+    byline?: string;
 }
 
 interface CardHeadlineType {
@@ -297,6 +298,7 @@ interface CardHeadlineType {
     kicker?: KickerType;
     showQuotes?: boolean; // Even with designType !== Comment, a piece can be opinion
     size?: SmallHeadlineSize;
+    byline?: string;
 }
 
 /**
@@ -392,8 +394,10 @@ interface TrailType {
     linkText: string;
     isLiveBlog: boolean;
     ageWarning: string;
-    image?: string;
     pillar: Pillar;
+    image?: string;
+    byline?: string;
+    showByline?: boolean;
 }
 
 // ------------------------------

--- a/index.d.ts
+++ b/index.d.ts
@@ -281,6 +281,7 @@ type HeadlineLink = {
 };
 
 interface LinkHeadlineType {
+    designType: DesignType;
     headlineText: string; // The text shown
     pillar: Pillar; // Used to colour the headline (dark) and the kicker (main)
     showUnderline?: boolean; // Some headlines have text-decoration underlined when hovered
@@ -391,6 +392,7 @@ type JSXElements = JSX.Element | JSX.Element[];
 
 interface TrailType {
     url: string;
+    designType: DesignType;
     linkText: string;
     isLiveBlog: boolean;
     ageWarning: string;

--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -4,7 +4,7 @@ import { palette } from '@guardian/src-foundations';
 import { between, until } from '@guardian/src-foundations/mq';
 
 import { SharingIcons } from './ShareIcons';
-import { Byline } from '@root/src/web/components/Byline';
+import { Contributor } from '@root/src/web/components/Contributor';
 import { GuardianLines } from '@root/src/web/components/GuardianLines';
 import { getSharingUrls } from '@root/src/lib/sharing-urls';
 import { Dateline } from './Dateline';
@@ -48,7 +48,7 @@ export const ArticleMeta = ({ CAPI }: Props) => {
         <>
             <GuardianLines pillar={CAPI.pillar} />
             <div className={cx(meta)}>
-                <Byline
+                <Contributor
                     author={CAPI.author}
                     tags={CAPI.tags}
                     pillar={CAPI.pillar}

--- a/src/web/components/Byline.tsx
+++ b/src/web/components/Byline.tsx
@@ -1,24 +1,54 @@
 import React from 'react';
-import { css } from 'emotion';
+import { css, cx } from 'emotion';
 
 import { palette } from '@guardian/src-foundations';
 import { headline } from '@guardian/src-foundations/typography';
 
 type Props = {
     text: string;
+    designType: DesignType;
     pillar: Pillar;
     size: SmallHeadlineSize;
 };
 
-const bylineStyles = (colour: string, size: SmallHeadlineSize) => css`
+const bylineStyles = (size: SmallHeadlineSize) => css`
     display: block;
-    color: ${colour};
     ${headline[size]()};
     font-style: italic;
 `;
 
-export const Byline = ({ text, pillar, size }: Props) => {
-    return (
-        <span className={bylineStyles(palette[pillar].main, size)}>{text}</span>
-    );
+const colourStyles = (designType: DesignType, pillar: Pillar) => {
+    switch (designType) {
+        // Sometimes comment pieces can have the news pillar but should still be styled as opinion
+        case 'Comment':
+            return css`
+                color: ${palette.opinion.main};
+            `;
+        case 'Comment':
+        case 'Analysis':
+        case 'Feature':
+        case 'Interview':
+        case 'Article':
+        case 'Media':
+        case 'Review':
+        case 'Live':
+        case 'SpecialReport':
+        case 'Recipe':
+        case 'MatchReport':
+        case 'GuardianView':
+        case 'GuardianLabs':
+        case 'Quiz':
+        case 'AdvertisementFeature':
+        case 'Immersive':
+        default:
+            return css`
+                color: ${palette[pillar].main};
+            `;
+    }
 };
+
+export const Byline = ({ text, designType, pillar, size }: Props) => (
+    <span className={cx(bylineStyles(size), colourStyles(designType, pillar))}>
+        {text}
+    </span>
+);

--- a/src/web/components/Byline.tsx
+++ b/src/web/components/Byline.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { palette } from '@guardian/src-foundations';
+import { headline } from '@guardian/src-foundations/typography';
+
+type Props = {
+    text: string;
+    pillar: Pillar;
+    size: SmallHeadlineSize;
+};
+
+const bylineStyles = (colour: string, size: SmallHeadlineSize) => css`
+    display: block;
+    color: ${colour};
+    ${headline[size]()};
+    font-style: italic;
+`;
+
+export const Byline = ({ text, pillar, size }: Props) => {
+    return (
+        <span className={bylineStyles(palette[pillar].main, size)}>{text}</span>
+    );
+};

--- a/src/web/components/Card/Card.stories.tsx
+++ b/src/web/components/Card/Card.stories.tsx
@@ -714,6 +714,7 @@ export const Quad = () => (
                                         pillar: 'opinion',
                                     },
                                     showQuotes: true,
+                                    byline: 'George Monbiot',
                                 },
                                 webPublicationDate: '2019-11-11T09:45:30.000Z',
                                 avatar: {

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -106,6 +106,7 @@ export const Card = ({
                                     size={headline.size}
                                     showQuotes={headline.showQuotes}
                                     kicker={headline.kicker}
+                                    byline={headline.byline}
                                 />
                             </HeadlineWrapper>
                             <div>

--- a/src/web/components/CardHeadline.tsx
+++ b/src/web/components/CardHeadline.tsx
@@ -6,6 +6,7 @@ import { palette } from '@guardian/src-foundations';
 
 import { QuoteIcon } from '@root/src/web/components/QuoteIcon';
 import { Kicker } from '@root/src/web/components/Kicker';
+import { Byline } from '@root/src/web/components/Byline';
 
 const fontStyles = (size: SmallHeadlineSize) => css`
     ${headline[size]()};
@@ -79,20 +80,26 @@ export const CardHeadline = ({
     showQuotes,
     kicker,
     size = 'xxsmall',
+    byline,
 }: CardHeadlineType) => (
-    <h4 className={fontStyles(size)}>
-        {kicker && (
-            <Kicker
-                text={kicker.text}
-                pillar={pillar}
-                showPulsingDot={kicker.showPulsingDot}
-                showSlash={kicker.showSlash}
-            />
-        )}
-        {showQuotes && <QuoteIcon colour={palette[pillar].main} size={size} />}
+    <>
+        <h4 className={fontStyles(size)}>
+            {kicker && (
+                <Kicker
+                    text={kicker.text}
+                    pillar={pillar}
+                    showPulsingDot={kicker.showPulsingDot}
+                    showSlash={kicker.showSlash}
+                />
+            )}
+            {showQuotes && (
+                <QuoteIcon colour={palette[pillar].main} size={size} />
+            )}
 
-        <span className={headlineStyles(designType, pillar, size)}>
-            {headlineText}
-        </span>
-    </h4>
+            <span className={headlineStyles(designType, pillar, size)}>
+                {headlineText}
+            </span>
+        </h4>
+        {byline && <Byline text={byline} pillar={pillar} size={size} />}
+    </>
 );

--- a/src/web/components/CardHeadline.tsx
+++ b/src/web/components/CardHeadline.tsx
@@ -100,6 +100,13 @@ export const CardHeadline = ({
                 {headlineText}
             </span>
         </h4>
-        {byline && <Byline text={byline} pillar={pillar} size={size} />}
+        {byline && (
+            <Byline
+                text={byline}
+                designType={designType}
+                pillar={pillar}
+                size={size}
+            />
+        )}
     </>
 );

--- a/src/web/components/Contributor.tsx
+++ b/src/web/components/Contributor.tsx
@@ -54,7 +54,7 @@ const bylineAsTokens = (bylineText: string, tags: TagType[]): string[] => {
     return bylineText.split(regex);
 };
 
-const RenderByline: React.FC<{
+const RenderContributor: React.FC<{
     bylineText: string;
     contributorTags: TagType[];
     pillar: Pillar;
@@ -66,7 +66,7 @@ const RenderByline: React.FC<{
             );
             if (associatedTags.length > 0) {
                 return (
-                    <BylineContributor
+                    <ContributorLink
                         contributor={token}
                         contributorTagId={associatedTags[0].id}
                         key={i}
@@ -80,7 +80,7 @@ const RenderByline: React.FC<{
     return <div className={bylineStyle(pillar)}>{renderedTokens}</div>;
 };
 
-const BylineContributor: React.FC<{
+const ContributorLink: React.FC<{
     contributor: string;
     contributorTagId: string;
 }> = ({ contributor, contributorTagId }) => (
@@ -93,7 +93,7 @@ const BylineContributor: React.FC<{
     </a>
 );
 
-export const Byline: React.FC<{
+export const Contributor: React.FC<{
     author: AuthorType;
     tags: TagType[];
     pillar: Pillar;
@@ -104,7 +104,7 @@ export const Byline: React.FC<{
 
     return (
         <address aria-label="Contributor info">
-            <RenderByline
+            <RenderContributor
                 bylineText={author.byline}
                 contributorTags={tags}
                 pillar={pillar}

--- a/src/web/components/Contributor.tsx
+++ b/src/web/components/Contributor.tsx
@@ -43,12 +43,16 @@ const bylineStyle = (pillar: Pillar) => css`
     }
 `;
 
-// this crazy function aims to split bylines such as
+// This crazy function aims to split bylines such as
 // 'Harry Potter in Hogwarts' to ['Harry Potter', 'in Hogwarts']
+// Or
+// 'Jane Doe and John Smith` to ['Jane Doe', ' and ', 'John Smith']
+// It does this so we can have separate links to both contributors
 const bylineAsTokens = (bylineText: string, tags: TagType[]): string[] => {
     const contributorTags = tags
         .filter(t => t.type === 'Contributor')
         .map(c => c.title);
+    // The contributor tag title should exist inside the bylineText for this regex to work
     const regex = new RegExp(`(${contributorTags.join('|')})`);
 
     return bylineText.split(regex);

--- a/src/web/components/GuardianLines.stories.tsx
+++ b/src/web/components/GuardianLines.stories.tsx
@@ -7,7 +7,7 @@ import { Flex } from './Flex';
 import { LeftColumn } from './LeftColumn';
 import { ArticleContainer } from './ArticleContainer';
 import { ArticleHeadline } from './ArticleHeadline';
-import { Byline } from './Byline';
+import { Contributor } from './Contributor';
 
 /* tslint:disable */
 export default {
@@ -93,7 +93,7 @@ export const paddedLines = () => {
                     <LeftColumn>
                         <div style={{ marginTop: '30px' }} />
                         <GuardianLines />
-                        <Byline
+                        <Contributor
                             author={{ byline: 'Jane doe' }}
                             tags={[]}
                             pillar="news"
@@ -130,7 +130,7 @@ export const squigglyLines = () => {
                     <LeftColumn>
                         <div style={{ marginTop: '30px' }} />
                         <GuardianLines squiggly={true} />
-                        <Byline
+                        <Contributor
                             author={{ byline: 'Jane doe' }}
                             tags={[]}
                             pillar="news"

--- a/src/web/components/LinkHeadline.stories.tsx
+++ b/src/web/components/LinkHeadline.stories.tsx
@@ -14,6 +14,7 @@ export default {
 export const xsmallStory = () => (
     <Section showTopBorder={false} showSideBorders={false}>
         <LinkHeadline
+            designType="Article"
             headlineText="This is how a xsmall headline link looks"
             pillar="news"
             size="xsmall"
@@ -25,6 +26,7 @@ xsmallStory.story = { name: 'Size | xsmall' };
 export const liveStory = () => (
     <Section showTopBorder={false} showSideBorders={false}>
         <LinkHeadline
+            designType="Article"
             headlineText="This is how a headline with a live kicker looks"
             pillar="news"
             kicker={{
@@ -38,6 +40,7 @@ liveStory.story = { name: 'With Live kicker' };
 export const noSlash = () => (
     <Section showTopBorder={false} showSideBorders={false}>
         <LinkHeadline
+            designType="Article"
             headlineText="This is how a headline with no kicker slash looks"
             pillar="news"
             kicker={{
@@ -52,6 +55,7 @@ noSlash.story = { name: 'With Live kicker but no slash' };
 export const pulsingDot = () => (
     <Section showTopBorder={false} showSideBorders={false}>
         <LinkHeadline
+            designType="Article"
             headlineText="This is how a headline with a pulsing dot looks"
             pillar="news"
             kicker={{
@@ -66,6 +70,7 @@ pulsingDot.story = { name: 'With pulsing dot' };
 export const cultureVariant = () => (
     <Section showTopBorder={false} showSideBorders={false}>
         <LinkHeadline
+            designType="Article"
             headlineText="This is how a headline with the culture pillar looks"
             pillar="culture"
             kicker={{
@@ -79,10 +84,12 @@ cultureVariant.story = { name: 'With a culture kicker' };
 export const opinionxxxsmall = () => (
     <Section showTopBorder={false} showSideBorders={false}>
         <LinkHeadline
+            designType="Comment"
             headlineText="This is how xxxsmall links to opinion articles look"
             pillar="opinion"
             showQuotes={true}
             size="xxxsmall"
+            byline="Comment byline"
         />
     </Section>
 );
@@ -91,6 +98,7 @@ opinionxxxsmall.story = { name: 'Quotes | xxxsmall' };
 export const OpinionKicker = () => (
     <Section showTopBorder={false} showSideBorders={false}>
         <LinkHeadline
+            designType="Comment"
             headlineText="This is how an opinion headline with a kicker looks"
             pillar="opinion"
             showQuotes={true}
@@ -106,6 +114,7 @@ OpinionKicker.story = { name: 'With an opinion kicker' };
 export const InUnderlinedState = () => (
     <Section showTopBorder={false} showSideBorders={false}>
         <LinkHeadline
+            designType="Article"
             headlineText="This is the underlined state when showUnderline is true"
             pillar="news"
             showUnderline={true}
@@ -126,6 +135,7 @@ InUnderlinedState.story = { name: 'With showUnderline true' };
 export const linkStory = () => (
     <Section showTopBorder={false} showSideBorders={false}>
         <LinkHeadline
+            designType="Article"
             headlineText="This is how a headline looks as a link"
             pillar="sport"
             kicker={{

--- a/src/web/components/LinkHeadline.tsx
+++ b/src/web/components/LinkHeadline.tsx
@@ -6,6 +6,7 @@ import { palette } from '@guardian/src-foundations';
 
 import { QuoteIcon } from '@root/src/web/components/QuoteIcon';
 import { Kicker } from '@root/src/web/components/Kicker';
+import { Byline } from '@root/src/web/components/Byline';
 
 const fontStyles = (size: SmallHeadlineSize) => css`
     ${headline[size]()};
@@ -40,6 +41,7 @@ export const LinkHeadline = ({
     showQuotes = false,
     size = 'xxsmall',
     link,
+    byline,
 }: LinkHeadlineType) => (
     <h4 className={fontStyles(size)}>
         {kicker && (
@@ -53,24 +55,30 @@ export const LinkHeadline = ({
         {showQuotes && <QuoteIcon colour={palette[pillar].main} size={size} />}
         {link ? (
             // We were passed a link object so headline should be a link, with link styling
-            <a
-                className={cx(
-                    // Composed styles - order matters for colours
-                    linkStyles,
-                    showUnderline && textDecorationUnderline,
-                    link.visitedColour && visitedStyles(link.visitedColour),
-                )}
-                href={link.to}
-                // If link.preventFocus is true, set tabIndex to -1 to ensure this
-                // link is not tabbed to. Useful if there is an outer link to the same
-                // place, such as with MostViewed
-                tabIndex={link.preventFocus ? -1 : undefined}
-            >
-                {headlineText}
-            </a>
+            <>
+                <a
+                    className={cx(
+                        // Composed styles - order matters for colours
+                        linkStyles,
+                        showUnderline && textDecorationUnderline,
+                        link.visitedColour && visitedStyles(link.visitedColour),
+                    )}
+                    href={link.to}
+                    // If link.preventFocus is true, set tabIndex to -1 to ensure this
+                    // link is not tabbed to. Useful if there is an outer link to the same
+                    // place, such as with MostViewed
+                    tabIndex={link.preventFocus ? -1 : undefined}
+                >
+                    {headlineText}
+                </a>
+                {byline && <Byline text={byline} pillar={pillar} size={size} />}
+            </>
         ) : (
             // We don't have a link so simply use a span here
-            <span>{headlineText}</span>
+            <>
+                <span>{headlineText}</span>
+                {byline && <Byline text={byline} pillar={pillar} size={size} />}
+            </>
         )}
     </h4>
 );

--- a/src/web/components/LinkHeadline.tsx
+++ b/src/web/components/LinkHeadline.tsx
@@ -34,6 +34,7 @@ const visitedStyles = (visitedColour: string) => css`
 `;
 
 export const LinkHeadline = ({
+    designType,
     headlineText,
     pillar,
     showUnderline = false,
@@ -71,13 +72,27 @@ export const LinkHeadline = ({
                 >
                     {headlineText}
                 </a>
-                {byline && <Byline text={byline} pillar={pillar} size={size} />}
+                {byline && (
+                    <Byline
+                        text={byline}
+                        designType={designType}
+                        pillar={pillar}
+                        size={size}
+                    />
+                )}
             </>
         ) : (
             // We don't have a link so simply use a span here
             <>
                 <span>{headlineText}</span>
-                {byline && <Byline text={byline} pillar={pillar} size={size} />}
+                {byline && (
+                    <Byline
+                        text={byline}
+                        designType={designType}
+                        pillar={pillar}
+                        size={size}
+                    />
+                )}
             </>
         )}
     </h4>

--- a/src/web/components/MostViewed/MostViewed.mocks.tsx
+++ b/src/web/components/MostViewed/MostViewed.mocks.tsx
@@ -6,7 +6,7 @@ export const mockTab1 = {
                 'https://www.theguardian.com/politics/2019/sep/15/eu-officials-reject-boris-johnson-claim-huge-progress-brexit-talks',
             linkText:
                 "LINKTEXT EU officials reject Boris Johnson claim of 'huge progress' in Brexit talks",
-            showByline: false,
+            showByline: true,
             byline: 'Jennifer Rankin and Daniel Boffey',
             image:
                 'https://i.guim.co.uk/img/media/85377038aacd71b2c0e55b0a55478165fe6d3014/0_0_6000_3600/master/6000.jpg?width=300&quality=85&auto=format&fit=max&s=de2cecf52b21492f01daa4520c4f2a97',
@@ -17,7 +17,7 @@ export const mockTab1 = {
             url:
                 'https://www.theguardian.com/us-news/2019/sep/15/brett-kavanaugh-donald-trump-impeachment-supreme-court-justice',
             linkText: 'LINKTEXT Trump blasts calls for impeachment',
-            showByline: false,
+            showByline: true,
             byline: 'Martin Pengelly',
             image:
                 'https://i.guim.co.uk/img/media/579fd19481e46b9d6ed3c69c2a6992483df84478/0_0_6000_3600/master/6000.jpg?width=300&quality=85&auto=format&fit=max&s=63a6a5c13a8087e607a44ce5c7da2090',

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterItem.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterItem.tsx
@@ -77,6 +77,7 @@ export const MostViewedFooterItem = ({ trail, position }: Props) => (
             <div className={headlineHeader}>
                 {trail.isLiveBlog ? (
                     <LinkHeadline
+                        designType={trail.designType}
                         headlineText={trail.linkText}
                         pillar={trail.pillar}
                         size="xxxsmall"
@@ -88,6 +89,7 @@ export const MostViewedFooterItem = ({ trail, position }: Props) => (
                     />
                 ) : (
                     <LinkHeadline
+                        designType={trail.designType}
                         headlineText={trail.linkText}
                         pillar={trail.pillar}
                         size="xxxsmall"

--- a/src/web/components/MostViewed/MostViewedRight/MostViewedRightItem.tsx
+++ b/src/web/components/MostViewed/MostViewedRight/MostViewedRightItem.tsx
@@ -97,6 +97,7 @@ export const MostViewedRightItem = ({ trail }: Props) => {
                     <div className={headlineWrapperStyles}>
                         {trail.isLiveBlog ? (
                             <LinkHeadline
+                                designType={trail.designType}
                                 headlineText={trail.linkText}
                                 pillar={trail.pillar}
                                 size="xxxsmall"
@@ -112,6 +113,7 @@ export const MostViewedRightItem = ({ trail }: Props) => {
                             />
                         ) : (
                             <LinkHeadline
+                                designType={trail.designType}
                                 headlineText={trail.linkText}
                                 pillar={trail.pillar}
                                 size="xxxsmall"

--- a/src/web/components/MostViewed/MostViewedRight/MostViewedRightItem.tsx
+++ b/src/web/components/MostViewed/MostViewedRight/MostViewedRightItem.tsx
@@ -60,6 +60,10 @@ const imageTagStyles = css`
     clip-path: circle(36% at 50% 50%);
 `;
 
+const marginTopStyles = css`
+    margin-top: 4px;
+`;
+
 type Props = {
     trail: TrailType;
 };
@@ -112,9 +116,14 @@ export const MostViewedRightItem = ({ trail }: Props) => {
                                 link={linkProps}
                             />
                         )}
-                        {trail.ageWarning && (
-                            <AgeWarning age={trail.ageWarning} size="small" />
-                        )}
+                        <div className={marginTopStyles}>
+                            {trail.ageWarning && (
+                                <AgeWarning
+                                    age={trail.ageWarning}
+                                    size="small"
+                                />
+                            )}
+                        </div>
                     </div>
                 </div>
             </a>

--- a/src/web/components/MostViewed/MostViewedRight/MostViewedRightItem.tsx
+++ b/src/web/components/MostViewed/MostViewedRight/MostViewedRightItem.tsx
@@ -106,6 +106,9 @@ export const MostViewedRightItem = ({ trail }: Props) => {
                                     text: 'Live',
                                     showSlash: false,
                                 }}
+                                byline={
+                                    trail.showByline ? trail.byline : undefined
+                                }
                             />
                         ) : (
                             <LinkHeadline
@@ -114,6 +117,9 @@ export const MostViewedRightItem = ({ trail }: Props) => {
                                 size="xxxsmall"
                                 showUnderline={isHovered}
                                 link={linkProps}
+                                byline={
+                                    trail.showByline ? trail.byline : undefined
+                                }
                             />
                         )}
                         <div className={marginTopStyles}>


### PR DESCRIPTION
## What does this change?
Adds support for showing the author byline under card and link headlines

![Screenshot 2019-12-04 at 13 55 06](https://user-images.githubusercontent.com/1336821/70148250-b6c10100-169d-11ea-9436-cc406d0c0666.jpg)
![Screenshot 2019-12-04 at 13 54 45](https://user-images.githubusercontent.com/1336821/70148251-b7599780-169d-11ea-9132-2bf25d1aad3c.jpg)


## Link to supporting Trello card
https://trello.com/c/L7kmOhio/954-card-headline-shows-byline