### PR TITLE
Don't use article standfirst for cards

### DIFF
--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { palette } from '@guardian/src-foundations';
 
 import { CardHeadline } from '@frontend/web/components/CardHeadline';
-import { Standfirst } from '@frontend/web/components/Standfirst';
 import { GuardianLines } from '@frontend/web/components/GuardianLines';
 import { Avatar } from '@frontend/web/components/Avatar';
 
@@ -111,10 +110,7 @@ export const Card = ({
                             <div>
                                 {standfirst && (
                                     <StandfirstWrapper>
-                                        <Standfirst
-                                            designType="Article"
-                                            standfirst={standfirst}
-                                        />
+                                        {standfirst}
                                     </StandfirstWrapper>
                                 )}
                                 {avatar && (

--- a/src/web/components/Card/components/StandfirstWrapper.tsx
+++ b/src/web/components/Card/components/StandfirstWrapper.tsx
@@ -4,7 +4,7 @@ import { css } from 'emotion';
 import { body } from '@guardian/src-foundations/typography';
 
 type Props = {
-    children: JSXElements;
+    children: string;
 };
 
 export const StandfirstWrapper = ({ children }: Props) => (
@@ -12,12 +12,9 @@ export const StandfirstWrapper = ({ children }: Props) => (
         className={css`
             display: flex;
             flex-direction: column;
-            justify-content: space-between;
 
-            ${body.small({
-                fontWeight: 'light',
-            })};
-            line-height: 20px;
+            ${body.small()};
+            font-size: 14px;
 
             padding-left: 5px;
             padding-right: 5px;


### PR DESCRIPTION
## What does this change?
This PR fixes the styles on the card standfirst

## Before
![Screenshot 2019-12-04 at 15 11 48](https://user-images.githubusercontent.com/1336821/70154450-6a2ef300-16a8-11ea-80c2-fa525e434592.jpg)


## After
![Screenshot 2019-12-04 at 15 09 27](https://user-images.githubusercontent.com/1336821/70154234-18866880-16a8-11ea-8697-7c39ca0b8b94.jpg)


## Why?
We were using the article `Standfirst` component before but the card styles are much simpler and do not need a separate component.

## Link to supporting Trello card
https://trello.com/c/8mdBy7zg/961-style-standfirst