### PR TITLE
Mobile Sticky is back (from the underworld)

### DIFF
--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -29,6 +29,8 @@ import GE2019 from '@frontend/static/badges/general-election-2019.svg';
 
 import { StandardHeader } from './StandardHeader';
 
+import { MobileStickyContainer } from '@root/src/web/components/AdSlot';
+
 function checkForGE2019Badge(tags: TagType[]) {
     if (tags.find(tag => tag.id === 'politics/general-election-2019')) {
         return {
@@ -172,6 +174,7 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
             </Section>
 
             <div data-island="cookie-banner" />
+            <MobileStickyContainer />
         </>
     );
 };


### PR DESCRIPTION
## What does this change?

Get the mobile sticky back ( after having been accidentally lost here: https://github.com/guardian/dotcom-rendering/pull/825 )

## Why?

Because we need it.
