### PR TITLE
Introduce mobile sticky to the showcase layout

### DIFF
--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -25,6 +25,8 @@ import { HeaderAdSlot } from '@root/src/web/components/HeaderAdSlot';
 
 import { ShowcaseHeader } from './ShowcaseHeader';
 
+import { MobileStickyContainer } from '@root/src/web/components/AdSlot';
+
 interface Props {
     CAPI: CAPIType;
     NAV: NavType;
@@ -157,5 +159,6 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => (
         </Section>
 
         <div data-island="cookie-banner" />
+        <MobileStickyContainer />
     </>
 );


### PR DESCRIPTION
## What does this change?

Introduce mobile sticky to the showcase layout. This is the second part of ( https://github.com/guardian/dotcom-rendering/pull/1007 )
