### PR TITLE
Bring veggie burger to the fore

### DIFF
--- a/src/web/components/Nav/ExpandedMenu/ExpandedMenuToggle/VeggieBurger.tsx
+++ b/src/web/components/Nav/ExpandedMenu/ExpandedMenuToggle/VeggieBurger.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 import { palette } from '@guardian/src-foundations';
-import { from } from '@guardian/src-foundations/mq';
+import { from, until } from '@guardian/src-foundations/mq';
 
 const veggieBurger = ({
     showExpandedMenu,
@@ -18,7 +18,12 @@ const veggieBurger = ({
     border: 0;
     border-radius: 50%;
     outline: none;
-    z-index: ${showExpandedMenu ? 1071 : 0};
+    ${until.tablet} {
+        z-index: 1;
+    }
+    ${from.tablet} {
+        z-index: ${showExpandedMenu ? 1071 : 0};
+    }
     right: 5px;
     bottom: 48px;
     ${from.mobileMedium} {


### PR DESCRIPTION
## What does this change?
This PR ensures the Veggie burger does not lay behind the main content on smaller screens

## Before
![Screenshot 2019-12-09 at 11 31 51](https://user-images.githubusercontent.com/1336821/70432614-9b783c00-1a77-11ea-94fc-ecf47d5eb900.jpg)

## After
![Screenshot 2019-12-09 at 11 31 35](https://user-images.githubusercontent.com/1336821/70432613-9adfa580-1a77-11ea-99db-2d2c676a70cc.jpg)

## Link to supporting Trello card
https://trello.com/c/NkOBTV0b/972-veggie-z-index-fix
