### PR TITLE
Hide Section as well as SubNav when there are no links

### DIFF
--- a/src/web/components/SubNav/SubNav.tsx
+++ b/src/web/components/SubNav/SubNav.tsx
@@ -27,7 +27,7 @@ const multiLine = css`
 `;
 
 interface Props {
-    subnav?: {
+    subnav: {
         parent?: LinkType;
         links: LinkType[];
     };
@@ -81,10 +81,6 @@ export class SubNav extends Component<
     }
 
     public render() {
-        if (!this.props.subnav) {
-            return null;
-        }
-
         const { showMore, isExpanded } = this.state;
         const collapseWrapper = !showMore || !isExpanded;
         const expandSubNav = !showMore || isExpanded;

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -60,13 +60,15 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => (
             <Nav pillar={CAPI.pillar} nav={NAV} />
         </Section>
 
-        <Section backgroundColour={palette.neutral[100]} padded={false}>
-            <SubNav
-                subnav={NAV.subNavSections}
-                currentNavLink={NAV.currentNavLink}
-                pillar={CAPI.pillar}
-            />
-        </Section>
+        {NAV.subNavSections && (
+            <Section backgroundColour={palette.neutral[100]} padded={false}>
+                <SubNav
+                    subnav={NAV.subNavSections}
+                    currentNavLink={NAV.currentNavLink}
+                    pillar={CAPI.pillar}
+                />
+            </Section>
+        )}
 
         <Hide when="above" breakpoint="tablet">
             {/* When below tablet, show the main article image in a full width container */}
@@ -136,13 +138,15 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => (
 
         <Section islandId="most-viewed-footer" />
 
-        <Section padded={false}>
-            <SubNav
-                subnav={NAV.subNavSections}
-                pillar={CAPI.pillar}
-                currentNavLink={NAV.currentNavLink}
-            />
-        </Section>
+        {NAV.subNavSections && (
+            <Section padded={false}>
+                <SubNav
+                    subnav={NAV.subNavSections}
+                    pillar={CAPI.pillar}
+                    currentNavLink={NAV.currentNavLink}
+                />
+            </Section>
+        )}
 
         <Section
             padded={false}

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -84,13 +84,15 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                 <Nav pillar={CAPI.pillar} nav={NAV} />
             </Section>
 
-            <Section backgroundColour={palette.neutral[100]} padded={false}>
-                <SubNav
-                    subnav={NAV.subNavSections}
-                    currentNavLink={NAV.currentNavLink}
-                    pillar={CAPI.pillar}
-                />
-            </Section>
+            {NAV.subNavSections && (
+                <Section backgroundColour={palette.neutral[100]} padded={false}>
+                    <SubNav
+                        subnav={NAV.subNavSections}
+                        currentNavLink={NAV.currentNavLink}
+                        pillar={CAPI.pillar}
+                    />
+                </Section>
+            )}
 
             <Hide when="above" breakpoint="tablet">
                 {/* When below tablet, show the main article image in a full width container */}
@@ -151,13 +153,15 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
 
             <Section islandId="most-viewed-footer" />
 
-            <Section padded={false}>
-                <SubNav
-                    subnav={NAV.subNavSections}
-                    pillar={CAPI.pillar}
-                    currentNavLink={NAV.currentNavLink}
-                />
-            </Section>
+            {NAV.subNavSections && (
+                <Section padded={false}>
+                    <SubNav
+                        subnav={NAV.subNavSections}
+                        pillar={CAPI.pillar}
+                        currentNavLink={NAV.currentNavLink}
+                    />
+                </Section>
+            )}
 
             <Section
                 padded={false}


### PR DESCRIPTION
## What does this change?
Makes the `subnav` property required moving the decision about if to show the SubNav or not up, into the layout component

## Why?
This prevents us rendering an empty Section, removing the 1px border that could appear in some cases.

## Before
![Screenshot 2019-12-09 at 12 05 45](https://user-images.githubusercontent.com/1336821/70434508-4ab71200-1a7c-11ea-9f0f-40b758296631.jpg)

## After
![Screenshot 2019-12-09 at 12 05 34](https://user-images.githubusercontent.com/1336821/70434507-4ab71200-1a7c-11ea-9d4a-02b6f3ba9270.jpg)

## Link to supporting Trello card
https://trello.com/c/OatA6EXD/973-subnav-section