### PR TITLE
Take snapshots at smaller widths

### DIFF
--- a/cypress/integration/percy/article.web.spec.js
+++ b/cypress/integration/percy/article.web.spec.js
@@ -17,7 +17,7 @@ describe('For WEB', function() {
             // Make the request, forcing the location to UK (for edition)
             cy.visit(`Article?url=${url}?_edition=UK`, fetchPolyfill);
             cy.percySnapshot(`WEB-${pillar}-${designType}-${index}`, {
-                widths: [739, 979, 1139, 1299, 1400],
+                widths: [600, 979, 1139, 1299, 1400],
             });
         });
     });


### PR DESCRIPTION
## What does this change?
This reduces the smallest screen size that we render articles at within Cypress

## Why?
So that we have better test coverage

## Link to supporting Trello card
https://trello.com/c/sRUQJoTu/976-snapshots-of-small-screens