### PR TITLE
Added stretch prop to LI

### DIFF
--- a/src/web/components/Card/Card.stories.tsx
+++ b/src/web/components/Card/Card.stories.tsx
@@ -114,7 +114,7 @@ export const News = () => (
                     </LI>
                     <LI percentage="25%" showDivider={true} padSides={true}>
                         <UL direction="column">
-                            <LI bottomMargin={true}>
+                            <LI bottomMargin={true} stretch={true}>
                                 <Card
                                     {...{
                                         linkTo:
@@ -138,7 +138,7 @@ export const News = () => (
                                     }}
                                 />
                             </LI>
-                            <LI bottomMargin={true}>
+                            <LI bottomMargin={true} stretch={true}>
                                 <Card
                                     {...{
                                         linkTo:
@@ -154,7 +154,7 @@ export const News = () => (
                                     }}
                                 />
                             </LI>
-                            <LI bottomMargin={false}>
+                            <LI bottomMargin={false} stretch={true}>
                                 <Card
                                     {...{
                                         linkTo:
@@ -178,7 +178,7 @@ export const News = () => (
                     </LI>
                     <LI percentage="25%" showDivider={true} padSides={true}>
                         <UL direction="column">
-                            <LI bottomMargin={true}>
+                            <LI bottomMargin={true} stretch={true}>
                                 <Card
                                     {...{
                                         linkTo:
@@ -198,7 +198,7 @@ export const News = () => (
                                     }}
                                 />
                             </LI>
-                            <LI bottomMargin={true}>
+                            <LI bottomMargin={true} stretch={true}>
                                 <Card
                                     {...{
                                         linkTo:
@@ -218,7 +218,7 @@ export const News = () => (
                                     }}
                                 />
                             </LI>
-                            <LI bottomMargin={true}>
+                            <LI bottomMargin={true} stretch={true}>
                                 <Card
                                     {...{
                                         linkTo:
@@ -238,7 +238,7 @@ export const News = () => (
                                     }}
                                 />
                             </LI>
-                            <LI bottomMargin={true}>
+                            <LI bottomMargin={true} stretch={true}>
                                 <Card
                                     {...{
                                         linkTo:
@@ -258,7 +258,7 @@ export const News = () => (
                                     }}
                                 />
                             </LI>
-                            <LI bottomMargin={true}>
+                            <LI bottomMargin={true} stretch={true}>
                                 <Card
                                     {...{
                                         linkTo:
@@ -278,7 +278,7 @@ export const News = () => (
                                     }}
                                 />
                             </LI>
-                            <LI bottomMargin={false}>
+                            <LI bottomMargin={false} stretch={true}>
                                 <Card
                                     {...{
                                         linkTo:
@@ -317,7 +317,7 @@ export const InDepth = () => (
                 <UL direction="row">
                     <LI percentage="50%" padSides={true}>
                         <UL direction="column">
-                            <LI bottomMargin={true}>
+                            <LI bottomMargin={true} stretch={true}>
                                 <Card
                                     {...{
                                         linkTo:
@@ -342,7 +342,7 @@ export const InDepth = () => (
                                     }}
                                 />
                             </LI>
-                            <LI bottomMargin={true}>
+                            <LI bottomMargin={true} stretch={true}>
                                 <Card
                                     {...{
                                         linkTo:
@@ -367,7 +367,7 @@ export const InDepth = () => (
                                     }}
                                 />
                             </LI>
-                            <LI bottomMargin={true}>
+                            <LI bottomMargin={true} stretch={true}>
                                 <Card
                                     {...{
                                         linkTo:
@@ -392,7 +392,7 @@ export const InDepth = () => (
                                     }}
                                 />
                             </LI>
-                            <LI bottomMargin={true}>
+                            <LI bottomMargin={true} stretch={true}>
                                 <Card
                                     {...{
                                         linkTo:
@@ -417,7 +417,7 @@ export const InDepth = () => (
                                     }}
                                 />
                             </LI>
-                            <LI bottomMargin={false}>
+                            <LI bottomMargin={false} stretch={true}>
                                 <Card
                                     {...{
                                         linkTo:

--- a/src/web/components/Card/components/LI.tsx
+++ b/src/web/components/Card/components/LI.tsx
@@ -3,14 +3,11 @@ import { css, cx } from 'emotion';
 
 import { verticalDivider } from '../lib/verticalDivider';
 
-const liStyles = (percentage?: CardPercentageType) => css`
+const liStyles = css`
     /* This position relative is needed to contain the veritcal divider */
     position: relative;
 
-    /* margin-bottom: 12px; */
-
     display: flex;
-    ${percentage ? `flex-basis: ${percentage};` : `flex-grow: 1;`}
 `;
 
 const sidePaddingStyles = css`
@@ -23,9 +20,28 @@ const marginBottomStyles = css`
     margin-bottom: 10px;
 `;
 
+const decideSize = (percentage?: CardPercentageType, stretch?: boolean) => {
+    let sizeStyle;
+    if (percentage) {
+        sizeStyle = css`
+            flex-basis: ${percentage};
+        `;
+    } else if (stretch) {
+        sizeStyle = css`
+            flex-grow: 1;
+        `;
+    } else {
+        sizeStyle = css`
+            flex: 1;
+        `;
+    }
+    return sizeStyle;
+};
+
 type Props = {
     children: JSXElements;
-    percentage?: CardPercentageType; // Passed to flex-basis, defaults to flex grow
+    percentage?: CardPercentageType; // Used to give a particular LI more or less weight / space
+    stretch?: boolean; // When true, the card stretches based on content
     showDivider?: boolean; // If this LI wraps a card in a row this should be true
     padSides?: boolean; // If this LI directly wraps a card this should be true
     bottomMargin?: boolean; // True when wrapping a card in a column and not the last item
@@ -34,14 +50,19 @@ type Props = {
 export const LI = ({
     children,
     percentage,
+    stretch,
     showDivider,
     padSides = false,
     bottomMargin,
 }: Props) => {
+    // Decide sizing
+    const sizeStyles = decideSize(percentage, stretch);
+
     return (
         <li
             className={cx(
-                liStyles(percentage),
+                liStyles,
+                sizeStyles,
                 showDivider && verticalDivider,
                 padSides && sidePaddingStyles,
                 bottomMargin && marginBottomStyles,


### PR DESCRIPTION
## What does this change?
Refactored LI props to make stretching explicit

```typescript
type Props = {
    children: JSXElements;
    percentage?: CardPercentageType; // Used to give a particular LI more or less weight / space
    stretch?: boolean; // When true, the card stretches based on content
    showDivider?: boolean; // If this LI wraps a card in a row this should be true
    padSides?: boolean; // If this LI directly wraps a card this should be true
    bottomMargin?: boolean; // True when wrapping a card in a column and not the last item
};
```

## Why?
Because a more semantic default is to evenly space cards (which you could only do with balanced percentages before)

## Link to supporting Trello card
https://trello.com/c/GhLKI3Iu/982-stretch-lis