### PR TITLE
Resize card headline on breakpoint

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -254,7 +254,7 @@ type CardImageType = {
     size?: ImageSizeType;
 };
 
-type SmallHeadlineSize = 'xxxsmall' | 'xxsmall' | 'xsmall';
+type SmallHeadlineSize = 'tiny' | 'small' | 'medium' | 'large';
 
 type AvatarType = {
     src: string;

--- a/src/web/components/Byline.tsx
+++ b/src/web/components/Byline.tsx
@@ -11,11 +11,28 @@ type Props = {
     size: SmallHeadlineSize;
 };
 
-const bylineStyles = (size: SmallHeadlineSize) => css`
-    display: block;
-    ${headline[size]()};
-    font-style: italic;
-`;
+const bylineStyles = (size: SmallHeadlineSize) => {
+    switch (size) {
+        case 'large':
+            return css`
+                display: block;
+                font-style: italic;
+                ${headline.xsmall()};
+            `;
+        case 'medium':
+            return css`
+                display: block;
+                font-style: italic;
+                ${headline.xxsmall()};
+            `;
+        case 'small':
+            return css`
+                display: block;
+                font-style: italic;
+                ${headline.xxxsmall()};
+            `;
+    }
+};
 
 const colourStyles = (designType: DesignType, pillar: Pillar) => {
     switch (designType) {

--- a/src/web/components/Card/Card.stories.tsx
+++ b/src/web/components/Card/Card.stories.tsx
@@ -41,7 +41,7 @@ export const News = () => (
                                     designType: 'Article',
                                     headlineText:
                                         'The Knights Who Say Ni demand a sacrifice',
-                                    size: 'xsmall',
+                                    size: 'large',
                                     pillar: 'news',
                                     kicker: {
                                         text: 'Monty Python',
@@ -67,7 +67,7 @@ export const News = () => (
                                 headline: {
                                     designType: 'Article',
                                     headlineText: "Yes. We're all individuals",
-                                    size: 'xsmall',
+                                    size: 'large',
                                     pillar: 'news',
                                     kicker: {
                                         text: 'Brian',
@@ -149,7 +149,7 @@ export const News = () => (
                                             headlineText:
                                                 'Listen. Strange women lying in ponds distributing swords is no basis for a system of government',
                                             pillar: 'news',
-                                            size: 'xxxsmall',
+                                            size: 'small',
                                         },
                                     }}
                                 />
@@ -165,7 +165,7 @@ export const News = () => (
                                             headlineText:
                                                 'Supreme executive power derives from a mandate from the masses, not from some farcical aquatic ceremony',
                                             pillar: 'news',
-                                            size: 'xxxsmall',
+                                            size: 'small',
                                             kicker: {
                                                 text: 'Monty Python',
                                                 pillar: 'news',
@@ -189,7 +189,7 @@ export const News = () => (
                                             headlineText:
                                                 'Are you suggesting that coconuts migrate?',
                                             pillar: 'news',
-                                            size: 'xxxsmall',
+                                            size: 'small',
                                             kicker: {
                                                 text: 'Run Away!',
                                                 pillar: 'sport',
@@ -209,7 +209,7 @@ export const News = () => (
                                             headlineText:
                                                 "On second thoughts, let's not go there. It is a silly place",
                                             pillar: 'news',
-                                            size: 'xxxsmall',
+                                            size: 'small',
                                             kicker: {
                                                 text: 'Monty Python!',
                                                 pillar: 'news',
@@ -229,7 +229,7 @@ export const News = () => (
                                             headlineText:
                                                 'Let us ride to Camelot',
                                             pillar: 'news',
-                                            size: 'xxxsmall',
+                                            size: 'small',
                                             kicker: {
                                                 text: 'Monty Python!',
                                                 pillar: 'news',
@@ -249,7 +249,7 @@ export const News = () => (
                                             headlineText:
                                                 "Where'd you get the coconuts?",
                                             pillar: 'news',
-                                            size: 'xxxsmall',
+                                            size: 'small',
                                             kicker: {
                                                 text: 'Monty Python!',
                                                 pillar: 'news',
@@ -269,7 +269,7 @@ export const News = () => (
                                             headlineText:
                                                 'Now, look here, my good man',
                                             pillar: 'news',
-                                            size: 'xxxsmall',
+                                            size: 'small',
                                             kicker: {
                                                 text: 'Terry Gillingham',
                                                 pillar: 'lifestyle',
@@ -289,7 +289,7 @@ export const News = () => (
                                             headlineText:
                                                 "We shall say 'Ni' again to you, if you do not appease us",
                                             pillar: 'news',
-                                            size: 'xxxsmall',
+                                            size: 'small',
                                             kicker: {
                                                 text: 'Monty Python',
                                                 pillar: 'news',
@@ -327,7 +327,7 @@ export const InDepth = () => (
                                             designType: 'Article',
                                             headlineText:
                                                 "We shall say 'Ni' again to you, if you do not appease us",
-                                            size: 'xxsmall',
+                                            size: 'medium',
                                             pillar: 'news',
                                             kicker: {
                                                 text: 'Holy Grail',
@@ -352,7 +352,7 @@ export const InDepth = () => (
                                             designType: 'Article',
                                             headlineText:
                                                 'Now, look here, my good man',
-                                            size: 'xxxsmall',
+                                            size: 'small',
                                             pillar: 'news',
                                             kicker: {
                                                 text: 'Holy Grail',
@@ -377,7 +377,7 @@ export const InDepth = () => (
                                             designType: 'Article',
                                             headlineText:
                                                 "Where'd you get the coconuts",
-                                            size: 'xxxsmall',
+                                            size: 'small',
                                             pillar: 'news',
                                             kicker: {
                                                 text: 'Holy Grail',
@@ -402,7 +402,7 @@ export const InDepth = () => (
                                             designType: 'Article',
                                             headlineText:
                                                 'Let us ride to Camelot!',
-                                            size: 'xxxsmall',
+                                            size: 'small',
                                             pillar: 'news',
                                             kicker: {
                                                 text: 'Holy Grail',
@@ -427,7 +427,7 @@ export const InDepth = () => (
                                             designType: 'Article',
                                             headlineText:
                                                 'How do you know she is a witch? Burn her!',
-                                            size: 'xxxsmall',
+                                            size: 'small',
                                             pillar: 'news',
                                             kicker: {
                                                 text: 'Holy Grail',
@@ -454,7 +454,7 @@ export const InDepth = () => (
                                     designType: 'Article',
                                     headlineText:
                                         "Go and boil your bottoms, sons of a silly person!'",
-                                    size: 'xsmall',
+                                    size: 'large',
                                     pillar: 'news',
                                     kicker: {
                                         text: 'Monty Python',
@@ -494,7 +494,7 @@ export const Related = () => (
                                     designType: 'Article',
                                     headlineText:
                                         "We shall say 'Ni' again to you, if you do not appease us",
-                                    size: 'xxsmall',
+                                    size: 'medium',
                                     pillar: 'news',
                                     kicker: {
                                         text: 'Holy Grail',
@@ -519,7 +519,7 @@ export const Related = () => (
                                 headline: {
                                     designType: 'Article',
                                     headlineText: 'Now, look here, my good man',
-                                    size: 'xxsmall',
+                                    size: 'medium',
                                     pillar: 'sport',
                                     kicker: {
                                         text: 'Holy Grail',
@@ -545,7 +545,7 @@ export const Related = () => (
                                     designType: 'Article',
                                     headlineText:
                                         "Where'd you get the coconuts",
-                                    size: 'xxsmall',
+                                    size: 'medium',
                                     pillar: 'sport',
                                     kicker: {
                                         text: 'Holy Grail',
@@ -573,7 +573,7 @@ export const Related = () => (
                                     designType: 'Article',
                                     headlineText:
                                         'Go and boil your bottoms, sons of a silly person!',
-                                    size: 'xxxsmall',
+                                    size: 'small',
                                     pillar: 'news',
                                     kicker: {
                                         text: 'Monty Python',
@@ -593,7 +593,7 @@ export const Related = () => (
                                 headline: {
                                     designType: 'Article',
                                     headlineText: 'Let us ride to Camelot!',
-                                    size: 'xxxsmall',
+                                    size: 'small',
                                     pillar: 'news',
                                     kicker: {
                                         text: 'Monty Python',
@@ -613,7 +613,7 @@ export const Related = () => (
                                 headline: {
                                     designType: 'Interview',
                                     headlineText: 'Let us ride to Camelot!',
-                                    size: 'xxxsmall',
+                                    size: 'small',
                                     pillar: 'culture',
                                     kicker: {
                                         text: 'Monty Python',
@@ -634,7 +634,7 @@ export const Related = () => (
                                     designType: 'Feature',
                                     headlineText:
                                         'How do you know she is a witch? Burn her!',
-                                    size: 'xxxsmall',
+                                    size: 'small',
                                     pillar: 'lifestyle',
                                     kicker: {
                                         text: 'Holy Grail',
@@ -668,7 +668,7 @@ export const Spotlight = () => (
                             designType: 'Feature',
                             headlineText:
                                 "We shall say 'Ni' again to you, if you do not appease us",
-                            size: 'xsmall',
+                            size: 'large',
                             pillar: 'sport',
                             kicker: {
                                 text: 'Holy Grail',
@@ -707,7 +707,7 @@ export const Quad = () => (
                                     designType: 'Comment',
                                     headlineText:
                                         "We shall say 'Ni' again to you, if you do not appease us",
-                                    size: 'xxsmall',
+                                    size: 'medium',
                                     pillar: 'opinion',
                                     kicker: {
                                         text: 'Holy Grail',
@@ -736,7 +736,7 @@ export const Quad = () => (
                                     designType: 'Comment',
                                     headlineText:
                                         "We shall say 'Ni' again to you, if you do not appease us",
-                                    size: 'xxsmall',
+                                    size: 'medium',
                                     pillar: 'opinion',
                                     showQuotes: true,
                                 },
@@ -760,7 +760,7 @@ export const Quad = () => (
                                     designType: 'Article',
                                     headlineText:
                                         "We shall say 'Ni' again to you, if you do not appease us",
-                                    size: 'xxsmall',
+                                    size: 'medium',
                                     pillar: 'news',
                                     kicker: {
                                         text: 'Holy Grail',
@@ -787,7 +787,7 @@ export const Quad = () => (
                                     designType: 'Article',
                                     headlineText:
                                         "We shall say 'Ni' again to you, if you do not appease us",
-                                    size: 'xxsmall',
+                                    size: 'medium',
                                     pillar: 'news',
                                     kicker: {
                                         text: 'Holy Grail',

--- a/src/web/components/CardHeadline.stories.tsx
+++ b/src/web/components/CardHeadline.stories.tsx
@@ -47,14 +47,14 @@ Feature.story = { name: 'Feature' };
 export const xsmallStory = () => (
     <Section showTopBorder={false} showSideBorders={false}>
         <CardHeadline
-            headlineText="This is how a xsmall card headline looks"
+            headlineText="This is how a large card headline looks"
             designType="Article"
             pillar="news"
-            size="xsmall"
+            size="large"
         />
     </Section>
 );
-xsmallStory.story = { name: 'Size | xsmall' };
+xsmallStory.story = { name: 'Size | large' };
 
 export const liveStory = () => (
     <Section showTopBorder={false} showSideBorders={false}>
@@ -120,24 +120,24 @@ export const AnalysisXSmall = () => (
             headlineText="Xsmall card headline for an Analysis article"
             designType="Analysis"
             pillar="lifestyle"
-            size="xsmall"
+            size="large"
         />
     </Section>
 );
-AnalysisXSmall.story = { name: 'Underlined | xsmall' };
+AnalysisXSmall.story = { name: 'Underlined | large' };
 
 export const opinionxxxsmall = () => (
     <Section showTopBorder={false} showSideBorders={false}>
         <CardHeadline
-            headlineText="This is how xxxsmall card headline for opinion articles look"
+            headlineText="This is how small card headline for opinion articles look"
             designType="Comment"
             pillar="opinion"
             showQuotes={true}
-            size="xxxsmall"
+            size="small"
         />
     </Section>
 );
-opinionxxxsmall.story = { name: 'Quotes | xxxsmall' };
+opinionxxxsmall.story = { name: 'Quotes | small' };
 
 export const OpinionKicker = () => (
     <Section showTopBorder={false} showSideBorders={false}>

--- a/src/web/components/CardHeadline.tsx
+++ b/src/web/components/CardHeadline.tsx
@@ -3,14 +3,39 @@ import { css, cx } from 'emotion';
 
 import { headline } from '@guardian/src-foundations/typography';
 import { palette } from '@guardian/src-foundations';
+import { until } from '@guardian/src-foundations/mq';
 
 import { QuoteIcon } from '@root/src/web/components/QuoteIcon';
 import { Kicker } from '@root/src/web/components/Kicker';
 import { Byline } from '@root/src/web/components/Byline';
 
-const fontStyles = (size: SmallHeadlineSize) => css`
-    ${headline[size]()};
-`;
+const fontStyles = (size: SmallHeadlineSize) => {
+    switch (size) {
+        case 'large':
+            return css`
+                ${headline.xsmall()};
+                ${until.desktop} {
+                    ${headline.xxsmall()};
+                }
+            `;
+        case 'medium':
+            return css`
+                ${headline.xxsmall()};
+                ${until.desktop} {
+                    ${headline.xxxsmall()};
+                }
+            `;
+        case 'small':
+            return css`
+                ${headline.xxxsmall()};
+            `;
+        case 'tiny':
+            return css`
+                ${headline.xxxsmall()};
+                font-size: 14px;
+            `;
+    }
+};
 
 const underlinedStyles = (size: SmallHeadlineSize) => {
     function generateUnderlinedCss(baseSize: number) {
@@ -29,11 +54,11 @@ const underlinedStyles = (size: SmallHeadlineSize) => {
         `;
     }
     switch (size) {
-        case 'xxxsmall':
+        case 'small':
             return generateUnderlinedCss(21);
-        case 'xxsmall':
+        case 'medium':
             return generateUnderlinedCss(24);
-        case 'xsmall':
+        case 'large':
             return generateUnderlinedCss(28);
         default:
             return generateUnderlinedCss(23);
@@ -78,7 +103,7 @@ export const CardHeadline = ({
     pillar,
     showQuotes,
     kicker,
-    size = 'xxsmall',
+    size = 'medium',
     byline,
 }: CardHeadlineType) => (
     <>

--- a/src/web/components/LinkHeadline.stories.tsx
+++ b/src/web/components/LinkHeadline.stories.tsx
@@ -15,13 +15,13 @@ export const xsmallStory = () => (
     <Section showTopBorder={false} showSideBorders={false}>
         <LinkHeadline
             designType="Article"
-            headlineText="This is how a xsmall headline link looks"
+            headlineText="This is how a large headline link looks"
             pillar="news"
-            size="xsmall"
+            size="large"
         />
     </Section>
 );
-xsmallStory.story = { name: 'Size | xsmall' };
+xsmallStory.story = { name: 'Size | large' };
 
 export const liveStory = () => (
     <Section showTopBorder={false} showSideBorders={false}>
@@ -85,15 +85,15 @@ export const opinionxxxsmall = () => (
     <Section showTopBorder={false} showSideBorders={false}>
         <LinkHeadline
             designType="Comment"
-            headlineText="This is how xxxsmall links to opinion articles look"
+            headlineText="This is how small links to opinion articles look"
             pillar="opinion"
             showQuotes={true}
-            size="xxxsmall"
+            size="small"
             byline="Comment byline"
         />
     </Section>
 );
-opinionxxxsmall.story = { name: 'Quotes | xxxsmall' };
+opinionxxxsmall.story = { name: 'Quotes | small' };
 
 export const OpinionKicker = () => (
     <Section showTopBorder={false} showSideBorders={false}>
@@ -118,7 +118,7 @@ export const InUnderlinedState = () => (
             headlineText="This is the underlined state when showUnderline is true"
             pillar="news"
             showUnderline={true}
-            size="xxxsmall"
+            size="small"
             kicker={{
                 text: 'I am never underlined',
                 showSlash: true,

--- a/src/web/components/LinkHeadline.tsx
+++ b/src/web/components/LinkHeadline.tsx
@@ -8,9 +8,27 @@ import { QuoteIcon } from '@root/src/web/components/QuoteIcon';
 import { Kicker } from '@root/src/web/components/Kicker';
 import { Byline } from '@root/src/web/components/Byline';
 
-const fontStyles = (size: SmallHeadlineSize) => css`
-    ${headline[size]()};
-`;
+const fontStyles = (size: SmallHeadlineSize) => {
+    switch (size) {
+        case 'large':
+            return css`
+                ${headline.xsmall()};
+            `;
+        case 'medium':
+            return css`
+                ${headline.xxsmall()};
+            `;
+        case 'small':
+            return css`
+                ${headline.xxxsmall()};
+            `;
+        case 'tiny':
+            return css`
+                ${headline.xxxsmall()};
+                font-size: 14px;
+            `;
+    }
+};
 
 const textDecorationUnderline = css`
     text-decoration: underline;
@@ -40,7 +58,7 @@ export const LinkHeadline = ({
     showUnderline = false,
     kicker,
     showQuotes = false,
-    size = 'xxsmall',
+    size = 'medium',
     link,
     byline,
 }: LinkHeadlineType) => (

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterItem.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterItem.tsx
@@ -53,7 +53,7 @@ const headlineLink = css`
     text-decoration: none;
     color: ${palette.neutral[7]};
     font-weight: 500;
-    ${headline.xxxsmall()};
+    ${headline.small()};
 `;
 
 const ageWarningStyles = css`
@@ -80,7 +80,7 @@ export const MostViewedFooterItem = ({ trail, position }: Props) => (
                         designType={trail.designType}
                         headlineText={trail.linkText}
                         pillar={trail.pillar}
-                        size="xxxsmall"
+                        size="small"
                         kicker={{
                             text: 'Live',
                             showSlash: true,
@@ -92,7 +92,7 @@ export const MostViewedFooterItem = ({ trail, position }: Props) => (
                         designType={trail.designType}
                         headlineText={trail.linkText}
                         pillar={trail.pillar}
-                        size="xxxsmall"
+                        size="small"
                     />
                 )}
             </div>

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterItem.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterItem.tsx
@@ -53,7 +53,7 @@ const headlineLink = css`
     text-decoration: none;
     color: ${palette.neutral[7]};
     font-weight: 500;
-    ${headline.small()};
+    ${headline.xxxsmall()};
 `;
 
 const ageWarningStyles = css`

--- a/src/web/components/MostViewed/MostViewedRight/MostViewedRightItem.tsx
+++ b/src/web/components/MostViewed/MostViewedRight/MostViewedRightItem.tsx
@@ -22,7 +22,7 @@ const listItemStyles = css`
 const linkTagStyles = css`
     text-decoration: none;
     font-weight: 500;
-    ${headline.xxxsmall()};
+    ${headline.small()};
 
     &:link,
     &:active {
@@ -100,7 +100,7 @@ export const MostViewedRightItem = ({ trail }: Props) => {
                                 designType={trail.designType}
                                 headlineText={trail.linkText}
                                 pillar={trail.pillar}
-                                size="xxxsmall"
+                                size="small"
                                 showUnderline={isHovered}
                                 link={linkProps}
                                 kicker={{
@@ -116,7 +116,7 @@ export const MostViewedRightItem = ({ trail }: Props) => {
                                 designType={trail.designType}
                                 headlineText={trail.linkText}
                                 pillar={trail.pillar}
-                                size="xxxsmall"
+                                size="small"
                                 showUnderline={isHovered}
                                 link={linkProps}
                                 byline={

--- a/src/web/components/MostViewed/MostViewedRight/MostViewedRightItem.tsx
+++ b/src/web/components/MostViewed/MostViewedRight/MostViewedRightItem.tsx
@@ -22,7 +22,7 @@ const listItemStyles = css`
 const linkTagStyles = css`
     text-decoration: none;
     font-weight: 500;
-    ${headline.small()};
+    ${headline.xxxsmall()};
 
     &:link,
     &:active {

--- a/src/web/components/Onwards/StoryPackage.tsx
+++ b/src/web/components/Onwards/StoryPackage.tsx
@@ -19,7 +19,7 @@ export const StoryPackage = ({ content }: Props) => (
                         headline: {
                             designType: content[0].designType,
                             headlineText: content[0].linkText,
-                            size: 'xxsmall',
+                            size: 'medium',
                             pillar: content[0].pillar,
                         },
                         webPublicationDate: content[0].webPublicationDate,
@@ -38,7 +38,7 @@ export const StoryPackage = ({ content }: Props) => (
                         headline: {
                             designType: content[1].designType,
                             headlineText: content[1].linkText,
-                            size: 'xxsmall',
+                            size: 'medium',
                             pillar: content[1].pillar,
                         },
                         webPublicationDate: content[1].webPublicationDate,
@@ -57,7 +57,7 @@ export const StoryPackage = ({ content }: Props) => (
                         headline: {
                             designType: content[2].designType,
                             headlineText: content[2].linkText,
-                            size: 'xxsmall',
+                            size: 'medium',
                             pillar: content[2].pillar,
                         },
                         webPublicationDate: content[2].webPublicationDate,
@@ -76,7 +76,7 @@ export const StoryPackage = ({ content }: Props) => (
                         headline: {
                             designType: content[3].designType,
                             headlineText: content[3].linkText,
-                            size: 'xxsmall',
+                            size: 'medium',
                             pillar: content[3].pillar,
                         },
                         webPublicationDate: content[3].webPublicationDate,
@@ -97,7 +97,7 @@ export const StoryPackage = ({ content }: Props) => (
                         headline: {
                             designType: content[4].designType,
                             headlineText: content[4].linkText,
-                            size: 'xxxsmall',
+                            size: 'small',
                             pillar: content[4].pillar,
                         },
                         webPublicationDate: content[4].webPublicationDate,
@@ -113,7 +113,7 @@ export const StoryPackage = ({ content }: Props) => (
                         headline: {
                             designType: content[5].designType,
                             headlineText: content[5].linkText,
-                            size: 'xxxsmall',
+                            size: 'small',
                             pillar: content[5].pillar,
                         },
                         webPublicationDate: content[5].webPublicationDate,
@@ -129,7 +129,7 @@ export const StoryPackage = ({ content }: Props) => (
                         headline: {
                             designType: content[6].designType,
                             headlineText: content[6].linkText,
-                            size: 'xxxsmall',
+                            size: 'small',
                             pillar: content[6].pillar,
                         },
                         webPublicationDate: content[6].webPublicationDate,
@@ -145,7 +145,7 @@ export const StoryPackage = ({ content }: Props) => (
                         headline: {
                             designType: content[7].designType,
                             headlineText: content[7].linkText,
-                            size: 'xxxsmall',
+                            size: 'small',
                             pillar: content[7].pillar,
                         },
                         webPublicationDate: content[7].webPublicationDate,

--- a/src/web/components/QuoteIcon.tsx
+++ b/src/web/components/QuoteIcon.tsx
@@ -10,16 +10,16 @@ const quoteStyles = (colour?: string) => css`
     fill: ${colour && colour};
 `;
 
-const sizeStyles = (size: 'xxxsmall' | 'xxsmall' | 'xsmall') => {
+const sizeStyles = (size: SmallHeadlineSize) => {
     switch (size) {
-        case 'xxxsmall':
+        case 'small':
             return css`
                 svg {
                     height: 16px;
                     width: 8px;
                 }
             `;
-        case 'xxsmall':
+        case 'medium':
             return css`
                 margin-right: 4px;
                 svg {
@@ -27,7 +27,7 @@ const sizeStyles = (size: 'xxxsmall' | 'xxsmall' | 'xsmall') => {
                     width: 11px;
                 }
             `;
-        case 'xsmall':
+        case 'large':
             return css`
                 margin-right: 8px;
                 svg {
@@ -47,10 +47,10 @@ const sizeStyles = (size: 'xxxsmall' | 'xxsmall' | 'xsmall') => {
 
 type Props = {
     colour?: string;
-    size?: 'xxxsmall' | 'xxsmall' | 'xsmall';
+    size?: SmallHeadlineSize;
 };
 
-export const QuoteIcon = ({ colour, size = 'xxsmall' }: Props) => (
+export const QuoteIcon = ({ colour, size = 'medium' }: Props) => (
     <span className={sizeStyles(size)}>
         <svg
             width="70"


### PR DESCRIPTION
## What does this change?
Card headlines should resize based on screen width

Below 980pixels:
_Large headlines drop to medium_
_Medium headlines drop to small_
_Small headlines remain the same_

To support these rules I removed the use of the source component size names (`xxxsmall`, `xxsmall`, `xsmall`, etc) replacing them with:

```typescript
type SmallHeadlineSize = 'tiny' | 'small' | 'medium' | 'large';
```

`tiny` was added to support the sub headlines that can appear in the card footer. The design system does not have a size for these so they are overridden to 14px.`


## Link to supporting Trello card
https://trello.com/c/X4AaLzaq/985-resize-card-headlines
