### PR TITLE
Refactor Card

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -11,6 +11,13 @@ module.exports = ({ config }) => {
         use: [
             {
                 loader: require.resolve('awesome-typescript-loader'),
+                options: {
+                    silent: true,
+                    useBabel: true,
+                    babelOptions: {
+                        plugins: ['@babel/plugin-proposal-optional-chaining'],
+                    },
+                },
             },
         ],
     });

--- a/index.d.ts
+++ b/index.d.ts
@@ -251,7 +251,7 @@ type ImagePositionType = 'left' | 'top' | 'right';
 type CardImageType = {
     url: string;
     position?: ImagePositionType;
-    size?: ImageSizeType;
+    size?: ImageSizeType; // Size is ignored when position = 'top' because in that case the image flows based on width
 };
 
 type SmallHeadlineSize = 'xxxsmall' | 'xxsmall' | 'xsmall';

--- a/src/web/components/Card/Card.stories.tsx
+++ b/src/web/components/Card/Card.stories.tsx
@@ -77,7 +77,6 @@ export const News = () => (
                                 trailImage: {
                                     url: imageUrls[5],
                                     position: 'top',
-                                    size: 'small',
                                 },
                                 standfirst:
                                     "Well, obviously it's not meant to be taken literally. It refers to any manufacturer of dairy products",
@@ -105,7 +104,6 @@ export const News = () => (
                                 trailImage: {
                                     url: imageUrls[3],
                                     position: 'top',
-                                    size: 'medium',
                                 },
                                 standfirst:
                                     'The swallow may fly south with the sun, and the house martin or the plover may seek warmer climes in winter, yet these are not strangers to our land. Burn her anyway!',
@@ -133,7 +131,6 @@ export const News = () => (
                                         trailImage: {
                                             url: imageUrls[6],
                                             position: 'top',
-                                            size: 'small',
                                         },
                                     }}
                                 />
@@ -464,7 +461,6 @@ export const InDepth = () => (
                                 trailImage: {
                                     url: imageUrls[0],
                                     position: 'top',
-                                    size: 'large',
                                 },
                             }}
                         />
@@ -505,7 +501,6 @@ export const Related = () => (
                                 trailImage: {
                                     url: imageUrls[5],
                                     position: 'top',
-                                    size: 'small',
                                 },
                             }}
                         />
@@ -530,7 +525,6 @@ export const Related = () => (
                                 trailImage: {
                                     url: imageUrls[6],
                                     position: 'top',
-                                    size: 'small',
                                 },
                             }}
                         />
@@ -556,7 +550,6 @@ export const Related = () => (
                                 trailImage: {
                                     url: imageUrls[4],
                                     position: 'top',
-                                    size: 'small',
                                 },
                             }}
                         />
@@ -744,7 +737,6 @@ export const Quad = () => (
                                 trailImage: {
                                     url: imageUrls[0],
                                     position: 'top',
-                                    size: 'medium',
                                 },
                                 showClock: true,
                             }}
@@ -771,7 +763,6 @@ export const Quad = () => (
                                 trailImage: {
                                     url: imageUrls[0],
                                     position: 'top',
-                                    size: 'medium',
                                 },
                                 showClock: true,
                             }}
@@ -798,7 +789,6 @@ export const Quad = () => (
                                 trailImage: {
                                     url: imageUrls[0],
                                     position: 'top',
-                                    size: 'medium',
                                 },
                                 showClock: true,
                             }}

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -61,12 +61,16 @@ export const Card = ({
     avatar,
     showClock,
 }: CardType) => {
-    // If there was no image given or image size was not set, percentage is null and
-    // no flex-basis property is set in the wrappers, so content flows normally
-    const imageCoverage =
-        trailImage && trailImage.size && coverages.image[trailImage.size];
-    const contentCoverage =
-        trailImage && trailImage.size && coverages.content[trailImage.size];
+    // Decide how we position the image on the card
+    let imageCoverage: CardPercentageType | undefined;
+    let contentCoverage: CardPercentageType | undefined;
+    if (trailImage?.size && trailImage.position !== 'top') {
+        // We only specifiy an explicit width for the image when
+        // we're positioning left or right, not top. Top positioned
+        // images flow naturally
+        imageCoverage = coverages.image[trailImage.size];
+        contentCoverage = coverages.content[trailImage.size];
+    }
 
     const isOpinion = pillar === 'opinion';
 
@@ -84,7 +88,7 @@ export const Card = ({
             }
         >
             <TopBar topBarColour={palette[pillar].main}>
-                <CardLayout imagePosition={trailImage && trailImage.position}>
+                <CardLayout imagePosition={trailImage?.position}>
                     <>
                         {trailImage && (
                             <ImageWrapper percentage={imageCoverage}>

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -66,7 +66,7 @@ export const Card = ({
     // Decide how we position the image on the card
     let imageCoverage: CardPercentageType | undefined;
     let contentCoverage: CardPercentageType | undefined;
-    if (trailImage?.size && trailImage.position !== 'top') {
+    if (trailImage && trailImage.size && trailImage.position !== 'top') {
         // We only specifiy an explicit width for the image when
         // we're positioning left or right, not top. Top positioned
         // images flow naturally
@@ -90,7 +90,7 @@ export const Card = ({
             }
         >
             <TopBar topBarColour={palette[pillar].main}>
-                <CardLayout imagePosition={trailImage?.position}>
+                <CardLayout imagePosition={trailImage && trailImage.position}>
                     <>
                         {trailImage && (
                             <ImageWrapper percentage={imageCoverage}>

--- a/src/web/components/Card/components/ContentWrapper.tsx
+++ b/src/web/components/Card/components/ContentWrapper.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 
-import { until } from '@guardian/src-foundations/mq';
-
 const sizingStyles = css`
     display: flex;
     flex-direction: column;
@@ -13,16 +11,9 @@ const coverageStyles = (percentage?: string) => {
     return percentage
         ? css`
               flex-basis: ${percentage};
-              ${until.tablet} {
-                  flex-basis: 75%;
-              }
           `
         : css`
               flex-grow: 1;
-              ${until.tablet} {
-                  /* This value pairs with the flex 1 used if there is an image */
-                  flex: 3;
-              }
           `;
 };
 

--- a/src/web/components/Card/components/ContentWrapper.tsx
+++ b/src/web/components/Card/components/ContentWrapper.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 
+import { until } from '@guardian/src-foundations/mq';
+
 const sizingStyles = css`
     display: flex;
     flex-direction: column;
@@ -11,6 +13,9 @@ const coverageStyles = (percentage?: string) => {
     return percentage
         ? css`
               flex-basis: ${percentage};
+              ${until.tablet} {
+                  flex-basis: unset;
+              }
           `
         : css`
               flex-grow: 1;

--- a/src/web/components/Card/components/ContentWrapper.tsx
+++ b/src/web/components/Card/components/ContentWrapper.tsx
@@ -19,6 +19,10 @@ const coverageStyles = (percentage?: string) => {
           `
         : css`
               flex-grow: 1;
+              ${until.tablet} {
+                  /* This value pairs with the flex 1 used if there is an image */
+                  flex: 3;
+              }
           `;
 };
 

--- a/src/web/components/Card/components/ImageWrapper.tsx
+++ b/src/web/components/Card/components/ImageWrapper.tsx
@@ -14,7 +14,8 @@ export const ImageWrapper = ({ children, percentage }: Props) => {
             className={css`
                 flex-basis: ${percentage && percentage};
                 ${until.tablet} {
-                    flex-basis: 25%;
+                    /* Until tablet, images are always left and this value pairs with the flex 3 used for content */
+                    flex: 1;
                 }
 
                 img {

--- a/src/web/components/Card/components/ImageWrapper.tsx
+++ b/src/web/components/Card/components/ImageWrapper.tsx
@@ -14,8 +14,13 @@ export const ImageWrapper = ({ children, percentage }: Props) => {
             className={css`
                 flex-basis: ${percentage && percentage};
                 ${until.tablet} {
-                    /* Until tablet, images are always left and this value pairs with the flex 3 used for content */
-                    flex: 1;
+                    /* Below tablet, we fix the size of the image and add a margin
+                       around it. The corresponding content flex grows to fill the space */
+                    margin-left: 6px;
+                    width: 119px;
+                    flex-shrink: 0;
+                    margin-top: 6px;
+                    margin-bottom: 6px;
                 }
 
                 img {

--- a/src/web/components/Card/components/ImageWrapper.tsx
+++ b/src/web/components/Card/components/ImageWrapper.tsx
@@ -21,6 +21,7 @@ export const ImageWrapper = ({ children, percentage }: Props) => {
                     flex-shrink: 0;
                     margin-top: 6px;
                     margin-bottom: 6px;
+                    flex-basis: unset;
                 }
 
                 img {

--- a/src/web/components/Card/components/LI.tsx
+++ b/src/web/components/Card/components/LI.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 
-import { until } from '@guardian/src-foundations/mq';
+import { from, until } from '@guardian/src-foundations/mq';
 
 import { verticalDivider } from '../lib/verticalDivider';
 
@@ -14,8 +14,10 @@ const liStyles = css`
 
 const sidePaddingStyles = css`
     /* Set spacing on the li element */
-    padding-left: 10px;
-    padding-right: 10px;
+    ${from.tablet} {
+        padding-left: 10px;
+        padding-right: 10px;
+    }
 `;
 
 const marginBottomStyles = css`

--- a/src/web/components/Onwards/OnwardsContainer.tsx
+++ b/src/web/components/Onwards/OnwardsContainer.tsx
@@ -14,10 +14,28 @@ export const OnwardsContainer = ({ children }: Props) => (
             flex-grow: 1;
             flex-direction: column;
 
-            margin-top: 10px;
-            margin-bottom: 50px;
-            ${from.tablet} {
+            margin-top: 6px;
+            ${from.leftCol} {
+                margin-top: 36px;
+            }
+
+            margin-bottom: 35px;
+
+            ${from.wide} {
                 margin-right: 70px;
+            }
+
+            margin-left: 0px;
+            margin-right: 0px;
+            ${from.tablet} {
+                /* Shrink the container to remove the leading and
+                   trailing side margins from the list of cards */
+                margin-left: -10px;
+                margin-right: -10px;
+            }
+            ${from.leftCol} {
+                margin-left: 0px;
+                margin-right: -10px;
             }
         `}
     >

--- a/src/web/components/Onwards/OnwardsContainer.tsx
+++ b/src/web/components/Onwards/OnwardsContainer.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { css } from 'emotion';
 
+import { from } from '@guardian/src-foundations/mq';
+
 type Props = {
     children: JSX.Element | JSX.Element[];
 };
@@ -14,7 +16,9 @@ export const OnwardsContainer = ({ children }: Props) => (
 
             margin-top: 10px;
             margin-bottom: 50px;
-            margin-right: 70px;
+            ${from.tablet} {
+                margin-right: 70px;
+            }
         `}
     >
         {children}

--- a/src/web/components/Onwards/OnwardsLayout.tsx
+++ b/src/web/components/Onwards/OnwardsLayout.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { Flex } from '@frontend/web/components/Flex';
 import { LeftColumn } from '@frontend/web/components/LeftColumn';
+import { Hide } from '@frontend/web/components/Hide';
 
 import { OnwardsTitle } from './OnwardsTitle';
 import { OnwardsContainer } from './OnwardsContainer';
@@ -17,6 +18,9 @@ export const OnwardsLayout = ({ content, component: Content }: Props) => (
             <OnwardsTitle title={content.heading} />
         </LeftColumn>
         <OnwardsContainer>
+            <Hide when="above" breakpoint="leftCol">
+                <OnwardsTitle title={content.heading} />
+            </Hide>
             <Content content={content.trails} />
         </OnwardsContainer>
     </Flex>

--- a/src/web/components/Onwards/OnwardsTitle.tsx
+++ b/src/web/components/Onwards/OnwardsTitle.tsx
@@ -23,6 +23,10 @@ export const OnwardsTitle = ({ title }: { title: string }) => (
             ${from.wide} {
                 font-weight: 900;
             }
+
+            ${from.tablet} {
+                margin-left: 10px;
+            }
         `}
     >
         {title}


### PR DESCRIPTION
## What does this change?
This PR clears up a few things after the recent Card changes. It:

- Rationalises how we pass `size` to Card
- Does a drive by fix for optional chaining in babel
- Stops the card content growing into the image below `tablet`
- Removes the right margin from the onwards container below `tablet`
- Fixes the size of the card image below `tablet`
- Brings the container padding inline with frontend for parity
- Ensures the container title displays below `leftCol`

## Why?
To support onwards

## Link to supporting Trello card
https://trello.com/c/SguUYP8X/984-refactor-card-image-props