### PR TITLE
Use designType in Cards

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -263,6 +263,7 @@ type AvatarType = {
 
 interface CardType {
     linkTo: string;
+    designType?: DesignType;
     pillar: Pillar;
     headline: CardHeadlineType;
     webPublicationDate?: string;

--- a/src/web/components/Card/Card.stories.tsx
+++ b/src/web/components/Card/Card.stories.tsx
@@ -771,12 +771,11 @@ export const Quad = () => (
                                     '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
                                 pillar: 'opinion',
                                 headline: {
-                                    designType: 'Comment',
+                                    designType: 'Article',
                                     headlineText:
                                         "We shall say 'Ni' again to you, if you do not appease us",
                                     size: 'medium',
                                     pillar: 'opinion',
-                                    showQuotes: true,
                                 },
                                 webPublicationDate: '2019-11-11T09:45:30.000Z',
                                 trailImage: {

--- a/src/web/components/Card/Card.stories.tsx
+++ b/src/web/components/Card/Card.stories.tsx
@@ -756,6 +756,7 @@ export const Quad = () => (
                                     alt: 'Avatar alt text',
                                 },
                                 showClock: true,
+                                designType: 'Comment',
                             }}
                         />
                     </LI>

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -75,8 +75,6 @@ export const Card = ({
         contentCoverage = coverages.content[trailImage.size];
     }
 
-    const isOpinion = pillar === 'opinion';
-
     return (
         <CardLink linkTo={linkTo} designType={designType}>
             <TopBar topBarColour={palette[pillar].main}>
@@ -145,7 +143,7 @@ export const Card = ({
                                                 showClock={showClock}
                                             />
                                         )}
-                                        {isOpinion && (
+                                        {designType === 'Comment' && (
                                             <LinesWrapper>
                                                 <GuardianLines pillar="opinion" />
                                             </LinesWrapper>

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -56,6 +56,7 @@ const coverages: CoveragesType = {
 export const Card = ({
     linkTo,
     pillar,
+    designType,
     headline,
     webPublicationDate,
     trailImage,
@@ -77,18 +78,7 @@ export const Card = ({
     const isOpinion = pillar === 'opinion';
 
     return (
-        <CardLink
-            linkTo={linkTo}
-            backgroundColour={
-                isOpinion ? palette.opinion.faded : palette.neutral[97]
-            }
-            backgroundOnHover={
-                // TODO: This colour is hard coded here because it does not yet
-                //       exist in src-foundation. Once it's been added, please
-                //       remove this. @siadcock is aware.
-                isOpinion ? '#FDF0E8' : palette.neutral[93]
-            }
-        >
+        <CardLink linkTo={linkTo} designType={designType}>
             <TopBar topBarColour={palette[pillar].main}>
                 <CardLayout imagePosition={trailImage && trailImage.position}>
                     <>

--- a/src/web/components/Card/components/CardLink.tsx
+++ b/src/web/components/Card/components/CardLink.tsx
@@ -1,58 +1,77 @@
 import React from 'react';
 import { css } from 'emotion';
+import { palette } from '@guardian/src-foundations';
 
-const linkStyles = ({
-    backgroundColour,
-    backgroundOnHover,
-}: {
-    backgroundColour: string;
-    backgroundOnHover: string;
-}) => css`
-    display: flex;
-    /* a tag specific styles */
-    color: inherit;
-    text-decoration: none;
+const linkStyles = (designType: DesignType | undefined) => {
+    const baseLinkStyles = css`
+        display: flex;
+        /* a tag specific styles */
+        color: inherit;
+        text-decoration: none;
 
-    /* The whole card is one link so we card level styles here */
-    width: 100%;
-    background-color: ${backgroundColour};
-    :hover {
-        background-color: ${backgroundOnHover};
-    }
+        /* The whole card is one link so we card level styles here */
+        width: 100%;
 
-    /* Sometimes a headline contains it's own link so we use the
+        /* Sometimes a headline contains it's own link so we use the
        approach described below to deal with nested links
        See: https://css-tricks.com/nested-links/ */
-    :before {
-        content: '';
-        position: absolute;
-        left: 0;
-        top: 0;
-        right: 0;
-        bottom: 0;
+        :before {
+            content: '';
+            position: absolute;
+            left: 0;
+            top: 0;
+            right: 0;
+            bottom: 0;
+        }
+    `;
+
+    switch (designType) {
+        case 'Comment':
+            return css`
+                ${baseLinkStyles}
+                background-color: ${palette.opinion.faded};
+                :hover {
+                     /* TODO: This colour is hard coded here because it does not yet
+                           exist in src-foundation. Once it's been added, please
+                           remove this. @siadcock is aware. */
+                    /* stylelint-disable-next-line color-no-hex */
+                    background-color: #FDF0E8;
+                }
+            `;
+        case 'Media':
+        case 'Article':
+        case 'Review':
+        case 'Live':
+        case 'SpecialReport':
+        case 'Recipe':
+        case 'MatchReport':
+        case 'GuardianView':
+        case 'GuardianLabs':
+        case 'Quiz':
+        case 'AdvertisementFeature':
+        case 'Feature':
+        case 'Analysis':
+        case 'Interview':
+        case 'Immersive':
+        default:
+            return css`
+                    ${baseLinkStyles}
+                    background-color: ${palette.neutral[97]};
+                    :hover {
+                        background-color: ${palette.neutral[93]};
+                    }
+                `;
     }
-`;
+};
 
 type Props = {
     children: JSXElements;
     linkTo: string;
-    backgroundColour: string;
-    backgroundOnHover: string;
+    designType: DesignType | undefined;
 };
 
-export const CardLink = ({
-    children,
-    linkTo,
-    backgroundColour,
-    backgroundOnHover,
-}: Props) => (
-    <a
-        href={linkTo}
-        className={linkStyles({
-            backgroundColour,
-            backgroundOnHover,
-        })}
-    >
+export const CardLink = ({ children, linkTo, designType }: Props) => (
+    <a href={linkTo} className={linkStyles(designType)}>
         {children}
     </a>
 );


### PR DESCRIPTION
## What does this change?
This PR adds the `designType` to the `Card` and `CardLink` components.

```typescript
interface CardType {
    linkTo: string;
    designType?: DesignType;
    pillar: Pillar;
    headline: CardHeadlineType;
    webPublicationDate?: string;
    trailImage?: CardImageType;
    standfirst?: string;
    avatar?: AvatarType;
    showClock?: boolean;
}
```

## Why?
Using designType is more declarative and helps future developers understand the component better.

This also adds support for supporting different article types in future. 

## Link to supporting Trello card
https://trello.com/c/lI9KHWBq/1003-add-designtype-to-card
