### PR TITLE
Card hover

### DIFF
--- a/src/web/components/Card/components/CardLink.tsx
+++ b/src/web/components/Card/components/CardLink.tsx
@@ -23,6 +23,16 @@ const linkStyles = (designType: DesignType | undefined) => {
             right: 0;
             bottom: 0;
         }
+
+        :hover .image-overlay {
+            position: absolute;
+            top: 0;
+            width: 100%;
+            height: 100%;
+            left: 0;
+            background-color: ${palette.neutral[7]};
+            opacity: 0.1;
+        }
     `;
 
     switch (designType) {

--- a/src/web/components/Card/components/ImageWrapper.tsx
+++ b/src/web/components/Card/components/ImageWrapper.tsx
@@ -12,6 +12,9 @@ export const ImageWrapper = ({ children, percentage }: Props) => {
     return (
         <div
             className={css`
+                /* position relative is required here to bound the image overlay */
+                position: relative;
+
                 flex-basis: ${percentage && percentage};
                 ${until.tablet} {
                     /* Below tablet, we fix the size of the image and add a margin
@@ -30,7 +33,11 @@ export const ImageWrapper = ({ children, percentage }: Props) => {
                 }
             `}
         >
-            {children}
+            <>
+                {children}
+                {/* This image overlay is styled when the CardLink is hovered */}
+                <div className="image-overlay" />
+            </>
         </div>
     );
 };


### PR DESCRIPTION
## What does this change?
Darken card image on card hover

(I probably shouldn't be writing PRs at 3am on election night. Maybe give this one some extra attention.)

![image hover](https://user-images.githubusercontent.com/1336821/70767896-dff72680-1d5a-11ea-9eac-5f6b335fdc12.gif)
![transparent gif hover](https://user-images.githubusercontent.com/1336821/70767897-dff72680-1d5a-11ea-9b5e-4eeff2ec038f.gif)


There are actually two ways of doing this. Frontend using one approach but it doesn't support transparency. Here we use a different approach to fix that but it introduces coupling

### The extra div solution (this PR)
The solution given here in this PR is to have an extra div that sits inside the image wrapper and, when the containing card is hovered, styles are applied to this div to expand it over the image with opacity of 0.1 to slightly darken things.

### The black background solution
In frontend we simply set a black background colour directly on the image with opacity 0.9

### Problems
*The transparency issue*
As shown [here](https://docs.google.com/document/d/1rWstjRUUh6-YH5XcPvOtLwsCc2nY7oMoL_JwHe-83z4/edit?pli=1). Hover styles on transparent svgs or gifs fail using the black background solution, this is not a problem with the extra div solution.

*The coupling problem*
In order to style the extra div we need to use a css selector from the `CardLink` component coupled with a div in the `ImageWrapper`. This is brittle


|                           | extra div | black background |
|---------------------------|-----------|------------------|
| Has transparency problem? |     N     |         Y        |
|       Components coupled? |     Y     |         N        |


## Link to supporting Trello card
https://trello.com/c/jJDZeMR1/1001-darken-card-image-on-hover