### PR TITLE
Flatten card props

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -248,12 +248,6 @@ interface KickerType {
 
 type ImagePositionType = 'left' | 'top' | 'right';
 
-type CardImageType = {
-    url: string;
-    position?: ImagePositionType;
-    size?: ImageSizeType; // Size is ignored when position = 'top' because in that case the image flows based on width
-};
-
 type SmallHeadlineSize = 'tiny' | 'small' | 'medium' | 'large';
 
 type AvatarType = {
@@ -266,15 +260,24 @@ type MediaType = 'Video' | 'Audio' | 'Photo';
 interface CardType {
     linkTo: string;
     pillar: Pillar;
-    headline: CardHeadlineType;
+    designType: DesignType;
+    headlineText: string;
+    headlineSize?: SmallHeadlineSize;
+    showQuotes?: boolean; // Even with designType !== Comment, a piece can be opinion
+    byline?: string;
     webPublicationDate?: string;
-    trailImage?: CardImageType;
+    imageUrl?: string;
+    imagePosition?: ImagePositionType;
+    imageSize?: ImageSizeType; // Size is ignored when position = 'top' because in that case the image flows based on width
     standfirst?: string;
     avatar?: AvatarType;
     showClock?: boolean;
-    designType?: DesignType;
     mediaType?: MediaType;
     mediaDuration?: number;
+    // Kicker
+    kickerText?: string;
+    showPulsingDot?: boolean;
+    showSlash?: boolean;
 }
 
 type ImageSizeType = 'small' | 'medium' | 'large' | 'jumbo';
@@ -291,7 +294,9 @@ interface LinkHeadlineType {
     headlineText: string; // The text shown
     pillar: Pillar; // Used to colour the headline (dark) and the kicker (main)
     showUnderline?: boolean; // Some headlines have text-decoration underlined when hovered
-    kicker?: KickerType;
+    kickerText?: string;
+    showPulsingDot?: boolean;
+    showSlash?: boolean;
     showQuotes?: boolean; // When true the QuoteIcon is shown
     size?: SmallHeadlineSize;
     link?: HeadlineLink; // An optional link object configures if/how the component renders an anchor tag
@@ -300,9 +305,11 @@ interface LinkHeadlineType {
 
 interface CardHeadlineType {
     headlineText: string; // The text shown
-    designType?: DesignType; // Used to decide when to add type specific styles
+    designType: DesignType; // Used to decide when to add type specific styles
     pillar: Pillar; // Used to colour the headline (dark) and the kicker (main)
-    kicker?: KickerType;
+    kickerText?: string;
+    showPulsingDot?: boolean;
+    showSlash?: boolean;
     showQuotes?: boolean; // Even with designType !== Comment, a piece can be opinion
     size?: SmallHeadlineSize;
     byline?: string;

--- a/src/web/components/Card/Card.stories.tsx
+++ b/src/web/components/Card/Card.stories.tsx
@@ -37,22 +37,15 @@ export const News = () => (
                                 linkTo:
                                     '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
                                 pillar: 'news',
-                                headline: {
-                                    designType: 'Article',
-                                    headlineText:
-                                        'The Knights Who Say Ni demand a sacrifice',
-                                    size: 'large',
-                                    pillar: 'news',
-                                    kicker: {
-                                        text: 'Monty Python',
-                                        pillar: 'news',
-                                    },
-                                },
-                                trailImage: {
-                                    url: imageUrls[0],
-                                    position: 'right',
-                                    size: 'large',
-                                },
+                                designType: 'Article',
+                                headlineText:
+                                    'The Knights Who Say Ni demand a sacrifice',
+                                headlineSize: 'large',
+                                kickerText: 'Monty Python',
+
+                                imageUrl: imageUrls[0],
+                                imagePosition: 'right',
+                                imageSize: 'large',
                                 standfirst:
                                     "I have to push the pram a lot. I'm not a witch. Shut up! The nose? And this isn't my nose. This is a false one. You don't vote for kings.",
                             }}
@@ -69,20 +62,13 @@ export const News = () => (
                                 linkTo:
                                     '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
                                 pillar: 'news',
-                                headline: {
-                                    designType: 'Article',
-                                    headlineText: "Yes. We're all individuals",
-                                    size: 'large',
-                                    pillar: 'news',
-                                    kicker: {
-                                        text: 'Brian',
-                                        pillar: 'news',
-                                    },
-                                },
-                                trailImage: {
-                                    url: imageUrls[5],
-                                    position: 'top',
-                                },
+                                designType: 'Article',
+                                headlineText: "Yes. We're all individuals",
+                                headlineSize: 'large',
+                                kickerText: 'Brian',
+
+                                imageUrl: imageUrls[5],
+                                imagePosition: 'top',
                                 standfirst:
                                     "Well, obviously it's not meant to be taken literally. It refers to any manufacturer of dairy products",
                             }}
@@ -96,20 +82,13 @@ export const News = () => (
                                 linkTo:
                                     '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
                                 pillar: 'culture',
-                                headline: {
-                                    designType: 'Article',
-                                    headlineText:
-                                        "You can't expect to wield supreme power just 'cause some watery tart threw a sword at you",
-                                    pillar: 'news',
-                                    kicker: {
-                                        text: 'Holy Grail',
-                                        pillar: 'culture',
-                                    },
-                                },
-                                trailImage: {
-                                    url: imageUrls[3],
-                                    position: 'top',
-                                },
+                                designType: 'Article',
+                                headlineText:
+                                    "You can't expect to wield supreme power just 'cause some watery tart threw a sword at you",
+                                kickerText: 'Holy Grail',
+
+                                imageUrl: imageUrls[3],
+                                imagePosition: 'top',
                                 standfirst:
                                     'The swallow may fly south with the sun, and the house martin or the plover may seek warmer climes in winter, yet these are not strangers to our land. Burn her anyway!',
                             }}
@@ -128,20 +107,12 @@ export const News = () => (
                                         linkTo:
                                             '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
                                         pillar: 'news',
-                                        headline: {
-                                            designType: 'Article',
-                                            headlineText:
-                                                'Go and boil your bottoms, sons of a silly person!',
-                                            pillar: 'news',
-                                            kicker: {
-                                                text: 'Monty Python',
-                                                pillar: 'news',
-                                            },
-                                        },
-                                        trailImage: {
-                                            url: imageUrls[6],
-                                            position: 'top',
-                                        },
+                                        designType: 'Article',
+                                        headlineText:
+                                            'Go and boil your bottoms, sons of a silly person!',
+                                        kickerText: 'Monty Python',
+                                        imageUrl: imageUrls[6],
+                                        imagePosition: 'top',
                                     }}
                                 />
                             </LI>
@@ -151,13 +122,10 @@ export const News = () => (
                                         linkTo:
                                             '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
                                         pillar: 'news',
-                                        headline: {
-                                            designType: 'Article',
-                                            headlineText:
-                                                'Listen. Strange women lying in ponds distributing swords is no basis for a system of government',
-                                            pillar: 'news',
-                                            size: 'small',
-                                        },
+                                        designType: 'Article',
+                                        headlineText:
+                                            'Listen. Strange women lying in ponds distributing swords is no basis for a system of government',
+                                        headlineSize: 'small',
                                     }}
                                 />
                             </LI>
@@ -167,17 +135,11 @@ export const News = () => (
                                         linkTo:
                                             '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
                                         pillar: 'news',
-                                        headline: {
-                                            designType: 'Article',
-                                            headlineText:
-                                                'Supreme executive power derives from a mandate from the masses, not from some farcical aquatic ceremony',
-                                            pillar: 'news',
-                                            size: 'small',
-                                            kicker: {
-                                                text: 'Monty Python',
-                                                pillar: 'news',
-                                            },
-                                        },
+                                        designType: 'Article',
+                                        headlineText:
+                                            'Supreme executive power derives from a mandate from the masses, not from some farcical aquatic ceremony',
+                                        headlineSize: 'small',
+                                        kickerText: 'Monty Python',
                                     }}
                                 />
                             </LI>
@@ -196,17 +158,11 @@ export const News = () => (
                                         linkTo:
                                             '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
                                         pillar: 'sport',
-                                        headline: {
-                                            designType: 'Article',
-                                            headlineText:
-                                                'Are you suggesting that coconuts migrate?',
-                                            pillar: 'news',
-                                            size: 'small',
-                                            kicker: {
-                                                text: 'Run Away!',
-                                                pillar: 'sport',
-                                            },
-                                        },
+                                        designType: 'Article',
+                                        headlineText:
+                                            'Are you suggesting that coconuts migrate?',
+                                        headlineSize: 'small',
+                                        kickerText: 'Run Away!',
                                     }}
                                 />
                             </LI>
@@ -216,17 +172,11 @@ export const News = () => (
                                         linkTo:
                                             '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
                                         pillar: 'news',
-                                        headline: {
-                                            designType: 'Article',
-                                            headlineText:
-                                                "On second thoughts, let's not go there. It is a silly place",
-                                            pillar: 'news',
-                                            size: 'small',
-                                            kicker: {
-                                                text: 'Monty Python!',
-                                                pillar: 'news',
-                                            },
-                                        },
+                                        designType: 'Article',
+                                        headlineText:
+                                            "On second thoughts, let's not go there. It is a silly place",
+                                        headlineSize: 'small',
+                                        kickerText: 'Monty Python!',
                                     }}
                                 />
                             </LI>
@@ -236,17 +186,10 @@ export const News = () => (
                                         linkTo:
                                             '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
                                         pillar: 'news',
-                                        headline: {
-                                            designType: 'Article',
-                                            headlineText:
-                                                'Let us ride to Camelot',
-                                            pillar: 'news',
-                                            size: 'small',
-                                            kicker: {
-                                                text: 'Monty Python!',
-                                                pillar: 'news',
-                                            },
-                                        },
+                                        designType: 'Article',
+                                        headlineText: 'Let us ride to Camelot',
+                                        headlineSize: 'small',
+                                        kickerText: 'Monty Python!',
                                     }}
                                 />
                             </LI>
@@ -256,17 +199,11 @@ export const News = () => (
                                         linkTo:
                                             '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
                                         pillar: 'news',
-                                        headline: {
-                                            designType: 'Article',
-                                            headlineText:
-                                                "Where'd you get the coconuts?",
-                                            pillar: 'news',
-                                            size: 'small',
-                                            kicker: {
-                                                text: 'Monty Python!',
-                                                pillar: 'news',
-                                            },
-                                        },
+                                        designType: 'Article',
+                                        headlineText:
+                                            "Where'd you get the coconuts?",
+                                        headlineSize: 'small',
+                                        kickerText: 'Monty Python!',
                                     }}
                                 />
                             </LI>
@@ -276,17 +213,11 @@ export const News = () => (
                                         linkTo:
                                             '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
                                         pillar: 'lifestyle',
-                                        headline: {
-                                            designType: 'Article',
-                                            headlineText:
-                                                'Now, look here, my good man',
-                                            pillar: 'news',
-                                            size: 'small',
-                                            kicker: {
-                                                text: 'Terry Gillingham',
-                                                pillar: 'lifestyle',
-                                            },
-                                        },
+                                        designType: 'Article',
+                                        headlineText:
+                                            'Now, look here, my good man',
+                                        headlineSize: 'small',
+                                        kickerText: 'Terry Gillingham',
                                     }}
                                 />
                             </LI>
@@ -296,17 +227,11 @@ export const News = () => (
                                         linkTo:
                                             '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
                                         pillar: 'news',
-                                        headline: {
-                                            designType: 'Article',
-                                            headlineText:
-                                                "We shall say 'Ni' again to you, if you do not appease us",
-                                            pillar: 'news',
-                                            size: 'small',
-                                            kicker: {
-                                                text: 'Monty Python',
-                                                pillar: 'news',
-                                            },
-                                        },
+                                        designType: 'Article',
+                                        headlineText:
+                                            "We shall say 'Ni' again to you, if you do not appease us",
+                                        headlineSize: 'small',
+                                        kickerText: 'Monty Python',
                                     }}
                                 />
                             </LI>
@@ -335,22 +260,14 @@ export const InDepth = () => (
                                         linkTo:
                                             '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
                                         pillar: 'sport',
-                                        headline: {
-                                            designType: 'Article',
-                                            headlineText:
-                                                "We shall say 'Ni' again to you, if you do not appease us",
-                                            size: 'medium',
-                                            pillar: 'news',
-                                            kicker: {
-                                                text: 'Holy Grail',
-                                                pillar: 'sport',
-                                            },
-                                        },
-                                        trailImage: {
-                                            url: imageUrls[5],
-                                            position: 'left',
-                                            size: 'small',
-                                        },
+                                        designType: 'Article',
+                                        headlineText:
+                                            "We shall say 'Ni' again to you, if you do not appease us",
+                                        headlineSize: 'medium',
+                                        kickerText: 'Holy Grail',
+                                        imageUrl: imageUrls[5],
+                                        imagePosition: 'left',
+                                        imageSize: 'small',
                                     }}
                                 />
                             </LI>
@@ -360,22 +277,14 @@ export const InDepth = () => (
                                         linkTo:
                                             '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
                                         pillar: 'sport',
-                                        headline: {
-                                            designType: 'Article',
-                                            headlineText:
-                                                'Now, look here, my good man',
-                                            size: 'small',
-                                            pillar: 'news',
-                                            kicker: {
-                                                text: 'Holy Grail',
-                                                pillar: 'sport',
-                                            },
-                                        },
-                                        trailImage: {
-                                            url: imageUrls[6],
-                                            position: 'left',
-                                            size: 'small',
-                                        },
+                                        designType: 'Article',
+                                        headlineText:
+                                            'Now, look here, my good man',
+                                        headlineSize: 'small',
+                                        kickerText: 'Holy Grail',
+                                        imageUrl: imageUrls[6],
+                                        imagePosition: 'left',
+                                        imageSize: 'small',
                                     }}
                                 />
                             </LI>
@@ -385,22 +294,14 @@ export const InDepth = () => (
                                         linkTo:
                                             '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
                                         pillar: 'sport',
-                                        headline: {
-                                            designType: 'Article',
-                                            headlineText:
-                                                "Where'd you get the coconuts",
-                                            size: 'small',
-                                            pillar: 'news',
-                                            kicker: {
-                                                text: 'Holy Grail',
-                                                pillar: 'sport',
-                                            },
-                                        },
-                                        trailImage: {
-                                            url: imageUrls[3],
-                                            position: 'left',
-                                            size: 'small',
-                                        },
+                                        designType: 'Article',
+                                        headlineText:
+                                            "Where'd you get the coconuts",
+                                        headlineSize: 'small',
+                                        kickerText: 'Holy Grail',
+                                        imageUrl: imageUrls[3],
+                                        imagePosition: 'left',
+                                        imageSize: 'small',
                                     }}
                                 />
                             </LI>
@@ -410,22 +311,13 @@ export const InDepth = () => (
                                         linkTo:
                                             '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
                                         pillar: 'sport',
-                                        headline: {
-                                            designType: 'Article',
-                                            headlineText:
-                                                'Let us ride to Camelot!',
-                                            size: 'small',
-                                            pillar: 'news',
-                                            kicker: {
-                                                text: 'Holy Grail',
-                                                pillar: 'sport',
-                                            },
-                                        },
-                                        trailImage: {
-                                            url: imageUrls[2],
-                                            position: 'left',
-                                            size: 'small',
-                                        },
+                                        designType: 'Article',
+                                        headlineText: 'Let us ride to Camelot!',
+                                        headlineSize: 'small',
+                                        kickerText: 'Holy Grail',
+                                        imageUrl: imageUrls[2],
+                                        imagePosition: 'left',
+                                        imageSize: 'small',
                                     }}
                                 />
                             </LI>
@@ -435,22 +327,14 @@ export const InDepth = () => (
                                         linkTo:
                                             '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
                                         pillar: 'sport',
-                                        headline: {
-                                            designType: 'Article',
-                                            headlineText:
-                                                'How do you know she is a witch? Burn her!',
-                                            size: 'small',
-                                            pillar: 'news',
-                                            kicker: {
-                                                text: 'Holy Grail',
-                                                pillar: 'sport',
-                                            },
-                                        },
-                                        trailImage: {
-                                            url: imageUrls[1],
-                                            position: 'left',
-                                            size: 'small',
-                                        },
+                                        designType: 'Article',
+                                        headlineText:
+                                            'How do you know she is a witch? Burn her!',
+                                        headlineSize: 'small',
+                                        kickerText: 'Holy Grail',
+                                        imageUrl: imageUrls[1],
+                                        imagePosition: 'left',
+                                        imageSize: 'small',
                                     }}
                                 />
                             </LI>
@@ -467,21 +351,13 @@ export const InDepth = () => (
                                 linkTo:
                                     '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
                                 pillar: 'news',
-                                headline: {
-                                    designType: 'Article',
-                                    headlineText:
-                                        "Go and boil your bottoms, sons of a silly person!'",
-                                    size: 'large',
-                                    pillar: 'news',
-                                    kicker: {
-                                        text: 'Monty Python',
-                                        pillar: 'sport',
-                                    },
-                                },
-                                trailImage: {
-                                    url: imageUrls[0],
-                                    position: 'top',
-                                },
+                                designType: 'Article',
+                                headlineText:
+                                    "Go and boil your bottoms, sons of a silly person!'",
+                                headlineSize: 'large',
+                                kickerText: 'Monty Python',
+                                imageUrl: imageUrls[0],
+                                imagePosition: 'top',
                             }}
                         />
                     </LI>
@@ -506,22 +382,14 @@ export const Related = () => (
                                 linkTo:
                                     '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
                                 pillar: 'sport',
-                                headline: {
-                                    designType: 'Article',
-                                    headlineText:
-                                        "We shall say 'Ni' again to you, if you do not appease us",
-                                    size: 'medium',
-                                    pillar: 'news',
-                                    kicker: {
-                                        text: 'Holy Grail',
-                                        pillar: 'sport',
-                                    },
-                                },
+                                designType: 'Article',
+                                headlineText:
+                                    "We shall say 'Ni' again to you, if you do not appease us",
+                                headlineSize: 'medium',
+                                kickerText: 'Holy Grail',
                                 webPublicationDate: '2019-11-11T09:45:30.000Z',
-                                trailImage: {
-                                    url: imageUrls[5],
-                                    position: 'top',
-                                },
+                                imageUrl: imageUrls[5],
+                                imagePosition: 'top',
                             }}
                         />
                     </LI>
@@ -535,21 +403,13 @@ export const Related = () => (
                                 linkTo:
                                     '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
                                 pillar: 'sport',
-                                headline: {
-                                    designType: 'Article',
-                                    headlineText: 'Now, look here, my good man',
-                                    size: 'medium',
-                                    pillar: 'sport',
-                                    kicker: {
-                                        text: 'Holy Grail',
-                                        pillar: 'sport',
-                                    },
-                                },
+                                designType: 'Article',
+                                headlineText: 'Now, look here, my good man',
+                                headlineSize: 'medium',
+                                kickerText: 'Holy Grail',
                                 webPublicationDate: '2019-11-11T09:45:30.000Z',
-                                trailImage: {
-                                    url: imageUrls[6],
-                                    position: 'top',
-                                },
+                                imageUrl: imageUrls[6],
+                                imagePosition: 'top',
                             }}
                         />
                     </LI>
@@ -563,22 +423,13 @@ export const Related = () => (
                                 linkTo:
                                     '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
                                 pillar: 'sport',
-                                headline: {
-                                    designType: 'Article',
-                                    headlineText:
-                                        "Where'd you get the coconuts",
-                                    size: 'medium',
-                                    pillar: 'sport',
-                                    kicker: {
-                                        text: 'Holy Grail',
-                                        pillar: 'sport',
-                                    },
-                                },
+                                designType: 'Article',
+                                headlineText: "Where'd you get the coconuts",
+                                headlineSize: 'medium',
+                                kickerText: 'Holy Grail',
                                 webPublicationDate: '2019-11-11T09:45:30.000Z',
-                                trailImage: {
-                                    url: imageUrls[4],
-                                    position: 'top',
-                                },
+                                imageUrl: imageUrls[4],
+                                imagePosition: 'top',
                             }}
                         />
                     </LI>
@@ -590,17 +441,11 @@ export const Related = () => (
                                 linkTo:
                                     '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
                                 pillar: 'news',
-                                headline: {
-                                    designType: 'Article',
-                                    headlineText:
-                                        'Go and boil your bottoms, sons of a silly person!',
-                                    size: 'small',
-                                    pillar: 'news',
-                                    kicker: {
-                                        text: 'Monty Python',
-                                        pillar: 'news',
-                                    },
-                                },
+                                designType: 'Article',
+                                headlineText:
+                                    'Go and boil your bottoms, sons of a silly person!',
+                                headlineSize: 'small',
+                                kickerText: 'Monty Python',
                                 webPublicationDate: '2019-11-11T09:45:30.000Z',
                             }}
                         />
@@ -615,16 +460,10 @@ export const Related = () => (
                                 linkTo:
                                     '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
                                 pillar: 'sport',
-                                headline: {
-                                    designType: 'Article',
-                                    headlineText: 'Let us ride to Camelot!',
-                                    size: 'small',
-                                    pillar: 'news',
-                                    kicker: {
-                                        text: 'Monty Python',
-                                        pillar: 'news',
-                                    },
-                                },
+                                designType: 'Article',
+                                headlineText: 'Let us ride to Camelot!',
+                                headlineSize: 'small',
+                                kickerText: 'Monty Python',
                                 webPublicationDate: '2019-11-11T09:45:30.000Z',
                             }}
                         />
@@ -639,16 +478,10 @@ export const Related = () => (
                                 linkTo:
                                     '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
                                 pillar: 'culture',
-                                headline: {
-                                    designType: 'Interview',
-                                    headlineText: 'Let us ride to Camelot!',
-                                    size: 'small',
-                                    pillar: 'culture',
-                                    kicker: {
-                                        text: 'Monty Python',
-                                        pillar: 'culture',
-                                    },
-                                },
+                                designType: 'Interview',
+                                headlineText: 'Let us ride to Camelot!',
+                                headlineSize: 'small',
+                                kickerText: 'Monty Python',
                                 webPublicationDate: '2019-11-11T09:45:30.000Z',
                             }}
                         />
@@ -663,17 +496,11 @@ export const Related = () => (
                                 linkTo:
                                     '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
                                 pillar: 'lifestyle',
-                                headline: {
-                                    designType: 'Feature',
-                                    headlineText:
-                                        'How do you know she is a witch? Burn her!',
-                                    size: 'small',
-                                    pillar: 'lifestyle',
-                                    kicker: {
-                                        text: 'Holy Grail',
-                                        pillar: 'lifestyle',
-                                    },
-                                },
+                                designType: 'Feature',
+                                headlineText:
+                                    'How do you know she is a witch? Burn her!',
+                                headlineSize: 'small',
+                                kickerText: 'Holy Grail',
                                 webPublicationDate: '2019-11-11T09:45:30.000Z',
                             }}
                         />
@@ -697,23 +524,15 @@ export const Spotlight = () => (
                         linkTo:
                             '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
                         pillar: 'sport',
-                        headline: {
-                            designType: 'Feature',
-                            headlineText:
-                                "We shall say 'Ni' again to you, if you do not appease us",
-                            size: 'large',
-                            pillar: 'sport',
-                            kicker: {
-                                text: 'Holy Grail',
-                                pillar: 'sport',
-                            },
-                        },
+                        designType: 'Feature',
+                        headlineText:
+                            "We shall say 'Ni' again to you, if you do not appease us",
+                        headlineSize: 'large',
+                        kickerText: 'Holy Grail',
                         webPublicationDate: '2019-11-11T09:45:30.000Z',
-                        trailImage: {
-                            url: imageUrls[0],
-                            position: 'right',
-                            size: 'jumbo',
-                        },
+                        imageUrl: imageUrls[0],
+                        imagePosition: 'right',
+                        imageSize: 'jumbo',
                     }}
                 />
             </ArticleContainer>
@@ -736,19 +555,13 @@ export const Quad = () => (
                                 linkTo:
                                     '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
                                 pillar: 'opinion',
-                                headline: {
-                                    designType: 'Comment',
-                                    headlineText:
-                                        "We shall say 'Ni' again to you, if you do not appease us",
-                                    size: 'medium',
-                                    pillar: 'opinion',
-                                    kicker: {
-                                        text: 'Holy Grail',
-                                        pillar: 'opinion',
-                                    },
-                                    showQuotes: true,
-                                    byline: 'George Monbiot',
-                                },
+                                designType: 'Comment',
+                                headlineText:
+                                    "We shall say 'Ni' again to you, if you do not appease us",
+                                headlineSize: 'medium',
+                                showQuotes: true,
+                                byline: 'George Monbiot',
+                                kickerText: 'Holy Grail',
                                 webPublicationDate: '2019-11-11T09:45:30.000Z',
                                 avatar: {
                                     src:
@@ -756,7 +569,6 @@ export const Quad = () => (
                                     alt: 'Avatar alt text',
                                 },
                                 showClock: true,
-                                designType: 'Comment',
                             }}
                         />
                     </LI>
@@ -770,18 +582,13 @@ export const Quad = () => (
                                 linkTo:
                                     '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
                                 pillar: 'opinion',
-                                headline: {
-                                    designType: 'Article',
-                                    headlineText:
-                                        "We shall say 'Ni' again to you, if you do not appease us",
-                                    size: 'medium',
-                                    pillar: 'opinion',
-                                },
+                                designType: 'Article',
+                                headlineText:
+                                    "We shall say 'Ni' again to you, if you do not appease us",
+                                headlineSize: 'medium',
                                 webPublicationDate: '2019-11-11T09:45:30.000Z',
-                                trailImage: {
-                                    url: imageUrls[0],
-                                    position: 'top',
-                                },
+                                imageUrl: imageUrls[0],
+                                imagePosition: 'top',
                                 showClock: true,
                             }}
                         />
@@ -796,22 +603,14 @@ export const Quad = () => (
                                 linkTo:
                                     '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
                                 pillar: 'news',
-                                headline: {
-                                    designType: 'Article',
-                                    headlineText:
-                                        "We shall say 'Ni' again to you, if you do not appease us",
-                                    size: 'medium',
-                                    pillar: 'news',
-                                    kicker: {
-                                        text: 'Holy Grail',
-                                        pillar: 'news',
-                                    },
-                                },
+                                designType: 'Article',
+                                headlineText:
+                                    "We shall say 'Ni' again to you, if you do not appease us",
+                                headlineSize: 'medium',
+                                kickerText: 'Holy Grail',
                                 webPublicationDate: '2019-11-11T09:45:30.000Z',
-                                trailImage: {
-                                    url: imageUrls[0],
-                                    position: 'top',
-                                },
+                                imageUrl: imageUrls[0],
+                                imagePosition: 'top',
                                 showClock: true,
                             }}
                         />
@@ -825,23 +624,15 @@ export const Quad = () => (
                             {...{
                                 linkTo:
                                     '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
+                                designType: 'Article',
                                 pillar: 'news',
-                                headline: {
-                                    designType: 'Article',
-                                    headlineText:
-                                        "We shall say 'Ni' again to you, if you do not appease us",
-                                    size: 'medium',
-                                    pillar: 'news',
-                                    kicker: {
-                                        text: 'Holy Grail',
-                                        pillar: 'news',
-                                    },
-                                },
+                                headlineText:
+                                    "We shall say 'Ni' again to you, if you do not appease us",
+                                headlineSize: 'medium',
+                                kickerText: 'Holy Grail',
                                 webPublicationDate: '2019-11-11T09:45:30.000Z',
-                                trailImage: {
-                                    url: imageUrls[0],
-                                    position: 'top',
-                                },
+                                imageUrl: imageUrls[0],
+                                imagePosition: 'top',
                                 showClock: true,
                             }}
                         />
@@ -871,20 +662,14 @@ export const Media = () => (
                                 linkTo:
                                     '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
                                 pillar: 'culture',
-                                headline: {
-                                    designType: 'Media',
-                                    headlineText:
-                                        "We shall say 'Ni' again to you, if you do not appease us",
-                                    size: 'medium',
-                                    pillar: 'culture',
-                                },
-                                webPublicationDate: '2019-11-11T09:45:30.000Z',
-                                trailImage: {
-                                    url: imageUrls[0],
-                                    position: 'top',
-                                },
-                                showClock: true,
                                 designType: 'Media',
+                                headlineText:
+                                    "We shall say 'Ni' again to you, if you do not appease us",
+                                headlineSize: 'medium',
+                                webPublicationDate: '2019-11-11T09:45:30.000Z',
+                                imageUrl: imageUrls[0],
+                                imagePosition: 'top',
+                                showClock: true,
                                 mediaType: 'Photo',
                             }}
                         />
@@ -899,24 +684,15 @@ export const Media = () => (
                                 linkTo:
                                     '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
                                 pillar: 'news',
-                                headline: {
-                                    designType: 'Media',
-                                    headlineText:
-                                        "We shall say 'Ni' again to you, if you do not appease us",
-                                    size: 'medium',
-                                    pillar: 'news',
-                                    kicker: {
-                                        text: 'Holy Grail',
-                                        pillar: 'sport',
-                                    },
-                                },
-                                webPublicationDate: '2019-11-11T09:45:30.000Z',
-                                trailImage: {
-                                    url: imageUrls[0],
-                                    position: 'top',
-                                },
-                                showClock: true,
                                 designType: 'Media',
+                                headlineText:
+                                    "We shall say 'Ni' again to you, if you do not appease us",
+                                headlineSize: 'medium',
+                                kickerText: 'Holy Grail',
+                                webPublicationDate: '2019-11-11T09:45:30.000Z',
+                                imageUrl: imageUrls[0],
+                                imagePosition: 'top',
+                                showClock: true,
                                 mediaType: 'Audio',
                                 mediaDuration: 35999,
                             }}
@@ -932,24 +708,15 @@ export const Media = () => (
                                 linkTo:
                                     '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
                                 pillar: 'sport',
-                                headline: {
-                                    designType: 'Media',
-                                    headlineText:
-                                        "We shall say 'Ni' again to you, if you do not appease us",
-                                    size: 'medium',
-                                    pillar: 'sport',
-                                    kicker: {
-                                        text: 'Holy Grail',
-                                        pillar: 'sport',
-                                    },
-                                },
-                                webPublicationDate: '2019-11-11T09:45:30.000Z',
-                                trailImage: {
-                                    url: imageUrls[0],
-                                    position: 'top',
-                                },
-                                showClock: true,
                                 designType: 'Media',
+                                headlineText:
+                                    "We shall say 'Ni' again to you, if you do not appease us",
+                                headlineSize: 'medium',
+                                kickerText: 'Holy Grail',
+                                webPublicationDate: '2019-11-11T09:45:30.000Z',
+                                imageUrl: imageUrls[0],
+                                imagePosition: 'top',
+                                showClock: true,
                                 mediaType: 'Video',
                                 mediaDuration: 59,
                             }}

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -58,35 +58,43 @@ export const Card = ({
     linkTo,
     pillar,
     designType,
-    mediaType,
-    mediaDuration,
-    headline,
+    headlineText,
+    headlineSize,
+    showQuotes,
+    byline,
     webPublicationDate,
-    trailImage,
+    imageUrl,
+    imagePosition,
+    imageSize,
     standfirst,
     avatar,
     showClock,
+    mediaType,
+    mediaDuration,
+    kickerText,
+    showPulsingDot,
+    showSlash,
 }: CardType) => {
     // Decide how we position the image on the card
     let imageCoverage: CardPercentageType | undefined;
     let contentCoverage: CardPercentageType | undefined;
-    if (trailImage && trailImage.size && trailImage.position !== 'top') {
+    if (imageSize && imagePosition !== 'top') {
         // We only specifiy an explicit width for the image when
         // we're positioning left or right, not top. Top positioned
         // images flow naturally
-        imageCoverage = coverages.image[trailImage.size];
-        contentCoverage = coverages.content[trailImage.size];
+        imageCoverage = coverages.image[imageSize];
+        contentCoverage = coverages.content[imageSize];
     }
 
     return (
         <CardLink linkTo={linkTo} designType={designType}>
             <TopBar topBarColour={palette[pillar].main}>
-                <CardLayout imagePosition={trailImage && trailImage.position}>
+                <CardLayout imagePosition={imagePosition}>
                     <>
-                        {trailImage && (
+                        {imageUrl && (
                             <ImageWrapper percentage={imageCoverage}>
                                 <img
-                                    src={trailImage.url}
+                                    src={imageUrl}
                                     alt=""
                                     role="presentation"
                                 />
@@ -96,13 +104,15 @@ export const Card = ({
                             <Flex>
                                 <HeadlineWrapper>
                                     <CardHeadline
-                                        headlineText={headline.headlineText}
-                                        designType={headline.designType}
-                                        pillar={headline.pillar}
-                                        size={headline.size}
-                                        showQuotes={headline.showQuotes}
-                                        kicker={headline.kicker}
-                                        byline={headline.byline}
+                                        headlineText={headlineText}
+                                        designType={designType}
+                                        pillar={pillar}
+                                        size={headlineSize}
+                                        showQuotes={showQuotes}
+                                        kickerText={kickerText}
+                                        showPulsingDot={showPulsingDot}
+                                        showSlash={showSlash}
+                                        byline={byline}
                                     />
                                 </HeadlineWrapper>
                                 <>

--- a/src/web/components/CardHeadline.stories.tsx
+++ b/src/web/components/CardHeadline.stories.tsx
@@ -62,9 +62,7 @@ export const liveStory = () => (
             headlineText="This is how a card headline with a live kicker looks"
             designType="Article"
             pillar="news"
-            kicker={{
-                text: 'Live',
-            }}
+            kickerText="Live"
         />
     </Section>
 );
@@ -76,10 +74,8 @@ export const noSlash = () => (
             headlineText="This is how a card headline with no kicker slash looks"
             designType="Article"
             pillar="news"
-            kicker={{
-                text: 'Live',
-                showSlash: false,
-            }}
+            kickerText="Live"
+            showSlash={false}
         />
     </Section>
 );
@@ -91,10 +87,8 @@ export const pulsingDot = () => (
             headlineText="This is how a card headline with a pulsing dot looks"
             designType="Article"
             pillar="news"
-            kicker={{
-                text: 'Live',
-                showPulsingDot: true,
-            }}
+            kickerText="Live"
+            showPulsingDot={true}
         />
     </Section>
 );
@@ -106,9 +100,7 @@ export const cultureVariant = () => (
             headlineText="This is how a Feature card headline with the culture pillar looks"
             designType="Feature"
             pillar="culture"
-            kicker={{
-                text: 'Art and stuff',
-            }}
+            kickerText="Art and stuff"
         />
     </Section>
 );
@@ -146,10 +138,8 @@ export const OpinionKicker = () => (
             designType="Article"
             pillar="opinion"
             showQuotes={true}
-            kicker={{
-                text: 'George Monbiot',
-                showSlash: true,
-            }}
+            kickerText="George Monbiot"
+            showSlash={true}
         />
     </Section>
 );
@@ -162,10 +152,8 @@ export const Busy = () => (
             designType="Feature"
             pillar="lifestyle"
             showQuotes={true}
-            kicker={{
-                text: 'Aerial Yoga',
-                showSlash: true,
-            }}
+            kickerText="Aerial Yoga"
+            showSlash={true}
         />
     </Section>
 );

--- a/src/web/components/CardHeadline.tsx
+++ b/src/web/components/CardHeadline.tsx
@@ -103,7 +103,9 @@ export const CardHeadline = ({
     designType = 'Article',
     pillar,
     showQuotes,
-    kicker,
+    kickerText,
+    showPulsingDot,
+    showSlash,
     size = 'medium',
     byline,
 }: CardHeadlineType) => (
@@ -114,12 +116,12 @@ export const CardHeadline = ({
                 designType === 'Analysis' && underlinedStyles(size),
             )}
         >
-            {kicker && (
+            {kickerText && (
                 <Kicker
-                    text={kicker.text}
+                    text={kickerText}
                     pillar={pillar}
-                    showPulsingDot={kicker.showPulsingDot}
-                    showSlash={kicker.showSlash}
+                    showPulsingDot={showPulsingDot}
+                    showSlash={showSlash}
                 />
             )}
             {showQuotes && (

--- a/src/web/components/LinkHeadline.stories.tsx
+++ b/src/web/components/LinkHeadline.stories.tsx
@@ -29,9 +29,7 @@ export const liveStory = () => (
             designType="Article"
             headlineText="This is how a headline with a live kicker looks"
             pillar="news"
-            kicker={{
-                text: 'Live',
-            }}
+            kickerText="Live"
         />
     </Section>
 );
@@ -43,10 +41,8 @@ export const noSlash = () => (
             designType="Article"
             headlineText="This is how a headline with no kicker slash looks"
             pillar="news"
-            kicker={{
-                text: 'Live',
-                showSlash: false,
-            }}
+            kickerText="Live"
+            showSlash={false}
         />
     </Section>
 );
@@ -58,10 +54,8 @@ export const pulsingDot = () => (
             designType="Article"
             headlineText="This is how a headline with a pulsing dot looks"
             pillar="news"
-            kicker={{
-                text: 'Live',
-                showPulsingDot: true,
-            }}
+            kickerText="Live"
+            showPulsingDot={true}
         />
     </Section>
 );
@@ -73,9 +67,7 @@ export const cultureVariant = () => (
             designType="Article"
             headlineText="This is how a headline with the culture pillar looks"
             pillar="culture"
-            kicker={{
-                text: 'Art and stuff',
-            }}
+            kickerText="Art and stuff"
         />
     </Section>
 );
@@ -102,10 +94,8 @@ export const OpinionKicker = () => (
             headlineText="This is how an opinion headline with a kicker looks"
             pillar="opinion"
             showQuotes={true}
-            kicker={{
-                text: 'George Monbiot',
-                showSlash: true,
-            }}
+            kickerText="George Monbiot"
+            showSlash={true}
         />
     </Section>
 );
@@ -119,10 +109,8 @@ export const InUnderlinedState = () => (
             pillar="news"
             showUnderline={true}
             size="small"
-            kicker={{
-                text: 'I am never underlined',
-                showSlash: true,
-            }}
+            kickerText="I am never underlined"
+            showSlash={true}
             link={{
                 to:
                     'https://www.theguardian.com/us-news/2019/nov/14/nancy-pelosi-trump-ukraine-bribery',
@@ -138,10 +126,8 @@ export const linkStory = () => (
             designType="Article"
             headlineText="This is how a headline looks as a link"
             pillar="sport"
-            kicker={{
-                text: 'I am not a link',
-                showSlash: true,
-            }}
+            kickerText="I am not a link"
+            showSlash={true}
             link={{
                 to:
                     'https://www.theguardian.com/us-news/2019/nov/14/nancy-pelosi-trump-ukraine-bribery',

--- a/src/web/components/LinkHeadline.tsx
+++ b/src/web/components/LinkHeadline.tsx
@@ -56,19 +56,21 @@ export const LinkHeadline = ({
     headlineText,
     pillar,
     showUnderline = false,
-    kicker,
+    kickerText,
+    showPulsingDot,
+    showSlash,
     showQuotes = false,
     size = 'medium',
     link,
     byline,
 }: LinkHeadlineType) => (
     <h4 className={fontStyles(size)}>
-        {kicker && (
+        {kickerText && (
             <Kicker
-                text={kicker.text}
+                text={kickerText}
                 pillar={pillar}
-                showPulsingDot={kicker.showPulsingDot}
-                showSlash={kicker.showSlash}
+                showPulsingDot={showPulsingDot}
+                showSlash={showSlash}
             />
         )}
         {showQuotes && <QuoteIcon colour={palette[pillar].main} size={size} />}

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterItem.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterItem.tsx
@@ -81,11 +81,9 @@ export const MostViewedFooterItem = ({ trail, position }: Props) => (
                         headlineText={trail.linkText}
                         pillar={trail.pillar}
                         size="small"
-                        kicker={{
-                            text: 'Live',
-                            showSlash: true,
-                            showPulsingDot: true,
-                        }}
+                        kickerText="Live"
+                        showSlash={true}
+                        showPulsingDot={true}
                     />
                 ) : (
                     <LinkHeadline

--- a/src/web/components/MostViewed/MostViewedRight/MostViewedRightItem.tsx
+++ b/src/web/components/MostViewed/MostViewedRight/MostViewedRightItem.tsx
@@ -103,10 +103,8 @@ export const MostViewedRightItem = ({ trail }: Props) => {
                                 size="small"
                                 showUnderline={isHovered}
                                 link={linkProps}
-                                kicker={{
-                                    text: 'Live',
-                                    showSlash: false,
-                                }}
+                                kickerText="Live"
+                                showSlash={false}
                                 byline={
                                     trail.showByline ? trail.byline : undefined
                                 }

--- a/src/web/components/Onwards/StoryPackage.tsx
+++ b/src/web/components/Onwards/StoryPackage.tsx
@@ -16,17 +16,12 @@ export const StoryPackage = ({ content }: Props) => (
                     {...{
                         linkTo: content[0].url,
                         pillar: content[0].pillar,
-                        headline: {
-                            designType: content[0].designType,
-                            headlineText: content[0].linkText,
-                            size: 'medium',
-                            pillar: content[0].pillar,
-                        },
+                        designType: content[0].designType,
+                        headlineText: content[0].linkText,
+                        headlineSize: 'medium',
                         webPublicationDate: content[0].webPublicationDate,
                         showClock: false,
-                        trailImage: {
-                            url: content[0].image,
-                        },
+                        imageUrl: content[0].image,
                     }}
                 />
             </LI>
@@ -40,17 +35,12 @@ export const StoryPackage = ({ content }: Props) => (
                     {...{
                         linkTo: content[1].url,
                         pillar: content[1].pillar,
-                        headline: {
-                            designType: content[1].designType,
-                            headlineText: content[1].linkText,
-                            size: 'medium',
-                            pillar: content[1].pillar,
-                        },
+                        designType: content[1].designType,
+                        headlineText: content[1].linkText,
+                        headlineSize: 'medium',
                         webPublicationDate: content[1].webPublicationDate,
                         showClock: false,
-                        trailImage: {
-                            url: content[1].image,
-                        },
+                        imageUrl: content[1].image,
                     }}
                 />
             </LI>
@@ -64,17 +54,12 @@ export const StoryPackage = ({ content }: Props) => (
                     {...{
                         linkTo: content[2].url,
                         pillar: content[2].pillar,
-                        headline: {
-                            designType: content[2].designType,
-                            headlineText: content[2].linkText,
-                            size: 'medium',
-                            pillar: content[2].pillar,
-                        },
+                        designType: content[2].designType,
+                        headlineText: content[2].linkText,
+                        headlineSize: 'medium',
                         webPublicationDate: content[2].webPublicationDate,
                         showClock: false,
-                        trailImage: {
-                            url: content[2].image,
-                        },
+                        imageUrl: content[2].image,
                     }}
                 />
             </LI>
@@ -88,17 +73,12 @@ export const StoryPackage = ({ content }: Props) => (
                     {...{
                         linkTo: content[3].url,
                         pillar: content[3].pillar,
-                        headline: {
-                            designType: content[3].designType,
-                            headlineText: content[3].linkText,
-                            size: 'medium',
-                            pillar: content[3].pillar,
-                        },
+                        designType: content[3].designType,
+                        headlineText: content[3].linkText,
+                        headlineSize: 'medium',
                         webPublicationDate: content[3].webPublicationDate,
                         showClock: false,
-                        trailImage: {
-                            url: content[3].image,
-                        },
+                        imageUrl: content[3].image,
                     }}
                 />
             </LI>
@@ -109,12 +89,9 @@ export const StoryPackage = ({ content }: Props) => (
                     {...{
                         linkTo: content[4].url,
                         pillar: content[4].pillar,
-                        headline: {
-                            designType: content[4].designType,
-                            headlineText: content[4].linkText,
-                            size: 'small',
-                            pillar: content[4].pillar,
-                        },
+                        designType: content[4].designType,
+                        headlineText: content[4].linkText,
+                        headlineSize: 'small',
                         webPublicationDate: content[4].webPublicationDate,
                         showClock: false,
                     }}
@@ -130,12 +107,9 @@ export const StoryPackage = ({ content }: Props) => (
                     {...{
                         linkTo: content[5].url,
                         pillar: content[5].pillar,
-                        headline: {
-                            designType: content[5].designType,
-                            headlineText: content[5].linkText,
-                            size: 'small',
-                            pillar: content[5].pillar,
-                        },
+                        designType: content[5].designType,
+                        headlineText: content[5].linkText,
+                        headlineSize: 'small',
                         webPublicationDate: content[5].webPublicationDate,
                         showClock: false,
                     }}
@@ -151,12 +125,9 @@ export const StoryPackage = ({ content }: Props) => (
                     {...{
                         linkTo: content[6].url,
                         pillar: content[6].pillar,
-                        headline: {
-                            designType: content[6].designType,
-                            headlineText: content[6].linkText,
-                            size: 'small',
-                            pillar: content[6].pillar,
-                        },
+                        designType: content[6].designType,
+                        headlineText: content[6].linkText,
+                        headlineSize: 'small',
                         webPublicationDate: content[6].webPublicationDate,
                         showClock: false,
                     }}
@@ -172,12 +143,9 @@ export const StoryPackage = ({ content }: Props) => (
                     {...{
                         linkTo: content[7].url,
                         pillar: content[7].pillar,
-                        headline: {
-                            designType: content[7].designType,
-                            headlineText: content[7].linkText,
-                            size: 'small',
-                            pillar: content[7].pillar,
-                        },
+                        designType: content[7].designType,
+                        headlineText: content[7].linkText,
+                        headlineSize: 'small',
                         webPublicationDate: content[7].webPublicationDate,
                         showClock: false,
                     }}


### PR DESCRIPTION
## What does this change?
This PR refactors the props for `Card` to remove nested prop objects in favour of a flatter structure.

## Before
```typescript
interface CardType {
    linkTo: string;
    pillar: Pillar;
    headline: CardHeadlineType;
    webPublicationDate?: string;
    trailImage?: CardImageType;
    standfirst?: string;
    avatar?: AvatarType;
    showClock?: boolean;
    designType?: DesignType;
    mediaType?: MediaType;
    mediaDuration?: number;
}
```

## After
```typescript
interface CardType {
    linkTo: string;
    pillar: Pillar;
    designType: DesignType;
    headlineText: string;
    headlineSize?: SmallHeadlineSize;
    showQuotes?: boolean; // Even with designType !== Comment, a piece can be opinion
    byline?: string;
    webPublicationDate?: string;
    imageUrl?: string;
    imagePosition?: ImagePositionType;
    imageSize?: ImageSizeType; // Size is ignored when position = 'top' because in that case the image flows based on width
    standfirst?: string;
    avatar?: AvatarType;
    showClock?: boolean;
    mediaType?: MediaType;
    mediaDuration?: number;
    kickerText?: string;
    showPulsingDot?: boolean;
    showSlash?: boolean;
}
```

## Why?
Whilst less verbose to define, in this case nesting prop objects leads to duplication when calling the component (repeated need to pass `designType` and `pillar`) which makes things brittle.

## Link to supporting Trello card
https://trello.com/c/b28PazHZ/1007-flatten-card-props