### PR TITLE
Speed up TS compilation on Storybook

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
 module.exports = ({ config }) => {
     const rules = config.module.rules;
@@ -12,6 +13,7 @@ module.exports = ({ config }) => {
             {
                 loader: require.resolve('awesome-typescript-loader'),
                 options: {
+                    transpileOnly: true,
                     silent: true,
                     useBabel: true,
                     babelOptions: {
@@ -22,6 +24,8 @@ module.exports = ({ config }) => {
         ],
     });
     extensions.push('.ts', '.tsx');
+
+    config.plugins.push(new ForkTsCheckerWebpackPlugin());
 
     // modify storybook's file-loader rule to avoid conflicts with our svg
     // https://stackoverflow.com/questions/54292667/react-storybook-svg-failed-to-execute-createelement-on-document

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
         "eslint": "^5.16.0",
         "eslint-plugin-dcr": "https://github.com/guardian/eslint-plugin-dcr#v0.1.0",
         "fetch-mock": "^8.0.0-alpha.14",
+        "fork-ts-checker-webpack-plugin": "^3.1.1",
         "friendly-errors-webpack-plugin": "^1.7.0",
         "husky": "^2.3.0",
         "jest": "^24.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4744,7 +4744,7 @@ chokidar@^2.0.2, chokidar@^2.0.4:
   optionalDependencies:
     fsevents "^1.2.7"
 
-chokidar@^3.2.2:
+chokidar@^3.2.2, chokidar@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.3.0.tgz#12c0714668c55800f659e262d4962a97faf554a6"
   integrity sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==
@@ -7215,6 +7215,20 @@ fork-ts-checker-webpack-plugin@1.5.0:
     babel-code-frame "^6.22.0"
     chalk "^2.4.1"
     chokidar "^2.0.4"
+    micromatch "^3.1.10"
+    minimatch "^3.0.4"
+    semver "^5.6.0"
+    tapable "^1.0.0"
+    worker-rpc "^0.1.0"
+
+fork-ts-checker-webpack-plugin@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-3.1.1.tgz#a1642c0d3e65f50c2cc1742e9c0a80f441f86b19"
+  integrity sha512-DuVkPNrM12jR41KM2e+N+styka0EgLkTnXmNcXdgOM37vtGeY+oCBK/Jx0hzSeEU6memFCtWb4htrHPMDfwwUQ==
+  dependencies:
+    babel-code-frame "^6.22.0"
+    chalk "^2.4.1"
+    chokidar "^3.3.0"
     micromatch "^3.1.10"
     minimatch "^3.0.4"
     semver "^5.6.0"


### PR DESCRIPTION
## What does this change?
Change Storybook's webpack config so that it transpiles only on the main process and validates TS on a child process.

## Why?
Storybook took ~30s to recompile, we needed to speed this up so that the feedback loop on code edits is manageable.

## Link to supporting Trello card
https://trello.com/c/qXBvTtxl/1010-speed-up-ts-compilation
