### PR TITLE
Drop Caps

### DIFF
--- a/src/web/components/ArticleBody.tsx
+++ b/src/web/components/ArticleBody.tsx
@@ -140,6 +140,7 @@ export const ArticleBody: React.FC<{
             <ArticleRenderer
                 elements={CAPI.blocks[0] ? CAPI.blocks[0].elements : []}
                 pillar={CAPI.pillar}
+                designType={CAPI.designType}
             />
         </div>
     );

--- a/src/web/components/DropCap.tsx
+++ b/src/web/components/DropCap.tsx
@@ -13,10 +13,11 @@ type Props = {
 
 const outerStyles = (pillar: Pillar, designType: DesignType) => {
     const baseStyles = css`
-        ${headline.large()}
+        ${headline.large({
+            fontWeight: 'light',
+        })}
         float: left;
         text-transform: uppercase;
-        font-weight: 200;
         box-sizing: border-box;
         margin-right: 4px;
     `;

--- a/src/web/components/DropCap.tsx
+++ b/src/web/components/DropCap.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { headline } from '@guardian/src-foundations/typography';
+
+import { palette } from '@guardian/src-foundations';
+
+type Props = {
+    letter: string;
+    pillar: Pillar;
+    designType: DesignType;
+};
+
+const outerStyles = (pillar: Pillar, designType: DesignType) => {
+    const baseStyles = css`
+        ${headline.large()}
+        float: left;
+        text-transform: uppercase;
+        font-weight: 200;
+        box-sizing: border-box;
+        margin-right: 4px;
+    `;
+
+    switch (designType) {
+        case 'Comment':
+            return css`
+                ${baseStyles};
+                color: ${palette.opinion.main};
+            `;
+        case 'Comment':
+        case 'Analysis':
+        case 'Feature':
+        case 'Interview':
+        case 'Article':
+        case 'Media':
+        case 'Review':
+        case 'Live':
+        case 'SpecialReport':
+        case 'Recipe':
+        case 'MatchReport':
+        case 'GuardianView':
+        case 'GuardianLabs':
+        case 'Quiz':
+        case 'AdvertisementFeature':
+        case 'Immersive':
+        default:
+            return css`
+                ${baseStyles};
+                color: ${palette[pillar].dark};
+            `;
+    }
+};
+
+const innerStyles = (designType: DesignType) => {
+    const baseStyles = css`
+        font-size: 109px;
+        line-height: 90px;
+
+        display: inline-block;
+        vertical-align: text-top;
+    `;
+
+    switch (designType) {
+        case 'Comment':
+            return css`
+                ${baseStyles};
+                font-weight: 200;
+            `;
+        case 'Comment':
+        case 'Analysis':
+        case 'Feature':
+        case 'Interview':
+        case 'Article':
+        case 'Media':
+        case 'Review':
+        case 'Live':
+        case 'SpecialReport':
+        case 'Recipe':
+        case 'MatchReport':
+        case 'GuardianView':
+        case 'GuardianLabs':
+        case 'Quiz':
+        case 'AdvertisementFeature':
+        case 'Immersive':
+        default:
+            return css`
+                ${baseStyles};
+                font-weight: 700;
+            `;
+    }
+};
+
+export const DropCap = ({ letter, pillar, designType }: Props) => (
+    <span className={outerStyles(pillar, designType)}>
+        <span className={innerStyles(designType)}>{letter}</span>
+    </span>
+);

--- a/src/web/components/elements/TextBlockComponent.stories.tsx
+++ b/src/web/components/elements/TextBlockComponent.stories.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { TextBlockComponent } from '@frontend/web/components/elements/TextBlockComponent';
+
+const html =
+    '<p>orem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesquepharetra libero nec varius feugiat. Nulla commodo sagittis erat amalesuada. Ut iaculis interdum eros, et tristique ex. In veldignissim arcu. Nulla nisi urna, laoreet a aliquam at, viverra eueros. Proin imperdiet pellentesque turpis sed luctus. Donecdignissim lacus in risus fermentum maximus eu vel justo. Duis nontortor ac elit dapibus imperdiet ut at risus. Etiam pretium, odioeget accumsan venenatis, tortor mi aliquet nisl, vel ullamcorperneque nulla vel elit. Etiam porta mauris nec sagittis luctus.</p>';
+const quotedHtml =
+    '<p>“orem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesquepharetra libero nec varius feugiat. Nulla commodo sagittis erat amalesuada. Ut iaculis interdum eros, et tristique ex. In veldignissim arcu. Nulla nisi urna, laoreet a aliquam at, viverra eueros. Proin imperdiet pellentesque turpis sed luctus. Donecdignissim lacus in risus fermentum maximus eu vel justo. Duis nontortor ac elit dapibus imperdiet ut at risus. Etiam pretium, odioeget accumsan venenatis, tortor mi aliquet nisl, vel ullamcorperneque nulla vel elit. Etiam porta mauris nec sagittis luctus.</p>';
+const shortHtml =
+    '<p>orem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesquepharetra libero </p>';
+const differentWrapperTags =
+    '<span><p>orem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesquepharetra libero nec varius feugiat. Nulla commodo sagittis erat amalesuada. Ut iaculis interdum eros, et tristique ex. In veldignissim arcu. Nulla nisi urna, laoreet a aliquam at, viverra eueros. Proin imperdiet pellentesque turpis sed luctus. Donecdignissim lacus in risus fermentum maximus eu vel justo. Duis nontortor ac elit dapibus imperdiet ut at risus. Etiam pretium, odioeget accumsan venenatis, tortor mi aliquet nisl, vel ullamcorperneque nulla vel elit. Etiam porta mauris nec sagittis luctus.</p></span>';
+
+const containerStyles = css`
+    max-width: 620px;
+    margin: 20px;
+`;
+
+/* tslint:disable */
+export default {
+    component: TextBlockComponent,
+    title: 'Components/TextBlockComponent',
+};
+/* tslint:enable */
+
+export const defaultStory = () => {
+    return (
+        <div className={containerStyles}>
+            <TextBlockComponent
+                html={html}
+                pillar={'news'}
+                designType="Article"
+            />
+        </div>
+    );
+};
+defaultStory.story = { name: 'default' };
+
+export const DropCap = () => {
+    return (
+        <div className={containerStyles}>
+            <TextBlockComponent
+                html={html}
+                pillar={'culture'}
+                dropCap={true}
+                designType="Article"
+            />
+        </div>
+    );
+};
+DropCap.story = { name: 'with drop cap' };
+
+export const QuotedDropCap = () => {
+    return (
+        <div className={containerStyles}>
+            <TextBlockComponent
+                html={quotedHtml}
+                pillar={'opinion'}
+                dropCap={true}
+                designType="Comment"
+            />
+        </div>
+    );
+};
+QuotedDropCap.story = { name: 'with quoted drop cap' };
+
+export const ShortText = () => {
+    return (
+        <div className={containerStyles}>
+            <TextBlockComponent
+                html={shortHtml}
+                pillar={'news'}
+                dropCap={true}
+                designType="Article"
+            />
+        </div>
+    );
+};
+ShortText.story = { name: 'with text less than 299 characters' };
+
+export const NoTags = () => {
+    return (
+        <div className={containerStyles}>
+            <TextBlockComponent
+                html={differentWrapperTags}
+                pillar={'news'}
+                dropCap={true}
+                designType="Article"
+            />
+        </div>
+    );
+};
+NoTags.story = { name: 'with no p tags' };

--- a/src/web/components/lib/ArticleRenderer.tsx
+++ b/src/web/components/lib/ArticleRenderer.tsx
@@ -32,7 +32,7 @@ export const ArticleRenderer: React.FC<{
                             html={element.html}
                             pillar={pillar}
                             designType={designType}
-                            dropCap={true} // TODO: Plug in the api response here when we have it
+                            dropCap={false} // TODO: Plug in the api response here when we have it
                         />
                     );
                 case 'model.dotcomrendering.pageElements.SubheadingBlockElement':

--- a/src/web/components/lib/ArticleRenderer.tsx
+++ b/src/web/components/lib/ArticleRenderer.tsx
@@ -14,7 +14,8 @@ const commercialPosition = css`
 export const ArticleRenderer: React.FC<{
     elements: CAPIElement[];
     pillar: Pillar;
-}> = ({ elements, pillar }) => {
+    designType: DesignType;
+}> = ({ elements, pillar, designType }) => {
     // const cleanedElements = elements.map(element =>
     //     'html' in element ? { ...element, html: clean(element.html) } : element,
     // );
@@ -25,7 +26,15 @@ export const ArticleRenderer: React.FC<{
         .map((element, i) => {
             switch (element._type) {
                 case 'model.dotcomrendering.pageElements.TextBlockElement':
-                    return <TextBlockComponent key={i} html={element.html} />;
+                    return (
+                        <TextBlockComponent
+                            key={i}
+                            html={element.html}
+                            pillar={pillar}
+                            designType={designType}
+                            dropCap={true} // TODO: Plug in the api response here when we have it
+                        />
+                    );
                 case 'model.dotcomrendering.pageElements.SubheadingBlockElement':
                     return (
                         <SubheadingBlockComponent key={i} html={element.html} />


### PR DESCRIPTION
## What does this change?
Adds the styling support for Drop Caps. The decision logic for when to show these is left to the server and expected as `dropCap` on the element type: `model.dotcomrendering.pageElements.TextBlockElement`

![2019-12-16 14 39 15](https://user-images.githubusercontent.com/1336821/70915519-e2cf7100-2011-11ea-955f-70fed55eddc0.gif)


## Link to supporting Trello card
https://trello.com/c/P0LbnQYZ/432-we-dont-support-the-big-leading-letters