### PR TITLE
Most commented & shared articles

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -422,6 +422,17 @@ interface TrailType {
     showByline?: boolean;
 }
 
+interface TrailTabType {
+    heading: string;
+    trails: TrailType[];
+}
+
+interface MostViewedFooterType {
+    tabs: TrailTabType[];
+    mostCommented: TrailType;
+    mostShared: TrailType;
+}
+
 // ------------------------------
 // 3rd party type declarations //
 // ------------------------------

--- a/index.d.ts
+++ b/index.d.ts
@@ -413,11 +413,12 @@ interface TrailType {
     url: string;
     linkText: string;
     isLiveBlog: boolean;
+    image: string;
+    webPublicationDate: string;
+    avatarUrl?: string;
     mediaType?: MediaType;
     mediaDuration?: number;
-    webPublicationDate: string;
     ageWarning?: string;
-    image: string;
     byline?: string;
     showByline?: boolean;
 }

--- a/src/web/components/MostViewed/MostViewed.mocks.tsx
+++ b/src/web/components/MostViewed/MostViewed.mocks.tsx
@@ -249,3 +249,29 @@ export const mockTab2 = {
         },
     ],
 };
+
+export const mockMostCommented = {
+    url:
+        'https://www.theguardian.com/politics/2019/sep/15/eu-officials-reject-boris-johnson-claim-huge-progress-brexit-talks',
+    linkText:
+        "LINKTEXT EU officials reject Boris Johnson claim of 'huge progress' in Brexit talks",
+    showByline: true,
+    byline: 'Jennifer Rankin and Daniel Boffey',
+    image:
+        'https://i.guim.co.uk/img/media/85377038aacd71b2c0e55b0a55478165fe6d3014/0_0_6000_3600/master/6000.jpg?width=300&quality=85&auto=format&fit=max&s=de2cecf52b21492f01daa4520c4f2a97',
+    isLiveBlog: true,
+    pillar: 'news',
+};
+
+export const mockMostShared = {
+    url:
+        'https://www.theguardian.com/us-news/2019/sep/15/brett-kavanaugh-donald-trump-impeachment-supreme-court-justice',
+    linkText: 'LINKTEXT Trump blasts calls for impeachment',
+    showByline: true,
+    byline: 'Martin Pengelly',
+    image:
+        'https://i.guim.co.uk/img/media/579fd19481e46b9d6ed3c69c2a6992483df84478/0_0_6000_3600/master/6000.jpg?width=300&quality=85&auto=format&fit=max&s=63a6a5c13a8087e607a44ce5c7da2090',
+    isLiveBlog: false,
+    pillar: 'opinion',
+    ageWarning: '1 year old',
+};

--- a/src/web/components/MostViewed/MostViewed.mocks.tsx
+++ b/src/web/components/MostViewed/MostViewed.mocks.tsx
@@ -259,8 +259,10 @@ export const mockMostCommented = {
     byline: 'Jennifer Rankin and Daniel Boffey',
     image:
         'https://i.guim.co.uk/img/media/85377038aacd71b2c0e55b0a55478165fe6d3014/0_0_6000_3600/master/6000.jpg?width=300&quality=85&auto=format&fit=max&s=de2cecf52b21492f01daa4520c4f2a97',
-    isLiveBlog: true,
+    isLiveBlog: false,
     pillar: 'news',
+    avatarUrl:
+        'https://i.guim.co.uk/img/uploads/2017/10/06/George-Monbiot,-L.png?width=173&quality=85&auto=format&fit=max&s=be5b0d3f3aa55682e4930057fc3929a3',
 };
 
 export const mockMostShared = {

--- a/src/web/components/MostViewed/MostViewed.mocks.tsx
+++ b/src/web/components/MostViewed/MostViewed.mocks.tsx
@@ -254,13 +254,14 @@ export const mockMostCommented = {
     url:
         'https://www.theguardian.com/politics/2019/sep/15/eu-officials-reject-boris-johnson-claim-huge-progress-brexit-talks',
     linkText:
-        "LINKTEXT EU officials reject Boris Johnson claim of 'huge progress' in Brexit talks",
+        "EU officials reject Boris Johnson claim of 'huge progress' in Brexit talks",
     showByline: true,
     byline: 'Jennifer Rankin and Daniel Boffey',
     image:
         'https://i.guim.co.uk/img/media/85377038aacd71b2c0e55b0a55478165fe6d3014/0_0_6000_3600/master/6000.jpg?width=300&quality=85&auto=format&fit=max&s=de2cecf52b21492f01daa4520c4f2a97',
     isLiveBlog: false,
-    pillar: 'news',
+    pillar: 'opinion',
+    designType: 'Comment',
     avatarUrl:
         'https://i.guim.co.uk/img/uploads/2017/10/06/George-Monbiot,-L.png?width=173&quality=85&auto=format&fit=max&s=be5b0d3f3aa55682e4930057fc3929a3',
 };
@@ -268,8 +269,8 @@ export const mockMostCommented = {
 export const mockMostShared = {
     url:
         'https://www.theguardian.com/us-news/2019/sep/15/brett-kavanaugh-donald-trump-impeachment-supreme-court-justice',
-    linkText: 'LINKTEXT Trump blasts calls for impeachment',
-    showByline: true,
+    linkText: 'Trump blasts calls for impeachment',
+    showByline: false,
     byline: 'Martin Pengelly',
     image:
         'https://i.guim.co.uk/img/media/579fd19481e46b9d6ed3c69c2a6992483df84478/0_0_6000_3600/master/6000.jpg?width=300&quality=85&auto=format&fit=max&s=63a6a5c13a8087e607a44ce5c7da2090',

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.mocks.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.mocks.tsx
@@ -1,9 +1,18 @@
-import { mockTab1, mockTab2 } from '../MostViewed.mocks';
+import {
+    mockTab1,
+    mockTab2,
+    mockMostCommented,
+    mockMostShared,
+} from '../MostViewed.mocks';
 
 export const responseWithTwoTabs = {
-    data: [mockTab1, mockTab2],
+    tabs: [mockTab1, mockTab2],
+    mostCommented: mockMostCommented,
+    mostShared: mockMostShared,
 };
 
 export const responseWithOneTab = {
-    data: [mockTab1],
+    tabs: [mockTab1],
+    mostCommented: mockMostCommented,
+    mostShared: mockMostShared,
 };

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.stories.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.stories.tsx
@@ -19,7 +19,7 @@ export default {
 export const withTwoTabs = () => {
     fetchMock.restore().getOnce('*', {
         status: 200,
-        body: responseWithTwoTabs.data,
+        body: responseWithTwoTabs,
     });
 
     return (
@@ -33,7 +33,7 @@ withTwoTabs.story = { name: 'with two tabs' };
 export const withOneTabs = () => {
     fetchMock.restore().getOnce('*', {
         status: 200,
-        body: responseWithOneTab.data,
+        body: responseWithOneTab,
     });
 
     return (

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.test.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.test.tsx
@@ -44,7 +44,7 @@ describe('MostViewedFooter', () => {
         expect(getAllByText(/Live/).length).toBe(3);
 
         // Renders appropriate number of age warnins
-        expect(getAllByText(/This article is more than/).length).toBe(2);
+        expect(getAllByText(/This article is more than/).length).toBe(3);
 
         // Handles &nbsp char
         expect(getByText('Across The Guardian')).toBeInTheDocument();

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.test.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.test.tsx
@@ -23,7 +23,7 @@ describe('MostViewedFooter', () => {
     });
 
     it('should call the api and render the response as expected', async () => {
-        useApi.mockReturnValue(responseWithTwoTabs);
+        useApi.mockReturnValue({ data: responseWithTwoTabs });
 
         const { getByText, getAllByText, getByTestId } = render(
             <MostViewedFooter sectionName="Section Name" pillar="news" />,
@@ -36,7 +36,7 @@ describe('MostViewedFooter', () => {
         expect(getAllByText(/LINKTEXT/).length).toBe(20);
 
         // First tab defaults to visible
-        expect(getByTestId(responseWithTwoTabs.data[0].heading)).toHaveStyle(
+        expect(getByTestId(responseWithTwoTabs.tabs[0].heading)).toHaveStyle(
             VISIBLE,
         );
 
@@ -51,14 +51,14 @@ describe('MostViewedFooter', () => {
     });
 
     it('should change the items shown when the associated tab is clicked', async () => {
-        useApi.mockReturnValue(responseWithTwoTabs);
+        useApi.mockReturnValue({ data: responseWithTwoTabs });
 
         const { getByTestId, getByText } = render(
             <MostViewedFooter sectionName="Section Name" pillar="news" />,
         );
 
-        const firstHeading = responseWithTwoTabs.data[0].heading;
-        const secondHeading = responseWithTwoTabs.data[1].heading;
+        const firstHeading = responseWithTwoTabs.tabs[0].heading;
+        const secondHeading = responseWithTwoTabs.tabs[1].heading;
 
         expect(getByTestId(firstHeading)).toHaveStyle(VISIBLE);
         expect(getByTestId(secondHeading)).toHaveStyle(HIDDEN);
@@ -76,27 +76,27 @@ describe('MostViewedFooter', () => {
     });
 
     it('should not show the tab menu when there is only one group of tabs', async () => {
-        useApi.mockReturnValue(responseWithOneTab);
+        useApi.mockReturnValue({ data: responseWithOneTab });
 
         const { queryByText } = render(
             <MostViewedFooter sectionName="Section Name" pillar="news" />,
         );
 
         expect(
-            queryByText(responseWithOneTab.data[0].heading),
+            queryByText(responseWithOneTab.tabs[0].heading),
         ).not.toBeInTheDocument();
     });
 
     // TODO: Restore this once the component has this feature added to it
     it.skip('should show a byline when this property is set to true', async () => {
-        useApi.mockReturnValue(responseWithTwoTabs);
+        useApi.mockReturnValue({ data: responseWithTwoTabs });
 
         const { getByText } = render(
             <MostViewedFooter sectionName="Section Name" pillar="news" />,
         );
 
         expect(
-            getByText(responseWithTwoTabs.data[0].trails[9].byline),
+            getByText(responseWithTwoTabs.tabs[0].trails[9].byline),
         ).toBeInTheDocument();
     });
 

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.tsx
@@ -75,11 +75,6 @@ const mostPopularAdStyle = css`
     ${labelStyles};
 `;
 
-export interface TabType {
-    heading: string;
-    trails: TrailType[];
-}
-
 interface Props {
     sectionName?: string;
     pillar: Pillar;
@@ -98,7 +93,7 @@ function buildSectionUrl(sectionName?: string) {
 
 export const MostViewedFooter = ({ sectionName, pillar }: Props) => {
     const url = buildSectionUrl(sectionName);
-    const { data, error } = useApi<TabType[]>(url);
+    const { data, error } = useApi<MostViewedFooterType | TrailTabType[]>(url);
 
     if (error) {
         window.guardian.modules.sentry.reportError(error, 'most-viewed-footer');
@@ -118,7 +113,7 @@ export const MostViewedFooter = ({ sectionName, pillar }: Props) => {
                     </section>
                     <section className={stackBelow('desktop')}>
                         <MostViewedFooterGrid
-                            data={data}
+                            data={'tabs' in data ? data.tabs : data}
                             sectionName={sectionName}
                             pillar={pillar}
                         />

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.tsx
@@ -79,6 +79,15 @@ const mostPopularAdStyle = css`
     ${labelStyles};
 `;
 
+const secondTierStyles = css`
+    border-left: 1px solid ${palette.neutral[86]};
+    border-right: 1px solid ${palette.neutral[86]};
+
+    ${from.tablet} {
+        padding-top: 24px;
+    }
+`;
+
 interface Props {
     sectionName?: string;
     pillar: Pillar;
@@ -122,18 +131,23 @@ export const MostViewedFooter = ({ sectionName, pillar }: Props) => {
                                 sectionName={sectionName}
                                 pillar={pillar}
                             />
-                            <div className={stackBelow('tablet')}>
+                            <div
+                                className={cx(
+                                    stackBelow('tablet'),
+                                    secondTierStyles,
+                                )}
+                            >
                                 {'mostCommented' in data && (
                                     <SecondTierItem
                                         trail={data.mostCommented}
                                         heading="Most commented"
+                                        showRightBorder={true}
                                     />
                                 )}
                                 {'mostShared' in data && (
                                     <SecondTierItem
                                         trail={data.mostShared}
                                         heading="Most shared"
-                                        showRightBorder={true}
                                     />
                                 )}
                             </div>

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
-import { useApi } from '@root/src/web/components/lib/api';
 import { css, cx } from 'emotion';
+
 import { palette } from '@guardian/src-foundations';
 import { headline } from '@guardian/src-foundations/typography';
 import { from, between, Breakpoint } from '@guardian/src-foundations/mq';
+
+import { useApi } from '@root/src/web/components/lib/api';
 import { namedAdSlotParameters } from '@root/src/model/advertisement';
 import { AdSlot, labelStyles } from '@root/src/web/components/AdSlot';
+
 import { MostViewedFooterGrid } from './MostViewedFooterGrid';
+import { SecondTierItem } from './SecondTierItem';
 
 const stackBelow = (breakpoint: Breakpoint) => css`
     display: flex;
@@ -112,11 +116,28 @@ export const MostViewedFooter = ({ sectionName, pillar }: Props) => {
                         <h2 className={headingStyles}>Most popular</h2>
                     </section>
                     <section className={stackBelow('desktop')}>
-                        <MostViewedFooterGrid
-                            data={'tabs' in data ? data.tabs : data}
-                            sectionName={sectionName}
-                            pillar={pillar}
-                        />
+                        <div>
+                            <MostViewedFooterGrid
+                                data={'tabs' in data ? data.tabs : data}
+                                sectionName={sectionName}
+                                pillar={pillar}
+                            />
+                            <div className={stackBelow('tablet')}>
+                                {'mostCommented' in data && (
+                                    <SecondTierItem
+                                        trail={data.mostCommented}
+                                        heading="Most commented"
+                                    />
+                                )}
+                                {'mostShared' in data && (
+                                    <SecondTierItem
+                                        trail={data.mostShared}
+                                        heading="Most shared"
+                                        showRightBorder={true}
+                                    />
+                                )}
+                            </div>
+                        </div>
                         <div
                             className={css`
                                 margin: 0.375rem 0 0 0.625rem;

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterGrid.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterGrid.tsx
@@ -5,7 +5,6 @@ import { headline } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
 import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 
-import { TabType } from './MostViewedFooter';
 import { MostViewedFooterItem } from './MostViewedFooterItem';
 
 const thinGreySolid = `1px solid ${palette.neutral[86]}`;
@@ -94,7 +93,7 @@ const gridContainer = css`
 `;
 
 type Props = {
-    data: TabType[];
+    data: TrailTabType[];
     sectionName?: string;
     pillar: Pillar;
 };
@@ -106,7 +105,7 @@ export const MostViewedFooterGrid = ({ data, sectionName, pillar }: Props) => {
         <div>
             {Array.isArray(data) && data.length > 1 && (
                 <ul className={tabsContainer} role="tablist">
-                    {data.map((tab: TabType, i: number) => (
+                    {data.map((tab: TrailTabType, i: number) => (
                         <li
                             className={cx(listTab, {
                                 [selectedListTab(pillar)]:
@@ -143,7 +142,7 @@ export const MostViewedFooterGrid = ({ data, sectionName, pillar }: Props) => {
                     ))}
                 </ul>
             )}
-            {data.map((tab: TabType, i: number) => (
+            {data.map((tab: TrailTabType, i: number) => (
                 <ol
                     className={cx(gridContainer, {
                         [hideList]: i !== selectedTabIndex,

--- a/src/web/components/MostViewed/MostViewedFooter/SecondTierItem.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/SecondTierItem.tsx
@@ -81,6 +81,8 @@ export const SecondTierItem = ({ trail, heading, showRightBorder }: Props) => {
         avatarUrl,
         image,
         designType,
+        byline,
+        showByline,
         pillar,
         ageWarning,
         linkText,
@@ -101,11 +103,7 @@ export const SecondTierItem = ({ trail, heading, showRightBorder }: Props) => {
                                 headlineText={linkText}
                                 pillar={pillar}
                                 size="small"
-                                kicker={{
-                                    text: 'Live',
-                                    showSlash: true,
-                                    showPulsingDot: true,
-                                }}
+                                byline={showByline ? byline : undefined}
                             />
                         ) : (
                             <LinkHeadline
@@ -113,6 +111,7 @@ export const SecondTierItem = ({ trail, heading, showRightBorder }: Props) => {
                                 headlineText={linkText}
                                 pillar={pillar}
                                 size="small"
+                                byline={showByline ? byline : undefined}
                             />
                         )}
                         {ageWarning && (

--- a/src/web/components/MostViewed/MostViewedFooter/SecondTierItem.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/SecondTierItem.tsx
@@ -3,6 +3,7 @@ import { css } from 'emotion';
 
 import { palette } from '@guardian/src-foundations';
 import { headline } from '@guardian/src-foundations/typography';
+import { from } from '@guardian/src-foundations/mq';
 
 import { AgeWarning } from '@root/src/web/components/AgeWarning';
 import { Avatar } from '@root/src/web/components/Avatar';
@@ -17,8 +18,9 @@ const itemStyles = (showRightBorder?: boolean) => css`
     padding-bottom: 12px;
 
     border-top: 1px solid ${palette.neutral[86]};
-    border-left: 1px solid ${palette.neutral[86]};
-    border-right: ${showRightBorder && `1px solid ${palette.neutral[86]}`};
+    ${from.tablet} {
+        border-right: ${showRightBorder && `1px solid ${palette.neutral[86]}`};
+    }
 
     min-height: 3.25rem;
 

--- a/src/web/components/MostViewed/MostViewedFooter/SecondTierItem.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/SecondTierItem.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { palette } from '@guardian/src-foundations';
+import { headline } from '@guardian/src-foundations/typography';
+
+import { AgeWarning } from '@root/src/web/components/AgeWarning';
+import { Avatar } from '@root/src/web/components/Avatar';
+import { LinkHeadline } from '@root/src/web/components/LinkHeadline';
+import { Flex } from '@root/src/web/components/Flex';
+
+const itemStyles = (showRightBorder?: boolean) => css`
+    position: relative;
+
+    padding-left: 10px;
+    padding-right: 10px;
+    padding-bottom: 12px;
+
+    border-top: 1px solid ${palette.neutral[86]};
+    border-left: 1px solid ${palette.neutral[86]};
+    border-right: ${showRightBorder && `1px solid ${palette.neutral[86]}`};
+
+    min-height: 3.25rem;
+
+    flex-basis: 50%;
+
+    &:hover {
+        cursor: pointer;
+    }
+
+    &:hover,
+    :focus {
+        background: ${palette.neutral[97]};
+    }
+`;
+
+const titleStyles = css`
+    ${headline.xxxsmall({ fontWeight: 'bold' })}
+    padding-top: 4px;
+`;
+
+const headlineStyles = css`
+    word-wrap: break-word;
+    overflow: hidden;
+`;
+
+const headlineLink = css`
+    text-decoration: none;
+    color: ${palette.neutral[7]};
+    font-weight: 500;
+    ${headline.xxxsmall()};
+`;
+
+const ageWarningStyles = css`
+    margin-top: 4px;
+`;
+
+const avatarSizeStyles = css`
+    height: 90px;
+    width: 90px;
+`;
+
+const avatarContainerStyles = css`
+    display: flex;
+    flex-direction: row-reverse;
+
+    margin-left: 5px;
+    margin-top: 24px;
+`;
+
+type Props = {
+    trail: TrailType;
+    heading: string;
+    showRightBorder?: boolean; // Prevents double borders
+};
+
+export const SecondTierItem = ({ trail, heading, showRightBorder }: Props) => {
+    const {
+        url,
+        isLiveBlog,
+        avatarUrl,
+        image,
+        designType,
+        pillar,
+        ageWarning,
+        linkText,
+    } = trail;
+
+    const avatarToShow = avatarUrl || image;
+
+    return (
+        <div className={itemStyles(showRightBorder)}>
+            {/* tslint:disable-next-line:react-a11y-anchors */}
+            <a className={headlineLink} href={url} data-link-name={'article'}>
+                <Flex>
+                    <div className={headlineStyles}>
+                        <div className={titleStyles}>{heading}</div>
+                        {isLiveBlog ? (
+                            <LinkHeadline
+                                designType={designType}
+                                headlineText={linkText}
+                                pillar={pillar}
+                                size="small"
+                                kicker={{
+                                    text: 'Live',
+                                    showSlash: true,
+                                    showPulsingDot: true,
+                                }}
+                            />
+                        ) : (
+                            <LinkHeadline
+                                designType={designType}
+                                headlineText={linkText}
+                                pillar={pillar}
+                                size="small"
+                            />
+                        )}
+                        {ageWarning && (
+                            <div className={ageWarningStyles}>
+                                <AgeWarning age={ageWarning} size="small" />
+                            </div>
+                        )}
+                    </div>
+                    <>
+                        {avatarToShow && (
+                            <div className={avatarContainerStyles}>
+                                <div className={avatarSizeStyles}>
+                                    <Avatar
+                                        imageSrc={avatarToShow}
+                                        imageAlt={''}
+                                        pillar={pillar}
+                                    />
+                                </div>
+                            </div>
+                        )}
+                    </>
+                </Flex>
+            </a>
+        </div>
+    );
+};


### PR DESCRIPTION
## What does this change?
Adds the items showing the most commented and most shared articles to the bottom of the most popular section

![Screenshot 2019-12-17 at 15 29 15](https://user-images.githubusercontent.com/1336821/71010030-247c1c80-20e3-11ea-8064-3e8a23548117.jpg)
![Screenshot 2019-12-17 at 15 28 54](https://user-images.githubusercontent.com/1336821/71010031-247c1c80-20e3-11ea-8de7-ca64b29ed0ed.jpg)

## What if no image is provided?
![Screenshot 2019-12-17 at 15 43 10](https://user-images.githubusercontent.com/1336821/71010655-111d8100-20e4-11ea-8f93-4b5c1088c183.jpg)



## Next Steps
This code is safe to deploy but the articles will not start showing until the format of the api response to [https://api.nextgen.guardianapps.co.uk/most-read/...etc](https://api.nextgen.guardianapps.co.uk/most-read/politics.json?dcr=true) is updated as per [this ticket](https://trello.com/c/NnisWuAi/1014-enhance-most-popular-api-response).

Once that api update is complete, we can update `MostViewedFooter.tsx` to only expect one type of data, `MostViewedFooterType`. 

## Link to supporting Trello card
https://trello.com/c/moVLaacL/1015-most-commented-client-side-code
