### PR TITLE
Fix IE scrollbar in header

### DIFF
--- a/src/web/components/Header/Header.tsx
+++ b/src/web/components/Header/Header.tsx
@@ -11,6 +11,8 @@ import { Links } from './Links/Links';
 const headerStyles = css`
     /* Ensure header height contains it's children */
     overflow: auto;
+    /* Prevent a scrollbar appearing here on IE/Edge */
+    -ms-overflow-style: none;
 `;
 
 interface Props {


### PR DESCRIPTION
## What does this change?
Removes the (awful) scrollbar that was showing for users of IE11 / Edge

## Before
![Screenshot 2019-12-17 at 17 04 34](https://user-images.githubusercontent.com/1336821/71018977-68761e00-20f1-11ea-88c5-6f7976227435.jpg)

## After
![Screenshot 2019-12-17 at 17 01 42](https://user-images.githubusercontent.com/1336821/71018978-68761e00-20f1-11ea-9809-b02f83dd454b.jpg)

## Link to supporting Trello card
https://trello.com/c/8gpcKMTv/897-header-renders-unnecessary-scrollbar-on-ie-edge