### PR TITLE
linkText > headline (fix merge errors)

### DIFF
--- a/src/web/components/MostViewed/MostViewed.mocks.tsx
+++ b/src/web/components/MostViewed/MostViewed.mocks.tsx
@@ -253,7 +253,7 @@ export const mockTab2 = {
 export const mockMostCommented = {
     url:
         'https://www.theguardian.com/politics/2019/sep/15/eu-officials-reject-boris-johnson-claim-huge-progress-brexit-talks',
-    linkText:
+    headline:
         "EU officials reject Boris Johnson claim of 'huge progress' in Brexit talks",
     showByline: true,
     byline: 'Jennifer Rankin and Daniel Boffey',
@@ -269,7 +269,7 @@ export const mockMostCommented = {
 export const mockMostShared = {
     url:
         'https://www.theguardian.com/us-news/2019/sep/15/brett-kavanaugh-donald-trump-impeachment-supreme-court-justice',
-    linkText: 'Trump blasts calls for impeachment',
+    headline: 'Trump blasts calls for impeachment',
     showByline: false,
     byline: 'Martin Pengelly',
     image:

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.tsx
@@ -140,14 +140,14 @@ export const MostViewedFooter = ({ sectionName, pillar }: Props) => {
                                 {'mostCommented' in data && (
                                     <SecondTierItem
                                         trail={data.mostCommented}
-                                        heading="Most commented"
+                                        title="Most commented"
                                         showRightBorder={true}
                                     />
                                 )}
                                 {'mostShared' in data && (
                                     <SecondTierItem
                                         trail={data.mostShared}
-                                        heading="Most shared"
+                                        title="Most shared"
                                     />
                                 )}
                             </div>

--- a/src/web/components/MostViewed/MostViewedFooter/SecondTierItem.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/SecondTierItem.tsx
@@ -72,11 +72,11 @@ const avatarContainerStyles = css`
 
 type Props = {
     trail: TrailType;
-    heading: string;
+    title: string;
     showRightBorder?: boolean; // Prevents double borders
 };
 
-export const SecondTierItem = ({ trail, heading, showRightBorder }: Props) => {
+export const SecondTierItem = ({ trail, title, showRightBorder }: Props) => {
     const {
         url,
         isLiveBlog,
@@ -87,7 +87,7 @@ export const SecondTierItem = ({ trail, heading, showRightBorder }: Props) => {
         showByline,
         pillar,
         ageWarning,
-        linkText,
+        headline: headlineText,
     } = trail;
 
     const avatarToShow = avatarUrl || image;
@@ -98,11 +98,11 @@ export const SecondTierItem = ({ trail, heading, showRightBorder }: Props) => {
             <a className={headlineLink} href={url} data-link-name={'article'}>
                 <Flex>
                     <div className={headlineStyles}>
-                        <div className={titleStyles}>{heading}</div>
+                        <div className={titleStyles}>{title}</div>
                         {isLiveBlog ? (
                             <LinkHeadline
                                 designType={designType}
-                                headlineText={linkText}
+                                headlineText={headlineText}
                                 pillar={pillar}
                                 size="small"
                                 byline={showByline ? byline : undefined}
@@ -110,7 +110,7 @@ export const SecondTierItem = ({ trail, heading, showRightBorder }: Props) => {
                         ) : (
                             <LinkHeadline
                                 designType={designType}
-                                headlineText={linkText}
+                                headlineText={headlineText}
                                 pillar={pillar}
                                 size="small"
                                 byline={showByline ? byline : undefined}


### PR DESCRIPTION
## What does this change?
Continues the replacement of `linkText` with `headline` 

## Why?
To fix some type errors on the build that slipped through
