### PR TITLE
Interview headline tag

### DIFF
--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -4,6 +4,7 @@ import { css, cx } from 'emotion';
 import { pillarPalette } from '@root/src/lib/pillars';
 import { getAgeWarning } from '@root/src/lib/age-warning';
 import { AgeWarning } from '@root/src/web/components/AgeWarning';
+import { HeadlineTag } from '@root/src/web/components/HeadlineTag';
 import { headline } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
 
@@ -158,6 +159,7 @@ const ageWarningMargins = css`
 
 const renderHeadline = (
     designType: DesignType,
+    pillar: Pillar,
     isShowcase: boolean,
     headlineString: string,
     options?: {
@@ -219,25 +221,28 @@ const renderHeadline = (
             return (
                 // Inverted headlines have a wrapper div for positioning
                 // and a black background (only for the text)
-                <h1
-                    className={cx(
-                        invertedFont,
-                        invertedWrapper,
-                        // We only shift the inverted headline down when main media is showcase
-                        isShowcase ? shiftPosition('down') : shiftSlightly,
-                        maxWidth,
-                    )}
-                >
-                    <span
+                <>
+                    <HeadlineTag tagText="Interview" pillar={pillar} />
+                    <h1
                         className={cx(
-                            blackBackground,
-                            invertedStyles,
-                            displayInline,
+                            invertedFont,
+                            invertedWrapper,
+                            // We only shift the inverted headline down when main media is showcase
+                            isShowcase ? shiftPosition('down') : shiftSlightly,
+                            maxWidth,
                         )}
                     >
-                        {curly(headlineString)}
-                    </span>
-                </h1>
+                        <span
+                            className={cx(
+                                blackBackground,
+                                invertedStyles,
+                                displayInline,
+                            )}
+                        >
+                            {curly(headlineString)}
+                        </span>
+                    </h1>
+                </>
             );
 
         case 'Immersive':
@@ -282,7 +287,7 @@ export const ArticleHeadline = ({
                     <AgeWarning age={age} />
                 </div>
             )}
-            {renderHeadline(designType, isShowcase, headlineString, {
+            {renderHeadline(designType, pillar, isShowcase, headlineString, {
                 colour: pillarPalette[pillar].dark,
             })}
             {age && <AgeWarning age={age} isScreenReader={true} />}

--- a/src/web/components/HeadlineTag.stories.tsx
+++ b/src/web/components/HeadlineTag.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { HeadlineTag } from './HeadlineTag';
+import { css } from 'emotion';
 
 /* tslint:disable */
 export default {
@@ -21,10 +22,16 @@ longTagNameStory.story = { name: 'With a longer tag name' };
 
 export const wrappedTagNameStory = () => {
     return (
-        <HeadlineTag
-            tagText="Very long tag name with enough text to wrap to a second line"
-            pillar="labs"
-        />
+        <div
+            className={css`
+                max-width: 400px;
+            `}
+        >
+            <HeadlineTag
+                tagText="Very long tag name with enough text to wrap to a second line"
+                pillar="labs"
+            />
+        </div>
     );
 };
 wrappedTagNameStory.story = { name: 'With wrapped tag name' };

--- a/src/web/components/HeadlineTag.tsx
+++ b/src/web/components/HeadlineTag.tsx
@@ -6,6 +6,7 @@ import { headline } from '@guardian/src-foundations/typography';
 
 const headlineTagWrapper = css`
     margin-left: 6px;
+    margin-top: 6px;
 `;
 
 const headlineTagStyles = (pillar: Pillar) => css`


### PR DESCRIPTION
## What does this change?
Adds a headline tag showing 'Interview' above the headline on Interview articles

![Screenshot 2019-12-18 at 16 14 50](https://user-images.githubusercontent.com/1336821/71103276-c0745980-21b1-11ea-91e9-c6a5157fb4eb.jpg)


## Link to supporting Trello card
https://trello.com/c/XZiKF5fZ/1019-interview-headline-tag