### PR TITLE
Headline byline

### DIFF
--- a/src/web/components/ArticleHeadline.stories.tsx
+++ b/src/web/components/ArticleHeadline.stories.tsx
@@ -97,6 +97,7 @@ export const ShowcaseInterview = () => (
                     webPublicationDate=""
                     tags={[]}
                     isShowcase={true}
+                    byline="Byline text"
                 />
                 <MainMedia
                     hideCaption={true}
@@ -122,6 +123,7 @@ export const Interview = () => (
                     pillar="culture"
                     webPublicationDate=""
                     tags={[]}
+                    byline="Byline text"
                 />
                 <Standfirst
                     designType="Interview"

--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -5,6 +5,7 @@ import { pillarPalette } from '@root/src/lib/pillars';
 import { getAgeWarning } from '@root/src/lib/age-warning';
 import { AgeWarning } from '@root/src/web/components/AgeWarning';
 import { HeadlineTag } from '@root/src/web/components/HeadlineTag';
+import { HeadlineByline } from '@root/src/web/components/HeadlineByline';
 import { headline } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
 
@@ -14,6 +15,7 @@ type Props = {
     pillar: Pillar; // Decides headline colour when relevant
     webPublicationDate: string; // Used for age warning
     tags: TagType[]; // Used for age warning
+    byline?: string;
     isShowcase?: boolean; // Used for Interviews to change headline position
 };
 
@@ -98,8 +100,14 @@ const colourStyles = (colour?: string) => css`
 const displayBlock = css`
     display: block;
 `;
+
 const displayInline = css`
     display: inline;
+`;
+
+const displayFlex = css`
+    display: flex;
+    flex-direction: column;
 `;
 
 const shiftPosition = (shift?: 'up' | 'down') => css`
@@ -114,7 +122,6 @@ const shiftSlightly = css`
 const invertedStyles = css`
     position: relative;
     color: white;
-    display: 'inline';
     white-space: pre-wrap;
     padding-bottom: 5px;
     padding-right: 5px;
@@ -157,15 +164,25 @@ const ageWarningMargins = css`
     }
 `;
 
-const renderHeadline = (
-    designType: DesignType,
-    pillar: Pillar,
-    isShowcase: boolean,
-    headlineString: string,
+const renderHeadline = ({
+    designType,
+    pillar,
+    isShowcase,
+    headlineString,
+    byline,
+    tags,
+    options,
+}: {
+    designType: DesignType;
+    pillar: Pillar;
+    isShowcase: boolean;
+    headlineString: string;
+    byline?: string;
+    tags: TagType[];
     options?: {
         colour?: string;
-    },
-) => {
+    };
+}) => {
     switch (designType) {
         case 'Article':
         case 'Media':
@@ -221,17 +238,16 @@ const renderHeadline = (
             return (
                 // Inverted headlines have a wrapper div for positioning
                 // and a black background (only for the text)
-                <>
+                <div
+                    className={cx(
+                        // We only shift the inverted headline down when main media is showcase
+                        isShowcase ? shiftPosition('down') : shiftSlightly,
+                        maxWidth,
+                        displayFlex,
+                    )}
+                >
                     <HeadlineTag tagText="Interview" pillar={pillar} />
-                    <h1
-                        className={cx(
-                            invertedFont,
-                            invertedWrapper,
-                            // We only shift the inverted headline down when main media is showcase
-                            isShowcase ? shiftPosition('down') : shiftSlightly,
-                            maxWidth,
-                        )}
-                    >
+                    <h1 className={cx(invertedFont, invertedWrapper)}>
                         <span
                             className={cx(
                                 blackBackground,
@@ -242,7 +258,8 @@ const renderHeadline = (
                             {curly(headlineString)}
                         </span>
                     </h1>
-                </>
+                    {byline && <HeadlineByline byline={byline} tags={tags} />}
+                </div>
             );
 
         case 'Immersive':
@@ -276,6 +293,7 @@ export const ArticleHeadline = ({
     designType,
     pillar,
     webPublicationDate,
+    byline,
     tags,
     isShowcase = false,
 }: Props) => {
@@ -287,8 +305,16 @@ export const ArticleHeadline = ({
                     <AgeWarning age={age} />
                 </div>
             )}
-            {renderHeadline(designType, pillar, isShowcase, headlineString, {
-                colour: pillarPalette[pillar].dark,
+            {renderHeadline({
+                designType,
+                pillar,
+                isShowcase,
+                headlineString,
+                byline,
+                tags,
+                options: {
+                    colour: pillarPalette[pillar].dark,
+                },
             })}
             {age && <AgeWarning age={age} isScreenReader={true} />}
         </>

--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -69,10 +69,12 @@ export const ArticleMeta = ({
         <div className={metaContainer}>
             <GuardianLines pillar={pillar} />
             <div className={cx(meta)}>
-                {/* For interview articles the byline appears below the headline */}
-                {designType !== 'Interview' && (
-                    <Contributor author={author} tags={tags} pillar={pillar} />
-                )}
+                <Contributor
+                    designType={designType}
+                    author={author}
+                    tags={tags}
+                    pillar={pillar}
+                />
                 <Dateline
                     dateDisplay={webPublicationDateDisplay}
                     descriptionText="Published on"

--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -45,29 +45,37 @@ const metaContainer = css`
 `;
 
 type Props = {
-    CAPI: CAPIType;
+    pillar: Pillar;
+    pageId: string;
+    webTitle: string;
+    author: AuthorType;
+    tags: TagType[];
+    webPublicationDateDisplay: string;
 };
 
-export const ArticleMeta = ({ CAPI }: Props) => {
-    const sharingUrls = getSharingUrls(CAPI.pageId, CAPI.webTitle);
+export const ArticleMeta = ({
+    pillar,
+    pageId,
+    webTitle,
+    author,
+    tags,
+    webPublicationDateDisplay,
+}: Props) => {
+    const sharingUrls = getSharingUrls(pageId, webTitle);
 
     return (
         <div className={metaContainer}>
-            <GuardianLines pillar={CAPI.pillar} />
+            <GuardianLines pillar={pillar} />
             <div className={cx(meta)}>
-                <Contributor
-                    author={CAPI.author}
-                    tags={CAPI.tags}
-                    pillar={CAPI.pillar}
-                />
+                <Contributor author={author} tags={tags} pillar={pillar} />
                 <Dateline
-                    dateDisplay={CAPI.webPublicationDateDisplay}
+                    dateDisplay={webPublicationDateDisplay}
                     descriptionText="Published on"
                 />
                 <div className={metaExtras}>
                     <SharingIcons
                         sharingUrls={sharingUrls}
-                        pillar={CAPI.pillar}
+                        pillar={pillar}
                         displayIcons={['facebook', 'twitter', 'email']}
                     />
                     <div data-island="share-count" />

--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -45,6 +45,7 @@ const metaContainer = css`
 `;
 
 type Props = {
+    designType: DesignType;
     pillar: Pillar;
     pageId: string;
     webTitle: string;
@@ -54,6 +55,7 @@ type Props = {
 };
 
 export const ArticleMeta = ({
+    designType,
     pillar,
     pageId,
     webTitle,
@@ -67,7 +69,10 @@ export const ArticleMeta = ({
         <div className={metaContainer}>
             <GuardianLines pillar={pillar} />
             <div className={cx(meta)}>
-                <Contributor author={author} tags={tags} pillar={pillar} />
+                {/* For interview articles the byline appears below the headline */}
+                {designType !== 'Interview' && (
+                    <Contributor author={author} tags={tags} pillar={pillar} />
+                )}
                 <Dateline
                     dateDisplay={webPublicationDateDisplay}
                     descriptionText="Published on"

--- a/src/web/components/BylineLink.tsx
+++ b/src/web/components/BylineLink.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+type Props = {
+    byline: string;
+    tags: TagType[];
+};
+
+// This crazy function aims to split bylines such as
+// 'Harry Potter in Hogwarts' to ['Harry Potter', 'in Hogwarts']
+// Or
+// 'Jane Doe and John Smith` to ['Jane Doe', ' and ', 'John Smith']
+// It does this so we can have separate links to both contributors
+const bylineAsTokens = (byline: string, tags: TagType[]): string[] => {
+    const contributorTags = tags
+        .filter(t => t.type === 'Contributor')
+        .map(c => c.title);
+    // The contributor tag title should exist inside the byline for this regex to work
+    const regex = new RegExp(`(${contributorTags.join('|')})`);
+
+    return byline.split(regex);
+};
+
+export const BylineLink = ({ byline, tags }: Props) => {
+    const renderedTokens = bylineAsTokens(byline, tags).map((token, i) => {
+        const associatedTags = tags.filter(t => t.title === token);
+        if (associatedTags.length > 0) {
+            return (
+                <ContributorLink
+                    contributor={token}
+                    contributorTagId={associatedTags[0].id}
+                    key={i}
+                />
+            );
+        }
+        return token;
+    });
+
+    return <>{renderedTokens}</>;
+};
+
+const ContributorLink: React.FC<{
+    contributor: string;
+    contributorTagId: string;
+}> = ({ contributor, contributorTagId }) => (
+    <a
+        rel="author"
+        data-link-name="auto tag link"
+        href={`//www.theguardian.com/${contributorTagId}`}
+    >
+        {contributor}
+    </a>
+);

--- a/src/web/components/Contributor.tsx
+++ b/src/web/components/Contributor.tsx
@@ -48,19 +48,22 @@ const bylineStyle = (pillar: Pillar) => css`
 `;
 
 export const Contributor: React.FC<{
+    designType: DesignType;
     author: AuthorType;
     tags: TagType[];
     pillar: Pillar;
-}> = ({ author, tags, pillar }) => {
+}> = ({ designType, author, tags, pillar }) => {
     if (!author.byline) {
         return null;
     }
 
     return (
         <address aria-label="Contributor info">
-            <div className={bylineStyle(pillar)}>
-                <BylineLink byline={author.byline} tags={tags} />
-            </div>
+            {designType !== 'Interview' && (
+                <div className={bylineStyle(pillar)}>
+                    <BylineLink byline={author.byline} tags={tags} />
+                </div>
+            )}
             {author.twitterHandle && (
                 <div className={twitterHandle}>
                     <TwitterIcon />

--- a/src/web/components/Contributor.tsx
+++ b/src/web/components/Contributor.tsx
@@ -61,8 +61,7 @@ const bylineAsTokens = (bylineText: string, tags: TagType[]): string[] => {
 const RenderContributor: React.FC<{
     bylineText: string;
     tags: TagType[];
-    pillar: Pillar;
-}> = ({ bylineText, tags, pillar }) => {
+}> = ({ bylineText, tags }) => {
     const renderedTokens = bylineAsTokens(bylineText, tags).map((token, i) => {
         const associatedTags = tags.filter(t => t.title === token);
         if (associatedTags.length > 0) {
@@ -77,7 +76,7 @@ const RenderContributor: React.FC<{
         return token;
     });
 
-    return <div className={bylineStyle(pillar)}>{renderedTokens}</div>;
+    return <>{renderedTokens}</>;
 };
 
 const ContributorLink: React.FC<{
@@ -104,11 +103,9 @@ export const Contributor: React.FC<{
 
     return (
         <address aria-label="Contributor info">
-            <RenderContributor
-                bylineText={author.byline}
-                tags={tags}
-                pillar={pillar}
-            />
+            <div className={bylineStyle(pillar)}>
+                <RenderContributor bylineText={author.byline} tags={tags} />
+            </div>
             {author.twitterHandle && (
                 <div className={twitterHandle}>
                     <TwitterIcon />

--- a/src/web/components/Contributor.tsx
+++ b/src/web/components/Contributor.tsx
@@ -60,26 +60,22 @@ const bylineAsTokens = (bylineText: string, tags: TagType[]): string[] => {
 
 const RenderContributor: React.FC<{
     bylineText: string;
-    contributorTags: TagType[];
+    tags: TagType[];
     pillar: Pillar;
-}> = ({ bylineText, contributorTags, pillar }) => {
-    const renderedTokens = bylineAsTokens(bylineText, contributorTags).map(
-        (token, i) => {
-            const associatedTags = contributorTags.filter(
-                t => t.title === token,
+}> = ({ bylineText, tags, pillar }) => {
+    const renderedTokens = bylineAsTokens(bylineText, tags).map((token, i) => {
+        const associatedTags = tags.filter(t => t.title === token);
+        if (associatedTags.length > 0) {
+            return (
+                <ContributorLink
+                    contributor={token}
+                    contributorTagId={associatedTags[0].id}
+                    key={i}
+                />
             );
-            if (associatedTags.length > 0) {
-                return (
-                    <ContributorLink
-                        contributor={token}
-                        contributorTagId={associatedTags[0].id}
-                        key={i}
-                    />
-                );
-            }
-            return token;
-        },
-    );
+        }
+        return token;
+    });
 
     return <div className={bylineStyle(pillar)}>{renderedTokens}</div>;
 };
@@ -110,7 +106,7 @@ export const Contributor: React.FC<{
         <address aria-label="Contributor info">
             <RenderContributor
                 bylineText={author.byline}
-                contributorTags={tags}
+                tags={tags}
                 pillar={pillar}
             />
             {author.twitterHandle && (

--- a/src/web/components/Contributor.tsx
+++ b/src/web/components/Contributor.tsx
@@ -1,9 +1,13 @@
 import React from 'react';
 import { css } from 'emotion';
-import TwitterIcon from '@frontend/static/icons/twitter.svg';
+
 import { palette } from '@guardian/src-foundations';
 import { headline, textSans } from '@guardian/src-foundations/typography';
 import { pillarPalette } from '@root/src/lib/pillars';
+
+import { BylineLink } from '@frontend/web/components/BylineLink';
+
+import TwitterIcon from '@frontend/static/icons/twitter.svg';
 
 const twitterHandle = css`
     ${textSans.xsmall()};
@@ -43,55 +47,6 @@ const bylineStyle = (pillar: Pillar) => css`
     }
 `;
 
-// This crazy function aims to split bylines such as
-// 'Harry Potter in Hogwarts' to ['Harry Potter', 'in Hogwarts']
-// Or
-// 'Jane Doe and John Smith` to ['Jane Doe', ' and ', 'John Smith']
-// It does this so we can have separate links to both contributors
-const bylineAsTokens = (bylineText: string, tags: TagType[]): string[] => {
-    const contributorTags = tags
-        .filter(t => t.type === 'Contributor')
-        .map(c => c.title);
-    // The contributor tag title should exist inside the bylineText for this regex to work
-    const regex = new RegExp(`(${contributorTags.join('|')})`);
-
-    return bylineText.split(regex);
-};
-
-const RenderContributor: React.FC<{
-    bylineText: string;
-    tags: TagType[];
-}> = ({ bylineText, tags }) => {
-    const renderedTokens = bylineAsTokens(bylineText, tags).map((token, i) => {
-        const associatedTags = tags.filter(t => t.title === token);
-        if (associatedTags.length > 0) {
-            return (
-                <ContributorLink
-                    contributor={token}
-                    contributorTagId={associatedTags[0].id}
-                    key={i}
-                />
-            );
-        }
-        return token;
-    });
-
-    return <>{renderedTokens}</>;
-};
-
-const ContributorLink: React.FC<{
-    contributor: string;
-    contributorTagId: string;
-}> = ({ contributor, contributorTagId }) => (
-    <a
-        rel="author"
-        data-link-name="auto tag link"
-        href={`//www.theguardian.com/${contributorTagId}`}
-    >
-        {contributor}
-    </a>
-);
-
 export const Contributor: React.FC<{
     author: AuthorType;
     tags: TagType[];
@@ -104,7 +59,7 @@ export const Contributor: React.FC<{
     return (
         <address aria-label="Contributor info">
             <div className={bylineStyle(pillar)}>
-                <RenderContributor bylineText={author.byline} tags={tags} />
+                <BylineLink byline={author.byline} tags={tags} />
             </div>
             {author.twitterHandle && (
                 <div className={twitterHandle}>

--- a/src/web/components/GuardianLines.stories.tsx
+++ b/src/web/components/GuardianLines.stories.tsx
@@ -94,6 +94,7 @@ export const paddedLines = () => {
                         <div style={{ marginTop: '30px' }} />
                         <GuardianLines />
                         <Contributor
+                            designType="Article"
                             author={{ byline: 'Jane doe' }}
                             tags={[]}
                             pillar="news"
@@ -131,6 +132,7 @@ export const squigglyLines = () => {
                         <div style={{ marginTop: '30px' }} />
                         <GuardianLines squiggly={true} />
                         <Contributor
+                            designType="Article"
                             author={{ byline: 'Jane doe' }}
                             tags={[]}
                             pillar="news"

--- a/src/web/components/HeadlineByline.tsx
+++ b/src/web/components/HeadlineByline.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { css } from 'emotion';
+import { palette } from '@guardian/src-foundations';
+import { headline } from '@guardian/src-foundations/typography';
+
+import { BylineLink } from '@root/src/web/components/BylineLink';
+
+const wrapperStyles = css`
+    margin-left: 6px;
+    margin-top: 5px;
+    /* Without z-index here the byline appears behind the main image for showcase views */
+    z-index: 1;
+`;
+
+const headlineBylineStyles = css`
+    ${headline.xxsmall({
+        fontWeight: 'regular',
+        lineHeight: 'loose',
+    })}
+    font-style: italic;
+    background-color: ${palette.brandYellow.main};
+    box-shadow: 4px 0 0 ${palette.brandYellow.main},
+        -6px 0 0 ${palette.brandYellow.main};
+    display: inline-block;
+    box-decoration-break: clone;
+
+    a {
+        color: inherit;
+        text-decoration: none;
+        :hover {
+            text-decoration: underline;
+        }
+    }
+`;
+
+type Props = {
+    byline: string;
+    tags: TagType[];
+};
+
+export const HeadlineByline = ({ byline, tags }: Props) => (
+    <div className={wrapperStyles}>
+        <div className={headlineBylineStyles}>
+            <BylineLink byline={byline} tags={tags} />
+        </div>
+    </div>
+);

--- a/src/web/layouts/ShowcaseHeader.tsx
+++ b/src/web/layouts/ShowcaseHeader.tsx
@@ -78,6 +78,7 @@ export const ShowcaseHeader = ({ CAPI, badge }: Props) => {
                     webPublicationDate={webPublicationDate}
                     tags={tags}
                     isShowcase={true}
+                    byline={CAPI.author.byline}
                 />
             </HeaderItem>
             <HeaderItem order={3}>

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -96,6 +96,7 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                     <LeftColumn>
                         <ArticleTitle CAPI={CAPI} inLeftCol={true} />
                         <ArticleMeta
+                            designType={CAPI.designType}
                             pillar={CAPI.pillar}
                             pageId={CAPI.pageId}
                             webTitle={CAPI.webTitle}
@@ -117,6 +118,7 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                                 <Hide when="above" breakpoint="leftCol">
                                     <ShowcaseHeader CAPI={CAPI} />
                                     <ArticleMeta
+                                        designType={CAPI.designType}
                                         pillar={CAPI.pillar}
                                         pageId={CAPI.pageId}
                                         webTitle={CAPI.webTitle}

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -95,7 +95,16 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                 <Flex>
                     <LeftColumn>
                         <ArticleTitle CAPI={CAPI} inLeftCol={true} />
-                        <ArticleMeta CAPI={CAPI} />
+                        <ArticleMeta
+                            pillar={CAPI.pillar}
+                            pageId={CAPI.pageId}
+                            webTitle={CAPI.webTitle}
+                            author={CAPI.author}
+                            tags={CAPI.tags}
+                            webPublicationDateDisplay={
+                                CAPI.webPublicationDateDisplay
+                            }
+                        />
                     </LeftColumn>
                     <ArticleContainer>
                         {/* When BELOW leftCol we display the header in this position, at the top of the page */}
@@ -107,7 +116,16 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                                 {/* When ABOVE leftCol we display the header in this position, above the article body, underneath the full width image */}
                                 <Hide when="above" breakpoint="leftCol">
                                     <ShowcaseHeader CAPI={CAPI} />
-                                    <ArticleMeta CAPI={CAPI} />
+                                    <ArticleMeta
+                                        pillar={CAPI.pillar}
+                                        pageId={CAPI.pageId}
+                                        webTitle={CAPI.webTitle}
+                                        author={CAPI.author}
+                                        tags={CAPI.tags}
+                                        webPublicationDateDisplay={
+                                            CAPI.webPublicationDateDisplay
+                                        }
+                                    />
                                 </Hide>
 
                                 <main

--- a/src/web/layouts/StandardHeader.tsx
+++ b/src/web/layouts/StandardHeader.tsx
@@ -78,6 +78,7 @@ export const StandardHeader = ({ CAPI, badge }: Props) => {
                     pillar={pillar}
                     webPublicationDate={webPublicationDate}
                     tags={tags}
+                    byline={CAPI.author.byline}
                 />
             </HeaderItem>
             <HeaderItem order={3}>

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -113,12 +113,30 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                             badge={GE2019Badge}
                             inLeftCol={true}
                         />
-                        <ArticleMeta CAPI={CAPI} />
+                        <ArticleMeta
+                            pillar={CAPI.pillar}
+                            pageId={CAPI.pageId}
+                            webTitle={CAPI.webTitle}
+                            author={CAPI.author}
+                            tags={CAPI.tags}
+                            webPublicationDateDisplay={
+                                CAPI.webPublicationDateDisplay
+                            }
+                        />
                     </LeftColumn>
                     <ArticleContainer>
                         <StandardHeader CAPI={CAPI} badge={GE2019Badge} />
                         <Hide when="above" breakpoint="leftCol">
-                            <ArticleMeta CAPI={CAPI} />
+                            <ArticleMeta
+                                pillar={CAPI.pillar}
+                                pageId={CAPI.pageId}
+                                webTitle={CAPI.webTitle}
+                                author={CAPI.author}
+                                tags={CAPI.tags}
+                                webPublicationDateDisplay={
+                                    CAPI.webPublicationDateDisplay
+                                }
+                            />
                         </Hide>
                         <main
                             className={css`

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -114,6 +114,7 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                             inLeftCol={true}
                         />
                         <ArticleMeta
+                            designType={CAPI.designType}
                             pillar={CAPI.pillar}
                             pageId={CAPI.pageId}
                             webTitle={CAPI.webTitle}
@@ -128,6 +129,7 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                         <StandardHeader CAPI={CAPI} badge={GE2019Badge} />
                         <Hide when="above" breakpoint="leftCol">
                             <ArticleMeta
+                                designType={CAPI.designType}
                                 pillar={CAPI.pillar}
                                 pageId={CAPI.pageId}
                                 webTitle={CAPI.webTitle}


### PR DESCRIPTION
## What does this change?
Shows the headline byline underneath the article headline when designType equals 'Interview'

To achieve this, this PR first breaks out the logic for building the byline text with embedded a tags (`BylineLink`) away from the fixed styling that it originally had so that it can now be called independently, and styles added separately. This allows the same link logic to be used in multiple places with different appearences. It also has the added advantage of simplifying each component

## Before
![Screenshot 2019-12-20 at 12 16 17](https://user-images.githubusercontent.com/1336821/71254352-92faed80-2322-11ea-93ff-27666a303f4f.jpg)

## After
![Screenshot 2019-12-20 at 12 22 00](https://user-images.githubusercontent.com/1336821/71254598-609dc000-2323-11ea-96ee-f1735a5d581c.jpg)



## Link to supporting Trello card
https://trello.com/c/bk6nak0W/825-headline-byline
