### PR TITLE
Ensure builds pass no matter the result from Chromatic

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "cypress:run:e2e": "cypress run --spec 'cypress/integration/e2e/**/*'",
         "storybook": "node --max-old-space-size=4096 $(yarn bin)/start-storybook -s ./src/static -p 6006",
         "storybook:build": "node --max-old-space-size=4096 $(yarn bin)/build-storybook",
-        "chromatic": "chromatic --build-script-name=storybook:build"
+        "chromatic": "chromatic --build-script-name=storybook:build --exit-zero-on-changes"
     },
     "husky": {
         "hooks": {


### PR DESCRIPTION
## What does this change?
Tells Chromatic to exit happy no matter what

## Why?
Otherwise it will fail our builds when it sees visual diffs, which is not the flow we want

## Link to supporting Trello card
https://trello.com/c/awMkJpx4/1022-chromaticqa