### PR TITLE
DCR not hydrating in IE11

### DIFF
--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -48,7 +48,7 @@ export const document = ({ data }: Props) => {
     ];
 
     const polyfillIO =
-        'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,es2018,default,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,fetch,NodeList.prototype.forEach&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1';
+        'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,es2018,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,fetch,NodeList.prototype.forEach&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1';
 
     /**
      * The highest priority scripts.


### PR DESCRIPTION
## What does this change?

It aligns the polyfill.io call link with what's used in production.

## Why?

The ads and most viewed element were not being shown on articles.

## Link to supporting Trello card
https://trello.com/c/DuxUVPko/1017-dcr-not-hydrating-in-ie11