### PR TITLE
Add byline test

### DIFF
--- a/src/web/components/MostViewed/MostViewed.mocks.tsx
+++ b/src/web/components/MostViewed/MostViewed.mocks.tsx
@@ -114,7 +114,7 @@ export const mockTab1 = {
             url:
                 'https://www.theguardian.com/commentisfree/2019/sep/15/government-boris-johnson-incredible-hulk-sam-gyimah',
             headline:
-                'LINKTEXT There’s nothing normal about this beast of a government | Matthew d’Ancona',
+                'LINKTEXT There’s nothing normal about this beast of a government',
             showByline: true,
             byline: 'Matthew d’Ancona',
             image:

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.test.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.test.tsx
@@ -87,19 +87,6 @@ describe('MostViewedFooter', () => {
         ).not.toBeInTheDocument();
     });
 
-    // TODO: Restore this once the component has this feature added to it
-    it.skip('should show a byline when this property is set to true', async () => {
-        useApi.mockReturnValue({ data: responseWithTwoTabs });
-
-        const { getByText } = render(
-            <MostViewedFooter sectionName="Section Name" pillar="news" />,
-        );
-
-        expect(
-            getByText(responseWithTwoTabs.tabs[0].trails[9].byline),
-        ).toBeInTheDocument();
-    });
-
     it("should display the text 'Live' for live blogs", () => {
         useApi.mockReturnValue({
             data: [

--- a/src/web/components/MostViewed/MostViewedRight/MostViewedRight.test.tsx
+++ b/src/web/components/MostViewed/MostViewedRight/MostViewedRight.test.tsx
@@ -52,4 +52,13 @@ describe('MostViewedList', () => {
         // Renders appropriate number of age warnins
         expect(getAllByText(/This article is more than/).length).toBe(1);
     });
+
+    // TODO: Restore this once the component has this feature added to it
+    it('should show a byline when this property is set to true', async () => {
+        useApi.mockReturnValue(response);
+
+        const { getByText } = render(<MostViewedRight pillar="news" />);
+
+        expect(getByText(response.data.trails[0].byline)).toBeInTheDocument();
+    });
 });


### PR DESCRIPTION
## What does this change?
Adds a test for the presence of the byline text in the most viewed right component.

## Why?
This test was skipped pending the addition of this feature. Now it has been added the test should be enabled.

## Link to supporting Trello card
https://trello.com/c/i86IGKof/1026-add-test-for-byline-text