### PR TITLE
first-child > first-of-type

### DIFF
--- a/src/web/components/MostViewed/MostViewedRight/MostViewedRightItem.tsx
+++ b/src/web/components/MostViewed/MostViewedRight/MostViewedRightItem.tsx
@@ -13,7 +13,7 @@ const listItemStyles = css`
     margin-bottom: 12px;
     border-top: 1px solid ${palette.neutral[86]};
 
-    &:first-child {
+    &:first-of-type {
         padding-top: 0;
         border-top: none;
     }


### PR DESCRIPTION
## What does this change?
Replaces the css selector `first-child` with `first-of-type`

## Why?
Because emotion told me to

`The pseudo class ":first-child" is potentially unsafe when doing server-side rendering. Try changing it to ":first-of-type"`

## Link to supporting Trello card
https://trello.com/c/4H4setFz/1027-first-child-first-of-type
