### PR TITLE
Only show twitter handle when exactly one contributor

### DIFF
--- a/src/web/components/Contributor.tsx
+++ b/src/web/components/Contributor.tsx
@@ -57,6 +57,9 @@ export const Contributor: React.FC<{
         return null;
     }
 
+    const onlyOneContributor: boolean =
+        tags.filter(tag => tag.type === 'Contributor').length === 1;
+
     return (
         <address aria-label="Contributor info">
             {designType !== 'Interview' && (
@@ -64,7 +67,7 @@ export const Contributor: React.FC<{
                     <BylineLink byline={author.byline} tags={tags} />
                 </div>
             )}
-            {author.twitterHandle && (
+            {onlyOneContributor && author.twitterHandle && (
                 <div className={twitterHandle}>
                     <TwitterIcon />
                     <a


### PR DESCRIPTION
## What does this change?
This hides the first author's twitter handle when there are multiple contributors

## Why?
For parity and, you know, to be fair to the other author

## Before
![Screenshot 2020-01-03 at 15 52 17](https://user-images.githubusercontent.com/1336821/71733252-0b909c80-2e41-11ea-99da-90bf418af88d.jpg)

## After
![Screenshot 2020-01-03 at 15 52 03](https://user-images.githubusercontent.com/1336821/71733283-1814f500-2e41-11ea-912f-ceb9a2466f53.jpg)

## Link to supporting Trello card
https://trello.com/c/4poiDVup/231-twitter-handle-should-not-appear-when-2-authors