### PR TITLE
Theme Colour

### DIFF
--- a/src/web/server/htmlTemplate.ts
+++ b/src/web/server/htmlTemplate.ts
@@ -3,6 +3,8 @@ import { getFontsCss } from '@root/src/lib/fonts-css';
 import { getStatic } from '@root/src/lib/assets';
 import { prepareCmpString } from '@root/src/web/browser/prepareCmp';
 
+import { palette } from '@guardian/src-foundations';
+
 export const htmlTemplate = ({
     title = 'The Guardian',
     description,
@@ -71,6 +73,7 @@ export const htmlTemplate = ({
                 <meta charset="utf-8">
 
                 <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+                <meta name="theme-color" content="${palette.brand.main}" />
                 <link rel="icon" href="https://static.guim.co.uk/images/${favicon}">
 
                 <script type="application/ld+json">


### PR DESCRIPTION
## What does this change?
Adds the theme-color meta tag to style the background colour of the header for Chrome on Android

## Why?
Parity and more blueness

## Link to supporting Trello card
https://trello.com/c/fbL6j3Iv/1029-header-gets-theme-colour-for-chrome-on-android
