### PR TITLE
Breadcrumb font sizing

### DIFF
--- a/src/web/components/SubNav/Inner.tsx
+++ b/src/web/components/SubNav/Inner.tsx
@@ -56,7 +56,6 @@ const fontStyle = css`
 
     ${from.tablet} {
         height: 42px;
-        ${textSans.medium()};
         /* Design System: We're overriding source foundation here for parity as 'medium' is too big */
         font-size: 16px;
         /* Design System: Line height is being used here for centering layout, we need the primitives */

--- a/src/web/components/SubNav/Inner.tsx
+++ b/src/web/components/SubNav/Inner.tsx
@@ -42,10 +42,13 @@ const subnavCollapsed = css`
 `;
 
 const fontStyle = css`
-    ${textSans.medium()};
+    ${textSans.small()};
+    /* Design System: We're overriding source foundation here for parity as 'small' is not small enough */
+    font-size: 14px;
+
     font-weight: 500;
     color: ${palette.neutral[7]};
-    padding: 0 5px;
+    padding: 0 4px;
     height: 36px;
     /* Design System: Line height is being used here for centering layout, we need the primitives */
     /* stylelint-disable-next-line property-blacklist */
@@ -53,6 +56,9 @@ const fontStyle = css`
 
     ${from.tablet} {
         height: 42px;
+        ${textSans.medium()};
+        /* Design System: We're overriding source foundation here for parity as 'medium' is too big */
+        font-size: 16px;
         /* Design System: Line height is being used here for centering layout, we need the primitives */
         /* stylelint-disable-next-line property-blacklist */
         line-height: 42px;


### PR DESCRIPTION
## What does this change?
This overrides source foundation and sets the breadcrumb font sizes (for different widths)

## Why?
For absolute parity now. The Subnav is a primary element and having a different font size between DCR and frontend is jarring.

## Should we change source foundation, change the subnav font size to fit or are we happy using overrides?
@SiAdcock I'm happy with the override, it does the job. But at the same time it would obviously be great to have all these things inside src. Is there scope for supporting `14px` and `16px`?

## Before
![Screenshot 2020-01-06 at 12 09 18](https://user-images.githubusercontent.com/1336821/71817347-78907600-307d-11ea-853b-69deef63a15b.jpg)


## After
![Screenshot 2020-01-06 at 12 09 44](https://user-images.githubusercontent.com/1336821/71817344-74645880-307d-11ea-978c-ce152bcab17d.jpg)


## Link to supporting Trello card
https://trello.com/c/HS8rakYe/749-visual-parity
