### PR TITLE
Prevent edition sitting too low when text is longer

### DIFF
--- a/src/web/components/Header/EditionDropdown.tsx
+++ b/src/web/components/Header/EditionDropdown.tsx
@@ -6,6 +6,7 @@ import { palette } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 
 const editionDropdown = css`
+    display: flex;
     position: absolute;
     right: 11px;
     z-index: 1072;


### PR DESCRIPTION
## What does this change?
Fixes a layout problem where, with longer edition text and at smaller screen widths, the edition dropdown label was positioned incorrectly

## Before
![Screenshot 2020-01-06 at 12 27 47](https://user-images.githubusercontent.com/1336821/71818173-22710200-3080-11ea-8414-c01dd4ca4d04.jpg)


## After
![Screenshot 2020-01-06 at 12 28 44](https://user-images.githubusercontent.com/1336821/71818180-256bf280-3080-11ea-9b71-294627cc07c1.jpg)


## Link to supporting Trello card
https://trello.com/c/SkrXCXVW/1032-fix-edition-spacing