### PR TITLE
Refactor Section Links

### DIFF
--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -65,45 +65,52 @@ export const SeriesSectionLink: React.FC<{
     CAPI: CAPIType;
     fallbackToSection: boolean;
 }> = ({ CAPI, fallbackToSection }) => {
-    const tag = CAPI.tags.find(t => t.type === 'Blog' || t.type === 'Series');
+    const { tags, sectionLabel, sectionUrl, guardianBaseURL, pillar } = CAPI;
 
-    if (!tag && !fallbackToSection) {
-        return null;
-    }
+    const blogTag = tags.find(tag => tag.type === 'Blog');
+    const seriesTag = tags.find(tag => tag.type === 'Series');
+    const publicationTag = tags.find(tag => tag.type === 'Publication');
 
-    if (!tag && (CAPI.sectionLabel && CAPI.sectionUrl)) {
-        return (
-            <TagLink
-                pillar={CAPI.pillar}
-                guardianBaseURL={CAPI.guardianBaseURL}
-                tagTitle={CAPI.sectionLabel}
-                tagUrl={CAPI.sectionUrl}
-                dataLinkName="article section"
-                weightingClass={primaryStyle}
-            />
-        );
-    }
+    if (
+        blogTag ||
+        seriesTag ||
+        (publicationTag && publicationTag.title === 'The Observer')
+    ) {
+        // Chose tag to use based on this order or importance
+        const tag = blogTag || seriesTag || publicationTag;
 
-    if (tag) {
-        return (
+        return tag ? (
             <>
                 <TagLink
-                    pillar={CAPI.pillar}
-                    guardianBaseURL={CAPI.guardianBaseURL}
+                    pillar={pillar}
+                    guardianBaseURL={guardianBaseURL}
                     tagTitle={tag.title}
                     tagUrl={tag.id}
                     dataLinkName="article series"
                     weightingClass={primaryStyle}
                 />
                 <TagLink
-                    pillar={CAPI.pillar}
-                    guardianBaseURL={CAPI.guardianBaseURL}
-                    tagTitle={CAPI.sectionLabel}
-                    tagUrl={CAPI.sectionUrl}
+                    pillar={pillar}
+                    guardianBaseURL={guardianBaseURL}
+                    tagTitle={sectionLabel}
+                    tagUrl={sectionUrl}
                     dataLinkName="article section"
                     weightingClass={secondaryStyle}
                 />
             </>
+        ) : null;
+    }
+
+    if (fallbackToSection && (sectionLabel && sectionUrl)) {
+        return (
+            <TagLink
+                pillar={pillar}
+                guardianBaseURL={guardianBaseURL}
+                tagTitle={sectionLabel}
+                tagUrl={sectionUrl}
+                dataLinkName="article section"
+                weightingClass={primaryStyle}
+            />
         );
     }
 

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -76,7 +76,7 @@ export const SeriesSectionLink: React.FC<{
         seriesTag ||
         (publicationTag && publicationTag.title === 'The Observer')
     ) {
-        // Chose tag to use based on this order or importance
+        // Chose tag to use based on this order of importance
         const tag = blogTag || seriesTag || publicationTag;
 
         return tag ? (

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -4,10 +4,6 @@ import { pillarMap, pillarPalette } from '@root/src/lib/pillars';
 import { headline } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 
-const sectionLabelText = css`
-    font-weight: 700;
-`;
-
 const sectionLabelLink = css`
     text-decoration: none;
     :hover {
@@ -24,14 +20,14 @@ const pillarColours = pillarMap(
 
 const primaryStyle = css`
     font-weight: 700;
-    ${headline.xxxsmall()};
+    ${headline.xxxsmall({ fontWeight: 'bold' })};
     ${from.leftCol} {
-        ${headline.xxsmall()};
+        ${headline.xxsmall({ fontWeight: 'bold' })};
     }
 `;
 
 const secondaryStyle = css`
-    ${headline.xxxsmall()};
+    ${headline.xxxsmall({ fontWeight: 'regular' })};
     display: block;
 `;
 
@@ -60,7 +56,7 @@ const TagLink: React.FC<{
             )}
             data-link-name={dataLinkName}
         >
-            <span className={sectionLabelText}>{tagTitle}</span>
+            <span>{tagTitle}</span>
         </a>
     );
 };


### PR DESCRIPTION
## What does this change?
This PR adds support for The Observer section title as well as fixing the font weight for secondary section titles

## Before
![Screenshot 2020-01-06 at 16 48 02](https://user-images.githubusercontent.com/1336821/71833180-552cf180-30a4-11ea-8f7a-12d34db4c052.jpg)


## After
![Screenshot 2020-01-06 at 16 47 22](https://user-images.githubusercontent.com/1336821/71833120-3cbcd700-30a4-11ea-8756-c30018a3b792.jpg)


## Link to supporting Trello card
https://trello.com/c/pjtuqjiL/823-section-links