### PR TITLE
Fix Media Cards

### DIFF
--- a/src/web/components/Card/components/MediaMeta.tsx
+++ b/src/web/components/Card/components/MediaMeta.tsx
@@ -14,7 +14,7 @@ type Props = {
     mediaDuration?: number;
 };
 
-const iconWrapperStyles = ({ pillar, mediaType }: Props) => css`
+const iconWrapperStyles = (mediaType: MediaType, pillar: Pillar) => css`
     width: 24px;
     height: 23px;
     /* Below we force the colour to be opinion if the pillar is news (because it looks better) */
@@ -35,7 +35,7 @@ const iconWrapperStyles = ({ pillar, mediaType }: Props) => css`
     }
 `;
 
-const durationStyles = ({ pillar }: Props) => css`
+const durationStyles = (pillar: Pillar) => css`
     color: ${palette[pillar].main};
     ${textSans.xsmall({ fontWeight: `bold` })}
 `;
@@ -68,7 +68,7 @@ export function secondsToDuration(secs?: number): string {
     return duration.join(':');
 }
 
-const Icon = ({ mediaType }: Props) => {
+const Icon = ({ mediaType }: { mediaType: MediaType }) => {
     switch (mediaType) {
         case 'Gallery':
             return <Photo />;
@@ -79,22 +79,34 @@ const Icon = ({ mediaType }: Props) => {
     }
 };
 
-const MediaIcon = (props: Props) => (
-    <span className={iconWrapperStyles(props)}>
-        <Icon {...props} />
+const MediaIcon = ({
+    mediaType,
+    pillar,
+}: {
+    mediaType: MediaType;
+    pillar: Pillar;
+}) => (
+    <span className={iconWrapperStyles(mediaType, pillar)}>
+        <Icon mediaType={mediaType} />
     </span>
 );
 
-const MediaDuration = (props: Props) => (
-    <p className={durationStyles(props)}>
-        {secondsToDuration(props.mediaDuration)}
-    </p>
+const MediaDuration = ({
+    mediaDuration,
+    pillar,
+}: {
+    mediaDuration: number;
+    pillar: Pillar;
+}) => (
+    <p className={durationStyles(pillar)}>{secondsToDuration(mediaDuration)}</p>
 );
 
-export const MediaMeta = (props: Props) => (
+export const MediaMeta = ({ mediaType, mediaDuration, pillar }: Props) => (
     <div className={wrapperStyles}>
-        <MediaIcon {...props} />
+        <MediaIcon mediaType={mediaType} pillar={pillar} />
         &nbsp;
-        {props.mediaDuration && <MediaDuration {...props} />}
+        {mediaDuration && (
+            <MediaDuration mediaDuration={mediaDuration} pillar={pillar} />
+        )}
     </div>
 );

--- a/src/web/components/Card/components/MediaMeta.tsx
+++ b/src/web/components/Card/components/MediaMeta.tsx
@@ -68,7 +68,7 @@ export function secondsToDuration(secs?: number): string {
     return duration.join(':');
 }
 
-export const Icon = ({ mediaType }: Props) => {
+const Icon = ({ mediaType }: Props) => {
     switch (mediaType) {
         case 'Gallery':
             return <Photo />;
@@ -79,13 +79,13 @@ export const Icon = ({ mediaType }: Props) => {
     }
 };
 
-export const MediaIcon = (props: Props) => (
+const MediaIcon = (props: Props) => (
     <span className={iconWrapperStyles(props)}>
         <Icon {...props} />
     </span>
 );
 
-export const MediaDuration = (props: Props) => (
+const MediaDuration = (props: Props) => (
     <p className={durationStyles(props)}>
         {secondsToDuration(props.mediaDuration)}
     </p>

--- a/src/web/components/Card/components/MediaMeta.tsx
+++ b/src/web/components/Card/components/MediaMeta.tsx
@@ -36,7 +36,8 @@ const iconWrapperStyles = (mediaType: MediaType, pillar: Pillar) => css`
 `;
 
 const durationStyles = (pillar: Pillar) => css`
-    color: ${palette[pillar].main};
+    /* Below we force the colour to be opinion if the pillar is news (because it looks better) */
+    color: ${pillar === 'news' ? palette.opinion.main : palette[pillar].main};
     ${textSans.xsmall({ fontWeight: `bold` })}
 `;
 

--- a/src/web/components/Card/components/MediaMeta.tsx
+++ b/src/web/components/Card/components/MediaMeta.tsx
@@ -17,7 +17,10 @@ type Props = {
 const iconWrapperStyles = ({ pillar, mediaType }: Props) => css`
     width: 24px;
     height: 23px;
-    background-color: ${palette[pillar].main};
+    /* Below we force the colour to be opinion if the pillar is news (because it looks better) */
+    background-color: ${pillar === 'news'
+        ? palette.opinion.main
+        : palette[pillar].main};
     border-radius: 50%;
     display: inline-block;
 

--- a/src/web/components/Card/components/MediaMeta.tsx
+++ b/src/web/components/Card/components/MediaMeta.tsx
@@ -17,9 +17,9 @@ type Props = {
 const iconWrapperStyles = (mediaType: MediaType, pillar: Pillar) => css`
     width: 24px;
     height: 23px;
-    /* Below we force the colour to be opinion if the pillar is news (because it looks better) */
+    /* Below we force the colour to be bright if the pillar is news (because it looks better) */
     background-color: ${pillar === 'news'
-        ? palette.opinion.main
+        ? palette[pillar].bright
         : palette[pillar].main};
     border-radius: 50%;
     display: inline-block;
@@ -36,8 +36,8 @@ const iconWrapperStyles = (mediaType: MediaType, pillar: Pillar) => css`
 `;
 
 const durationStyles = (pillar: Pillar) => css`
-    /* Below we force the colour to be opinion if the pillar is news (because it looks better) */
-    color: ${pillar === 'news' ? palette.opinion.main : palette[pillar].main};
+    /* Below we force the colour to be bright if the pillar is news (because it looks better) */
+    color: ${pillar === 'news' ? palette[pillar].bright : palette[pillar].main};
     ${textSans.xsmall({ fontWeight: `bold` })}
 `;
 

--- a/src/web/components/Kicker.tsx
+++ b/src/web/components/Kicker.tsx
@@ -30,9 +30,13 @@ const decideColour = (
         case 'Live':
             // TODO: We need this colour in source foundation
             return inCard ? decidePillarLight(pillar) : palette[pillar].main;
+        case 'Media':
+            // On Media cards, when pillar is news we use the opinion colour as this looks better on a dark background vs. news
+            return inCard && pillar === 'news'
+                ? palette.opinion.main
+                : palette[pillar].main;
         case 'Feature':
         case 'Interview':
-        case 'Media':
         case 'Analysis':
         case 'Article':
         case 'Review':

--- a/src/web/components/Kicker.tsx
+++ b/src/web/components/Kicker.tsx
@@ -31,9 +31,9 @@ const decideColour = (
             // TODO: We need this colour in source foundation
             return inCard ? decidePillarLight(pillar) : palette[pillar].main;
         case 'Media':
-            // On Media cards, when pillar is news we use the opinion colour as this looks better on a dark background vs. news
+            // On Media cards, when pillar is news we use the bright colour as this looks better on a dark background vs. main
             return inCard && pillar === 'news'
-                ? palette.opinion.main
+                ? palette[pillar].bright
                 : palette[pillar].main;
         case 'Feature':
         case 'Interview':

--- a/src/web/components/Onwards/StoryPackage.tsx
+++ b/src/web/components/Onwards/StoryPackage.tsx
@@ -137,6 +137,8 @@ export const StoryPackage = ({ content }: Props) => (
                         showPulsingDot: content[4].isLiveBlog,
                         showSlash: true,
                         showClock: false,
+                        mediaType: content[4].mediaType,
+                        mediaDuration: content[4].mediaDuration,
                     }}
                 />
             </LI>
@@ -162,6 +164,8 @@ export const StoryPackage = ({ content }: Props) => (
                         showPulsingDot: content[5].isLiveBlog,
                         showSlash: true,
                         showClock: false,
+                        mediaType: content[5].mediaType,
+                        mediaDuration: content[5].mediaDuration,
                     }}
                 />
             </LI>
@@ -187,6 +191,8 @@ export const StoryPackage = ({ content }: Props) => (
                         showPulsingDot: content[6].isLiveBlog,
                         showSlash: true,
                         showClock: false,
+                        mediaType: content[6].mediaType,
+                        mediaDuration: content[6].mediaDuration,
                     }}
                 />
             </LI>
@@ -212,6 +218,8 @@ export const StoryPackage = ({ content }: Props) => (
                         showPulsingDot: content[7].isLiveBlog,
                         showSlash: true,
                         showClock: false,
+                        mediaType: content[7].mediaType,
+                        mediaDuration: content[7].mediaDuration,
                     }}
                 />
             </LI>


### PR DESCRIPTION
## What does this change?
This PR ensures Video media cards display correctly when `mediaType` is `Video`. It:

1. Adds some missing props in StoryPackage and
2. Replaces the news pillar colour with opinion

## Why?
Parity

## Link to supporting Trello card
https://trello.com/c/jvwweqTl/1011-mediaduration-mediatype
