### PR TITLE
Outbrain layout and formatting

### DIFF
--- a/src/web/components/Outbrain.tsx
+++ b/src/web/components/Outbrain.tsx
@@ -48,6 +48,11 @@ const outbrainContainer = css`
         padding-bottom: 12px;
     }
 
+    .ob_about_this_content {
+        display: none;
+    }
+`;
+
 export const OutbrainContainer: React.FC<{}> = () => {
     return (
         <div className={outbrainContainer}>

--- a/src/web/components/Outbrain.tsx
+++ b/src/web/components/Outbrain.tsx
@@ -1,6 +1,4 @@
 import React from 'react';
-import { css } from 'emotion';
-import { textSans, body, headline } from '@guardian/src-foundations/typography';
 
 interface OutbrainSelectors {
     widget: string;
@@ -43,41 +41,6 @@ const OutbrainWidget: React.FC<{}> = ({}) => {
     );
 };
 
-const outbrainContainer = css`
-    .js-outbrain-container {
-        padding-top: 20px;
-        padding-bottom: 20px;
-    }
-    .ob-widget {
-        div.ob-widget-header {
-            ${headline.xsmall()};
-            font-weight: 900;
-            span,
-            .ob_about_this_content a {
-                ${body.small({ fontWeight: 'regular' })};
-                font-size: 17px;
-
-                text-decoration: none;
-                /* stylelint-disable-next-line color-no-hex */
-                color: #00456e;
-            }
-        }
-        div.ob-widget-section {
-            margin-top: 0px;
-        }
-
-        span.ob-rec-text {
-            max-height: fit-content;
-            ${textSans.medium({ fontWeight: 'bold' })};
-            font-size: 16px;
-        }
-    }
-`;
-
 export const OutbrainContainer: React.FC<{}> = () => {
-    return (
-        <div className={outbrainContainer}>
-            <OutbrainWidget />
-        </div>
-    );
+    return <OutbrainWidget />;
 };

--- a/src/web/components/Outbrain.tsx
+++ b/src/web/components/Outbrain.tsx
@@ -47,10 +47,6 @@ const outbrainContainer = css`
         padding-top: 6px;
         padding-bottom: 12px;
     }
-
-    .ob_about_this_content {
-        display: none;
-    }
 `;
 
 export const OutbrainContainer: React.FC<{}> = () => {

--- a/src/web/components/Outbrain.tsx
+++ b/src/web/components/Outbrain.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { css } from 'emotion';
 
 interface OutbrainSelectors {
     widget: string;
@@ -41,6 +42,16 @@ const OutbrainWidget: React.FC<{}> = ({}) => {
     );
 };
 
+const outbrainContainer = css`
+    .js-outbrain-container {
+        padding-top: 6px;
+        padding-bottom: 12px;
+    }
+
 export const OutbrainContainer: React.FC<{}> = () => {
-    return <OutbrainWidget />;
+    return (
+        <div className={outbrainContainer}>
+            <OutbrainWidget />
+        </div>
+    );
 };

--- a/src/web/components/Outbrain.tsx
+++ b/src/web/components/Outbrain.tsx
@@ -44,6 +44,10 @@ const OutbrainWidget: React.FC<{}> = ({}) => {
 };
 
 const outbrainContainer = css`
+    .js-outbrain-container {
+        padding-top: 20px;
+        padding-bottom: 20px;
+    }
     .ob-widget {
         div.ob-widget-header {
             ${body.medium()};

--- a/src/web/components/Outbrain.tsx
+++ b/src/web/components/Outbrain.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from 'emotion';
-import { textSans, body } from '@guardian/src-foundations/typography';
+import { textSans, body, headline } from '@guardian/src-foundations/typography';
 
 interface OutbrainSelectors {
     widget: string;
@@ -50,10 +50,13 @@ const outbrainContainer = css`
     }
     .ob-widget {
         div.ob-widget-header {
-            ${body.medium()};
+            ${headline.xsmall()};
+            font-weight: 900;
             span,
             .ob_about_this_content a {
-                ${body.small()};
+                ${body.small({ fontWeight: 'regular' })};
+                font-size: 17px;
+
                 text-decoration: none;
                 /* stylelint-disable-next-line color-no-hex */
                 color: #00456e;
@@ -65,7 +68,8 @@ const outbrainContainer = css`
 
         span.ob-rec-text {
             max-height: fit-content;
-            ${textSans.medium()};
+            ${textSans.medium({ fontWeight: 'bold' })};
+            font-size: 16px;
         }
     }
 `;

--- a/src/web/components/Outbrain.tsx
+++ b/src/web/components/Outbrain.tsx
@@ -1,10 +1,6 @@
-// tslint:disable:react-no-dangerous-html
-
 import React from 'react';
 import { css } from 'emotion';
-import { palette } from '@guardian/src-foundations';
 import { textSans, body } from '@guardian/src-foundations/typography';
-import { from } from '@guardian/src-foundations/mq';
 
 interface OutbrainSelectors {
     widget: string;
@@ -48,40 +44,6 @@ const OutbrainWidget: React.FC<{}> = ({}) => {
 };
 
 const outbrainContainer = css`
-    .js-outbrain {
-        width: 100vw;
-        position: relative;
-        left: 50%;
-        right: 50%;
-        margin-left: -50vw;
-        margin-right: -50vw;
-        background-color: ${palette.neutral[97]};
-    }
-
-    .js-outbrain-container {
-        margin: auto;
-        border-left: 1px solid ${palette.neutral[86]};
-        border-right: 1px solid ${palette.neutral[86]};
-        border-top: 1px solid ${palette.neutral[86]};
-        padding: 20px;
-
-        ${from.tablet} {
-            max-width: 740px;
-        }
-
-        ${from.desktop} {
-            max-width: 980px;
-        }
-
-        ${from.leftCol} {
-            max-width: 1140px;
-        }
-
-        ${from.wide} {
-            max-width: 1300px;
-        }
-    }
-
     .ob-widget {
         div.ob-widget-header {
             ${body.medium()};

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -175,7 +175,6 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
             <Section
                 showTopBorder={false}
                 backgroundColour={palette.neutral[97]}
-                padded={false}
             >
                 <OutbrainContainer />
             </Section>

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -172,7 +172,11 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
 
             <Section islandId="story-package" />
 
-            <Section showTopBorder={false}>
+            <Section
+                showTopBorder={false}
+                backgroundColour={palette.neutral[97]}
+                padded={false}
+            >
                 <OutbrainContainer />
             </Section>
             {!isPaidContent && (

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -175,7 +175,6 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                     <Section
                         showTopBorder={false}
                         backgroundColour={palette.neutral[97]}
-                        padded={false}
                     >
                         <OutbrainContainer />
                     </Section>

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -172,7 +172,11 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
 
             {!isPaidContent && (
                 <>
-                    <Section showTopBorder={false}>
+                    <Section
+                        showTopBorder={false}
+                        backgroundColour={palette.neutral[97]}
+                        padded={false}
+                    >
                         <OutbrainContainer />
                     </Section>
 


### PR DESCRIPTION
## What does this change?
This PR fixes a layout problem with Outbrain where the content was breaking out of the viewport causing a horizontal scrollbar to show

In addition, it also improves some font styling for parity

## Before
![Screenshot 2020-01-08 at 11 47 01](https://user-images.githubusercontent.com/1336821/71976694-d86a5680-320e-11ea-98d3-133cae8e2fd0.jpg)

## After
![Screenshot 2020-01-08 at 11 44 51](https://user-images.githubusercontent.com/1336821/71976705-ddc7a100-320e-11ea-8785-67d6f23e30e4.jpg)

_*Note. The text 'Promoted links from around...' is dynamically set by Outbrain and changes to 'You might also like' based on the url making the outbrain request._

## Why?
This PR is in response to [this issue](https://github.com/guardian/dotcom-rendering/issues/1039) kindly raised by @WillsB3

## Link to supporting Trello card
https://trello.com/c/cHRUHbZU/830-display-problem-with-outbrain