### PR TITLE
20 pixel column space, not 10

### DIFF
--- a/src/web/components/RightColumn.tsx
+++ b/src/web/components/RightColumn.tsx
@@ -21,7 +21,7 @@ const padding = css`
     padding-top: 6px;
     /* Use margin here to the prevent flicker on load that you get
        with padding (because the header section has flex-grow: 1) */
-    margin-left: 10px;
+    margin-left: 20px;
 `;
 
 type Props = {


### PR DESCRIPTION
## What does this change?
This changes the space between the article body to 20px from 10px.

## Why?
Parity

## Link to supporting Trello card
https://trello.com/c/CtA5q7GH/1038-20-pixel-column-spacing
