### PR TITLE
Fix react key warning

### DIFF
--- a/src/web/components/lib/ArticleRenderer.tsx
+++ b/src/web/components/lib/ArticleRenderer.tsx
@@ -60,7 +60,7 @@ export const ArticleRenderer: React.FC<{
                         />
                     );
                 case 'model.dotcomrendering.pageElements.RichLinkBlockElement':
-                    return <div data-island={`rich-link-${i}`} />;
+                    return <div key={i} data-island={`rich-link-${i}`} />;
                 default:
                     return null;
             }


### PR DESCRIPTION
## What does this change?
This removes an annoying warning from the console where `ArticleRenderer` was adding items to an array without a key prop

## Why?
Clean up console output

## Link to supporting Trello card
https://trello.com/c/jl905Owl/1039-remove-react-key-warning
