### PR TITLE
Prevent Outbrain causing horizontal overflow

### DIFF
--- a/src/web/components/Outbrain.tsx
+++ b/src/web/components/Outbrain.tsx
@@ -44,6 +44,7 @@ const OutbrainWidget: React.FC<{}> = ({}) => {
 
 const outbrainContainer = css`
     .js-outbrain-container {
+        overflow: hidden;
         padding-top: 6px;
         padding-bottom: 12px;
     }


### PR DESCRIPTION
## What does this change?
Outbrain contains elements that have fixed width values greater than the viewport. This causes overflow and an undesired horizontal scroll on the page.

This PR adds an `overflow: hidden;` css property on the outbrain container to prevent this.

## Link to supporting Trello card
https://trello.com/c/cHRUHbZU/830-display-problem-with-outbrain