### PR TITLE
Use source foundation to set Outbrain header font

### DIFF
--- a/src/web/components/Outbrain.tsx
+++ b/src/web/components/Outbrain.tsx
@@ -51,7 +51,7 @@ const outbrainContainer = css`
         padding-bottom: 12px;
     }
 
-    .ob-widget-header {
+    .ob-widget .ob-widget-section .ob-widget-header {
         ${headline.xsmall()};
         color: ${palette.neutral[7]};
         font-weight: 900;

--- a/src/web/components/Outbrain.tsx
+++ b/src/web/components/Outbrain.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { css } from 'emotion';
 
+import { palette } from '@guardian/src-foundations';
+import { headline } from '@guardian/src-foundations/typography';
+
 interface OutbrainSelectors {
     widget: string;
     container: string;
@@ -46,6 +49,12 @@ const outbrainContainer = css`
     .js-outbrain-container {
         padding-top: 6px;
         padding-bottom: 12px;
+    }
+
+    .ob-widget-header {
+        ${headline.xsmall()};
+        color: ${palette.neutral[7]};
+        font-weight: 900;
     }
 `;
 

--- a/src/web/components/Outbrain.tsx
+++ b/src/web/components/Outbrain.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { css } from 'emotion';
 
-import { palette } from '@guardian/src-foundations';
 import { headline } from '@guardian/src-foundations/typography';
 
 interface OutbrainSelectors {
@@ -53,7 +52,6 @@ const outbrainContainer = css`
 
     .ob-widget .ob-widget-section .ob-widget-header {
         ${headline.xsmall()};
-        color: ${palette.neutral[7]};
         font-weight: 900;
     }
 `;


### PR DESCRIPTION
## What does this change?
This styles the Outbrain header using source foundation

## Why?
We want the Outbrain header to have similar styling to the other left column headers

## Link to supporting Trello card
https://trello.com/c/cHRUHbZU/830-display-problem-with-outbrain