### PR TITLE
Outbrain heading font size to 22 pixels

### DIFF
--- a/src/web/components/Outbrain.tsx
+++ b/src/web/components/Outbrain.tsx
@@ -53,6 +53,7 @@ const outbrainContainer = css`
 
     .ob-widget .ob-widget-section .ob-widget-header {
         ${headline.xsmall()};
+        font-size: 22px;
         font-weight: 900;
     }
 `;


### PR DESCRIPTION
## What does this change?
This forces the font size of the Outbrain heading to be 22px

## Why?
Because then the text will fit on one line

## Link to supporting Trello card
https://trello.com/c/1rHwhoPd/1055-outbrain-header