### PR TITLE
Fix lint error

### DIFF
--- a/src/web/components/ArticleMeta.stories.tsx
+++ b/src/web/components/ArticleMeta.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
+import { css } from 'emotion';
 
 import { ArticleMeta } from './ArticleMeta';
-import { css } from 'emotion';
 
 const Container = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
     <div


### PR DESCRIPTION
## What does this change?
A [recently merged PR](https://github.com/guardian/dotcom-rendering/pull/1074) made an update to eslint which did not get merged into [the subsequent PR](https://github.com/guardian/dotcom-rendering/pull/1073) before it got merged into master and because this subsequent PR broke one of the new linting rules it caused the build to fail.

This PR fixes the lint error to fix the build.
