### PR TITLE
Related Content

### DIFF
--- a/fixtures/CAPI.ts
+++ b/fixtures/CAPI.ts
@@ -506,6 +506,8 @@ export const CAPI: CAPIType = {
         edition: '',
         section: '',
         sharedAdTargeting: {},
+        keywordIds: [],
+        showRelatedContent: false,
     },
     webTitle: 'Foobar',
     nav: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -327,11 +327,12 @@ interface CardHeadlineType {
 /**
  * Onwards
  */
-type OnwardsIdType = 'story-package' | 'more-in-series';
+type OnwardsLayoutType = 'fourAndFour';
 
 type OnwardsType = {
     heading: string;
     trails: TrailType[];
+    layout: OnwardsLayoutType;
 };
 
 /**
@@ -363,6 +364,8 @@ interface ConfigType {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     sharedAdTargeting: { [key: string]: any };
     isPaidContent?: boolean;
+    keywordIds: string[];
+    showRelatedContent: boolean;
 }
 
 interface GADataType {

--- a/src/web/components/Onwards/Onwards.mocks.ts
+++ b/src/web/components/Onwards/Onwards.mocks.ts
@@ -115,4 +115,5 @@ export const storyPackageTrails: OnwardsType = {
             designType: 'Article',
         },
     ],
+    layout: 'fourAndFour',
 };

--- a/src/web/components/Onwards/Onwards.stories.tsx
+++ b/src/web/components/Onwards/Onwards.stories.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { Section } from '@frontend/web/components/Section';
 
 import { OnwardsLayout } from './OnwardsLayout';
-import { StoryPackage } from './StoryPackage';
 
 import { storyPackageTrails } from './Onwards.mocks';
 
@@ -17,11 +16,19 @@ export default {
 export const storyPackage = () => {
     return (
         <Section>
-            <OnwardsLayout
-                content={storyPackageTrails}
-                component={StoryPackage}
-            />
+            <OnwardsLayout onwardSections={[storyPackageTrails]} />
         </Section>
     );
 };
 storyPackage.story = { name: 'Story Package' };
+
+export const twoSections = () => {
+    return (
+        <Section>
+            <OnwardsLayout
+                onwardSections={[storyPackageTrails, storyPackageTrails]}
+            />
+        </Section>
+    );
+};
+twoSections.story = { name: 'with two sections' };

--- a/src/web/components/Onwards/Onwards.tsx
+++ b/src/web/components/Onwards/Onwards.tsx
@@ -64,11 +64,12 @@ const firstPopularTag = (pageTags: string[], isPaidContent: boolean) => {
         return false;
     }
 
-    const isInWhitelist = (tag: string) => WHITELISTED_TAGS.includes(tag);
+    const firstTagInWhitelist =
+        pageTags.find((tag: string) => WHITELISTED_TAGS.includes(tag)) || false;
 
     // For paid content we just return the first tag, otherwise we
     // filter for the first tag in the whitelist
-    return isPaidContent ? pageTags[0] : pageTags.find(isInWhitelist);
+    return isPaidContent ? pageTags[0] : firstTagInWhitelist;
 };
 
 type Props = {

--- a/src/web/components/Onwards/Onwards.tsx
+++ b/src/web/components/Onwards/Onwards.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { useApi } from '@frontend/web/components/lib/api';
+import { joinUrl } from '@frontend/web/components/lib/joinUrl';
 
 import { OnwardsLayout } from './OnwardsLayout';
 
@@ -37,25 +38,6 @@ export const WHITELISTED_TAGS = [
     'football/tottenham-hotspur',
     'football/liverpool',
 ];
-
-const joinUrl = (parts: string[]) => {
-    // Remove any leading or trailing slashes from all parts and then join cleanly on
-    // a single slash - prevents malformed urls
-    const trimmed = parts
-        .map(part => {
-            // Trim left
-            if (part.substr(0, 1) === '/') return part.slice(1);
-            return part;
-        })
-        .map(part => {
-            // Trim right
-            if (part.substr(part.length - 1, 1) === '/')
-                return part.slice(0, -1);
-            return part;
-        });
-
-    return trimmed.join('/');
-};
 
 const firstPopularTag = (pageTags: string[], isPaidContent: boolean) => {
     // This function looks for the first tag in pageTags, that also exists in our whitelist
@@ -169,7 +151,6 @@ export const Onwards = ({
                 layout: 'fourAndFour',
             });
         }
-
     }
 
     if (!onwardSections || onwardSections.length === 0) {

--- a/src/web/components/Onwards/Onwards.tsx
+++ b/src/web/components/Onwards/Onwards.tsx
@@ -131,7 +131,7 @@ export const Onwards = ({
 
         const { data } = useApi(joinUrl([ajaxUrl, popularInTagUrl]));
 
-        if (data?.trails?.length > 7) {
+        if (data && data.trails && data?.trails?.length > 7) {
             onwardSections.push({
                 heading: data.heading,
                 trails: data.trails,
@@ -144,7 +144,7 @@ export const Onwards = ({
 
         const { data } = useApi(joinUrl([ajaxUrl, relatedUrl]));
 
-        if (data?.trails?.length > 7) {
+        if (data && data.trails && data?.trails?.length > 7) {
             onwardSections.push({
                 heading: data.heading,
                 trails: data.trails,

--- a/src/web/components/Onwards/Onwards.tsx
+++ b/src/web/components/Onwards/Onwards.tsx
@@ -1,28 +1,170 @@
 import React from 'react';
 
-import { useApi } from '@root/src/web/components/lib/api';
+import { useApi } from '@frontend/web/components/lib/api';
 
 import { OnwardsLayout } from './OnwardsLayout';
 
-type Props = {
-    ajaxUrl: string;
-    pageId: string;
-    pathId: OnwardsIdType;
-    component: React.ElementType;
+// This list is a direct copy from https://github.com/guardian/frontend/blob/6da0b3d8bfd58e8e20f80fc738b070fb23ed154e/static/src/javascripts/projects/common/modules/onward/related.js#L27
+// If you change this list then you should also update ^
+// order matters here (first match wins)
+export const WHITELISTED_TAGS = [
+    // sport tags
+    'sport/cricket',
+    'sport/rugby-union',
+    'sport/rugbyleague',
+    'sport/formulaone',
+    'sport/tennis',
+    'sport/cycling',
+    'sport/motorsports',
+    'sport/golf',
+    'sport/horse-racing',
+    'sport/boxing',
+    'sport/us-sport',
+    'sport/australia-sport',
+
+    // football tags
+    'football/championsleague',
+    'football/premierleague',
+    'football/championship',
+    'football/europeanfootball',
+    'football/world-cup-2014',
+
+    // football team tags
+    'football/manchester-united',
+    'football/chelsea',
+    'football/arsenal',
+    'football/manchestercity',
+    'football/tottenham-hotspur',
+    'football/liverpool',
+];
+
+const joinUrl = (parts: string[]) => {
+    // Remove any leading or trailing slashes from all parts and then join cleanly on
+    // a single slash - prevents malformed urls
+    const trimmed = parts
+        .map(part => {
+            // Trim left
+            if (part.substr(0, 1) === '/') return part.slice(1);
+            return part;
+        })
+        .map(part => {
+            // Trim right
+            if (part.substr(part.length - 1, 1) === '/')
+                return part.slice(0, -1);
+            return part;
+        });
+
+    return trimmed.join('/');
 };
 
-export const Onwards = ({ ajaxUrl, pageId, pathId, component }: Props) => {
-    const url = `${new URL(`${pathId}/${pageId}`, ajaxUrl)}.json`;
-    const { data, error } = useApi<OnwardsType>(url);
+const firstPopularTag = (pageTags: string[], isPaidContent: boolean) => {
+    // This function looks for the first tag in pageTags, that also exists in our whitelist
+    if (!pageTags) {
+        // If there are no page tags we will never find a match so
+        return false;
+    }
 
-    if (error) {
-        window.guardian.modules.sentry.reportError(error, 'story-package');
+    const isInWhitelist = (tag: string) => WHITELISTED_TAGS.includes(tag);
+
+    // For paid content we just return the first tag, otherwise we
+    // filter for the first tag in the whitelist
+    return isPaidContent ? pageTags[0] : pageTags.find(isInWhitelist);
+};
+
+type Props = {
+    ajaxUrl: string;
+    hasRelated: boolean;
+    hasStoryPackage: boolean;
+    isAdFreeUser: boolean;
+    pageId: string;
+    isPaidContent: boolean;
+    showRelatedContent: boolean;
+    keywordIds: string[];
+    contentType: string;
+};
+
+export const Onwards = ({
+    ajaxUrl,
+    hasRelated,
+    hasStoryPackage,
+    isAdFreeUser,
+    pageId,
+    isPaidContent,
+    showRelatedContent,
+    keywordIds,
+    contentType,
+}: Props) => {
+    const onwardSections: OnwardsType[] = [];
+
+    if (hasStoryPackage) {
+        // Always fetch the story package if it exists
+        const { data } = useApi(
+            joinUrl([ajaxUrl, 'story-package', `${pageId}.json?dcr=true`]),
+        );
+
+        const storyPackage = data;
+
+        if (data && data.trails && data.trails.length > 7) {
+            onwardSections.push({
+                heading: storyPackage.heading,
+                trails: storyPackage.trails,
+                layout: 'fourAndFour',
+            });
+        }
+    } else if (isAdFreeUser && isPaidContent) {
+        // Don't show any related content (other than story packages) for
+        // adfree users when the content is paid for
+    } else if (showRelatedContent && hasRelated) {
+        // Related content can be a collection of articles based on
+        // two things, 1: A popular tag, or 2: A generic text match
+        const popularTag = firstPopularTag(keywordIds, isPaidContent);
+
+        let relatedUrl;
+        if (popularTag) {
+            // Use popular in tag endpoint
+            relatedUrl = `/popular-in-tag/${popularTag}.json`;
+        } else {
+            // Default to generic related endpoint
+            relatedUrl = `/related/${pageId}.json`;
+        }
+        relatedUrl += '?dcr=true';
+
+        // --- Tag excludes --- //
+        const tagsToExclude = [];
+        // Exclude ad features from non-ad feature content
+        if (!isPaidContent) {
+            tagsToExclude.push('tone/advertisement-features');
+        }
+        // We don't want to show professional network content on videos or interactives
+        if (
+            contentType.toLowerCase() === 'video' ||
+            contentType.toLowerCase() === 'interactive'
+        ) {
+            tagsToExclude.push('guardian-professional/guardian-professional');
+        }
+
+        // Add any exclude tags to the url
+        if (tagsToExclude.length > 0) {
+            const queryParams = tagsToExclude.map(tag => `exclude-tag=${tag}`);
+            relatedUrl += `&${queryParams.join('&')}`;
+        }
+
+        const { data } = useApi(joinUrl([ajaxUrl, relatedUrl]));
+
+        const relatedContent = data;
+
+        if (data && data.trails && data.trails.length > 7) {
+            onwardSections.push({
+                heading: relatedContent.heading,
+                trails: relatedContent.trails,
+                layout: 'fourAndFour',
+            });
+        }
+    }
+
+    if (!onwardSections || onwardSections.length === 0) {
         return null;
     }
 
-    if (data && data.trails && data.trails.length > 7) {
-        return <OnwardsLayout content={data} component={component} />;
-    }
-
-    return null;
+    return <OnwardsLayout onwardSections={onwardSections} />;
 };

--- a/src/web/components/Onwards/OnwardsLayout.tsx
+++ b/src/web/components/Onwards/OnwardsLayout.tsx
@@ -6,22 +6,40 @@ import { Hide } from '@frontend/web/components/Hide';
 
 import { OnwardsTitle } from './OnwardsTitle';
 import { OnwardsContainer } from './OnwardsContainer';
+import { StoryPackage } from './StoryPackage';
 
 type Props = {
-    content: OnwardsType;
-    component: React.ElementType;
+    onwardSections: OnwardsType[];
 };
 
-export const OnwardsLayout = ({ content, component: Content }: Props) => (
-    <Flex>
-        <LeftColumn showRightBorder={false} showPartialRightBorder={true}>
-            <OnwardsTitle title={content.heading} />
-        </LeftColumn>
-        <OnwardsContainer>
-            <Hide when="above" breakpoint="leftCol">
-                <OnwardsTitle title={content.heading} />
-            </Hide>
-            <Content content={content.trails} />
-        </OnwardsContainer>
-    </Flex>
-);
+const decideLayout = (layout: OnwardsLayoutType, trails: TrailType[]) => {
+    switch (layout) {
+        case 'fourAndFour':
+            return <StoryPackage content={trails} />;
+        default:
+            return <></>;
+    }
+};
+
+export const OnwardsLayout = ({ onwardSections }: Props) => {
+    return (
+        <>
+            {onwardSections.map((onward, index) => (
+                <Flex key={`${onward.heading}-${index}`}>
+                    <LeftColumn
+                        showRightBorder={false}
+                        showPartialRightBorder={true}
+                    >
+                        <OnwardsTitle title={onward.heading} />
+                    </LeftColumn>
+                    <OnwardsContainer>
+                        <Hide when="above" breakpoint="leftCol">
+                            <OnwardsTitle title={onward.heading} />
+                        </Hide>
+                        {decideLayout(onward.layout, onward.trails)}
+                    </OnwardsContainer>
+                </Flex>
+            ))}
+        </>
+    );
+};

--- a/src/web/components/Onwards/OnwardsLayout.tsx
+++ b/src/web/components/Onwards/OnwardsLayout.tsx
@@ -13,11 +13,12 @@ type Props = {
 };
 
 const decideLayout = (layout: OnwardsLayoutType, trails: TrailType[]) => {
+    // TODO: This switch is a stub pending https://trello.com/c/rBoduy1y/1065-dynamic-onward-layouts
     switch (layout) {
         case 'fourAndFour':
             return <StoryPackage content={trails} />;
         default:
-            return <></>;
+            return <StoryPackage content={trails} />;
     }
 };
 

--- a/src/web/components/lib/joinUrl.test.ts
+++ b/src/web/components/lib/joinUrl.test.ts
@@ -28,7 +28,7 @@ describe('joinUrl', () => {
     });
 
     it('returns an empty string on empty input', () => {
-        const input = [];
+        const input: string[] = [];
 
         expect(joinUrl(input)).toBe('');
     });

--- a/src/web/components/lib/joinUrl.test.ts
+++ b/src/web/components/lib/joinUrl.test.ts
@@ -1,0 +1,35 @@
+import { joinUrl } from './joinUrl';
+
+const expectedOutput = 'http://example.com/abc/xyz';
+
+describe('joinUrl', () => {
+    it('prevents double slashes correctly', () => {
+        const input = ['http://example.com/', '/abc/', '/xyz/'];
+
+        expect(joinUrl(input)).toBe(expectedOutput);
+    });
+
+    it('adds slashes if none are present', () => {
+        const input = ['http://example.com', 'abc', 'xyz'];
+
+        expect(joinUrl(input)).toBe(expectedOutput);
+    });
+
+    it('deals with combinations of slash present and not', () => {
+        const input = ['http://example.com/', 'abc/', '/xyz'];
+
+        expect(joinUrl(input)).toBe(expectedOutput);
+    });
+
+    it('works with normal strings', () => {
+        const input = ['/notadomain/', 'abc/', '/xyz'];
+
+        expect(joinUrl(input)).toBe('notadomain/abc/xyz');
+    });
+
+    it('returns an empty string on empty input', () => {
+        const input = [];
+
+        expect(joinUrl(input)).toBe('');
+    });
+});

--- a/src/web/components/lib/joinUrl.ts
+++ b/src/web/components/lib/joinUrl.ts
@@ -1,0 +1,18 @@
+export const joinUrl = (parts: string[]) => {
+    // Remove any leading or trailing slashes from all parts and then join cleanly on
+    // a single slash - prevents malformed urls
+    const trimmed = parts
+        .map(part => {
+            // Trim left
+            if (part.substr(0, 1) === '/') return part.slice(1);
+            return part;
+        })
+        .map(part => {
+            // Trim right
+            if (part.substr(part.length - 1, 1) === '/')
+                return part.slice(0, -1);
+            return part;
+        });
+
+    return trimmed.join('/');
+};

--- a/src/web/islands/islands.tsx
+++ b/src/web/islands/islands.tsx
@@ -10,7 +10,6 @@ import { RichLinkComponent } from '@frontend/web/components/elements/RichLinkCom
 import { ReaderRevenueLinks } from '@frontend/web/components/ReaderRevenueLinks';
 import { CookieBanner } from '@frontend/web/components/CookieBanner';
 import { Onwards } from '@frontend/web/components/Onwards/Onwards';
-import { StoryPackage } from '@frontend/web/components/Onwards/StoryPackage';
 
 type IslandProps =
     | {
@@ -50,9 +49,14 @@ type IslandProps =
       }
     | {
           ajaxUrl: string;
+          hasRelated: boolean;
+          hasStoryPackage: boolean;
+          isAdFreeUser: boolean;
           pageId: string;
-          pathId: OnwardsIdType;
-          component: React.ElementType;
+          isPaidContent: boolean;
+          showRelatedContent: boolean;
+          keywordIds: string[];
+          contentType: string;
       };
 
 type IslandType = {
@@ -142,11 +146,16 @@ export const hydrateIslands = (CAPI: CAPIType, NAV: NavType) => {
             component: Onwards,
             props: {
                 ajaxUrl: CAPI.config.ajaxUrl,
+                hasRelated: CAPI.hasRelated,
+                hasStoryPackage: CAPI.hasStoryPackage,
+                isAdFreeUser: CAPI.isAdFreeUser,
                 pageId: CAPI.pageId,
-                pathId: 'story-package',
-                component: StoryPackage,
+                isPaidContent: CAPI.config.isPaidContent,
+                showRelatedContent: CAPI.config.showRelatedContent,
+                keywordIds: CAPI.config.keywordIds,
+                contentType: CAPI.contentType,
             },
-            root: 'story-package',
+            root: 'onwards-content',
         },
     ];
 

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -179,7 +179,7 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                 </Flex>
             </Section>
 
-            <Section islandId="story-package" />
+            <Section islandId="onwards-content" />
 
             <Section
                 showTopBorder={false}

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -30,7 +30,6 @@ import GE2019 from '@frontend/static/badges/general-election-2019.svg';
 import { buildAdTargeting } from '@root/src/lib/ad-targeting';
 import { StandardHeader } from './StandardHeader';
 
-
 function checkForGE2019Badge(tags: TagType[]) {
     if (tags.find(tag => tag.id === 'politics/general-election-2019')) {
         return {
@@ -38,7 +37,6 @@ function checkForGE2019Badge(tags: TagType[]) {
             svgSrc: GE2019,
         };
     }
-    
 }
 
 interface Props {
@@ -176,7 +174,7 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                 </Flex>
             </Section>
 
-            <Section islandId="story-package" />
+            <Section islandId="onwards-content" />
 
             {!isPaidContent && (
                 <>


### PR DESCRIPTION
## What does this change?
This PR adds  support for related content in the onwards section of an article.

![Screenshot 2020-01-16 at 17 07 45](https://user-images.githubusercontent.com/1336821/72546482-bdd55480-3882-11ea-9552-00815a671d4b.jpg)

The logic for when to show which content is taken [from frontend](https://github.com/guardian/frontend/blob/6da0b3d8bfd58e8e20f80fc738b070fb23ed154e/static/src/javascripts/projects/common/modules/onward/related.js)


## Why?
To increase parity

## What's not supported in this PR
_More in the Series_
This needs backend work covered  in https://trello.com/c/KFLcUf6h/967-more-in-series

_Dynamic layouts_
Support is limited to four on top, four below. Other layout support is covered in https://trello.com/c/rBoduy1y/1065-dynamic-onward-layouts

## Link to supporting Trello card
https://trello.com/c/29TNSl5H/1061-extend-onwards-content
