### PR TITLE
Add validation unit test against PROD Json response

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "@sentry/browser": "^5.7.1",
         "@types/ajv": "^1.0.0",
         "@types/lodash.escape": "^4.0.6",
+        "@types/node-fetch": "^2.5.4",
         "@types/sanitize-html": "^1.18.3",
         "@typescript-eslint/eslint-plugin-tslint": "^2.7.0",
         "ajv": "^6.10.1",

--- a/src/model/validate.test.ts
+++ b/src/model/validate.test.ts
@@ -1,5 +1,16 @@
-import { CAPI } from '@root/fixtures/CAPI';
+import fetch from 'node-fetch';
 import { validateAsCAPIType } from './validate';
+
+// TODO avoid fetch, write script to fetch new version in gen-schema.js and store as fixture files
+const urlsToTest = [
+    'https://www.theguardian.com/politics/2020/jan/16/long-bailey-says-abortion-limit-should-not-be-different-for-disability.json?dcr',
+    'https://www.theguardian.com/uk-news/2020/jan/16/benita-mehra-grenfell-inquiry-boris-johnson-appoints-engineer-with-links-to-cladding-firm.json?dcr',
+    'https://www.theguardian.com/commentisfree/2020/jan/16/boris-johnson-scottish-independence-nicola-sturgeon-snp.json?dcr',
+    'https://www.theguardian.com/sport/2020/jan/16/south-africa-england-third-test-day-one-match-report.json?dcr',
+    'https://www.theguardian.com/music/2020/jan/16/midas-touch-how-to-create-the-perfect-james-bond-song-billie-eilish-no-time-to-die.json?dcr',
+    'https://www.theguardian.com/society/2020/jan/16/the-agony-of-weekend-loneliness-i-wont-speak-to-another-human-until-monday.json?dcr',
+    'https://www.theguardian.com/us-news/live/2020/jan/16/trump-impeachment-trial-live-news-ukraine-pelosi-giuliani-latest-updates-senate-democrats.json?dcr',
+];
 
 describe('validate', () => {
     it('throws on invalid data', () => {
@@ -7,7 +18,13 @@ describe('validate', () => {
         expect(() => validateAsCAPIType(data)).toThrowError(TypeError);
     });
 
-    it('confirm valid data', () => {
-        expect(validateAsCAPIType(CAPI)).toBe(CAPI);
+    urlsToTest.forEach(url => {
+        it('confirm valid data', () => {
+            return fetch(url)
+                .then(response => response.json())
+                .then(myJson => {
+                    expect(validateAsCAPIType(myJson)).toBe(myJson);
+                });
+        });
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2776,6 +2776,13 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
+"@types/node-fetch@^2.5.4":
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.4.tgz#5245b6d8841fc3a6208b82291119bc11c4e0ce44"
+  integrity sha512-Oz6id++2qAOFuOlE1j0ouk1dzl3mmI1+qINPNBhi9nt/gVOz0G+13Ao6qjhdF0Ys+eOkhu6JnFmt38bR3H0POQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/node@*":
   version "12.6.8"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.6.8.tgz#e469b4bf9d1c9832aee4907ba8a051494357c12c"


### PR DESCRIPTION
I get the niggly feeling this is a bad idea but it feels like a good idea but don't be afraid to tell me why it's a bad idea.

## What does this change?

Rather than test against a single fixture, we chuck a few of the PROD Json DCR responses at the validator to make sure it validates.

![image](https://user-images.githubusercontent.com/638051/72546399-a007ef80-3882-11ea-8ed8-a323c5ca2095.png)

and, for example setting `sectionName` to string literal `politics` in `index.d.ts`

![image](https://user-images.githubusercontent.com/638051/72547837-57056a80-3885-11ea-9d97-8269c1d4063a.png)

as the first url is politics url and the rest are not.

## Why?

- If we're testing a branch against PROD, we know that when we merge that branch, the validation is probably going to pass (at least for those articles)
- The JSON is always up-to-date with the live version, so out of date fixture can't be missed

## Link to supporting Trello card

https://trello.com/c/enWQGY9u