### PR TITLE
Age warning always ends with 'old'

### DIFF
--- a/src/web/components/AgeWarning.stories.tsx
+++ b/src/web/components/AgeWarning.stories.tsx
@@ -23,3 +23,8 @@ export const ScreenReaderVersion = () => {
     return <AgeWarning age="20 million years old" isScreenReader={true} />;
 };
 ScreenReaderVersion.story = { name: 'with screen reader true (invisible)' };
+
+export const MissingOldText = () => {
+    return <AgeWarning age="5 years" />;
+};
+MissingOldText.story = { name: 'with old text missing from input' };

--- a/src/web/components/AgeWarning.tsx
+++ b/src/web/components/AgeWarning.tsx
@@ -8,6 +8,12 @@ import { palette } from '@guardian/src-foundations';
 import { textSans } from '@guardian/src-foundations/typography';
 import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 
+type Props = {
+    age: string;
+    isScreenReader?: boolean;
+    size?: 'small' | 'medium';
+};
+
 const ageWarningStyles = (isSmall: boolean) => css`
     ${isSmall ? textSans.xsmall() : textSans.medium()};
     color: ${palette.neutral[7]};
@@ -33,15 +39,13 @@ const ageWarningScreenReader = css`
     ${visuallyHidden};
 `;
 
-type Props = {
-    age: string;
-    isScreenReader?: boolean;
-    size?: 'small' | 'medium';
-};
+const ensureOldText = (age: string) =>
+    age.endsWith('old') ? age : `${age} old`;
 
 export const AgeWarning = ({ age, isScreenReader, size = 'medium' }: Props) => {
     const warningPrefix = 'This article is more than ';
     const isSmall = size === 'small';
+    const ageOld = ensureOldText(age);
 
     if (isScreenReader) {
         return (
@@ -52,7 +56,7 @@ export const AgeWarning = ({ age, isScreenReader, size = 'medium' }: Props) => {
     return (
         <div className={ageWarningStyles(isSmall)} aria-hidden="true">
             <ClockIcon /> {warningPrefix}
-            <strong>{age}</strong>
+            <strong>{ageOld}</strong>
         </div>
     );
 };


### PR DESCRIPTION
## What does this change?
This PR ensures the age warning string always ends with the text 'old'

## Why?
Sometimes api responses send strings like "3 months old" which `AgeWarning` uses to display, but sometimes we get "3 months" which needs manipulation to display

## Link to supporting Trello card
https://trello.com/c/gsJs3FTz/1068-article-age-warning-always-ends-with-old
