### PR TITLE
Don't use sticky ads for showcase articles

### DIFF
--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -4,7 +4,7 @@ import { css } from 'emotion';
 import { palette } from '@guardian/src-foundations';
 
 import { Flex } from '@root/src/web/components/Flex';
-import { StickyAd } from '@root/src/web/components/StickyAd';
+import { namedAdSlotParameters } from '@root/src/model/advertisement';
 import { ArticleBody } from '@root/src/web/components/ArticleBody';
 import { RightColumn } from '@root/src/web/components/RightColumn';
 import { LeftColumn } from '@root/src/web/components/LeftColumn';
@@ -23,7 +23,7 @@ import { OutbrainContainer } from '@root/src/web/components/Outbrain';
 import { Section } from '@root/src/web/components/Section';
 import { Nav } from '@root/src/web/components/Nav/Nav';
 import { HeaderAdSlot } from '@root/src/web/components/HeaderAdSlot';
-import { MobileStickyContainer } from '@root/src/web/components/AdSlot';
+import { MobileStickyContainer, AdSlot } from '@root/src/web/components/AdSlot';
 
 import { buildAdTargeting } from '@root/src/lib/ad-targeting';
 
@@ -167,7 +167,10 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                                 </main>
                             </div>
                             <RightColumn>
-                                <StickyAd />
+                                <AdSlot
+                                    asps={namedAdSlotParameters('right')}
+                                    className=""
+                                />
                                 {!isPaidContent ? (
                                     <MostViewedRightIsland />
                                 ) : (


### PR DESCRIPTION
## What does this change?
This PR removes the sticky functionality from showcase articles, simply displaying the advert inline

## Why?
Because Showcase articles do not have sticky adverts in frontend and including this css causes the in body adverts to overlay the most viewed element in the right column

## Link to supporting Trello card
https://trello.com/c/qm6EhRBG/955-showcase-adslots-overlapping-most-viewed-right
