### PR TITLE
Ensure strong tags in the standfirst make the text bold

### DIFF
--- a/src/web/components/Standfirst.tsx
+++ b/src/web/components/Standfirst.tsx
@@ -32,6 +32,10 @@ const nestedStyles = css`
     li {
         ${headline.xxxsmall()};
     }
+
+    strong {
+        font-weight: bold;
+    }
 `;
 
 const standfirstStyles = (designType: DesignType) => {


### PR DESCRIPTION
## What does this change?
Adds some css to make sure that the `<strong>` html tag is respected

## Why?
It wasn't being respected before and text was being displayed that was not bold

## Link to supporting Trello card
https://trello.com/c/5PP1ZfIC/1070-respect-strong-tag-in-standfirst