### PR TITLE
Correct headline styling for Review designType

### DIFF
--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -186,7 +186,6 @@ const renderHeadline = ({
     switch (designType) {
         case 'Article':
         case 'Media':
-        case 'Review':
         case 'Live':
         case 'SpecialReport':
         case 'Recipe':
@@ -201,6 +200,7 @@ const renderHeadline = ({
                 </h1>
             );
 
+        case 'Review':
         case 'Feature':
             return (
                 <h1


### PR DESCRIPTION
## What does this change?
This styles the headline for `Review` articles the same as for `Feature` articles

## Why?
Parity

## Link to supporting Trello card
https://trello.com/c/OjZhd6SD/1069-headline-for-review-articles