### PR TITLE
Refactor decision for when to show Most View Right

### DIFF
--- a/src/web/components/MostViewed/MostViewedRight/MostViewedRightWrapper.tsx
+++ b/src/web/components/MostViewed/MostViewedRight/MostViewedRightWrapper.tsx
@@ -1,33 +1,49 @@
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useRef, useState, useEffect, RefObject } from 'react';
 import { css } from 'emotion';
 import { MostViewedRight } from './MostViewedRight';
+
+type Props = {
+    pillar: Pillar;
+    limitItems?: number;
+};
+
+// Minimum height needed to render MostViewedRight is its own outer height.
+const HEIGHT_REQUIRED = 482 + 24 + 24;
 
 const flexGrow = css`
     flex-grow: 1;
 `;
 
-interface Props {
-    pillar: Pillar;
-    limitItems?: number;
-}
-
 // Wrapping MostViewedRight so we can determine whether or not there's enough vertical space in the container to render it.
 export const MostViewedRightWrapper = ({ pillar, limitItems }: Props) => {
     const bodyRef = useRef<HTMLDivElement>(null);
-    const [availableHeight, setAvailableHeight] = useState(0);
+    const [heightIsAvailable, setHeightIsAvailable] = useState<boolean>(false);
+
+    const checkHeight = (ref: RefObject<HTMLDivElement>) => {
+        if (!heightIsAvailable) {
+            // Don't bother checking if height already available
+            if (ref.current) {
+                const { offsetHeight } = ref.current;
+                setHeightIsAvailable(offsetHeight > HEIGHT_REQUIRED);
+            }
+        }
+    };
 
     useEffect(() => {
-        if (bodyRef.current) {
-            const { offsetHeight } = bodyRef.current;
-            setAvailableHeight(offsetHeight);
-        }
-    }, [availableHeight]);
+        // Check if we have the available height
+        checkHeight(bodyRef);
 
-    // Minimum height needed to render MostViewedRight is its own outer height.
-    const heightRequired = 482 + 24 + 24;
+        // setTimeout here lets us put another check at the end of the
+        // event queue in case any in body elements still need to render
+        // which could push the page down giving us the space we need
+        setTimeout(() => {
+            checkHeight(bodyRef);
+        });
+    }, [heightIsAvailable]);
+
     return (
         <div ref={bodyRef} className={flexGrow}>
-            {availableHeight > heightRequired ? (
+            {heightIsAvailable ? (
                 <MostViewedRight pillar={pillar} limitItems={limitItems} />
             ) : null}
         </div>

--- a/src/web/components/MostViewed/MostViewedRight/MostViewedRightWrapper.tsx
+++ b/src/web/components/MostViewed/MostViewedRight/MostViewedRightWrapper.tsx
@@ -13,12 +13,14 @@ interface Props {
 
 // Wrapping MostViewedRight so we can determine whether or not there's enough vertical space in the container to render it.
 export const MostViewedRightWrapper = ({ pillar, limitItems }: Props) => {
-    const bodyRef = useRef<any>(null);
+    const bodyRef = useRef<HTMLDivElement>(null);
     const [availableHeight, setAvailableHeight] = useState(0);
 
     useEffect(() => {
-        const { offsetHeight } = bodyRef.current;
-        setAvailableHeight(offsetHeight);
+        if (bodyRef.current) {
+            const { offsetHeight } = bodyRef.current;
+            setAvailableHeight(offsetHeight);
+        }
     }, [availableHeight]);
 
     // Minimum height needed to render MostViewedRight is its own outer height.

--- a/src/web/components/MostViewed/MostViewedRight/MostViewedRightWrapper.tsx
+++ b/src/web/components/MostViewed/MostViewedRight/MostViewedRightWrapper.tsx
@@ -14,18 +14,18 @@ interface Props {
 // Wrapping MostViewedRight so we can determine whether or not there's enough vertical space in the container to render it.
 export const MostViewedRightWrapper = ({ pillar, limitItems }: Props) => {
     const bodyRef = useRef<any>(null);
-    const [myHeight, setMyHeight] = useState(0);
+    const [availableHeight, setAvailableHeight] = useState(0);
 
     useEffect(() => {
-        const { clientHeight } = bodyRef.current;
-        setMyHeight(clientHeight);
-    }, [myHeight]);
+        const { offsetHeight } = bodyRef.current;
+        setAvailableHeight(offsetHeight);
+    }, [availableHeight]);
 
     // Minimum height needed to render MostViewedRight is its own outer height.
-    const minWrapperHeight = 550;
+    const heightRequired = 482 + 24 + 24;
     return (
         <div ref={bodyRef} className={flexGrow}>
-            {myHeight > minWrapperHeight ? (
+            {availableHeight > heightRequired ? (
                 <MostViewedRight pillar={pillar} limitItems={limitItems} />
             ) : null}
         </div>


### PR DESCRIPTION
## What does this change?
This PR refactors the logic around how we decide if the Most View Right content should appear or not

The main change was to introduce this pattern

```typescript
    useEffect(() => {
        // Check if we have the available height
        checkHeight(bodyRef);

        // setTimeout here lets us put another check at the end of the
        // event queue in case any in body elements still need to render
        // which could push the page down giving us the space we need
        setTimeout(() => {
            checkHeight(bodyRef);
        });
    }, [heightIsAvailable]);
```

It was observed that the main media image on an article often loaded later, after this component had rendered. Because the presence of this element affected the height of the wrapper div that is being used to here to decide if there is enough space, we need to handle running a second check. This is an edge case for when the article is so short that there is not enough height to show MV right but that when the image loads it adds just enough height to let it appear

### Is using setTimeout a hack?
`setTimeout` is not ideal as it is not guaranteed that it will cause the check to fire _after_ the image has loaded but I tested this with various scenarios including simulated slow connections and it seems to hold up well

## Why?
Adding a grid layout changed how this component behaved; to get it working again it needed some changes and was refactored along the way 

## Link to supporting Trello card
https://trello.com/c/EZwOZrny/1071-refactor-decision-for-showing-mv-right
