### PR TITLE
Add reader revenue flag

### DIFF
--- a/fixtures/CAPI.ts
+++ b/fixtures/CAPI.ts
@@ -355,6 +355,7 @@ export const CAPI: CAPIType = {
     sectionLabel: 'Ticket prices',
     sectionUrl: 'money/ticket-prices',
     shouldHideAds: false,
+    shouldHideReaderRevenue: true,
     isAdFreeUser: false,
     webURL:
         'https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',

--- a/fixtures/CAPI.ts
+++ b/fixtures/CAPI.ts
@@ -507,7 +507,7 @@ export const CAPI: CAPIType = {
         edition: '',
         section: '',
         sharedAdTargeting: {},
-        keywordIds: [],
+        keywordIds: '',
         showRelatedContent: false,
     },
     webTitle: 'Foobar',

--- a/index.d.ts
+++ b/index.d.ts
@@ -365,7 +365,7 @@ interface ConfigType {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     sharedAdTargeting: { [key: string]: any };
     isPaidContent?: boolean;
-    keywordIds: string[];
+    keywordIds: string;
     showRelatedContent: boolean;
     shouldHideReaderRevenue?: boolean;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -208,6 +208,7 @@ interface CAPIType {
     config: ConfigType;
     designType: DesignType;
     showBottomSocialButtons: boolean;
+    shouldHideReaderRevenue: boolean;
 
     // AMP specific (for now)
     guardianBaseURL: string;

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -206,6 +206,9 @@
         "showBottomSocialButtons": {
             "type": "boolean"
         },
+        "shouldHideReaderRevenue": {
+            "type": "boolean"
+        },
         "guardianBaseURL": {
             "type": "string"
         },
@@ -267,6 +270,7 @@
         "sectionLabel",
         "sectionUrl",
         "shouldHideAds",
+        "shouldHideReaderRevenue",
         "showBottomSocialButtons",
         "standfirst",
         "subMetaKeywordLinks",
@@ -1487,6 +1491,15 @@
                 },
                 "isPaidContent": {
                     "type": "boolean"
+                },
+                "keywordIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "showRelatedContent": {
+                    "type": "boolean"
                 }
             },
             "required": [
@@ -1501,11 +1514,13 @@
                 "googletagUrl",
                 "hbImpl",
                 "isSensitive",
+                "keywordIds",
                 "revisionNumber",
                 "section",
                 "sentryHost",
                 "sentryPublicApiKey",
                 "sharedAdTargeting",
+                "showRelatedContent",
                 "stage",
                 "switches",
                 "videoDuration"

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -1493,10 +1493,7 @@
                     "type": "boolean"
                 },
                 "keywordIds": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "showRelatedContent": {
                     "type": "boolean"

--- a/src/web/islands/islands.tsx
+++ b/src/web/islands/islands.tsx
@@ -56,7 +56,7 @@ type IslandProps =
           pageId: string;
           isPaidContent: boolean;
           showRelatedContent: boolean;
-          keywordIds: string[];
+          keywordIds: string;
           contentType: string;
       };
 


### PR DESCRIPTION
## What does this change?

Update to reflect https://github.com/guardian/frontend/pull/22221, which this depends on. **The tests currently fail because this dependency is not live yet.**

Note, when I ran `make gen-schema` a few other updates happened as well, including for `keywordIds` which was modelled as an array but is actually a (comma-separated) string in PROD so I've fixed that in a follow-on commit.

cc @oliverlloyd and @gtrufitt maybe it's close to the point now where we should make the gen-schema update automatic somehow as it's easy to forget?

## Why?

As part of testing the epic in DCR.

## Link to supporting Trello card

https://trello.com/c/pzcUqc35/14-integrate-default-epic-with-dcr
