### PR TITLE
Adding LayoutBottomSlot component to Standard & Showcase layouts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -366,6 +366,7 @@ interface ConfigType {
     isPaidContent?: boolean;
     keywordIds: string[];
     showRelatedContent: boolean;
+    shouldHideReaderRevenue: boolean;
 }
 
 interface GADataType {

--- a/index.d.ts
+++ b/index.d.ts
@@ -366,7 +366,7 @@ interface ConfigType {
     isPaidContent?: boolean;
     keywordIds: string[];
     showRelatedContent: boolean;
-    shouldHideReaderRevenue: boolean;
+    shouldHideReaderRevenue?: boolean;
 }
 
 interface GADataType {

--- a/src/web/components/LayoutSlotBottom.tsx
+++ b/src/web/components/LayoutSlotBottom.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { css } from 'emotion';
+import { useApi } from '@root/src/web/components/lib/api';
+
+const wrapperMargins = css`
+    margin: 18px 0;
+`;
+
+export const LayoutSlotBottom = () => {
+    const endpointUrl =
+        'https://zsxulafpt1.execute-api.eu-west-1.amazonaws.com/prod';
+    const { data, error } = useApi(endpointUrl);
+
+    if (error) {
+        window.guardian.modules.sentry.reportError(error, 'layout-slot-bottom');
+        return null;
+    }
+
+    if (data) {
+        return (
+            <div className={wrapperMargins}>
+                <style>{data.css}</style>
+                <div
+                    // eslint-disable-next-line react/no-danger
+                    dangerouslySetInnerHTML={{ __html: data.html }}
+                />
+            </div>
+        );
+    }
+
+    return null;
+};

--- a/src/web/components/LayoutSlotBottom.tsx
+++ b/src/web/components/LayoutSlotBottom.tsx
@@ -16,10 +16,10 @@ export const LayoutSlotBottom = () => {
         return null;
     }
 
-    if (data) {
+    if (data && data.html) {
         return (
             <div className={wrapperMargins}>
-                <style>{data.css}</style>
+                {data.css && <style>{data.css}</style>}
                 <div
                     // eslint-disable-next-line react/no-danger
                     dangerouslySetInnerHTML={{ __html: data.html }}

--- a/src/web/islands/islands.tsx
+++ b/src/web/islands/islands.tsx
@@ -10,6 +10,7 @@ import { RichLinkComponent } from '@frontend/web/components/elements/RichLinkCom
 import { ReaderRevenueLinks } from '@frontend/web/components/ReaderRevenueLinks';
 import { CookieBanner } from '@frontend/web/components/CookieBanner';
 import { Onwards } from '@frontend/web/components/Onwards/Onwards';
+import { LayoutSlotBottom } from '@root/src/web/components/LayoutSlotBottom';
 
 type IslandProps =
     | {
@@ -136,6 +137,11 @@ export const hydrateIslands = (CAPI: CAPIType, NAV: NavType) => {
                 inHeader: false,
             },
             root: 'reader-revenue-links-footer',
+        },
+        {
+            component: LayoutSlotBottom,
+            props: {},
+            root: 'layout-slot-bottom',
         },
         {
             component: CookieBanner,

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -39,13 +39,11 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
 
     const adTargeting: AdTargeting = buildAdTargeting(CAPI.config);
 
-    // Allow 'LayoutSlotBottom' component to render if:
-    // - a 'forceEpic' URL flag is set to true (under any circumstance)
-    // - article not set to hide reader revenue (unless 'forceEpic' is set to true)
-    // TODO: plug 'forceEpic' variable below into the URL param through frontend
-    const forceEpic = false;
-    const renderBottomSlot =
-        forceEpic || (forceEpic && !CAPI.config.shouldHideReaderRevenue);
+    // Currently hardcode this condition to true or false, so we can easily control the slot during development.
+    const renderBottomSlot = false;
+    // TODO:
+    // 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
+    // 2) Otherwise, ensure slot only renders if `CAPI.config.shouldHideReaderRevenue` equals false.
 
     return (
         <>

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -39,6 +39,14 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
 
     const adTargeting: AdTargeting = buildAdTargeting(CAPI.config);
 
+    // Allow 'LayoutSlotBottom' component to render if:
+    // - a 'forceEpic' URL flag is set to true (under any circumstance)
+    // - article not set to hide reader revenue (unless 'forceEpic' is set to true)
+    // TODO: plug 'forceEpic' variable below into the URL param through frontend
+    const forceEpic = false;
+    const renderBottomSlot =
+        forceEpic || (forceEpic && !CAPI.config.shouldHideReaderRevenue);
+
     return (
         <>
             <Section
@@ -148,6 +156,16 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                                         CAPI={CAPI}
                                         isShowcase={true}
                                     />
+
+                                    {renderBottomSlot && (
+                                        <Section
+                                            islandId="layout-slot-bottom"
+                                            showSideBorders={false}
+                                            showTopBorder={false}
+                                            padded={false}
+                                        />
+                                    )}
+
                                     <GuardianLines pillar={CAPI.pillar} />
                                     <SubMeta
                                         pillar={CAPI.pillar}

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -50,6 +50,14 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
 
     const adTargeting: AdTargeting = buildAdTargeting(CAPI.config);
 
+    // Allow 'LayoutSlotBottom' component to render if:
+    // - a 'forceEpic' URL flag is set to true (under any circumstance)
+    // - article not set to hide reader revenue (unless 'forceEpic' is set to true)
+    // TODO: plug 'forceEpic' variable below into the URL param through frontend
+    const forceEpic = false;
+    const renderBottomSlot =
+        forceEpic || (forceEpic && !CAPI.config.shouldHideReaderRevenue);
+
     return (
         <>
             <Section
@@ -152,6 +160,16 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                             `}
                         >
                             <ArticleBody CAPI={CAPI} />
+
+                            {renderBottomSlot && (
+                                <Section
+                                    islandId="layout-slot-bottom"
+                                    showSideBorders={false}
+                                    showTopBorder={false}
+                                    padded={false}
+                                />
+                            )}
+
                             <GuardianLines pillar={CAPI.pillar} />
                             <SubMeta
                                 pillar={CAPI.pillar}

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -50,13 +50,11 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
 
     const adTargeting: AdTargeting = buildAdTargeting(CAPI.config);
 
-    // Allow 'LayoutSlotBottom' component to render if:
-    // - a 'forceEpic' URL flag is set to true (under any circumstance)
-    // - article not set to hide reader revenue (unless 'forceEpic' is set to true)
-    // TODO: plug 'forceEpic' variable below into the URL param through frontend
-    const forceEpic = false;
-    const renderBottomSlot =
-        forceEpic || (forceEpic && !CAPI.config.shouldHideReaderRevenue);
+    // Currently hardcode this condition to true or false, so we can easily control the slot during development.
+    const renderBottomSlot = false;
+    // TODO:
+    // 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
+    // 2) Otherwise, ensure slot only renders if `CAPI.config.shouldHideReaderRevenue` equals false.
 
     return (
         <>


### PR DESCRIPTION
## What does this change?
Adds a new component responsible for fetching the 'default epic' from the new Contributions service, and render the returned markup and styles in the component structure on both layouts (standard & showcase). The goal is to create the slot where the first user revenue epic will be displayed on the page, and enable the capacity to actually fetch and render such data from the Contributions service.

## Why?
Because we need a slot where we can inject the Default Epic providing the necessary conditions are met.

## Link to supporting Trello card
https://trello.com/c/cyqrZXfS/1080-integrate-default-epic-from-contributions-service-in-standard-and-showcase-layouts

## Screenshots
Standard Layout:
![Screenshot 2020-01-20 at 16 33 58](https://user-images.githubusercontent.com/1692169/72743015-bf648c80-3ba2-11ea-8a2e-b913411b0641.png)
Showcase Layout:
![Screenshot 2020-01-20 at 16 33 33](https://user-images.githubusercontent.com/1692169/72743617-ef605f80-3ba3-11ea-9280-704c56f0ec1e.png)

