### PR TITLE
Use prod URL

### DIFF
--- a/src/web/components/LayoutSlotBottom.tsx
+++ b/src/web/components/LayoutSlotBottom.tsx
@@ -7,8 +7,7 @@ const wrapperMargins = css`
 `;
 
 export const LayoutSlotBottom = () => {
-    const endpointUrl =
-        'https://zsxulafpt1.execute-api.eu-west-1.amazonaws.com/prod';
+    const endpointUrl = 'https://contributions.guardianapis.com';
     const { data, error } = useApi(endpointUrl);
 
     if (error) {


### PR DESCRIPTION
## What does this change?

Update URL to Fastly one.

## Why?

For caching/scalability.

## Link to supporting Trello card

https://trello.com/c/pzcUqc35/14-integrate-default-epic-with-dcr
