### PR TITLE
Fix breaking build by putting a url that isn't a live url:

### DIFF
--- a/src/model/validate.test.ts
+++ b/src/model/validate.test.ts
@@ -9,7 +9,7 @@ const urlsToTest = [
     'https://www.theguardian.com/sport/2020/jan/16/south-africa-england-third-test-day-one-match-report.json?dcr',
     'https://www.theguardian.com/music/2020/jan/16/midas-touch-how-to-create-the-perfect-james-bond-song-billie-eilish-no-time-to-die.json?dcr',
     'https://www.theguardian.com/society/2020/jan/16/the-agony-of-weekend-loneliness-i-wont-speak-to-another-human-until-monday.json?dcr',
-    'https://www.theguardian.com/us-news/live/2020/jan/16/trump-impeachment-trial-live-news-ukraine-pelosi-giuliani-latest-updates-senate-democrats.json?dcr',
+    'https://www.theguardian.com/uk-news/2020/jan/22/man-74-was-shot-with-crossbow-as-he-fixed-satellite-dish-court-told.json?dcr',
 ];
 
 describe('validate', () => {


### PR DESCRIPTION
## What does this change?

I was pinging a liveblog URL which we don't support. Whoops. Sorry.			

## Link to supporting Trello card

https://trello.com/c/bxLDf3DL/1090-solve-the-mysterious-failing-test-problem-on-dcr