### PR TITLE
Support ?slot-machine-flags query parameter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -225,6 +225,8 @@ interface CAPIType {
     nav: any; // as not extracting directly into NavType here for now (nav stuff is getting moved out)
 
     pageFooter: FooterType;
+
+    slotMachineFlags?: string;
 }
 
 interface TagType {

--- a/src/lib/slot-machine-flags.ts
+++ b/src/lib/slot-machine-flags.ts
@@ -1,0 +1,12 @@
+interface Flags {
+    showBodyEnd: boolean;
+}
+
+export const parse = (flags: string): Flags => {
+    const arr = flags.split(',');
+    const args = new Set(arr);
+
+    return {
+        showBodyEnd: args.has('showBodyEnd'),
+    };
+};

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -239,6 +239,9 @@
         "nav": {},
         "pageFooter": {
             "$ref": "#/definitions/FooterType"
+        },
+        "slotMachineFlags": {
+            "type": "string"
         }
     },
     "required": [
@@ -1496,6 +1499,9 @@
                     "type": "string"
                 },
                 "showRelatedContent": {
+                    "type": "boolean"
+                },
+                "shouldHideReaderRevenue": {
                     "type": "boolean"
                 }
             },

--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -6,12 +6,12 @@ const wrapperMargins = css`
     margin: 18px 0;
 `;
 
-export const LayoutSlotBottom = () => {
+export const SlotBodyEnd = () => {
     const endpointUrl = 'https://contributions.guardianapis.com';
     const { data, error } = useApi(endpointUrl);
 
     if (error) {
-        window.guardian.modules.sentry.reportError(error, 'layout-slot-bottom');
+        window.guardian.modules.sentry.reportError(error, 'slot-body-end');
         return null;
     }
 

--- a/src/web/islands/islands.tsx
+++ b/src/web/islands/islands.tsx
@@ -10,7 +10,7 @@ import { RichLinkComponent } from '@frontend/web/components/elements/RichLinkCom
 import { ReaderRevenueLinks } from '@frontend/web/components/ReaderRevenueLinks';
 import { CookieBanner } from '@frontend/web/components/CookieBanner';
 import { Onwards } from '@frontend/web/components/Onwards/Onwards';
-import { LayoutSlotBottom } from '@root/src/web/components/LayoutSlotBottom';
+import { SlotBodyEnd } from '@frontend/web/components/SlotBodyEnd';
 
 type IslandProps =
     | {
@@ -139,7 +139,7 @@ export const hydrateIslands = (CAPI: CAPIType, NAV: NavType) => {
             root: 'reader-revenue-links-footer',
         },
         {
-            component: LayoutSlotBottom,
+            component: SlotBodyEnd,
             props: {},
             root: 'layout-slot-bottom',
         },

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -27,6 +27,7 @@ import { MobileStickyContainer, AdSlot } from '@root/src/web/components/AdSlot';
 
 import { buildAdTargeting } from '@root/src/lib/ad-targeting';
 
+import { parse } from '@frontend/lib/slot-machine-flags';
 import { ShowcaseHeader } from './ShowcaseHeader';
 
 interface Props {
@@ -39,8 +40,9 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
 
     const adTargeting: AdTargeting = buildAdTargeting(CAPI.config);
 
-    // Currently hardcode this condition to true or false, so we can easily control the slot during development.
-    const renderBottomSlot = false;
+    // defaults to false, but use ?slot-machine-flags=showBodyEnd to show
+    const renderBottomSlot = parse(CAPI.slotMachineFlags || '').showBodyEnd;
+
     // TODO:
     // 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
     // 2) Otherwise, ensure slot only renders if `CAPI.config.shouldHideReaderRevenue` equals false.

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -41,7 +41,7 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
     const adTargeting: AdTargeting = buildAdTargeting(CAPI.config);
 
     // defaults to false, but use ?slot-machine-flags=showBodyEnd to show
-    const renderBottomSlot = parse(CAPI.slotMachineFlags || '').showBodyEnd;
+    const showBodyEndSlot = parse(CAPI.slotMachineFlags || '').showBodyEnd;
 
     // TODO:
     // 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
@@ -157,7 +157,7 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                                         isShowcase={true}
                                     />
 
-                                    {renderBottomSlot && (
+                                    {showBodyEndSlot && (
                                         <Section
                                             islandId="layout-slot-bottom"
                                             showSideBorders={false}

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -52,7 +52,7 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
     const adTargeting: AdTargeting = buildAdTargeting(CAPI.config);
 
     // defaults to false, but use ?slot-machine-flags=showBodyEnd to show
-    const renderBottomSlot = parse(CAPI.slotMachineFlags || '').showBodyEnd;
+    const showBodyEndSlot = parse(CAPI.slotMachineFlags || '').showBodyEnd;
 
     // TODO:
     // 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
@@ -161,7 +161,7 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                         >
                             <ArticleBody CAPI={CAPI} />
 
-                            {renderBottomSlot && (
+                            {showBodyEndSlot && (
                                 <Section
                                     islandId="layout-slot-bottom"
                                     showSideBorders={false}

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -28,6 +28,7 @@ import { palette } from '@guardian/src-foundations';
 import GE2019 from '@frontend/static/badges/general-election-2019.svg';
 
 import { buildAdTargeting } from '@root/src/lib/ad-targeting';
+import { parse } from '@frontend/lib/slot-machine-flags';
 import { StandardHeader } from './StandardHeader';
 
 function checkForGE2019Badge(tags: TagType[]) {
@@ -50,8 +51,9 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
 
     const adTargeting: AdTargeting = buildAdTargeting(CAPI.config);
 
-    // Currently hardcode this condition to true or false, so we can easily control the slot during development.
-    const renderBottomSlot = false;
+    // defaults to false, but use ?slot-machine-flags=showBodyEnd to show
+    const renderBottomSlot = parse(CAPI.slotMachineFlags || '').showBodyEnd;
+
     // TODO:
     // 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
     // 2) Otherwise, ensure slot only renders if `CAPI.config.shouldHideReaderRevenue` equals false.


### PR DESCRIPTION
At the moment this can be used to show the contributions epic, but
it's a general solution which we can use for other stuff in the
future.
