### PR TITLE
Add subnav to islands as it has JS interactivity

### DIFF
--- a/src/web/islands/islands.tsx
+++ b/src/web/islands/islands.tsx
@@ -11,11 +11,20 @@ import { ReaderRevenueLinks } from '@frontend/web/components/ReaderRevenueLinks'
 import { CookieBanner } from '@frontend/web/components/CookieBanner';
 import { Onwards } from '@frontend/web/components/Onwards/Onwards';
 import { SlotBodyEnd } from '@frontend/web/components/SlotBodyEnd';
+import { SubNav } from '@frontend/web/components/SubNav/SubNav';
 
 type IslandProps =
     | {
           pillar: Pillar;
           nav: NavType;
+      }
+    | {
+          subnav: {
+              parent?: LinkType;
+              links: LinkType[];
+          };
+          pillar: Pillar;
+          currentNavLink: string;
       }
     | {
           edition: Edition;
@@ -94,6 +103,15 @@ export const hydrateIslands = (CAPI: CAPIType, NAV: NavType) => {
             component: Nav,
             props: { pillar, nav: NAV },
             root: 'nav-root',
+        },
+        {
+            component: SubNav,
+            props: {
+                pillar,
+                subnav: NAV.subNavSections,
+                currentNavLink: NAV.currentNavLink,
+            },
+            root: 'sub-nav-root',
         },
     ];
 

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -288,7 +288,11 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
             </Section>
 
             {NAV.subNavSections && (
-                <Section backgroundColour={palette.neutral[100]} padded={false}>
+                <Section
+                    backgroundColour={palette.neutral[100]}
+                    padded={false}
+                    islandId="sub-nav-root"
+                >
                     <SubNav
                         subnav={NAV.subNavSections}
                         currentNavLink={NAV.currentNavLink}
@@ -413,7 +417,7 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
             )}
 
             {NAV.subNavSections && (
-                <Section padded={false}>
+                <Section padded={false} islandId="sub-nav-root">
                     <SubNav
                         subnav={NAV.subNavSections}
                         pillar={CAPI.pillar}

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -199,7 +199,11 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
             </Section>
 
             {NAV.subNavSections && (
-                <Section backgroundColour={palette.neutral[100]} padded={false}>
+                <Section
+                    backgroundColour={palette.neutral[100]}
+                    padded={false}
+                    islandId="sub-nav-root"
+                >
                     <SubNav
                         subnav={NAV.subNavSections}
                         currentNavLink={NAV.currentNavLink}
@@ -321,7 +325,7 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
             )}
 
             {NAV.subNavSections && (
-                <Section padded={false}>
+                <Section padded={false} islandId="sub-nav-root">
                     <SubNav
                         subnav={NAV.subNavSections}
                         pillar={CAPI.pillar}


### PR DESCRIPTION
## What does this change?

Subnav has a 'more' button that no longer worked.

> As a user using a smaller screen I still want to be able to click all the possible sub nav options

### Before

![image](https://user-images.githubusercontent.com/638051/72980985-97a83b00-3dd3-11ea-8a63-3c0e36feb1d1.png)

### After

![2020-01-23 11 23 23](https://user-images.githubusercontent.com/638051/72980990-9b3bc200-3dd3-11ea-984c-bae32e383b3c.gif)


## Link to supporting Trello card

https://trello.com/c/olwM93gs
