### PR TITLE
Prevent showing the consent banner

### DIFF
--- a/src/web/components/CookieBanner.test.tsx
+++ b/src/web/components/CookieBanner.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render /* , fireEvent */ } from '@testing-library/react';
 import {
     getCookie as getCookie_,
     addCookie as addCookie_,
@@ -15,7 +15,7 @@ jest.mock('@frontend/web/browser/cookie', () => ({
 }));
 
 describe('CookieBanner', () => {
-    const consentCookie = 'GU_TK';
+    // const consentCookie = 'GU_TK';
 
     beforeEach(() => {
         addCookie.mockReset();
@@ -23,35 +23,39 @@ describe('CookieBanner', () => {
     });
 
     afterEach(() => {
-        expect(getCookie).toHaveBeenCalledWith(consentCookie);
+        // expect(getCookie).toHaveBeenCalledWith(consentCookie);
     });
 
-    it('It should render null if consentCookie set', () => {
-        getCookie.mockImplementation(() => true);
-
+    it('It should render null', () => {
         const { container } = render(<CookieBanner />);
-
         expect(container.firstChild).toBeNull();
     });
+    // it('It should render null if consentCookie set', () => {
+    //     getCookie.mockImplementation(() => true);
 
-    it('It should not render null if consentCookie not set', () => {
-        getCookie.mockImplementation(() => false);
+    //     const { container } = render(<CookieBanner />);
 
-        const { container } = render(<CookieBanner />);
+    //     expect(container.firstChild).toBeNull();
+    // });
 
-        expect(container.firstChild).not.toBeNull();
-    });
+    // it('It should not render null if consentCookie not set', () => {
+    //     getCookie.mockImplementation(() => false);
 
-    it('It should add consentCookie on button click', () => {
-        getCookie.mockImplementation(() => false);
+    //     const { container } = render(<CookieBanner />);
 
-        const { container, getByText } = render(<CookieBanner />);
+    //     expect(container.firstChild).not.toBeNull();
+    // });
 
-        expect(container.firstChild).not.toBeNull();
+    // it('It should add consentCookie on button click', () => {
+    //     getCookie.mockImplementation(() => false);
 
-        fireEvent.click(getByText("I'm OK with that"));
+    //     const { container, getByText } = render(<CookieBanner />);
 
-        expect(container.firstChild).toBeNull();
-        expect(addCookie).toHaveBeenCalled();
-    });
+    //     expect(container.firstChild).not.toBeNull();
+
+    //     fireEvent.click(getByText("I'm OK with that"));
+
+    //     expect(container.firstChild).toBeNull();
+    //     expect(addCookie).toHaveBeenCalled();
+    // });
 });

--- a/src/web/components/CookieBanner.test.tsx
+++ b/src/web/components/CookieBanner.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render /* , fireEvent */ } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import {
     getCookie as getCookie_,
     addCookie as addCookie_,
@@ -23,6 +23,8 @@ describe('CookieBanner', () => {
     });
 
     afterEach(() => {
+        // Below tests are temporarily being skipped.
+        // See https://github.com/guardian/dotcom-rendering/pull/1097
         // expect(getCookie).toHaveBeenCalledWith(consentCookie);
     });
 
@@ -30,32 +32,35 @@ describe('CookieBanner', () => {
         const { container } = render(<CookieBanner />);
         expect(container.firstChild).toBeNull();
     });
-    // it('It should render null if consentCookie set', () => {
-    //     getCookie.mockImplementation(() => true);
 
-    //     const { container } = render(<CookieBanner />);
+    // Below tests are temporarily being skipped in favour of the test above.
+    // See https://github.com/guardian/dotcom-rendering/pull/1097
+    it.skip('It should render null if consentCookie set', () => {
+        getCookie.mockImplementation(() => true);
 
-    //     expect(container.firstChild).toBeNull();
-    // });
+        const { container } = render(<CookieBanner />);
 
-    // it('It should not render null if consentCookie not set', () => {
-    //     getCookie.mockImplementation(() => false);
+        expect(container.firstChild).toBeNull();
+    });
 
-    //     const { container } = render(<CookieBanner />);
+    it.skip('It should not render null if consentCookie not set', () => {
+        getCookie.mockImplementation(() => false);
 
-    //     expect(container.firstChild).not.toBeNull();
-    // });
+        const { container } = render(<CookieBanner />);
 
-    // it('It should add consentCookie on button click', () => {
-    //     getCookie.mockImplementation(() => false);
+        expect(container.firstChild).not.toBeNull();
+    });
 
-    //     const { container, getByText } = render(<CookieBanner />);
+    it.skip('It should add consentCookie on button click', () => {
+        getCookie.mockImplementation(() => false);
 
-    //     expect(container.firstChild).not.toBeNull();
+        const { container, getByText } = render(<CookieBanner />);
 
-    //     fireEvent.click(getByText("I'm OK with that"));
+        expect(container.firstChild).not.toBeNull();
 
-    //     expect(container.firstChild).toBeNull();
-    //     expect(addCookie).toHaveBeenCalled();
-    // });
+        fireEvent.click(getByText("I'm OK with that"));
+
+        expect(container.firstChild).toBeNull();
+        expect(addCookie).toHaveBeenCalled();
+    });
 });

--- a/src/web/components/CookieBanner.tsx
+++ b/src/web/components/CookieBanner.tsx
@@ -5,7 +5,7 @@ import { headline, textSans, body } from '@guardian/src-foundations/typography';
 import { until } from '@guardian/src-foundations/mq';
 import TickIcon from '@frontend/static/icons/tick.svg';
 import RoundelIcon from '@frontend/static/icons/the-guardian-roundel.svg';
-import { getCookie, addCookie } from '@root/src/web/browser/cookie';
+import { /* getCookie, */ addCookie } from '@root/src/web/browser/cookie';
 
 const banner = css`
     position: fixed;
@@ -121,12 +121,12 @@ export class CookieBanner extends Component<{}, { show: boolean }> {
         this.setState({ show: false });
     };
 
-    public componentDidMount() {
-        const seenBanner = getCookie(consentCookie);
-        if (!seenBanner) {
-            this.setState({ show: true });
-        }
-    }
+    // public componentDidMount() {
+    //     const seenBanner = getCookie(consentCookie);
+    //     if (!seenBanner) {
+    //         this.setState({ show: true });
+    //     }
+    // }
 
     public render() {
         const { show } = this.state;

--- a/src/web/components/CookieBanner.tsx
+++ b/src/web/components/CookieBanner.tsx
@@ -121,6 +121,8 @@ export class CookieBanner extends Component<{}, { show: boolean }> {
         this.setState({ show: false });
     };
 
+    // Below code is temporarily commented out.
+    // See https://github.com/guardian/dotcom-rendering/pull/1097
     // public componentDidMount() {
     //     const seenBanner = getCookie(consentCookie);
     //     if (!seenBanner) {


### PR DESCRIPTION
## What does this change?
Temporarily prevent the consent banner from showing in DCR for behaviour consistency as a consequence of https://github.com/guardian/frontend/pull/22231

Over the next week we will integrate the new CMP into DCR as well.