### PR TITLE
Moving "body end" slot to its original place

### DIFF
--- a/src/web/islands/islands.tsx
+++ b/src/web/islands/islands.tsx
@@ -164,7 +164,7 @@ export const hydrateIslands = (CAPI: CAPIType, NAV: NavType) => {
         {
             component: SlotBodyEnd,
             props: {},
-            root: 'layout-slot-bottom',
+            root: 'slot-body-end',
         },
         {
             component: CookieBanner,

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -360,6 +360,9 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                         <ArticleContainer>
                             <main className={maxWidth}>
                                 <ArticleBody CAPI={CAPI} />
+                                {showBodyEndSlot && (
+                                    <div data-island="slot-body-end" />
+                                )}
                                 <GuardianLines pillar={CAPI.pillar} />
                                 <SubMeta
                                     pillar={CAPI.pillar}
@@ -391,15 +394,6 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                     </GridItem>
                 </ShowcaseGrid>
             </Section>
-
-            {showBodyEndSlot && (
-                <Section
-                    islandId="layout-slot-bottom"
-                    showSideBorders={false}
-                    showTopBorder={false}
-                    padded={false}
-                />
-            )}
 
             <Section islandId="onwards-content" />
 

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -271,6 +271,9 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                         <ArticleContainer>
                             <main className={maxWidth}>
                                 <ArticleBody CAPI={CAPI} />
+                                {showBodyEndSlot && (
+                                    <div data-island="slot-body-end" />
+                                )}
                                 <GuardianLines pillar={CAPI.pillar} />
                                 <SubMeta
                                     pillar={CAPI.pillar}
@@ -299,15 +302,6 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                     </GridItem>
                 </StandardGrid>
             </Section>
-
-            {showBodyEndSlot && (
-                <Section
-                    islandId="layout-slot-bottom"
-                    showSideBorders={false}
-                    showTopBorder={false}
-                    padded={false}
-                />
-            )}
 
             <Section islandId="onwards-content" />
 


### PR DESCRIPTION
## What does this change?
Moves the `slot-body-end` root element to its original place, between `<ArticleBody>` and `<GuardianLines>`, on both StandardLayout and ShowcaseLayout.
Also updates that element to be a `<div>` instead of a `<Section>` and renames the data island ID to be consistent with the slot name.

## Why?
So the Contributions Epic renders in the same position in the page as it does on frontend.

## Screenshots
![Screenshot 2020-01-23 at 12 12 02](https://user-images.githubusercontent.com/1692169/72983604-9548df80-3dd9-11ea-90d3-f60df517c6f8.png)
