### PR TITLE
Ensure each card will stretch if it's on its own

### DIFF
--- a/src/web/components/MostViewed/MostViewedFooter/SecondTierItem.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/SecondTierItem.tsx
@@ -24,7 +24,7 @@ const itemStyles = (showRightBorder?: boolean) => css`
 
     min-height: 3.25rem;
 
-    flex-basis: 50%;
+    flex-basis: 100%;
 
     &:hover {
         cursor: pointer;


### PR DESCRIPTION
## What does this change?
This ensures that if there is only one mostX element, that it stretches to fill the entire row

## Two
![Screenshot 2020-01-23 at 14 08 27](https://user-images.githubusercontent.com/1336821/72991484-faa4cc80-3de9-11ea-8c03-8bfc188c8eab.jpg)

## One
![Screenshot 2020-01-23 at 14 07 37](https://user-images.githubusercontent.com/1336821/72991485-faa4cc80-3de9-11ea-9c2d-9fe0496c66ec.jpg)


## Why?
Sometimes there can be only one

## Link to supporting Trello card
https://trello.com/c/76CkVCRl/1041-most-commented-shared-full-width