### PR TITLE
Remove more key from type PillarType

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -75,7 +75,6 @@ interface LinkType extends SimpleLinkType {
 
 interface PillarType extends LinkType {
     pillar: Pillar;
-    more: false;
 }
 
 interface MoreType extends LinkType {


### PR DESCRIPTION
## What does this change?
Remove the the key `more: false;` from the interface PillarType.

## Why?
As part of adding a fixture for NAV props to be able to implement storybook Layouts, I used prod data quickly build the fixture. However TypeScript flagging up an error in the data saying `more` was not defined in the NAV obj.

Git logs showed the original addition of that code was added by @GHaberis  who mentioned this code was added at least a year ago.

I am confused as to why this hasn't been flagged up earlier by TS as part of the build process, so would be interested if anyone else has any ideas?
