### PR TITLE
Optional trail image

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -438,8 +438,8 @@ interface TrailType {
     url: string;
     headline: string;
     isLiveBlog: boolean;
-    image: string;
     webPublicationDate: string;
+    image?: string;
     avatarUrl?: string;
     mediaType?: MediaType;
     mediaDuration?: number;

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.mocks.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.mocks.tsx
@@ -16,3 +16,12 @@ export const responseWithOneTab = {
     mostCommented: mockMostCommented,
     mostShared: mockMostShared,
 };
+
+export const responseWithMissingImage = {
+    tabs: [mockTab1],
+    mostCommented: mockMostCommented,
+    mostShared: {
+        ...mockMostShared,
+        image: null,
+    },
+};

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.stories.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.stories.tsx
@@ -7,6 +7,7 @@ import { MostViewedFooter } from './MostViewedFooter';
 import {
     responseWithTwoTabs,
     responseWithOneTab,
+    responseWithMissingImage,
 } from './MostViewedFooter.mocks';
 
 /* tslint:disable */
@@ -52,3 +53,21 @@ export const withOneTabs = () => {
     );
 };
 withOneTabs.story = { name: 'with one tab' };
+
+export const withNoMostSharedImage = () => {
+    fetchMock.restore().getOnce('*', {
+        status: 200,
+        body: responseWithMissingImage,
+    });
+
+    return (
+        <Section>
+            <MostViewedFooter
+                pillar="news"
+                ajaxUrl="https://api.nextgen.guardianapps.co.uk"
+            />
+            ;
+        </Section>
+    );
+};
+withNoMostSharedImage.story = { name: 'with a missing image on most shared' };

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.stories.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.stories.tsx
@@ -30,7 +30,6 @@ export const withTwoTabs = () => {
                 sectionName="politics"
                 ajaxUrl="https://api.nextgen.guardianapps.co.uk"
             />
-            ;
         </Section>
     );
 };
@@ -48,7 +47,6 @@ export const withOneTabs = () => {
                 pillar="news"
                 ajaxUrl="https://api.nextgen.guardianapps.co.uk"
             />
-            ;
         </Section>
     );
 };
@@ -66,7 +64,6 @@ export const withNoMostSharedImage = () => {
                 pillar="news"
                 ajaxUrl="https://api.nextgen.guardianapps.co.uk"
             />
-            ;
         </Section>
     );
 };


### PR DESCRIPTION
## What does this change?
This PR makes the `image` property on `TrailType` optional.

It also adds a story to show how mostX cards appear without an image

## Why?
It was found that CAPI can sometimes not send an image for trails and so we need to respect this type within DCR

## Link to supporting Trello card
https://trello.com/c/Ch98vht1/1092-make-trailtype-image-optional