### PR TITLE
Fix the build!

### DIFF
--- a/cypress/integration/e2e/article.e2e.spec.js
+++ b/cypress/integration/e2e/article.e2e.spec.js
@@ -16,7 +16,7 @@ describe('E2E Page rendering', function() {
                 cy.contains('Sign in');
 
                 cy.wait('@getMostRead').then(xhr => {
-                    expect(xhr.response.body.length).to.be.at.least(1);
+                    expect(xhr.response.body).to.have.property('tabs');
                     expect(xhr.status).to.be.equal(200);
 
                     cy.contains('Most popular');


### PR DESCRIPTION
## What does this change?
This PR fixes the Cypress tests to fix the build

## Why?
The `./most-read/...` api response from frontend has gone from an array to an object, which broke a Cypress test which checked the format of the response

## Link to supporting Trello card
https://trello.com/c/Hu9Gmh7y/1095-fix-the-build
