### PR TITLE
Smaller headline on 2nd tier onwards items

### DIFF
--- a/src/web/components/Onwards/MoreThanFive.tsx
+++ b/src/web/components/Onwards/MoreThanFive.tsx
@@ -150,7 +150,7 @@ export const MoreThanFive = ({ content }: Props) => {
                                 pillar: trail.pillar,
                                 designType: trail.designType,
                                 headlineText: trail.headline,
-                                headlineSize: 'medium',
+                                headlineSize: 'small',
                                 byline: trail.byline,
                                 showByline: trail.showByline,
                                 showQuotes: trail.designType === 'Comment',


### PR DESCRIPTION
## What does this change?
This PR adds a smaller headline for second tier items

## Why?
Parity

## Before
![Screenshot 2020-01-24 at 14 01 30](https://user-images.githubusercontent.com/1336821/73074671-0bb91080-3eb2-11ea-9e0b-5bdd45432b3d.jpg)

## After

![Screenshot 2020-01-24 at 13 59 36](https://user-images.githubusercontent.com/1336821/73074679-0f4c9780-3eb2-11ea-8509-997c1967b22d.jpg)
101-smaller-2nd-tier-onwards-headline

## Link to supporting Trello card
https://trello.com/c/7OWCxIJ2/1