### PR TITLE
Extends API helpers to support POST method HTTP requests

### DIFF
--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -7,8 +7,10 @@ const wrapperMargins = css`
 `;
 
 export const SlotBodyEnd = () => {
-    const endpointUrl = 'https://contributions.guardianapis.com';
-    const { data, error } = useApi(endpointUrl);
+    const endpointUrl = 'https://contributions.guardianapis.com/epic';
+
+    const trackingParams = {};
+    const { data, error } = useApi(endpointUrl, trackingParams);
 
     if (error) {
         window.guardian.modules.sentry.reportError(error, 'slot-body-end');

--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -10,7 +10,13 @@ export const SlotBodyEnd = () => {
     const endpointUrl = 'https://contributions.guardianapis.com/epic';
 
     const trackingParams = {};
-    const { data, error } = useApi(endpointUrl, trackingParams);
+    const { data, error } = useApi(endpointUrl, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: JSON.stringify(trackingParams),
+    });
 
     if (error) {
         window.guardian.modules.sentry.reportError(error, 'slot-body-end');

--- a/src/web/components/lib/api.tsx
+++ b/src/web/components/lib/api.tsx
@@ -1,5 +1,26 @@
 import { useState, useEffect } from 'react';
 
+interface FetchOptions {
+    method?:
+        | 'GET'
+        | 'HEAD'
+        | 'POST'
+        | 'PUT'
+        | 'DELETE'
+        | 'CONNECT'
+        | 'OPTIONS'
+        | 'TRACE'
+        | 'PATCH';
+    headers?: {
+        'Content-Type':
+            | 'text/plain'
+            | 'multipart/form-data'
+            | 'application/json'
+            | 'application/x-www-form-urlencoded';
+    };
+    body?: string;
+}
+
 function checkForErrors(response: any) {
     if (!response.ok) {
         throw Error(response.statusText);
@@ -7,24 +28,13 @@ function checkForErrors(response: any) {
     return response;
 }
 
-const callApi = (url: string, body?: object) => {
-    // If a `body` object has been passed in, assume POST request using that data
-    // Otherwise, default to basic GET request
-    const fetchPromise =
-        typeof body === 'object'
-            ? fetch(url, {
-                  method: 'POST',
-                  headers: {
-                      'Content-Type': 'application/x-www-form-urlencoded',
-                  },
-                  body: JSON.stringify(body),
-              })
-            : fetch(url);
-
-    return fetchPromise.then(checkForErrors).then(response => response.json());
+const callApi = (url: string, options?: FetchOptions) => {
+    return fetch(url, options)
+        .then(checkForErrors)
+        .then(response => response.json());
 };
 
-export function useApi<T>(url: string, body?: object) {
+export function useApi<T>(url: string, options?: FetchOptions) {
     const [request, setRequest] = useState<{
         loading: boolean;
         data?: T;
@@ -34,7 +44,7 @@ export function useApi<T>(url: string, body?: object) {
     });
 
     useEffect(() => {
-        callApi(url, body)
+        callApi(url, options)
             .then(data => {
                 setRequest({
                     data,

--- a/src/web/components/lib/api.tsx
+++ b/src/web/components/lib/api.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect } from 'react';
 
+// Not meant to be an exhaustive type definition of the fetch API,
+// just a starting point to get us going on 99% of our possible use cases
 interface FetchOptions {
     method?:
         | 'GET'

--- a/src/web/components/lib/api.tsx
+++ b/src/web/components/lib/api.tsx
@@ -7,13 +7,24 @@ function checkForErrors(response: any) {
     return response;
 }
 
-const callApi = (url: string) => {
-    return fetch(url)
-        .then(checkForErrors)
-        .then(response => response.json());
+const callApi = (url: string, body?: object) => {
+    // If a `body` object has been passed in, assume POST request using that data
+    // Otherwise, default to basic GET request
+    const fetchPromise =
+        typeof body === 'object'
+            ? fetch(url, {
+                  method: 'POST',
+                  headers: {
+                      'Content-Type': 'application/x-www-form-urlencoded',
+                  },
+                  body: JSON.stringify(body),
+              })
+            : fetch(url);
+
+    return fetchPromise.then(checkForErrors).then(response => response.json());
 };
 
-export function useApi<T>(url: string) {
+export function useApi<T>(url: string, body?: object) {
     const [request, setRequest] = useState<{
         loading: boolean;
         data?: T;
@@ -23,7 +34,7 @@ export function useApi<T>(url: string) {
     });
 
     useEffect(() => {
-        callApi(url)
+        callApi(url, body)
             .then(data => {
                 setRequest({
                     data,
@@ -40,3 +51,5 @@ export function useApi<T>(url: string) {
 
     return request;
 }
+
+// //////////////////////////////

--- a/src/web/components/lib/api.tsx
+++ b/src/web/components/lib/api.tsx
@@ -51,5 +51,3 @@ export function useApi<T>(url: string, body?: object) {
 
     return request;
 }
-
-// //////////////////////////////


### PR DESCRIPTION
## What does this change?
Extends the existing API helpers `callApi` and `useApi` to support POST requests using `body` data.

## Why?
Because we now have to make a POST call to the Contributions service which requires some data to be sent to the server.