### PR TITLE
Lift article headline padding to wrapper component

### DIFF
--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -187,11 +187,7 @@ const renderHeadline = ({
         case 'GuardianLabs':
         case 'Quiz':
         case 'AdvertisementFeature':
-            return (
-                <h1 className={cx(standardFont, standardPadding)}>
-                    {curly(headlineString)}
-                </h1>
-            );
+            return <h1 className={standardFont}>{curly(headlineString)}</h1>;
 
         case 'Review':
         case 'Feature':
@@ -199,7 +195,6 @@ const renderHeadline = ({
                 <h1
                     className={cx(
                         boldFont,
-                        standardPadding,
                         colourStyles(options && options.colour),
                     )}
                 >
@@ -208,21 +203,11 @@ const renderHeadline = ({
             );
 
         case 'Comment':
-            return (
-                <h1 className={cx(lightFont, standardPadding)}>
-                    {curly(headlineString)}
-                </h1>
-            );
+            return <h1 className={lightFont}>{curly(headlineString)}</h1>;
 
         case 'Analysis':
             return (
-                <h1
-                    className={cx(
-                        standardFont,
-                        standardPadding,
-                        underlinedStyles,
-                    )}
-                >
+                <h1 className={cx(standardFont, underlinedStyles)}>
                     {curly(headlineString)}
                 </h1>
             );
@@ -266,6 +251,37 @@ const renderHeadline = ({
                 </h1>
             );
     }
+};
+
+const determinPadding = (designType: DesignType) => {
+    switch (designType) {
+        case 'Article':
+        case 'Media':
+        case 'Live':
+        case 'SpecialReport':
+        case 'Recipe':
+        case 'MatchReport':
+        case 'GuardianView':
+        case 'GuardianLabs':
+        case 'Quiz':
+        case 'AdvertisementFeature':
+        case 'Review':
+        case 'Feature':
+        case 'Comment':
+        case 'Analysis':
+            return standardPadding;
+        case 'Interview':
+        case 'Immersive':
+            return null;
+    }
+};
+
+export const ArticleHeadlineWrapper: React.FC<{
+    children: React.ReactNode;
+    designType: DesignType;
+}> = ({ children, designType }) => {
+    const paddingClassName = determinPadding(designType);
+    return <div className={paddingClassName || ''}>{children}</div>;
 };
 
 export const ArticleHeadline = ({

--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -60,14 +60,6 @@ const lightFont = css`
     }
 `;
 
-const standardPadding = css`
-    padding-bottom: 24px;
-    padding-top: 3px;
-    ${from.tablet} {
-        padding-bottom: 36px;
-    }
-`;
-
 const underlinedStyles = css`
     background-image: repeating-linear-gradient(
         to bottom,
@@ -251,37 +243,6 @@ const renderHeadline = ({
                 </h1>
             );
     }
-};
-
-const determinPadding = (designType: DesignType) => {
-    switch (designType) {
-        case 'Article':
-        case 'Media':
-        case 'Live':
-        case 'SpecialReport':
-        case 'Recipe':
-        case 'MatchReport':
-        case 'GuardianView':
-        case 'GuardianLabs':
-        case 'Quiz':
-        case 'AdvertisementFeature':
-        case 'Review':
-        case 'Feature':
-        case 'Comment':
-        case 'Analysis':
-            return standardPadding;
-        case 'Interview':
-        case 'Immersive':
-            return null;
-    }
-};
-
-export const ArticleHeadlineWrapper: React.FC<{
-    children: React.ReactNode;
-    designType: DesignType;
-}> = ({ children, designType }) => {
-    const paddingClassName = determinPadding(designType);
-    return <div className={paddingClassName || ''}>{children}</div>;
 };
 
 export const ArticleHeadline = ({

--- a/src/web/components/ArticleHeadlinePadding.tsx
+++ b/src/web/components/ArticleHeadlinePadding.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
-import { css } from 'emotion';
+import { css, cx } from 'emotion';
 
 import { from } from '@guardian/src-foundations/mq';
 
+const paddingTop = css`
+    padding-top: 3px;
+`;
+
 const standardPadding = css`
     padding-bottom: 24px;
-    padding-top: 3px;
     ${from.tablet} {
         padding-bottom: 36px;
     }
@@ -23,11 +26,12 @@ const determinPadding = (designType: DesignType) => {
         case 'GuardianLabs':
         case 'Quiz':
         case 'AdvertisementFeature':
-        case 'Review':
         case 'Feature':
         case 'Comment':
         case 'Analysis':
             return standardPadding;
+
+        case 'Review':
         case 'Interview':
         case 'Immersive':
             return null;
@@ -39,5 +43,7 @@ export const ArticleHeadlinePadding: React.FC<{
     designType: DesignType;
 }> = ({ children, designType }) => {
     const paddingClassName = determinPadding(designType);
-    return <div className={paddingClassName || ''}>{children}</div>;
+    return (
+        <div className={cx(paddingTop, paddingClassName || '')}>{children}</div>
+    );
 };

--- a/src/web/components/ArticleHeadlinePadding.tsx
+++ b/src/web/components/ArticleHeadlinePadding.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { from } from '@guardian/src-foundations/mq';
+
+const standardPadding = css`
+    padding-bottom: 24px;
+    padding-top: 3px;
+    ${from.tablet} {
+        padding-bottom: 36px;
+    }
+`;
+
+const determinPadding = (designType: DesignType) => {
+    switch (designType) {
+        case 'Article':
+        case 'Media':
+        case 'Live':
+        case 'SpecialReport':
+        case 'Recipe':
+        case 'MatchReport':
+        case 'GuardianView':
+        case 'GuardianLabs':
+        case 'Quiz':
+        case 'AdvertisementFeature':
+        case 'Review':
+        case 'Feature':
+        case 'Comment':
+        case 'Analysis':
+            return standardPadding;
+        case 'Interview':
+        case 'Immersive':
+            return null;
+    }
+};
+
+export const ArticleHeadlinePadding: React.FC<{
+    children: React.ReactNode;
+    designType: DesignType;
+}> = ({ children, designType }) => {
+    const paddingClassName = determinPadding(designType);
+    return <div className={paddingClassName || ''}>{children}</div>;
+};

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -14,7 +14,10 @@ import { GuardianLines } from '@root/src/web/components/GuardianLines';
 import { MostViewedRightIsland } from '@root/src/web/components/MostViewedRightIsland';
 import { SubMeta } from '@root/src/web/components/SubMeta';
 import { MainMedia } from '@root/src/web/components/MainMedia';
-import { ArticleHeadline } from '@root/src/web/components/ArticleHeadline';
+import {
+    ArticleHeadline,
+    ArticleHeadlineWrapper,
+} from '@root/src/web/components/ArticleHeadline';
 import { ArticleStandfirst } from '@root/src/web/components/ArticleStandfirst';
 import { Header } from '@root/src/web/components/Header';
 import { Footer } from '@root/src/web/components/Footer';
@@ -315,14 +318,18 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                     </GridItem>
                     <GridItem area="headline">
                         <PositionHeadline designType={CAPI.designType}>
-                            <ArticleHeadline
-                                headlineString={CAPI.headline}
+                            <ArticleHeadlineWrapper
                                 designType={CAPI.designType}
-                                pillar={CAPI.pillar}
-                                webPublicationDate={CAPI.webPublicationDate}
-                                tags={CAPI.tags}
-                                byline={CAPI.author.byline}
-                            />
+                            >
+                                <ArticleHeadline
+                                    headlineString={CAPI.headline}
+                                    designType={CAPI.designType}
+                                    pillar={CAPI.pillar}
+                                    webPublicationDate={CAPI.webPublicationDate}
+                                    tags={CAPI.tags}
+                                    byline={CAPI.author.byline}
+                                />
+                            </ArticleHeadlineWrapper>
                         </PositionHeadline>
                     </GridItem>
                     <GridItem area="media">

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -14,10 +14,8 @@ import { GuardianLines } from '@root/src/web/components/GuardianLines';
 import { MostViewedRightIsland } from '@root/src/web/components/MostViewedRightIsland';
 import { SubMeta } from '@root/src/web/components/SubMeta';
 import { MainMedia } from '@root/src/web/components/MainMedia';
-import {
-    ArticleHeadline,
-    ArticleHeadlineWrapper,
-} from '@root/src/web/components/ArticleHeadline';
+import { ArticleHeadline } from '@root/src/web/components/ArticleHeadline';
+import { ArticleHeadlinePadding } from '@root/src/web/components/ArticleHeadlinePadding';
 import { ArticleStandfirst } from '@root/src/web/components/ArticleStandfirst';
 import { Header } from '@root/src/web/components/Header';
 import { Footer } from '@root/src/web/components/Footer';
@@ -318,7 +316,7 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                     </GridItem>
                     <GridItem area="headline">
                         <PositionHeadline designType={CAPI.designType}>
-                            <ArticleHeadlineWrapper
+                            <ArticleHeadlinePadding
                                 designType={CAPI.designType}
                             >
                                 <ArticleHeadline
@@ -329,7 +327,7 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                                     tags={CAPI.tags}
                                     byline={CAPI.author.byline}
                                 />
-                            </ArticleHeadlineWrapper>
+                            </ArticleHeadlinePadding>
                         </PositionHeadline>
                     </GridItem>
                     <GridItem area="media">

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -14,7 +14,10 @@ import { GuardianLines } from '@root/src/web/components/GuardianLines';
 import { MostViewedRightIsland } from '@root/src/web/components/MostViewedRightIsland';
 import { SubMeta } from '@root/src/web/components/SubMeta';
 import { MainMedia } from '@root/src/web/components/MainMedia';
-import { ArticleHeadline } from '@root/src/web/components/ArticleHeadline';
+import {
+    ArticleHeadline,
+    ArticleHeadlineWrapper,
+} from '@root/src/web/components/ArticleHeadline';
 import { ArticleStandfirst } from '@root/src/web/components/ArticleStandfirst';
 import { Header } from '@root/src/web/components/Header';
 import { Footer } from '@root/src/web/components/Footer';
@@ -226,14 +229,18 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                     </GridItem>
                     <GridItem area="headline">
                         <div className={maxWidth}>
-                            <ArticleHeadline
-                                headlineString={CAPI.headline}
+                            <ArticleHeadlineWrapper
                                 designType={CAPI.designType}
-                                pillar={CAPI.pillar}
-                                webPublicationDate={CAPI.webPublicationDate}
-                                tags={CAPI.tags}
-                                byline={CAPI.author.byline}
-                            />
+                            >
+                                <ArticleHeadline
+                                    headlineString={CAPI.headline}
+                                    designType={CAPI.designType}
+                                    pillar={CAPI.pillar}
+                                    webPublicationDate={CAPI.webPublicationDate}
+                                    tags={CAPI.tags}
+                                    byline={CAPI.author.byline}
+                                />
+                            </ArticleHeadlineWrapper>
                         </div>
                     </GridItem>
                     <GridItem area="standfirst">

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -14,10 +14,8 @@ import { GuardianLines } from '@root/src/web/components/GuardianLines';
 import { MostViewedRightIsland } from '@root/src/web/components/MostViewedRightIsland';
 import { SubMeta } from '@root/src/web/components/SubMeta';
 import { MainMedia } from '@root/src/web/components/MainMedia';
-import {
-    ArticleHeadline,
-    ArticleHeadlineWrapper,
-} from '@root/src/web/components/ArticleHeadline';
+import { ArticleHeadline } from '@root/src/web/components/ArticleHeadline';
+import { ArticleHeadlinePadding } from '@root/src/web/components/ArticleHeadlinePadding';
 import { ArticleStandfirst } from '@root/src/web/components/ArticleStandfirst';
 import { Header } from '@root/src/web/components/Header';
 import { Footer } from '@root/src/web/components/Footer';
@@ -229,7 +227,7 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                     </GridItem>
                     <GridItem area="headline">
                         <div className={maxWidth}>
-                            <ArticleHeadlineWrapper
+                            <ArticleHeadlinePadding
                                 designType={CAPI.designType}
                             >
                                 <ArticleHeadline
@@ -240,7 +238,7 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                                     tags={CAPI.tags}
                                     byline={CAPI.author.byline}
                                 />
-                            </ArticleHeadlineWrapper>
+                            </ArticleHeadlinePadding>
                         </div>
                     </GridItem>
                     <GridItem area="standfirst">


### PR DESCRIPTION
## What does this change?
Moves the headline padding to a parent component wrapper.

## Why?
Some articles have different padding around headlines (eg: Reviews with stars), therefore separating this logic out would allow use to have more control.

## Link to supporting Trello card
https://trello.com/c/2YBy2eQY/1098-lift-headline-padding-as-its-own-component