### PR TITLE
Support multiple byline styles

### DIFF
--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -244,7 +244,14 @@ const renderHeadline = ({
                             {curly(headlineString)}
                         </span>
                     </h1>
-                    {byline && <HeadlineByline byline={byline} tags={tags} />}
+                    {byline && (
+                        <HeadlineByline
+                            designType={designType}
+                            pillar={pillar}
+                            byline={byline}
+                            tags={tags}
+                        />
+                    )}
                 </div>
             );
 

--- a/src/web/components/HeadlineByline.stories.tsx
+++ b/src/web/components/HeadlineByline.stories.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import { HeadlineByline } from './HeadlineByline';
+
+/* tslint:disable */
+export default {
+    component: HeadlineByline,
+    title: 'Components/HeadlineByline',
+};
+/* tslint:enable */
+
+export const interviewStory = () => {
+    return (
+        <HeadlineByline
+            designType="Interview"
+            pillar="culture"
+            byline="Jane Smith"
+            tags={[]}
+        />
+    );
+};
+interviewStory.story = { name: 'Interview' };
+
+export const commentStory = () => {
+    return (
+        <HeadlineByline
+            designType="Comment"
+            pillar="sport"
+            byline="Jane Smith"
+            tags={[]}
+        />
+    );
+};
+commentStory.story = { name: 'Comment' };

--- a/src/web/components/HeadlineByline.tsx
+++ b/src/web/components/HeadlineByline.tsx
@@ -12,7 +12,7 @@ const wrapperStyles = css`
     z-index: 1;
 `;
 
-const headlineBylineStyles = css`
+const yellowBoxStyles = css`
     ${headline.xxsmall({
         fontWeight: 'regular',
         lineHeight: 'loose',
@@ -33,14 +33,58 @@ const headlineBylineStyles = css`
     }
 `;
 
+const opinionStyles = (pillar: Pillar) => css`
+    ${headline.medium({
+        fontWeight: 'light',
+        lineHeight: 'loose',
+    })}
+    font-style: italic;
+    color: ${palette[pillar].main};
+
+    a {
+        color: inherit;
+        text-decoration: none;
+        :hover {
+            text-decoration: underline;
+        }
+    }
+`;
+
+const determineStyles = (designType: DesignType, pillar: Pillar) => {
+    switch (designType) {
+        case 'Interview':
+            return yellowBoxStyles;
+        case 'Comment':
+            return opinionStyles(pillar);
+        case 'Feature':
+        case 'Review':
+        case 'Live':
+        case 'Media':
+        case 'Analysis':
+        case 'Article':
+        case 'SpecialReport':
+        case 'Recipe':
+        case 'MatchReport':
+        case 'GuardianView':
+        case 'GuardianLabs':
+        case 'Quiz':
+        case 'AdvertisementFeature':
+        case 'Immersive':
+        default:
+            return undefined;
+    }
+};
+
 type Props = {
+    designType: 'Interview' | 'Comment';
+    pillar: Pillar;
     byline: string;
     tags: TagType[];
 };
 
-export const HeadlineByline = ({ byline, tags }: Props) => (
+export const HeadlineByline = ({ designType, pillar, byline, tags }: Props) => (
     <div className={wrapperStyles}>
-        <div className={headlineBylineStyles}>
+        <div className={determineStyles(designType, pillar)}>
             <BylineLink byline={byline} tags={tags} />
         </div>
     </div>


### PR DESCRIPTION
## What does this change?
The byline that appears below the headline was initially created in the style for Interview articles. This PR adds the styles for Comment pieces as well.

The split had been done based on `designType` and `pillar`

```typescript
type Props = {
    designType: 'Interview' | 'Comment';
    pillar: Pillar;
    byline: string;
    tags: TagType[];
};
```

![2020-01-27 09 28 09](https://user-images.githubusercontent.com/1336821/73163206-5f606f80-40e7-11ea-8d14-7e34467dc265.gif)


## Why?
For parity

## Link to supporting Trello card
https://trello.com/c/HDp0eicN/1033-comment-articles