### PR TITLE
Extract lines from Meta

### DIFF
--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -3,7 +3,6 @@ import { css, cx } from 'emotion';
 import { palette } from '@guardian/src-foundations';
 import { between, until } from '@guardian/src-foundations/mq';
 import { Contributor } from '@root/src/web/components/Contributor';
-import { GuardianLines } from '@root/src/web/components/GuardianLines';
 import { Avatar } from '@root/src/web/components/Avatar';
 
 import { getSharingUrls } from '@root/src/lib/sharing-urls';
@@ -64,26 +63,6 @@ const getBylineImageUrl = (tags: TagType[]) => {
 const getAuthorName = (tags: TagType[]) => {
     const contributorTag = tags.find(tag => tag.type === 'Contributor');
     return contributorTag && contributorTag.title;
-};
-
-const decideEffect = (
-    designType: DesignType,
-    pillar: Pillar,
-): LineEffectType => {
-    if (pillar === 'sport') {
-        return 'dotted';
-    }
-    if (designType === 'Feature') {
-        return 'squiggly';
-    }
-    return 'straight';
-};
-
-const decideLineCount = (designType?: DesignType): 8 | 4 => {
-    if (designType === 'Comment') {
-        return 8;
-    }
-    return 4;
 };
 
 const shouldShowAvatar = (designType: DesignType, isImmersive?: boolean) => {
@@ -214,11 +193,6 @@ export const ArticleMeta = ({
 
     return (
         <div className={metaContainer}>
-            <GuardianLines
-                pillar={pillar}
-                effect={decideEffect(designType, pillar)}
-                count={decideLineCount(designType)}
-            />
             <div className={cx(meta)}>
                 <RowBelowLeftCol>
                     <>

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -30,6 +30,7 @@ import { parse } from '@frontend/lib/slot-machine-flags';
 
 import GE2019 from '@frontend/static/badges/general-election-2019.svg';
 
+import { decideLineCount, decideLineEffect } from './layoutHelpers';
 import { Border } from './Border';
 import { GridItem } from './GridItem';
 
@@ -342,6 +343,14 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                     <GridItem area="meta">
                         <PositionMeta designType={CAPI.designType}>
                             <div className={maxWidth}>
+                                <GuardianLines
+                                    pillar={CAPI.pillar}
+                                    effect={decideLineEffect(
+                                        CAPI.designType,
+                                        CAPI.pillar,
+                                    )}
+                                    count={decideLineCount(CAPI.designType)}
+                                />
                                 <ArticleMeta
                                     designType={CAPI.designType}
                                     pillar={CAPI.pillar}

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -78,8 +78,9 @@ const ShowcaseGrid = ({
                         300px; /* Right Column */
                     grid-template-areas:
                         'title  border  headline    headline'
+                        'lines  border  media       media'
                         'meta   border  media       media'
-                        '.      border  standfirst  right-column'
+                        'meta   border  standfirst  right-column'
                         '.      border  body        right-column';
                 }
 
@@ -92,8 +93,9 @@ const ShowcaseGrid = ({
                     grid-template-areas:
                         'title  border  headline    right-column'
                         '.      border  standfirst  right-column'
+                        'lines  border  media       right-column'
                         'meta   border  media       right-column'
-                        '.      border  body        right-column';
+                        'meta   border  body        right-column';
                 }
 
                 ${until.leftCol} {
@@ -105,6 +107,7 @@ const ShowcaseGrid = ({
                         'headline   right-column'
                         'standfirst right-column'
                         'media      right-column'
+                        'lines      right-column'
                         'meta       right-column'
                         'body       right-column';
                 }
@@ -117,6 +120,7 @@ const ShowcaseGrid = ({
                         'headline'
                         'standfirst'
                         'media'
+                        'lines'
                         'meta'
                         'body';
                 }
@@ -129,6 +133,7 @@ const ShowcaseGrid = ({
                         'title'
                         'headline'
                         'standfirst'
+                        'lines'
                         'meta'
                         'body';
                 }
@@ -142,6 +147,13 @@ const ShowcaseGrid = ({
 const maxWidth = css`
     ${from.desktop} {
         max-width: 620px;
+    }
+`;
+
+const stretchLines = css`
+    ${until.phablet} {
+        margin-left: -20px;
+        margin-right: -20px;
     }
 `;
 
@@ -302,8 +314,9 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                             standfirst={CAPI.standfirst}
                         />
                     </GridItem>
-                    <GridItem area="meta">
-                            <div className={maxWidth}>
+                    <GridItem area="lines">
+                        <div className={maxWidth}>
+                            <div className={stretchLines}>
                                 <GuardianLines
                                     pillar={CAPI.pillar}
                                     effect={decideLineEffect(
@@ -312,18 +325,23 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                                     )}
                                     count={decideLineCount(CAPI.designType)}
                                 />
-                                <ArticleMeta
-                                    designType={CAPI.designType}
-                                    pillar={CAPI.pillar}
-                                    pageId={CAPI.pageId}
-                                    webTitle={CAPI.webTitle}
-                                    author={CAPI.author}
-                                    tags={CAPI.tags}
-                                    webPublicationDateDisplay={
-                                        CAPI.webPublicationDateDisplay
-                                    }
-                                />
                             </div>
+                        </div>
+                    </GridItem>
+                    <GridItem area="meta">
+                        <div className={maxWidth}>
+                            <ArticleMeta
+                                designType={CAPI.designType}
+                                pillar={CAPI.pillar}
+                                pageId={CAPI.pageId}
+                                webTitle={CAPI.webTitle}
+                                author={CAPI.author}
+                                tags={CAPI.tags}
+                                webPublicationDateDisplay={
+                                    CAPI.webPublicationDateDisplay
+                                }
+                            />
+                        </div>
                     </GridItem>
                     <GridItem area="body">
                         <ArticleContainer>

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -196,44 +196,6 @@ const PositionHeadline = ({
     }
 };
 
-const PositionMeta = ({
-    designType,
-    children,
-}: {
-    designType: DesignType;
-    children: JSX.Element | JSX.Element[];
-}) => {
-    switch (designType) {
-        case 'Interview':
-            return (
-                <div
-                    className={css`
-                        margin-top: 36px;
-                    `}
-                >
-                    {children}
-                </div>
-            );
-        case 'Immersive':
-        case 'Article':
-        case 'Media':
-        case 'Review':
-        case 'Live':
-        case 'SpecialReport':
-        case 'Recipe':
-        case 'MatchReport':
-        case 'GuardianView':
-        case 'GuardianLabs':
-        case 'Quiz':
-        case 'AdvertisementFeature':
-        case 'Feature':
-        case 'Comment':
-        case 'Analysis':
-        default:
-            return <>{children}</>;
-    }
-};
-
 interface Props {
     CAPI: CAPIType;
     NAV: NavType;
@@ -341,7 +303,6 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                         />
                     </GridItem>
                     <GridItem area="meta">
-                        <PositionMeta designType={CAPI.designType}>
                             <div className={maxWidth}>
                                 <GuardianLines
                                     pillar={CAPI.pillar}
@@ -363,7 +324,6 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                                     }
                                 />
                             </div>
-                        </PositionMeta>
                     </GridItem>
                     <GridItem area="body">
                         <ArticleContainer>

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -79,8 +79,9 @@ const StandardGrid = ({
                     grid-template-areas:
                         'title  border  headline    right-column'
                         '.      border  standfirst  right-column'
+                        'lines  border  media       right-column'
                         'meta   border  media       right-column'
-                        '.      border  body        right-column';
+                        'meta   border  body        right-column';
                 }
 
                 ${until.wide} {
@@ -92,8 +93,9 @@ const StandardGrid = ({
                     grid-template-areas:
                         'title  border  headline    right-column'
                         '.      border  standfirst  right-column'
+                        'lines  border  media       right-column'
                         'meta   border  media       right-column'
-                        '.      border  body        right-column';
+                        'meta   border  body        right-column';
                 }
 
                 ${until.leftCol} {
@@ -105,6 +107,7 @@ const StandardGrid = ({
                         'headline   right-column'
                         'standfirst right-column'
                         'media      right-column'
+                        'lines      right-column'
                         'meta       right-column'
                         'body       right-column';
                 }
@@ -116,6 +119,7 @@ const StandardGrid = ({
                         'headline'
                         'standfirst'
                         'media'
+                        'lines'
                         'meta'
                         'body';
                 }
@@ -129,6 +133,7 @@ const StandardGrid = ({
                         'title'
                         'headline'
                         'standfirst'
+                        'lines'
                         'meta'
                         'body';
                 }
@@ -142,6 +147,13 @@ const StandardGrid = ({
 const maxWidth = css`
     ${from.desktop} {
         max-width: 620px;
+    }
+`;
+
+const stretchLines = css`
+    ${until.phablet} {
+        margin-left: -20px;
+        margin-right: -20px;
     }
 `;
 
@@ -253,16 +265,22 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                             />
                         </div>
                     </GridItem>
+                    <GridItem area="lines">
+                        <div className={maxWidth}>
+                            <div className={stretchLines}>
+                                <GuardianLines
+                                    pillar={CAPI.pillar}
+                                    effect={decideLineEffect(
+                                        CAPI.designType,
+                                        CAPI.pillar,
+                                    )}
+                                    count={decideLineCount(CAPI.designType)}
+                                />
+                            </div>
+                        </div>
+                    </GridItem>
                     <GridItem area="meta">
                         <div className={maxWidth}>
-                            <GuardianLines
-                                pillar={CAPI.pillar}
-                                effect={decideLineEffect(
-                                    CAPI.designType,
-                                    CAPI.pillar,
-                                )}
-                                count={decideLineCount(CAPI.designType)}
-                            />
                             <ArticleMeta
                                 designType={CAPI.designType}
                                 pillar={CAPI.pillar}

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -30,6 +30,7 @@ import { parse } from '@frontend/lib/slot-machine-flags';
 
 import GE2019 from '@frontend/static/badges/general-election-2019.svg';
 
+import { decideLineCount, decideLineEffect } from './layoutHelpers';
 import { Border } from './Border';
 import { GridItem } from './GridItem';
 
@@ -254,6 +255,14 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                     </GridItem>
                     <GridItem area="meta">
                         <div className={maxWidth}>
+                            <GuardianLines
+                                pillar={CAPI.pillar}
+                                effect={decideLineEffect(
+                                    CAPI.designType,
+                                    CAPI.pillar,
+                                )}
+                                count={decideLineCount(CAPI.designType)}
+                            />
                             <ArticleMeta
                                 designType={CAPI.designType}
                                 pillar={CAPI.pillar}

--- a/src/web/layouts/layoutHelpers.ts
+++ b/src/web/layouts/layoutHelpers.ts
@@ -12,3 +12,26 @@ export const hasShowcase = (elements: CAPIElement[]) => {
     // with the 'showcase' role
     return elements.find(isShowcase);
 };
+
+export const decideLineEffect = (
+    designType: DesignType,
+    pillar: Pillar,
+): LineEffectType => {
+    if (designType === 'Comment') {
+        return 'straight';
+    }
+    if (designType === 'Feature') {
+        return 'squiggly';
+    }
+    if (pillar === 'sport') {
+        return 'dotted';
+    }
+    return 'straight';
+};
+
+export const decideLineCount = (designType?: DesignType): 8 | 4 => {
+    if (designType === 'Comment') {
+        return 8;
+    }
+    return 4;
+};


### PR DESCRIPTION
## What does this change?
This PR extracts `GuardianLines` from `ArticleMeta` and puts it explicitly in the layout files

## Why?
To support the Comment layout which requires the lines to be positioned differently

## Link to supporting Trello card
https://trello.com/c/x0HySr0L/1105-create-lines-grid-item