### PR TITLE
Updating tracking data posted to Contributions service

### DIFF
--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -24,7 +24,7 @@ export interface WindowGuardianConfig {
     };
     switches: { [key: string]: boolean };
     tests?: { [key: string]: string };
-    ophan: {
+    ophan?: {
         pageViewId: string;
     };
 }

--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -24,6 +24,9 @@ export interface WindowGuardianConfig {
     };
     switches: { [key: string]: boolean };
     tests?: { [key: string]: string };
+    ophan: {
+        pageViewId: string;
+    };
 }
 
 const makeWindowGuardianConfig = (

--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -9,7 +9,16 @@ const wrapperMargins = css`
 export const SlotBodyEnd = () => {
     const endpointUrl = 'https://contributions.guardianapis.com/epic';
 
-    const trackingParams = {};
+    const trackingParams = {
+        ophanPageId: window.guardian.config.ophan.pageViewId,
+        ophanComponentId: 'ACQUISITIONS_EPIC',
+        platformId: 'GUARDIAN_WEB',
+        campaignCode: '',
+        abTestName: '',
+        abTestVariant: '',
+        referrerUrl: window.location.href.split('?')[0],
+    };
+
     const { data, error } = useApi(endpointUrl, trackingParams);
 
     if (error) {

--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -13,9 +13,9 @@ export const SlotBodyEnd = () => {
         ophanPageId: window.guardian.config.ophan?.pageViewId,
         ophanComponentId: 'ACQUISITIONS_EPIC',
         platformId: 'GUARDIAN_WEB',
-        campaignCode: '',
-        abTestName: '',
-        abTestVariant: '',
+        campaignCode: 'gdnwb_copts_memco_remote_epic_test_api',
+        abTestName: 'remote_epic_test',
+        abTestVariant: 'api',
         referrerUrl: window.location.href.split('?')[0],
     };
     const { data, error } = useApi(endpointUrl, {

--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -10,7 +10,7 @@ export const SlotBodyEnd = () => {
     const endpointUrl = 'https://contributions.guardianapis.com/epic';
 
     const trackingParams = {
-        ophanPageId: window.guardian.config.ophan.pageViewId,
+        ophanPageId: window.guardian.config.ophan?.pageViewId,
         ophanComponentId: 'ACQUISITIONS_EPIC',
         platformId: 'GUARDIAN_WEB',
         campaignCode: '',


### PR DESCRIPTION
## What does this change?
Updates the data inside the `SlotBodyEnd` component to be passed into the Contributions service in order to generate a proper query string for our first A/B test.

## Why?
So we can track clicks originating from the Default Epic served through our service - and do it in such a way that it's easy for the Contributions team to find them.