### PR TITLE
Decorate onwards trail objects with commentCount

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -444,6 +444,8 @@ interface TrailType {
     byline?: string;
     showByline?: boolean;
     kickerText?: string;
+    shortUrl?: string;
+    commentCount?: number;
 }
 
 interface TrailTabType {

--- a/src/web/components/Onwards/OnwardsLayout.tsx
+++ b/src/web/components/Onwards/OnwardsLayout.tsx
@@ -4,6 +4,8 @@ import { Flex } from '@frontend/web/components/Flex';
 import { LeftColumn } from '@frontend/web/components/LeftColumn';
 import { Hide } from '@frontend/web/components/Hide';
 
+import { useComments } from '@frontend/web/components/lib/useComments';
+
 import { OnwardsTitle } from './OnwardsTitle';
 import { OnwardsContainer } from './OnwardsContainer';
 import { MoreThanFive } from './MoreThanFive';
@@ -33,23 +35,27 @@ const decideLayout = (trails: TrailType[]) => {
     }
 };
 
-export const OnwardsLayout = ({ onwardSections }: Props) => (
-    <>
-        {onwardSections.map((onward, index) => (
-            <Flex key={`${onward.heading}-${index}`}>
-                <LeftColumn
-                    showRightBorder={false}
-                    showPartialRightBorder={true}
-                >
-                    <OnwardsTitle title={onward.heading} />
-                </LeftColumn>
-                <OnwardsContainer>
-                    <Hide when="above" breakpoint="leftCol">
+export const OnwardsLayout = ({ onwardSections }: Props) => {
+    const withComments = useComments(onwardSections);
+
+    return (
+        <>
+            {withComments.map((onward, index) => (
+                <Flex key={`${onward.heading}-${index}`}>
+                    <LeftColumn
+                        showRightBorder={false}
+                        showPartialRightBorder={true}
+                    >
                         <OnwardsTitle title={onward.heading} />
-                    </Hide>
-                    {decideLayout(onward.trails.slice(0, 8))}
-                </OnwardsContainer>
-            </Flex>
-        ))}
-    </>
-);
+                    </LeftColumn>
+                    <OnwardsContainer>
+                        <Hide when="above" breakpoint="leftCol">
+                            <OnwardsTitle title={onward.heading} />
+                        </Hide>
+                        {decideLayout(onward.trails.slice(0, 8))}
+                    </OnwardsContainer>
+                </Flex>
+            ))}
+        </>
+    );
+};

--- a/src/web/components/Onwards/OnwardsLayout.tsx
+++ b/src/web/components/Onwards/OnwardsLayout.tsx
@@ -36,23 +36,23 @@ const decideLayout = (trails: TrailType[]) => {
 };
 
 export const OnwardsLayout = ({ onwardSections }: Props) => {
-    const withComments = useComments(onwardSections);
+    const sections = useComments(onwardSections);
 
     return (
         <>
-            {withComments.map((onward, index) => (
-                <Flex key={`${onward.heading}-${index}`}>
+            {sections.map((section, index) => (
+                <Flex key={`${section.heading}-${index}`}>
                     <LeftColumn
                         showRightBorder={false}
                         showPartialRightBorder={true}
                     >
-                        <OnwardsTitle title={onward.heading} />
+                        <OnwardsTitle title={section.heading} />
                     </LeftColumn>
                     <OnwardsContainer>
                         <Hide when="above" breakpoint="leftCol">
-                            <OnwardsTitle title={onward.heading} />
+                            <OnwardsTitle title={section.heading} />
                         </Hide>
-                        {decideLayout(onward.trails.slice(0, 8))}
+                        {decideLayout(section.trails.slice(0, 8))}
                     </OnwardsContainer>
                 </Flex>
             ))}

--- a/src/web/components/lib/useComments.ts
+++ b/src/web/components/lib/useComments.ts
@@ -1,0 +1,82 @@
+import { useState, useEffect } from 'react';
+import { useApi } from '@frontend/web/components/lib/api';
+
+type CommentType = {
+    id: string;
+    count: number;
+};
+
+type CommentsType = {
+    counts: CommentType[];
+};
+
+const findComments = (counts: CommentType[], shortUrl?: string): number => {
+    if (!shortUrl) return 0;
+    const match = counts.find(
+        count => count.id === shortUrl.split('gu.com')[1],
+    );
+    return match ? match.count : 0;
+};
+
+const updateTrailsWithCounts = (trails: TrailType[], counts: CommentType[]) => {
+    const updated: TrailType[] = [];
+    trails.forEach(trail => {
+        const { shortUrl } = trail;
+        const countOfComments = findComments(counts, shortUrl);
+        updated.push({
+            ...trail,
+            commentCount: countOfComments,
+        });
+    });
+    return updated;
+};
+
+const withComments = (
+    onwardSections: OnwardsType[],
+    counts: CommentType[],
+): OnwardsType[] => {
+    if (counts.length === 0) return [];
+    const updatedSections: OnwardsType[] = [];
+    onwardSections.forEach(section => {
+        const updatedTrails = updateTrailsWithCounts(section.trails, counts);
+        updatedSections.push({
+            heading: section.heading,
+            trails: updatedTrails,
+        });
+    });
+    return updatedSections;
+};
+
+const buildUrl = (sections: OnwardsType[]) => {
+    const shortUrls: string[] = [];
+    sections.forEach(section => {
+        section.trails.forEach(trail => {
+            if (trail.shortUrl) shortUrls.push(trail.shortUrl);
+        });
+    });
+
+    // Expected input: ["https://gu.com/p/cngmz", ..., "https://gu.com/p/cngtm"]
+    const shortUrlIds = shortUrls.map(url => url.split('gu.com')[1]).join(',');
+    // Expected output: /p/3pm9v,/p/4k83z,/p/6bnba,/p/8zv38,/p/b6xa7,/p/b7cp9,/p/by5xp
+
+    return `https://api.nextgen.guardianapps.co.uk/discussion/comment-counts.json?shortUrls=${shortUrlIds}`;
+};
+
+export function useComments<T>(onwardsSections: OnwardsType[]) {
+    // useComments takes the onwards response and makes a batch call to the
+    // discussion api (useApi) to get comment counts for all articles referenced in
+    // the trails. It then uses the response from that call to create a copy of the
+    // onwards data that has the commentCount property filled in
+    const [counts, setCounts] = useState<CommentType[]>([]);
+
+    const url = buildUrl(onwardsSections);
+    const { data } = useApi<CommentsType>(url);
+
+    useEffect(() => {
+        setCounts((data && data.counts) || []);
+    }, [data]);
+
+    const sectionsWithComments = withComments(onwardsSections, counts);
+
+    return sectionsWithComments;
+}

--- a/src/web/components/lib/useComments.ts
+++ b/src/web/components/lib/useComments.ts
@@ -19,16 +19,14 @@ const findComments = (counts: CommentType[], shortUrl?: string): number => {
 };
 
 const updateTrailsWithCounts = (trails: TrailType[], counts: CommentType[]) => {
-    const updated: TrailType[] = [];
-    trails.forEach(trail => {
+    return trails.map(trail => {
         const { shortUrl } = trail;
         const countOfComments = findComments(counts, shortUrl);
-        updated.push({
+        return {
             ...trail,
             commentCount: countOfComments,
-        });
+        };
     });
-    return updated;
 };
 
 const withComments = (

--- a/src/web/components/lib/useComments.ts
+++ b/src/web/components/lib/useComments.ts
@@ -36,15 +36,12 @@ const withComments = (
     counts: CommentType[],
 ): OnwardsType[] => {
     if (counts.length === 0) return onwardSections;
-    const updatedSections: OnwardsType[] = [];
-    onwardSections.forEach(section => {
-        const updatedTrails = updateTrailsWithCounts(section.trails, counts);
-        updatedSections.push({
+    return onwardSections.map(section => {
+        return {
             heading: section.heading,
-            trails: updatedTrails,
-        });
+            trails: updateTrailsWithCounts(section.trails, counts),
+        };
     });
-    return updatedSections;
 };
 
 const buildUrl = (sections: OnwardsType[]) => {

--- a/src/web/components/lib/useComments.ts
+++ b/src/web/components/lib/useComments.ts
@@ -35,7 +35,7 @@ const withComments = (
     onwardSections: OnwardsType[],
     counts: CommentType[],
 ): OnwardsType[] => {
-    if (counts.length === 0) return [];
+    if (counts.length === 0) return onwardSections;
     const updatedSections: OnwardsType[] = [];
     onwardSections.forEach(section => {
         const updatedTrails = updateTrailsWithCounts(section.trails, counts);


### PR DESCRIPTION
## What does this change?
Here we add the logic to place the comment count on each onwards trail object.

The hook `useComments` is passed the whole onwards data object and then does 3 things:

1. It extracts the `sharlUrlIds` from each trail object
2. It uses these `shareUrlIds` in an api call to `discussion` to get an array of comment counts
3. and then it merges these counts into the original onwards data object, returning a new object

After this point nothing happens because we don't have the presentation logic yet. This will follow in a separate PR

## Trail type
```typescript
interface TrailType {
    designType: DesignType;
    pillar: Pillar;
    url: string;
    headline: string;
    isLiveBlog: boolean;
    webPublicationDate: string;
    image?: string;
    avatarUrl?: string;
    mediaType?: MediaType;
    mediaDuration?: number;
    ageWarning?: string;
    byline?: string;
    showByline?: boolean;
    kickerText?: string;
    shortUrl?: string;
    commentCount?: number; <---- NEW
}
```

## Why?
Because we want to display the comment count for a card in the bottom right, the same as on frontend

## Link to supporting Trello card
https://trello.com/c/YexUqJRV/890-add-comment-count-to-cards