### PR TITLE
Mock share count stories

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,5 +1,9 @@
+import fetchMock from 'fetch-mock';
 import { configure, addParameters, addDecorator } from '@storybook/react';
 import { withA11y } from '@storybook/addon-a11y';
+
+import { meta } from '@root/fixtures/article';
+import { commentCount } from '@root/fixtures/commentCounts';
 
 import { defaults } from './default-css';
 
@@ -66,6 +70,27 @@ const guardianViewports = {
         },
     },
 };
+
+fetchMock
+    .restore()
+    // Comment count
+    .get(
+        'begin:https://api.nextgen.guardianapps.co.uk/discussion/comment-counts.json?shortUrls=',
+        {
+            status: 200,
+            body: commentCount,
+        },
+        { overwriteRoutes: false },
+    )
+    // Share count
+    .get(
+        'begin:https://api.nextgen.guardianapps.co.uk/sharecount/',
+        {
+            status: 200,
+            body: meta,
+        },
+        { overwriteRoutes: false },
+    );
 
 addParameters({
     viewport: {

--- a/src/web/components/Counts.stories.tsx
+++ b/src/web/components/Counts.stories.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
 import { css } from 'emotion';
+import fetchMock from 'fetch-mock';
+
+import { meta } from '@root/fixtures/article';
+import { commentCount } from '@root/fixtures/commentCounts';
 
 import { Counts } from './Counts';
 
@@ -35,6 +39,34 @@ export const Live = () => {
 Live.story = { name: 'with both results' };
 
 export const ShareOnly = () => {
+    fetchMock
+        .restore()
+        // Comment count
+        .getOnce(
+            'begin:https://api.nextgen.guardianapps.co.uk/discussion/comment-counts.json?shortUrls=',
+            {
+                status: 200,
+                body: {
+                    counts: [
+                        {
+                            id: '/p/4k83z',
+                            count: 0,
+                        },
+                    ],
+                },
+            },
+            { overwriteRoutes: false },
+        )
+        // Share count
+        .getOnce(
+            'begin:https://api.nextgen.guardianapps.co.uk/sharecount/',
+            {
+                status: 200,
+                body: meta,
+            },
+            { overwriteRoutes: false },
+        );
+
     return (
         <Container>
             <Counts
@@ -49,6 +81,31 @@ export const ShareOnly = () => {
 ShareOnly.story = { name: 'with share count only' };
 
 export const CommentOnly = () => {
+    fetchMock
+        .restore()
+        // Comment count
+        .getOnce(
+            'begin:https://api.nextgen.guardianapps.co.uk/discussion/comment-counts.json?shortUrls=',
+            {
+                status: 200,
+                body: commentCount,
+            },
+            { overwriteRoutes: false },
+        )
+        // Share count
+        .getOnce(
+            'begin:https://api.nextgen.guardianapps.co.uk/sharecount/',
+            {
+                status: 200,
+                body: {
+                    path:
+                        'money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+                    share_count: 0,
+                    refreshStatus: true,
+                },
+            },
+            { overwriteRoutes: false },
+        );
     return (
         <Container>
             <Counts

--- a/src/web/components/Counts.tsx
+++ b/src/web/components/Counts.tsx
@@ -7,6 +7,7 @@ import { ShareCount } from '@frontend/web/components/ShareCount';
 import { CommentCount } from '@frontend/web/components/CommentCount';
 import { integerCommas } from '@root/src/lib/formatters';
 import { useApi } from '@root/src/web/components/lib/api';
+import { joinUrl } from '@root/src/web/components/lib/joinUrl';
 
 type Props = {
     ajaxUrl: string;
@@ -62,12 +63,15 @@ const formatForDisplay = (count: number) => {
 };
 
 export const Counts = ({ ajaxUrl, pageId, shortUrlId, pillar }: Props) => {
-    const shareUrl = `${ajaxUrl}/sharecount/${pageId}.json`;
+    const shareUrl = joinUrl([ajaxUrl, 'sharecount', `${pageId}.json`]);
     const { data: shareData, error: shareError } = useApi<ShareCountType>(
         shareUrl,
     );
 
-    const commentUrl = `${ajaxUrl}/discussion/comment-counts.json?shortUrls=${shortUrlId}`;
+    const commentUrl = joinUrl([
+        ajaxUrl,
+        `discussion/comment-counts.json?shortUrls=${shortUrlId}`,
+    ]);
     const { data: commentData, error: commentError } = useApi<
         CommentCountsType
     >(commentUrl);


### PR DESCRIPTION
## What does this change?
This PR mocks the share and comment count apis calls to fix the values shown on the page

## Why?
The `shareCount` and `commentCount` components were using live data and causing false negatives in Chromatic

## Link to supporting Trello card
https://trello.com/c/sdCImwPG/1116-mock-shared-comment-apis