### PR TITLE
Card comment count

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -288,6 +288,7 @@ interface CardType {
     kickerText?: string;
     showPulsingDot?: boolean;
     showSlash?: boolean;
+    commentCount?: number;
 }
 
 type ImageSizeType = 'small' | 'medium' | 'large' | 'jumbo';

--- a/src/web/components/Card/Card.stories.tsx
+++ b/src/web/components/Card/Card.stories.tsx
@@ -668,7 +668,6 @@ export const Media = () => (
                                 headlineText: headlines[11],
                                 headlineSize: 'medium',
                                 kickerText: kickers[0],
-                                webPublicationDate: '2019-11-11T09:45:30.000Z',
                                 imageUrl: images[0],
                                 imagePosition: 'top',
                                 showClock: true,

--- a/src/web/components/Card/Card.stories.tsx
+++ b/src/web/components/Card/Card.stories.tsx
@@ -45,6 +45,7 @@ export const News = () => (
                                 imagePosition: 'right',
                                 imageSize: 'large',
                                 standfirst: standfirsts[0],
+                                commentCount: 864,
                             }}
                         />
                     </LI>
@@ -104,6 +105,7 @@ export const News = () => (
                                         kickerText: kickers[2],
                                         imageUrl: images[6],
                                         imagePosition: 'top',
+                                        commentCount: 82224,
                                     }}
                                 />
                             </LI>
@@ -151,6 +153,7 @@ export const News = () => (
                                         headlineText: headlines[6],
                                         headlineSize: 'small',
                                         kickerText: kickers[3],
+                                        commentCount: 26,
                                     }}
                                 />
                             </LI>
@@ -216,6 +219,7 @@ export const News = () => (
                                         headlineText: headlines[11],
                                         headlineSize: 'small',
                                         kickerText: kickers[3],
+                                        commentCount: 44,
                                     }}
                                 />
                             </LI>
@@ -267,6 +271,7 @@ export const InDepth = () => (
                                         imageUrl: images[6],
                                         imagePosition: 'left',
                                         imageSize: 'small',
+                                        commentCount: 864,
                                     }}
                                 />
                             </LI>
@@ -337,6 +342,7 @@ export const InDepth = () => (
                                 kickerText: kickers[0],
                                 imageUrl: images[0],
                                 imagePosition: 'top',
+                                commentCount: 864333,
                             }}
                         />
                     </LI>
@@ -388,6 +394,7 @@ export const Related = () => (
                                 webPublicationDate: '2019-11-11T09:45:30.000Z',
                                 imageUrl: images[6],
                                 imagePosition: 'top',
+                                commentCount: 222864,
                             }}
                         />
                     </LI>
@@ -408,6 +415,7 @@ export const Related = () => (
                                 webPublicationDate: '2019-11-11T09:45:30.000Z',
                                 imageUrl: images[4],
                                 imagePosition: 'top',
+                                commentCount: 4,
                             }}
                         />
                     </LI>
@@ -543,6 +551,7 @@ export const Quad = () => (
                                     alt: 'Avatar alt text',
                                 },
                                 showClock: true,
+                                commentCount: 3,
                             }}
                         />
                     </LI>
@@ -563,6 +572,7 @@ export const Quad = () => (
                                 imageUrl: images[0],
                                 imagePosition: 'top',
                                 showClock: true,
+                                commentCount: 30989,
                             }}
                         />
                     </LI>
@@ -584,6 +594,7 @@ export const Quad = () => (
                                 imageUrl: images[0],
                                 imagePosition: 'top',
                                 showClock: true,
+                                commentCount: 0,
                             }}
                         />
                     </LI>
@@ -641,6 +652,7 @@ export const Media = () => (
                                 imagePosition: 'top',
                                 showClock: true,
                                 mediaType: 'Gallery',
+                                commentCount: 0, // I should not show
                             }}
                         />
                     </LI>
@@ -664,6 +676,7 @@ export const Media = () => (
                                 showClock: true,
                                 mediaType: 'Audio',
                                 mediaDuration: 35999,
+                                commentCount: 864, // I should not show
                             }}
                         />
                     </LI>

--- a/src/web/components/Card/Card.stories.tsx
+++ b/src/web/components/Card/Card.stories.tsx
@@ -45,7 +45,6 @@ export const News = () => (
                                 imagePosition: 'right',
                                 imageSize: 'large',
                                 standfirst: standfirsts[0],
-                                commentCount: 864,
                             }}
                         />
                     </LI>
@@ -336,13 +335,14 @@ export const InDepth = () => (
                                 linkTo:
                                     '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
                                 pillar: 'news',
-                                designType: 'Article',
+                                designType: 'Comment',
                                 headlineText: headlines[7],
                                 headlineSize: 'large',
                                 kickerText: kickers[0],
                                 imageUrl: images[0],
                                 imagePosition: 'top',
-                                commentCount: 864333,
+                                webPublicationDate: '2019-11-11T09:45:30.000Z',
+                                commentCount: 3694,
                             }}
                         />
                     </LI>
@@ -408,14 +408,13 @@ export const Related = () => (
                                 linkTo:
                                     '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
                                 pillar: 'sport',
-                                designType: 'Article',
+                                designType: 'Comment',
                                 headlineText: headlines[8],
                                 headlineSize: 'medium',
                                 kickerText: kickers[1],
                                 webPublicationDate: '2019-11-11T09:45:30.000Z',
                                 imageUrl: images[4],
                                 imagePosition: 'top',
-                                commentCount: 4,
                             }}
                         />
                     </LI>
@@ -551,7 +550,6 @@ export const Quad = () => (
                                     alt: 'Avatar alt text',
                                 },
                                 showClock: true,
-                                commentCount: 3,
                             }}
                         />
                     </LI>
@@ -652,7 +650,7 @@ export const Media = () => (
                                 imagePosition: 'top',
                                 showClock: true,
                                 mediaType: 'Gallery',
-                                commentCount: 0, // I should not show
+                                commentCount: 0,
                             }}
                         />
                     </LI>
@@ -676,7 +674,7 @@ export const Media = () => (
                                 showClock: true,
                                 mediaType: 'Audio',
                                 mediaDuration: 35999,
-                                commentCount: 864, // I should not show
+                                commentCount: 864,
                             }}
                         />
                     </LI>

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -8,6 +8,9 @@ import { Avatar } from '@frontend/web/components/Avatar';
 import { Flex } from '@frontend/web/components/Flex';
 import { Hide } from '@frontend/web/components/Hide';
 import { MediaMeta } from '@frontend/web/components/MediaMeta';
+import { CardCommentCount } from '@frontend/web/components/CardCommentCount';
+
+import { formatCount } from '@root/src/web/components/lib/formatCount';
 
 import { ContentWrapper } from './components/ContentWrapper';
 import { HeadlineWrapper } from './components/HeadlineWrapper';
@@ -75,6 +78,7 @@ export const Card = ({
     kickerText,
     showPulsingDot,
     showSlash,
+    commentCount,
 }: CardType) => {
     // Decide how we position the image on the card
     let imageCoverage: CardPercentageType | undefined;
@@ -86,6 +90,8 @@ export const Card = ({
         imageCoverage = coverages.image[imageSize];
         contentCoverage = coverages.content[imageSize];
     }
+
+    const { long: longCount, short: shortCount } = formatCount(commentCount);
 
     return (
         <CardLink linkTo={linkTo} designType={designType} pillar={pillar}>
@@ -179,6 +185,16 @@ export const Card = ({
                                                 />
                                             </>
                                         )}
+                                        {designType !== 'Media' &&
+                                            longCount &&
+                                            shortCount && (
+                                                <>
+                                                    <CardCommentCount
+                                                        long={longCount}
+                                                        short={shortCount}
+                                                    />
+                                                </>
+                                            )}
                                     </>
                                 </CardFooter>
                             </div>

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { palette } from '@guardian/src-foundations';
 
 import { CardHeadline } from '@frontend/web/components/CardHeadline';
-import { GuardianLines } from '@frontend/web/components/GuardianLines';
 import { Avatar } from '@frontend/web/components/Avatar';
 import { Flex } from '@frontend/web/components/Flex';
 import { Hide } from '@frontend/web/components/Hide';
@@ -18,7 +17,6 @@ import { CardLayout } from './components/CardLayout';
 import { ImageWrapper } from './components/ImageWrapper';
 import { AvatarContainer } from './components/AvatarContainer';
 import { StandfirstWrapper } from './components/StandfirstWrapper';
-import { LinesWrapper } from './components/LinesWrapper';
 import { CardFooter } from './components/CardFooter';
 import { TopBar } from './components/TopBar';
 import { CardLink } from './components/CardLink';
@@ -154,9 +152,10 @@ export const Card = ({
                                         </AvatarContainer>
                                     </Hide>
                                 )}
-                                <CardFooter designType={designType}>
-                                    <>
-                                        {webPublicationDate && (
+                                <CardFooter
+                                    designType={designType}
+                                    age={
+                                        webPublicationDate ? (
                                             <CardAge
                                                 designType={designType}
                                                 pillar={pillar}
@@ -165,16 +164,12 @@ export const Card = ({
                                                 }
                                                 showClock={showClock}
                                             />
-                                        )}
-                                        {designType === 'Comment' && (
-                                            <LinesWrapper>
-                                                <GuardianLines
-                                                    pillar="opinion"
-                                                    count={4}
-                                                />
-                                            </LinesWrapper>
-                                        )}
-                                        {designType === 'Media' && mediaType && (
+                                        ) : (
+                                            undefined
+                                        )
+                                    }
+                                    mediaMeta={
+                                        designType === 'Media' && mediaType ? (
                                             <>
                                                 <MediaMeta
                                                     pillar={pillar}
@@ -184,19 +179,25 @@ export const Card = ({
                                                     }
                                                 />
                                             </>
-                                        )}
-                                        {designType !== 'Media' &&
-                                            longCount &&
-                                            shortCount && (
-                                                <>
-                                                    <CardCommentCount
-                                                        long={longCount}
-                                                        short={shortCount}
-                                                    />
-                                                </>
-                                            )}
-                                    </>
-                                </CardFooter>
+                                        ) : (
+                                            undefined
+                                        )
+                                    }
+                                    commentCount={
+                                        longCount && shortCount ? (
+                                            <>
+                                                <CardCommentCount
+                                                    designType={designType}
+                                                    pillar={pillar}
+                                                    long={longCount}
+                                                    short={shortCount}
+                                                />
+                                            </>
+                                        ) : (
+                                            undefined
+                                        )
+                                    }
+                                />
                             </div>
                         </ContentWrapper>
                     </>

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -170,29 +170,23 @@ export const Card = ({
                                     }
                                     mediaMeta={
                                         designType === 'Media' && mediaType ? (
-                                            <>
-                                                <MediaMeta
-                                                    pillar={pillar}
-                                                    mediaType={mediaType}
-                                                    mediaDuration={
-                                                        mediaDuration
-                                                    }
-                                                />
-                                            </>
+                                            <MediaMeta
+                                                pillar={pillar}
+                                                mediaType={mediaType}
+                                                mediaDuration={mediaDuration}
+                                            />
                                         ) : (
                                             undefined
                                         )
                                     }
                                     commentCount={
                                         longCount && shortCount ? (
-                                            <>
-                                                <CardCommentCount
-                                                    designType={designType}
-                                                    pillar={pillar}
-                                                    long={longCount}
-                                                    short={shortCount}
-                                                />
-                                            </>
+                                            <CardCommentCount
+                                                designType={designType}
+                                                pillar={pillar}
+                                                long={longCount}
+                                                short={shortCount}
+                                            />
                                         ) : (
                                             undefined
                                         )

--- a/src/web/components/Card/components/CardAge.tsx
+++ b/src/web/components/Card/components/CardAge.tsx
@@ -15,8 +15,8 @@ const ageStyles = (designType?: DesignType) => css`
 
     /* Provide side padding for positioning and also to keep spacing
     between any sibings (like GuardianLines) */
-    padding-left: ${designType === `Media` ? 0 : `5px`};
-    padding-right: ${designType === `Media` ? 0 : `5px`};
+    padding-left: 5px;
+    padding-right: 5px;
 
     svg {
         fill: ${palette.neutral[46]};

--- a/src/web/components/Card/components/CardFooter.tsx
+++ b/src/web/components/Card/components/CardFooter.tsx
@@ -48,7 +48,8 @@ export const CardFooter = ({
             <footer className={spaceBetween}>
                 <>
                     {mediaMeta}
-                    {commentCount}
+                    {/* Show age if we have it otherwise try for commentCount */}
+                    {age || commentCount}
                 </>
             </footer>
         );

--- a/src/web/components/Card/components/CardFooter.tsx
+++ b/src/web/components/Card/components/CardFooter.tsx
@@ -17,13 +17,15 @@ const mediaFooterStyles = css`
     padding: 0 5px 5px 5px;
 `;
 
-export const CardFooter = ({ children, designType }: Props) => (
-    <footer
-        className={cx(
-            footerStyles,
-            designType === 'Media' && mediaFooterStyles,
-        )}
-    >
-        {children}
-    </footer>
-);
+export const CardFooter = ({ children, designType }: Props) => {
+    return (
+        <footer
+            className={cx(
+                footerStyles,
+                designType === 'Media' && mediaFooterStyles,
+            )}
+        >
+            {children}
+        </footer>
+    );
+};

--- a/src/web/components/Card/components/CardFooter.tsx
+++ b/src/web/components/Card/components/CardFooter.tsx
@@ -32,13 +32,11 @@ export const CardFooter = ({
     if (designType === 'Comment') {
         return (
             <footer className={spaceBetween}>
-                <>
-                    {age}
-                    <LinesWrapper>
-                        <GuardianLines pillar="opinion" count={4} />
-                    </LinesWrapper>
-                    {commentCount}
-                </>
+                {age}
+                <LinesWrapper>
+                    <GuardianLines pillar="opinion" count={4} />
+                </LinesWrapper>
+                {commentCount}
             </footer>
         );
     }
@@ -46,11 +44,9 @@ export const CardFooter = ({
     if (designType === 'Media') {
         return (
             <footer className={spaceBetween}>
-                <>
-                    {mediaMeta}
-                    {/* Show age if we have it otherwise try for commentCount */}
-                    {age || commentCount}
-                </>
+                {mediaMeta}
+                {/* Show age if we have it otherwise try for commentCount */}
+                {age || commentCount}
             </footer>
         );
     }
@@ -58,10 +54,8 @@ export const CardFooter = ({
     if (age) {
         return (
             <footer className={spaceBetween}>
-                <>
-                    {age}
-                    {commentCount}
-                </>
+                {age}
+                {commentCount}
             </footer>
         );
     }

--- a/src/web/components/Card/components/CardFooter.tsx
+++ b/src/web/components/Card/components/CardFooter.tsx
@@ -1,31 +1,73 @@
 import React from 'react';
-import { css, cx } from 'emotion';
+import { css } from 'emotion';
+
+import { GuardianLines } from '@frontend/web/components/GuardianLines';
+
+import { LinesWrapper } from './LinesWrapper';
 
 type Props = {
-    children: JSXElements;
-    designType?: DesignType;
+    designType: DesignType;
+    age?: JSX.Element;
+    mediaMeta?: JSX.Element;
+    commentCount?: JSX.Element;
 };
 
-const footerStyles = css`
+const spaceBetween = css`
     display: flex;
     justify-content: space-between;
     align-items: center;
 `;
 
-const mediaFooterStyles = css`
-    flex-direction: row-reverse;
-    padding: 0 5px 5px 5px;
+const flexEnd = css`
+    display: flex;
+    justify-content: flex-end;
 `;
 
-export const CardFooter = ({ children, designType }: Props) => {
+export const CardFooter = ({
+    designType,
+    age,
+    mediaMeta,
+    commentCount,
+}: Props) => {
+    if (designType === 'Comment') {
+        return (
+            <footer className={spaceBetween}>
+                <>
+                    {age}
+                    <LinesWrapper>
+                        <GuardianLines pillar="opinion" count={4} />
+                    </LinesWrapper>
+                    {commentCount}
+                </>
+            </footer>
+        );
+    }
+
+    if (designType === 'Media') {
+        return (
+            <footer className={spaceBetween}>
+                <>
+                    {mediaMeta}
+                    {commentCount}
+                </>
+            </footer>
+        );
+    }
+
+    if (age) {
+        return (
+            <footer className={spaceBetween}>
+                <>
+                    {age}
+                    {commentCount}
+                </>
+            </footer>
+        );
+    }
+
     return (
-        <footer
-            className={cx(
-                footerStyles,
-                designType === 'Media' && mediaFooterStyles,
-            )}
-        >
-            {children}
+        <footer className={flexEnd}>
+            <>{commentCount}</>
         </footer>
     );
 };

--- a/src/web/components/CardCommentCount.stories.tsx
+++ b/src/web/components/CardCommentCount.stories.tsx
@@ -23,8 +23,27 @@ const Container = ({ children }: { children: JSXElements }) => (
 export const CommentCountStory = () => {
     return (
         <Container>
-            <CardCommentCount short="11k" long="10,899" />
+            <CardCommentCount
+                designType="Article"
+                pillar="news"
+                short="11k"
+                long="10,899"
+            />
         </Container>
     );
 };
 CommentCountStory.story = { name: 'default' };
+
+export const MediaStory = () => {
+    return (
+        <Container>
+            <CardCommentCount
+                designType="Media"
+                pillar="culture"
+                short="11k"
+                long="10,899"
+            />
+        </Container>
+    );
+};
+MediaStory.story = { name: 'Media' };

--- a/src/web/components/CardCommentCount.stories.tsx
+++ b/src/web/components/CardCommentCount.stories.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { CardCommentCount } from './CardCommentCount';
+
+/* tslint:disable */
+export default {
+    component: CardCommentCount,
+    title: 'Components/CardCommentCount',
+};
+/* tslint:enable */
+
+const Container = ({ children }: { children: JSXElements }) => (
+    <div
+        className={css`
+            margin: 40px;
+        `}
+    >
+        {children}
+    </div>
+);
+
+export const CommentCountStory = () => {
+    return (
+        <Container>
+            <CardCommentCount short="11k" long="10,899" />
+        </Container>
+    );
+};
+CommentCountStory.story = { name: 'default' };

--- a/src/web/components/CardCommentCount.tsx
+++ b/src/web/components/CardCommentCount.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'emotion';
+import { css, cx } from 'emotion';
 
 import { palette } from '@guardian/src-foundations';
 import { textSans } from '@guardian/src-foundations/typography';
@@ -8,6 +8,8 @@ import { between } from '@guardian/src-foundations/mq';
 import CommentIcon from '@frontend/static/icons/comment.svg';
 
 type Props = {
+    designType: DesignType;
+    pillar: Pillar;
     short: string;
     long: string;
 };
@@ -47,9 +49,31 @@ const shortStyles = css`
     }
 `;
 
-export const CardCommentCount = ({ short, long }: Props) => {
+const mediaStyles = (pillar: Pillar) => css`
+    /* Below we force the colour to be bright if the pillar is news (because it looks better) */
+    color: ${pillar === 'news' ? palette[pillar].bright : palette[pillar].main};
+
+    svg {
+        fill: ${pillar === 'news'
+            ? palette[pillar].bright
+            : palette[pillar].main};
+    }
+`;
+
+export const CardCommentCount = ({
+    designType,
+    pillar,
+    short,
+    long,
+}: Props) => {
     return (
-        <div className={containerStyles} aria-label={`${short} Comments`}>
+        <div
+            className={cx(
+                containerStyles,
+                designType === 'Media' && mediaStyles(pillar),
+            )}
+            aria-label={`${short} Comments`}
+        >
             <div className={iconContainerStyles}>
                 <CommentIcon />
             </div>

--- a/src/web/components/CardCommentCount.tsx
+++ b/src/web/components/CardCommentCount.tsx
@@ -17,14 +17,16 @@ const containerStyles = css`
     flex-direction: row;
     ${textSans.xsmall()};
     color: ${palette.neutral[60]};
+    padding-left: 5px;
+    padding-right: 5px;
 `;
 
 const iconContainerStyles = css`
     svg {
         fill: ${palette.neutral[46]};
-        margin-bottom: -7px;
-        height: 16px;
-        width: 16px;
+        margin-bottom: -5px;
+        height: 14px;
+        width: 14px;
         margin-right: 2px;
     }
 `;

--- a/src/web/components/CardCommentCount.tsx
+++ b/src/web/components/CardCommentCount.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { palette } from '@guardian/src-foundations';
+import { textSans } from '@guardian/src-foundations/typography';
+import { between } from '@guardian/src-foundations/mq';
+
+import CommentIcon from '@frontend/static/icons/comment.svg';
+
+type Props = {
+    short: string;
+    long: string;
+};
+
+const containerStyles = css`
+    display: flex;
+    flex-direction: row;
+    ${textSans.xsmall()};
+    color: ${palette.neutral[60]};
+`;
+
+const iconContainerStyles = css`
+    svg {
+        fill: ${palette.neutral[46]};
+        margin-bottom: -7px;
+        height: 16px;
+        width: 16px;
+        margin-right: 2px;
+    }
+`;
+
+const longStyles = css`
+    display: block;
+
+    ${between.leftCol.and.wide} {
+        display: none;
+    }
+`;
+
+const shortStyles = css`
+    display: none;
+
+    ${between.leftCol.and.wide} {
+        display: block;
+    }
+`;
+
+export const CardCommentCount = ({ short, long }: Props) => {
+    return (
+        <div className={containerStyles} aria-label={`${short} Comments`}>
+            <div className={iconContainerStyles}>
+                <CommentIcon />
+            </div>
+            <div className={longStyles} aria-hidden="true">
+                {long}
+            </div>
+            <div className={shortStyles} aria-hidden="true">
+                {short}
+            </div>
+        </div>
+    );
+};

--- a/src/web/components/Counts.tsx
+++ b/src/web/components/Counts.tsx
@@ -5,8 +5,8 @@ import { palette } from '@guardian/src-foundations';
 
 import { ShareCount } from '@frontend/web/components/ShareCount';
 import { CommentCount } from '@frontend/web/components/CommentCount';
-import { integerCommas } from '@root/src/lib/formatters';
 import { useApi } from '@root/src/web/components/lib/api';
+import { formatCount } from '@root/src/web/components/lib/formatCount';
 
 type Props = {
     ajaxUrl: string;
@@ -48,19 +48,6 @@ const NumbersBorder = () => (
     />
 );
 
-const formatForDisplay = (count: number) => {
-    const countAsInteger = parseInt(count.toFixed(0), 10);
-    const displayCountLong = integerCommas(countAsInteger);
-    const displayCountShort =
-        countAsInteger > 10000
-            ? `${Math.round(countAsInteger / 1000)}k`
-            : countAsInteger.toString();
-    return {
-        short: displayCountShort,
-        long: displayCountLong,
-    };
-};
-
 export const Counts = ({ ajaxUrl, pageId, shortUrlId, pillar }: Props) => {
     const shareUrl = `${ajaxUrl}/sharecount/${pageId}.json`;
     const { data: shareData, error: shareError } = useApi<ShareCountType>(
@@ -98,11 +85,11 @@ export const Counts = ({ ajaxUrl, pageId, shortUrlId, pillar }: Props) => {
         return null;
     }
 
-    const { short: shareShort, long: shareLong } = formatForDisplay(
+    const { short: shareShort, long: shareLong } = formatCount(
         (shareData && shareData.share_count) || 0,
     );
 
-    const { short: commentShort, long: commentLong } = formatForDisplay(
+    const { short: commentShort, long: commentLong } = formatCount(
         (commentData &&
             commentData.counts &&
             commentData.counts[0] &&

--- a/src/web/components/MediaMeta.tsx
+++ b/src/web/components/MediaMeta.tsx
@@ -44,6 +44,8 @@ const durationStyles = (pillar: Pillar) => css`
 const wrapperStyles = css`
     display: flex;
     align-items: center;
+
+    padding: 0 5px 5px 5px;
 `;
 
 export function secondsToDuration(secs?: number): string {

--- a/src/web/components/lib/formatCount.ts
+++ b/src/web/components/lib/formatCount.ts
@@ -1,6 +1,7 @@
 import { integerCommas } from '@root/src/lib/formatters';
 
-export const formatCount = (count: number) => {
+export const formatCount = (count?: number) => {
+    if (!count) return { short: '', long: '' };
     const countAsInteger = parseInt(count.toFixed(0), 10);
     const displayCountLong = integerCommas(countAsInteger);
     const displayCountShort =

--- a/src/web/components/lib/formatCount.ts
+++ b/src/web/components/lib/formatCount.ts
@@ -1,0 +1,14 @@
+import { integerCommas } from '@root/src/lib/formatters';
+
+export const formatCount = (count: number) => {
+    const countAsInteger = parseInt(count.toFixed(0), 10);
+    const displayCountLong = integerCommas(countAsInteger);
+    const displayCountShort =
+        countAsInteger > 10000
+            ? `${Math.round(countAsInteger / 1000)}k`
+            : countAsInteger.toString();
+    return {
+        short: displayCountShort,
+        long: displayCountLong,
+    };
+};


### PR DESCRIPTION
## What does this change?
This PR adds the ability to display comment counts in cards

![Screenshot 2020-01-30 at 10 41 19](https://user-images.githubusercontent.com/1336821/73442615-127dd280-434d-11ea-9940-f8d03db4b8bb.jpg)
![Screenshot 2020-01-30 at 10 41 14](https://user-images.githubusercontent.com/1336821/73442616-13166900-434d-11ea-9418-8f2be7f0651c.jpg)
![Screenshot 2020-01-30 at 10 40 51](https://user-images.githubusercontent.com/1336821/73442617-13166900-434d-11ea-9dfc-3de721e85c17.jpg)
![Screenshot 2020-01-30 at 10 40 41](https://user-images.githubusercontent.com/1336821/73442619-13166900-434d-11ea-8f12-1cf308687303.jpg)

There's a [separate PR](https://github.com/guardian/dotcom-rendering/pull/1117) to fetch the comment counts for onwards content. The code here only deals with the display of the count.

## CardFooter was refactored
In order to correctly position the elements in the card footer it was necessary to refactor how that component works to something more flexible.

## Link to supporting Trello card
https://trello.com/c/YexUqJRV/890-add-comment-count-to-cards