### PR TITLE
MainMedia component support children prop

### DIFF
--- a/src/web/components/MainMedia.tsx
+++ b/src/web/components/MainMedia.tsx
@@ -52,6 +52,7 @@ function renderElement(
     i: number,
     hideCaption?: boolean,
     adTargeting?: AdTargeting,
+    children?: JSXElements,
 ) {
     switch (element._type) {
         case 'model.dotcomrendering.pageElements.ImageBlockElement':
@@ -63,7 +64,9 @@ function renderElement(
                     hideCaption={hideCaption}
                     role={element.role}
                     isMainMedia={true}
-                />
+                >
+                    {children}
+                </ImageComponent>
             );
         case 'model.dotcomrendering.pageElements.YoutubeBlockElement':
             return (
@@ -75,7 +78,9 @@ function renderElement(
                     // tslint:disable-next-line react-a11y-role
                     role="inline"
                     adTargeting={adTargeting}
-                />
+                >
+                    {children}
+                </YouTubeComponent>
             );
         default:
             // tslint:disable-next-line no-console
@@ -91,10 +96,18 @@ export const MainMedia: React.FC<{
     pillar: Pillar;
     hideCaption?: boolean;
     adTargeting?: AdTargeting;
-}> = ({ elements, pillar, hideCaption, adTargeting }) => (
+    children?: JSXElements;
+}> = ({ elements, pillar, hideCaption, adTargeting, children }) => (
     <div className={mainMedia}>
         {elements.map((element, i) =>
-            renderElement(element, pillar, i, hideCaption, adTargeting),
+            renderElement(
+                element,
+                pillar,
+                i,
+                hideCaption,
+                adTargeting,
+                children,
+            ),
         )}
     </div>
 );

--- a/src/web/components/Picture.tsx
+++ b/src/web/components/Picture.tsx
@@ -35,8 +35,9 @@ export const Picture: React.FC<{
                             '',
                         )}<!--[if IE 9]></video><![endif]--><img itemprop="contentUrl" alt="${alt}" src="${src}" />`,
                 }}
-            />
-            {children}
+            >
+                {children}
+            </picture>
         </>
     );
 };

--- a/src/web/components/Picture.tsx
+++ b/src/web/components/Picture.tsx
@@ -23,16 +23,20 @@ export const Picture: React.FC<{
     sources: PictureSource[];
     alt: string;
     src: string;
-}> = ({ sources, alt, src }) => {
+    children?: JSXElements;
+}> = ({ sources, alt, src, children }) => {
     return (
-        <picture
-            dangerouslySetInnerHTML={{
-                __html: `<!--[if IE 9]><video style="display: none;"><![endif]-->${sources
-                    .map(forSource)
-                    .join(
-                        '',
-                    )}<!--[if IE 9]></video><![endif]--><img itemprop="contentUrl" alt="${alt}" src="${src}" />`,
-            }}
-        />
+        <>
+            <picture
+                dangerouslySetInnerHTML={{
+                    __html: `<!--[if IE 9]><video style="display: none;"><![endif]-->${sources
+                        .map(forSource)
+                        .join(
+                            '',
+                        )}<!--[if IE 9]></video><![endif]--><img itemprop="contentUrl" alt="${alt}" src="${src}" />`,
+                }}
+            />
+            {children}
+        </>
     );
 };

--- a/src/web/components/YouTubeEmbed.tsx
+++ b/src/web/components/YouTubeEmbed.tsx
@@ -12,6 +12,7 @@ type Props = {
     overlayImage?: string;
     duration?: number; // in seconds
     title?: string;
+    children?: JSX.Element | JSX.Element[];
 };
 
 type EmbedConfig = {

--- a/src/web/components/elements/ImageComponent.tsx
+++ b/src/web/components/elements/ImageComponent.tsx
@@ -70,7 +70,8 @@ export const ImageComponent: React.FC<{
     hideCaption?: boolean;
     role: RoleType;
     isMainMedia?: boolean;
-}> = ({ element, pillar, hideCaption, role, isMainMedia }) => {
+    children?: JSXElements;
+}> = ({ element, pillar, hideCaption, role, isMainMedia, children }) => {
     const sources = makeSources(element.imageSources, element.role);
     if (hideCaption) {
         return (
@@ -78,7 +79,9 @@ export const ImageComponent: React.FC<{
                 sources={sources}
                 alt={element.data.alt || ''}
                 src={getFallback(element.imageSources)}
-            />
+            >
+                {children}
+            </Picture>
         );
     }
     return (
@@ -95,7 +98,9 @@ export const ImageComponent: React.FC<{
                 sources={sources}
                 alt={element.data.alt || ''}
                 src={getFallback(element.imageSources)}
-            />
+            >
+                {children}
+            </Picture>
         </Caption>
     );
 };

--- a/src/web/components/elements/YouTubeComponent.tsx
+++ b/src/web/components/elements/YouTubeComponent.tsx
@@ -9,6 +9,7 @@ type Props = {
     hideCaption?: boolean;
     role: RoleType;
     adTargeting?: AdTargeting;
+    children?: JSX.Element | JSX.Element[];
 };
 
 export const YouTubeComponent = ({
@@ -17,6 +18,7 @@ export const YouTubeComponent = ({
     hideCaption,
     role,
     adTargeting,
+    children,
 }: Props) => {
     if (hideCaption) {
         return (
@@ -26,7 +28,9 @@ export const YouTubeComponent = ({
                 adTargeting={adTargeting}
                 duration={element.duration}
                 title={element.mediaTitle}
-            />
+            >
+                {children}
+            </YouTubeEmbed>
         );
     }
     return (
@@ -43,7 +47,9 @@ export const YouTubeComponent = ({
                 adTargeting={adTargeting}
                 duration={element.duration}
                 title={element.mediaTitle}
-            />
+            >
+                {children}
+            </YouTubeEmbed>
         </Caption>
     );
 };


### PR DESCRIPTION
## What does this change?
MainMedia/Picture/Youtube component support children prop

## Why?
Make it easier to add components on imgs and videos by extending MainMedia to use children prop to wrap.

Will be useful for star rating and youtube play button

## Link to supporting Trello card
https://trello.com/c/A3tvKqfc/1117-mainmedia-component-to-use-children-to-be-able-to-render-elements-on-img-and-videos