### PR TITLE
Ensure commentCount is passed down

### DIFF
--- a/src/web/components/Onwards/ExactlyFive.tsx
+++ b/src/web/components/Onwards/ExactlyFive.tsx
@@ -31,6 +31,7 @@ export const ExactlyFive = ({ content }: Props) => (
                         imageUrl: content[0].image,
                         mediaType: content[0].mediaType,
                         mediaDuration: content[0].mediaDuration,
+                        commentCount: content[0].commentCount,
                     }}
                 />
             </LI>
@@ -59,6 +60,7 @@ export const ExactlyFive = ({ content }: Props) => (
                         imageUrl: content[1].image,
                         mediaType: content[1].mediaType,
                         mediaDuration: content[1].mediaDuration,
+                        commentCount: content[1].commentCount,
                     }}
                 />
             </LI>
@@ -89,6 +91,7 @@ export const ExactlyFive = ({ content }: Props) => (
                                 showClock: false,
                                 mediaType: content[2].mediaType,
                                 mediaDuration: content[2].mediaDuration,
+                                commentCount: content[2].commentCount,
                             }}
                         />
                     </LI>
@@ -112,6 +115,7 @@ export const ExactlyFive = ({ content }: Props) => (
                                 showClock: false,
                                 mediaType: content[3].mediaType,
                                 mediaDuration: content[3].mediaDuration,
+                                commentCount: content[3].commentCount,
                             }}
                         />
                     </LI>
@@ -135,6 +139,7 @@ export const ExactlyFive = ({ content }: Props) => (
                                 showClock: false,
                                 mediaType: content[4].mediaType,
                                 mediaDuration: content[4].mediaDuration,
+                                commentCount: content[4].commentCount,
                             }}
                         />
                     </LI>

--- a/src/web/components/Onwards/FourOrLess.tsx
+++ b/src/web/components/Onwards/FourOrLess.tsx
@@ -54,6 +54,7 @@ export const FourOrLess = ({ content }: Props) => {
                                 imageUrl: trail.image,
                                 mediaType: trail.mediaType,
                                 mediaDuration: trail.mediaDuration,
+                                commentCount: trail.commentCount,
                             }}
                         />
                     </LI>

--- a/src/web/components/Onwards/MoreThanFive.tsx
+++ b/src/web/components/Onwards/MoreThanFive.tsx
@@ -48,6 +48,7 @@ export const MoreThanFive = ({ content }: Props) => {
                             imageUrl: content[0].image,
                             mediaType: content[0].mediaType,
                             mediaDuration: content[0].mediaDuration,
+                            commentCount: content[0].commentCount,
                         }}
                     />
                 </LI>
@@ -76,6 +77,7 @@ export const MoreThanFive = ({ content }: Props) => {
                             imageUrl: content[1].image,
                             mediaType: content[1].mediaType,
                             mediaDuration: content[1].mediaDuration,
+                            commentCount: content[1].commentCount,
                         }}
                     />
                 </LI>
@@ -104,6 +106,7 @@ export const MoreThanFive = ({ content }: Props) => {
                             imageUrl: content[2].image,
                             mediaType: content[2].mediaType,
                             mediaDuration: content[2].mediaDuration,
+                            commentCount: content[2].commentCount,
                         }}
                     />
                 </LI>
@@ -132,6 +135,7 @@ export const MoreThanFive = ({ content }: Props) => {
                             imageUrl: content[3].image,
                             mediaType: content[3].mediaType,
                             mediaDuration: content[3].mediaDuration,
+                            commentCount: content[3].commentCount,
                         }}
                     />
                 </LI>
@@ -162,6 +166,7 @@ export const MoreThanFive = ({ content }: Props) => {
                                 showClock: false,
                                 mediaType: trail.mediaType,
                                 mediaDuration: trail.mediaDuration,
+                                commentCount: trail.commentCount,
                             }}
                         />
                     </LI>

--- a/src/web/components/Onwards/Spotlight.tsx
+++ b/src/web/components/Onwards/Spotlight.tsx
@@ -26,6 +26,7 @@ export const Spotlight = ({ content }: Props) => (
             imageUrl: content[0].image,
             mediaType: content[0].mediaType,
             mediaDuration: content[0].mediaDuration,
+            commentCount: content[0].commentCount,
             imagePosition: 'right',
             imageSize: 'jumbo',
         }}


### PR DESCRIPTION
## What does this change?
Here we explicitly pass `commentCount` into our layout components

## Why?
We have the code to [display the commentCount](https://github.com/guardian/dotcom-rendering/pull/1120). And the code to [add the commentCounts](https://github.com/guardian/dotcom-rendering/pull/1117) to the trail model. This PR connects the 2.

## Link to supporting Trello card
https://trello.com/c/YexUqJRV/890-add-comment-count-to-cards