### PR TITLE
Add some gruesome styling / targeting to fix sticky ad stuff

### DIFF
--- a/src/web/components/AdSlot.tsx
+++ b/src/web/components/AdSlot.tsx
@@ -9,7 +9,6 @@ import { from } from '@guardian/src-foundations/mq';
 export const labelStyles = css`
     .ad-slot__label {
         ${textSans.xsmall()};
-        position: relative;
         height: 24px;
         background-color: ${palette.neutral[97]};
         padding: 0 8px;

--- a/src/web/components/StickyAd.tsx
+++ b/src/web/components/StickyAd.tsx
@@ -14,7 +14,7 @@ const adSlotWrapper = css`
 
 const stickyAdSlot = css`
     > .ad-slot__content {
-        height: 1095px;
+        height: 1059px;
     }
 
     > .ad-slot__label {

--- a/src/web/components/StickyAd.tsx
+++ b/src/web/components/StickyAd.tsx
@@ -4,14 +4,29 @@ import { css } from 'emotion';
 import { AdSlot } from '@root/src/web/components/AdSlot';
 import { namedAdSlotParameters } from '@root/src/model/advertisement';
 
+// Note that 'StickyAd' seems heavily scoped
+// to the right column, if we want to 'stickyAd' somewhere
+// else then we'll need to send props through
+
 const adSlotWrapper = css`
     position: static;
-    height: 1059px;
 `;
 
 const stickyAdSlot = css`
-    position: sticky;
-    top: 0;
+    > .ad-slot__content {
+        height: 1095px;
+    }
+
+    > .ad-slot__label {
+        position: sticky;
+        top: 0;
+    }
+
+    /* iframe is inserted into ad-slot__content */
+    > .ad-slot__content > iframe {
+        position: sticky;
+        top: 24px; /* Height of label */
+    }
 `;
 
 export const StickyAd = () => (


### PR DESCRIPTION
## What does this change?

Makes the sticky ad height fixed (to parity on Dotcom, rather than related content at the top).

Oh, I know the css is harsh, but this saves making these an island or messing with commercial JS - shout if it gives you fear!

## Why?

So related content is randomly halfway down the page without ads.

![2020-01-30 17 52 20](https://user-images.githubusercontent.com/638051/73476840-fac53f00-438a-11ea-91aa-e5567718613b.gif)

## Link to supporting Trello card

https://trello.com/c/6kCzZgKm
