### PR TITLE
More in this Series

### DIFF
--- a/src/web/components/Onwards/Onwards.tsx
+++ b/src/web/components/Onwards/Onwards.tsx
@@ -87,7 +87,10 @@ export const Onwards = ({
     // two things, 1: A popular tag, or 2: A generic text match
     const tagToFilterBy = firstPopularTag(keywordIds, isPaidContent);
 
-    const seriesTag = tags.find(tag => tag.type === 'Series');
+    // In this context, Blog tags are treated the same as Series tags
+    const seriesTag = tags.find(
+        tag => tag.type === 'Series' || tag.type === 'Blog',
+    );
 
     if (hasStoryPackage) {
         // Always fetch the story package if it exists

--- a/src/web/components/Onwards/Onwards.tsx
+++ b/src/web/components/Onwards/Onwards.tsx
@@ -64,6 +64,7 @@ type Props = {
     showRelatedContent: boolean;
     keywordIds: string[];
     contentType: string;
+    tags: TagType[];
 };
 
 export const Onwards = ({
@@ -76,6 +77,7 @@ export const Onwards = ({
     showRelatedContent,
     keywordIds,
     contentType,
+    tags,
 }: Props) => {
     const onwardSections: OnwardsType[] = [];
 
@@ -84,6 +86,8 @@ export const Onwards = ({
     // Related content can be a collection of articles based on
     // two things, 1: A popular tag, or 2: A generic text match
     const tagToFilterBy = firstPopularTag(keywordIds, isPaidContent);
+
+    const seriesTag = tags.find(tag => tag.type === 'Series');
 
     if (hasStoryPackage) {
         // Always fetch the story package if it exists
@@ -102,6 +106,27 @@ export const Onwards = ({
     } else if (isAdFreeUser && isPaidContent) {
         // Don't show any related content (other than story packages) for
         // adfree users when the content is paid for
+    } else if (seriesTag) {
+        // Use the series tag to get other data in the same series
+        // Example: {
+        //              id: "cities/series/the-illustrated-city",
+        //              title: "The illustrated city",
+        //              type: "Series",
+        //          }
+        //
+        const seriesUrl = joinUrl([
+            ajaxUrl,
+            'series',
+            `${seriesTag.id}.json?dcr`,
+        ]);
+        const { data } = useApi(seriesUrl);
+
+        if (data && data.trails) {
+            onwardSections.push({
+                heading: data.displayname, // This displayname property is called 'heading' elsewhere
+                trails: data.trails.slice(0, 4), // Series onwards is four only
+            });
+        }
     } else if (dontShowRelatedContent) {
         // Then don't show related content
     } else if (tagToFilterBy) {

--- a/src/web/islands/islands.tsx
+++ b/src/web/islands/islands.tsx
@@ -73,6 +73,7 @@ type IslandProps =
           showRelatedContent: boolean;
           keywordIds: string;
           contentType: string;
+          tags: TagType[];
       }
     | {
           contentType: string;
@@ -202,6 +203,7 @@ export const hydrateIslands = (CAPI: CAPIType, NAV: NavType) => {
                 showRelatedContent: CAPI.config.showRelatedContent,
                 keywordIds: CAPI.config.keywordIds,
                 contentType: CAPI.contentType,
+                tags: CAPI.tags,
             },
             root: 'onwards-content',
         },


### PR DESCRIPTION
## What does this change?
Adds support for more in this series onwards content

![Screenshot 2020-01-31 at 14 40 53](https://user-images.githubusercontent.com/1336821/73548329-7af5ae00-4438-11ea-87e2-d537e7242e6a.jpg)

## What am I not sure about?
The logic around when to show series content. I've made some assumptions here, am I right?

```typescript
    if (hasStoryPackage) {
        // Always fetch the story package if it exists
        // ...
    } else if (isAdFreeUser && isPaidContent) {
        // Don't show any related content (other than story packages) for
        // adfree users when the content is paid for
    } else if (seriesTag) {
        // Use the series tag to get other data in the same series
        // ...
    } else if (dontShowRelatedContent) {
        // Then don't show related content
    } else if (tagToFilterBy) {
        // Use popular in tag endpoint
        // ...
    } else {
        // Default to generic related endpoint
        // ...
    }
```

## Why?
Because we want to know more about what's in the series

## Link to supporting Trello card
https://trello.com/c/KFLcUf6h/967-more-in-series