### PR TITLE
Sandbox amp-iframe to allow same origin

### DIFF
--- a/src/amp/components/AnalyticsIframe.tsx
+++ b/src/amp/components/AnalyticsIframe.tsx
@@ -17,7 +17,7 @@ export const AnalyticsIframe: React.FC<{ url: string }> = ({ url }) => {
             title="Analytics Iframe"
             height="1"
             width="1"
-            sandbox="allow-scripts"
+            sandbox="allow-scripts allow-same-origin"
             frameborder="0"
             src={url}
         >


### PR DESCRIPTION
## What does this change?
This looks like a missing tag in the `<amp-iframe />` preventing Permutive from running on AMP

