### PR TITLE
Set comment count colour based on designType

### DIFF
--- a/src/web/components/Card/Card.stories.tsx
+++ b/src/web/components/Card/Card.stories.tsx
@@ -387,7 +387,7 @@ export const Related = () => (
                                 linkTo:
                                     '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
                                 pillar: 'sport',
-                                designType: 'Article',
+                                designType: 'Live',
                                 headlineText: headlines[8],
                                 headlineSize: 'medium',
                                 kickerText: kickers[0],

--- a/src/web/components/CardCommentCount.tsx
+++ b/src/web/components/CardCommentCount.tsx
@@ -87,7 +87,7 @@ const colourStyles = (designType: DesignType, pillar: Pillar) => {
             return css`
                 color: ${palette.neutral[60]};
                 svg {
-                    fill: ${palette.neutral[60]};
+                    fill: ${palette.neutral[46]};
                 }
             `;
     }

--- a/src/web/components/CardCommentCount.tsx
+++ b/src/web/components/CardCommentCount.tsx
@@ -6,6 +6,7 @@ import { textSans } from '@guardian/src-foundations/typography';
 import { between } from '@guardian/src-foundations/mq';
 
 import CommentIcon from '@frontend/static/icons/comment.svg';
+import { decidePillarLight } from '@frontend/web/components/lib/decidePillarLight';
 
 type Props = {
     designType: DesignType;
@@ -18,14 +19,12 @@ const containerStyles = css`
     display: flex;
     flex-direction: row;
     ${textSans.xsmall()};
-    color: ${palette.neutral[60]};
     padding-left: 5px;
     padding-right: 5px;
 `;
 
-const iconContainerStyles = css`
+const svgStyles = css`
     svg {
-        fill: ${palette.neutral[46]};
         margin-bottom: -5px;
         height: 14px;
         width: 14px;
@@ -60,6 +59,40 @@ const mediaStyles = (pillar: Pillar) => css`
     }
 `;
 
+const colourStyles = (designType: DesignType, pillar: Pillar) => {
+    switch (designType) {
+        case 'Live':
+            return css`
+                color: ${decidePillarLight(pillar)};
+                svg {
+                    fill: ${decidePillarLight(pillar)};
+                }
+            `;
+        case 'Feature':
+        case 'Interview':
+        case 'Media':
+        case 'Analysis':
+        case 'Article':
+        case 'Review':
+        case 'SpecialReport':
+        case 'Recipe':
+        case 'MatchReport':
+        case 'GuardianView':
+        case 'GuardianLabs':
+        case 'Quiz':
+        case 'AdvertisementFeature':
+        case 'Comment':
+        case 'Immersive':
+        default:
+            return css`
+                color: ${palette.neutral[60]};
+                svg {
+                    fill: ${palette.neutral[60]};
+                }
+            `;
+    }
+};
+
 export const CardCommentCount = ({
     designType,
     pillar,
@@ -70,11 +103,13 @@ export const CardCommentCount = ({
         <div
             className={cx(
                 containerStyles,
-                designType === 'Media' && mediaStyles(pillar),
+                designType === 'Media'
+                    ? mediaStyles(pillar)
+                    : colourStyles(designType, pillar),
             )}
             aria-label={`${short} Comments`}
         >
-            <div className={iconContainerStyles}>
+            <div className={svgStyles}>
                 <CommentIcon />
             </div>
             <div className={longStyles} aria-hidden="true">


### PR DESCRIPTION
## What does this change?
This PR ensures comment counts have the correct colour when shown on Live cards

## Before
![Screenshot 2020-02-03 at 10 10 17](https://user-images.githubusercontent.com/1336821/73644495-69e1b280-466d-11ea-9702-704fe19ffcb3.jpg)


## After
![Screenshot 2020-02-03 at 10 09 13](https://user-images.githubusercontent.com/1336821/73644424-49b1f380-466d-11ea-8675-490f389e1447.jpg)


## Why?
Because grey on red doesn't look good at all

## Link to supporting Trello card
https://trello.com/c/7wx7SyXV/1133-comment-count-colour
