### PR TITLE
Standfirst should be 540px, not 550px

### DIFF
--- a/src/web/components/ArticleStandfirst.tsx
+++ b/src/web/components/ArticleStandfirst.tsx
@@ -6,7 +6,7 @@ import { palette } from '@guardian/src-foundations';
 import { Standfirst } from '@frontend/web/components/Standfirst';
 
 const standfirstStyles = css`
-    max-width: 550px;
+    max-width: 540px;
     margin-bottom: 12px;
 `;
 


### PR DESCRIPTION
## What does this change?
This PR narrows the standfirst from 550px to 540px

## Why?
Because that's what frontend does and we want parity on wrapping

## Link to supporting Trello card
https://trello.com/c/AqDyL9G1/1134-narrow-standfirst