### PR TITLE
Onwards description text

### DIFF
--- a/fixtures/onwards.mocks.ts
+++ b/fixtures/onwards.mocks.ts
@@ -157,3 +157,10 @@ export const eightTrails: OnwardsType = {
     heading: 'More on this story',
     trails: trails.slice(0, 8),
 };
+
+export const withDescription: OnwardsType = {
+    description:
+        'Our writers reflect on the people, issues and curiosities in the news',
+    heading: 'More on this story',
+    trails: trails.slice(0, 8),
+};

--- a/fixtures/onwards.mocks.ts
+++ b/fixtures/onwards.mocks.ts
@@ -164,3 +164,10 @@ export const withDescription: OnwardsType = {
     heading: 'More on this story',
     trails: trails.slice(0, 8),
 };
+
+export const withLongDescription: OnwardsType = {
+    description:
+        "<p>A blog by the Guardian's internal Digital team. We build the Guardian website, mobile apps, Editorial tools, revenue products, support our infrastructure and manage all things tech around the Guardian.</p><p>Our team contains Developers, UX, Quality, Product and Enterprise IT. This blog is where we share our experiences and approaches, including software  development tips, code examples, open source software and product  development stories </p>",
+    heading: 'More on this story',
+    trails: trails.slice(0, 8),
+};

--- a/index.d.ts
+++ b/index.d.ts
@@ -348,6 +348,7 @@ interface CardHeadlineType {
 type OnwardsType = {
     heading: string;
     trails: TrailType[];
+    description?: string;
 };
 
 interface CommercialConfigType {

--- a/src/web/components/Onwards/Onwards.stories.tsx
+++ b/src/web/components/Onwards/Onwards.stories.tsx
@@ -4,6 +4,7 @@ import { Section } from '@frontend/web/components/Section';
 
 import {
     withDescription,
+    withLongDescription,
     oneTrail,
     twoTrails,
     threeTrails,
@@ -26,6 +27,13 @@ export const withDescriptionStory = () => (
     </Section>
 );
 withDescriptionStory.story = { name: 'With description' };
+
+export const withLongDescriptionStory = () => (
+    <Section>
+        <OnwardsLayout onwardSections={[withLongDescription]} />
+    </Section>
+);
+withDescriptionStory.story = { name: 'With long description' };
 
 export const oneTrailStory = () => (
     <Section>

--- a/src/web/components/Onwards/Onwards.stories.tsx
+++ b/src/web/components/Onwards/Onwards.stories.tsx
@@ -2,9 +2,8 @@ import React from 'react';
 
 import { Section } from '@frontend/web/components/Section';
 
-import { OnwardsLayout } from './OnwardsLayout';
-
 import {
+    withDescription,
     oneTrail,
     twoTrails,
     threeTrails,
@@ -13,14 +12,20 @@ import {
     sixTrails,
     sevenTrails,
     eightTrails,
-} from './Onwards.mocks';
+} from '@root/fixtures/onwards.mocks';
+import { OnwardsLayout } from './OnwardsLayout';
 
-/* tslint:disable */
 export default {
     component: OnwardsLayout,
     title: 'Components/Onwards',
 };
-/* tslint:enable */
+
+export const withDescriptionStory = () => (
+    <Section>
+        <OnwardsLayout onwardSections={[withDescription]} />
+    </Section>
+);
+withDescriptionStory.story = { name: 'With description' };
 
 export const oneTrailStory = () => (
     <Section>

--- a/src/web/components/Onwards/OnwardsLayout.tsx
+++ b/src/web/components/Onwards/OnwardsLayout.tsx
@@ -46,11 +46,17 @@ export const OnwardsLayout = ({ onwardSections }: Props) => {
                         showRightBorder={false}
                         showPartialRightBorder={true}
                     >
-                        <OnwardsTitle title={section.heading} />
+                        <OnwardsTitle
+                            title={section.heading}
+                            description={section.description}
+                        />
                     </LeftColumn>
                     <OnwardsContainer>
                         <Hide when="above" breakpoint="leftCol">
-                            <OnwardsTitle title={section.heading} />
+                            <OnwardsTitle
+                                title={section.heading}
+                                description={section.description}
+                            />
                         </Hide>
                         {decideLayout(section.trails.slice(0, 8))}
                     </OnwardsContainer>

--- a/src/web/components/Onwards/OnwardsTitle.tsx
+++ b/src/web/components/Onwards/OnwardsTitle.tsx
@@ -15,22 +15,12 @@ export const OnwardsTitle = ({
     <>
         <h2
             className={css`
-                ${headline.xsmall()};
+                ${headline.xsmall({ fontWeight: 'bold' })};
                 color: ${palette.neutral[7]};
-                font-weight: 900;
                 padding-bottom: 14px;
                 padding-top: 6px;
-
-                ${from.leftCol} {
-                    ${headline.xsmall()};
-                    font-weight: 900;
-                }
-
-                ${from.wide} {
-                    font-weight: 900;
-                }
-
                 margin-left: 10px;
+
                 ${from.leftCol} {
                     margin-left: 0;
                 }
@@ -41,9 +31,8 @@ export const OnwardsTitle = ({
         {description && (
             <h3
                 className={css`
-                    ${headline.xxxsmall()};
+                    ${headline.xxxsmall({ fontWeight: 'medium' })};
                     color: ${palette.neutral[46]};
-                    font-weight: 500;
                 `}
             >
                 {description}

--- a/src/web/components/Onwards/OnwardsTitle.tsx
+++ b/src/web/components/Onwards/OnwardsTitle.tsx
@@ -5,30 +5,49 @@ import { palette } from '@guardian/src-foundations';
 import { headline } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 
-export const OnwardsTitle = ({ title }: { title: string }) => (
-    <h2
-        className={css`
-            ${headline.xsmall()};
-            color: ${palette.neutral[7]};
-            font-weight: 900;
-            padding-bottom: 14px;
-            padding-top: 6px;
-
-            ${from.leftCol} {
+export const OnwardsTitle = ({
+    title,
+    description,
+}: {
+    title: string;
+    description?: string;
+}) => (
+    <>
+        <h2
+            className={css`
                 ${headline.xsmall()};
+                color: ${palette.neutral[7]};
                 font-weight: 900;
-            }
+                padding-bottom: 14px;
+                padding-top: 6px;
 
-            ${from.wide} {
-                font-weight: 900;
-            }
+                ${from.leftCol} {
+                    ${headline.xsmall()};
+                    font-weight: 900;
+                }
 
-            margin-left: 10px;
-            ${from.leftCol} {
-                margin-left: 0;
-            }
-        `}
-    >
-        {title}
-    </h2>
+                ${from.wide} {
+                    font-weight: 900;
+                }
+
+                margin-left: 10px;
+                ${from.leftCol} {
+                    margin-left: 0;
+                }
+            `}
+        >
+            {title}
+        </h2>
+        {description && (
+            <h3
+                className={css`
+                    ${headline.xxxsmall()};
+                    color: ${palette.neutral[46]};
+                    font-weight: 500;
+                `}
+            >
+                {description}
+            </h3>
+        )}
+    </>
 );

--- a/src/web/components/Onwards/OnwardsTitle.tsx
+++ b/src/web/components/Onwards/OnwardsTitle.tsx
@@ -29,14 +29,16 @@ export const OnwardsTitle = ({
             {title}
         </h2>
         {description && (
-            <h3
+            <p
                 className={css`
                     ${headline.xxxsmall({ fontWeight: 'medium' })};
                     color: ${palette.neutral[46]};
+                    p {
+                        margin-bottom: 8px;
+                    }
                 `}
-            >
-                {description}
-            </h3>
+                dangerouslySetInnerHTML={{ __html: description }}
+            />
         )}
     </>
 );

--- a/src/web/components/lib/useComments.ts
+++ b/src/web/components/lib/useComments.ts
@@ -36,6 +36,7 @@ const withComments = (
     if (counts.length === 0) return onwardSections;
     return onwardSections.map(section => {
         return {
+            description: section.description,
             heading: section.heading,
             trails: updateTrailsWithCounts(section.trails, counts),
         };


### PR DESCRIPTION
## What does this change?
Onwards description now appears if returned by the API
![Screenshot 2020-02-03 at 15 28 57](https://user-images.githubusercontent.com/8831403/73666068-15086100-469a-11ea-82a6-9abd4ebc8d5b.png)

## Why?
Because it makes Onwards cool

## Link to supporting Trello card
https://trello.com/c/OpazBl2Q/1129-onwards-description-text