### PR TITLE
Onwards with urls

### DIFF
--- a/fixtures/onwards.mocks.ts
+++ b/fixtures/onwards.mocks.ts
@@ -158,7 +158,8 @@ export const eightTrails: OnwardsType = {
     trails: trails.slice(0, 8),
 };
 
-export const withDescription: OnwardsType = {
+export const linkAndDescription: OnwardsType = {
+    url: 'https://www.theguardian.com/news/shortcuts',
     description:
         'Our writers reflect on the people, issues and curiosities in the news',
     heading: 'More on this story',

--- a/index.d.ts
+++ b/index.d.ts
@@ -349,6 +349,7 @@ type OnwardsType = {
     heading: string;
     trails: TrailType[];
     description?: string;
+    url?: string;
 };
 
 interface CommercialConfigType {

--- a/src/web/components/Onwards/Onwards.stories.tsx
+++ b/src/web/components/Onwards/Onwards.stories.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Section } from '@frontend/web/components/Section';
 
 import {
-    withDescription,
+    linkAndDescription,
     oneTrail,
     twoTrails,
     threeTrails,
@@ -20,12 +20,12 @@ export default {
     title: 'Components/Onwards',
 };
 
-export const withDescriptionStory = () => (
+export const linkAndDescriptionStory = () => (
     <Section>
-        <OnwardsLayout onwardSections={[withDescription]} />
+        <OnwardsLayout onwardSections={[linkAndDescription]} />
     </Section>
 );
-withDescriptionStory.story = { name: 'With description' };
+linkAndDescriptionStory.story = { name: 'With link and description' };
 
 export const oneTrailStory = () => (
     <Section>

--- a/src/web/components/Onwards/OnwardsLayout.tsx
+++ b/src/web/components/Onwards/OnwardsLayout.tsx
@@ -49,6 +49,7 @@ export const OnwardsLayout = ({ onwardSections }: Props) => {
                         <OnwardsTitle
                             title={section.heading}
                             description={section.description}
+                            url={section.url}
                         />
                     </LeftColumn>
                     <OnwardsContainer>
@@ -56,6 +57,7 @@ export const OnwardsLayout = ({ onwardSections }: Props) => {
                             <OnwardsTitle
                                 title={section.heading}
                                 description={section.description}
+                                url={section.url}
                             />
                         </Hide>
                         {decideLayout(section.trails.slice(0, 8))}

--- a/src/web/components/Onwards/OnwardsTitle.tsx
+++ b/src/web/components/Onwards/OnwardsTitle.tsx
@@ -5,39 +5,67 @@ import { palette } from '@guardian/src-foundations';
 import { headline } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 
+const linkStyles = css`
+    text-decoration: none;
+    color: ${palette.neutral[7]};
+
+    :hover {
+        text-decoration: underline;
+    }
+`;
+
+const TitleWrapper = ({
+    url,
+    children,
+}: {
+    url?: string;
+    children: JSXElements;
+}) =>
+    url ? (
+        <a className={linkStyles} href={url}>
+            {children}
+        </a>
+    ) : (
+        <>{children}</>
+    );
+
 export const OnwardsTitle = ({
     title,
     description,
+    url,
 }: {
     title: string;
     description?: string;
+    url?: string;
 }) => (
     <>
-        <h2
-            className={css`
-                ${headline.xsmall()};
-                color: ${palette.neutral[7]};
-                font-weight: 900;
-                padding-bottom: 14px;
-                padding-top: 6px;
-
-                ${from.leftCol} {
+        <TitleWrapper url={url}>
+            <h2
+                className={css`
                     ${headline.xsmall()};
+                    color: ${palette.neutral[7]};
                     font-weight: 900;
-                }
+                    padding-bottom: 14px;
+                    padding-top: 6px;
 
-                ${from.wide} {
-                    font-weight: 900;
-                }
+                    ${from.leftCol} {
+                        ${headline.xsmall()};
+                        font-weight: 900;
+                    }
 
-                margin-left: 10px;
-                ${from.leftCol} {
-                    margin-left: 0;
-                }
-            `}
-        >
-            {title}
-        </h2>
+                    ${from.wide} {
+                        font-weight: 900;
+                    }
+
+                    margin-left: 10px;
+                    ${from.leftCol} {
+                        margin-left: 0;
+                    }
+                `}
+            >
+                {title}
+            </h2>
+        </TitleWrapper>
         {description && (
             <h3
                 className={css`

--- a/src/web/components/lib/useComments.ts
+++ b/src/web/components/lib/useComments.ts
@@ -38,6 +38,7 @@ const withComments = (
         return {
             description: section.description,
             heading: section.heading,
+            url: section.url,
             trails: updateTrailsWithCounts(section.trails, counts),
         };
     });


### PR DESCRIPTION
## What does this change?
Onwards now supports URL redirects in titles
![Screenshot 2020-02-03 at 16 55 48](https://user-images.githubusercontent.com/8831403/73674551-a8e12980-46a8-11ea-9ec2-997efa36b8ca.png)

## Why?
Bec frontend supports them and we want to be as cool as frontend

## Link to supporting Trello card
https://trello.com/c/feDcf1zi/1130-onwards-title-is-a-link

## NOTE:
depends on (please review 1st):
https://trello.com/c/OpazBl2Q/1129-onwards-description-text