### PR TITLE
Show Quotes

### DIFF
--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterItem.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterItem.tsx
@@ -84,6 +84,7 @@ export const MostViewedFooterItem = ({ trail, position }: Props) => (
                         kickerText="Live"
                         showSlash={true}
                         showPulsingDot={true}
+                        showQuotes={trail.designType === 'Comment'}
                     />
                 ) : (
                     <LinkHeadline
@@ -91,6 +92,7 @@ export const MostViewedFooterItem = ({ trail, position }: Props) => (
                         headlineText={trail.headline}
                         pillar={trail.pillar}
                         size="small"
+                        showQuotes={trail.designType === 'Comment'}
                     />
                 )}
             </div>


### PR DESCRIPTION
## What does this change?
This PR shows quotes before the headline in the Most Viewed Footer for comment articles

![Screenshot 2020-02-04 at 09 14 19](https://user-images.githubusercontent.com/1336821/73730509-c2c54f80-472e-11ea-8006-fefb50e7b404.jpg)


## Why?
Because then readers will be able to tell that they are comment pieces

## Link to supporting Trello card
https://trello.com/c/IAbeERpa/1138-show-quotes