### PR TITLE
Adjust source prop of ConsentManagementPlatform to "www"

### DIFF
--- a/src/web/components/CMP.tsx
+++ b/src/web/components/CMP.tsx
@@ -30,7 +30,7 @@ export const CMP = () => {
     }
 
     const props = {
-        source: 'dcr',
+        source: 'www',
         onClose,
     };
 


### PR DESCRIPTION
## What does this change?

Since https://github.com/guardian/dotcom-rendering/pull/1140 we've seen errors in Sentry linked to the data we post to the "consent logs" end point, when we attempt to post we get a `400` error code response with the body: `Body for consent request seems to be invalid: invalid sourceType, expected one of www, amp`. 

This is because in the data we're posting "dcr" as the source and not "www", the source indicates the site on which the CMP UI posting the data resides - we were passing "dcr" so we could differentiate between standard frontend and dotcom-rendering, unfortunately this isn't possible right now.

## Why?

This fixes that by using "www" instead of "dcr". We were unware "dcr" was invalid.

