### PR TITLE
Update merchandising styling

### DIFF
--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -329,7 +329,7 @@ export const CommentLayout = ({ CAPI, NAV }: Props) => {
                 padded={false}
                 showTopBorder={false}
                 showSideBorders={false}
-                backgroundColour={palette.neutral[97]}
+                backgroundColour={palette.neutral[93]}
             >
                 <AdSlot
                     asps={namedAdSlotParameters('merchandising-high')}

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -325,7 +325,12 @@ export const CommentLayout = ({ CAPI, NAV }: Props) => {
                 </StandardGrid>
             </Section>
 
-            <Section padded={false} showTopBorder={false}>
+            <Section
+                padded={false}
+                showTopBorder={false}
+                showSideBorders={false}
+                backgroundColour={palette.neutral[97]}
+            >
                 <AdSlot
                     asps={namedAdSlotParameters('merchandising-high')}
                     className=""

--- a/src/web/layouts/ShowcaseLayout/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout/ShowcaseLayout.tsx
@@ -427,7 +427,7 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                 </ShowcaseGrid>
             </Section>
 
-            <Section padded={false} showTopBorder={false}>
+            <Section padded={false} showTopBorder={false} showSideBorders={false} backgroundColour={palette.neutral[97]}>
                 <AdSlot
                     asps={namedAdSlotParameters('merchandising-high')}
                     className=""

--- a/src/web/layouts/ShowcaseLayout/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout/ShowcaseLayout.tsx
@@ -427,7 +427,12 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                 </ShowcaseGrid>
             </Section>
 
-            <Section padded={false} showTopBorder={false} showSideBorders={false} backgroundColour={palette.neutral[97]}>
+            <Section
+                padded={false}
+                showTopBorder={false}
+                showSideBorders={false}
+                backgroundColour={palette.neutral[93]}
+            >
                 <AdSlot
                     asps={namedAdSlotParameters('merchandising-high')}
                     className=""

--- a/src/web/layouts/StandardLayout/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout/StandardLayout.tsx
@@ -394,7 +394,12 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                 </StandardGrid>
             </Section>
 
-            <Section padded={false} showTopBorder={false}>
+            <Section
+                padded={false}
+                showTopBorder={false}
+                showSideBorders={false}
+                backgroundColour={palette.neutral[97]}
+            >
                 <AdSlot
                     asps={namedAdSlotParameters('merchandising-high')}
                     className=""

--- a/src/web/layouts/StandardLayout/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout/StandardLayout.tsx
@@ -398,7 +398,7 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                 padded={false}
                 showTopBorder={false}
                 showSideBorders={false}
-                backgroundColour={palette.neutral[97]}
+                backgroundColour={palette.neutral[93]}
             >
                 <AdSlot
                     asps={namedAdSlotParameters('merchandising-high')}


### PR DESCRIPTION
## What does this change?
This PR adds a grey background and removes the side borders from the merchandising Section

## Before

![Screenshot 2020-02-04 at 14 26 16](https://user-images.githubusercontent.com/1336821/73757773-a393e580-4761-11ea-916f-51d2175f7472.jpg)

## After 🤞 
![Screenshot 2020-02-04 at 14 41 52](https://user-images.githubusercontent.com/1336821/73757772-a2fb4f00-4761-11ea-8c8b-2b0c8cb58297.jpg)

## Why?
Parity

## What's missing?
The spacing under the article body - that's in a separate PR

## Link to supporting Trello card
https://trello.com/c/9mqlKWIw/1110-fix-investigate-merchandising-slot