### PR TITLE
Add some padding to the bottom of the article

### DIFF
--- a/src/web/components/SubMeta.tsx
+++ b/src/web/components/SubMeta.tsx
@@ -9,6 +9,7 @@ import { SubMetaLinksList } from '@frontend/web/components/SubMetaLinksList';
 import { SyndicationButton } from '@frontend/web/components/SyndicationButton';
 import { Badge } from '@frontend/web/components/Badge';
 import { getSharingUrls } from '@frontend/lib/sharing-urls';
+import { until } from '@guardian/src-foundations/mq';
 
 const subMetaLabel = css`
     ${textSans.xsmall()};
@@ -27,6 +28,13 @@ const subMetaSharingIcons = css`
 const badgeWrapper = css`
     float: right;
     margin-top: 6px;
+`;
+
+const bottomPadding = css`
+    padding-bottom: 72px;
+    ${until.desktop} {
+        padding-bottom: 58px;
+    }
 `;
 
 type Props = {
@@ -54,7 +62,7 @@ export const SubMeta = ({
     const hasSubMetaKeywordLinks = subMetaKeywordLinks.length > 0;
     const sharingUrls = getSharingUrls(pageId, webTitle);
     return (
-        <>
+        <div className={bottomPadding}>
             {badge && (
                 <div className={badgeWrapper}>
                     <Badge svgSrc={badge.svgSrc} linkTo={badge.linkTo} />
@@ -96,6 +104,6 @@ export const SubMeta = ({
             {showBottomSocialButtons && (
                 <SyndicationButton webUrl={webUrl} internalPageCode={pageId} />
             )}
-        </>
+        </div>
     );
 };


### PR DESCRIPTION
## What does this change?
Adds a bit of padding below the article body

## Before
![Screenshot 2020-02-04 at 15 23 09](https://user-images.githubusercontent.com/1336821/73758229-46e4fa80-4762-11ea-8a34-fb54b6e87d72.jpg)

## After
![Screenshot 2020-02-04 at 15 22 50](https://user-images.githubusercontent.com/1336821/73758290-55331680-4762-11ea-881b-7b5cf081aca7.jpg)

## Why?
Because it looks better and that's what frontend does

## Link to supporting Trello card
https://trello.com/c/9mqlKWIw/1110-fix-investigate-merchandising-slot
