### PR TITLE
Fix rich link edge case logic

### DIFF
--- a/fixtures/CAPI/richLink.ts
+++ b/fixtures/CAPI/richLink.ts
@@ -1,0 +1,2822 @@
+export const richLink: CAPIType = {
+    shouldHideReaderRevenue: false,
+    slotMachineFlags: '',
+    isAdFreeUser: false,
+    main:
+        '<figure class="element element-image" data-media-id="db2348b8bc322340bdf9a842ea8e562321164050"> <img src="https://media.guim.co.uk/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/1000.jpg" alt="Rap god ... Eminem performing at the MTV EMAs last year." width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">Rap god ... Eminem performing at the MTV EMAs last year.</span> <span class="element-image__credit">Photograph: Dave J Hogan/Getty Images for MTV</span> </figcaption> </figure>',
+    subMetaSectionLinks: [
+        {
+            url: '/music/eminem',
+            title: 'Eminem',
+        },
+    ],
+    commercialProperties: {
+        UK: {
+            adTargeting: [
+                {
+                    name: 'edition',
+                    value: 'uk',
+                },
+                {
+                    name: 'co',
+                    value: ['alexispetridis'],
+                },
+                {
+                    name: 'sh',
+                    value: 'https://gu.com/p/99h48',
+                },
+                {
+                    name: 'su',
+                    value: ['0'],
+                },
+                {
+                    name: 'ct',
+                    value: 'article',
+                },
+                {
+                    name: 'p',
+                    value: 'ng',
+                },
+                {
+                    name: 'url',
+                    value: '/music/2018/aug/31/eminem-kamikaze-album-review',
+                },
+                {
+                    name: 'k',
+                    value: ['eminem', 'rap', 'hip-hop', 'music', 'culture'],
+                },
+                {
+                    name: 'tn',
+                    value: ['albumreview', 'reviews'],
+                },
+            ],
+        },
+        US: {
+            adTargeting: [
+                {
+                    name: 'co',
+                    value: ['alexispetridis'],
+                },
+                {
+                    name: 'sh',
+                    value: 'https://gu.com/p/99h48',
+                },
+                {
+                    name: 'su',
+                    value: ['0'],
+                },
+                {
+                    name: 'ct',
+                    value: 'article',
+                },
+                {
+                    name: 'p',
+                    value: 'ng',
+                },
+                {
+                    name: 'edition',
+                    value: 'us',
+                },
+                {
+                    name: 'url',
+                    value: '/music/2018/aug/31/eminem-kamikaze-album-review',
+                },
+                {
+                    name: 'k',
+                    value: ['eminem', 'rap', 'hip-hop', 'music', 'culture'],
+                },
+                {
+                    name: 'tn',
+                    value: ['albumreview', 'reviews'],
+                },
+            ],
+        },
+        AU: {
+            adTargeting: [
+                {
+                    name: 'co',
+                    value: ['alexispetridis'],
+                },
+                {
+                    name: 'sh',
+                    value: 'https://gu.com/p/99h48',
+                },
+                {
+                    name: 'su',
+                    value: ['0'],
+                },
+                {
+                    name: 'ct',
+                    value: 'article',
+                },
+                {
+                    name: 'p',
+                    value: 'ng',
+                },
+                {
+                    name: 'url',
+                    value: '/music/2018/aug/31/eminem-kamikaze-album-review',
+                },
+                {
+                    name: 'k',
+                    value: ['eminem', 'rap', 'hip-hop', 'music', 'culture'],
+                },
+                {
+                    name: 'tn',
+                    value: ['albumreview', 'reviews'],
+                },
+                {
+                    name: 'edition',
+                    value: 'au',
+                },
+            ],
+        },
+        INT: {
+            adTargeting: [
+                {
+                    name: 'co',
+                    value: ['alexispetridis'],
+                },
+                {
+                    name: 'sh',
+                    value: 'https://gu.com/p/99h48',
+                },
+                {
+                    name: 'edition',
+                    value: 'int',
+                },
+                {
+                    name: 'su',
+                    value: ['0'],
+                },
+                {
+                    name: 'ct',
+                    value: 'article',
+                },
+                {
+                    name: 'p',
+                    value: 'ng',
+                },
+                {
+                    name: 'url',
+                    value: '/music/2018/aug/31/eminem-kamikaze-album-review',
+                },
+                {
+                    name: 'k',
+                    value: ['eminem', 'rap', 'hip-hop', 'music', 'culture'],
+                },
+                {
+                    name: 'tn',
+                    value: ['albumreview', 'reviews'],
+                },
+            ],
+        },
+    },
+    pageFooter: {
+        footerLinks: [
+            [
+                {
+                    text: 'About us',
+                    url: '/about',
+                    dataLinkName: 'uk : footer : about us',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Contact us',
+                    url: '/help/contact-us',
+                    dataLinkName: 'uk : footer : contact us',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Complaints & corrections',
+                    url: '/info/complaints-and-corrections',
+                    dataLinkName: 'complaints',
+                    extraClasses: '',
+                },
+                {
+                    text: 'SecureDrop',
+                    url: 'https://www.theguardian.com/securedrop',
+                    dataLinkName: 'securedrop',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Work for us',
+                    url: 'https://workforus.theguardian.com',
+                    dataLinkName: 'uk : footer : work for us',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Privacy policy',
+                    url: '/info/privacy',
+                    dataLinkName: 'privacy',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Cookie policy',
+                    url: '/info/cookies',
+                    dataLinkName: 'cookie',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Terms & conditions',
+                    url: '/help/terms-of-service',
+                    dataLinkName: 'terms',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Help',
+                    url: '/help',
+                    dataLinkName: 'uk : footer : tech feedback',
+                    extraClasses: 'js-tech-feedback-report',
+                },
+            ],
+            [
+                {
+                    text: 'All topics',
+                    url: '/index/subjects/a',
+                    dataLinkName: 'uk : footer : all topics',
+                    extraClasses: '',
+                },
+                {
+                    text: 'All writers',
+                    url: '/index/contributors',
+                    dataLinkName: 'uk : footer : all contributors',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Modern Slavery Act',
+                    url:
+                        '/info/2016/jul/27/modern-slavery-and-our-supply-chains?INTCMP=NGW_FOOTER_UK_GU_MODERN_SLAVERY_ACT',
+                    dataLinkName: 'uk : footer : modern slavery act statement',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Digital newspaper archive',
+                    url: 'https://theguardian.newspapers.com',
+                    dataLinkName: 'digital newspaper archive',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Facebook',
+                    url: 'https://www.facebook.com/theguardian',
+                    dataLinkName: 'uk : footer : facebook',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Twitter',
+                    url: 'https://twitter.com/guardian',
+                    dataLinkName: 'uk: footer : twitter',
+                    extraClasses: '',
+                },
+            ],
+            [
+                {
+                    text: 'Advertise with us',
+                    url: 'https://advertising.theguardian.com',
+                    dataLinkName: 'uk : footer : advertise with us',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Guardian Labs',
+                    url: '/guardian-labs',
+                    dataLinkName: 'uk : footer : guardian labs',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Search jobs',
+                    url:
+                        'https://jobs.theguardian.com?INTCMP=NGW_FOOTER_UK_GU_JOBS',
+                    dataLinkName: 'uk : footer : jobs',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Dating',
+                    url:
+                        'https://soulmates.theguardian.com?INTCMP=NGW_FOOTER_UK_GU_SOULMATES',
+                    dataLinkName: 'uk : footer : soulmates',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Patrons',
+                    url:
+                        'https://patrons.theguardian.com?INTCMP=footer_patrons',
+                    dataLinkName: 'uk : footer : patrons',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Discount Codes',
+                    url: 'https://discountcode.theguardian.com/',
+                    dataLinkName: 'uk: footer : discount code',
+                    extraClasses: 'js-discount-code-link',
+                },
+            ],
+        ],
+    },
+    twitterData: {
+        'twitter:app:id:iphone': '409128287',
+        'twitter:app:name:googleplay': 'The Guardian',
+        'twitter:app:name:ipad': 'The Guardian',
+        'twitter:image':
+            'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctcmV2aWV3LTMucG5n&s=0da92712d13da4cf9b9f446c78ec083e',
+        'twitter:site': '@guardian',
+        'twitter:app:url:ipad':
+            'gnmguardian://music/2018/aug/31/eminem-kamikaze-album-review?contenttype=Article&source=twitter',
+        'twitter:card': 'summary_large_image',
+        'twitter:app:name:iphone': 'The Guardian',
+        'twitter:app:id:ipad': '409128287',
+        'twitter:app:id:googleplay': 'com.guardian',
+        'twitter:app:url:googleplay':
+            'guardian://www.theguardian.com/music/2018/aug/31/eminem-kamikaze-album-review',
+        'twitter:app:url:iphone':
+            'gnmguardian://music/2018/aug/31/eminem-kamikaze-album-review?contenttype=Article&source=twitter',
+    },
+    beaconURL: '//phar.gu-web.net',
+    sectionName: 'music',
+    editionLongForm: 'UK edition',
+    hasRelated: true,
+    pageType: {
+        hasShowcaseMainElement: false,
+        isFront: false,
+        isLiveblog: false,
+        isMinuteArticle: false,
+        isPaidContent: false,
+        isPreview: false,
+        isSensitive: false,
+    },
+    hasStoryPackage: false,
+    publication: 'theguardian.com',
+    trailText:
+        'The hooks are middling and the moans at his critics get tedious – but a flurry of brutal potshots at witless SoundCloud rappers prove Eminem can still hit exhilarating heights',
+    subMetaKeywordLinks: [
+        {
+            url: '/music/rap',
+            title: 'Rap',
+        },
+        {
+            url: '/music/hip-hop',
+            title: 'Hip-hop',
+        },
+        {
+            url: '/tone/albumreview',
+            title: 'album reviews',
+        },
+    ],
+    starRating: 3,
+    headline:
+        'Eminem: Kamikaze review – middle-aged gripes aired with blazing skill',
+    contentType: 'Article',
+    guardianBaseURL: 'https://www.theguardian.com',
+    nav: {
+        currentUrl: '/music',
+        pillars: [
+            {
+                title: 'News',
+                url: '/',
+                longTitle: 'Headlines',
+                iconName: 'home',
+                children: [
+                    {
+                        title: 'UK',
+                        url: '/uk-news',
+                        longTitle: 'UK news',
+                        iconName: '',
+                        children: [
+                            {
+                                title: 'UK politics',
+                                url: '/politics',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Education',
+                                url: '/education',
+                                longTitle: '',
+                                iconName: '',
+                                children: [
+                                    {
+                                        title: 'Schools',
+                                        url: '/education/schools',
+                                        longTitle: '',
+                                        iconName: '',
+                                        children: [],
+                                        classList: [],
+                                    },
+                                    {
+                                        title: 'Teachers',
+                                        url: '/teacher-network',
+                                        longTitle: '',
+                                        iconName: '',
+                                        children: [],
+                                        classList: [],
+                                    },
+                                    {
+                                        title: 'Universities',
+                                        url: '/education/universities',
+                                        longTitle: '',
+                                        iconName: '',
+                                        children: [],
+                                        classList: [],
+                                    },
+                                    {
+                                        title: 'Students',
+                                        url: '/education/students',
+                                        longTitle: '',
+                                        iconName: '',
+                                        children: [],
+                                        classList: [],
+                                    },
+                                ],
+                                classList: [],
+                            },
+                            {
+                                title: 'Media',
+                                url: '/media',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Society',
+                                url: '/society',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Law',
+                                url: '/law',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Scotland',
+                                url: '/uk/scotland',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Wales',
+                                url: '/uk/wales',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Northern Ireland',
+                                url: '/uk/northernireland',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                        ],
+                        classList: [],
+                    },
+                    {
+                        title: 'World',
+                        url: '/world',
+                        longTitle: 'World news',
+                        iconName: '',
+                        children: [
+                            {
+                                title: 'Europe',
+                                url: '/world/europe-news',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'US',
+                                url: '/us-news',
+                                longTitle: 'US news',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Americas',
+                                url: '/world/americas',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Asia',
+                                url: '/world/asia',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Australia',
+                                url: '/australia-news',
+                                longTitle: 'Australia news',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Middle East',
+                                url: '/world/middleeast',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Africa',
+                                url: '/world/africa',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Inequality',
+                                url: '/inequality',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Cities',
+                                url: '/cities',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Global development',
+                                url: '/global-development',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                        ],
+                        classList: [],
+                    },
+                    {
+                        title: 'Business',
+                        url: '/business',
+                        longTitle: '',
+                        iconName: '',
+                        children: [
+                            {
+                                title: 'Economics',
+                                url: '/business/economics',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Banking',
+                                url: '/business/banking',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Money',
+                                url: '/money',
+                                longTitle: '',
+                                iconName: '',
+                                children: [
+                                    {
+                                        title: 'Property',
+                                        url: '/money/property',
+                                        longTitle: '',
+                                        iconName: '',
+                                        children: [],
+                                        classList: [],
+                                    },
+                                    {
+                                        title: 'Pensions',
+                                        url: '/money/pensions',
+                                        longTitle: '',
+                                        iconName: '',
+                                        children: [],
+                                        classList: [],
+                                    },
+                                    {
+                                        title: 'Savings',
+                                        url: '/money/savings',
+                                        longTitle: '',
+                                        iconName: '',
+                                        children: [],
+                                        classList: [],
+                                    },
+                                    {
+                                        title: 'Borrowing',
+                                        url: '/money/debt',
+                                        longTitle: '',
+                                        iconName: '',
+                                        children: [],
+                                        classList: [],
+                                    },
+                                    {
+                                        title: 'Careers',
+                                        url: '/money/work-and-careers',
+                                        longTitle: '',
+                                        iconName: '',
+                                        children: [],
+                                        classList: [],
+                                    },
+                                ],
+                                classList: [],
+                            },
+                            {
+                                title: 'Markets',
+                                url: '/business/stock-markets',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Project Syndicate',
+                                url:
+                                    '/business/series/project-syndicate-economists',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'B2B',
+                                url: '/business-to-business',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                        ],
+                        classList: [],
+                    },
+                    {
+                        title: 'Football',
+                        url: '/football',
+                        longTitle: '',
+                        iconName: '',
+                        children: [
+                            {
+                                title: 'Live scores',
+                                url: '/football/live',
+                                longTitle: 'football/live',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Tables',
+                                url: '/football/tables',
+                                longTitle: 'football/tables',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Fixtures',
+                                url: '/football/fixtures',
+                                longTitle: 'football/fixtures',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Results',
+                                url: '/football/results',
+                                longTitle: 'football/results',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Competitions',
+                                url: '/football/competitions',
+                                longTitle: 'football/competitions',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Clubs',
+                                url: '/football/teams',
+                                longTitle: 'football/teams',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                        ],
+                        classList: [],
+                    },
+                    {
+                        title: 'Environment',
+                        url: '/environment',
+                        longTitle: '',
+                        iconName: '',
+                        children: [
+                            {
+                                title: 'Climate change',
+                                url: '/environment/climate-change',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Wildlife',
+                                url: '/environment/wildlife',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Energy',
+                                url: '/environment/energy',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Pollution',
+                                url: '/environment/pollution',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                        ],
+                        classList: [],
+                    },
+                    {
+                        title: 'UK politics',
+                        url: '/politics',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Education',
+                        url: '/education',
+                        longTitle: '',
+                        iconName: '',
+                        children: [
+                            {
+                                title: 'Schools',
+                                url: '/education/schools',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Teachers',
+                                url: '/teacher-network',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Universities',
+                                url: '/education/universities',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Students',
+                                url: '/education/students',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                        ],
+                        classList: [],
+                    },
+                    {
+                        title: 'Society',
+                        url: '/society',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Science',
+                        url: '/science',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Tech',
+                        url: '/technology',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Global development',
+                        url: '/global-development',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Cities',
+                        url: '/cities',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Obituaries',
+                        url: '/tone/obituaries',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                ],
+                classList: [],
+            },
+            {
+                title: 'Opinion',
+                url: '/commentisfree',
+                longTitle: 'Opinion home',
+                iconName: 'home',
+                children: [
+                    {
+                        title: 'The Guardian view',
+                        url: '/profile/editorial',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Columnists',
+                        url: '/index/contributors',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Cartoons',
+                        url: '/cartoons/archive',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Opinion videos',
+                        url: '/type/video+tone/comment',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Letters',
+                        url: '/tone/letters',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                ],
+                classList: [],
+            },
+            {
+                title: 'Sport',
+                url: '/sport',
+                longTitle: 'Sport home',
+                iconName: 'home',
+                children: [
+                    {
+                        title: 'Football',
+                        url: '/football',
+                        longTitle: '',
+                        iconName: '',
+                        children: [
+                            {
+                                title: 'Live scores',
+                                url: '/football/live',
+                                longTitle: 'football/live',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Tables',
+                                url: '/football/tables',
+                                longTitle: 'football/tables',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Fixtures',
+                                url: '/football/fixtures',
+                                longTitle: 'football/fixtures',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Results',
+                                url: '/football/results',
+                                longTitle: 'football/results',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Competitions',
+                                url: '/football/competitions',
+                                longTitle: 'football/competitions',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Clubs',
+                                url: '/football/teams',
+                                longTitle: 'football/teams',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                        ],
+                        classList: [],
+                    },
+                    {
+                        title: 'Cricket',
+                        url: '/sport/cricket',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Rugby union',
+                        url: '/sport/rugby-union',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Tennis',
+                        url: '/sport/tennis',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Cycling',
+                        url: '/sport/cycling',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'F1',
+                        url: '/sport/formulaone',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Golf',
+                        url: '/sport/golf',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Boxing',
+                        url: '/sport/boxing',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Rugby league',
+                        url: '/sport/rugbyleague',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Racing',
+                        url: '/sport/horse-racing',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'US sports',
+                        url: '/sport/us-sport',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                ],
+                classList: [],
+            },
+            {
+                title: 'Culture',
+                url: '/culture',
+                longTitle: 'Culture home',
+                iconName: 'home',
+                children: [
+                    {
+                        title: 'Film',
+                        url: '/film',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Music',
+                        url: '/music',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'TV & radio',
+                        url: '/tv-and-radio',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Books',
+                        url: '/books',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Art & design',
+                        url: '/artanddesign',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Stage',
+                        url: '/stage',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Games',
+                        url: '/games',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Classical',
+                        url: '/music/classicalmusicandopera',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                ],
+                classList: [],
+            },
+            {
+                title: 'Lifestyle',
+                url: '/lifeandstyle',
+                longTitle: 'Lifestyle home',
+                iconName: 'home',
+                children: [
+                    {
+                        title: 'Fashion',
+                        url: '/fashion',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Food',
+                        url: '/food',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Recipes',
+                        url: '/tone/recipes',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Travel',
+                        url: '/travel',
+                        longTitle: '',
+                        iconName: '',
+                        children: [
+                            {
+                                title: 'UK',
+                                url: '/travel/uk',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Europe',
+                                url: '/travel/europe',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'US',
+                                url: '/travel/usa',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                        ],
+                        classList: [],
+                    },
+                    {
+                        title: 'Health & fitness',
+                        url: '/lifeandstyle/health-and-wellbeing',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Women',
+                        url: '/lifeandstyle/women',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Men',
+                        url: '/lifeandstyle/men',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Love & sex',
+                        url: '/lifeandstyle/love-and-sex',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Beauty',
+                        url: '/fashion/beauty',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Home & garden',
+                        url: '/lifeandstyle/home-and-garden',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Money',
+                        url: '/money',
+                        longTitle: '',
+                        iconName: '',
+                        children: [
+                            {
+                                title: 'Property',
+                                url: '/money/property',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Pensions',
+                                url: '/money/pensions',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Savings',
+                                url: '/money/savings',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Borrowing',
+                                url: '/money/debt',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Careers',
+                                url: '/money/work-and-careers',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                        ],
+                        classList: [],
+                    },
+                    {
+                        title: 'Cars',
+                        url: '/technology/motoring',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                ],
+                classList: [],
+            },
+        ],
+        otherLinks: [
+            {
+                title: 'The Guardian app',
+                url:
+                    'https://www.theguardian.com/mobile/2014/may/29/the-guardian-for-mobile-and-tablet',
+                longTitle: '',
+                iconName: '',
+                children: [],
+                classList: [],
+            },
+            {
+                title: 'Video',
+                url: '/video',
+                longTitle: '',
+                iconName: '',
+                children: [],
+                classList: [],
+            },
+            {
+                title: 'Podcasts',
+                url: '/podcasts',
+                longTitle: '',
+                iconName: '',
+                children: [],
+                classList: [],
+            },
+            {
+                title: 'Pictures',
+                url: '/inpictures',
+                longTitle: '',
+                iconName: '',
+                children: [],
+                classList: [],
+            },
+            {
+                title: 'Newsletters',
+                url: '/email-newsletters',
+                longTitle: '',
+                iconName: '',
+                children: [],
+                classList: [],
+            },
+            {
+                title: "Today's paper",
+                url: '/theguardian',
+                longTitle: '',
+                iconName: '',
+                children: [
+                    {
+                        title: 'Obituaries',
+                        url: '/tone/obituaries',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'G2',
+                        url: '/theguardian/g2',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Weekend',
+                        url: '/theguardian/weekend',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'The Guide',
+                        url: '/theguardian/theguide',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Saturday review',
+                        url: '/theguardian/guardianreview',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                ],
+                classList: [],
+            },
+            {
+                title: 'Inside the Guardian',
+                url: 'https://www.theguardian.com/membership',
+                longTitle: '',
+                iconName: '',
+                children: [],
+                classList: [],
+            },
+            {
+                title: 'The Observer',
+                url: '/observer',
+                longTitle: '',
+                iconName: '',
+                children: [
+                    {
+                        title: 'Comment',
+                        url: '/theobserver/news/comment',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'The New Review',
+                        url: '/theobserver/new-review',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Observer Magazine',
+                        url: '/theobserver/magazine',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                ],
+                classList: [],
+            },
+            {
+                title: 'Guardian Weekly',
+                url:
+                    'https://www.theguardian.com/weekly?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_UK',
+                longTitle: '',
+                iconName: '',
+                children: [],
+                classList: [],
+            },
+            {
+                title: 'Professional networks',
+                url: '/guardian-professional',
+                longTitle: '',
+                iconName: '',
+                children: [],
+                classList: [],
+            },
+            {
+                title: 'Crosswords',
+                url: '/crosswords',
+                longTitle: '',
+                iconName: '',
+                children: [
+                    {
+                        title: 'Blog',
+                        url: '/crosswords/crossword-blog',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Editor',
+                        url: '/crosswords/series/crossword-editor-update',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Quick',
+                        url: '/crosswords/series/quick',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Cryptic',
+                        url: '/crosswords/series/cryptic',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Prize',
+                        url: '/crosswords/series/prize',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Weekend',
+                        url: '/crosswords/series/weekend-crossword',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Quiptic',
+                        url: '/crosswords/series/quiptic',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Genius',
+                        url: '/crosswords/series/genius',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Speedy',
+                        url: '/crosswords/series/speedy',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Everyman',
+                        url: '/crosswords/series/everyman',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Azed',
+                        url: '/crosswords/series/azed',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                ],
+                classList: [],
+            },
+        ],
+        brandExtensions: [
+            {
+                title: 'Search jobs',
+                url:
+                    'https://jobs.theguardian.com?INTCMP=jobs_uk_web_newheader_dropdown',
+                longTitle: '',
+                iconName: '',
+                children: [],
+                classList: [],
+            },
+            {
+                title: 'Dating',
+                url:
+                    'https://soulmates.theguardian.com?INTCMP=soulmates_uk_web_newheader_dropdown',
+                longTitle: '',
+                iconName: '',
+                children: [],
+                classList: [],
+            },
+            {
+                title: 'Holidays',
+                url:
+                    'https://holidays.theguardian.com?INTCMP=holidays_uk_web_newheader',
+                longTitle: '',
+                iconName: '',
+                children: [],
+                classList: [],
+            },
+            {
+                title: 'Live events',
+                url:
+                    'https://membership.theguardian.com/events?INTCMP=live_uk_header_dropdown',
+                longTitle: '',
+                iconName: '',
+                children: [],
+                classList: [],
+            },
+            {
+                title: 'Masterclasses',
+                url: '/guardian-masterclasses',
+                longTitle: '',
+                iconName: '',
+                children: [],
+                classList: [],
+            },
+            {
+                title: 'Digital Archive',
+                url: 'https://theguardian.newspapers.com',
+                longTitle: '',
+                iconName: '',
+                children: [],
+                classList: [],
+            },
+            {
+                title: 'Guardian Print Shop',
+                url: '/artanddesign/series/gnm-print-sales',
+                longTitle: '',
+                iconName: '',
+                children: [],
+                classList: [],
+            },
+            {
+                title: 'Patrons',
+                url: 'https://patrons.theguardian.com/?INTCMP=header_patrons',
+                longTitle: '',
+                iconName: '',
+                children: [],
+                classList: [],
+            },
+            {
+                title: 'Discount Codes',
+                url: 'https://discountcode.theguardian.com',
+                longTitle: '',
+                iconName: '',
+                children: [],
+                classList: ['js-discount-code-link'],
+            },
+        ],
+        currentNavLink: {
+            title: 'Music',
+            url: '/music',
+            longTitle: '',
+            iconName: '',
+            children: [],
+            classList: [],
+        },
+        currentParent: {
+            title: 'Culture',
+            url: '/culture',
+            longTitle: 'Culture home',
+            iconName: 'home',
+            children: [
+                {
+                    title: 'Film',
+                    url: '/film',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Music',
+                    url: '/music',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'TV & radio',
+                    url: '/tv-and-radio',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Books',
+                    url: '/books',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Art & design',
+                    url: '/artanddesign',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Stage',
+                    url: '/stage',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Games',
+                    url: '/games',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Classical',
+                    url: '/music/classicalmusicandopera',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+            ],
+            classList: [],
+        },
+        currentPillar: {
+            title: 'Culture',
+            url: '/culture',
+            longTitle: 'Culture home',
+            iconName: 'home',
+            children: [
+                {
+                    title: 'Film',
+                    url: '/film',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Music',
+                    url: '/music',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'TV & radio',
+                    url: '/tv-and-radio',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Books',
+                    url: '/books',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Art & design',
+                    url: '/artanddesign',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Stage',
+                    url: '/stage',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Games',
+                    url: '/games',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Classical',
+                    url: '/music/classicalmusicandopera',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+            ],
+            classList: [],
+        },
+        subNavSections: {
+            links: [
+                {
+                    title: 'Film',
+                    url: '/film',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Music',
+                    url: '/music',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'TV & radio',
+                    url: '/tv-and-radio',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Books',
+                    url: '/books',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Art & design',
+                    url: '/artanddesign',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Stage',
+                    url: '/stage',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Games',
+                    url: '/games',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Classical',
+                    url: '/music/classicalmusicandopera',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+            ],
+        },
+        readerRevenueLinks: {
+            header: {
+                contribute:
+                    'https://support.theguardian.com/contribute?INTCMP=header_support_contribute&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support_contribute%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+                subscribe:
+                    'https://support.theguardian.com/subscribe?INTCMP=header_support_subscribe&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support_subscribe%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+                support:
+                    'https://support.theguardian.com?INTCMP=header_support&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+            },
+            footer: {
+                contribute:
+                    'https://support.theguardian.com/contribute?INTCMP=footer_support_contribute&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22footer_support_contribute%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+                subscribe:
+                    'https://support.theguardian.com/subscribe?INTCMP=footer_support_subscribe&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22footer_support_subscribe%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+                support:
+                    'https://support.theguardian.com?INTCMP=footer_support&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22footer_support%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+            },
+            sideMenu: {
+                contribute:
+                    'https://support.theguardian.com/contribute?INTCMP=side_menu_support_contribute&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22side_menu_support_contribute%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+                subscribe:
+                    'https://support.theguardian.com/subscribe?INTCMP=side_menu_support_subscribe&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22side_menu_support_subscribe%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+                support:
+                    'https://support.theguardian.com?INTCMP=side_menu_support&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22side_menu_support%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+            },
+            ampHeader: {
+                contribute:
+                    'https://support.theguardian.com/contribute?INTCMP=header_support_contribute&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support_contribute%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+                subscribe:
+                    'https://support.theguardian.com/subscribe?INTCMP=header_support_subscribe&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support_subscribe%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+                support:
+                    'https://support.theguardian.com?INTCMP=amp_header_support&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22amp_header_support%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+            },
+            ampFooter: {
+                contribute:
+                    'https://support.theguardian.com/contribute?INTCMP=amp_footer_support_contribute&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22amp_footer_support_contribute%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+                subscribe:
+                    'https://support.theguardian.com/subscribe?INTCMP=amp_footer_support_subscribe&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22amp_footer_support_subscribe%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+                support:
+                    'https://support.theguardian.com?INTCMP=footer_support&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22footer_support%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+            },
+        },
+    },
+    mainMediaElements: [
+        {
+            role: 'inline',
+            data: {
+                copyright: '2017 Getty Images',
+                alt: 'Rap god ... Eminem performing at the MTV EMAs last year.',
+                caption:
+                    'Rap god ... Eminem performing at the MTV EMAs last year.',
+                credit: 'Photograph: Dave J Hogan/Getty Images for MTV',
+            },
+            imageSources: [
+                {
+                    weighting: 'inline',
+                    srcSet: [
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=9692341d702c2fadad48ba71f5779283',
+                            width: 1240,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=adaa73232ffc2bb229d6d1ff85db56a7',
+                            width: 1210,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=1c85ec6caee30b8868492ba8eaab1ec2',
+                            width: 890,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=620&quality=85&auto=format&fit=max&s=8522e35d0cfea221dacfdf0751f64187',
+                            width: 620,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=605&quality=85&auto=format&fit=max&s=57aedef16ed295819f9f57bf31fdf2ea',
+                            width: 605,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=445&quality=85&auto=format&fit=max&s=3169c757b6ef4420e56d107bbfffc4e0',
+                            width: 445,
+                        },
+                    ],
+                },
+                {
+                    weighting: 'thumbnail',
+                    srcSet: [
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=140&quality=85&auto=format&fit=max&s=b04a99ac8368e13b3e0b3f47cbfda3e1',
+                            width: 140,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=7eeed2f3223bd17e1fb694518754a3ac',
+                            width: 280,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=120&quality=85&auto=format&fit=max&s=8c9aca86b840102b15cf7c2f251c7709',
+                            width: 120,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=69bcf5c642f2771823f0dadfe05bc0bc',
+                            width: 240,
+                        },
+                    ],
+                },
+                {
+                    weighting: 'supporting',
+                    srcSet: [
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=380&quality=85&auto=format&fit=max&s=524e37c50312ba81b7341ca378ee00d8',
+                            width: 380,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=70472531758905e9702631506c5a3ce0',
+                            width: 760,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=300&quality=85&auto=format&fit=max&s=9238845d238ecb6e199485b25239a3f8',
+                            width: 300,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=f59702d71add10893daaceaf564c7fd8',
+                            width: 600,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=620&quality=85&auto=format&fit=max&s=8522e35d0cfea221dacfdf0751f64187',
+                            width: 620,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=9692341d702c2fadad48ba71f5779283',
+                            width: 1240,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=605&quality=85&auto=format&fit=max&s=57aedef16ed295819f9f57bf31fdf2ea',
+                            width: 605,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=adaa73232ffc2bb229d6d1ff85db56a7',
+                            width: 1210,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=445&quality=85&auto=format&fit=max&s=3169c757b6ef4420e56d107bbfffc4e0',
+                            width: 445,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=1c85ec6caee30b8868492ba8eaab1ec2',
+                            width: 890,
+                        },
+                    ],
+                },
+                {
+                    weighting: 'showcase',
+                    srcSet: [
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=860&quality=85&auto=format&fit=max&s=5569f67304151f3067c77598fcae2ca8',
+                            width: 860,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=860&quality=45&auto=format&fit=max&dpr=2&s=8407f994aabf7fd82af078aa5eda45c1',
+                            width: 1720,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=780&quality=85&auto=format&fit=max&s=0fb38ad54f283c00837ee46e5ce5483c',
+                            width: 780,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=780&quality=45&auto=format&fit=max&dpr=2&s=b18f5d92507b1111bec70a1d3cdb7e68',
+                            width: 1560,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=620&quality=85&auto=format&fit=max&s=8522e35d0cfea221dacfdf0751f64187',
+                            width: 620,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=9692341d702c2fadad48ba71f5779283',
+                            width: 1240,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=605&quality=85&auto=format&fit=max&s=57aedef16ed295819f9f57bf31fdf2ea',
+                            width: 605,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=adaa73232ffc2bb229d6d1ff85db56a7',
+                            width: 1210,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=445&quality=85&auto=format&fit=max&s=3169c757b6ef4420e56d107bbfffc4e0',
+                            width: 445,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=1c85ec6caee30b8868492ba8eaab1ec2',
+                            width: 890,
+                        },
+                    ],
+                },
+                {
+                    weighting: 'halfwidth',
+                    srcSet: [
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=620&quality=85&auto=format&fit=max&s=8522e35d0cfea221dacfdf0751f64187',
+                            width: 620,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=9692341d702c2fadad48ba71f5779283',
+                            width: 1240,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=605&quality=85&auto=format&fit=max&s=57aedef16ed295819f9f57bf31fdf2ea',
+                            width: 605,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=adaa73232ffc2bb229d6d1ff85db56a7',
+                            width: 1210,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=445&quality=85&auto=format&fit=max&s=3169c757b6ef4420e56d107bbfffc4e0',
+                            width: 445,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=1c85ec6caee30b8868492ba8eaab1ec2',
+                            width: 890,
+                        },
+                    ],
+                },
+                {
+                    weighting: 'immersive',
+                    srcSet: [
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=620&quality=85&auto=format&fit=max&s=8522e35d0cfea221dacfdf0751f64187',
+                            width: 620,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=9692341d702c2fadad48ba71f5779283',
+                            width: 1240,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=605&quality=85&auto=format&fit=max&s=57aedef16ed295819f9f57bf31fdf2ea',
+                            width: 605,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=adaa73232ffc2bb229d6d1ff85db56a7',
+                            width: 1210,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=445&quality=85&auto=format&fit=max&s=3169c757b6ef4420e56d107bbfffc4e0',
+                            width: 445,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=1c85ec6caee30b8868492ba8eaab1ec2',
+                            width: 890,
+                        },
+                    ],
+                },
+            ],
+            _type: 'model.dotcomrendering.pageElements.ImageBlockElement',
+            media: {
+                allImages: [
+                    {
+                        index: 0,
+                        fields: {
+                            height: '1200',
+                            width: '2000',
+                        },
+                        mediaType: 'Image',
+                        mimeType: 'image/jpeg',
+                        url:
+                            'https://media.guim.co.uk/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/2000.jpg',
+                    },
+                    {
+                        index: 1,
+                        fields: {
+                            height: '600',
+                            width: '1000',
+                        },
+                        mediaType: 'Image',
+                        mimeType: 'image/jpeg',
+                        url:
+                            'https://media.guim.co.uk/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/1000.jpg',
+                    },
+                    {
+                        index: 2,
+                        fields: {
+                            height: '300',
+                            width: '500',
+                        },
+                        mediaType: 'Image',
+                        mimeType: 'image/jpeg',
+                        url:
+                            'https://media.guim.co.uk/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/500.jpg',
+                    },
+                    {
+                        index: 3,
+                        fields: {
+                            height: '84',
+                            width: '140',
+                        },
+                        mediaType: 'Image',
+                        mimeType: 'image/jpeg',
+                        url:
+                            'https://media.guim.co.uk/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/140.jpg',
+                    },
+                    {
+                        index: 4,
+                        fields: {
+                            height: '2511',
+                            width: '4184',
+                        },
+                        mediaType: 'Image',
+                        mimeType: 'image/jpeg',
+                        url:
+                            'https://media.guim.co.uk/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/4184.jpg',
+                    },
+                    {
+                        index: 5,
+                        fields: {
+                            isMaster: 'true',
+                            height: '2511',
+                            width: '4184',
+                        },
+                        mediaType: 'Image',
+                        mimeType: 'image/jpeg',
+                        url:
+                            'https://media.guim.co.uk/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg',
+                    },
+                ],
+            },
+            displayCredit: true,
+        },
+    ],
+    webPublicationDate: '2018-08-31T14:02:23.000Z',
+    blocks: [
+        {
+            id: '5b8931d1e4b04106c28a2ea0',
+            elements: [
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>Eminem’s 10th album arrived on streaming services, without any pre-emptory buildup, accompanied by a nonchalant tweet from the 45-year-old rapper: “I tried not 2 overthink this 1 … enjoy.” It’s a theme reiterated within the opening seconds of the album: “I’m just gonna write down my first thoughts,” he mutters, “and see where it takes me.”</p>',
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>Not for the first time in his career, it’s easy to feel that Marshall Mathers III is being slightly disingenuous. Kamikaze is fairly obviously the product of a great deal of thinking indeed, largely of the stewing and fulminating variety. Clearly a not man at ease with the sanity-salving concept of Not Reading The Comments, virtually the entirety of its 45-minute running time is consumed with complaining about the cool reception afforded to his last album – 2017’s weak and audibly confused <a href="https://www.theguardian.com/music/2017/dec/15/eminem-revival-review">Revival</a> – and bemoaning the current state of hip-hop. </p>',
+                },
+                {
+                    role: 'supporting',
+                    data: {
+                        alt: 'The cover art for Kamikaze.',
+                        caption: 'The cover art for Kamikaze.',
+                        credit: 'Photograph: Aftermath/Shady/Interscope',
+                    },
+                    imageSources: [
+                        {
+                            weighting: 'inline',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=e7b61fdd2aca5e37d4091723f7410a67',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=dc969702e5d57f6f41f8c48ae10aa0ea',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=c5bdbd0c501d3aff4758f831c2ea4a76',
+                                    width: 890,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=620&quality=85&auto=format&fit=max&s=013cf6a39d58387da74a0f4cdecdfa1d',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=605&quality=85&auto=format&fit=max&s=ce4895cfed0127af3b17b5065807442d',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=445&quality=85&auto=format&fit=max&s=5fd90f94815d752ed81bc7cba753c4e7',
+                                    width: 445,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'thumbnail',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=140&quality=85&auto=format&fit=max&s=7597023a78da074c4aee75f60206d23a',
+                                    width: 140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=401a50c02a524adf67bc740e3d1fe1e3',
+                                    width: 280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=120&quality=85&auto=format&fit=max&s=8ca1d0fc7ac9d2cbb943e22099f2c433',
+                                    width: 120,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=583a2b2df3bb429525a0afbee63228a7',
+                                    width: 240,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'supporting',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=e7b61fdd2aca5e37d4091723f7410a67',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=dc969702e5d57f6f41f8c48ae10aa0ea',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=c5bdbd0c501d3aff4758f831c2ea4a76',
+                                    width: 890,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=84ca950eb2ac67e07530ab5af52457cd',
+                                    width: 760,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=620&quality=85&auto=format&fit=max&s=013cf6a39d58387da74a0f4cdecdfa1d',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=605&quality=85&auto=format&fit=max&s=ce4895cfed0127af3b17b5065807442d',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=a3f19a75d492bda708a5d0492568414d',
+                                    width: 600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=445&quality=85&auto=format&fit=max&s=5fd90f94815d752ed81bc7cba753c4e7',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=380&quality=85&auto=format&fit=max&s=b9b9fd2ff89b022a9b8b73c56165e66d',
+                                    width: 380,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=300&quality=85&auto=format&fit=max&s=781e48bea05ede48949290e76251bce3',
+                                    width: 300,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'showcase',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=860&quality=85&auto=format&fit=max&s=d0e0b0e885b678ccabde50f2fe8c2947',
+                                    width: 860,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=860&quality=45&auto=format&fit=max&dpr=2&s=a2d3317d612748ff33b11b277c676b92',
+                                    width: 1720,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=780&quality=85&auto=format&fit=max&s=284d948e66fa07d2e7cc106347a9e2ad',
+                                    width: 780,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=780&quality=45&auto=format&fit=max&dpr=2&s=9ce2bbc31862a5a8c4b88472aa1729ed',
+                                    width: 1560,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=620&quality=85&auto=format&fit=max&s=013cf6a39d58387da74a0f4cdecdfa1d',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=e7b61fdd2aca5e37d4091723f7410a67',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=605&quality=85&auto=format&fit=max&s=ce4895cfed0127af3b17b5065807442d',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=dc969702e5d57f6f41f8c48ae10aa0ea',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=445&quality=85&auto=format&fit=max&s=5fd90f94815d752ed81bc7cba753c4e7',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=c5bdbd0c501d3aff4758f831c2ea4a76',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'halfwidth',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=620&quality=85&auto=format&fit=max&s=013cf6a39d58387da74a0f4cdecdfa1d',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=e7b61fdd2aca5e37d4091723f7410a67',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=605&quality=85&auto=format&fit=max&s=ce4895cfed0127af3b17b5065807442d',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=dc969702e5d57f6f41f8c48ae10aa0ea',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=445&quality=85&auto=format&fit=max&s=5fd90f94815d752ed81bc7cba753c4e7',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=c5bdbd0c501d3aff4758f831c2ea4a76',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'immersive',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=620&quality=85&auto=format&fit=max&s=013cf6a39d58387da74a0f4cdecdfa1d',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=e7b61fdd2aca5e37d4091723f7410a67',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=605&quality=85&auto=format&fit=max&s=ce4895cfed0127af3b17b5065807442d',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=dc969702e5d57f6f41f8c48ae10aa0ea',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=445&quality=85&auto=format&fit=max&s=5fd90f94815d752ed81bc7cba753c4e7',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=c5bdbd0c501d3aff4758f831c2ea4a76',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                    ],
+                    _type:
+                        'model.dotcomrendering.pageElements.ImageBlockElement',
+                    media: {
+                        allImages: [
+                            {
+                                index: 0,
+                                fields: {
+                                    height: '800',
+                                    width: '800',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/800.jpg',
+                            },
+                            {
+                                index: 1,
+                                fields: {
+                                    isMaster: 'true',
+                                    height: '800',
+                                    width: '800',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/master/800.jpg',
+                            },
+                            {
+                                index: 2,
+                                fields: {
+                                    height: '500',
+                                    width: '500',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/500.jpg',
+                            },
+                            {
+                                index: 3,
+                                fields: {
+                                    height: '140',
+                                    width: '140',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/e9b6de266608a63d095c878e5dba7ef29a949b70/200_0_800_800/140.jpg',
+                            },
+                        ],
+                    },
+                    displayCredit: true,
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>His latterday nemesis Donald Trump <a href="https://www.theguardian.com/music/2018/aug/31/eminem-donald-trump-surprise-album-kamikaze">gets a look-in</a> on opener The Ringer, but by the time he gets around to denouncing the president, he appears to have run out of bile, having expended it on critics, social media commentators and other rappers. He can’t summon any terms of disapproval he hasn’t already lavished on Lil Pump and Charlamagne Tha God. “My beef is more media journalists,” he admits. Similarly, when he does what you might call the “Slim Shady thing” – making queasy jokes about Harvey Weinstein and last year’s mass shooting in Las Vegas on Greatest, claiming that beating his partner with a baseball bat “only makes our love stronger” on Normal – you get the feeling he’s going through the motions, giving his audience the unconscionable stuff they expect. </p>',
+                },
+                {
+                    prefix: 'Related: ',
+                    _type:
+                        'model.dotcomrendering.pageElements.RichLinkBlockElement',
+                    text:
+                        'Eminem attacks Donald Trump on surprise album Kamikaze',
+                    url:
+                        'https://www.theguardian.com/music/2018/aug/31/eminem-donald-trump-surprise-album-kamikaze',
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>The weakest thing here might be Good Guy, a <a href="https://en.wikipedia.org/wiki/Thy_name_is">frailty-thy-name-is-woman</a> saga of infidelity, marked both by a dreary beat and the sense that Eminem’s heart really isn’t in it. He sounds like a man killing time until he can return to the topics that really get him going: negative reactions to his recent work and the vogue for <a href="https://www.theguardian.com/music/2017/jan/27/phonk-soundcloud-spaceghostpurrp-lil-uzi-vert">SoundCloud-disseminated mumble rap</a>. </p>',
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>On the one hand, the stuff about Revival’s reception gets a bit wearying and invites the obvious response: if its pop hooks and guest appearances from Pink and Ed Sheeran were as unfairly maligned as their author keeps claiming, why has he ditched them almost completely for its follow-up? Plus, there’s something odd about hearing Eminem, once the generation gap-cleaving voice of disaffected youth, sounding like a grumpy dad huffing from behind his newspaper in front of Top of the Pops, peevishly insisting that modern music is “mumbo jumbo” and deliberately getting the names of young artists wrong: “Earl the Hooded Sweater or whatever his name is”.</p>',
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>That said, if you’re going to listen to a middle-aged man complain that hip-hop isn’t as good as it used to be, that it might as well be Eminem. Whatever you make of his point about hip-hop’s decline, the central plank of his thesis – that the current generation of SoundCloud stars lack his astonishing technical skills and his wit, and there’s something a bit off about rappers penning their rhymes via ghostwriters – is pretty indisputable. </p>',
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>Unlike its predecessor, the punchlines on Kamikaze largely land on target. The section where he describes mutilating his own genitals in detail, not out of Slim Shady-esque nihilism but because he’d rather do that than listen to Lil Yachty, is genuinely funny, and you anticipate many of the rappers attacked responding with anything as potent. Moreover, he spends chunks of Kamikaze demonstrating his point about technical skill in considerable style. He sounds more alive and exigent on The Ringer or Greatest than he has in years, mocking latterday triplet flows and lyrical content before letting fly with hyperspeed bars and intricate wordplay. His alternately baffled and livid verse on Lucky Me, gradually increasing in intensity and speed, is fantastic.</p>',
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>Kamikaze is a variable, flawed album. The hooks are nothing special – in the case of Nice Guy, a lumbering bass-heavy grind bedecked with a racked vocal from Jessie Reyez, it’s actively painful. The beats are of noticeably spotty quality, ranging from the clean, cool electronics of Fall at one extreme, to the distinctly ho-hum Venom, a pallid contribution to the soundtrack of the forthcoming Marvel movie tacked awkwardly to the end of the album. </p>',
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>When it’s on fire, however, it really crackles, blazing considerably brighter than any Eminem album for some time. Whether that’s enough to restore its author to the centre of the action is debatable: its predecessor shifted a mere 1.1m copies worldwide, a fraction of the sales he is used to. As he notes on Stepping Stone, a thoughtful examination of the collapse of his group D12, times have changed. “One minute you’re bodying shit / But then your audience splits,” he raps, “you can already sense the climate is starting to shift / To these kids you no longer exist.” </p>',
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>But at its best, Kamikaze makes clear that Eminem is prepared to rage against the dying of the light – and the sound of him raging can still make for electrifying listening. </p>',
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.AudioBlockElement',
+                },
+            ],
+            createdOn: 1535717841000,
+            createdOnDisplay: '13:17 BST',
+            lastUpdatedDisplay: '14:28 BST',
+            firstPublished: 1535717845000,
+            firstPublishedDisplay: '13:17 BST',
+        },
+    ],
+    author: {
+        byline: 'Alexis Petridis',
+    },
+    designType: 'Review',
+    linkedData: [
+        {
+            '@type': 'NewsArticle',
+            '@context': 'https://schema.org',
+            '@id':
+                'https://amp.theguardian.commusic/2018/aug/31/eminem-kamikaze-album-review',
+            publisher: {
+                '@type': 'Organization',
+                '@context': 'https://schema.org',
+                '@id': 'https://www.theguardian.com#publisher',
+                name: 'The Guardian',
+                url: 'https://www.theguardian.com/',
+                logo: {
+                    '@type': 'ImageObject',
+                    url:
+                        'https://uploads.guim.co.uk/2018/01/31/TheGuardian_AMP.png',
+                    width: 190,
+                    height: 60,
+                },
+                sameAs: [
+                    'https://www.facebook.com/theguardian',
+                    'https://twitter.com/guardian',
+                    'https://www.youtube.com/user/TheGuardian',
+                ],
+            },
+            isAccessibleForFree: true,
+            isPartOf: {
+                '@type': ['CreativeWork', 'Product'],
+                name: 'The Guardian',
+                productID: 'theguardian.com:basic',
+            },
+            image: [
+                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctcmV2aWV3LTMucG5n&enable=upscale&s=19ff134b1c30d533c8248da55e4cd892',
+                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=1200&height=1200&quality=85&auto=format&fit=crop&s=473370f8653451c67c287b7f09919608',
+                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=1200&height=900&quality=85&auto=format&fit=crop&s=e197c21017be45b8fdafbe3050cb29a9',
+                'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=1200&quality=85&auto=format&fit=max&s=3b9ffe6eb83be3936ae89fd3ab522fb4',
+            ],
+            author: [
+                {
+                    '@type': 'Person',
+                    name: 'Alexis Petridis',
+                    sameAs:
+                        'https://www.theguardian.com/profile/alexispetridis',
+                },
+            ],
+            datePublished: '2018-08-31T14:02:23.000Z',
+            headline:
+                'Eminem: Kamikaze review – middle-aged gripes aired with blazing skill',
+            dateModified: '2018-08-31T17:18:04.000Z',
+            mainEntityOfPage:
+                'https://www.theguardian.com/music/2018/aug/31/eminem-kamikaze-album-review',
+        },
+        {
+            '@type': 'WebPage',
+            '@context': 'https://schema.org',
+            '@id':
+                'https://www.theguardian.com/music/2018/aug/31/eminem-kamikaze-album-review',
+            potentialAction: {
+                '@type': 'ViewAction',
+                target:
+                    'android-app://com.guardian/https/www.theguardian.com/music/2018/aug/31/eminem-kamikaze-album-review',
+            },
+        },
+    ],
+    webPublicationDateDisplay: 'Fri 31 Aug 2018 15.02 BST',
+    editionId: 'UK',
+    shouldHideAds: false,
+    standfirst:
+        '<p>The hooks are middling and the moans at his critics get tedious – but a flurry of brutal potshots at witless SoundCloud rappers prove Eminem can still hit exhilarating heights</p>',
+    webTitle:
+        'Eminem: Kamikaze review – middle-aged gripes aired with blazing skill',
+    openGraphData: {
+        'og:url':
+            'http://www.theguardian.com/music/2018/aug/31/eminem-kamikaze-album-review',
+        'article:author': 'https://www.theguardian.com/profile/alexispetridis',
+        'og:image:height': '720',
+        'og:description':
+            'The hooks are middling and the moans at his critics get tedious – but a flurry of brutal potshots at witless SoundCloud rappers prove Eminem can still hit exhilarating heights',
+        'og:image:width': '1200',
+        'og:image':
+            'https://i.guim.co.uk/img/media/db2348b8bc322340bdf9a842ea8e562321164050/0_0_4184_2511/master/4184.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctcmV2aWV3LTMucG5n&enable=upscale&s=19ff134b1c30d533c8248da55e4cd892',
+        'al:ios:url':
+            'gnmguardian://music/2018/aug/31/eminem-kamikaze-album-review?contenttype=Article&source=applinks',
+        'article:publisher': 'https://www.facebook.com/theguardian',
+        'og:type': 'article',
+        'al:ios:app_store_id': '409128287',
+        'article:section': 'Music',
+        'article:published_time': '2018-08-31T14:02:23.000Z',
+        'og:title':
+            'Eminem: Kamikaze review – middle-aged gripes aired with blazing skill',
+        'fb:app_id': '180444840287',
+        'article:tag': 'Eminem,Music,Rap,Hip-hop,Culture',
+        'al:ios:app_name': 'The Guardian',
+        'og:site_name': 'the Guardian',
+        'article:modified_time': '2018-08-31T17:18:04.000Z',
+    },
+    sectionUrl: 'music/eminem',
+    pageId: 'music/2018/aug/31/eminem-kamikaze-album-review',
+    version: 3,
+    tags: [
+        {
+            id: 'music/eminem',
+            type: 'Keyword',
+            title: 'Eminem',
+        },
+        {
+            id: 'music/music',
+            type: 'Keyword',
+            title: 'Music',
+        },
+        {
+            id: 'music/rap',
+            type: 'Keyword',
+            title: 'Rap',
+        },
+        {
+            id: 'music/hip-hop',
+            type: 'Keyword',
+            title: 'Hip-hop',
+        },
+        {
+            id: 'culture/culture',
+            type: 'Keyword',
+            title: 'Culture',
+        },
+        {
+            id: 'type/article',
+            type: 'Type',
+            title: 'Article',
+        },
+        {
+            id: 'tone/albumreview',
+            type: 'Tone',
+            title: 'Album reviews',
+        },
+        {
+            id: 'tone/reviews',
+            type: 'Tone',
+            title: 'Reviews',
+        },
+        {
+            id: 'profile/alexispetridis',
+            type: 'Contributor',
+            title: 'Alexis Petridis',
+            bylineImageUrl:
+                'https://i.guim.co.uk/img/uploads/2018/01/31/Alexis_Petridis,_L.png?width=300&quality=85&auto=format&fit=max&s=b5d21be0a55e44ecebb0dd783db1d6d7',
+        },
+        {
+            id: 'tracking/commissioningdesk/uk-culture',
+            type: 'Tracking',
+            title: 'UK Culture',
+        },
+    ],
+    pillar: 'culture',
+    isCommentable: true,
+    webURL:
+        'https://www.theguardian.com/music/2018/aug/31/eminem-kamikaze-album-review',
+    keyEvents: [],
+    showBottomSocialButtons: true,
+    isImmersive: false,
+    config: {
+        ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
+        sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
+        sentryHost: 'app.getsentry.com/35463',
+        dcrSentryDsn:
+            'https://1937ab71c8804b2b8438178dfdd6468f@sentry.io/1377847',
+        switches: {
+            cmpUi: true,
+        },
+        shortUrlId: '/p/4k83z',
+        abTests: {},
+        dfpAccountId: '',
+        commercialBundleUrl:
+            'https://assets.guim.co.uk/javascripts/3d3cbc5f29df7c0cdd65/graun.dotcom-rendering-commercial.js',
+        revisionNumber: '62cf0d6e4609276d37e09fd596430fbf8b629418',
+        isDev: false,
+        googletagUrl: '//www.googletagservices.com/tag/js/gpt.js',
+        stage: 'DEV',
+        frontendAssetsFullURL: 'https://assets.guim.co.uk/',
+        hbImpl: {
+            prebid: false,
+            a9: false,
+        },
+        adUnit: '/59666047/theguardian.com/film/article/ng',
+        isSensitive: false,
+        videoDuration: 0,
+        edition: '',
+        section: '',
+        sharedAdTargeting: {},
+        pageId: '',
+        webPublicationDate: 1579185778186,
+        headline: '',
+        author: '',
+        keywords: '',
+        series: '',
+        contentType: '',
+        isPaidContent: false,
+        keywordIds: '',
+        showRelatedContent: false,
+        ampIframeUrl:
+            'https://assets.guim.co.uk/data/vendor/a994b749adae30cd58f0e84c8fa28013/amp-iframe.html',
+    },
+    sectionLabel: 'Eminem',
+};

--- a/fixtures/card.ts
+++ b/fixtures/card.ts
@@ -1,0 +1,88 @@
+export const richLinkCard = {
+    tags: [
+        {
+            id: 'music/eminem',
+            type: 'Keyword',
+            title: 'Eminem',
+        },
+        {
+            id: 'music/music',
+            type: 'Keyword',
+            title: 'Music',
+        },
+        {
+            id: 'music/hip-hop',
+            type: 'Keyword',
+            title: 'Hip-hop',
+        },
+        {
+            id: 'music/rap',
+            type: 'Keyword',
+            title: 'Rap',
+        },
+        {
+            id: 'culture/culture',
+            type: 'Keyword',
+            title: 'Culture',
+        },
+        {
+            id: 'us-news/donaldtrump',
+            type: 'Keyword',
+            title: 'Donald Trump',
+        },
+        {
+            id: 'us-news/trump-administration',
+            type: 'Keyword',
+            title: 'Trump administration',
+        },
+        {
+            id: 'us-news/secret-service',
+            type: 'Keyword',
+            title: 'Secret Service',
+        },
+        {
+            id: 'type/article',
+            type: 'Type',
+            title: 'Article',
+        },
+        {
+            id: 'tone/news',
+            type: 'Tone',
+            title: 'News',
+        },
+        {
+            id: 'profile/ben-beaumont-thomas',
+            type: 'Contributor',
+            title: 'Ben Beaumont-Thomas',
+        },
+        {
+            id: 'publication/theguardian',
+            type: 'Publication',
+            title: 'The Guardian',
+        },
+        {
+            id: 'theguardian/mainsection',
+            type: 'NewspaperBook',
+            title: 'Main section',
+        },
+        {
+            id: 'theguardian/mainsection/international',
+            type: 'NewspaperBookSection',
+            title: 'International',
+        },
+        {
+            id: 'tracking/commissioningdesk/uk-culture',
+            type: 'Tracking',
+            title: 'UK Culture',
+        },
+    ],
+    cardStyle: 'news',
+    thumbnailUrl:
+        'https://i.guim.co.uk/img/media/0847eccb8898d4e91499f8a68c4cfdb454f91382/101_177_3650_2191/master/3650.jpg?width=460&quality=85&auto=format&fit=max&s=ca06880ab92aee625f7b6f691bf3e8c5',
+    headline: 'Eminem attacks Donald Trump on surprise album Kamikaze',
+    contentType: 'Article',
+    contributorImage:
+        'https://i.guim.co.uk/img/uploads/2017/10/06/Ben-Beaumont-Thomas,-L.png?width=173&quality=85&auto=format&fit=max&s=e5b75fdef4eecc5eba2db1966e9b5d93',
+    url: '/music/2018/aug/31/eminem-donald-trump-surprise-album-kamikaze',
+    pillar: 'culture',
+};

--- a/src/web/components/Caption.tsx
+++ b/src/web/components/Caption.tsx
@@ -19,7 +19,6 @@ const captionStyle = (role?: RoleType) => css`
 const limitedWidth = css`
     ${from.leftCol} {
         width: 140px;
-        position: absolute;
     }
     ${from.wide} {
         width: 220px;

--- a/src/web/components/elements/RichLinkComponent.tsx
+++ b/src/web/components/elements/RichLinkComponent.tsx
@@ -48,6 +48,14 @@ const richLinkPillarColour: (pillar: Pillar) => colour = pillar => {
 };
 
 const richLinkContainer = css`
+    /*
+        TODO: avoid this edge case from appearing in editorials
+        edge case:
+        If rich link div is pushed further inline to the page the "margin-left: -240px;" wont work.
+        Using "clear: left;" allows us to igrnore the effects of other elements on the left.
+    */
+    clear: left;
+
     ${until.wide} {
         width: 140px;
     }

--- a/src/web/layouts/ShowcaseLayout/ShowcaseLayout.stories.tsx
+++ b/src/web/layouts/ShowcaseLayout/ShowcaseLayout.stories.tsx
@@ -1,80 +1,19 @@
 import React from 'react';
-import fetchMock from 'fetch-mock';
 
 import { viewports } from '@root/.storybook/config';
 import { showcaseReviewCAPI } from '@root/fixtures/CAPI/review/showcaseReview';
 import { NAV } from '@root/fixtures/NAV';
-import { mockTab1, responseWithTwoTabs } from '@root/fixtures/mostViewed';
-import { series } from '@root/fixtures/series';
-import { sharecount } from '@root/fixtures/article';
-import { commentCount } from '@root/fixtures/commentCounts';
+import { mockRESTCalls } from '@root/src/web/lib/mockRESTCalls';
 
 import { hydrateIslands } from '@frontend/web/islands/islands';
 import { ShowcaseLayout } from '@root/src/web/layouts/ShowcaseLayout/ShowcaseLayout';
 
 export default {
-    title: 'Articles/Review/Showcase',
+    title: 'Articles/Showcase',
     parameters: {
         chromatic: { delay: 600, viewports },
     },
 };
-
-const mockRESTCalls = () =>
-    fetchMock
-        .restore()
-        // Most read by Geo
-        .getOnce(
-            'https://api.nextgen.guardianapps.co.uk/most-read-geo.json?dcr=true',
-            {
-                status: 200,
-                body: mockTab1,
-            },
-            { overwriteRoutes: false },
-        )
-        // Comment count
-        .getOnce(
-            'https://api.nextgen.guardianapps.co.uk/discussion/comment-counts.json?shortUrls=/p/4k83z',
-            {
-                status: 200,
-                body: commentCount,
-            },
-            { overwriteRoutes: false },
-        )
-        .getOnce(
-            'https://api.nextgen.guardianapps.co.uk/discussion/comment-counts.json?shortUrls=/p/d7m9d,/p/d79vx,/p/d6qze,/p/d6yth',
-            {
-                status: 200,
-                body: commentCount,
-            },
-            { overwriteRoutes: false },
-        )
-        // Most read by category
-        .getOnce(
-            'https://api.nextgen.guardianapps.co.uk/most-read/tv-and-radio.json?dcr=true',
-            {
-                status: 200,
-                body: responseWithTwoTabs,
-            },
-            { overwriteRoutes: false },
-        )
-        // Series
-        .getOnce(
-            'https://api.nextgen.guardianapps.co.uk/series/tv-and-radio/series/tv-review.json?dcr',
-            {
-                status: 200,
-                body: series,
-            },
-            { overwriteRoutes: false },
-        )
-        // Article share count
-        .getOnce(
-            'https://api.nextgen.guardianapps.co.uk/sharecount/tv-and-radio/2020/jan/17/sex-education-season-two-review-netflix.json',
-            {
-                status: 200,
-                body: sharecount,
-            },
-            { overwriteRoutes: false },
-        );
 
 export const Review = () => {
     mockRESTCalls();

--- a/src/web/layouts/StandardLayout/StandardLayout.stories.tsx
+++ b/src/web/layouts/StandardLayout/StandardLayout.stories.tsx
@@ -1,83 +1,29 @@
 import React from 'react';
-import fetchMock from 'fetch-mock';
 
 import { viewports } from '@root/.storybook/config';
 import { standardReviewCAPI } from '@root/fixtures/CAPI/review/standardReview';
+import { richLink } from '@root/fixtures/CAPI/richLink';
 import { NAV } from '@root/fixtures/NAV';
-import { mockTab1, responseWithTwoTabs } from '@root/fixtures/mostViewed';
-import { series } from '@root/fixtures/series';
-import { sharecount } from '@root/fixtures/article';
-import { commentCount } from '@root/fixtures/commentCounts';
 
+import { mockRESTCalls } from '@root/src/web/lib/mockRESTCalls';
 import { hydrateIslands } from '@frontend/web/islands/islands';
 import { StandardLayout } from '@root/src/web/layouts/StandardLayout/StandardLayout';
 
 export default {
-    title: 'Articles/Review/Standard',
+    title: 'Articles/Standard',
     parameters: {
         chromatic: { delay: 600, viewports },
     },
 };
 
-const mockRESTCalls = () =>
-    fetchMock
-        .restore()
-        // Most read by Geo
-        .getOnce(
-            'https://api.nextgen.guardianapps.co.uk/most-read-geo.json?dcr=true',
-            {
-                status: 200,
-                body: mockTab1,
-            },
-            { overwriteRoutes: false },
-        )
-        // Comment count
-        .getOnce(
-            'https://api.nextgen.guardianapps.co.uk/discussion/comment-counts.json?shortUrls=/p/4k83z',
-            {
-                status: 200,
-                body: commentCount,
-            },
-            { overwriteRoutes: false },
-        )
-        .getOnce(
-            'https://api.nextgen.guardianapps.co.uk/discussion/comment-counts.json?shortUrls=/p/d7m9d,/p/d79vx,/p/d6qze,/p/d6yth',
-            {
-                status: 200,
-                body: commentCount,
-            },
-            { overwriteRoutes: false },
-        )
-        // Most read by category
-        .getOnce(
-            'https://api.nextgen.guardianapps.co.uk/most-read/stage.json?dcr=true',
-            {
-                status: 200,
-                body: responseWithTwoTabs,
-            },
-            { overwriteRoutes: false },
-        )
-        // Series
-        .getOnce(
-            'https://api.nextgen.guardianapps.co.uk/series/tv-and-radio/series/tv-review.json?dcr',
-            {
-                status: 200,
-                body: series,
-            },
-            { overwriteRoutes: false },
-        )
-        // Article share count
-        .getOnce(
-            'https://api.nextgen.guardianapps.co.uk/sharecount/stage/2020/jan/28/flights-review-project-arts-centre-dublin.json',
-            {
-                status: 200,
-                body: sharecount,
-            },
-            { overwriteRoutes: false },
-        );
-
 export const Review = () => {
     mockRESTCalls();
     setTimeout(() => hydrateIslands(standardReviewCAPI, NAV));
     return <StandardLayout CAPI={standardReviewCAPI} NAV={NAV} />;
+};
+
+export const RichLink = () => {
+    mockRESTCalls();
+    setTimeout(() => hydrateIslands(richLink, NAV));
+    return <StandardLayout CAPI={richLink} NAV={NAV} />;
 };

--- a/src/web/lib/mockRESTCalls.ts
+++ b/src/web/lib/mockRESTCalls.ts
@@ -1,0 +1,65 @@
+import fetchMock from 'fetch-mock';
+
+import { richLinkCard } from '@root/fixtures/card';
+import { mockTab1, responseWithTwoTabs } from '@root/fixtures/mostViewed';
+import { series } from '@root/fixtures/series';
+import { sharecount } from '@root/fixtures/article';
+import { commentCount } from '@root/fixtures/commentCounts';
+
+export const mockRESTCalls = () =>
+    fetchMock
+        .restore()
+        // Most read by Geo
+        .getOnce(
+            /.*api.nextgen.guardianapps.co.uk\/most-read-geo.*/,
+            {
+                status: 200,
+                body: mockTab1,
+            },
+            { overwriteRoutes: false },
+        )
+        // Comment count
+        .getOnce(
+            /.*api.nextgen.guardianapps.co.uk\/discussion.*/,
+            {
+                status: 200,
+                body: commentCount,
+            },
+            { overwriteRoutes: false },
+        )
+        // Most read by category
+        .getOnce(
+            /.*api.nextgen.guardianapps.co.uk\/most-read.*/,
+            {
+                status: 200,
+                body: responseWithTwoTabs,
+            },
+            { overwriteRoutes: false },
+        )
+        // Series
+        .getOnce(
+            /.*api.nextgen.guardianapps.co.uk\/series.*/,
+            {
+                status: 200,
+                body: series,
+            },
+            { overwriteRoutes: false },
+        )
+        // Rich link
+        .getOnce(
+            /.*api.nextgen.guardianapps.co.uk\/embed\/card.*/,
+            {
+                status: 200,
+                body: richLinkCard,
+            },
+            { overwriteRoutes: false },
+        )
+        // Article share count
+        .getOnce(
+            /.*api.nextgen.guardianapps.co.uk\/sharecount.*/,
+            {
+                status: 200,
+                body: sharecount,
+            },
+            { overwriteRoutes: false },
+        );


### PR DESCRIPTION
## What does this change?
Added `clear: left;` css to rich link container (in order for the container to disregard other elements).

Removed `position: absolute;` from Caption component in order for its height to be added to the total height of the ImageBlockElement on render

Added Story for this article (and added regex to the mock API calls)

## Why?
When rendering we had and `ImageBlockElement` then a short text element followed by a rich link element. As we use negative margins to place the rich link card in the left column, the starting point for that calculation starts at the center of the page. 

To avoid this we need to add `clear: left;` to the wrapper of the rich link card for it to ignore elements for its calculation.

### Before
![Screenshot 2020-01-31 at 10 55 33](https://user-images.githubusercontent.com/8831403/73766809-7b5eb380-476e-11ea-9fb2-98f87bf76cb1.png)

### After
![Screenshot 2020-02-04 at 15 21 07](https://user-images.githubusercontent.com/8831403/73766932-a47f4400-476e-11ea-9874-87aff7f35462.png)

## Link to supporting Trello card
https://trello.com/c/jyxw0edI/1125-rich-links-mixed-with-images-can-cause-some-layout-issues