### PR TITLE
Revert "Adjust source prop of ConsentManagementPlatform to "www""

### DIFF
--- a/src/web/components/CMP.tsx
+++ b/src/web/components/CMP.tsx
@@ -30,7 +30,7 @@ export const CMP = () => {
     }
 
     const props = {
-        source: 'www',
+        source: 'dcr',
         onClose,
     };
 


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#1142
Changes have been made in the consent logs so it accepts the 'dcr' value as a souceType.