### PR TITLE
Merge pull request #1147 from guardian/gtrufitt/scale-back-article-title

### DIFF
--- a/src/web/components/ArticleTitle.tsx
+++ b/src/web/components/ArticleTitle.tsx
@@ -15,11 +15,11 @@ const sectionStyles = css`
 `;
 
 type Props = {
-    tags: CAPIType['tags'];
-    sectionLabel: CAPIType['sectionLabel'];
-    sectionUrl: CAPIType['sectionUrl'];
-    guardianBaseURL: CAPIType['guardianBaseURL'];
-    pillar: CAPIType['pillar'];
+    tags: TagType[];
+    sectionLabel: string;
+    sectionUrl: string;
+    guardianBaseURL: string;
+    pillar: Pillar;
     badge?: BadgeType;
     inLeftCol?: boolean;
     fallbackToSection?: boolean;

--- a/src/web/components/ArticleTitle.tsx
+++ b/src/web/components/ArticleTitle.tsx
@@ -15,7 +15,11 @@ const sectionStyles = css`
 `;
 
 type Props = {
-    CAPI: CAPIType;
+    tags: CAPIType['tags'];
+    sectionLabel: CAPIType['sectionLabel'];
+    sectionUrl: CAPIType['sectionUrl'];
+    guardianBaseURL: CAPIType['guardianBaseURL'];
+    pillar: CAPIType['pillar'];
     badge?: BadgeType;
     inLeftCol?: boolean;
     fallbackToSection?: boolean;
@@ -41,7 +45,11 @@ const marginTop = css`
 `;
 
 export const ArticleTitle = ({
-    CAPI,
+    tags,
+    sectionLabel,
+    sectionUrl,
+    guardianBaseURL,
+    pillar,
     badge,
     inLeftCol,
     fallbackToSection = true,
@@ -54,8 +62,14 @@ export const ArticleTitle = ({
         )}
         <div className={badge && marginTop}>
             <SeriesSectionLink
-                CAPI={CAPI}
-                fallbackToSection={fallbackToSection}
+                {...{
+                    tags,
+                    sectionLabel,
+                    sectionUrl,
+                    guardianBaseURL,
+                    pillar,
+                    fallbackToSection,
+                }}
             />
         </div>
     </div>

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -62,12 +62,12 @@ const TagLink: React.FC<{
 };
 
 export const SeriesSectionLink: React.FC<{
-    tags: CAPIType['tags'];
-    sectionLabel: CAPIType['sectionLabel'];
-    sectionUrl: CAPIType['sectionUrl'];
-    guardianBaseURL: CAPIType['guardianBaseURL'];
-    pillar: CAPIType['pillar'];
-    fallbackToSection: boolean;
+    tags: TagType[];
+    sectionLabel: string;
+    sectionUrl: string;
+    guardianBaseURL: string;
+    pillar: Pillar;
+    fallbackToSection?: boolean;
 }> = ({
     tags,
     sectionLabel,

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -62,11 +62,20 @@ const TagLink: React.FC<{
 };
 
 export const SeriesSectionLink: React.FC<{
-    CAPI: CAPIType;
+    tags: CAPIType['tags'];
+    sectionLabel: CAPIType['sectionLabel'];
+    sectionUrl: CAPIType['sectionUrl'];
+    guardianBaseURL: CAPIType['guardianBaseURL'];
+    pillar: CAPIType['pillar'];
     fallbackToSection: boolean;
-}> = ({ CAPI, fallbackToSection }) => {
-    const { tags, sectionLabel, sectionUrl, guardianBaseURL, pillar } = CAPI;
-
+}> = ({
+    tags,
+    sectionLabel,
+    sectionUrl,
+    guardianBaseURL,
+    pillar,
+    fallbackToSection,
+}) => {
     const blogTag = tags.find(tag => tag.type === 'Blog');
     const seriesTag = tags.find(tag => tag.type === 'Series');
     const publicationTag = tags.find(tag => tag.type === 'Publication');

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -226,7 +226,11 @@ export const CommentLayout = ({ CAPI, NAV }: Props) => {
                 <StandardGrid>
                     <GridItem area="title">
                         <ArticleTitle
-                            CAPI={CAPI}
+                            tags={CAPI.tags}
+                            sectionLabel={CAPI.sectionLabel}
+                            sectionUrl={CAPI.sectionUrl}
+                            guardianBaseURL={CAPI.guardianBaseURL}
+                            pillar={CAPI.pillar}
                             badge={GE2019Badge}
                             inLeftCol={true}
                         />

--- a/src/web/layouts/ShowcaseLayout/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout/ShowcaseLayout.tsx
@@ -311,7 +311,11 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                 <ShowcaseGrid>
                     <GridItem area="title">
                         <ArticleTitle
-                            CAPI={CAPI}
+                            tags={CAPI.tags}
+                            sectionLabel={CAPI.sectionLabel}
+                            sectionUrl={CAPI.sectionUrl}
+                            guardianBaseURL={CAPI.guardianBaseURL}
+                            pillar={CAPI.pillar}
                             badge={GE2019Badge}
                             inLeftCol={true}
                         />

--- a/src/web/layouts/StandardLayout/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout/StandardLayout.tsx
@@ -279,7 +279,11 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                 <StandardGrid>
                     <GridItem area="title">
                         <ArticleTitle
-                            CAPI={CAPI}
+                            tags={CAPI.tags}
+                            sectionLabel={CAPI.sectionLabel}
+                            sectionUrl={CAPI.sectionUrl}
+                            guardianBaseURL={CAPI.guardianBaseURL}
+                            pillar={CAPI.pillar}
                             badge={GE2019Badge}
                             inLeftCol={true}
                         />


### PR DESCRIPTION
## What does this change?

Explode out the CAPI types we need

## Why?

Makes it harder to reason/work with/story-ise the component when it expects all CAPIType
