### PR TITLE
Grid settings for short articles

### DIFF
--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -82,7 +82,8 @@ const StandardGrid = ({
                         'metalines  border  lines       right-column'
                         'meta       border  standfirst  right-column'
                         'meta       border  media       right-column'
-                        '.          border  body        right-column';
+                        '.          border  body        right-column'
+                        '.          border  .           right-column';
                 }
 
                 ${until.wide} {
@@ -96,7 +97,8 @@ const StandardGrid = ({
                         'metalines  border  lines       right-column'
                         'meta       border  standfirst  right-column'
                         'meta       border  media       right-column'
-                        '.          border  body        right-column';
+                        '.          border  body        right-column'
+                        '.          border  .           right-column';
                 }
 
                 ${until.leftCol} {
@@ -110,7 +112,8 @@ const StandardGrid = ({
                         'standfirst right-column'
                         'meta       right-column'
                         'media      right-column'
-                        'body       right-column';
+                        'body       right-column'
+                        '.          right-column';
                 }
 
                 ${until.desktop} {

--- a/src/web/layouts/ShowcaseLayout/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout/ShowcaseLayout.tsx
@@ -84,7 +84,8 @@ const ShowcaseGrid = ({
                         'lines  border  media       media'
                         'meta   border  media       media'
                         'meta   border  standfirst  right-column'
-                        '.      border  body        right-column';
+                        '.      border  body        right-column'
+                        '.      border  .           right-column';
                 }
 
                 ${until.wide} {
@@ -98,7 +99,8 @@ const ShowcaseGrid = ({
                         '.      border  standfirst  right-column'
                         'lines  border  media       right-column'
                         'meta   border  media       right-column'
-                        'meta   border  body        right-column';
+                        'meta   border  body        right-column'
+                        '.      border  .           right-column';
                 }
 
                 ${until.leftCol} {
@@ -112,7 +114,8 @@ const ShowcaseGrid = ({
                         'media      right-column'
                         'lines      right-column'
                         'meta       right-column'
-                        'body       right-column';
+                        'body       right-column'
+                        '.          right-column';
                 }
 
                 ${until.desktop} {

--- a/src/web/layouts/StandardLayout/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout/StandardLayout.tsx
@@ -87,7 +87,8 @@ const StandardGrid = ({
                         '.      border  standfirst  right-column'
                         'lines  border  media       right-column'
                         'meta   border  media       right-column'
-                        'meta   border  body        right-column';
+                        'meta   border  body        right-column'
+                        '.      border  .           right-column';
                 }
 
                 ${until.wide} {
@@ -101,7 +102,8 @@ const StandardGrid = ({
                         '.      border  standfirst  right-column'
                         'lines  border  media       right-column'
                         'meta   border  media       right-column'
-                        'meta   border  body        right-column';
+                        'meta   border  body        right-column'
+                        '.      border  .           right-column';
                 }
 
                 ${until.leftCol} {
@@ -115,7 +117,8 @@ const StandardGrid = ({
                         'media      right-column'
                         'lines      right-column'
                         'meta       right-column'
-                        'body       right-column';
+                        'body       right-column'
+                        '.          right-column';
                 }
 
                 ${until.desktop} {


### PR DESCRIPTION
## What does this change?
This prevents body content being spaced over the page

## Before
![Screenshot 2020-02-05 at 07 30 16](https://user-images.githubusercontent.com/1336821/73820311-62dfaf00-47e9-11ea-88b9-e3f79a7ece02.jpg)

## After
![Screenshot 2020-02-05 at 07 29 20](https://user-images.githubusercontent.com/1336821/73820259-4c395800-47e9-11ea-95ac-4d08437a638d.jpg)

## Why?
Because it's better to have white space at the bottom of the page

## Link to supporting Trello card
https://trello.com/c/5ffBSclg/1099-short-articles-grid-impacted-by-sticky-ad-height