### PR TITLE
Epic attributes are now nested under a data key

### DIFF
--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -48,7 +48,7 @@ export const SlotBodyEnd = ({
     };
 
     const endpointUrl = 'https://contributions.guardianapis.com/epic';
-    const { data, error } = useApi(endpointUrl, {
+    const { data: responseBody, error } = useApi(endpointUrl, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
@@ -61,7 +61,9 @@ export const SlotBodyEnd = ({
         return null;
     }
 
-    if (data && data.html) {
+    if (responseBody && responseBody.data) {
+        const { data } = responseBody;
+
         return (
             <div className={wrapperMargins}>
                 {data.css && <style>{data.css}</style>}


### PR DESCRIPTION
##  What does this change?

Epic attributes (html and css) are now nested under a data key. If there is no epic to display, the value of the data key will be null.

## Why?

More semantic when it comes to representing no epic.

The response format is updated here: guardian/contributions-service#27.
