### PR TITLE
Accept CodeBlockElement with isMandatory flag

### DIFF
--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -262,6 +262,11 @@ interface VideoBlockElement {
     _type: 'model.dotcomrendering.pageElements.VideoBlockElement';
 }
 
+interface CodeBlockElement {
+    _type: 'model.dotcomrendering.pageElements.CodeBlockElement';
+    isMandatory: boolean;
+}
+
 type CAPIElement =
     | TextBlockElement
     | SubheadingBlockElement
@@ -289,4 +294,5 @@ type CAPIElement =
     | MapBlockElement
     | AudioAtomElement
     | AudioBlockElement
-    | VideoBlockElement;
+    | VideoBlockElement
+    | CodeBlockElement;

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -94,6 +94,9 @@
                     },
                     {
                         "$ref": "#/definitions/VideoBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/CodeBlockElement"
                     }
                 ]
             }
@@ -134,6 +137,9 @@
         },
         "pageId": {
             "type": "string"
+        },
+        "version": {
+            "type": "number"
         },
         "tags": {
             "type": "array",
@@ -218,6 +224,9 @@
         "hasRelated": {
             "type": "boolean"
         },
+        "publication": {
+            "type": "string"
+        },
         "hasStoryPackage": {
             "type": "boolean"
         },
@@ -242,6 +251,41 @@
         },
         "slotMachineFlags": {
             "type": "string"
+        },
+        "pageType": {
+            "type": "object",
+            "properties": {
+                "hasShowcaseMainElement": {
+                    "type": "boolean"
+                },
+                "isFront": {
+                    "type": "boolean"
+                },
+                "isLiveblog": {
+                    "type": "boolean"
+                },
+                "isMinuteArticle": {
+                    "type": "boolean"
+                },
+                "isPaidContent": {
+                    "type": "boolean"
+                },
+                "isPreview": {
+                    "type": "boolean"
+                },
+                "isSensitive": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "hasShowcaseMainElement",
+                "isFront",
+                "isLiveblog",
+                "isMinuteArticle",
+                "isPaidContent",
+                "isPreview",
+                "isSensitive"
+            ]
         }
     },
     "required": [
@@ -269,7 +313,9 @@
         "openGraphData",
         "pageFooter",
         "pageId",
+        "pageType",
         "pillar",
+        "publication",
         "sectionLabel",
         "sectionUrl",
         "shouldHideAds",
@@ -281,6 +327,7 @@
         "tags",
         "trailText",
         "twitterData",
+        "version",
         "webPublicationDate",
         "webPublicationDateDisplay",
         "webTitle",
@@ -340,6 +387,9 @@
                 },
                 "prefix": {
                     "type": "string"
+                },
+                "role": {
+                    "$ref": "#/definitions/Weighting"
                 }
             },
             "required": [
@@ -348,6 +398,17 @@
                 "text",
                 "url"
             ]
+        },
+        "Weighting": {
+            "enum": [
+                "halfwidth",
+                "immersive",
+                "inline",
+                "showcase",
+                "supporting",
+                "thumbnail"
+            ],
+            "type": "string"
         },
         "ImageBlockElement": {
             "type": "object",
@@ -469,17 +530,6 @@
                 "srcSet",
                 "weighting"
             ]
-        },
-        "Weighting": {
-            "enum": [
-                "halfwidth",
-                "immersive",
-                "inline",
-                "showcase",
-                "supporting",
-                "thumbnail"
-            ],
-            "type": "string"
         },
         "SrcSet": {
             "type": "object",
@@ -1190,6 +1240,24 @@
                 "_type"
             ]
         },
+        "CodeBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.CodeBlockElement"
+                    ]
+                },
+                "isMandatory": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "_type",
+                "isMandatory"
+            ]
+        },
         "Block": {
             "type": "object",
             "properties": {
@@ -1280,6 +1348,9 @@
                             },
                             {
                                 "$ref": "#/definitions/VideoBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/CodeBlockElement"
                             }
                         ]
                     }
@@ -1289,6 +1360,9 @@
                 },
                 "createdOnDisplay": {
                     "type": "string"
+                },
+                "lastUpdated": {
+                    "type": "number"
                 },
                 "lastUpdatedDisplay": {
                     "type": "string"
@@ -1506,13 +1580,39 @@
                 },
                 "shouldHideReaderRevenue": {
                     "type": "boolean"
+                },
+                "pageId": {
+                    "type": "string"
+                },
+                "webPublicationDate": {
+                    "type": "number"
+                },
+                "headline": {
+                    "type": "string"
+                },
+                "author": {
+                    "type": "string"
+                },
+                "keywords": {
+                    "type": "string"
+                },
+                "series": {
+                    "type": "string"
+                },
+                "contentType": {
+                    "type": "string"
+                },
+                "ampIframeUrl": {
+                    "type": "string"
                 }
             },
             "required": [
                 "abTests",
                 "adUnit",
                 "ajaxUrl",
+                "ampIframeUrl",
                 "commercialBundleUrl",
+                "contentType",
                 "dcrSentryDsn",
                 "dfpAccountId",
                 "edition",
@@ -1521,6 +1621,7 @@
                 "hbImpl",
                 "isSensitive",
                 "keywordIds",
+                "pageId",
                 "revisionNumber",
                 "section",
                 "sentryHost",


### PR DESCRIPTION
## What does this change?

In Frontend, we pass `isMandatory: true` https://github.com/guardian/frontend/pull/22265 and we haven't added codeBlockElement to the elements switch so it forces DCR to prevent rendering in AMP.

## Why?

Content without a code block is generally useless, lets just not render in AMP until we're able to use the `code` type properly which requires CAPI work.

## Link to supporting Trello card
https://trello.com/c/iaYzjPbx