### PR TITLE
Bump @guardian/consent-management-platform to 2.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     ],
     "dependencies": {
         "@emotion/core": "^10.0.5",
-        "@guardian/consent-management-platform": "^2.0.7",
+        "@guardian/consent-management-platform": "^2.0.8",
         "@guardian/src-foundations": "^0.10.0",
         "@sentry/browser": "^5.7.1",
         "@types/ajv": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1456,10 +1456,10 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
-"@guardian/consent-management-platform@^2.0.7":
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-2.0.7.tgz#95b9a08f44cf0efb06e0f87e28e4767af73cd489"
-  integrity sha512-MBgrS4duAojBDenh7nBwqLm4VPjrjwaacO2L2KMx9QxeTRBbFjbYXlgpZuTnNZ1uwEFw+fD52uio0W5/0CVwFA==
+"@guardian/consent-management-platform@^2.0.8":
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-2.0.8.tgz#64357857be785136302dfffcfcd447a4a33b97dd"
+  integrity sha512-71RKQ4z383RT5J12ySLOxAih/fcrE2VNCibwd8JYSn021grhGT1WtrhJokazuuBFN/TRoUUJuX6fgNCXndhDhg==
   dependencies:
     "@guardian/src-button" "^0.5.1"
     "@guardian/src-foundations" "^0.10.0"


### PR DESCRIPTION
## What does this change?

Bump `@guardian/consent-management-platform to 2.0.8`, details of update can be found here: https://github.com/guardian/consent-management-platform/releases/tag/2.0.8

## Does this change need to be reproduced in dotcom-rendering ?

Similar PR on `dotcom-rendering` to be raised.

### Tested

- [x] Locally