### PR TITLE
Comment pull quotes

### DIFF
--- a/src/web/components/elements/PullQuoteComponent.tsx
+++ b/src/web/components/elements/PullQuoteComponent.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { css } from 'emotion';
-import Quote from '@frontend/static/icons/quote.svg';
+import { css, cx } from 'emotion';
+import { QuoteIcon } from '@frontend/web/components/QuoteIcon';
 import { pillarPalette } from '@root/src/lib/pillars';
 import { palette } from '@guardian/src-foundations';
-import { body } from '@guardian/src-foundations/typography';
+import { headline } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 import { unescapeData } from '@root/src/lib/escapeData';
 
@@ -13,40 +13,61 @@ const quoteMark = 35;
 
 const gsSpan = (nColumns: number) => nColumns * 60 + gutter * (nColumns - 1);
 
-const commonStyles = (pillar: Pillar) =>
-    css(`
-    font-weight: bold;
-    position: relative;
-    background-color: ${palette.neutral[97]};
-    padding: 0.375rem 0.625rem 0.75rem;
-    margin-bottom: 1.75rem;
-    color: ${pillarPalette[pillar].dark};
+const commonStyles = (pillar: Pillar, designType: DesignType) => {
+    switch (designType) {
+        case 'Comment':
+            return css`
+                ${headline.xxsmall({ fontWeight: 'light' })};
+                line-height: 25px;
+                position: relative;
+                background-color: #fbe6d5;
+                padding-left: 10px;
+                padding-right: 10px;
+                padding-top: 6px;
+                padding-bottom: 12px;
+                margin-bottom: 1.75rem;
 
-    :after {
-        content: '';
-        width: ${quoteTail}px;
-        height: ${quoteTail}px;
-        bottom: -${quoteTail}px;
-        position: absolute;
-        background-color: ${palette.neutral[97]};
-    }
+                :after {
+                    content: '';
+                    width: ${quoteTail}px;
+                    height: ${quoteTail}px;
+                    bottom: -${quoteTail}px;
+                    position: absolute;
+                    background-color: #fbe6d5;
+                }
+            `;
+        default:
+            return css`
+                ${headline.xxsmall({ fontWeight: 'bold' })};
+                line-height: 25px;
+                position: relative;
+                background-color: ${palette.neutral[97]};
+                padding-left: 10px;
+                padding-right: 10px;
+                padding-top: 6px;
+                padding-bottom: 12px;
+                margin-bottom: 1.75rem;
+                color: ${pillarPalette[pillar].dark};
 
-    cite,
-    svg {
-        color: ${pillarPalette[pillar].main};
-        fill: ${pillarPalette[pillar].main};
+                :after {
+                    content: '';
+                    width: ${quoteTail}px;
+                    height: ${quoteTail}px;
+                    bottom: -${quoteTail}px;
+                    position: absolute;
+                    background-color: ${palette.neutral[97]};
+                }
+            `;
     }
-`);
+};
 
 const supportingStyles = (pillar: Pillar) =>
-    css(
-        `
+    css`
         width: ${gsSpan(3)}px;
         margin-left: -${gutter / 2}px;
         margin-right: 0.6rem;
         clear: left;
         float: left;
-        ${body.medium()};
 
         ${from.leftCol} {
             margin-left: -${gutter / 2 + gsSpan(3) / 2}px;
@@ -61,16 +82,13 @@ const supportingStyles = (pillar: Pillar) =>
                 left: 0rem;
                 margin-left: ${gsSpan(3) / 2 - quoteTail + 1}px;
             }
-        }`,
-        commonStyles(pillar),
-    );
+        }
+    `;
 
 const inlineStyles = (pillar: Pillar) =>
-    css(
-        `
+    css`
         margin-left: 0rem;
         display: block;
-        ${body.medium()};
 
         ${from.mobileLandscape} {
             margin-left: -${gutter}px;
@@ -98,9 +116,8 @@ const inlineStyles = (pillar: Pillar) =>
             ${from.leftCol} {
                 left: ${quoteMark + gutter / 2}px;
             }
-        }`,
-        commonStyles(pillar),
-    );
+        }
+    `;
 
 function getStyles(role: string, pillar: Pillar) {
     return role === 'supporting'
@@ -111,12 +128,22 @@ function getStyles(role: string, pillar: Pillar) {
 export const PullQuoteComponent: React.FC<{
     html: string;
     pillar: Pillar;
+    designType: DesignType;
     role: string;
     attribution?: string;
-}> = ({ html, pillar, attribution, role }) => (
-    <aside className={getStyles(role, pillar)}>
-        <Quote />{' '}
-        <span // tslint:disable-line:react-no-dangerous-html
+}> = ({ html, pillar, designType, attribution, role }) => (
+    <aside
+        className={cx(
+            getStyles(role, pillar),
+            commonStyles(pillar, designType),
+        )}
+    >
+        <QuoteIcon colour={pillarPalette[pillar].main} />
+        <blockquote
+            className={css`
+                display: inline;
+            `}
+            // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{
                 __html: unescapeData(html),
             }}

--- a/src/web/components/elements/PullQuoteComponent.tsx
+++ b/src/web/components/elements/PullQuoteComponent.tsx
@@ -20,6 +20,8 @@ const commonStyles = (pillar: Pillar, designType: DesignType) => {
                 ${headline.xxsmall({ fontWeight: 'light' })};
                 line-height: 25px;
                 position: relative;
+                /* TODO: Source foundation doesn't have this colour, once it does, remove the hex below */
+                /* stylelint-disable-next-line color-no-hex */
                 background-color: #fbe6d5;
                 padding-left: 10px;
                 padding-right: 10px;
@@ -33,6 +35,8 @@ const commonStyles = (pillar: Pillar, designType: DesignType) => {
                     height: ${quoteTail}px;
                     bottom: -${quoteTail}px;
                     position: absolute;
+                    /* TODO: Source foundation doesn't have this colour, once it does, remove the hex below */
+                    /* stylelint-disable-next-line color-no-hex */
                     background-color: #fbe6d5;
                 }
             `;

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -59,6 +59,7 @@ export const ArticleRenderer: React.FC<{
                             key={i}
                             html={element.html}
                             pillar={pillar}
+                            designType={designType}
                             attribution={element.attribution}
                             role={element.role}
                         />


### PR DESCRIPTION
## What does this change?
We now support special styles for pull quotes for `Comment` articles.

## What else?
Along the way, I refactored to:
- Replace `body` with `headline` as the font style
- Replace `Quote`, the svg, with `QuoteIcon`, a component that allows different styles and colours as props.
- rem to px for padding
- Replace use of `css(...), otherStyle` with `cx`

## Why?
Comment pieces are special

## Link to supporting Trello card
https://trello.com/c/5f1zCWCh/1114-pullquote-has-comment-styling
