### PR TITLE
AMP Outbrain amp-embed test

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -542,6 +542,7 @@ declare namespace JSX {
         'amp-consent': any;
         'amp-live-list': any;
         'amp-audio': any;
+        'amp-embed': any;
     }
     /* eslint-enable @typescript-eslint/no-explicit-any */
 }

--- a/src/amp/components/Onward.tsx
+++ b/src/amp/components/Onward.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { css } from 'emotion';
+import Plus from '@frontend/static/icons/plus.svg';
 import { InnerContainer } from '@root/src/amp/components/InnerContainer';
 import { OnwardContainer } from '@root/src/amp/components/OnwardContainer';
 
@@ -8,18 +9,66 @@ const wrapper = css`
     padding-top: 24px;
 `;
 
+const outbrainStyle = css`
+    border-top: none;
+`;
+
 const outbrainContainer = (webURL: string, isCompliant: boolean) => {
+    const encodedWebURL = encodeURIComponent(`${webURL}`);
+    const encodedAMPURL = encodeURIComponent(`${webURL}?amp`);
     const widgetID = isCompliant ? 'AMP_1' : 'AMP_2';
+    const outbrainParams = `widgetIds=${widgetID}&htmlURL=${encodedWebURL}&ampURL=${encodedAMPURL}`;
+    const outbrainURL = `https://widgets.outbrain.com/hub/amp.html#${outbrainParams}`;
+
+    const isEmbedResponsiveTest = webURL.includes(
+        `world/2007/jan/01/italy.mainsection`,
+    );
+    const isEmbedFixedLayoutTest = webURL.includes(
+        `uk/2007/jan/01/arts.thefarright`,
+    );
+
+    if (isEmbedResponsiveTest) {
+        return (
+            <amp-embed
+                width="100"
+                height="100"
+                type="outbrain"
+                layout="responsive"
+                data-widgetIds={widgetID}
+                data-htmlURL={webURL}
+                data-ampURL={`${webURL}?amp`}
+            />
+        );
+    }
+
+    if (isEmbedFixedLayoutTest) {
+        return (
+            <amp-embed
+                height="485"
+                type="outbrain"
+                layout="fixed-height"
+                data-widgetIds={widgetID}
+                data-htmlURL={webURL}
+                data-ampURL={`${webURL}?amp`}
+            />
+        );
+    }
 
     return (
-        <amp-embed
+        <amp-iframe
+            key={outbrainURL}
             height="480"
-            type="outbrain"
+            sandbox="allow-scripts allow-same-origin allow-popups"
             layout="fixed-height"
-            data-widgetIds={widgetID}
-            data-htmlURL={webURL}
-            data-ampURL={`${webURL}?amp`}
-        />
+            frameborder="0"
+            src={outbrainURL}
+            class={outbrainStyle}
+        >
+            <div overflow="true">
+                More stories
+                <Plus />
+            </div>
+        </amp-iframe>
     );
 };
 

--- a/src/amp/components/Onward.tsx
+++ b/src/amp/components/Onward.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { css } from 'emotion';
-import Plus from '@frontend/static/icons/plus.svg';
 import { InnerContainer } from '@root/src/amp/components/InnerContainer';
 import { OnwardContainer } from '@root/src/amp/components/OnwardContainer';
 
@@ -9,32 +8,18 @@ const wrapper = css`
     padding-top: 24px;
 `;
 
-const outbrainStyle = css`
-    border-top: none;
-`;
-
 const outbrainContainer = (webURL: string, isCompliant: boolean) => {
-    const encodedWebURL = encodeURIComponent(`${webURL}`);
-    const encodedAMPURL = encodeURIComponent(`${webURL}?amp`);
-    const widgetID = isCompliant ? 'AMP_1' : 'AMP_3';
-    const outbrainParams = `widgetIds=${widgetID}&htmlURL=${encodedWebURL}&ampURL=${encodedAMPURL}`;
-    const outbrainURL = `https://widgets.outbrain.com/hub/amp.html#${outbrainParams}`;
+    const widgetID = isCompliant ? 'AMP_1' : 'AMP_2';
 
     return (
-        <amp-iframe
-            key={outbrainURL}
+        <amp-embed
             height="480"
-            sandbox="allow-scripts allow-same-origin allow-popups"
+            type="outbrain"
             layout="fixed-height"
-            frameborder="0"
-            src={outbrainURL}
-            class={outbrainStyle}
-        >
-            <div overflow="true">
-                More stories
-                <Plus />
-            </div>
-        </amp-iframe>
+            data-widgetIds={widgetID}
+            data-htmlURL={webURL}
+            data-ampURL={`${webURL}?amp`}
+        />
     );
 };
 


### PR DESCRIPTION
## What does this change?
We have been recommended to use the `amp-embed` instead of `amp-iframe` for performance and semantics. I have noticed the new tag lazy loads the outbrain container (which in general is great) but we would like to see how this behaves in real life and if there might be a negative impact on revenue. I have chosen two old articles to test two different `amp-embed` configurations before we roll it out to 100%. As far as I'm aware that's the only way to work around making a pretend "A/B test" on AMP.

There's also change in the AMP widget id as apparently it should have been this way all long 🤷‍♂️

## Link to supporting Trello card
https://trello.com/c/CcE4SBZ2
