### PR TITLE
Reduce left column width at leftCol

### DIFF
--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -76,7 +76,7 @@ const StandardGrid = ({
 
                 ${until.wide} {
                     grid-template-columns:
-                        150px /* Left Column (220 - 1px border) */
+                        140px /* Left Column (220 - 1px border) */
                         1px /* Vertical grey border */
                         1fr /* Main content */
                         300px; /* Right Column */

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -79,7 +79,7 @@ const ShowcaseGrid = ({
 
                 ${until.wide} {
                     grid-template-columns:
-                        150px /* Left Column (220 - 1px border) */
+                        140px /* Left Column (220 - 1px border) */
                         1px /* Vertical grey border */
                         1fr /* Main content */
                         300px; /* Right Column */

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -82,7 +82,7 @@ const StandardGrid = ({
 
                 ${until.wide} {
                     grid-template-columns:
-                        150px /* Left Column (220 - 1px border) */
+                        140px /* Left Column */
                         1px /* Vertical grey border */
                         1fr /* Main content */
                         300px; /* Right Column */


### PR DESCRIPTION
## What does this change?
Reduces the width of the left column from 150px to 140px at the leftCol breakpoint

## Why?
Because parity and also because doing this gives us 10px extra space in-between the article body and the right column, so more parity

## Link to supporting Trello card
https://trello.com/c/5aNzS3lP/1158-incorrect-behaviour-of-right-hand-side-ad-slot-on-dcr