### PR TITLE
Allow dirtyHtml in AMP component VideoYoutube

### DIFF
--- a/src/amp/components/elements/VideoYoutube.tsx
+++ b/src/amp/components/elements/VideoYoutube.tsx
@@ -13,7 +13,7 @@ export const VideoYoutube: React.FC<{
         'v',
     );
     return (
-        <Caption captionText={element.caption} pillar={pillar}>
+        <Caption captionText={element.caption} pillar={pillar} dirtyHtml={true}>
             <amp-youtube
                 data-videoid={youtubeId}
                 layout="responsive"


### PR DESCRIPTION
## What does this change?

Correct a problem by which HTML code can be used as caption of a video. 

Before:

![Screenshot 2020-02-17 at 16 35 32](https://user-images.githubusercontent.com/6035518/74671643-8b7d8680-51a3-11ea-921d-6d99612d5f88.png)


After:

![Screenshot 2020-02-17 at 16 31 52](https://user-images.githubusercontent.com/6035518/74671647-8ddfe080-51a3-11ea-8180-7228ab970386.png)

