### PR TITLE
Add lighthouse badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Lighthouse](https://github.com/guardian/dotcom-rendering/workflows/Lighthouse/badge.svg?branch=gtrufitt%2Flighthouse-budgets)
+
 # dotcom-rendering
 
 Frontend rendering framework for theguardian.com. It uses [React](https://reactjs.org/), with [Emotion](https://emotion.sh) for styling.


### PR DESCRIPTION
## What does this change?

Adds the lighthouse badge to shame us into improving our resource sizes. Currently the budget and workflow file is in https://github.com/guardian/dotcom-rendering/tree/gtrufitt/lighthouse-budgets the Action can be found under the Actions tab and runs against live pages. 

Our budgets are currently aspirations...

![Lighthouse](https://github.com/guardian/dotcom-rendering/workflows/Lighthouse/badge.svg?branch=gtrufitt%2Flighthouse-budgets)

## Why?

Visible perf metrics. 

## Link to supporting Trello card

https://trello.com/c/dPRNH7gE
