### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @gtrufitt @shtukas @oliverlloyd @liywjl


### PR DESCRIPTION
## What does this change?

Add CODEOWNERS, of currently active team (this can be replaced with team later but for now it's useful to scope to just us)
