### PR TITLE
Add z-index to the right column and body to allow clickable ads

### DIFF
--- a/src/web/components/GridItem.tsx
+++ b/src/web/components/GridItem.tsx
@@ -13,6 +13,8 @@ const gridAreaStyles = (area: string) => {
             position: absolute;
             top: 0;
             right: 0;
+            /* Pop me below the body */
+            z-index: 1;
 
             @supports (display: grid) {
                 position: relative;
@@ -20,6 +22,15 @@ const gridAreaStyles = (area: string) => {
             }
         `;
     }
+
+    if (area === 'body') {
+        return css`
+            grid-area: ${area};
+            /* Pop me above the right column */
+            z-index: 2;
+        `;
+    }
+
     return css`
         grid-area: ${area};
     `;


### PR DESCRIPTION
## What does this change?

Adds a `z-index` to the body and right column to ensure that the element layering forces body above, making right column live below the body.

## Why?
After the first one, the ads in the right column *actually* live in the body, so if the body is below the right column then you can't click on them.

![2020-02-18 15 39 26](https://user-images.githubusercontent.com/638051/74751836-bd572180-5265-11ea-814a-588e7dbd3b5d.gif)

z-index forces above so you can click on them

![2020-02-18 15 38 40](https://user-images.githubusercontent.com/638051/74751858-c3e59900-5265-11ea-8cea-0533123b1c0a.gif)

## Link to supporting Trello card
https://trello.com/c/D1EHIctU