### PR TITLE
Webpack: symlinks: false

### DIFF
--- a/scripts/webpack/frontend.js
+++ b/scripts/webpack/frontend.js
@@ -1,27 +1,15 @@
 const path = require('path');
 const webpack = require('webpack');
-const {
-    promisify
-} = require('util');
+const { promisify } = require('util');
 const glob = promisify(require('glob'));
-const {
-    smart: merge
-} = require('webpack-merge');
-const {
-    BundleAnalyzerPlugin
-} = require('webpack-bundle-analyzer');
+const { smart: merge } = require('webpack-merge');
+const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const ReportBundleSize = require('./plugins/report-bundle-size');
-const {
-    root,
-    dist,
-    siteName
-} = require('../frontend/config');
+const { root, dist, siteName } = require('../frontend/config');
 
 const PROD = process.env.NODE_ENV === 'production';
 
-const commonConfigs = ({
-    platform
-}) => ({
+const commonConfigs = ({ platform }) => ({
     name: platform,
     mode: process.env.NODE_ENV,
     output: {
@@ -29,9 +17,10 @@ const commonConfigs = ({
         path: dist,
     },
     stats: 'errors-only',
-    devtool: process.env.NODE_ENV === 'production' ?
-        'sourcemap' :
-        'cheap-module-eval-source-map',
+    devtool:
+        process.env.NODE_ENV === 'production'
+            ? 'sourcemap'
+            : 'cheap-module-eval-source-map',
     resolve: {
         alias: {
             '@root': path.resolve(__dirname, '.'),
@@ -41,6 +30,7 @@ const commonConfigs = ({
             'react-dom': 'preact/compat',
         },
         extensions: ['.js', '.ts', '.tsx', '.jsx'],
+        symlinks: false,
     },
     plugins: [
         new webpack.DefinePlugin({
@@ -48,12 +38,12 @@ const commonConfigs = ({
         }),
         PROD && !process.env.HIDE_BUNDLES && new ReportBundleSize(),
         PROD &&
-        new BundleAnalyzerPlugin({
-            reportFilename: path.join(dist, `${platform}-bundles.html`),
-            analyzerMode: 'static',
-            openAnalyzer: false,
-            logLevel: 'warn',
-        }),
+            new BundleAnalyzerPlugin({
+                reportFilename: path.join(dist, `${platform}-bundles.html`),
+                analyzerMode: 'static',
+                openAnalyzer: false,
+                logLevel: 'warn',
+            }),
         // https://www.freecodecamp.org/forum/t/algorithm-falsy-bouncer-help-with-how-filter-boolean-works/25089/7
         // [...].filter(Boolean) why it is used
     ].filter(Boolean),


### PR DESCRIPTION
## What does this change?

I noticed yesterday that after this PR https://github.com/guardian/dotcom-rendering/pull/1157/files we were no longer able to run `yarn link "@guardian/consent-management-platform"` and `make dev` within the `dotcom-rendering` project. Whenever we attempted to do this the module resolution for the `react` alias was failing and we had the following error in the terminal:

![Screenshot 2020-02-19 at 14 20 03](https://user-images.githubusercontent.com/1590704/74843575-079ed800-5324-11ea-8534-735222d9a89c.png)

Introducing the `symlinks: false` property to the webpack config fixed this. Disabling `symlinks` means the `react` imports in these symlinked modules will resolve to their symlinked location in and not their _real_ location.

## Why?

So we can develop linked `ConsentManagementPlatform` component with `dotcom-rendering` locally.
