### PR TITLE
Guard against undefined currentPillar value

### DIFF
--- a/src/web/layouts/ShowcaseLayout.stories.tsx
+++ b/src/web/layouts/ShowcaseLayout.stories.tsx
@@ -24,7 +24,7 @@ import { DecideLayout } from './DecideLayout';
 export default {
     title: 'Layouts/Showcase',
     parameters: {
-        chromatic: { viewports: [1300] },
+        chromatic: { viewports: [1300], delay: 800 },
     },
 };
 /* tslint:enable */

--- a/src/web/layouts/StandardLayout.stories.tsx
+++ b/src/web/layouts/StandardLayout.stories.tsx
@@ -24,7 +24,7 @@ import { DecideLayout } from './DecideLayout';
 export default {
     title: 'Layouts/Standard',
     parameters: {
-        chromatic: { viewports: [1300] },
+        chromatic: { viewports: [1300], delay: 800 },
     },
 };
 /* tslint:enable */

--- a/src/web/lib/layoutHelpers.ts
+++ b/src/web/lib/layoutHelpers.ts
@@ -22,5 +22,9 @@ export const decideLineCount = (designType?: DesignType): 8 | 4 => {
 };
 
 export const getCurrentPillar = (CAPI: CAPIType): Pillar => {
-    return CAPI.nav.currentPillar.title.toLowerCase() || CAPI.pillar;
+    return (
+        (CAPI.nav.currentPillar &&
+            CAPI.nav.currentPillar.title.toLowerCase()) ||
+        CAPI.pillar
+    );
 };


### PR DESCRIPTION
## What does this change?
Fixes a bug that only surfaced on `AdvertisementFeature` design types where the `CAPI.nav.currentPillar` value was undefined


## Link to supporting Trello card
https://trello.com/c/agZqkcBL/1197-fix-undefined-currentpillar-bug