### PR TITLE
Country Code

### DIFF
--- a/src/web/browser/App.tsx
+++ b/src/web/browser/App.tsx
@@ -43,8 +43,8 @@ export const hydrateApp = ({ CAPI, NAV }: { CAPI: CAPIType; NAV: NavType }) => {
 };
 
 const App = ({ CAPI, NAV }: Props) => {
-    const [isSignedIn, setIsSignedIn] = useState<boolean>(false);
-    const [countryCode, setCountryCode] = useState<string>('');
+    const [isSignedIn, setIsSignedIn] = useState<boolean>();
+    const [countryCode, setCountryCode] = useState<string>();
 
     useEffect(() => {
         setIsSignedIn(!!getCookie('GU_U'));

--- a/src/web/browser/App.tsx
+++ b/src/web/browser/App.tsx
@@ -16,6 +16,8 @@ import { Header } from '@frontend/web/components/Header';
 
 import { getCookie } from '@root/src/web/browser/cookie';
 
+import { getCountryCode } from '@frontend/web/lib/getCountryCode';
+
 type Props = { CAPI: CAPIType; NAV: NavType };
 
 type RootType =
@@ -42,10 +44,22 @@ export const hydrateApp = ({ CAPI, NAV }: { CAPI: CAPIType; NAV: NavType }) => {
 
 const App = ({ CAPI, NAV }: Props) => {
     const [isSignedIn, setIsSignedIn] = useState<boolean>(false);
+    const [countryCode, setCountryCode] = useState<string>('');
 
     useEffect(() => {
         setIsSignedIn(!!getCookie('GU_U'));
     }, []);
+
+    useEffect(() => {
+        const callFetch = async () => {
+            setCountryCode(await getCountryCode());
+        };
+        callFetch();
+    }, []);
+
+    console.log(
+        `TODO: Now that we have countryCode ${countryCode} then we should use it (Andre, I'm looking at you)`,
+    );
 
     const richLinks: {
         element: RichLinkBlockElement;

--- a/src/web/lib/getCountryCode.test.ts
+++ b/src/web/lib/getCountryCode.test.ts
@@ -1,0 +1,88 @@
+import fetchMock from 'fetch-mock';
+
+import { getCountryCode } from './getCountryCode';
+
+// Mock Local Storage
+// See: https://github.com/facebook/jest/issues/2098#issuecomment-260733457
+// eslint-disable-next-line func-names
+const localStorageMock = (function() {
+    let store: {
+        [key: string]: string;
+    } = {};
+    return {
+        getItem(key: string) {
+            return store[key] || null;
+        },
+        setItem(key: string, value: string) {
+            store[key] = value.toString();
+        },
+        clear() {
+            store = {};
+        },
+    };
+})();
+
+Object.defineProperty(window, 'localStorage', {
+    value: localStorageMock,
+});
+
+const expectedCountry = 'GB';
+const COUNTRY_CODE_KEY = 'gu.geolocation';
+const TEN_DAYS = 60 * 60 * 24 * 10;
+
+const validLocalState = JSON.stringify({
+    value: 'GB',
+    expires: new Date().getTime() + TEN_DAYS,
+});
+
+const expiredLocalState = JSON.stringify({
+    value: 'GB',
+    expires: 1381299014861,
+});
+
+describe('getCountryCode', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        fetchMock.restore();
+    });
+
+    it('fetches country code if nothing is stored locally', async () => {
+        fetchMock.getOnce(
+            'https://api.nextgen.guardianapps.co.uk/geolocation',
+            {
+                status: 200,
+                body: { country: 'GB' },
+            },
+        );
+        expect(await getCountryCode()).toBe(expectedCountry);
+        expect(fetchMock.called()).toBe(true);
+    });
+
+    it('does not call the api if there is a local value', async () => {
+        fetchMock.getOnce(
+            'https://api.nextgen.guardianapps.co.uk/geolocation',
+            {
+                status: 200,
+                body: { country: 'I AM NEVER USED' },
+            },
+        );
+
+        localStorage.setItem(COUNTRY_CODE_KEY, validLocalState);
+        expect(await getCountryCode()).toBe(expectedCountry);
+        expect(fetchMock.called()).toBe(false);
+    });
+
+    it('it refreshes local state if it has expired', async () => {
+        fetchMock.getOnce(
+            'https://api.nextgen.guardianapps.co.uk/geolocation',
+            {
+                status: 200,
+                body: { country: 'GB' },
+            },
+        );
+
+        localStorage.setItem(COUNTRY_CODE_KEY, expiredLocalState);
+        expect(await getCountryCode()).toBe(expectedCountry);
+        expect(fetchMock.called()).toBe(true);
+    });
+});

--- a/src/web/lib/getCountryCode.ts
+++ b/src/web/lib/getCountryCode.ts
@@ -1,0 +1,48 @@
+type LocalCountryCodeType = {
+    value: string;
+    expires: number;
+};
+
+function hasExpired(whenItExpires: number) {
+    return new Date().getTime() > whenItExpires;
+}
+
+export const getCountryCode = async () => {
+    const TEN_DAYS = 60 * 60 * 24 * 10;
+    const COUNTRY_CODE_KEY = 'gu.geolocation';
+
+    // Read local storage to see if we already have a value
+    let localCountryCode: LocalCountryCodeType | null;
+    try {
+        const item = localStorage.getItem(COUNTRY_CODE_KEY);
+        localCountryCode = item ? JSON.parse(item) : null;
+    } catch (error) {
+        localCountryCode = null;
+    }
+
+    if (!localCountryCode || hasExpired(localCountryCode.expires)) {
+        const countryCode = await fetch(
+            'https://api.nextgen.guardianapps.co.uk/geolocation',
+        )
+            .then(response => response.json())
+            .then(json => json.country);
+
+        // What's this setTimeout business?
+        // localStorage calls are syncronous and we don't need to wait for this
+        // one so we use setTimeout to put this step on the end of the event queue
+        // for later, letting the thread continue
+        setTimeout(() => {
+            localStorage.setItem(
+                COUNTRY_CODE_KEY,
+                JSON.stringify({
+                    value: countryCode,
+                    expires: new Date().getTime() + TEN_DAYS,
+                }),
+            );
+        });
+        // Return the country value that we got from our fetch call
+        return countryCode;
+    }
+    // THere was no need to fetch, return the local value
+    return localCountryCode.value;
+};


### PR DESCRIPTION
## What does this change?
Adds a call to our internal api endpoint `/geolocation` to get the country that we think a user is in based on their IP address, stores the result in the local state of `App` and remembers it for 10 days in local storage.

`App` is our top level component making this state effectively global.

### Why are we using localStorage and not a cookie?
Because we don't need to pass this back to the server and localStorage is 🚤 🐎 🚀 and cookies are 🐌 🐢 👎 

We save this data as:

```typescript
type LocalCountryCodeType = {
    value: string;
    expires: number;
};
```

### What about how frontend stores this value?
FE seems (admittedly, I just clicked around a bit watching dev tools) to only call this api from within `discussion` and it also uses local state. I used the same key name so values will live between applications.

## Why?
Because it's a useful value to know in general but specifically because Slot Machine needs to know this and doesn't want to make the same call multiple times from each of their slots.

## Link to supporting Trello card
https://trello.com/c/kBAFb6aK/1115-implement-country-code-in-client-side-apps