### PR TITLE
Onwards Lower

### DIFF
--- a/src/web/browser/App.tsx
+++ b/src/web/browser/App.tsx
@@ -9,7 +9,8 @@ import { Counts } from '@frontend/web/components/Counts';
 import { RichLinkComponent } from '@frontend/web/components/elements/RichLinkComponent';
 import { ReaderRevenueLinks } from '@frontend/web/components/ReaderRevenueLinks';
 import { CMP } from '@frontend/web/components/CMP';
-import { Onwards } from '@frontend/web/components/Onwards/Onwards';
+import { OnwardsUpper } from '@frontend/web/components/Onwards/OnwardsUpper';
+import { OnwardsLower } from '@frontend/web/components/Onwards/OnwardsLower';
 import { SlotBodyEnd } from '@frontend/web/components/SlotBodyEnd';
 import { SubNav } from '@frontend/web/components/SubNav/SubNav';
 import { Header } from '@frontend/web/components/Header';
@@ -29,7 +30,8 @@ type RootType =
     | 'reader-revenue-links-footer'
     | 'slot-body-end'
     | 'cmp'
-    | 'onwards-content'
+    | 'onwards-upper'
+    | 'onwards-lower'
     | 'rich-link'
     | 'header-root';
 
@@ -137,8 +139,8 @@ const App = ({ CAPI, NAV }: Props) => {
                     tags={CAPI.tags}
                 />
             </Portal>
-            <Portal root="onwards-content">
-                <Onwards
+            <Portal root="onwards-upper">
+                <OnwardsUpper
                     ajaxUrl={CAPI.config.ajaxUrl}
                     hasRelated={CAPI.hasRelated}
                     hasStoryPackage={CAPI.hasStoryPackage}
@@ -148,6 +150,14 @@ const App = ({ CAPI, NAV }: Props) => {
                     showRelatedContent={CAPI.config.showRelatedContent}
                     keywordIds={CAPI.config.keywordIds}
                     contentType={CAPI.contentType}
+                    tags={CAPI.tags}
+                />
+            </Portal>
+            <Portal root="onwards-lower">
+                <OnwardsLower
+                    ajaxUrl={CAPI.config.ajaxUrl}
+                    hasStoryPackage={CAPI.hasStoryPackage}
+                    pageId={CAPI.pageId}
                     tags={CAPI.tags}
                 />
             </Portal>

--- a/src/web/browser/App.tsx
+++ b/src/web/browser/App.tsx
@@ -157,7 +157,6 @@ const App = ({ CAPI, NAV }: Props) => {
                 <OnwardsLower
                     ajaxUrl={CAPI.config.ajaxUrl}
                     hasStoryPackage={CAPI.hasStoryPackage}
-                    pageId={CAPI.pageId}
                     tags={CAPI.tags}
                 />
             </Portal>

--- a/src/web/components/Onwards/OnwardsLower.tsx
+++ b/src/web/components/Onwards/OnwardsLower.tsx
@@ -8,16 +8,10 @@ import { OnwardsLayout } from './OnwardsLayout';
 type Props = {
     ajaxUrl: string;
     hasStoryPackage: boolean;
-    pageId: string;
     tags: TagType[];
 };
 
-export const OnwardsLower = ({
-    ajaxUrl,
-    hasStoryPackage,
-    pageId,
-    tags,
-}: Props) => {
+export const OnwardsLower = ({ ajaxUrl, hasStoryPackage, tags }: Props) => {
     const onwardSections: OnwardsType[] = [];
 
     // In this context, Blog tags are treated the same as Series tags

--- a/src/web/components/Onwards/OnwardsLower.tsx
+++ b/src/web/components/Onwards/OnwardsLower.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+import { useApi } from '@root/src/web/lib/api';
+import { joinUrl } from '@root/src/web/lib/joinUrl';
+
+import { OnwardsLayout } from './OnwardsLayout';
+
+type Props = {
+    ajaxUrl: string;
+    hasStoryPackage: boolean;
+    pageId: string;
+    tags: TagType[];
+};
+
+export const OnwardsLower = ({
+    ajaxUrl,
+    hasStoryPackage,
+    pageId,
+    tags,
+}: Props) => {
+    const onwardSections: OnwardsType[] = [];
+
+    // In this context, Blog tags are treated the same as Series tags
+    const seriesTag = tags.find(
+        tag => tag.type === 'Series' || tag.type === 'Blog',
+    );
+
+    if (hasStoryPackage && seriesTag) {
+        // Use the series tag to get other data in the same series
+        // Example: {
+        //              id: "cities/series/the-illustrated-city",
+        //              title: "The illustrated city",
+        //              type: "Series",
+        //          }
+        //
+        const seriesUrl = joinUrl([
+            ajaxUrl,
+            'series',
+            `${seriesTag.id}.json?dcr`,
+        ]);
+        const { data } = useApi(seriesUrl);
+
+        if (data && data.trails) {
+            onwardSections.push({
+                heading: data.displayname, // This displayname property is called 'heading' elsewhere
+                trails: data.trails.slice(0, 4), // Series onwards is four only
+            });
+        }
+    }
+
+    return <OnwardsLayout onwardSections={onwardSections} />;
+};

--- a/src/web/components/Onwards/OnwardsUpper.tsx
+++ b/src/web/components/Onwards/OnwardsUpper.tsx
@@ -78,7 +78,7 @@ type Props = {
     tags: TagType[];
 };
 
-export const Onwards = ({
+export const OnwardsUpper = ({
     ajaxUrl,
     hasRelated,
     hasStoryPackage,

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -191,6 +191,11 @@ export const CommentLayout = ({ CAPI, NAV }: Props) => {
     // 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
     // 2) Otherwise, ensure slot only renders if `CAPI.config.shouldHideReaderRevenue` equals false.
 
+    const seriesTag = CAPI.tags.find(
+        tag => tag.type === 'Series' || tag.type === 'Blog',
+    );
+    const showOnwardsLower = seriesTag && CAPI.hasStoryPackage;
+
     const contributorTag = CAPI.tags.find(tag => tag.type === 'Contributor');
     const avatarUrl = contributorTag && contributorTag.bylineImageUrl;
 
@@ -394,7 +399,7 @@ export const CommentLayout = ({ CAPI, NAV }: Props) => {
                         <OutbrainContainer />
                     </Section>
 
-                    <Section islandId="onwards-lower" />
+                    {showOnwardsLower && <Section islandId="onwards-lower" />}
 
                     <Section islandId="most-viewed-footer" />
                 </>

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -383,7 +383,7 @@ export const CommentLayout = ({ CAPI, NAV }: Props) => {
                 <AdSlot asps={namedAdSlotParameters('merchandising-high')} />
             </Section>
 
-            <Section islandId="onwards-content" />
+            <Section islandId="onwards-upper" />
 
             {!isPaidContent && (
                 <>
@@ -393,6 +393,8 @@ export const CommentLayout = ({ CAPI, NAV }: Props) => {
                     >
                         <OutbrainContainer />
                     </Section>
+
+                    <Section islandId="onwards-lower" />
 
                     <Section islandId="most-viewed-footer" />
                 </>

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -248,6 +248,11 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
     // 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
     // 2) Otherwise, ensure slot only renders if `CAPI.config.shouldHideReaderRevenue` equals false.
 
+    const seriesTag = CAPI.tags.find(
+        tag => tag.type === 'Series' || tag.type === 'Blog',
+    );
+    const showOnwardsLower = seriesTag && CAPI.hasStoryPackage;
+
     return (
         <>
             <div>
@@ -439,7 +444,7 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                         <OutbrainContainer />
                     </Section>
 
-                    <Section islandId="onwards-lower" />
+                    {showOnwardsLower && <Section islandId="onwards-lower" />}
 
                     <Section islandId="most-viewed-footer" />
                 </>

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -428,7 +428,7 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                 <AdSlot asps={namedAdSlotParameters('merchandising-high')} />
             </Section>
 
-            <Section islandId="onwards-content" />
+            <Section islandId="onwards-upper" />
 
             {!isPaidContent && (
                 <>
@@ -438,6 +438,8 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                     >
                         <OutbrainContainer />
                     </Section>
+
+                    <Section islandId="onwards-lower" />
 
                     <Section islandId="most-viewed-footer" />
                 </>

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -403,7 +403,7 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                 <AdSlot asps={namedAdSlotParameters('merchandising-high')} />
             </Section>
 
-            <Section islandId="onwards-content" />
+            <Section islandId="onwards-upper" />
 
             {!isPaidContent && (
                 <>
@@ -413,6 +413,8 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                     >
                         <OutbrainContainer />
                     </Section>
+
+                    <Section islandId="onwards-lower" />
 
                     <Section islandId="most-viewed-footer" />
                 </>

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -221,6 +221,11 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
     // 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
     // 2) Otherwise, ensure slot only renders if `CAPI.config.shouldHideReaderRevenue` equals false.
 
+    const seriesTag = CAPI.tags.find(
+        tag => tag.type === 'Series' || tag.type === 'Blog',
+    );
+    const showOnwardsLower = seriesTag && CAPI.hasStoryPackage;
+
     return (
         <>
             <div>
@@ -414,7 +419,7 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                         <OutbrainContainer />
                     </Section>
 
-                    <Section islandId="onwards-lower" />
+                    {showOnwardsLower && <Section islandId="onwards-lower" />}
 
                     <Section islandId="most-viewed-footer" />
                 </>


### PR DESCRIPTION
## What does this change?
Adds support for a second row of Onwards content underneath Outbrain.

We already knew that Onwards sometimes has a second row so we already pass an array of sections to the client but in the case where Outbrain also appears, it divides the two rows, sitting in-between, which means we need to architect our solution to handle this

We now have `OnwardsUpper` and `OnwardsLower` where upper is the same as before but lower only shows content if the article has a story package _and_ is part of a series or blog. In this case the upper content will show the story package and the lower section will show the series onwards content.

![Screenshot 2020-02-24 at 08 53 36](https://user-images.githubusercontent.com/1336821/75139024-88265580-56e3-11ea-852c-e5cf61299ca7.jpg)


## Why?
It's important that Outbrain maintains a certain distance from the bottom of the article

## Link to supporting Trello card
https://trello.com/b/oiJfQBKo/dcr-dotcom-rendering