### PR TITLE
Fix ad targeting and GA tests by updating the CAPI fixture

### DIFF
--- a/fixtures/CAPI/CAPI.ts
+++ b/fixtures/CAPI/CAPI.ts
@@ -1,13 +1,299 @@
-const pillar: Pillar = 'lifestyle';
-const editionId: Edition = 'UK';
-const designType = 'Article';
+// COPY FROM https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software.json?dcr
 
-export const CAPI: CAPIType = {
-    pillar,
-    editionId,
-    designType,
-    webPublicationDate: '2018-11-02T09:45:30.000Z',
-    webPublicationDateDisplay: 'Fri 02 Mar 2018 09.45 GMT',
+const addSeriesTag = (modCAPI: CAPIType): CAPIType => {
+    modCAPI.tags.push({
+        id: 'testseries',
+        type: 'Series',
+        title: 'This Series',
+    });
+
+    return modCAPI;
+};
+
+const modifyDCRJsonResponse = (CAPI: {}): CAPIType =>
+    [addSeriesTag].reduce(
+        (prev, func) => func(prev as CAPIType),
+        CAPI,
+    ) as CAPIType;
+
+export const CAPI: CAPIType = modifyDCRJsonResponse({
+    shouldHideReaderRevenue: true,
+    slotMachineFlags: '',
+    isAdFreeUser: false,
+    main:
+        '<figure class="element element-image" data-media-id="c0c1beb4b6c6889b095fbb4aef36009222420d65"> <img src="https://media.guim.co.uk/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/1000.jpg" alt="The Palace Theatre, London, showing Harry Potter and the Cursed Child" width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">Tickets for the West End show Harry Potter and the Cursed Child at the Palace Theatre, London, are among those targeted by the secondary ticketing industry. </span> <span class="element-image__credit">Photograph: Kirsty Wigglesworth/AP</span> </figcaption> </figure>',
+    subMetaSectionLinks: [
+        { url: '/money/ticket-prices', title: 'Ticket prices' },
+    ],
+    commercialProperties: {
+        UK: {
+            adTargeting: [
+                { name: 'edition', value: 'uk' },
+                {
+                    name: 'url',
+                    value:
+                        '/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+                },
+                { name: 'tn', value: ['news'] },
+                { name: 'sh', value: 'https://gu.com/p/64ak8' },
+                { name: 'su', value: ['0'] },
+                { name: 'co', value: ['rob-davies'] },
+                { name: 'ct', value: 'article' },
+                { name: 'p', value: 'ng' },
+                {
+                    name: 'k',
+                    value: [
+                        'ticket-prices',
+                        'consumer-affairs',
+                        'internet',
+                        'viagogo',
+                        'money',
+                    ],
+                },
+            ],
+        },
+        US: {
+            adTargeting: [
+                {
+                    name: 'url',
+                    value:
+                        '/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+                },
+                { name: 'tn', value: ['news'] },
+                { name: 'sh', value: 'https://gu.com/p/64ak8' },
+                { name: 'su', value: ['0'] },
+                { name: 'co', value: ['rob-davies'] },
+                { name: 'ct', value: 'article' },
+                { name: 'p', value: 'ng' },
+                { name: 'edition', value: 'us' },
+                {
+                    name: 'k',
+                    value: [
+                        'ticket-prices',
+                        'consumer-affairs',
+                        'internet',
+                        'viagogo',
+                        'money',
+                    ],
+                },
+            ],
+        },
+        AU: {
+            adTargeting: [
+                {
+                    name: 'url',
+                    value:
+                        '/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+                },
+                { name: 'tn', value: ['news'] },
+                { name: 'sh', value: 'https://gu.com/p/64ak8' },
+                { name: 'su', value: ['0'] },
+                { name: 'co', value: ['rob-davies'] },
+                { name: 'ct', value: 'article' },
+                { name: 'p', value: 'ng' },
+                {
+                    name: 'k',
+                    value: [
+                        'ticket-prices',
+                        'consumer-affairs',
+                        'internet',
+                        'viagogo',
+                        'money',
+                    ],
+                },
+                { name: 'edition', value: 'au' },
+            ],
+        },
+        INT: {
+            adTargeting: [
+                {
+                    name: 'url',
+                    value:
+                        '/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+                },
+                { name: 'tn', value: ['news'] },
+                { name: 'edition', value: 'int' },
+                { name: 'sh', value: 'https://gu.com/p/64ak8' },
+                { name: 'su', value: ['0'] },
+                { name: 'co', value: ['rob-davies'] },
+                { name: 'ct', value: 'article' },
+                { name: 'p', value: 'ng' },
+                {
+                    name: 'k',
+                    value: [
+                        'ticket-prices',
+                        'consumer-affairs',
+                        'internet',
+                        'viagogo',
+                        'money',
+                    ],
+                },
+            ],
+        },
+    },
+    pageFooter: {
+        footerLinks: [
+            [
+                {
+                    text: 'About us',
+                    url: '/about',
+                    dataLinkName: 'uk : footer : about us',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Contact us',
+                    url: '/help/contact-us',
+                    dataLinkName: 'uk : footer : contact us',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Complaints & corrections',
+                    url: '/info/complaints-and-corrections',
+                    dataLinkName: 'complaints',
+                    extraClasses: '',
+                },
+                {
+                    text: 'SecureDrop',
+                    url: 'https://www.theguardian.com/securedrop',
+                    dataLinkName: 'securedrop',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Work for us',
+                    url: 'https://workforus.theguardian.com',
+                    dataLinkName: 'uk : footer : work for us',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Privacy policy',
+                    url: '/info/privacy',
+                    dataLinkName: 'privacy',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Cookie policy',
+                    url: '/info/cookies',
+                    dataLinkName: 'cookie',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Terms & conditions',
+                    url: '/help/terms-of-service',
+                    dataLinkName: 'terms',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Help',
+                    url: '/help',
+                    dataLinkName: 'uk : footer : tech feedback',
+                    extraClasses: 'js-tech-feedback-report',
+                },
+            ],
+            [
+                {
+                    text: 'All topics',
+                    url: '/index/subjects/a',
+                    dataLinkName: 'uk : footer : all topics',
+                    extraClasses: '',
+                },
+                {
+                    text: 'All writers',
+                    url: '/index/contributors',
+                    dataLinkName: 'uk : footer : all contributors',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Modern Slavery Act',
+                    url:
+                        '/info/2016/jul/27/modern-slavery-and-our-supply-chains?INTCMP=NGW_FOOTER_UK_GU_MODERN_SLAVERY_ACT',
+                    dataLinkName: 'uk : footer : modern slavery act statement',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Digital newspaper archive',
+                    url: 'https://theguardian.newspapers.com',
+                    dataLinkName: 'digital newspaper archive',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Facebook',
+                    url: 'https://www.facebook.com/theguardian',
+                    dataLinkName: 'uk : footer : facebook',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Twitter',
+                    url: 'https://twitter.com/guardian',
+                    dataLinkName: 'uk: footer : twitter',
+                    extraClasses: '',
+                },
+            ],
+            [
+                {
+                    text: 'Advertise with us',
+                    url: 'https://advertising.theguardian.com',
+                    dataLinkName: 'uk : footer : advertise with us',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Guardian Labs',
+                    url: '/guardian-labs',
+                    dataLinkName: 'uk : footer : guardian labs',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Search jobs',
+                    url:
+                        'https://jobs.theguardian.com?INTCMP=NGW_FOOTER_UK_GU_JOBS',
+                    dataLinkName: 'uk : footer : jobs',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Dating',
+                    url:
+                        'https://soulmates.theguardian.com?INTCMP=NGW_FOOTER_UK_GU_SOULMATES',
+                    dataLinkName: 'uk : footer : soulmates',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Patrons',
+                    url:
+                        'https://patrons.theguardian.com?INTCMP=footer_patrons',
+                    dataLinkName: 'uk : footer : patrons',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Discount Codes',
+                    url: 'https://discountcode.theguardian.com/',
+                    dataLinkName: 'uk: footer : discount code',
+                    extraClasses: 'js-discount-code-link',
+                },
+            ],
+        ],
+    },
+    twitterData: {
+        'twitter:app:id:iphone': '409128287',
+        'twitter:app:name:googleplay': 'The Guardian',
+        'twitter:app:name:ipad': 'The Guardian',
+        'twitter:image':
+            'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctYWdlLTIwMTcucG5n&s=ed5803e29000adb1fa8dc5e37157e89c',
+        'twitter:site': '@guardian',
+        'twitter:app:url:ipad':
+            'gnmguardian://money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software?contenttype=Article&source=twitter',
+        'twitter:card': 'summary_large_image',
+        'twitter:app:name:iphone': 'The Guardian',
+        'twitter:creator': '@ByRobDavies',
+        'twitter:app:id:ipad': '409128287',
+        'twitter:app:id:googleplay': 'com.guardian',
+        'twitter:app:url:googleplay':
+            'guardian://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+        'twitter:app:url:iphone':
+            'gnmguardian://money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software?contenttype=Article&source=twitter',
+    },
+    beaconURL: '//phar.gu-web.net',
+    sectionName: 'money',
+    editionLongForm: 'UK edition',
+    hasRelated: true,
     pageType: {
         hasShowcaseMainElement: false,
         isFront: false,
@@ -17,659 +303,20 @@ export const CAPI: CAPIType = {
         isPreview: false,
         isSensitive: false,
     },
-    tags: [
-        {
-            id: 'money/ticket-prices',
-            type: 'Keyword',
-            title: 'Ticket prices',
-            twitterHandle: '',
-        },
-        {
-            id: 'money/consumer-affairs',
-            type: 'Keyword',
-            title: 'Consumer affairs',
-            twitterHandle: '',
-        },
-        {
-            id: 'money/money',
-            type: 'Keyword',
-            title: 'Money',
-            twitterHandle: '',
-        },
-        {
-            id: 'technology/internet',
-            type: 'Keyword',
-            title: 'Internet',
-            twitterHandle: '',
-        },
-        {
-            id: 'type/article',
-            type: 'Type',
-            title: 'Article',
-            twitterHandle: '',
-        },
-        {
-            id: 'tone/news',
-            type: 'Tone',
-            title: 'News',
-            twitterHandle: '',
-        },
-        {
-            id: 'money/viagogo',
-            type: 'Keyword',
-            title: 'Viagogo',
-            twitterHandle: '',
-        },
-        {
-            id: 'profile/rob-davies',
-            type: 'Contributor',
-            title: 'Rob Davies',
-            twitterHandle: 'ByRobDavies',
-        },
-        {
-            id: 'publication/theguardian',
-            type: 'Publication',
-            title: 'The Guardian',
-            twitterHandle: '',
-        },
-        {
-            id: 'theguardian/mainsection',
-            type: 'NewspaperBook',
-            title: 'Main section',
-            twitterHandle: '',
-        },
-        {
-            id: 'theguardian/mainsection/topstories',
-            type: 'NewspaperBookSection',
-            title: 'Top stories',
-            twitterHandle: '',
-        },
-        {
-            id: 'tracking/commissioningdesk/uk-business',
-            type: 'Tracking',
-            title: 'UK Business',
-            twitterHandle: '',
-        },
-        {
-            id: 'testseries',
-            type: 'Series',
-            title: 'This Series',
-        },
-    ],
-    sectionName: 'money',
-    headline:
-        'Ticket touts face unlimited fines for using ‘bots’ to buy in bulk',
-    standfirst:
-        '<p><strong>Exclusive:</strong> Package of measures designed to curb growing power of ‘secondary ticketing’ industry and protect fans</p>',
-    main:
-        '<figure data-media-id="c0c1beb4b6c6889b095fbb4aef36009222420d65" class="element element-image"><img class="gu-image" height="600" width="1000" alt="The Palace Theatre, London, showing Harry Potter and the Cursed Child" src="https://media.guim.co.uk/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/1000.jpg"><figcaption><span class="element-image__caption">Tickets for the West End show Harry Potter and the Cursed Child at the Palace Theatre, London, are among those targeted by the secondary ticketing industry. </span><span class="element-image__credit">Photograph: Kirsty Wigglesworth/AP</span></figcaption></figure>',
-    mainMediaElements: [
-        {
-            media: {
-                allImages: [
-                    {
-                        index: 0,
-                        fields: {
-                            height: '1200',
-                            width: '2000',
-                        },
-                        mediaType: 'Image',
-                        mimeType: 'image/jpeg',
-                        url:
-                            'https://media.guim.co.uk/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/2000.jpg',
-                    },
-                    {
-                        index: 1,
-                        fields: {
-                            height: '600',
-                            width: '1000',
-                        },
-                        mediaType: 'Image',
-                        mimeType: 'image/jpeg',
-                        url:
-                            'https://media.guim.co.uk/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/1000.jpg',
-                    },
-                    {
-                        index: 2,
-                        fields: {
-                            height: '300',
-                            width: '500',
-                        },
-                        mediaType: 'Image',
-                        mimeType: 'image/jpeg',
-                        url:
-                            'https://media.guim.co.uk/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/500.jpg',
-                    },
-                    {
-                        index: 3,
-                        fields: {
-                            height: '84',
-                            width: '140',
-                        },
-                        mediaType: 'Image',
-                        mimeType: 'image/jpeg',
-                        url:
-                            'https://media.guim.co.uk/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/140.jpg',
-                    },
-                    {
-                        index: 4,
-                        fields: {
-                            height: '3009',
-                            width: '5015',
-                        },
-                        mediaType: 'Image',
-                        mimeType: 'image/jpeg',
-                        url:
-                            'https://media.guim.co.uk/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/5015.jpg',
-                    },
-                    {
-                        index: 5,
-                        fields: {
-                            isMaster: 'true',
-                            height: '3009',
-                            width: '5015',
-                        },
-                        mediaType: 'Image',
-                        mimeType: 'image/jpeg',
-                        url:
-                            'http://media.guim.co.uk/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg',
-                    },
-                ],
-            },
-            data: {
-                copyright:
-                    'Copyright 2016 The Associated Press. All rights reserved. This material may not be published, broadcast, rewritten or redistribu',
-                alt:
-                    'The Palace Theatre, London, showing Harry Potter and the Cursed Child',
-                caption:
-                    'Tickets for the West End show Harry Potter and the Cursed Child at the Palace Theatre, London, are among those targeted by the secondary ticketing industry. ',
-                credit: 'Photograph: Kirsty Wigglesworth/AP',
-            },
-            displayCredit: true,
-            role: 'inline',
-            imageSources: [
-                {
-                    weighting: 'inline',
-                    srcSet: [
-                        {
-                            src:
-                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=620&quality=85&auto=format&fit=max&s=1bcb12104405d365e4176d25f9bff704',
-                            width: 620,
-                        },
-                        {
-                            src:
-                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=605&quality=85&auto=format&fit=max&s=2c0e6978b4b165ca97f03f8a816529a8',
-                            width: 605,
-                        },
-                        {
-                            src:
-                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=445&quality=85&auto=format&fit=max&s=516527f4ac7bdcab733dbcb0f13c25bd',
-                            width: 445,
-                        },
-                    ],
-                },
-                {
-                    weighting: 'thumbnail',
-                    srcSet: [
-                        {
-                            src:
-                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=140&quality=85&auto=format&fit=max&s=47fa9641d01f7b562c1407c999bd9da0',
-                            width: 140,
-                        },
-                        {
-                            src:
-                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=120&quality=85&auto=format&fit=max&s=0aec1c40ad08585352196ba9cbbe712e',
-                            width: 120,
-                        },
-                    ],
-                },
-                {
-                    weighting: 'supporting',
-                    srcSet: [
-                        {
-                            src:
-                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=380&quality=85&auto=format&fit=max&s=6bf99684d34d7e640b42e77de94d2369',
-                            width: 380,
-                        },
-                        {
-                            src:
-                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=300&quality=85&auto=format&fit=max&s=4e8c8811000fc54bea72dedd69ab13d6',
-                            width: 300,
-                        },
-                        {
-                            src:
-                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=620&quality=85&auto=format&fit=max&s=1bcb12104405d365e4176d25f9bff704',
-                            width: 620,
-                        },
-                        {
-                            src:
-                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=605&quality=85&auto=format&fit=max&s=2c0e6978b4b165ca97f03f8a816529a8',
-                            width: 605,
-                        },
-                        {
-                            src:
-                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=445&quality=85&auto=format&fit=max&s=516527f4ac7bdcab733dbcb0f13c25bd',
-                            width: 445,
-                        },
-                    ],
-                },
-                {
-                    weighting: 'showcase',
-                    srcSet: [
-                        {
-                            src:
-                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=860&quality=85&auto=format&fit=max&s=16f69557a812fa0f97f386567be954d6',
-                            width: 860,
-                        },
-                        {
-                            src:
-                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=780&quality=85&auto=format&fit=max&s=ce247f6cf701cb7c91cc6243a0b52bbe',
-                            width: 780,
-                        },
-                        {
-                            src:
-                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=620&quality=85&auto=format&fit=max&s=1bcb12104405d365e4176d25f9bff704',
-                            width: 620,
-                        },
-                        {
-                            src:
-                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=605&quality=85&auto=format&fit=max&s=2c0e6978b4b165ca97f03f8a816529a8',
-                            width: 605,
-                        },
-                        {
-                            src:
-                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=445&quality=85&auto=format&fit=max&s=516527f4ac7bdcab733dbcb0f13c25bd',
-                            width: 445,
-                        },
-                    ],
-                },
-                {
-                    weighting: 'halfwidth',
-                    srcSet: [
-                        {
-                            src:
-                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=620&quality=85&auto=format&fit=max&s=1bcb12104405d365e4176d25f9bff704',
-                            width: 620,
-                        },
-                        {
-                            src:
-                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=605&quality=85&auto=format&fit=max&s=2c0e6978b4b165ca97f03f8a816529a8',
-                            width: 605,
-                        },
-                        {
-                            src:
-                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=445&quality=85&auto=format&fit=max&s=516527f4ac7bdcab733dbcb0f13c25bd',
-                            width: 445,
-                        },
-                    ],
-                },
-                {
-                    weighting: 'immersive',
-                    srcSet: [
-                        {
-                            src:
-                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=620&quality=85&auto=format&fit=max&s=1bcb12104405d365e4176d25f9bff704',
-                            width: 620,
-                        },
-                        {
-                            src:
-                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=605&quality=85&auto=format&fit=max&s=2c0e6978b4b165ca97f03f8a816529a8',
-                            width: 605,
-                        },
-                        {
-                            src:
-                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=445&quality=85&auto=format&fit=max&s=516527f4ac7bdcab733dbcb0f13c25bd',
-                            width: 445,
-                        },
-                    ],
-                },
-            ],
-            _type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-        },
-    ],
-    editionLongForm: 'uk edition',
-    author: {
-        byline: 'Rob Davies',
-        twitterHandle: 'ByRobDavies',
-        email: 'none',
-    },
-    blocks: [
-        {
-            id: '12',
-            elements: [
-                {
-                    _type:
-                        'model.dotcomrendering.pageElements.TextBlockElement',
-                    html:
-                        '<p>Touts who use computer software to <a href="https://www.theguardian.com/business/2017/jan/23/ticket-touts-beat-adele-take-that-hamilton">harvest concert tickets in bulk</a> and resell them at vast mark-ups face unlimited fines as part of a crackdown on highly profitable resale sites such as Viagogo, StubHub and GetMeIn.</p>',
-                },
-                {
-                    _type:
-                        'model.dotcomrendering.pageElements.TextBlockElement',
-                    html:
-                        '<p>The Department of Culture, Media and Sport will announce a package of measures to curb the growing power of the so-called “secondary ticketing” industry, which now regularly offers tickets at huge mark-ups, even before they are available to the general public.</p>',
-                },
-                {
-                    _type:
-                        'model.dotcomrendering.pageElements.TextBlockElement',
-                    html:
-                        '<p>Proposals will include a new criminal offence for the use of “bots” – <a href="https://www.theguardian.com/money/2016/may/21/ticket-touts-powerful-software-assist-widely-available">software that helps touts bypass limits</a> on the number of tickets one person can buy.</p>',
-                },
-                {
-                    _type:
-                        'model.dotcomrendering.pageElements.TextBlockElement',
-                    html:
-                        '<p>National Trading Standards will also be handed a ringfenced pot of money to fund efforts to stop fans being ripped off or shut out of the most in-demand events.</p>',
-                },
-                {
-                    _type:
-                        'model.dotcomrendering.pageElements.TextBlockElement',
-                    html:
-                        '<p>The government is taking action following outrage that face-value tickets to see <a href="https://www.theguardian.com/music/2016/dec/02/adele-tickets-appear-online-for-9000-despite-singers-efforts-to-stop-touts">artists such as Adele</a> and Ed Sheeran are selling out in minutes, only to appear for thousands of pounds on resale websites such as <a href="https://www.theguardian.com/business/2016/sep/23/what-we-know-about-ticket-reseller-viagogo">Viagogo</a>, StubHub and GetMeIn moments later.</p>',
-                },
-                {
-                    _type:
-                        'model.dotcomrendering.pageElements.TextBlockElement',
-                    html:
-                        '<p>These websites make money by allowing touts, as well as genuine fans, to resell tickets in return for a cut of anything up to 25% of the sale price.</p>',
-                },
-                {
-                    _type:
-                        'model.dotcomrendering.pageElements.TextBlockElement',
-                    html:
-                        '<p>As well as criminalising bots, ministers at DCMS will accept in full the recommendations of a <a href="https://www.theguardian.com/money/2016/may/26/ticket-touts-review-licensing-enforcement">review by Professor Michael Waterson</a>, who <a href="https://www.gov.uk/government/publications/consumer-protection-measures-applying-to-ticket-resale-waterson-review">published proposals</a> to tackle rogue ticket traders last year.</p>',
-                },
-                {
-                    _type:
-                        'model.dotcomrendering.pageElements.TextBlockElement',
-                    html:
-                        '<p>These include demanding that ticket firms to step up their own efforts to prevent the use of bots and to report any attacks on their systems by touts trying to harvest tickets.</p>',
-                },
-                {
-                    _type:
-                        'model.dotcomrendering.pageElements.TextBlockElement',
-                    html:
-                        '<p>While primary ticket firms such as Ticketmaster say they are doing their utmost to stop bot users, the company also owns secondary sites, such as GetMeIn and Seatwave, which have <a href="https://www.theguardian.com/money/2016/jul/16/bands-fans-declare-war-online-ticket-touts">close relationships with major touts</a> and take a cut of their profits.</p>',
-                },
-                {
-                    _type:
-                        'model.dotcomrendering.pageElements.TextBlockElement',
-                    html:
-                        '<p>Ministers will also propose stronger enforcement of consumer rights laws, amid concern that tickets are being sold with no information about the seat location or the name of the seller, in contravention of the Consumer Rights Act 2015.</p>',
-                },
-                {
-                    _type:
-                        'model.dotcomrendering.pageElements.TextBlockElement',
-                    html:
-                        '<p>Efforts to step up scrutiny of firms’ adherence to consumer laws is also aimed at sites that sell tickets whose terms and conditions specifically ban resale, meaning fans are turned away at the door.</p>',
-                },
-                {
-                    _type:
-                        'model.dotcomrendering.pageElements.TextBlockElement',
-                    html:
-                        '<p>Labour MP Sharon Hodgson, a long-time campaigner for ticket reform, welcomed measures she said would address a “broken and parasitic market”. </p>',
-                },
-                {
-                    _type:
-                        'model.dotcomrendering.pageElements.TextBlockElement',
-                    html:
-                        '<p>“These measures will ensure that fans are protected, but there still remains work to do to make sure that these measures are enforced properly so touts do not circumvent them as this is going to very soon be the law of the land.”</p>',
-                },
-                {
-                    _type:
-                        'model.dotcomrendering.pageElements.TextBlockElement',
-                    html:
-                        '<p>The DCMS proposals will be informed by an <a href="https://www.theguardian.com/business/2016/dec/19/ticket-resale-websites-run-risk-of-fines-cma-launches-investigation-competition-and-markets-authority">ongoing review by the Competition and Market Authority</a> into secondary ticketing firms’ compliance with the law.</p>',
-                },
-                {
-                    _type:
-                        'model.dotcomrendering.pageElements.TextBlockElement',
-                    html:
-                        '<p>Ticket resale sites will face even harsher measures if they do not prove that they are taking sufficient steps to address the power of touts, the Guardian understands.</p>',
-                },
-                {
-                    _type:
-                        'model.dotcomrendering.pageElements.TextBlockElement',
-                    html:
-                        '<p>Theresa May <a href="https://www.theguardian.com/money/2017/mar/01/viagogo-ticket-rip-off-parliament-theresa-may-promises-crackdown">promised to take action on ticket resale</a> at Prime Minister’s Questions after Nigel Adams MP urged her to help “ensure genuine fans are not fleeced by <a href="https://www.theguardian.com/money/2016/may/15/shady-world-of-the-ticket-touts">ticket touts and rogues</a>”.</p>',
-                },
-                {
-                    _type:
-                        'model.dotcomrendering.pageElements.TextBlockElement',
-                    html:
-                        '<p>Increased scrutiny of secondary ticketing follows revelations in the Guardian about the actions of well-known ticket resale sites and the <a href="https://www.theguardian.com/money/2016/may/15/shady-world-of-the-ticket-touts">touts who have used them to build multi-million pound businesses</a> by harvesting tickets in bulk.</p>',
-                },
-                {
-                    _type:
-                        'model.dotcomrendering.pageElements.TextBlockElement',
-                    html:
-                        '<p>Viagogo, which is based in Switzerland but has a large office in Cannon Street, London, was recently <a href="https://www.theguardian.com/money/2017/feb/17/viagogo-condemned-ed-sheeran-cancer-benefit-concert-tickets-teenage-cancer-trust">accused of “moral repugnance”</a> for seeking to profit from the resale of tickets for an Ed Sheeran gig at the Royal Albert Hall in aid of the Teenage Cancer Trust.</p>',
-                },
-                {
-                    _type:
-                        'model.dotcomrendering.pageElements.TextBlockElement',
-                    html:
-                        '<p>Ticketmaster, which owns resale sites GetMeIn and Seatwave, has also come under the spotlight after it emerged that a <a href="https://www.theguardian.com/business/2017/feb/22/convicted-fraudsters-sell-ed-sheeran-tickets-through-ticketmaster">man previously convicted of a £2m ticket fraud</a> was using the sites to sell thousands of pounds’ worth of tickets.<br></p>',
-                },
-                {
-                    _type:
-                        'model.dotcomrendering.pageElements.TextBlockElement',
-                    html:
-                        '<p>The identities of some of the UK’s most powerful touts were revealed last year after a whistleblower passed the Guardian information revealing the vast rewards on offer to those with a grip on access to the UK’s most popular events.</p>',
-                },
-                {
-                    _type:
-                        'model.dotcomrendering.pageElements.TextBlockElement',
-                    html:
-                        '<p>Many have since <a href="https://www.theguardian.com/business/2017/jan/23/ticket-touts-investigations-competition-hmrc">rebranded their companies</a> amid mounting outrage about their business models.</p>',
-                },
-                {
-                    _type:
-                        'model.dotcomrendering.pageElements.TextBlockElement',
-                    html:
-                        '<p>While music concerts have proved the most lucrative targets for touts, high-profile theatre productions such as <a href="https://www.theguardian.com/stage/2017/jan/16/hamilton-west-end-tickets-found-on-resale-sites-viagogo-despite-anti-tout-measures">critically acclaimed hip-hop musical Hamilton</a>, as well as <a href="https://www.theguardian.com/stage/2016/aug/13/harry-potter-cursed-child-ticket-resale-prices">Harry Potter and the Cursed Child</a>, have also been targeted.</p>',
-                },
-            ],
-        },
-    ],
-    pageId:
-        'money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
-    version: 3,
-    isImmersive: false,
-    subMetaSectionLinks: [
-        {
-            url: '/money/ticket-prices',
-            title: 'Ticket prices',
-        },
-    ],
-    subMetaKeywordLinks: [
-        {
-            url: '/money/consumer-affairs',
-            title: 'Consumer affairs',
-        },
-        {
-            url: '/technology/internet',
-            title: 'Internet',
-        },
-        {
-            url: '/money/viagogo',
-            title: 'Viagogo',
-        },
-        {
-            url: '/tone/news',
-            title: 'News',
-        },
-    ],
-    sectionLabel: 'Ticket prices',
-    sectionUrl: 'money/ticket-prices',
-    shouldHideAds: false,
-    shouldHideReaderRevenue: true,
-    isAdFreeUser: false,
-    webURL:
-        'https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
-    guardianBaseURL: 'https://www.theguardian.com',
-    contentType: 'Article',
-    hasRelated: false,
-    hasStoryPackage: false,
-    publication: 'theguardian.com',
-    beaconURL: '//fake.url',
-    isCommentable: false,
-    commercialProperties: {
-        UK: { adTargeting: [] },
-        US: { adTargeting: [] },
-        AU: { adTargeting: [] },
-        INT: { adTargeting: [] },
-    },
+    hasStoryPackage: true,
+    publication: 'The Guardian',
     trailText:
-        'Ticket touts face unlimited fines for using ‘bots’ to buy in bulk',
-    keyEvents: [],
-    twitterData: {
-        'twitter:app:id:iphone': '409128287',
-        'twitter:app:name:googleplay': 'The Guardian',
-        'twitter:app:name:ipad': 'The Guardian',
-        'twitter:image':
-            'https://i.guim.co.uk/img/media/6787bd3346264fdf786495e079523f9ae7b1a126/1649_294_1820_1092/master/1820.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctYWdlLTIwMTgucG5n&s=d3dd838e1b6ef5a72abc846f0fd783a2',
-        'twitter:site': '@guardian',
-        'twitter:app:url:ipad':
-            'gnmguardian://money/2018/jul/05/ticket-touts-face-unlimited-fines-for-using-bots?contenttype=Article&source=twitter',
-        'twitter:card': 'summary_large_image',
-        'twitter:app:name:iphone': 'The Guardian',
-        'twitter:creator': '@ByRobDavies',
-        'twitter:app:id:ipad': '409128287',
-        'twitter:app:id:googleplay': 'com.guardian',
-        'twitter:app:url:googleplay':
-            'guardian://www.theguardian.com/money/2018/jul/05/ticket-touts-face-unlimited-fines-for-using-bots',
-        'twitter:app:url:iphone':
-            'gnmguardian://money/2018/jul/05/ticket-touts-face-unlimited-fines-for-using-bots?contenttype=Article&source=twitter',
-    },
-    openGraphData: {
-        'og:url':
-            'http://www.theguardian.com/money/2018/jul/05/ticket-touts-face-unlimited-fines-for-using-bots',
-        'article:author': 'https://www.theguardian.com/profile/rob-davies',
-        'og:image:height': '720',
-        'og:description':
-            'Music industry groups hails law, part of wider effort to crack down on ‘secondary ticketing’',
-        'og:image:width': '1200',
-        'og:image':
-            'https://i.guim.co.uk/img/media/6787bd3346264fdf786495e079523f9ae7b1a126/1649_294_1820_1092/master/1820.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctYWdlLTIwMTgucG5n&enable=upscale&s=a1303790ad17807b9c68053d0226ace4',
-        'al:ios:url':
-            'gnmguardian://money/2018/jul/05/ticket-touts-face-unlimited-fines-for-using-bots?contenttype=Article&source=applinks',
-        'article:publisher': 'https://www.facebook.com/theguardian',
-        'og:type': 'article',
-        'al:ios:app_store_id': '409128287',
-        'article:section': 'Money',
-        'article:published_time': '2018-07-05T05:01:22.000Z',
-        'og:title': 'Ticket touts face unlimited fines for using bots',
-        'fb:app_id': '180444840287',
-        'article:tag':
-            'Ticket prices,Viagogo,Taylor Swift,Consumer affairs,Retail industry,Culture,Money,Ed Sheeran,Music',
-        'al:ios:app_name': 'The Guardian',
-        'og:site_name': 'the Guardian',
-        'article:modified_time': '2018-07-05T17:23:09.000Z',
-    },
-    linkedData: [
-        {
-            '@type': 'NewsArticle',
-            '@context': 'https://schema.org',
-            '@id':
-                'https://amp.theguardian.commoney/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
-            publisher: {
-                '@type': 'Organization',
-                '@context': 'https://schema.org',
-                '@id': 'https://www.theguardian.com#publisher',
-                name: 'The Guardian',
-                url: 'https://www.theguardian.com/',
-                logo: {
-                    '@type': 'ImageObject',
-                    url:
-                        'https://uploads.guim.co.uk/2018/01/31/TheGuardian_AMP.png',
-                    width: 190,
-                    height: 60,
-                },
-                sameAs: [
-                    'https://www.facebook.com/theguardian',
-                    'https://twitter.com/guardian',
-                    'https://www.youtube.com/user/TheGuardian',
-                ],
-            },
-            isAccessibleForFree: true,
-            isPartOf: {
-                '@type': ['CreativeWork', 'Product'],
-                name: 'The Guardian',
-                productID: 'theguardian.com:basic',
-            },
-            image: [
-                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=1200&height=1200&quality=85&auto=format&fit=max&s=81c451031902977f730a5ce8889745f3',
-                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=1200&height=900&quality=85&auto=format&fit=max&s=4bc0fff8555ac350f33d81703e0ac7f4',
-                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=1200&quality=85&auto=format&fit=max&s=c52c6ee4e127be64398a289551edcbfa',
-            ],
-            author: [
-                {
-                    '@type': 'Person',
-                    name: 'Rob Davies',
-                    sameAs: 'https://www.theguardian.com/profile/rob-davies',
-                },
-            ],
-            datePublished: '2017-03-11T06:15:05.000+11:00',
-            headline:
-                "Ticket touts face unlimited fines for using 'bots' to buy in bulk",
-            dateModified: '2017-11-28T14:55:02.000+11:00',
-            mainEntityOfPage:
-                'https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
-        },
-        {
-            '@type': 'WebPage',
-            '@context': 'https://schema.org',
-            '@id':
-                'https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
-            potentialAction: {
-                '@type': 'ViewAction',
-                target:
-                    'android-app://com.guardian/https/www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
-            },
-        },
+        'Package of measures designed to curb growing power of ‘secondary ticketing’ industry and protect fans',
+    subMetaKeywordLinks: [
+        { url: '/money/consumer-affairs', title: 'Consumer affairs' },
+        { url: '/technology/internet', title: 'Internet' },
+        { url: '/money/viagogo', title: 'Viagogo' },
+        { url: '/tone/news', title: 'news' },
     ],
-    config: {
-        ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
-        sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
-        sentryHost: 'app.getsentry.com/35463',
-        dcrSentryDsn:
-            'https://1937ab71c8804b2b8438178dfdd6468f@sentry.io/1377847',
-        switches: {},
-        shortUrlId: '/p/4k83z',
-        abTests: {},
-        dfpAccountId: '',
-        commercialBundleUrl:
-            'https://assets.guim.co.uk/javascripts/3d3cbc5f29df7c0cdd65/graun.dotcom-rendering-commercial.js',
-        revisionNumber: '62cf0d6e4609276d37e09fd596430fbf8b629418',
-        isDev: false,
-        googletagUrl: '//www.googletagservices.com/tag/js/gpt.js',
-        stage: 'DEV',
-        frontendAssetsFullURL: 'https://assets.guim.co.uk/',
-        hbImpl: {
-            prebid: false,
-            a9: false,
-        },
-        adUnit: '/59666047/theguardian.com/film/article/ng',
-        isSensitive: false,
-        videoDuration: 0,
-        edition: '',
-        section: '',
-        sharedAdTargeting: {},
-        pageId: '',
-        webPublicationDate: 1579185778186,
-        headline: '',
-        author: '',
-        keywords: '',
-        series: '',
-        contentType: '',
-        isPaidContent: false,
-        keywordIds: '',
-        showRelatedContent: false,
-        ampIframeUrl:
-            'https://assets.guim.co.uk/data/vendor/a994b749adae30cd58f0e84c8fa28013/amp-iframe.html',
-    },
-    webTitle: 'Foobar',
+    headline:
+        "Ticket touts face unlimited fines for using 'bots' to buy in bulk",
+    contentType: 'Article',
+    guardianBaseURL: 'https://www.theguardian.com',
     nav: {
         currentUrl: '/money',
         pillars: [
@@ -856,14 +503,6 @@ export const CAPI: CAPIType = {
                                 classList: [],
                             },
                             {
-                                title: 'Cities',
-                                url: '/cities',
-                                longTitle: '',
-                                iconName: '',
-                                children: [],
-                                classList: [],
-                            },
-                            {
                                 title: 'Global development',
                                 url: '/global-development',
                                 longTitle: '',
@@ -1027,23 +666,7 @@ export const CAPI: CAPIType = {
                                 children: [],
                                 classList: [],
                             },
-                            {
-                                title: 'World Cup 2019',
-                                url: '/football/womens-world-cup-2019',
-                                longTitle: '',
-                                iconName: '',
-                                children: [],
-                                classList: [],
-                            },
                         ],
-                        classList: [],
-                    },
-                    {
-                        title: 'UK politics',
-                        url: '/politics',
-                        longTitle: '',
-                        iconName: '',
-                        children: [],
                         classList: [],
                     },
                     {
@@ -1085,6 +708,14 @@ export const CAPI: CAPIType = {
                                 classList: [],
                             },
                         ],
+                        classList: [],
+                    },
+                    {
+                        title: 'UK politics',
+                        url: '/politics',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
                         classList: [],
                     },
                     {
@@ -1161,14 +792,6 @@ export const CAPI: CAPIType = {
                         classList: [],
                     },
                     {
-                        title: 'Cities',
-                        url: '/cities',
-                        longTitle: '',
-                        iconName: '',
-                        children: [],
-                        classList: [],
-                    },
-                    {
                         title: 'Obituaries',
                         url: '/tone/obituaries',
                         longTitle: '',
@@ -1211,7 +834,7 @@ export const CAPI: CAPIType = {
                     },
                     {
                         title: 'Opinion videos',
-                        url: '/commentisfree/series/comment-is-free-weekly',
+                        url: '/type/video+tone/comment',
                         longTitle: '',
                         iconName: '',
                         children: [],
@@ -1288,28 +911,20 @@ export const CAPI: CAPIType = {
                                 children: [],
                                 classList: [],
                             },
-                            {
-                                title: 'World Cup 2019',
-                                url: '/football/womens-world-cup-2019',
-                                longTitle: '',
-                                iconName: '',
-                                children: [],
-                                classList: [],
-                            },
                         ],
                         classList: [],
                     },
                     {
-                        title: 'Rugby union',
-                        url: '/sport/rugby-union',
+                        title: 'Cricket',
+                        url: '/sport/cricket',
                         longTitle: '',
                         iconName: '',
                         children: [],
                         classList: [],
                     },
                     {
-                        title: 'Cricket',
-                        url: '/sport/cricket',
+                        title: 'Rugby union',
+                        url: '/sport/rugby-union',
                         longTitle: '',
                         iconName: '',
                         children: [],
@@ -1873,77 +1488,12 @@ export const CAPI: CAPIType = {
                 ],
                 classList: [],
             },
-            {
-                title: 'Guardian Masterclasses',
-                url: '/guardian-masterclasses',
-                longTitle: '',
-                iconName: '',
-                children: [
-                    {
-                        title: 'Journalism',
-                        url: '/guardian-masterclasses/journalism',
-                        longTitle: '',
-                        iconName: '',
-                        children: [],
-                        classList: [],
-                    },
-                    {
-                        title: 'Digital',
-                        url: '/guardian-masterclasses/digital',
-                        longTitle: '',
-                        iconName: '',
-                        children: [],
-                        classList: [],
-                    },
-                    {
-                        title: 'Business',
-                        url: '/guardian-masterclasses/business',
-                        longTitle: '',
-                        iconName: '',
-                        children: [],
-                        classList: [],
-                    },
-                    {
-                        title: 'Creative writing',
-                        url: '/guardian-masterclasses/writing-and-publishing',
-                        longTitle: '',
-                        iconName: '',
-                        children: [],
-                        classList: [],
-                    },
-                    {
-                        title: 'Wellbeing & Culture',
-                        url: '/guardian-masterclasses/culture',
-                        longTitle: '',
-                        iconName: '',
-                        children: [],
-                        classList: [],
-                    },
-                    {
-                        title: 'Bespoke training',
-                        url: '/guardian-masterclasses/corporate-training',
-                        longTitle: '',
-                        iconName: '',
-                        children: [],
-                        classList: [],
-                    },
-                    {
-                        title: 'Calendar',
-                        url: '/guardian-masterclasses/calendar',
-                        longTitle: '',
-                        iconName: '',
-                        children: [],
-                        classList: [],
-                    },
-                ],
-                classList: [],
-            },
         ],
         brandExtensions: [
             {
                 title: 'Search jobs',
                 url:
-                    'https://jobs.theguardian.com?INTCMP=jobs_uk_web_newheader',
+                    'https://jobs.theguardian.com?INTCMP=jobs_uk_web_newheader_dropdown',
                 longTitle: '',
                 iconName: '',
                 children: [],
@@ -1952,7 +1502,7 @@ export const CAPI: CAPIType = {
             {
                 title: 'Dating',
                 url:
-                    'https://soulmates.theguardian.com?INTCMP=soulmates_uk_web_newheader',
+                    'https://soulmates.theguardian.com?INTCMP=soulmates_uk_web_newheader_dropdown',
                 longTitle: '',
                 iconName: '',
                 children: [],
@@ -1968,9 +1518,17 @@ export const CAPI: CAPIType = {
                 classList: [],
             },
             {
-                title: 'Masterclasses',
+                title: 'Live events',
                 url:
-                    'https://membership.theguardian.com/masterclasses?INTCMP=masterclasses_uk_web_newheader',
+                    'https://membership.theguardian.com/events?INTCMP=live_uk_header_dropdown',
+                longTitle: '',
+                iconName: '',
+                children: [],
+                classList: [],
+            },
+            {
+                title: 'Masterclasses',
+                url: '/guardian-masterclasses',
                 longTitle: '',
                 iconName: '',
                 children: [],
@@ -1979,6 +1537,14 @@ export const CAPI: CAPIType = {
             {
                 title: 'Digital Archive',
                 url: 'https://theguardian.newspapers.com',
+                longTitle: '',
+                iconName: '',
+                children: [],
+                classList: [],
+            },
+            {
+                title: 'Guardian Print Shop',
+                url: '/artanddesign/series/gnm-print-sales',
                 longTitle: '',
                 iconName: '',
                 children: [],
@@ -1994,12 +1560,11 @@ export const CAPI: CAPIType = {
             },
             {
                 title: 'Discount Codes',
-                url:
-                    'https://discountcode.theguardian.com/uk?INTCMP=guardian_header',
+                url: 'https://discountcode.theguardian.com',
                 longTitle: '',
                 iconName: '',
                 children: [],
-                classList: [],
+                classList: ['js-discount-code-link'],
             },
         ],
         currentNavLink: {
@@ -2489,161 +2054,1683 @@ export const CAPI: CAPIType = {
         readerRevenueLinks: {
             header: {
                 contribute:
-                    'https://support.theguardian.com/contribute?INTCMP=…_contribute%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+                    'https://support.theguardian.com/contribute?INTCMP=header_support_contribute&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support_contribute%22,%22source%22:%22GUARDIAN_WEB%22%7D',
                 subscribe:
-                    'https://support.theguardian.com/subscribe?INTCMP=h…t_subscribe%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+                    'https://support.theguardian.com/subscribe?INTCMP=header_support_subscribe&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support_subscribe%22,%22source%22:%22GUARDIAN_WEB%22%7D',
                 support:
-                    'https://support.theguardian.com?INTCMP=header_supp…der_support%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+                    'https://support.theguardian.com?INTCMP=header_support&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support%22,%22source%22:%22GUARDIAN_WEB%22%7D',
             },
             footer: {
                 contribute:
-                    'https://support.theguardian.com/contribute?INTCMP=…_contribute%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+                    'https://support.theguardian.com/contribute?INTCMP=footer_support_contribute&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22footer_support_contribute%22,%22source%22:%22GUARDIAN_WEB%22%7D',
                 subscribe:
-                    'https://support.theguardian.com/subscribe?INTCMP=h…t_subscribe%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+                    'https://support.theguardian.com/subscribe?INTCMP=footer_support_subscribe&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22footer_support_subscribe%22,%22source%22:%22GUARDIAN_WEB%22%7D',
                 support:
-                    'https://support.theguardian.com?INTCMP=header_supp…der_support%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+                    'https://support.theguardian.com?INTCMP=footer_support&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22footer_support%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+            },
+            sideMenu: {
+                contribute:
+                    'https://support.theguardian.com/contribute?INTCMP=side_menu_support_contribute&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22side_menu_support_contribute%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+                subscribe:
+                    'https://support.theguardian.com/subscribe?INTCMP=side_menu_support_subscribe&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22side_menu_support_subscribe%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+                support:
+                    'https://support.theguardian.com?INTCMP=side_menu_support&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22side_menu_support%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+            },
+            ampHeader: {
+                contribute:
+                    'https://support.theguardian.com/contribute?INTCMP=header_support_contribute&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support_contribute%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+                subscribe:
+                    'https://support.theguardian.com/subscribe?INTCMP=header_support_subscribe&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support_subscribe%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+                support:
+                    'https://support.theguardian.com?INTCMP=amp_header_support&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22amp_header_support%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+            },
+            ampFooter: {
+                contribute:
+                    'https://support.theguardian.com/contribute?INTCMP=amp_footer_support_contribute&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22amp_footer_support_contribute%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+                subscribe:
+                    'https://support.theguardian.com/subscribe?INTCMP=amp_footer_support_subscribe&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22amp_footer_support_subscribe%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+                support:
+                    'https://support.theguardian.com?INTCMP=footer_support&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22footer_support%22,%22source%22:%22GUARDIAN_WEB%22%7D',
             },
         },
     },
-    showBottomSocialButtons: true,
-    pageFooter: {
-        footerLinks: [
-            [
+    mainMediaElements: [
+        {
+            role: 'inline',
+            data: {
+                copyright:
+                    'Copyright 2016 The Associated Press. All rights reserved. This material may not be published, broadcast, rewritten or redistribu',
+                alt:
+                    'The Palace Theatre, London, showing Harry Potter and the Cursed Child',
+                caption:
+                    'Tickets for the West End show Harry Potter and the Cursed Child at the Palace Theatre, London, are among those targeted by the secondary ticketing industry. ',
+                credit: 'Photograph: Kirsty Wigglesworth/AP',
+            },
+            imageSources: [
                 {
-                    text: 'About us',
-                    url: '/about',
-                    dataLinkName: 'uk : footer : about us',
-                    extraClasses: '',
+                    weighting: 'inline',
+                    srcSet: [
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=620&quality=85&auto=format&fit=max&s=1bcb12104405d365e4176d25f9bff704',
+                            width: 620,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=e63191832b3ff60087cb1a565fe03cbe',
+                            width: 1240,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=605&quality=85&auto=format&fit=max&s=2c0e6978b4b165ca97f03f8a816529a8',
+                            width: 605,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=0cd2b8a169119596cbda1a8ed1d9cdae',
+                            width: 1210,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=445&quality=85&auto=format&fit=max&s=516527f4ac7bdcab733dbcb0f13c25bd',
+                            width: 445,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=60f452a7811b0c27eff30e63a4cd3c3e',
+                            width: 890,
+                        },
+                    ],
                 },
                 {
-                    text: 'Contact us',
-                    url: '/help/contact-us',
-                    dataLinkName: 'uk : footer : contact us',
-                    extraClasses: '',
+                    weighting: 'thumbnail',
+                    srcSet: [
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=140&quality=85&auto=format&fit=max&s=47fa9641d01f7b562c1407c999bd9da0',
+                            width: 140,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=bb5e1c55366dc4afea21bc242f806254',
+                            width: 280,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=120&quality=85&auto=format&fit=max&s=0aec1c40ad08585352196ba9cbbe712e',
+                            width: 120,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=eca5b89df36244bef649aa5dd2bef5dc',
+                            width: 240,
+                        },
+                    ],
                 },
                 {
-                    text: 'Complaints &amp; corrections',
-                    url: '/info/complaints-and-corrections',
-                    dataLinkName: 'complaints',
-                    extraClasses: '',
+                    weighting: 'supporting',
+                    srcSet: [
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=380&quality=85&auto=format&fit=max&s=6bf99684d34d7e640b42e77de94d2369',
+                            width: 380,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=43bd991891c56216306181f09f77fabb',
+                            width: 760,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=300&quality=85&auto=format&fit=max&s=4e8c8811000fc54bea72dedd69ab13d6',
+                            width: 300,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=12b53b4a8d09307b49178303cf53eade',
+                            width: 600,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=620&quality=85&auto=format&fit=max&s=1bcb12104405d365e4176d25f9bff704',
+                            width: 620,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=e63191832b3ff60087cb1a565fe03cbe',
+                            width: 1240,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=605&quality=85&auto=format&fit=max&s=2c0e6978b4b165ca97f03f8a816529a8',
+                            width: 605,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=0cd2b8a169119596cbda1a8ed1d9cdae',
+                            width: 1210,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=445&quality=85&auto=format&fit=max&s=516527f4ac7bdcab733dbcb0f13c25bd',
+                            width: 445,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=60f452a7811b0c27eff30e63a4cd3c3e',
+                            width: 890,
+                        },
+                    ],
                 },
                 {
-                    text: 'SecureDrop',
-                    url: 'https://www.theguardian.com/securedrop',
-                    dataLinkName: 'securedrop',
-                    extraClasses: '',
+                    weighting: 'showcase',
+                    srcSet: [
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=860&quality=85&auto=format&fit=max&s=16f69557a812fa0f97f386567be954d6',
+                            width: 860,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=860&quality=45&auto=format&fit=max&dpr=2&s=3daab5bd6e4919bf223fc919b9f6d0e4',
+                            width: 1720,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=780&quality=85&auto=format&fit=max&s=ce247f6cf701cb7c91cc6243a0b52bbe',
+                            width: 780,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=780&quality=45&auto=format&fit=max&dpr=2&s=ff47d88286761fcd7f5c6c80471c79a0',
+                            width: 1560,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=620&quality=85&auto=format&fit=max&s=1bcb12104405d365e4176d25f9bff704',
+                            width: 620,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=e63191832b3ff60087cb1a565fe03cbe',
+                            width: 1240,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=605&quality=85&auto=format&fit=max&s=2c0e6978b4b165ca97f03f8a816529a8',
+                            width: 605,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=0cd2b8a169119596cbda1a8ed1d9cdae',
+                            width: 1210,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=445&quality=85&auto=format&fit=max&s=516527f4ac7bdcab733dbcb0f13c25bd',
+                            width: 445,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=60f452a7811b0c27eff30e63a4cd3c3e',
+                            width: 890,
+                        },
+                    ],
                 },
                 {
-                    text: 'Work for us',
-                    url: 'https://workforus.theguardian.com',
-                    dataLinkName: 'uk : footer : work for us',
-                    extraClasses: '',
+                    weighting: 'halfwidth',
+                    srcSet: [
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=620&quality=85&auto=format&fit=max&s=1bcb12104405d365e4176d25f9bff704',
+                            width: 620,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=e63191832b3ff60087cb1a565fe03cbe',
+                            width: 1240,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=605&quality=85&auto=format&fit=max&s=2c0e6978b4b165ca97f03f8a816529a8',
+                            width: 605,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=0cd2b8a169119596cbda1a8ed1d9cdae',
+                            width: 1210,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=445&quality=85&auto=format&fit=max&s=516527f4ac7bdcab733dbcb0f13c25bd',
+                            width: 445,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=60f452a7811b0c27eff30e63a4cd3c3e',
+                            width: 890,
+                        },
+                    ],
                 },
                 {
-                    text: 'Privacy policy',
-                    url: '/info/privacy',
-                    dataLinkName: 'privacy',
-                    extraClasses: '',
-                },
-                {
-                    text: 'Cookie policy',
-                    url: '/info/cookies',
-                    dataLinkName: 'cookie',
-                    extraClasses: '',
-                },
-                {
-                    text: 'Terms &amp; conditions',
-                    url: '/help/terms-of-service',
-                    dataLinkName: 'terms',
-                    extraClasses: '',
-                },
-                {
-                    text: 'Help',
-                    url: '/help',
-                    dataLinkName: 'uk : footer : tech feedback',
-                    extraClasses: 'js-tech-feedback-report',
+                    weighting: 'immersive',
+                    srcSet: [
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=620&quality=85&auto=format&fit=max&s=1bcb12104405d365e4176d25f9bff704',
+                            width: 620,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=e63191832b3ff60087cb1a565fe03cbe',
+                            width: 1240,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=605&quality=85&auto=format&fit=max&s=2c0e6978b4b165ca97f03f8a816529a8',
+                            width: 605,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=0cd2b8a169119596cbda1a8ed1d9cdae',
+                            width: 1210,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=445&quality=85&auto=format&fit=max&s=516527f4ac7bdcab733dbcb0f13c25bd',
+                            width: 445,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=60f452a7811b0c27eff30e63a4cd3c3e',
+                            width: 890,
+                        },
+                    ],
                 },
             ],
-            [
+            _type: 'model.dotcomrendering.pageElements.ImageBlockElement',
+            media: {
+                allImages: [
+                    {
+                        index: 0,
+                        fields: { height: '1200', width: '2000' },
+                        mediaType: 'Image',
+                        mimeType: 'image/jpeg',
+                        url:
+                            'https://media.guim.co.uk/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/2000.jpg',
+                    },
+                    {
+                        index: 1,
+                        fields: { height: '600', width: '1000' },
+                        mediaType: 'Image',
+                        mimeType: 'image/jpeg',
+                        url:
+                            'https://media.guim.co.uk/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/1000.jpg',
+                    },
+                    {
+                        index: 2,
+                        fields: { height: '300', width: '500' },
+                        mediaType: 'Image',
+                        mimeType: 'image/jpeg',
+                        url:
+                            'https://media.guim.co.uk/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/500.jpg',
+                    },
+                    {
+                        index: 3,
+                        fields: { height: '84', width: '140' },
+                        mediaType: 'Image',
+                        mimeType: 'image/jpeg',
+                        url:
+                            'https://media.guim.co.uk/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/140.jpg',
+                    },
+                    {
+                        index: 4,
+                        fields: { height: '3009', width: '5015' },
+                        mediaType: 'Image',
+                        mimeType: 'image/jpeg',
+                        url:
+                            'https://media.guim.co.uk/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/5015.jpg',
+                    },
+                    {
+                        index: 5,
+                        fields: {
+                            isMaster: 'true',
+                            height: '3009',
+                            width: '5015',
+                        },
+                        mediaType: 'Image',
+                        mimeType: 'image/jpeg',
+                        url:
+                            'http://media.guim.co.uk/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg',
+                    },
+                ],
+            },
+            displayCredit: true,
+        },
+    ],
+    webPublicationDate: '2017-03-10T19:15:05.000Z',
+    blocks: [
+        {
+            id: '58c2d708e4b00bd41ba509f8',
+            elements: [
                 {
-                    text: 'All topics',
-                    url: '/index/subjects/a',
-                    dataLinkName: 'uk : footer : all topics',
-                    extraClasses: '',
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>Touts who use computer software to <a href="https://www.theguardian.com/business/2017/jan/23/ticket-touts-beat-adele-take-that-hamilton">harvest concert tickets in bulk</a> and resell them at vast mark-ups face unlimited fines as part of a crackdown on highly profitable resale sites such as Viagogo, StubHub and GetMeIn.</p>',
                 },
                 {
-                    text: 'All writers',
-                    url: '/index/contributors',
-                    dataLinkName: 'uk : footer : all contributors',
-                    extraClasses: '',
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>The Department of Culture, Media and Sport will announce a package of measures to curb the growing power of the so-called “secondary ticketing” industry, which now regularly offers tickets at huge mark-ups, even before they are available to the general public.</p>',
                 },
                 {
-                    text: 'Modern Slavery Act',
-                    url:
-                        '/info/2016/jul/27/modern-slavery-and-our-supply-chains?INTCMP=NGW_FOOTER_UK_GU_MODERN_SLAVERY_ACT',
-                    dataLinkName: 'uk : footer : modern slavery act statement',
-                    extraClasses: '',
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>Proposals will include a new criminal offence for the use of “bots” – <a href="https://www.theguardian.com/money/2016/may/21/ticket-touts-powerful-software-assist-widely-available">software that helps touts bypass limits</a> on the number of tickets one person can buy.</p>',
                 },
                 {
-                    text: 'Digital newspaper archive',
-                    url: 'https://theguardian.newspapers.com',
-                    dataLinkName: 'digital newspaper archive',
-                    extraClasses: '',
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>National Trading Standards will also be handed a ringfenced pot of money to fund efforts to stop fans being ripped off or shut out of the most in-demand events.</p>',
                 },
                 {
-                    text: 'Facebook',
-                    url: 'https://www.facebook.com/theguardian',
-                    dataLinkName: 'uk : footer : facebook',
-                    extraClasses: '',
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>The government is taking action following outrage that face-value tickets to see <a href="https://www.theguardian.com/music/2016/dec/02/adele-tickets-appear-online-for-9000-despite-singers-efforts-to-stop-touts">artists such as Adele</a> and Ed Sheeran are selling out in minutes, only to appear for thousands of pounds on resale websites such as <a href="https://www.theguardian.com/business/2016/sep/23/what-we-know-about-ticket-reseller-viagogo">Viagogo</a>, StubHub and GetMeIn moments later.</p>',
                 },
                 {
-                    text: 'Twitter',
-                    url: 'https://twitter.com/guardian',
-                    dataLinkName: 'uk: footer : twitter',
-                    extraClasses: '',
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>These websites make money by allowing touts, as well as genuine fans, to resell tickets in return for a cut of anything up to 25% of the sale price.</p>',
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>As well as criminalising bots, ministers at DCMS will accept in full the recommendations of a <a href="https://www.theguardian.com/money/2016/may/26/ticket-touts-review-licensing-enforcement">review by Professor Michael Waterson</a>, who <a href="https://www.gov.uk/government/publications/consumer-protection-measures-applying-to-ticket-resale-waterson-review">published proposals</a> to tackle rogue ticket traders last year.</p>',
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>These include demanding that ticket firms to step up their own efforts to prevent the use of bots and to report any attacks on their systems by touts trying to harvest tickets.</p>',
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>While primary ticket firms such as Ticketmaster say they are doing their utmost to stop bot users, the company also owns secondary sites, such as GetMeIn and Seatwave, which have <a href="https://www.theguardian.com/money/2016/jul/16/bands-fans-declare-war-online-ticket-touts">close relationships with major touts</a> and take a cut of their profits.</p>',
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>Ministers will also propose stronger enforcement of consumer rights laws, amid concern that tickets are being sold with no information about the seat location or the name of the seller, in contravention of the Consumer Rights Act 2015.</p>',
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>Efforts to step up scrutiny of firms’ adherence to consumer laws is also aimed at sites that sell tickets whose terms and conditions specifically ban resale, meaning fans are turned away at the door.</p>',
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>Labour MP Sharon Hodgson, a long-time campaigner for ticket reform, welcomed measures she said would address a “broken and parasitic market”. </p>',
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>“These measures will ensure that fans are protected, but there still remains work to do to make sure that these measures are enforced properly so touts do not circumvent them as this is going to very soon be the law of the land.”</p>',
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>The DCMS proposals will be informed by an <a href="https://www.theguardian.com/business/2016/dec/19/ticket-resale-websites-run-risk-of-fines-cma-launches-investigation-competition-and-markets-authority">ongoing review by the Competition and Market Authority</a> into secondary ticketing firms’ compliance with the law.</p>',
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>Ticket resale sites will face even harsher measures if they do not prove that they are taking sufficient steps to address the power of touts, the Guardian understands.</p>',
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>Theresa May <a href="https://www.theguardian.com/money/2017/mar/01/viagogo-ticket-rip-off-parliament-theresa-may-promises-crackdown">promised to take action on ticket resale</a> at Prime Minister’s Questions after Nigel Adams MP urged her to help “ensure genuine fans are not fleeced by <a href="https://www.theguardian.com/money/2016/may/15/shady-world-of-the-ticket-touts">ticket touts and rogues</a>”.</p>',
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>Increased scrutiny of secondary ticketing follows revelations in the Guardian about the actions of well-known ticket resale sites and the <a href="https://www.theguardian.com/money/2016/may/15/shady-world-of-the-ticket-touts">touts who have used them to build multi-million pound businesses</a> by harvesting tickets in bulk.</p>',
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>Viagogo, which is based in Switzerland but has a large office in Cannon Street, London, was recently <a href="https://www.theguardian.com/money/2017/feb/17/viagogo-condemned-ed-sheeran-cancer-benefit-concert-tickets-teenage-cancer-trust">accused of “moral repugnance”</a> for seeking to profit from the resale of tickets for an Ed Sheeran gig at the Royal Albert Hall in aid of the Teenage Cancer Trust.</p>',
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>Ticketmaster, which owns resale sites GetMeIn and Seatwave, has also come under the spotlight after it emerged that a <a href="https://www.theguardian.com/business/2017/feb/22/convicted-fraudsters-sell-ed-sheeran-tickets-through-ticketmaster">man previously convicted of a £2m ticket fraud</a> was using the sites to sell thousands of pounds’ worth of tickets.<br></p>',
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>The identities of some of the UK’s most powerful touts were revealed last year after a whistleblower passed the Guardian information revealing the vast rewards on offer to those with a grip on access to the UK’s most popular events.</p>',
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>Many have since <a href="https://www.theguardian.com/business/2017/jan/23/ticket-touts-investigations-competition-hmrc">rebranded their companies</a> amid mounting outrage about their business models.</p>',
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>While music concerts have proved the most lucrative targets for touts, high-profile theatre productions such as <a href="https://www.theguardian.com/stage/2017/jan/16/hamilton-west-end-tickets-found-on-resale-sites-viagogo-despite-anti-tout-measures">critically acclaimed hip-hop musical Hamilton</a>, as well as <a href="https://www.theguardian.com/stage/2016/aug/13/harry-potter-cursed-child-ticket-resale-prices">Harry Potter and the Cursed Child</a>, have also been targeted.</p>',
                 },
             ],
-            [
-                {
-                    text: 'Advertise with us',
-                    url: 'https://advertising.theguardian.com',
-                    dataLinkName: 'uk : footer : advertise with us',
-                    extraClasses: '',
-                },
-                {
-                    text: 'Guardian Labs',
-                    url: '/guardian-labs',
-                    dataLinkName: 'uk : footer : guardian labs',
-                    extraClasses: '',
-                },
-                {
-                    text: 'Search jobs',
+            createdOn: 1489164040000,
+            createdOnDisplay: '16:40 GMT',
+            lastUpdated: 1489173028000,
+            lastUpdatedDisplay: '19:10 GMT',
+            firstPublished: 1489164042000,
+            firstPublishedDisplay: '16:40 GMT',
+        },
+    ],
+    author: { byline: 'Rob Davies', twitterHandle: 'ByRobDavies' },
+    designType: 'Article',
+    linkedData: [
+        {
+            '@type': 'NewsArticle',
+            '@context': 'https://schema.org',
+            '@id':
+                'https://amp.theguardian.commoney/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+            publisher: {
+                '@type': 'Organization',
+                '@context': 'https://schema.org',
+                '@id': 'https://www.theguardian.com#publisher',
+                name: 'The Guardian',
+                url: 'https://www.theguardian.com/',
+                logo: {
+                    '@type': 'ImageObject',
                     url:
-                        'https://jobs.theguardian.com/jobs?INTCMP=NGW_FOOTER_UK_GU_JOBS',
-                    dataLinkName: 'uk : footer : jobs',
-                    extraClasses: '',
+                        'https://uploads.guim.co.uk/2018/01/31/TheGuardian_AMP.png',
+                    width: 190,
+                    height: 60,
                 },
+                sameAs: [
+                    'https://www.facebook.com/theguardian',
+                    'https://twitter.com/guardian',
+                    'https://www.youtube.com/user/TheGuardian',
+                ],
+            },
+            isAccessibleForFree: true,
+            isPartOf: {
+                '@type': ['CreativeWork', 'Product'],
+                name: 'The Guardian',
+                productID: 'theguardian.com:basic',
+            },
+            image: [
+                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctYWdlLTIwMTcucG5n&enable=upscale&s=d91406f7524821912b5f9815380773aa',
+                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=1200&height=1200&quality=85&auto=format&fit=crop&s=6bf4b7135279c5af30de621692a9bf59',
+                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=1200&height=900&quality=85&auto=format&fit=crop&s=98fdc47750779135aaf937aee1612d78',
+                'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=1200&quality=85&auto=format&fit=max&s=c52c6ee4e127be64398a289551edcbfa',
+            ],
+            author: [
                 {
-                    text: 'Dating',
-                    url:
-                        'https://soulmates.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_SOULMATES',
-                    dataLinkName: 'uk : footer : soulmates',
-                    extraClasses: '',
-                },
-                {
-                    text: 'Patrons',
-                    url:
-                        'https://patrons.theguardian.com/?INTCMP=footer_patrons',
-                    dataLinkName: 'uk : footer : patrons',
-                    extraClasses: '',
-                },
-                {
-                    text: 'Discount Codes',
-                    url: 'https://discountcode.theguardian.com/',
-                    dataLinkName: 'uk: footer : discount code',
-                    extraClasses: 'js-discount-code-link',
+                    '@type': 'Person',
+                    name: 'Rob Davies',
+                    sameAs: 'https://www.theguardian.com/profile/rob-davies',
                 },
             ],
-        ],
+            datePublished: '2017-03-10T19:15:05.000Z',
+            headline:
+                "Ticket touts face unlimited fines for using 'bots' to buy in bulk",
+            dateModified: '2017-11-28T03:55:02.000Z',
+            mainEntityOfPage:
+                'https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+        },
+        {
+            '@type': 'WebPage',
+            '@context': 'https://schema.org',
+            '@id':
+                'https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+            potentialAction: {
+                '@type': 'ViewAction',
+                target:
+                    'android-app://com.guardian/https/www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+            },
+        },
+    ],
+    webPublicationDateDisplay: 'Fri 10 Mar 2017 19.15 GMT',
+    editionId: 'UK',
+    shouldHideAds: true,
+    standfirst:
+        '<p><strong>Exclusive:</strong> Package of measures designed to curb growing power of ‘secondary ticketing’ industry and protect fans</p>',
+    webTitle:
+        "Ticket touts face unlimited fines for using 'bots' to buy in bulk",
+    openGraphData: {
+        'og:url':
+            'http://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+        'article:author': 'https://www.theguardian.com/profile/rob-davies',
+        'og:image:height': '720',
+        'og:description':
+            'Package of measures designed to curb growing power of ‘secondary ticketing’ industry and protect fans',
+        'og:image:width': '1200',
+        'og:image':
+            'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctYWdlLTIwMTcucG5n&enable=upscale&s=d91406f7524821912b5f9815380773aa',
+        'al:ios:url':
+            'gnmguardian://money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software?contenttype=Article&source=applinks',
+        'article:publisher': 'https://www.facebook.com/theguardian',
+        'og:type': 'article',
+        'al:ios:app_store_id': '409128287',
+        'article:section': 'Money',
+        'article:published_time': '2017-03-10T19:15:05.000Z',
+        'og:title':
+            "Ticket touts face unlimited fines for using 'bots' to buy in bulk",
+        'fb:app_id': '180444840287',
+        'article:tag': 'Ticket prices,Consumer affairs,Money,Internet,Viagogo',
+        'al:ios:app_name': 'The Guardian',
+        'og:site_name': 'the Guardian',
+        'article:modified_time': '2017-11-28T03:55:02.000Z',
     },
-};
+    sectionUrl: 'money/ticket-prices',
+    pageId:
+        'money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+    version: 3,
+    tags: [
+        { id: 'money/ticket-prices', type: 'Keyword', title: 'Ticket prices' },
+        {
+            id: 'money/consumer-affairs',
+            type: 'Keyword',
+            title: 'Consumer affairs',
+        },
+        { id: 'money/money', type: 'Keyword', title: 'Money' },
+        { id: 'technology/internet', type: 'Keyword', title: 'Internet' },
+        { id: 'type/article', type: 'Type', title: 'Article' },
+        { id: 'tone/news', type: 'Tone', title: 'News' },
+        { id: 'money/viagogo', type: 'Keyword', title: 'Viagogo' },
+        {
+            id: 'profile/rob-davies',
+            type: 'Contributor',
+            title: 'Rob Davies',
+            twitterHandle: 'ByRobDavies',
+        },
+        {
+            id: 'publication/theguardian',
+            type: 'Publication',
+            title: 'The Guardian',
+        },
+        {
+            id: 'theguardian/mainsection',
+            type: 'NewspaperBook',
+            title: 'Main section',
+        },
+        {
+            id: 'theguardian/mainsection/topstories',
+            type: 'NewspaperBookSection',
+            title: 'Top stories',
+        },
+        {
+            id: 'tracking/commissioningdesk/uk-business',
+            type: 'Tracking',
+            title: 'UK Business',
+        },
+    ],
+    pillar: 'lifestyle',
+    isCommentable: false,
+    webURL:
+        'https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+    keyEvents: [],
+    showBottomSocialButtons: true,
+    isImmersive: false,
+    config: {
+        avatarApiUrl: 'https://avatar.theguardian.com',
+        references: [],
+        isProd: true,
+        shortUrlId: '/p/64ak8',
+        switches: {
+            abContributionsBannerArticlesViewed: false,
+            prebidTrustx: true,
+            scAdFreeBanner: true,
+            abCommercialXaxisAdapter: true,
+            enableSentryReporting: true,
+            lazyLoadContainers: true,
+            adFreeStrictExpiryEnforcement: false,
+            abCommercialAppnexusUsAdapter: true,
+            cmpUi: true,
+            remarketing: true,
+            registerWithPhone: false,
+            subscriptionBanner: true,
+            lotame: true,
+            targeting: true,
+            extendedMostPopularFronts: true,
+            slotBodyEnd: false,
+            emailInlineInFooter: true,
+            prebidPangaea: true,
+            adomik: true,
+            facebookTrackingPixel: true,
+            serviceWorkerEnabled: false,
+            iasAdTargeting: true,
+            extendedMostPopular: true,
+            abCommercialA9: true,
+            prebidAnalytics: true,
+            imrWorldwide: true,
+            abCommercialPangaeaAdapter: true,
+            twitterUwt: true,
+            membershipEngagementBannerBlockUs: false,
+            prebidAppnexusInvcode: true,
+            prebidAppnexus: true,
+            abContributionsEpicPrecontributionReminderRoundOne: true,
+            enableDiscussionSwitch: true,
+            enableConsentManagementService: true,
+            prebidXaxis: false,
+            oldTlsSupportDeprecation: true,
+            abContributionsEpicAskFourEarning: true,
+            usHeaderAndFooterSubscribeLinkSwitch: true,
+            interactiveFullHeaderSwitch: false,
+            discussionAllPageSize: true,
+            prebidUserSync: true,
+            audioOnwardJourneySwitch: true,
+            abSignInGateSecundus: false,
+            mobileStickyPrebid: true,
+            breakingNews: true,
+            externalVideoEmbeds: true,
+            simpleReach: true,
+            carrotTrafficDriver: true,
+            geoMostPopular: true,
+            weAreHiring: true,
+            relatedContent: true,
+            thirdPartyEmbedTracking: true,
+            prebidOzone: true,
+            commercialPageViewAnalytics: true,
+            prebidAdYouLike: true,
+            membershipEngagementBanner: true,
+            mostViewedFronts: true,
+            ampPrebid: true,
+            googleSearch: true,
+            membershipEngagementBannerBlockAu: false,
+            outbrain: true,
+            commercial: true,
+            plistaForOutbrainAu: true,
+            prebidSonobi: true,
+            membershipEngagementBannerBlockUk: false,
+            idProfileNavigation: true,
+            confiantAdVerification: true,
+            discussionAllowAnonymousRecommendsSwitch: false,
+            scrollDepth: true,
+            permutive: true,
+            krux: false,
+            webFonts: true,
+            prebidImproveDigital: true,
+            abCommercialPrebidSafeframe: true,
+            ophan: true,
+            abAcquisitionsEpicAlwaysAskIfTagged: true,
+            crosswordSvgThumbnails: true,
+            prebidTriplelift: true,
+            weather: true,
+            commercialOutbrainNewids: true,
+            abRemoteRenderEpic: true,
+            hostedVideoAutoplay: true,
+            engagementBannerTestsFromGoogleDocs: true,
+            prebidS2sozone: false,
+            abAdblockAsk: true,
+            prebidPubmatic: true,
+            useConfiguredEpicTests: true,
+            serverShareCounts: true,
+            autoRefresh: true,
+            enhanceTweets: true,
+            prebidIndexExchange: true,
+            prebidOpenx: true,
+            idCookieRefresh: true,
+            sharingComments: true,
+            discussionPageSize: true,
+            smartAppBanner: false,
+            dotcomRenderingAdvertisements: true,
+            abSubsBannerNewYearCopyTest: true,
+            prebidPangaeaUsAu: true,
+            boostGaUserTimingFidelity: false,
+            historyTags: true,
+            mobileStickyLeaderboard: true,
+            videojs: true,
+            surveys: true,
+            inizio: true,
+        },
+        hasYouTubeAtom: false,
+        inBodyInternalLinkCount: 15,
+        keywordIds:
+            'money/ticket-prices,money/consumer-affairs,money/money,technology/internet,money/viagogo',
+        blogIds: '',
+        sharedAdTargeting: {
+            ct: 'article',
+            co: ['rob-davies'],
+            url:
+                '/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+            su: ['0'],
+            edition: 'uk',
+            tn: ['news'],
+            p: 'ng',
+            k: [
+                'ticket-prices',
+                'consumer-affairs',
+                'internet',
+                'viagogo',
+                'money',
+            ],
+            sh: 'https://gu.com/p/64ak8',
+        },
+        beaconUrl: '//phar.gu-web.net',
+        campaigns: [],
+        calloutsUrl:
+            'https://callouts.code.dev-guardianapis.com/formstack-campaign/submit',
+        requiresMembershipAccess: false,
+        hasMultipleVideosInPage: false,
+        onwardWebSocket:
+            'ws://api.nextgen.guardianapps.co.uk/recently-published',
+        a9PublisherId: '3722',
+        pbIndexSites: [
+            { bp: 'D', id: 208236 },
+            { bp: 'M', id: 213509 },
+            { bp: 'T', id: 215444 },
+        ],
+        toneIds: 'tone/news',
+        dcrSentryDsn:
+            'https://1937ab71c8804b2b8438178dfdd6468f@sentry.io/1377847',
+        idWebAppUrl: 'https://oauth.theguardian.com',
+        discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
+        sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
+        omnitureAccount: 'guardiangu-network',
+        contributorBio: '',
+        pageCode: '3275216',
+        pillar: 'Lifestyle',
+        commercialBundleUrl:
+            'https://assets.guim.co.uk/javascripts/cb04b59461a2e131f0cf/graun.dotcom-rendering-commercial.js',
+        discussionApiClientHeader: 'nextgen',
+        membershipUrl: 'https://membership.theguardian.com',
+        cardStyle: 'news',
+        shouldHideReaderRevenue: true,
+        sentryHost: 'app.getsentry.com/35463',
+        shouldHideAdverts: true,
+        membershipAccess: '',
+        isPreview: false,
+        googletagJsUrl: '//www.googletagservices.com/tag/js/gpt.js',
+        supportUrl: 'https://support.theguardian.com',
+        hasShowcaseMainElement: false,
+        isColumn: false,
+        isPaidContent: false,
+        sectionName: 'Money',
+        mobileAppsAdUnitRoot: 'beta-guardian-app',
+        disableStickyTopBanner: true,
+        dfpAdUnitRoot: 'theguardian.com',
+        headline:
+            "Ticket touts face unlimited fines for using 'bots' to buy in bulk",
+        commentable: false,
+        idApiUrl: 'https://idapi.theguardian.com',
+        showRelatedContent: false,
+        commissioningDesks: 'uk-business',
+        inBodyExternalLinkCount: 1,
+        adUnit: '/59666047/theguardian.com/money/article/ng',
+        stripePublicToken: 'pk_live_2O6zPMHXNs2AGea4bAmq5R7Z',
+        videoDuration: 0,
+        stage: 'PROD',
+        idOAuthUrl: 'https://oauth.theguardian.com',
+        isSensitive: false,
+        isDev: false,
+        thirdPartyAppsAccount: 'guardiangu-thirdpartyapps',
+        richLink: '',
+        avatarImagesUrl: 'https://avatar.guim.co.uk',
+        trackingNames: 'UK Business',
+        fbAppId: '180444840287',
+        externalEmbedHost: 'https://embed.theguardian.com',
+        ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
+        keywords: 'Ticket prices,Consumer affairs,Money,Internet,Viagogo',
+        revisionNumber: 'DEV',
+        blogs: '',
+        section: 'money',
+        hasInlineMerchandise: false,
+        locationapiurl: '/weatherapi/locations?query=',
+        buildNumber: '33183',
+        isPhotoEssay: false,
+        ampIframeUrl:
+            'https://assets.guim.co.uk/data/vendor/a994b749adae30cd58f0e84c8fa28013/amp-iframe.html',
+        userAttributesApiUrl:
+            'https://members-data-api.theguardian.com/user-attributes',
+        isLive: false,
+        publication: 'The Guardian',
+        host: 'https://www.theguardian.com',
+        contentType: 'Article',
+        facebookIaAdUnitRoot: 'facebook-instant-articles',
+        ophanEmbedJsUrl: '//j.ophan.co.uk/ophan.embed',
+        idUrl: 'https://profile.theguardian.com',
+        thumbnail:
+            'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/500.jpg?quality=85&auto=format&fit=max&s=164668f5f3f138d374309e4eb61b6c76',
+        isFront: false,
+        wordCount: 738,
+        author: 'Rob Davies',
+        dfpAccountId: '59666047',
+        nonKeywordTagIds:
+            'type/article,tone/news,profile/rob-davies,publication/theguardian,theguardian/mainsection,theguardian/mainsection/topstories,tracking/commissioningdesk/uk-business',
+        pageId:
+            'money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+        forecastsapiurl: '/weatherapi/forecast',
+        assetsPath: 'https://assets.guim.co.uk/',
+        lightboxImages: {
+            id:
+                'money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+            headline:
+                "Ticket touts face unlimited fines for using 'bots' to buy in bulk",
+            shouldHideAdverts: true,
+            standfirst:
+                '<p><strong>Exclusive:</strong> Package of measures designed to curb growing power of ‘secondary ticketing’ industry and protect fans</p>',
+            images: [
+                {
+                    caption:
+                        'Tickets for the West End show Harry Potter and the Cursed Child at the Palace Theatre, London, are among those targeted by the secondary ticketing industry. ',
+                    credit: 'Photograph: Kirsty Wigglesworth/AP',
+                    displayCredit: true,
+                    src:
+                        'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=700&quality=85&auto=format&fit=max&s=3bb296f21d5550137205744239693735',
+                    srcsets:
+                        'https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=1920&quality=85&auto=format&fit=max&s=e8c37c0f4c819cd192743f909eb297af 1920w, https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=1225&quality=85&auto=format&fit=max&s=3b651224231aa99f560794079db720bb 1225w, https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=1065&quality=85&auto=format&fit=max&s=967e69d459a38c34474a2425f666b253 1065w, https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=965&quality=85&auto=format&fit=max&s=f90dbac480ed24ba2958e58f09eaa17f 965w, https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=725&quality=85&auto=format&fit=max&s=52cfe29790fb139ddc1896549ea12b40 725w, https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=645&quality=85&auto=format&fit=max&s=65e14e39bfbc77b4bf468f2bd3fd49b0 645w, https://i.guim.co.uk/img/media/c0c1beb4b6c6889b095fbb4aef36009222420d65/0_184_5015_3009/master/5015.jpg?width=465&quality=85&auto=format&fit=max&s=d74fc00b51b81ae309716d26928d3e82 465w',
+                    sizes:
+                        '(min-width: 1300px) 1920px, (min-width: 1140px) 1225px, (min-width: 980px) 1065px, (min-width: 740px) 965px, (min-width: 660px) 725px, (min-width: 480px) 645px, 465px',
+                    ratio: 1.6666666666666667,
+                    role: 'None',
+                    parentContentId:
+                        'money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+                    id:
+                        'money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+                },
+            ],
+        },
+        isImmersive: false,
+        dfpHost: 'pubads.g.doubleclick.net',
+        googletagUrl: '//www.googletagservices.com/tag/js/gpt.js',
+        mmaUrl: 'https://manage.theguardian.com',
+        hbImpl: { prebid: true, a9: true },
+        abTests: {
+            dotcomRenderingAdvertisementsVariant: 'variant',
+            oldTlsSupportDeprecationControl: 'control',
+        },
+        shortUrl: 'https://gu.com/p/64ak8',
+        isContent: true,
+        contentId:
+            'money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+        edition: 'UK',
+        discussionFrontendUrl:
+            'https://assets.guim.co.uk/discussion/discussion-frontend.preact.iife.8bdbd9194e.js',
+        ophanJsUrl: '//j.ophan.co.uk/ophan.ng',
+        productionOffice: 'Uk',
+        dfpNonRefreshableLineItemIds: [
+            66868167,
+            66972327,
+            68842407,
+            69144807,
+            69710127,
+            70516407,
+            70931847,
+            71342607,
+            72502287,
+            72503607,
+            73773207,
+            73829127,
+            74480367,
+            74645967,
+            74823567,
+            74824167,
+            75586767,
+            75588207,
+            76352007,
+            76437927,
+            76443087,
+            76443567,
+            76603287,
+            77324247,
+            77504847,
+            77546367,
+            77561007,
+            77590287,
+            77622207,
+            77747367,
+            78316047,
+            78455967,
+            78470967,
+            78507807,
+            78713607,
+            79009167,
+            79094487,
+            80502447,
+            80568087,
+            80568207,
+            80568327,
+            80568447,
+            80569047,
+            81002967,
+            82211367,
+            82339767,
+            82879287,
+            82881807,
+            83178927,
+            85253487,
+            85558287,
+            85961247,
+            86814567,
+            87004887,
+            87191607,
+            87726207,
+            87852807,
+            87878367,
+            88153527,
+            88333647,
+            88420407,
+            88526727,
+            88621527,
+            88861167,
+            89035647,
+            89035887,
+            89036607,
+            89084607,
+            89084967,
+            89141967,
+            89356167,
+            89743047,
+            89793087,
+            90159687,
+            90323007,
+            90359967,
+            90935367,
+            91095807,
+            91118247,
+            91732647,
+            91985967,
+            92216007,
+            92355087,
+            92436807,
+            92506887,
+            92681487,
+            92948847,
+            93121767,
+            93550767,
+            93717567,
+            93784887,
+            93785607,
+            93930207,
+            94193007,
+            94674927,
+            94822527,
+            95840847,
+            95931207,
+            96296367,
+            97911207,
+            97980687,
+            98151207,
+            98165247,
+            98610447,
+            98671647,
+            98893047,
+            101192247,
+            101476527,
+            101684007,
+            101999127,
+            102061647,
+            102066567,
+            102344847,
+            102790767,
+            102792207,
+            102892767,
+            102894687,
+            102895167,
+            102895647,
+            103062327,
+            104218407,
+            106736607,
+            107115927,
+            107235087,
+            107509047,
+            107955087,
+            108799287,
+            108893967,
+            109638687,
+            109648167,
+            109761807,
+            109831287,
+            111055527,
+            111057567,
+            112799127,
+            112882647,
+            112888527,
+            112950567,
+            113374647,
+            113880927,
+            114906327,
+            115133247,
+            116149647,
+            117980727,
+            118236687,
+            118631847,
+            118934247,
+            119632887,
+            121592967,
+            122583687,
+            123487167,
+            123873927,
+            123978567,
+            123996567,
+            123996927,
+            123997527,
+            124001247,
+            124418247,
+            125878047,
+            126003687,
+            126004167,
+            130630407,
+            130630647,
+            130686687,
+            130686807,
+            130693287,
+            130777407,
+            130840767,
+            130954407,
+            131115447,
+            131135007,
+            131652687,
+            132065367,
+            132325287,
+            132348327,
+            132758367,
+            133502127,
+            133852047,
+            133854327,
+            133989327,
+            134130087,
+            134567967,
+            134876607,
+            134979567,
+            135278007,
+            135292767,
+            135353727,
+            135773007,
+            135776847,
+            135826887,
+            135841887,
+            135850407,
+            136120767,
+            136236207,
+            136278807,
+            136455207,
+            136550247,
+            137025927,
+            137200287,
+            137382567,
+            140139567,
+            140711127,
+            141827967,
+            142466367,
+            142883847,
+            143109567,
+            144237927,
+            146321007,
+            146324607,
+            146326287,
+            146339727,
+            146355567,
+            147006447,
+            147500367,
+            147801807,
+            148154487,
+            148154607,
+            148446687,
+            148454487,
+            152119407,
+            152146047,
+            153546927,
+            154108047,
+            154108167,
+            154112007,
+            154112367,
+            154113087,
+            154113207,
+            154114887,
+            154125567,
+            154126407,
+            154290807,
+            154290927,
+            154291287,
+            154291407,
+            154291527,
+            154291887,
+            154295007,
+            154295967,
+            154297527,
+            154303287,
+            154303527,
+            154332087,
+            154386087,
+            154387407,
+            154391247,
+            154391967,
+            154392927,
+            154394847,
+            154540527,
+            154544247,
+            154693287,
+            154793967,
+            154794087,
+            155010327,
+            155010447,
+            158149767,
+            160437567,
+            163112127,
+            163372647,
+            165575127,
+            4345086236,
+            4345095356,
+            4345169885,
+            4345177565,
+            4345182855,
+            4345186250,
+            4349172433,
+            4360612711,
+            4360793649,
+            4371265570,
+            4371369115,
+            4393832120,
+            4400994377,
+            4428613611,
+            4443205897,
+            4451525654,
+            4480779579,
+            4498662865,
+            4512645730,
+            4516493673,
+            4516698376,
+            4517304218,
+            4517378559,
+            4517379732,
+            4517380203,
+            4539078702,
+            4539981050,
+            4546091198,
+            4548855586,
+            4549107258,
+            4552894255,
+            4555165414,
+            4555183615,
+            4555236856,
+            4555635725,
+            4555650690,
+            4555674903,
+            4555684517,
+            4555688577,
+            4556153989,
+            4556285026,
+            4556324359,
+            4556326294,
+            4556648082,
+            4556678787,
+            4557241378,
+            4557634755,
+            4557708173,
+            4557762374,
+            4557783054,
+            4557975570,
+            4558001894,
+            4558745950,
+            4558957661,
+            4559094602,
+            4559618101,
+            4560130208,
+            4560176292,
+            4560182777,
+            4579011086,
+            4579746196,
+            4584262791,
+            4586005424,
+            4586012639,
+            4598413679,
+            4600377077,
+            4608554346,
+            4612781170,
+            4613725167,
+            4631660550,
+            4652061785,
+            4659761500,
+            4666709965,
+            4667573429,
+            4671027724,
+            4671116147,
+            4680579583,
+            4680686606,
+            4684616813,
+            4688643082,
+            4689601181,
+            4689828177,
+            4698081076,
+            4698085906,
+            4698483837,
+            4698485673,
+            4698836785,
+            4700389583,
+            4702727917,
+            4705009339,
+            4706776058,
+            4715712191,
+            4719669541,
+            4739368280,
+            4740423257,
+            4741268540,
+            4741269263,
+            4752748306,
+            4770577846,
+            4794336160,
+            4795460127,
+            4801997974,
+            4813434715,
+            4814193728,
+            4816151238,
+            4818099525,
+            4833940287,
+            4843101319,
+            4843259745,
+            4851611473,
+            4875004757,
+            4889122311,
+            4894471199,
+            4898516140,
+            4899249557,
+            4900192015,
+            4914559913,
+            4948313020,
+            4948313458,
+            4949099173,
+            4950965688,
+            4953561994,
+            4954044942,
+            4956216414,
+            4956359904,
+            4957449531,
+            4957639563,
+            4963347489,
+            4963865755,
+            4964615668,
+            4970750314,
+            4972816526,
+            4974103111,
+            4974150367,
+            4974378154,
+            4974421332,
+            4974425718,
+            4974440616,
+            4974909599,
+            4974917942,
+            4979472123,
+            4979611347,
+            4980225738,
+            4981770423,
+            4986877832,
+            4986883844,
+            4988662283,
+            4988900800,
+            4992010014,
+            4994594770,
+            4995359684,
+            4995363299,
+            4995664790,
+            4999774536,
+            5000134545,
+            5000531182,
+            5000790614,
+            5002624314,
+            5004234716,
+            5008215061,
+            5008428214,
+            5008745198,
+            5014861653,
+            5015013326,
+            5017538127,
+            5017618519,
+            5017627117,
+            5017870049,
+            5017880045,
+            5017883228,
+            5017885847,
+            5018142683,
+            5022785722,
+            5025139359,
+            5030227901,
+            5031882476,
+            5032005985,
+            5033068546,
+            5033399504,
+            5043072122,
+            5044224363,
+            5048369906,
+            5048446713,
+            5048474394,
+            5048578765,
+            5048623579,
+            5048855939,
+            5048896271,
+            5050809297,
+            5051271119,
+            5051688660,
+            5051862705,
+            5052097433,
+            5058276148,
+            5058861737,
+            5060861401,
+            5070734376,
+            5074013907,
+            5075292382,
+            5080503991,
+            5080700777,
+            5084422705,
+            5084769575,
+            5086430628,
+            5089439429,
+            5089656445,
+            5092818847,
+            5094408955,
+            5094978878,
+            5095477169,
+            5100382690,
+            5106137416,
+            5106578097,
+            5108771973,
+            5108801259,
+            5108834289,
+            5109414149,
+            5109477985,
+            5112760220,
+            5114958382,
+            5115460784,
+            5119369095,
+            5119589887,
+            5119608376,
+            5119622833,
+            5120038706,
+            5120633507,
+            5122977293,
+            5124775878,
+            5125813833,
+            5126210840,
+            5132699513,
+            5133611676,
+            5133616221,
+            5134921406,
+            5135185825,
+            5135800503,
+            5135919817,
+            5136222120,
+            5138121327,
+            5138315476,
+            5138858096,
+            5139829373,
+            5139840665,
+            5140474550,
+            5144321936,
+            5146213631,
+            5149375150,
+            5151561498,
+            5153027495,
+            5153589998,
+            5154348200,
+            5154699509,
+            5159413879,
+            5159854943,
+            5159859116,
+            5159942800,
+            5163825115,
+            5164704205,
+            5168254035,
+            5168480847,
+            5168728930,
+            5168743192,
+            5168757037,
+            5168769787,
+            5168772901,
+            5168778655,
+            5168970951,
+            5168989869,
+            5169221645,
+            5169233267,
+            5169280048,
+            5169303034,
+            5169331108,
+            5169711263,
+            5169713450,
+            5169776357,
+            5170070115,
+            5171648064,
+            5171650710,
+            5171896510,
+            5172351482,
+            5174265103,
+            5174441005,
+            5175952556,
+            5176804734,
+            5179364348,
+            5182269069,
+            5184981581,
+            5188523710,
+            5188524448,
+            5189431118,
+            5189548223,
+            5189828618,
+            5191810924,
+            5192098697,
+            5193340753,
+            5193544766,
+            5194297564,
+            5198567242,
+            5198762566,
+            5199544925,
+            5199894385,
+            5200250154,
+            5202346462,
+            5202735047,
+            5203815492,
+            5204846310,
+            5207674965,
+            5208066656,
+            5210336775,
+            5213865762,
+            5214330163,
+            5214574966,
+            5215350402,
+            5216601102,
+            5221774258,
+            5222871346,
+            5224972730,
+            5228690379,
+            5230445460,
+            5230787472,
+            5232420946,
+            5232724060,
+            5233477608,
+            5234306368,
+            5235889561,
+            5237536072,
+            5239370859,
+            5239610122,
+            5240124892,
+            5240125189,
+            5243391588,
+            5244514933,
+            5244515179,
+            5245089789,
+            5246856420,
+            5247061830,
+            5247376316,
+            5249109579,
+            5249412878,
+            5249601981,
+            5249951978,
+            5250544014,
+            5250580464,
+            5251098692,
+            5251160132,
+            5252381002,
+            5252759738,
+            5255393980,
+            5255556611,
+            5256506837,
+            5262457809,
+            5262459972,
+            5263265980,
+            5263323816,
+            5263634639,
+            5264553263,
+            5264553578,
+            5265568262,
+            5265770329,
+            5265816662,
+            5266175458,
+            5266175887,
+            5266175890,
+            5266307404,
+            5266542660,
+            5266560195,
+            5266581080,
+            5266942441,
+            5267368009,
+            5267511755,
+            5267513642,
+            5267743679,
+            5267744291,
+            5268949598,
+            5272012695,
+            5272864458,
+            5272978506,
+            5273035174,
+            5274077999,
+            5274199911,
+            5275649500,
+            5275864745,
+            5276285433,
+            5276745809,
+            5277107277,
+            5277107403,
+            5277108141,
+            5277318463,
+            5277410634,
+            5278187913,
+            5278357439,
+            5278753376,
+            5279467867,
+            5280773724,
+            5281116862,
+            5281591595,
+            5281772778,
+            5282021677,
+            5282473111,
+            5282817776,
+            5283964984,
+            5286073415,
+            5286073592,
+            5286074771,
+            5286075083,
+            5286867299,
+            5287997419,
+            5288243957,
+            5288867037,
+            5290045100,
+            5291373087,
+            5292107247,
+            5292107481,
+            5292108600,
+            5292108654,
+            5292112480,
+            5292242146,
+            5292326384,
+            5293402784,
+            5293749332,
+            5294751966,
+            5294756358,
+            5294943513,
+            5294951442,
+            5295184531,
+            5295449474,
+            5295793156,
+            5295885078,
+            5295908809,
+            5295912856,
+            5295923206,
+            5295997419,
+            5296142792,
+            5296165115,
+            5296174964,
+            5296186976,
+            5296791760,
+            5296958103,
+            5297194961,
+            5297371370,
+            5297792777,
+            5298147491,
+            5298193115,
+            5298742296,
+            5299562343,
+            5299650958,
+            5299651081,
+            5299899000,
+            5299930718,
+            5300800228,
+            5300802142,
+            5303360554,
+            5303718651,
+            5303758551,
+            5303759250,
+            5304865373,
+            5304918365,
+            5304918368,
+            5305522012,
+            5305962214,
+            5306027703,
+            5306886406,
+            5307038116,
+            5307792237,
+            5308175989,
+            5308176679,
+            5308699342,
+        ],
+        tones: 'News',
+        plistaPublicApiKey: '462925f4f131001fd974bebe',
+        isLiveBlog: false,
+        frontendAssetsFullURL: 'https://assets.guim.co.uk/',
+        googleSearchId: '007466294097402385199:m2ealvuxh1i',
+        allowUserGeneratedContent: false,
+        byline: 'Rob Davies',
+        authorIds: 'profile/rob-davies',
+        webPublicationDate: 1489173305000,
+        omnitureAmpAccount: 'guardiangu-thirdpartyapps',
+        isHosted: false,
+        hasPageSkin: false,
+        webTitle:
+            "Ticket touts face unlimited fines for using 'bots' to buy in bulk",
+        discussionD2Uid: 'zHoBy6HNKsk',
+        weatherapiurl: '/weatherapi/city',
+        googleSearchUrl: '//www.google.co.uk/cse/cse.js',
+        optimizeEpicUrl:
+            'https://support.theguardian.com/epic/control/index.html',
+        isSplash: false,
+        isNumberedList: false,
+    },
+    sectionLabel: 'Ticket prices',
+});

--- a/src/lib/ad-targeting.test.ts
+++ b/src/lib/ad-targeting.test.ts
@@ -31,8 +31,7 @@ describe('buildAdTargeting', () => {
         },
     };
 
-    it.skip('builds adTargeting correctly', () => {
-        // TODO FIX ME
+    it('builds adTargeting correctly', () => {
         expect(buildAdTargeting(CAPI.config)).toEqual(expectedAdTargeting);
     });
 });

--- a/src/model/extract-ga.test.ts
+++ b/src/model/extract-ga.test.ts
@@ -14,15 +14,14 @@ const base = {
         'money/ticket-prices,money/consumer-affairs,money/money,technology/internet,money/viagogo',
     pillar: 'lifestyle',
     section: 'money',
-    seriesId: '',
+    seriesId: 'testseries',
     toneIds: 'tone/news',
     webTitle:
         "Ticket touts face unlimited fines for using 'bots' to buy in bulk",
 };
 
 describe('Google Analytics extracts and formats CAPI response correctly', () => {
-    it.skip('GA Extract returns correctly formatted GA response', () => {
-        // TODO FIX ME
+    it('GA Extract returns correctly formatted GA response', () => {
         expect(extract(CAPI)).toEqual(base);
     });
 });


### PR DESCRIPTION
## What does this change?

I had to turn off some tests as updating the CAPI fixture caused a load of Type issues. I'm now accepting the fixture as an object and casting to CAPIType later (as per the PROD flow for this JSON).  

I also separated out any modifications to the object into separate functions.

## Why?

Turn on the tests and we can now update the fixture object without worrying about it having been modified directly.

## Link to supporting Trello card

https://trello.com/c/ZQjEWr0Y
https://trello.com/c/t6VQ6MtL
