### PR TITLE
Epic geolocation & contributions

### DIFF
--- a/src/web/browser/App.tsx
+++ b/src/web/browser/App.tsx
@@ -57,10 +57,6 @@ const App = ({ CAPI, NAV }: Props) => {
         callFetch();
     }, []);
 
-    console.log(
-        `TODO: Now that we have countryCode ${countryCode} then we should use it (Andre, I'm looking at you)`,
-    );
-
     const richLinks: {
         element: RichLinkBlockElement;
         root: RootType;

--- a/src/web/browser/App.tsx
+++ b/src/web/browser/App.tsx
@@ -140,16 +140,20 @@ const App = ({ CAPI, NAV }: Props) => {
             <Portal root="most-viewed-right">
                 <MostViewedRightWrapper pillar={CAPI.pillar} />
             </Portal>
-            <Portal root="slot-body-end">
-                <SlotBodyEnd
-                    contentType={CAPI.contentType}
-                    sectionName={CAPI.sectionName}
-                    shouldHideReaderRevenue={CAPI.shouldHideReaderRevenue}
-                    isMinuteArticle={CAPI.pageType.isMinuteArticle}
-                    isPaidContent={CAPI.pageType.isPaidContent}
-                    tags={CAPI.tags}
-                />
-            </Portal>
+            {isSignedIn !== undefined && countryCode !== undefined && (
+                <Portal root="slot-body-end">
+                    <SlotBodyEnd
+                        isSignedIn={isSignedIn}
+                        countryCode={countryCode}
+                        contentType={CAPI.contentType}
+                        sectionName={CAPI.sectionName}
+                        shouldHideReaderRevenue={CAPI.shouldHideReaderRevenue}
+                        isMinuteArticle={CAPI.pageType.isMinuteArticle}
+                        isPaidContent={CAPI.pageType.isPaidContent}
+                        tags={CAPI.tags}
+                    />
+                </Portal>
+            )}
             <Portal root="onwards-content">
                 <Onwards
                     ajaxUrl={CAPI.config.ajaxUrl}

--- a/src/web/browser/App.tsx
+++ b/src/web/browser/App.tsx
@@ -53,9 +53,8 @@ const App = ({ CAPI, NAV }: Props) => {
     }, []);
 
     useEffect(() => {
-        const callFetch = async () => {
-            setCountryCode(await getCountryCode());
-        };
+        const callFetch = async () =>
+            setCountryCode((await getCountryCode()) || '');
         callFetch();
     }, []);
 

--- a/src/web/browser/App.tsx
+++ b/src/web/browser/App.tsx
@@ -138,6 +138,7 @@ const App = ({ CAPI, NAV }: Props) => {
             <Portal root="most-viewed-right">
                 <MostViewedRightWrapper pillar={CAPI.pillar} />
             </Portal>
+            {/* Ensure component only renders after both variables have been assigned true or false */}
             {isSignedIn !== undefined && countryCode !== undefined && (
                 <Portal root="slot-body-end">
                     <SlotBodyEnd

--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { css } from 'emotion';
 import {
-    getShowSupportMessaging,
-    getIsRecurringContributor,
-    lastOneOffContributionDate,
+    shouldShowSupportMessaging,
+    isRecurringContributor,
+    getLastOneOffContributionDate,
 } from '@root/src/web/lib/contributions';
 
 const wrapperMargins = css`
@@ -56,14 +56,15 @@ export const SlotBodyEnd = ({
                     isMinuteArticle,
                     isPaidContent,
                     tags,
-                    showSupportMessaging: getShowSupportMessaging(),
-                    isRecurringContributor: getIsRecurringContributor(isSignedIn),
-                    lastOneOffContributionDate: lastOneOffContributionDate(),
+                    showSupportMessaging: shouldShowSupportMessaging(),
+                    isRecurringContributor: isRecurringContributor(isSignedIn),
+                    lastOneOffContributionDate: getLastOneOffContributionDate(),
                 },
             };
 
             const getEpicContent = () => {
-                const endpointUrl = 'https://contributions.guardianapis.com/epic';
+                // const endpointUrl = 'https://contributions.guardianapis.com/epic';
+                const endpointUrl = 'http://localhost:8081/epic';
                 return fetch(endpointUrl, {
                     method: 'POST',
                     headers: {

--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -63,8 +63,7 @@ export const SlotBodyEnd = ({
             };
 
             const getEpicContent = () => {
-                // const endpointUrl = 'https://contributions.guardianapis.com/epic';
-                const endpointUrl = 'http://localhost:8081/epic';
+                const endpointUrl = 'https://contributions.guardianapis.com/epic';
                 return fetch(endpointUrl, {
                     method: 'POST',
                     headers: {

--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -60,7 +60,7 @@ export const SlotBodyEnd = ({
 
     const { data: bodyResponse, error } = useApi<{
         data: { html: string; css: string };
-    }>('http://localhost:8081/epic', {
+    }>('https://contributions.guardianapis.com/epic', {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',

--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -63,8 +63,8 @@ export const SlotBodyEnd = ({
             };
 
             const getEpicContent = () => {
-                const endpointUrl = 'https://contributions.guardianapis.com/epic';
-                return fetch(endpointUrl, {
+                return fetch('http://localhost:8081/epic', {
+                // return fetch('https://contributions.guardianapis.com/epic', {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',

--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -7,6 +7,8 @@ const wrapperMargins = css`
 `;
 
 type Props = {
+    isSignedIn: boolean;
+    countryCode: string;
     contentType: string;
     sectionName?: string;
     shouldHideReaderRevenue: boolean;
@@ -16,6 +18,8 @@ type Props = {
 };
 
 export const SlotBodyEnd = ({
+    isSignedIn,
+    countryCode,
     contentType,
     sectionName,
     shouldHideReaderRevenue,

--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -35,7 +35,6 @@ export const SlotBodyEnd = ({
 
     useEffect(() => {
         const callFetch = async () => {
-
             // Putting together the request payload
             const contributionsPayload = {
                 tracking: {
@@ -64,8 +63,7 @@ export const SlotBodyEnd = ({
             };
 
             const getEpicContent = () => {
-                const endpointUrl = 'http://localhost:8081/epic';
-                // const endpointUrl = 'https://contributions.guardianapis.com/epic';
+                const endpointUrl = 'https://contributions.guardianapis.com/epic';
                 return fetch(endpointUrl, {
                     method: 'POST',
                     headers: {

--- a/src/web/lib/contributions.test.ts
+++ b/src/web/lib/contributions.test.ts
@@ -4,7 +4,7 @@ import {
     SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE,
 } from './contributions';
 
-const setCookie = (name: string, value: string) => {
+const setCookie = (name: string, value: string | number) => {
     Object.defineProperty(window.document, 'cookie', {
         writable: true,
         value: `${name}=${value}`,
@@ -28,14 +28,16 @@ describe('getLastOneOffContributionDate', () => {
 
     it('returns date from attributes cookie if only cookie found', () => {
         const somePastDate = '2020-01-28';
-        const formattedPastDate = Date.parse(somePastDate).toString();
         setCookie(ONE_OFF_CONTRIBUTION_DATE_COOKIE, somePastDate);
         const lastOneOffContributionDate = getLastOneOffContributionDate();
-        expect(lastOneOffContributionDate).toBe(formattedPastDate);
+
+        // Our function will convert YYYY-MM-DD into a timestamp
+        const somePastDateToTimestamp = Date.parse(somePastDate);
+        expect(lastOneOffContributionDate).toBe(somePastDateToTimestamp);
     });
 
     it('returns a support cookie date if only cookie found', () => {
-        const somePastDate = '1582567969093';
+        const somePastDate = 1582567969093;
         setCookie(SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE, somePastDate);
         const lastOneOffContributionDate = getLastOneOffContributionDate();
         expect(lastOneOffContributionDate).toBe(somePastDate);
@@ -45,7 +47,7 @@ describe('getLastOneOffContributionDate', () => {
         const muchLongerAgo = '2020-01-28';
         setCookie(ONE_OFF_CONTRIBUTION_DATE_COOKIE, muchLongerAgo);
 
-        const notSoLongAgo = '1582567969093';
+        const notSoLongAgo = 1582567969093;
         setCookie(SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE, notSoLongAgo);
 
         const lastOneOffContributionDate = getLastOneOffContributionDate();
@@ -57,11 +59,11 @@ describe('getLastOneOffContributionDate', () => {
         setCookie(SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE, 'OR_THIS');
 
         const lastOneOffContributionDate = getLastOneOffContributionDate();
-        expect(lastOneOffContributionDate).toBe('');
+        expect(lastOneOffContributionDate).toBeUndefined();
     });
 
     it('returns an empty string if no one-off contribution found', () => {
         const lastOneOffContributionDate = getLastOneOffContributionDate();
-        expect(lastOneOffContributionDate).toBe('');
+        expect(lastOneOffContributionDate).toBeUndefined();
     });
 });

--- a/src/web/lib/contributions.test.ts
+++ b/src/web/lib/contributions.test.ts
@@ -1,15 +1,9 @@
+import { addCookie } from '../browser/cookie';
 import {
     getLastOneOffContributionDate,
     ONE_OFF_CONTRIBUTION_DATE_COOKIE,
     SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE,
 } from './contributions';
-
-const setCookie = (name: string, value: string | number) => {
-    Object.defineProperty(window.document, 'cookie', {
-        writable: true,
-        value: `${name}=${value}`,
-    });
-};
 
 const clearAllCookies = () => {
     const cookies = document.cookie.split(';');
@@ -28,7 +22,7 @@ describe('getLastOneOffContributionDate', () => {
 
     it('returns date from attributes cookie if only cookie found', () => {
         const somePastDate = '2020-01-28';
-        setCookie(ONE_OFF_CONTRIBUTION_DATE_COOKIE, somePastDate);
+        addCookie(ONE_OFF_CONTRIBUTION_DATE_COOKIE, somePastDate);
         const lastOneOffContributionDate = getLastOneOffContributionDate();
 
         // Our function will convert YYYY-MM-DD into a timestamp
@@ -38,25 +32,25 @@ describe('getLastOneOffContributionDate', () => {
 
     it('returns a support cookie date if only cookie found', () => {
         const somePastDate = 1582567969093;
-        setCookie(SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE, somePastDate);
+        addCookie(SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE, String(somePastDate));
         const lastOneOffContributionDate = getLastOneOffContributionDate();
         expect(lastOneOffContributionDate).toBe(somePastDate);
     });
 
     it('returns the most recent date if both cookies present', () => {
         const muchLongerAgo = '2020-01-28';
-        setCookie(ONE_OFF_CONTRIBUTION_DATE_COOKIE, muchLongerAgo);
+        addCookie(ONE_OFF_CONTRIBUTION_DATE_COOKIE, muchLongerAgo);
 
         const notSoLongAgo = 1582567969093;
-        setCookie(SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE, notSoLongAgo);
+        addCookie(SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE, String(notSoLongAgo));
 
         const lastOneOffContributionDate = getLastOneOffContributionDate();
         expect(lastOneOffContributionDate).toBe(notSoLongAgo);
     });
 
     it('returns an empty string if no dates can be parsed correctly', () => {
-        setCookie(ONE_OFF_CONTRIBUTION_DATE_COOKIE, 'CANT_TOUCH_THIS');
-        setCookie(SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE, 'OR_THIS');
+        addCookie(ONE_OFF_CONTRIBUTION_DATE_COOKIE, 'CANT_TOUCH_THIS');
+        addCookie(SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE, 'OR_THIS');
 
         const lastOneOffContributionDate = getLastOneOffContributionDate();
         expect(lastOneOffContributionDate).toBeUndefined();

--- a/src/web/lib/contributions.test.ts
+++ b/src/web/lib/contributions.test.ts
@@ -53,11 +53,8 @@ describe('getLastOneOffContributionDate', () => {
     });
 
     it('returns an empty string if no dates can be parsed correctly', () => {
-        const noDate1 = 'CANT_TOUCH_THIS';
-        setCookie(ONE_OFF_CONTRIBUTION_DATE_COOKIE, noDate1);
-
-        const noDate2 = 'OR_THIS';
-        setCookie(SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE, noDate2);
+        setCookie(ONE_OFF_CONTRIBUTION_DATE_COOKIE, 'CANT_TOUCH_THIS');
+        setCookie(SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE, 'OR_THIS');
 
         const lastOneOffContributionDate = getLastOneOffContributionDate();
         expect(lastOneOffContributionDate).toBe('');

--- a/src/web/lib/contributions.test.ts
+++ b/src/web/lib/contributions.test.ts
@@ -1,0 +1,70 @@
+import {
+    getLastOneOffContributionDate,
+    ONE_OFF_CONTRIBUTION_DATE_COOKIE,
+    SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE,
+} from './contributions';
+
+const setCookie = (name: string, value: string) => {
+    Object.defineProperty(window.document, 'cookie', {
+        writable: true,
+        value: `${name}=${value}`,
+    });
+};
+
+const clearAllCookies = () => {
+    const cookies = document.cookie.split(';');
+
+    // eslint-disable-next-line no-plusplus
+    for (let i = 0; i < cookies.length; i++) {
+        const cookie = cookies[i];
+        const eqPos = cookie.indexOf('=');
+        const name = eqPos > -1 ? cookie.substr(0, eqPos) : cookie;
+        document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+    }
+};
+
+describe('getLastOneOffContributionDate', () => {
+    beforeEach(clearAllCookies);
+
+    it('returns date from attributes cookie if only cookie found', () => {
+        const somePastDate = '2020-01-28';
+        const formattedPastDate = Date.parse(somePastDate).toString();
+        setCookie(ONE_OFF_CONTRIBUTION_DATE_COOKIE, somePastDate);
+        const lastOneOffContributionDate = getLastOneOffContributionDate();
+        expect(lastOneOffContributionDate).toBe(formattedPastDate);
+    });
+
+    it('returns a support cookie date if only cookie found', () => {
+        const somePastDate = '1582567969093';
+        setCookie(SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE, somePastDate);
+        const lastOneOffContributionDate = getLastOneOffContributionDate();
+        expect(lastOneOffContributionDate).toBe(somePastDate);
+    });
+
+    it('returns the most recent date if both cookies present', () => {
+        const muchLongerAgo = '2020-01-28';
+        setCookie(ONE_OFF_CONTRIBUTION_DATE_COOKIE, muchLongerAgo);
+
+        const notSoLongAgo = '1582567969093';
+        setCookie(SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE, notSoLongAgo);
+
+        const lastOneOffContributionDate = getLastOneOffContributionDate();
+        expect(lastOneOffContributionDate).toBe(notSoLongAgo);
+    });
+
+    it('returns an empty string if no dates can be parsed correctly', () => {
+        const noDate1 = 'CANT_TOUCH_THIS';
+        setCookie(ONE_OFF_CONTRIBUTION_DATE_COOKIE, noDate1);
+
+        const noDate2 = 'OR_THIS';
+        setCookie(SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE, noDate2);
+
+        const lastOneOffContributionDate = getLastOneOffContributionDate();
+        expect(lastOneOffContributionDate).toBe('');
+    });
+
+    it('returns an empty string if no one-off contribution found', () => {
+        const lastOneOffContributionDate = getLastOneOffContributionDate();
+        expect(lastOneOffContributionDate).toBe('');
+    });
+});

--- a/src/web/lib/contributions.tsx
+++ b/src/web/lib/contributions.tsx
@@ -54,7 +54,7 @@ export const isRecurringContributor = (isSignedIn: boolean): boolean => {
 // SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE (support cookie, when making one-off contribution)
 // Get the date of the latest one-off contribution by looking at the two relevant cookies
 // and returning a Unix epoch string of the latest date found.
-export const getLastOneOffContributionDate = (): string => {
+export const getLastOneOffContributionDate = (): number | undefined => {
     // Attributes cookie - expects YYYY-MM-DD
     const contributionDateFromAttributes = getCookie(
         ONE_OFF_CONTRIBUTION_DATE_COOKIE,
@@ -65,28 +65,23 @@ export const getLastOneOffContributionDate = (): string => {
         SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE,
     );
 
-    try {
-        // Parse dates into common format so they can be compared
-        const parsedDateFromAttributes = contributionDateFromAttributes
-            ? Date.parse(contributionDateFromAttributes)
-            : 0;
-        const parsedDateFromSupport = contributionDateFromSupport
-            ? parseInt(contributionDateFromSupport, 10)
-            : 0;
-
-        // Determine the latest of two dates
-        const latestOnOffContributionDate = Math.max(
-            parsedDateFromAttributes,
-            parsedDateFromSupport,
-        );
-
-        // Return stringified latest contribution date
-        return latestOnOffContributionDate
-            ? String(latestOnOffContributionDate)
-            : '';
-    } catch (e) {
-        // eslint-disable-next-line no-console
-        console.log('Could not parse latestOneOffContribution date');
-        return '';
+    if (!contributionDateFromAttributes && !contributionDateFromSupport) {
+        return undefined;
     }
+
+    // Parse dates into common format so they can be compared
+    const parsedDateFromAttributes = contributionDateFromAttributes
+        ? Date.parse(contributionDateFromAttributes)
+        : 0;
+    const parsedDateFromSupport = contributionDateFromSupport
+        ? parseInt(contributionDateFromSupport, 10)
+        : 0;
+
+    // Return most recent date
+    // Condition only passed if 'parsedDateFromAttributes' is NOT NaN
+    if (parsedDateFromAttributes > parsedDateFromSupport) {
+        return parsedDateFromAttributes;
+    }
+
+    return parsedDateFromSupport || undefined; // This guards against 'parsedDateFromSupport' being NaN
 };

--- a/src/web/lib/contributions.tsx
+++ b/src/web/lib/contributions.tsx
@@ -1,0 +1,92 @@
+import { getCookie } from '@root/src/web/browser/cookie';
+
+// User Atributes API cookies (dropped on sign-in)
+const HIDE_SUPPORT_MESSAGING_COOKIE = 'gu_hide_support_messaging';
+const RECURRING_CONTRIBUTOR_COOKIE = 'gu_recurring_contributor';
+const ONE_OFF_CONTRIBUTION_DATE_COOKIE = 'gu_one_off_contribution_date';
+
+// Support Frontend cookies (dropped when contribution is made)
+const SUPPORT_RECURRING_CONTRIBUTOR_MONTHLY_COOKIE =
+    'gu.contributions.recurring.contrib-timestamp.Monthly';
+const SUPPORT_RECURRING_CONTRIBUTOR_ANNUAL_COOKIE =
+    'gu.contributions.recurring.contrib-timestamp.Annual';
+const SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE =
+    'gu.contributions.contrib-timestamp';
+
+// Cookie set by the User Attributes API upon signing in.
+// Value computed server-side and looks at all of the user's active products,
+// including but not limited to recurring & one-off contributions,
+// paper & digital subscriptions, as well as user tiers (GU supporters/staff/partners/patrons).
+// https://github.com/guardian/members-data-api/blob/3a72dc00b9389968d91e5930686aaf34d8040c52/membership-attribute-service/app/models/Attributes.scala
+export const getShowSupportMessaging = (): boolean => {
+    const hideSupportMessaging =
+        getCookie(HIDE_SUPPORT_MESSAGING_COOKIE) === 'true';
+
+    return !hideSupportMessaging;
+};
+
+// Determine if user is a recurring contributor by checking if they are signed in
+// AND have at least one of the relevant cookies.
+// We need to look at both User Attributes and Frontend Support cookies
+// as the former might not reflect the latest contributor status, since it's set upon signing in.
+// Frontend Support cookies are set when a contribution is made.
+export const getIsRecurringContributor = (isSignedIn: boolean): boolean => {
+    // Attributes cookie - we want this to have a specific value
+    const isRecurringContributor =
+        getCookie(RECURRING_CONTRIBUTOR_COOKIE) === 'true';
+
+    // Support cookies - we only care whether these exist
+    const hasMonthlyContributionCookie =
+        getCookie(SUPPORT_RECURRING_CONTRIBUTOR_MONTHLY_COOKIE) !== null;
+    const hasAnnualContributionCookie =
+        getCookie(SUPPORT_RECURRING_CONTRIBUTOR_ANNUAL_COOKIE) !== null;
+
+    return (
+        isSignedIn &&
+        (isRecurringContributor ||
+            hasMonthlyContributionCookie ||
+            hasAnnualContributionCookie)
+    );
+};
+
+// looks at attribute and support cookies
+// ONE_OFF_CONTRIBUTION_DATE_COOKIE (attributes cookie, when loggin in)
+// SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE (support cookie, when making one-off contribution)
+// Get the date of the latest one-off contribution by looking at the two relevant cookies
+// and returning a Unix epoch string of the latest date found.
+export const lastOneOffContributionDate = (): string => {
+    // Attributes cookie - expects YYYY-MM-DD
+    const contributionDateFromAttributes = getCookie(
+        ONE_OFF_CONTRIBUTION_DATE_COOKIE,
+    );
+
+    // Support cookies - expects Unix epoch
+    const contributionDateFromSupport = getCookie(
+        SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE,
+    );
+
+    try {
+        // Parse dates into common format so they can be compared
+        const parsedDateFromAttributes = contributionDateFromAttributes
+            ? Date.parse(contributionDateFromAttributes)
+            : 0;
+        const parsedDateFromSupport = contributionDateFromSupport
+            ? parseInt(contributionDateFromSupport, 10)
+            : 0;
+
+        // Determine the latest of two dates
+        const latestOnOffContributionDate = Math.max(
+            parsedDateFromAttributes,
+            parsedDateFromSupport,
+        );
+
+        // Return stringified latest contribution date
+        return latestOnOffContributionDate
+            ? String(latestOnOffContributionDate)
+            : '';
+    } catch (e) {
+        // eslint-disable-next-line no-console
+        console.log('Could not parse latestOneOffContribution date');
+        return '';
+    }
+};

--- a/src/web/lib/contributions.tsx
+++ b/src/web/lib/contributions.tsx
@@ -1,16 +1,16 @@
 import { getCookie } from '@root/src/web/browser/cookie';
 
 // User Atributes API cookies (dropped on sign-in)
-const HIDE_SUPPORT_MESSAGING_COOKIE = 'gu_hide_support_messaging';
-const RECURRING_CONTRIBUTOR_COOKIE = 'gu_recurring_contributor';
-const ONE_OFF_CONTRIBUTION_DATE_COOKIE = 'gu_one_off_contribution_date';
+export const HIDE_SUPPORT_MESSAGING_COOKIE = 'gu_hide_support_messaging';
+export const RECURRING_CONTRIBUTOR_COOKIE = 'gu_recurring_contributor';
+export const ONE_OFF_CONTRIBUTION_DATE_COOKIE = 'gu_one_off_contribution_date';
 
 // Support Frontend cookies (dropped when contribution is made)
-const SUPPORT_RECURRING_CONTRIBUTOR_MONTHLY_COOKIE =
+export const SUPPORT_RECURRING_CONTRIBUTOR_MONTHLY_COOKIE =
     'gu.contributions.recurring.contrib-timestamp.Monthly';
-const SUPPORT_RECURRING_CONTRIBUTOR_ANNUAL_COOKIE =
+export const SUPPORT_RECURRING_CONTRIBUTOR_ANNUAL_COOKIE =
     'gu.contributions.recurring.contrib-timestamp.Annual';
-const SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE =
+export const SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE =
     'gu.contributions.contrib-timestamp';
 
 // Cookie set by the User Attributes API upon signing in.
@@ -18,7 +18,7 @@ const SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE =
 // including but not limited to recurring & one-off contributions,
 // paper & digital subscriptions, as well as user tiers (GU supporters/staff/partners/patrons).
 // https://github.com/guardian/members-data-api/blob/3a72dc00b9389968d91e5930686aaf34d8040c52/membership-attribute-service/app/models/Attributes.scala
-export const getShowSupportMessaging = (): boolean => {
+export const shouldShowSupportMessaging = (): boolean => {
     const hideSupportMessaging =
         getCookie(HIDE_SUPPORT_MESSAGING_COOKIE) === 'true';
 
@@ -30,9 +30,9 @@ export const getShowSupportMessaging = (): boolean => {
 // We need to look at both User Attributes and Frontend Support cookies
 // as the former might not reflect the latest contributor status, since it's set upon signing in.
 // Frontend Support cookies are set when a contribution is made.
-export const getIsRecurringContributor = (isSignedIn: boolean): boolean => {
+export const isRecurringContributor = (isSignedIn: boolean): boolean => {
     // Attributes cookie - we want this to have a specific value
-    const isRecurringContributor =
+    const isRecurringContributorFromAttrs =
         getCookie(RECURRING_CONTRIBUTOR_COOKIE) === 'true';
 
     // Support cookies - we only care whether these exist
@@ -43,7 +43,7 @@ export const getIsRecurringContributor = (isSignedIn: boolean): boolean => {
 
     return (
         isSignedIn &&
-        (isRecurringContributor ||
+        (isRecurringContributorFromAttrs ||
             hasMonthlyContributionCookie ||
             hasAnnualContributionCookie)
     );
@@ -54,7 +54,7 @@ export const getIsRecurringContributor = (isSignedIn: boolean): boolean => {
 // SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE (support cookie, when making one-off contribution)
 // Get the date of the latest one-off contribution by looking at the two relevant cookies
 // and returning a Unix epoch string of the latest date found.
-export const lastOneOffContributionDate = (): string => {
+export const getLastOneOffContributionDate = (): string => {
     // Attributes cookie - expects YYYY-MM-DD
     const contributionDateFromAttributes = getCookie(
         ONE_OFF_CONTRIBUTION_DATE_COOKIE,


### PR DESCRIPTION
## What does this change?
Updates the Epic payload in `SlotBodyEnd` to include the `countryCode` (passed downstream via props) as well as the contributions data needed by the recent updates to the targeting on the Contributions service.
This involves adding a fair bit of logic to DCR to be able to read and make sense of Contributions-related cookies dropped by Frontend. All of this has been added to a new helper file and will eventually be refactored for simplicity or moved over to the Contributions client lib to remove the burden from DCR.

## Why?
Because we need data about the use's "contributor status" in order to implement proper targeting logic. We use this, on the service side, to ensure we don't show Epics to users who already pay us (recurring/one-off contributors, paper/digital subscribers, etc.)