### PR TITLE
Add zindex utility to coordinate across application

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@sentry/browser": "^5.7.1",
     "@types/ajv": "^1.0.0",
     "@types/lodash.escape": "^4.0.6",
-    "@types/lodash.memoize": "^4.1.6",
     "@types/node-fetch": "^2.5.4",
     "@types/sanitize-html": "^1.18.3",
     "@typescript-eslint/eslint-plugin-tslint": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -17,10 +17,12 @@
     "storybook:build": "node --max-old-space-size=4096 $(yarn bin)/build-storybook",
     "chromatic": "chromatic --build-script-name=storybook:build --exit-zero-on-changes"
   },
-  "bundlesize": [{
-    "path": "./dist/ga.*.js",
-    "maxSize": "20 kB"
-  }],
+  "bundlesize": [
+    {
+      "path": "./dist/ga.*.js",
+      "maxSize": "20 kB"
+    }
+  ],
   "dependencies": {
     "@emotion/core": "^10.0.5",
     "@guardian/consent-management-platform": "^2.0.9",
@@ -28,6 +30,7 @@
     "@sentry/browser": "^5.7.1",
     "@types/ajv": "^1.0.0",
     "@types/lodash.escape": "^4.0.6",
+    "@types/lodash.memoize": "^4.1.6",
     "@types/node-fetch": "^2.5.4",
     "@types/sanitize-html": "^1.18.3",
     "@typescript-eslint/eslint-plugin-tslint": "^2.7.0",

--- a/src/web/components/GridItem.tsx
+++ b/src/web/components/GridItem.tsx
@@ -15,7 +15,7 @@ const gridAreaStyles = (area: string) => {
             top: 0;
             right: 0;
             /* Pop me below the body */
-            ${getZIndex({ group: 'bodyGroup', name: 'rightColumnArea' })}
+            ${getZIndex('rightColumnArea')}
 
             @supports (display: grid) {
                 position: relative;
@@ -28,7 +28,7 @@ const gridAreaStyles = (area: string) => {
         return css`
             grid-area: ${area};
             /* Pop me above the right column */
-            ${getZIndex({ group: 'bodyGroup', name: 'bodyArea' })}
+            ${getZIndex('bodyArea')}
         `;
     }
 

--- a/src/web/components/GridItem.tsx
+++ b/src/web/components/GridItem.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { css } from 'emotion';
+import { getZIndex } from '@frontend/web/lib/getZIndex';
 
 type Props = {
     children: JSX.Element | JSX.Element[];
@@ -14,7 +15,7 @@ const gridAreaStyles = (area: string) => {
             top: 0;
             right: 0;
             /* Pop me below the body */
-            z-index: 1;
+            ${getZIndex({ group: 'bodyGroup', name: 'rightColumnArea' })}
 
             @supports (display: grid) {
                 position: relative;
@@ -27,7 +28,7 @@ const gridAreaStyles = (area: string) => {
         return css`
             grid-area: ${area};
             /* Pop me above the right column */
-            z-index: 2;
+            ${getZIndex({ group: 'bodyGroup', name: 'bodyArea' })}
         `;
     }
 

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -220,12 +220,12 @@ const stickyAdWrapper = css`
     border-bottom: 0.0625rem solid ${palette.neutral[86]};
     position: sticky;
     top: 0;
-    ${getZIndex({ group: 'headerGroup', name: 'stickyAdWrapper' })}
+    ${getZIndex('stickyAdWrapper')}
 `;
 
 const headerWrapper = css`
     position: relative;
-    ${getZIndex({ group: 'headerGroup', name: 'headerWrapper' })}
+    ${getZIndex('headerWrapper')}
 `;
 
 interface Props {

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -27,6 +27,7 @@ import { MobileStickyContainer, AdSlot } from '@root/src/web/components/AdSlot';
 import { Border } from '@root/src/web/components/Border';
 import { GridItem } from '@root/src/web/components/GridItem';
 
+import { getZIndex } from '@frontend/web/lib/getZIndex';
 import { buildAdTargeting } from '@root/src/lib/ad-targeting';
 import { parse } from '@frontend/lib/slot-machine-flags';
 
@@ -219,12 +220,12 @@ const stickyAdWrapper = css`
     border-bottom: 0.0625rem solid ${palette.neutral[86]};
     position: sticky;
     top: 0;
-    z-index: 2;
+    ${getZIndex({ group: 'headerGroup', name: 'stickyAdWrapper' })}
 `;
 
 const headerWrapper = css`
     position: relative;
-    z-index: 1;
+    ${getZIndex({ group: 'headerGroup', name: 'headerWrapper' })}
 `;
 
 interface Props {

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -32,7 +32,7 @@ import { GridItem } from '@root/src/web/components/GridItem';
 
 import { buildAdTargeting } from '@root/src/lib/ad-targeting';
 import { parse } from '@frontend/lib/slot-machine-flags';
-
+import { getZIndex } from '@frontend/web/lib/getZIndex';
 import {
     decideLineCount,
     decideLineEffect,
@@ -192,12 +192,12 @@ const stickyAdWrapper = css`
     border-bottom: 0.0625rem solid ${palette.neutral[86]};
     position: sticky;
     top: 0;
-    z-index: 2;
+    ${getZIndex({ group: 'headerGroup', name: 'stickyAdWrapper' })}
 `;
 
 const headerWrapper = css`
     position: relative;
-    z-index: 1;
+    ${getZIndex({ group: 'headerGroup', name: 'headerWrapper' })}
 `;
 
 interface Props {

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -192,12 +192,12 @@ const stickyAdWrapper = css`
     border-bottom: 0.0625rem solid ${palette.neutral[86]};
     position: sticky;
     top: 0;
-    ${getZIndex({ group: 'headerGroup', name: 'stickyAdWrapper' })}
+    ${getZIndex('stickyAdWrapper')}
 `;
 
 const headerWrapper = css`
     position: relative;
-    ${getZIndex({ group: 'headerGroup', name: 'headerWrapper' })}
+    ${getZIndex('headerWrapper')}
 `;
 
 interface Props {

--- a/src/web/lib/getZIndex.test.tsx
+++ b/src/web/lib/getZIndex.test.tsx
@@ -2,25 +2,10 @@ import { getZIndex } from './getZIndex';
 
 describe('getZIndex', () => {
     it('gets the correct zindex for group and sibling', () => {
-        expect(
-            getZIndex({
-                group: 'bodyGroup',
-                name: 'rightColumnArea',
-            }),
-        ).toBe('z-index: 1;');
+        expect(getZIndex('rightColumnArea')).toBe('z-index: 1;');
 
-        expect(
-            getZIndex({
-                group: 'bodyGroup',
-                name: 'bodyArea',
-            }),
-        ).toBe('z-index: 2;');
+        expect(getZIndex('bodyArea')).toBe('z-index: 2;');
 
-        expect(
-            getZIndex({
-                group: 'headerGroup',
-                name: 'stickyAdWrapper',
-            }),
-        ).toBe('z-index: 4;');
+        expect(getZIndex('stickyAdWrapper')).toBe('z-index: 4;');
     });
 });

--- a/src/web/lib/getZIndex.test.tsx
+++ b/src/web/lib/getZIndex.test.tsx
@@ -1,0 +1,26 @@
+import { getZIndex } from './getZIndex';
+
+describe('getZIndex', () => {
+    it('gets the correct zindex for group and sibling', () => {
+        expect(
+            getZIndex({
+                group: 'bodyGroup',
+                name: 'rightColumnArea',
+            }),
+        ).toBe('z-index: 1;');
+
+        expect(
+            getZIndex({
+                group: 'bodyGroup',
+                name: 'bodyArea',
+            }),
+        ).toBe('z-index: 2;');
+
+        expect(
+            getZIndex({
+                group: 'headerGroup',
+                name: 'stickyAdWrapper',
+            }),
+        ).toBe('z-index: 4;');
+    });
+});

--- a/src/web/lib/getZIndex.tsx
+++ b/src/web/lib/getZIndex.tsx
@@ -1,0 +1,46 @@
+import memoize from 'lodash.memoize';
+
+type GroupNames = 'headerGroup' | 'bodyGroup';
+type GroupObject<GroupNames extends string> = {
+    [name in GroupNames]: string[];
+};
+type GroupLengths<GroupNames extends string> = {
+    [name in GroupNames]: number;
+};
+type GetZIndexProps = { group: GroupNames; name: string };
+
+// Ordering matters
+// Later groups have higher z-index
+// Siblings z-index, later = higher z-index
+const bodyGroup = ['rightColumnArea', 'bodyArea'];
+const headerGroup = ['headerWrapper', 'stickyAdWrapper'];
+const zIndexGroups: GroupObject<string> = {
+    bodyGroup,
+    headerGroup,
+};
+
+// Returns the start index of each group
+// eg: {bodyGroup: 3, headerGroup: 4}
+const getStartIndexObj = () => {
+    const startIdxes: GroupLengths<string> = {};
+    let currentIdx: number = 1;
+    Object.keys(zIndexGroups).forEach(item => {
+        startIdxes[item] = currentIdx;
+        currentIdx += zIndexGroups[item].length; // Start index for next group
+    });
+    return startIdxes;
+};
+
+// Returns the start index of the group
+const getGroupStartIndex = (group: GroupNames): number => {
+    const allStartIndexes = memoize(() => getStartIndexObj()); // We only need to build this once per run
+    return allStartIndexes()[group];
+};
+
+export const getZIndex = ({ group, name }: GetZIndexProps) => {
+    const groupStartIndex = getGroupStartIndex(group);
+    const siblingIndexInGroup = zIndexGroups[group].indexOf(name);
+    const zIndex = groupStartIndex + siblingIndexInGroup;
+
+    return `z-index: ${zIndex};`;
+};

--- a/src/web/lib/getZIndex.tsx
+++ b/src/web/lib/getZIndex.tsx
@@ -1,68 +1,19 @@
-import memoize from 'lodash.memoize';
+// The z-indexes will be applied in order from 1 -> length of the array.
+// The later in the array, the higher the z-index will be
+// All indexes will be adjusted when new elements are added
+const indices = [
+    // Header
+    'headerWrapper',
+    'stickyAdWrapper',
 
-type GroupNames = 'headerGroup' | 'bodyGroup';
-type BodyGroupTuple = typeof bodyGroup; // ['rightColumnArea', 'bodyArea']
-type BodyGroup = BodyGroupTuple[number]; // UnionType: 'rightColumnArea' | 'bodyArea'
-type HeaderGroupTuple = typeof headerGroup;
-type HeaderGroup = HeaderGroupTuple[number];
+    // Body
+    'rightColumnArea',
+    'bodyArea',
 
-type GroupObject<GroupNames extends string> = {
-    [name in GroupNames]: BodyGroupTuple | HeaderGroupTuple;
-};
-type GroupLengths<GroupNames extends string> = {
-    [name in GroupNames]: number;
-};
-type GetZIndexProps = { group: GroupNames; name: BodyGroup | HeaderGroup };
+    // Modals will go here at the top
+] as const;
 
-// Ordering matters
-// You have:
-// 1. ZIndexGroups - An object of {key: groupArr} that contains all the sibling groups, in order.
-// 2. Group Arrays - An ordered list of elements that require a z-index, that live in a group together.
-//    Elements live together in groups - header, footer, body, modal for example.
+type ZIndex = typeof indices[number];
 
-// A group is an array of siblings.
-// The array is ordered and z-index will be higher for elements
-// that live later in the array.
-// The array is frozen at this point as siblings must only
-// be added here.
-// `as const` allows us to generate a union type from the array.
-const bodyGroup = ['rightColumnArea', 'bodyArea'] as const;
-const headerGroup = ['headerWrapper', 'stickyAdWrapper'] as const;
-
-// The order of the group in the object defines the z-index
-// of the group's children based on the length of the previous
-// group arrays.
-// The util will take each group, looping the siblings of the group
-// incrementally assigning a z-index to each one until the groups are
-// exhausted. Phew.
-const zIndexGroups: GroupObject<string> = {
-    bodyGroup,
-    headerGroup,
-};
-
-// Returns the start index of each group
-// eg: {bodyGroup: 3, headerGroup: 4}
-const getStartIndexObj = () => {
-    const startIdxes: GroupLengths<string> = {};
-    let currentIdx: number = 1;
-    Object.keys(zIndexGroups).forEach(item => {
-        startIdxes[item] = currentIdx;
-        currentIdx += zIndexGroups[item].length; // Start index for next group
-    });
-    return startIdxes;
-};
-
-// Returns the start index of the group
-const getGroupStartIndex = (group: GroupNames): number => {
-    const allStartIndexes = memoize(() => getStartIndexObj()); // We only need to build this once per run
-    return allStartIndexes()[group];
-};
-
-export const getZIndex = ({ group, name }: GetZIndexProps): string => {
-    const groupStartIndex = getGroupStartIndex(group);
-    const zIndexGroupArray: readonly string[] = zIndexGroups[group];
-    const siblingIdxInGroup = zIndexGroupArray.indexOf(name);
-    const zIndex = groupStartIndex + siblingIdxInGroup;
-
-    return `z-index: ${zIndex};`;
-};
+export const getZIndex = (zIndex: ZIndex): string =>
+    `z-index: ${indices.indexOf(zIndex)};`;

--- a/src/web/lib/getZIndex.tsx
+++ b/src/web/lib/getZIndex.tsx
@@ -2,13 +2,13 @@
 // The later in the array, the higher the z-index will be
 // All indexes will be adjusted when new elements are added
 const indices = [
-    // Header
-    'headerWrapper',
-    'stickyAdWrapper',
-
     // Body
     'rightColumnArea',
     'bodyArea',
+
+    // Header
+    'headerWrapper',
+    'stickyAdWrapper',
 
     // Modals will go here at the top
 ] as const;
@@ -16,4 +16,4 @@ const indices = [
 type ZIndex = typeof indices[number];
 
 export const getZIndex = (zIndex: ZIndex): string =>
-    `z-index: ${indices.indexOf(zIndex)};`;
+    `z-index: ${indices.indexOf(zIndex) + 1};`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3395,6 +3395,13 @@
   dependencies:
     "@types/lodash" "*"
 
+"@types/lodash.memoize@^4.1.6":
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.memoize/-/lodash.memoize-4.1.6.tgz#3221f981790a415cab1a239f25c17efd8b604c23"
+  integrity sha512-mYxjKiKzRadRJVClLKxS4wb3Iy9kzwJ1CkbyKiadVxejnswnRByyofmPMscFKscmYpl36BEEhCMPuWhA1R/1ZQ==
+  dependencies:
+    "@types/lodash" "*"
+
 "@types/lodash@*":
   version "4.14.136"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.136.tgz#413e85089046b865d960c9ff1d400e04c31ab60f"


### PR DESCRIPTION
## What does this change?

Adds a getZIndex utility based on a 'group' and 'name'. This adds some complexity to the codebase but in the long run should allow easier management of z-indexes.

Note: there are other z-indexes in the system, in a later PR I'd like to put all of them in the util allowing management and generation in a single place so the stacking order is fully controlled and then lint out any use of z-index in the system. This will then prevent any issues going forward.

## Why?

We were getting in a muddle with z-index already - right column overriding article meaning ads weren't clickable, right column overriding drop down so ad appears over navigation etc.

Handling z-index in one place and generating them (memo'd) at run time means they're less likely to clash.

## Link to supporting Trello card
https://trello.com/c/8G3tAMPa

