### PR TITLE
Upgrade to src-foundations v0.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,14 +17,16 @@
     "storybook:build": "node --max-old-space-size=4096 $(yarn bin)/build-storybook",
     "chromatic": "chromatic --build-script-name=storybook:build --exit-zero-on-changes"
   },
-  "bundlesize": [{
-    "path": "./dist/ga.*.js",
-    "maxSize": "20 kB"
-  }],
+  "bundlesize": [
+    {
+      "path": "./dist/ga.*.js",
+      "maxSize": "20 kB"
+    }
+  ],
   "dependencies": {
     "@emotion/core": "^10.0.5",
     "@guardian/consent-management-platform": "^2.0.9",
-    "@guardian/src-foundations": "^0.10.0",
+    "@guardian/src-foundations": "^0.13.0",
     "@sentry/browser": "^5.7.1",
     "@types/ajv": "^1.0.0",
     "@types/lodash.escape": "^4.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2098,11 +2098,6 @@
   dependencies:
     "@guardian/src-svgs" "^0.13.0"
 
-"@guardian/src-foundations@^0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.10.0.tgz#b7773484f2b9e661d31f1d400950a83fb261fe63"
-  integrity sha512-w5xvrYqCLngxFUsivhVhJ35EppFi2GtPMAUxN6EG/Hc9FDD3qiWHiT0nwSPOReNq3UXOLH6DxbNxanFVaOelCg==
-
 "@guardian/src-foundations@^0.13.0":
   version "0.13.0"
   resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.13.0.tgz#8bfed9b94e2e4f24ecacb754bbe573b6e0cfe088"


### PR DESCRIPTION
## What does this change?

Upgrades `src-foundations` to 0.13

## Why?

Keeps things shiny and up to date. I don't think there's anything breaking. This is a preliminary change before I make a more substantial PR (with any luck!)

[Release notes](https://github.com/guardian/source/releases)
