### PR TITLE
Respect isSensitive by not showing Outbrain

### DIFF
--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -176,7 +176,10 @@ interface Props {
 }
 
 export const CommentLayout = ({ CAPI, NAV }: Props) => {
-    const { isPaidContent } = CAPI.config;
+    const {
+        config: { isPaidContent },
+        pageType: { isSensitive },
+    } = CAPI;
 
     const adTargeting: AdTargeting = buildAdTargeting(CAPI.config);
 
@@ -392,12 +395,14 @@ export const CommentLayout = ({ CAPI, NAV }: Props) => {
 
             {!isPaidContent && (
                 <>
-                    <Section
-                        showTopBorder={false}
-                        backgroundColour={palette.neutral[97]}
-                    >
-                        <OutbrainContainer />
-                    </Section>
+                    {!isSensitive && (
+                        <Section
+                            showTopBorder={false}
+                            backgroundColour={palette.neutral[97]}
+                        >
+                            <OutbrainContainer />
+                        </Section>
+                    )}
 
                     {showOnwardsLower && <Section islandId="onwards-lower" />}
 

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -233,7 +233,10 @@ interface Props {
 }
 
 export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
-    const { isPaidContent } = CAPI.config;
+    const {
+        config: { isPaidContent },
+        pageType: { isSensitive },
+    } = CAPI;
 
     const adTargeting: AdTargeting = buildAdTargeting(CAPI.config);
 
@@ -437,12 +440,14 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
 
             {!isPaidContent && (
                 <>
-                    <Section
-                        showTopBorder={false}
-                        backgroundColour={palette.neutral[97]}
-                    >
-                        <OutbrainContainer />
-                    </Section>
+                    {!isSensitive && (
+                        <Section
+                            showTopBorder={false}
+                            backgroundColour={palette.neutral[97]}
+                        >
+                            <OutbrainContainer />
+                        </Section>
+                    )}
 
                     {showOnwardsLower && <Section islandId="onwards-lower" />}
 

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -206,7 +206,10 @@ interface Props {
 }
 
 export const StandardLayout = ({ CAPI, NAV }: Props) => {
-    const { isPaidContent } = CAPI.config;
+    const {
+        config: { isPaidContent },
+        pageType: { isSensitive },
+    } = CAPI;
 
     const adTargeting: AdTargeting = buildAdTargeting(CAPI.config);
 
@@ -412,12 +415,14 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
 
             {!isPaidContent && (
                 <>
-                    <Section
-                        showTopBorder={false}
-                        backgroundColour={palette.neutral[97]}
-                    >
-                        <OutbrainContainer />
-                    </Section>
+                    {!isSensitive && (
+                        <Section
+                            showTopBorder={false}
+                            backgroundColour={palette.neutral[97]}
+                        >
+                            <OutbrainContainer />
+                        </Section>
+                    )}
 
                     {showOnwardsLower && <Section islandId="onwards-lower" />}
 


### PR DESCRIPTION
## What does this change?
Hide `Outbrain` when an article is sensitive

## Why?
Because we want to respect the intention of the editors

## Link to supporting Trello card
https://trello.com/c/LzgwuTqq/1201-respect-issensitive