### PR TITLE
Set min width to thinner ad size for ad-slot

### DIFF
--- a/src/web/components/ArticleContainer.tsx
+++ b/src/web/components/ArticleContainer.tsx
@@ -27,7 +27,7 @@ const articleAdStyles = css`
     .ad-slot {
         width: 300px;
         margin: 12px auto;
-        min-width: 300px;
+        min-width: 160px;
         min-height: 274px;
         text-align: center;
     }


### PR DESCRIPTION
## What does this change?

Sets the ad-slot `min-width` to the thinner ad slots.

Before

![Screen Shot 2020-03-02 at 08 24 35](https://user-images.githubusercontent.com/638051/75658149-a2ba7a80-5c5f-11ea-8ee7-d0c9012c343c.png)

After

![Screen Shot 2020-03-02 at 08 26 13](https://user-images.githubusercontent.com/638051/75658144-a1894d80-5c5f-11ea-93c2-b94048b3207c.png)

## Why?

Parity with Frontend.

## Link to supporting Trello card
https://trello.com/c/f34c5lwZ