### PR TITLE
Avatar Background Colour

### DIFF
--- a/src/web/components/Avatar.tsx
+++ b/src/web/components/Avatar.tsx
@@ -11,7 +11,9 @@ const contributorImage = css`
 
 const pillarBackground = (pillar: Pillar = 'opinion') =>
     css`
-        background-color: ${pillarPalette[pillar].bright};
+        background-color: ${pillar === 'opinion'
+            ? pillarPalette[pillar].main
+            : pillarPalette[pillar].bright};
     `;
 
 export const Avatar: React.FC<{


### PR DESCRIPTION
## What does this change?
When pillar is opinion we use the `main` colour for avatar background, otherwise we pick `bright`

![2020-02-28 14 36 31](https://user-images.githubusercontent.com/1336821/75557358-c602e100-5a37-11ea-90b0-7e4e57cb4ef0.gif)


## Why?
Because parity

## Link to supporting Trello card
https://trello.com/c/46cT4nM3/1224-avatar-background-colour
