### PR TITLE
Avoid DoS'ing Slot Machine API calls :0

### DIFF
--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { css } from 'emotion';
 import { getBodyEnd } from '@guardian/slot-machine-client';
 import {
@@ -59,9 +59,14 @@ export const SlotBodyEnd = ({
         },
     };
 
+    const getSlot: () => Promise<Response> = useCallback(
+        () => getBodyEnd(contributionsPayload),
+        [], // empty as we only want to call the API once and payload will always fail a reference equality check anyway
+    );
+
     const { data: bodyResponse, error } = useApiFn<{
         data: { html: string; css: string };
-    }>(() => getBodyEnd(contributionsPayload));
+    }>(getSlot);
 
     if (error) {
         window.guardian.modules.sentry.reportError(error, 'slot-body-end');

--- a/src/web/lib/api.tsx
+++ b/src/web/lib/api.tsx
@@ -73,6 +73,9 @@ export const useApi = <T,>(
     return request;
 };
 
+// Warning: if your function is constructed dynamically in your component, you
+// should use https://reactjs.org/docs/hooks-reference.html#usecallback to wrap
+// it before calling this helper to avoid DoS'ing your API!
 export const useApiFn = <T,>(fn: () => Promise<Response>): ApiResponse<T> => {
     const [request, setRequest] = useState<{
         loading: boolean;


### PR DESCRIPTION
The reason being, that the passed in function is likely to be
dynamically generated within a component (i.e. is itself a function
of component props). As such, using it as a second argument (to skip)
useEffect calls is likely a mistake and will result in spamming the
API.

cc @oliverlloyd and @liywjl 