### PR TITLE
SignedInAs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -353,6 +353,27 @@ interface CardHeadlineType {
     showByline?: boolean;
 }
 
+type UserBadge = {
+    name: string;
+};
+
+type UserProfile = {
+    userId: string;
+    displayName: string;
+    webUrl: string;
+    apiUrl: string;
+    avatar: string;
+    secureAvatarUrl: string;
+    badge: UserBadge[];
+
+    // only included from /profile/me endpoint
+    privateFields?: {
+        canPostComment: boolean;
+        isPremoderated: boolean;
+        hasCommented: boolean;
+    };
+};
+
 /**
  * Onwards
  */

--- a/src/web/components/SignedInAs.stories.tsx
+++ b/src/web/components/SignedInAs.stories.tsx
@@ -27,6 +27,19 @@ export const SignedIn = () => {
 };
 SignedIn.story = { name: 'signed in' };
 
+export const Image = () => {
+    return (
+        <SignedInAs
+            commentCount={32}
+            user={{
+                ...aUser,
+                secureAvatarUrl: 'https://avatar.guim.co.uk/user/101885881',
+            }}
+        />
+    );
+};
+Image.story = { name: 'with image' };
+
 export const NotSignedIn = () => {
     return <SignedInAs commentCount={32} />;
 };

--- a/src/web/components/SignedInAs.stories.tsx
+++ b/src/web/components/SignedInAs.stories.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import { SignedInAs } from './SignedInAs';
+
+const aUser = {
+    userId: 'abc123',
+    displayName: 'Jane Smith',
+    webUrl: '',
+    apiUrl: '',
+    avatar: '',
+    secureAvatarUrl: '',
+    badge: [],
+    privateFields: {
+        canPostComment: true,
+        isPremoderated: false,
+        hasCommented: true,
+    },
+};
+
+export default {
+    component: SignedInAs,
+    title: 'Components/SignedInAs',
+};
+
+export const SignedIn = () => {
+    return <SignedInAs commentCount={3} user={aUser} />;
+};
+SignedIn.story = { name: 'signed in' };
+
+export const NotSignedIn = () => {
+    return <SignedInAs commentCount={32} />;
+};
+NotSignedIn.story = { name: 'not signed in' };

--- a/src/web/components/SignedInAs.stories.tsx
+++ b/src/web/components/SignedInAs.stories.tsx
@@ -40,6 +40,19 @@ export const Image = () => {
 };
 Image.story = { name: 'with image' };
 
+export const NoDisplayName = () => {
+    return (
+        <SignedInAs
+            commentCount={32}
+            user={{
+                ...aUser,
+                displayName: '',
+            }}
+        />
+    );
+};
+NoDisplayName.story = { name: 'before a display name has been set' };
+
 export const NotSignedIn = () => {
     return <SignedInAs commentCount={32} />;
 };

--- a/src/web/components/SignedInAs.tsx
+++ b/src/web/components/SignedInAs.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { headline, textSans } from '@guardian/src-foundations/typography';
+import { palette, space } from '@guardian/src-foundations';
+
+type Props = {
+    commentCount: number;
+    user?: UserProfile;
+};
+
+const containerStyles = css`
+    padding: ${space[2]}px;
+`;
+
+const imageStyles = css`
+    border-radius: 70px;
+    width: 60px;
+    height: 60px;
+`;
+
+const imageWrapper = css`
+    padding-bottom: ${space[1]}px;
+`;
+
+const headingStyles = css`
+    ${headline.xxsmall({ fontWeight: 'bold' })};
+    padding-bottom: ${space[1]}px;
+`;
+
+const signedInStyles = css`
+    ${textSans.small()}
+    color: ${palette.neutral[46]};
+    padding-bottom: ${space[1]}px;
+`;
+
+const signedOutStyles = css`
+    ${headline.xxxsmall()}
+    color: ${palette.neutral[46]};
+    padding-bottom: ${space[1]}px;
+`;
+
+const usernameStyles = css`
+    font-weight: 700;
+    color: ${palette.neutral[7]};
+`;
+
+const linkStyles = css`
+    color: ${palette.news[300]};
+    text-decoration: none;
+    border-bottom: 1px solid ${palette.neutral[86]};
+    transition: border-color 0.15s ease-out;
+    :hover {
+        border-color: ${palette.news[300]};
+    }
+`;
+
+export const SignedInAs = ({ commentCount, user }: Props) => {
+    return (
+        <div className={containerStyles}>
+            <h2 className={headingStyles}>
+                comments{' '}
+                <span
+                    className={css`
+                        color: ${palette.neutral[60]};
+                    `}
+                >
+                    ({commentCount})
+                </span>
+            </h2>
+            {user ? (
+                <>
+                    <div className={imageWrapper}>
+                        <img
+                            src={
+                                user.secureAvatarUrl ||
+                                'https://avatar.guim.co.uk/no-user-image.gif'
+                            }
+                            alt={user.displayName}
+                            className={imageStyles}
+                        />
+                    </div>
+                    <div className={signedInStyles}>
+                        Signed in as
+                        <div className={usernameStyles}>{user.displayName}</div>
+                    </div>
+                </>
+            ) : (
+                <span className={signedOutStyles}>
+                    <a
+                        href="https://profile.theguardian.com/signin?INTCMP=DOTCOM_COMMENTS_SIGNIN"
+                        className={linkStyles}
+                    >
+                        Sign in
+                    </a>{' '}
+                    or{' '}
+                    <a
+                        href="https://profile.theguardian.com/register?INTCMP=DOTCOM_COMMENTS_REG"
+                        className={linkStyles}
+                    >
+                        create your Guardian account
+                    </a>{' '}
+                    to join the discussion.
+                </span>
+            )}
+        </div>
+    );
+};

--- a/src/web/components/SignedInAs.tsx
+++ b/src/web/components/SignedInAs.tsx
@@ -3,6 +3,7 @@ import { css } from 'emotion';
 
 import { headline, textSans } from '@guardian/src-foundations/typography';
 import { palette, space } from '@guardian/src-foundations';
+import { until } from '@guardian/src-foundations/mq';
 
 type Props = {
     commentCount: number;
@@ -17,10 +18,15 @@ const imageStyles = css`
     border-radius: 70px;
     width: 60px;
     height: 60px;
+    ${until.desktop} {
+        width: 36px;
+        height: 36px;
+    }
 `;
 
 const imageWrapper = css`
     padding-bottom: ${space[1]}px;
+    padding-right: ${space[2]}px;
 `;
 
 const headingStyles = css`
@@ -30,6 +36,9 @@ const headingStyles = css`
 
 const signedInStyles = css`
     ${textSans.small()}
+    ${until.desktop} {
+        ${textSans.xsmall()}
+    }
     color: ${palette.neutral[46]};
     padding-bottom: ${space[1]}px;
 `;
@@ -55,6 +64,14 @@ const linkStyles = css`
     }
 `;
 
+const rowUntilDesktop = css`
+    display: flex;
+    flex-direction: column;
+    ${until.desktop} {
+        flex-direction: row;
+    }
+`;
+
 export const SignedInAs = ({ commentCount, user }: Props) => {
     return (
         <div className={containerStyles}>
@@ -69,7 +86,7 @@ export const SignedInAs = ({ commentCount, user }: Props) => {
                 </span>
             </h2>
             {user ? (
-                <>
+                <div className={rowUntilDesktop}>
                     <div className={imageWrapper}>
                         <img
                             src={
@@ -84,7 +101,7 @@ export const SignedInAs = ({ commentCount, user }: Props) => {
                         Signed in as
                         <div className={usernameStyles}>{user.displayName}</div>
                     </div>
-                </>
+                </div>
             ) : (
                 <span className={signedOutStyles}>
                     <a

--- a/src/web/components/SignedInAs.tsx
+++ b/src/web/components/SignedInAs.tsx
@@ -93,13 +93,15 @@ export const SignedInAs = ({ commentCount, user }: Props) => {
                                 user.secureAvatarUrl ||
                                 'https://avatar.guim.co.uk/no-user-image.gif'
                             }
-                            alt={user.displayName}
+                            alt={user.displayName || 'Guardian User'}
                             className={imageStyles}
                         />
                     </div>
                     <div className={signedInStyles}>
                         Signed in as
-                        <div className={usernameStyles}>{user.displayName}</div>
+                        <div className={usernameStyles}>
+                            {user.displayName || 'Guardian User'}
+                        </div>
                     </div>
                 </div>
             ) : (


### PR DESCRIPTION
## What does this change?
Here we add the `SignedInAs` component which will show alongside comments when they are integrated

_No image:_
![Screenshot 2020-03-03 at 09 42 03](https://user-images.githubusercontent.com/1336821/75762850-445ecc00-5d33-11ea-81dc-d58944c56394.jpg)

_With image:_
![Screenshot 2020-03-03 at 09 41 59](https://user-images.githubusercontent.com/1336821/75762852-44f76280-5d33-11ea-9452-92fa0502115c.jpg)

_Signed out version:_
![Screenshot 2020-03-03 at 09 41 50](https://user-images.githubusercontent.com/1336821/75762853-458ff900-5d33-11ea-873f-54c5dd8162fb.jpg)

_Compact version (below desktop):_
![Screenshot 2020-03-03 at 10 12 30](https://user-images.githubusercontent.com/1336821/75765492-84c04900-5d37-11ea-9808-6f9bd20ab49e.jpg)



## Why?
We could have built this component as part of `discussion-rendering` but because DCR is responsible for the layout of the section (or at least it should be) and because DCR already has the comment count in scope, then it makes sense to render this component from outside the discussion repo.

## Link to supporting Trello card
https://trello.com/c/WIU3Zwav/1181-signed-in-as-component