### PR TITLE
Don't show interactives on AMP

### DIFF
--- a/src/amp/components/Elements.tsx
+++ b/src/amp/components/Elements.tsx
@@ -143,7 +143,7 @@ export const Elements = (
                         adTargeting={adTargeting}
                     />
                 );
-            // Disabled because we were seeing errors when trying to load js from a different
+            // TODO: Disabled because we were seeing errors when trying to load js from a different
             // origin but you're not allowed to add the 'allow-same-origin' sandbox property
             // when using the srcdoc option
             // case 'model.dotcomrendering.pageElements.InteractiveMarkupBlockElement':

--- a/src/amp/components/Elements.tsx
+++ b/src/amp/components/Elements.tsx
@@ -20,7 +20,7 @@ import { clean } from '@root/src/model/clean';
 import { Timeline } from '@root/src/amp/components/elements/Timeline';
 import { YoutubeVideo } from '@root/src/amp/components/elements/YoutubeVideo';
 import { InteractiveUrl } from '@root/src/amp/components/elements/InteractiveUrl';
-import { InteractiveMarkup } from '@root/src/amp/components/elements/InteractiveMarkup';
+// import { InteractiveMarkup } from '@root/src/amp/components/elements/InteractiveMarkup';
 import { MapEmbed } from '@root/src/amp/components/elements/MapEmbed';
 import { AudioAtom } from '@root/src/amp/components/elements/AudioAtom';
 
@@ -143,14 +143,17 @@ export const Elements = (
                         adTargeting={adTargeting}
                     />
                 );
-            case 'model.dotcomrendering.pageElements.InteractiveMarkupBlockElement':
-                return (
-                    <InteractiveMarkup
-                        html={element.html}
-                        styles={element.css}
-                        js={element.js}
-                    />
-                );
+            // Disabled because we were seeing errors when trying to load js from a different
+            // origin but you're not allowed to add the 'allow-same-origin' sandbox property
+            // when using the srcdoc option
+            // case 'model.dotcomrendering.pageElements.InteractiveMarkupBlockElement':
+            //     return (
+            //         <InteractiveMarkup
+            //             html={element.html}
+            //             styles={element.css}
+            //             js={element.js}
+            //         />
+            //     );
             case 'model.dotcomrendering.pageElements.InteractiveUrlBlockElement':
                 return <InteractiveUrl url={element.url} />;
             case 'model.dotcomrendering.pageElements.AudioAtomBlockElement':


### PR DESCRIPTION
## What does this change?
This disabled interactives on AMP by commenting out the case statement that is normally used to render the `InteractiveMarkup` element

## Why?
Because on [this article](http://localhost:3030/AMPArticle?url=https://www.theguardian.com/world/2020/mar/02/worse-than-the-flu-busting-the-coronavirus-myths-face-masks-vaccine-covid-19) the interactives were not rendering correctly because of an error.

```
Failed to read the 'localStorage' property from 'Window': The document is sandboxed and lacks the 'allow-same-origin' flag.
```

This error cause the element to render like this:

![Screenshot 2020-03-03 at 11 20 39](https://user-images.githubusercontent.com/1336821/75771208-695a3b80-5d41-11ea-87ba-99c9407c14fd.jpg)


To fix this we need to set `sandbox="allow-scripts allow-same-origin"` to allow this interactive to make an api call to a different domain than origin but the `allow-same-origin` flag is not allowed when the `srcdoc` property is being used for security reasons and the element doesn't render at all and gives this error:

```
allow-same-origin is not allowed with the srcdoc attribute
```

## Link to supporting Trello card
https://trello.com/c/gNgwpVUb/881-help-the-visuals-team-improve-the-appearance-and-rendering-of-interactives-in-amp
