### PR TITLE
Add MVT ID to Slot Machine calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dependencies": {
         "@emotion/core": "^10.0.5",
         "@guardian/consent-management-platform": "^2.0.10",
-        "@guardian/slot-machine-client": "^0.1.60",
+        "@guardian/slot-machine-client": "^0.2.1",
         "@guardian/src-foundations": "^0.14.1",
         "@sentry/browser": "^5.7.1",
         "@types/ajv": "^1.0.0",

--- a/src/web/browser/App.tsx
+++ b/src/web/browser/App.tsx
@@ -161,21 +161,19 @@ const App = ({ CAPI, NAV }: Props) => {
             <Portal root="most-viewed-right">
                 <MostViewedRightWrapper pillar={CAPI.pillar} />
             </Portal>
-            {/* Ensure component only renders after both variables have been assigned true or false */}
-            {isSignedIn !== undefined && countryCode !== undefined && (
-                <Portal root="slot-body-end">
-                    <SlotBodyEnd
-                        isSignedIn={isSignedIn}
-                        countryCode={countryCode}
-                        contentType={CAPI.contentType}
-                        sectionName={CAPI.sectionName}
-                        shouldHideReaderRevenue={CAPI.shouldHideReaderRevenue}
-                        isMinuteArticle={CAPI.pageType.isMinuteArticle}
-                        isPaidContent={CAPI.pageType.isPaidContent}
-                        tags={CAPI.tags}
-                    />
-                </Portal>
-            )}
+            <Portal root="slot-body-end">
+                <SlotBodyEnd
+                    isSignedIn={isSignedIn}
+                    countryCode={countryCode}
+                    contentType={CAPI.contentType}
+                    sectionName={CAPI.sectionName}
+                    shouldHideReaderRevenue={CAPI.shouldHideReaderRevenue}
+                    isMinuteArticle={CAPI.pageType.isMinuteArticle}
+                    isPaidContent={CAPI.pageType.isPaidContent}
+                    tags={CAPI.tags}
+                />
+            </Portal>
+
             <Portal root="onwards-upper">
                 <OnwardsUpper
                     ajaxUrl={CAPI.config.ajaxUrl}

--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { css } from 'emotion';
 import { getBodyEnd, getViewLog, logView } from '@guardian/slot-machine-client';
 import {
@@ -7,6 +7,7 @@ import {
     getLastOneOffContributionDate,
 } from '@root/src/web/lib/contributions';
 import { useApiFn } from '../lib/api';
+import { getCookie } from '../browser/cookie';
 
 const sendOphanInsertEvent = (): void => {
     const componentEvent = {
@@ -56,6 +57,18 @@ export const SlotBodyEnd = ({
     // Load the view log from localStorage so it can be added to the Contributions payload
     const epicViewLog = getViewLog();
 
+    // These are expensive - only retrieve them once
+    const mvtId = useMemo(() => Number(getCookie('GU_mvt_id')), []);
+    const lastOneOffContributionDate = useMemo(
+        getLastOneOffContributionDate,
+        [],
+    );
+    const showSupportMessaging = useMemo(shouldShowSupportMessaging, []);
+    const recurringContributor = useMemo(
+        () => isRecurringContributor(isSignedIn),
+        [],
+    );
+
     const contributionsPayload = {
         tracking: {
             ophanPageId: window.guardian.config.ophan.pageViewId,
@@ -76,10 +89,11 @@ export const SlotBodyEnd = ({
             isMinuteArticle,
             isPaidContent,
             tags,
-            showSupportMessaging: shouldShowSupportMessaging(),
-            isRecurringContributor: isRecurringContributor(isSignedIn),
-            lastOneOffContributionDate: getLastOneOffContributionDate(),
+            showSupportMessaging,
+            isRecurringContributor: recurringContributor,
+            lastOneOffContributionDate,
             epicViewLog,
+            mvtId,
         },
     };
 

--- a/src/web/lib/api.tsx
+++ b/src/web/lib/api.tsx
@@ -72,36 +72,3 @@ export const useApi = <T,>(
 
     return request;
 };
-
-// Warning: if your function is constructed dynamically in your component, you
-// should use https://reactjs.org/docs/hooks-reference.html#usecallback to wrap
-// it before calling this helper to avoid DoS'ing your API!
-export const useApiFn = <T,>(fn: () => Promise<Response>): ApiResponse<T> => {
-    const [request, setRequest] = useState<{
-        loading: boolean;
-        data?: T;
-        error?: Error;
-    }>({
-        loading: true,
-    });
-
-    useEffect(() => {
-        fn()
-            .then(checkForErrors)
-            .then(resp => resp.json())
-            .then(data => {
-                setRequest({
-                    data,
-                    loading: false,
-                });
-            })
-            .catch(error => {
-                setRequest({
-                    error,
-                    loading: false,
-                });
-            });
-    }, [fn]);
-
-    return request;
-};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2091,10 +2091,10 @@
     js-cookie "^2.2.1"
     whatwg-fetch "^3.0.0"
 
-"@guardian/slot-machine-client@^0.1.60":
-  version "0.1.60"
-  resolved "https://registry.yarnpkg.com/@guardian/slot-machine-client/-/slot-machine-client-0.1.60.tgz#7ffa3c573e48b6dc635be8d5ebc5a42dbac42754"
-  integrity sha512-+39+TgBoSJMWsdzeoIa3GcZoaCepxWjXb/fpNf5yGC2i8TtRsWTZxU65y2cevwtdcpZ0kFmHze1QyKfKmV2ojg==
+"@guardian/slot-machine-client@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@guardian/slot-machine-client/-/slot-machine-client-0.2.1.tgz#883fd7f2503231c3e1d3fe06947f7b2afe8fce2e"
+  integrity sha512-ztYqAI/BN76smiIQz2ImrkFHypkjqqjwEopIqVlFjhLGkFutwcwJ4yE8KTQn+OD3FJ8GXQpbN+tGBHJ5+t/BcQ==
 
 "@guardian/src-button@^0.13.0":
   version "0.13.0"


### PR DESCRIPTION
## What does this change?

Updates SM client and passes MVT ID with requests.

I've also memoised some of the cookie calls in the `SlotBodyEnd` component for performance reasons.

Caveat: @oliverlloyd does this get rendered server side initially? - is there a chance we'll memoise the cookie values before they are accessible?

## Why?

It is required for variant (MVT) logic.

## Link to supporting Trello card

https://trello.com/c/kXuhn5cY/45-implement-remaining-variants