### PR TITLE
Add OphanComponentName to allow data-component for analytics to be typed

### DIFF
--- a/fixtures/onwards.mocks.ts
+++ b/fixtures/onwards.mocks.ts
@@ -115,55 +115,55 @@ const trails: TrailType[] = [
 export const storyPackageTrails: OnwardsType = {
     heading: 'More on this story',
     trails,
-    typeOfOnwards: 'more-on-this-story',
+    ophanComponentName: 'more-on-this-story',
 };
 
 export const oneTrail: OnwardsType = {
     heading: 'More on this story',
     trails: trails.slice(0, 1),
-    typeOfOnwards: 'more-on-this-story',
+    ophanComponentName: 'more-on-this-story',
 };
 
 export const twoTrails: OnwardsType = {
     heading: 'More on this story',
     trails: trails.slice(0, 2),
-    typeOfOnwards: 'more-on-this-story',
+    ophanComponentName: 'more-on-this-story',
 };
 
 export const threeTrails: OnwardsType = {
     heading: 'More on this story',
     trails: trails.slice(0, 3),
-    typeOfOnwards: 'more-on-this-story',
+    ophanComponentName: 'more-on-this-story',
 };
 
 export const fourTrails: OnwardsType = {
     heading: 'More on this story',
     trails: trails.slice(0, 4),
-    typeOfOnwards: 'more-on-this-story',
+    ophanComponentName: 'more-on-this-story',
 };
 
 export const fiveTrails: OnwardsType = {
     heading: 'More on this story',
     trails: trails.slice(0, 5),
-    typeOfOnwards: 'more-on-this-story',
+    ophanComponentName: 'more-on-this-story',
 };
 
 export const sixTrails: OnwardsType = {
     heading: 'More on this story',
     trails: trails.slice(0, 6),
-    typeOfOnwards: 'more-on-this-story',
+    ophanComponentName: 'more-on-this-story',
 };
 
 export const sevenTrails: OnwardsType = {
     heading: 'More on this story',
     trails: trails.slice(0, 7),
-    typeOfOnwards: 'more-on-this-story',
+    ophanComponentName: 'more-on-this-story',
 };
 
 export const eightTrails: OnwardsType = {
     heading: 'More on this story',
     trails: trails.slice(0, 8),
-    typeOfOnwards: 'more-on-this-story',
+    ophanComponentName: 'more-on-this-story',
 };
 
 export const linkAndDescription: OnwardsType = {
@@ -172,7 +172,7 @@ export const linkAndDescription: OnwardsType = {
         'Our writers reflect on the people, issues and curiosities in the news',
     heading: 'More on this story',
     trails: trails.slice(0, 8),
-    typeOfOnwards: 'more-on-this-story',
+    ophanComponentName: 'more-on-this-story',
 };
 
 export const withLongDescription: OnwardsType = {
@@ -180,5 +180,5 @@ export const withLongDescription: OnwardsType = {
         "<p>A blog by the Guardian's internal Digital team. We build the Guardian website, mobile apps, Editorial tools, revenue products, support our infrastructure and manage all things tech around the Guardian.</p><p>Our team contains Developers, UX, Quality, Product and Enterprise IT. This blog is where we share our experiences and approaches, including software  development tips, code examples, open source software and product  development stories </p>",
     heading: 'More on this story',
     trails: trails.slice(0, 8),
-    typeOfOnwards: 'more-on-this-story',
+    ophanComponentName: 'more-on-this-story',
 };

--- a/fixtures/onwards.mocks.ts
+++ b/fixtures/onwards.mocks.ts
@@ -115,46 +115,55 @@ const trails: TrailType[] = [
 export const storyPackageTrails: OnwardsType = {
     heading: 'More on this story',
     trails,
+    typeOfOnwards: 'more-on-this-story',
 };
 
 export const oneTrail: OnwardsType = {
     heading: 'More on this story',
     trails: trails.slice(0, 1),
+    typeOfOnwards: 'more-on-this-story',
 };
 
 export const twoTrails: OnwardsType = {
     heading: 'More on this story',
     trails: trails.slice(0, 2),
+    typeOfOnwards: 'more-on-this-story',
 };
 
 export const threeTrails: OnwardsType = {
     heading: 'More on this story',
     trails: trails.slice(0, 3),
+    typeOfOnwards: 'more-on-this-story',
 };
 
 export const fourTrails: OnwardsType = {
     heading: 'More on this story',
     trails: trails.slice(0, 4),
+    typeOfOnwards: 'more-on-this-story',
 };
 
 export const fiveTrails: OnwardsType = {
     heading: 'More on this story',
     trails: trails.slice(0, 5),
+    typeOfOnwards: 'more-on-this-story',
 };
 
 export const sixTrails: OnwardsType = {
     heading: 'More on this story',
     trails: trails.slice(0, 6),
+    typeOfOnwards: 'more-on-this-story',
 };
 
 export const sevenTrails: OnwardsType = {
     heading: 'More on this story',
     trails: trails.slice(0, 7),
+    typeOfOnwards: 'more-on-this-story',
 };
 
 export const eightTrails: OnwardsType = {
     heading: 'More on this story',
     trails: trails.slice(0, 8),
+    typeOfOnwards: 'more-on-this-story',
 };
 
 export const linkAndDescription: OnwardsType = {
@@ -163,6 +172,7 @@ export const linkAndDescription: OnwardsType = {
         'Our writers reflect on the people, issues and curiosities in the news',
     heading: 'More on this story',
     trails: trails.slice(0, 8),
+    typeOfOnwards: 'more-on-this-story',
 };
 
 export const withLongDescription: OnwardsType = {
@@ -170,4 +180,5 @@ export const withLongDescription: OnwardsType = {
         "<p>A blog by the Guardian's internal Digital team. We build the Guardian website, mobile apps, Editorial tools, revenue products, support our infrastructure and manage all things tech around the Guardian.</p><p>Our team contains Developers, UX, Quality, Product and Enterprise IT. This blog is where we share our experiences and approaches, including software  development tips, code examples, open source software and product  development stories </p>",
     heading: 'More on this story',
     trails: trails.slice(0, 8),
+    typeOfOnwards: 'more-on-this-story',
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -382,10 +382,10 @@ type OnwardsType = {
     trails: TrailType[];
     description?: string;
     url?: string;
-    typeOfOnwards: TypeOfOnwards;
+    ophanComponentName: OphanComponentName;
 };
 
-type TypeOfOnwards =
+type OphanComponentName =
     | 'series'
     | 'more-on-this-story'
     | 'related-stories'

--- a/index.d.ts
+++ b/index.d.ts
@@ -382,7 +382,17 @@ type OnwardsType = {
     trails: TrailType[];
     description?: string;
     url?: string;
+    typeOfOnwards: TypeOfOnwards;
 };
+
+type TypeOfOnwards =
+    | 'series'
+    | 'more-on-this-story'
+    | 'related-stories'
+    | 'related-content'
+    | 'more-media-in-section'
+    | 'more-galleries'
+    | 'default-onwards'; // We should never see this in the analytics data!
 
 interface CommercialConfigType {
     isPaidContent?: boolean;

--- a/src/web/components/Onwards/OnwardsContainer.tsx
+++ b/src/web/components/Onwards/OnwardsContainer.tsx
@@ -6,9 +6,14 @@ import { from } from '@guardian/src-foundations/mq';
 type Props = {
     children: JSX.Element | JSX.Element[];
     dataComponentName: string;
+    dataLinkName: string;
 };
 
-export const OnwardsContainer = ({ children, dataComponentName }: Props) => (
+export const OnwardsContainer = ({
+    children,
+    dataComponentName,
+    dataLinkName,
+}: Props) => (
     <div
         className={css`
             display: flex;
@@ -43,7 +48,7 @@ export const OnwardsContainer = ({ children, dataComponentName }: Props) => (
             }
         `}
         data-component={dataComponentName}
-        data-link-name={dataComponentName}
+        data-link-name={dataLinkName}
     >
         {children}
     </div>

--- a/src/web/components/Onwards/OnwardsData.tsx
+++ b/src/web/components/Onwards/OnwardsData.tsx
@@ -7,17 +7,17 @@ import { OnwardsLayout } from './OnwardsLayout';
 type Props = {
     url: string;
     limit: number; // Limit the number of items shown (the api often returns more)
-    typeOfOnwards: TypeOfOnwards;
+    ophanComponentName: OphanComponentName;
 };
 
-export const OnwardsData = ({ url, limit, typeOfOnwards }: Props) => {
+export const OnwardsData = ({ url, limit, ophanComponentName }: Props) => {
     const { data } = useApi(url);
     const onwardSections: OnwardsType[] = [];
     if (data && data.trails) {
         onwardSections.push({
             heading: data.heading || data.displayname, // Sometimes the api returns heading as 'displayName'
             trails: limit ? data.trails.slice(0, limit) : data.trails,
-            typeOfOnwards,
+            ophanComponentName,
         });
     }
 

--- a/src/web/components/Onwards/OnwardsData.tsx
+++ b/src/web/components/Onwards/OnwardsData.tsx
@@ -7,16 +7,17 @@ import { OnwardsLayout } from './OnwardsLayout';
 type Props = {
     url: string;
     limit: number; // Limit the number of items shown (the api often returns more)
+    typeOfOnwards: TypeOfOnwards;
 };
 
-export const OnwardsData = ({ url, limit }: Props) => {
+export const OnwardsData = ({ url, limit, typeOfOnwards }: Props) => {
     const { data } = useApi(url);
     const onwardSections: OnwardsType[] = [];
-
     if (data && data.trails) {
         onwardSections.push({
             heading: data.heading || data.displayname, // Sometimes the api returns heading as 'displayName'
             trails: limit ? data.trails.slice(0, limit) : data.trails,
+            typeOfOnwards,
         });
     }
 

--- a/src/web/components/Onwards/OnwardsLayout.tsx
+++ b/src/web/components/Onwards/OnwardsLayout.tsx
@@ -54,7 +54,7 @@ export const OnwardsLayout = ({ onwardSections }: Props) => {
                         />
                     </LeftColumn>
                     <OnwardsContainer
-                        dataComponentName={section.typeOfOnwards}
+                        dataComponentName={section.ophanComponentName}
                         dataLinkName={formatAttrString(section.heading)}
                     >
                         <Hide when="above" breakpoint="leftCol">

--- a/src/web/components/Onwards/OnwardsLayout.tsx
+++ b/src/web/components/Onwards/OnwardsLayout.tsx
@@ -54,7 +54,8 @@ export const OnwardsLayout = ({ onwardSections }: Props) => {
                         />
                     </LeftColumn>
                     <OnwardsContainer
-                        dataComponentName={formatAttrString(section.heading)}
+                        dataComponentName={section.typeOfOnwards}
+                        dataLinkName={formatAttrString(section.heading)}
                     >
                         <Hide when="above" breakpoint="leftCol">
                             <OnwardsTitle

--- a/src/web/components/Onwards/OnwardsLower.tsx
+++ b/src/web/components/Onwards/OnwardsLower.tsx
@@ -17,7 +17,7 @@ export const OnwardsLower = ({ ajaxUrl, hasStoryPackage, tags }: Props) => {
     );
 
     let url;
-    let typeOfOnwards: TypeOfOnwards = 'default-onwards';
+    let ophanComponentName: OphanComponentName = 'default-onwards';
 
     if (hasStoryPackage && seriesTag) {
         // Use the series tag to get other data in the same series
@@ -28,10 +28,16 @@ export const OnwardsLower = ({ ajaxUrl, hasStoryPackage, tags }: Props) => {
         //          }
         //
         url = joinUrl([ajaxUrl, 'series', `${seriesTag.id}.json?dcr`]);
-        typeOfOnwards = 'series';
+        ophanComponentName = 'series';
     }
 
     if (!url) return null;
 
-    return <OnwardsData url={url} limit={4} typeOfOnwards={typeOfOnwards} />;
+    return (
+        <OnwardsData
+            url={url}
+            limit={4}
+            ophanComponentName={ophanComponentName}
+        />
+    );
 };

--- a/src/web/components/Onwards/OnwardsLower.tsx
+++ b/src/web/components/Onwards/OnwardsLower.tsx
@@ -17,6 +17,8 @@ export const OnwardsLower = ({ ajaxUrl, hasStoryPackage, tags }: Props) => {
     );
 
     let url;
+    let typeOfOnwards: TypeOfOnwards = 'default-onwards';
+
     if (hasStoryPackage && seriesTag) {
         // Use the series tag to get other data in the same series
         // Example: {
@@ -26,9 +28,10 @@ export const OnwardsLower = ({ ajaxUrl, hasStoryPackage, tags }: Props) => {
         //          }
         //
         url = joinUrl([ajaxUrl, 'series', `${seriesTag.id}.json?dcr`]);
+        typeOfOnwards = 'series';
     }
 
     if (!url) return null;
 
-    return <OnwardsData url={url} limit={4} />;
+    return <OnwardsData url={url} limit={4} typeOfOnwards={typeOfOnwards} />;
 };

--- a/src/web/components/Onwards/OnwardsUpper.tsx
+++ b/src/web/components/Onwards/OnwardsUpper.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import { joinUrl } from '@root/src/web/lib/joinUrl';
-
 import { OnwardsData } from './OnwardsData';
 
 // This list is a direct copy from https://github.com/guardian/frontend/blob/6da0b3d8bfd58e8e20f80fc738b070fb23ed154e/static/src/javascripts/projects/common/modules/onward/related.js#L27
@@ -101,9 +100,12 @@ export const OnwardsUpper = ({
     );
 
     let url;
+    let typeOfOnwards: TypeOfOnwards = 'default-onwards';
+
     if (hasStoryPackage) {
         // Always fetch the story package if it exists
         url = joinUrl([ajaxUrl, 'story-package', `${pageId}.json?dcr=true`]);
+        typeOfOnwards = 'more-on-this-story';
     } else if (isAdFreeUser && isPaidContent) {
         // Don't show any related content (other than story packages) for
         // adfree users when the content is paid for
@@ -116,6 +118,7 @@ export const OnwardsUpper = ({
         //          }
         //
         url = joinUrl([ajaxUrl, 'series', `${seriesTag.id}.json?dcr`]);
+        typeOfOnwards = 'series';
     } else if (dontShowRelatedContent) {
         // Then don't show related content
     } else if (tagToFilterBy) {
@@ -143,16 +146,18 @@ export const OnwardsUpper = ({
         }
 
         url = joinUrl([ajaxUrl, popularInTagUrl]);
+        typeOfOnwards = 'related-content';
     } else {
         // Default to generic related endpoint
         const relatedUrl = `/related/${pageId}.json?dcr=true`;
 
         url = joinUrl([ajaxUrl, relatedUrl]);
+        typeOfOnwards = 'related-stories';
     }
 
     if (!url) {
         return null;
     }
 
-    return <OnwardsData url={url} limit={8} />;
+    return <OnwardsData url={url} limit={8} typeOfOnwards={typeOfOnwards} />;
 };

--- a/src/web/components/Onwards/OnwardsUpper.tsx
+++ b/src/web/components/Onwards/OnwardsUpper.tsx
@@ -100,12 +100,12 @@ export const OnwardsUpper = ({
     );
 
     let url;
-    let typeOfOnwards: TypeOfOnwards = 'default-onwards';
+    let ophanComponentName: OphanComponentName = 'default-onwards';
 
     if (hasStoryPackage) {
         // Always fetch the story package if it exists
         url = joinUrl([ajaxUrl, 'story-package', `${pageId}.json?dcr=true`]);
-        typeOfOnwards = 'more-on-this-story';
+        ophanComponentName = 'more-on-this-story';
     } else if (isAdFreeUser && isPaidContent) {
         // Don't show any related content (other than story packages) for
         // adfree users when the content is paid for
@@ -118,7 +118,7 @@ export const OnwardsUpper = ({
         //          }
         //
         url = joinUrl([ajaxUrl, 'series', `${seriesTag.id}.json?dcr`]);
-        typeOfOnwards = 'series';
+        ophanComponentName = 'series';
     } else if (dontShowRelatedContent) {
         // Then don't show related content
     } else if (tagToFilterBy) {
@@ -146,18 +146,24 @@ export const OnwardsUpper = ({
         }
 
         url = joinUrl([ajaxUrl, popularInTagUrl]);
-        typeOfOnwards = 'related-content';
+        ophanComponentName = 'related-content';
     } else {
         // Default to generic related endpoint
         const relatedUrl = `/related/${pageId}.json?dcr=true`;
 
         url = joinUrl([ajaxUrl, relatedUrl]);
-        typeOfOnwards = 'related-stories';
+        ophanComponentName = 'related-stories';
     }
 
     if (!url) {
         return null;
     }
 
-    return <OnwardsData url={url} limit={8} typeOfOnwards={typeOfOnwards} />;
+    return (
+        <OnwardsData
+            url={url}
+            limit={8}
+            ophanComponentName={ophanComponentName}
+        />
+    );
 };

--- a/src/web/lib/useComments.ts
+++ b/src/web/lib/useComments.ts
@@ -40,6 +40,7 @@ const withComments = (
             heading: section.heading,
             url: section.url,
             trails: updateTrailsWithCounts(section.trails, counts),
+            typeOfOnwards: section.typeOfOnwards,
         };
     });
 };

--- a/src/web/lib/useComments.ts
+++ b/src/web/lib/useComments.ts
@@ -40,7 +40,7 @@ const withComments = (
             heading: section.heading,
             url: section.url,
             trails: updateTrailsWithCounts(section.trails, counts),
-            typeOfOnwards: section.typeOfOnwards,
+            ophanComponentName: section.ophanComponentName,
         };
     });
 };


### PR DESCRIPTION
## What does this change?

Fixes 

_the series container at the bottom of articles (eg slide 7 of here) now has a component and link name that are specific to the series itself (eg rumour-mill,the-breakdown), rather than the component name being 'series'. Can we change just this so that the component name is 'series' but the link names remain as they are? It means we would be able to aggregate all the series clicks up across articles and series.

Another smaller, super picky request would be can we change the component name for the other series component (slide 6 here) from 'Series' to 'series', so it matches DCP?_

![image](https://user-images.githubusercontent.com/638051/75877095-cff95b00-5e0e-11ea-9859-9646e5f295d9.png)


## Why?

Better tracking.

## Link to supporting Trello card

https://trello.com/c/S0rAbEPO