### PR TITLE
Track Largest Contentful Paint to GA

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -606,3 +606,11 @@ declare module '*.svg' {
     const content: any;
     export default content;
 }
+
+// Extend PerformanceEntry from lib.dom.ts with current 'In Draft' properties (to allow access as use in browsers that support)
+// lib.dom.ts: https://microsoft.github.io/PowerBI-JavaScript/interfaces/_node_modules_typedoc_node_modules_typescript_lib_lib_dom_d_.performanceentry.html
+// Draft: https://wicg.github.io/element-timing/#sec-performance-element-timing
+interface PerformanceEntry {
+    loadTime: number;
+    renderTime: number;
+}

--- a/src/web/browser/ga/ga.ts
+++ b/src/web/browser/ga/ga.ts
@@ -119,4 +119,61 @@ export const sendPageView = (): void => {
             image.src = `${GA.beaconUrl}/count/pvg.gif`;
         },
     });
+
+    trackLCP(send);
+};
+
+// Adapted from https://web.dev/lcp/#measure-lcp-in-javascript
+const trackLCP = (send: string) => {
+    const { ga } = window;
+    // Create a variable to hold the latest LCP value (since it can change).
+    let lcp: number;
+
+    if (!window.PerformanceObserver) {
+        return;
+    }
+
+    // Create the PerformanceObserver instance.
+    const po = new window.PerformanceObserver(entryList => {
+        const entries = entryList.getEntries();
+        const lastEntry = entries[entries.length - 1];
+
+        // Update `lcp` to the latest value, using `renderTime` if it's available,
+        // otherwise using `loadTime`. (Note: `renderTime` may not be available if
+        // the element is an image and it's loaded cross-origin without the
+        // `Timing-Allow-Origin` header.)
+        lcp = lastEntry.renderTime || lastEntry.loadTime;
+    });
+
+    // Observe entries of type `largest-contentful-paint`, including buffered
+    // entries, i.e. entries that occurred before calling `observe()`.
+    try {
+        // This inexplicably fires off an error instead of just ignoring a type it doesn't understand
+        // until fairly recent browsers.
+        // https://github.com/w3c/performance-timeline/issues/87
+        // If we can't observer LCP, catch and return early.
+        po.observe({ type: 'largest-contentful-paint', buffered: true });
+    } catch {
+        return;
+    }
+
+    // Send the latest LCP value to your analytics server once the user
+    // leaves the tab.
+    window.addEventListener(
+        'visibilitychange',
+        function fn() {
+            if (lcp && document.visibilityState === 'hidden') {
+                ga(
+                    send,
+                    'timing',
+                    'timing',
+                    'Javascript Load', // Matches Frontend
+                    'LCP', // Largest Contentful Paint (We can filter to DCR with the Dimension 43 segment)
+                    lcp,
+                );
+                window.removeEventListener('visibilitychange', fn, true);
+            }
+        },
+        true,
+    );
 };


### PR DESCRIPTION
Had to revert [this](https://github.com/guardian/dotcom-rendering/pull/1219) because:

```
// This inexplicably fires off an error instead of just ignoring a type it doesn't understand
// until fairly recent browsers.
// https://github.com/w3c/performance-timeline/issues/87
// If we can't observer LCP, catch and return early.
```

## What does this change?
[Largest Contentful Paint](https://docs.google.com/document/d/13KZ-ho-TprtzFW8TfxYbijZl2FcZU5K0VeRkyqAtZJQ/edit#heading=h.d2uxciz9v6d0) is one of the new performance metrics that we want to track. This adds a (sampled) call to GA with that metric.

# Why?
While it can be tracked synthetically in Speedcurve, it's also useful to have RUM metrics around it as a more realistic view of LCP times for users.

## Link to supporting Trello card
https://trello.com/c/J2A5s9zo 