### PR TITLE
Lowercase series and section in the data link name and data component…

### DIFF
--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -98,7 +98,7 @@ export const SeriesSectionLink: React.FC<{
                     guardianBaseURL={guardianBaseURL}
                     tagTitle={tag.title}
                     tagUrl={tag.id}
-                    dataComponentName="Series"
+                    dataComponentName="series"
                     dataLinkName="article series"
                     weightingClass={primaryStyle}
                 />
@@ -107,7 +107,7 @@ export const SeriesSectionLink: React.FC<{
                     guardianBaseURL={guardianBaseURL}
                     tagTitle={sectionLabel}
                     tagUrl={sectionUrl}
-                    dataComponentName="Section"
+                    dataComponentName="section"
                     dataLinkName="article section"
                     weightingClass={secondaryStyle}
                 />

--- a/src/web/server/document.test.tsx
+++ b/src/web/server/document.test.tsx
@@ -60,14 +60,14 @@ test('Meta ophan data-attributes exist', () => {
 });
 
 test('Section ophan data-attributes do not exist', () => {
-    expect(result).toEqual(expect.stringContaining(`data-component="Section"`));
+    expect(result).toEqual(expect.stringContaining(`data-component="section"`));
 
     expect(result).toEqual(
         expect.stringContaining(`data-link-name="article section"`),
     );
 });
 test('Series ophan data-attributes exist', () => {
-    expect(result).toEqual(expect.stringContaining(`data-component="Series"`));
+    expect(result).toEqual(expect.stringContaining(`data-component="series"`));
 
     expect(result).toEqual(
         expect.stringContaining(`data-link-name="article series"`),


### PR DESCRIPTION
… name of the article title component

## Why?

Matches tracking on Frontend so can be directly compared.