### PR TITLE
Add bundlesize action

### DIFF
--- a/.github/workflows/compress.yml
+++ b/.github/workflows/compress.yml
@@ -1,0 +1,18 @@
+name: Compressed Size
+
+on: [pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '10.15.3'
+    - uses: preactjs/compressed-size-action@v1
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        build-script: makeBuild

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
         "cypress:run:e2e": "cypress run --spec 'cypress/integration/e2e/**/*'",
         "storybook": "node --max-old-space-size=4096 $(yarn bin)/start-storybook -s ./src/static -p 6006",
         "storybook:build": "node --max-old-space-size=4096 $(yarn bin)/build-storybook",
-        "chromatic": "chromatic --build-script-name=storybook:build --exit-zero-on-changes"
+        "chromatic": "chromatic --build-script-name=storybook:build --exit-zero-on-changes",
+        "makeBuild": "NODE_ENV=production webpack --config scripts/webpack/frontend"
     },
     "bundlesize": [
         {


### PR DESCRIPTION
## What does this change?

Runs an action that reports the bundle size changes 

![image](https://user-images.githubusercontent.com/638051/75899769-dd750c00-5e33-11ea-899f-08b9689d8fdb.png)


## Why?
Visibility on bundlesizes.

## Link to supporting Trello card
https://trello.com/c/Qb80CggQ
