### PR TITLE
Send INSERT event to Ophan when Epic added to DOM

### DIFF
--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -8,6 +8,24 @@ import {
 } from '@root/src/web/lib/contributions';
 import { useApiFn } from '../lib/api';
 
+const sendOphanInsertEvent = (): void => {
+    const componentEvent = {
+        component: {
+            componentType: 'ACQUISITIONS_EPIC',
+            products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
+            campaignCode: 'gdnwb_copts_memco_remote_epic_test_api',
+            id: 'gdnwb_copts_memco_remote_epic_test_api',
+        },
+        abTest: {
+            name: 'remote_epic_test',
+            variant: 'api',
+        },
+        action: 'INSERT',
+    };
+
+    window.guardian.ophan.record({ componentEvent });
+};
+
 const wrapperMargins = css`
     margin: 18px 0;
 `;
@@ -81,6 +99,8 @@ export const SlotBodyEnd = ({
     if (bodyResponse && bodyResponse.data) {
         // Add a new entry to the view log when we know an Epic is being rendered
         logView(epicTestName);
+        sendOphanInsertEvent();
+
         const { html: epicHtml, css: epicCss } = bodyResponse.data;
         return (
             <div className={wrapperMargins}>


### PR DESCRIPTION
## What does this change?

We'd like to replicate the events/data we send to Ophan on Frontend around rendering the Epic, starting with the simplest case (inserting the Epic into the DOM). The payload data is all hardcoded currently. Some of this may end up being part of the slot-machine-client lib, but as a first step I'm adding directly to DCR.

## Why?

Visibility into Epic behaviour.

## Link to supporting Trello card

https://trello.com/c/Jokwpuce/58-add-ophan-event-tracking-for-dcr