### PR TITLE
Refactor CommentCount

### DIFF
--- a/src/web/browser/App.tsx
+++ b/src/web/browser/App.tsx
@@ -18,6 +18,7 @@ import { Header } from '@frontend/web/components/Header';
 import { getCookie } from '@root/src/web/browser/cookie';
 
 import { getCountryCode } from '@frontend/web/lib/getCountryCode';
+import { getCommentCount } from '@frontend/web/lib/getCommentCount';
 
 type Props = { CAPI: CAPIType; NAV: NavType };
 
@@ -47,6 +48,7 @@ export const hydrateApp = ({ CAPI, NAV }: { CAPI: CAPIType; NAV: NavType }) => {
 const App = ({ CAPI, NAV }: Props) => {
     const [isSignedIn, setIsSignedIn] = useState<boolean>();
     const [countryCode, setCountryCode] = useState<string>();
+    const [commentCount, setCommentCount] = useState<number>(0);
 
     useEffect(() => {
         setIsSignedIn(!!getCookie('GU_U'));
@@ -57,6 +59,17 @@ const App = ({ CAPI, NAV }: Props) => {
             setCountryCode((await getCountryCode()) || '');
         callFetch();
     }, []);
+
+    useEffect(() => {
+        const callFetch = async () =>
+            setCommentCount(
+                await getCommentCount(
+                    CAPI.config.ajaxUrl,
+                    CAPI.config.shortUrlId,
+                ),
+            );
+        callFetch();
+    }, [CAPI.config.ajaxUrl, CAPI.config.shortUrlId]);
 
     const richLinks: {
         element: RichLinkBlockElement;
@@ -131,7 +144,7 @@ const App = ({ CAPI, NAV }: Props) => {
                 <Counts
                     ajaxUrl={CAPI.config.ajaxUrl}
                     pageId={CAPI.config.pageId}
-                    shortUrlId={CAPI.config.shortUrlId}
+                    commentCount={commentCount}
                     pillar={CAPI.pillar}
                 />
             </Portal>

--- a/src/web/components/Counts.stories.tsx
+++ b/src/web/components/Counts.stories.tsx
@@ -3,7 +3,6 @@ import { css } from 'emotion';
 import fetchMock from 'fetch-mock';
 
 import { sharecount } from '@root/fixtures/article';
-import { commentCount } from '@root/fixtures/commentCounts';
 
 import { Counts } from './Counts';
 
@@ -29,7 +28,7 @@ export const Live = () => {
         <Container>
             <Counts
                 ajaxUrl="https://api.nextgen.guardianapps.co.uk"
-                shortUrlId="/p/4k83z"
+                commentCount={239}
                 pageId="/lifeandstyle/2020/jan/25/deborah-orr-parents-jailers-i-loved"
                 pillar="news"
             />
@@ -41,22 +40,6 @@ Live.story = { name: 'with both results' };
 export const ShareOnly = () => {
     fetchMock
         .restore()
-        // Comment count
-        .getOnce(
-            'begin:https://api.nextgen.guardianapps.co.uk/discussion/comment-counts.json?shortUrls=',
-            {
-                status: 200,
-                body: {
-                    counts: [
-                        {
-                            id: '/p/4k83z',
-                            count: 0,
-                        },
-                    ],
-                },
-            },
-            { overwriteRoutes: false },
-        )
         // Share count
         .getOnce(
             'begin:https://api.nextgen.guardianapps.co.uk/sharecount/',
@@ -71,7 +54,7 @@ export const ShareOnly = () => {
         <Container>
             <Counts
                 ajaxUrl="https://api.nextgen.guardianapps.co.uk"
-                shortUrlId="/p/abc"
+                commentCount={0}
                 pageId="/lifeandstyle/2020/jan/25/deborah-orr-parents-jailers-i-loved"
                 pillar="news"
             />
@@ -83,15 +66,6 @@ ShareOnly.story = { name: 'with share count only' };
 export const CommentOnly = () => {
     fetchMock
         .restore()
-        // Comment count
-        .getOnce(
-            'begin:https://api.nextgen.guardianapps.co.uk/discussion/comment-counts.json?shortUrls=',
-            {
-                status: 200,
-                body: commentCount,
-            },
-            { overwriteRoutes: false },
-        )
         // Share count
         .getOnce(
             'begin:https://api.nextgen.guardianapps.co.uk/sharecount/',
@@ -110,7 +84,7 @@ export const CommentOnly = () => {
         <Container>
             <Counts
                 ajaxUrl="https://api.nextgen.guardianapps.co.uk"
-                shortUrlId="/p/4k83z"
+                commentCount={239}
                 pageId="/lifeandstyle/abc"
                 pillar="news"
             />

--- a/src/web/components/Counts.test.tsx
+++ b/src/web/components/Counts.test.tsx
@@ -15,7 +15,6 @@ describe('Counts', () => {
     const ajaxUrl = 'https://api.nextgen.guardianapps.co.uk';
     const pageId =
         '/environment/2020/jan/25/court-probe-carrie-symonds-influence-boris-johnson-badger-cull';
-    const shortUrlId = '/p/4k83z';
 
     beforeEach(() => {
         useApi.mockReset();
@@ -23,14 +22,14 @@ describe('Counts', () => {
 
     it('It should render null if share_count is falsy', () => {
         useApi.mockReturnValue({
-            data: { share_count: 0, counts: [{ id: 'abc', count: 0 }] },
+            data: { share_count: 0 },
         });
 
         const { container } = render(
             <Counts
                 ajaxUrl={ajaxUrl}
                 pageId={pageId}
-                shortUrlId={shortUrlId}
+                commentCount={0}
                 pillar="news"
             />,
         );
@@ -45,7 +44,7 @@ describe('Counts', () => {
             <Counts
                 ajaxUrl={ajaxUrl}
                 pageId={pageId}
-                shortUrlId={shortUrlId}
+                commentCount={0}
                 pillar="news"
             />,
         );
@@ -60,7 +59,7 @@ describe('Counts', () => {
             <Counts
                 ajaxUrl={ajaxUrl}
                 pageId={pageId}
-                shortUrlId={shortUrlId}
+                commentCount={0}
                 pillar="news"
             />,
         );
@@ -76,7 +75,7 @@ describe('Counts', () => {
             <Counts
                 ajaxUrl={ajaxUrl}
                 pageId={pageId}
-                shortUrlId={shortUrlId}
+                commentCount={0}
                 pillar="news"
             />,
         );
@@ -87,14 +86,14 @@ describe('Counts', () => {
 
     it('It should not render the share component if there are no shares', () => {
         useApi.mockReturnValue({
-            data: { share_count: 0, counts: [{ id: 'abc', count: 280 }] },
+            data: { share_count: 0 },
         });
 
         const { queryAllByTestId } = render(
             <Counts
                 ajaxUrl={ajaxUrl}
                 pageId={pageId}
-                shortUrlId={shortUrlId}
+                commentCount={1}
                 pillar="news"
             />,
         );
@@ -112,7 +111,7 @@ describe('Counts', () => {
             <Counts
                 ajaxUrl={ajaxUrl}
                 pageId={pageId}
-                shortUrlId={shortUrlId}
+                commentCount={0}
                 pillar="news"
             />,
         );
@@ -130,7 +129,7 @@ describe('Counts', () => {
             <Counts
                 ajaxUrl={ajaxUrl}
                 pageId={pageId}
-                shortUrlId={shortUrlId}
+                commentCount={1}
                 pillar="news"
             />,
         );
@@ -149,7 +148,7 @@ describe('Counts', () => {
             <Counts
                 ajaxUrl={ajaxUrl}
                 pageId={pageId}
-                shortUrlId={shortUrlId}
+                commentCount={0}
                 pillar="news"
             />,
         );
@@ -168,7 +167,7 @@ describe('Counts', () => {
             <Counts
                 ajaxUrl={ajaxUrl}
                 pageId={pageId}
-                shortUrlId={shortUrlId}
+                commentCount={1}
                 pillar="news"
             />,
         );

--- a/src/web/components/Counts.tsx
+++ b/src/web/components/Counts.tsx
@@ -46,14 +46,6 @@ export const Counts = ({ ajaxUrl, pageId, commentCount, pillar }: Props) => {
         shareUrl,
     );
 
-    // const commentUrl = joinUrl([
-    //     ajaxUrl,
-    //     `discussion/comment-counts.json?shortUrls=${shortUrlId}`,
-    // ]);
-    // const { data: commentData, error: commentError } = useApi<
-    //     CommentCountsType
-    // >(commentUrl);
-
     if (shareError) {
         window.guardian.modules.sentry.reportError(
             shareError,

--- a/src/web/components/Counts.tsx
+++ b/src/web/components/Counts.tsx
@@ -12,23 +12,14 @@ import { joinUrl } from '@root/src/web/lib/joinUrl';
 type Props = {
     ajaxUrl: string;
     pageId: string;
-    shortUrlId: string;
     pillar: Pillar;
+    commentCount: number;
 };
 
 type ShareCountType = {
     path: string;
     share_count: number;
     refreshStatus: boolean;
-};
-
-type CountType = {
-    id: string;
-    count: number;
-};
-
-type CommentCountsType = {
-    counts: CountType[];
 };
 
 const containerStyles = css`
@@ -49,19 +40,19 @@ const NumbersBorder = () => (
     />
 );
 
-export const Counts = ({ ajaxUrl, pageId, shortUrlId, pillar }: Props) => {
+export const Counts = ({ ajaxUrl, pageId, commentCount, pillar }: Props) => {
     const shareUrl = joinUrl([ajaxUrl, 'sharecount', `${pageId}.json`]);
     const { data: shareData, error: shareError } = useApi<ShareCountType>(
         shareUrl,
     );
 
-    const commentUrl = joinUrl([
-        ajaxUrl,
-        `discussion/comment-counts.json?shortUrls=${shortUrlId}`,
-    ]);
-    const { data: commentData, error: commentError } = useApi<
-        CommentCountsType
-    >(commentUrl);
+    // const commentUrl = joinUrl([
+    //     ajaxUrl,
+    //     `discussion/comment-counts.json?shortUrls=${shortUrlId}`,
+    // ]);
+    // const { data: commentData, error: commentError } = useApi<
+    //     CommentCountsType
+    // >(commentUrl);
 
     if (shareError) {
         window.guardian.modules.sentry.reportError(
@@ -70,21 +61,9 @@ export const Counts = ({ ajaxUrl, pageId, shortUrlId, pillar }: Props) => {
         );
     }
 
-    if (commentError) {
-        window.guardian.modules.sentry.reportError(
-            commentError,
-            'comment-count',
-        );
-    }
-
-    // Or false because we use these vars to decide if to render or not and react sees 0 as truthy
+    // We use || false below because we use these vars to decide if to render or not and react sees 0 as truthy
     const hasShareData = (shareData && shareData.share_count) || false;
-    const hasCommentData =
-        (commentData &&
-            commentData.counts &&
-            commentData.counts[0] &&
-            commentData.counts[0].count) ||
-        false;
+    const hasCommentData = commentCount || false;
     if (!hasShareData && !hasCommentData) {
         return null;
     }
@@ -94,11 +73,7 @@ export const Counts = ({ ajaxUrl, pageId, shortUrlId, pillar }: Props) => {
     );
 
     const { short: commentShort, long: commentLong } = formatCount(
-        (commentData &&
-            commentData.counts &&
-            commentData.counts[0] &&
-            commentData.counts[0].count) ||
-            0,
+        commentCount || 0,
     );
 
     return (

--- a/src/web/lib/getCommentCount.ts
+++ b/src/web/lib/getCommentCount.ts
@@ -1,0 +1,27 @@
+import { joinUrl } from '@root/src/web/lib/joinUrl';
+
+export const getCommentCount = async (ajaxUrl: string, shortUrl: string) => {
+    const url = joinUrl([
+        ajaxUrl,
+        `discussion/comment-counts.json?shortUrls=${shortUrl}`,
+    ]);
+    return fetch(url)
+        .then(response => {
+            if (!response.ok) {
+                throw Error(response.statusText);
+            }
+            return response;
+        })
+        .then(response => response.json())
+        .then(
+            json =>
+                (json &&
+                    json.counts &&
+                    json.counts[0] &&
+                    json.counts[0].count) ||
+                0,
+        )
+        .catch(error => {
+            window.guardian.modules.sentry.reportError(error, 'comment-count');
+        });
+};


### PR DESCRIPTION
## What does this change?
This PR lifts up the call to get the count of comments for an article up out of `Counts` and into `App`

## Why?
Because we also want to use this count elsewhere on the page. The `SignedInAs` component needs it and we will also want to pass it to Comments later when we load them. 

## Link to supporting Trello card
https://trello.com/c/QmSt9xB6/1264-refactor-counts