### PR TITLE
Ensure array of scripts is unique

### DIFF
--- a/src/amp/lib/scripts.ts
+++ b/src/amp/lib/scripts.ts
@@ -1,4 +1,6 @@
 const notEmpty = (value: string | null): value is string => value !== null;
+const unique = (value: string | null, index: number, self: any) =>
+    self.indexOf(value) === index;
 
 export const extractScripts: (
     elements: CAPIElement[],
@@ -27,7 +29,8 @@ export const extractScripts: (
                     return null;
             }
         })
-        .filter(notEmpty) as string[];
+        .filter(notEmpty)
+        .filter(unique) as string[];
     // I have no idea why the type predicate isn't working here. I think it has something to do with the union type.
     // It works with simpler arrays of type Array<string | null> but not this one.
 };


### PR DESCRIPTION
## What does this change?
This fix the AMP problem where if an article has two elements needing a script loaded it was being loaded twice failing the amp validation

## Why?
AMP ⚡️ 

## Link to supporting Trello card
https://trello.com/c/Ts5CoABG/1267-getting-amp-error-message-on-the-us-politics-live-blog
