### PR TITLE
Fewer Sentry Errors

### DIFF
--- a/src/web/browser/sentry/sentry.tsx
+++ b/src/web/browser/sentry/sentry.tsx
@@ -17,6 +17,8 @@ const ignoreErrors = [
     /InvalidStateError/gi,
     /Fetch error:/gi,
     'Network request failed',
+    'NetworkError',
+    'Failed to fetch',
     'This video is no longer available.',
     'UnknownError',
 ];

--- a/src/web/browser/sentry/sentry.tsx
+++ b/src/web/browser/sentry/sentry.tsx
@@ -1,8 +1,6 @@
 import * as Sentry from '@sentry/browser';
 
-// This is set to 10% here rather than the normal 1% so we get good
-// feedback early on. TODO: This should be reduced to 1% once the site is fully deployed.
-const SAMPLE_RATE = 0.1;
+const SAMPLE_RATE = 0.01; // 1%
 
 // Only send errors matching these regexes
 const whitelistUrls = [


### PR DESCRIPTION
## What does this change?
This PR lowers the number of Sentry errors that will be sent. It reduces sample size for Sentry and adds some items to the blacklist.

## Why?
At our scale there's no need to capture 10% of errors, 1% is sufficient. In addition, we don't need to capture errors regarding network transience, these can be ignored.

## Link to supporting Trello card
https://trello.com/c/Vad3UwJa/1268-reduce-sentry-volume