### PR TITLE
SignedInAs supports discussion closed state

### DIFF
--- a/src/web/components/SignedInAs.stories.tsx
+++ b/src/web/components/SignedInAs.stories.tsx
@@ -59,6 +59,15 @@ export const NotSignedIn = () => {
 NotSignedIn.story = { name: 'not signed in' };
 
 export const DiscussionClosed = () => {
+    return (
+        <SignedInAs commentCount={32} discussionClosed={true} user={aUser} />
+    );
+};
+DiscussionClosed.story = { name: 'discussion closed, user signed in' };
+
+export const DiscussionClosedSignedOut = () => {
     return <SignedInAs commentCount={32} discussionClosed={true} />;
 };
-DiscussionClosed.story = { name: 'with discussion closed' };
+DiscussionClosedSignedOut.story = {
+    name: 'discussion closed, user not signed in',
+};

--- a/src/web/components/SignedInAs.stories.tsx
+++ b/src/web/components/SignedInAs.stories.tsx
@@ -57,3 +57,8 @@ export const NotSignedIn = () => {
     return <SignedInAs commentCount={32} />;
 };
 NotSignedIn.story = { name: 'not signed in' };
+
+export const DiscussionClosed = () => {
+    return <SignedInAs commentCount={32} discussionClosed={true} />;
+};
+DiscussionClosed.story = { name: 'with discussion closed' };

--- a/src/web/components/SignedInAs.tsx
+++ b/src/web/components/SignedInAs.tsx
@@ -8,6 +8,7 @@ import { until } from '@guardian/src-foundations/mq';
 type Props = {
     commentCount: number;
     user?: UserProfile;
+    discussionClosed?: boolean;
 };
 
 const containerStyles = css`
@@ -34,7 +35,7 @@ const headingStyles = css`
     padding-bottom: ${space[1]}px;
 `;
 
-const signedInStyles = css`
+const textStyles = css`
     ${textSans.small()}
     ${until.desktop} {
         ${textSans.xsmall()}
@@ -43,7 +44,7 @@ const signedInStyles = css`
     padding-bottom: ${space[1]}px;
 `;
 
-const signedOutStyles = css`
+const headlineStyles = css`
     ${headline.xxxsmall()}
     color: ${palette.neutral[46]};
     padding-bottom: ${space[1]}px;
@@ -72,7 +73,7 @@ const rowUntilDesktop = css`
     }
 `;
 
-export const SignedInAs = ({ commentCount, user }: Props) => {
+export const SignedInAs = ({ commentCount, user, discussionClosed }: Props) => {
     return (
         <div className={containerStyles}>
             <h2 className={headingStyles}>
@@ -85,7 +86,9 @@ export const SignedInAs = ({ commentCount, user }: Props) => {
                     ({commentCount})
                 </span>
             </h2>
-            {user ? (
+
+            {/* Discussion open and user logged in */}
+            {user && !discussionClosed && (
                 <div className={rowUntilDesktop}>
                     <div className={imageWrapper}>
                         <img
@@ -97,15 +100,18 @@ export const SignedInAs = ({ commentCount, user }: Props) => {
                             className={imageStyles}
                         />
                     </div>
-                    <div className={signedInStyles}>
+                    <div className={textStyles}>
                         Signed in as
                         <div className={usernameStyles}>
                             {user.displayName || 'Guardian User'}
                         </div>
                     </div>
                 </div>
-            ) : (
-                <span className={signedOutStyles}>
+            )}
+
+            {/* Discussion open but user is logged out */}
+            {!user && !discussionClosed && (
+                <span className={headlineStyles}>
                     <a
                         href="https://profile.theguardian.com/signin?INTCMP=DOTCOM_COMMENTS_SIGNIN"
                         className={linkStyles}
@@ -120,6 +126,13 @@ export const SignedInAs = ({ commentCount, user }: Props) => {
                         create your Guardian account
                     </a>{' '}
                     to join the discussion.
+                </span>
+            )}
+
+            {/* The discussion is closed */}
+            {discussionClosed && (
+                <span className={headlineStyles}>
+                    This discussion is closed for comments
                 </span>
             )}
         </div>

--- a/src/web/components/SignedInAs.tsx
+++ b/src/web/components/SignedInAs.tsx
@@ -109,8 +109,8 @@ export const SignedInAs = ({ commentCount, user, discussionClosed }: Props) => {
                 </div>
             )}
 
-            {/* Discussion open but user is logged out */}
-            {!user && !discussionClosed && (
+            {/* User is logged out (show this even if the discussion is closed) */}
+            {!user && (
                 <span className={headlineStyles}>
                     <a
                         href="https://profile.theguardian.com/signin?INTCMP=DOTCOM_COMMENTS_SIGNIN"
@@ -129,8 +129,8 @@ export const SignedInAs = ({ commentCount, user, discussionClosed }: Props) => {
                 </span>
             )}
 
-            {/* The discussion is closed */}
-            {discussionClosed && (
+            {/* The discussion is closed (only appears for logged in users) */}
+            {user && discussionClosed && (
                 <span className={headlineStyles}>
                     This discussion is closed for comments
                 </span>


### PR DESCRIPTION
## What does this change?
The SignedInAs component now shows a relevant message when the discussion is closed

![Screenshot 2020-03-06 at 08 32 28](https://user-images.githubusercontent.com/1336821/76066193-0822aa00-5f85-11ea-9ebe-dd58d6026fe9.jpg)


## Why?
Because this is how we communicate with the user the fact that they can't comment anymore

## Link to supporting Trello card
https://trello.com/c/y7jPAJ4S/1242-signedinas-supports-closed-for-discussion-state
