### PR TITLE
Send Ophan VIEW event for epic

### DIFF
--- a/src/web/lib/useHasBeenSeen.ts
+++ b/src/web/lib/useHasBeenSeen.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState, useRef } from 'react';
+
+const useHasBeenSeen = (options: IntersectionObserverInit) => {
+    const [hasBeenSeen, setHasBeenSeen] = useState<boolean>(false);
+    const [node, setNode] = useState<HTMLElement | null>(null);
+
+    const observer = useRef<IntersectionObserver | null>(null);
+
+    useEffect(() => {
+        if (observer.current) {
+            observer.current.disconnect();
+        }
+
+        observer.current = new window.IntersectionObserver(([entry]) => {
+            if (entry.isIntersecting) {
+                setHasBeenSeen(true);
+            }
+        }, options);
+
+        const { current: currentObserver } = observer;
+
+        if (node) {
+            currentObserver.observe(node);
+        }
+
+        return () => currentObserver.disconnect();
+    }, [node, options]);
+
+    return [hasBeenSeen, setNode];
+};
+
+export { useHasBeenSeen };


### PR DESCRIPTION
## What does this change?

When the epic scrolls into view (more than 1/2 in viewport - see [this comment](https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js#L274) on frontend) send a `VIEW` event to Ophan. Also move the local storage view log to happen at the same time, rather than on render/insert.

~~This is a draft PR because there's still a TypeScript error I need to fix, but opening for visibility.~~ I ended up giving in and "fixing" this by casting (see the call to `useVisibility`). Any ideas on how to avoid this welcome!

### TODO

- [x] Remove remaining `console.log`s (they've been really useful to see in the browser when events are getting sent)

## Why?

Better visibility into behaviour around Epics.

## Link to supporting Trello card

https://trello.com/c/Jokwpuce/58-add-ophan-event-tracking-for-dcr
https://trello.com/c/64HbNXO1/65-ensure-view-log-is-only-updated-when-epic-scrolls-into-view