### PR TITLE
migrate from palette.brandYellow to brandAlt[400]

### DIFF
--- a/src/web/components/AgeWarning.tsx
+++ b/src/web/components/AgeWarning.tsx
@@ -4,7 +4,10 @@ import { css } from 'emotion';
 import ClockIcon from '@frontend/static/icons/clock.svg';
 
 import { from } from '@guardian/src-foundations/mq';
-import { palette } from '@guardian/src-foundations';
+import {
+    brandAltText,
+    brandAltBackground,
+} from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 
@@ -16,8 +19,8 @@ type Props = {
 
 const ageWarningStyles = (isSmall: boolean) => css`
     ${isSmall ? textSans.xsmall() : textSans.medium()};
-    color: ${palette.neutral[7]};
-    background-color: ${palette.brandYellow.main};
+    color: ${brandAltText.primary};
+    background-color: ${brandAltBackground.primary};
     display: inline-block;
 
     > strong {

--- a/src/web/components/BackToTop.tsx
+++ b/src/web/components/BackToTop.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { css, cx } from 'emotion';
-import { palette } from '@guardian/src-foundations';
-import { background, brandText } from '@guardian/src-foundations/palette';
+import {
+    brandBackground,
+    brandText,
+    brandAlt,
+} from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 
 const iconHeight = '42px';
@@ -10,7 +13,7 @@ const iconContainer = css`
     position: relative;
     float: right;
     border-radius: 100%;
-    background-color: ${background.primary};
+    background-color: ${brandBackground.ctaPrimary};
     cursor: pointer;
     height: ${iconHeight};
     min-width: ${iconHeight};
@@ -23,10 +26,10 @@ const link = css`
     line-height: ${iconHeight};
 
     :hover {
-        color: ${palette.brandYellow.main};
+        color: ${brandAlt[400]};
 
         .icon-container {
-            background-color: ${palette.brandYellow.main};
+            background-color: ${brandAlt[400]};
         }
     }
 `;
@@ -39,7 +42,7 @@ const icon = css`
         left: 0;
         right: 0;
         margin: auto;
-        border: 2px solid ${palette.neutral[7]};
+        border: 2px solid ${brandText.ctaPrimary};
         border-bottom: 0;
         border-right: 0;
         content: '';
@@ -50,7 +53,7 @@ const icon = css`
 `;
 
 const textStyles = css`
-    ${textSans.small()};
+    ${textSans.small({ fontWeight: 'bold' })};
     padding-right: 5px;
 `;
 

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 import { palette } from '@guardian/src-foundations';
+import { brandAltBackground } from '@guardian/src-foundations/palette';
 
 import { StarRating } from '@root/src/web/components/StarRating/StarRating';
 import { CardHeadline } from '@frontend/web/components/CardHeadline';
@@ -73,7 +74,7 @@ const StarRatingComponent: React.FC<{ rating: number }> = ({ rating }) => (
 );
 
 const starWrapper = css`
-    background-color: ${palette.brandYellow.main};
+    background-color: ${brandAltBackground.primary};
     position: absolute;
     bottom: 0;
     margin-top: 2px;

--- a/src/web/components/Dropdown.tsx
+++ b/src/web/components/Dropdown.tsx
@@ -2,7 +2,12 @@ import React, { useState, useEffect } from 'react';
 import { css, cx } from 'emotion';
 
 import { palette } from '@guardian/src-foundations';
-import { neutral, border, brandText } from '@guardian/src-foundations/palette';
+import {
+    neutral,
+    border,
+    brandText,
+    brandAlt,
+} from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
 import { visuallyHidden } from '@guardian/src-foundations/accessibility';
@@ -127,7 +132,7 @@ const button = css`
     text-decoration: none;
 
     :hover {
-        color: ${palette.brandYellow.main};
+        color: ${brandAlt[400]};
 
         :after {
             transform: translateY(0) rotate(45deg);

--- a/src/web/components/Footer.tsx
+++ b/src/web/components/Footer.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css, cx } from 'emotion';
 
 import { palette } from '@guardian/src-foundations';
-import { brandText } from '@guardian/src-foundations/palette';
+import { brandText, brandAlt } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
 
@@ -72,7 +72,7 @@ const footerLink = css`
 
     :hover {
         text-decoration: underline;
-        color: ${palette.brandYellow.main};
+        color: ${brandAlt[400]};
     }
 `;
 

--- a/src/web/components/HeadlineByline.tsx
+++ b/src/web/components/HeadlineByline.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 import { palette } from '@guardian/src-foundations';
+import { brandAltBackground } from '@guardian/src-foundations/palette';
 import { headline } from '@guardian/src-foundations/typography';
 
 import { BylineLink } from '@root/src/web/components/BylineLink';
@@ -18,9 +19,9 @@ const yellowBoxStyles = css`
         lineHeight: 'loose',
     })}
     font-style: italic;
-    background-color: ${palette.brandYellow.main};
-    box-shadow: 4px 0 0 ${palette.brandYellow.main},
-        -6px 0 0 ${palette.brandYellow.main};
+    background-color: ${brandAltBackground.primary};
+    box-shadow: 4px 0 0 ${brandAltBackground.primary},
+        -6px 0 0 ${brandAltBackground.primary};
     display: inline-block;
     box-decoration-break: clone;
 

--- a/src/web/components/Links.tsx
+++ b/src/web/components/Links.tsx
@@ -4,7 +4,7 @@ import { css, cx } from 'emotion';
 import SearchIcon from '@frontend/static/icons/search.svg';
 
 import { palette } from '@guardian/src-foundations';
-import { brandText } from '@guardian/src-foundations/palette';
+import { brandText, brandAlt } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 
@@ -52,7 +52,7 @@ const linkStyles = css`
 
     :hover,
     :focus {
-        color: ${palette.brandYellow.main};
+        color: ${brandAlt[400]};
     }
 
     svg {

--- a/src/web/components/Nav/ExpandedMenu/Column.tsx
+++ b/src/web/components/Nav/ExpandedMenu/Column.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { css, cx } from 'emotion';
 import { palette } from '@guardian/src-foundations';
-import { brandText } from '@guardian/src-foundations/palette';
+import { brandText, brandAlt } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
 import { CollapseColumnButton } from './CollapseColumnButton';
@@ -68,7 +68,7 @@ const columnLinkTitle = css`
 
     :hover,
     :focus {
-        color: ${palette.brandYellow.main};
+        color: ${brandAlt[400]};
         text-decoration: underline;
     }
 

--- a/src/web/components/Nav/ExpandedMenu/Columns.tsx
+++ b/src/web/components/Nav/ExpandedMenu/Columns.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 import { palette } from '@guardian/src-foundations';
-import { brandText } from '@guardian/src-foundations/palette';
+import { brandText, brandAlt } from '@guardian/src-foundations/palette';
 import { headline, textSans } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 
@@ -90,7 +90,7 @@ const brandExtensionLink = css`
     }
     :hover,
     :focus {
-        color: ${palette.brandYellow.main};
+        color: ${brandAlt[400]};
     }
     > * {
         pointer-events: none;

--- a/src/web/components/Nav/ExpandedMenu/ExpandedMenuToggle/ExpandedMenuToggle.tsx
+++ b/src/web/components/Nav/ExpandedMenu/ExpandedMenuToggle/ExpandedMenuToggle.tsx
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import { css, cx } from 'emotion';
-import { palette } from '@guardian/src-foundations';
-import { brandText } from '@guardian/src-foundations/palette';
+import { brandText, brandAlt } from '@guardian/src-foundations/palette';
 import { headline } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 import { visuallyHidden } from '@guardian/src-foundations/accessibility';
@@ -28,11 +27,9 @@ const openExpandedMenu = css`
         padding-top: 5px;
         height: 42px;
     }
-    :hover {
-        color: ${palette.brandYellow.main};
-    }
+    :hover,
     :focus {
-        color: ${palette.brandYellow.main};
+        color: ${brandAlt[400]};
     }
 `;
 const checkbox = css`

--- a/src/web/components/Nav/ExpandedMenu/ExpandedMenuToggle/VeggieBurger.tsx
+++ b/src/web/components/Nav/ExpandedMenu/ExpandedMenuToggle/VeggieBurger.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 import { palette } from '@guardian/src-foundations';
+import { brandAlt } from '@guardian/src-foundations/palette';
 import { from, until } from '@guardian/src-foundations/mq';
 
 const veggieBurger = ({
@@ -9,7 +10,7 @@ const veggieBurger = ({
 }: {
     showExpandedMenu: boolean;
 }) => css`
-    background-color: ${palette.brandYellow.main};
+    background-color: ${brandAlt[400]};
     color: ${palette.neutral[7]};
     cursor: pointer;
     height: 42px;

--- a/src/web/components/ReaderRevenueLinks.tsx
+++ b/src/web/components/ReaderRevenueLinks.tsx
@@ -3,7 +3,7 @@ import { css, cx } from 'emotion';
 
 import ArrowRightIcon from '@frontend/static/icons/arrow-right.svg';
 import { palette } from '@guardian/src-foundations';
-import { brandText } from '@guardian/src-foundations/palette';
+import { brandText, brandAlt } from '@guardian/src-foundations/palette';
 import { textSans, headline } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
 
@@ -34,7 +34,7 @@ const paddingStyles = css`
 `;
 
 const messageStyles = css`
-    color: ${palette.brandYellow.main};
+    color: ${brandAlt[400]};
     ${headline.xxsmall({ fontWeight: 'bold' })};
     padding-top: 3px;
     margin-bottom: 3px;
@@ -49,7 +49,7 @@ const messageStyles = css`
 `;
 
 const linkStyles = css`
-    background: ${palette.brandYellow.main};
+    background: ${brandAlt[400]};
     border-radius: 16px;
     box-sizing: border-box;
     color: ${palette.neutral[7]};

--- a/src/web/components/elements/ImageComponent.tsx
+++ b/src/web/components/elements/ImageComponent.tsx
@@ -5,7 +5,7 @@ import { Picture, PictureSource } from '@root/src/web/components/Picture';
 import { Caption } from '@root/src/web/components/Caption';
 import { StarRating } from '@root/src/web/components/StarRating/StarRating';
 import { until, from, between } from '@guardian/src-foundations/mq';
-import { palette } from '@guardian/src-foundations';
+import { brandAltBackground } from '@guardian/src-foundations/palette';
 
 const widths = [1020, 660, 480, 0];
 
@@ -73,7 +73,7 @@ const getFallback: (imageSources: ImageSource[]) => string = imageSources => {
 };
 
 const starsWrapper = css`
-    background-color: ${palette.brandYellow.main};
+    background-color: ${brandAltBackground.primary};
 
     position: absolute;
     ${until.tablet} {

--- a/src/web/components/elements/RichLinkComponent.tsx
+++ b/src/web/components/elements/RichLinkComponent.tsx
@@ -4,8 +4,11 @@ import { css, cx } from 'emotion';
 import { pillarPalette } from '@frontend/lib/pillars';
 import ArrowInCircle from '@frontend/static/icons/arrow-in-circle.svg';
 import Quote from '@frontend/static/icons/quote.svg';
-import { text, neutral } from '@guardian/src-foundations/palette';
-import { palette } from '@guardian/src-foundations';
+import {
+    text,
+    neutral,
+    brandAltBackground,
+} from '@guardian/src-foundations/palette';
 import { StarRating } from '@root/src/web/components/StarRating/StarRating';
 import { Avatar } from '@frontend/web/components/Avatar';
 import { headline, textSans } from '@guardian/src-foundations/typography';
@@ -192,7 +195,7 @@ const paidForBranding = css`
 `;
 
 const starWrapper = css`
-    background-color: ${palette.brandYellow.main};
+    background-color: ${brandAltBackground.primary};
     display: inline-block;
 `;
 

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -2,7 +2,12 @@ import React from 'react';
 import { css } from 'emotion';
 
 import { palette } from '@guardian/src-foundations';
-import { neutral, border, background } from '@guardian/src-foundations/palette';
+import {
+    neutral,
+    border,
+    background,
+    brandAltBackground,
+} from '@guardian/src-foundations/palette';
 import { from, until } from '@guardian/src-foundations/mq';
 
 import { namedAdSlotParameters } from '@root/src/model/advertisement';
@@ -166,7 +171,7 @@ const stretchLines = css`
 const starWrapper = css`
     margin-bottom: 18px;
     margin-top: 6px;
-    background-color: ${palette.brandYellow.main};
+    background-color: ${brandAltBackground.primary};
     display: inline-block;
 
     ${until.phablet} {


### PR DESCRIPTION
## What does this change?

Replaces references to `palette.brandYellow.main` with `brandAlt[400]`, or `brandAltBackground.primary` if the context suits.

## Why?

Gets us closer to elimating the `palette` import
