### PR TITLE
Add CI check to enable comparison with previous build

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "storybook": "node --max-old-space-size=4096 $(yarn bin)/start-storybook -s ./src/static -p 6006",
         "storybook:build": "node --max-old-space-size=4096 $(yarn bin)/build-storybook",
         "chromatic": "chromatic --build-script-name=storybook:build --exit-zero-on-changes",
-        "makeBuild": "NODE_ENV=production webpack --config scripts/webpack/frontend"
+        "makeBuild": "NODE_ENV=production CI_ENV=github webpack --config scripts/webpack/frontend"
     },
     "bundlesize": [
         {

--- a/scripts/webpack/browser.js
+++ b/scripts/webpack/browser.js
@@ -19,11 +19,12 @@ const friendlyErrorsWebpackPlugin = () =>
 
 const PROD = process.env.NODE_ENV === 'production';
 const DEV = process.env.NODE_ENV === 'development';
+const GITHUB = process.env.CI_ENV === 'github';
 
 // We need to distinguish files compiled by @babel/preset-env with the prefix "legacy"
 const generateName = isLegacyJS => {
     const legacyString = isLegacyJS ? '.legacy' : '';
-    const chunkhashString = PROD ? '.[chunkhash]' : '';
+    const chunkhashString = PROD && !GITHUB ? '.[chunkhash]' : '';
     return `[name]${legacyString}${chunkhashString}.js`;
 };
 


### PR DESCRIPTION
## What does this change?

Removes the webpack chunk hash for bundlesize comparison as it meant you couldn't compare previous bundle if the bundle changed.