### PR TITLE
Don't assume a response

### DIFF
--- a/src/web/browser/App.tsx
+++ b/src/web/browser/App.tsx
@@ -67,12 +67,16 @@ const App = ({ CAPI, NAV }: Props) => {
 
     useEffect(() => {
         const callFetch = async () => {
-            const { discussion } = await getDiscussion(
+            const response = await getDiscussion(
                 CAPI.config.ajaxUrl,
                 CAPI.config.shortUrlId,
             );
-            setCommentCount(discussion.commentCount);
-            setIsClosedForComments(discussion.isClosedForComments);
+            setCommentCount(
+                (response && response.discussion.commentCount) || 0,
+            );
+            setIsClosedForComments(
+                response && response.discussion.isClosedForComments,
+            );
         };
         callFetch();
     }, [CAPI.config.ajaxUrl, CAPI.config.shortUrlId]);


### PR DESCRIPTION
## What does this change?
This fixes a problem I caused where I assumed that there would always be a response to the call to get the discussion for an article.

## Why?
To prevent destructure errors on the page

## Link to supporting Trello card
https://trello.com/c/mcvbreUB/1275-fix-discussion-api-call-errors
