### PR TITLE
Use functional colours: brand background primary

### DIFF
--- a/src/web/components/Dropdown.stories.tsx
+++ b/src/web/components/Dropdown.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 
-import { palette } from '@guardian/src-foundations';
+import { brandBackground } from '@guardian/src-foundations/palette';
 
 import { Dropdown } from '@frontend/web/components/Dropdown';
 
@@ -10,7 +10,7 @@ const Header = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
         className={css`
             height: 300px;
             width: 100%;
-            background-color: ${palette.brand.main};
+            background-color: ${brandBackground.primary};
         `}
     >
         {children}

--- a/src/web/components/Footer.tsx
+++ b/src/web/components/Footer.tsx
@@ -2,7 +2,11 @@ import React from 'react';
 import { css, cx } from 'emotion';
 
 import { palette } from '@guardian/src-foundations';
-import { brandText, brandAlt } from '@guardian/src-foundations/palette';
+import {
+    brandText,
+    brandAlt,
+    brandBackground,
+} from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
 
@@ -21,7 +25,7 @@ const footerBorders = `1px solid ${palette.brand.pastel}`;
 
 // CSS
 const footer = css`
-    background-color: ${palette.brand.main};
+    background-color: ${brandBackground.primary};
     color: ${brandText.primary};
     padding-bottom: 6px;
     ${textSans.medium()};
@@ -158,7 +162,7 @@ const footerItemContainers = css`
 `;
 
 const bttPosition = css`
-    background-color: ${palette.brand.main};
+    background-color: ${brandBackground.primary};
     padding: 0 5px;
     position: absolute;
     bottom: -21px;

--- a/src/web/components/Nav/ExpandedMenu/ExpandedMenu.tsx
+++ b/src/web/components/Nav/ExpandedMenu/ExpandedMenu.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 
-import { palette } from '@guardian/src-foundations';
+import { brandBackground } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
 
@@ -19,7 +19,7 @@ const showExpandedMenuStyles = css`
 `;
 
 const mainMenu = css`
-    background-color: ${palette.brand.main};
+    background-color: ${brandBackground.primary};
     box-sizing: border-box;
     ${textSans.large()};
     left: 0;

--- a/src/web/server/htmlTemplate.ts
+++ b/src/web/server/htmlTemplate.ts
@@ -3,7 +3,7 @@ import { getFontsCss } from '@root/src/lib/fonts-css';
 import { getStatic } from '@root/src/lib/assets';
 import { prepareCmpString } from '@root/src/web/browser/prepareCmp';
 
-import { palette } from '@guardian/src-foundations';
+import { brandBackground } from '@guardian/src-foundations/palette';
 
 export const htmlTemplate = ({
     title = 'The Guardian',
@@ -103,7 +103,7 @@ export const htmlTemplate = ({
                 <meta charset="utf-8">
 
                 <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-                <meta name="theme-color" content="${palette.brand.main}" />
+                <meta name="theme-color" content="${brandBackground.primary}" />
                 <link rel="icon" href="https://static.guim.co.uk/images/${favicon}">
 
                 <script type="application/ld+json">


### PR DESCRIPTION
## What does this change?

Gets rid of references to another palette colour, and replaces it with a functional colour: `palette.brand.main` -> `brandBackground.primary`

## Why?

See #1227 
