### PR TITLE
Refactor CMP

### DIFF
--- a/src/web/browser/App.tsx
+++ b/src/web/browser/App.tsx
@@ -148,7 +148,7 @@ const App = ({ CAPI, NAV }: Props) => {
                 ))}
 
             <Portal root="cmp">
-                <CMP />
+                <CMP cmpUi={CAPI.config.switches.cmpUi} />
             </Portal>
             <Portal root="share-comment-counts">
                 <Counts

--- a/src/web/components/CMP.test.tsx
+++ b/src/web/components/CMP.test.tsx
@@ -35,7 +35,15 @@ describe('CMP', () => {
     it('It should render null if shouldShow returns false', () => {
         shouldShow.mockImplementation(() => false);
 
-        const { container } = render(<CMP />);
+        const { container } = render(<CMP cmpUi={true} />);
+
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('It should render null if shouldShow ireturns true but cmpUi switch is false', () => {
+        shouldShow.mockImplementation(() => true);
+
+        const { container } = render(<CMP cmpUi={false} />);
 
         expect(container.firstChild).toBeNull();
     });

--- a/src/web/components/CMP.test.tsx
+++ b/src/web/components/CMP.test.tsx
@@ -2,11 +2,13 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { shouldShow as shouldShow_ } from '@guardian/consent-management-platform';
 import { ConsentManagementPlatform as ConsentManagementPlatform_ } from '@guardian/consent-management-platform/lib/ConsentManagementPlatform';
+
 import { CMP } from './CMP';
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const shouldShow: any = shouldShow_;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const ConsentManagementPlatform: any = ConsentManagementPlatform_;
-const globalAny: any = global;
 
 jest.mock('@guardian/consent-management-platform', () => ({
     shouldShow: jest.fn(),
@@ -28,28 +30,6 @@ describe('CMP', () => {
 
     beforeEach(() => {
         shouldShow.mockReset();
-        globalAny.guardian = {
-            app: {
-                data: {
-                    CAPI: {
-                        config: {
-                            switches: {
-                                cmpUi: true,
-                            },
-                        },
-                    },
-                },
-            },
-            modules: {
-                sentry: {
-                    reportError: () => {},
-                },
-            },
-        };
-    });
-
-    afterEach(() => {
-        delete globalAny.guardian;
     });
 
     it('It should render null if shouldShow returns false', () => {
@@ -63,7 +43,7 @@ describe('CMP', () => {
     it('It should not render null if shouldShow returns true', () => {
         shouldShow.mockImplementation(() => true);
 
-        const { container } = render(<CMP />);
+        const { container } = render(<CMP cmpUi={true} />);
 
         expect(container.firstChild).not.toBeNull();
     });

--- a/src/web/components/CMP.tsx
+++ b/src/web/components/CMP.tsx
@@ -5,7 +5,11 @@ import {
 } from '@guardian/consent-management-platform';
 import { ConsentManagementPlatform } from '@guardian/consent-management-platform/lib/ConsentManagementPlatform';
 
-export const CMP = () => {
+type Props = {
+    cmpUi: boolean; // A switch to decide if we show CMP or not
+};
+
+export const CMP = ({ cmpUi }: Props) => {
     const [show, setShow] = useState(false);
 
     useEffect(() => {
@@ -22,8 +26,6 @@ export const CMP = () => {
     }, []);
 
     const onClose = () => setShow(false);
-
-    const { cmpUi } = window.guardian.app.data.CAPI.config.switches;
 
     if (!show || !cmpUi) {
         return null;

--- a/src/web/components/CMP.tsx
+++ b/src/web/components/CMP.tsx
@@ -29,10 +29,5 @@ export const CMP = () => {
         return null;
     }
 
-    const props = {
-        source: 'dcr',
-        onClose,
-    };
-
-    return <ConsentManagementPlatform {...props} />;
+    return <ConsentManagementPlatform source="dcr" onClose={onClose} />;
 };


### PR DESCRIPTION
## What does this change?
This refactors CMP to accept the `cmpUi` switch as a prop rather than reading it from `window.guardian`

## Why?
Because we want to be able to mock the entire page for our layout tests and it's easier to test using props than by mocking the window object. It's also easier to test in general as evidenced by the changes to the jest tests here where we remove some mocks and add an extra test.

## Link to supporting Trello card
https://trello.com/c/K9T7J8Le/1281-refactor-cmp
