### PR TITLE
Fix discussion call

### DIFF
--- a/fixtures/CAPI/comment.ts
+++ b/fixtures/CAPI/comment.ts
@@ -2564,6 +2564,7 @@ export const comment: CAPIType = {
     isImmersive: false,
     config: {
         ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
+        discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
         sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
         sentryHost: 'app.getsentry.com/35463',
         dcrSentryDsn:

--- a/fixtures/CAPI/review/showcaseReview.ts
+++ b/fixtures/CAPI/review/showcaseReview.ts
@@ -2670,6 +2670,7 @@ export const showcaseReviewCAPI: CAPIType = {
     isImmersive: false,
     config: {
         ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
+        discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
         sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
         sentryHost: 'app.getsentry.com/35463',
         dcrSentryDsn:

--- a/fixtures/CAPI/review/standardReview.ts
+++ b/fixtures/CAPI/review/standardReview.ts
@@ -2347,6 +2347,7 @@ export const standardReviewCAPI: CAPIType = {
     isImmersive: false,
     config: {
         ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
+        discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
         sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
         sentryHost: 'app.getsentry.com/35463',
         dcrSentryDsn:

--- a/fixtures/CAPI/richLink.ts
+++ b/fixtures/CAPI/richLink.ts
@@ -2778,6 +2778,7 @@ export const richLink: CAPIType = {
     isImmersive: false,
     config: {
         ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
+        discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
         sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
         sentryHost: 'app.getsentry.com/35463',
         dcrSentryDsn:

--- a/fixtures/articles/AdvertisementFeature.ts
+++ b/fixtures/articles/AdvertisementFeature.ts
@@ -2516,6 +2516,7 @@ export const AdvertisementFeature: CAPIType = {
     isImmersive: false,
     config: {
         ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
+        discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
         sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
         sentryHost: 'app.getsentry.com/35463',
         dcrSentryDsn:

--- a/fixtures/articles/Analysis.ts
+++ b/fixtures/articles/Analysis.ts
@@ -2966,6 +2966,7 @@ export const Analysis: CAPIType = {
     isImmersive: false,
     config: {
         ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
+        discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
         sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
         sentryHost: 'app.getsentry.com/35463',
         dcrSentryDsn:

--- a/fixtures/articles/Article.ts
+++ b/fixtures/articles/Article.ts
@@ -3304,6 +3304,7 @@ export const Article: CAPIType = {
     isImmersive: false,
     config: {
         ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
+        discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
         sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
         sentryHost: 'app.getsentry.com/35463',
         dcrSentryDsn:

--- a/fixtures/articles/Comment.ts
+++ b/fixtures/articles/Comment.ts
@@ -3153,6 +3153,7 @@ export const Comment: CAPIType = {
     isImmersive: false,
     config: {
         ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
+        discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
         sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
         sentryHost: 'app.getsentry.com/35463',
         dcrSentryDsn:

--- a/fixtures/articles/Feature.ts
+++ b/fixtures/articles/Feature.ts
@@ -3004,6 +3004,7 @@ export const Feature: CAPIType = {
     isImmersive: false,
     config: {
         ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
+        discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
         sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
         sentryHost: 'app.getsentry.com/35463',
         dcrSentryDsn:

--- a/fixtures/articles/GuardianView.ts
+++ b/fixtures/articles/GuardianView.ts
@@ -2975,6 +2975,7 @@ export const GuardianView: CAPIType = {
     isImmersive: false,
     config: {
         ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
+        discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
         sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
         sentryHost: 'app.getsentry.com/35463',
         dcrSentryDsn:

--- a/fixtures/articles/Immersive.ts
+++ b/fixtures/articles/Immersive.ts
@@ -4794,6 +4794,7 @@ export const Immersive: CAPIType = {
     isImmersive: true,
     config: {
         ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
+        discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
         sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
         sentryHost: 'app.getsentry.com/35463',
         dcrSentryDsn:

--- a/fixtures/articles/Interview.ts
+++ b/fixtures/articles/Interview.ts
@@ -6000,6 +6000,7 @@ export const Interview: CAPIType = {
     isImmersive: false,
     config: {
         ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
+        discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
         sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
         sentryHost: 'app.getsentry.com/35463',
         dcrSentryDsn:

--- a/fixtures/articles/MatchReport.ts
+++ b/fixtures/articles/MatchReport.ts
@@ -2801,6 +2801,7 @@ export const MatchReport: CAPIType = {
     isImmersive: false,
     config: {
         ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
+        discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
         sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
         sentryHost: 'app.getsentry.com/35463',
         dcrSentryDsn:

--- a/fixtures/articles/Quiz.ts
+++ b/fixtures/articles/Quiz.ts
@@ -3043,6 +3043,7 @@ export const Quiz: CAPIType = {
     isImmersive: false,
     config: {
         ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
+        discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
         sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
         sentryHost: 'app.getsentry.com/35463',
         dcrSentryDsn:

--- a/fixtures/articles/Recipe.ts
+++ b/fixtures/articles/Recipe.ts
@@ -2715,6 +2715,7 @@ export const Recipe: CAPIType = {
     isImmersive: false,
     config: {
         ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
+        discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
         sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
         sentryHost: 'app.getsentry.com/35463',
         dcrSentryDsn:

--- a/fixtures/articles/Review.ts
+++ b/fixtures/articles/Review.ts
@@ -2670,6 +2670,7 @@ export const Review: CAPIType = {
     isImmersive: false,
     config: {
         ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
+        discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
         sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
         sentryHost: 'app.getsentry.com/35463',
         dcrSentryDsn:

--- a/index.d.ts
+++ b/index.d.ts
@@ -436,6 +436,7 @@ interface ConfigType extends CommercialConfigType {
     keywordIds: string;
     showRelatedContent: boolean;
     shouldHideReaderRevenue?: boolean;
+    discussionApiUrl: string;
 }
 
 interface GADataType {

--- a/makefile
+++ b/makefile
@@ -132,7 +132,7 @@ check-env: # private
 	@node scripts/env/check-yarn.js
 
 clear: # private
-	#@clear
+	@clear
 
 gen-schema:
 	@node scripts/json-schema/gen-schema.js

--- a/makefile
+++ b/makefile
@@ -132,7 +132,7 @@ check-env: # private
 	@node scripts/env/check-yarn.js
 
 clear: # private
-	@clear
+	#@clear
 
 gen-schema:
 	@node scripts/json-schema/gen-schema.js

--- a/src/web/browser/App.tsx
+++ b/src/web/browser/App.tsx
@@ -79,6 +79,9 @@ const App = ({ CAPI, NAV }: Props) => {
             );
         };
 
+        if (CAPI.isCommentable) {
+            callFetch();
+        }
     }, [
         CAPI.config.discussionApiUrl,
         CAPI.config.shortUrlId,

--- a/src/web/browser/App.tsx
+++ b/src/web/browser/App.tsx
@@ -68,7 +68,7 @@ const App = ({ CAPI, NAV }: Props) => {
     useEffect(() => {
         const callFetch = async () => {
             const response = await getDiscussion(
-                CAPI.config.ajaxUrl,
+                CAPI.config.discussionApiUrl,
                 CAPI.config.shortUrlId,
             );
             setCommentCount(
@@ -78,8 +78,12 @@ const App = ({ CAPI, NAV }: Props) => {
                 response && response.discussion.isClosedForComments,
             );
         };
-        callFetch();
-    }, [CAPI.config.ajaxUrl, CAPI.config.shortUrlId]);
+
+    }, [
+        CAPI.config.discussionApiUrl,
+        CAPI.config.shortUrlId,
+        CAPI.isCommentable,
+    ]);
 
     const richLinks: {
         element: RichLinkBlockElement;

--- a/src/web/lib/getDiscussion.ts
+++ b/src/web/lib/getDiscussion.ts
@@ -54,7 +54,7 @@ export const getDiscussion = async (
     ajaxUrl: string,
     shortUrl: string,
 ): Promise<DiscussionResponse> => {
-    const url = joinUrl([ajaxUrl, `discussion/${shortUrl}`]);
+    const url = joinUrl([ajaxUrl, 'discussion', shortUrl]);
     return fetch(url)
         .then(response => {
             if (!response.ok) {


### PR DESCRIPTION
## What does this change?
Fixes how we call the discussion api

## Why?
So we can get the whole discussion object to know if it is closed or not

## Link to supporting Trello card
https://trello.com/c/mcvbreUB/1275-fix-discussion-api-call-errors