### PR TITLE
Remove blocks from CAPI browser

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -270,7 +270,7 @@ type CAPIBrowserType = {
         sharedAdTargeting: { [key: string]: any };
         adUnit: string;
     };
-    blocks: Block[];
+    richLinks: RichLinkBlockElement[];
     editionId: Edition;
     pillar: Pillar;
     contentType: string;

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -26,6 +26,7 @@ interface RichLinkBlockElement {
     text: string;
     prefix: string;
     role?: Weighting;
+    richLinkIndex?: number;
 }
 
 // aka weighting. RoleType affects how an image is placed. It is called weighting

--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -66,55 +66,73 @@ const makeWindowGuardianConfig = (
     } as WindowGuardianConfig;
 };
 
-export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => ({
-    config: {
-        isDev: process.env.NODE_ENV !== 'production',
-        ajaxUrl: CAPI.config.ajaxUrl,
-        shortUrlId: CAPI.config.shortUrlId,
-        pageId: CAPI.config.pageId,
-        isPaidContent: !!CAPI.config.isPaidContent,
-        showRelatedContent: CAPI.config.showRelatedContent,
-        keywordIds: CAPI.config.keywordIds,
-        ampIframeUrl: CAPI.config.ampIframeUrl,
-        // commercialBundleUrl is only used in SSR
-        // commercialBundleUrl: CAPI.config.commercialBundleUrl,
-
-        // switches
-        cmpUi: CAPI.config.switches.cmpUi,
-        slotBodyEnd: CAPI.config.switches.slotBodyEnd,
-        ampPrebid: CAPI.config.switches.ampPrebid,
-        permutive: CAPI.config.switches.permutive,
-
-        // used by lib/ad-targeting.ts
-        isSensitive: CAPI.config.isSensitive,
-        videoDuration: CAPI.config.videoDuration,
-        edition: CAPI.config.edition,
-        section: CAPI.config.section,
-        sharedAdTargeting: CAPI.config.sharedAdTargeting, // missing type definition
-        adUnit: CAPI.config.adUnit,
-    },
-    blocks: CAPI.blocks,
-    editionId: CAPI.editionId,
-    pillar: CAPI.pillar,
-    contentType: CAPI.contentType,
-    sectionName: CAPI.sectionName,
-    shouldHideReaderRevenue: CAPI.shouldHideReaderRevenue,
-    pageType: {
-        isMinuteArticle: CAPI.pageType.isMinuteArticle,
-        isPaidContent: CAPI.pageType.isPaidContent,
-    },
-    hasRelated: CAPI.hasRelated,
-    hasStoryPackage: CAPI.hasStoryPackage,
-    isAdFreeUser: CAPI.isAdFreeUser,
-    pageId: CAPI.pageId,
-    tags: CAPI.tags,
-    nav: {
-        readerRevenueLinks: {
-            footer: CAPI.nav.readerRevenueLinks.footer,
-            header: CAPI.nav.readerRevenueLinks.header,
+export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
+    // it is important to pass down the index of rich links as well as the component itself
+    const richLinksWithIndex: RichLinkBlockElement[] = CAPI.blocks[0].elements.reduce(
+        (acc, element, index: number) => {
+            if (
+                element._type ===
+                'model.dotcomrendering.pageElements.RichLinkBlockElement'
+            ) {
+                acc.push({
+                    ...element,
+                    richLinkIndex: index,
+                } as RichLinkBlockElement);
+            }
+            return acc;
         },
-    },
-});
+        [] as RichLinkBlockElement[],
+    );
+    return {
+        config: {
+            isDev: process.env.NODE_ENV !== 'production',
+            ajaxUrl: CAPI.config.ajaxUrl,
+            shortUrlId: CAPI.config.shortUrlId,
+            pageId: CAPI.config.pageId,
+            isPaidContent: !!CAPI.config.isPaidContent,
+            showRelatedContent: CAPI.config.showRelatedContent,
+            keywordIds: CAPI.config.keywordIds,
+            ampIframeUrl: CAPI.config.ampIframeUrl,
+            // commercialBundleUrl is only used in SSR
+            // commercialBundleUrl: CAPI.config.commercialBundleUrl,
+
+            // switches
+            cmpUi: CAPI.config.switches.cmpUi,
+            slotBodyEnd: CAPI.config.switches.slotBodyEnd,
+            ampPrebid: CAPI.config.switches.ampPrebid,
+            permutive: CAPI.config.switches.permutive,
+
+            // used by lib/ad-targeting.ts
+            isSensitive: CAPI.config.isSensitive,
+            videoDuration: CAPI.config.videoDuration,
+            edition: CAPI.config.edition,
+            section: CAPI.config.section,
+            sharedAdTargeting: CAPI.config.sharedAdTargeting, // missing type definition
+            adUnit: CAPI.config.adUnit,
+        },
+        richLinks: richLinksWithIndex,
+        editionId: CAPI.editionId,
+        pillar: CAPI.pillar,
+        contentType: CAPI.contentType,
+        sectionName: CAPI.sectionName,
+        shouldHideReaderRevenue: CAPI.shouldHideReaderRevenue,
+        pageType: {
+            isMinuteArticle: CAPI.pageType.isMinuteArticle,
+            isPaidContent: CAPI.pageType.isPaidContent,
+        },
+        hasRelated: CAPI.hasRelated,
+        hasStoryPackage: CAPI.hasStoryPackage,
+        isAdFreeUser: CAPI.isAdFreeUser,
+        pageId: CAPI.pageId,
+        tags: CAPI.tags,
+        nav: {
+            readerRevenueLinks: {
+                footer: CAPI.nav.readerRevenueLinks.footer,
+                header: CAPI.nav.readerRevenueLinks.header,
+            },
+        },
+    };
+};
 export interface WindowGuardian {
     // At least until October 2019, do not modify this interface without checking with Pascal first.
 

--- a/src/web/browser/App.tsx
+++ b/src/web/browser/App.tsx
@@ -87,24 +87,6 @@ const App = ({ CAPI, NAV }: Props) => {
         callFetch();
     }, [CAPI.config.ajaxUrl, CAPI.config.shortUrlId]);
 
-    const richLinks: {
-        element: RichLinkBlockElement;
-        root: RootType;
-        richLinkIndex: number;
-    }[] = [];
-    CAPI.blocks[0].elements.map((element, i) => {
-        if (
-            element._type ===
-            'model.dotcomrendering.pageElements.RichLinkBlockElement'
-        ) {
-            richLinks.push({
-                element,
-                root: `rich-link`,
-                richLinkIndex: i,
-            });
-        }
-    });
-
     return (
         // Do you need to Hydrate or do you want a Portal?
         //
@@ -137,21 +119,20 @@ const App = ({ CAPI, NAV }: Props) => {
                 />
             </Hydrate>
 
-            {richLinks &&
-                richLinks.map((link, index) => (
-                    <Portal
-                        key={index}
-                        root={link.root}
-                        richLinkIndex={link.richLinkIndex}
-                    >
-                        <RichLinkComponent
-                            element={link.element}
-                            pillar={CAPI.pillar}
-                            ajaxEndpoint={CAPI.config.ajaxUrl}
-                            richLinkIndex={link.richLinkIndex}
-                        />
-                    </Portal>
-                ))}
+            {CAPI.richLinks.map((link, index) => (
+                <Portal
+                    key={index}
+                    root="rich-link"
+                    richLinkIndex={link.richLinkIndex}
+                >
+                    <RichLinkComponent
+                        element={link}
+                        pillar={CAPI.pillar}
+                        ajaxEndpoint={CAPI.config.ajaxUrl}
+                        richLinkIndex={index}
+                    />
+                </Portal>
+            ))}
 
             <Portal root="cmp">
                 <CMP cmpUi={CAPI.config.cmpUi} />


### PR DESCRIPTION
## What does this change?
Remove blocks from CAPI browser and replaces it with richLinks

## Why?
We only need rich links for hydration but send all block data to the frontend. 

## Link to supporting Trello card
https://trello.com/c/MfrTjOAI/1220-reduce-the-size-of-windowguardian
