### PR TITLE
Update h2 to styling to be as close to prod as the design system allows

### DIFF
--- a/src/web/components/ArticleBody.tsx
+++ b/src/web/components/ArticleBody.tsx
@@ -42,7 +42,7 @@ const bodyStyle = css`
     }
 
     h2 {
-        ${headline.xxsmall()};
+        ${headline.xxsmall({ fontWeight: 'bold' })};
     }
 
     strong {


### PR DESCRIPTION
## What does this change?
Updates the h2 styling within the body to be closer to prod

![Screen Shot 2020-03-11 at 15 08 52](https://user-images.githubusercontent.com/2051501/76433040-ac548880-63ab-11ea-8992-70f72cc125be.png)
![Screen Shot 2020-03-11 at 15 09 03](https://user-images.githubusercontent.com/2051501/76433042-aced1f00-63ab-11ea-966b-d29370df2cd6.png)

## Why?

## Link to supporting Trello card
