### PR TITLE
Read and write article viewing history for SM

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dependencies": {
         "@emotion/core": "^10.0.5",
         "@guardian/consent-management-platform": "^2.0.10",
-        "@guardian/slot-machine-client": "^0.2.1",
+        "@guardian/slot-machine-client": "^0.2.4",
         "@guardian/src-foundations": "^0.14.1",
         "@sentry/browser": "^5.7.1",
         "@types/ajv": "^1.0.0",

--- a/src/web/browser/App.tsx
+++ b/src/web/browser/App.tsx
@@ -90,9 +90,9 @@ const App = ({ CAPI, NAV }: Props) => {
     ]);
 
     // Log an article view using the Slot Machine client lib
-    // This function must be called once per article render.
+    // This function must be called once per article serving.
     // We should monitor this function call to ensure it only happens within an
-    // article view.
+    // article pages when other pages are supported by DCR.
     useEffect(() => {
         incrementWeeklyArticleCount();
     }, []);

--- a/src/web/browser/App.tsx
+++ b/src/web/browser/App.tsx
@@ -15,6 +15,7 @@ import { SlotBodyEnd } from '@frontend/web/components/SlotBodyEnd';
 import { SubNav } from '@frontend/web/components/SubNav/SubNav';
 import { Header } from '@frontend/web/components/Header';
 import { CommentsLayout } from '@frontend/web/components/CommentsLayout';
+import { incrementWeeklyArticleCount } from '@guardian/slot-machine-client';
 
 import { getCookie } from '@root/src/web/browser/cookie';
 
@@ -80,6 +81,14 @@ const App = ({ CAPI, NAV }: Props) => {
         };
         callFetch();
     }, [CAPI.config.ajaxUrl, CAPI.config.shortUrlId]);
+
+    // Log an article view using the Slot Machine client lib
+    // This function must be called once per article render.
+    // We should monitor this function call to ensure it only happens within an
+    // article view.
+    useEffect(() => {
+        incrementWeeklyArticleCount();
+    }, []);
 
     const richLinks: {
         element: RichLinkBlockElement;

--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -91,7 +91,7 @@ const MemoisedInner = (props: Props) => {
 
     useEffect(() => {
         const contributionsPayload = buildPayload(props);
-        getBodyEnd(contributionsPayload)
+        getBodyEnd(contributionsPayload, 'http://localhost:8081/epic')
             .then(checkForErrors)
             .then(response => response.json())
             .then(json =>

--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -96,7 +96,7 @@ const MemoisedInner = (props: Props) => {
 
     useEffect(() => {
         const contributionsPayload = buildPayload(props);
-        getBodyEnd(contributionsPayload, 'http://localhost:8081/epic')
+        getBodyEnd(contributionsPayload)
             .then(checkForErrors)
             .then(response => response.json())
             .then(json =>

--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -1,6 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { css } from 'emotion';
-import { getBodyEnd, getViewLog } from '@guardian/slot-machine-client';
+import {
+    getBodyEnd,
+    getViewLog,
+    getWeeklyArticleHistory,
+} from '@guardian/slot-machine-client';
 import {
     shouldShowSupportMessaging,
     isRecurringContributor,
@@ -76,6 +80,7 @@ const buildPayload = (props: Props) => {
             ),
             lastOneOffContributionDate: getLastOneOffContributionDate(),
             epicViewLog: getViewLog(),
+            weeklyArticleHistory: getWeeklyArticleHistory(),
             mvtId: Number(getCookie('GU_mvt_id')),
         },
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2091,10 +2091,10 @@
     js-cookie "^2.2.1"
     whatwg-fetch "^3.0.0"
 
-"@guardian/slot-machine-client@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@guardian/slot-machine-client/-/slot-machine-client-0.2.1.tgz#883fd7f2503231c3e1d3fe06947f7b2afe8fce2e"
-  integrity sha512-ztYqAI/BN76smiIQz2ImrkFHypkjqqjwEopIqVlFjhLGkFutwcwJ4yE8KTQn+OD3FJ8GXQpbN+tGBHJ5+t/BcQ==
+"@guardian/slot-machine-client@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@guardian/slot-machine-client/-/slot-machine-client-0.2.4.tgz#fece85f95c41190c5194ac77b09123faf1c7e293"
+  integrity sha512-4kHpDb1G/x9DoGThDBr5U5vryIBhugBHxuY6T4VbhyJTcEkKf1m99/KnaMHyu+w2Cpa3zqagQrw/en+0Pj2RAw==
 
 "@guardian/src-button@^0.13.0":
   version "0.13.0"


### PR DESCRIPTION
## What does this change?
Makes use of two new functions made available by the SM client lib, to track number of articles viewed by the user on a weekly basis.
- Updates the history log when an article is served
- Includes the history log in the Epic payload

## Why?
Because selecting a variant in Contributions involves looking at the article history and the only way we can do this is by tracking article views in the same way Frontend does, and using backwards compatible names/formats.