### PR TITLE
Add timing label for Largest Contentful Paint.

### DIFF
--- a/src/web/browser/ga/ga.ts
+++ b/src/web/browser/ga/ga.ts
@@ -169,6 +169,7 @@ const trackLCP = (send: string) => {
                     'Javascript Load', // Matches Frontend
                     'LCP', // Largest Contentful Paint (We can filter to DCR with the Dimension 43 segment)
                     lcp,
+                    'Largest Contentful Paint'
                 );
                 window.removeEventListener('visibilitychange', fn, true);
             }


### PR DESCRIPTION
I'm clutching at straws, trying to find a difference in the timing reporting. I thought this wouldn't matter but maybe it does.