### PR TITLE
Migrate from palette in layout components

### DIFF
--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -2,7 +2,12 @@ import React from 'react';
 import { css, cx } from 'emotion';
 
 import { palette } from '@guardian/src-foundations';
-import { neutral, background } from '@guardian/src-foundations/palette';
+import {
+    neutral,
+    background,
+    brandBorder,
+    brandBackground,
+} from '@guardian/src-foundations/palette';
 import { from, until } from '@guardian/src-foundations/mq';
 
 import { namedAdSlotParameters } from '@root/src/model/advertisement';
@@ -222,7 +227,7 @@ export const CommentLayout = ({ CAPI, NAV }: Props) => {
                 showTopBorder={false}
                 showSideBorders={false}
                 padded={false}
-                backgroundColour={palette.brand.main}
+                backgroundColour={brandBackground.primary}
             >
                 <Header edition={CAPI.editionId} />
             </Section>
@@ -230,10 +235,10 @@ export const CommentLayout = ({ CAPI, NAV }: Props) => {
             <Section
                 islandId="nav-root"
                 showSideBorders={true}
-                borderColour={palette.brand.pastel}
+                borderColour={brandBorder.primary}
                 showTopBorder={false}
                 padded={false}
-                backgroundColour={palette.brand.main}
+                backgroundColour={brandBackground.primary}
             >
                 <Nav pillar={getCurrentPillar(CAPI)} nav={NAV} />
             </Section>
@@ -455,8 +460,8 @@ export const CommentLayout = ({ CAPI, NAV }: Props) => {
 
             <Section
                 padded={false}
-                backgroundColour={palette.brand.main}
-                borderColour={palette.brand.pastel}
+                backgroundColour={brandBackground.primary}
+                borderColour={brandBorder.primary}
             >
                 <Footer
                     nav={NAV}

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import { css } from 'emotion';
 
-import { palette } from '@guardian/src-foundations';
-import { neutral, border, background } from '@guardian/src-foundations/palette';
+import {
+    neutral,
+    border,
+    background,
+    brandBackground,
+    brandBorder,
+} from '@guardian/src-foundations/palette';
 import { from, until } from '@guardian/src-foundations/mq';
 
 import { namedAdSlotParameters } from '@root/src/model/advertisement';
@@ -281,7 +286,7 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                         showTopBorder={false}
                         showSideBorders={false}
                         padded={false}
-                        backgroundColour={palette.brand.main}
+                        backgroundColour={brandBackground.primary}
                     >
                         <Header edition={CAPI.editionId} />
                     </Section>
@@ -289,10 +294,10 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                     <Section
                         islandId="nav-root"
                         showSideBorders={true}
-                        borderColour={palette.brand.pastel}
+                        borderColour={brandBorder.primary}
                         showTopBorder={false}
                         padded={false}
-                        backgroundColour={palette.brand.main}
+                        backgroundColour={brandBackground.primary}
                     >
                         <Nav pillar={getCurrentPillar(CAPI)} nav={NAV} />
                     </Section>
@@ -501,8 +506,8 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
 
             <Section
                 padded={false}
-                backgroundColour={palette.brand.main}
-                borderColour={palette.brand.pastel}
+                backgroundColour={brandBackground.primary}
+                borderColour={brandBorder.primary}
             >
                 <Footer
                     nav={NAV}

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { css } from 'emotion';
 
-import { palette } from '@guardian/src-foundations';
 import {
     neutral,
     border,
     background,
     brandAltBackground,
+    brandBackground,
+    brandBorder,
 } from '@guardian/src-foundations/palette';
 import { from, until } from '@guardian/src-foundations/mq';
 
@@ -258,7 +259,7 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                         showTopBorder={false}
                         showSideBorders={false}
                         padded={false}
-                        backgroundColour={palette.brand.main}
+                        backgroundColour={brandBackground.primary}
                     >
                         <Header edition={CAPI.editionId} />
                     </Section>
@@ -266,10 +267,10 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                     <Section
                         islandId="nav-root"
                         showSideBorders={true}
-                        borderColour={palette.brand.pastel}
+                        borderColour={brandBorder.primary}
                         showTopBorder={false}
                         padded={false}
-                        backgroundColour={palette.brand.main}
+                        backgroundColour={brandBackground.primary}
                     >
                         <Nav pillar={getCurrentPillar(CAPI)} nav={NAV} />
                     </Section>
@@ -480,8 +481,8 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
 
             <Section
                 padded={false}
-                backgroundColour={palette.brand.main}
-                borderColour={palette.brand.pastel}
+                backgroundColour={brandBackground.primary}
+                borderColour={brandBorder.primary}
             >
                 <Footer
                     nav={NAV}


### PR DESCRIPTION
## What does this change?

Removes a few more references to `palette` from the layout components

## Why?

Reduce bundle size (See #1227)

