### PR TITLE
Twitter embed overflow problem

### DIFF
--- a/src/web/components/ArticleContainer.tsx
+++ b/src/web/components/ArticleContainer.tsx
@@ -4,12 +4,6 @@ import { from, until } from '@guardian/src-foundations/mq';
 import { labelStyles } from '@root/src/web/components/AdSlot';
 
 const articleContainer = css`
-    /* Set min-width: 0 here to prevent flex children breaking out of the
-    containing parent. This ws happening for embedded tweets which have
-    a width: 500px property.
-    See: https://stackoverflow.com/a/47457331 */
-    min-width: 0;
-
     ${until.leftCol} {
         /* below 1140 */
         padding-left: 0;

--- a/src/web/components/elements/TweetBlockComponent.tsx
+++ b/src/web/components/elements/TweetBlockComponent.tsx
@@ -19,6 +19,17 @@ const noJSStyling = css`
         padding-bottom: 10px;
     }
 
+    /* Why are we using important here? Because this is the only way to override
+    the inline styles of the twitter-widget element and for some reason twitter
+    is adding display: block and width: 500px on this embed causing it to overflow.
+    I did think this might be caused by
+    https://stackoverflow.com/questions/36247140/why-dont-flex-items-shrink-past-content-size
+    but the solutions posted there did not help. Checking other sites with twitter embeds
+    like the BBC, we saw that this important override was being used as well. */
+    .twitter-tweet-rendered {
+        display: inline !important;
+    }
+
     a {
         /* stylelint-disable-next-line color-no-hex */
         color: #2b7bb9;


### PR DESCRIPTION
## What does this change?
This solves the problem where the twitter embed was causing horizontal overflow issues at mobile

## Why are we using `!important`!
Because this is the only way to override the inline styles of the `twitter-widget` element and for some reason twitter is adding `display: block;` and `width: 500px;` on this embed causing it to overflow. I did think this might be caused by  https://stackoverflow.com/questions/36247140/why-dont-flex-items-shrink-past-content-size but the solutions posted there did not help. Checking other sites with twitter embeds like the BBC, we saw that this important override was being used as well so

![Screenshot 2020-03-17 at 09 50 10](https://user-images.githubusercontent.com/1336821/76844119-c3282e80-6834-11ea-881b-a3d31520a1b5.jpg)


## Link to supporting Trello card
https://trello.com/c/3uapR6Dr/1297-twitter-embed-width-overflow