### PR TITLE
Fix Most View Outflow Issue

### DIFF
--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterData.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterData.tsx
@@ -61,7 +61,11 @@ export const MostViewedFooterData = ({
 
     if (data) {
         return (
-            <div>
+            <div
+                className={css`
+                    width: 100%;
+                `}
+            >
                 <MostViewedFooterGrid
                     data={'tabs' in data ? data.tabs : data}
                     sectionName={sectionName}


### PR DESCRIPTION
## What does this change?
Fixes an issue where the Most Viewed grid was pushing the horizontal width of the page out and causing a horizontal scrollbar to appear on mobile viewports


## Before
![Screenshot 2020-03-17 at 14 27 44](https://user-images.githubusercontent.com/1336821/76866136-976c6f00-685b-11ea-974f-043e924bfe3e.jpg)



## After
![Screenshot 2020-03-17 at 14 28 04](https://user-images.githubusercontent.com/1336821/76866113-8de30700-685b-11ea-85b8-3a43ede89d28.jpg)


## Link to supporting Trello card
https://trello.com/c/fgAGhhue/1300-fix-most-viewed-width