### PR TITLE
Tweak component gate condition

### DIFF
--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -154,7 +154,7 @@ const MemoisedInner = (props: Props) => {
 
 export const SlotBodyEnd = (props: Props) => {
     const { isSignedIn, countryCode } = props;
-    if (isSignedIn === undefined && countryCode === undefined) {
+    if (isSignedIn === undefined || countryCode === undefined) {
         return null;
     }
 


### PR DESCRIPTION
## What does this change?
The condition used to gate the SlotBodyEnd component so it only lets us in when both `isSignedIn` and `countryCode` have been defined.

## Why?
Because otherwise it's not a gate and we'll render the component before the 2nd variable is defined.
