### PR TITLE
Migrate brand colours away from palette

### DIFF
--- a/src/web/components/EditionDropdown.tsx
+++ b/src/web/components/EditionDropdown.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 import { Dropdown } from '@root/src/web/components/Dropdown';
-import { palette } from '@guardian/src-foundations';
+import { brand } from '@guardian/src-foundations/palette';
 import { from } from '@guardian/src-foundations/mq';
 
 const editionDropdown = css`
@@ -14,7 +14,7 @@ const editionDropdown = css`
 
     :before {
         content: '';
-        border-left: 1px solid ${palette.brand.pastel};
+        border-left: 1px solid ${brand[600]};
         display: block;
         float: left;
         height: 24px;

--- a/src/web/components/Footer.tsx
+++ b/src/web/components/Footer.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 
-import { palette } from '@guardian/src-foundations';
 import {
+    brand,
     brandText,
     brandAlt,
     brandBackground,
@@ -21,7 +21,7 @@ const emailSignupWidth =
     pillarWidth +
     firstPillarWidth -
     (emailSignupSideMargins * 2 + footerItemContainerPadding);
-const footerBorders = `1px solid ${palette.brand.pastel}`;
+const footerBorders = `1px solid ${brand[600]}`;
 
 // CSS
 const footer = css`

--- a/src/web/components/Links.tsx
+++ b/src/web/components/Links.tsx
@@ -3,8 +3,7 @@ import { css, cx } from 'emotion';
 
 import SearchIcon from '@frontend/static/icons/search.svg';
 
-import { palette } from '@guardian/src-foundations';
-import { brandText, brandAlt } from '@guardian/src-foundations/palette';
+import { brand, brandText, brandAlt } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 
@@ -77,7 +76,7 @@ const linkTablet = ({ showAtTablet }: { showAtTablet: boolean }) => css`
 `;
 
 const seperatorStyles = css`
-    border-left: 1px solid ${palette.brand.pastel};
+    border-left: 1px solid ${brand[600]};
     float: left;
     height: 24px;
     margin: 0 -2px 0 10px;
@@ -89,7 +88,7 @@ const seperatorStyles = css`
 `;
 
 const seperatorHideStyles = css`
-    border-left: 1px solid ${palette.brand.pastel};
+    border-left: 1px solid ${brand[600]};
     float: left;
     height: 24px;
     margin: 0 -2px 0 10px;

--- a/src/web/components/Nav/ExpandedMenu/Column.tsx
+++ b/src/web/components/Nav/ExpandedMenu/Column.tsx
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import { css, cx } from 'emotion';
-import { palette } from '@guardian/src-foundations';
-import { brandText, brandAlt } from '@guardian/src-foundations/palette';
+import { brand, brandText, brandAlt } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
 import { CollapseColumnButton } from './CollapseColumnButton';
@@ -27,7 +26,7 @@ const pillarDivider = css`
             top: 0;
             bottom: 0;
             width: 1px;
-            background-color: ${palette.brand.pastel};
+            background-color: ${brand[600]};
             z-index: 1;
         }
     }
@@ -135,7 +134,7 @@ const firstColumnLinks = css`
 
 const pillarColumnLinks = css`
     ${until.tablet} {
-        background: ${palette.brand.dark};
+        background: ${brand[300]};
     }
 `;
 
@@ -178,7 +177,7 @@ const columnStyle = css`
     position: relative;
 
     :after {
-        background-color: ${palette.brand.pastel};
+        background-color: ${brand[600]};
         top: 0;
         content: '';
         display: block;

--- a/src/web/components/Nav/ExpandedMenu/Columns.tsx
+++ b/src/web/components/Nav/ExpandedMenu/Columns.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 
-import { palette } from '@guardian/src-foundations';
-import { brandText, brandAlt } from '@guardian/src-foundations/palette';
+import { brand, brandText, brandAlt } from '@guardian/src-foundations/palette';
 import { headline, textSans } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 
@@ -17,8 +16,8 @@ const ColumnsStyle = css`
         position: relative;
         margin: 0 auto;
         display: flex;
-        border-left: 1px solid ${palette.brand.pastel};
-        border-right: 1px solid ${palette.brand.pastel};
+        border-left: 1px solid ${brand[600]};
+        border-right: 1px solid ${brand[600]};
     }
     ${from.leftCol} {
         max-width: 1140px;

--- a/src/web/components/Pillars.tsx
+++ b/src/web/components/Pillars.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 
-import { palette } from '@guardian/src-foundations';
-import { brandText } from '@guardian/src-foundations/palette';
+import { brand, brandText } from '@guardian/src-foundations/palette';
 import { headline } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
 
@@ -42,7 +41,7 @@ const pillarsStyles = css`
 
     :after {
         content: '';
-        border-top: 1px solid ${palette.brand.pastel};
+        border-top: 1px solid ${brand[600]};
         position: absolute;
         bottom: 0;
         left: 0;
@@ -107,7 +106,7 @@ const pillarDivider = css`
         top: 0;
         bottom: 0;
         width: 1px;
-        background-color: ${palette.brand.pastel};
+        background-color: ${brand[600]};
 
         ${from.tablet} {
             bottom: 17px;


### PR DESCRIPTION
## What does this change?

Migrates the final few instances of `palette.brand.<longName>` toward the preferable `brand.<lightnessValue>`

## Why?

See #1227 
