### PR TITLE
Upgrade foundations to 0.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "@emotion/core": "^10.0.5",
         "@guardian/consent-management-platform": "^2.0.10",
         "@guardian/slot-machine-client": "^0.2.6",
-        "@guardian/src-foundations": "^0.14.1",
+        "@guardian/src-foundations": "^0.15.1",
         "@sentry/browser": "^5.7.1",
         "@types/ajv": "^1.0.0",
         "@types/lodash.escape": "^4.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2108,10 +2108,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.13.0.tgz#8bfed9b94e2e4f24ecacb754bbe573b6e0cfe088"
   integrity sha512-8lTZSo49W1lPhBFaaLrg2Eo2jrwUB3VGw6a7ZRI7oBEyTglmlbjFDiciu2Di6WSrzuSWiI+9OJTSSjCP6lTT2A==
 
-"@guardian/src-foundations@^0.14.1":
-  version "0.14.1"
-  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.14.1.tgz#33cf2e95eedf184fdfc40cc75c1dbca4d6d46fdf"
-  integrity sha512-FiH2nsPvHS6wG7b0AePXTGbDCIV+q0aRHZKhsH2X2WeS9K3fZqEF9y+8lTv22nW3r3sv6nSyh4tT7y5+XPC9pA==
+"@guardian/src-foundations@^0.15.1":
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.15.1.tgz#9e621aa2efee0cdb368ebbee129cd2a7d7e5868e"
+  integrity sha512-49Kjd9v6bAy3Xjs9q6/WV+J63bKgUWG5biOScUPE4UKFf3HkNFtafrrvnWf2/1qpDlhGYRFK9tGCh/enagMajA==
 
 "@guardian/src-svgs@^0.13.0":
   version "0.13.0"


### PR DESCRIPTION
## What does this change?

Upgrade @guardian/src-foundations to v0.15.1  

## Why?

- It's useful to keep up to date
- Hopefully it's a slightly smaller bundle 🤞 
