### PR TITLE
Remove US-specific support subtext

### DIFF
--- a/src/web/components/ReaderRevenueLinks.tsx
+++ b/src/web/components/ReaderRevenueLinks.tsx
@@ -154,15 +154,9 @@ export const ReaderRevenueLinks: React.FC<Props> = ({
                     <div className={messageStyles}>
                         Support The&nbsp;Guardian
                     </div>
-                    {edition === 'US' ? (
-                        <div className={subMessageStyles}>
-                            Support our journalism with a year-end gift
-                        </div>
-                    ) : (
-                        <div className={subMessageStyles}>
-                            Available for everyone, funded by readers
-                        </div>
-                    )}
+                    <div className={subMessageStyles}>
+                        Available for everyone, funded by readers
+                    </div>
                     <a
                         className={linkStyles}
                         href={urls.contribute}


### PR DESCRIPTION
## What does this change?

Removes some old US-specific text that appears below the reader revenue links.

Introduced in DCR here: #942
Introduced in frontend here: guardian/frontend#22019
Removed in frontend here: guardian/frontend#22176

## Why?

It's no longer year-end. Unless we mean tax year-end 😅 
