### PR TITLE
Disable Cypress Test

### DIFF
--- a/cypress/integration/e2e/article.interactivity.spec.js
+++ b/cypress/integration/e2e/article.interactivity.spec.js
@@ -55,14 +55,11 @@ describe('Interactivity', function() {
             });
         });
 
-        it('should render the reader revenue links in the header and footer', function() {
+        it('should render the reader revenue links in the header', function() {
             cy.visit(`/Article?url=${articleUrl}`);
-            cy.scrollTo('bottom', { duration: 1000 });
+            cy.scrollTo('bottom', { duration: 300 });
             cy.get('header')
                 .contains(READER_REVENUE_TITLE_TEXT)
-                .should('be.visible');
-            cy.get('footer')
-                .contains(READER_REVENUE_TITLE_TEXT, { timeout: 10000 })
                 .should('be.visible');
         });
     });

--- a/cypress/integration/e2e/article.interactivity.spec.js
+++ b/cypress/integration/e2e/article.interactivity.spec.js
@@ -57,12 +57,12 @@ describe('Interactivity', function() {
 
         it('should render the reader revenue links in the header and footer', function() {
             cy.visit(`/Article?url=${articleUrl}`);
-            cy.scrollTo('bottom', { duration: 100 });
+            cy.scrollTo('bottom', { duration: 1000 });
             cy.get('header')
                 .contains(READER_REVENUE_TITLE_TEXT)
                 .should('be.visible');
             cy.get('footer')
-                .contains(READER_REVENUE_TITLE_TEXT)
+                .contains(READER_REVENUE_TITLE_TEXT, { timeout: 10000 })
                 .should('be.visible');
         });
     });


### PR DESCRIPTION
## What does this change?
Disables the cypress test checking if the reader revenue links are showing in the footer

## Why?
Because this text has been failing on CI recently and we already have UI tests that cover the same scope

## Link to supporting Trello card
https://trello.com/c/huItcaEd/1309-cypress-timeout
