### PR TITLE
Add discussion tracking headers to data model

### DIFF
--- a/fixtures/CAPI/comment.ts
+++ b/fixtures/CAPI/comment.ts
@@ -2600,6 +2600,8 @@ export const comment: CAPIType = {
         series: '',
         contentType: '',
         isPaidContent: false,
+        discussionD2Uid: "testD2Header",
+        discussionApiClientHeader: "testClientHeader",
         ampIframeUrl:
             'https://assets.guim.co.uk/data/vendor/a994b749adae30cd58f0e84c8fa28013/amp-iframe.html',
     },

--- a/fixtures/CAPI/review/showcaseReview.ts
+++ b/fixtures/CAPI/review/showcaseReview.ts
@@ -2708,6 +2708,8 @@ export const showcaseReviewCAPI: CAPIType = {
         isPaidContent: false,
         ampIframeUrl:
             'https://assets.guim.co.uk/data/vendor/a994b749adae30cd58f0e84c8fa28013/amp-iframe.html',
+        discussionD2Uid: "testD2Header",
+        discussionApiClientHeader: "testClientHeader",
     },
     sectionLabel: 'TV comedy',
 };

--- a/fixtures/CAPI/review/standardReview.ts
+++ b/fixtures/CAPI/review/standardReview.ts
@@ -2385,6 +2385,8 @@ export const standardReviewCAPI: CAPIType = {
         isPaidContent: false,
         ampIframeUrl:
             'https://assets.guim.co.uk/data/vendor/a994b749adae30cd58f0e84c8fa28013/amp-iframe.html',
+        discussionD2Uid: "testD2Header",
+        discussionApiClientHeader: "testClientHeader",
     },
     sectionLabel: 'Theatre',
 };

--- a/fixtures/CAPI/richLink.ts
+++ b/fixtures/CAPI/richLink.ts
@@ -2818,6 +2818,8 @@ export const richLink: CAPIType = {
         showRelatedContent: false,
         ampIframeUrl:
             'https://assets.guim.co.uk/data/vendor/a994b749adae30cd58f0e84c8fa28013/amp-iframe.html',
+        discussionD2Uid: "testD2Header",
+        discussionApiClientHeader: "testClientHeader",
     },
     sectionLabel: 'Eminem',
 };

--- a/fixtures/articles/AdvertisementFeature.ts
+++ b/fixtures/articles/AdvertisementFeature.ts
@@ -2552,6 +2552,8 @@ export const AdvertisementFeature: CAPIType = {
         series: '',
         contentType: '',
         isPaidContent: false,
+        discussionD2Uid: "testD2Header",
+        discussionApiClientHeader: "testClientHeader",
         ampIframeUrl:
             'https://assets.guim.co.uk/data/vendor/a994b749adae30cd58f0e84c8fa28013/amp-iframe.html',
     },

--- a/fixtures/articles/Analysis.ts
+++ b/fixtures/articles/Analysis.ts
@@ -3002,6 +3002,8 @@ export const Analysis: CAPIType = {
         series: '',
         contentType: '',
         isPaidContent: false,
+        discussionD2Uid: "testD2Header",
+        discussionApiClientHeader: "testClientHeader",
         ampIframeUrl:
             'https://assets.guim.co.uk/data/vendor/a994b749adae30cd58f0e84c8fa28013/amp-iframe.html',
     },

--- a/fixtures/articles/Article.ts
+++ b/fixtures/articles/Article.ts
@@ -3340,6 +3340,8 @@ export const Article: CAPIType = {
         series: '',
         contentType: '',
         isPaidContent: false,
+        discussionD2Uid: "testD2Header",
+        discussionApiClientHeader: "testClientHeader",
         ampIframeUrl:
             'https://assets.guim.co.uk/data/vendor/a994b749adae30cd58f0e84c8fa28013/amp-iframe.html',
     },

--- a/fixtures/articles/Comment.ts
+++ b/fixtures/articles/Comment.ts
@@ -3189,6 +3189,8 @@ export const Comment: CAPIType = {
         series: '',
         contentType: '',
         isPaidContent: false,
+        discussionD2Uid: "testD2Header",
+        discussionApiClientHeader: "testClientHeader",
         ampIframeUrl:
             'https://assets.guim.co.uk/data/vendor/a994b749adae30cd58f0e84c8fa28013/amp-iframe.html',
     },

--- a/fixtures/articles/Feature.ts
+++ b/fixtures/articles/Feature.ts
@@ -3040,6 +3040,8 @@ export const Feature: CAPIType = {
         series: '',
         contentType: '',
         isPaidContent: false,
+        discussionD2Uid: "testD2Header",
+        discussionApiClientHeader: "testClientHeader",
         ampIframeUrl:
             'https://assets.guim.co.uk/data/vendor/a994b749adae30cd58f0e84c8fa28013/amp-iframe.html',
     },

--- a/fixtures/articles/GuardianView.ts
+++ b/fixtures/articles/GuardianView.ts
@@ -3011,6 +3011,8 @@ export const GuardianView: CAPIType = {
         series: '',
         contentType: '',
         isPaidContent: false,
+        discussionD2Uid: "testD2Header",
+        discussionApiClientHeader: "testClientHeader",
         ampIframeUrl:
             'https://assets.guim.co.uk/data/vendor/a994b749adae30cd58f0e84c8fa28013/amp-iframe.html',
     },

--- a/fixtures/articles/Immersive.ts
+++ b/fixtures/articles/Immersive.ts
@@ -4830,6 +4830,8 @@ export const Immersive: CAPIType = {
         series: '',
         contentType: '',
         isPaidContent: false,
+        discussionD2Uid: "testD2Header",
+        discussionApiClientHeader: "testClientHeader",
         ampIframeUrl:
             'https://assets.guim.co.uk/data/vendor/a994b749adae30cd58f0e84c8fa28013/amp-iframe.html',
     },

--- a/fixtures/articles/Interview.ts
+++ b/fixtures/articles/Interview.ts
@@ -6036,6 +6036,8 @@ export const Interview: CAPIType = {
         series: '',
         contentType: '',
         isPaidContent: false,
+        discussionD2Uid: "testD2Header",
+        discussionApiClientHeader: "testClientHeader",
         ampIframeUrl:
             'https://assets.guim.co.uk/data/vendor/a994b749adae30cd58f0e84c8fa28013/amp-iframe.html',
     },

--- a/fixtures/articles/MatchReport.ts
+++ b/fixtures/articles/MatchReport.ts
@@ -2837,6 +2837,8 @@ export const MatchReport: CAPIType = {
         series: '',
         contentType: '',
         isPaidContent: false,
+        discussionD2Uid: "testD2Header",
+        discussionApiClientHeader: "testClientHeader",
         ampIframeUrl:
             'https://assets.guim.co.uk/data/vendor/a994b749adae30cd58f0e84c8fa28013/amp-iframe.html',
     },

--- a/fixtures/articles/Quiz.ts
+++ b/fixtures/articles/Quiz.ts
@@ -3079,6 +3079,8 @@ export const Quiz: CAPIType = {
         series: '',
         contentType: '',
         isPaidContent: false,
+        discussionD2Uid: "testD2Header",
+        discussionApiClientHeader: "testClientHeader",
         ampIframeUrl:
             'https://assets.guim.co.uk/data/vendor/a994b749adae30cd58f0e84c8fa28013/amp-iframe.html',
     },

--- a/fixtures/articles/Recipe.ts
+++ b/fixtures/articles/Recipe.ts
@@ -2751,6 +2751,8 @@ export const Recipe: CAPIType = {
         series: '',
         contentType: '',
         isPaidContent: false,
+        discussionD2Uid: "testD2Header",
+        discussionApiClientHeader: "testClientHeader",
         ampIframeUrl:
             'https://assets.guim.co.uk/data/vendor/a994b749adae30cd58f0e84c8fa28013/amp-iframe.html',
     },

--- a/fixtures/articles/Review.ts
+++ b/fixtures/articles/Review.ts
@@ -2706,6 +2706,8 @@ export const Review: CAPIType = {
         series: '',
         contentType: '',
         isPaidContent: false,
+        discussionD2Uid: "testD2Header",
+        discussionApiClientHeader: "testClientHeader",
         ampIframeUrl:
             'https://assets.guim.co.uk/data/vendor/a994b749adae30cd58f0e84c8fa28013/amp-iframe.html',
     },

--- a/index.d.ts
+++ b/index.d.ts
@@ -270,6 +270,8 @@ type CAPIBrowserType = {
         sharedAdTargeting: { [key: string]: any };
         adUnit: string;
         discussionApiUrl: string;
+        discussionD2Uid: string;
+        discussionApiClientHeader: string;
     };
     richLinks: RichLinkBlockElement[];
     editionId: Edition;
@@ -484,6 +486,8 @@ interface ConfigType extends CommercialConfigType {
     showRelatedContent: boolean;
     shouldHideReaderRevenue?: boolean;
     discussionApiUrl: string;
+    discussionD2Uid: string;
+    discussionApiClientHeader: string;
 }
 
 interface GADataType {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dependencies": {
         "@emotion/core": "^10.0.5",
         "@guardian/consent-management-platform": "^2.0.10",
-        "@guardian/discussion-rendering": "^0.1.1",
+        "@guardian/discussion-rendering": "^0.1.3",
         "@guardian/slot-machine-client": "^0.2.6",
         "@guardian/src-foundations": "^0.15.1",
         "@sentry/browser": "^5.7.1",

--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -83,7 +83,8 @@ export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
         },
         [] as RichLinkBlockElement[],
     );
-    return ({
+
+    return {
         config: {
             isDev: process.env.NODE_ENV !== 'production',
             ajaxUrl: CAPI.config.ajaxUrl,
@@ -108,6 +109,8 @@ export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
             sharedAdTargeting: CAPI.config.sharedAdTargeting, // missing type definition
             adUnit: CAPI.config.adUnit,
             discussionApiUrl: CAPI.config.discussionApiUrl,
+            discussionD2Uid: CAPI.config.discussionD2Uid,
+            discussionApiClientHeader: CAPI.config.discussionApiClientHeader,
         },
         richLinks: richLinksWithIndex,
         editionId: CAPI.editionId,
@@ -131,8 +134,8 @@ export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
                 header: CAPI.nav.readerRevenueLinks.header,
             },
         },
-    });
-}
+    };
+};
 
 export interface WindowGuardian {
     // The app contains only data that we require for app hydration

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -189,6 +189,10 @@ export const App = ({ CAPI, NAV }: Props) => {
                         shortUrl={CAPI.config.shortUrlId}
                         commentCount={commentCount}
                         isClosedForComments={isClosedForComments}
+                        discussionD2Uid={CAPI.config.discussionD2Uid}
+                        discussionApiClientHeader={
+                            CAPI.config.discussionApiClientHeader
+                        }
                     />
                 </Lazy>
             </Portal>

--- a/src/web/components/CommentsLayout.stories.tsx
+++ b/src/web/components/CommentsLayout.stories.tsx
@@ -24,6 +24,8 @@ export const Default = () => (
                 shortUrl="p/39f5z/"
                 commentCount={345}
                 isClosedForComments={false}
+                discussionD2Uid="testD2Header"
+                discussionApiClientHeader="testClientHeader"
             />
             <RightColumn>{/* TODO: Comments ad slot goes here */}</RightColumn>
         </Flex>

--- a/src/web/components/CommentsLayout.tsx
+++ b/src/web/components/CommentsLayout.tsx
@@ -14,6 +14,8 @@ type Props = {
     shortUrl: string;
     commentCount: number;
     isClosedForComments: boolean;
+    discussionD2Uid: string;
+    discussionApiClientHeader: string;
 };
 
 const containerStyles = css`
@@ -28,6 +30,8 @@ export const CommentsLayout = ({
     shortUrl,
     commentCount,
     isClosedForComments,
+    discussionD2Uid,
+    discussionApiClientHeader,
 }: Props) => (
     <Flex direction="row">
         <LeftColumn showRightBorder={false}>
@@ -40,7 +44,13 @@ export const CommentsLayout = ({
             <Hide when="above" breakpoint="leftCol">
                 <SignedInAs commentCount={commentCount} />
             </Hide>
-            <Comments shortUrl={shortUrl} />
+            <Comments
+                shortUrl={shortUrl}
+                additionalHeaders={{
+                    'D2-X-UID': discussionD2Uid,
+                    'GU-Client': discussionApiClientHeader,
+                }}
+            />
         </div>
     </Flex>
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2091,10 +2091,10 @@
     js-cookie "^2.2.1"
     whatwg-fetch "^3.0.0"
 
-"@guardian/discussion-rendering@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-0.1.1.tgz#68d378e07b8f97493f5a35a5be896835cacd5a54"
-  integrity sha512-EcARwj2bp0ndej9bWDYVw+QrQ5ehqKniP9y68zxKo1nBLFMtqVRTdHC6b+TSQmoQPTs8rLYOA8Nr3t3Mmmi7Cw==
+"@guardian/discussion-rendering@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-0.1.3.tgz#c49429c644e84edf3d3b0e0b4ebcc8cd72c2fc66"
+  integrity sha512-4OfCx273RrLRE7xNVE7YxuvUhnKpFCWI6JDU1YvkhBgSRmbDe91Xh9cwOt8xfqdk+NRRweAx4cqYeazQuYcx1A==
   dependencies:
     regenerator-runtime "^0.13.3"
     timeago.js "^4.0.2"


### PR DESCRIPTION
## What does this change?
Adds support for tracking headers in discussion.

It adds the 2 tracking header values that discussion needs from CAPI to the DCR data model. It then takes these values and passes them to discussion

## Why?
So that we can support v0.1.3 of discussion

## Link to supporting Trello card
https://trello.com/c/NCfUhe77/1313-discussion-tracking