### PR TITLE
Send baseUrl to discussion

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dependencies": {
         "@emotion/core": "^10.0.5",
         "@guardian/consent-management-platform": "^2.0.10",
-        "@guardian/discussion-rendering": "^0.1.3",
+        "@guardian/discussion-rendering": "^0.1.6",
         "@guardian/slot-machine-client": "^0.2.6",
         "@guardian/src-foundations": "^0.15.1",
         "@sentry/browser": "^5.7.1",

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -75,8 +75,6 @@ export const App = ({ CAPI, NAV }: Props) => {
         incrementWeeklyArticleCount();
     }, []);
 
-    console.log('ca', CAPI);
-
     return (
         // Do you need to Hydrate or do you want a Portal?
         //

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -75,6 +75,8 @@ export const App = ({ CAPI, NAV }: Props) => {
         incrementWeeklyArticleCount();
     }, []);
 
+    console.log('ca', CAPI);
+
     return (
         // Do you need to Hydrate or do you want a Portal?
         //
@@ -186,6 +188,7 @@ export const App = ({ CAPI, NAV }: Props) => {
             <Portal root="comments-root">
                 <Lazy margin={300}>
                     <CommentsLayout
+                        baseUrl={CAPI.config.discussionApiUrl}
                         shortUrl={CAPI.config.shortUrlId}
                         commentCount={commentCount}
                         isClosedForComments={isClosedForComments}

--- a/src/web/components/CommentsLayout.stories.tsx
+++ b/src/web/components/CommentsLayout.stories.tsx
@@ -21,6 +21,7 @@ export const Default = () => (
     <Section>
         <Flex>
             <CommentsLayout
+                baseUrl="https://discussion.theguardian.com/discussion-api"
                 shortUrl="p/39f5z/"
                 commentCount={345}
                 isClosedForComments={false}

--- a/src/web/components/CommentsLayout.tsx
+++ b/src/web/components/CommentsLayout.tsx
@@ -11,6 +11,7 @@ import { Flex } from '@frontend/web/components/Flex';
 import { App as Comments } from '@guardian/discussion-rendering';
 
 type Props = {
+    baseUrl: string;
     shortUrl: string;
     commentCount: number;
     isClosedForComments: boolean;
@@ -27,6 +28,7 @@ const containerStyles = css`
 `;
 
 export const CommentsLayout = ({
+    baseUrl,
     shortUrl,
     commentCount,
     isClosedForComments,
@@ -45,6 +47,7 @@ export const CommentsLayout = ({
                 <SignedInAs commentCount={commentCount} />
             </Hide>
             <Comments
+                baseUrl={baseUrl}
                 shortUrl={shortUrl}
                 additionalHeaders={{
                     'D2-X-UID': discussionD2Uid,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2091,10 +2091,10 @@
     js-cookie "^2.2.1"
     whatwg-fetch "^3.0.0"
 
-"@guardian/discussion-rendering@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-0.1.3.tgz#c49429c644e84edf3d3b0e0b4ebcc8cd72c2fc66"
-  integrity sha512-4OfCx273RrLRE7xNVE7YxuvUhnKpFCWI6JDU1YvkhBgSRmbDe91Xh9cwOt8xfqdk+NRRweAx4cqYeazQuYcx1A==
+"@guardian/discussion-rendering@^0.1.6":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-0.1.6.tgz#ddc8559c1abce4bcda1d2d401da74d02b27edb85"
+  integrity sha512-UIR1I0NKMg0bo+ZL5iqMW9P+bKIN2hN5Yo88FAeQebKI12wRzF44H8fcn9PbIloB/1C/ni/vzsepWeeND5Pgvg==
   dependencies:
     regenerator-runtime "^0.13.3"
     timeago.js "^4.0.2"


### PR DESCRIPTION
## What does this change?
Now that the latest version of `discussion-rendering` takes baseUrl as a prop, update DCR to pass this over

## Why?
So we can test on CODE

## Link to supporting Trello card
https://trello.com/c/fNn0CFdy/1310-pass-in-a-baseurl-to-comments