### PR TITLE
Get User Profile

### DIFF
--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -23,11 +23,13 @@ import { Lazy } from '@frontend/web/components/Lazy';
 import { getCookie } from '@root/src/web/browser/cookie';
 import { getCountryCode } from '@frontend/web/lib/getCountryCode';
 import { getDiscussion } from '@root/src/web/lib/getDiscussion';
+import { getUser } from '@root/src/web/lib/getUser';
 
 type Props = { CAPI: CAPIBrowserType; NAV: NavType };
 
 export const App = ({ CAPI, NAV }: Props) => {
     const [isSignedIn, setIsSignedIn] = useState<boolean>();
+    const [user, setUser] = useState<UserProfile>();
     const [countryCode, setCountryCode] = useState<string>();
     const [commentCount, setCommentCount] = useState<number>(0);
     const [isClosedForComments, setIsClosedForComments] = useState<boolean>(
@@ -37,6 +39,16 @@ export const App = ({ CAPI, NAV }: Props) => {
     useEffect(() => {
         setIsSignedIn(!!getCookie('GU_U'));
     }, []);
+
+    useEffect(() => {
+        const callGetUser = async () => {
+            setUser(await getUser(CAPI.config.discussionApiUrl));
+        };
+
+        if (isSignedIn) {
+            callGetUser();
+        }
+    }, [isSignedIn, CAPI.config.discussionApiUrl]);
 
     useEffect(() => {
         const callFetch = async () =>
@@ -186,6 +198,7 @@ export const App = ({ CAPI, NAV }: Props) => {
             <Portal root="comments-root">
                 <Lazy margin={300}>
                     <CommentsLayout
+                        user={user}
                         baseUrl={CAPI.config.discussionApiUrl}
                         shortUrl={CAPI.config.shortUrlId}
                         commentCount={commentCount}

--- a/src/web/components/CommentsLayout.tsx
+++ b/src/web/components/CommentsLayout.tsx
@@ -11,6 +11,7 @@ import { Flex } from '@frontend/web/components/Flex';
 import { App as Comments } from '@guardian/discussion-rendering';
 
 type Props = {
+    user?: UserProfile;
     baseUrl: string;
     shortUrl: string;
     commentCount: number;
@@ -28,6 +29,7 @@ const containerStyles = css`
 `;
 
 export const CommentsLayout = ({
+    user,
     baseUrl,
     shortUrl,
     commentCount,
@@ -47,6 +49,7 @@ export const CommentsLayout = ({
                 <SignedInAs commentCount={commentCount} />
             </Hide>
             <Comments
+                user={user}
                 baseUrl={baseUrl}
                 shortUrl={shortUrl}
                 additionalHeaders={{

--- a/src/web/components/CommentsLayout.tsx
+++ b/src/web/components/CommentsLayout.tsx
@@ -40,13 +40,14 @@ export const CommentsLayout = ({
     <Flex direction="row">
         <LeftColumn showRightBorder={false}>
             <SignedInAs
+                user={user}
                 commentCount={commentCount}
                 isClosedForComments={isClosedForComments}
             />
         </LeftColumn>
         <div className={containerStyles}>
             <Hide when="above" breakpoint="leftCol">
-                <SignedInAs commentCount={commentCount} />
+                <SignedInAs user={user} commentCount={commentCount} />
             </Hide>
             <Comments
                 user={user}

--- a/src/web/lib/getUser.ts
+++ b/src/web/lib/getUser.ts
@@ -13,7 +13,7 @@ export const getUser = async (ajaxUrl: string): Promise<UserProfile> => {
             return response;
         })
         .then(response => response.json())
-        .then(json => json.UserResponse)
+        .then(json => json.userProfile)
         .catch(error => {
             window.guardian.modules.sentry.reportError(error, 'get-user');
         });

--- a/src/web/lib/getUser.ts
+++ b/src/web/lib/getUser.ts
@@ -17,6 +17,7 @@ export const getUser = async (ajaxUrl: string): Promise<UserProfile> => {
             return json.userProfile;
         })
         .catch(error => {
+            console.log('error fetching profile', error);
             window.guardian.modules.sentry.reportError(error, 'get-user');
         });
 };

--- a/src/web/lib/getUser.ts
+++ b/src/web/lib/getUser.ts
@@ -2,7 +2,9 @@ import { joinUrl } from '@root/src/web/lib/joinUrl';
 
 export const getUser = async (ajaxUrl: string): Promise<UserProfile> => {
     const url = joinUrl([ajaxUrl, 'profile/me']);
-    return fetch(url)
+    return fetch(url, {
+        credentials: 'same-origin',
+    })
         .then(response => {
             if (!response.ok) {
                 throw Error(response.statusText);

--- a/src/web/lib/getUser.ts
+++ b/src/web/lib/getUser.ts
@@ -4,7 +4,6 @@ export const getUser = async (ajaxUrl: string): Promise<UserProfile> => {
     const url = joinUrl([ajaxUrl, 'profile/me']);
     return fetch(url, {
         credentials: 'include',
-        mode: 'no-cors',
     })
         .then(response => {
             if (!response.ok) {

--- a/src/web/lib/getUser.ts
+++ b/src/web/lib/getUser.ts
@@ -12,7 +12,10 @@ export const getUser = async (ajaxUrl: string): Promise<UserProfile> => {
             return response;
         })
         .then(response => response.json())
-        .then(json => json.userProfile)
+        .then(json => {
+            console.log('getuser json', json);
+            return json.userProfile;
+        })
         .catch(error => {
             window.guardian.modules.sentry.reportError(error, 'get-user');
         });

--- a/src/web/lib/getUser.ts
+++ b/src/web/lib/getUser.ts
@@ -1,0 +1,17 @@
+import { joinUrl } from '@root/src/web/lib/joinUrl';
+
+export const getUser = async (ajaxUrl: string): Promise<UserProfile> => {
+    const url = joinUrl([ajaxUrl, 'profile/me']);
+    return fetch(url)
+        .then(response => {
+            if (!response.ok) {
+                throw Error(response.statusText);
+            }
+            return response;
+        })
+        .then(response => response.json())
+        .then(json => json.UserResponse)
+        .catch(error => {
+            window.guardian.modules.sentry.reportError(error, 'get-user');
+        });
+};

--- a/src/web/lib/getUser.ts
+++ b/src/web/lib/getUser.ts
@@ -12,12 +12,8 @@ export const getUser = async (ajaxUrl: string): Promise<UserProfile> => {
             return response;
         })
         .then(response => response.json())
-        .then(json => {
-            console.log('getuser json', json);
-            return json.userProfile;
-        })
+        .then(json => json.userProfile)
         .catch(error => {
-            console.log('error fetching profile', error);
             window.guardian.modules.sentry.reportError(error, 'get-user');
         });
 };

--- a/src/web/lib/getUser.ts
+++ b/src/web/lib/getUser.ts
@@ -3,7 +3,7 @@ import { joinUrl } from '@root/src/web/lib/joinUrl';
 export const getUser = async (ajaxUrl: string): Promise<UserProfile> => {
     const url = joinUrl([ajaxUrl, 'profile/me']);
     return fetch(url, {
-        credentials: 'same-origin',
+        credentials: 'include',
     })
         .then(response => {
             if (!response.ok) {

--- a/src/web/lib/getUser.ts
+++ b/src/web/lib/getUser.ts
@@ -4,6 +4,7 @@ export const getUser = async (ajaxUrl: string): Promise<UserProfile> => {
     const url = joinUrl([ajaxUrl, 'profile/me']);
     return fetch(url, {
         credentials: 'include',
+        mode: 'no-cors',
     })
         .then(response => {
             if (!response.ok) {


### PR DESCRIPTION
## What does this change?
Add a getUser call to App and passes the userProfile result to both `SignedInAs` and the discussion app

## Why?
We use this profile object to know discussion related things about the user, such as their display name or if they are banned

## Depends on
https://github.com/guardian/discussion-api/pull/644

## Link to supporting Trello card
https://trello.com/c/hEzgRUHh/1311-discussion-owns-user-profile