### PR TITLE
More permissive interactive iframe

### DIFF
--- a/src/amp/components/elements/InteractiveUrl.tsx
+++ b/src/amp/components/elements/InteractiveUrl.tsx
@@ -22,7 +22,7 @@ export const InteractiveUrl: React.SFC<{ url: string }> = ({ url }) => {
             class={styles}
             src={url}
             layout="responsive"
-            sandbox="allow-scripts allow-same-origin"
+            sandbox="allow-scripts allow-same-origin allow-top-navigation-by-user-activation"
             height="1"
             width="8"
             resizable=""

--- a/src/amp/components/elements/InteractiveUrl.tsx
+++ b/src/amp/components/elements/InteractiveUrl.tsx
@@ -22,7 +22,7 @@ export const InteractiveUrl: React.SFC<{ url: string }> = ({ url }) => {
             class={styles}
             src={url}
             layout="responsive"
-            sandbox="allow-scripts allow-same-origin allow-top-navigation-by-user-activation"
+            sandbox="allow-scripts allow-same-origin allow-top-navigation-by-user-activation allow-popups"
             height="1"
             width="8"
             resizable=""


### PR DESCRIPTION
## What does this change?

Adds `allow-top-navigation-by-user-activation` and `allow-popups` to the iframe used to render interactive embeds and atoms on amp.

## Why?

To support opening links from the interactive. For example this interactive atom `atom/interactive/interactives/2020/03/interactive-coronavirus-live/totals` has links. [This page](https://amp.theguardian.com/politics/2016/apr/28/british-expats-lose-legal-battle-right-to-vote-eu-referendum) has an interactive embed with links which open in a new tab (not currently working).

## Link to supporting Trello card

Part of https://trello.com/c/gNgwpVUb/881-render-interactives-on-their-unique-end-points-to-be-used-in-amp-iframe-and-replace-srcdoc-with-src-for-amp-iframe.