### PR TITLE
Discussion Permalinks

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dependencies": {
         "@emotion/core": "^10.0.5",
         "@guardian/consent-management-platform": "^2.0.10",
-        "@guardian/discussion-rendering": "^0.2.0",
+        "@guardian/discussion-rendering": "^0.3.0",
         "@guardian/slot-machine-client": "^0.2.6",
         "@guardian/src-foundations": "^0.15.1",
         "@sentry/browser": "^5.7.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dependencies": {
         "@emotion/core": "^10.0.5",
         "@guardian/consent-management-platform": "^2.0.10",
-        "@guardian/discussion-rendering": "^0.1.6",
+        "@guardian/discussion-rendering": "^0.2.0",
         "@guardian/slot-machine-client": "^0.2.6",
         "@guardian/src-foundations": "^0.15.1",
         "@sentry/browser": "^5.7.1",

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -27,6 +27,14 @@ import { getCommentContext } from '@root/src/web/lib/getCommentContext';
 
 type Props = { CAPI: CAPIBrowserType; NAV: NavType };
 
+const commentIdFromUrl = () => {
+    const { hash } = window.location;
+    if (!hash) return;
+    if (!hash.includes('comment')) return;
+    if (!hash.split('-')[1]) return;
+    return parseInt(hash.split('-')[1], 10);
+};
+
 export const App = ({ CAPI, NAV }: Props) => {
     const [isSignedIn, setIsSignedIn] = useState<boolean>();
     const [countryCode, setCountryCode] = useState<string>();
@@ -41,6 +49,8 @@ export const App = ({ CAPI, NAV }: Props) => {
     const [commentOrderBy, setCommentOrderBy] = useState<
         'newest' | 'oldest' | 'mostrecommended'
     >();
+
+    const hashCommentId = commentIdFromUrl();
 
     useEffect(() => {
         setIsSignedIn(!!getCookie('GU_U'));
@@ -87,12 +97,6 @@ export const App = ({ CAPI, NAV }: Props) => {
     // If so, make a call to get the context of this comment so we know what page it is
     // on.
     useEffect(() => {
-        const commentIdFromUrl = () => {
-            const { hash } = window.location;
-            return hash && hash.includes('comment') && hash.split('-')[1];
-        };
-
-        const hashCommentId = commentIdFromUrl();
         if (hashCommentId) {
             getCommentContext(CAPI.config.discussionApiUrl, hashCommentId).then(
                 context => {
@@ -102,7 +106,7 @@ export const App = ({ CAPI, NAV }: Props) => {
                 },
             );
         }
-    }, [CAPI.config.discussionApiUrl]);
+    }, [CAPI.config.discussionApiUrl, hashCommentId]);
 
     return (
         // Do you need to Hydrate or do you want a Portal?
@@ -212,8 +216,11 @@ export const App = ({ CAPI, NAV }: Props) => {
                     />
                 </Lazy>
             </Portal>
+
+            {/* Don't lazy render comments if we have a comment id in the url because
+                we want to scroll the page to it */}
             <Portal root="comments-root">
-                <Lazy margin={300}>
+                {hashCommentId ? (
                     <CommentsLayout
                         baseUrl={CAPI.config.discussionApiUrl}
                         shortUrl={CAPI.config.shortUrlId}
@@ -226,8 +233,27 @@ export const App = ({ CAPI, NAV }: Props) => {
                         discussionApiClientHeader={
                             CAPI.config.discussionApiClientHeader
                         }
+                        expanded={true}
+                        commentToScrollTo={hashCommentId}
                     />
-                </Lazy>
+                ) : (
+                    <Lazy margin={300}>
+                        <CommentsLayout
+                            baseUrl={CAPI.config.discussionApiUrl}
+                            shortUrl={CAPI.config.shortUrlId}
+                            commentCount={commentCount}
+                            commentPage={commentPage}
+                            commentPageSize={commentPageSize}
+                            commentOrderBy={commentOrderBy}
+                            isClosedForComments={isClosedForComments}
+                            discussionD2Uid={CAPI.config.discussionD2Uid}
+                            discussionApiClientHeader={
+                                CAPI.config.discussionApiClientHeader
+                            }
+                            expanded={false}
+                        />
+                    </Lazy>
+                )}
             </Portal>
             <Portal root="most-viewed-footer">
                 <MostViewedFooter

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -23,7 +23,7 @@ import { Lazy } from '@frontend/web/components/Lazy';
 import { getCookie } from '@root/src/web/browser/cookie';
 import { getCountryCode } from '@frontend/web/lib/getCountryCode';
 import { getDiscussion } from '@root/src/web/lib/getDiscussion';
-import { getCommentPage } from '@root/src/web/lib/getCommentPage';
+import { getCommentContext } from '@root/src/web/lib/getCommentContext';
 
 type Props = { CAPI: CAPIBrowserType; NAV: NavType };
 
@@ -88,9 +88,9 @@ export const App = ({ CAPI, NAV }: Props) => {
 
         const hashCommentId = commentIdFromUrl();
         if (hashCommentId) {
-            getCommentPage(CAPI.config.discussionApiUrl, hashCommentId).then(
-                page => {
-                    setCommentPage(page);
+            getCommentContext(CAPI.config.discussionApiUrl, hashCommentId).then(
+                context => {
+                    setCommentPage(context.page);
                 },
             );
         }

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -35,7 +35,12 @@ export const App = ({ CAPI, NAV }: Props) => {
         true,
     );
     const [commentPage, setCommentPage] = useState<number>();
-    const [commentPageSize, setCommentPageSize] = useState<number>();
+    const [commentPageSize, setCommentPageSize] = useState<
+        20 | 25 | 50 | 100
+    >();
+    const [commentOrderBy, setCommentOrderBy] = useState<
+        'newest' | 'oldest' | 'mostrecommended'
+    >();
 
     useEffect(() => {
         setIsSignedIn(!!getCookie('GU_U'));
@@ -93,6 +98,7 @@ export const App = ({ CAPI, NAV }: Props) => {
                 context => {
                     setCommentPage(context.page);
                     setCommentPageSize(context.pageSize);
+                    setCommentOrderBy(context.orderBy);
                 },
             );
         }
@@ -214,6 +220,7 @@ export const App = ({ CAPI, NAV }: Props) => {
                         commentCount={commentCount}
                         commentPage={commentPage}
                         commentPageSize={commentPageSize}
+                        commentOrderBy={commentOrderBy}
                         isClosedForComments={isClosedForComments}
                         discussionD2Uid={CAPI.config.discussionD2Uid}
                         discussionApiClientHeader={

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -35,6 +35,7 @@ export const App = ({ CAPI, NAV }: Props) => {
         true,
     );
     const [commentPage, setCommentPage] = useState<number>();
+    const [commentPageSize, setCommentPageSize] = useState<number>();
 
     useEffect(() => {
         setIsSignedIn(!!getCookie('GU_U'));
@@ -91,6 +92,7 @@ export const App = ({ CAPI, NAV }: Props) => {
             getCommentContext(CAPI.config.discussionApiUrl, hashCommentId).then(
                 context => {
                     setCommentPage(context.page);
+                    setCommentPageSize(context.pageSize);
                 },
             );
         }
@@ -211,6 +213,7 @@ export const App = ({ CAPI, NAV }: Props) => {
                         shortUrl={CAPI.config.shortUrlId}
                         commentCount={commentCount}
                         commentPage={commentPage}
+                        commentPageSize={commentPageSize}
                         isClosedForComments={isClosedForComments}
                         discussionD2Uid={CAPI.config.discussionD2Uid}
                         discussionApiClientHeader={

--- a/src/web/components/CommentsLayout.stories.tsx
+++ b/src/web/components/CommentsLayout.stories.tsx
@@ -27,9 +27,28 @@ export const Default = () => (
                 isClosedForComments={false}
                 discussionD2Uid="testD2Header"
                 discussionApiClientHeader="testClientHeader"
+                expanded={false}
             />
             <RightColumn>{/* TODO: Comments ad slot goes here */}</RightColumn>
         </Flex>
     </Section>
 );
 Default.story = { name: 'default' };
+
+export const Expanded = () => (
+    <Section>
+        <Flex>
+            <CommentsLayout
+                baseUrl="https://discussion.theguardian.com/discussion-api"
+                shortUrl="p/39f5z/"
+                commentCount={345}
+                isClosedForComments={false}
+                discussionD2Uid="testD2Header"
+                discussionApiClientHeader="testClientHeader"
+                expanded={true}
+            />
+            <RightColumn>{/* TODO: Comments ad slot goes here */}</RightColumn>
+        </Flex>
+    </Section>
+);
+Expanded.story = { name: 'expanded' };

--- a/src/web/components/CommentsLayout.stories.tsx
+++ b/src/web/components/CommentsLayout.stories.tsx
@@ -34,21 +34,3 @@ export const Default = () => (
     </Section>
 );
 Default.story = { name: 'default' };
-
-export const Expanded = () => (
-    <Section>
-        <Flex>
-            <CommentsLayout
-                baseUrl="https://discussion.theguardian.com/discussion-api"
-                shortUrl="p/39f5z/"
-                commentCount={345}
-                isClosedForComments={false}
-                discussionD2Uid="testD2Header"
-                discussionApiClientHeader="testClientHeader"
-                expanded={true}
-            />
-            <RightColumn>{/* TODO: Comments ad slot goes here */}</RightColumn>
-        </Flex>
-    </Section>
-);
-Expanded.story = { name: 'expanded' };

--- a/src/web/components/CommentsLayout.tsx
+++ b/src/web/components/CommentsLayout.tsx
@@ -17,6 +17,7 @@ type Props = {
     isClosedForComments: boolean;
     discussionD2Uid: string;
     discussionApiClientHeader: string;
+    commentPage?: number;
 };
 
 const containerStyles = css`
@@ -31,6 +32,7 @@ export const CommentsLayout = ({
     baseUrl,
     shortUrl,
     commentCount,
+    // commentPage,
     isClosedForComments,
     discussionD2Uid,
     discussionApiClientHeader,
@@ -48,6 +50,8 @@ export const CommentsLayout = ({
             </Hide>
             <Comments
                 baseUrl={baseUrl}
+                // TODO: Enable this when https://github.com/guardian/discussion-rendering/pull/113 is deployed and a new version published
+                // initialPage={commentPage}
                 shortUrl={shortUrl}
                 additionalHeaders={{
                     'D2-X-UID': discussionD2Uid,

--- a/src/web/components/CommentsLayout.tsx
+++ b/src/web/components/CommentsLayout.tsx
@@ -37,14 +37,14 @@ export const CommentsLayout = ({
     shortUrl,
     commentCount,
     commentPage,
-    // commentPageSize,
-    // commentOrderBy,
-    // expanded,
+    commentPageSize,
+    commentOrderBy,
+    expanded,
     isClosedForComments,
     discussionD2Uid,
     discussionApiClientHeader,
-}: // commentToScrollTo,
-Props) => (
+    commentToScrollTo,
+}: Props) => (
     <Flex direction="row">
         <LeftColumn showRightBorder={false}>
             <SignedInAs
@@ -59,19 +59,15 @@ Props) => (
             <Comments
                 baseUrl={baseUrl}
                 initialPage={commentPage}
-                // TODO: Enable this when https://github.com/guardian/discussion-rendering/pull/115 is deployed and a new version published
-                // pageSizeOverride={commentPageSize}
-                // TODO: Enable this when https://github.com/guardian/discussion-rendering/pull/116 is deployed and a new version published
-                // orderByOverride={commentOrderBy}
+                pageSizeOverride={commentPageSize}
+                orderByOverride={commentOrderBy}
                 shortUrl={shortUrl}
                 additionalHeaders={{
                     'D2-X-UID': discussionD2Uid,
                     'GU-Client': discussionApiClientHeader,
                 }}
-                // TODO: Enable this when https://github.com/guardian/discussion-rendering/pull/117 is deployed and a new version published
-                // expanded={expanded}
-                // TODO: Enable this when https://github.com/guardian/discussion-rendering/pull/118 is deployed and a new version published
-                // commentToScrollTo={commentToScrollTo}
+                expanded={expanded}
+                commentToScrollTo={commentToScrollTo}
             />
         </div>
     </Flex>

--- a/src/web/components/CommentsLayout.tsx
+++ b/src/web/components/CommentsLayout.tsx
@@ -18,7 +18,8 @@ type Props = {
     discussionD2Uid: string;
     discussionApiClientHeader: string;
     commentPage?: number;
-    commentPageSize?: number;
+    commentPageSize?: 20 | 25 | 50 | 100;
+    commentOrderBy?: 'newest' | 'oldest' | 'mostrecommended';
 };
 
 const containerStyles = css`
@@ -33,8 +34,9 @@ export const CommentsLayout = ({
     baseUrl,
     shortUrl,
     commentCount,
-    // commentPage,
-    // commentPageSize,
+    commentPage,
+    commentPageSize,
+    commentOrderBy,
     isClosedForComments,
     discussionD2Uid,
     discussionApiClientHeader,
@@ -56,6 +58,7 @@ export const CommentsLayout = ({
                 // initialPage={commentPage}
                 // TODO: Enable this when https://github.com/guardian/discussion-rendering/pull/115 is deployed and a new version published
                 // pageSizeOverride={commentPageSize}
+                // orderByOverride={commentOrderBy}
                 shortUrl={shortUrl}
                 additionalHeaders={{
                     'D2-X-UID': discussionD2Uid,

--- a/src/web/components/CommentsLayout.tsx
+++ b/src/web/components/CommentsLayout.tsx
@@ -18,6 +18,7 @@ type Props = {
     discussionD2Uid: string;
     discussionApiClientHeader: string;
     commentPage?: number;
+    commentPageSize?: number;
 };
 
 const containerStyles = css`
@@ -33,6 +34,7 @@ export const CommentsLayout = ({
     shortUrl,
     commentCount,
     // commentPage,
+    // commentPageSize,
     isClosedForComments,
     discussionD2Uid,
     discussionApiClientHeader,
@@ -52,6 +54,8 @@ export const CommentsLayout = ({
                 baseUrl={baseUrl}
                 // TODO: Enable this when https://github.com/guardian/discussion-rendering/pull/113 is deployed and a new version published
                 // initialPage={commentPage}
+                // TODO: Enable this when https://github.com/guardian/discussion-rendering/pull/115 is deployed and a new version published
+                // pageSizeOverride={commentPageSize}
                 shortUrl={shortUrl}
                 additionalHeaders={{
                     'D2-X-UID': discussionD2Uid,

--- a/src/web/components/CommentsLayout.tsx
+++ b/src/web/components/CommentsLayout.tsx
@@ -17,9 +17,11 @@ type Props = {
     isClosedForComments: boolean;
     discussionD2Uid: string;
     discussionApiClientHeader: string;
+    expanded: boolean;
     commentPage?: number;
     commentPageSize?: 20 | 25 | 50 | 100;
     commentOrderBy?: 'newest' | 'oldest' | 'mostrecommended';
+    commentToScrollTo?: number;
 };
 
 const containerStyles = css`
@@ -35,12 +37,14 @@ export const CommentsLayout = ({
     shortUrl,
     commentCount,
     commentPage,
-    commentPageSize,
-    commentOrderBy,
+    // commentPageSize,
+    // commentOrderBy,
+    // expanded,
     isClosedForComments,
     discussionD2Uid,
     discussionApiClientHeader,
-}: Props) => (
+}: // commentToScrollTo,
+Props) => (
     <Flex direction="row">
         <LeftColumn showRightBorder={false}>
             <SignedInAs
@@ -54,16 +58,20 @@ export const CommentsLayout = ({
             </Hide>
             <Comments
                 baseUrl={baseUrl}
-                // TODO: Enable this when https://github.com/guardian/discussion-rendering/pull/113 is deployed and a new version published
-                // initialPage={commentPage}
+                initialPage={commentPage}
                 // TODO: Enable this when https://github.com/guardian/discussion-rendering/pull/115 is deployed and a new version published
                 // pageSizeOverride={commentPageSize}
+                // TODO: Enable this when https://github.com/guardian/discussion-rendering/pull/116 is deployed and a new version published
                 // orderByOverride={commentOrderBy}
                 shortUrl={shortUrl}
                 additionalHeaders={{
                     'D2-X-UID': discussionD2Uid,
                     'GU-Client': discussionApiClientHeader,
                 }}
+                // TODO: Enable this when https://github.com/guardian/discussion-rendering/pull/117 is deployed and a new version published
+                // expanded={expanded}
+                // TODO: Enable this when https://github.com/guardian/discussion-rendering/pull/118 is deployed and a new version published
+                // commentToScrollTo={commentToScrollTo}
             />
         </div>
     </Flex>

--- a/src/web/lib/getCommentContext.ts
+++ b/src/web/lib/getCommentContext.ts
@@ -1,6 +1,6 @@
 import { joinUrl } from '@root/src/web/lib/joinUrl';
 
-// An example /context response
+// GET http://discussion.guardianapis.com/discussion-api/comment/3519111/context
 // {
 //     status: 'ok',
 //     commentId: 3519111,
@@ -15,10 +15,22 @@ import { joinUrl } from '@root/src/web/lib/joinUrl';
 //     page: 1,
 // };
 
-export const getCommentPage = async (
+type CommentContextType = {
+    status: 'ok' | 'error';
+    commentId: number;
+    commentAncestorId: number;
+    discussionKey: string;
+    discussionWebUrl: string;
+    discussionApiUrl: string;
+    orderBy: 'oldest' | 'newest' | 'recommended';
+    pageSize: 20 | 25 | 50 | 100; // TODO: Review these https://trello.com/c/7v4VDNY0/1326-review-page-size-values
+    page: number;
+};
+
+export const getCommentContext = async (
     ajaxUrl: string,
     commentId: string,
-): Promise<number> => {
+): Promise<CommentContextType> => {
     const url = joinUrl([ajaxUrl, 'comment', commentId, 'context']);
     return fetch(url)
         .then(response => {
@@ -28,7 +40,6 @@ export const getCommentPage = async (
             return response;
         })
         .then(response => response.json())
-        .then(json => json.page)
         .catch(error => {
             window.guardian.modules.sentry.reportError(
                 error,

--- a/src/web/lib/getCommentContext.ts
+++ b/src/web/lib/getCommentContext.ts
@@ -22,7 +22,7 @@ type CommentContextType = {
     discussionKey: string;
     discussionWebUrl: string;
     discussionApiUrl: string;
-    orderBy: 'oldest' | 'newest' | 'recommended';
+    orderBy: 'oldest' | 'newest' | 'mostrecommended';
     pageSize: 20 | 25 | 50 | 100; // TODO: Review these https://trello.com/c/7v4VDNY0/1326-review-page-size-values
     page: number;
 };

--- a/src/web/lib/getCommentContext.ts
+++ b/src/web/lib/getCommentContext.ts
@@ -29,9 +29,9 @@ type CommentContextType = {
 
 export const getCommentContext = async (
     ajaxUrl: string,
-    commentId: string,
+    commentId: number,
 ): Promise<CommentContextType> => {
-    const url = joinUrl([ajaxUrl, 'comment', commentId, 'context']);
+    const url = joinUrl([ajaxUrl, 'comment', commentId.toString(), 'context']);
     return fetch(url)
         .then(response => {
             if (!response.ok) {

--- a/src/web/lib/getCommentPage.ts
+++ b/src/web/lib/getCommentPage.ts
@@ -1,0 +1,38 @@
+import { joinUrl } from '@root/src/web/lib/joinUrl';
+
+// An example /context response
+// {
+//     status: 'ok',
+//     commentId: 3519111,
+//     commentAncestorId: 3519111,
+//     discussionKey: '/p/27y27',
+//     discussionWebUrl:
+//         'https://www.theguardian.com/commentisfree/cifamerica/2009/may/14/washington-post-torture-libel',
+//     discussionApiUrl:
+//         'https://discussion.guardianapis.com/discussion-api/discussion//p/27y27?orderBy=oldest&pageSize=20&page=1',
+//     orderBy: 'oldest',
+//     pageSize: 20,
+//     page: 1,
+// };
+
+export const getCommentPage = async (
+    ajaxUrl: string,
+    commentId: string,
+): Promise<number> => {
+    const url = joinUrl([ajaxUrl, 'comment', commentId, 'context']);
+    return fetch(url)
+        .then(response => {
+            if (!response.ok) {
+                throw Error(response.statusText);
+            }
+            return response;
+        })
+        .then(response => response.json())
+        .then(json => json.page)
+        .catch(error => {
+            window.guardian.modules.sentry.reportError(
+                error,
+                'get-comment-page',
+            );
+        });
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2091,10 +2091,10 @@
     js-cookie "^2.2.1"
     whatwg-fetch "^3.0.0"
 
-"@guardian/discussion-rendering@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-0.2.0.tgz#4213f685f19d4940622416cc9a2b583a2eb3d0eb"
-  integrity sha512-+ZmhOu0mXG/7tPO/13uoOHnZSk9+b/WaJ0Si6lscJ/Ljlg2T198ofnuHQkpDl8ts68Iz+HLADUwV/f6QWpH8DA==
+"@guardian/discussion-rendering@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-0.3.0.tgz#00d6846d65d12cac6931e2b18a123fe8e55f563d"
+  integrity sha512-Bq2qFMoCHM4BAZZP5fz9u9AVBP35ULXUdSPKZW01xnl5EiuwW1/BtWSyC0HvNsJAh1CApId59vOx4ZXO8Kbgsg==
   dependencies:
     regenerator-runtime "^0.13.3"
     timeago.js "^4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2091,10 +2091,10 @@
     js-cookie "^2.2.1"
     whatwg-fetch "^3.0.0"
 
-"@guardian/discussion-rendering@^0.1.6":
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-0.1.6.tgz#ddc8559c1abce4bcda1d2d401da74d02b27edb85"
-  integrity sha512-UIR1I0NKMg0bo+ZL5iqMW9P+bKIN2hN5Yo88FAeQebKI12wRzF44H8fcn9PbIloB/1C/ni/vzsepWeeND5Pgvg==
+"@guardian/discussion-rendering@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-0.2.0.tgz#4213f685f19d4940622416cc9a2b583a2eb3d0eb"
+  integrity sha512-+ZmhOu0mXG/7tPO/13uoOHnZSk9+b/WaJ0Si6lscJ/Ljlg2T198ofnuHQkpDl8ts68Iz+HLADUwV/f6QWpH8DA==
   dependencies:
     regenerator-runtime "^0.13.3"
     timeago.js "^4.0.2"


### PR DESCRIPTION
## What does this change?
Adds the main framework needed to support permalinks. Essentially, the flow is:

- Page loads
- Does it have a `comment-123` hash?
- If so, call the `/context` api to get the page number
- Pass the page number, order and commentId into `discussion-rendering` as props
- Tell `discussion-rendering` to expand by default (via `expanded` prop)

## Why?
Because discussion has the requirement to let the reader deep link to a particular comment, on a particular page of the discussion


## Link to supporting Trello card
https://trello.com/c/Di3G6pkZ/1180-permalinks