### PR TITLE
Stack Comments

### DIFF
--- a/src/web/components/CommentsLayout.tsx
+++ b/src/web/components/CommentsLayout.tsx
@@ -22,6 +22,7 @@ type Props = {
 const containerStyles = css`
     display: flex;
     flex-grow: 1;
+    flex-direction: column;
     ${from.desktop} {
         width: 620px;
     }

--- a/src/web/components/CommentsLayout.tsx
+++ b/src/web/components/CommentsLayout.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 import { from } from '@guardian/src-foundations/mq';
+import { space } from '@guardian/src-foundations';
 
 import { LeftColumn } from '@frontend/web/components/LeftColumn';
 import { SignedInAs } from '@frontend/web/components/SignedInAs';
@@ -28,6 +29,10 @@ const containerStyles = css`
     }
 `;
 
+const bottomPadding = css`
+    padding-bottom: ${space[2]}px;
+`;
+
 export const CommentsLayout = ({
     baseUrl,
     shortUrl,
@@ -45,7 +50,9 @@ export const CommentsLayout = ({
         </LeftColumn>
         <div className={containerStyles}>
             <Hide when="above" breakpoint="leftCol">
-                <SignedInAs commentCount={commentCount} />
+                <div className={bottomPadding}>
+                    <SignedInAs commentCount={commentCount} />
+                </div>
             </Hide>
             <Comments
                 baseUrl={baseUrl}


### PR DESCRIPTION
## What does this change?
This adds the css to stack comment columns below leftCol

## Before
![Screenshot 2020-03-23 at 14 49 44](https://user-images.githubusercontent.com/1336821/77329251-a3ea3f00-6d15-11ea-847a-7a59b45ebf06.jpg)

## After
![Screenshot 2020-03-23 at 14 50 07](https://user-images.githubusercontent.com/1336821/77329237-9e8cf480-6d15-11ea-946e-36bf1154b9d5.jpg)


## Why?
Because it looks weird otherwise

## Link to supporting Trello card
https://trello.com/c/QByW7ILL/1322-stack-leftcol
