### PR TITLE
Always pass through user to comments layout

### DIFF
--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -252,6 +252,7 @@ export const App = ({ CAPI, NAV }: Props) => {
                 ) : (
                     <Lazy margin={300}>
                         <CommentsLayout
+                            user={user}
                             baseUrl={CAPI.config.discussionApiUrl}
                             shortUrl={CAPI.config.shortUrlId}
                             commentCount={commentCount}


### PR DESCRIPTION
## What does this change?
Sets the `user` profile prop in all cases of `CommentsLayout`

## Why?
Because I missed a prop in my [earlier PR](https://github.com/guardian/dotcom-rendering/pull/1281) which meant that the user profile object wasn't defined if there was no comment has in the url

## Link to supporting Trello card
https://trello.com/c/JOsU4Tr7/1339-fix-getuser