### PR TITLE
Add comscore noscript tag

### DIFF
--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -105,6 +105,11 @@ export const document = ({ data }: Props) => {
 
     const { openGraphData } = CAPI;
     const { twitterData } = CAPI;
+    const keywords =
+        typeof CAPI.config.keywords === 'undefined' ||
+        CAPI.config.keywords === 'Network Front'
+            ? ''
+            : CAPI.config.keywords;
 
     return htmlTemplate({
         linkedData,
@@ -126,5 +131,6 @@ export const document = ({ data }: Props) => {
         ampLink,
         openGraphData,
         twitterData,
+        keywords,
     });
 };

--- a/src/web/server/htmlTemplate.ts
+++ b/src/web/server/htmlTemplate.ts
@@ -22,6 +22,7 @@ export const htmlTemplate = ({
     ampLink,
     openGraphData,
     twitterData,
+    keywords,
 }: {
     title?: string;
     description: string;
@@ -39,6 +40,7 @@ export const htmlTemplate = ({
     ampLink?: string;
     openGraphData: { [key: string]: string };
     twitterData: { [key: string]: string };
+    keywords: string;
 }) => {
     const favicon =
         process.env.NODE_ENV === 'production'
@@ -160,6 +162,9 @@ export const htmlTemplate = ({
 
                 <script>${prepareCmpString}</script>
 
+                <noscript>
+                    <img src="https://sb.scorecardresearch.com/p?c1=2&c2=6035250&cv=2.0&cj=1&cs_ucfr=0&comscorekw=${keywords}" />
+                </noscript>
                 ${[
                     ...priorityScriptTags,
                     ...priorityLegacyScriptTags,


### PR DESCRIPTION
## What does this change?
Adds a noscript tag so comscore still runs even Javascript is disabled on the page. This is the last piece needed to fully implement comscore (first piece here https://github.com/guardian/frontend/pull/22431)