### PR TITLE
Pad Comments

### DIFF
--- a/src/web/components/CommentsLayout.tsx
+++ b/src/web/components/CommentsLayout.tsx
@@ -33,6 +33,9 @@ const containerStyles = css`
     ${from.desktop} {
         width: 620px;
     }
+
+    padding-top: ${space[3]}px;
+    padding-bottom: ${space[6]}px;
 `;
 
 const bottomPadding = css`


### PR DESCRIPTION
## What does this change?
Adds top and bottom padding to the comments layout container

![Screenshot 2020-03-24 at 14 29 45](https://user-images.githubusercontent.com/1336821/77437239-57b60200-6ddc-11ea-8cd5-175d53a591f7.jpg)
![Screenshot 2020-03-24 at 14 29 32](https://user-images.githubusercontent.com/1336821/77437241-584e9880-6ddc-11ea-90a6-d0e8b38a3165.jpg)
![Screenshot 2020-03-24 at 14 29 20](https://user-images.githubusercontent.com/1336821/77437245-58e72f00-6ddc-11ea-9c95-bc2b2438d758.jpg)


## Why?
Because padding is important

## Link to supporting Trello card
https://trello.com/c/te6kdiMT/1324-pad-the-comments-container-in-dcr-top-and-bottom