### PR TITLE
Add Math.round to LCP metric

### DIFF
--- a/src/web/browser/ga/ga.ts
+++ b/src/web/browser/ga/ga.ts
@@ -89,7 +89,7 @@ const trackLCP = (send: string) => {
                     'timing',
                     'Javascript Load', // Matches Frontend
                     'LCP', // Largest Contentful Paint (We can filter to DCR with the Dimension 43 segment)
-                    lcp,
+                    Math.round(lcp),
                     'Largest Contentful Paint',
                 );
                 window.removeEventListener('visibilitychange', fn, true);


### PR DESCRIPTION
## What does this change?

This is the only difference I could see between this and a working metric, and I read the docs properly which defines this value as an `integer` so I'm pretty sure this is the problem.

Unless there's something wrong with the sampling or method but it seems to work as expected locally and I can see it firing on PROD too.

## Why?

I'd quite like to get this working finally.

## Link to supporting Trello card
https://trello.com/c/84pLyiAr