### PR TITLE
Rename islandId > sectionId

### DIFF
--- a/src/web/components/Section.tsx
+++ b/src/web/components/Section.tsx
@@ -49,7 +49,7 @@ const setBackgroundColour = (colour: string) => css`
 `;
 
 type Props = {
-    islandId?: string;
+    sectionId?: string;
     showSideBorders?: boolean;
     showTopBorder?: boolean;
     padded?: boolean;
@@ -60,7 +60,7 @@ type Props = {
 };
 
 export const Section = ({
-    islandId,
+    sectionId,
     showSideBorders = true,
     showTopBorder = true,
     padded = true,
@@ -75,7 +75,7 @@ export const Section = ({
         )}
     >
         <div
-            id={islandId}
+            id={sectionId}
             className={cx(
                 shouldCenter && center,
                 showSideBorders && sideBorders(borderColour),

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -233,7 +233,7 @@ export const CommentLayout = ({ CAPI, NAV }: Props) => {
             </Section>
 
             <Section
-                islandId="nav-root"
+                sectionId="nav-root"
                 showSideBorders={true}
                 borderColour={brandBorder.primary}
                 showTopBorder={false}
@@ -247,7 +247,7 @@ export const CommentLayout = ({ CAPI, NAV }: Props) => {
                 <Section
                     backgroundColour={palette.opinion.faded}
                     padded={false}
-                    islandId="sub-nav-root"
+                    sectionId="sub-nav-root"
                 >
                     <SubNav
                         subNavSections={NAV.subNavSections}
@@ -408,7 +408,7 @@ export const CommentLayout = ({ CAPI, NAV }: Props) => {
                 <AdSlot asps={namedAdSlotParameters('merchandising-high')} />
             </Section>
 
-            <Section islandId="onwards-upper" />
+            <Section sectionId="onwards-upper" />
 
             {!isPaidContent && (
                 <>
@@ -421,7 +421,7 @@ export const CommentLayout = ({ CAPI, NAV }: Props) => {
                         </Section>
                     )}
 
-                    {showOnwardsLower && <Section islandId="onwards-lower" />}
+                    {showOnwardsLower && <Section sectionId="onwards-lower" />}
 
                     {showComments && (
                         <Section>
@@ -434,7 +434,7 @@ export const CommentLayout = ({ CAPI, NAV }: Props) => {
                         </Section>
                     )}
 
-                    <Section islandId="most-viewed-footer" />
+                    <Section sectionId="most-viewed-footer" />
                 </>
             )}
 
@@ -448,7 +448,7 @@ export const CommentLayout = ({ CAPI, NAV }: Props) => {
             </Section>
 
             {NAV.subNavSections && (
-                <Section padded={false} islandId="sub-nav-root">
+                <Section padded={false} sectionId="sub-nav-root">
                     <SubNav
                         subNavSections={NAV.subNavSections}
                         currentNavLink={NAV.currentNavLink}

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -292,7 +292,7 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                     </Section>
 
                     <Section
-                        islandId="nav-root"
+                        sectionId="nav-root"
                         showSideBorders={true}
                         borderColour={brandBorder.primary}
                         showTopBorder={false}
@@ -306,7 +306,7 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                         <Section
                             backgroundColour={background.primary}
                             padded={false}
-                            islandId="sub-nav-root"
+                            sectionId="sub-nav-root"
                         >
                             <SubNav
                                 subNavSections={NAV.subNavSections}
@@ -454,7 +454,7 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                 <AdSlot asps={namedAdSlotParameters('merchandising-high')} />
             </Section>
 
-            <Section islandId="onwards-upper" />
+            <Section sectionId="onwards-upper" />
 
             {!isPaidContent && (
                 <>
@@ -467,7 +467,7 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                         </Section>
                     )}
 
-                    {showOnwardsLower && <Section islandId="onwards-lower" />}
+                    {showOnwardsLower && <Section sectionId="onwards-lower" />}
 
                     {showComments && (
                         <Section>
@@ -480,7 +480,7 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                         </Section>
                     )}
 
-                    <Section islandId="most-viewed-footer" />
+                    <Section sectionId="most-viewed-footer" />
                 </>
             )}
 
@@ -494,7 +494,7 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
             </Section>
 
             {NAV.subNavSections && (
-                <Section padded={false} islandId="sub-nav-root">
+                <Section padded={false} sectionId="sub-nav-root">
                     <SubNav
                         subNavSections={NAV.subNavSections}
                         currentNavLink={NAV.currentNavLink}

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -265,7 +265,7 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                     </Section>
 
                     <Section
-                        islandId="nav-root"
+                        sectionId="nav-root"
                         showSideBorders={true}
                         borderColour={brandBorder.primary}
                         showTopBorder={false}
@@ -279,7 +279,7 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                         <Section
                             backgroundColour={background.primary}
                             padded={false}
-                            islandId="sub-nav-root"
+                            sectionId="sub-nav-root"
                         >
                             <SubNav
                                 subNavSections={NAV.subNavSections}
@@ -429,7 +429,7 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                 <AdSlot asps={namedAdSlotParameters('merchandising-high')} />
             </Section>
 
-            <Section islandId="onwards-upper" />
+            <Section sectionId="onwards-upper" />
 
             {!isPaidContent && (
                 <>
@@ -442,7 +442,7 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                         </Section>
                     )}
 
-                    {showOnwardsLower && <Section islandId="onwards-lower" />}
+                    {showOnwardsLower && <Section sectionId="onwards-lower" />}
 
                     {showComments && (
                         <Section>
@@ -455,7 +455,7 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                         </Section>
                     )}
 
-                    <Section islandId="most-viewed-footer" />
+                    <Section sectionId="most-viewed-footer" />
                 </>
             )}
 
@@ -469,7 +469,7 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
             </Section>
 
             {NAV.subNavSections && (
-                <Section padded={false} islandId="sub-nav-root">
+                <Section padded={false} sectionId="sub-nav-root">
                     <SubNav
                         subNavSections={NAV.subNavSections}
                         currentNavLink={NAV.currentNavLink}


### PR DESCRIPTION
## What does this change?
The prop `islandId` is now called `sectionId`

## Why?
Because the term 'island' was proscriptive for only using this prop for islands but there are now other use cases for setting an `id` on a section ([linking to comments](https://trello.com/c/tbPlxVb2/1112-comment-count-is-a-link) using a hash) so this name is no longer appropriate.

## Link to supporting Trello card
https://trello.com/c/HJCGzUOC/1342-islandid-sectionid