### PR TITLE
Comment count as link

### DIFF
--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -36,6 +36,11 @@ const commentIdFromUrl = () => {
     return parseInt(hash.split('-')[1], 10);
 };
 
+const hasCommentsHashInUrl = () => {
+    const { hash } = window.location;
+    return hash && hash === '#comments';
+};
+
 export const App = ({ CAPI, NAV }: Props) => {
     const [isSignedIn, setIsSignedIn] = useState<boolean>();
     const [user, setUser] = useState<UserProfile>();
@@ -51,8 +56,10 @@ export const App = ({ CAPI, NAV }: Props) => {
     const [commentOrderBy, setCommentOrderBy] = useState<
         'newest' | 'oldest' | 'mostrecommended'
     >();
+    const [openComments, setOpenComments] = useState<boolean>(false);
 
     const hashCommentId = commentIdFromUrl();
+    const hasCommentsHash = hasCommentsHashInUrl();
 
     useEffect(() => {
         setIsSignedIn(!!getCookie('GU_U'));
@@ -115,10 +122,17 @@ export const App = ({ CAPI, NAV }: Props) => {
                     setCommentPage(context.page);
                     setCommentPageSize(context.pageSize);
                     setCommentOrderBy(context.orderBy);
+                    setOpenComments(true);
                 },
             );
         }
     }, [CAPI.config.discussionApiUrl, hashCommentId]);
+
+    useEffect(() => {
+        if (hasCommentsHash) {
+            setOpenComments(true);
+        }
+    }, [hasCommentsHash]);
 
     return (
         // Do you need to Hydrate or do you want a Portal?
@@ -184,6 +198,7 @@ export const App = ({ CAPI, NAV }: Props) => {
                     pageId={CAPI.config.pageId}
                     commentCount={commentCount}
                     pillar={CAPI.pillar}
+                    setOpenComments={setOpenComments}
                 />
             </Portal>
             <Portal root="most-viewed-right">
@@ -229,10 +244,10 @@ export const App = ({ CAPI, NAV }: Props) => {
                 </Lazy>
             </Portal>
 
-            {/* Don't lazy render comments if we have a comment id in the url because
-                we want to scroll the page to it */}
+            {/* Don't lazy render comments if we have a comment id in the url or the comments hash. In
+                these cases we will be scrolling to comments and want them loaded */}
             <Portal root="comments-root">
-                {hashCommentId ? (
+                {openComments ? (
                     <CommentsLayout
                         user={user}
                         baseUrl={CAPI.config.discussionApiUrl}

--- a/src/web/components/CommentCount.stories.tsx
+++ b/src/web/components/CommentCount.stories.tsx
@@ -24,7 +24,12 @@ const Container = ({ children }: { children: JSXElements }) => (
 export const CommentCountStory = () => {
     return (
         <Container>
-            <CommentCount short="11k" long="10,898" pillar="news" />
+            <CommentCount
+                short="11k"
+                long="10,898"
+                pillar="news"
+                setOpenComments={() => {}}
+            />
         </Container>
     );
 };

--- a/src/web/components/CommentCount.tsx
+++ b/src/web/components/CommentCount.tsx
@@ -11,6 +11,7 @@ type Props = {
     pillar: Pillar;
     short: string;
     long: string;
+    setOpenComments: Function;
 };
 
 const containerStyles = (pillar: Pillar) => css`
@@ -64,7 +65,12 @@ const linkStyles = css`
     }
 `;
 
-export const CommentCount = ({ short, long, pillar }: Props) => {
+export const CommentCount = ({
+    short,
+    long,
+    pillar,
+    setOpenComments,
+}: Props) => {
     return (
         <div
             className={containerStyles(pillar)}
@@ -79,7 +85,11 @@ export const CommentCount = ({ short, long, pillar }: Props) => {
                 className={longStyles}
                 aria-hidden="true"
             >
-                <a href="#comments" className={linkStyles}>
+                <a
+                    href="#comments"
+                    className={linkStyles}
+                    onClick={() => setOpenComments(true)}
+                >
                     {long}
                 </a>
             </div>

--- a/src/web/components/CommentCount.tsx
+++ b/src/web/components/CommentCount.tsx
@@ -53,6 +53,17 @@ const shortStyles = css`
     }
 `;
 
+const linkStyles = css`
+    color: inherit;
+    text-decoration: none;
+    :hover {
+        text-decoration: underline;
+    }
+    :visited {
+        color: inherit;
+    }
+`;
+
 export const CommentCount = ({ short, long, pillar }: Props) => {
     return (
         <div
@@ -68,7 +79,9 @@ export const CommentCount = ({ short, long, pillar }: Props) => {
                 className={longStyles}
                 aria-hidden="true"
             >
-                {long}
+                <a href="#comments" className={linkStyles}>
+                    {long}
+                </a>
             </div>
             <div
                 data-testid="short-comment-count"

--- a/src/web/components/Counts.stories.tsx
+++ b/src/web/components/Counts.stories.tsx
@@ -29,6 +29,7 @@ export const Live = () => {
                 commentCount={239}
                 pageId="/lifeandstyle/2020/jan/25/deborah-orr-parents-jailers-i-loved"
                 pillar="news"
+                setOpenComments={() => {}}
             />
         </Container>
     );
@@ -55,6 +56,7 @@ export const ShareOnly = () => {
                 commentCount={0}
                 pageId="/lifeandstyle/2020/jan/25/deborah-orr-parents-jailers-i-loved"
                 pillar="news"
+                setOpenComments={() => {}}
             />
         </Container>
     );
@@ -85,6 +87,7 @@ export const CommentOnly = () => {
                 commentCount={239}
                 pageId="/lifeandstyle/abc"
                 pillar="news"
+                setOpenComments={() => {}}
             />
         </Container>
     );

--- a/src/web/components/Counts.test.tsx
+++ b/src/web/components/Counts.test.tsx
@@ -31,6 +31,7 @@ describe('Counts', () => {
                 pageId={pageId}
                 commentCount={0}
                 pillar="news"
+                setOpenComments={() => {}}
             />,
         );
 
@@ -46,6 +47,7 @@ describe('Counts', () => {
                 pageId={pageId}
                 commentCount={0}
                 pillar="news"
+                setOpenComments={() => {}}
             />,
         );
 
@@ -61,6 +63,7 @@ describe('Counts', () => {
                 pageId={pageId}
                 commentCount={0}
                 pillar="news"
+                setOpenComments={() => {}}
             />,
         );
 
@@ -77,6 +80,7 @@ describe('Counts', () => {
                 pageId={pageId}
                 commentCount={0}
                 pillar="news"
+                setOpenComments={() => {}}
             />,
         );
 
@@ -95,6 +99,7 @@ describe('Counts', () => {
                 pageId={pageId}
                 commentCount={1}
                 pillar="news"
+                setOpenComments={() => {}}
             />,
         );
 
@@ -113,6 +118,7 @@ describe('Counts', () => {
                 pageId={pageId}
                 commentCount={0}
                 pillar="news"
+                setOpenComments={() => {}}
             />,
         );
 
@@ -131,6 +137,7 @@ describe('Counts', () => {
                 pageId={pageId}
                 commentCount={1}
                 pillar="news"
+                setOpenComments={() => {}}
             />,
         );
 
@@ -150,6 +157,7 @@ describe('Counts', () => {
                 pageId={pageId}
                 commentCount={0}
                 pillar="news"
+                setOpenComments={() => {}}
             />,
         );
 
@@ -169,6 +177,7 @@ describe('Counts', () => {
                 pageId={pageId}
                 commentCount={1}
                 pillar="news"
+                setOpenComments={() => {}}
             />,
         );
 

--- a/src/web/components/Counts.tsx
+++ b/src/web/components/Counts.tsx
@@ -14,6 +14,7 @@ type Props = {
     pageId: string;
     pillar: Pillar;
     commentCount: number;
+    setOpenComments: Function;
 };
 
 type ShareCountType = {
@@ -40,7 +41,13 @@ const NumbersBorder = () => (
     />
 );
 
-export const Counts = ({ ajaxUrl, pageId, commentCount, pillar }: Props) => {
+export const Counts = ({
+    ajaxUrl,
+    pageId,
+    commentCount,
+    pillar,
+    setOpenComments,
+}: Props) => {
     const shareUrl = joinUrl([ajaxUrl, 'sharecount', `${pageId}.json`]);
     const { data: shareData, error: shareError } = useApi<ShareCountType>(
         shareUrl,
@@ -77,6 +84,7 @@ export const Counts = ({ ajaxUrl, pageId, commentCount, pillar }: Props) => {
                     short={commentShort}
                     long={commentLong}
                     pillar={pillar}
+                    setOpenComments={setOpenComments}
                 />
             )}
         </div>

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -424,7 +424,7 @@ export const CommentLayout = ({ CAPI, NAV }: Props) => {
                     {showOnwardsLower && <Section sectionId="onwards-lower" />}
 
                     {showComments && (
-                        <Section>
+                        <Section sectionId="comments">
                             <Flex>
                                 <div id="comments-root" />
                                 <RightColumn>

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -470,7 +470,7 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                     {showOnwardsLower && <Section sectionId="onwards-lower" />}
 
                     {showComments && (
-                        <Section>
+                        <Section sectionId="comments">
                             <Flex>
                                 <div id="comments-root" />
                                 <RightColumn>

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -445,7 +445,7 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                     {showOnwardsLower && <Section sectionId="onwards-lower" />}
 
                     {showComments && (
-                        <Section>
+                        <Section sectionId="comments">
                             <Flex>
                                 <div id="comments-root" />
                                 <RightColumn>


### PR DESCRIPTION
## What does this change?
Now when you click on the comment count it links through to the comments section at the bottom of the page. The same is true if you put `#comments` at the end of an article url.

There are 4 main changes here:
1. Make the comment count a link, pointing at "#comments"
2. Add the "comments" id to each `Section` containing discussion
3. Create a `openComments` state property and use that to expand the discussion section
4. Bind the `setOpenComments` to an `onClick` event for the share count link and also to a check on the url at page load


### Clicking comment count
![2020-03-25 12 04 08](https://user-images.githubusercontent.com/1336821/77534634-ed12ce00-6e90-11ea-833c-f9cc5a9772ef.gif)


### Refreshing page with `#comments` on the url
![2020-03-25 12 05 53](https://user-images.githubusercontent.com/1336821/77534705-0d428d00-6e91-11ea-939b-30e37a418775.gif)


## Why?
To support navigation within the page and also to support a richer url definition for an article

## Link to supporting Trello card
https://trello.com/c/tbPlxVb2/1112-comment-count-is-a-link