### PR TITLE
Use 'dark' for opinion and culture anchors

### DIFF
--- a/src/web/components/ArticleBody.tsx
+++ b/src/web/components/ArticleBody.tsx
@@ -12,7 +12,9 @@ import { Hide } from '@root/src/web/components/Hide';
 const pillarColours = pillarMap(
     pillar =>
         css`
-            color: ${pillarPalette[pillar].main};
+            color: ${pillar === 'opinion' || pillar === 'culture'
+                ? pillarPalette[pillar].dark
+                : pillarPalette[pillar].main};
         `,
 );
 


### PR DESCRIPTION
## What does this change?

As above. Take a look at opinion and culture in chromatic.

## Why?

Fixes A11Y contrast issues by moving to the darker palette colour.

## Link to supporting Trello card
https://trello.com/c/RDsi9UZc