### PR TITLE
Add `enableSentryReporting` to the config object from switches

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -260,6 +260,7 @@ type CAPIBrowserType = {
         ampIframeUrl: string;
         ampPrebid: boolean;
         permutive: boolean;
+        enableSentryReporting: boolean;
         cmpUi: boolean;
         slotBodyEnd: boolean;
         isSensitive: boolean;

--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -100,6 +100,7 @@ export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
             slotBodyEnd: CAPI.config.switches.slotBodyEnd,
             ampPrebid: CAPI.config.switches.ampPrebid,
             permutive: CAPI.config.switches.permutive,
+            enableSentryReporting: CAPI.config.switches.enableSentryReporting,
 
             // used by lib/ad-targeting.ts
             isSensitive: CAPI.config.isSensitive,

--- a/src/web/browser/sentry/sentry.tsx
+++ b/src/web/browser/sentry/sentry.tsx
@@ -27,11 +27,7 @@ export const initialiseSentry = (adBlockInUse: boolean) => {
     const {
         editionLongForm,
         contentType,
-        config: {
-            isDev,
-            switches: { enableSentryReporting },
-            dcrSentryDsn,
-        },
+        config: { isDev, enableSentryReporting, dcrSentryDsn },
     } = window.guardian.app.data.CAPI;
 
     Sentry.init({


### PR DESCRIPTION
## What does this change?

enableSentryReporting was missing of the new browser CAPI window object and so was erroring and forcing the sentry initialisation silently into `catch` of try catch

## Why?

Fix

## Link to supporting Trello card

https://trello.com/c/LmYGpZH5
