### PR TITLE
Refactor ReaderRevenueLinks

### DIFF
--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -151,7 +151,6 @@ export const App = ({ CAPI, NAV }: Props) => {
                     urls={CAPI.nav.readerRevenueLinks.footer}
                     edition={CAPI.editionId}
                     dataLinkNamePrefix="footer : "
-                    noResponsive={true}
                     inHeader={true}
                 />
             </Portal>
@@ -297,7 +296,6 @@ export const App = ({ CAPI, NAV }: Props) => {
                         urls={CAPI.nav.readerRevenueLinks.header}
                         edition={CAPI.editionId}
                         dataLinkNamePrefix="nav2 : "
-                        noResponsive={false}
                         inHeader={false}
                     />
                 </Lazy>

--- a/src/web/components/ReaderRevenueLinks.stories.tsx
+++ b/src/web/components/ReaderRevenueLinks.stories.tsx
@@ -37,7 +37,6 @@ export const Header = () => {
                 edition="UK"
                 urls={revenueUrls}
                 dataLinkNamePrefix=""
-                noResponsive={true}
                 inHeader={true}
             />
         </Container>
@@ -57,7 +56,6 @@ export const HeaderMobile = () => {
                 edition="UK"
                 urls={revenueUrls}
                 dataLinkNamePrefix=""
-                noResponsive={false}
                 inHeader={true}
             />
         </Container>
@@ -77,7 +75,6 @@ export const Footer = () => {
                 edition="UK"
                 urls={revenueUrls}
                 dataLinkNamePrefix=""
-                noResponsive={false}
                 inHeader={false}
             />
         </Container>
@@ -97,7 +94,6 @@ export const FooterMobile = () => {
                 edition="UK"
                 urls={revenueUrls}
                 dataLinkNamePrefix=""
-                noResponsive={true}
                 inHeader={false}
             />
         </Container>

--- a/src/web/components/ReaderRevenueLinks.stories.tsx
+++ b/src/web/components/ReaderRevenueLinks.stories.tsx
@@ -46,6 +46,7 @@ Header.story = {
     name: 'Header - desktop',
     parameters: {
         viewport: { defaultViewport: 'desktop' },
+        chromatic: { viewports: [1300] },
     },
 };
 
@@ -65,6 +66,7 @@ HeaderMobile.story = {
     name: 'Header - mobileMedium',
     parameters: {
         viewport: { defaultViewport: 'mobileMedium' },
+        chromatic: { viewports: [380] },
     },
 };
 
@@ -84,6 +86,7 @@ Footer.story = {
     name: 'Footer - desktop',
     parameters: {
         viewport: { defaultViewport: 'desktop' },
+        chromatic: { viewports: [1300] },
     },
 };
 
@@ -103,5 +106,6 @@ FooterMobile.story = {
     name: 'Footer - mobileMedium',
     parameters: {
         viewport: { defaultViewport: 'mobileMedium' },
+        chromatic: { viewports: [380] },
     },
 };

--- a/src/web/components/ReaderRevenueLinks.stories.tsx
+++ b/src/web/components/ReaderRevenueLinks.stories.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { brandBackground } from '@guardian/src-foundations/palette';
+
+import { ReaderRevenueLinks } from './ReaderRevenueLinks';
+
+export default {
+    component: ReaderRevenueLinks,
+    title: 'Components/ReaderRevenueLinks',
+};
+
+const revenueUrls = {
+    subscribe: '',
+    support: '',
+    contribute: '',
+};
+
+const Container = ({ children }: { children: JSXElements }) => (
+    <div
+        className={css`
+            margin: 40px;
+            padding-top: 20px;
+            padding-left: 20px;
+            padding-bottom: 60px;
+            background-color: ${brandBackground.primary};
+        `}
+    >
+        {children}
+    </div>
+);
+
+export const Header = () => {
+    return (
+        <Container>
+            <ReaderRevenueLinks
+                edition="UK"
+                urls={revenueUrls}
+                dataLinkNamePrefix=""
+                noResponsive={true}
+                inHeader={true}
+            />
+        </Container>
+    );
+};
+Header.story = {
+    name: 'Header - desktop',
+    parameters: {
+        viewport: { defaultViewport: 'desktop' },
+    },
+};
+
+export const HeaderMobile = () => {
+    return (
+        <Container>
+            <ReaderRevenueLinks
+                edition="UK"
+                urls={revenueUrls}
+                dataLinkNamePrefix=""
+                noResponsive={false}
+                inHeader={true}
+            />
+        </Container>
+    );
+};
+HeaderMobile.story = {
+    name: 'Header - mobileMedium',
+    parameters: {
+        viewport: { defaultViewport: 'mobileMedium' },
+    },
+};
+
+export const Footer = () => {
+    return (
+        <Container>
+            <ReaderRevenueLinks
+                edition="UK"
+                urls={revenueUrls}
+                dataLinkNamePrefix=""
+                noResponsive={false}
+                inHeader={false}
+            />
+        </Container>
+    );
+};
+Footer.story = {
+    name: 'Footer - desktop',
+    parameters: {
+        viewport: { defaultViewport: 'desktop' },
+    },
+};
+
+export const FooterMobile = () => {
+    return (
+        <Container>
+            <ReaderRevenueLinks
+                edition="UK"
+                urls={revenueUrls}
+                dataLinkNamePrefix=""
+                noResponsive={true}
+                inHeader={false}
+            />
+        </Container>
+    );
+};
+FooterMobile.story = {
+    name: 'Footer - mobileMedium',
+    parameters: {
+        viewport: { defaultViewport: 'mobileMedium' },
+    },
+};

--- a/src/web/components/ReaderRevenueLinks.test.tsx
+++ b/src/web/components/ReaderRevenueLinks.test.tsx
@@ -42,7 +42,7 @@ describe('ReaderRevenueLinks', () => {
                 urls={urls}
                 edition={edition}
                 dataLinkNamePrefix="nav2 : "
-                noResponsive={false}
+                inHeader={true}
             />,
         );
 
@@ -69,7 +69,7 @@ describe('ReaderRevenueLinks', () => {
                 urls={urls}
                 edition={edition}
                 dataLinkNamePrefix="nav2 : "
-                noResponsive={false}
+                inHeader={true}
             />,
         );
 
@@ -96,7 +96,7 @@ describe('ReaderRevenueLinks', () => {
                 urls={urls}
                 edition={edition}
                 dataLinkNamePrefix="nav2 : "
-                noResponsive={false}
+                inHeader={true}
             />,
         );
 

--- a/src/web/components/ReaderRevenueLinks.tsx
+++ b/src/web/components/ReaderRevenueLinks.tsx
@@ -20,8 +20,7 @@ type Props = {
         contribute: string;
     };
     dataLinkNamePrefix: string;
-    noResponsive: boolean;
-    inHeader?: boolean;
+    inHeader: boolean;
 };
 
 const paddingStyles = css`
@@ -131,7 +130,6 @@ export const ReaderRevenueLinks: React.FC<Props> = ({
     edition,
     urls,
     dataLinkNamePrefix,
-    noResponsive,
     inHeader,
 }) => {
     const [isPayingMember, setIsPayingMember] = useState<boolean>(false);
@@ -151,7 +149,7 @@ export const ReaderRevenueLinks: React.FC<Props> = ({
             <div className={cx(inHeader && paddingStyles)}>
                 <div
                     className={cx({
-                        [hiddenUntilTablet]: !noResponsive,
+                        [hiddenUntilTablet]: inHeader,
                     })}
                 >
                     <div className={messageStyles}>
@@ -178,8 +176,8 @@ export const ReaderRevenueLinks: React.FC<Props> = ({
 
                 <div
                     className={cx({
-                        [hiddenFromTablet]: !noResponsive,
-                        [hidden]: noResponsive,
+                        [hiddenFromTablet]: inHeader,
+                        [hidden]: !inHeader,
                     })}
                 >
                     {edition === 'UK' ? (


### PR DESCRIPTION
## What does this change?
Fixes a problem where the ReaderRevenueLinks were not showing in the mobile format in the header

I also refactored the props to simplify this component and added some stories to reduce the chance of issues like this happening again

## Before
![Screenshot 2020-03-25 at 17 38 48](https://user-images.githubusercontent.com/1336821/77567907-bd2eef00-6ebf-11ea-8d70-cc2c6b460254.jpg)

## After
![Screenshot 2020-03-25 at 17 37 14](https://user-images.githubusercontent.com/1336821/77567895-bacc9500-6ebf-11ea-9aa9-56256bf0b402.jpg)


## Why?
So we don't crowd the screen of mobile devices

## Link to supporting Trello card
https://trello.com/c/eC5vCmYS/1344-revenue-links-are-broken-on-mobile