### PR TITLE
Migrate neutral-60 away from palette import

### DIFF
--- a/src/web/components/AdSlot.tsx
+++ b/src/web/components/AdSlot.tsx
@@ -72,7 +72,7 @@ const mobileStickyAdStyles = css`
         background-color: ${neutral[97]};
         padding: 0 0.5rem;
         border-top: 0.0625rem solid ${border.secondary};
-        color: ${palette.neutral[60]};
+        color: ${neutral[60]};
         text-align: left;
         box-sizing: border-box;
         ${textSans.xsmall()};

--- a/src/web/components/Card/components/CardAge.tsx
+++ b/src/web/components/Card/components/CardAge.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 
-import { palette } from '@guardian/src-foundations';
 import { neutral } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 
@@ -12,7 +11,7 @@ import { decidePillarLight } from '@root/src/web/lib/decidePillarLight';
 
 const ageStyles = (designType?: DesignType) => css`
     ${textSans.xsmall()};
-    color: ${palette.neutral[60]};
+    color: ${neutral[60]};
 
     /* Provide side padding for positioning and also to keep spacing
     between any sibings (like GuardianLines) */
@@ -58,7 +57,7 @@ const colourStyles = (designType: DesignType, pillar: Pillar) => {
         case 'Immersive':
         default:
             return css`
-                color: ${palette.neutral[60]};
+                color: ${neutral[60]};
             `;
     }
 };

--- a/src/web/components/CardCommentCount.tsx
+++ b/src/web/components/CardCommentCount.tsx
@@ -86,7 +86,7 @@ const colourStyles = (designType: DesignType, pillar: Pillar) => {
         case 'Immersive':
         default:
             return css`
-                color: ${palette.neutral[60]};
+                color: ${neutral[60]};
                 svg {
                     fill: ${neutral[46]};
                 }

--- a/src/web/components/SignedInAs.tsx
+++ b/src/web/components/SignedInAs.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 
-import { text, border } from '@guardian/src-foundations/palette';
+import { text, border, neutral } from '@guardian/src-foundations/palette';
 import { headline, textSans } from '@guardian/src-foundations/typography';
 import { palette, space } from '@guardian/src-foundations';
 import { until } from '@guardian/src-foundations/mq';
@@ -86,7 +86,7 @@ export const SignedInAs = ({
                 comments{' '}
                 <span
                     className={css`
-                        color: ${palette.neutral[60]};
+                        color: ${neutral[60]};
                     `}
                 >
                     ({commentCount})

--- a/src/web/components/SubMeta.tsx
+++ b/src/web/components/SubMeta.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 import { textSans } from '@guardian/src-foundations/typography';
-import { palette } from '@guardian/src-foundations';
+import { neutral } from '@guardian/src-foundations/palette';
 
 import { SharingIcons } from '@frontend/web/components/ShareIcons';
 import { SubMetaLinksList } from '@frontend/web/components/SubMetaLinksList';
@@ -14,7 +14,7 @@ import { until } from '@guardian/src-foundations/mq';
 const subMetaLabel = css`
     ${textSans.xsmall()};
     display: block;
-    color: ${palette.neutral[60]};
+    color: ${neutral[60]};
 `;
 
 const subMetaSharingIcons = css`


### PR DESCRIPTION
## What does this change?

Migrates instances of `neutral[60]` to the named export rather than plucking it off the `palette`

**Note:** there are [accessibility concerns](https://whocanuse.com/?b=FFFFFF&c=999999&f=20&s=) with the use of this colour for text on a white background. We should consider using [`text.supporting`](https://www.theguardian.design/2a1e5182b/p/1377a6-themes/b/293ddb) as a replacement in the first instance.

## Why?

See #1227 

