### PR TITLE
Update Ophan event component id to match frontend

### DIFF
--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -34,7 +34,7 @@ const sendOphanEvent = (action: OphanAction): void => {
             componentType: 'ACQUISITIONS_EPIC',
             products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
             campaignCode,
-            id: 'epic_frontend_dotcom_rendering_epic',
+            id: campaignCode,
         },
         abTest: {
             name: testName,


### PR DESCRIPTION
## What does this change?

Update Ophan event component id sent for Epic view to match frontend.

## Why?

We’re trying to figure out why we’re seeing a mismatch in the number of impressions between frontend and dcr and noticed that this part of the Ophan event payload differed.

## Link to supporting Trello card

https://trello.com/c/VtmXCpdU/87-investigate-impressions-gap-between-frontend-dcr