### PR TITLE
Pass filters to context call

### DIFF
--- a/src/web/lib/getCommentContext.ts
+++ b/src/web/lib/getCommentContext.ts
@@ -22,11 +22,20 @@ type CommentContextType = {
     discussionKey: string;
     discussionWebUrl: string;
     discussionApiUrl: string;
-    orderBy: 'oldest' | 'newest' | 'mostrecommended';
-    pageSize: 20 | 25 | 50 | 100; // TODO: Review these https://trello.com/c/7v4VDNY0/1326-review-page-size-values
+    orderBy: OrderByType;
+    pageSize: PageSizeType; // TODO: Review these https://trello.com/c/7v4VDNY0/1326-review-page-size-values
     page: number;
 };
 
+type OrderByType = 'newest' | 'oldest' | 'mostrecommended';
+type ThreadsType = 'collapsed' | 'expanded' | 'unthreaded';
+type PageSizeType = 25 | 50 | 100;
+
+interface FilterOptions {
+    orderBy: OrderByType;
+    pageSize: PageSizeType;
+    threads: ThreadsType;
+}
 export const getCommentContext = async (
     ajaxUrl: string,
     commentId: number,

--- a/src/web/lib/getCommentContext.ts
+++ b/src/web/lib/getCommentContext.ts
@@ -74,6 +74,16 @@ const initFiltersFromLocalStorage = (): FilterOptions => {
         pageSize: pageSize ? JSON.parse(pageSize).value : 25,
     };
 };
+
+const buildParams = (filters: FilterOptions) => {
+    return {
+        orderBy: filters.orderBy,
+        pageSize: filters.pageSize,
+        displayThreaded:
+            filters.threads === 'collapsed' || filters.threads === 'expanded',
+    };
+};
+
 export const getCommentContext = async (
     ajaxUrl: string,
     commentId: number,

--- a/src/web/lib/getCommentContext.ts
+++ b/src/web/lib/getCommentContext.ts
@@ -46,6 +46,34 @@ const objAsParams = (obj: any): string => {
 
     return `?${params}`;
 };
+
+const initFiltersFromLocalStorage = (): FilterOptions => {
+    let threads;
+    let pageSize;
+    let orderBy;
+
+    try {
+        // Try to read from local storage
+        orderBy = localStorage.getItem('gu.prefs.discussioni.order');
+        threads = localStorage.getItem('gu.prefs.discussioni.threading');
+        pageSize = localStorage.getItem('gu.prefs.discussioni.pagesize');
+    } catch (error) {
+        // Sometimes it's not possible to access localStorage, we accept this and don't want to
+        // capture these errors
+        return {
+            orderBy: 'newest',
+            pageSize: 25,
+            threads: 'collapsed',
+        };
+    }
+
+    // If we found something in LS, use it, otherwise return defaults
+    return {
+        orderBy: orderBy ? JSON.parse(orderBy).value : 'newest',
+        threads: threads ? JSON.parse(threads).value : 'collapsed',
+        pageSize: pageSize ? JSON.parse(pageSize).value : 25,
+    };
+};
 export const getCommentContext = async (
     ajaxUrl: string,
     commentId: number,

--- a/src/web/lib/getCommentContext.ts
+++ b/src/web/lib/getCommentContext.ts
@@ -54,9 +54,9 @@ const initFiltersFromLocalStorage = (): FilterOptions => {
 
     try {
         // Try to read from local storage
-        orderBy = localStorage.getItem('gu.prefs.discussioni.order');
-        threads = localStorage.getItem('gu.prefs.discussioni.threading');
-        pageSize = localStorage.getItem('gu.prefs.discussioni.pagesize');
+        orderBy = localStorage.getItem('gu.prefs.discussion.order');
+        threads = localStorage.getItem('gu.prefs.discussion.threading');
+        pageSize = localStorage.getItem('gu.prefs.discussion.pagesize');
     } catch (error) {
         // Sometimes it's not possible to access localStorage, we accept this and don't want to
         // capture these errors

--- a/src/web/lib/getCommentContext.ts
+++ b/src/web/lib/getCommentContext.ts
@@ -36,6 +36,16 @@ interface FilterOptions {
     pageSize: PageSizeType;
     threads: ThreadsType;
 }
+
+const objAsParams = (obj: any): string => {
+    const params = Object.keys(obj)
+        .map(key => {
+            return `${key}=${obj[key]}`;
+        })
+        .join('&');
+
+    return `?${params}`;
+};
 export const getCommentContext = async (
     ajaxUrl: string,
     commentId: number,

--- a/src/web/lib/getCommentContext.ts
+++ b/src/web/lib/getCommentContext.ts
@@ -89,7 +89,10 @@ export const getCommentContext = async (
     commentId: number,
 ): Promise<CommentContextType> => {
     const url = joinUrl([ajaxUrl, 'comment', commentId.toString(), 'context']);
-    return fetch(url)
+    const filters = initFiltersFromLocalStorage();
+    const params = buildParams(filters);
+
+    return fetch(url + objAsParams(params))
         .then(response => {
             if (!response.ok) {
                 throw Error(response.statusText);


### PR DESCRIPTION
## What does this change?
This adds some additional parameters to the call made to `/context` when we're deep linking to a comment

## Why?
Because the page size and if we're threaded are needed to ensure the comment is displayed on the page when we try to link to it

## Link to supporting Trello card
https://trello.com/c/7v4VDNY0/1326-review-page-size-values
