### PR TITLE
Wait an bit longer before taking showcase snapshots

### DIFF
--- a/src/web/layouts/ShowcaseLayout.stories.tsx
+++ b/src/web/layouts/ShowcaseLayout.stories.tsx
@@ -26,7 +26,7 @@ mockRESTCalls();
 export default {
     title: 'Layouts/Showcase',
     parameters: {
-        chromatic: { viewports: [1300], delay: 800 },
+        chromatic: { viewports: [1300], delay: 1200 },
     },
 };
 


### PR DESCRIPTION
## What does this change?
Wait an bit longer before taking showcase snapshots

## Why?
There is this one snapshot which keeps having or not having the most popular element on the page. I suspect this could be a timing problem so hopefully waiting a bit longer here will stabilise things

