### PR TITLE
SignedInAs pillar

### DIFF
--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -249,6 +249,7 @@ export const App = ({ CAPI, NAV }: Props) => {
                 {openComments ? (
                     <CommentsLayout
                         user={user}
+                        pillar={CAPI.pillar}
                         baseUrl={CAPI.config.discussionApiUrl}
                         shortUrl={CAPI.config.shortUrlId}
                         commentCount={commentCount}
@@ -267,6 +268,7 @@ export const App = ({ CAPI, NAV }: Props) => {
                     <Lazy margin={300}>
                         <CommentsLayout
                             user={user}
+                            pillar={CAPI.pillar}
                             baseUrl={CAPI.config.discussionApiUrl}
                             shortUrl={CAPI.config.shortUrlId}
                             commentCount={commentCount}

--- a/src/web/components/CommentsLayout.stories.tsx
+++ b/src/web/components/CommentsLayout.stories.tsx
@@ -22,6 +22,7 @@ export const Default = () => (
         <Flex>
             <CommentsLayout
                 baseUrl="https://discussion.theguardian.com/discussion-api"
+                pillar="news"
                 shortUrl="p/39f5z/"
                 commentCount={345}
                 isClosedForComments={false}

--- a/src/web/components/CommentsLayout.tsx
+++ b/src/web/components/CommentsLayout.tsx
@@ -13,6 +13,7 @@ import { App as Comments } from '@guardian/discussion-rendering';
 
 type Props = {
     user?: UserProfile;
+    pillar: Pillar;
     baseUrl: string;
     shortUrl: string;
     commentCount: number;
@@ -44,6 +45,7 @@ const bottomPadding = css`
 
 export const CommentsLayout = ({
     user,
+    pillar,
     baseUrl,
     shortUrl,
     commentCount,
@@ -59,6 +61,7 @@ export const CommentsLayout = ({
     <Flex direction="row">
         <LeftColumn showRightBorder={false}>
             <SignedInAs
+                pillar={pillar}
                 user={user}
                 commentCount={commentCount}
                 isClosedForComments={isClosedForComments}
@@ -67,7 +70,11 @@ export const CommentsLayout = ({
         <div className={containerStyles}>
             <Hide when="above" breakpoint="leftCol">
                 <div className={bottomPadding}>
-                    <SignedInAs user={user} commentCount={commentCount} />
+                    <SignedInAs
+                        pillar={pillar}
+                        user={user}
+                        commentCount={commentCount}
+                    />
                 </div>
             </Hide>
             <Comments

--- a/src/web/components/SignedInAs.stories.tsx
+++ b/src/web/components/SignedInAs.stories.tsx
@@ -23,13 +23,14 @@ export default {
 };
 
 export const SignedIn = () => {
-    return <SignedInAs commentCount={3} user={aUser} />;
+    return <SignedInAs pillar="news" commentCount={3} user={aUser} />;
 };
 SignedIn.story = { name: 'signed in' };
 
 export const Image = () => {
     return (
         <SignedInAs
+            pillar="culture"
             commentCount={32}
             user={{
                 ...aUser,
@@ -43,6 +44,7 @@ Image.story = { name: 'with image' };
 export const NoDisplayName = () => {
     return (
         <SignedInAs
+            pillar="labs"
             commentCount={32}
             user={{
                 ...aUser,
@@ -54,19 +56,50 @@ export const NoDisplayName = () => {
 NoDisplayName.story = { name: 'before a display name has been set' };
 
 export const NotSignedIn = () => {
-    return <SignedInAs commentCount={32} />;
+    return <SignedInAs pillar="lifestyle" commentCount={32} />;
 };
 NotSignedIn.story = { name: 'not signed in' };
 
+export const Culture = () => {
+    return <SignedInAs pillar="culture" commentCount={32} />;
+};
+Culture.story = { name: 'with culture pillar' };
+
+export const Opinion = () => {
+    return <SignedInAs pillar="opinion" commentCount={32} />;
+};
+Opinion.story = { name: 'with opinion pillar' };
+
+export const news = () => {
+    return <SignedInAs pillar="news" commentCount={32} />;
+};
+news.story = { name: 'with news pillar' };
+
+export const Sport = () => {
+    return <SignedInAs pillar="sport" commentCount={32} />;
+};
+Sport.story = { name: 'with sport pillar' };
+
 export const DiscussionClosed = () => {
     return (
-        <SignedInAs commentCount={32} isClosedForComments={true} user={aUser} />
+        <SignedInAs
+            pillar="opinion"
+            commentCount={32}
+            isClosedForComments={true}
+            user={aUser}
+        />
     );
 };
 DiscussionClosed.story = { name: 'discussion closed, user signed in' };
 
 export const DiscussionClosedSignedOut = () => {
-    return <SignedInAs commentCount={32} isClosedForComments={true} />;
+    return (
+        <SignedInAs
+            pillar="sport"
+            commentCount={32}
+            isClosedForComments={true}
+        />
+    );
 };
 DiscussionClosedSignedOut.story = {
     name: 'discussion closed, user not signed in',

--- a/src/web/components/SignedInAs.tsx
+++ b/src/web/components/SignedInAs.tsx
@@ -8,6 +8,7 @@ import { until } from '@guardian/src-foundations/mq';
 
 type Props = {
     commentCount: number;
+    pillar: Pillar;
     user?: UserProfile;
     isClosedForComments?: boolean;
 };
@@ -57,8 +58,8 @@ const usernameStyles = css`
     color: ${text.primary};
 `;
 
-const linkStyles = css`
-    color: ${palette.news[300]};
+const linkStyles = (pillar: Pillar) => css`
+    color: ${palette[pillar][300]};
     text-decoration: none;
     border-bottom: 1px solid ${border.secondary};
     transition: border-color 0.15s ease-out;
@@ -77,6 +78,7 @@ const rowUntilDesktop = css`
 
 export const SignedInAs = ({
     commentCount,
+    pillar,
     user,
     isClosedForComments,
 }: Props) => {
@@ -120,14 +122,14 @@ export const SignedInAs = ({
                 <span className={headlineStyles}>
                     <a
                         href="https://profile.theguardian.com/signin?INTCMP=DOTCOM_COMMENTS_SIGNIN"
-                        className={linkStyles}
+                        className={linkStyles(pillar)}
                     >
                         Sign in
                     </a>{' '}
                     or{' '}
                     <a
                         href="https://profile.theguardian.com/register?INTCMP=DOTCOM_COMMENTS_REG"
-                        className={linkStyles}
+                        className={linkStyles(pillar)}
                     >
                         create your Guardian account
                     </a>{' '}


### PR DESCRIPTION
## What does this change?
Added pillar prop to SignedInAs

![2020-03-26 17 23 24](https://user-images.githubusercontent.com/1336821/77676683-8ec81700-6f86-11ea-9d41-a017bb4fda4f.gif)


## Why?
So we can style the links with pillar colours

## Link to supporting Trello card
https://trello.com/c/tN7q8cED/1320-signedinas-accepts-pillar