### PR TITLE
Updating date time content for parity with frontend

### DIFF
--- a/src/web/components/Card/components/CardAge.tsx
+++ b/src/web/components/Card/components/CardAge.tsx
@@ -78,7 +78,7 @@ export const CardAge = ({
     const displayString = makeRelativeDate(
         new Date(webPublicationDate).getTime(),
         {
-            format: 'short',
+            format: 'med',
         },
     );
 


### PR DESCRIPTION
## What does this change?

<img width="238" alt="Screen Shot 2020-03-27 at 15 10 39" src="https://user-images.githubusercontent.com/2051501/77770494-3bfd6680-703d-11ea-93ce-923b9e07dd72.png">
<img width="238" alt="Screen Shot 2020-03-27 at 15 11 01" src="https://user-images.githubusercontent.com/2051501/77770498-3c95fd00-703d-11ea-8b8c-ab354ad056bc.png">
## Why?
For parity

## Link to supporting Trello card
