### PR TITLE
Pass isSensitive to Automat (rebranded Slot Machine)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "@emotion/core": "^10.0.5",
         "@guardian/consent-management-platform": "^2.0.10",
         "@guardian/discussion-rendering": "^0.3.1",
-        "@guardian/slot-machine-client": "^0.2.6",
+        "@guardian/automat-client": "^0.2.10",
         "@guardian/src-foundations": "^0.15.1",
         "@sentry/browser": "^5.7.1",
         "@types/ajv": "^1.0.0",

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -14,7 +14,7 @@ import { SlotBodyEnd } from '@frontend/web/components/SlotBodyEnd';
 import { Links } from '@frontend/web/components/Links';
 import { SubNav } from '@frontend/web/components/SubNav/SubNav';
 import { CommentsLayout } from '@frontend/web/components/CommentsLayout';
-import { incrementWeeklyArticleCount } from '@guardian/slot-machine-client';
+import { incrementWeeklyArticleCount } from '@guardian/automat-client';
 
 import { Portal } from '@frontend/web/components/Portal';
 import { Hydrate } from '@frontend/web/components/Hydrate';
@@ -214,6 +214,7 @@ export const App = ({ CAPI, NAV }: Props) => {
                     shouldHideReaderRevenue={CAPI.shouldHideReaderRevenue}
                     isMinuteArticle={CAPI.pageType.isMinuteArticle}
                     isPaidContent={CAPI.pageType.isPaidContent}
+                    isSensitive={CAPI.config.isSensitive}
                     tags={CAPI.tags}
                     contributionsServiceUrl={CAPI.contributionsServiceUrl}
                 />

--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -5,7 +5,7 @@ import {
     getViewLog,
     logView,
     getWeeklyArticleHistory,
-} from '@guardian/slot-machine-client';
+} from '@guardian/automat-client';
 import {
     shouldShowSupportMessaging,
     isRecurringContributor,
@@ -58,6 +58,7 @@ type Props = {
     shouldHideReaderRevenue: boolean;
     isMinuteArticle: boolean;
     isPaidContent: boolean;
+    isSensitive: boolean;
     tags: TagType[];
     contributionsServiceUrl: string;
 };
@@ -83,6 +84,7 @@ const buildPayload = (props: Props) => {
             shouldHideReaderRevenue: props.shouldHideReaderRevenue,
             isMinuteArticle: props.isMinuteArticle,
             isPaidContent: props.isPaidContent,
+            isSensitive: props.isSensitive,
             tags: props.tags,
             showSupportMessaging: shouldShowSupportMessaging(),
             isRecurringContributor: isRecurringContributor(
@@ -104,6 +106,7 @@ const MemoisedInner = ({
     shouldHideReaderRevenue,
     isMinuteArticle,
     isPaidContent,
+    isSensitive,
     tags,
     contributionsServiceUrl,
 }: Props) => {
@@ -129,6 +132,7 @@ const MemoisedInner = ({
             isPaidContent,
             tags,
             contributionsServiceUrl,
+            isSensitive,
         });
         getBodyEnd(contributionsPayload, `${contributionsServiceUrl}/epic`)
             .then(checkForErrors)
@@ -183,6 +187,7 @@ export const SlotBodyEnd = ({
     shouldHideReaderRevenue,
     isMinuteArticle,
     isPaidContent,
+    isSensitive,
     tags,
     contributionsServiceUrl,
 }: Props) => {
@@ -208,6 +213,7 @@ export const SlotBodyEnd = ({
             shouldHideReaderRevenue={shouldHideReaderRevenue}
             isMinuteArticle={isMinuteArticle}
             isPaidContent={isPaidContent}
+            isSensitive={isSensitive}
             tags={tags}
             contributionsServiceUrl={contributionsServiceUrl}
         />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2079,6 +2079,11 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
+"@guardian/automat-client@^0.2.10":
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.10.tgz#4b3abbc7c32944e2d9643af27c07aa9e3224379f"
+  integrity sha512-VVJ09UuMOnbYksjwlhuSCUFpToYm6XVpXtvrFqps15GXDb65g/WU9MmT8KcsejB9EGH77kSdEDhMR/fbOqFHUA==
+
 "@guardian/consent-management-platform@^2.0.10":
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-2.0.10.tgz#b1d322f7fa5da858353102fb584224218fffbf37"
@@ -2098,11 +2103,6 @@
   dependencies:
     regenerator-runtime "^0.13.3"
     timeago.js "^4.0.2"
-
-"@guardian/slot-machine-client@^0.2.6":
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/@guardian/slot-machine-client/-/slot-machine-client-0.2.6.tgz#4d323d31322ad4ae56bd9cc578516ec28e3ef36f"
-  integrity sha512-2rPLnFOs0kBp6rvWYyZURSLcsD6gzP9WSiN3bv/ZSC07LLnKyQwhGB8q/sNtFkkgCdt1sbVcMtlzmCAKsNudBA==
 
 "@guardian/src-button@^0.13.0":
   version "0.13.0"


### PR DESCRIPTION
As part of this, the client-lib has been updated.

## What does this change?

Passes `isSensitive` in Automat (née slot-machine) calls.

## Why?

For context, see https://github.com/guardian/contributions-service/pull/80 

## Link to supporting Trello card

https://trello.com/c/kXuhn5cY/45-implement-remaining-variants
