### PR TITLE
Upgrade src-foundations to 0.16.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "@guardian/consent-management-platform": "^2.0.10",
         "@guardian/discussion-rendering": "^0.3.1",
         "@guardian/automat-client": "^0.2.10",
-        "@guardian/src-foundations": "^0.15.1",
+        "@guardian/src-foundations": "^0.16.1",
         "@sentry/browser": "^5.7.1",
         "@types/ajv": "^1.0.0",
         "@types/lodash.escape": "^4.0.6",
@@ -203,7 +203,8 @@
             "^svgs/(.*)$": "<rootDir>/__mocks__/svgMock.tsx",
             "^(.*)\\.svg$": "<rootDir>/__mocks__/svgMock.tsx",
             "^@root(.*)$": "<rootDir>$1",
-            "^@frontend(.*)$": "<rootDir>/src$1"
+            "^@frontend(.*)$": "<rootDir>/src$1",
+            "^@guardian/src-foundations/(.*)$": "@guardian/src-foundations/$1/cjs"
         },
         "testResultsProcessor": "jest-teamcity-reporter",
         "collectCoverageFrom": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2116,10 +2116,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.13.0.tgz#8bfed9b94e2e4f24ecacb754bbe573b6e0cfe088"
   integrity sha512-8lTZSo49W1lPhBFaaLrg2Eo2jrwUB3VGw6a7ZRI7oBEyTglmlbjFDiciu2Di6WSrzuSWiI+9OJTSSjCP6lTT2A==
 
-"@guardian/src-foundations@^0.15.1":
-  version "0.15.1"
-  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.15.1.tgz#9e621aa2efee0cdb368ebbee129cd2a7d7e5868e"
-  integrity sha512-49Kjd9v6bAy3Xjs9q6/WV+J63bKgUWG5biOScUPE4UKFf3HkNFtafrrvnWf2/1qpDlhGYRFK9tGCh/enagMajA==
+"@guardian/src-foundations@^0.16.1":
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.16.1.tgz#d5e52a57012c588d146b05ded7f9fbc4a9af40d5"
+  integrity sha512-E6YDqq53gy5CoO8xFPWDBjiYiI0o+4BE1/mFcwkpWGwtpkSnxi21LhkaQ63r+KRxoDB29clc86ChbNHXw9keFA==
 
 "@guardian/src-svgs@^0.13.0":
   version "0.13.0"


### PR DESCRIPTION
## What does this change?

Upgrades to latest version of src-foundations

## Why?

Hopefully it's more treeshakeable and thus bundles will be smaller.

Note that this means folders under `src-foundations` (e.g. `src-foundations/palette`) will be exposed as ES Modules by default (previously CommonJS). I've done some module-mapping in the package.json so Jest can find the CommonJS files (it has trouble with ES Modules). 

See [release notes](https://github.com/guardian/source/releases/tag/0.16.0) for more

## Link to supporting Trello card
