### PR TITLE
discusion-rendering@0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dependencies": {
         "@emotion/core": "^10.0.5",
         "@guardian/consent-management-platform": "^2.0.10",
-        "@guardian/discussion-rendering": "^0.4.2",
+        "@guardian/discussion-rendering": "^0.5.0",
         "@guardian/slot-machine-client": "^0.2.6",
         "@guardian/src-foundations": "^0.15.1",
         "@sentry/browser": "^5.7.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dependencies": {
         "@emotion/core": "^10.0.5",
         "@guardian/consent-management-platform": "^2.0.10",
-        "@guardian/discussion-rendering": "^0.4.0",
+        "@guardian/discussion-rendering": "^0.4.1",
         "@guardian/slot-machine-client": "^0.2.6",
         "@guardian/src-foundations": "^0.15.1",
         "@sentry/browser": "^5.7.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dependencies": {
         "@emotion/core": "^10.0.5",
         "@guardian/consent-management-platform": "^2.0.10",
-        "@guardian/discussion-rendering": "^0.5.0",
+        "@guardian/discussion-rendering": "^0.6.0",
         "@guardian/slot-machine-client": "^0.2.6",
         "@guardian/src-foundations": "^0.15.1",
         "@sentry/browser": "^5.7.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dependencies": {
         "@emotion/core": "^10.0.5",
         "@guardian/consent-management-platform": "^2.0.10",
-        "@guardian/discussion-rendering": "^0.3.1",
+        "@guardian/discussion-rendering": "^0.4.0",
         "@guardian/slot-machine-client": "^0.2.6",
         "@guardian/src-foundations": "^0.15.1",
         "@sentry/browser": "^5.7.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dependencies": {
         "@emotion/core": "^10.0.5",
         "@guardian/consent-management-platform": "^2.0.10",
-        "@guardian/discussion-rendering": "^0.4.1",
+        "@guardian/discussion-rendering": "^0.4.2",
         "@guardian/slot-machine-client": "^0.2.6",
         "@guardian/src-foundations": "^0.15.1",
         "@sentry/browser": "^5.7.1",

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -50,9 +50,7 @@ export const App = ({ CAPI, NAV }: Props) => {
         true,
     );
     const [commentPage, setCommentPage] = useState<number>();
-    const [commentPageSize, setCommentPageSize] = useState<
-        20 | 25 | 50 | 100
-    >();
+    const [commentPageSize, setCommentPageSize] = useState<25 | 50 | 100>();
     const [commentOrderBy, setCommentOrderBy] = useState<
         'newest' | 'oldest' | 'mostrecommended'
     >();

--- a/src/web/components/CommentsLayout.tsx
+++ b/src/web/components/CommentsLayout.tsx
@@ -87,10 +87,9 @@ export const CommentsLayout = ({
                 pillar={pillar}
                 initialPage={commentPage}
                 pageSizeOverride={commentPageSize}
-                // TODO: Disabled pending discussion publishing a version supporting this prop
-                // isClosedForComments={
-                //     isClosedForComments || !enableDiscussionSwitch
-                // }
+                isClosedForComments={
+                    isClosedForComments || !enableDiscussionSwitch
+                }
                 orderByOverride={commentOrderBy}
                 shortUrl={shortUrl}
                 additionalHeaders={{

--- a/src/web/components/CommentsLayout.tsx
+++ b/src/web/components/CommentsLayout.tsx
@@ -80,6 +80,7 @@ export const CommentsLayout = ({
             <Comments
                 user={user}
                 baseUrl={baseUrl}
+                pillar={pillar}
                 initialPage={commentPage}
                 pageSizeOverride={commentPageSize}
                 orderByOverride={commentOrderBy}

--- a/src/web/components/CommentsLayout.tsx
+++ b/src/web/components/CommentsLayout.tsx
@@ -22,7 +22,7 @@ type Props = {
     discussionApiClientHeader: string;
     expanded: boolean;
     commentPage?: number;
-    commentPageSize?: 20 | 25 | 50 | 100;
+    commentPageSize?: 25 | 50 | 100;
     commentOrderBy?: 'newest' | 'oldest' | 'mostrecommended';
     commentToScrollTo?: number;
 };

--- a/src/web/components/CommentsLayout.tsx
+++ b/src/web/components/CommentsLayout.tsx
@@ -87,9 +87,10 @@ export const CommentsLayout = ({
                 pillar={pillar}
                 initialPage={commentPage}
                 pageSizeOverride={commentPageSize}
-                isClosedForComments={
-                    isClosedForComments || !enableDiscussionSwitch
-                }
+                // TODO: Disabled pending discussion publishing a version supporting this prop
+                // isClosedForComments={
+                //     isClosedForComments || !enableDiscussionSwitch
+                // }
                 orderByOverride={commentOrderBy}
                 shortUrl={shortUrl}
                 additionalHeaders={{

--- a/yarn.lock
+++ b/yarn.lock
@@ -2091,11 +2091,12 @@
     js-cookie "^2.2.1"
     whatwg-fetch "^3.0.0"
 
-"@guardian/discussion-rendering@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-0.3.1.tgz#265eff7d72b6e06d728cdfc7d5937b4e0bb314bf"
-  integrity sha512-y7ZWVqGvRKKjL7AwCGqSBI0f+Ak0Wc5PBLJw/iFTZqPJwX6Xgv+R/KWkFu1B/0hZ3hfFEAKIxF8GHd4CEI04LQ==
+"@guardian/discussion-rendering@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-0.4.0.tgz#5f99984732c4fd01593df587b0a9b4c06abf2605"
+  integrity sha512-MV1Lh61GUCY9MjcRLyLMC1yLz8/JiE4uYhSDFtnoF5wJ8jweVo9WbMGM3bwkcZYn2cgSaDI47BAKcj1+s4PUfg==
   dependencies:
+    "@guardian/src-link" "^0.15.1"
     regenerator-runtime "^0.13.3"
     timeago.js "^4.0.2"
 
@@ -2120,6 +2121,20 @@
   version "0.15.1"
   resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.15.1.tgz#9e621aa2efee0cdb368ebbee129cd2a7d7e5868e"
   integrity sha512-49Kjd9v6bAy3Xjs9q6/WV+J63bKgUWG5biOScUPE4UKFf3HkNFtafrrvnWf2/1qpDlhGYRFK9tGCh/enagMajA==
+
+"@guardian/src-helpers@^0.15.1":
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/@guardian/src-helpers/-/src-helpers-0.15.1.tgz#ec5b75117bb066ef95002bfedaa76a371c4b1b33"
+  integrity sha512-A564LrM0c8SKC5TySb/dUxO+ggKhp5D+yWagQb3r3r/IS8SxWLhKQUzZpgaXNWyNWXrFTX362G7hAwL3SCNE5g==
+  dependencies:
+    "@guardian/src-foundations" "^0.15.1"
+
+"@guardian/src-link@^0.15.1":
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/@guardian/src-link/-/src-link-0.15.1.tgz#2b5c196e9c57ac7a920d630ef7c47cacbefa9997"
+  integrity sha512-WZHHoFSd+vx1CU01M5lWAob3lrnNzIoPH00M5cxL5mXvl/3911l2WeiwMGC46MZkmZvHQ+ju3b4khk9nuBDFeA==
+  dependencies:
+    "@guardian/src-helpers" "^0.15.1"
 
 "@guardian/src-svgs@^0.13.0":
   version "0.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2091,10 +2091,10 @@
     js-cookie "^2.2.1"
     whatwg-fetch "^3.0.0"
 
-"@guardian/discussion-rendering@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-0.5.0.tgz#2b2d420532918980e2a8b14aace3619a43b46ca8"
-  integrity sha512-1FtrEISaCDpT1Oirk5FKns2jBPlbywiDEv9+ZMhBVJnH0r2wnm7zkx7nbMUwmgiH+/Csw0EMtqPRhmdOYTQAjA==
+"@guardian/discussion-rendering@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-0.6.0.tgz#09b7254161d7f31fbb150cf9353bb6524062ad33"
+  integrity sha512-Rd6JFORlfqVvXMCoACKrMKUW1pRQeKnhoEMBuwocnraofNhhBLllUdC0JkrsloRSp7aTsWpj8VkGCj1JdMb9iw==
   dependencies:
     "@guardian/src-link" "^0.15.1"
     regenerator-runtime "^0.13.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2091,10 +2091,10 @@
     js-cookie "^2.2.1"
     whatwg-fetch "^3.0.0"
 
-"@guardian/discussion-rendering@^0.4.2":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-0.4.2.tgz#9162b42cafc23d9aa8b9da4422a37e489358ffec"
-  integrity sha512-duz0JOXa4sGqkeuTlUuYSWY3x93k60V3teNhNIzbJiGEsy5cp5Mqszek84Mq2lnEvNafMr6MaXn9hXWZG9F3qQ==
+"@guardian/discussion-rendering@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-0.5.0.tgz#2b2d420532918980e2a8b14aace3619a43b46ca8"
+  integrity sha512-1FtrEISaCDpT1Oirk5FKns2jBPlbywiDEv9+ZMhBVJnH0r2wnm7zkx7nbMUwmgiH+/Csw0EMtqPRhmdOYTQAjA==
   dependencies:
     "@guardian/src-link" "^0.15.1"
     regenerator-runtime "^0.13.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2117,6 +2117,11 @@
   resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.13.0.tgz#8bfed9b94e2e4f24ecacb754bbe573b6e0cfe088"
   integrity sha512-8lTZSo49W1lPhBFaaLrg2Eo2jrwUB3VGw6a7ZRI7oBEyTglmlbjFDiciu2Di6WSrzuSWiI+9OJTSSjCP6lTT2A==
 
+"@guardian/src-foundations@^0.15.1":
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.15.1.tgz#9e621aa2efee0cdb368ebbee129cd2a7d7e5868e"
+  integrity sha512-49Kjd9v6bAy3Xjs9q6/WV+J63bKgUWG5biOScUPE4UKFf3HkNFtafrrvnWf2/1qpDlhGYRFK9tGCh/enagMajA==
+
 "@guardian/src-foundations@^0.16.1":
   version "0.16.1"
   resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.16.1.tgz#d5e52a57012c588d146b05ded7f9fbc4a9af40d5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2091,10 +2091,10 @@
     js-cookie "^2.2.1"
     whatwg-fetch "^3.0.0"
 
-"@guardian/discussion-rendering@^0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-0.4.1.tgz#78823d6ad2721a7ee3336f9e877060270aec1137"
-  integrity sha512-cSGTGL8Dn4+Wz77mAz3BaCe2NpHj9PjV5j5CYmvl0o5Y8SaN+3OiIgqt7e4/vs9p7xzM4GK0sfhsZFJPOfDdsg==
+"@guardian/discussion-rendering@^0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-0.4.2.tgz#9162b42cafc23d9aa8b9da4422a37e489358ffec"
+  integrity sha512-duz0JOXa4sGqkeuTlUuYSWY3x93k60V3teNhNIzbJiGEsy5cp5Mqszek84Mq2lnEvNafMr6MaXn9hXWZG9F3qQ==
   dependencies:
     "@guardian/src-link" "^0.15.1"
     regenerator-runtime "^0.13.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2091,10 +2091,10 @@
     js-cookie "^2.2.1"
     whatwg-fetch "^3.0.0"
 
-"@guardian/discussion-rendering@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-0.4.0.tgz#5f99984732c4fd01593df587b0a9b4c06abf2605"
-  integrity sha512-MV1Lh61GUCY9MjcRLyLMC1yLz8/JiE4uYhSDFtnoF5wJ8jweVo9WbMGM3bwkcZYn2cgSaDI47BAKcj1+s4PUfg==
+"@guardian/discussion-rendering@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-0.4.1.tgz#78823d6ad2721a7ee3336f9e877060270aec1137"
+  integrity sha512-cSGTGL8Dn4+Wz77mAz3BaCe2NpHj9PjV5j5CYmvl0o5Y8SaN+3OiIgqt7e4/vs9p7xzM4GK0sfhsZFJPOfDdsg==
   dependencies:
     "@guardian/src-link" "^0.15.1"
     regenerator-runtime "^0.13.3"


### PR DESCRIPTION
## What does this change?
This upgrades `@guardian/discussion-rendering` to `v0.6.0`. To support this version we neede to remove the `20` option for pageSize and passing `pilllar` as a prop to discussion-rendering.

## Why?
There are a range of new and exciting discussion advances we want to benefit from in DCR

