### PR TITLE
Send client name to the contributions service

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "@emotion/core": "^10.0.5",
         "@guardian/consent-management-platform": "^2.0.10",
         "@guardian/discussion-rendering": "^0.3.1",
-        "@guardian/automat-client": "^0.2.10",
+        "@guardian/automat-client": "^0.2.13",
         "@guardian/src-foundations": "^0.16.1",
         "@sentry/browser": "^5.7.1",
         "@types/ajv": "^1.0.0",

--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -70,6 +70,7 @@ const buildPayload = (props: Props) => {
             ophanPageId: window.guardian.config.ophan.pageViewId,
             ophanComponentId: 'ACQUISITIONS_EPIC',
             platformId: 'GUARDIAN_WEB',
+            clientName: 'dcr',
             campaignCode,
             abTestName: testName,
             abTestVariant: 'dcr',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2079,10 +2079,10 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
-"@guardian/automat-client@^0.2.10":
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.10.tgz#4b3abbc7c32944e2d9643af27c07aa9e3224379f"
-  integrity sha512-VVJ09UuMOnbYksjwlhuSCUFpToYm6XVpXtvrFqps15GXDb65g/WU9MmT8KcsejB9EGH77kSdEDhMR/fbOqFHUA==
+"@guardian/automat-client@^0.2.13":
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.13.tgz#69ad5559160726ca49714d44d6ab77f3db25f5ef"
+  integrity sha512-OHAZv3MZkuFHJkEoWLkiR5nWnzG0i3Unt3w972n6SmkbOr0xLaUhyM+WZvetNn8dOPzHPVwHW6IYi7Z+TQ5Gug==
 
 "@guardian/consent-management-platform@^2.0.10":
   version "2.0.10"


### PR DESCRIPTION
## What does this change?

Start sending the client name in requests to the contributions service.

## Why?

It's needed for comparing results across DCR and frontend.

## Link to supporting Trello card

Part of https://trello.com/c/CNlYq1rK/93-update-platforms-to-use-tracking-metadata-returned-by-epic
