### PR TITLE
enableDiscussionSwitch

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -263,6 +263,7 @@ type CAPIBrowserType = {
         permutive: boolean;
         enableSentryReporting: boolean;
         cmpUi: boolean;
+        enableDiscussionSwitch: boolean;
         slotBodyEnd: boolean;
         isSensitive: boolean;
         videoDuration: number;

--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -101,6 +101,7 @@ export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
             ampPrebid: CAPI.config.switches.ampPrebid,
             permutive: CAPI.config.switches.permutive,
             enableSentryReporting: CAPI.config.switches.enableSentryReporting,
+            enableDiscussionSwitch: CAPI.config.switches.enableDiscussionSwitch,
 
             // used by lib/ad-targeting.ts
             isSensitive: CAPI.config.isSensitive,

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -263,6 +263,9 @@ export const App = ({ CAPI, NAV }: Props) => {
                         discussionApiClientHeader={
                             CAPI.config.discussionApiClientHeader
                         }
+                        enableDiscussionSwitch={
+                            CAPI.config.enableDiscussionSwitch
+                        }
                         expanded={true}
                         commentToScrollTo={hashCommentId}
                     />
@@ -281,6 +284,9 @@ export const App = ({ CAPI, NAV }: Props) => {
                             discussionD2Uid={CAPI.config.discussionD2Uid}
                             discussionApiClientHeader={
                                 CAPI.config.discussionApiClientHeader
+                            }
+                            enableDiscussionSwitch={
+                                CAPI.config.enableDiscussionSwitch
                             }
                             expanded={false}
                         />

--- a/src/web/components/CommentsLayout.stories.tsx
+++ b/src/web/components/CommentsLayout.stories.tsx
@@ -26,6 +26,7 @@ export const Default = () => (
                 shortUrl="p/39f5z/"
                 commentCount={345}
                 isClosedForComments={false}
+                enableDiscussionSwitch={true}
                 discussionD2Uid="testD2Header"
                 discussionApiClientHeader="testClientHeader"
                 expanded={false}

--- a/src/web/components/CommentsLayout.tsx
+++ b/src/web/components/CommentsLayout.tsx
@@ -18,6 +18,7 @@ type Props = {
     shortUrl: string;
     commentCount: number;
     isClosedForComments: boolean;
+    enableDiscussionSwitch: boolean;
     discussionD2Uid: string;
     discussionApiClientHeader: string;
     expanded: boolean;
@@ -54,6 +55,7 @@ export const CommentsLayout = ({
     commentOrderBy,
     expanded,
     isClosedForComments,
+    enableDiscussionSwitch,
     discussionD2Uid,
     discussionApiClientHeader,
     commentToScrollTo,
@@ -62,6 +64,7 @@ export const CommentsLayout = ({
         <LeftColumn showRightBorder={false}>
             <SignedInAs
                 pillar={pillar}
+                enableDiscussionSwitch={enableDiscussionSwitch}
                 user={user}
                 commentCount={commentCount}
                 isClosedForComments={isClosedForComments}
@@ -72,6 +75,7 @@ export const CommentsLayout = ({
                 <div className={bottomPadding}>
                     <SignedInAs
                         pillar={pillar}
+                        enableDiscussionSwitch={enableDiscussionSwitch}
                         user={user}
                         commentCount={commentCount}
                     />
@@ -82,6 +86,10 @@ export const CommentsLayout = ({
                 baseUrl={baseUrl}
                 initialPage={commentPage}
                 pageSizeOverride={commentPageSize}
+                // TODO: Disabled pending discussion publishing a version supporting this prop
+                // isClosedForComments={
+                //     isClosedForComments || !enableDiscussionSwitch
+                // }
                 orderByOverride={commentOrderBy}
                 shortUrl={shortUrl}
                 additionalHeaders={{

--- a/src/web/components/SignedInAs.stories.tsx
+++ b/src/web/components/SignedInAs.stories.tsx
@@ -23,7 +23,14 @@ export default {
 };
 
 export const SignedIn = () => {
-    return <SignedInAs pillar="news" commentCount={3} user={aUser} />;
+    return (
+        <SignedInAs
+            pillar="news"
+            enableDiscussionSwitch={true}
+            commentCount={3}
+            user={aUser}
+        />
+    );
 };
 SignedIn.story = { name: 'signed in' };
 
@@ -31,6 +38,7 @@ export const Image = () => {
     return (
         <SignedInAs
             pillar="culture"
+            enableDiscussionSwitch={true}
             commentCount={32}
             user={{
                 ...aUser,
@@ -45,6 +53,7 @@ export const NoDisplayName = () => {
     return (
         <SignedInAs
             pillar="labs"
+            enableDiscussionSwitch={true}
             commentCount={32}
             user={{
                 ...aUser,
@@ -56,27 +65,57 @@ export const NoDisplayName = () => {
 NoDisplayName.story = { name: 'before a display name has been set' };
 
 export const NotSignedIn = () => {
-    return <SignedInAs pillar="lifestyle" commentCount={32} />;
+    return (
+        <SignedInAs
+            pillar="lifestyle"
+            enableDiscussionSwitch={true}
+            commentCount={32}
+        />
+    );
 };
 NotSignedIn.story = { name: 'not signed in' };
 
 export const Culture = () => {
-    return <SignedInAs pillar="culture" commentCount={32} />;
+    return (
+        <SignedInAs
+            pillar="culture"
+            enableDiscussionSwitch={true}
+            commentCount={32}
+        />
+    );
 };
 Culture.story = { name: 'with culture pillar' };
 
 export const Opinion = () => {
-    return <SignedInAs pillar="opinion" commentCount={32} />;
+    return (
+        <SignedInAs
+            pillar="opinion"
+            enableDiscussionSwitch={true}
+            commentCount={32}
+        />
+    );
 };
 Opinion.story = { name: 'with opinion pillar' };
 
 export const news = () => {
-    return <SignedInAs pillar="news" commentCount={32} />;
+    return (
+        <SignedInAs
+            pillar="news"
+            enableDiscussionSwitch={true}
+            commentCount={32}
+        />
+    );
 };
 news.story = { name: 'with news pillar' };
 
 export const Sport = () => {
-    return <SignedInAs pillar="sport" commentCount={32} />;
+    return (
+        <SignedInAs
+            pillar="sport"
+            enableDiscussionSwitch={true}
+            commentCount={32}
+        />
+    );
 };
 Sport.story = { name: 'with sport pillar' };
 
@@ -84,6 +123,7 @@ export const DiscussionClosed = () => {
     return (
         <SignedInAs
             pillar="opinion"
+            enableDiscussionSwitch={true}
             commentCount={32}
             isClosedForComments={true}
             user={aUser}
@@ -96,6 +136,7 @@ export const DiscussionClosedSignedOut = () => {
     return (
         <SignedInAs
             pillar="sport"
+            enableDiscussionSwitch={true}
             commentCount={32}
             isClosedForComments={true}
         />
@@ -103,4 +144,33 @@ export const DiscussionClosedSignedOut = () => {
 };
 DiscussionClosedSignedOut.story = {
     name: 'discussion closed, user not signed in',
+};
+
+export const DiscussionDisabled = () => {
+    return (
+        <SignedInAs
+            pillar="opinion"
+            enableDiscussionSwitch={false}
+            commentCount={32}
+            isClosedForComments={false}
+            user={aUser}
+        />
+    );
+};
+DiscussionDisabled.story = {
+    name: 'discussion disabled sitewide, user signed in',
+};
+
+export const DiscussionDisabledSignedOut = () => {
+    return (
+        <SignedInAs
+            pillar="opinion"
+            enableDiscussionSwitch={false}
+            commentCount={32}
+            isClosedForComments={false}
+        />
+    );
+};
+DiscussionDisabledSignedOut.story = {
+    name: 'discussion disabled sitewide, user signed out',
 };

--- a/src/web/components/SignedInAs.tsx
+++ b/src/web/components/SignedInAs.tsx
@@ -9,6 +9,7 @@ import { until } from '@guardian/src-foundations/mq';
 type Props = {
     commentCount: number;
     pillar: Pillar;
+    enableDiscussionSwitch: boolean;
     user?: UserProfile;
     isClosedForComments?: boolean;
 };
@@ -79,6 +80,7 @@ const rowUntilDesktop = css`
 export const SignedInAs = ({
     commentCount,
     pillar,
+    enableDiscussionSwitch,
     user,
     isClosedForComments,
 }: Props) => {
@@ -95,8 +97,15 @@ export const SignedInAs = ({
                 </span>
             </h2>
 
+            {/* Discussion is disabled sitewide */}
+            {user && enableDiscussionSwitch === false && (
+                <span className={headlineStyles}>
+                    Commenting has been disabled at this time
+                </span>
+            )}
+
             {/* Discussion open and user logged in */}
-            {user && !isClosedForComments && (
+            {enableDiscussionSwitch && user && !isClosedForComments && (
                 <div className={rowUntilDesktop}>
                     <div className={imageWrapper}>
                         <img
@@ -138,7 +147,7 @@ export const SignedInAs = ({
             )}
 
             {/* The discussion is closed (only appears for logged in users) */}
-            {user && isClosedForComments && (
+            {enableDiscussionSwitch && user && isClosedForComments && (
                 <span className={headlineStyles}>
                     This discussion is closed for comments
                 </span>


### PR DESCRIPTION
## What does this change?
This adds support for the `enableDiscussionSwitch` switch

If true, all users, over all discussions, will not be able to post or reply to comments

The `enabledDiscussionSwitch` prop going into the discussion app is commented out here pending it being supported on that side.

## Why?
This switch is used to turn off discussion site wide

## Link to supporting Trello card
https://trello.com/c/U9rwFXUm/1248-respect-when-discussion-is-turned-off-sitewide