### PR TITLE
Add countryCode to Automat targeting params

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "@emotion/core": "^10.0.5",
         "@guardian/consent-management-platform": "^2.0.10",
         "@guardian/discussion-rendering": "^0.6.0",
-        "@guardian/automat-client": "^0.2.13",
+        "@guardian/automat-client": "^0.2.14",
         "@guardian/src-foundations": "^0.16.1",
         "@sentry/browser": "^5.7.1",
         "@types/ajv": "^1.0.0",

--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -95,6 +95,7 @@ const buildPayload = (props: Props) => {
             epicViewLog: getViewLog(),
             weeklyArticleHistory: getWeeklyArticleHistory(),
             mvtId: Number(getCookie('GU_mvt_id')),
+            countryCode: props.countryCode,
         },
     };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2079,10 +2079,10 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
-"@guardian/automat-client@^0.2.13":
-  version "0.2.13"
-  resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.13.tgz#69ad5559160726ca49714d44d6ab77f3db25f5ef"
-  integrity sha512-OHAZv3MZkuFHJkEoWLkiR5nWnzG0i3Unt3w972n6SmkbOr0xLaUhyM+WZvetNn8dOPzHPVwHW6IYi7Z+TQ5Gug==
+"@guardian/automat-client@^0.2.14":
+  version "0.2.14"
+  resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.14.tgz#eed3a79609d57aeac81be80473f8fc34e76bc88d"
+  integrity sha512-A4K+rH0cag/yvHk8bR5X/anPIZbP8PqUFkV8o1fXS1s4cpe23KWx60XKrc+cZAPdCws6uIjsqWey19bzB/LUwg==
 
 "@guardian/consent-management-platform@^2.0.10":
   version "2.0.10"


### PR DESCRIPTION
## What does this change?

Add countryCode to Automat targeting params (it's already there on frontend).

## Why?

We are settling on passing the countryCode as part of the targeting object. Once the contributions-service has started reading from there we can remove the localisation object from the payload.

Once guardian/automat-client#24 is merged, I'll update the package version on this PR, so that the types line up.

## Link to supporting Trello card

Part of https://trello.com/c/oZ22JNsF/89-dynamically-serve-test-variant.