### PR TITLE
Remove all remaining instances of palette

### DIFF
--- a/src/lib/pillars.ts
+++ b/src/lib/pillars.ts
@@ -1,4 +1,12 @@
-import { palette } from '@guardian/src-foundations';
+import {
+    news,
+    opinion,
+    sport,
+    culture,
+    lifestyle,
+    labs,
+    border,
+} from '@guardian/src-foundations/palette';
 
 type colour = string;
 
@@ -20,19 +28,19 @@ export const pillarNames: Pillar[] = [
 ];
 
 export const augmentedLabs: PillarColours = {
-    dark: palette.labs.dark,
-    main: palette.labs.main,
+    dark: labs[300],
+    main: labs[400],
     bright: '#69d1ca', // bright teal
     pastel: '', // TODO
     faded: '#65a897', // dark teal
 };
 
 export const pillarPalette: Record<Pillar, PillarColours> = {
-    news: palette.news,
-    opinion: palette.opinion,
-    sport: palette.sport,
-    culture: palette.culture,
-    lifestyle: palette.lifestyle,
+    news,
+    opinion,
+    sport,
+    culture,
+    lifestyle,
     labs: augmentedLabs,
 };
 
@@ -68,8 +76,8 @@ export const getPillar = (pillar: Pillar, designType: DesignType): Pillar => {
 export const neutralBorder = (pillar: Pillar): colour => {
     switch (pillar) {
         case 'labs':
-            return palette.neutral[60]; // 'dark' theme
+            return border.primary; // 'dark' theme
         default:
-            return palette.neutral[86];
+            return border.secondary;
     }
 };

--- a/src/web/components/Byline.tsx
+++ b/src/web/components/Byline.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 
-import { palette } from '@guardian/src-foundations';
 import { headline } from '@guardian/src-foundations/typography';
 import { until } from '@guardian/src-foundations/mq';
+import { pillarPalette } from '@frontend/lib/pillars';
 
 type Props = {
     text: string;
@@ -61,7 +61,7 @@ const colourStyles = (designType: DesignType, pillar: Pillar) => {
         case 'Immersive':
         default:
             return css`
-                color: ${palette[pillar].main};
+                color: ${pillarPalette[pillar].main};
             `;
     }
 };

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { css } from 'emotion';
 
-import { palette } from '@guardian/src-foundations';
 import { brandAltBackground } from '@guardian/src-foundations/palette';
 
 import { StarRating } from '@root/src/web/components/StarRating/StarRating';
@@ -11,6 +10,7 @@ import { Flex } from '@frontend/web/components/Flex';
 import { Hide } from '@frontend/web/components/Hide';
 import { MediaMeta } from '@frontend/web/components/MediaMeta';
 import { CardCommentCount } from '@frontend/web/components/CardCommentCount';
+import { pillarPalette } from '@frontend/lib/pillars';
 
 import { formatCount } from '@root/src/web/lib/formatCount';
 
@@ -119,7 +119,7 @@ export const Card = ({
 
     return (
         <CardLink linkTo={linkTo} designType={designType} pillar={pillar}>
-            <TopBar topBarColour={palette[pillar].main}>
+            <TopBar topBarColour={pillarPalette[pillar].main}>
                 <CardLayout imagePosition={imagePosition}>
                     <>
                         {imageUrl && (

--- a/src/web/components/Card/components/CardLink.tsx
+++ b/src/web/components/Card/components/CardLink.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
-import { palette } from '@guardian/src-foundations';
-import { neutral } from '@guardian/src-foundations/palette';
+import { neutral, opinion } from '@guardian/src-foundations/palette';
+import { pillarPalette } from '@frontend/lib/pillars';
 
 const linkStyles = (designType: DesignType, pillar: Pillar) => {
     const baseLinkStyles = css`
@@ -40,7 +40,7 @@ const linkStyles = (designType: DesignType, pillar: Pillar) => {
         case 'Comment':
             return css`
                 ${baseLinkStyles}
-                background-color: ${palette.opinion.faded};
+                background-color: ${opinion[800]};
                 :hover {
                      /* TODO: This colour is hard coded here because it does not yet
                            exist in src-foundation. Once it's been added, please
@@ -61,7 +61,7 @@ const linkStyles = (designType: DesignType, pillar: Pillar) => {
         case 'Live':
             return css`
                 ${baseLinkStyles}
-                background-color: ${palette[pillar].dark};
+                background-color: ${pillarPalette[pillar].dark};
 
                 :hover {
                     filter: brightness(90%);

--- a/src/web/components/CardCommentCount.tsx
+++ b/src/web/components/CardCommentCount.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import { css, cx } from 'emotion';
 
 import { neutral } from '@guardian/src-foundations/palette';
-import { palette } from '@guardian/src-foundations';
 import { textSans } from '@guardian/src-foundations/typography';
 import { between } from '@guardian/src-foundations/mq';
 
 import CommentIcon from '@frontend/static/icons/comment.svg';
 import { decidePillarLight } from '@root/src/web/lib/decidePillarLight';
+import { pillarPalette } from '@frontend/lib/pillars';
 
 type Props = {
     designType: DesignType;
@@ -51,12 +51,14 @@ const shortStyles = css`
 
 const mediaStyles = (pillar: Pillar) => css`
     /* Below we force the colour to be bright if the pillar is news (because it looks better) */
-    color: ${pillar === 'news' ? palette[pillar].bright : palette[pillar].main};
+    color: ${pillar === 'news'
+        ? pillarPalette[pillar].bright
+        : pillarPalette[pillar].main};
 
     svg {
         fill: ${pillar === 'news'
-            ? palette[pillar].bright
-            : palette[pillar].main};
+            ? pillarPalette[pillar].bright
+            : pillarPalette[pillar].main};
     }
 `;
 

--- a/src/web/components/CardHeadline.tsx
+++ b/src/web/components/CardHeadline.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { css, cx } from 'emotion';
 
 import { headline } from '@guardian/src-foundations/typography';
-import { palette } from '@guardian/src-foundations';
 import { neutral } from '@guardian/src-foundations/palette';
 import { until } from '@guardian/src-foundations/mq';
 
 import { QuoteIcon } from '@root/src/web/components/QuoteIcon';
 import { Kicker } from '@root/src/web/components/Kicker';
 import { Byline } from '@root/src/web/components/Byline';
+import { pillarPalette } from '@frontend/lib/pillars';
 
 const fontStyles = (size: SmallHeadlineSize) => {
     switch (size) {
@@ -74,7 +74,7 @@ const headlineStyles = (designType: DesignType, pillar: Pillar) => {
     switch (designType) {
         case 'Feature':
         case 'Interview':
-            return colourStyles(palette[pillar].dark);
+            return colourStyles(pillarPalette[pillar].dark);
         case 'Media':
         case 'Live':
             return colourStyles(neutral[97]);
@@ -124,7 +124,7 @@ export const CardHeadline = ({
                 />
             )}
             {showQuotes && (
-                <QuoteIcon colour={palette[pillar].main} size={size} />
+                <QuoteIcon colour={pillarPalette[pillar].main} size={size} />
             )}
 
             <span className={headlineStyles(designType, pillar)}>

--- a/src/web/components/DropCap.tsx
+++ b/src/web/components/DropCap.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { css } from 'emotion';
-
 import { headline } from '@guardian/src-foundations/typography';
-
-import { palette } from '@guardian/src-foundations';
+import { opinion } from '@guardian/src-foundations/palette';
+import { pillarPalette } from '@frontend/lib/pillars';
 
 type Props = {
     letter: string;
@@ -26,7 +25,7 @@ const outerStyles = (pillar: Pillar, designType: DesignType) => {
         case 'Comment':
             return css`
                 ${baseStyles};
-                color: ${palette.opinion.main};
+                color: ${opinion[400]};
             `;
         case 'Analysis':
         case 'Feature':
@@ -46,7 +45,7 @@ const outerStyles = (pillar: Pillar, designType: DesignType) => {
         default:
             return css`
                 ${baseStyles};
-                color: ${palette[pillar].dark};
+                color: ${pillarPalette[pillar].dark};
             `;
     }
 };

--- a/src/web/components/Dropdown.tsx
+++ b/src/web/components/Dropdown.tsx
@@ -1,13 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import { css, cx } from 'emotion';
 
-import { palette } from '@guardian/src-foundations';
 import {
     text,
     neutral,
     border,
     brandText,
     brandAlt,
+    news,
 } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
@@ -100,7 +100,7 @@ const linkActive = css`
 
     :after {
         content: '';
-        border: 2px solid ${palette.news.main};
+        border: 2px solid ${news[400]};
         border-top: 0px;
         border-right: 0px;
         position: absolute;

--- a/src/web/components/HeadlineByline.tsx
+++ b/src/web/components/HeadlineByline.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { css } from 'emotion';
-import { palette } from '@guardian/src-foundations';
 import { brandAltBackground } from '@guardian/src-foundations/palette';
 import { headline } from '@guardian/src-foundations/typography';
 
 import { BylineLink } from '@root/src/web/components/BylineLink';
+import { pillarPalette } from '@frontend/lib/pillars';
 
 const wrapperStyles = css`
     margin-left: 6px;
@@ -40,7 +40,7 @@ const opinionStyles = (pillar: Pillar) => css`
     })}
     line-height: 38px;
     font-style: italic;
-    color: ${palette[pillar].main};
+    color: ${pillarPalette[pillar].main};
 
     a {
         color: inherit;

--- a/src/web/components/Kicker.tsx
+++ b/src/web/components/Kicker.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 
-import { palette } from '@guardian/src-foundations';
-
 import { PulsingDot } from '@root/src/web/components/PulsingDot';
 
 import { decidePillarLight } from '@root/src/web/lib/decidePillarLight';
+import { pillarPalette } from '@frontend/lib/pillars';
 
 const kickerStyles = (colour: string) => css`
     color: ${colour};
@@ -29,12 +28,14 @@ const decideColour = (
     switch (designType) {
         case 'Live':
             // TODO: We need this colour in source foundation
-            return inCard ? decidePillarLight(pillar) : palette[pillar].main;
+            return inCard
+                ? decidePillarLight(pillar)
+                : pillarPalette[pillar].main;
         case 'Media':
             // On Media cards, when pillar is news we use the bright colour as this looks better on a dark background vs. main
             return inCard && pillar === 'news'
-                ? palette[pillar].bright
-                : palette[pillar].main;
+                ? pillarPalette[pillar].bright
+                : pillarPalette[pillar].main;
         case 'Feature':
         case 'Interview':
         case 'Analysis':
@@ -50,7 +51,7 @@ const decideColour = (
         case 'Comment':
         case 'Immersive':
         default:
-            return palette[pillar].main;
+            return pillarPalette[pillar].main;
     }
 };
 

--- a/src/web/components/LinkHeadline.tsx
+++ b/src/web/components/LinkHeadline.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { css, cx } from 'emotion';
 
 import { headline } from '@guardian/src-foundations/typography';
-import { palette } from '@guardian/src-foundations';
 
 import { QuoteIcon } from '@root/src/web/components/QuoteIcon';
 import { Kicker } from '@root/src/web/components/Kicker';
 import { Byline } from '@root/src/web/components/Byline';
+import { pillarPalette } from '@frontend/lib/pillars';
 
 const fontStyles = (size: SmallHeadlineSize) => {
     switch (size) {
@@ -74,7 +74,9 @@ export const LinkHeadline = ({
                 showSlash={showSlash}
             />
         )}
-        {showQuotes && <QuoteIcon colour={palette[pillar].main} size={size} />}
+        {showQuotes && (
+            <QuoteIcon colour={pillarPalette[pillar].main} size={size} />
+        )}
         {link ? (
             // We were passed a link object so headline should be a link, with link styling
             <>

--- a/src/web/components/MediaMeta.tsx
+++ b/src/web/components/MediaMeta.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { css } from 'emotion';
 
-import { palette } from '@guardian/src-foundations';
 import { textSans } from '@guardian/src-foundations/typography';
 
+import { pillarPalette } from '@frontend/lib/pillars';
 import Audio from '@frontend/static/icons/audio.svg';
 import Photo from '@frontend/static/icons/photo.svg';
 import Video from '@frontend/static/icons/video.svg';
@@ -19,8 +19,8 @@ const iconWrapperStyles = (mediaType: MediaType, pillar: Pillar) => css`
     height: 23px;
     /* Below we force the colour to be bright if the pillar is news (because it looks better) */
     background-color: ${pillar === 'news'
-        ? palette[pillar].bright
-        : palette[pillar].main};
+        ? pillarPalette[pillar].bright
+        : pillarPalette[pillar].main};
     border-radius: 50%;
     display: inline-block;
 
@@ -37,7 +37,9 @@ const iconWrapperStyles = (mediaType: MediaType, pillar: Pillar) => css`
 
 const durationStyles = (pillar: Pillar) => css`
     /* Below we force the colour to be bright if the pillar is news (because it looks better) */
-    color: ${pillar === 'news' ? palette[pillar].bright : palette[pillar].main};
+    color: ${pillar === 'news'
+        ? pillarPalette[pillar].bright
+        : pillarPalette[pillar].main};
     ${textSans.xsmall({ fontWeight: `bold` })}
 `;
 

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterGrid.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterGrid.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
 import { css, cx } from 'emotion';
-import { palette } from '@guardian/src-foundations';
 import { neutral, border } from '@guardian/src-foundations/palette';
 import { headline } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
 import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 
+import { pillarPalette } from '@frontend/lib/pillars';
 import { MostViewedFooterItem } from './MostViewedFooterItem';
 
 const thinGreySolid = `1px solid ${border.secondary}`;
@@ -44,7 +44,7 @@ const firstTab = css`
 
 const selectedListTab = (pillar: Pillar) => css`
     /* TODO: Using a pseudo selector here could be faster? */
-    box-shadow: inset 0px 4px 0px 0px ${pillar && palette[pillar].dark};
+    box-shadow: inset 0px 4px 0px 0px ${pillar && pillarPalette[pillar].dark};
     transition: box-shadow 0.3s ease-in-out;
 `;
 

--- a/src/web/components/SignedInAs.tsx
+++ b/src/web/components/SignedInAs.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { css } from 'emotion';
 
-import { text, border, neutral } from '@guardian/src-foundations/palette';
+import { text, border, neutral, news } from '@guardian/src-foundations/palette';
 import { headline, textSans } from '@guardian/src-foundations/typography';
-import { palette, space } from '@guardian/src-foundations';
+import { space } from '@guardian/src-foundations';
 import { until } from '@guardian/src-foundations/mq';
+import { pillarPalette } from '@frontend/lib/pillars';
 
 type Props = {
     commentCount: number;
@@ -60,12 +61,12 @@ const usernameStyles = css`
 `;
 
 const linkStyles = (pillar: Pillar) => css`
-    color: ${palette[pillar][300]};
+    color: ${pillarPalette[pillar].dark};
     text-decoration: none;
     border-bottom: 1px solid ${border.secondary};
     transition: border-color 0.15s ease-out;
     :hover {
-        border-color: ${palette.news[300]};
+        border-color: ${news[300]};
     }
 `;
 

--- a/src/web/components/SubNav/SubNav.tsx
+++ b/src/web/components/SubNav/SubNav.tsx
@@ -177,8 +177,7 @@ export const SubNav = ({ subNavSections, pillar, currentNavLink }: Props) => {
                     <li key={link.url}>
                         <a
                             className={cx(linkStyle, {
-                                [selected]:
-                                    link.title === currentNavLink,
+                                [selected]: link.title === currentNavLink,
                             })}
                             href={link.url}
                             data-link-name={`nav2 : subnav : ${trimLeadingSlash(

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 
-import { palette } from '@guardian/src-foundations';
 import {
     neutral,
     background,
     brandBorder,
     brandBackground,
+    opinion,
 } from '@guardian/src-foundations/palette';
 import { from, until } from '@guardian/src-foundations/mq';
 
@@ -245,7 +245,7 @@ export const CommentLayout = ({ CAPI, NAV }: Props) => {
 
             {NAV.subNavSections && (
                 <Section
-                    backgroundColour={palette.opinion.faded}
+                    backgroundColour={opinion[800]}
                     padded={false}
                     sectionId="sub-nav-root"
                 >
@@ -265,10 +265,7 @@ export const CommentLayout = ({ CAPI, NAV }: Props) => {
                 <GuardianLines pillar={CAPI.pillar} />
             </Section>
 
-            <Section
-                showTopBorder={false}
-                backgroundColour={palette.opinion.faded}
-            >
+            <Section showTopBorder={false} backgroundColour={opinion[800]}>
                 <StandardGrid>
                     <GridItem area="title">
                         <ArticleTitle

--- a/src/web/lib/decidePillarLight.ts
+++ b/src/web/lib/decidePillarLight.ts
@@ -1,4 +1,4 @@
-import { palette } from '@guardian/src-foundations';
+import { pillarPalette } from '@frontend/lib/pillars';
 
 export const decidePillarLight = (pillar: Pillar) => {
     // TODO: This function is a tempoary workaround while we wait for source foundation to be updated with
@@ -9,12 +9,12 @@ export const decidePillarLight = (pillar: Pillar) => {
         case 'sport':
             return '#90dcff';
         case 'culture':
-            return palette[pillar].main;
+            return pillarPalette[pillar].main;
         case 'lifestyle':
-            return palette[pillar].main;
+            return pillarPalette[pillar].main;
         case 'opinion':
-            return palette[pillar].main;
+            return pillarPalette[pillar].main;
         default:
-            return palette[pillar].main;
+            return pillarPalette[pillar].main;
     }
 };


### PR DESCRIPTION
## What does this change?

Banishes palette imports from the web forever. Assuming I'm using it correctly, `pillarPalette` turns out to be quite a useful abstraction!

## Why?

See #1227 
