### PR TITLE
Ozone AMP spike

### DIFF
--- a/src/amp/components/Ad.test.tsx
+++ b/src/amp/components/Ad.test.tsx
@@ -34,8 +34,8 @@ describe('AdComponent', () => {
             PLACEMENT_ID: 'OZONE_PROVIDED_PLACEMENT_ID',
             AD_UNIT_CODE: 'YOUR_AD_UNIT_CODE',
             PUBCID: 'YOUR_PUBCID',
-        }
-    }
+        },
+    };
     beforeEach(() => {
         commercialConfig.usePermutive = true;
         commercialConfig.usePrebid = true;
@@ -68,31 +68,28 @@ describe('AdComponent', () => {
             expect(rowRtcAttribute).not.toBeNull();
 
             if (usRtcAttribute) {
-                expect(JSON.parse(usRtcAttribute)).toEqual(expect.objectContaining({
-                    urls: [
-                        usPrebidURL,
-                        permutiveURL,
-                    ],
-                    vendors: ozoneConfig,
-                }));
+                expect(JSON.parse(usRtcAttribute)).toEqual(
+                    expect.objectContaining({
+                        urls: [usPrebidURL, permutiveURL],
+                        vendors: ozoneConfig,
+                    }),
+                );
             }
             if (auRtcAttribute) {
-                expect(JSON.parse(auRtcAttribute)).toEqual(expect.objectContaining({
-                    urls: [
-                        auPrebidURL,
-                        permutiveURL,
-                    ],
-                    vendors: ozoneConfig,
-                }));
+                expect(JSON.parse(auRtcAttribute)).toEqual(
+                    expect.objectContaining({
+                        urls: [auPrebidURL, permutiveURL],
+                        vendors: ozoneConfig,
+                    }),
+                );
             }
             if (rowRtcAttribute) {
-                expect(JSON.parse(rowRtcAttribute)).toEqual(expect.objectContaining({
-                    urls: [
-                        rowPrebidURL,
-                        permutiveURL,
-                    ],
-                    vendors: ozoneConfig,
-                }));
+                expect(JSON.parse(rowRtcAttribute)).toEqual(
+                    expect.objectContaining({
+                        urls: [rowPrebidURL, permutiveURL],
+                        vendors: ozoneConfig,
+                    }),
+                );
             }
         }
     });
@@ -217,28 +214,32 @@ describe('AdComponent', () => {
             expect(auRtcAttribute).not.toBeNull();
             expect(rowRtcAttribute).not.toBeNull();
 
-
-
             if (usRtcAttribute) {
-                expect(JSON.parse(usRtcAttribute)).toEqual(expect.objectContaining({
-                    urls: [],
-                    vendors: ozoneConfig,
-                }));
+                expect(JSON.parse(usRtcAttribute)).toEqual(
+                    expect.objectContaining({
+                        urls: [],
+                        vendors: ozoneConfig,
+                    }),
+                );
             }
             if (auRtcAttribute) {
-                expect(JSON.parse(auRtcAttribute)).toEqual(expect.objectContaining({
-                    urls: [],
-                    vendors: ozoneConfig,
-                }));
+                expect(JSON.parse(auRtcAttribute)).toEqual(
+                    expect.objectContaining({
+                        urls: [],
+                        vendors: ozoneConfig,
+                    }),
+                );
             }
             if (rowRtcAttribute) {
-                expect(JSON.parse(rowRtcAttribute)).toEqual(expect.objectContaining({
-                    urls: [],
-                    vendors: ozoneConfig,
-                }));
+                expect(JSON.parse(rowRtcAttribute)).toEqual(
+                    expect.objectContaining({
+                        urls: [],
+                        vendors: ozoneConfig,
+                    }),
+                );
             }
         }
-    })
+    });
 
     it('rtc-config returns no URLs when usePermutive and usePrebid flags are set to false', () => {
         commercialConfig.usePrebid = false;

--- a/src/amp/components/Ad.test.tsx
+++ b/src/amp/components/Ad.test.tsx
@@ -9,6 +9,7 @@ describe('AdComponent', () => {
     const commercialConfig = {
         usePrebid: true,
         usePermutive: true,
+        useOzone: true,
     };
     const commercialProperties = {
         UK: { adTargeting: [] },
@@ -25,12 +26,81 @@ describe('AdComponent', () => {
     const rowPrebidURL =
         'https://prebid.adnxs.com/pbs/v1/openrtb2/amp?tag_id=4&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF';
 
+    const ozoneConfig = {
+        ozone: {
+            PUBLISHER_ID: 'OZONE_PROVIDED_PUBLISHER_ID',
+            SITE_ID: 'YOUR_SITE_ID',
+            TAG_ID: 'OZONE_PROVIDED_STORED_REQUEST_ID',
+            PLACEMENT_ID: 'OZONE_PROVIDED_PLACEMENT_ID',
+            AD_UNIT_CODE: 'YOUR_AD_UNIT_CODE',
+            PUBCID: 'YOUR_PUBCID',
+        }
+    }
     beforeEach(() => {
         commercialConfig.usePermutive = true;
         commercialConfig.usePrebid = true;
+        commercialConfig.useOzone = true;
     });
 
-    it('rtc-config returns correctly formed Permutive and PreBid URLs when usePermutive and usePrebid flags are set to true', () => {
+    it('rtc-config returns correctly formed Permutive and PreBid URLs and the correctly formed ozone config when usePermutive, usePrebid and useOzone flags are set to true', () => {
+        const { container } = render(
+            <Ad
+                edition={edition}
+                section={section}
+                contentType={contentType}
+                config={commercialConfig}
+                commercialProperties={commercialProperties}
+                className=""
+            />,
+        );
+
+        const ampAdElement = container.querySelectorAll('amp-ad');
+
+        expect(ampAdElement).not.toBeNull();
+
+        if (ampAdElement) {
+            const usRtcAttribute = ampAdElement[0].getAttribute('rtc-config');
+            const auRtcAttribute = ampAdElement[1].getAttribute('rtc-config');
+            const rowRtcAttribute = ampAdElement[2].getAttribute('rtc-config');
+
+            expect(usRtcAttribute).not.toBeNull();
+            expect(auRtcAttribute).not.toBeNull();
+            expect(rowRtcAttribute).not.toBeNull();
+
+            if (usRtcAttribute) {
+                expect(JSON.parse(usRtcAttribute)).toEqual(expect.objectContaining({
+                    urls: [
+                        usPrebidURL,
+                        permutiveURL,
+                    ],
+                    vendors: ozoneConfig,
+                }));
+            }
+            if (auRtcAttribute) {
+                expect(JSON.parse(auRtcAttribute)).toEqual(expect.objectContaining({
+                    urls: [
+                        auPrebidURL,
+                        permutiveURL,
+                    ],
+                    vendors: ozoneConfig,
+                }));
+            }
+            if (rowRtcAttribute) {
+                expect(JSON.parse(rowRtcAttribute)).toEqual(expect.objectContaining({
+                    urls: [
+                        rowPrebidURL,
+                        permutiveURL,
+                    ],
+                    vendors: ozoneConfig,
+                }));
+            }
+        }
+    });
+
+    it('rtc-config returns only the correctly formed PreBid URL when usePermutive and useOzone flags are set to false and usePrebid flag is set to true', () => {
+        commercialConfig.usePermutive = false;
+        commercialConfig.useOzone = false;
+
         const { container } = render(
             <Ad
                 edition={edition}
@@ -58,25 +128,69 @@ describe('AdComponent', () => {
             if (usRtcAttribute) {
                 expect(JSON.parse(usRtcAttribute).urls).toMatchObject([
                     usPrebidURL,
-                    permutiveURL,
                 ]);
             }
             if (auRtcAttribute) {
                 expect(JSON.parse(auRtcAttribute).urls).toMatchObject([
                     auPrebidURL,
-                    permutiveURL,
                 ]);
             }
             if (rowRtcAttribute) {
                 expect(JSON.parse(rowRtcAttribute).urls).toMatchObject([
                     rowPrebidURL,
+                ]);
+            }
+        }
+    });
+
+    it('rtc-config returns only the Permutive URL when usePermutive flags is set to true and usePrebid and useOzone flags are set to false', () => {
+        commercialConfig.usePrebid = false;
+        commercialConfig.useOzone = false;
+
+        const { container } = render(
+            <Ad
+                edition={edition}
+                section={section}
+                contentType={contentType}
+                config={commercialConfig}
+                commercialProperties={commercialProperties}
+                className=""
+            />,
+        );
+
+        const ampAdElement = container.querySelectorAll('amp-ad');
+
+        expect(ampAdElement).not.toBeNull();
+
+        if (ampAdElement) {
+            const usRtcAttribute = ampAdElement[0].getAttribute('rtc-config');
+            const auRtcAttribute = ampAdElement[1].getAttribute('rtc-config');
+            const rowRtcAttribute = ampAdElement[2].getAttribute('rtc-config');
+
+            expect(usRtcAttribute).not.toBeNull();
+            expect(auRtcAttribute).not.toBeNull();
+            expect(rowRtcAttribute).not.toBeNull();
+
+            if (usRtcAttribute) {
+                expect(JSON.parse(usRtcAttribute).urls).toMatchObject([
+                    permutiveURL,
+                ]);
+            }
+            if (auRtcAttribute) {
+                expect(JSON.parse(auRtcAttribute).urls).toMatchObject([
+                    permutiveURL,
+                ]);
+            }
+            if (rowRtcAttribute) {
+                expect(JSON.parse(rowRtcAttribute).urls).toMatchObject([
                     permutiveURL,
                 ]);
             }
         }
     });
 
-    it('rtc-config returns only the correctly formed PreBid URL when usePermutive flag is set to false and usePrebid flag is set to true', () => {
+    it('rtc-config returns no URLs and the correct Ozone config when usePermutive and usePrebid flags are set to false and useOzone flag is set to true', () => {
+        commercialConfig.usePrebid = false;
         commercialConfig.usePermutive = false;
 
         const { container } = render(
@@ -103,72 +217,33 @@ describe('AdComponent', () => {
             expect(auRtcAttribute).not.toBeNull();
             expect(rowRtcAttribute).not.toBeNull();
 
-            if (usRtcAttribute) {
-                expect(JSON.parse(usRtcAttribute).urls).toMatchObject([
-                    usPrebidURL,
-                ]);
-            }
-            if (auRtcAttribute) {
-                expect(JSON.parse(auRtcAttribute).urls).toMatchObject([
-                    auPrebidURL,
-                ]);
-            }
-            if (rowRtcAttribute) {
-                expect(JSON.parse(rowRtcAttribute).urls).toMatchObject([
-                    rowPrebidURL,
-                ]);
-            }
-        }
-    });
 
-    it('rtc-config returns only the Permutive URL when usePermutive flags is set to true and usePrebid flag is set to false', () => {
-        commercialConfig.usePrebid = false;
-
-        const { container } = render(
-            <Ad
-                edition={edition}
-                section={section}
-                contentType={contentType}
-                config={commercialConfig}
-                commercialProperties={commercialProperties}
-                className=""
-            />,
-        );
-
-        const ampAdElement = container.querySelectorAll('amp-ad');
-
-        expect(ampAdElement).not.toBeNull();
-
-        if (ampAdElement) {
-            const usRtcAttribute = ampAdElement[0].getAttribute('rtc-config');
-            const auRtcAttribute = ampAdElement[1].getAttribute('rtc-config');
-            const rowRtcAttribute = ampAdElement[2].getAttribute('rtc-config');
-
-            expect(usRtcAttribute).not.toBeNull();
-            expect(auRtcAttribute).not.toBeNull();
-            expect(rowRtcAttribute).not.toBeNull();
 
             if (usRtcAttribute) {
-                expect(JSON.parse(usRtcAttribute).urls).toMatchObject([
-                    permutiveURL,
-                ]);
+                expect(JSON.parse(usRtcAttribute)).toEqual(expect.objectContaining({
+                    urls: [],
+                    vendors: ozoneConfig,
+                }));
             }
             if (auRtcAttribute) {
-                expect(JSON.parse(auRtcAttribute).urls).toMatchObject([
-                    permutiveURL,
-                ]);
+                expect(JSON.parse(auRtcAttribute)).toEqual(expect.objectContaining({
+                    urls: [],
+                    vendors: ozoneConfig,
+                }));
             }
             if (rowRtcAttribute) {
-                expect(JSON.parse(rowRtcAttribute).urls).toMatchObject([
-                    permutiveURL,
-                ]);
+                expect(JSON.parse(rowRtcAttribute)).toEqual(expect.objectContaining({
+                    urls: [],
+                    vendors: ozoneConfig,
+                }));
             }
         }
-    });
+    })
 
     it('rtc-config returns no URLs when usePermutive and usePrebid flags are set to false', () => {
         commercialConfig.usePrebid = false;
         commercialConfig.usePermutive = false;
+        commercialConfig.useOzone = false;
 
         const { container } = render(
             <Ad

--- a/src/amp/components/Ad.tsx
+++ b/src/amp/components/Ad.tsx
@@ -89,10 +89,16 @@ const getPlacementId = (adRegion: AdRegion): number => {
     }
 };
 
+interface RtcData {
+    urls: Array<string>;
+    vendors?: { ozone: {} };
+}
+
 const realTimeConfig = (
     adRegion: AdRegion,
     usePrebid: boolean,
     usePermutive: boolean,
+    useOzone: boolean,
 ): any => {
     const placementID = getPlacementId(adRegion);
     const preBidServerPrefix = 'https://prebid.adnxs.com/pbs/v1/openrtb2/amp';
@@ -114,12 +120,27 @@ const realTimeConfig = (
         'purl=HREF',
     ].join('&');
 
-    const data = {
+    const ozoneVendor = {
+        ozone: {
+            PUBLISHER_ID: 'OZONE_PROVIDED_PUBLISHER_ID',
+            SITE_ID: 'YOUR_SITE_ID',
+            TAG_ID: 'OZONE_PROVIDED_STORED_REQUEST_ID',
+            PLACEMENT_ID: 'OZONE_PROVIDED_PLACEMENT_ID',
+            AD_UNIT_CODE: 'YOUR_AD_UNIT_CODE',
+            PUBCID: 'YOUR_PUBCID',
+        },
+    };
+
+    const data: RtcData = {
         urls: [
             usePrebid ? prebidURL : '',
             usePermutive ? permutiveURL : '',
         ].filter(url => url),
     };
+
+    if (useOzone) {
+        data.vendors = ozoneVendor;
+    }
 
     return JSON.stringify(data);
 };
@@ -127,6 +148,7 @@ const realTimeConfig = (
 interface CommercialConfig {
     usePrebid: boolean;
     usePermutive: boolean;
+    useOzone: boolean;
 }
 
 const ampAdElem = (
@@ -153,6 +175,7 @@ const ampAdElem = (
                 adRegion,
                 config.usePrebid,
                 config.usePermutive,
+                config.useOzone,
             )}
         />
     );
@@ -175,28 +198,28 @@ export const Ad: React.SFC<{
 }) => (
     <div className={cx(adStyle, className)}>
         {ampAdElem(
-            'US',
-            edition,
-            section || '',
-            contentType,
-            config,
-            commercialProperties,
-        )}
+                    'US',
+                    edition,
+                    section || '',
+                    contentType,
+                    config,
+                    commercialProperties,
+                )}
         {ampAdElem(
-            'AU',
-            edition,
-            section || '',
-            contentType,
-            config,
-            commercialProperties,
-        )}
+                    'AU',
+                    edition,
+                    section || '',
+                    contentType,
+                    config,
+                    commercialProperties,
+                )}
         {ampAdElem(
-            'ROW',
-            edition,
-            section || '',
-            contentType,
-            config,
-            commercialProperties,
-        )}
+                    'ROW',
+                    edition,
+                    section || '',
+                    contentType,
+                    config,
+                    commercialProperties,
+                )}
     </div>
-);
+        );

--- a/src/amp/components/Ad.tsx
+++ b/src/amp/components/Ad.tsx
@@ -198,28 +198,28 @@ export const Ad: React.SFC<{
 }) => (
     <div className={cx(adStyle, className)}>
         {ampAdElem(
-                    'US',
-                    edition,
-                    section || '',
-                    contentType,
-                    config,
-                    commercialProperties,
-                )}
+            'US',
+            edition,
+            section || '',
+            contentType,
+            config,
+            commercialProperties,
+        )}
         {ampAdElem(
-                    'AU',
-                    edition,
-                    section || '',
-                    contentType,
-                    config,
-                    commercialProperties,
-                )}
+            'AU',
+            edition,
+            section || '',
+            contentType,
+            config,
+            commercialProperties,
+        )}
         {ampAdElem(
-                    'ROW',
-                    edition,
-                    section || '',
-                    contentType,
-                    config,
-                    commercialProperties,
-                )}
+            'ROW',
+            edition,
+            section || '',
+            contentType,
+            config,
+            commercialProperties,
+        )}
     </div>
-        );
+);

--- a/src/amp/components/AnalyticsIframe.tsx
+++ b/src/amp/components/AnalyticsIframe.tsx
@@ -1,18 +1,19 @@
 import React from 'react';
 import { css } from 'emotion';
 
-const prebidImg =
-    'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==';
-
-const prebidIframeStyle = css`
+const analyticsIframeStyle = css`
     position: fixed;
     top: -1px;
 `;
 
+const prebidImg =
+    'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==';
+const ozoneImg = 'https://elb.the-ozone-project.com/';
+
 export const AnalyticsIframe: React.FC<{ url: string }> = ({ url }) => {
     return (
         <amp-iframe
-            class={prebidIframeStyle}
+            class={analyticsIframeStyle}
             data-block-on-consent="_till_accepted"
             title="Analytics Iframe"
             height="1"
@@ -22,6 +23,7 @@ export const AnalyticsIframe: React.FC<{ url: string }> = ({ url }) => {
             src={url}
         >
             <amp-img layout="fill" src={prebidImg} placeholder="" />
+            <amp-img layout="fill" src={ozoneImg} placeholder="" />
         </amp-iframe>
     );
 };

--- a/src/amp/components/Blocks.tsx
+++ b/src/amp/components/Blocks.tsx
@@ -58,60 +58,61 @@ export const Blocks: React.SFC<{
     url,
     shouldHideAds,
 }) => {
-    // TODO add last updated for blocks to show here
-    const liveBlogBlocks = blocks.map(block => {
+        // TODO add last updated for blocks to show here
+        const liveBlogBlocks = blocks.map(block => {
+            return (
+                <div
+                    id={block.id}
+                    data-sort-time={block.firstPublished}
+                    key={block.id}
+                    className={blockStyle(pillar)}
+                >
+                    {block.firstPublishedDisplay && (
+                        <a
+                            className={firstPublishedStyle}
+                            href={blockLink(url, block.id)}
+                        >
+                            {block.firstPublishedDisplay}
+                        </a>
+                    )}
+                    {block.title && <h2>{block.title}</h2>}
+                    {Elements(block.elements, pillar, false)}
+                    {/* Some elements float (e.g. rich links) */}
+                    <div className={clearBoth} />{' '}
+                    {block.lastUpdatedDisplay && (
+                        <div className={lastUpdatedStyle}>
+                            Updated at {block.lastUpdatedDisplay}
+                        </div>
+                    )}
+                </div>
+            );
+        });
+
+        if (shouldHideAds) {
+            return <>{liveBlogBlocks}</>;
+        }
+
+        const slotIndexes = findBlockAdSlots(liveBlogBlocks);
+        const adInfo = {
+            section,
+            edition,
+            contentType,
+            commercialProperties,
+            switches: {
+                ampPrebid: switches.ampPrebid,
+                permutive: switches.permutive,
+                ampOzone: switches.ampOzone,
+            },
+        };
+
         return (
-            <div
-                id={block.id}
-                data-sort-time={block.firstPublished}
-                key={block.id}
-                className={blockStyle(pillar)}
-            >
-                {block.firstPublishedDisplay && (
-                    <a
-                        className={firstPublishedStyle}
-                        href={blockLink(url, block.id)}
-                    >
-                        {block.firstPublishedDisplay}
-                    </a>
-                )}
-                {block.title && <h2>{block.title}</h2>}
-                {Elements(block.elements, pillar, false)}
-                {/* Some elements float (e.g. rich links) */}
-                <div className={clearBoth} />{' '}
-                {block.lastUpdatedDisplay && (
-                    <div className={lastUpdatedStyle}>
-                        Updated at {block.lastUpdatedDisplay}
-                    </div>
-                )}
-            </div>
+            <>
+                <WithAds
+                    items={liveBlogBlocks}
+                    adSlots={slotIndexes}
+                    adClassName=""
+                    adInfo={adInfo}
+                />
+            </>
         );
-    });
-
-    if (shouldHideAds) {
-        return <>{liveBlogBlocks}</>;
-    }
-
-    const slotIndexes = findBlockAdSlots(liveBlogBlocks);
-    const adInfo = {
-        section,
-        edition,
-        contentType,
-        commercialProperties,
-        switches: {
-            ampPrebid: switches.ampPrebid,
-            permutive: switches.permutive,
-        },
     };
-
-    return (
-        <>
-            <WithAds
-                items={liveBlogBlocks}
-                adSlots={slotIndexes}
-                adClassName=""
-                adInfo={adInfo}
-            />
-        </>
-    );
-};

--- a/src/amp/components/Blocks.tsx
+++ b/src/amp/components/Blocks.tsx
@@ -58,61 +58,61 @@ export const Blocks: React.SFC<{
     url,
     shouldHideAds,
 }) => {
-        // TODO add last updated for blocks to show here
-        const liveBlogBlocks = blocks.map(block => {
-            return (
-                <div
-                    id={block.id}
-                    data-sort-time={block.firstPublished}
-                    key={block.id}
-                    className={blockStyle(pillar)}
-                >
-                    {block.firstPublishedDisplay && (
-                        <a
-                            className={firstPublishedStyle}
-                            href={blockLink(url, block.id)}
-                        >
-                            {block.firstPublishedDisplay}
-                        </a>
-                    )}
-                    {block.title && <h2>{block.title}</h2>}
-                    {Elements(block.elements, pillar, false)}
-                    {/* Some elements float (e.g. rich links) */}
-                    <div className={clearBoth} />{' '}
-                    {block.lastUpdatedDisplay && (
-                        <div className={lastUpdatedStyle}>
-                            Updated at {block.lastUpdatedDisplay}
-                        </div>
-                    )}
-                </div>
-            );
-        });
-
-        if (shouldHideAds) {
-            return <>{liveBlogBlocks}</>;
-        }
-
-        const slotIndexes = findBlockAdSlots(liveBlogBlocks);
-        const adInfo = {
-            section,
-            edition,
-            contentType,
-            commercialProperties,
-            switches: {
-                ampPrebid: switches.ampPrebid,
-                permutive: switches.permutive,
-                ampOzone: switches.ampOzone,
-            },
-        };
-
+    // TODO add last updated for blocks to show here
+    const liveBlogBlocks = blocks.map(block => {
         return (
-            <>
-                <WithAds
-                    items={liveBlogBlocks}
-                    adSlots={slotIndexes}
-                    adClassName=""
-                    adInfo={adInfo}
-                />
-            </>
+            <div
+                id={block.id}
+                data-sort-time={block.firstPublished}
+                key={block.id}
+                className={blockStyle(pillar)}
+            >
+                {block.firstPublishedDisplay && (
+                    <a
+                        className={firstPublishedStyle}
+                        href={blockLink(url, block.id)}
+                    >
+                        {block.firstPublishedDisplay}
+                    </a>
+                )}
+                {block.title && <h2>{block.title}</h2>}
+                {Elements(block.elements, pillar, false)}
+                {/* Some elements float (e.g. rich links) */}
+                <div className={clearBoth} />{' '}
+                {block.lastUpdatedDisplay && (
+                    <div className={lastUpdatedStyle}>
+                        Updated at {block.lastUpdatedDisplay}
+                    </div>
+                )}
+            </div>
         );
+    });
+
+    if (shouldHideAds) {
+        return <>{liveBlogBlocks}</>;
+    }
+
+    const slotIndexes = findBlockAdSlots(liveBlogBlocks);
+    const adInfo = {
+        section,
+        edition,
+        contentType,
+        commercialProperties,
+        switches: {
+            ampPrebid: switches.ampPrebid,
+            permutive: switches.permutive,
+            ampOzone: switches.ampOzone,
+        },
     };
+
+    return (
+        <>
+            <WithAds
+                items={liveBlogBlocks}
+                adSlots={slotIndexes}
+                adClassName=""
+                adInfo={adInfo}
+            />
+        </>
+    );
+};

--- a/src/amp/components/BodyArticle.tsx
+++ b/src/amp/components/BodyArticle.tsx
@@ -97,7 +97,7 @@ export const Body: React.FC<{
             adClassName={adStyle}
             adInfo={adInfo}
         />
-        );
+    );
     return (
         <InnerContainer className={body(pillar, designType)}>
             <TopMeta

--- a/src/amp/components/BodyArticle.tsx
+++ b/src/amp/components/BodyArticle.tsx
@@ -84,6 +84,7 @@ export const Body: React.FC<{
         switches: {
             ampPrebid: config.switches.ampPrebid,
             permutive: config.switches.permutive,
+            ampOzone: config.switches.ampOzone,
         },
     };
 
@@ -96,7 +97,7 @@ export const Body: React.FC<{
             adClassName={adStyle}
             adInfo={adInfo}
         />
-    );
+        );
     return (
         <InnerContainer className={body(pillar, designType)}>
             <TopMeta

--- a/src/amp/components/WithAds.tsx
+++ b/src/amp/components/WithAds.tsx
@@ -13,6 +13,7 @@ interface AdInfo {
     switches: {
         ampPrebid: boolean;
         permutive: boolean;
+        ampOzone: boolean;
     };
     section?: string;
 }
@@ -26,6 +27,7 @@ export const WithAds: React.SFC<{
     const commercialConfig = {
         usePrebid: adInfo.switches.ampPrebid,
         usePermutive: adInfo.switches.permutive,
+        useOzone: adInfo.switches.ampOzone,
     };
 
     const ad = (id: string): JSX.Element => (


### PR DESCRIPTION
## What does this change?
Adds Ozone integration to the AMP code. This involves adding ozone as a switch and then including config details in the [Ad component rtc field](https://github.com/guardian/dotcom-rendering/compare/ozone-amp-spike?expand=1#diff-cf393e74bad4023dbfb9e8c63cc4797fR71-R77)
## Why?
Ozone is now a supported vendor for AMP and adding integration is important for ad revenue.
## Link to supporting Trello card
https://trello.com/c/UlTu12yq/724-integrate-ozone-into-amp

Co-authored with @ripecosta 