### PR TITLE
Dynamically set Epic tracking params

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     ],
     "dependencies": {
         "@emotion/core": "^10.0.5",
-        "@guardian/automat-client": "^0.2.14",
+        "@guardian/automat-client": "^0.2.15",
         "@guardian/consent-management-platform": "^3.0.0",
         "@guardian/discussion-rendering": "^1.0.0",
         "@guardian/src-button": "^0.16.1",

--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -186,8 +186,8 @@ const MemoisedInner = ({
         // fine to add it as a dependency because it won't ever change after
         // viewing, so we shouldn't ever run the hook multiple times. If we _do_
         // ever have an implementation where information in data could change
-        // after viewing, we'll need to revising this. Perhaps it's clearer to
-        // remote data from the dependencies and disable the exhaustive-deps
+        // after viewing, we'll need to revisit this. Perhaps it's clearer to
+        // remove data from the dependencies and disable the exhaustive-deps
         // rule, as above.
     }, [hasBeenSeen, data]);
 

--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -75,9 +75,6 @@ const buildPayload = (props: Props) => {
             ophanComponentId: 'ACQUISITIONS_EPIC',
             platformId: 'GUARDIAN_WEB',
             clientName: 'dcr',
-            campaignCode: 'UNUSED', // TODO: remove me
-            abTestName: 'UNUSED', // TODO: remove me
-            abTestVariant: 'UNUSED', // TODO: remove me
             referrerUrl: window.location.origin + window.location.pathname,
         },
         localisation: {

--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -25,20 +25,24 @@ const checkForErrors = (response: any) => {
 
 type OphanAction = 'INSERT' | 'VIEW';
 
-const testName = 'FrontendDotcomRenderingEpic';
-const campaignCode = 'gdnwb_copts_memco_frontend_dotcom_rendering_epic_dcr';
+type TestMeta = {
+    abTestName: string;
+    abTestVariant: string;
+    campaignCode: string;
+    campaignId: string;
+};
 
-const sendOphanEvent = (action: OphanAction): void => {
+const sendOphanEvent = (action: OphanAction, testMeta: TestMeta): void => {
     const componentEvent = {
         component: {
             componentType: 'ACQUISITIONS_EPIC',
             products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
-            campaignCode,
-            id: campaignCode,
+            campaignCode: testMeta.campaignCode,
+            id: testMeta.campaignId,
         },
         abTest: {
-            name: testName,
-            variant: 'dcr',
+            name: testMeta.abTestName,
+            variant: testMeta.abTestVariant,
         },
         action,
     };
@@ -71,9 +75,9 @@ const buildPayload = (props: Props) => {
             ophanComponentId: 'ACQUISITIONS_EPIC',
             platformId: 'GUARDIAN_WEB',
             clientName: 'dcr',
-            campaignCode,
-            abTestName: testName,
-            abTestVariant: 'dcr',
+            campaignCode: 'UNUSED', // TODO: remove me
+            abTestName: 'UNUSED', // TODO: remove me
+            abTestVariant: 'UNUSED', // TODO: remove me
             referrerUrl: window.location.origin + window.location.pathname,
         },
         localisation: {
@@ -100,6 +104,13 @@ const buildPayload = (props: Props) => {
     };
 };
 
+type SlotState = {
+    html: string;
+    css: string;
+    js: string;
+    meta: TestMeta;
+};
+
 const MemoisedInner = ({
     isSignedIn,
     countryCode,
@@ -113,11 +124,7 @@ const MemoisedInner = ({
     contributionsServiceUrl,
 }: Props) => {
     const [data, setData] = useState<{
-        slot?: {
-            html: string;
-            css: string;
-            js: string;
-        };
+        slot?: SlotState;
     }>();
 
     const [hasBeenSeen, setNode] = useHasBeenSeen({
@@ -143,16 +150,18 @@ const MemoisedInner = ({
         getBodyEnd(contributionsPayload, `${contributionsServiceUrl}/epic`)
             .then(checkForErrors)
             .then(response => response.json())
-            .then(json =>
+            .then(json => {
                 setData({
                     slot: {
                         html: json.data.html,
                         css: json.data.css,
                         js: json.data.js,
+                        meta: json.data.meta,
                     },
-                }),
-            )
-            .then(() => sendOphanEvent('INSERT'))
+                });
+
+                sendOphanEvent('INSERT', json.data.meta);
+            })
             .catch(error =>
                 window.guardian.modules.sentry.reportError(
                     error,
@@ -168,11 +177,22 @@ const MemoisedInner = ({
         // because of the way the hook behaves, it'll only ever go from false ->
         // true once.
         if (hasBeenSeen) {
-            // Add a new entry to the view log when we know an Epic is viewed
-            logView(testName);
-            sendOphanEvent('VIEW');
+            const meta = data?.slot?.meta;
+
+            if (meta) {
+                // Add a new entry to the view log when we know an Epic is viewed
+                logView(meta.abTestName);
+                sendOphanEvent('VIEW', meta);
+            }
         }
-    }, [hasBeenSeen]);
+        // At the moment, given the information we currently store in data, it's
+        // fine to add it as a dependency because it won't ever change after
+        // viewing, so we shouldn't ever run the hook multiple times. If we _do_
+        // ever have an implementation where information in data could change
+        // after viewing, we'll need to revising this. Perhaps it's clearer to
+        // remote data from the dependencies and disable the exhaustive-deps
+        // rule, as above.
+    }, [hasBeenSeen, data]);
 
     // Rely on useEffect to run a function that initialises the slot once it's
     // been injected in the DOM.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2079,10 +2079,10 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
-"@guardian/automat-client@^0.2.14":
-  version "0.2.14"
-  resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.14.tgz#eed3a79609d57aeac81be80473f8fc34e76bc88d"
-  integrity sha512-A4K+rH0cag/yvHk8bR5X/anPIZbP8PqUFkV8o1fXS1s4cpe23KWx60XKrc+cZAPdCws6uIjsqWey19bzB/LUwg==
+"@guardian/automat-client@^0.2.15":
+  version "0.2.15"
+  resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.15.tgz#cbcba911da239af92bc5ea54182939defb8d5adf"
+  integrity sha512-tncjoK3M3dLNwxyf0XAECRKE+EBVEpQ/AL3UY6qDV6LQbjks84kNi6d68rHPO5k2RLtZOljEJyNnJxf23Uwftg==
 
 "@guardian/consent-management-platform@^3.0.0":
   version "3.0.0"


### PR DESCRIPTION
## What does this change?

Now that the contributions service provides us all the tracking params we need in the `meta` part of the response, we can use those instead of hardcoding.

## Why?

For the default epic which we're currently serving this should all be identical to the hardcoded values, but going forward once we're selecting tests/variants dynamically this is required.

## Link to supporting Trello card

https://trello.com/c/CNlYq1rK/93-update-platforms-to-use-tracking-metadata-returned-by-epic