### PR TITLE
GuardianLines  Background

### DIFF
--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -3,7 +3,6 @@ import { css, cx } from 'emotion';
 
 import {
     neutral,
-    background,
     brandBorder,
     brandBackground,
     opinion,
@@ -258,7 +257,7 @@ export const CommentLayout = ({ CAPI, NAV }: Props) => {
             )}
 
             <Section
-                backgroundColour={background.primary}
+                backgroundColour={opinion[800]}
                 padded={false}
                 showTopBorder={false}
             >


### PR DESCRIPTION
## What does this change?
Fixes the background colour for GuardianLines on comment articles

### Before
![Screenshot 2020-04-04 at 18 38 58](https://user-images.githubusercontent.com/1336821/78457631-946ade80-76a3-11ea-90c5-a5f33a35f787.jpg)

### After
![Screenshot 2020-04-04 at 18 39 21](https://user-images.githubusercontent.com/1336821/78457634-9df44680-76a3-11ea-8696-4b233c036306.jpg)

## Why?
It was white before and looked wrong

## Link to supporting Trello card
https://trello.com/c/cS5R5AUq/1405-guardianlines-background