### PR TITLE
Update discussion package

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "@emotion/core": "^10.0.5",
         "@guardian/automat-client": "^0.2.14",
         "@guardian/consent-management-platform": "^2.0.10",
-        "@guardian/discussion-rendering": "^0.6.0",
+        "@guardian/discussion-rendering": "^0.8.0",
         "@guardian/src-foundations": "^0.16.1",
         "@sentry/browser": "^5.7.1",
         "@types/ajv": "^1.0.0",

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -52,7 +52,7 @@ export const App = ({ CAPI, NAV }: Props) => {
     const [commentPage, setCommentPage] = useState<number>();
     const [commentPageSize, setCommentPageSize] = useState<25 | 50 | 100>();
     const [commentOrderBy, setCommentOrderBy] = useState<
-        'newest' | 'oldest' | 'mostrecommended'
+        'newest' | 'oldest' | 'recommendations'
     >();
     const [openComments, setOpenComments] = useState<boolean>(false);
 

--- a/src/web/components/CommentsLayout.tsx
+++ b/src/web/components/CommentsLayout.tsx
@@ -24,7 +24,7 @@ type Props = {
     expanded: boolean;
     commentPage?: number;
     commentPageSize?: 25 | 50 | 100;
-    commentOrderBy?: 'newest' | 'oldest' | 'mostrecommended';
+    commentOrderBy?: 'newest' | 'oldest' | 'recommendations';
     commentToScrollTo?: number;
 };
 
@@ -88,10 +88,9 @@ export const CommentsLayout = ({
                 pillar={pillar}
                 initialPage={commentPage}
                 pageSizeOverride={commentPageSize}
-                // TODO: Disabled pending discussion publishing a version supporting this prop
-                // isClosedForComments={
-                //     isClosedForComments || !enableDiscussionSwitch
-                // }
+                isClosedForComments={
+                    isClosedForComments || !enableDiscussionSwitch
+                }
                 orderByOverride={commentOrderBy}
                 shortUrl={shortUrl}
                 additionalHeaders={{

--- a/src/web/lib/getCommentContext.ts
+++ b/src/web/lib/getCommentContext.ts
@@ -27,7 +27,7 @@ type CommentContextType = {
     page: number;
 };
 
-type OrderByType = 'newest' | 'oldest' | 'mostrecommended';
+type OrderByType = 'newest' | 'oldest' | 'recommendations';
 type ThreadsType = 'collapsed' | 'expanded' | 'unthreaded';
 type PageSizeType = 25 | 50 | 100;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2096,13 +2096,11 @@
     js-cookie "^2.2.1"
     whatwg-fetch "^3.0.0"
 
-"@guardian/discussion-rendering@^0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-0.6.0.tgz#09b7254161d7f31fbb150cf9353bb6524062ad33"
-  integrity sha512-Rd6JFORlfqVvXMCoACKrMKUW1pRQeKnhoEMBuwocnraofNhhBLllUdC0JkrsloRSp7aTsWpj8VkGCj1JdMb9iw==
+"@guardian/discussion-rendering@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-0.8.0.tgz#8f0e421126ceefd84c28a84d3d8ab97010f461ca"
+  integrity sha512-xJj4NRBKfa/fn35SjZzbiHE6zdop22CYpertvff1ba6OvLHO5ZQYHio3krgMKssH1YdEDMEkORbMpXA9DdwzPw==
   dependencies:
-    "@guardian/src-link" "^0.15.1"
-    regenerator-runtime "^0.13.3"
     timeago.js "^4.0.2"
 
 "@guardian/src-button@^0.13.0":
@@ -2117,29 +2115,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.13.0.tgz#8bfed9b94e2e4f24ecacb754bbe573b6e0cfe088"
   integrity sha512-8lTZSo49W1lPhBFaaLrg2Eo2jrwUB3VGw6a7ZRI7oBEyTglmlbjFDiciu2Di6WSrzuSWiI+9OJTSSjCP6lTT2A==
 
-"@guardian/src-foundations@^0.15.1":
-  version "0.15.1"
-  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.15.1.tgz#9e621aa2efee0cdb368ebbee129cd2a7d7e5868e"
-  integrity sha512-49Kjd9v6bAy3Xjs9q6/WV+J63bKgUWG5biOScUPE4UKFf3HkNFtafrrvnWf2/1qpDlhGYRFK9tGCh/enagMajA==
-
 "@guardian/src-foundations@^0.16.1":
   version "0.16.1"
   resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.16.1.tgz#d5e52a57012c588d146b05ded7f9fbc4a9af40d5"
   integrity sha512-E6YDqq53gy5CoO8xFPWDBjiYiI0o+4BE1/mFcwkpWGwtpkSnxi21LhkaQ63r+KRxoDB29clc86ChbNHXw9keFA==
-
-"@guardian/src-helpers@^0.15.1":
-  version "0.15.1"
-  resolved "https://registry.yarnpkg.com/@guardian/src-helpers/-/src-helpers-0.15.1.tgz#ec5b75117bb066ef95002bfedaa76a371c4b1b33"
-  integrity sha512-A564LrM0c8SKC5TySb/dUxO+ggKhp5D+yWagQb3r3r/IS8SxWLhKQUzZpgaXNWyNWXrFTX362G7hAwL3SCNE5g==
-  dependencies:
-    "@guardian/src-foundations" "^0.15.1"
-
-"@guardian/src-link@^0.15.1":
-  version "0.15.1"
-  resolved "https://registry.yarnpkg.com/@guardian/src-link/-/src-link-0.15.1.tgz#2b5c196e9c57ac7a920d630ef7c47cacbefa9997"
-  integrity sha512-WZHHoFSd+vx1CU01M5lWAob3lrnNzIoPH00M5cxL5mXvl/3911l2WeiwMGC46MZkmZvHQ+ju3b4khk9nuBDFeA==
-  dependencies:
-    "@guardian/src-helpers" "^0.15.1"
 
 "@guardian/src-svgs@^0.13.0":
   version "0.13.0"
@@ -14256,11 +14235,6 @@ regenerator-runtime@^0.13.2:
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
   integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
-
-regenerator-runtime@^0.13.3:
-  version "0.13.5"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697"
-  integrity sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==
 
 regenerator-transform@^0.14.0:
   version "0.14.1"


### PR DESCRIPTION
## What does this change?
Update `@guardian/discussion-rendering`, changes included in update:
- change `mostrecommended` to `recommendations` for order by filters
- enable `isClosedForComments`
- bugfixes 

## Why?
Get closer to frontend comment parity

## Link to supporting Trello card
https://trello.com/c/hyAVeTOF/1398-bug-comment-box-still-displayed-when-comments-are-closed