### PR TITLE
Use FocusStyleManager to control focus states on Source components

### DIFF
--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -25,6 +25,7 @@ import { getCountryCode } from '@frontend/web/lib/getCountryCode';
 import { getDiscussion } from '@root/src/web/lib/getDiscussion';
 import { getUser } from '@root/src/web/lib/getUser';
 import { getCommentContext } from '@root/src/web/lib/getCommentContext';
+import { FocusStyleManager } from '@guardian/src-foundations/utils';
 
 type Props = { CAPI: CAPIBrowserType; NAV: NavType };
 
@@ -131,6 +132,13 @@ export const App = ({ CAPI, NAV }: Props) => {
             setOpenComments(true);
         }
     }, [hasCommentsHash]);
+
+    // Ensure the focus state of any buttons/inputs in any of the Source
+    // components are only applied when navigating via keyboard.
+    // READ: https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/32e9fb
+    useEffect(() => {
+        // FocusStyleManager.onlyShowFocusOnTabs();
+    }, []);
 
     return (
         // Do you need to Hydrate or do you want a Portal?

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -137,7 +137,7 @@ export const App = ({ CAPI, NAV }: Props) => {
     // components are only applied when navigating via keyboard.
     // READ: https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/32e9fb
     useEffect(() => {
-        // FocusStyleManager.onlyShowFocusOnTabs();
+        FocusStyleManager.onlyShowFocusOnTabs();
     }, []);
 
     return (


### PR DESCRIPTION
## What does this change?
Imports the `FocusStyleManager` util from `@guardian/src-foundations` and calls the `onlyShowFocusOnTabs()` method at the top of the client-side app. There should be no bundle size increase.

## Why?
Because we're making use of Source components and it is recommended that we do this to ensure the focus styles only apply to buttons/inputs when the user is tabbing through the page. By default, we'll see them on mouse clicks as well, but this limits them to keyboard events.

## Context
https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/32e9fb
https://github.com/guardian/source/blob/master/src/core/foundations/src/utils/focus-style-manager.ts

## Screenshots
Before (on click):
![Screenshot 2020-04-06 at 18 12 39](https://user-images.githubusercontent.com/1692169/78586370-3ff66900-7833-11ea-99b3-e9ad4111e5a4.png)

After (on click):
![Screenshot 2020-04-06 at 18 12 13](https://user-images.githubusercontent.com/1692169/78586400-4b499480-7833-11ea-9ed8-cec2fe8f368c.png)
