### PR TITLE
Fire epic view event with 10px or more in viewport

### DIFF
--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -121,7 +121,8 @@ const MemoisedInner = ({
     }>();
 
     const [hasBeenSeen, setNode] = useHasBeenSeen({
-        threshold: 0.5,
+        rootMargin: '-10px',
+        threshold: 0,
     }) as HasBeenSeen;
 
     const slotRoot = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
## What does this change?

This is what Frontend does at the moment, rather than the 50% in view that DCR previously used.

## Why?

Have noticed a discrepancy in our stats for views - DCR is lower even though it has higher insert events which didn't really make any sense.

(First image is when DCR fires off event before this change, second is when Frontend currently does and how DCR should behave.)

<img width="334" alt="Screenshot 2020-04-08 at 14 46 17" src="https://user-images.githubusercontent.com/858402/78792648-4e669100-79a9-11ea-98db-8e7555852cba.png">

and (Frontend): 

<img width="334" alt="Screenshot 2020-04-08 at 14 47 40" src="https://user-images.githubusercontent.com/858402/78792654-51618180-79a9-11ea-85b0-5ad5b14ff9f6.png">

## Link to supporting Trello card

https://trello.com/c/fqvfyIbv/106-investigate-dcr-default-test-tableau-issues