### PR TITLE
Better yarn check

### DIFF
--- a/docs/contributing/detailed-setup-guide.md
+++ b/docs/contributing/detailed-setup-guide.md
@@ -4,7 +4,7 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 <!-- Automatically created with yarn run createtoc and on push hook -->
 
-- [Chat](#chat)
+- [High level diagram](#high-level-diagram)
 - [Developing](#developing)
   - [Setup](#setup)
   - [Start](#start)

--- a/scripts/env/check-yarn.js
+++ b/scripts/env/check-yarn.js
@@ -3,22 +3,21 @@ const exec = promisify(require('child_process').execFile);
 
 const ensure = require('./ensure');
 
-// 1.13.0 was the first version of yarn to support policies
-// https://classic.yarnpkg.com/en/docs/cli/policies/
-const YARN_VERSION = '>=1.13.0';
+// Yarn v1.x support .yarnrc, so we can use a local (check-in) copy of yarn
+const YARN_MIN_VERSION = '1.x';
 
 (async () => {
     try {
-        // This will fail if yarn isn't installed, and force into the catch, where we install yarn
-        // for CI
-        const { stdout: version } = await exec('yarn', ['-v']);
+        // This will fail if yarn isn't installed, and force into the catch,
+        // where we install yarn with NPM (mainly for CI)
+        const { stdout: version } = await exec('yarn', ['--version']);
 
         const [semver] = await ensure('semver');
 
-        if (!semver.satisfies(version, YARN_VERSION)) {
+        if (!semver.satisfies(version, YARN_MIN_VERSION)) {
             const { warn, prompt, log } = require('./log');
             warn(
-                `dotcom-rendering requires Yarn ${YARN_VERSION}`,
+                `dotcom-rendering requires Yarn >=${YARN_MIN_VERSION}`,
                 `You are using v${version}`,
             );
             prompt('Please upgrade yarn');
@@ -26,8 +25,8 @@ const YARN_VERSION = '>=1.13.0';
 
             process.exit(1);
         }
-    } catch {
-        require('./log').log(`Installing yarn@${YARN_VERSION}`);
-        await exec('npm', ['i', '-g', `yarn@${YARN_VERSION}`]);
+    } catch (e) {
+        require('./log').log(`Installing yarn`);
+        await exec('npm', ['i', '-g', `yarn@${YARN_MIN_VERSION}`]);
     }
 })();


### PR DESCRIPTION
## What does this change?

further to breaking yarn check in #1322 and @gtrufitt fixing in #1328, this tidies up yarn checking further:

- `v1.0.0` [introduced support for `yarn-path` in `.yarnrc`](https://github.com/yarnpkg/yarn/releases/tag/v1.0.0) which is all we need, so this now just checks for that version as a minimum
- very early versions of yarn didn't support the `-v` shorthand flag, now uses `--version`
- installs `1.x` if it's not present since that will get latest security updates etc while still using the `yarn-path` version to manage packages

- doesn't update the catch mechanism, because `promisify`d functions no longer return errors but `catch()` if used as a promise or `throw` in `await`s

## Why?
will hopefully break stuff less than it would have
