### PR TITLE
Set viewed threshold to 18px for remote epic

### DIFF
--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -121,7 +121,7 @@ const MemoisedInner = ({
     }>();
 
     const [hasBeenSeen, setNode] = useHasBeenSeen({
-        rootMargin: '-10px',
+        rootMargin: '-18px',
         threshold: 0,
     }) as HasBeenSeen;
 


### PR DESCRIPTION
## What does this change?

Set viewed threshold to 18px into the component (previously 10px).

## Why?

I misread the Frontend value here. It's actually 18:

https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js#L276

## Link to supporting Trello card

n/a
