### PR TITLE
Display double MPU for comment ads slot

### DIFF
--- a/src/model/advertisement.ts
+++ b/src/model/advertisement.ts
@@ -120,15 +120,11 @@ export const namedAdSlotParameters = (name: AdSlotType): AdSlotParameters => {
             name: 'comments',
             adTypes: ['mpu-banner-ad', 'rendered'],
             sizeMapping: {
-                mobile: ['1,1|2,2|300,250|300,274|300,600|fluid'],
-                // Pascal: It's not totally obvious where this sequence should come from the frontend code,
-                // but it should be correct.
+                mobile: ['1,1|2,2|300,600|fluid'],
                 desktop: [
-                    '1,1|2,2|300,250|300,274|620,1|620,350|550,310|fluid|300,600|160,600',
+                    '1,1|2,2|620,1|620,350|550,310|fluid|300,600|160,600',
                 ],
-                phablet: [
-                    '1,1|2,2|300,197|300,250|300,274|620,350|550,310|fluid',
-                ],
+                phablet: ['1,1|2,2|620,350|550,310|fluid'],
             },
             showLabel: true,
             refresh: false,


### PR DESCRIPTION
## What does this change?

Modify the available sizes for the comment ad slot to only display double MPUs 
