### PR TITLE
Use property attribute for opengraph meta tags

### DIFF
--- a/src/web/server/document.test.tsx
+++ b/src/web/server/document.test.tsx
@@ -23,6 +23,33 @@ test('that all the required meta SEO fields exist', () => {
     );
 });
 
+test('that all some of the most important opengraph meta tags exist', () => {
+    const names = [
+        'og:url',
+        'og:description',
+        'og:title',
+        'og:type',
+        'og:image',
+        'article:author',
+    ];
+
+    names.map(name =>
+        expect(result).toEqual(
+            expect.stringContaining(`<meta property="${name}"`),
+        ),
+    );
+});
+
+test('that all some of the most important twitter meta tags exist', () => {
+    const names = ['card', 'image', 'site'];
+
+    names.map(name =>
+        expect(result).toEqual(
+            expect.stringContaining(`<meta name="twitter:${name}"`),
+        ),
+    );
+});
+
 test('that all the required links exist', () => {
     const names = ['amphtml'];
 

--- a/src/web/server/document.test.tsx
+++ b/src/web/server/document.test.tsx
@@ -40,7 +40,7 @@ test('that the most important opengraph meta tags exist', () => {
     );
 });
 
-test('that all some of the most important twitter meta tags exist', () => {
+test('that the most important twitter meta tags exist', () => {
     const names = ['card', 'image', 'site'];
 
     names.map(name =>

--- a/src/web/server/document.test.tsx
+++ b/src/web/server/document.test.tsx
@@ -23,7 +23,7 @@ test('that all the required meta SEO fields exist', () => {
     );
 });
 
-test('that all some of the most important opengraph meta tags exist', () => {
+test('that the most important opengraph meta tags exist', () => {
     const names = [
         'og:url',
         'og:description',

--- a/src/web/server/htmlTemplate.ts
+++ b/src/web/server/htmlTemplate.ts
@@ -84,18 +84,24 @@ export const htmlTemplate = ({
             )}" as="font" crossorigin>`,
     );
 
-    const generateMetaTags = (dataObject: { [key: string]: string }) => {
+    const generateMetaTags = (
+        dataObject: { [key: string]: string },
+        attributeName: 'name' | 'property',
+    ) => {
         if (dataObject) {
             return Object.entries(dataObject)
-                .map(([id, value]) => `<meta name="${id}" content="${value}"/>`)
+                .map(
+                    ([id, value]) =>
+                        `<meta ${attributeName}="${id}" content="${value}"/>`,
+                )
                 .join('\n');
         }
         return '';
     };
 
-    const openGraphMetaTags = generateMetaTags(openGraphData);
+    const openGraphMetaTags = generateMetaTags(openGraphData, 'property');
 
-    const twitterMetaTags = generateMetaTags(twitterData);
+    const twitterMetaTags = generateMetaTags(twitterData, 'name');
 
     return `<!doctype html>
         <html lang="en">


### PR DESCRIPTION
## What does this change?
Uses the `property` attribute in meta tags for opengraph specifically. We believe that is why echobox is using the page title instead of the `og:title` when rendering previews. The facebook opengraph debugger specifically flags that we are not using the property attribute:

![image](https://user-images.githubusercontent.com/8754692/78891287-2f2a3b00-7a5f-11ea-9e34-56cfc2c82ad6.png)

For extra confidence, this will also match the behaviour of frontend - which has never had these problems.

## Why?
Fixes social shares, particularly ones that rely on opengraph - like hangout chat (see trello card), facebook (see screenshot above) or echobox.

## Link to supporting Trello card
https://trello.com/c/lGkJLv2E/730-implement-open-graph-in-dotcom-rendering-correctly
