### PR TITLE
ArticleBody Refactor

### DIFF
--- a/src/web/components/ArticleBody.tsx
+++ b/src/web/components/ArticleBody.tsx
@@ -117,14 +117,26 @@ const linkColour = pillarMap(
 );
 
 export const ArticleBody: React.FC<{
-    CAPI: CAPIType;
-    isShowcase?: boolean;
-    adTargeting?: AdTargeting;
-}> = ({ CAPI, isShowcase, adTargeting }) => {
+    pillar: Pillar;
+    isImmersive: boolean;
+    standfirst: string;
+    blocks: Block[];
+    designType: DesignType;
+    isShowcase: boolean;
+    adTargeting: AdTargeting;
+}> = ({
+    pillar,
+    isImmersive,
+    standfirst,
+    blocks,
+    designType,
+    isShowcase,
+    adTargeting,
+}) => {
     return (
         <div
-            className={cx(bodyStyle, linkColour[CAPI.pillar], {
-                [immersiveBodyStyle]: CAPI.isImmersive,
+            className={cx(bodyStyle, linkColour[pillar], {
+                [immersiveBodyStyle]: isImmersive,
             })}
         >
             {isShowcase && (
@@ -132,16 +144,16 @@ export const ArticleBody: React.FC<{
                 // sits inside here so that the right column advert does not get pushed down
                 <Hide when="below" breakpoint="leftCol">
                     <ArticleStandfirst
-                        designType={CAPI.designType}
-                        pillar={CAPI.pillar}
-                        standfirst={CAPI.standfirst}
+                        designType={designType}
+                        pillar={pillar}
+                        standfirst={standfirst}
                     />
                 </Hide>
             )}
             <ArticleRenderer
-                elements={CAPI.blocks[0] ? CAPI.blocks[0].elements : []}
-                pillar={CAPI.pillar}
-                designType={CAPI.designType}
+                elements={blocks[0] ? blocks[0].elements : []}
+                pillar={pillar}
+                designType={designType}
                 adTargeting={adTargeting}
             />
         </div>

--- a/src/web/components/ArticleBody.tsx
+++ b/src/web/components/ArticleBody.tsx
@@ -6,16 +6,12 @@ import { textSans, headline } from '@guardian/src-foundations/typography';
 import { from, between } from '@guardian/src-foundations/mq';
 import { pillarMap, pillarPalette } from '@root/src/lib/pillars';
 import { ArticleRenderer } from '@root/src/web/lib/ArticleRenderer';
-import { ArticleStandfirst } from '@root/src/web/components/ArticleStandfirst';
-import { Hide } from '@root/src/web/components/Hide';
 
 type Props = {
     pillar: Pillar;
     isImmersive: boolean;
-    standfirst: string;
     blocks: Block[];
     designType: DesignType;
-    isShowcase: boolean;
     adTargeting: AdTargeting;
 };
 
@@ -129,10 +125,8 @@ const linkColour = pillarMap(
 export const ArticleBody = ({
     pillar,
     isImmersive,
-    standfirst,
     blocks,
     designType,
-    isShowcase,
     adTargeting,
 }: Props) => {
     return (
@@ -141,17 +135,6 @@ export const ArticleBody = ({
                 [immersiveBodyStyle]: isImmersive,
             })}
         >
-            {isShowcase && (
-                // For articles with main media set as showcase, the standfirst sometimes
-                // sits inside here so that the right column advert does not get pushed down
-                <Hide when="below" breakpoint="leftCol">
-                    <ArticleStandfirst
-                        designType={designType}
-                        pillar={pillar}
-                        standfirst={standfirst}
-                    />
-                </Hide>
-            )}
             <ArticleRenderer
                 elements={blocks[0] ? blocks[0].elements : []}
                 pillar={pillar}

--- a/src/web/components/ArticleBody.tsx
+++ b/src/web/components/ArticleBody.tsx
@@ -9,6 +9,16 @@ import { ArticleRenderer } from '@root/src/web/lib/ArticleRenderer';
 import { ArticleStandfirst } from '@root/src/web/components/ArticleStandfirst';
 import { Hide } from '@root/src/web/components/Hide';
 
+type Props = {
+    pillar: Pillar;
+    isImmersive: boolean;
+    standfirst: string;
+    blocks: Block[];
+    designType: DesignType;
+    isShowcase: boolean;
+    adTargeting: AdTargeting;
+};
+
 const pillarColours = pillarMap(
     pillar =>
         css`
@@ -116,15 +126,7 @@ const linkColour = pillarMap(
     `,
 );
 
-export const ArticleBody: React.FC<{
-    pillar: Pillar;
-    isImmersive: boolean;
-    standfirst: string;
-    blocks: Block[];
-    designType: DesignType;
-    isShowcase: boolean;
-    adTargeting: AdTargeting;
-}> = ({
+export const ArticleBody = ({
     pillar,
     isImmersive,
     standfirst,
@@ -132,7 +134,7 @@ export const ArticleBody: React.FC<{
     designType,
     isShowcase,
     adTargeting,
-}) => {
+}: Props) => {
     return (
         <div
             className={cx(bodyStyle, linkColour[pillar], {

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -364,7 +364,15 @@ export const CommentLayout = ({ CAPI, NAV }: Props) => {
                     <GridItem area="body">
                         <ArticleContainer>
                             <main className={maxWidth}>
-                                <ArticleBody CAPI={CAPI} />
+                                <ArticleBody
+                                    pillar={CAPI.pillar}
+                                    blocks={CAPI.blocks}
+                                    isImmersive={CAPI.isImmersive}
+                                    standfirst={CAPI.standfirst}
+                                    designType={CAPI.designType}
+                                    isShowcase={false}
+                                    adTargeting={adTargeting}
+                                />
                                 {showBodyEndSlot && <div id="slot-body-end" />}
                                 <GuardianLines pillar={CAPI.pillar} />
                                 <SubMeta

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -368,9 +368,7 @@ export const CommentLayout = ({ CAPI, NAV }: Props) => {
                                     pillar={CAPI.pillar}
                                     blocks={CAPI.blocks}
                                     isImmersive={CAPI.isImmersive}
-                                    standfirst={CAPI.standfirst}
                                     designType={CAPI.designType}
-                                    isShowcase={false}
                                     adTargeting={adTargeting}
                                 />
                                 {showBodyEndSlot && <div id="slot-body-end" />}

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -414,7 +414,15 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                     <GridItem area="body">
                         <ArticleContainer>
                             <main className={maxWidth}>
-                                <ArticleBody CAPI={CAPI} />
+                                <ArticleBody
+                                    pillar={CAPI.pillar}
+                                    blocks={CAPI.blocks}
+                                    isImmersive={CAPI.isImmersive}
+                                    standfirst={CAPI.standfirst}
+                                    designType={CAPI.designType}
+                                    isShowcase={true}
+                                    adTargeting={adTargeting}
+                                />
                                 {showBodyEndSlot && <div id="slot-body-end" />}
                                 <GuardianLines pillar={CAPI.pillar} />
                                 <SubMeta

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -418,9 +418,7 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                                     pillar={CAPI.pillar}
                                     blocks={CAPI.blocks}
                                     isImmersive={CAPI.isImmersive}
-                                    standfirst={CAPI.standfirst}
                                     designType={CAPI.designType}
-                                    isShowcase={true}
                                     adTargeting={adTargeting}
                                 />
                                 {showBodyEndSlot && <div id="slot-body-end" />}

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -397,7 +397,6 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                                     designType={CAPI.designType}
                                     isShowcase={false}
                                     adTargeting={adTargeting}
-                                    ß={true}
                                 />
                                 {showBodyEndSlot && <div id="slot-body-end" />}
                                 <GuardianLines pillar={CAPI.pillar} />

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -389,7 +389,16 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                     <GridItem area="body">
                         <ArticleContainer>
                             <main className={articleWidth}>
-                                <ArticleBody CAPI={CAPI} />
+                                <ArticleBody
+                                    pillar={CAPI.pillar}
+                                    blocks={CAPI.blocks}
+                                    isImmersive={CAPI.isImmersive}
+                                    standfirst={CAPI.standfirst}
+                                    designType={CAPI.designType}
+                                    isShowcase={false}
+                                    adTargeting={adTargeting}
+                                    ß={true}
+                                />
                                 {showBodyEndSlot && <div id="slot-body-end" />}
                                 <GuardianLines pillar={CAPI.pillar} />
                                 <SubMeta

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -393,9 +393,7 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                                     pillar={CAPI.pillar}
                                     blocks={CAPI.blocks}
                                     isImmersive={CAPI.isImmersive}
-                                    standfirst={CAPI.standfirst}
                                     designType={CAPI.designType}
-                                    isShowcase={false}
                                     adTargeting={adTargeting}
                                 />
                                 {showBodyEndSlot && <div id="slot-body-end" />}


### PR DESCRIPTION
## What does this change?
Makes the props for `ArticleBody` explicit, instead of passing in the whole`CAPI` object

## Why?
Ro make it clear what props are required by this component and so that the layout file is the only place where CAPI is destrutured, making it easy to see what goes where

## Link to supporting Trello card
https://trello.com/c/oXy53OQ5/1433-refactor-articlebody