### PR TITLE
Fix Showcase Layout

### DIFF
--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -93,11 +93,11 @@ const ShowcaseGrid = ({
                         1fr /* Main content */
                         300px; /* Right Column */
                     grid-template-areas:
-                        'title  border  headline    right-column'
-                        '.      border  standfirst  right-column'
-                        'lines  border  media       right-column'
-                        'meta   border  media       right-column'
-                        'meta   border  body        right-column'
+                        'title  border  headline    headline'
+                        'lines  border  media       media'
+                        'meta   border  media       media'
+                        'meta   border  standfirst  right-column'
+                        '.      border  body        right-column'
                         '.      border  .           right-column';
                 }
 


### PR DESCRIPTION
## What does this change?
Break out into showcase earlier, after leftCol, not wide.

The previous breakpoint that the main media element broke out into showcase was `wide` but on frontend this is `leftCol` so this PR aligns these properly

### Before
![2020-04-11 11 22 02](https://user-images.githubusercontent.com/1336821/79041310-b655eb00-7be6-11ea-88d2-87b0b3bec760.gif)


### After
![2020-04-11 11 19 27](https://user-images.githubusercontent.com/1336821/79041273-65de8d80-7be6-11ea-99c8-3db8ab57cd4a.gif)


## Why?
For parity

## Link to supporting Trello card
https://trello.com/c/b04p3ubp/1444-fix-showcase-layout