### PR TITLE
GuardianView is the same as Comment

### DIFF
--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -182,7 +182,6 @@ const renderHeadline = ({
         case 'SpecialReport':
         case 'Recipe':
         case 'MatchReport':
-        case 'GuardianView':
         case 'GuardianLabs':
         case 'Quiz':
         case 'AdvertisementFeature':
@@ -201,6 +200,7 @@ const renderHeadline = ({
                 </h1>
             );
 
+        case 'GuardianView':
         case 'Comment':
             return (
                 <>

--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -125,6 +125,7 @@ const shouldShowContributor = (
 
     switch (designType) {
         case 'Comment':
+        case 'GuardianView':
             return false;
         case 'Feature':
         case 'Review':
@@ -136,7 +137,6 @@ const shouldShowContributor = (
         case 'SpecialReport':
         case 'Recipe':
         case 'MatchReport':
-        case 'GuardianView':
         case 'GuardianLabs':
         case 'Quiz':
         case 'AdvertisementFeature':

--- a/src/web/components/Card/components/CardLink.tsx
+++ b/src/web/components/Card/components/CardLink.tsx
@@ -37,6 +37,7 @@ const linkStyles = (designType: DesignType, pillar: Pillar) => {
     `;
 
     switch (designType) {
+        case 'GuardianView':
         case 'Comment':
             return css`
                 ${baseLinkStyles}
@@ -72,7 +73,6 @@ const linkStyles = (designType: DesignType, pillar: Pillar) => {
         case 'SpecialReport':
         case 'Recipe':
         case 'MatchReport':
-        case 'GuardianView':
         case 'GuardianLabs':
         case 'Quiz':
         case 'AdvertisementFeature':

--- a/src/web/components/DropCap.tsx
+++ b/src/web/components/DropCap.tsx
@@ -22,6 +22,7 @@ const outerStyles = (pillar: Pillar, designType: DesignType) => {
     `;
 
     switch (designType) {
+        case 'GuardianView':
         case 'Comment':
             return css`
                 ${baseStyles};
@@ -37,7 +38,6 @@ const outerStyles = (pillar: Pillar, designType: DesignType) => {
         case 'SpecialReport':
         case 'Recipe':
         case 'MatchReport':
-        case 'GuardianView':
         case 'GuardianLabs':
         case 'Quiz':
         case 'AdvertisementFeature':
@@ -60,6 +60,7 @@ const innerStyles = (designType: DesignType) => {
     `;
 
     switch (designType) {
+        case 'GuardianView':
         case 'Comment':
             return css`
                 ${baseStyles};
@@ -75,7 +76,6 @@ const innerStyles = (designType: DesignType) => {
         case 'SpecialReport':
         case 'Recipe':
         case 'MatchReport':
-        case 'GuardianView':
         case 'GuardianLabs':
         case 'Quiz':
         case 'AdvertisementFeature':

--- a/src/web/components/HeadlineByline.tsx
+++ b/src/web/components/HeadlineByline.tsx
@@ -52,7 +52,7 @@ const opinionStyles = (pillar: Pillar) => css`
 `;
 
 type Props = {
-    designType: 'Interview' | 'Comment';
+    designType: DesignType;
     pillar: Pillar;
     byline: string;
     tags: TagType[];
@@ -68,12 +68,27 @@ export const HeadlineByline = ({ designType, pillar, byline, tags }: Props) => {
                     </div>
                 </div>
             );
+        case 'GuardianView':
         case 'Comment':
             return (
                 <div className={opinionStyles(pillar)}>
                     <BylineLink byline={byline} tags={tags} />
                 </div>
             );
+
+        case 'Analysis':
+        case 'Feature':
+        case 'Article':
+        case 'Media':
+        case 'Review':
+        case 'Live':
+        case 'SpecialReport':
+        case 'Recipe':
+        case 'MatchReport':
+        case 'GuardianLabs':
+        case 'Quiz':
+        case 'AdvertisementFeature':
+        case 'Immersive':
         default:
             return null;
     }

--- a/src/web/components/elements/PullQuoteComponent.tsx
+++ b/src/web/components/elements/PullQuoteComponent.tsx
@@ -15,6 +15,7 @@ const gsSpan = (nColumns: number) => nColumns * 60 + gutter * (nColumns - 1);
 
 const commonStyles = (pillar: Pillar, designType: DesignType) => {
     switch (designType) {
+        case 'GuardianView':
         case 'Comment':
             return css`
                 ${headline.xxsmall({ fontWeight: 'light' })};

--- a/src/web/layouts/DecideLayout.tsx
+++ b/src/web/layouts/DecideLayout.tsx
@@ -10,7 +10,7 @@ type Props = {
     NAV: NavType;
 };
 
-export const DecideLayout = ({CAPI, NAV }: Props) => {
+export const DecideLayout = ({ CAPI, NAV }: Props) => {
     if (CAPI.pageType.hasShowcaseMainElement) {
         return <ShowcaseLayout CAPI={CAPI} NAV={NAV} />;
     }
@@ -21,6 +21,7 @@ export const DecideLayout = ({CAPI, NAV }: Props) => {
     );
 
     designTypeContent.Comment = <CommentLayout CAPI={CAPI} NAV={NAV} />;
+    designTypeContent.GuardianView = <CommentLayout CAPI={CAPI} NAV={NAV} />;
 
     return designTypeContent[CAPI.designType];
 };


### PR DESCRIPTION
## What does this change?
Treat `GuardianView` pieces the same as `Comment`

## Why?
Because it turns out they are

## Link to supporting Trello card
https://trello.com/c/qTwTHEOe/1359-guardian-editorial-pieces-should-take-on-the-opinion-styling