### PR TITLE
ArticleTitle Direction

### DIFF
--- a/src/web/components/ArticleTitle.tsx
+++ b/src/web/components/ArticleTitle.tsx
@@ -64,6 +64,7 @@ export const ArticleTitle = ({
                 guardianBaseURL={guardianBaseURL}
                 pillar={pillar}
                 fallbackToSection={true}
+                badge={badge}
             />
         </div>
     </div>

--- a/src/web/components/ArticleTitle.tsx
+++ b/src/web/components/ArticleTitle.tsx
@@ -20,7 +20,6 @@ type Props = {
     sectionUrl: string;
     guardianBaseURL: string;
     pillar: Pillar;
-    inLeftCol?: boolean;
     fallbackToSection?: boolean;
     badge?: BadgeType;
 };
@@ -50,11 +49,10 @@ export const ArticleTitle = ({
     sectionUrl,
     guardianBaseURL,
     pillar,
-    inLeftCol,
     fallbackToSection = true,
     badge,
 }: Props) => (
-    <div className={cx(inLeftCol && sectionStyles, badge && badgeContainer)}>
+    <div className={cx(sectionStyles, badge && badgeContainer)}>
         {badge && (
             <div className={titleBadgeWrapper}>
                 <Badge imageUrl={badge.imageUrl} seriesTag={badge.seriesTag} />

--- a/src/web/components/ArticleTitle.tsx
+++ b/src/web/components/ArticleTitle.tsx
@@ -63,7 +63,6 @@ export const ArticleTitle = ({
                 sectionUrl={sectionUrl}
                 guardianBaseURL={guardianBaseURL}
                 pillar={pillar}
-                fallbackToSection={true}
                 badge={badge}
             />
         </div>

--- a/src/web/components/ArticleTitle.tsx
+++ b/src/web/components/ArticleTitle.tsx
@@ -20,7 +20,6 @@ type Props = {
     sectionUrl: string;
     guardianBaseURL: string;
     pillar: Pillar;
-    fallbackToSection?: boolean;
     badge?: BadgeType;
 };
 
@@ -49,7 +48,6 @@ export const ArticleTitle = ({
     sectionUrl,
     guardianBaseURL,
     pillar,
-    fallbackToSection = true,
     badge,
 }: Props) => (
     <div className={cx(sectionStyles, badge && badgeContainer)}>
@@ -65,7 +63,7 @@ export const ArticleTitle = ({
                 sectionUrl={sectionUrl}
                 guardianBaseURL={guardianBaseURL}
                 pillar={pillar}
-                fallbackToSection={fallbackToSection}
+                fallbackToSection={true}
             />
         </div>
     </div>

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -84,17 +84,8 @@ export const SeriesSectionLink: React.FC<{
     sectionUrl: string;
     guardianBaseURL: string;
     pillar: Pillar;
-    fallbackToSection?: boolean;
     badge?: BadgeType;
-}> = ({
-    tags,
-    sectionLabel,
-    sectionUrl,
-    guardianBaseURL,
-    pillar,
-    fallbackToSection,
-    badge,
-}) => {
+}> = ({ tags, sectionLabel, sectionUrl, guardianBaseURL, pillar, badge }) => {
     const blogTag = tags.find(tag => tag.type === 'Blog');
     const seriesTag = tags.find(tag => tag.type === 'Series');
     const publicationTag = tags.find(tag => tag.type === 'Publication');
@@ -134,19 +125,15 @@ export const SeriesSectionLink: React.FC<{
         ) : null;
     }
 
-    if (fallbackToSection) {
-        return (
-            <TagLink
-                pillar={pillar}
-                guardianBaseURL={guardianBaseURL}
-                tagTitle={sectionLabel}
-                tagUrl={sectionUrl}
-                dataComponentName="Section"
-                dataLinkName="article section"
-                weightingClass={primaryStyle}
-            />
-        );
-    }
-
-    return null;
+    return (
+        <TagLink
+            pillar={pillar}
+            guardianBaseURL={guardianBaseURL}
+            tagTitle={sectionLabel}
+            tagUrl={sectionUrl}
+            dataComponentName="Section"
+            dataLinkName="article section"
+            weightingClass={primaryStyle}
+        />
+    );
 };

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { css, cx } from 'emotion';
+
 import { pillarMap, pillarPalette } from '@root/src/lib/pillars';
 import { headline } from '@guardian/src-foundations/typography';
-import { from } from '@guardian/src-foundations/mq';
+import { from, until } from '@guardian/src-foundations/mq';
+import { space } from '@guardian/src-foundations';
 
 import { Hide } from '@frontend/web/components/Hide';
 
@@ -10,6 +12,14 @@ const sectionLabelLink = css`
     text-decoration: none;
     :hover {
         text-decoration: underline;
+    }
+`;
+
+const rowBelowLeftCol = css`
+    display: flex;
+    flex-direction: column;
+    ${until.leftCol} {
+        flex-direction: row;
     }
 `;
 
@@ -26,6 +36,8 @@ const primaryStyle = css`
     ${from.leftCol} {
         ${headline.xxsmall({ fontWeight: 'bold' })};
     }
+
+    padding-right: ${space[2]}px;
 `;
 
 const secondaryStyle = css`
@@ -73,6 +85,7 @@ export const SeriesSectionLink: React.FC<{
     guardianBaseURL: string;
     pillar: Pillar;
     fallbackToSection?: boolean;
+    badge?: BadgeType;
 }> = ({
     tags,
     sectionLabel,
@@ -80,6 +93,7 @@ export const SeriesSectionLink: React.FC<{
     guardianBaseURL,
     pillar,
     fallbackToSection,
+    badge,
 }) => {
     const blogTag = tags.find(tag => tag.type === 'Blog');
     const seriesTag = tags.find(tag => tag.type === 'Series');
@@ -94,7 +108,7 @@ export const SeriesSectionLink: React.FC<{
         const tag = blogTag || seriesTag || publicationTag;
 
         return tag ? (
-            <>
+            <div className={cx(!badge && rowBelowLeftCol)}>
                 <TagLink
                     pillar={pillar}
                     guardianBaseURL={guardianBaseURL}

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -4,6 +4,8 @@ import { pillarMap, pillarPalette } from '@root/src/lib/pillars';
 import { headline } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 
+import { Hide } from '@frontend/web/components/Hide';
+
 const sectionLabelLink = css`
     text-decoration: none;
     :hover {
@@ -102,16 +104,19 @@ export const SeriesSectionLink: React.FC<{
                     dataLinkName="article series"
                     weightingClass={primaryStyle}
                 />
-                <TagLink
-                    pillar={pillar}
-                    guardianBaseURL={guardianBaseURL}
-                    tagTitle={sectionLabel}
-                    tagUrl={sectionUrl}
-                    dataComponentName="section"
-                    dataLinkName="article section"
-                    weightingClass={secondaryStyle}
-                />
-            </>
+
+                <Hide when="below" breakpoint="tablet">
+                    <TagLink
+                        pillar={pillar}
+                        guardianBaseURL={guardianBaseURL}
+                        tagTitle={sectionLabel}
+                        tagUrl={sectionUrl}
+                        dataComponentName="section"
+                        dataLinkName="article section"
+                        weightingClass={secondaryStyle}
+                    />
+                </Hide>
+            </div>
         ) : null;
     }
 

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -86,6 +86,7 @@ export const SeriesSectionLink: React.FC<{
     pillar: Pillar;
     badge?: BadgeType;
 }> = ({ tags, sectionLabel, sectionUrl, guardianBaseURL, pillar, badge }) => {
+    // If we have a tag, use it to show 2 section titles
     const blogTag = tags.find(tag => tag.type === 'Blog');
     const seriesTag = tags.find(tag => tag.type === 'Series');
     const publicationTag = tags.find(tag => tag.type === 'Publication');
@@ -99,6 +100,7 @@ export const SeriesSectionLink: React.FC<{
         const tag = blogTag || seriesTag || publicationTag;
 
         return tag ? (
+            // Sometimes the tags/titles are shown inline, sometimes stacked
             <div className={cx(!badge && rowBelowLeftCol)}>
                 <TagLink
                     pillar={pillar}
@@ -125,6 +127,7 @@ export const SeriesSectionLink: React.FC<{
         ) : null;
     }
 
+    // Otherwise, there was no tag so just show 1 title
     return (
         <TagLink
             pillar={pillar}

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -134,7 +134,7 @@ export const SeriesSectionLink: React.FC<{
         ) : null;
     }
 
-    if (fallbackToSection && (sectionLabel && sectionUrl)) {
+    if (fallbackToSection) {
         return (
             <TagLink
                 pillar={pillar}

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -274,7 +274,6 @@ export const CommentLayout = ({ CAPI, NAV }: Props) => {
                             guardianBaseURL={CAPI.guardianBaseURL}
                             pillar={CAPI.pillar}
                             badge={CAPI.badge}
-                            inLeftCol={true}
                         />
                     </GridItem>
                     <GridItem area="border">

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -336,7 +336,6 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                             guardianBaseURL={CAPI.guardianBaseURL}
                             pillar={CAPI.pillar}
                             badge={CAPI.badge}
-                            inLeftCol={true}
                         />
                     </GridItem>
                     <GridItem area="border">

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -309,7 +309,6 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                             guardianBaseURL={CAPI.guardianBaseURL}
                             pillar={CAPI.pillar}
                             badge={CAPI.badge}
-                            inLeftCol={true}
                         />
                     </GridItem>
                     <GridItem area="border">


### PR DESCRIPTION
## What does this change?
This adds the logic to inline the article titles below `leftCol`

Note. Inlining always occurs on frontend at this breakpoint but here we add the design decision to _not_ inline the items when a badge is showing on DCR because with the height of the badge present, there's no need and we may as well keep the text stacked

@HarryFischer Just a heads up that we're doing this ☝️ shout if we missed something or you'd rather we didn't, happy to change this to keep parity if that's the design call.

### Before (with badge)
![Screenshot 2020-04-12 at 12 50 56](https://user-images.githubusercontent.com/1336821/79068160-bde7c380-7cbc-11ea-88c2-6a89abde5cd9.jpg)

### After (with badge)
![Screenshot 2020-04-12 at 12 50 23](https://user-images.githubusercontent.com/1336821/79068159-bd4f2d00-7cbc-11ea-8ca6-fc5028c9c70e.jpg)

### Before (without badge)
![Screenshot 2020-04-12 at 12 51 08](https://user-images.githubusercontent.com/1336821/79068161-be805a00-7cbc-11ea-8940-8b0e808556c8.jpg)

### After (without badge)
![Screenshot 2020-04-12 at 12 49 59](https://user-images.githubusercontent.com/1336821/79068157-bcb69680-7cbc-11ea-9336-7d999b1c5064.jpg)


## Why?
Because at smaller screen widths we want to reduce the amount that we push content down

## Link to supporting Trello card
https://trello.com/c/TKNUhPZP/1113-section-headers-are-inline-below-wide
