### PR TITLE
Adjust spacing for immersive headlines

### DIFF
--- a/src/web/components/ArticleHeadline.stories.tsx
+++ b/src/web/components/ArticleHeadline.stories.tsx
@@ -385,7 +385,7 @@ export const Live = () => (
 );
 Live.story = { name: 'Live' };
 
-export const Immersive = () => (
+export const LongImmersive = () => (
     <>
         <MainMedia
             hideCaption={true}
@@ -421,4 +421,42 @@ export const Immersive = () => (
         </Section>
     </>
 );
-Immersive.story = { name: 'Immersive' };
+LongImmersive.story = { name: 'Immersive with a long headline' };
+
+export const ShortImmersive = () => (
+    <>
+        <MainMedia
+            hideCaption={true}
+            elements={mainMediaElements}
+            pillar="news"
+        />
+        <Section
+            showTopBorder={false}
+            showSideBorders={false}
+            padded={false}
+            shouldCenter={false}
+        >
+            <Flex>
+                <LeftColumn showRightBorder={false}>
+                    <></>
+                </LeftColumn>
+                <ArticleContainer>
+                    <div
+                        className={css`
+                            margin-top: -100px;
+                        `}
+                    >
+                        <ArticleHeadline
+                            headlineString="Ken Loach – all his films ranked!"
+                            designType="Immersive"
+                            pillar="culture"
+                            webPublicationDate=""
+                            tags={[]}
+                        />
+                    </div>
+                </ArticleContainer>
+            </Flex>
+        </Section>
+    </>
+);
+ShortImmersive.story = { name: 'Immersive with a short headline' };

--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -6,8 +6,10 @@ import { getAgeWarning } from '@root/src/lib/age-warning';
 import { AgeWarning } from '@root/src/web/components/AgeWarning';
 import { HeadlineTag } from '@root/src/web/components/HeadlineTag';
 import { HeadlineByline } from '@root/src/web/components/HeadlineByline';
+
 import { headline } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
+import { space } from '@guardian/src-foundations';
 
 type Props = {
     headlineString: string;
@@ -110,11 +112,17 @@ const invertedStyles = css`
     position: relative;
     color: white;
     white-space: pre-wrap;
-    padding-bottom: 5px;
-    padding-right: 5px;
+    padding-bottom: ${space[1]}px;
+    padding-right: ${space[1]}px;
     box-shadow: -6px 0 0 black;
     /* Box decoration is required to push the box shadow out on Firefox */
     box-decoration-break: clone;
+`;
+
+const immersiveStyles = css`
+    min-height: 112px;
+    padding-bottom: ${space[9]}px;
+    padding-left: ${space[3]}px;
 `;
 
 const blackBackground = css`
@@ -261,6 +269,7 @@ const renderHeadline = ({
                             jumboFont,
                             maxWidth,
                             invertedStyles,
+                            immersiveStyles,
                             displayBlock,
                         )}
                     >


### PR DESCRIPTION
## What does this change?
Fixes spacing for an immersive headline

### Before
![Screenshot 2020-04-13 at 10 35 58](https://user-images.githubusercontent.com/1336821/79110592-b682f180-7d72-11ea-9986-9d56f6327109.jpg)

### After
![Screenshot 2020-04-13 at 10 34 31](https://user-images.githubusercontent.com/1336821/79110602-ba167880-7d72-11ea-835b-d2d41618aee4.jpg)

## Why?
Because we want to handle shorter headlines better

## Link to supporting Trello card
https://trello.com/c/KZ7TdHwq/1439-immersive-headline-styles