### PR TITLE
Refactor DecideLayout

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,33 @@ type RealPillars = 'news' | 'opinion' | 'sport' | 'culture' | 'lifestyle';
 type FakePillars = 'labs';
 type Pillar = RealPillars | FakePillars;
 
+type Display = 'standard' | 'immersive' | 'showcase';
+
+// https://github.com/guardian/content-api-scala-client/blob/master/client/src/main/scala/com.gu.contentapi.client/utils/DesignType.scala
+type DesignType =
+    | 'Article'
+    | 'Immersive'
+    | 'Media'
+    | 'Review'
+    | 'Analysis'
+    | 'Comment'
+    | 'Feature'
+    | 'Live'
+    | 'SpecialReport'
+    | 'Recipe'
+    | 'MatchReport'
+    | 'Interview'
+    | 'GuardianView'
+    | 'GuardianLabs'
+    | 'Quiz'
+    | 'AdvertisementFeature';
+
+// This is an object that allows you Type defaults of the designTypes.
+// The return type looks like: { Feature: any, Live: any, ...}
+// and can be used to add TypeSafety when needing to override a style in a designType
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type DesignTypesObj = { [key in DesignType]: any };
+
 type Edition = 'UK' | 'US' | 'INT' | 'AU';
 
 type SharePlatform =
@@ -509,31 +536,6 @@ interface GADataType {
     edition: Edition;
     beaconUrl: string;
 }
-
-// https://github.com/guardian/content-api-scala-client/blob/master/client/src/main/scala/com.gu.contentapi.client/utils/DesignType.scala
-type DesignType =
-    | 'Article'
-    | 'Immersive'
-    | 'Media'
-    | 'Review'
-    | 'Analysis'
-    | 'Comment'
-    | 'Feature'
-    | 'Live'
-    | 'SpecialReport'
-    | 'Recipe'
-    | 'MatchReport'
-    | 'Interview'
-    | 'GuardianView'
-    | 'GuardianLabs'
-    | 'Quiz'
-    | 'AdvertisementFeature';
-
-// This is an object that allows you Type defaults of the designTypes.
-// The return type looks like: { Feature: any, Live: any, ...}
-// and can be used to add TypeSafety when needing to override a style in a designType
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type DesignTypesObj = { [key in DesignType]: any };
 
 // ----------------- //
 // General DataTypes //

--- a/src/web/layouts/DecideLayout.tsx
+++ b/src/web/layouts/DecideLayout.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { designTypeDefault } from '@root/src/lib/designTypes';
 
 import { StandardLayout } from './StandardLayout';
 import { ShowcaseLayout } from './ShowcaseLayout';
@@ -10,17 +9,85 @@ type Props = {
     NAV: NavType;
 };
 
-export const DecideLayout = ({CAPI, NAV }: Props) => {
-    if (CAPI.pageType.hasShowcaseMainElement) {
-        return <ShowcaseLayout CAPI={CAPI} NAV={NAV} />;
+const decideDisplay = (CAPI: CAPIType): Display => {
+    if (CAPI.isImmersive) return 'immersive';
+    if (CAPI.pageType.hasShowcaseMainElement) return 'showcase';
+    return 'standard';
+};
+
+export const DecideLayout = ({ CAPI, NAV }: Props) => {
+    const display: Display = decideDisplay(CAPI);
+    const { designType } = CAPI;
+
+    switch (display) {
+        case 'immersive': {
+            switch (designType) {
+                case 'Comment':
+                case 'GuardianView':
+                    return <CommentLayout CAPI={CAPI} NAV={NAV} />;
+                case 'Feature':
+                case 'Review':
+                case 'Interview':
+                case 'Live':
+                case 'Media':
+                case 'Analysis':
+                case 'Article':
+                case 'SpecialReport':
+                case 'Recipe':
+                case 'MatchReport':
+                case 'GuardianLabs':
+                case 'Quiz':
+                case 'AdvertisementFeature':
+                case 'Immersive':
+                    return <StandardLayout CAPI={CAPI} NAV={NAV} />;
+            }
+            break;
+        }
+        case 'showcase': {
+            switch (designType) {
+                case 'Comment':
+                case 'GuardianView':
+                    return <CommentLayout CAPI={CAPI} NAV={NAV} />;
+                case 'Feature':
+                case 'Review':
+                case 'Interview':
+                case 'Live':
+                case 'Media':
+                case 'Analysis':
+                case 'Article':
+                case 'SpecialReport':
+                case 'Recipe':
+                case 'MatchReport':
+                case 'GuardianLabs':
+                case 'Quiz':
+                case 'AdvertisementFeature':
+                case 'Immersive':
+                    return <ShowcaseLayout CAPI={CAPI} NAV={NAV} />;
+            }
+            break;
+        }
+        case 'standard': {
+            switch (designType) {
+                case 'Comment':
+                case 'GuardianView':
+                    return <CommentLayout CAPI={CAPI} NAV={NAV} />;
+                case 'Feature':
+                case 'Review':
+                case 'Interview':
+                case 'Live':
+                case 'Media':
+                case 'Analysis':
+                case 'Article':
+                case 'SpecialReport':
+                case 'Recipe':
+                case 'MatchReport':
+                case 'GuardianLabs':
+                case 'Quiz':
+                case 'AdvertisementFeature':
+                case 'Immersive':
+                    return <StandardLayout CAPI={CAPI} NAV={NAV} />;
+            }
+            break;
+        }
     }
-
-    // Otherwise, switch based on designType
-    const designTypeContent: DesignTypesObj = designTypeDefault(
-        <StandardLayout CAPI={CAPI} NAV={NAV} />,
-    );
-
-    designTypeContent.Comment = <CommentLayout CAPI={CAPI} NAV={NAV} />;
-
-    return designTypeContent[CAPI.designType];
 };

--- a/src/web/layouts/DecideLayout.tsx
+++ b/src/web/layouts/DecideLayout.tsx
@@ -39,7 +39,7 @@ export const DecideLayout = ({ CAPI, NAV }: Props) => {
                 case 'Quiz':
                 case 'AdvertisementFeature':
                 case 'Immersive':
-                    return <StandardLayout CAPI={CAPI} NAV={NAV} />;
+                    return <ShowcaseLayout CAPI={CAPI} NAV={NAV} />;
             }
             break;
         }


### PR DESCRIPTION
## What does this change?
Refactors `DecideLayout` to handle both `designType` and the new `display` type

```typescript
type Display = 'standard' | 'immersive' | 'showcase';
```

## Why?
Having a switch statement here allows us to be very explicit and will also scale well when we want to start branching for immersive layouts, showcase comment layouts, immersive comment pieces, etc.

## Next steps
To remove `designType: Immersive` replacing it with `display: immersive`, adapting the various switch statements in the code.

## Link to supporting Trello card
https://trello.com/c/cIDwM4es/1436-format