### PR TITLE
Immersive images

### DIFF
--- a/src/web/components/Caption.tsx
+++ b/src/web/components/Caption.tsx
@@ -81,7 +81,8 @@ export const Caption: React.FC<{
     };
 
     const shouldLimitWidth =
-        !isMainMedia && (role === 'showcase' || role === 'supporting');
+        !isMainMedia &&
+        (role === 'showcase' || role === 'supporting' || role === 'immersive');
 
     return (
         <figure className={figureStyle}>

--- a/src/web/components/elements/ImageBlockComponent.tsx
+++ b/src/web/components/elements/ImageBlockComponent.tsx
@@ -30,25 +30,21 @@ const imageCss = {
     `,
 
     immersive: css`
-        ${from.mobileMedium} {
-            margin-left: -20px;
-            margin-right: -20px;
-        }
         ${from.tablet} {
-            margin-left: -20px;
-            margin-right: -120px;
+            margin-left: 0px;
+            margin-right: -100px;
         }
         ${from.desktop} {
-            margin-left: -20px;
-            margin-right: -340px;
+            margin-left: 0px;
+            margin-right: -320px;
         }
         ${from.leftCol} {
-            margin-left: -180px;
-            margin-right: -340px;
+            margin-left: -160px;
+            margin-right: -320px;
         }
         ${from.wide} {
-            margin-left: -260px;
-            margin-right: -420px;
+            margin-left: -240px;
+            margin-right: -400px;
         }
     `,
 

--- a/src/web/components/elements/ImageBlockComponent.tsx
+++ b/src/web/components/elements/ImageBlockComponent.tsx
@@ -29,8 +29,28 @@ const imageCss = {
         }
     `,
 
-    // TODO: immersive is pending review of different article types
-    immersive: css``,
+    immersive: css`
+        ${from.mobileMedium} {
+            margin-left: -20px;
+            margin-right: -20px;
+        }
+        ${from.tablet} {
+            margin-left: -20px;
+            margin-right: -120px;
+        }
+        ${from.desktop} {
+            margin-left: -20px;
+            margin-right: -340px;
+        }
+        ${from.leftCol} {
+            margin-left: -180px;
+            margin-right: -340px;
+        }
+        ${from.wide} {
+            margin-left: -260px;
+            margin-right: -420px;
+        }
+    `,
 
     showcase: css`
         position: relative;

--- a/src/web/components/elements/ImageBlockComponent.tsx
+++ b/src/web/components/elements/ImageBlockComponent.tsx
@@ -37,7 +37,6 @@ const imageCss = {
         margin-top: 16px;
         margin-bottom: 12px;
         ${from.leftCol} {
-            position: relative;
             margin-bottom: 16px;
             margin-left: -160px;
         }
@@ -54,22 +53,14 @@ const imageCss = {
         margin-right: 20px;
         margin-top: 6px;
         ${from.tablet} {
-            margin-right: 20px;
-        }
-        ${from.wide} {
-            margin-left: -160px;
+            width: 140px;
         }
         ${from.wide} {
             margin-left: -240px;
         }
         ${from.leftCol} {
-            margin-left: -160px;
-        }
-        ${from.leftCol} {
             position: relative;
-        }
-        ${from.tablet} {
-            width: 140px;
+            margin-left: -160px;
         }
     `,
 


### PR DESCRIPTION
## What does this change?
Adds the css for images with the `immersive` weighting

Immersive images are stretched to the left and right to fill the main display column. They do not completely fill the viewport the way immersive main media does

![Screenshot 2020-04-13 at 21 36 41](https://user-images.githubusercontent.com/1336821/79158804-e19b2e80-7dce-11ea-8013-bac64ca0eb40.jpg)


### Gutters
On Frontend the margins are pushed an extra 20 pixels on the left and right filling the article gutters, this works for photo essays because the gutters aren't shown but looks broken for other article types. In order to allow support for immersive images over all articles the margins are cropped by 20 pixels here, preserving the gutter.

If we wanted to restore that extra 20 pixels and lose the gutters then we need to solve the caption problem. This is addressed on photo essays by deleting the normal captions and showing special elements but this solution is extremely limited and inflexible.

## Why?
So we support immersive articles and other artilce types that show immersive images

## Link to supporting Trello card
https://trello.com/c/EPmYufDg/1082-immersive-in-body-images