### PR TITLE
Only show an avatar when there's one contributor

### DIFF
--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -209,6 +209,10 @@ export const CommentLayout = ({ CAPI, NAV }: Props) => {
 
     const contributorTag = CAPI.tags.find(tag => tag.type === 'Contributor');
     const avatarUrl = contributorTag && contributorTag.bylineImageUrl;
+    const onlyOneContributor: boolean =
+        CAPI.tags.filter(tag => tag.type === 'Contributor').length === 1;
+
+    const showAvatar = avatarUrl && onlyOneContributor;
 
     return (
         <>
@@ -285,13 +289,13 @@ export const CommentLayout = ({ CAPI, NAV }: Props) => {
                             <div
                                 className={cx(
                                     avatarHeadlineWrapper,
-                                    avatarUrl && minHeightWithAvatar,
+                                    showAvatar && minHeightWithAvatar,
                                 )}
                             >
                                 {/* TOP - we use divs here to position content in groups using flex */}
                                 <div
                                     className={cx(
-                                        !avatarUrl && headlinePadding,
+                                        !showAvatar && headlinePadding,
                                     )}
                                 >
                                     <ArticleHeadline
@@ -307,7 +311,7 @@ export const CommentLayout = ({ CAPI, NAV }: Props) => {
                                 </div>
                                 {/* BOTTOM */}
                                 <div>
-                                    {avatarUrl && (
+                                    {showAvatar && avatarUrl && (
                                         <div className={avatarPositionStyles}>
                                             <ContributorAvatar
                                                 imageSrc={avatarUrl}


### PR DESCRIPTION
## What does this change?
Prevents the author avatar from showing when there is more then one contributor to a comment piece

### Before
![Screenshot 2020-04-13 at 21 50 47](https://user-images.githubusercontent.com/1336821/79160871-6fc4e400-7dd2-11ea-8ca2-3fbc9160df40.jpg)

### After
![Screenshot 2020-04-13 at 21 57 40](https://user-images.githubusercontent.com/1336821/79160879-72bfd480-7dd2-11ea-811b-c2e21edfbe79.jpg)

## Why?
To keep everyone happy

## Link to supporting Trello card
https://trello.com/c/V6tV7HCn/1333-multiple-comment-contributors-hide-image