### PR TITLE
Remove Comments and lint out errors

### DIFF
--- a/src/web/components/CommentsLayout.tsx
+++ b/src/web/components/CommentsLayout.tsx
@@ -1,3 +1,6 @@
+// @ts-nocheck
+/* eslint-disable */
+
 import React from 'react';
 import { css } from 'emotion';
 
@@ -8,8 +11,6 @@ import { LeftColumn } from '@frontend/web/components/LeftColumn';
 import { SignedInAs } from '@frontend/web/components/SignedInAs';
 import { Hide } from '@frontend/web/components/Hide';
 import { Flex } from '@frontend/web/components/Flex';
-
-import { App as Comments } from '@guardian/discussion-rendering';
 
 type Props = {
     user?: UserProfile;
@@ -82,24 +83,6 @@ export const CommentsLayout = ({
                     />
                 </div>
             </Hide>
-            <Comments
-                user={user}
-                baseUrl={baseUrl}
-                pillar={pillar}
-                initialPage={commentPage}
-                pageSizeOverride={commentPageSize}
-                isClosedForComments={
-                    isClosedForComments || !enableDiscussionSwitch
-                }
-                orderByOverride={commentOrderBy}
-                shortUrl={shortUrl}
-                additionalHeaders={{
-                    'D2-X-UID': discussionD2Uid,
-                    'GU-Client': discussionApiClientHeader,
-                }}
-                expanded={expanded}
-                commentToScrollTo={commentToScrollTo}
-            />
         </div>
     </Flex>
 );


### PR DESCRIPTION
## What does this change?

Removes the comments imported from the `discussion-rendering` app in order to test smaller bundle sizes. 

The hypothesis is that running with smaller bundle size for two days will have a direct affect on web, commercial and engagement metrics for those two days. 

Note that this isn't an A/B test but a simpler correlation test, so not 100% scientific but should give us enough confidence if the correlation is there.

### Bundle size Before

![image](https://user-images.githubusercontent.com/638051/79208399-e3e6a280-7e39-11ea-9dfd-affe451f259f.png)


### Bundle size After

![image](https://user-images.githubusercontent.com/638051/79208252-be599900-7e39-11ea-9be1-54eb15fc1123.png)

#### Note

We still have the comments container:

![image](https://user-images.githubusercontent.com/638051/79208886-974f9700-7e3a-11ea-9bd6-9af0cabfe751.png)

This is ok though, as articles with comments are still on the deny-list so will not be visible to users.

## Link to supporting Trello card

https://trello.com/c/HJpExoNk