### PR TITLE
Explicit Design Props

### DIFF
--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -179,9 +179,11 @@ const headlinePadding = css`
 interface Props {
     CAPI: CAPIType;
     NAV: NavType;
+    display: Display;
+    designType: DesignType;
 }
 
-export const CommentLayout = ({ CAPI, NAV }: Props) => {
+export const CommentLayout = ({ CAPI, NAV, designType }: Props) => {
     const {
         config: { isPaidContent },
         pageType: { isSensitive },
@@ -302,7 +304,7 @@ export const CommentLayout = ({ CAPI, NAV }: Props) => {
                                 >
                                     <ArticleHeadline
                                         headlineString={CAPI.headline}
-                                        designType={CAPI.designType}
+                                        designType={designType}
                                         pillar={pillar}
                                         webPublicationDate={
                                             CAPI.webPublicationDate
@@ -335,7 +337,7 @@ export const CommentLayout = ({ CAPI, NAV }: Props) => {
                     </GridItem>
                     <GridItem area="standfirst">
                         <ArticleStandfirst
-                            designType={CAPI.designType}
+                            designType={designType}
                             pillar={pillar}
                             standfirst={CAPI.standfirst}
                         />
@@ -352,7 +354,7 @@ export const CommentLayout = ({ CAPI, NAV }: Props) => {
                     <GridItem area="meta">
                         <div className={maxWidth}>
                             <ArticleMeta
-                                designType={CAPI.designType}
+                                designType={designType}
                                 pillar={pillar}
                                 pageId={CAPI.pageId}
                                 webTitle={CAPI.webTitle}
@@ -371,7 +373,7 @@ export const CommentLayout = ({ CAPI, NAV }: Props) => {
                                     pillar={pillar}
                                     blocks={CAPI.blocks}
                                     isImmersive={CAPI.isImmersive}
-                                    designType={CAPI.designType}
+                                    designType={designType}
                                     adTargeting={adTargeting}
                                 />
                                 {showBodyEndSlot && <div id="slot-body-end" />}

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -181,9 +181,10 @@ interface Props {
     NAV: NavType;
     display: Display;
     designType: DesignType;
+    pillar: Pillar;
 }
 
-export const CommentLayout = ({ CAPI, NAV, designType }: Props) => {
+export const CommentLayout = ({ CAPI, NAV, designType, pillar }: Props) => {
     const {
         config: { isPaidContent },
         pageType: { isSensitive },
@@ -215,9 +216,6 @@ export const CommentLayout = ({ CAPI, NAV, designType }: Props) => {
         CAPI.tags.filter(tag => tag.type === 'Contributor').length === 1;
 
     const showAvatar = avatarUrl && onlyOneContributor;
-
-    // We override the pillar to be opinion on Comment news pieces
-    const pillar = CAPI.pillar === 'news' ? 'opinion' : CAPI.pillar;
 
     return (
         <>

--- a/src/web/layouts/DecideLayout.tsx
+++ b/src/web/layouts/DecideLayout.tsx
@@ -24,7 +24,14 @@ export const DecideLayout = ({ CAPI, NAV }: Props) => {
             switch (designType) {
                 case 'Comment':
                 case 'GuardianView':
-                    return <CommentLayout CAPI={CAPI} NAV={NAV} />;
+                    return (
+                        <CommentLayout
+                            CAPI={CAPI}
+                            NAV={NAV}
+                            display="immersive"
+                            designType={designType}
+                        />
+                    );
                 case 'Feature':
                 case 'Review':
                 case 'Interview':
@@ -39,7 +46,14 @@ export const DecideLayout = ({ CAPI, NAV }: Props) => {
                 case 'Quiz':
                 case 'AdvertisementFeature':
                 case 'Immersive':
-                    return <ShowcaseLayout CAPI={CAPI} NAV={NAV} />;
+                    return (
+                        <ShowcaseLayout
+                            CAPI={CAPI}
+                            NAV={NAV}
+                            display="immersive"
+                            designType={designType}
+                        />
+                    );
             }
             break;
         }
@@ -47,7 +61,14 @@ export const DecideLayout = ({ CAPI, NAV }: Props) => {
             switch (designType) {
                 case 'Comment':
                 case 'GuardianView':
-                    return <CommentLayout CAPI={CAPI} NAV={NAV} />;
+                    return (
+                        <CommentLayout
+                            CAPI={CAPI}
+                            NAV={NAV}
+                            display="showcase"
+                            designType={designType}
+                        />
+                    );
                 case 'Feature':
                 case 'Review':
                 case 'Interview':
@@ -62,7 +83,14 @@ export const DecideLayout = ({ CAPI, NAV }: Props) => {
                 case 'Quiz':
                 case 'AdvertisementFeature':
                 case 'Immersive':
-                    return <ShowcaseLayout CAPI={CAPI} NAV={NAV} />;
+                    return (
+                        <ShowcaseLayout
+                            CAPI={CAPI}
+                            NAV={NAV}
+                            display="showcase"
+                            designType={designType}
+                        />
+                    );
             }
             break;
         }
@@ -70,7 +98,14 @@ export const DecideLayout = ({ CAPI, NAV }: Props) => {
             switch (designType) {
                 case 'Comment':
                 case 'GuardianView':
-                    return <CommentLayout CAPI={CAPI} NAV={NAV} />;
+                    return (
+                        <CommentLayout
+                            CAPI={CAPI}
+                            NAV={NAV}
+                            display="standard"
+                            designType={designType}
+                        />
+                    );
                 case 'Feature':
                 case 'Review':
                 case 'Interview':
@@ -85,7 +120,14 @@ export const DecideLayout = ({ CAPI, NAV }: Props) => {
                 case 'Quiz':
                 case 'AdvertisementFeature':
                 case 'Immersive':
-                    return <StandardLayout CAPI={CAPI} NAV={NAV} />;
+                    return (
+                        <StandardLayout
+                            CAPI={CAPI}
+                            NAV={NAV}
+                            display="standard"
+                            designType={designType}
+                        />
+                    );
             }
             break;
         }

--- a/src/web/layouts/DecideLayout.tsx
+++ b/src/web/layouts/DecideLayout.tsx
@@ -15,8 +15,16 @@ const decideDisplay = (CAPI: CAPIType): Display => {
     return 'standard';
 };
 
+const decidePillar = (CAPI: CAPIType): Pillar => {
+    // We override the pillar to be opinion on Comment news pieces
+    if (CAPI.designType === 'Comment' && CAPI.pillar === 'news')
+        return 'opinion';
+    return CAPI.pillar;
+};
+
 export const DecideLayout = ({ CAPI, NAV }: Props) => {
     const display: Display = decideDisplay(CAPI);
+    const pillar: Pillar = decidePillar(CAPI);
     const { designType } = CAPI;
 
     switch (display) {
@@ -30,6 +38,7 @@ export const DecideLayout = ({ CAPI, NAV }: Props) => {
                             NAV={NAV}
                             display="immersive"
                             designType={designType}
+                            pillar={pillar}
                         />
                     );
                 case 'Feature':
@@ -52,6 +61,7 @@ export const DecideLayout = ({ CAPI, NAV }: Props) => {
                             NAV={NAV}
                             display="immersive"
                             designType={designType}
+                            pillar={pillar}
                         />
                     );
             }
@@ -67,6 +77,7 @@ export const DecideLayout = ({ CAPI, NAV }: Props) => {
                             NAV={NAV}
                             display="showcase"
                             designType={designType}
+                            pillar={pillar}
                         />
                     );
                 case 'Feature':
@@ -89,6 +100,7 @@ export const DecideLayout = ({ CAPI, NAV }: Props) => {
                             NAV={NAV}
                             display="showcase"
                             designType={designType}
+                            pillar={pillar}
                         />
                     );
             }
@@ -104,6 +116,7 @@ export const DecideLayout = ({ CAPI, NAV }: Props) => {
                             NAV={NAV}
                             display="standard"
                             designType={designType}
+                            pillar={pillar}
                         />
                     );
                 case 'Feature':
@@ -126,6 +139,7 @@ export const DecideLayout = ({ CAPI, NAV }: Props) => {
                             NAV={NAV}
                             display="standard"
                             designType={designType}
+                            pillar={pillar}
                         />
                     );
             }

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -238,9 +238,11 @@ const headerWrapper = css`
 interface Props {
     CAPI: CAPIType;
     NAV: NavType;
+    display: Display;
+    designType: DesignType;
 }
 
-export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
+export const ShowcaseLayout = ({ CAPI, NAV, designType }: Props) => {
     const {
         config: { isPaidContent },
         pageType: { isSensitive },
@@ -342,7 +344,7 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                         <Border />
                     </GridItem>
                     <GridItem area="headline">
-                        <PositionHeadline designType={CAPI.designType}>
+                        <PositionHeadline designType={designType}>
                             <div
                                 className={css`
                                     padding-bottom: 24px;
@@ -350,7 +352,7 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                             >
                                 <ArticleHeadline
                                     headlineString={CAPI.headline}
-                                    designType={CAPI.designType}
+                                    designType={designType}
                                     pillar={CAPI.pillar}
                                     webPublicationDate={CAPI.webPublicationDate}
                                     tags={CAPI.tags}
@@ -366,8 +368,7 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                                 pillar={CAPI.pillar}
                                 adTargeting={adTargeting}
                                 starRating={
-                                    CAPI.designType === 'Review' &&
-                                    CAPI.starRating
+                                    designType === 'Review' && CAPI.starRating
                                         ? CAPI.starRating
                                         : undefined
                                 }
@@ -376,7 +377,7 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                     </GridItem>
                     <GridItem area="standfirst">
                         <ArticleStandfirst
-                            designType={CAPI.designType}
+                            designType={designType}
                             pillar={CAPI.pillar}
                             standfirst={CAPI.standfirst}
                         />
@@ -387,10 +388,10 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                                 <GuardianLines
                                     pillar={CAPI.pillar}
                                     effect={decideLineEffect(
-                                        CAPI.designType,
+                                        designType,
                                         CAPI.pillar,
                                     )}
-                                    count={decideLineCount(CAPI.designType)}
+                                    count={decideLineCount(designType)}
                                 />
                             </div>
                         </div>
@@ -398,7 +399,7 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                     <GridItem area="meta">
                         <div className={maxWidth}>
                             <ArticleMeta
-                                designType={CAPI.designType}
+                                designType={designType}
                                 pillar={CAPI.pillar}
                                 pageId={CAPI.pageId}
                                 webTitle={CAPI.webTitle}
@@ -417,7 +418,7 @@ export const ShowcaseLayout = ({ CAPI, NAV }: Props) => {
                                     pillar={CAPI.pillar}
                                     blocks={CAPI.blocks}
                                     isImmersive={CAPI.isImmersive}
-                                    designType={CAPI.designType}
+                                    designType={designType}
                                     adTargeting={adTargeting}
                                 />
                                 {showBodyEndSlot && <div id="slot-body-end" />}

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -240,9 +240,10 @@ interface Props {
     NAV: NavType;
     display: Display;
     designType: DesignType;
+    pillar: Pillar;
 }
 
-export const ShowcaseLayout = ({ CAPI, NAV, designType }: Props) => {
+export const ShowcaseLayout = ({ CAPI, NAV, designType, pillar }: Props) => {
     const {
         config: { isPaidContent },
         pageType: { isSensitive },
@@ -313,7 +314,7 @@ export const ShowcaseLayout = ({ CAPI, NAV, designType }: Props) => {
                             <SubNav
                                 subNavSections={NAV.subNavSections}
                                 currentNavLink={NAV.currentNavLink}
-                                pillar={CAPI.pillar}
+                                pillar={pillar}
                             />
                         </Section>
                     )}
@@ -323,7 +324,7 @@ export const ShowcaseLayout = ({ CAPI, NAV, designType }: Props) => {
                         padded={false}
                         showTopBorder={false}
                     >
-                        <GuardianLines pillar={CAPI.pillar} />
+                        <GuardianLines pillar={pillar} />
                     </Section>
                 </div>
             </div>
@@ -336,7 +337,7 @@ export const ShowcaseLayout = ({ CAPI, NAV, designType }: Props) => {
                             sectionLabel={CAPI.sectionLabel}
                             sectionUrl={CAPI.sectionUrl}
                             guardianBaseURL={CAPI.guardianBaseURL}
-                            pillar={CAPI.pillar}
+                            pillar={pillar}
                             badge={CAPI.badge}
                         />
                     </GridItem>
@@ -353,7 +354,7 @@ export const ShowcaseLayout = ({ CAPI, NAV, designType }: Props) => {
                                 <ArticleHeadline
                                     headlineString={CAPI.headline}
                                     designType={designType}
-                                    pillar={CAPI.pillar}
+                                    pillar={pillar}
                                     webPublicationDate={CAPI.webPublicationDate}
                                     tags={CAPI.tags}
                                     byline={CAPI.author.byline}
@@ -365,7 +366,7 @@ export const ShowcaseLayout = ({ CAPI, NAV, designType }: Props) => {
                         <div className={mainMediaWrapper}>
                             <MainMedia
                                 elements={CAPI.mainMediaElements}
-                                pillar={CAPI.pillar}
+                                pillar={pillar}
                                 adTargeting={adTargeting}
                                 starRating={
                                     designType === 'Review' && CAPI.starRating
@@ -378,7 +379,7 @@ export const ShowcaseLayout = ({ CAPI, NAV, designType }: Props) => {
                     <GridItem area="standfirst">
                         <ArticleStandfirst
                             designType={designType}
-                            pillar={CAPI.pillar}
+                            pillar={pillar}
                             standfirst={CAPI.standfirst}
                         />
                     </GridItem>
@@ -386,10 +387,10 @@ export const ShowcaseLayout = ({ CAPI, NAV, designType }: Props) => {
                         <div className={maxWidth}>
                             <div className={stretchLines}>
                                 <GuardianLines
-                                    pillar={CAPI.pillar}
+                                    pillar={pillar}
                                     effect={decideLineEffect(
                                         designType,
-                                        CAPI.pillar,
+                                        pillar,
                                     )}
                                     count={decideLineCount(designType)}
                                 />
@@ -400,7 +401,7 @@ export const ShowcaseLayout = ({ CAPI, NAV, designType }: Props) => {
                         <div className={maxWidth}>
                             <ArticleMeta
                                 designType={designType}
-                                pillar={CAPI.pillar}
+                                pillar={pillar}
                                 pageId={CAPI.pageId}
                                 webTitle={CAPI.webTitle}
                                 author={CAPI.author}
@@ -415,16 +416,16 @@ export const ShowcaseLayout = ({ CAPI, NAV, designType }: Props) => {
                         <ArticleContainer>
                             <main className={maxWidth}>
                                 <ArticleBody
-                                    pillar={CAPI.pillar}
+                                    pillar={pillar}
                                     blocks={CAPI.blocks}
                                     isImmersive={CAPI.isImmersive}
                                     designType={designType}
                                     adTargeting={adTargeting}
                                 />
                                 {showBodyEndSlot && <div id="slot-body-end" />}
-                                <GuardianLines pillar={CAPI.pillar} />
+                                <GuardianLines pillar={pillar} />
                                 <SubMeta
-                                    pillar={CAPI.pillar}
+                                    pillar={pillar}
                                     subMetaKeywordLinks={
                                         CAPI.subMetaKeywordLinks
                                     }
@@ -506,9 +507,9 @@ export const ShowcaseLayout = ({ CAPI, NAV, designType }: Props) => {
                     <SubNav
                         subNavSections={NAV.subNavSections}
                         currentNavLink={NAV.currentNavLink}
-                        pillar={CAPI.pillar}
+                        pillar={pillar}
                     />
-                    <GuardianLines pillar={CAPI.pillar} />
+                    <GuardianLines pillar={pillar} />
                 </Section>
             )}
 
@@ -519,7 +520,7 @@ export const ShowcaseLayout = ({ CAPI, NAV, designType }: Props) => {
             >
                 <Footer
                     pageFooter={CAPI.pageFooter}
-                    pillar={CAPI.pillar}
+                    pillar={pillar}
                     pillars={NAV.pillars}
                 />
             </Section>

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -213,9 +213,10 @@ interface Props {
     NAV: NavType;
     display: Display;
     designType: DesignType;
+    pillar: Pillar;
 }
 
-export const StandardLayout = ({ CAPI, NAV, designType }: Props) => {
+export const StandardLayout = ({ CAPI, NAV, designType, pillar }: Props) => {
     const {
         config: { isPaidContent },
         pageType: { isSensitive },
@@ -286,7 +287,7 @@ export const StandardLayout = ({ CAPI, NAV, designType }: Props) => {
                             <SubNav
                                 subNavSections={NAV.subNavSections}
                                 currentNavLink={NAV.currentNavLink}
-                                pillar={CAPI.pillar}
+                                pillar={pillar}
                             />
                         </Section>
                     )}
@@ -296,7 +297,7 @@ export const StandardLayout = ({ CAPI, NAV, designType }: Props) => {
                         padded={false}
                         showTopBorder={false}
                     >
-                        <GuardianLines pillar={CAPI.pillar} />
+                        <GuardianLines pillar={pillar} />
                     </Section>
                 </div>
             </div>
@@ -309,7 +310,7 @@ export const StandardLayout = ({ CAPI, NAV, designType }: Props) => {
                             sectionLabel={CAPI.sectionLabel}
                             sectionUrl={CAPI.sectionUrl}
                             guardianBaseURL={CAPI.guardianBaseURL}
-                            pillar={CAPI.pillar}
+                            pillar={pillar}
                             badge={CAPI.badge}
                         />
                     </GridItem>
@@ -322,7 +323,7 @@ export const StandardLayout = ({ CAPI, NAV, designType }: Props) => {
                                 <ArticleHeadline
                                     headlineString={CAPI.headline}
                                     designType={designType}
-                                    pillar={CAPI.pillar}
+                                    pillar={pillar}
                                     webPublicationDate={CAPI.webPublicationDate}
                                     tags={CAPI.tags}
                                     byline={CAPI.author.byline}
@@ -343,7 +344,7 @@ export const StandardLayout = ({ CAPI, NAV, designType }: Props) => {
                     <GridItem area="standfirst">
                         <ArticleStandfirst
                             designType={designType}
-                            pillar={CAPI.pillar}
+                            pillar={pillar}
                             standfirst={CAPI.standfirst}
                         />
                     </GridItem>
@@ -351,7 +352,7 @@ export const StandardLayout = ({ CAPI, NAV, designType }: Props) => {
                         <div className={maxWidth}>
                             <MainMedia
                                 elements={CAPI.mainMediaElements}
-                                pillar={CAPI.pillar}
+                                pillar={pillar}
                                 adTargeting={adTargeting}
                             />
                         </div>
@@ -360,7 +361,7 @@ export const StandardLayout = ({ CAPI, NAV, designType }: Props) => {
                         <div className={maxWidth}>
                             <div className={stretchLines}>
                                 <GuardianLines
-                                    pillar={CAPI.pillar}
+                                    pillar={pillar}
                                     effect={decideLineEffect(
                                         designType,
                                         CAPI.pillar,
@@ -374,7 +375,7 @@ export const StandardLayout = ({ CAPI, NAV, designType }: Props) => {
                         <div className={maxWidth}>
                             <ArticleMeta
                                 designType={designType}
-                                pillar={CAPI.pillar}
+                                pillar={pillar}
                                 pageId={CAPI.pageId}
                                 webTitle={CAPI.webTitle}
                                 author={CAPI.author}
@@ -389,16 +390,16 @@ export const StandardLayout = ({ CAPI, NAV, designType }: Props) => {
                         <ArticleContainer>
                             <main className={articleWidth}>
                                 <ArticleBody
-                                    pillar={CAPI.pillar}
+                                    pillar={pillar}
                                     blocks={CAPI.blocks}
                                     isImmersive={CAPI.isImmersive}
                                     designType={designType}
                                     adTargeting={adTargeting}
                                 />
                                 {showBodyEndSlot && <div id="slot-body-end" />}
-                                <GuardianLines pillar={CAPI.pillar} />
+                                <GuardianLines pillar={pillar} />
                                 <SubMeta
-                                    pillar={CAPI.pillar}
+                                    pillar={pillar}
                                     subMetaKeywordLinks={
                                         CAPI.subMetaKeywordLinks
                                     }
@@ -480,9 +481,9 @@ export const StandardLayout = ({ CAPI, NAV, designType }: Props) => {
                     <SubNav
                         subNavSections={NAV.subNavSections}
                         currentNavLink={NAV.currentNavLink}
-                        pillar={CAPI.pillar}
+                        pillar={pillar}
                     />
-                    <GuardianLines pillar={CAPI.pillar} />
+                    <GuardianLines pillar={pillar} />
                 </Section>
             )}
 
@@ -493,7 +494,7 @@ export const StandardLayout = ({ CAPI, NAV, designType }: Props) => {
             >
                 <Footer
                     pageFooter={CAPI.pageFooter}
-                    pillar={CAPI.pillar}
+                    pillar={pillar}
                     pillars={NAV.pillars}
                 />
             </Section>

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -211,9 +211,11 @@ const headerWrapper = css`
 interface Props {
     CAPI: CAPIType;
     NAV: NavType;
+    display: Display;
+    designType: DesignType;
 }
 
-export const StandardLayout = ({ CAPI, NAV }: Props) => {
+export const StandardLayout = ({ CAPI, NAV, designType }: Props) => {
     const {
         config: { isPaidContent },
         pageType: { isSensitive },
@@ -316,12 +318,10 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                     </GridItem>
                     <GridItem area="headline">
                         <div className={maxWidth}>
-                            <ArticleHeadlinePadding
-                                designType={CAPI.designType}
-                            >
+                            <ArticleHeadlinePadding designType={designType}>
                                 <ArticleHeadline
                                     headlineString={CAPI.headline}
-                                    designType={CAPI.designType}
+                                    designType={designType}
                                     pillar={CAPI.pillar}
                                     webPublicationDate={CAPI.webPublicationDate}
                                     tags={CAPI.tags}
@@ -342,7 +342,7 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                     </GridItem>
                     <GridItem area="standfirst">
                         <ArticleStandfirst
-                            designType={CAPI.designType}
+                            designType={designType}
                             pillar={CAPI.pillar}
                             standfirst={CAPI.standfirst}
                         />
@@ -362,10 +362,10 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                                 <GuardianLines
                                     pillar={CAPI.pillar}
                                     effect={decideLineEffect(
-                                        CAPI.designType,
+                                        designType,
                                         CAPI.pillar,
                                     )}
-                                    count={decideLineCount(CAPI.designType)}
+                                    count={decideLineCount(designType)}
                                 />
                             </div>
                         </div>
@@ -373,7 +373,7 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                     <GridItem area="meta">
                         <div className={maxWidth}>
                             <ArticleMeta
-                                designType={CAPI.designType}
+                                designType={designType}
                                 pillar={CAPI.pillar}
                                 pageId={CAPI.pageId}
                                 webTitle={CAPI.webTitle}
@@ -392,7 +392,7 @@ export const StandardLayout = ({ CAPI, NAV }: Props) => {
                                     pillar={CAPI.pillar}
                                     blocks={CAPI.blocks}
                                     isImmersive={CAPI.isImmersive}
-                                    designType={CAPI.designType}
+                                    designType={designType}
                                     adTargeting={adTargeting}
                                 />
                                 {showBodyEndSlot && <div id="slot-body-end" />}


### PR DESCRIPTION
## What does this change?
Makes the three design props explicit for each layout component

### Before
```typescript
interface Props {
    CAPI: CAPIType;
    NAV: NavType;
}
```

### Afrer
```typescript
interface Props {
    CAPI: CAPIType;
    NAV: NavType;
    display: Display;
    designType: DesignType;
    pillar: Pillar;
}
```

## Why?
So we're centralising these decisions in one place and in preparation for making more use of the `display` property in place of `designType`

## Link to supporting Trello card
https://trello.com/c/cIDwM4es/1436-format