### PR TITLE
Use display

### DIFF
--- a/src/web/components/ArticleBody.tsx
+++ b/src/web/components/ArticleBody.tsx
@@ -9,7 +9,7 @@ import { ArticleRenderer } from '@root/src/web/lib/ArticleRenderer';
 
 type Props = {
     pillar: Pillar;
-    isImmersive: boolean;
+    display: Display;
     blocks: Block[];
     designType: DesignType;
     adTargeting: AdTargeting;
@@ -42,13 +42,15 @@ const captionFont = css`
     color: ${text.supporting};
 `;
 
-const bodyStyle = css`
+const bodyStyle = (display: Display) => css`
     ${between.tablet.and.desktop} {
         padding-right: 80px;
     }
 
     h2 {
-        ${headline.xxsmall({ fontWeight: 'bold' })};
+        ${display === 'immersive'
+            ? headline.medium({ fontWeight: 'light' })
+            : headline.xxsmall({ fontWeight: 'bold' })};
     }
 
     strong {
@@ -101,13 +103,6 @@ const bodyStyle = css`
     }
 `;
 
-const immersiveBodyStyle = css`
-    h2 {
-        ${headline.medium()};
-        font-weight: 200;
-    }
-`;
-
 const linkColour = pillarMap(
     pillar => css`
         a {
@@ -124,17 +119,13 @@ const linkColour = pillarMap(
 
 export const ArticleBody = ({
     pillar,
-    isImmersive,
+    display,
     blocks,
     designType,
     adTargeting,
 }: Props) => {
     return (
-        <div
-            className={cx(bodyStyle, linkColour[pillar], {
-                [immersiveBodyStyle]: isImmersive,
-            })}
-        >
+        <div className={cx(bodyStyle(display), linkColour[pillar])}>
             <ArticleRenderer
                 elements={blocks[0] ? blocks[0].elements : []}
                 pillar={pillar}

--- a/src/web/components/ArticleHeadline.stories.tsx
+++ b/src/web/components/ArticleHeadline.stories.tsx
@@ -136,6 +136,7 @@ export const Interview = () => (
                     byline="Byline text"
                 />
                 <Standfirst
+                    display="standard"
                     designType="Interview"
                     standfirst="This is the standfirst text. We include here to demonstrate spacing in this case where we have a Interview type article that does not have a showcase main media element"
                 />

--- a/src/web/components/ArticleHeadline.stories.tsx
+++ b/src/web/components/ArticleHeadline.stories.tsx
@@ -24,6 +24,7 @@ export const ArticleStory = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is how the default headline looks"
+                    display="standard"
                     designType="Article"
                     pillar="news"
                     webPublicationDate=""
@@ -44,6 +45,7 @@ export const oldHeadline = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is an old headline"
+                    display="standard"
                     designType="Article"
                     pillar="news"
                     webPublicationDate="2014-07-13T18:46:01.933Z"
@@ -71,6 +73,7 @@ export const Feature = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is a Feature headline, it has colour applied based on pillar"
+                    display="standard"
                     designType="Feature"
                     pillar="lifestyle"
                     webPublicationDate=""
@@ -96,6 +99,7 @@ export const ShowcaseInterview = () => (
                 >
                     <ArticleHeadline
                         headlineString="This is an Interview headline. It has a black background, white text and overlays the image below it (as a sibling)"
+                        display="showcase"
                         designType="Interview"
                         pillar="culture"
                         webPublicationDate=""
@@ -124,6 +128,7 @@ export const Interview = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is an Interview headline. It has a black background, white text and overlays the image below it (as a sibling)"
+                    display="standard"
                     designType="Interview"
                     pillar="culture"
                     webPublicationDate=""
@@ -154,6 +159,7 @@ export const Comment = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="Yes, the billionaire club is one we really need to shut down"
+                    display="standard"
                     designType="Comment"
                     pillar="opinion"
                     webPublicationDate=""
@@ -174,6 +180,7 @@ export const Analysis = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is an Analysis headline, it's underlined. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor"
+                    display="standard"
                     designType="Analysis"
                     pillar="news"
                     webPublicationDate=""
@@ -194,6 +201,7 @@ export const Media = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is the headline you see when design type is Media"
+                    display="standard"
                     designType="Media"
                     pillar="news"
                     webPublicationDate=""
@@ -214,6 +222,7 @@ export const Review = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is the headline you see when design type is Review"
+                    display="standard"
                     designType="Review"
                     pillar="news"
                     webPublicationDate=""
@@ -234,6 +243,7 @@ export const AdvertisementFeature = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is the headline you see when design type is AdvertisementFeature"
+                    display="standard"
                     designType="AdvertisementFeature"
                     pillar="news"
                     webPublicationDate=""
@@ -254,6 +264,7 @@ export const Quiz = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is the headline you see when design type is Quiz"
+                    display="standard"
                     designType="Quiz"
                     pillar="news"
                     webPublicationDate=""
@@ -274,6 +285,7 @@ export const GuardianLabs = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is the headline you see when design type is GuardianLabs"
+                    display="standard"
                     designType="GuardianLabs"
                     pillar="news"
                     webPublicationDate=""
@@ -294,6 +306,7 @@ export const Recipe = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is the headline you see when design type is Recipe"
+                    display="standard"
                     designType="Recipe"
                     pillar="news"
                     webPublicationDate=""
@@ -314,6 +327,7 @@ export const GuardianView = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is the headline you see when design type is GuardianView"
+                    display="standard"
                     designType="GuardianView"
                     pillar="news"
                     webPublicationDate=""
@@ -334,6 +348,7 @@ export const MatchReport = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is the headline you see when design type is MatchReport"
+                    display="standard"
                     designType="MatchReport"
                     pillar="news"
                     webPublicationDate=""
@@ -354,6 +369,7 @@ export const SpecialReport = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is the headline you see when design type is SpecialReport"
+                    display="standard"
                     designType="SpecialReport"
                     pillar="news"
                     webPublicationDate=""
@@ -374,6 +390,7 @@ export const Live = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is the headline you see when design type is Live"
+                    display="standard"
                     designType="Live"
                     pillar="news"
                     webPublicationDate=""
@@ -410,6 +427,7 @@ export const LongImmersive = () => (
                     >
                         <ArticleHeadline
                             headlineString="Here the headline overlays the image above it, the text is larger and the black background should extend to the right"
+                            display="immersive"
                             designType="Immersive"
                             pillar="culture"
                             webPublicationDate=""
@@ -448,6 +466,7 @@ export const ShortImmersive = () => (
                     >
                         <ArticleHeadline
                             headlineString="Ken Loach – all his films ranked!"
+                            display="standard"
                             designType="Immersive"
                             pillar="culture"
                             webPublicationDate=""

--- a/src/web/components/ArticleHeadline.stories.tsx
+++ b/src/web/components/ArticleHeadline.stories.tsx
@@ -466,7 +466,7 @@ export const ShortImmersive = () => (
                     >
                         <ArticleHeadline
                             headlineString="Ken Loach – all his films ranked!"
-                            display="standard"
+                            display="immersive"
                             designType="Immersive"
                             pillar="culture"
                             webPublicationDate=""

--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -239,6 +239,7 @@ const renderHeadline = ({
                     <h1 className={lightFont}>{curly(headlineString)}</h1>
                     {byline && (
                         <HeadlineByline
+                            display={display}
                             designType={designType}
                             pillar={pillar}
                             byline={byline}
@@ -274,6 +275,7 @@ const renderHeadline = ({
                     </h1>
                     {byline && (
                         <HeadlineByline
+                            display={display}
                             designType={designType}
                             pillar={pillar}
                             byline={byline}

--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -13,6 +13,7 @@ import { space } from '@guardian/src-foundations';
 
 type Props = {
     headlineString: string;
+    display: Display;
     designType: DesignType; // Decides headline appearance
     pillar: Pillar; // Decides headline colour when relevant
     webPublicationDate: string; // Used for age warning
@@ -167,6 +168,7 @@ const ageWarningMargins = css`
 `;
 
 const renderHeadline = ({
+    display,
     designType,
     pillar,
     headlineString,
@@ -174,6 +176,7 @@ const renderHeadline = ({
     tags,
     options,
 }: {
+    display: Display;
     designType: DesignType;
     pillar: Pillar;
     headlineString: string;
@@ -183,7 +186,28 @@ const renderHeadline = ({
         colour?: string;
     };
 }) => {
+    if (display === 'immersive') {
+        return (
+            // Immersive headlines are large and inverted and have their black background
+            // extended to the right
+            <h1 className={cx(invertedWrapper, blackBackground)}>
+                <span
+                    className={cx(
+                        jumboFont,
+                        maxWidth,
+                        invertedStyles,
+                        immersiveStyles,
+                        displayBlock,
+                    )}
+                >
+                    {curly(headlineString)}
+                </span>
+            </h1>
+        );
+    }
+
     switch (designType) {
+        case 'Immersive':
         case 'Article':
         case 'Media':
         case 'Live':
@@ -258,30 +282,12 @@ const renderHeadline = ({
                     )}
                 </div>
             );
-
-        case 'Immersive':
-            return (
-                // Immersive headlines are large and inverted and have their black background
-                // extended to the right
-                <h1 className={cx(invertedWrapper, blackBackground)}>
-                    <span
-                        className={cx(
-                            jumboFont,
-                            maxWidth,
-                            invertedStyles,
-                            immersiveStyles,
-                            displayBlock,
-                        )}
-                    >
-                        {curly(headlineString)}
-                    </span>
-                </h1>
-            );
     }
 };
 
 export const ArticleHeadline = ({
     headlineString,
+    display,
     designType,
     pillar,
     webPublicationDate,
@@ -297,6 +303,7 @@ export const ArticleHeadline = ({
                 </div>
             )}
             {renderHeadline({
+                display,
                 designType,
                 pillar,
                 headlineString,

--- a/src/web/components/ArticleMeta.stories.tsx
+++ b/src/web/components/ArticleMeta.stories.tsx
@@ -50,6 +50,7 @@ export const ArticleStory = () => {
     return (
         <Container>
             <ArticleMeta
+                display="standard"
                 designType="Article"
                 pillar="news"
                 pageId=""
@@ -70,6 +71,7 @@ export const FeatureStory = () => {
     return (
         <Container>
             <ArticleMeta
+                display="standard"
                 designType="Feature"
                 pillar="culture"
                 pageId=""
@@ -90,6 +92,7 @@ export const CommentStory = () => {
     return (
         <Container>
             <ArticleMeta
+                display="standard"
                 designType="Comment"
                 pillar="opinion"
                 pageId=""
@@ -110,6 +113,7 @@ export const InterviewStory = () => {
     return (
         <Container>
             <ArticleMeta
+                display="standard"
                 designType="Interview"
                 pillar="lifestyle"
                 pageId=""
@@ -130,6 +134,7 @@ export const ImmersiveStory = () => {
     return (
         <Container>
             <ArticleMeta
+                display="immersive"
                 designType="Immersive"
                 pillar="news"
                 pageId=""
@@ -140,7 +145,6 @@ export const ImmersiveStory = () => {
                 }}
                 tags={tagsWithBylineImage}
                 webPublicationDateDisplay="Sun 12 Jan 2020 18.00 GMT"
-                isImmersive={true}
             />
         </Container>
     );
@@ -151,6 +155,7 @@ export const TwoContributorsStory = () => {
     return (
         <Container>
             <ArticleMeta
+                display="standard"
                 designType="Feature"
                 pillar="sport"
                 pageId=""

--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -10,6 +10,7 @@ import { SharingIcons } from './ShareIcons';
 import { Dateline } from './Dateline';
 
 type Props = {
+    display: Display;
     designType: DesignType;
     pillar: Pillar;
     pageId: string;
@@ -17,7 +18,6 @@ type Props = {
     author: AuthorType;
     tags: TagType[];
     webPublicationDateDisplay: string;
-    isImmersive?: boolean;
 };
 
 const meta = css`
@@ -87,8 +87,8 @@ const getAuthorName = (tags: TagType[]) => {
     return contributorTag && contributorTag.title;
 };
 
-const shouldShowAvatar = (designType: DesignType, isImmersive?: boolean) => {
-    if (isImmersive) {
+const shouldShowAvatar = (designType: DesignType, display: Display) => {
+    if (display === 'immersive') {
         return false;
     }
 
@@ -115,11 +115,8 @@ const shouldShowAvatar = (designType: DesignType, isImmersive?: boolean) => {
     }
 };
 
-const shouldShowContributor = (
-    designType: DesignType,
-    isImmersive?: boolean,
-) => {
-    if (isImmersive) {
+const shouldShowContributor = (designType: DesignType, display: Display) => {
+    if (display === 'immersive') {
         return false;
     }
 
@@ -194,6 +191,7 @@ const RowBelowLeftCol = ({
 );
 
 export const ArticleMeta = ({
+    display,
     designType,
     pillar,
     pageId,
@@ -201,7 +199,6 @@ export const ArticleMeta = ({
     author,
     tags,
     webPublicationDateDisplay,
-    isImmersive,
 }: Props) => {
     const sharingUrls = getSharingUrls(pageId, webTitle);
     const bylineImageUrl = getBylineImageUrl(tags);
@@ -211,7 +208,7 @@ export const ArticleMeta = ({
         tags.filter(tag => tag.type === 'Contributor').length === 1;
 
     const showAvatar =
-        onlyOneContributor && shouldShowAvatar(designType, isImmersive);
+        onlyOneContributor && shouldShowAvatar(designType, display);
 
     return (
         <div className={metaContainer}>
@@ -228,7 +225,7 @@ export const ArticleMeta = ({
                             </AvatarContainer>
                         )}
                         <div>
-                            {shouldShowContributor(designType, isImmersive) && (
+                            {shouldShowContributor(designType, display) && (
                                 <Contributor
                                     designType={designType}
                                     author={author}

--- a/src/web/components/ArticleStandfirst.stories.tsx
+++ b/src/web/components/ArticleStandfirst.stories.tsx
@@ -21,6 +21,8 @@ export const defaultStory = () => {
                 </LeftColumn>
                 <ArticleContainer>
                     <ArticleStandfirst
+                        display="standard"
+                        designType="Article"
                         standfirst="This the default standfirst text. Aut explicabo officia delectus omnis repellendus voluptas"
                         pillar="news"
                     />

--- a/src/web/components/ArticleStandfirst.tsx
+++ b/src/web/components/ArticleStandfirst.tsx
@@ -23,17 +23,23 @@ const standfirstLinks = pillarMap(
 );
 
 type Props = {
-    designType?: DesignType;
+    display: Display;
+    designType: DesignType;
     pillar: Pillar;
     standfirst: string; // Can be html
 };
 
 export const ArticleStandfirst = ({
-    designType = 'Article',
+    display,
+    designType,
     pillar,
     standfirst,
 }: Props) => (
     <div className={cx(standfirstStyles, standfirstLinks[pillar])}>
-        <Standfirst designType={designType} standfirst={standfirst} />
+        <Standfirst
+            display={display}
+            designType={designType}
+            standfirst={standfirst}
+        />
     </div>
 );

--- a/src/web/components/GuardianLines.stories.tsx
+++ b/src/web/components/GuardianLines.stories.tsx
@@ -31,6 +31,7 @@ export const defaultStory = () => {
                     </LeftColumn>
                     <ArticleContainer>
                         <ArticleHeadline
+                            display="standard"
                             headlineString="Headline text"
                             webPublicationDate=""
                             tags={[]}
@@ -62,6 +63,7 @@ export const eightLines = () => {
                     </LeftColumn>
                     <ArticleContainer>
                         <ArticleHeadline
+                            display="standard"
                             headlineString="Headline text"
                             webPublicationDate=""
                             tags={[]}
@@ -100,6 +102,7 @@ export const paddedLines = () => {
                     </LeftColumn>
                     <ArticleContainer>
                         <ArticleHeadline
+                            display="standard"
                             headlineString="Headline text"
                             webPublicationDate=""
                             tags={[]}
@@ -138,6 +141,7 @@ export const squigglyLines = () => {
                     </LeftColumn>
                     <ArticleContainer>
                         <ArticleHeadline
+                            display="standard"
                             headlineString="Headline text"
                             webPublicationDate=""
                             tags={[]}
@@ -176,6 +180,7 @@ export const dottedLines = () => {
                     </LeftColumn>
                     <ArticleContainer>
                         <ArticleHeadline
+                            display="standard"
                             headlineString="Headline text"
                             webPublicationDate=""
                             tags={[]}

--- a/src/web/components/HeadlineByline.stories.tsx
+++ b/src/web/components/HeadlineByline.stories.tsx
@@ -10,6 +10,7 @@ export default {
 export const interviewStory = () => {
     return (
         <HeadlineByline
+            display="standard"
             designType="Interview"
             pillar="culture"
             byline="Jane Smith"
@@ -22,6 +23,7 @@ interviewStory.story = { name: 'Interview' };
 export const commentStory = () => {
     return (
         <HeadlineByline
+            display="standard"
             designType="Comment"
             pillar="sport"
             byline="Jane Smith"
@@ -34,6 +36,7 @@ commentStory.story = { name: 'Comment' };
 export const immersiveStory = () => {
     return (
         <HeadlineByline
+            display="immersive"
             designType="Immersive"
             pillar="lifestyle"
             byline="Jane Smith"
@@ -52,6 +55,7 @@ immersiveStory.story = { name: 'Immersive' };
 export const MultipleStory = () => {
     return (
         <HeadlineByline
+            display="immersive"
             designType="Immersive"
             pillar="lifestyle"
             byline="Jane Smith, John Doe and Nae Bevan"

--- a/src/web/components/HeadlineByline.tsx
+++ b/src/web/components/HeadlineByline.tsx
@@ -72,13 +72,31 @@ const immersiveLinkStyles = (pillar: Pillar) => css`
 `;
 
 type Props = {
+    display: Display;
     designType: DesignType;
     pillar: Pillar;
     byline: string;
     tags: TagType[];
 };
 
-export const HeadlineByline = ({ designType, pillar, byline, tags }: Props) => {
+export const HeadlineByline = ({
+    display,
+    designType,
+    pillar,
+    byline,
+    tags,
+}: Props) => {
+    if (display === 'immersive') {
+        return (
+            <div className={immersiveStyles}>
+                by{' '}
+                <span className={immersiveLinkStyles(pillar)}>
+                    <BylineLink byline={byline} tags={tags} />
+                </span>
+            </div>
+        );
+    }
+
     switch (designType) {
         case 'Interview':
             return (
@@ -97,14 +115,6 @@ export const HeadlineByline = ({ designType, pillar, byline, tags }: Props) => {
             );
 
         case 'Immersive':
-            return (
-                <div className={immersiveStyles}>
-                    by{' '}
-                    <span className={immersiveLinkStyles(pillar)}>
-                        <BylineLink byline={byline} tags={tags} />
-                    </span>
-                </div>
-            );
         case 'Analysis':
         case 'Feature':
         case 'Article':

--- a/src/web/components/Standfirst.stories.tsx
+++ b/src/web/components/Standfirst.stories.tsx
@@ -13,6 +13,7 @@ export const Article = () => {
     return (
         <Section>
             <Standfirst
+                display="standard"
                 designType="Article"
                 standfirst="This is how Article standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
             />
@@ -25,6 +26,7 @@ export const Comment = () => {
     return (
         <Section>
             <Standfirst
+                display="standard"
                 designType="Comment"
                 standfirst="This is how Comment standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
             />
@@ -37,6 +39,7 @@ export const Feature = () => {
     return (
         <Section>
             <Standfirst
+                display="standard"
                 designType="Feature"
                 standfirst="This is how Feature standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
             />
@@ -49,6 +52,7 @@ export const Immersive = () => {
     return (
         <Section>
             <Standfirst
+                display="immersive"
                 designType="Immersive"
                 standfirst="This is how Immersive standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
             />
@@ -61,6 +65,7 @@ export const Review = () => {
     return (
         <Section>
             <Standfirst
+                display="standard"
                 designType="Review"
                 standfirst="This is how Review standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
             />
@@ -73,6 +78,7 @@ export const Live = () => {
     return (
         <Section>
             <Standfirst
+                display="standard"
                 designType="Live"
                 standfirst="This is how Live standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
             />
@@ -85,6 +91,7 @@ export const Interview = () => {
     return (
         <Section>
             <Standfirst
+                display="standard"
                 designType="Interview"
                 standfirst="This is how Interview standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
             />
@@ -97,6 +104,7 @@ export const Analysis = () => {
     return (
         <Section>
             <Standfirst
+                display="standard"
                 designType="Analysis"
                 standfirst="This is how Analysis standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
             />
@@ -109,6 +117,7 @@ export const Media = () => {
     return (
         <Section>
             <Standfirst
+                display="standard"
                 designType="Media"
                 standfirst="This is how Media standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
             />
@@ -121,6 +130,7 @@ export const Recipe = () => {
     return (
         <Section>
             <Standfirst
+                display="standard"
                 designType="Recipe"
                 standfirst="This is how Recipe standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
             />
@@ -133,6 +143,7 @@ export const MatchReport = () => {
     return (
         <Section>
             <Standfirst
+                display="standard"
                 designType="MatchReport"
                 standfirst="This is how MatchReport standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
             />
@@ -145,6 +156,7 @@ export const Quiz = () => {
     return (
         <Section>
             <Standfirst
+                display="standard"
                 designType="Quiz"
                 standfirst="This is how Quiz standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
             />
@@ -157,6 +169,7 @@ export const SpecialReport = () => {
     return (
         <Section>
             <Standfirst
+                display="standard"
                 designType="SpecialReport"
                 standfirst="This is how SpecialReport standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
             />
@@ -169,6 +182,7 @@ export const GuardianView = () => {
     return (
         <Section>
             <Standfirst
+                display="standard"
                 designType="GuardianView"
                 standfirst="This is how GuardianView standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
             />
@@ -181,6 +195,7 @@ export const GuardianLabs = () => {
     return (
         <Section>
             <Standfirst
+                display="standard"
                 designType="GuardianLabs"
                 standfirst="This is how GuardianLabs standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
             />
@@ -193,6 +208,7 @@ export const AdvertisementFeature = () => {
     return (
         <Section>
             <Standfirst
+                display="standard"
                 designType="AdvertisementFeature"
                 standfirst="This is how AdvertisementFeature standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
             />

--- a/src/web/components/Standfirst.tsx
+++ b/src/web/components/Standfirst.tsx
@@ -40,7 +40,15 @@ const nestedStyles = css`
     }
 `;
 
-const standfirstStyles = (designType: DesignType) => {
+const standfirstStyles = (designType: DesignType, display: Display) => {
+    if (display === 'immersive') {
+        return css`
+            ${headline.xsmall({
+                fontWeight: 'light',
+            })};
+        `;
+    }
+
     switch (designType) {
         case 'Comment':
         case 'GuardianView':
@@ -53,11 +61,6 @@ const standfirstStyles = (designType: DesignType) => {
                 })};
             `;
         case 'Immersive':
-            return css`
-                ${headline.xsmall({
-                    fontWeight: 'light',
-                })};
-            `;
         case 'Media':
         case 'SpecialReport':
         case 'MatchReport':
@@ -79,14 +82,15 @@ const standfirstStyles = (designType: DesignType) => {
 };
 
 type Props = {
+    display: Display;
     designType: DesignType;
     standfirst: string;
 };
 
-export const Standfirst = ({ designType = 'Article', standfirst }: Props) => {
+export const Standfirst = ({ display, designType, standfirst }: Props) => {
     return (
         <div
-            className={cx(nestedStyles, standfirstStyles(designType))}
+            className={cx(nestedStyles, standfirstStyles(designType, display))}
             // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{
                 __html: standfirst,

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -377,7 +377,7 @@ export const CommentLayout = ({
                                 <ArticleBody
                                     pillar={pillar}
                                     blocks={CAPI.blocks}
-                                    isImmersive={CAPI.isImmersive}
+                                    display={display}
                                     designType={designType}
                                     adTargeting={adTargeting}
                                 />

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -184,7 +184,13 @@ interface Props {
     pillar: Pillar;
 }
 
-export const CommentLayout = ({ CAPI, NAV, designType, pillar }: Props) => {
+export const CommentLayout = ({
+    CAPI,
+    NAV,
+    display,
+    designType,
+    pillar,
+}: Props) => {
     const {
         config: { isPaidContent },
         pageType: { isSensitive },
@@ -301,6 +307,7 @@ export const CommentLayout = ({ CAPI, NAV, designType, pillar }: Props) => {
                                     )}
                                 >
                                     <ArticleHeadline
+                                        display={display}
                                         headlineString={CAPI.headline}
                                         designType={designType}
                                         pillar={pillar}

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -359,6 +359,7 @@ export const CommentLayout = ({
                     <GridItem area="meta">
                         <div className={maxWidth}>
                             <ArticleMeta
+                                display={display}
                                 designType={designType}
                                 pillar={pillar}
                                 pageId={CAPI.pageId}

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -342,6 +342,7 @@ export const CommentLayout = ({
                     </GridItem>
                     <GridItem area="standfirst">
                         <ArticleStandfirst
+                            display={display}
                             designType={designType}
                             pillar={pillar}
                             standfirst={CAPI.standfirst}

--- a/src/web/layouts/Immersive.stories.tsx
+++ b/src/web/layouts/Immersive.stories.tsx
@@ -7,7 +7,6 @@ import { Review } from '@root/fixtures/articles/Review';
 import { Analysis } from '@root/fixtures/articles/Analysis';
 import { Feature } from '@root/fixtures/articles/Feature';
 import { GuardianView } from '@root/fixtures/articles/GuardianView';
-import { Immersive } from '@root/fixtures/articles/Immersive';
 import { Interview } from '@root/fixtures/articles/Interview';
 import { Quiz } from '@root/fixtures/articles/Quiz';
 import { Recipe } from '@root/fixtures/articles/Recipe';
@@ -93,12 +92,6 @@ export const GuardianViewStory = () => {
     return <HydratedLayout ServerCAPI={ServerCAPI} />;
 };
 GuardianViewStory.story = { name: 'GuardianView' };
-
-export const ImmersiveStory = () => {
-    const ServerCAPI = convertToImmersive(Immersive);
-    return <HydratedLayout ServerCAPI={ServerCAPI} />;
-};
-ImmersiveStory.story = { name: 'Immersive' };
 
 export const InterviewStory = () => {
     const ServerCAPI = convertToImmersive(Interview);

--- a/src/web/layouts/Showcase.stories.tsx
+++ b/src/web/layouts/Showcase.stories.tsx
@@ -7,7 +7,6 @@ import { Review } from '@root/fixtures/articles/Review';
 import { Analysis } from '@root/fixtures/articles/Analysis';
 import { Feature } from '@root/fixtures/articles/Feature';
 import { GuardianView } from '@root/fixtures/articles/GuardianView';
-import { Immersive } from '@root/fixtures/articles/Immersive';
 import { Interview } from '@root/fixtures/articles/Interview';
 import { Quiz } from '@root/fixtures/articles/Quiz';
 import { Recipe } from '@root/fixtures/articles/Recipe';
@@ -93,12 +92,6 @@ export const GuardianViewStory = () => {
     return <HydratedLayout ServerCAPI={ServerCAPI} />;
 };
 GuardianViewStory.story = { name: 'GuardianView' };
-
-export const ImmersiveStory = () => {
-    const ServerCAPI = convertToShowcase(Immersive);
-    return <HydratedLayout ServerCAPI={ServerCAPI} />;
-};
-ImmersiveStory.story = { name: 'Immersive' };
 
 export const InterviewStory = () => {
     const ServerCAPI = convertToShowcase(Interview);

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -186,17 +186,6 @@ const PositionHeadline = ({
                 </div>
             );
         case 'Immersive':
-            return (
-                <div
-                    className={css`
-                        ${from.leftCol} {
-                            margin-top: -100px;
-                        }
-                    `}
-                >
-                    {children}
-                </div>
-            );
         case 'Article':
         case 'Media':
         case 'Review':

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -243,7 +243,13 @@ interface Props {
     pillar: Pillar;
 }
 
-export const ShowcaseLayout = ({ CAPI, NAV, designType, pillar }: Props) => {
+export const ShowcaseLayout = ({
+    CAPI,
+    NAV,
+    display,
+    designType,
+    pillar,
+}: Props) => {
     const {
         config: { isPaidContent },
         pageType: { isSensitive },
@@ -352,6 +358,7 @@ export const ShowcaseLayout = ({ CAPI, NAV, designType, pillar }: Props) => {
                                 `}
                             >
                                 <ArticleHeadline
+                                    display={display}
                                     headlineString={CAPI.headline}
                                     designType={designType}
                                     pillar={pillar}

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -385,6 +385,7 @@ export const ShowcaseLayout = ({
                     </GridItem>
                     <GridItem area="standfirst">
                         <ArticleStandfirst
+                            display={display}
                             designType={designType}
                             pillar={pillar}
                             standfirst={CAPI.standfirst}

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -407,6 +407,7 @@ export const ShowcaseLayout = ({
                     <GridItem area="meta">
                         <div className={maxWidth}>
                             <ArticleMeta
+                                display={display}
                                 designType={designType}
                                 pillar={pillar}
                                 pageId={CAPI.pageId}

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -425,7 +425,7 @@ export const ShowcaseLayout = ({
                                 <ArticleBody
                                     pillar={pillar}
                                     blocks={CAPI.blocks}
-                                    isImmersive={CAPI.isImmersive}
+                                    display={display}
                                     designType={designType}
                                     adTargeting={adTargeting}
                                 />

--- a/src/web/layouts/Standard.stories.tsx
+++ b/src/web/layouts/Standard.stories.tsx
@@ -7,7 +7,6 @@ import { Review } from '@root/fixtures/articles/Review';
 import { Analysis } from '@root/fixtures/articles/Analysis';
 import { Feature } from '@root/fixtures/articles/Feature';
 import { GuardianView } from '@root/fixtures/articles/GuardianView';
-import { Immersive } from '@root/fixtures/articles/Immersive';
 import { Interview } from '@root/fixtures/articles/Interview';
 import { Quiz } from '@root/fixtures/articles/Quiz';
 import { Recipe } from '@root/fixtures/articles/Recipe';
@@ -93,12 +92,6 @@ export const GuardianViewStory = () => {
     return <HydratedLayout ServerCAPI={ServerCAPI} />;
 };
 GuardianViewStory.story = { name: 'GuardianView' };
-
-export const ImmersiveStory = () => {
-    const ServerCAPI = convertToStandard(Immersive);
-    return <HydratedLayout ServerCAPI={ServerCAPI} />;
-};
-ImmersiveStory.story = { name: 'Immersive' };
 
 export const InterviewStory = () => {
     const ServerCAPI = convertToStandard(Interview);

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -381,6 +381,7 @@ export const StandardLayout = ({
                     <GridItem area="meta">
                         <div className={maxWidth}>
                             <ArticleMeta
+                                display={display}
                                 designType={designType}
                                 pillar={pillar}
                                 pageId={CAPI.pageId}

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -216,7 +216,13 @@ interface Props {
     pillar: Pillar;
 }
 
-export const StandardLayout = ({ CAPI, NAV, designType, pillar }: Props) => {
+export const StandardLayout = ({
+    CAPI,
+    NAV,
+    display,
+    designType,
+    pillar,
+}: Props) => {
     const {
         config: { isPaidContent },
         pageType: { isSensitive },
@@ -321,6 +327,7 @@ export const StandardLayout = ({ CAPI, NAV, designType, pillar }: Props) => {
                         <div className={maxWidth}>
                             <ArticleHeadlinePadding designType={designType}>
                                 <ArticleHeadline
+                                    display={display}
                                     headlineString={CAPI.headline}
                                     designType={designType}
                                     pillar={pillar}

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -399,7 +399,7 @@ export const StandardLayout = ({
                                 <ArticleBody
                                     pillar={pillar}
                                     blocks={CAPI.blocks}
-                                    isImmersive={CAPI.isImmersive}
+                                    display={display}
                                     designType={designType}
                                     adTargeting={adTargeting}
                                 />

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -350,6 +350,7 @@ export const StandardLayout = ({
                     </GridItem>
                     <GridItem area="standfirst">
                         <ArticleStandfirst
+                            display={display}
                             designType={designType}
                             pillar={pillar}
                             standfirst={CAPI.standfirst}


### PR DESCRIPTION
## What does this change?
Propagates the `display` property down into thos sub components that branch based on if the context is an immersive article or not

Previously this components applied different styles based on when `designType` was `Immersive` but now we do that using `display === 'immersive'

### Why so many changes?
There are a lot of changes here but they're repetative and well distributed by commit so I suggest reviewing on a commit by commit bases for increased reviewing pleasure

### Why are my stories broken?
The immersive layout stories are not broken but this is a good thing. We don't yet support immersive layout but we're starting to and these visual changes in the stories show this movement

### Just why?
This prepares the way for things like having immersive Feature articles and also means we'll be able to remove the `Immersive` design type completely soon.

## Link to supporting Trello card
https://trello.com/c/cIDwM4es/1436-format