### PR TITLE
Show AgeWarning on old opinion articles

### DIFF
--- a/src/lib/age-warning.ts
+++ b/src/lib/age-warning.ts
@@ -5,40 +5,39 @@ export const getAgeWarning = (
     const isNews = tags.some(t => t.id === 'tone/news');
     const isOpinion = tags.some(t => t.id === 'commentisfree/commentisfree');
 
-    if (!isNews && !isOpinion) {
-        return;
-    }
+    // Only show an age warning for news or opinion pieces
+    if (isNews || isOpinion) {
+        const warnLimitDays = 30;
+        const currentDate = new Date();
+        const dateThreshold = new Date();
 
-    const warnLimitDays = 30;
-    const currentDate = new Date();
-    const dateThreshold = new Date();
+        dateThreshold.setDate(currentDate.getDate() - warnLimitDays);
 
-    dateThreshold.setDate(currentDate.getDate() - warnLimitDays);
+        const publicationDate = new Date(webPublicationDate);
 
-    const publicationDate = new Date(webPublicationDate);
+        // if the publication date is before the date threshold generate message
+        if (publicationDate < dateThreshold) {
+            // Unary + coerces dates to numbers for TypeScript
+            const diffMilliseconds = +currentDate - +publicationDate;
+            const diffSeconds = Math.floor(diffMilliseconds / 1000);
+            const diffMinutes = diffSeconds / 60;
+            const diffHours = diffMinutes / 60;
+            const diffDays = diffHours / 24;
+            const diffMonths = diffDays / 31;
+            const diffYears = diffDays / 365;
+            let message;
 
-    // if the publication date is before the date threshold generate message
-    if (publicationDate < dateThreshold) {
-        // Unary + coerces dates to numbers for TypeScript
-        const diffMilliseconds = +currentDate - +publicationDate;
-        const diffSeconds = Math.floor(diffMilliseconds / 1000);
-        const diffMinutes = diffSeconds / 60;
-        const diffHours = diffMinutes / 60;
-        const diffDays = diffHours / 24;
-        const diffMonths = diffDays / 31;
-        const diffYears = diffDays / 365;
-        let message;
+            if (diffYears >= 2) {
+                message = `${Math.floor(diffYears)} years old`;
+            } else if (diffYears > 1) {
+                message = '1 year old';
+            } else if (diffMonths >= 2) {
+                message = `${Math.floor(diffMonths)} months old`;
+            } else if (diffMonths > 1) {
+                message = '1 month old';
+            }
 
-        if (diffYears >= 2) {
-            message = `${Math.floor(diffYears)} years old`;
-        } else if (diffYears > 1) {
-            message = '1 year old';
-        } else if (diffMonths >= 2) {
-            message = `${Math.floor(diffMonths)} months old`;
-        } else if (diffMonths > 1) {
-            message = '1 month old';
+            return message;
         }
-
-        return message;
     }
 };

--- a/src/lib/age-warning.ts
+++ b/src/lib/age-warning.ts
@@ -3,8 +3,9 @@ export const getAgeWarning = (
     webPublicationDate: string,
 ): string | undefined => {
     const isNews = tags.some(t => t.id === 'tone/news');
+    const isOpinion = tags.some(t => t.id === 'commentisfree/commentisfree');
 
-    if (!isNews) {
+    if (!isNews && !isOpinion) {
         return;
     }
 


### PR DESCRIPTION
## What does this change?
Also shows the age warning header for opinion pieces, not just news

### Desktop
![Screenshot 2020-04-15 at 17 21 25](https://user-images.githubusercontent.com/1336821/79361690-8e93b980-7f3d-11ea-9e04-a014f46dc407.jpg)

### AMP
![Screenshot 2020-04-15 at 17 24 27](https://user-images.githubusercontent.com/1336821/79362087-0eba1f00-7f3e-11ea-9b19-e5389fdf3f17.jpg)


## Why?
Because sometimes old comment pieces become popular again and it's important to indicate to the reader the age of the content to better inform their understanding

## Link to supporting Trello card
https://trello.com/c/4fpvTscg/1454-opinion-age-warning