### PR TITLE
Refactor article title

### DIFF
--- a/src/web/components/ArticleTitle.stories.tsx
+++ b/src/web/components/ArticleTitle.stories.tsx
@@ -54,7 +54,7 @@ export const defaultStory = () => {
     return (
         <Container>
             {/* eslint-disable-next-line react/jsx-props-no-spreading */}
-            <ArticleTitle {...brexitCAPI} pillar="sport" />
+            <ArticleTitle {...brexitCAPI} display="standard" pillar="sport" />
         </Container>
     );
 };
@@ -63,8 +63,12 @@ defaultStory.story = { name: 'Brexit badge' };
 export const beyondTheBlade = () => {
     return (
         <Container>
-            {/* eslint-disable-next-line react/jsx-props-no-spreading */}
-            <ArticleTitle {...beyondTheBladeCAPI} pillar="news" />
+            <ArticleTitle
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                {...beyondTheBladeCAPI}
+                display="standard"
+                pillar="news"
+            />
         </Container>
     );
 };

--- a/src/web/components/ArticleTitle.tsx
+++ b/src/web/components/ArticleTitle.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@frontend/web/components/Badge';
 import { SeriesSectionLink } from './SeriesSectionLink';
 
 type Props = {
+    display: Display;
     tags: TagType[];
     sectionLabel: string;
     sectionUrl: string;
@@ -43,6 +44,7 @@ const marginTop = css`
 `;
 
 export const ArticleTitle = ({
+    display,
     tags,
     sectionLabel,
     sectionUrl,
@@ -51,13 +53,14 @@ export const ArticleTitle = ({
     badge,
 }: Props) => (
     <div className={cx(sectionStyles, badge && badgeContainer)}>
-        {badge && (
+        {badge && display !== 'immersive' && (
             <div className={titleBadgeWrapper}>
                 <Badge imageUrl={badge.imageUrl} seriesTag={badge.seriesTag} />
             </div>
         )}
         <div className={badge && marginTop}>
             <SeriesSectionLink
+                display={display}
                 tags={tags}
                 sectionLabel={sectionLabel}
                 sectionUrl={sectionUrl}

--- a/src/web/components/ArticleTitle.tsx
+++ b/src/web/components/ArticleTitle.tsx
@@ -5,15 +5,6 @@ import { from, until } from '@guardian/src-foundations/mq';
 import { Badge } from '@frontend/web/components/Badge';
 import { SeriesSectionLink } from './SeriesSectionLink';
 
-const sectionStyles = css`
-    padding-top: 8px;
-    display: flex;
-    flex-direction: row;
-    ${from.leftCol} {
-        flex-direction: column;
-    }
-`;
-
 type Props = {
     tags: TagType[];
     sectionLabel: string;
@@ -22,6 +13,15 @@ type Props = {
     pillar: Pillar;
     badge?: BadgeType;
 };
+
+const sectionStyles = css`
+    padding-top: 8px;
+    display: flex;
+    flex-direction: row;
+    ${from.leftCol} {
+        flex-direction: column;
+    }
+`;
 
 const titleBadgeWrapper = css`
     margin-bottom: 6px;

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -4,11 +4,12 @@ import { css, cx } from 'emotion';
 import { pillarMap, pillarPalette } from '@root/src/lib/pillars';
 import { headline } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
-import { space } from '@guardian/src-foundations';
+import { space, neutral } from '@guardian/src-foundations';
 
 import { Hide } from '@frontend/web/components/Hide';
 
 type Props = {
+    display: Display;
     tags: TagType[];
     sectionLabel: string;
     sectionUrl: string;
@@ -49,12 +50,28 @@ const primaryStyle = css`
     padding-right: ${space[2]}px;
 `;
 
+const invertedStyle = (pillar: Pillar) => css`
+    font-weight: 700;
+    ${headline.xxxsmall({ fontWeight: 'bold' })};
+    ${from.leftCol} {
+        ${headline.xxsmall({ fontWeight: 'bold' })};
+    }
+    color: ${neutral[100]};
+    background-color: ${pillarPalette[pillar].main};
+
+    padding-left: ${space[2]}px;
+    padding-right: ${space[2]}px;
+    padding-top: ${space[1]}px;
+    padding-bottom: ${space[1]}px;
+`;
+
 const secondaryStyle = css`
     ${headline.xxxsmall({ fontWeight: 'regular' })};
     display: block;
 `;
 
 export const SeriesSectionLink = ({
+    display,
     tags,
     sectionLabel,
     sectionUrl,
@@ -83,7 +100,9 @@ export const SeriesSectionLink = ({
                     className={cx(
                         sectionLabelLink,
                         pillarColours[pillar],
-                        primaryStyle,
+                        display === 'immersive'
+                            ? invertedStyle(pillar)
+                            : primaryStyle,
                     )}
                     data-component="series"
                     data-link-name="article series"
@@ -91,20 +110,22 @@ export const SeriesSectionLink = ({
                     <span>{tag.title}</span>
                 </a>
 
-                <Hide when="below" breakpoint="tablet">
-                    <a
-                        href={`${guardianBaseURL}/${sectionUrl}`}
-                        className={cx(
-                            sectionLabelLink,
-                            pillarColours[pillar],
-                            secondaryStyle,
-                        )}
-                        data-component="section"
-                        data-link-name="article section"
-                    >
-                        <span>{sectionLabel}</span>
-                    </a>
-                </Hide>
+                {display !== 'immersive' && (
+                    <Hide when="below" breakpoint="tablet">
+                        <a
+                            href={`${guardianBaseURL}/${sectionUrl}`}
+                            className={cx(
+                                sectionLabelLink,
+                                pillarColours[pillar],
+                                secondaryStyle,
+                            )}
+                            data-component="section"
+                            data-link-name="article section"
+                        >
+                            <span>{sectionLabel}</span>
+                        </a>
+                    </Hide>
+                )}
             </div>
         ) : null;
     }
@@ -116,7 +137,7 @@ export const SeriesSectionLink = ({
             className={cx(
                 sectionLabelLink,
                 pillarColours[pillar],
-                primaryStyle,
+                display === 'immersive' ? invertedStyle(pillar) : primaryStyle,
             )}
             data-component="section"
             data-link-name="article section"

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -94,7 +94,11 @@ export const SeriesSectionLink = ({
 
         return tag ? (
             // Sometimes the tags/titles are shown inline, sometimes stacked
-            <div className={cx(!badge && rowBelowLeftCol)}>
+            <div
+                className={cx(
+                    !badge && display !== 'immersive' && rowBelowLeftCol,
+                )}
+            >
                 <a
                     href={`${guardianBaseURL}/${tag.id}`}
                     className={cx(

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -45,39 +45,6 @@ const secondaryStyle = css`
     display: block;
 `;
 
-const TagLink: React.FC<{
-    pillar: Pillar;
-    guardianBaseURL: string;
-    tagTitle: string;
-    tagUrl: string;
-    dataComponentName: string;
-    dataLinkName: string;
-    weightingClass: string;
-}> = ({
-    pillar,
-    guardianBaseURL,
-    tagTitle,
-    tagUrl,
-    dataComponentName,
-    dataLinkName,
-    weightingClass,
-}) => {
-    return (
-        <a
-            href={`${guardianBaseURL}/${tagUrl}`}
-            className={cx(
-                sectionLabelLink,
-                pillarColours[pillar],
-                weightingClass,
-            )}
-            data-component={dataComponentName}
-            data-link-name={dataLinkName}
-        >
-            <span>{tagTitle}</span>
-        </a>
-    );
-};
-
 export const SeriesSectionLink: React.FC<{
     tags: TagType[];
     sectionLabel: string;
@@ -102,26 +69,32 @@ export const SeriesSectionLink: React.FC<{
         return tag ? (
             // Sometimes the tags/titles are shown inline, sometimes stacked
             <div className={cx(!badge && rowBelowLeftCol)}>
-                <TagLink
-                    pillar={pillar}
-                    guardianBaseURL={guardianBaseURL}
-                    tagTitle={tag.title}
-                    tagUrl={tag.id}
-                    dataComponentName="series"
-                    dataLinkName="article series"
-                    weightingClass={primaryStyle}
-                />
+                <a
+                    href={`${guardianBaseURL}/${tag.id}`}
+                    className={cx(
+                        sectionLabelLink,
+                        pillarColours[pillar],
+                        primaryStyle,
+                    )}
+                    data-component="series"
+                    data-link-name="article series"
+                >
+                    <span>{tag.title}</span>
+                </a>
 
                 <Hide when="below" breakpoint="tablet">
-                    <TagLink
-                        pillar={pillar}
-                        guardianBaseURL={guardianBaseURL}
-                        tagTitle={sectionLabel}
-                        tagUrl={sectionUrl}
-                        dataComponentName="section"
-                        dataLinkName="article section"
-                        weightingClass={secondaryStyle}
-                    />
+                    <a
+                        href={`${guardianBaseURL}/${sectionUrl}`}
+                        className={cx(
+                            sectionLabelLink,
+                            pillarColours[pillar],
+                            secondaryStyle,
+                        )}
+                        data-component="section"
+                        data-link-name="article section"
+                    >
+                        <span>{sectionLabel}</span>
+                    </a>
                 </Hide>
             </div>
         ) : null;
@@ -129,14 +102,17 @@ export const SeriesSectionLink: React.FC<{
 
     // Otherwise, there was no tag so just show 1 title
     return (
-        <TagLink
-            pillar={pillar}
-            guardianBaseURL={guardianBaseURL}
-            tagTitle={sectionLabel}
-            tagUrl={sectionUrl}
-            dataComponentName="Section"
-            dataLinkName="article section"
-            weightingClass={primaryStyle}
-        />
+        <a
+            href={`${guardianBaseURL}/${sectionUrl}`}
+            className={cx(
+                sectionLabelLink,
+                pillarColours[pillar],
+                primaryStyle,
+            )}
+            data-component="section"
+            data-link-name="article section"
+        >
+            <span>{sectionLabel}</span>
+        </a>
     );
 };

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -8,6 +8,15 @@ import { space } from '@guardian/src-foundations';
 
 import { Hide } from '@frontend/web/components/Hide';
 
+type Props = {
+    tags: TagType[];
+    sectionLabel: string;
+    sectionUrl: string;
+    guardianBaseURL: string;
+    pillar: Pillar;
+    badge?: BadgeType;
+};
+
 const sectionLabelLink = css`
     text-decoration: none;
     :hover {
@@ -45,14 +54,14 @@ const secondaryStyle = css`
     display: block;
 `;
 
-export const SeriesSectionLink: React.FC<{
-    tags: TagType[];
-    sectionLabel: string;
-    sectionUrl: string;
-    guardianBaseURL: string;
-    pillar: Pillar;
-    badge?: BadgeType;
-}> = ({ tags, sectionLabel, sectionUrl, guardianBaseURL, pillar, badge }) => {
+export const SeriesSectionLink = ({
+    tags,
+    sectionLabel,
+    sectionUrl,
+    guardianBaseURL,
+    pillar,
+    badge,
+}: Props) => {
     // If we have a tag, use it to show 2 section titles
     const blogTag = tags.find(tag => tag.type === 'Blog');
     const seriesTag = tags.find(tag => tag.type === 'Series');

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -281,6 +281,7 @@ export const CommentLayout = ({
                 <StandardGrid>
                     <GridItem area="title">
                         <ArticleTitle
+                            display={display}
                             tags={CAPI.tags}
                             sectionLabel={CAPI.sectionLabel}
                             sectionUrl={CAPI.sectionUrl}

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -328,6 +328,7 @@ export const ShowcaseLayout = ({
                 <ShowcaseGrid>
                     <GridItem area="title">
                         <ArticleTitle
+                            display={display}
                             tags={CAPI.tags}
                             sectionLabel={CAPI.sectionLabel}
                             sectionUrl={CAPI.sectionUrl}

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -312,6 +312,7 @@ export const StandardLayout = ({
                 <StandardGrid>
                     <GridItem area="title">
                         <ArticleTitle
+                            display={display}
                             tags={CAPI.tags}
                             sectionLabel={CAPI.sectionLabel}
                             sectionUrl={CAPI.sectionUrl}


### PR DESCRIPTION
## What does this change?
Adds the `display` prop to `ArticleTitle` using it to create a new inverted style

![Screenshot 2020-04-16 at 08 32 05](https://user-images.githubusercontent.com/1336821/79427538-c4c44e00-7fbc-11ea-9061-786ce10002b0.jpg)


## Why?
So we can use this component, and its associated link logic, with immersive articles

## Link to supporting Trello card
https://trello.com/c/HcWLFBfG/1438-review-articletitle
