### PR TITLE
Extract age warning

### DIFF
--- a/src/web/components/ArticleHeadline.stories.tsx
+++ b/src/web/components/ArticleHeadline.stories.tsx
@@ -27,7 +27,6 @@ export const ArticleStory = () => (
                     display="standard"
                     designType="Article"
                     pillar="news"
-                    webPublicationDate=""
                     tags={[]}
                 />
             </ArticleContainer>
@@ -48,7 +47,6 @@ export const oldHeadline = () => (
                     display="standard"
                     designType="Article"
                     pillar="news"
-                    webPublicationDate="2014-07-13T18:46:01.933Z"
                     tags={[
                         // Age warnings only show for old articles when the tone/news tag is present
                         {
@@ -76,7 +74,6 @@ export const Feature = () => (
                     display="standard"
                     designType="Feature"
                     pillar="lifestyle"
-                    webPublicationDate=""
                     tags={[]}
                 />
             </ArticleContainer>
@@ -102,7 +99,6 @@ export const ShowcaseInterview = () => (
                         display="showcase"
                         designType="Interview"
                         pillar="culture"
-                        webPublicationDate=""
                         tags={[]}
                         isShowcase={true}
                         byline="Byline text"
@@ -131,7 +127,6 @@ export const Interview = () => (
                     display="standard"
                     designType="Interview"
                     pillar="culture"
-                    webPublicationDate=""
                     tags={[]}
                     byline="Byline text"
                 />
@@ -163,7 +158,6 @@ export const Comment = () => (
                     display="standard"
                     designType="Comment"
                     pillar="opinion"
-                    webPublicationDate=""
                     tags={[]}
                 />
             </ArticleContainer>
@@ -184,7 +178,6 @@ export const Analysis = () => (
                     display="standard"
                     designType="Analysis"
                     pillar="news"
-                    webPublicationDate=""
                     tags={[]}
                 />
             </ArticleContainer>
@@ -205,7 +198,6 @@ export const Media = () => (
                     display="standard"
                     designType="Media"
                     pillar="news"
-                    webPublicationDate=""
                     tags={[]}
                 />
             </ArticleContainer>
@@ -226,7 +218,6 @@ export const Review = () => (
                     display="standard"
                     designType="Review"
                     pillar="news"
-                    webPublicationDate=""
                     tags={[]}
                 />
             </ArticleContainer>
@@ -247,7 +238,6 @@ export const AdvertisementFeature = () => (
                     display="standard"
                     designType="AdvertisementFeature"
                     pillar="news"
-                    webPublicationDate=""
                     tags={[]}
                 />
             </ArticleContainer>
@@ -268,7 +258,6 @@ export const Quiz = () => (
                     display="standard"
                     designType="Quiz"
                     pillar="news"
-                    webPublicationDate=""
                     tags={[]}
                 />
             </ArticleContainer>
@@ -289,7 +278,6 @@ export const GuardianLabs = () => (
                     display="standard"
                     designType="GuardianLabs"
                     pillar="news"
-                    webPublicationDate=""
                     tags={[]}
                 />
             </ArticleContainer>
@@ -310,7 +298,6 @@ export const Recipe = () => (
                     display="standard"
                     designType="Recipe"
                     pillar="news"
-                    webPublicationDate=""
                     tags={[]}
                 />
             </ArticleContainer>
@@ -331,7 +318,6 @@ export const GuardianView = () => (
                     display="standard"
                     designType="GuardianView"
                     pillar="news"
-                    webPublicationDate=""
                     tags={[]}
                 />
             </ArticleContainer>
@@ -352,7 +338,6 @@ export const MatchReport = () => (
                     display="standard"
                     designType="MatchReport"
                     pillar="news"
-                    webPublicationDate=""
                     tags={[]}
                 />
             </ArticleContainer>
@@ -373,7 +358,6 @@ export const SpecialReport = () => (
                     display="standard"
                     designType="SpecialReport"
                     pillar="news"
-                    webPublicationDate=""
                     tags={[]}
                 />
             </ArticleContainer>
@@ -394,7 +378,6 @@ export const Live = () => (
                     display="standard"
                     designType="Live"
                     pillar="news"
-                    webPublicationDate=""
                     tags={[]}
                 />
             </ArticleContainer>
@@ -431,7 +414,6 @@ export const LongImmersive = () => (
                             display="immersive"
                             designType="Immersive"
                             pillar="culture"
-                            webPublicationDate=""
                             tags={[]}
                         />
                     </div>
@@ -470,7 +452,6 @@ export const ShortImmersive = () => (
                             display="immersive"
                             designType="Immersive"
                             pillar="culture"
-                            webPublicationDate=""
                             tags={[]}
                         />
                     </div>

--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 import { css, cx } from 'emotion';
 
 import { pillarPalette } from '@root/src/lib/pillars';
-import { getAgeWarning } from '@root/src/lib/age-warning';
-import { AgeWarning } from '@root/src/web/components/AgeWarning';
 import { HeadlineTag } from '@root/src/web/components/HeadlineTag';
 import { HeadlineByline } from '@root/src/web/components/HeadlineByline';
 
@@ -16,9 +14,8 @@ type Props = {
     display: Display;
     designType: DesignType; // Decides headline appearance
     pillar: Pillar; // Decides headline colour when relevant
-    webPublicationDate: string; // Used for age warning
-    tags: TagType[]; // Used for age warning
     byline?: string;
+    tags: TagType[];
     isShowcase?: boolean; // Used for Interviews to change headline position
 };
 
@@ -152,21 +149,6 @@ const zIndex = css`
     z-index: 1;
 `;
 
-const ageWarningMargins = css`
-    margin-top: 12px;
-    margin-left: -10px;
-    margin-bottom: 6px;
-
-    ${from.tablet} {
-        margin-left: -20px;
-    }
-
-    ${from.leftCol} {
-        margin-left: -10px;
-        margin-top: 0;
-    }
-`;
-
 const renderHeadline = ({
     display,
     designType,
@@ -292,18 +274,11 @@ export const ArticleHeadline = ({
     display,
     designType,
     pillar,
-    webPublicationDate,
-    byline,
     tags,
+    byline,
 }: Props) => {
-    const age = getAgeWarning(tags, webPublicationDate);
     return (
         <>
-            {age && (
-                <div className={ageWarningMargins}>
-                    <AgeWarning age={age} />
-                </div>
-            )}
             {renderHeadline({
                 display,
                 designType,
@@ -315,7 +290,6 @@ export const ArticleHeadline = ({
                     colour: pillarPalette[pillar].dark,
                 },
             })}
-            {age && <AgeWarning age={age} isScreenReader={true} />}
         </>
     );
 };

--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -149,25 +149,14 @@ const zIndex = css`
     z-index: 1;
 `;
 
-const renderHeadline = ({
+export const ArticleHeadline = ({
+    headlineString,
     display,
     designType,
     pillar,
-    headlineString,
-    byline,
     tags,
-    options,
-}: {
-    display: Display;
-    designType: DesignType;
-    pillar: Pillar;
-    headlineString: string;
-    byline?: string;
-    tags: TagType[];
-    options?: {
-        colour?: string;
-    };
-}) => {
+    byline,
+}: Props) => {
     if (display === 'immersive') {
         return (
             // Immersive headlines are large and inverted and have their black background
@@ -207,7 +196,7 @@ const renderHeadline = ({
                 <h1
                     className={cx(
                         boldFont,
-                        colourStyles(options && options.colour),
+                        colourStyles(pillarPalette[pillar].dark),
                     )}
                 >
                     {curly(headlineString)}
@@ -267,29 +256,4 @@ const renderHeadline = ({
                 </div>
             );
     }
-};
-
-export const ArticleHeadline = ({
-    headlineString,
-    display,
-    designType,
-    pillar,
-    tags,
-    byline,
-}: Props) => {
-    return (
-        <>
-            {renderHeadline({
-                display,
-                designType,
-                pillar,
-                headlineString,
-                byline,
-                tags,
-                options: {
-                    colour: pillarPalette[pillar].dark,
-                },
-            })}
-        </>
-    );
 };

--- a/src/web/components/GuardianLines.stories.tsx
+++ b/src/web/components/GuardianLines.stories.tsx
@@ -33,7 +33,6 @@ export const defaultStory = () => {
                         <ArticleHeadline
                             display="standard"
                             headlineString="Headline text"
-                            webPublicationDate=""
                             tags={[]}
                             designType="Article"
                             pillar="news"
@@ -65,7 +64,6 @@ export const eightLines = () => {
                         <ArticleHeadline
                             display="standard"
                             headlineString="Headline text"
-                            webPublicationDate=""
                             tags={[]}
                             designType="Article"
                             pillar="news"
@@ -104,7 +102,6 @@ export const paddedLines = () => {
                         <ArticleHeadline
                             display="standard"
                             headlineString="Headline text"
-                            webPublicationDate=""
                             tags={[]}
                             designType="Article"
                             pillar="news"
@@ -143,7 +140,6 @@ export const squigglyLines = () => {
                         <ArticleHeadline
                             display="standard"
                             headlineString="Headline text"
-                            webPublicationDate=""
                             tags={[]}
                             designType="Article"
                             pillar="news"
@@ -182,7 +178,6 @@ export const dottedLines = () => {
                         <ArticleHeadline
                             display="standard"
                             headlineString="Headline text"
-                            webPublicationDate=""
                             tags={[]}
                             designType="Article"
                             pillar="news"

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -34,10 +34,11 @@ import { MobileStickyContainer, AdSlot } from '@root/src/web/components/AdSlot';
 import { Border } from '@root/src/web/components/Border';
 import { GridItem } from '@root/src/web/components/GridItem';
 import { Flex } from '@root/src/web/components/Flex';
+import { AgeWarning } from '@root/src/web/components/AgeWarning';
 
 import { buildAdTargeting } from '@root/src/lib/ad-targeting';
 import { parse } from '@frontend/lib/slot-machine-flags';
-
+import { getAgeWarning } from '@root/src/lib/age-warning';
 import { getCurrentPillar } from '@root/src/web/lib/layoutHelpers';
 
 const StandardGrid = ({
@@ -176,6 +177,21 @@ const headlinePadding = css`
     padding-bottom: 43px;
 `;
 
+const ageWarningMargins = css`
+    margin-top: 12px;
+    margin-left: -10px;
+    margin-bottom: 6px;
+
+    ${from.tablet} {
+        margin-left: -20px;
+    }
+
+    ${from.leftCol} {
+        margin-left: -10px;
+        margin-top: 0;
+    }
+`;
+
 interface Props {
     CAPI: CAPIType;
     NAV: NavType;
@@ -222,6 +238,8 @@ export const CommentLayout = ({
         CAPI.tags.filter(tag => tag.type === 'Contributor').length === 1;
 
     const showAvatar = avatarUrl && onlyOneContributor;
+
+    const age = getAgeWarning(CAPI.tags, CAPI.webPublicationDate);
 
     return (
         <>
@@ -306,17 +324,25 @@ export const CommentLayout = ({
                                         !showAvatar && headlinePadding,
                                     )}
                                 >
+                                    {age && (
+                                        <div className={ageWarningMargins}>
+                                            <AgeWarning age={age} />
+                                        </div>
+                                    )}
                                     <ArticleHeadline
                                         display={display}
                                         headlineString={CAPI.headline}
                                         designType={designType}
                                         pillar={pillar}
-                                        webPublicationDate={
-                                            CAPI.webPublicationDate
-                                        }
                                         tags={CAPI.tags}
                                         byline={CAPI.author.byline}
                                     />
+                                    {age && (
+                                        <AgeWarning
+                                            age={age}
+                                            isScreenReader={true}
+                                        />
+                                    )}
                                 </div>
                                 {/* BOTTOM */}
                                 <div>

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -33,11 +33,12 @@ import { MobileStickyContainer, AdSlot } from '@root/src/web/components/AdSlot';
 import { Border } from '@root/src/web/components/Border';
 import { GridItem } from '@root/src/web/components/GridItem';
 import { Flex } from '@root/src/web/components/Flex';
+import { AgeWarning } from '@root/src/web/components/AgeWarning';
 
 import { getZIndex } from '@frontend/web/lib/getZIndex';
 import { buildAdTargeting } from '@root/src/lib/ad-targeting';
 import { parse } from '@frontend/lib/slot-machine-flags';
-
+import { getAgeWarning } from '@root/src/lib/age-warning';
 import {
     decideLineCount,
     decideLineEffect,
@@ -224,6 +225,21 @@ const headerWrapper = css`
     ${getZIndex('headerWrapper')}
 `;
 
+const ageWarningMargins = css`
+    margin-top: 12px;
+    margin-left: -10px;
+    margin-bottom: 6px;
+
+    ${from.tablet} {
+        margin-left: -20px;
+    }
+
+    ${from.leftCol} {
+        margin-left: -10px;
+        margin-top: 0;
+    }
+`;
+
 interface Props {
     CAPI: CAPIType;
     NAV: NavType;
@@ -263,6 +279,8 @@ export const ShowcaseLayout = ({
     const showOnwardsLower = seriesTag && CAPI.hasStoryPackage;
 
     const showComments = CAPI.isCommentable;
+
+    const age = getAgeWarning(CAPI.tags, CAPI.webPublicationDate);
 
     return (
         <>
@@ -346,15 +364,25 @@ export const ShowcaseLayout = ({
                                     padding-bottom: 24px;
                                 `}
                             >
+                                {age && (
+                                    <div className={ageWarningMargins}>
+                                        <AgeWarning age={age} />
+                                    </div>
+                                )}
                                 <ArticleHeadline
                                     display={display}
                                     headlineString={CAPI.headline}
                                     designType={designType}
                                     pillar={pillar}
-                                    webPublicationDate={CAPI.webPublicationDate}
                                     tags={CAPI.tags}
                                     byline={CAPI.author.byline}
                                 />
+                                {age && (
+                                    <AgeWarning
+                                        age={age}
+                                        isScreenReader={true}
+                                    />
+                                )}
                             </div>
                         </PositionHeadline>
                     </GridItem>

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -37,10 +37,12 @@ import { MobileStickyContainer, AdSlot } from '@root/src/web/components/AdSlot';
 import { Border } from '@root/src/web/components/Border';
 import { GridItem } from '@root/src/web/components/GridItem';
 import { Flex } from '@root/src/web/components/Flex';
+import { AgeWarning } from '@root/src/web/components/AgeWarning';
 
 import { buildAdTargeting } from '@root/src/lib/ad-targeting';
 import { parse } from '@frontend/lib/slot-machine-flags';
 import { getZIndex } from '@frontend/web/lib/getZIndex';
+import { getAgeWarning } from '@root/src/lib/age-warning';
 import {
     decideLineCount,
     decideLineEffect,
@@ -208,6 +210,21 @@ const headerWrapper = css`
     ${getZIndex('headerWrapper')}
 `;
 
+const ageWarningMargins = css`
+    margin-top: 12px;
+    margin-left: -10px;
+    margin-bottom: 6px;
+
+    ${from.tablet} {
+        margin-left: -20px;
+    }
+
+    ${from.leftCol} {
+        margin-left: -10px;
+        margin-top: 0;
+    }
+`;
+
 interface Props {
     CAPI: CAPIType;
     NAV: NavType;
@@ -247,6 +264,8 @@ export const StandardLayout = ({
     const showOnwardsLower = seriesTag && CAPI.hasStoryPackage;
 
     const showComments = CAPI.isCommentable;
+
+    const age = getAgeWarning(CAPI.tags, CAPI.webPublicationDate);
 
     return (
         <>
@@ -326,15 +345,25 @@ export const StandardLayout = ({
                     <GridItem area="headline">
                         <div className={maxWidth}>
                             <ArticleHeadlinePadding designType={designType}>
+                                {age && (
+                                    <div className={ageWarningMargins}>
+                                        <AgeWarning age={age} />
+                                    </div>
+                                )}
                                 <ArticleHeadline
                                     display={display}
                                     headlineString={CAPI.headline}
                                     designType={designType}
                                     pillar={pillar}
-                                    webPublicationDate={CAPI.webPublicationDate}
                                     tags={CAPI.tags}
                                     byline={CAPI.author.byline}
                                 />
+                                {age && (
+                                    <AgeWarning
+                                        age={age}
+                                        isScreenReader={true}
+                                    />
+                                )}
                             </ArticleHeadlinePadding>
                         </div>
                         {CAPI.starRating || CAPI.starRating === 0 ? (


### PR DESCRIPTION
## What does this change?
Extracts the display of the age warning message out of `ArticleHeadline` and puts it in the layout files

## Why?
So we have more control over where the message will appear in different contexts

## Link to supporting Trello card
https://trello.com/c/v3LwjbKn/1437-extract-agewarning
