### PR TITLE
GuardianRoundel

### DIFF
--- a/src/web/components/GuardianRoundel.stories.tsx
+++ b/src/web/components/GuardianRoundel.stories.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import { GuardianRoundel } from './GuardianRoundel';
+
+export default {
+    component: GuardianRoundel,
+    title: 'Components/GuardianRoundel',
+};
+
+export const defaultStory = () => {
+    return <GuardianRoundel />;
+};
+defaultStory.story = { name: 'default' };

--- a/src/web/components/GuardianRoundel.tsx
+++ b/src/web/components/GuardianRoundel.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { brand, neutral } from '@guardian/src-foundations/palette';
+
+export const GuardianRoundel = () => {
+    return (
+        <div
+            className={css`
+                height: 42px;
+                width: 42px;
+            `}
+        >
+            <a href="https://www.theguardian.com" data-link-name="nav2 : logo">
+                <svg viewBox="0 0 56 56">
+                    <path
+                        d="M28 0a28 28 0 1 0 28 28A28 28 0 0 0 28 0"
+                        fill={brand[400]}
+                    />
+                    <path
+                        d="M33 6.92c3.63.58 8.24 3.06 9.89 4.83v8h-1L33 7.82zm-3.34.5h-.09c-6.35 0-9.8 8.8-9.8 20.66 0 11.87 3.45 20.66 9.8 20.66h.09v.91c-9.56.65-22.42-6.63-22.09-21.58C7.23 13.14 20.09 5.86 29.66 6.51zm16.16 22.53l-3 1.3v13.44A24.26 24.26 0 0 1 33 49.52V31l-3.3-1.09V29h16.12z"
+                        fill={neutral[100]}
+                    />
+                </svg>
+            </a>
+        </div>
+    );
+};


### PR DESCRIPTION
## What does this change?
Adds the Guardian Roundel

![Screenshot 2020-04-16 at 10 45 40](https://user-images.githubusercontent.com/1336821/79441671-6fde0300-7fcf-11ea-9a8d-05cabc765918.jpg)

## Why?
So we can include this in Nav for immersive articles

## Link to supporting Trello card
https://trello.com/c/AuZ4Wblf/1442-g-button