### PR TITLE
Support immersive main media image

### DIFF
--- a/src/web/components/ArticleBody.tsx
+++ b/src/web/components/ArticleBody.tsx
@@ -127,6 +127,7 @@ export const ArticleBody = ({
     return (
         <div className={cx(bodyStyle(display), linkColour[pillar])}>
             <ArticleRenderer
+                display={display}
                 elements={blocks[0] ? blocks[0].elements : []}
                 pillar={pillar}
                 designType={designType}

--- a/src/web/components/ArticleHeadline.stories.tsx
+++ b/src/web/components/ArticleHeadline.stories.tsx
@@ -105,6 +105,7 @@ export const ShowcaseInterview = () => (
                     />
                 </div>
                 <MainMedia
+                    display="standard"
                     hideCaption={true}
                     elements={mainMediaElements}
                     pillar="news"
@@ -136,6 +137,7 @@ export const Interview = () => (
                     standfirst="This is the standfirst text. We include here to demonstrate spacing in this case where we have a Interview type article that does not have a showcase main media element"
                 />
                 <MainMedia
+                    display="standard"
                     hideCaption={true}
                     elements={mainMediaElements}
                     pillar="news"
@@ -389,6 +391,7 @@ Live.story = { name: 'Live' };
 export const LongImmersive = () => (
     <>
         <MainMedia
+            display="immersive"
             hideCaption={true}
             elements={mainMediaElements}
             pillar="news"
@@ -427,6 +430,7 @@ LongImmersive.story = { name: 'Immersive with a long headline' };
 export const ShortImmersive = () => (
     <>
         <MainMedia
+            display="immersive"
             hideCaption={true}
             elements={mainMediaElements}
             pillar="news"

--- a/src/web/components/ArticleHeadline.stories.tsx
+++ b/src/web/components/ArticleHeadline.stories.tsx
@@ -390,12 +390,18 @@ Live.story = { name: 'Live' };
 
 export const LongImmersive = () => (
     <>
-        <MainMedia
-            display="immersive"
-            hideCaption={true}
-            elements={mainMediaElements}
-            pillar="news"
-        />
+        <div
+            className={css`
+                height: 100vh;
+            `}
+        >
+            <MainMedia
+                display="immersive"
+                hideCaption={true}
+                elements={mainMediaElements}
+                pillar="news"
+            />
+        </div>
         <Section
             showTopBorder={false}
             showSideBorders={false}
@@ -429,12 +435,18 @@ LongImmersive.story = { name: 'Immersive with a long headline' };
 
 export const ShortImmersive = () => (
     <>
-        <MainMedia
-            display="immersive"
-            hideCaption={true}
-            elements={mainMediaElements}
-            pillar="news"
-        />
+        <div
+            className={css`
+                height: 100vh;
+            `}
+        >
+            <MainMedia
+                display="immersive"
+                hideCaption={true}
+                elements={mainMediaElements}
+                pillar="news"
+            />
+        </div>
         <Section
             showTopBorder={false}
             showSideBorders={false}

--- a/src/web/components/MainMedia.tsx
+++ b/src/web/components/MainMedia.tsx
@@ -47,6 +47,7 @@ const mainMedia = css`
 `;
 
 function renderElement(
+    display: Display,
     element: CAPIElement,
     pillar: Pillar,
     i: number,
@@ -58,6 +59,7 @@ function renderElement(
         case 'model.dotcomrendering.pageElements.ImageBlockElement':
             return (
                 <ImageComponent
+                    display={display}
                     key={i}
                     element={element}
                     pillar={pillar}
@@ -90,15 +92,17 @@ function renderElement(
 }
 
 export const MainMedia: React.FC<{
+    display: Display;
     elements: CAPIElement[];
     pillar: Pillar;
     hideCaption?: boolean;
     adTargeting?: AdTargeting;
     starRating?: number;
-}> = ({ elements, pillar, hideCaption, adTargeting, starRating }) => (
+}> = ({ display, elements, pillar, hideCaption, adTargeting, starRating }) => (
     <div className={mainMedia}>
         {elements.map((element, i) =>
             renderElement(
+                display,
                 element,
                 pillar,
                 i,

--- a/src/web/components/elements/ImageBlockComponent.tsx
+++ b/src/web/components/elements/ImageBlockComponent.tsx
@@ -4,6 +4,13 @@ import { ImageComponent } from '@root/src/web/components/elements/ImageComponent
 
 import { from } from '@guardian/src-foundations/mq';
 
+type Props = {
+    display: Display;
+    element: ImageBlockElement;
+    pillar: Pillar;
+    hideCaption?: boolean;
+};
+
 const imageCss = {
     inline: css`
         margin-top: 16px;
@@ -103,15 +110,17 @@ const decidePosition = (role: RoleType) => {
     }
 };
 
-export const ImageBlockComponent: React.FC<{
-    element: ImageBlockElement;
-    pillar: Pillar;
-    hideCaption?: boolean;
-}> = ({ element, pillar, hideCaption }) => {
+export const ImageBlockComponent = ({
+    display,
+    element,
+    pillar,
+    hideCaption,
+}: Props) => {
     const { role } = element;
     return (
         <div className={decidePosition(role)}>
             <ImageComponent
+                display={display}
                 element={element}
                 pillar={pillar}
                 hideCaption={hideCaption}

--- a/src/web/components/elements/ImageComponent.tsx
+++ b/src/web/components/elements/ImageComponent.tsx
@@ -7,6 +7,16 @@ import { StarRating } from '@root/src/web/components/StarRating/StarRating';
 import { until, from, between } from '@guardian/src-foundations/mq';
 import { brandAltBackground } from '@guardian/src-foundations/palette';
 
+type Props = {
+    display: Display;
+    element: ImageBlockElement;
+    pillar: Pillar;
+    hideCaption?: boolean;
+    role: RoleType;
+    isMainMedia?: boolean;
+    starRating?: number;
+};
+
 const widths = [1020, 660, 480, 0];
 
 const bestFor = (
@@ -105,19 +115,44 @@ const StarRatingComponent: React.FC<{ rating: number }> = ({ rating }) => (
     </div>
 );
 
-export const ImageComponent: React.FC<{
-    element: ImageBlockElement;
-    pillar: Pillar;
-    hideCaption?: boolean;
-    role: RoleType;
-    isMainMedia?: boolean;
-    starRating?: number;
-}> = ({ element, pillar, hideCaption, role, isMainMedia, starRating }) => {
+export const ImageComponent = ({
+    display,
+    element,
+    pillar,
+    hideCaption,
+    role,
+    isMainMedia,
+    starRating,
+}: Props) => {
     const { imageSources } = element;
     const sources = makeSources(imageSources, role);
     const shouldLimitWidth =
         !isMainMedia &&
         (role === 'showcase' || role === 'supporting' || role === 'immersive');
+
+    if (isMainMedia && display === 'immersive') {
+        return (
+            <div
+                className={css`
+                    position: absolute;
+                    top: 0;
+                    height: 100%;
+                    width: 100%;
+
+                    img {
+                        object-fit: cover;
+                    }
+                `}
+            >
+                <Picture
+                    sources={sources}
+                    alt={element.data.alt || ''}
+                    src={getFallback(element.imageSources)}
+                />
+                {starRating && <StarRatingComponent rating={starRating} />}
+            </div>
+        );
+    }
 
     if (hideCaption) {
         return (

--- a/src/web/components/elements/ImageComponent.tsx
+++ b/src/web/components/elements/ImageComponent.tsx
@@ -134,6 +134,9 @@ export const ImageComponent = ({
         return (
             <div
                 className={css`
+                    /* These styles depend on the containing layout component wrapping the main media
+                    with a div set to 100vh. This is the case for ImmersiveLayout which should
+                    always be used if display === 'immersive' */
                     position: absolute;
                     top: 0;
                     height: 100%;

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -378,6 +378,7 @@ export const CommentLayout = ({
                     <GridItem area="media">
                         <div className={maxWidth}>
                             <MainMedia
+                                display={display}
                                 elements={CAPI.mainMediaElements}
                                 pillar={pillar}
                                 adTargeting={adTargeting}

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -390,6 +390,7 @@ export const ShowcaseLayout = ({
                     <GridItem area="media">
                         <div className={mainMediaWrapper}>
                             <MainMedia
+                                display={display}
                                 elements={CAPI.mainMediaElements}
                                 pillar={pillar}
                                 adTargeting={adTargeting}

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -389,6 +389,7 @@ export const StandardLayout = ({
                     <GridItem area="media">
                         <div className={maxWidth}>
                             <MainMedia
+                                display={display}
                                 elements={CAPI.mainMediaElements}
                                 pillar={pillar}
                                 adTargeting={adTargeting}

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -15,11 +15,12 @@ const commercialPosition = css`
 `;
 
 export const ArticleRenderer: React.FC<{
+    display: Display;
     elements: CAPIElement[];
     pillar: Pillar;
     designType: DesignType;
     adTargeting?: AdTargeting;
-}> = ({ elements, pillar, designType, adTargeting }) => {
+}> = ({ display, elements, pillar, designType, adTargeting }) => {
     // const cleanedElements = elements.map(element =>
     //     'html' in element ? { ...element, html: clean(element.html) } : element,
     // );
@@ -46,6 +47,7 @@ export const ArticleRenderer: React.FC<{
                 case 'model.dotcomrendering.pageElements.ImageBlockElement':
                     return (
                         <ImageBlockComponent
+                            display={display}
                             key={i}
                             element={element}
                             pillar={pillar}


### PR DESCRIPTION
## What does this change?
Adds support for applying immersive styles to an image

```typescript
                    position: absolute;
                    top: 0;
                    height: 100%;
                    width: 100%;

                    img {
                        object-fit: cover;
                    }
```

To know when to apply these styles, we're passing `display` down the stack

## Why?
So that when an immersive main media element is shown it correctly display full width with the correct scaling

### Why are the immersive layout snapshots so weird?
Because there's a dependency built in between the layout and this immersive image styling. If the image has immersive styling but isn't wrapped in an appropriate container by the layout, then it breaks.

## Depends on
The image and associated page header being wrapped in a div with `100vh` applied to it. This styling is part of the `ImmersiveLayout` work

## Link to supporting Trello card
https://trello.com/c/V12DmkH2/1462-immersive-image