### PR TITLE
Refactor ArticleTitle

### DIFF
--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -4,7 +4,7 @@ import { css, cx } from 'emotion';
 import { pillarMap, pillarPalette } from '@root/src/lib/pillars';
 import { headline } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
-import { space, neutral } from '@guardian/src-foundations';
+import { space, neutral, brandAltBackground } from '@guardian/src-foundations';
 
 import { Hide } from '@frontend/web/components/Hide';
 
@@ -31,6 +31,11 @@ const rowBelowLeftCol = css`
     ${until.leftCol} {
         flex-direction: row;
     }
+`;
+
+const yellowBackground = css`
+    background-color: ${brandAltBackground.primary};
+    padding-left: 2px;
 `;
 
 const pillarColours = pillarMap(
@@ -80,19 +85,15 @@ export const SeriesSectionLink = ({
     badge,
 }: Props) => {
     // If we have a tag, use it to show 2 section titles
-    const blogTag = tags.find(tag => tag.type === 'Blog');
-    const seriesTag = tags.find(tag => tag.type === 'Series');
-    const publicationTag = tags.find(tag => tag.type === 'Publication');
+    const tag = tags.find(
+        thisTag =>
+            thisTag.type === 'Blog' ||
+            thisTag.type === 'Series' ||
+            thisTag.title === 'The Observer',
+    );
 
-    if (
-        blogTag ||
-        seriesTag ||
-        (publicationTag && publicationTag.title === 'The Observer')
-    ) {
-        // Chose tag to use based on this order of importance
-        const tag = blogTag || seriesTag || publicationTag;
-
-        return tag ? (
+    if (tag) {
+        return (
             // Sometimes the tags/titles are shown inline, sometimes stacked
             <div
                 className={cx(
@@ -107,6 +108,10 @@ export const SeriesSectionLink = ({
                         display === 'immersive'
                             ? invertedStyle(pillar)
                             : primaryStyle,
+                        badge &&
+                            display !== 'immersive' &&
+                            tag.type === 'Series' &&
+                            yellowBackground,
                     )}
                     data-component="series"
                     data-link-name="article series"
@@ -131,7 +136,7 @@ export const SeriesSectionLink = ({
                     </Hide>
                 )}
             </div>
-        ) : null;
+        );
     }
 
     // Otherwise, there was no tag so just show 1 title

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -16,6 +16,7 @@ type Props = {
     guardianBaseURL: string;
     pillar: Pillar;
     badge?: BadgeType;
+    isSpecial?: boolean;
 };
 
 const sectionLabelLink = css`
@@ -83,6 +84,7 @@ export const SeriesSectionLink = ({
     guardianBaseURL,
     pillar,
     badge,
+    isSpecial,
 }: Props) => {
     // If we have a tag, use it to show 2 section titles
     const tag = tags.find(
@@ -108,10 +110,7 @@ export const SeriesSectionLink = ({
                         display === 'immersive'
                             ? invertedStyle(pillar)
                             : primaryStyle,
-                        badge &&
-                            display !== 'immersive' &&
-                            tag.type === 'Series' &&
-                            yellowBackground,
+                        isSpecial && yellowBackground,
                     )}
                     data-component="series"
                     data-link-name="article series"


### PR DESCRIPTION
## What does this change?
Changes how we search for the tag to use for the article title so that the order of tags is now the primary method for deciding which tag to use

## Why?
Because this is the established method for deciding the primacy of tags

## isSpecial
In addition, this PR adds a `isSpecial` flag to `SeriesSectionLinks` so that we can decide when to apply the yellow background style. This flag is currently unused but is now available when the model gets updated

## Link to supporting Trello card
https://trello.com/c/1vn5h7uK/1461-bring-in-special-series-name
