### PR TITLE
Option Caption Children

### DIFF
--- a/src/web/components/Caption.tsx
+++ b/src/web/components/Caption.tsx
@@ -10,7 +10,7 @@ import TriangleIcon from '@frontend/static/icons/triangle.svg';
 type Props = {
     captionText?: string;
     pillar: Pillar;
-    children: React.ReactNode;
+    children?: React.ReactNode;
     padCaption?: boolean;
     credit?: string;
     displayCredit?: boolean;


### PR DESCRIPTION
## What does this change?
Makes the `children` prop optional

## Why?
So we can use the `Caption` component by itself, not just wrapped around an image

## Link to supporting Trello card
https://trello.com/c/2yxG8rWl/1467-optional-caption-children
