### PR TITLE
Refactor Nav to support immersives

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -277,6 +277,8 @@ interface CAPIType {
 }
 
 type CAPIBrowserType = {
+    designType: DesignType;
+    pillar: Pillar;
     config: {
         isDev: boolean;
         ajaxUrl: string;
@@ -305,13 +307,13 @@ type CAPIBrowserType = {
     };
     richLinks: RichLinkBlockElement[];
     editionId: Edition;
-    pillar: Pillar;
     contentType: string;
     sectionName?: string;
     shouldHideReaderRevenue: boolean;
     pageType: {
         isMinuteArticle: boolean;
         isPaidContent: boolean;
+        hasShowcaseMainElement: boolean;
     };
     hasRelated: boolean;
     hasStoryPackage: boolean;
@@ -326,6 +328,7 @@ type CAPIBrowserType = {
         };
     };
     contributionsServiceUrl: string;
+    isImmersive: boolean;
 };
 
 interface TagType {

--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -85,6 +85,8 @@ export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
     );
 
     return {
+        designType: CAPI.designType,
+        pillar: CAPI.pillar,
         config: {
             isDev: process.env.NODE_ENV !== 'production',
             ajaxUrl: CAPI.config.ajaxUrl,
@@ -116,13 +118,13 @@ export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
         },
         richLinks: richLinksWithIndex,
         editionId: CAPI.editionId,
-        pillar: CAPI.pillar,
         contentType: CAPI.contentType,
         sectionName: CAPI.sectionName,
         shouldHideReaderRevenue: CAPI.shouldHideReaderRevenue,
         pageType: {
             isMinuteArticle: CAPI.pageType.isMinuteArticle,
             isPaidContent: CAPI.pageType.isPaidContent,
+            hasShowcaseMainElement: CAPI.pageType.hasShowcaseMainElement,
         },
         hasRelated: CAPI.hasRelated,
         hasStoryPackage: CAPI.hasStoryPackage,
@@ -137,6 +139,7 @@ export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
             },
         },
         contributionsServiceUrl: CAPI.contributionsServiceUrl,
+        isImmersive: CAPI.isImmersive,
     };
 };
 

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -42,6 +42,19 @@ const hasCommentsHashInUrl = () => {
     return hash && hash === '#comments';
 };
 
+const decideDisplay = (CAPI: CAPIBrowserType): Display => {
+    if (CAPI.isImmersive) return 'immersive';
+    if (CAPI.pageType.hasShowcaseMainElement) return 'showcase';
+    return 'standard';
+};
+
+const decidePillar = (CAPI: CAPIBrowserType): Pillar => {
+    // We override the pillar to be opinion on Comment news pieces
+    if (CAPI.designType === 'Comment' && CAPI.pillar === 'news')
+        return 'opinion';
+    return CAPI.pillar;
+};
+
 export const App = ({ CAPI, NAV }: Props) => {
     const [isSignedIn, setIsSignedIn] = useState<boolean>();
     const [user, setUser] = useState<UserProfile>();
@@ -140,6 +153,9 @@ export const App = ({ CAPI, NAV }: Props) => {
         FocusStyleManager.onlyShowFocusOnTabs();
     }, []);
 
+    const pillar = decidePillar(CAPI);
+    const display = decideDisplay(CAPI);
+
     return (
         // Do you need to Hydrate or do you want a Portal?
         //
@@ -170,7 +186,7 @@ export const App = ({ CAPI, NAV }: Props) => {
                 />
             </Hydrate>
             <Hydrate root="nav-root">
-                <Nav pillar={CAPI.pillar} nav={NAV} />
+                <Nav pillar={pillar} nav={NAV} display={display} />
             </Hydrate>
             {NAV.subNavSections && (
                 <Hydrate root="sub-nav-root">
@@ -178,7 +194,7 @@ export const App = ({ CAPI, NAV }: Props) => {
                         <SubNav
                             subNavSections={NAV.subNavSections}
                             currentNavLink={NAV.currentNavLink}
-                            pillar={CAPI.pillar}
+                            pillar={pillar}
                         />
                     </>
                 </Hydrate>
@@ -191,7 +207,7 @@ export const App = ({ CAPI, NAV }: Props) => {
                 >
                     <RichLinkComponent
                         element={link}
-                        pillar={CAPI.pillar}
+                        pillar={pillar}
                         ajaxEndpoint={CAPI.config.ajaxUrl}
                         richLinkIndex={index}
                     />
@@ -202,13 +218,13 @@ export const App = ({ CAPI, NAV }: Props) => {
                     ajaxUrl={CAPI.config.ajaxUrl}
                     pageId={CAPI.config.pageId}
                     commentCount={commentCount}
-                    pillar={CAPI.pillar}
+                    pillar={pillar}
                     setOpenComments={setOpenComments}
                 />
             </Portal>
             <Portal root="most-viewed-right">
                 <Lazy margin={100}>
-                    <MostViewedRightWrapper pillar={CAPI.pillar} />
+                    <MostViewedRightWrapper pillar={pillar} />
                 </Lazy>
             </Portal>
             <Portal root="slot-body-end">
@@ -257,7 +273,7 @@ export const App = ({ CAPI, NAV }: Props) => {
                 {openComments ? (
                     <CommentsLayout
                         user={user}
-                        pillar={CAPI.pillar}
+                        pillar={pillar}
                         baseUrl={CAPI.config.discussionApiUrl}
                         shortUrl={CAPI.config.shortUrlId}
                         commentCount={commentCount}
@@ -279,7 +295,7 @@ export const App = ({ CAPI, NAV }: Props) => {
                     <Lazy margin={300}>
                         <CommentsLayout
                             user={user}
-                            pillar={CAPI.pillar}
+                            pillar={pillar}
                             baseUrl={CAPI.config.discussionApiUrl}
                             shortUrl={CAPI.config.shortUrlId}
                             commentCount={commentCount}
@@ -301,7 +317,7 @@ export const App = ({ CAPI, NAV }: Props) => {
             </Portal>
             <Portal root="most-viewed-footer">
                 <MostViewedFooter
-                    pillar={CAPI.pillar}
+                    pillar={pillar}
                     sectionName={CAPI.sectionName}
                     ajaxUrl={CAPI.config.ajaxUrl}
                 />

--- a/src/web/components/Footer.tsx
+++ b/src/web/components/Footer.tsx
@@ -212,6 +212,7 @@ export const Footer: React.FC<{
     <footer className={footer} data-link-name="footer" data-component="footer">
         <div className={pillarWrap}>
             <Pillars
+                display="standard"
                 mainMenuOpen={false}
                 pillars={pillars}
                 pillar={pillar}

--- a/src/web/components/Nav/ExpandedMenu/ExpandedMenu.tsx
+++ b/src/web/components/Nav/ExpandedMenu/ExpandedMenu.tsx
@@ -69,14 +69,16 @@ const mainMenu = css`
 `;
 
 export const ExpandedMenu: React.FC<{
+    display: Display;
     id: string;
     nav: NavType;
     showExpandedMenu: boolean;
     toggleExpandedMenu: (value: boolean) => void;
-}> = ({ id, nav, showExpandedMenu, toggleExpandedMenu }) => {
+}> = ({ display, id, nav, showExpandedMenu, toggleExpandedMenu }) => {
     return (
         <>
             <ExpandedMenuToggle
+                display={display}
                 showExpandedMenu={showExpandedMenu}
                 toggleExpandedMenu={toggleExpandedMenu}
                 ariaControls={id}

--- a/src/web/components/Nav/ExpandedMenu/ExpandedMenuToggle/ExpandedMenuToggle.tsx
+++ b/src/web/components/Nav/ExpandedMenu/ExpandedMenuToggle/ExpandedMenuToggle.tsx
@@ -9,7 +9,7 @@ import { VeggieBurger } from './VeggieBurger';
 const screenReadable = css`
     ${visuallyHidden};
 `;
-const openExpandedMenu = css`
+const openExpandedMenu = (display: Display) => css`
     ${headline.xsmall()};
     font-weight: 300;
     color: ${brandText.primary};
@@ -24,7 +24,7 @@ const openExpandedMenu = css`
     padding-right: 20px;
     ${from.desktop} {
         display: block;
-        padding-top: 5px;
+        padding-top: ${display === 'immersive' ? '9px' : '5px'};
         height: 42px;
     }
     :hover,
@@ -65,6 +65,7 @@ const text = ({ showExpandedMenu }: { showExpandedMenu: boolean }) => css`
 `;
 
 interface Props {
+    display: Display;
     showExpandedMenu: boolean;
     toggleExpandedMenu: (value: boolean) => void;
     ariaControls: string;
@@ -97,6 +98,7 @@ export class ExpandedMenuToggle extends Component<
 
     public render() {
         const {
+            display,
             toggleExpandedMenu,
             ariaControls,
             showExpandedMenu,
@@ -107,6 +109,7 @@ export class ExpandedMenuToggle extends Component<
         if (enhanceCheckbox) {
             return [
                 <VeggieBurger
+                    display={display}
                     showExpandedMenu={showExpandedMenu}
                     toggleExpandedMenu={toggleExpandedMenu}
                     enhanceCheckbox={enhanceCheckbox}
@@ -115,7 +118,7 @@ export class ExpandedMenuToggle extends Component<
                     key="VeggieBurger"
                 />,
                 <button
-                    className={openExpandedMenu}
+                    className={openExpandedMenu(display)}
                     onClick={() => toggleExpandedMenu(!showExpandedMenu)}
                     aria-controls={ariaControls}
                     key="OpenExpandedMenuButton"
@@ -131,6 +134,7 @@ export class ExpandedMenuToggle extends Component<
 
         return [
             <VeggieBurger
+                display={display}
                 showExpandedMenu={showExpandedMenu}
                 toggleExpandedMenu={toggleExpandedMenu}
                 enhanceCheckbox={enhanceCheckbox}
@@ -141,7 +145,7 @@ export class ExpandedMenuToggle extends Component<
             // We can't nest the input inside the label because the structure is important for CSS reasons
             // eslint-disable-next-line jsx-a11y/label-has-associated-control
             <label
-                className={openExpandedMenu}
+                className={openExpandedMenu(display)}
                 htmlFor={CHECKBOX_ID}
                 key="OpenExpandedMenuLabel"
             >

--- a/src/web/components/Nav/ExpandedMenu/ExpandedMenuToggle/VeggieBurger.tsx
+++ b/src/web/components/Nav/ExpandedMenu/ExpandedMenuToggle/VeggieBurger.tsx
@@ -5,8 +5,10 @@ import { brandAlt, neutral } from '@guardian/src-foundations/palette';
 import { from, until } from '@guardian/src-foundations/mq';
 
 const veggieBurger = ({
+    display,
     showExpandedMenu,
 }: {
+    display: Display;
     showExpandedMenu: boolean;
 }) => css`
     background-color: ${brandAlt[400]};
@@ -27,7 +29,7 @@ const veggieBurger = ({
     right: 5px;
     bottom: 48px;
     ${from.mobileMedium} {
-        bottom: -3px;
+        bottom: ${display === 'immersive' ? '3px' : '-3px'};
         right: 5px;
     }
     ${from.mobileLandscape} {
@@ -87,12 +89,14 @@ const veggieBurgerIcon = ({
 };
 
 export const VeggieBurger: React.FC<{
+    display: Display;
     toggleExpandedMenu: (value: boolean) => void;
     showExpandedMenu: boolean;
     enhanceCheckbox: boolean;
     htmlFor: string;
     ariaControls: string;
 }> = ({
+    display,
     toggleExpandedMenu,
     showExpandedMenu,
     enhanceCheckbox,
@@ -102,7 +106,7 @@ export const VeggieBurger: React.FC<{
     if (enhanceCheckbox) {
         return (
             <button
-                className={veggieBurger({ showExpandedMenu })}
+                className={veggieBurger({ display, showExpandedMenu })}
                 onClick={() => toggleExpandedMenu(!showExpandedMenu)}
                 aria-controls={ariaControls}
                 aria-label="Toggle main menu"
@@ -120,7 +124,7 @@ export const VeggieBurger: React.FC<{
         // means working and accessible
         // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/label-has-associated-control
         <label
-            className={veggieBurger({ showExpandedMenu })}
+            className={veggieBurger({ display, showExpandedMenu })}
             onClick={() => toggleExpandedMenu(!showExpandedMenu)}
             htmlFor={htmlFor}
             tabIndex={0}

--- a/src/web/components/Nav/Nav.stories.tsx
+++ b/src/web/components/Nav/Nav.stories.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import {
+    brandBackground,
+    brandBorder,
+} from '@guardian/src-foundations/palette';
+
+import { Section } from '@frontend/web/components/Section';
+
+import { nav } from './Nav.mock';
+import { Nav } from './Nav';
+
+export default {
+    component: Nav,
+    title: 'Components/Nav',
+};
+
+export const StandardStory = () => {
+    return (
+        <Section
+            sectionId="nav-root"
+            showSideBorders={true}
+            borderColour={brandBorder.primary}
+            showTopBorder={false}
+            padded={false}
+            backgroundColour={brandBackground.primary}
+        >
+            <Nav pillar="news" display="standard" nav={nav} />
+        </Section>
+    );
+};
+StandardStory.story = { name: 'standard' };
+
+export const ImmersiveStory = () => {
+    return (
+        <Section
+            sectionId="nav-root"
+            showSideBorders={false}
+            borderColour={brandBorder.primary}
+            showTopBorder={false}
+            padded={false}
+            backgroundColour={brandBackground.primary}
+        >
+            <Nav pillar="news" display="immersive" nav={nav} />
+        </Section>
+    );
+};
+ImmersiveStory.story = { name: 'immersive' };

--- a/src/web/components/Nav/Nav.test.tsx
+++ b/src/web/components/Nav/Nav.test.tsx
@@ -7,7 +7,9 @@ import { nav } from './Nav.mock';
 
 describe('Nav', () => {
     it('should display pillar titles', () => {
-        const { getByText } = render(<Nav pillar="news" nav={nav} />);
+        const { getByText } = render(
+            <Nav pillar="news" nav={nav} display="standard" />,
+        );
 
         expect(getByText('News')).toBeInTheDocument();
         expect(getByText('Opinion')).toBeInTheDocument();
@@ -16,7 +18,9 @@ describe('Nav', () => {
     });
 
     it('should render the correct number of pillar items', () => {
-        const { container } = render(<Nav pillar="news" nav={nav} />);
+        const { container } = render(
+            <Nav pillar="news" nav={nav} display="standard" />,
+        );
 
         const listItems = container.querySelectorAll('li');
 
@@ -25,7 +29,7 @@ describe('Nav', () => {
 
     it('should open and close the expanded menu by clicking More', () => {
         const { getByTestId, getByText, queryAllByRole } = render(
-            <Nav pillar="news" nav={nav} />,
+            <Nav pillar="news" nav={nav} display="standard" />,
         );
 
         const expandedMenu = getByTestId('expanded-menu');

--- a/src/web/components/Nav/Nav.tsx
+++ b/src/web/components/Nav/Nav.tsx
@@ -1,7 +1,10 @@
 import React, { useState } from 'react';
-import { css } from 'emotion';
+import { css, cx } from 'emotion';
 
 import { Pillars } from '@root/src/web/components/Pillars';
+import { GuardianRoundel } from '@root/src/web/components/GuardianRoundel';
+import { until } from '@guardian/src-foundations/mq';
+
 import { clearFix } from '@root/src/lib/mixins';
 
 import { ExpandedMenu } from './ExpandedMenu/ExpandedMenu';
@@ -10,33 +13,66 @@ const clearFixStyle = css`
     ${clearFix};
 `;
 
+const rowStyles = css`
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+`;
+
+const PositionRoundel = ({ children }: { children: React.ReactNode }) => (
+    <div
+        className={css`
+            margin-top: 3px;
+            z-index: 2;
+
+            ${until.desktop} {
+                margin-right: 51px;
+            }
+
+            margin-right: 24px;
+        `}
+    >
+        {children}
+    </div>
+);
+
 type Props = {
     pillar: Pillar;
     nav: NavType;
+    display: Display;
 };
-export const Nav = ({ pillar, nav }: Props) => {
+export const Nav = ({ display, pillar, nav }: Props) => {
     const [showExpandedMenu, toggleExpandedMenu] = useState<boolean>(false);
     const mainMenuId = 'main-menu';
 
     return (
-        <nav
-            className={clearFixStyle}
-            role="navigation"
-            aria-label="Guardian sections"
-            data-component="nav2"
-        >
-            <Pillars
-                mainMenuOpen={showExpandedMenu}
-                pillars={nav.pillars}
-                pillar={pillar}
-                dataLinkName="nav2"
-            />
-            <ExpandedMenu
-                id={mainMenuId}
-                nav={nav}
-                showExpandedMenu={showExpandedMenu}
-                toggleExpandedMenu={toggleExpandedMenu}
-            />
-        </nav>
+        <div className={rowStyles}>
+            <nav
+                className={cx(clearFixStyle, rowStyles)}
+                role="navigation"
+                aria-label="Guardian sections"
+                data-component="nav2"
+            >
+                <Pillars
+                    display={display}
+                    mainMenuOpen={showExpandedMenu}
+                    pillars={nav.pillars}
+                    pillar={pillar}
+                    dataLinkName="nav2"
+                />
+                <ExpandedMenu
+                    display={display}
+                    id={mainMenuId}
+                    nav={nav}
+                    showExpandedMenu={showExpandedMenu}
+                    toggleExpandedMenu={toggleExpandedMenu}
+                />
+            </nav>
+            {display === 'immersive' && (
+                <PositionRoundel>
+                    <GuardianRoundel />
+                </PositionRoundel>
+            )}
+        </div>
     );
 };

--- a/src/web/components/Pillars.tsx
+++ b/src/web/components/Pillars.tsx
@@ -17,7 +17,7 @@ export const preDesktopPillarWidth = 'auto';
 
 // CSS
 
-const pillarsStyles = css`
+const pillarsStyles = (display: Display) => css`
     clear: right;
     margin: 0;
     list-style: none;
@@ -46,13 +46,13 @@ const pillarsStyles = css`
         bottom: 0;
         left: 0;
         right: 0;
-        height: 37px;
+        height: ${display === 'immersive' ? '49px' : '37px'};
         ${from.tablet} {
             border-bottom: 0;
             height: 49px;
         }
         ${from.desktop} {
-            height: 43px;
+            height: ${display === 'immersive' ? '49px' : '43px'};
         }
     }
 `;
@@ -118,7 +118,7 @@ const pillarDivider = css`
     }
 `;
 
-const linkStyle = css`
+const linkStyle = (display: Display) => css`
     ${headline.xxxsmall()};
     box-sizing: border-box;
     font-weight: 900;
@@ -126,34 +126,44 @@ const linkStyle = css`
     cursor: pointer;
     display: block;
     font-size: 15.4px;
-    height: 36px;
-    padding: 9px 5px 0;
+    height: ${display === 'immersive' ? '48px' : '36px'};
+    padding-top: ${display === 'immersive' ? '10px' : '9px'};
+    padding-right: ${display === 'immersive' ? '5px' : '5px'};
+    padding-bottom: ${display === 'immersive' ? '0' : '0'};
+    padding-left: ${display === 'immersive' ? '5px' : '5px'};
     position: relative;
     overflow: hidden;
     text-decoration: none;
     z-index: 1;
     ${from.mobileMedium} {
         font-size: 15.7px;
-        padding: 9px 4px 0;
+        padding-top: ${display === 'immersive' ? '9px' : '9px'};
+        padding-right: ${display === 'immersive' ? '5px' : '5px'};
+        padding-bottom: ${display === 'immersive' ? '0' : '0'};
+        padding-left: ${display === 'immersive' ? '5px' : '5px'};
     }
     ${from.mobileLandscape} {
         font-size: 18px;
-        padding: 7px 4px 0;
+        padding-top: ${display === 'immersive' ? '9px' : '9px'};
+        padding-right: ${display === 'immersive' ? '5px' : '5px'};
+        padding-bottom: ${display === 'immersive' ? '0' : '0'};
+        padding-left: ${display === 'immersive' ? '5px' : '5px'};
     }
     ${from.tablet} {
         font-size: 22px;
-        padding-top: 9px;
         height: 48px;
-        padding-right: 20px;
-        padding-left: 9px;
+        padding-top: ${display === 'immersive' ? '9px' : '9px'};
+        padding-right: ${display === 'immersive' ? '20px' : '20px'};
+        padding-bottom: ${display === 'immersive' ? '0' : '0'};
+        padding-left: ${display === 'immersive' ? '9px' : '9px'};
     }
     ${from.desktop} {
-        padding-top: 5px;
-        height: 42px;
+        padding-top: ${display === 'immersive' ? '9px' : '5px'};
+        height: ${display === 'immersive' ? '48px' : '42px'};
     }
 
     ${from.wide} {
-        padding-top: 7px;
+        padding-top: ${display === 'immersive' ? '10px' : '7px'};
         font-size: 24px;
     }
 
@@ -201,29 +211,35 @@ const isNotLastPillar = (i: number, noOfPillars: number): boolean =>
     i !== noOfPillars - 1;
 
 export const Pillars: React.FC<{
+    display: Display;
     mainMenuOpen: boolean;
     pillars: PillarType[];
     pillar: Pillar;
     showLastPillarDivider?: boolean;
     dataLinkName: string;
 }> = ({
+    display,
     mainMenuOpen,
     pillars,
     pillar,
     showLastPillarDivider = true,
     dataLinkName,
 }) => (
-    <ul className={pillarsStyles}>
+    <ul className={pillarsStyles(display)}>
         {pillars.map((p, i) => (
             <li key={p.title} className={pillarStyle}>
                 <a
-                    className={cx(linkStyle, pillarUnderline[p.pillar], {
-                        [pillarDivider]:
-                            showLastPillarDivider ||
-                            isNotLastPillar(i, pillars.length),
-                        [showMenuUnderline]: mainMenuOpen,
-                        [forceUnderline]: p.pillar === pillar,
-                    })}
+                    className={cx(
+                        linkStyle(display),
+                        pillarUnderline[p.pillar],
+                        {
+                            [pillarDivider]:
+                                showLastPillarDivider ||
+                                isNotLastPillar(i, pillars.length),
+                            [showMenuUnderline]: mainMenuOpen,
+                            [forceUnderline]: p.pillar === pillar,
+                        },
+                    )}
                     href={p.url}
                     data-link-name={`${dataLinkName} : primary : ${p.title}`}
                 >

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -270,7 +270,11 @@ export const CommentLayout = ({
                 padded={false}
                 backgroundColour={brandBackground.primary}
             >
-                <Nav pillar={getCurrentPillar(CAPI)} nav={NAV} />
+                <Nav
+                    pillar={getCurrentPillar(CAPI)}
+                    nav={NAV}
+                    display={display}
+                />
             </Section>
 
             {NAV.subNavSections && (

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -315,7 +315,11 @@ export const ShowcaseLayout = ({
                         padded={false}
                         backgroundColour={brandBackground.primary}
                     >
-                        <Nav pillar={getCurrentPillar(CAPI)} nav={NAV} />
+                        <Nav
+                            pillar={getCurrentPillar(CAPI)}
+                            nav={NAV}
+                            display={display}
+                        />
                     </Section>
 
                     {NAV.subNavSections && (

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -300,7 +300,11 @@ export const StandardLayout = ({
                         padded={false}
                         backgroundColour={brandBackground.primary}
                     >
-                        <Nav pillar={getCurrentPillar(CAPI)} nav={NAV} />
+                        <Nav
+                            pillar={getCurrentPillar(CAPI)}
+                            nav={NAV}
+                            display={display}
+                        />
                     </Section>
 
                     {NAV.subNavSections && (


### PR DESCRIPTION
## What does this change?
Adds support for an immersive version of `Nav`

The nav bar is slightly higher when showing on an immersive article and shows a Roundel. This PR adds the styling to support these things and passes in the `display` prop to decide when to do this. There's a lot of prop passing in this PR as well as a small refactor to `App` so we can pass in `display` when hydrating (as well as SSR)

### Standard
![Screenshot 2020-04-19 at 21 21 13](https://user-images.githubusercontent.com/1336821/79698885-dee38200-8283-11ea-8acb-42b2a96d5966.jpg)

### Immersive
![Screenshot 2020-04-19 at 21 21 20](https://user-images.githubusercontent.com/1336821/79698887-df7c1880-8283-11ea-8c29-36e978aaf92a.jpg)



## Why?
To support immersive articles

## Link to supporting Trello card
https://trello.com/c/MnvVu3Bn/1470-immersive-nav