### PR TITLE
Refactor ArticleTitle

### DIFF
--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -94,7 +94,53 @@ export const SeriesSectionLink = ({
             thisTag.title === 'The Observer',
     );
 
+    const hasSeriesTag = tag && tag.type === 'Series';
+    const isImmersive = display === 'immersive';
+
+    if (isImmersive && !hasSeriesTag) {
+        // Immersives show nothing at all if there's no series tag
+        return null;
+    }
+
+    if (isImmersive && hasSeriesTag) {
+        // If it is immersive and has a series tag, show this
+        if (!tag) return null;
+        return (
+            <a
+                href={`${guardianBaseURL}/${tag.id}`}
+                className={cx(
+                    sectionLabelLink,
+                    pillarColours[pillar],
+                    invertedStyle(pillar),
+                )}
+                data-component="series"
+                data-link-name="article series"
+            >
+                <span>{tag.title}</span>
+            </a>
+        );
+    }
+
+    if (!tag) {
+        // There's no tag so fallback to section title
+        return (
+            <a
+                href={`${guardianBaseURL}/${sectionUrl}`}
+                className={cx(
+                    sectionLabelLink,
+                    pillarColours[pillar],
+                    primaryStyle,
+                )}
+                data-component="section"
+                data-link-name="article section"
+            >
+                <span>{sectionLabel}</span>
+            </a>
+        );
+    }
+
     if (tag) {
+        // We have a tag, we're not immersive, show both series and section titles
         return (
             // Sometimes the tags/titles are shown inline, sometimes stacked
             <div
@@ -107,9 +153,7 @@ export const SeriesSectionLink = ({
                     className={cx(
                         sectionLabelLink,
                         pillarColours[pillar],
-                        display === 'immersive'
-                            ? invertedStyle(pillar)
-                            : primaryStyle,
+                        primaryStyle,
                         isSpecial && yellowBackground,
                     )}
                     data-component="series"
@@ -138,19 +182,5 @@ export const SeriesSectionLink = ({
         );
     }
 
-    // Otherwise, there was no tag so just show 1 title
-    return (
-        <a
-            href={`${guardianBaseURL}/${sectionUrl}`}
-            className={cx(
-                sectionLabelLink,
-                pillarColours[pillar],
-                display === 'immersive' ? invertedStyle(pillar) : primaryStyle,
-            )}
-            data-component="section"
-            data-link-name="article section"
-        >
-            <span>{sectionLabel}</span>
-        </a>
-    );
+    return null;
 };


### PR DESCRIPTION
## What does this change?
Tidies up the logic around deciding which titles to show to make it more readable and fix immersive title choice so we only show titles on immersive articles if part of a series (eg. `The Long Read` or `Ranked`) @rcrphillips is this correct or should we also show blog titles on immersives as well?

## Why?
As we layered in support for immersives things became less readable and more prone to bugs. This makes the decision making logic clearer and easier to reason about

## Link to supporting Trello card
https://trello.com/c/Ay25CGVB/1471-refactor-title-choice
