### PR TITLE
Re-enable discussion on Dotcom Rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "@emotion/core": "^10.0.28",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/consent-management-platform": "^3.0.0",
-        "@guardian/discussion-rendering": "^1.1.0",
+        "@guardian/discussion-rendering": "^2.1.0",
         "@guardian/src-button": "^0.17.0",
         "@guardian/src-foundations": "^0.17.0",
         "@guardian/src-link": "^0.18.0-rc.0",

--- a/src/web/components/CommentsLayout.tsx
+++ b/src/web/components/CommentsLayout.tsx
@@ -1,12 +1,9 @@
-// @ts-nocheck
-/* eslint-disable */
-
 import React from 'react';
 import { css } from 'emotion';
 
 import { from } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
-
+import { App as Comments } from '@guardian/discussion-rendering';
 import { LeftColumn } from '@frontend/web/components/LeftColumn';
 import { SignedInAs } from '@frontend/web/components/SignedInAs';
 import { Hide } from '@frontend/web/components/Hide';
@@ -83,6 +80,25 @@ export const CommentsLayout = ({
                     />
                 </div>
             </Hide>
+
+            <Comments
+                user={user}
+                baseUrl={baseUrl}
+                pillar={pillar}
+                initialPage={commentPage}
+                pageSizeOverride={commentPageSize}
+                isClosedForComments={
+                    isClosedForComments || !enableDiscussionSwitch
+                }
+                orderByOverride={commentOrderBy}
+                shortUrl={shortUrl}
+                additionalHeaders={{
+                    'D2-X-UID': discussionD2Uid,
+                    'GU-Client': discussionApiClientHeader,
+                }}
+                expanded={expanded}
+                commentToScrollTo={commentToScrollTo}
+            />
         </div>
     </Flex>
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2166,10 +2166,10 @@
     js-cookie "^2.2.1"
     whatwg-fetch "^3.0.0"
 
-"@guardian/discussion-rendering@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-1.1.0.tgz#0d18eba5d091610c89ba5fa920122b71b25d36ef"
-  integrity sha512-TEahZMXMWh9CvlNj4VkwcIrg0xv/SWp4Hs3N7y4tF7LONMoAhnUC9RF/jgI9sETckYxGW7UQC8kAu29KO9HXEQ==
+"@guardian/discussion-rendering@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-2.1.0.tgz#2eb2606a696eeb08b63e7a0cd45dad8e8fcd22f6"
+  integrity sha512-Wh+LyC2de3My9Yksk+QdpWbkCxrjqdQMwHQTPzi1gY0P8W1VBlJy3HLoXjvRBBZgMc33peCHt+ECkHI6bnKHeQ==
   dependencies:
     react-focus-lock "^2.2.1"
     timeago.js "^4.0.2"


### PR DESCRIPTION
## What does this change?

Re=enables discussion on dotcom rendering as we've completed the test against a reduced bundle size.

## Why?

We want comments! We want comments!

## Link to supporting Trello card
https://trello.com/c/wDeoC5kD
