### PR TITLE
Increase minimum PROD capacity to 6

### DIFF
--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -60,8 +60,8 @@ Mappings:
       Value: rendering
   StageMap:
     PROD:
-      MinCapacity: 4
-      MaxCapacity: 16
+      MinCapacity: 8
+      MaxCapacity: 32
     CODE:
       MinCapacity: 1
       MaxCapacity: 4

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -60,8 +60,8 @@ Mappings:
       Value: rendering
   StageMap:
     PROD:
-      MinCapacity: 8
-      MaxCapacity: 32
+      MinCapacity: 6
+      MaxCapacity: 24
     CODE:
       MinCapacity: 1
       MaxCapacity: 4


### PR DESCRIPTION
## What does this change?

Increase ASG minimum PROD capacity to 6

## Why?

Struggles occasionally on 4 instances, so doubling gives us room to investigate a longer term fix (different instance types?)

## Link to supporting Trello card

https://trello.com/c/hKPOpMqY
