### PR TITLE
guardian/discussion@2.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "@emotion/core": "^10.0.28",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/consent-management-platform": "^3.0.0",
-        "@guardian/discussion-rendering": "^2.2.1",
+        "@guardian/discussion-rendering": "^2.2.2",
         "@guardian/src-button": "^0.17.0",
         "@guardian/src-foundations": "^0.17.0",
         "@guardian/src-link": "^0.18.0-rc.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2151,10 +2151,10 @@
     js-cookie "^2.2.1"
     whatwg-fetch "^3.0.0"
 
-"@guardian/discussion-rendering@^2.2.1":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-2.2.1.tgz#3b43cfb3f4c737acad65d98b872aaa5330ef3279"
-  integrity sha512-6VWfm648Awdh3pZmtAiVax4lfBd6zzGsiIvCTYETCo4zh8nuDOdjO8Prd/KYjPiQ2OHedU2r+RFtrIiCP8wbaw==
+"@guardian/discussion-rendering@^2.2.2":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-2.2.2.tgz#4b92ec5924d80c010ff2600ee1945599908a6f80"
+  integrity sha512-4cmRR8PvC9K9kodD3236w+QGYDJqAby8LEXN1c3Xg90Dt/LQCaT0tQNNVPS5ioNAXwmWTfwuRbLUzc9Uk14WxA==
   dependencies:
     react-focus-lock "^2.2.1"
     timeago.js "^4.0.2"


### PR DESCRIPTION
## What does this change?
Bumps @guardian/discussion-rendering to `v2.2.2`