### PR TITLE
Enable age warnings on opinion pieces

### DIFF
--- a/src/lib/age-warning.ts
+++ b/src/lib/age-warning.ts
@@ -3,12 +3,10 @@ export const getAgeWarning = (
     webPublicationDate: string,
 ): string | undefined => {
     const isNews = tags.some(t => t.id === 'tone/news');
-    // TODO: Enable age warnings on opinion pieces once the same logic is active on
-    // frontend
-    // const isOpinion = tags.some(t => t.id === 'commentisfree/commentisfree');
+    const isOpinion = tags.some(t => t.id === 'tone/comment');
 
     // Only show an age warning for news or opinion pieces
-    if (isNews) {
+    if (isNews || isOpinion) {
         const warnLimitDays = 30;
         const currentDate = new Date();
         const dateThreshold = new Date();


### PR DESCRIPTION
## What does this change?
Also show the age warning for opinion articles, not just news

![Screenshot 2020-04-21 at 15 38 26](https://user-images.githubusercontent.com/1336821/79879094-2c780000-83e6-11ea-853f-ce6069dcac7e.jpg)


## Why?
To support an editorial decision to better inform readers of older content

## Link to supporting Trello card
https://trello.com/c/4fpvTscg/1454-opinion-age-warning
