### PR TITLE
Use mostRecommended for api calls, not recommendations

### DIFF
--- a/src/web/lib/getCommentContext.ts
+++ b/src/web/lib/getCommentContext.ts
@@ -77,7 +77,12 @@ const initFiltersFromLocalStorage = (): FilterOptions => {
 
 const buildParams = (filters: FilterOptions) => {
     return {
-        orderBy: filters.orderBy,
+        // Frontend uses the 'recommendations' key to store this options but the api expects
+        // 'mostRecommended' so we have to map here to support both
+        orderBy:
+            filters.orderBy === 'recommendations'
+                ? 'mostRecommended'
+                : filters.orderBy,
         pageSize: filters.pageSize,
         displayThreaded:
             filters.threads === 'collapsed' || filters.threads === 'expanded',


### PR DESCRIPTION
## What does this change?
Adjusts the keyname used for the discussion `orderBy` value from 'recommendations' to `mostRecommended` when making api calls

## Why?
We still need to store the value in local storage using the 'recommendations' key because this is what frontend does

## Link to supporting Trello card
https://trello.com/c/R71oD3GC/1496-mostrecommended