### PR TITLE
Asset Manifest Localhost

### DIFF
--- a/scripts/webpack/browser.js
+++ b/scripts/webpack/browser.js
@@ -2,9 +2,7 @@ const webpack = require('webpack');
 const AssetsManifest = require('webpack-assets-manifest');
 const FriendlyErrorsWebpackPlugin = require('friendly-errors-webpack-plugin');
 const chalk = require('chalk');
-const {
-    siteName
-} = require('../frontend/config');
+const { siteName } = require('../frontend/config');
 
 const friendlyErrorsWebpackPlugin = () =>
     new FriendlyErrorsWebpackPlugin({
@@ -32,15 +30,14 @@ const generateName = isLegacyJS => {
 const manifestData = {};
 const legacyManifestData = {};
 
-const scriptPath = package => [
-    `./src/web/browser/${package}/init.ts`,
-    DEV &&
-    'webpack-hot-middleware/client?name=browser&overlayWarnings=true',
-].filter(Boolean);
+const scriptPath = package =>
+    [
+        `./src/web/browser/${package}/init.ts`,
+        DEV &&
+            'webpack-hot-middleware/client?name=browser&overlayWarnings=true',
+    ].filter(Boolean);
 
-module.exports = ({
-    isLegacyJS
-}) => ({
+module.exports = ({ isLegacyJS }) => ({
     entry: {
         sentry: scriptPath('sentry'),
         ga: scriptPath('ga'),
@@ -53,7 +50,6 @@ module.exports = ({
         chunkFilename: generateName(isLegacyJS),
     },
     plugins: [
-        PROD &&
         new AssetsManifest({
             writeToDisk: true,
             assets: isLegacyJS ? legacyManifestData : manifestData,
@@ -67,32 +63,35 @@ module.exports = ({
         // [...].filter(Boolean) why it is used
     ].filter(Boolean),
     module: {
-        rules: [{
+        rules: [
+            {
                 test: /(\.tsx)|(\.js)|(\.ts)$/,
                 exclude: /node_modules\/(?!(@guardian\/discussion-rendering)\/).*/,
-                use: [{
-                    loader: 'babel-loader',
-                    options: {
-                        presets: [
-                            '@babel/preset-typescript',
-                            '@babel/preset-react',
-                            // @babel/preset-env is used for legacy browsers
-                            // @babel/preset-modules is used for modern browsers
-                            // this allows us to reduce bundle sizes
-                            isLegacyJS ?
-                            [
-                                '@babel/preset-env',
-                                {
-                                    targets: {
-                                        ie: '11',
-                                    },
-                                    modules: false,
-                                },
-                            ] :
-                            '@babel/preset-modules',
-                        ],
+                use: [
+                    {
+                        loader: 'babel-loader',
+                        options: {
+                            presets: [
+                                '@babel/preset-typescript',
+                                '@babel/preset-react',
+                                // @babel/preset-env is used for legacy browsers
+                                // @babel/preset-modules is used for modern browsers
+                                // this allows us to reduce bundle sizes
+                                isLegacyJS
+                                    ? [
+                                          '@babel/preset-env',
+                                          {
+                                              targets: {
+                                                  ie: '11',
+                                              },
+                                              modules: false,
+                                          },
+                                      ]
+                                    : '@babel/preset-modules',
+                            ],
+                        },
                     },
-                }, ],
+                ],
             },
             {
                 test: /\.css$/,


### PR DESCRIPTION
## What does this change?
We remove  the PROD flag from the Asset Manifest generation in webpack

## Why?
We should load both legacy and non legacy file locally to be able to test older browsers like IE.

## Link to supporting Trello card
https://trello.com/c/WLdlGWct/1499-webpack-support-legacy-build-localhost
