### PR TITLE
Introduce the ContentAtom Element

### DIFF
--- a/src/amp/components/Elements.tsx
+++ b/src/amp/components/Elements.tsx
@@ -23,6 +23,7 @@ import { InteractiveUrl } from '@root/src/amp/components/elements/InteractiveUrl
 import { InteractiveMarkup } from '@root/src/amp/components/elements/InteractiveMarkup';
 import { MapEmbed } from '@root/src/amp/components/elements/MapEmbed';
 import { AudioAtom } from '@root/src/amp/components/elements/AudioAtom';
+import { ContentAtom } from '@root/src/amp/components/elements/ContentAtom';
 
 export const Elements = (
     elements: CAPIElement[],
@@ -155,6 +156,8 @@ export const Elements = (
                 return <InteractiveUrl url={element.url} />;
             case 'model.dotcomrendering.pageElements.AudioAtomBlockElement':
                 return <AudioAtom element={element} />;
+            case 'model.dotcomrendering.pageElements.ContentAtomBlockElement':
+                return <ContentAtom element={element} />;
             default:
                 // eslint-disable-next-line no-console
                 console.log('Unsupported Element', JSON.stringify(element));

--- a/src/amp/components/elements/ContentAtom.tsx
+++ b/src/amp/components/elements/ContentAtom.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export const ContentAtom: React.FC<{
+    element: ContentAtomElement;
+}> = ({}) => {
+    return <div />;
+};

--- a/src/amp/components/elements/ContentAtom.tsx
+++ b/src/amp/components/elements/ContentAtom.tsx
@@ -3,5 +3,5 @@ import React from 'react';
 export const ContentAtom: React.FC<{
     element: ContentAtomElement;
 }> = ({}) => {
-    return <div />;
+    return null;
 };

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -255,6 +255,11 @@ interface AudioAtomElement {
     coverUrl: string;
 }
 
+interface ContentAtomElement {
+    _type: 'model.dotcomrendering.pageElements.ContentAtomBlockElement';
+    atomId: string;
+}
+
 interface AudioBlockElement {
     _type: 'model.dotcomrendering.pageElements.AudioBlockElement';
 }
@@ -294,6 +299,7 @@ type CAPIElement =
     | InteractiveUrlElement
     | MapBlockElement
     | AudioAtomElement
+    | ContentAtomElement
     | AudioBlockElement
     | VideoBlockElement
     | CodeBlockElement;

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -90,6 +90,9 @@
                         "$ref": "#/definitions/AudioAtomElement"
                     },
                     {
+                        "$ref": "#/definitions/ContentAtomElement"
+                    },
+                    {
                         "$ref": "#/definitions/AudioBlockElement"
                     },
                     {
@@ -354,10 +357,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "html"
-            ]
+            "required": ["_type", "html"]
         },
         "SubheadingBlockElement": {
             "type": "object",
@@ -372,10 +372,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "html"
-            ]
+            "required": ["_type", "html"]
         },
         "RichLinkBlockElement": {
             "type": "object",
@@ -402,12 +399,7 @@
                     "type": "number"
                 }
             },
-            "required": [
-                "_type",
-                "prefix",
-                "text",
-                "url"
-            ]
+            "required": ["_type", "prefix", "text", "url"]
         },
         "Weighting": {
             "enum": [
@@ -439,9 +431,7 @@
                             }
                         }
                     },
-                    "required": [
-                        "allImages"
-                    ]
+                    "required": ["allImages"]
                 },
                 "data": {
                     "type": "object",
@@ -473,13 +463,7 @@
                     "$ref": "#/definitions/RoleType"
                 }
             },
-            "required": [
-                "_type",
-                "data",
-                "imageSources",
-                "media",
-                "role"
-            ]
+            "required": ["_type", "data", "imageSources", "media", "role"]
         },
         "Image": {
             "type": "object",
@@ -500,10 +484,7 @@
                             "type": "string"
                         }
                     },
-                    "required": [
-                        "height",
-                        "width"
-                    ]
+                    "required": ["height", "width"]
                 },
                 "mediaType": {
                     "type": "string"
@@ -515,13 +496,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "fields",
-                "index",
-                "mediaType",
-                "mimeType",
-                "url"
-            ]
+            "required": ["fields", "index", "mediaType", "mimeType", "url"]
         },
         "ImageSource": {
             "type": "object",
@@ -536,10 +511,7 @@
                     }
                 }
             },
-            "required": [
-                "srcSet",
-                "weighting"
-            ]
+            "required": ["srcSet", "weighting"]
         },
         "SrcSetItem": {
             "type": "object",
@@ -551,10 +523,7 @@
                     "type": "number"
                 }
             },
-            "required": [
-                "src",
-                "width"
-            ]
+            "required": ["src", "width"]
         },
         "RoleType": {
             "enum": [
@@ -601,11 +570,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "assetId",
-                "mediaTitle"
-            ]
+            "required": ["_type", "assetId", "mediaTitle"]
         },
         "VideoYoutube": {
             "type": "object",
@@ -629,13 +594,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "caption",
-                "height",
-                "url",
-                "width"
-            ]
+            "required": ["_type", "caption", "height", "url", "width"]
         },
         "VideoVimeo": {
             "type": "object",
@@ -659,13 +618,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "caption",
-                "height",
-                "url",
-                "width"
-            ]
+            "required": ["_type", "caption", "height", "url", "width"]
         },
         "VideoFacebook": {
             "type": "object",
@@ -689,13 +642,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "caption",
-                "height",
-                "url",
-                "width"
-            ]
+            "required": ["_type", "caption", "height", "url", "width"]
         },
         "VideoGuardian": {
             "type": "object",
@@ -716,11 +663,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "assets",
-                "caption"
-            ]
+            "required": ["_type", "assets", "caption"]
         },
         "VideoAssets": {
             "type": "object",
@@ -732,10 +675,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "mimeType",
-                "url"
-            ]
+            "required": ["mimeType", "url"]
         },
         "InstagramBlockElement": {
             "type": "object",
@@ -756,12 +696,7 @@
                     "type": "boolean"
                 }
             },
-            "required": [
-                "_type",
-                "hasCaption",
-                "html",
-                "url"
-            ]
+            "required": ["_type", "hasCaption", "html", "url"]
         },
         "TweetBlockElement": {
             "type": "object",
@@ -785,13 +720,7 @@
                     "type": "boolean"
                 }
             },
-            "required": [
-                "_type",
-                "hasMedia",
-                "html",
-                "id",
-                "url"
-            ]
+            "required": ["_type", "hasMedia", "html", "id", "url"]
         },
         "CommentBlockElement": {
             "type": "object",
@@ -853,13 +782,7 @@
                     "type": "boolean"
                 }
             },
-            "required": [
-                "_type",
-                "html",
-                "id",
-                "isMandatory",
-                "isTrack"
-            ]
+            "required": ["_type", "html", "id", "isMandatory", "isTrack"]
         },
         "EmbedBlockElement": {
             "type": "object",
@@ -883,11 +806,7 @@
                     "type": "boolean"
                 }
             },
-            "required": [
-                "_type",
-                "html",
-                "isMandatory"
-            ]
+            "required": ["_type", "html", "isMandatory"]
         },
         "DisclaimerBlockElement": {
             "type": "object",
@@ -902,10 +821,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "html"
-            ]
+            "required": ["_type", "html"]
         },
         "PullquoteBlockElement": {
             "type": "object",
@@ -926,11 +842,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "html",
-                "role"
-            ]
+            "required": ["_type", "html", "role"]
         },
         "BlockquoteBlockElement": {
             "type": "object",
@@ -945,10 +857,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "html"
-            ]
+            "required": ["_type", "html"]
         },
         "QABlockElement": {
             "type": "object",
@@ -975,13 +884,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "credit",
-                "html",
-                "id",
-                "title"
-            ]
+            "required": ["_type", "credit", "html", "id", "title"]
         },
         "GuideBlockElement": {
             "type": "object",
@@ -1011,14 +914,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "credit",
-                "html",
-                "id",
-                "label",
-                "title"
-            ]
+            "required": ["_type", "credit", "html", "id", "label", "title"]
         },
         "ProfileBlockElement": {
             "type": "object",
@@ -1048,14 +944,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "credit",
-                "html",
-                "id",
-                "label",
-                "title"
-            ]
+            "required": ["_type", "credit", "html", "id", "label", "title"]
         },
         "TimelineBlockElement": {
             "type": "object",
@@ -1082,12 +971,7 @@
                     }
                 }
             },
-            "required": [
-                "_type",
-                "events",
-                "id",
-                "title"
-            ]
+            "required": ["_type", "events", "id", "title"]
         },
         "TimelineEvent": {
             "type": "object",
@@ -1105,10 +989,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "date",
-                "title"
-            ]
+            "required": ["date", "title"]
         },
         "InteractiveMarkupBlockElement": {
             "type": "object",
@@ -1132,9 +1013,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type"
-            ]
+            "required": ["_type"]
         },
         "InteractiveUrlElement": {
             "type": "object",
@@ -1149,10 +1028,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "url"
-            ]
+            "required": ["_type", "url"]
         },
         "MapBlockElement": {
             "type": "object",
@@ -1222,6 +1098,21 @@
                 "trackUrl"
             ]
         },
+        "ContentAtomElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.ContentAtomBlockElement"
+                    ]
+                },
+                "atomId": {
+                    "type": "string"
+                }
+            },
+            "required": ["_type", "atomId"]
+        },
         "AudioBlockElement": {
             "type": "object",
             "properties": {
@@ -1232,9 +1123,7 @@
                     ]
                 }
             },
-            "required": [
-                "_type"
-            ]
+            "required": ["_type"]
         },
         "VideoBlockElement": {
             "type": "object",
@@ -1246,9 +1135,7 @@
                     ]
                 }
             },
-            "required": [
-                "_type"
-            ]
+            "required": ["_type"]
         },
         "CodeBlockElement": {
             "type": "object",
@@ -1263,10 +1150,7 @@
                     "type": "boolean"
                 }
             },
-            "required": [
-                "_type",
-                "isMandatory"
-            ]
+            "required": ["_type", "isMandatory"]
         },
         "Block": {
             "type": "object",
@@ -1354,6 +1238,9 @@
                                 "$ref": "#/definitions/AudioAtomElement"
                             },
                             {
+                                "$ref": "#/definitions/ContentAtomElement"
+                            },
+                            {
                                 "$ref": "#/definitions/AudioBlockElement"
                             },
                             {
@@ -1387,10 +1274,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "elements",
-                "id"
-            ]
+            "required": ["elements", "id"]
         },
         "Pagination": {
             "type": "object",
@@ -1414,10 +1298,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "currentPage",
-                "totalPages"
-            ]
+            "required": ["currentPage", "totalPages"]
         },
         "AuthorType": {
             "type": "object",
@@ -1434,12 +1315,7 @@
             }
         },
         "Edition": {
-            "enum": [
-                "AU",
-                "INT",
-                "UK",
-                "US"
-            ],
+            "enum": ["AU", "INT", "UK", "US"],
             "type": "string"
         },
         "TagType": {
@@ -1464,11 +1340,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "id",
-                "title",
-                "type"
-            ]
+            "required": ["id", "title", "type"]
         },
         "Pillar": {
             "enum": [
@@ -1491,10 +1363,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "title",
-                "url"
-            ]
+            "required": ["title", "url"]
         },
         "ConfigType": {
             "description": "the config model will contain useful app/site\nlevel data. Although currently derived from the config model\nconstructed in frontend and passed to dotcom-rendering\nthis data could eventually be defined in dotcom-rendering",
@@ -1693,12 +1562,7 @@
                     "$ref": "#/definitions/EditionCommercialProperties"
                 }
             },
-            "required": [
-                "AU",
-                "INT",
-                "UK",
-                "US"
-            ]
+            "required": ["AU", "INT", "UK", "US"]
         },
         "EditionCommercialProperties": {
             "type": "object",
@@ -1713,9 +1577,7 @@
                     "$ref": "#/definitions/Branding"
                 }
             },
-            "required": [
-                "adTargeting"
-            ]
+            "required": ["adTargeting"]
         },
         "AdTargetParam": {
             "type": "object",
@@ -1737,10 +1599,7 @@
                     ]
                 }
             },
-            "required": [
-                "name",
-                "value"
-            ]
+            "required": ["name", "value"]
         },
         "Branding": {
             "type": "object",
@@ -1752,9 +1611,7 @@
                             "type": "string"
                         }
                     },
-                    "required": [
-                        "name"
-                    ]
+                    "required": ["name"]
                 },
                 "sponsorName": {
                     "type": "string"
@@ -1781,18 +1638,10 @@
                                     "type": "number"
                                 }
                             },
-                            "required": [
-                                "height",
-                                "width"
-                            ]
+                            "required": ["height", "width"]
                         }
                     },
-                    "required": [
-                        "dimensions",
-                        "label",
-                        "link",
-                        "src"
-                    ]
+                    "required": ["dimensions", "label", "link", "src"]
                 },
                 "aboutThisLink": {
                     "type": "string"
@@ -1813,10 +1662,7 @@
                                     "type": "number"
                                 }
                             },
-                            "required": [
-                                "height",
-                                "width"
-                            ]
+                            "required": ["height", "width"]
                         },
                         "link": {
                             "type": "string"
@@ -1825,19 +1671,10 @@
                             "type": "string"
                         }
                     },
-                    "required": [
-                        "dimensions",
-                        "label",
-                        "link",
-                        "src"
-                    ]
+                    "required": ["dimensions", "label", "link", "src"]
                 }
             },
-            "required": [
-                "aboutThisLink",
-                "logo",
-                "sponsorName"
-            ]
+            "required": ["aboutThisLink", "logo", "sponsorName"]
         },
         "BadgeType": {
             "type": "object",
@@ -1849,10 +1686,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "imageUrl",
-                "seriesTag"
-            ]
+            "required": ["imageUrl", "seriesTag"]
         },
         "FooterType": {
             "type": "object",
@@ -1867,9 +1701,7 @@
                     }
                 }
             },
-            "required": [
-                "footerLinks"
-            ]
+            "required": ["footerLinks"]
         },
         "FooterLink": {
             "type": "object",
@@ -1887,11 +1719,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "dataLinkName",
-                "text",
-                "url"
-            ]
+            "required": ["dataLinkName", "text", "url"]
         }
     },
     "$schema": "http://json-schema.org/draft-07/schema#"


### PR DESCRIPTION
## What does this change?

This introduce a currently empty but important "catch all" new element for any possible ContentAtom that would be released to AMP due to an apparent blanket support of `ContentAtomBlockElement` here: https://github.com/guardian/frontend/pull/22517/files#diff-5775f8f47d521441655ea7d7f0ce47d8L151
