### PR TITLE
Support onPermalinkClick prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "@emotion/core": "^10.0.28",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/consent-management-platform": "^3.0.0",
-        "@guardian/discussion-rendering": "^2.2.4",
+        "@guardian/discussion-rendering": "^2.2.5",
         "@guardian/src-button": "^0.17.0",
         "@guardian/src-ed-lines": "^0.18.0-rc.0",
         "@guardian/src-foundations": "^0.17.0",

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -69,8 +69,10 @@ export const App = ({ CAPI, NAV }: Props) => {
         'newest' | 'oldest' | 'recommendations'
     >();
     const [openComments, setOpenComments] = useState<boolean>(false);
+    const [hashCommentId, sethashCommentId] = useState<number | undefined>(
+        commentIdFromUrl(),
+    );
 
-    const hashCommentId = commentIdFromUrl();
     const hasCommentsHash = hasCommentsHashInUrl();
 
     useEffect(() => {
@@ -155,6 +157,12 @@ export const App = ({ CAPI, NAV }: Props) => {
 
     const pillar = decidePillar(CAPI);
     const display = decideDisplay(CAPI);
+
+    const handlePermalink = (commentId: number) => {
+        window.location.hash = `#comments-${commentId}`;
+        sethashCommentId(commentId);
+        return false;
+    };
 
     return (
         // Do you need to Hydrate or do you want a Portal?
@@ -290,6 +298,7 @@ export const App = ({ CAPI, NAV }: Props) => {
                         }
                         expanded={true}
                         commentToScrollTo={hashCommentId}
+                        onPermalinkClick={handlePermalink}
                     />
                 ) : (
                     <Lazy margin={300}>
@@ -311,6 +320,8 @@ export const App = ({ CAPI, NAV }: Props) => {
                                 CAPI.config.enableDiscussionSwitch
                             }
                             expanded={false}
+                            commentToScrollTo={hashCommentId}
+                            onPermalinkClick={handlePermalink}
                         />
                     </Lazy>
                 )}

--- a/src/web/components/CommentsLayout.stories.tsx
+++ b/src/web/components/CommentsLayout.stories.tsx
@@ -33,6 +33,7 @@ export const Default = () => (
                 discussionD2Uid="testD2Header"
                 discussionApiClientHeader="testClientHeader"
                 expanded={false}
+                onPermalinkClick={() => {}}
             />
             <RightColumn>
                 <AdSlot asps={namedAdSlotParameters('comments')} />

--- a/src/web/components/CommentsLayout.tsx
+++ b/src/web/components/CommentsLayout.tsx
@@ -24,6 +24,7 @@ type Props = {
     commentPageSize?: 25 | 50 | 100;
     commentOrderBy?: 'newest' | 'oldest' | 'recommendations';
     commentToScrollTo?: number;
+    onPermalinkClick: (commentId: number) => void;
 };
 
 const containerStyles = css`
@@ -58,6 +59,7 @@ export const CommentsLayout = ({
     discussionD2Uid,
     discussionApiClientHeader,
     commentToScrollTo,
+    onPermalinkClick,
 }: Props) => (
     <Flex direction="row">
         <LeftColumn showRightBorder={false}>
@@ -98,6 +100,7 @@ export const CommentsLayout = ({
                 }}
                 expanded={expanded}
                 commentToScrollTo={commentToScrollTo}
+                onPermalinkClick={onPermalinkClick}
             />
         </div>
     </Flex>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2151,10 +2151,10 @@
     js-cookie "^2.2.1"
     whatwg-fetch "^3.0.0"
 
-"@guardian/discussion-rendering@^2.2.4":
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-2.2.4.tgz#47dbdf2b598aa76e3fa70badcb54745253d4c5df"
-  integrity sha512-v/MGFVNg29Pg41HOxkE/T15kOk3sUakwb4K/Nv8nDdC4u6W/RYhIfBOT06RNOXA45BXwQAwglKnjtZYQYfECDA==
+"@guardian/discussion-rendering@^2.2.5":
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-2.2.5.tgz#88114f5e58ac9e37b0d272baef259cb0997bf103"
+  integrity sha512-Uibd0G2ccm+zOCscAjBe3uQBlI8QBu6YW5BEhzpATdFYmN64WfV3RWBqId2Cb9p0LVCzTDrU+unpOr5SDnm8CQ==
   dependencies:
     react-focus-lock "^2.2.1"
     timeago.js "^4.0.2"


### PR DESCRIPTION
## What does this change?
This supports using an `onPermalinkClick` function to give to discussion for it to call with the comment id clicked upon

## Why?
This allows us to prevent the default of refreshing the page in favour of manually passing in the `commentIdToScrollTo` prop

## Link to supporting Trello card
https://trello.com/c/o95XCIxg/1509-jump-to-comment-causes-page-refresh