### PR TITLE
AtomEmbedMarkup and AtomEmbedUrl migration 1/3

### DIFF
--- a/docs/contributing/detailed-setup-guide.md
+++ b/docs/contributing/detailed-setup-guide.md
@@ -95,4 +95,10 @@ You may need to run these with `sudo`
 
 Production environment uses `pm2`. More scripts can be found in the `makefile` [scripts](https://github.com/guardian/dotcom-rendering/blob/e2c020f7e0ed24751ea729eec93f1271d37e3b50/makefile#L31)
 
-The production port default is 9000 for deployment, but to run locally alongside frontend, you will need to manually override in `scripts/frontend/config.js`. To hit the server, add `rendering.endpoint = "http://localhost:${port}/Article"` with the overide port number to `frontend.conf` and run frontend locally.
+The production port default is 9000 for deployment, but to run locally alongside frontend, you will need to manually override in `scripts/frontend/config.js`. To hit the server, add 
+
+```
+rendering.endpoint = "http://localhost:${port}/Article"
+``` 
+
+with the overide port number to `frontend.conf` and run frontend locally.

--- a/src/amp/components/Elements.tsx
+++ b/src/amp/components/Elements.tsx
@@ -20,7 +20,9 @@ import { clean } from '@root/src/model/clean';
 import { Timeline } from '@root/src/amp/components/elements/Timeline';
 import { YoutubeVideo } from '@root/src/amp/components/elements/YoutubeVideo';
 import { InteractiveUrl } from '@root/src/amp/components/elements/InteractiveUrl';
+import { AtomEmbedUrl } from '@root/src/amp/components/elements/AtomEmbedUrl';
 import { InteractiveMarkup } from '@root/src/amp/components/elements/InteractiveMarkup';
+import { AtomEmbedMarkup } from '@root/src/amp/components/elements/AtomEmbedMarkup';
 import { MapEmbed } from '@root/src/amp/components/elements/MapEmbed';
 import { AudioAtom } from '@root/src/amp/components/elements/AudioAtom';
 import { ContentAtom } from '@root/src/amp/components/elements/ContentAtom';
@@ -152,8 +154,18 @@ export const Elements = (
                         js={element.js}
                     />
                 );
+            case 'model.dotcomrendering.pageElements.AtomEmbedMarkupBlockElement':
+                return (
+                    <AtomEmbedMarkup
+                        html={element.html}
+                        styles={element.css}
+                        js={element.js}
+                    />
+                );
             case 'model.dotcomrendering.pageElements.InteractiveUrlBlockElement':
                 return <InteractiveUrl url={element.url} />;
+            case 'model.dotcomrendering.pageElements.AtomEmbedUrlBlockElement':
+                return <AtomEmbedUrl url={element.url} />;
             case 'model.dotcomrendering.pageElements.AudioAtomBlockElement':
                 return <AudioAtom element={element} />;
             case 'model.dotcomrendering.pageElements.ContentAtomBlockElement':

--- a/src/amp/components/elements/AtomEmbedMarkup.tsx
+++ b/src/amp/components/elements/AtomEmbedMarkup.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { ShowMoreButton } from '@root/src/amp/components/ShowMoreButton';
+import { css } from 'emotion';
+
+const iframeStyle = css`
+    margin-top: 16px;
+    margin-bottom: 12px;
+`;
+
+const showMore = css`
+    &[overflow] {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        right: 0;
+    }
+`;
+
+export const AtomEmbedMarkup: React.SFC<{
+    html?: string;
+    styles?: string;
+    js?: string;
+}> = ({ html, styles, js }) => {
+    const styleTag = styles ? `<style>${styles}</style>` : '';
+    const scripts = js ? `<script>${js}</script>` : '';
+
+    const body = `
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charSet="utf-8" />
+        <meta
+            name="viewport"
+            content="width=device-width,minimum-scale=1,initial-scale=1"
+        />
+
+        ${styleTag}
+    </head>
+
+    <body>
+        ${html}
+        ${scripts}
+    </body>
+    </html>
+`;
+
+    return (
+        <amp-iframe
+            class={iframeStyle}
+            layout="responsive"
+            height="1"
+            width="8"
+            sandbox="allow-scripts"
+            srcdoc={body}
+            resizable=""
+        >
+            <div overflow="" className={showMore}>
+                <ShowMoreButton />
+            </div>
+        </amp-iframe>
+    );
+};

--- a/src/amp/components/elements/AtomEmbedUrl.tsx
+++ b/src/amp/components/elements/AtomEmbedUrl.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { css } from 'emotion';
+import { ShowMoreButton } from '@root/src/amp/components/ShowMoreButton';
+
+const styles = css`
+    margin-top: 16px;
+    margin-bottom: 12px;
+`;
+
+const showMore = css`
+    &[overflow] {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        right: 0;
+    }
+`;
+
+export const AtomEmbedUrl: React.SFC<{ url: string }> = ({ url }) => {
+    return (
+        <amp-iframe
+            class={styles}
+            src={url}
+            layout="responsive"
+            sandbox="allow-scripts allow-same-origin allow-top-navigation-by-user-activation allow-popups"
+            height="1"
+            width="8"
+            resizable=""
+        >
+            <div overflow="" className={showMore}>
+                <ShowMoreButton />
+            </div>
+        </amp-iframe>
+    );
+};

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -232,8 +232,21 @@ interface InteractiveMarkupBlockElement {
     js?: string;
 }
 
+interface AtomEmbedMarkupBlockElement {
+    _type: 'model.dotcomrendering.pageElements.AtomEmbedMarkupBlockElement';
+    id?: string;
+    html?: string;
+    css?: string;
+    js?: string;
+}
+
 interface InteractiveUrlElement {
     _type: 'model.dotcomrendering.pageElements.InteractiveUrlBlockElement';
+    url: string;
+}
+
+interface AtomEmbedUrlElement {
+    _type: 'model.dotcomrendering.pageElements.AtomEmbedUrlBlockElement';
     url: string;
 }
 
@@ -296,7 +309,9 @@ type CAPIElement =
     | ProfileBlockElement
     | TimelineBlockElement
     | InteractiveMarkupBlockElement
+    | AtomEmbedMarkupBlockElement
     | InteractiveUrlElement
+    | AtomEmbedUrlElement
     | MapBlockElement
     | AudioAtomElement
     | ContentAtomElement

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -81,7 +81,13 @@
                         "$ref": "#/definitions/InteractiveMarkupBlockElement"
                     },
                     {
+                        "$ref": "#/definitions/AtomEmbedMarkupBlockElement"
+                    },
+                    {
                         "$ref": "#/definitions/InteractiveUrlElement"
+                    },
+                    {
+                        "$ref": "#/definitions/AtomEmbedUrlElement"
                     },
                     {
                         "$ref": "#/definitions/MapBlockElement"
@@ -1015,6 +1021,30 @@
             },
             "required": ["_type"]
         },
+        "AtomEmbedMarkupBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.AtomEmbedMarkupBlockElement"
+                    ]
+                },
+                "id": {
+                    "type": "string"
+                },
+                "html": {
+                    "type": "string"
+                },
+                "css": {
+                    "type": "string"
+                },
+                "js": {
+                    "type": "string"
+                }
+            },
+            "required": ["_type"]
+        },
         "InteractiveUrlElement": {
             "type": "object",
             "properties": {
@@ -1022,6 +1052,21 @@
                     "type": "string",
                     "enum": [
                         "model.dotcomrendering.pageElements.InteractiveUrlBlockElement"
+                    ]
+                },
+                "url": {
+                    "type": "string"
+                }
+            },
+            "required": ["_type", "url"]
+        },
+        "AtomEmbedUrlElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.AtomEmbedUrlBlockElement"
                     ]
                 },
                 "url": {
@@ -1229,7 +1274,13 @@
                                 "$ref": "#/definitions/InteractiveMarkupBlockElement"
                             },
                             {
+                                "$ref": "#/definitions/AtomEmbedMarkupBlockElement"
+                            },
+                            {
                                 "$ref": "#/definitions/InteractiveUrlElement"
+                            },
+                            {
+                                "$ref": "#/definitions/AtomEmbedUrlElement"
                             },
                             {
                                 "$ref": "#/definitions/MapBlockElement"


### PR DESCRIPTION
## What does this change?

First part of the renaming of 

```
InteractiveMarkupBlockElement
InteractiveUrlBlockElement
```

Into

``` 
AtomEmbedMarkupBlockElement
AtomEmbedUrlBlockElement
```

## Why?

Both the Scala classes and the DCR Elements they are referring to were born as part of the general Interactive Atom work, but are now used for both Interactives and Charts and are in fact (and will be more and more) used for general embeds. 
