### PR TITLE
Immersive

### DIFF
--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -194,7 +194,13 @@ export const App = ({ CAPI, NAV }: Props) => {
                 />
             </Hydrate>
             <Hydrate root="nav-root">
-                <Nav pillar={pillar} nav={NAV} display={display} />
+                <Nav
+                    pillar={pillar}
+                    nav={NAV}
+                    display={display}
+                    subscribeUrl={CAPI.nav.readerRevenueLinks.header.subscribe}
+                    edition={CAPI.editionId}
+                />
             </Hydrate>
             {NAV.subNavSections && (
                 <Hydrate root="sub-nav-root">

--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -121,6 +121,10 @@ const immersiveStyles = css`
     min-height: 112px;
     padding-bottom: ${space[9]}px;
     padding-left: ${space[3]}px;
+    ${from.phablet} {
+        padding-left: ${space[1]}px;
+    }
+    margin-right: ${space[5]}px;
 `;
 
 const blackBackground = css`

--- a/src/web/components/ArticleTitle.tsx
+++ b/src/web/components/ArticleTitle.tsx
@@ -43,6 +43,10 @@ const marginTop = css`
     margin-top: 6px;
 `;
 
+const marginBottom = css`
+    margin-bottom: 5px;
+`;
+
 export const ArticleTitle = ({
     display,
     tags,
@@ -58,7 +62,12 @@ export const ArticleTitle = ({
                 <Badge imageUrl={badge.imageUrl} seriesTag={badge.seriesTag} />
             </div>
         )}
-        <div className={badge && marginTop}>
+        <div
+            className={cx(
+                badge && marginTop,
+                display === 'immersive' && marginBottom,
+            )}
+        >
             <SeriesSectionLink
                 display={display}
                 tags={tags}

--- a/src/web/components/Caption.tsx
+++ b/src/web/components/Caption.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 
 import { text } from '@guardian/src-foundations/palette';
-import { from } from '@guardian/src-foundations/mq';
+import { from, until } from '@guardian/src-foundations/mq';
 import { textSans } from '@guardian/src-foundations/typography';
 import { css, cx } from 'emotion';
 import { pillarPalette } from '@root/src/lib/pillars';
 import TriangleIcon from '@frontend/static/icons/triangle.svg';
 
 type Props = {
+    display: Display;
     captionText?: string;
     pillar: Pillar;
     children?: React.ReactNode;
@@ -41,7 +42,14 @@ const captionPadding = css`
     padding-right: 8px;
 `;
 
+const hideIconBelowLeftCol = css`
+    ${until.leftCol} {
+        display: none;
+    }
+`;
+
 export const Caption = ({
+    display,
     captionText,
     pillar,
     padCaption = false,
@@ -93,7 +101,12 @@ export const Caption = ({
                             { [captionPadding]: padCaption },
                         )}
                     >
-                        <span className={iconStyle}>
+                        <span
+                            className={cx(
+                                iconStyle,
+                                display === 'immersive' && hideIconBelowLeftCol,
+                            )}
+                        >
                             <TriangleIcon />
                         </span>
                         {getCaptionHtml()} {displayCredit && credit}

--- a/src/web/components/ImmersiveHeadline.tsx
+++ b/src/web/components/ImmersiveHeadline.tsx
@@ -7,6 +7,7 @@ import { ArticleTitle } from '@root/src/web/components/ArticleTitle';
 import { ArticleHeadline } from '@root/src/web/components/ArticleHeadline';
 import { LeftColumn } from '@root/src/web/components/LeftColumn';
 import { Flex } from '@root/src/web/components/Flex';
+import { Caption } from '@root/src/web/components/Caption';
 
 type Props = {
     display: Display;
@@ -18,6 +19,7 @@ type Props = {
     sectionUrl: string;
     guardianBaseURL: string;
     pillar: Pillar;
+    captionText?: string;
     badge?: BadgeType;
 };
 
@@ -103,6 +105,7 @@ export const ImmersiveHeadline = ({
     sectionUrl,
     guardianBaseURL,
     pillar,
+    captionText,
     badge,
 }: Props) => (
     <div className={cx(postionRelative)}>
@@ -110,7 +113,12 @@ export const ImmersiveHeadline = ({
             <div className={cx(center, padding)}>
                 <Flex>
                     <LeftColumn showRightBorder={false}>
-                        <></>
+                        <Caption
+                            display={display}
+                            captionText={captionText}
+                            pillar={pillar}
+                            shouldLimitWidth={true}
+                        />
                     </LeftColumn>
                     <PositionHeadline>
                         <ArticleTitle

--- a/src/web/components/ImmersiveHeadline.tsx
+++ b/src/web/components/ImmersiveHeadline.tsx
@@ -7,7 +7,6 @@ import { ArticleTitle } from '@root/src/web/components/ArticleTitle';
 import { ArticleHeadline } from '@root/src/web/components/ArticleHeadline';
 import { LeftColumn } from '@root/src/web/components/LeftColumn';
 import { Flex } from '@root/src/web/components/Flex';
-import { ArticleContainer } from '@root/src/web/components/ArticleContainer';
 
 type Props = {
     display: Display;
@@ -48,7 +47,13 @@ const blackBlock = css`
         background-color: black;
         position: absolute;
         content: '';
-        width: 20%;
+        width: 0%;
+        ${from.phablet} {
+            width: 15%;
+        }
+        ${from.wide} {
+            width: 20%;
+        }
         right: 0;
         bottom: 0;
         display: block;
@@ -62,10 +67,10 @@ const blackBlock = css`
 `;
 
 const padding = css`
-    padding: 0 10px;
+    padding-left: 0px;
 
-    ${from.mobileLandscape} {
-        padding: 0 20px;
+    ${from.phablet} {
+        padding-left: 20px;
     }
 `;
 
@@ -81,6 +86,7 @@ const PositionHeadline = ({
     <div
         className={css`
             margin-top: -100px;
+            flex-grow: 1;
         `}
     >
         {children}
@@ -106,27 +112,25 @@ export const ImmersiveHeadline = ({
                     <LeftColumn showRightBorder={false}>
                         <></>
                     </LeftColumn>
-                    <ArticleContainer>
-                        <PositionHeadline>
-                            <ArticleTitle
-                                display={display}
-                                tags={tags}
-                                sectionLabel={sectionLabel}
-                                sectionUrl={sectionUrl}
-                                guardianBaseURL={guardianBaseURL}
-                                pillar={pillar}
-                                badge={badge}
-                            />
-                            <ArticleHeadline
-                                display={display}
-                                headlineString={headline}
-                                designType={designType}
-                                pillar={pillar}
-                                tags={tags}
-                                byline={author.byline}
-                            />
-                        </PositionHeadline>
-                    </ArticleContainer>
+                    <PositionHeadline>
+                        <ArticleTitle
+                            display={display}
+                            tags={tags}
+                            sectionLabel={sectionLabel}
+                            sectionUrl={sectionUrl}
+                            guardianBaseURL={guardianBaseURL}
+                            pillar={pillar}
+                            badge={badge}
+                        />
+                        <ArticleHeadline
+                            display={display}
+                            headlineString={headline}
+                            designType={designType}
+                            pillar={pillar}
+                            tags={tags}
+                            byline={author.byline}
+                        />
+                    </PositionHeadline>
                 </Flex>
             </div>
         </div>

--- a/src/web/components/MainMedia.tsx
+++ b/src/web/components/MainMedia.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'emotion';
+import { css, cx } from 'emotion';
 
 import { text } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
@@ -30,11 +30,6 @@ const mainMedia = css`
         }
     }
 
-    ${until.phablet} {
-        margin-left: -20px;
-        margin-right: -20px;
-    }
-
     img {
         flex: 0 0 auto; /* IE */
         width: 100%;
@@ -43,6 +38,13 @@ const mainMedia = css`
 
     figcaption {
         ${captionFont};
+    }
+`;
+
+const noGutters = css`
+    ${until.phablet} {
+        margin-left: -20px;
+        margin-right: -20px;
     }
 `;
 
@@ -99,7 +101,7 @@ export const MainMedia: React.FC<{
     adTargeting?: AdTargeting;
     starRating?: number;
 }> = ({ display, elements, pillar, hideCaption, adTargeting, starRating }) => (
-    <div className={mainMedia}>
+    <div className={cx(mainMedia, display !== 'immersive' && noGutters)}>
         {elements.map((element, i) =>
             renderElement(
                 display,

--- a/src/web/components/MainMedia.tsx
+++ b/src/web/components/MainMedia.tsx
@@ -74,6 +74,7 @@ function renderElement(
         case 'model.dotcomrendering.pageElements.YoutubeBlockElement':
             return (
                 <YouTubeComponent
+                    display={display}
                     key={i}
                     element={element}
                     pillar={pillar}

--- a/src/web/components/Nav/Nav.stories.tsx
+++ b/src/web/components/Nav/Nav.stories.tsx
@@ -24,7 +24,13 @@ export const StandardStory = () => {
             padded={false}
             backgroundColour={brandBackground.primary}
         >
-            <Nav pillar="news" display="standard" nav={nav} />
+            <Nav
+                pillar="news"
+                display="standard"
+                nav={nav}
+                subscribeUrl=""
+                edition="UK"
+            />
         </Section>
     );
 };
@@ -40,7 +46,13 @@ export const ImmersiveStory = () => {
             padded={false}
             backgroundColour={brandBackground.primary}
         >
-            <Nav pillar="news" display="immersive" nav={nav} />
+            <Nav
+                pillar="news"
+                display="immersive"
+                nav={nav}
+                subscribeUrl=""
+                edition="UK"
+            />
         </Section>
     );
 };

--- a/src/web/components/Nav/Nav.test.tsx
+++ b/src/web/components/Nav/Nav.test.tsx
@@ -8,7 +8,13 @@ import { nav } from './Nav.mock';
 describe('Nav', () => {
     it('should display pillar titles', () => {
         const { getByText } = render(
-            <Nav pillar="news" nav={nav} display="standard" />,
+            <Nav
+                pillar="news"
+                nav={nav}
+                display="standard"
+                subscribeUrl=""
+                edition="UK"
+            />,
         );
 
         expect(getByText('News')).toBeInTheDocument();
@@ -19,7 +25,13 @@ describe('Nav', () => {
 
     it('should render the correct number of pillar items', () => {
         const { container } = render(
-            <Nav pillar="news" nav={nav} display="standard" />,
+            <Nav
+                pillar="news"
+                nav={nav}
+                display="standard"
+                subscribeUrl=""
+                edition="UK"
+            />,
         );
 
         const listItems = container.querySelectorAll('li');
@@ -29,7 +41,13 @@ describe('Nav', () => {
 
     it('should open and close the expanded menu by clicking More', () => {
         const { getByTestId, getByText, queryAllByRole } = render(
-            <Nav pillar="news" nav={nav} display="standard" />,
+            <Nav
+                pillar="news"
+                nav={nav}
+                display="standard"
+                subscribeUrl=""
+                edition="UK"
+            />,
         );
 
         const expandedMenu = getByTestId('expanded-menu');

--- a/src/web/components/Nav/Nav.tsx
+++ b/src/web/components/Nav/Nav.tsx
@@ -3,11 +3,25 @@ import { css, cx } from 'emotion';
 
 import { Pillars } from '@root/src/web/components/Pillars';
 import { GuardianRoundel } from '@root/src/web/components/GuardianRoundel';
+import { space } from '@guardian/src-foundations';
 import { until } from '@guardian/src-foundations/mq';
+import { ThemeProvider } from 'emotion-theming';
+import { Button, buttonReaderRevenueBrand } from '@guardian/src-button';
+import { SvgArrowRightStraight } from '@guardian/src-svgs';
+
+import { Hide } from '@frontend/web/components/Hide';
 
 import { clearFix } from '@root/src/lib/mixins';
 
 import { ExpandedMenu } from './ExpandedMenu/ExpandedMenu';
+
+type Props = {
+    pillar: Pillar;
+    nav: NavType;
+    display: Display;
+    subscribeUrl: string;
+    edition: Edition;
+};
 
 const clearFixStyle = css`
     ${clearFix};
@@ -17,6 +31,10 @@ const rowStyles = css`
     display: flex;
     flex-direction: row;
     justify-content: space-between;
+`;
+
+const minHeight = css`
+    min-height: 48px;
 `;
 
 const PositionRoundel = ({ children }: { children: React.ReactNode }) => (
@@ -36,23 +54,53 @@ const PositionRoundel = ({ children }: { children: React.ReactNode }) => (
     </div>
 );
 
-type Props = {
-    pillar: Pillar;
-    nav: NavType;
-    display: Display;
-};
-export const Nav = ({ display, pillar, nav }: Props) => {
+const PositionButton = ({ children }: { children: React.ReactNode }) => (
+    <div
+        className={css`
+            margin-top: ${space[1]}px;
+            margin-left: ${space[2]}px;
+        `}
+    >
+        {children}
+    </div>
+);
+
+export const Nav = ({ display, pillar, nav, subscribeUrl, edition }: Props) => {
     const [showExpandedMenu, toggleExpandedMenu] = useState<boolean>(false);
     const mainMenuId = 'main-menu';
 
     return (
         <div className={rowStyles}>
             <nav
-                className={cx(clearFixStyle, rowStyles)}
+                className={cx(
+                    clearFixStyle,
+                    rowStyles,
+                    display === 'immersive' && minHeight,
+                )}
                 role="navigation"
                 aria-label="Guardian sections"
                 data-component="nav2"
             >
+                <Hide when="above" breakpoint="tablet">
+                    <ThemeProvider theme={buttonReaderRevenueBrand}>
+                        <PositionButton>
+                            <Button
+                                priority="primary"
+                                size="small"
+                                iconSide="right"
+                                icon={<SvgArrowRightStraight />}
+                                data-link-name="nav2 : support-cta"
+                                data-edition={edition}
+                                onClick={() => {
+                                    window.location.href = subscribeUrl;
+                                    return false;
+                                }}
+                            >
+                                Subscribe
+                            </Button>
+                        </PositionButton>
+                    </ThemeProvider>
+                </Hide>
                 <Pillars
                     display={display}
                     mainMenuOpen={showExpandedMenu}

--- a/src/web/components/Pillars.tsx
+++ b/src/web/components/Pillars.tsx
@@ -18,6 +18,9 @@ export const preDesktopPillarWidth = 'auto';
 // CSS
 
 const pillarsStyles = (display: Display) => css`
+    ${until.tablet} {
+        display: ${display === 'immersive' && 'none'};
+    }
     clear: right;
     margin: 0;
     list-style: none;

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -69,8 +69,11 @@ const invertedStyle = (pillar: Pillar) => css`
     color: ${neutral[100]};
     background-color: ${pillarPalette[pillar].main};
 
-    padding-left: ${space[2]}px;
-    padding-right: ${space[2]}px;
+    padding-left: ${space[5]}px;
+    ${from.phablet} {
+        padding-left: ${space[3]}px;
+    }
+    padding-right: ${space[3]}px;
     padding-top: ${space[1]}px;
     padding-bottom: ${space[1]}px;
 `;

--- a/src/web/components/Standfirst.tsx
+++ b/src/web/components/Standfirst.tsx
@@ -47,6 +47,7 @@ const standfirstStyles = (designType: DesignType, display: Display) => {
             ${headline.xsmall({
                 fontWeight: 'light',
             })};
+            padding-top: ${space[4]}px;
         `;
     }
 

--- a/src/web/components/Standfirst.tsx
+++ b/src/web/components/Standfirst.tsx
@@ -2,7 +2,14 @@ import React from 'react';
 import { css, cx } from 'emotion';
 import { neutral } from '@guardian/src-foundations/palette';
 import { space } from '@guardian/src-foundations';
+import { from } from '@guardian/src-foundations/mq';
 import { headline, textSans } from '@guardian/src-foundations/typography';
+
+type Props = {
+    display: Display;
+    designType: DesignType;
+    standfirst: string;
+};
 
 const nestedStyles = css`
     li {
@@ -48,6 +55,14 @@ const standfirstStyles = (designType: DesignType, display: Display) => {
                 fontWeight: 'light',
             })};
             padding-top: ${space[4]}px;
+
+            max-width: 280px;
+            ${from.tablet} {
+                max-width: 400px;
+            }
+            ${from.tablet} {
+                max-width: 460px;
+            }
         `;
     }
 
@@ -83,12 +98,6 @@ const standfirstStyles = (designType: DesignType, display: Display) => {
                 margin-bottom: ${space[3]}px;
             `;
     }
-};
-
-type Props = {
-    display: Display;
-    designType: DesignType;
-    standfirst: string;
 };
 
 export const Standfirst = ({ display, designType, standfirst }: Props) => {

--- a/src/web/components/elements/ImageComponent.tsx
+++ b/src/web/components/elements/ImageComponent.tsx
@@ -175,6 +175,7 @@ export const ImageComponent = ({
     }
     return (
         <Caption
+            display={display}
             captionText={element.data.caption || ''}
             pillar={pillar}
             credit={element.data.credit}

--- a/src/web/components/elements/YouTubeComponent.stories.tsx
+++ b/src/web/components/elements/YouTubeComponent.stories.tsx
@@ -23,6 +23,7 @@ export const noOverlay = () => {
     return (
         <Container>
             <YouTubeComponent
+                display="standard"
                 element={{
                     mediaTitle:
                         "Prince Harry and Meghan's 'bombshell' plans explained – video",

--- a/src/web/components/elements/YouTubeComponent.tsx
+++ b/src/web/components/elements/YouTubeComponent.tsx
@@ -4,6 +4,7 @@ import { Caption } from '@root/src/web/components/Caption';
 import { YouTubeEmbed } from '@root/src/web/components/YouTubeEmbed';
 
 type Props = {
+    display: Display;
     element: YoutubeBlockElement;
     pillar: Pillar;
     hideCaption?: boolean;
@@ -14,6 +15,7 @@ type Props = {
 };
 
 export const YouTubeComponent = ({
+    display,
     element,
     pillar,
     hideCaption,
@@ -38,6 +40,7 @@ export const YouTubeComponent = ({
     }
     return (
         <Caption
+            display={display}
             captionText={element.mediaTitle || ''}
             pillar={pillar}
             displayCredit={false}

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -274,6 +274,8 @@ export const CommentLayout = ({
                     pillar={getCurrentPillar(CAPI)}
                     nav={NAV}
                     display={display}
+                    subscribeUrl={CAPI.nav.readerRevenueLinks.header.subscribe}
+                    edition={CAPI.editionId}
                 />
             </Section>
 

--- a/src/web/layouts/DecideLayout.tsx
+++ b/src/web/layouts/DecideLayout.tsx
@@ -34,7 +34,7 @@ export const DecideLayout = ({ CAPI, NAV }: Props) => {
                 case 'Comment':
                 case 'GuardianView':
                     return (
-                        <CommentLayout
+                        <ImmersiveLayout
                             CAPI={CAPI}
                             NAV={NAV}
                             display="immersive"

--- a/src/web/layouts/DecideLayout.tsx
+++ b/src/web/layouts/DecideLayout.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { StandardLayout } from './StandardLayout';
 import { ShowcaseLayout } from './ShowcaseLayout';
 import { CommentLayout } from './CommentLayout';
+import { ImmersiveLayout } from './ImmersiveLayout';
 
 type Props = {
     CAPI: CAPIType;
@@ -56,7 +57,7 @@ export const DecideLayout = ({ CAPI, NAV }: Props) => {
                 case 'AdvertisementFeature':
                 case 'Immersive':
                     return (
-                        <ShowcaseLayout
+                        <ImmersiveLayout
                             CAPI={CAPI}
                             NAV={NAV}
                             display="immersive"

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -38,6 +38,7 @@ import {
     decideLineEffect,
     getCurrentPillar,
 } from '@root/src/web/lib/layoutHelpers';
+import { Hide } from '../components/Hide';
 
 const ImmersiveGrid = ({
     children,
@@ -89,7 +90,7 @@ const ImmersiveGrid = ({
                         1fr /* Main content */
                         300px; /* Right Column */
                     grid-template-areas:
-                        'caption    border      standfirst  right-column'
+                        '.          border      standfirst  right-column'
                         '.          border      byline      right-column'
                         'lines      border      body        right-column'
                         'meta       border      body        right-column'
@@ -245,26 +246,24 @@ export const ImmersiveLayout = ({
                 sectionUrl={CAPI.sectionUrl}
                 guardianBaseURL={CAPI.guardianBaseURL}
                 pillar={CAPI.pillar}
+                captionText={captionText}
                 badge={CAPI.badge}
             />
 
             <Section showTopBorder={false} showSideBorders={false}>
                 <ImmersiveGrid>
+                    {/* Above leftCol, the Caption is controled by ImmersiveHeadline because the
+                    headline stretches all the way right it can't be inside a Section so that
+                    top area of the page is rendered outside the grid */}
                     <GridItem area="caption">
-                        <div
-                            className={css`
-                                ${from.leftCol} {
-                                    margin-top: -80px;
-                                }
-                            `}
-                        >
+                        <Hide when="above" breakpoint="leftCol">
                             <Caption
                                 display={display}
                                 captionText={captionText}
                                 pillar={pillar}
-                                shouldLimitWidth={true}
+                                shouldLimitWidth={false}
                             />
-                        </div>
+                        </Hide>
                     </GridItem>
                     <GridItem area="border">
                         <Border />

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -1,0 +1,433 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import {
+    neutral,
+    brandBackground,
+    brandBorder,
+} from '@guardian/src-foundations/palette';
+import { from, until } from '@guardian/src-foundations/mq';
+
+import { namedAdSlotParameters } from '@root/src/model/advertisement';
+import { ArticleBody } from '@root/src/web/components/ArticleBody';
+import { RightColumn } from '@root/src/web/components/RightColumn';
+import { ArticleContainer } from '@root/src/web/components/ArticleContainer';
+import { ArticleMeta } from '@root/src/web/components/ArticleMeta';
+import { GuardianLines } from '@root/src/web/components/GuardianLines';
+import { SubMeta } from '@root/src/web/components/SubMeta';
+import { MainMedia } from '@root/src/web/components/MainMedia';
+import { ArticleStandfirst } from '@root/src/web/components/ArticleStandfirst';
+import { Footer } from '@root/src/web/components/Footer';
+import { SubNav } from '@root/src/web/components/SubNav/SubNav';
+import { OutbrainContainer } from '@root/src/web/components/Outbrain';
+import { Section } from '@root/src/web/components/Section';
+import { Nav } from '@root/src/web/components/Nav/Nav';
+import { MobileStickyContainer, AdSlot } from '@root/src/web/components/AdSlot';
+import { Border } from '@root/src/web/components/Border';
+import { GridItem } from '@root/src/web/components/GridItem';
+import { Flex } from '@root/src/web/components/Flex';
+import { Caption } from '@root/src/web/components/Caption';
+import { HeadlineByline } from '@root/src/web/components/HeadlineByline';
+import { ImmersiveHeadline } from '@root/src/web/components/ImmersiveHeadline';
+
+import { buildAdTargeting } from '@root/src/lib/ad-targeting';
+import { parse } from '@frontend/lib/slot-machine-flags';
+
+import {
+    decideLineCount,
+    decideLineEffect,
+    getCurrentPillar,
+} from '@root/src/web/lib/layoutHelpers';
+
+const ImmersiveGrid = ({
+    children,
+}: {
+    children: JSX.Element | JSX.Element[];
+}) => (
+    <div
+        className={css`
+            /* IE Fallback */
+            display: flex;
+            flex-direction: column;
+            ${until.leftCol} {
+                margin-left: 0px;
+            }
+            ${from.leftCol} {
+                margin-left: 151px;
+            }
+            ${from.wide} {
+                margin-left: 230px;
+            }
+
+            @supports (display: grid) {
+                display: grid;
+                width: 100%;
+                margin-left: 0;
+
+                ${from.wide} {
+                    grid-column-gap: 10px;
+                    grid-template-columns:
+                        219px /* Left Column (220 - 1px border) */
+                        1px /* Vertical grey border */
+                        1fr /* Main content */
+                        300px; /* Right Column */
+                    grid-template-areas:
+                        'caption    border      standfirst  right-column'
+                        '.          border      byline      right-column'
+                        'lines      border      body        right-column'
+                        'meta       border      body        right-column'
+                        'meta       border      body        right-column'
+                        '.          border      body        right-column'
+                        '.          border      .           right-column';
+                }
+
+                ${until.wide} {
+                    grid-column-gap: 10px;
+                    grid-template-columns:
+                        140px /* Left Column (220 - 1px border) */
+                        1px /* Vertical grey border */
+                        1fr /* Main content */
+                        300px; /* Right Column */
+                    grid-template-areas:
+                        'caption    border      standfirst  right-column'
+                        '.          border      byline      right-column'
+                        'lines      border      body        right-column'
+                        'meta       border      body        right-column'
+                        'meta       border      body        right-column'
+                        '.          border      body        right-column'
+                        '.          border      .           right-column';
+                }
+
+                ${until.leftCol} {
+                    grid-column-gap: 20px;
+                    grid-template-columns:
+                        1fr /* Main content */
+                        300px; /* Right Column */
+                    grid-template-areas:
+                        'standfirst  right-column'
+                        'byline      right-column'
+                        'caption     right-column'
+                        'lines       right-column'
+                        'meta        right-column'
+                        'body        right-column';
+                }
+
+                ${until.desktop} {
+                    grid-column-gap: 0px;
+                    grid-template-columns: 1fr; /* Main content */
+                    grid-template-areas:
+                        'standfirst'
+                        'byline'
+                        'caption'
+                        'lines'
+                        'meta'
+                        'body';
+                }
+            }
+        `}
+    >
+        {children}
+    </div>
+);
+
+const maxWidth = css`
+    ${from.desktop} {
+        max-width: 620px;
+    }
+`;
+
+const stretchLines = css`
+    ${until.phablet} {
+        margin-left: -20px;
+        margin-right: -20px;
+    }
+`;
+
+interface Props {
+    CAPI: CAPIType;
+    NAV: NavType;
+    display: Display;
+    designType: DesignType;
+    pillar: Pillar;
+}
+
+export const ImmersiveLayout = ({
+    CAPI,
+    NAV,
+    display,
+    designType,
+    pillar,
+}: Props) => {
+    const {
+        config: { isPaidContent },
+        pageType: { isSensitive },
+    } = CAPI;
+
+    const adTargeting: AdTargeting = buildAdTargeting(CAPI.config);
+
+    // Render the slot if one is true:
+    // 1) The flag for this slot exists in the URL (i.e. ?slot-machine-flags=showBodyEnd)
+    // 2) The global switch for the Frontend/DCR Epic test is true
+    const showBodyEndSlot =
+        parse(CAPI.slotMachineFlags || '').showBodyEnd ||
+        CAPI.config.switches.abFrontendDotcomRenderingEpic;
+
+    // TODO:
+    // 1) Read 'forceEpic' value from URL parameter and use it to force the slot to render
+    // 2) Otherwise, ensure slot only renders if `CAPI.config.shouldHideReaderRevenue` equals false.
+
+    const seriesTag = CAPI.tags.find(
+        tag => tag.type === 'Series' || tag.type === 'Blog',
+    );
+    const showOnwardsLower = seriesTag && CAPI.hasStoryPackage;
+
+    const showComments = CAPI.isCommentable;
+
+    const mainMedia = CAPI.mainMediaElements[0] as ImageBlockElement;
+    const captionText = mainMedia.data.caption;
+
+    return (
+        <>
+            <div
+                className={css`
+                    display: flex;
+                    flex-direction: column;
+                    min-height: 100vh;
+                `}
+            >
+                <Section
+                    sectionId="nav-root"
+                    showSideBorders={false}
+                    borderColour={brandBorder.primary}
+                    showTopBorder={false}
+                    padded={false}
+                    backgroundColour={brandBackground.primary}
+                >
+                    <Nav
+                        pillar={getCurrentPillar(CAPI)}
+                        nav={NAV}
+                        display={display}
+                    />
+                </Section>
+                <div
+                    className={css`
+                        flex: 1;
+                        min-height: 31.25rem;
+                        position: relative;
+                    `}
+                >
+                    <MainMedia
+                        display={display}
+                        elements={CAPI.mainMediaElements}
+                        pillar={pillar}
+                        adTargeting={adTargeting}
+                        starRating={
+                            CAPI.designType === 'Review' && CAPI.starRating
+                                ? CAPI.starRating
+                                : undefined
+                        }
+                        hideCaption={true}
+                    />
+                </div>
+            </div>
+
+            <ImmersiveHeadline
+                display={display}
+                designType={designType}
+                tags={CAPI.tags}
+                author={CAPI.author}
+                headline={CAPI.headline}
+                sectionLabel={CAPI.sectionLabel}
+                sectionUrl={CAPI.sectionUrl}
+                guardianBaseURL={CAPI.guardianBaseURL}
+                pillar={CAPI.pillar}
+                badge={CAPI.badge}
+            />
+
+            <Section showTopBorder={false} showSideBorders={false}>
+                <ImmersiveGrid>
+                    <GridItem area="caption">
+                        <div
+                            className={css`
+                                ${from.leftCol} {
+                                    margin-top: -80px;
+                                }
+                            `}
+                        >
+                            <Caption
+                                display={display}
+                                captionText={captionText}
+                                pillar={pillar}
+                                shouldLimitWidth={true}
+                            />
+                        </div>
+                    </GridItem>
+                    <GridItem area="border">
+                        <Border />
+                    </GridItem>
+                    <GridItem area="standfirst">
+                        <ArticleStandfirst
+                            display={display}
+                            designType={designType}
+                            pillar={pillar}
+                            standfirst={CAPI.standfirst}
+                        />
+                    </GridItem>
+                    <GridItem area="byline">
+                        <HeadlineByline
+                            display={display}
+                            designType={designType}
+                            pillar={pillar}
+                            tags={CAPI.tags}
+                            byline={
+                                CAPI.author.byline ? CAPI.author.byline : ''
+                            }
+                        />
+                    </GridItem>
+                    <GridItem area="lines">
+                        <div className={maxWidth}>
+                            <div className={stretchLines}>
+                                <GuardianLines
+                                    pillar={pillar}
+                                    effect={decideLineEffect(
+                                        'Immersive',
+                                        pillar,
+                                    )}
+                                    count={decideLineCount('Immersive')}
+                                />
+                            </div>
+                        </div>
+                    </GridItem>
+                    <GridItem area="meta">
+                        <div className={maxWidth}>
+                            <ArticleMeta
+                                display={display}
+                                designType={designType}
+                                pillar={pillar}
+                                pageId={CAPI.pageId}
+                                webTitle={CAPI.webTitle}
+                                author={CAPI.author}
+                                tags={CAPI.tags}
+                                webPublicationDateDisplay={
+                                    CAPI.webPublicationDateDisplay
+                                }
+                            />
+                        </div>
+                    </GridItem>
+                    <GridItem area="body">
+                        <ArticleContainer>
+                            <main className={maxWidth}>
+                                <ArticleBody
+                                    display={display}
+                                    pillar={pillar}
+                                    blocks={CAPI.blocks}
+                                    designType={designType}
+                                    adTargeting={adTargeting}
+                                />
+                                {showBodyEndSlot && <div id="slot-body-end" />}
+                                <GuardianLines count={4} pillar={pillar} />
+                                <SubMeta
+                                    pillar={pillar}
+                                    subMetaKeywordLinks={
+                                        CAPI.subMetaKeywordLinks
+                                    }
+                                    subMetaSectionLinks={
+                                        CAPI.subMetaSectionLinks
+                                    }
+                                    pageId={CAPI.pageId}
+                                    webUrl={CAPI.webURL}
+                                    webTitle={CAPI.webTitle}
+                                    showBottomSocialButtons={
+                                        CAPI.showBottomSocialButtons
+                                    }
+                                    badge={CAPI.badge}
+                                />
+                            </main>
+                        </ArticleContainer>
+                    </GridItem>
+                    <GridItem area="right-column">
+                        <RightColumn>
+                            <AdSlot asps={namedAdSlotParameters('right')} />
+                        </RightColumn>
+                    </GridItem>
+                </ImmersiveGrid>
+            </Section>
+
+            <Section
+                padded={false}
+                showTopBorder={false}
+                showSideBorders={false}
+                backgroundColour={neutral[93]}
+            >
+                <AdSlot asps={namedAdSlotParameters('merchandising-high')} />
+            </Section>
+
+            <Section sectionId="onwards-upper" />
+
+            {!isPaidContent && (
+                <>
+                    {!isSensitive && (
+                        <Section
+                            showTopBorder={false}
+                            backgroundColour={neutral[97]}
+                        >
+                            <OutbrainContainer />
+                        </Section>
+                    )}
+
+                    {showOnwardsLower && <Section sectionId="onwards-lower" />}
+
+                    {showComments && (
+                        <Section sectionId="comments">
+                            <Flex>
+                                <div id="comments-root" />
+                                <RightColumn>
+                                    <AdSlot
+                                        asps={namedAdSlotParameters('comments')}
+                                    />
+                                </RightColumn>
+                            </Flex>
+                        </Section>
+                    )}
+
+                    <Section sectionId="most-viewed-footer" />
+                </>
+            )}
+
+            <Section
+                padded={false}
+                showTopBorder={false}
+                showSideBorders={false}
+                backgroundColour={neutral[93]}
+            >
+                <AdSlot asps={namedAdSlotParameters('merchandising')} />
+            </Section>
+
+            {NAV.subNavSections && (
+                <Section padded={false} sectionId="sub-nav-root">
+                    <SubNav
+                        subNavSections={NAV.subNavSections}
+                        currentNavLink={NAV.currentNavLink}
+                        pillar={pillar}
+                    />
+                    <GuardianLines count={4} pillar={pillar} />
+                </Section>
+            )}
+
+            <Section
+                padded={false}
+                backgroundColour={brandBackground.primary}
+                borderColour={brandBorder.primary}
+            >
+                <Footer
+                    pageFooter={CAPI.pageFooter}
+                    pillar={pillar}
+                    pillars={NAV.pillars}
+                />
+            </Section>
+
+            <div id="cmp" />
+            <MobileStickyContainer />
+        </>
+    );
+};

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -7,6 +7,7 @@ import {
     brandBorder,
 } from '@guardian/src-foundations/palette';
 import { from, until } from '@guardian/src-foundations/mq';
+import { space } from '@guardian/src-foundations';
 
 import { namedAdSlotParameters } from '@root/src/model/advertisement';
 import { ArticleBody } from '@root/src/web/components/ArticleBody';
@@ -350,7 +351,13 @@ export const ImmersiveLayout = ({
                     </GridItem>
                     <GridItem area="right-column">
                         <RightColumn>
-                            <AdSlot asps={namedAdSlotParameters('right')} />
+                            <div
+                                className={css`
+                                    margin-top: ${space[4]}px;
+                                `}
+                            >
+                                <AdSlot asps={namedAdSlotParameters('right')} />
+                            </div>
                         </RightColumn>
                     </GridItem>
                 </ImmersiveGrid>

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -186,7 +186,7 @@ export const ImmersiveLayout = ({
     const showComments = CAPI.isCommentable;
 
     const mainMedia = CAPI.mainMediaElements[0] as ImageBlockElement;
-    const captionText = mainMedia.data.caption;
+    const captionText = mainMedia && mainMedia.data && mainMedia.data.caption;
 
     return (
         <>

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -207,6 +207,10 @@ export const ImmersiveLayout = ({
                         pillar={getCurrentPillar(CAPI)}
                         nav={NAV}
                         display={display}
+                        subscribeUrl={
+                            CAPI.nav.readerRevenueLinks.header.subscribe
+                        }
+                        edition={CAPI.editionId}
                     />
                 </Section>
                 <div

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -319,6 +319,10 @@ export const ShowcaseLayout = ({
                             pillar={getCurrentPillar(CAPI)}
                             nav={NAV}
                             display={display}
+                            subscribeUrl={
+                                CAPI.nav.readerRevenueLinks.header.subscribe
+                            }
+                            edition={CAPI.editionId}
                         />
                     </Section>
 

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -304,6 +304,10 @@ export const StandardLayout = ({
                             pillar={getCurrentPillar(CAPI)}
                             nav={NAV}
                             display={display}
+                            subscribeUrl={
+                                CAPI.nav.readerRevenueLinks.header.subscribe
+                            }
+                            edition={CAPI.editionId}
                         />
                     </Section>
 

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -71,6 +71,7 @@ export const ArticleRenderer: React.FC<{
                 case 'model.dotcomrendering.pageElements.YoutubeBlockElement':
                     return (
                         <YouTubeComponent
+                            display={display}
                             key={i}
                             element={element}
                             pillar={pillar}


### PR DESCRIPTION
## What does this change?
Adds support for immersive articles using a new `ImmersiveLayout` file

Please review snapshots to see how this looks / approve the layout

### What's different?
_I raised the beginning of the right column up_
On frontend the right advert is displayed further down the page, alongside the meta, but, for more promenance and to be more semantic, I raised this up on DCR. I'm assuming the reason it was lower on frontend was a layout constraint that we don't have.

_selected pillar_
We (DCR) show which pillar the article is in by using the top colour bar (see Culture below). On frontend this is removed

DCR:
![Screenshot 2020-04-24 at 15 33 32](https://user-images.githubusercontent.com/1336821/80224095-25006300-8641-11ea-8b8e-9430feeec03c.jpg)

Frontend:
![Screenshot 2020-04-24 at 15 33 43](https://user-images.githubusercontent.com/1336821/80224103-2762bd00-8641-11ea-9d26-8a15feab9a00.jpg)

### What's interesting?
We use the same method to render blackness all the way to the right of the screen as frontend, an after pseudo selector, but this also means the headline had to be rendered outside of the grid. And because the headline was out of the grid the corresponding `Caption` had to be broken out as well. However, we still render a `Caption` in the grid when below `leftCol` because in this case the caption is inlined in the body.

### So many diffs...
Changes are organised by commit and can be reivewed step by step that way

## Link to supporting Trello card
https://trello.com/c/zi1EudDh/807-immersive-layout