### PR TITLE
Update CMP version to 3.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "@babel/runtime": "^7.9.2",
         "@emotion/core": "^10.0.28",
         "@guardian/automat-client": "^0.2.16",
-        "@guardian/consent-management-platform": "^3.0.0",
+        "@guardian/consent-management-platform": "^3.0.4",
         "@guardian/discussion-rendering": "^2.2.5",
         "@guardian/src-button": "^0.17.0",
         "@guardian/src-ed-lines": "^0.18.0-rc.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2142,10 +2142,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.16.tgz#3ef47e7f49e633aea51c67f061d8d313a26fa9bc"
   integrity sha512-SgNU2bgiyQaXNfqanx4SDmxqAhXW6QBCTk4tRnCgV9Ht6noRl7UsDfx4I0u+M4H3TRnK4I/i2mmlJBtnuwhxEg==
 
-"@guardian/consent-management-platform@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-3.0.0.tgz#6e91aca0330ce8cd8653124287f51a99d0ea727a"
-  integrity sha512-Vu0Q2n/gJew35AxxsEse50f29cAGfcywc7+6FPG7HLMeyS1BymsFxUQAEcem3rM4j6Uq6F/pdtmfsxeXAQJfsA==
+"@guardian/consent-management-platform@^3.0.4":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-3.0.4.tgz#8e64bf1c2d92e124c60f0869f2e3b59be786dcaa"
+  integrity sha512-QOd2NbTFWGhh9qhd6wQOU0xyF0dqB9yIFT3W2fZI529Qie+NqPDFU3yVKrvsSQvYpW0ITTZhzCtULQ8rf2kc8w==
   dependencies:
     consent-string "^1.5.1"
     js-cookie "^2.2.1"


### PR DESCRIPTION
## What does this change?
Updating the CMP to the latest version as it introduces some changes that impact IAB compliance. (Corresponding frontend PR: https://github.com/guardian/frontend/pull/22530)