### PR TITLE
Dynamically set CDN path using webpack

### DIFF
--- a/scripts/webpack/frontend.js
+++ b/scripts/webpack/frontend.js
@@ -16,14 +16,14 @@ const stage =
         : process.env.GU_STAGE;
 
 const CDN = stage
-    ? `//assets${stage === 'CODE' ? '-code' : ''}.guim.co.uk/`
+    ? `https://assets${stage === 'CODE' ? '-code' : ''}.guim.co.uk/`
     : '/';
 
 const commonConfigs = ({ platform }) => ({
     name: platform,
     mode: process.env.NODE_ENV,
     output: {
-        publicPath: `${CDN}/assets/`,
+        publicPath: `${CDN}assets/`,
         path: dist,
     },
     stats: 'errors-only',

--- a/scripts/webpack/frontend.js
+++ b/scripts/webpack/frontend.js
@@ -9,11 +9,21 @@ const { root, dist, siteName } = require('../frontend/config');
 
 const PROD = process.env.NODE_ENV === 'production';
 
+// GU_STAGE is set in cloudformation.yml, so will be undefined locally
+const stage =
+    typeof process.env.GU_STAGE === 'string'
+        ? process.env.GU_STAGE.toUpperCase()
+        : process.env.GU_STAGE;
+
+const CDN = stage
+    ? `//assets${stage === 'CODE' ? '-code' : ''}.guim.co.uk/`
+    : '/';
+
 const commonConfigs = ({ platform }) => ({
     name: platform,
     mode: process.env.NODE_ENV,
     output: {
-        publicPath: '/assets/',
+        publicPath: `${CDN}/assets/`,
         path: dist,
     },
     stats: 'errors-only',

--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -33,7 +33,7 @@ export const getDist = ({
     legacy: boolean;
 }): string => {
     const selectedAssetHash = legacy ? assetHashLegacy : assetHash;
-    return selectedAssetHash[path] || path;
+    return `${CDN}assets/${selectedAssetHash[path] || path}`;
 };
 
 // TODO: Do static files ever appear in the manifest.json?

--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -33,7 +33,7 @@ export const getDist = ({
     legacy: boolean;
 }): string => {
     const selectedAssetHash = legacy ? assetHashLegacy : assetHash;
-    return `${CDN}assets/${selectedAssetHash[path] || path}`;
+    return selectedAssetHash[path] || path;
 };
 
 // TODO: Do static files ever appear in the manifest.json?


### PR DESCRIPTION
## What does this change?
specify the entire publicPath of the asset in webpack

## Why?
when it comes to dynamic import, webpack determines the path of each chuck so we need to specify the full path or it will fall back to the URL

https://webpack.js.org/configuration/output/#outputpublicpath

## Link to supporting Trello card
https://trello.com/c/v8XUWxzT/1528-dynamic-cdn-webpack