### PR TITLE
Opinion cards with news pillar

### DIFF
--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -122,7 +122,7 @@ export const Card = ({
 
     return (
         <CardLink linkTo={linkTo} designType={designType} pillar={pillarToUse}>
-            <TopBar topBarColour={pillarPalette[pillar].main}>
+            <TopBar topBarColour={pillarPalette[pillarToUse].main}>
                 <CardLayout imagePosition={imagePosition}>
                     <>
                         {imageUrl && (

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -117,8 +117,11 @@ export const Card = ({
 
     const { long: longCount, short: shortCount } = formatCount(commentCount);
 
+    const pillarToUse =
+        designType === 'Comment' && pillar === 'news' ? 'opinion' : pillar;
+
     return (
-        <CardLink linkTo={linkTo} designType={designType} pillar={pillar}>
+        <CardLink linkTo={linkTo} designType={designType} pillar={pillarToUse}>
             <TopBar topBarColour={pillarPalette[pillar].main}>
                 <CardLayout imagePosition={imagePosition}>
                     <>
@@ -144,7 +147,7 @@ export const Card = ({
                                     <CardHeadline
                                         headlineText={headlineText}
                                         designType={designType}
-                                        pillar={pillar}
+                                        pillar={pillarToUse}
                                         size={headlineSize}
                                         showQuotes={showQuotes}
                                         kickerText={
@@ -170,7 +173,7 @@ export const Card = ({
                                                 <Avatar
                                                     imageSrc={avatar.src}
                                                     imageAlt={avatar.alt}
-                                                    pillar={pillar}
+                                                    pillar={pillarToUse}
                                                 />
                                             </AvatarContainer>
                                         </Hide>
@@ -189,7 +192,7 @@ export const Card = ({
                                             <Avatar
                                                 imageSrc={avatar.src}
                                                 imageAlt={avatar.alt}
-                                                pillar={pillar}
+                                                pillar={pillarToUse}
                                             />
                                         </AvatarContainer>
                                     </Hide>
@@ -200,7 +203,7 @@ export const Card = ({
                                         webPublicationDate ? (
                                             <CardAge
                                                 designType={designType}
-                                                pillar={pillar}
+                                                pillar={pillarToUse}
                                                 webPublicationDate={
                                                     webPublicationDate
                                                 }
@@ -213,7 +216,7 @@ export const Card = ({
                                     mediaMeta={
                                         designType === 'Media' && mediaType ? (
                                             <MediaMeta
-                                                pillar={pillar}
+                                                pillar={pillarToUse}
                                                 mediaType={mediaType}
                                                 mediaDuration={mediaDuration}
                                             />
@@ -225,7 +228,7 @@ export const Card = ({
                                         longCount && shortCount ? (
                                             <CardCommentCount
                                                 designType={designType}
-                                                pillar={pillar}
+                                                pillar={pillarToUse}
                                                 long={longCount}
                                                 short={shortCount}
                                             />


### PR DESCRIPTION
## What does this change?
Ensures that comment cards that have the news pillar are styled with the opinion pillar

![Screenshot 2020-04-24 at 15 38 33](https://user-images.githubusercontent.com/1336821/80224505-af48c700-8641-11ea-8524-0fc89a445eb7.jpg)


## Why?
To support the design decison that made around this and to stay in line with the rest of the site

## Link to supporting Trello card
https://trello.com/c/oWbbWVPM/1479-onwards-cards-not-being-styled-correctly-from-tone-pillar