### PR TITLE
Comments should fill the available space

### DIFF
--- a/src/web/components/CommentsLayout.stories.tsx
+++ b/src/web/components/CommentsLayout.stories.tsx
@@ -11,6 +11,21 @@ import { AdSlot } from '@root/src/web/components/AdSlot';
 
 import { CommentsLayout } from './CommentsLayout';
 
+const user: UserProfile = {
+    userId: 'abc123',
+    displayName: 'Jane Smith',
+    webUrl: '',
+    apiUrl: '',
+    avatar: '',
+    secureAvatarUrl: '',
+    badge: [],
+    privateFields: {
+        canPostComment: true,
+        isPremoderated: false,
+        hasCommented: true,
+    },
+};
+
 /* tslint:disable */
 export default {
     component: CommentsLayout,
@@ -42,3 +57,27 @@ export const Default = () => (
     </Section>
 );
 Default.story = { name: 'default' };
+
+export const LoggedIn = () => (
+    <Section>
+        <Flex>
+            <CommentsLayout
+                user={user}
+                baseUrl="https://discussion.theguardian.com/discussion-api"
+                pillar="news"
+                shortUrl="p/39f5z/"
+                commentCount={345}
+                isClosedForComments={false}
+                enableDiscussionSwitch={true}
+                discussionD2Uid="testD2Header"
+                discussionApiClientHeader="testClientHeader"
+                expanded={false}
+                onPermalinkClick={() => {}}
+            />
+            <RightColumn>
+                <AdSlot asps={namedAdSlotParameters('comments')} />
+            </RightColumn>
+        </Flex>
+    </Section>
+);
+LoggedIn.story = { name: 'when signed in' };

--- a/src/web/components/CommentsLayout.tsx
+++ b/src/web/components/CommentsLayout.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { css } from 'emotion';
 
-import { from } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
 import { App as Comments } from '@guardian/discussion-rendering';
 import { LeftColumn } from '@frontend/web/components/LeftColumn';
@@ -31,9 +30,6 @@ const containerStyles = css`
     display: flex;
     flex-grow: 1;
     flex-direction: column;
-    ${from.desktop} {
-        width: 620px;
-    }
 
     padding-top: ${space[3]}px;
     padding-bottom: ${space[6]}px;


### PR DESCRIPTION
## What does this change?
Removes the width limit that was being set on the comments container when the reader was logged in

## Why?
So the comments can fill the available space

## Link to supporting Trello card
https://trello.com/c/xTwk3XYQ/1493-skinny-commenting-container