### PR TITLE
Clickable comment icon

### DIFF
--- a/src/web/components/CommentCount.tsx
+++ b/src/web/components/CommentCount.tsx
@@ -77,29 +77,29 @@ export const CommentCount = ({
             aria-label={`${short} Comments`}
             data-cy="comment-counts"
         >
-            <div className={iconContainerStyles}>
-                <CommentIcon className={iconStyles(pillar)} />
-            </div>
-            <div
-                data-testid="long-comment-count"
-                className={longStyles}
-                aria-hidden="true"
+            <a
+                href="#comments"
+                className={linkStyles}
+                onClick={() => setOpenComments(true)}
             >
-                <a
-                    href="#comments"
-                    className={linkStyles}
-                    onClick={() => setOpenComments(true)}
+                <div className={iconContainerStyles}>
+                    <CommentIcon className={iconStyles(pillar)} />
+                </div>
+                <div
+                    data-testid="long-comment-count"
+                    className={longStyles}
+                    aria-hidden="true"
                 >
                     {long}
-                </a>
-            </div>
-            <div
-                data-testid="short-comment-count"
-                className={shortStyles}
-                aria-hidden="true"
-            >
-                {short}
-            </div>
+                </div>
+                <div
+                    data-testid="short-comment-count"
+                    className={shortStyles}
+                    aria-hidden="true"
+                >
+                    {short}
+                </div>
+            </a>
         </div>
     );
 };


### PR DESCRIPTION
## What does this change?
Expands the area that can be clicked for the comment count

![2020-04-25 23 26 27](https://user-images.githubusercontent.com/1336821/80292162-3e420600-874c-11ea-887f-4a65ec08fa8c.gif)


## Why?
So the icon becomes part of the link too

## Link to supporting Trello card
https://trello.com/c/fFZ42589/1521-comment-count-icon-is-not-a-link
