### PR TITLE
Sometimes onwards content appears below comments

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -579,8 +579,10 @@ type IslandType =
     | 'reader-revenue-links-footer'
     | 'slot-body-end'
     | 'cmp'
-    | 'onwards-upper'
-    | 'onwards-lower'
+    | 'onwards-upper-whensignedin'
+    | 'onwards-upper-whensignedout'
+    | 'onwards-lower-whensignedin'
+    | 'onwards-lower-whensignedout'
     | 'rich-link'
     | 'links-root'
     | 'comments-root';

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -249,7 +249,13 @@ export const App = ({ CAPI, NAV }: Props) => {
                     contributionsServiceUrl={CAPI.contributionsServiceUrl}
                 />
             </Portal>
-            <Portal root="onwards-upper">
+            <Portal
+                root={
+                    isSignedIn
+                        ? 'onwards-upper-whensignedin'
+                        : 'onwards-upper-whensignedout'
+                }
+            >
                 <Lazy margin={300}>
                     <OnwardsUpper
                         ajaxUrl={CAPI.config.ajaxUrl}
@@ -265,7 +271,13 @@ export const App = ({ CAPI, NAV }: Props) => {
                     />
                 </Lazy>
             </Portal>
-            <Portal root="onwards-lower">
+            <Portal
+                root={
+                    isSignedIn
+                        ? 'onwards-lower-whensignedin'
+                        : 'onwards-lower-whensignedout'
+                }
+            >
                 <Lazy margin={300}>
                     <OnwardsLower
                         ajaxUrl={CAPI.config.ajaxUrl}

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -26,7 +26,6 @@ import { ArticleStandfirst } from '@root/src/web/components/ArticleStandfirst';
 import { Header } from '@root/src/web/components/Header';
 import { Footer } from '@root/src/web/components/Footer';
 import { SubNav } from '@root/src/web/components/SubNav/SubNav';
-import { OutbrainContainer } from '@root/src/web/components/Outbrain';
 import { Section } from '@root/src/web/components/Section';
 import { Nav } from '@root/src/web/components/Nav/Nav';
 import { HeaderAdSlot } from '@root/src/web/components/HeaderAdSlot';
@@ -209,7 +208,6 @@ export const CommentLayout = ({
 }: Props) => {
     const {
         config: { isPaidContent },
-        pageType: { isSensitive },
     } = CAPI;
 
     const adTargeting: AdTargeting = buildAdTargeting(CAPI.config);
@@ -454,20 +452,13 @@ export const CommentLayout = ({
                 <AdSlot asps={namedAdSlotParameters('merchandising-high')} />
             </Section>
 
-            <Section sectionId="onwards-upper" />
-
             {!isPaidContent && (
                 <>
-                    {!isSensitive && (
-                        <Section
-                            showTopBorder={false}
-                            backgroundColour={neutral[97]}
-                        >
-                            <OutbrainContainer />
-                        </Section>
+                    {/* Onwards (when signed IN) */}
+                    <Section sectionId="onwards-upper-whensignedin" />
+                    {showOnwardsLower && (
+                        <Section sectionId="onwards-lower-whensignedin" />
                     )}
-
-                    {showOnwardsLower && <Section sectionId="onwards-lower" />}
 
                     {showComments && (
                         <Section sectionId="comments">
@@ -480,6 +471,15 @@ export const CommentLayout = ({
                                 </RightColumn>
                             </Flex>
                         </Section>
+                    )}
+
+                    {/* Onwards (when signed OUT) */}
+                    <Section
+                        sectionId="onwards-upper-whensignedout"
+                        showTopBorder={false}
+                    />
+                    {showOnwardsLower && (
+                        <Section sectionId="onwards-lower-whensignedout" />
                     )}
 
                     <Section sectionId="most-viewed-footer" />

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -25,7 +25,6 @@ import { ArticleStandfirst } from '@root/src/web/components/ArticleStandfirst';
 import { Header } from '@root/src/web/components/Header';
 import { Footer } from '@root/src/web/components/Footer';
 import { SubNav } from '@root/src/web/components/SubNav/SubNav';
-import { OutbrainContainer } from '@root/src/web/components/Outbrain';
 import { Section } from '@root/src/web/components/Section';
 import { Nav } from '@root/src/web/components/Nav/Nav';
 import { HeaderAdSlot } from '@root/src/web/components/HeaderAdSlot';
@@ -257,7 +256,6 @@ export const ShowcaseLayout = ({
 }: Props) => {
     const {
         config: { isPaidContent },
-        pageType: { isSensitive },
     } = CAPI;
 
     const adTargeting: AdTargeting = buildAdTargeting(CAPI.config);
@@ -493,20 +491,13 @@ export const ShowcaseLayout = ({
                 <AdSlot asps={namedAdSlotParameters('merchandising-high')} />
             </Section>
 
-            <Section sectionId="onwards-upper" />
-
             {!isPaidContent && (
                 <>
-                    {!isSensitive && (
-                        <Section
-                            showTopBorder={false}
-                            backgroundColour={neutral[97]}
-                        >
-                            <OutbrainContainer />
-                        </Section>
+                    {/* Onwards (when signed IN) */}
+                    <Section sectionId="onwards-upper-whensignedin" />
+                    {showOnwardsLower && (
+                        <Section sectionId="onwards-lower-whensignedin" />
                     )}
-
-                    {showOnwardsLower && <Section sectionId="onwards-lower" />}
 
                     {showComments && (
                         <Section sectionId="comments">
@@ -519,6 +510,15 @@ export const ShowcaseLayout = ({
                                 </RightColumn>
                             </Flex>
                         </Section>
+                    )}
+
+                    {/* Onwards (when signed OUT) */}
+                    <Section
+                        sectionId="onwards-upper-whensignedout"
+                        showTopBorder={false}
+                    />
+                    {showOnwardsLower && (
+                        <Section sectionId="onwards-lower-whensignedout" />
                     )}
 
                     <Section sectionId="most-viewed-footer" />

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -29,7 +29,6 @@ import { ArticleStandfirst } from '@root/src/web/components/ArticleStandfirst';
 import { Header } from '@root/src/web/components/Header';
 import { Footer } from '@root/src/web/components/Footer';
 import { SubNav } from '@root/src/web/components/SubNav/SubNav';
-import { OutbrainContainer } from '@root/src/web/components/Outbrain';
 import { Section } from '@root/src/web/components/Section';
 import { Nav } from '@root/src/web/components/Nav/Nav';
 import { HeaderAdSlot } from '@root/src/web/components/HeaderAdSlot';
@@ -242,7 +241,6 @@ export const StandardLayout = ({
 }: Props) => {
     const {
         config: { isPaidContent },
-        pageType: { isSensitive },
     } = CAPI;
 
     const adTargeting: AdTargeting = buildAdTargeting(CAPI.config);
@@ -479,20 +477,13 @@ export const StandardLayout = ({
                 <AdSlot asps={namedAdSlotParameters('merchandising-high')} />
             </Section>
 
-            <Section sectionId="onwards-upper" />
-
             {!isPaidContent && (
                 <>
-                    {!isSensitive && (
-                        <Section
-                            showTopBorder={false}
-                            backgroundColour={neutral[97]}
-                        >
-                            <OutbrainContainer />
-                        </Section>
+                    {/* Onwards (when signed IN) */}
+                    <Section sectionId="onwards-upper-whensignedin" />
+                    {showOnwardsLower && (
+                        <Section sectionId="onwards-lower-whensignedin" />
                     )}
-
-                    {showOnwardsLower && <Section sectionId="onwards-lower" />}
 
                     {showComments && (
                         <Section sectionId="comments">
@@ -505,6 +496,15 @@ export const StandardLayout = ({
                                 </RightColumn>
                             </Flex>
                         </Section>
+                    )}
+
+                    {/* Onwards (when signed OUT) */}
+                    <Section
+                        sectionId="onwards-upper-whensignedout"
+                        showTopBorder={false}
+                    />
+                    {showOnwardsLower && (
+                        <Section sectionId="onwards-lower-whensignedout" />
                     )}
 
                     <Section sectionId="most-viewed-footer" />


### PR DESCRIPTION
## What does this change?
Now we show onwards content below the comments section if the reader is signed in


### Signed out
![Screenshot 2020-04-26 at 18 00 36](https://user-images.githubusercontent.com/1336821/80314208-1902d580-87e8-11ea-8716-d90f0345ea02.jpg)


### Signed in
![Screenshot 2020-04-26 at 18 00 14](https://user-images.githubusercontent.com/1336821/80314211-1b652f80-87e8-11ea-90c7-830760d3812d.jpg)

## Why?
Parity

## Link to supporting Trello card
https://trello.com/c/SbkjNUws/1514-comments-position-when-signed-in-changes
