### PR TITLE
Wrap attempt to write to local storage with a try catch

### DIFF
--- a/src/web/lib/getCountryCode.ts
+++ b/src/web/lib/getCountryCode.ts
@@ -45,13 +45,18 @@ export const getCountryCode = async () => {
         // for later, letting the thread continue
         setTimeout(() => {
             if (countryCode) {
-                localStorage.setItem(
-                    COUNTRY_CODE_KEY,
-                    JSON.stringify({
-                        value: countryCode,
-                        expires: new Date().getTime() + TEN_DAYS,
-                    }),
-                );
+                try {
+                    localStorage.setItem(
+                        COUNTRY_CODE_KEY,
+                        JSON.stringify({
+                            value: countryCode,
+                            expires: new Date().getTime() + TEN_DAYS,
+                        }),
+                    );
+                } catch (error) {
+                    // We tried, it failed. Often local storage is not available and we
+                    // need to live with that
+                }
             }
         });
         // Return the country value that we got from our fetch call


### PR DESCRIPTION
## What does this change?
Prevents us clogging up Sentry with lots of but I'm a strange device and don't support `localStorage` errors such as https://sentry.io/organizations/the-guardian/issues/1535109376/?project=35463&query=is%3Aunresolved

## Why?
To calm down Sentry

## Link to supporting Trello card
https://trello.com/c/ZrHm1sFb/1536-ls-try-catch