### PR TITLE
Added local frontend examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,12 @@ You can also find these extensions by searching for `@recommended` in the extens
 
 We recommend you update your workspace settings to automatically fix formatting errors on save, this avoids code style validation failures. These instructions assume you have installed the `esbenp.prettier-vscode` VSCode plugin:
 
-1. Open the Command Palette (`shift + cmd + P`) and type `>Preferences: Open Settings (JSON)`
+1. Open the Command Palette (`shift + cmd + P`) and type 
+
+	```
+	>Preferences: Open Settings (JSON)
+	```
+
 2. Add the key value `"tslint.autoFixOnSave": true,`
 
 ## Thanks

--- a/scripts/frontend/landing/index.html
+++ b/scripts/frontend/landing/index.html
@@ -65,31 +65,31 @@
     <script>
 
         var testContentTypes = [
-            { name: "Live Blog", article: "https://www.theguardian.com/football/live/2018/jul/03/world-cup-2018-england-v-colombia-switzerland-v-sweden-buildup-live" },
-            { name: "Opinion Piece", article: "https://www.theguardian.com/politics/2019/jul/15/it-will-be-boris-johnson-and-it-will-certainly-be-a-disaster" },
-            { name: "Review", article: "https://www.theguardian.com/music/2018/aug/31/eminem-kamikaze-album-review"},
-            { name: "Paid Content", article: "https://www.theguardian.com/bank-australia-clean-money/2019/feb/11/three-trillion-reasons-for-australians-to-join-the-clean-money-revolution"}
+            { name: "Live Blog", article: "/football/live/2018/jul/03/world-cup-2018-england-v-colombia-switzerland-v-sweden-buildup-live" },
+            { name: "Opinion Piece", article: "/politics/2019/jul/15/it-will-be-boris-johnson-and-it-will-certainly-be-a-disaster" },
+            { name: "Review", article: "/music/2018/aug/31/eminem-kamikaze-album-review"},
+            { name: "Paid Content", article: "/bank-australia-clean-money/2019/feb/11/three-trillion-reasons-for-australians-to-join-the-clean-money-revolution"}
         ];
 
         var testArticles = [
-            { name: "ImageBlockElement", article: "https://www.theguardian.com/environment/2018/dec/21/from-spectacular-orchids-to-towering-trees-2018s-top-new-plant-discoveries" },
-            { name: "ImageBlockElement (left)", article: "https://www.theguardian.com/film/2018/aug/30/damon-herriman-to-play-charles-manson-in-quentin-tarantino-film" },
-            { name: "TweetBlockElement", article: "https://www.theguardian.com/uk-news/reality-check/2015/sep/19/daily-mail-syrian-refugees-story-three-problems" },
-            { name: "RichLinkBlockElement", article: "https://www.theguardian.com/football/2019/jun/04/juventus-interested-paul-pogba-manchester-united" },
-            { name: "PullquoteBlockElement", article: "https://www.theguardian.com/world/2018/dec/28/south-koreas-sexist-sex-education" },
-            { name: "VideoBlockElement", article: "https://www.theguardian.com/us-news/2017/feb/23/los-angeles-police-officer-teen-gun-video-protests" },
-            { name: "AudioBlockElement", article: "https://www.theguardian.com/music/2018/nov/02/the-prodigy-no-tourists-review" },
-            { name: "EmbedBlockElement", article: "https://www.theguardian.com/australia-news/2018/jun/12/shorten-wants-more-aged-care-spending-but-wont-back-royal-commission" },
-            { name: "ContentAtomBlockElement", article: "https://www.theguardian.com/world/2018/jun/18/yemen-crisis-saudi-coalition-demands-houthis-unconditional-withdrawal-from-port" }
+            { name: "ImageBlockElement", article: "/environment/2018/dec/21/from-spectacular-orchids-to-towering-trees-2018s-top-new-plant-discoveries" },
+            { name: "ImageBlockElement (left)", article: "/film/2018/aug/30/damon-herriman-to-play-charles-manson-in-quentin-tarantino-film" },
+            { name: "TweetBlockElement", article: "/uk-news/reality-check/2015/sep/19/daily-mail-syrian-refugees-story-three-problems" },
+            { name: "RichLinkBlockElement", article: "/football/2019/jun/04/juventus-interested-paul-pogba-manchester-united" },
+            { name: "PullquoteBlockElement", article: "/world/2018/dec/28/south-koreas-sexist-sex-education" },
+            { name: "VideoBlockElement", article: "/us-news/2017/feb/23/los-angeles-police-officer-teen-gun-video-protests" },
+            { name: "AudioBlockElement", article: "/music/2018/nov/02/the-prodigy-no-tourists-review" },
+            { name: "EmbedBlockElement", article: "/australia-news/2018/jun/12/shorten-wants-more-aged-care-spending-but-wont-back-royal-commission" },
+            { name: "ContentAtomBlockElement", article: "/world/2018/jun/18/yemen-crisis-saudi-coalition-demands-houthis-unconditional-withdrawal-from-port" }
         ];
 
         var makeTestArticle = (a) => `
             <div class="test-article">
                 <span>${a.name}</span>
-                <span><a href="/Article?url=${a.article}">example</a></span>
-                <span><a href="/AMPArticle?url=${a.article}">example</a></span>
-                <span><a href="${a.article}">example</a></span>
-                <span><a href="${a.article.replace("www.", "amp.")}">example</a></span>
+                <span><a href="/Article?url=https://www.theguardian.com${a.article}">🔗</a> <a href="/Article?url=http://localhost:9000${a.article}">🔗(local FE)</a></span>
+                <span><a href="/AMPArticle?url=https://www.theguardian.com${a.article}">🔗</a> <a href="/AMPArticle?url=http://localhost:9000${a.article}">🔗(local FE)</a></span>
+                <span><a href="https://www.theguardian.com${a.article}">example</a></span>
+                <span><a href="https://amp.theguardian.com${a.article}">example</a></span>
             </div>
         `;
 


### PR DESCRIPTION
## What does this change?

Adds links that uses a local frontend installation to the example page.

## Why?

Makes developing DCR and FE in parallel easier.

