### PR TITLE
Only show Subscribe button for immersives

### DIFF
--- a/src/web/components/Nav/Nav.tsx
+++ b/src/web/components/Nav/Nav.tsx
@@ -81,26 +81,28 @@ export const Nav = ({ display, pillar, nav, subscribeUrl, edition }: Props) => {
                 aria-label="Guardian sections"
                 data-component="nav2"
             >
-                <Hide when="above" breakpoint="tablet">
-                    <ThemeProvider theme={buttonReaderRevenueBrand}>
-                        <PositionButton>
-                            <Button
-                                priority="primary"
-                                size="small"
-                                iconSide="right"
-                                icon={<SvgArrowRightStraight />}
-                                data-link-name="nav2 : support-cta"
-                                data-edition={edition}
-                                onClick={() => {
-                                    window.location.href = subscribeUrl;
-                                    return false;
-                                }}
-                            >
-                                Subscribe
-                            </Button>
-                        </PositionButton>
-                    </ThemeProvider>
-                </Hide>
+                {display === 'immersive' && (
+                    <Hide when="above" breakpoint="tablet">
+                        <ThemeProvider theme={buttonReaderRevenueBrand}>
+                            <PositionButton>
+                                <Button
+                                    priority="primary"
+                                    size="small"
+                                    iconSide="right"
+                                    icon={<SvgArrowRightStraight />}
+                                    data-link-name="nav2 : support-cta"
+                                    data-edition={edition}
+                                    onClick={() => {
+                                        window.location.href = subscribeUrl;
+                                        return false;
+                                    }}
+                                >
+                                    Subscribe
+                                </Button>
+                            </PositionButton>
+                        </ThemeProvider>
+                    </Hide>
+                )}
                 <Pillars
                     display={display}
                     mainMenuOpen={showExpandedMenu}


### PR DESCRIPTION
## What does this change?
Removbes the Subscribe button in the Nav bar on mobile view for non immersive articles

### Before
![Screenshot 2020-04-27 at 21 34 55](https://user-images.githubusercontent.com/1336821/80418217-f4355d80-88ce-11ea-97a7-f8236adcf719.jpg)


### After
![Screenshot 2020-04-27 at 21 34 07](https://user-images.githubusercontent.com/1336821/80418156-db2cac80-88ce-11ea-9bf4-c84f8cbaffd0.jpg)



## Why?
Becasue I broke this when making changes to the Nav bar for immersive article support by forgetting to only show this button for immersive articles
