### PR TITLE
Implement picnic ad slot on AMP

### DIFF
--- a/src/amp/components/Ad.tsx
+++ b/src/amp/components/Ad.tsx
@@ -6,7 +6,40 @@ import { palette } from '@guardian/src-foundations';
 import { textSans } from '@guardian/src-foundations/typography';
 import { adJson, stringify } from '@root/src/amp/lib/ad-json';
 
-const adStyle = css`
+const picnicAdContainerStyle = css`
+    background: ${palette.neutral[93]};
+    background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiP…AsMy45LTAuOCw3LjMtMi40LDEwLjNDODEsNjIuNSw4Niw1MS42LDg2LDM5LjYiLz48L3N2Zz4=);
+    background-size: 105px;
+    background-repeat: no-repeat;
+    background-position: center;
+    border-top: 1px solid ${palette.neutral[86]};
+    min-height: 272px;
+    min-width: 300px;
+    clear: both;
+    text-align: center;
+    margin: 0 auto 12px;
+
+    :before {
+        content: 'Advertisement';
+        background: ${palette.neutral[93]};
+        display: block;
+        ${textSans.xsmall()};
+        /* Adverts specifcally don't use the GU font branding. */
+        /* stylelint-disable-next-line property-blacklist */
+        font-family: 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande',
+            sans-serif;
+        padding: 3px 10px;
+        color: ${text.supporting};
+        text-align: right;
+    }
+`;
+
+const picnicAdSlotStyle = css`
+    display: none;
+    margin: auto;
+`;
+
+const adContainerStyle = css`
     background: ${palette.neutral[93]};
     background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiP…AsMy45LTAuOCw3LjMtMi40LDEwLjNDODEsNjIuNSw4Niw1MS42LDg2LDM5LjYiLz48L3N2Zz4=);
     background-size: 105px;
@@ -33,7 +66,7 @@ const adStyle = css`
     }
 `;
 
-const adClass = css`
+const adSlotStyle = css`
     display: none;
 `;
 
@@ -139,7 +172,36 @@ const ampAdElem = (
 ) => {
     return (
         <amp-ad
-            class={cx(adClass, adRegionClasses[adRegion])}
+            class={cx(adSlotStyle, adRegionClasses[adRegion])}
+            data-block-on-consent=""
+            width={300}
+            height={250}
+            data-npa-on-unknown-consent={true}
+            data-loading-strategy="prefer-viewability-over-views"
+            layout="responsive"
+            type="doubleclick"
+            json={stringify(adJson(commercialProperties[edition].adTargeting))}
+            data-slot={ampData(section, contentType)}
+            rtc-config={realTimeConfig(
+                adRegion,
+                config.usePrebid,
+                config.usePermutive,
+            )}
+        />
+    );
+};
+
+const picnicAmpAdElem = (
+    adRegion: AdRegion,
+    edition: Edition,
+    section: string,
+    contentType: string,
+    config: CommercialConfig,
+    commercialProperties: CommercialProperties,
+) => {
+    return (
+        <amp-ad
+            class={cx(picnicAdSlotStyle, adRegionClasses[adRegion])}
             data-block-on-consent=""
             width={320}
             height={480}
@@ -175,30 +237,63 @@ export const Ad: React.SFC<{
     commercialProperties,
     className,
 }) => (
-    <div className={cx(adStyle, className)}>
-        {ampAdElem(
-            'US',
-            edition,
-            section || '',
-            contentType,
-            config,
-            commercialProperties,
-        )}
-        {ampAdElem(
-            'AU',
-            edition,
-            section || '',
-            contentType,
-            config,
-            commercialProperties,
-        )}
-        {ampAdElem(
-            'ROW',
-            edition,
-            section || '',
-            contentType,
-            config,
-            commercialProperties,
-        )}
-    </div>
+    <>
+        <div className={`control-ad-style ${cx(adContainerStyle, className)}`}>
+            {ampAdElem(
+                'US',
+                edition,
+                section || '',
+                contentType,
+                config,
+                commercialProperties,
+            )}
+            {ampAdElem(
+                'AU',
+                edition,
+                section || '',
+                contentType,
+                config,
+                commercialProperties,
+            )}
+            {ampAdElem(
+                'ROW',
+                edition,
+                section || '',
+                contentType,
+                config,
+                commercialProperties,
+            )}
+        </div>
+        <div
+            className={`picnic-ad-style ${cx(
+                picnicAdContainerStyle,
+                className,
+            )}`}
+        >
+            {picnicAmpAdElem(
+                'US',
+                edition,
+                section || '',
+                contentType,
+                config,
+                commercialProperties,
+            )}
+            {picnicAmpAdElem(
+                'AU',
+                edition,
+                section || '',
+                contentType,
+                config,
+                commercialProperties,
+            )}
+            {picnicAmpAdElem(
+                'ROW',
+                edition,
+                section || '',
+                contentType,
+                config,
+                commercialProperties,
+            )}
+        </div>
+    </>
 );

--- a/src/amp/components/Ad.tsx
+++ b/src/amp/components/Ad.tsx
@@ -141,8 +141,10 @@ const ampAdElem = (
         <amp-ad
             class={cx(adClass, adRegionClasses[adRegion])}
             data-block-on-consent=""
-            width={300}
-            height={250}
+            width={320}
+            height={480}
+            data-multi-size="300x250"
+            data-multi-size-validation="false"
             data-npa-on-unknown-consent={true}
             data-loading-strategy="prefer-viewability-over-views"
             layout="responsive"


### PR DESCRIPTION
_Note: This is a clean version of https://github.com/guardian/dotcom-rendering/pull/1321, which broke after a bad rebase._
## What does this change?
Add ad slot format details as per Picnic's recommendations. The result of these changes is that we will add the data-multi-size property to ad tags in AMP and increase the primary ad size to be 320x480.

This will have the effect of making the primary ad slot larger than the current size of 300x250. If the new larger ad slot cannot be filled with an ad of that size there are two resulting situations:

If the ad renders below the viewport, the runtime automatically resizes the ad below the line, with not visual reflow for the user.

If the ad renders inside the viewport, the runtime will centre the ad in the middle of the reserved ad space.

Given that picnic is intended to serve ads mid-article, they should appear below the fold meaning that situation 1) is the most likely.

Information about multi-data-size can be found here

## Why?
As per the Trello card, there is significant revenue opportunity available if we can introduce these changes successfully.

## Link to supporting Trello card
https://trello.com/c/CoEW5KzV/535-picnic-update-amp-placements-to-run-320-x-480-size
