### PR TITLE
@guardian/discussion-rendering@2.2.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "@emotion/core": "^10.0.28",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/consent-management-platform": "^3.0.4",
-        "@guardian/discussion-rendering": "^2.2.6",
+        "@guardian/discussion-rendering": "^2.2.7",
         "@guardian/src-button": "^0.17.0",
         "@guardian/src-ed-lines": "^0.18.0-rc.0",
         "@guardian/src-foundations": "^0.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2151,10 +2151,10 @@
     js-cookie "^2.2.1"
     whatwg-fetch "^3.0.0"
 
-"@guardian/discussion-rendering@^2.2.6":
-  version "2.2.6"
-  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-2.2.6.tgz#7f74bc8fdde9c27a4bba5e42ddc2fa58502e71fa"
-  integrity sha512-OySXayAM2c/z8OTSashJrC0B9G4AY/+9GSNwJoerC9u3LQ2AVLlDkeTu+71iMjem1pTymYrYYAczVbI9JCXCew==
+"@guardian/discussion-rendering@^2.2.7":
+  version "2.2.7"
+  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-2.2.7.tgz#5f12c9bd8497960155bdc9c0e517c749d8661fa3"
+  integrity sha512-RmGowbqNg/fTu8Ols7YcIcY5wlrMW4qFzOCUjttHoLiwlpnkojNtvGvQBcqp50KOzN4sAHUfbMFX9cRXqpIkhg==
   dependencies:
     react-focus-lock "^2.2.1"
     timeago.js "^4.0.2"


### PR DESCRIPTION
## What does this change?
Adds @guardian/discussion-rendering@2.2.7

## Why?
To fix an issue where readers with the `pagesize` value of `All` stored locally had issues fetching comments
