### PR TITLE
Refactor Subnav More/Less

### DIFF
--- a/src/web/components/SubNav/SubNav.tsx
+++ b/src/web/components/SubNav/SubNav.tsx
@@ -73,11 +73,21 @@ const linkStyle = css`
         text-decoration: underline;
     }
 `;
+
 const selected = css`
     font-weight: 700;
 `;
+
+const spaceBetween = css`
+    display: flex;
+    justify-content: space-between;
+`;
+
 const showMoreStyle = css`
     ${fontStyle};
+
+    padding-left: 10px;
+    padding-right: 10px;
 
     cursor: pointer;
     border: none;
@@ -152,7 +162,12 @@ export const SubNav = ({ subNavSections, pillar, currentNavLink }: Props) => {
     const expandSubNav = !showMore || isExpanded;
 
     return (
-        <div className={cx({ [wrapperCollapsed]: collapseWrapper })}>
+        <div
+            className={cx(
+                { [wrapperCollapsed]: collapseWrapper },
+                spaceBetween,
+            )}
+        >
             <ul
                 ref={ulRef}
                 className={cx({


### PR DESCRIPTION
## What does this change?
Uses flex to position the More/Less buttons that show in the SubNav on narrow screen widths

### Before
![Screenshot 2020-04-28 at 16 53 39](https://user-images.githubusercontent.com/1336821/80509124-db7d8400-8970-11ea-8413-0d3cdf0d2aa3.jpg)


### After
![Screenshot 2020-04-28 at 16 49 19](https://user-images.githubusercontent.com/1336821/80509045-bf79e280-8970-11ea-9ea8-94b246596ed5.jpg)



## Why?
To prevent content breaking out of the container, looking weird
