### PR TITLE
Refactor line type decisions

### DIFF
--- a/src/web/lib/layoutHelpers.ts
+++ b/src/web/lib/layoutHelpers.ts
@@ -5,13 +5,28 @@ export const decideLineEffect = (
     if (pillar === 'sport') {
         return 'dotted';
     }
-    if (designType === 'Comment') {
-        return 'straight';
+
+    switch (designType) {
+        case 'Feature':
+        case 'Recipe':
+            return 'squiggly';
+        case 'Comment':
+        case 'GuardianView':
+        case 'Review':
+        case 'Interview':
+        case 'Live':
+        case 'Media':
+        case 'Analysis':
+        case 'Article':
+        case 'SpecialReport':
+        case 'MatchReport':
+        case 'GuardianLabs':
+        case 'Quiz':
+        case 'AdvertisementFeature':
+        case 'Immersive':
+        default:
+            return 'straight';
     }
-    if (designType === 'Feature' || designType === 'Recipe') {
-        return 'squiggly';
-    }
-    return 'straight';
 };
 
 export const decideLineCount = (designType?: DesignType): 8 | 4 => {

--- a/src/web/lib/layoutHelpers.ts
+++ b/src/web/lib/layoutHelpers.ts
@@ -8,7 +8,7 @@ export const decideLineEffect = (
     if (designType === 'Comment') {
         return 'straight';
     }
-    if (designType === 'Feature') {
+    if (designType === 'Feature' || designType === 'Recipe') {
         return 'squiggly';
     }
     return 'straight';

--- a/src/web/lib/layoutHelpers.ts
+++ b/src/web/lib/layoutHelpers.ts
@@ -2,14 +2,14 @@ export const decideLineEffect = (
     designType: DesignType,
     pillar: Pillar,
 ): LineEffectType => {
+    if (pillar === 'sport') {
+        return 'dotted';
+    }
     if (designType === 'Comment') {
         return 'straight';
     }
     if (designType === 'Feature') {
         return 'squiggly';
-    }
-    if (pillar === 'sport') {
-        return 'dotted';
     }
     return 'straight';
 };


### PR DESCRIPTION
## What does this change?
Refactored how we decide the type of line:

If an article has the `sport` pillar it gets `dotted` lines no matter what Otherwise, if it has designType of 'Feature' or 'Recipe' then it's `squiggly`. For the rest, it's `striaght` lines.
