### PR TITLE
Make Caption position absolute when width limited

### DIFF
--- a/src/web/components/Caption.tsx
+++ b/src/web/components/Caption.tsx
@@ -29,6 +29,10 @@ const captionStyle = css`
 `;
 
 const limitedWidth = css`
+    /* use absolute position here to allow the article text to push up alongside
+    the caption when it is limited in width */
+    position: absolute;
+
     ${from.leftCol} {
         width: 140px;
     }


### PR DESCRIPTION
## What does this change?
Makes the `Caption` absolutely positioned when `shouldLimitWidth` is true

### Before
![Screenshot 2020-04-28 at 23 55 46](https://user-images.githubusercontent.com/1336821/80545646-cbcf6100-89ab-11ea-9df1-f0e5cfdd2fe0.jpg)

### After
![Screenshot 2020-04-28 at 23 54 50](https://user-images.githubusercontent.com/1336821/80545624-c1ad6280-89ab-11ea-9352-d620f2e39e7e.jpg)


## Why?
So the article text can push up alongside the caption, filling the white space
