### PR TITLE
Restyle blockquotes

### DIFF
--- a/src/web/components/elements/BlockquoteComponent.stories.tsx
+++ b/src/web/components/elements/BlockquoteComponent.stories.tsx
@@ -19,7 +19,7 @@ const containerStyles = css`
 export const defaultStory = () => {
     return (
         <div className={containerStyles}>
-            <BlockquoteComponent html={html} />
+            <BlockquoteComponent html={html} pillar="news" />
         </div>
     );
 };

--- a/src/web/components/elements/BlockquoteComponent.tsx
+++ b/src/web/components/elements/BlockquoteComponent.tsx
@@ -4,18 +4,37 @@ import { css } from 'emotion';
 import { body } from '@guardian/src-foundations/typography';
 import { unwrapHtml } from '@root/src/model/unwrapHtml';
 import { RewrappedComponent } from '@root/src/web/components/elements/RewrappedComponent';
+import { pillarPalette } from '@root/src/lib/pillars';
+import { neutral } from '@guardian/src-foundations/palette';
+import { QuoteIcon } from '@root/src/web/components/QuoteIcon';
 
 type Props = {
     html: string;
+    pillar: Pillar;
 };
 
-export const BlockquoteComponent: React.FC<Props> = ({ html }: Props) => {
-    const blockquoteStyles = css`
-        margin-bottom: 16px;
-        ${body.medium()};
-        font-style: italic;
-    `;
+const Row = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
+    <div
+        className={css`
+            display: flex;
+            flex-direction: row;
+        `}
+    >
+        {children}
+    </div>
+);
 
+const blockquoteStyles = css`
+    margin-bottom: 16px;
+    ${body.medium()};
+    font-style: italic;
+    color: ${neutral[46]};
+`;
+
+export const BlockquoteComponent: React.FC<Props> = ({
+    html,
+    pillar,
+}: Props) => {
     const { willUnwrap: isUnwrapped, unwrappedHtml } = unwrapHtml({
         prefix: '<blockquote class="quted">',
         suffix: '</blockquote>',
@@ -23,11 +42,14 @@ export const BlockquoteComponent: React.FC<Props> = ({ html }: Props) => {
     });
 
     return (
-        <RewrappedComponent
-            isUnwrapped={isUnwrapped}
-            html={unwrappedHtml}
-            elCss={blockquoteStyles}
-            tagName="blockquote"
-        />
+        <Row>
+            <QuoteIcon colour={pillarPalette[pillar].main} size="large" />
+            <RewrappedComponent
+                isUnwrapped={isUnwrapped}
+                html={unwrappedHtml}
+                elCss={blockquoteStyles}
+                tagName="blockquote"
+            />
+        </Row>
     );
 };

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -67,7 +67,13 @@ export const ArticleRenderer: React.FC<{
                         />
                     );
                 case 'model.dotcomrendering.pageElements.BlockquoteBlockElement':
-                    return <BlockquoteComponent key={i} html={element.html} />;
+                    return (
+                        <BlockquoteComponent
+                            key={i}
+                            html={element.html}
+                            pillar={pillar}
+                        />
+                    );
                 case 'model.dotcomrendering.pageElements.YoutubeBlockElement':
                     return (
                         <YouTubeComponent


### PR DESCRIPTION
## What does this change?
Enhances the styling for block quotes

### Before
![Screenshot 2020-04-29 at 11 07 56](https://user-images.githubusercontent.com/1336821/80584525-b38e2f00-8a09-11ea-9f81-65604db9c336.jpg)


### After
![Screenshot 2020-04-29 at 11 07 15](https://user-images.githubusercontent.com/1336821/80584533-b5f08900-8a09-11ea-90d6-75569ab75695.jpg)

## Why?
Parity
