### PR TITLE
Add apiKey param for discussion

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "@emotion/core": "^10.0.28",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/consent-management-platform": "^3.0.4",
-        "@guardian/discussion-rendering": "^2.2.7",
+        "@guardian/discussion-rendering": "^2.2.8",
         "@guardian/src-button": "^0.17.0",
         "@guardian/src-ed-lines": "^0.18.0-rc.0",
         "@guardian/src-foundations": "^0.17.0",

--- a/src/web/components/CommentsLayout.tsx
+++ b/src/web/components/CommentsLayout.tsx
@@ -97,6 +97,7 @@ export const CommentsLayout = ({
                 expanded={expanded}
                 commentToScrollTo={commentToScrollTo}
                 onPermalinkClick={onPermalinkClick}
+                apiKey="dotcom-rendering"
             />
         </div>
     </Flex>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2151,10 +2151,10 @@
     js-cookie "^2.2.1"
     whatwg-fetch "^3.0.0"
 
-"@guardian/discussion-rendering@^2.2.7":
-  version "2.2.7"
-  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-2.2.7.tgz#5f12c9bd8497960155bdc9c0e517c749d8661fa3"
-  integrity sha512-RmGowbqNg/fTu8Ols7YcIcY5wlrMW4qFzOCUjttHoLiwlpnkojNtvGvQBcqp50KOzN4sAHUfbMFX9cRXqpIkhg==
+"@guardian/discussion-rendering@^2.2.8":
+  version "2.2.8"
+  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-2.2.8.tgz#022ff28b6d6b4b828002338f556c44bd9ed82514"
+  integrity sha512-5/RVjLXHAu+pLCNnGY4YCt8UW0t7SNAqn5ZQYYpjCvYlwui9MYR5FO+ZTR0rsZxrhk0PjGrrr8wHa51a05xREQ==
   dependencies:
     react-focus-lock "^2.2.1"
     timeago.js "^4.0.2"


### PR DESCRIPTION
## What does this change?

Adds bump to discussion-rendering 2.2.8 and api key param

## Why?

so we can see requests from dotcom-rendering

