### PR TITLE
Bugfix for IE11 flexbox

### DIFF
--- a/src/web/components/Flex.tsx
+++ b/src/web/components/Flex.tsx
@@ -17,6 +17,8 @@ export const Flex = ({
             display: flex;
             flex-direction: ${direction};
             justify-content: ${justify};
+            /* Fixes IE 10/11 bug that collapses this container by default: */
+            -ms-flex-positive: 1;
         `}
     >
         {children}

--- a/src/web/components/Flex.tsx
+++ b/src/web/components/Flex.tsx
@@ -12,6 +12,7 @@ export const Flex = ({
     direction = 'row',
     justify = 'space-between',
 }: Props) => (
+    /* eslint-disable property-no-vendor-prefix */
     <div
         className={css`
             display: flex;
@@ -19,11 +20,10 @@ export const Flex = ({
             justify-content: ${justify};
 
             /* Fixes IE 10/11 bug that collapses this container by default: */
-            /* eslint-disable property-no-vendor-prefix */
             -ms-flex-positive: 1;
-            /* eslint-enable property-no-vendor-prefix */
         `}
     >
         {children}
     </div>
+    /* eslint-enable property-no-vendor-prefix */
 );

--- a/src/web/components/Flex.tsx
+++ b/src/web/components/Flex.tsx
@@ -12,18 +12,16 @@ export const Flex = ({
     direction = 'row',
     justify = 'space-between',
 }: Props) => (
-    /* eslint-disable property-no-vendor-prefix */
     <div
         className={css`
             display: flex;
             flex-direction: ${direction};
             justify-content: ${justify};
-
             /* Fixes IE 10/11 bug that collapses this container by default: */
+            /* stylelint-disable-next-line property-no-vendor-prefix */
             -ms-flex-positive: 1;
         `}
     >
         {children}
     </div>
-    /* eslint-enable property-no-vendor-prefix */
 );

--- a/src/web/components/Flex.tsx
+++ b/src/web/components/Flex.tsx
@@ -17,8 +17,11 @@ export const Flex = ({
             display: flex;
             flex-direction: ${direction};
             justify-content: ${justify};
+
             /* Fixes IE 10/11 bug that collapses this container by default: */
+            /* eslint-disable property-no-vendor-prefix */
             -ms-flex-positive: 1;
+            /* eslint-enable property-no-vendor-prefix */
         `}
     >
         {children}


### PR DESCRIPTION
## What does this change?
Defaults the `Flex` container to have a positive grow property in the case of IE10 or IE11

## Why?
There's an IE bug causing the `Flex` container to collapse on initialisation, particularly when it is inside another container which has the property `display: flex` on it.

## Link to supporting Trello card
https://trello.com/c/IaAtcy0x/1484-layout-issues-in-onwards-in-ie11

IE Bug:
<img width="1305" alt="ie 11 broken" src="https://user-images.githubusercontent.com/3300789/80625021-78f5b800-8a44-11ea-9f69-4b9d4660e218.png">

IE "Fix":
<img width="1283" alt="ie11 fix" src="https://user-images.githubusercontent.com/3300789/80624968-5fed0700-8a44-11ea-9a9c-8d0f3257c4b3.png">

