### PR TITLE
Hide Border

### DIFF
--- a/src/web/components/Border.tsx
+++ b/src/web/components/Border.tsx
@@ -2,17 +2,15 @@ import React from 'react';
 import { css } from 'emotion';
 
 import { border } from '@guardian/src-foundations/palette';
-import { until } from '@guardian/src-foundations/mq';
+import { from } from '@guardian/src-foundations/mq';
 
 export const Border = () => (
     <div
         className={css`
-            ${until.leftCol} {
-                visibility: collapse;
+            ${from.leftCol} {
+                border-left: 1px solid ${border.secondary};
+                height: 100%;
             }
-
-            border-left: 1px solid ${border.secondary};
-            height: 100%;
         `}
     />
 );

--- a/src/web/components/Border.tsx
+++ b/src/web/components/Border.tsx
@@ -2,10 +2,15 @@ import React from 'react';
 import { css } from 'emotion';
 
 import { border } from '@guardian/src-foundations/palette';
+import { until } from '@guardian/src-foundations/mq';
 
 export const Border = () => (
     <div
         className={css`
+            ${until.leftCol} {
+                visibility: collapse;
+            }
+
             border-left: 1px solid ${border.secondary};
             height: 100%;
         `}


### PR DESCRIPTION
## What does this change?
Hides the `Border` when it's not in use

### Before
![Screenshot 2020-05-01 at 11 07 23](https://user-images.githubusercontent.com/1336821/80799787-ac008e80-8b9f-11ea-98d0-2b8579b4f2e7.jpg)

### After
![Screenshot 2020-05-01 at 11 06 52](https://user-images.githubusercontent.com/1336821/80799788-ad31bb80-8b9f-11ea-8c1b-26747b9c844d.jpg)


## Why?
We were still displaying the `Border` on the page even when it wasn't included in the `grid`
