### PR TITLE
Extend Cypress Coverage

### DIFF
--- a/cypress/lib/articles.js
+++ b/cypress/lib/articles.js
@@ -23,6 +23,14 @@ export const articles = [
         hasRichLinks: false,
         hideMostViewed: true,
     },
+    {
+        url:
+            'https://www.theguardian.com/environment/2020/may/01/not-just-weeds-how-rebel-botanists-are-using-graffiti-to-name-forgotten-flora-aoe',
+        pillar: 'news',
+        designType: 'Feature',
+        hasRichLinks: true,
+        hideMostViewed: true,
+    },
 ];
 
 export const AMPArticles = [


### PR DESCRIPTION
## What does this change?
Added a news Feature article that contains supporting images to the list of articles rendered by Cypress

## Why?
We are seeing this image type cause issues and didn't have a test blocking them
