### PR TITLE
Show avatar for recipes

### DIFF
--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -99,6 +99,7 @@ const shouldShowAvatar = (designType: DesignType, display: Display) => {
     switch (designType) {
         case 'Feature':
         case 'Review':
+        case 'Recipe':
         case 'Interview':
             return true;
         case 'Live':
@@ -106,7 +107,6 @@ const shouldShowAvatar = (designType: DesignType, display: Display) => {
         case 'Analysis':
         case 'Article':
         case 'SpecialReport':
-        case 'Recipe':
         case 'MatchReport':
         case 'GuardianView':
         case 'GuardianLabs':


### PR DESCRIPTION
## What does this change?
Shows the avatar in the article meta for `designType: Recipe`

### Before
![Screenshot 2020-05-03 at 11 41 55](https://user-images.githubusercontent.com/1336821/80912298-ea2eb700-8d33-11ea-94d3-48a196d55bab.jpg)

### After
![Screenshot 2020-05-03 at 11 42 29](https://user-images.githubusercontent.com/1336821/80912297-e9962080-8d33-11ea-8614-e39785a4b74d.jpg)