### PR TITLE
Fix headline styles for recipes

### DIFF
--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -187,7 +187,6 @@ export const ArticleHeadline = ({
         case 'Media':
         case 'Live':
         case 'SpecialReport':
-        case 'Recipe':
         case 'MatchReport':
         case 'GuardianLabs':
         case 'Quiz':
@@ -195,6 +194,7 @@ export const ArticleHeadline = ({
             return <h1 className={standardFont}>{curly(headlineString)}</h1>;
 
         case 'Review':
+        case 'Recipe':
         case 'Feature':
             return (
                 <h1


### PR DESCRIPTION
## What does this change?
Fixes headline styling for `designType: Recipe`

### Before
![Screenshot 2020-05-03 at 11 48 53](https://user-images.githubusercontent.com/1336821/80912328-23ffbd80-8d34-11ea-89b5-e9d418addca0.jpg)

### After
![Screenshot 2020-05-03 at 11 46 42](https://user-images.githubusercontent.com/1336821/80912327-23672700-8d34-11ea-9a14-f57f7be39ff3.jpg)

