### PR TITLE
Allow zero comments or shares to be displayed

### DIFF
--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -115,6 +115,7 @@ export const Card = ({
         contentCoverage = coverages.content[imageSize];
     }
 
+    const showCommentCount = commentCount || commentCount === 0;
     const { long: longCount, short: shortCount } = formatCount(commentCount);
 
     const pillarToUse =
@@ -225,7 +226,9 @@ export const Card = ({
                                         )
                                     }
                                     commentCount={
-                                        longCount && shortCount ? (
+                                        showCommentCount &&
+                                        longCount &&
+                                        shortCount ? (
                                             <CardCommentCount
                                                 designType={designType}
                                                 pillar={pillarToUse}

--- a/src/web/components/Counts.stories.tsx
+++ b/src/web/components/Counts.stories.tsx
@@ -21,7 +21,24 @@ const Container = ({ children }: { children: JSXElements }) => (
     </div>
 );
 
-export const Live = () => {
+export const Both = () => {
+    fetchMock
+        .restore()
+        // Share count
+        .getOnce(
+            'begin:https://api.nextgen.guardianapps.co.uk/sharecount/',
+            {
+                status: 200,
+                body: {
+                    path:
+                        'money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+                    share_count: 80,
+                    refreshStatus: true,
+                },
+            },
+            { overwriteRoutes: false },
+        );
+
     return (
         <Container>
             <Counts
@@ -34,7 +51,7 @@ export const Live = () => {
         </Container>
     );
 };
-Live.story = { name: 'with both results' };
+Both.story = { name: 'with both results' };
 
 export const ShareOnly = () => {
     fetchMock
@@ -53,7 +70,6 @@ export const ShareOnly = () => {
         <Container>
             <Counts
                 ajaxUrl="https://api.nextgen.guardianapps.co.uk"
-                commentCount={0}
                 pageId="/lifeandstyle/2020/jan/25/deborah-orr-parents-jailers-i-loved"
                 pillar="news"
                 setOpenComments={() => {}}
@@ -61,7 +77,7 @@ export const ShareOnly = () => {
         </Container>
     );
 };
-ShareOnly.story = { name: 'with share count only' };
+ShareOnly.story = { name: 'with comments disabled' };
 
 export const CommentOnly = () => {
     fetchMock
@@ -80,6 +96,7 @@ export const CommentOnly = () => {
             },
             { overwriteRoutes: false },
         );
+
     return (
         <Container>
             <Counts
@@ -92,4 +109,68 @@ export const CommentOnly = () => {
         </Container>
     );
 };
-CommentOnly.story = { name: 'with comment count only' };
+CommentOnly.story = { name: 'with zero shares' };
+
+export const ZeroComments = () => {
+    fetchMock
+        .restore()
+        // Share count
+        .getOnce(
+            'begin:https://api.nextgen.guardianapps.co.uk/sharecount/',
+            {
+                status: 200,
+                body: {
+                    path:
+                        'money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+                    share_count: 60,
+                    refreshStatus: true,
+                },
+            },
+            { overwriteRoutes: false },
+        );
+
+    return (
+        <Container>
+            <Counts
+                ajaxUrl="https://api.nextgen.guardianapps.co.uk"
+                commentCount={0}
+                pageId="/lifeandstyle/2020/jan/25/deborah-orr-parents-jailers-i-loved"
+                pillar="news"
+                setOpenComments={() => {}}
+            />
+        </Container>
+    );
+};
+ZeroComments.story = { name: 'with zero comments' };
+
+export const BigNumbers = () => {
+    fetchMock
+        .restore()
+        // Share count
+        .getOnce(
+            'begin:https://api.nextgen.guardianapps.co.uk/sharecount/',
+            {
+                status: 200,
+                body: {
+                    path:
+                        'money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+                    share_count: 204320,
+                    refreshStatus: true,
+                },
+            },
+            { overwriteRoutes: false },
+        );
+
+    return (
+        <Container>
+            <Counts
+                ajaxUrl="https://api.nextgen.guardianapps.co.uk"
+                commentCount={4320}
+                pageId="/lifeandstyle/2020/jan/25/deborah-orr-parents-jailers-i-loved"
+                pillar="news"
+                setOpenComments={() => {}}
+            />
+        </Container>
+    );
+};
+BigNumbers.story = { name: 'with long numbers' };

--- a/src/web/components/Counts.tsx
+++ b/src/web/components/Counts.tsx
@@ -13,7 +13,7 @@ type Props = {
     ajaxUrl: string;
     pageId: string;
     pillar: Pillar;
-    commentCount: number;
+    commentCount?: number;
     setOpenComments: Function;
 };
 
@@ -60,9 +60,10 @@ export const Counts = ({
         );
     }
 
-    // We use || false below because we use these vars to decide if to render or not and react sees 0 as truthy
-    const hasShareData = (shareData && shareData.share_count) || false;
-    const hasCommentData = commentCount || false;
+    const shareCount = shareData && shareData.share_count;
+    const hasShareData = !shareError && (shareCount || shareCount === 0);
+    const hasCommentData = commentCount || commentCount === 0;
+
     if (!hasShareData && !hasCommentData) {
         return null;
     }

--- a/src/web/lib/formatCount.ts
+++ b/src/web/lib/formatCount.ts
@@ -1,7 +1,9 @@
 import { integerCommas } from '@root/src/lib/formatters';
 
-export const formatCount = (count?: number) => {
-    if (!count) return { short: '', long: '' };
+export const formatCount = (
+    count?: number,
+): { short: string; long: string } => {
+    if (!count) return { short: '0', long: '0' };
     const countAsInteger = parseInt(count.toFixed(0), 10);
     const displayCountLong = integerCommas(countAsInteger);
     const displayCountShort =

--- a/src/web/lib/useComments.ts
+++ b/src/web/lib/useComments.ts
@@ -24,7 +24,9 @@ const updateTrailsWithCounts = (trails: TrailType[], counts: CommentType[]) => {
         const countOfComments = findComments(counts, shortUrl);
         return {
             ...trail,
-            commentCount: countOfComments,
+            // Only set the comment count on a card if some comments were made
+            // (otherwise we'd fill the page with distracting zero comment icons)
+            commentCount: countOfComments > 0 ? countOfComments : undefined,
         };
     });
 };


### PR DESCRIPTION
## What does this change?
Previously we didn't render anything if the comment or share count was zero, now we do

![2020-05-03 17 54 39](https://user-images.githubusercontent.com/1336821/80920419-af467680-8d67-11ea-866f-901bc3cd7263.gif)


## Why?
Zero is useful information 