### PR TITLE
Don't pass commentCount if comments disabled

### DIFF
--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -233,13 +233,22 @@ export const App = ({ CAPI, NAV }: Props) => {
                 </Portal>
             ))}
             <Portal root="share-comment-counts">
-                <Counts
-                    ajaxUrl={CAPI.config.ajaxUrl}
-                    pageId={CAPI.config.pageId}
-                    commentCount={commentCount}
-                    pillar={pillar}
-                    setOpenComments={setOpenComments}
-                />
+                {CAPI.isCommentable ? (
+                    <Counts
+                        ajaxUrl={CAPI.config.ajaxUrl}
+                        pageId={CAPI.config.pageId}
+                        commentCount={commentCount}
+                        pillar={pillar}
+                        setOpenComments={setOpenComments}
+                    />
+                ) : (
+                    <Counts
+                        ajaxUrl={CAPI.config.ajaxUrl}
+                        pageId={CAPI.config.pageId}
+                        pillar={pillar}
+                        setOpenComments={setOpenComments}
+                    />
+                )}
             </Portal>
             <Portal root="most-viewed-right">
                 <Lazy margin={100}>


### PR DESCRIPTION
## What does this change?
Prevents the `commentCount` prop was being set if comments are disabled

## Why?
Because of a previous PR to show the comment count even if it was zero, we inadvertently made it so the zero comment count was showing for all articles
