### PR TITLE
Adds support for embed blocks

### DIFF
--- a/cypress/integration/e2e/article.elements.spec.js
+++ b/cypress/integration/e2e/article.elements.spec.js
@@ -31,35 +31,30 @@ describe('Elements', function() {
     });
 
     describe('WEB', function() {
-        // https://www.cypress.io/blog/2020/02/12/working-with-iframes-in-cypress/
-        const getIframeBody = () => {
-            return cy
-                .get('div[data-cy="instagram-embed"] > iframe')
-                .its('0.contentDocument.body')
-                .should('not.be.empty')
-                .then(cy.wrap);
-        };
-
         it('should render the instagram embed', function() {
+            // https://www.cypress.io/blog/2020/02/12/working-with-iframes-in-cypress/
+            const getIframeBody = () => {
+                return cy
+                    .get('div[data-cy="instagram-embed"] > iframe')
+                    .its('0.contentDocument.body')
+                    .should('not.be.empty')
+                    .then(cy.wrap);
+            };
             cy.visit(
                 'Article?url=https://www.theguardian.com/media/2018/aug/29/flat-tummy-instagram-women-appetite-suppressant-lollipops',
             );
 
             getIframeBody().contains('View More on Instagram');
         });
-    });
-
-    describe('WEB', function() {
-        // https://www.cypress.io/blog/2020/02/12/working-with-iframes-in-cypress/
-        const getIframeBody = () => {
-            return cy
-                .get('div[data-cy="embed-block"] > div > iframe')
-                .its('0.contentDocument.body')
-                .should('not.be.empty')
-                .then(cy.wrap);
-        };
 
         it('should render the embed', function() {
+            const getIframeBody = () => {
+                return cy
+                    .get('div[data-cy="embed-block"] > div > iframe')
+                    .its('0.contentDocument.body')
+                    .should('not.be.empty')
+                    .then(cy.wrap);
+            };
             cy.visit(
                 'Article?url=https://www.theguardian.com/sport/blog/2015/dec/02/the-joy-of-six-sports-radio-documentaries',
             );

--- a/cypress/integration/e2e/article.elements.spec.js
+++ b/cypress/integration/e2e/article.elements.spec.js
@@ -48,4 +48,23 @@ describe('Elements', function() {
             getIframeBody().contains('View More on Instagram');
         });
     });
+
+    describe('WEB', function() {
+        // https://www.cypress.io/blog/2020/02/12/working-with-iframes-in-cypress/
+        const getIframeBody = () => {
+            return cy
+                .get('div[data-cy="embed-block"] > div > iframe')
+                .its('0.contentDocument.body')
+                .should('not.be.empty')
+                .then(cy.wrap);
+        };
+
+        it('should render the embed', function() {
+            cy.visit(
+                'Article?url=https://www.theguardian.com/sport/blog/2015/dec/02/the-joy-of-six-sports-radio-documentaries',
+            );
+
+            getIframeBody().contains('radiolab');
+        });
+    });
 });

--- a/src/web/components/elements/EmbedBlockComponent.tsx
+++ b/src/web/components/elements/EmbedBlockComponent.tsx
@@ -25,7 +25,7 @@ const embedContainer = css`
 `;
 
 export const EmbedBlockComponent = ({ html, alt }: Props) => {
-    // Email embeds are being turned into atoms, so we can remove this hack when that happens
+    // TODO: Email embeds are being turned into atoms, so we can remove this hack when that happens
     const isEmailEmbed = html.includes('email/form');
     return (
         <div data-cy="embed-block" className={embedContainer}>

--- a/src/web/components/elements/EmbedBlockComponent.tsx
+++ b/src/web/components/elements/EmbedBlockComponent.tsx
@@ -28,7 +28,7 @@ export const EmbedBlockComponent = ({ html, alt }: Props) => {
     // Email embeds are being turned into atoms, so we can remove this hack when that happens
     const isEmailEmbed = html.includes('email/form');
     return (
-        <div className={embedContainer}>
+        <div data-cy="embed-block" className={embedContainer}>
             <div dangerouslySetInnerHTML={{ __html: unescapeData(html) }} />
             {isEmailEmbed && alt && (
                 <div className={emailCaptionStyle}>{alt}</div>

--- a/src/web/components/elements/EmbedBlockComponent.tsx
+++ b/src/web/components/elements/EmbedBlockComponent.tsx
@@ -3,6 +3,11 @@ import React from 'react';
 import { unescapeData } from '@root/src/lib/escapeData';
 import { css } from 'emotion';
 
+type Props = {
+    html: string;
+    alt?: string;
+};
+
 const widthOverride = css`
     iframe {
         /* Some embeds can hijack the iframe and calculate an incorrect width, which pushes the body out */
@@ -10,15 +15,12 @@ const widthOverride = css`
     }
 `;
 
-export const EmbedBlockComponent: React.FC<{
-    element: EmbedBlockElement;
-}> = ({ element }) => {
+export const EmbedBlockComponent = ({ html, alt }: Props) => {
+    const isEmailEmbed = html.includes('email/form');
     return (
         <div className={widthOverride}>
-            <div
-                dangerouslySetInnerHTML={{ __html: unescapeData(element.html) }}
-            />
-            <div>{element.alt}</div>
+            <div dangerouslySetInnerHTML={{ __html: unescapeData(html) }} />
+            {isEmailEmbed && alt && <div>{alt}</div>}
         </div>
     );
 };

--- a/src/web/components/elements/EmbedBlockComponent.tsx
+++ b/src/web/components/elements/EmbedBlockComponent.tsx
@@ -16,7 +16,7 @@ const emailCaptionStyle = css`
     color: ${text.supporting};
 `;
 
-const widthOverride = css`
+const embedContainer = css`
     iframe {
         /* Some embeds can hijack the iframe and calculate an incorrect width, which pushes the body out */
         width: 100% !important;
@@ -25,9 +25,10 @@ const widthOverride = css`
 `;
 
 export const EmbedBlockComponent = ({ html, alt }: Props) => {
+    // Email embeds are being turned into atoms, so we can remove this hack when that happens
     const isEmailEmbed = html.includes('email/form');
     return (
-        <div className={widthOverride}>
+        <div className={embedContainer}>
             <div dangerouslySetInnerHTML={{ __html: unescapeData(html) }} />
             {isEmailEmbed && alt && (
                 <div className={emailCaptionStyle}>{alt}</div>

--- a/src/web/components/elements/EmbedBlockComponent.tsx
+++ b/src/web/components/elements/EmbedBlockComponent.tsx
@@ -2,17 +2,26 @@ import React from 'react';
 
 import { unescapeData } from '@root/src/lib/escapeData';
 import { css } from 'emotion';
+import { textSans } from '@guardian/src-foundations/typography';
+import { text } from '@guardian/src-foundations/palette';
 
 type Props = {
     html: string;
     alt?: string;
 };
 
+const emailCaptionStyle = css`
+    ${textSans.xsmall()};
+    word-wrap: break-word;
+    color: ${text.supporting};
+`;
+
 const widthOverride = css`
     iframe {
         /* Some embeds can hijack the iframe and calculate an incorrect width, which pushes the body out */
         width: 100% !important;
     }
+    margin-bottom: 16px;
 `;
 
 export const EmbedBlockComponent = ({ html, alt }: Props) => {
@@ -20,7 +29,9 @@ export const EmbedBlockComponent = ({ html, alt }: Props) => {
     return (
         <div className={widthOverride}>
             <div dangerouslySetInnerHTML={{ __html: unescapeData(html) }} />
-            {isEmailEmbed && alt && <div>{alt}</div>}
+            {isEmailEmbed && alt && (
+                <div className={emailCaptionStyle}>{alt}</div>
+            )}
         </div>
     );
 };

--- a/src/web/components/elements/EmbedBlockComponent.tsx
+++ b/src/web/components/elements/EmbedBlockComponent.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import { unescapeData } from '@root/src/lib/escapeData';
+import { css } from 'emotion';
+
+const widthOverride = css`
+    iframe {
+        /* Some embeds can hijack the iframe and calculate an incorrect width, which pushes the body out */
+        width: 100% !important;
+    }
+`;
+
+export const EmbedBlockComponent: React.FC<{
+    element: EmbedBlockElement;
+}> = ({ element }) => {
+    return (
+        <div className={widthOverride}>
+            <div
+                dangerouslySetInnerHTML={{ __html: unescapeData(element.html) }}
+            />
+            <div>{element.alt}</div>
+        </div>
+    );
+};

--- a/src/web/components/elements/EmbedBlockComponent.tsx
+++ b/src/web/components/elements/EmbedBlockComponent.tsx
@@ -12,7 +12,7 @@ type Props = {
 
 const emailCaptionStyle = css`
     ${textSans.xsmall()};
-    word-wrap: break-word;
+    word-break: break-all;
     color: ${text.supporting};
 `;
 

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -62,7 +62,13 @@ export const ArticleRenderer: React.FC<{
                         <InstagramBlockComponent key={i} element={element} />
                     );
                 case 'model.dotcomrendering.pageElements.EmbedBlockElement':
-                    return <EmbedBlockComponent key={i} element={element} />;
+                    return (
+                        <EmbedBlockComponent
+                            key={i}
+                            html={element.html}
+                            alt={element.alt}
+                        />
+                    );
                 case 'model.dotcomrendering.pageElements.PullquoteBlockElement':
                     return (
                         <PullQuoteComponent

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -9,6 +9,7 @@ import { PullQuoteComponent } from '@root/src/web/components/elements/PullQuoteC
 import { BlockquoteComponent } from '@root/src/web/components/elements/BlockquoteComponent';
 import { YouTubeComponent } from '@root/src/web/components/elements/YouTubeComponent';
 import { InstagramBlockComponent } from '@root/src/web/components/elements/InstagramBlockComponent';
+import { EmbedBlockComponent } from '@root/src/web/components/elements/EmbedBlockComponent';
 
 // This is required for spacefinder to work!
 const commercialPosition = css`
@@ -60,6 +61,8 @@ export const ArticleRenderer: React.FC<{
                     return (
                         <InstagramBlockComponent key={i} element={element} />
                     );
+                case 'model.dotcomrendering.pageElements.EmbedBlockElement':
+                    return <EmbedBlockComponent key={i} element={element} />;
                 case 'model.dotcomrendering.pageElements.PullquoteBlockElement':
                     return (
                         <PullQuoteComponent


### PR DESCRIPTION
## What does this change?
<img width="652" alt="Screen Shot 2020-05-04 at 13 40 54" src="https://user-images.githubusercontent.com/2051501/80973405-3ef72e00-8e17-11ea-94b6-7bdaf989af52.png">
<img width="276" alt="Screen Shot 2020-05-04 at 13 41 18" src="https://user-images.githubusercontent.com/2051501/80973426-428ab500-8e17-11ea-8a66-6262e0b81a28.png">



## Why?
Parity with frontend
