### PR TITLE
Prefetch/Preconnect round two

### DIFF
--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -107,7 +107,6 @@ export const document = ({ data }: Props) => {
 
     const { openGraphData } = CAPI;
     const { twitterData } = CAPI;
-    const { isAdFreeUser } = CAPI;
     const keywords =
         typeof CAPI.config.keywords === 'undefined' ||
         CAPI.config.keywords === 'Network Front'
@@ -135,6 +134,5 @@ export const document = ({ data }: Props) => {
         openGraphData,
         twitterData,
         keywords,
-        isAdFreeUser,
     });
 };

--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -107,6 +107,7 @@ export const document = ({ data }: Props) => {
 
     const { openGraphData } = CAPI;
     const { twitterData } = CAPI;
+    const { isAdFreeUser } = CAPI;
     const keywords =
         typeof CAPI.config.keywords === 'undefined' ||
         CAPI.config.keywords === 'Network Front'
@@ -134,5 +135,6 @@ export const document = ({ data }: Props) => {
         openGraphData,
         twitterData,
         keywords,
+        isAdFreeUser,
     });
 };

--- a/src/web/server/htmlTemplate.ts
+++ b/src/web/server/htmlTemplate.ts
@@ -118,7 +118,6 @@ export const htmlTemplate = ({
     const staticPreconnectUrls = [
         `${CDN}`,
         `https://i.guim.co.uk`,
-        `https://securepubads.g.doubleclick.net`,
         `https://j.ophan.co.uk`,
         `https://ophan.theguardian.com`,
     ];
@@ -132,8 +131,6 @@ export const htmlTemplate = ({
         `https://phar.gu-web.net`,
         `https://static.theguardian.com`,
         `https://support.theguardian.com`,
-        `https://www.facebook.com`,
-        `https://www.google-analytics.com`,
     ];
 
     const preconnectTags = staticPreconnectUrls.map(

--- a/src/web/server/htmlTemplate.ts
+++ b/src/web/server/htmlTemplate.ts
@@ -23,6 +23,7 @@ export const htmlTemplate = ({
     openGraphData,
     twitterData,
     keywords,
+    isAdFreeUser,
 }: {
     title?: string;
     description: string;
@@ -41,6 +42,7 @@ export const htmlTemplate = ({
     openGraphData: { [key: string]: string };
     twitterData: { [key: string]: string };
     keywords: string;
+    isAdFreeUser: boolean;
 }) => {
     const favicon =
         process.env.NODE_ENV === 'production'
@@ -116,47 +118,59 @@ export const htmlTemplate = ({
     // More information on prefetching:
     // https://developer.mozilla.org/en-US/docs/Web/Performance/dns-prefetch
 
+    // Preconnect links that are only necessary for ads:
+    const staticPreconnctAdUrls = isAdFreeUser
+        ? []
+        : [`https://googleads.g.doubleclick.net`];
+
+    // Prefetch links that are only necessary for ads:
+    const staticPrefetchAdUrls = isAdFreeUser
+        ? []
+        : [
+              `https://ad.crwdcntrl.net`,
+              `https://api.permutive.com`,
+              `https://cdn-gl.imrworldwide.com`,
+              `https://cdn.adsafeprotected.com`,
+              `https://cdn.brandmetrics.com`,
+              `https://cdn.permutive.com`,
+              `https://collector.brandmetrics.com`,
+              `https://confiant-integrations.global.ssl.fastly.net`,
+              `https://ib.adnxs.com`,
+              `https://pagead2.googlesyndication.com`,
+              `https://pixel.adsafeprotected.com`,
+              `https://pubads.g.doubleclick.net`,
+              `https://sb.scorecardresearch.com`,
+              `https://secure-gl.imrworldwide.com`,
+              `https://securepubads.g.doubleclick.net`,
+              `https://static.ads-twitter.com`,
+              `https://stats.g.doubleclick.net`,
+              `https://tpc.googlesyndication.com`,
+              `https://www.google.co.uk`,
+              `https://www.google.com`,
+              `https://www.googleadservices.com`,
+          ];
+
     const staticPreconnectUrls = [
         `${CDN}`,
         `https://i.guim.co.uk`,
         `https://securepubads.g.doubleclick.net`,
         `https://j.ophan.co.uk`,
         `https://ophan.theguardian.com`,
-        `https://googleads.g.doubleclick.net`,
+        ...staticPreconnctAdUrls,
     ];
 
     const staticPrefetchUrls = [
         ...staticPreconnectUrls,
-        `https://ad.crwdcntrl.net`,
+        ...staticPrefetchAdUrls,
         `https://api.nextgen.guardianapps.co.uk`,
-        `https://api.permutive.com`,
-        `https://cdn-gl.imrworldwide.com`,
-        `https://cdn.adsafeprotected.com`,
-        `https://cdn.brandmetrics.com`,
-        `https://cdn.permutive.com`,
-        `https://collector.brandmetrics.com`,
-        `https://confiant-integrations.global.ssl.fastly.net`,
         `https://hits-secure.theguardian.com`,
-        `https://ib.adnxs.com`,
         `https://interactive.guim.co.uk`,
         `https://ipv6.guim.co.uk`,
-        `https://pagead2.googlesyndication.com`,
         `https://phar.gu-web.net`,
-        `https://pixel.adsafeprotected.com`,
-        `https://pubads.g.doubleclick.net`,
-        `https://sb.scorecardresearch.com`,
-        `https://secure-gl.imrworldwide.com`,
-        `https://securepubads.g.doubleclick.net`,
-        `https://static.ads-twitter.com`,
         `https://static.theguardian.com`,
-        `https://stats.g.doubleclick.net`,
         `https://support.theguardian.com`,
-        `https://tpc.googlesyndication.com`,
         `https://www.facebook.com`,
         `https://www.google-analytics.com`,
-        `https://www.google.co.uk`,
-        `https://www.google.com`,
-        `https://www.googleadservices.com`,
     ];
 
     const preconnectTags = staticPreconnectUrls.map(

--- a/src/web/server/htmlTemplate.ts
+++ b/src/web/server/htmlTemplate.ts
@@ -23,7 +23,6 @@ export const htmlTemplate = ({
     openGraphData,
     twitterData,
     keywords,
-    isAdFreeUser,
 }: {
     title?: string;
     description: string;
@@ -42,7 +41,6 @@ export const htmlTemplate = ({
     openGraphData: { [key: string]: string };
     twitterData: { [key: string]: string };
     keywords: string;
-    isAdFreeUser: boolean;
 }) => {
     const favicon =
         process.env.NODE_ENV === 'production'

--- a/src/web/server/htmlTemplate.ts
+++ b/src/web/server/htmlTemplate.ts
@@ -105,36 +105,66 @@ export const htmlTemplate = ({
 
     // Duplicated prefetch and preconnect tags from DCP:
     // Documented here: https://github.com/guardian/frontend/pull/12935
-
-    // Information on preconnecting:
+    // Preconnect should be used for the most crucial third party domains
+    // "use preconnect when you know for sure that you’re going to be accessing a resource"
+    // - https://www.smashingmagazine.com/2019/04/optimization-performance-resource-hints/
+    // DNS-prefetch should be used for other third party domains that we are likely to connect to but not sure (ads)
+    // Preconnecting to too many URLs can reduce page performance
+    // DNS-prefetch can also be used as a fallback for IE11
+    // More information on preconnecting:
     // https://css-tricks.com/using-relpreconnect-to-establish-network-connections-early-and-increase-performance/
+    // More information on prefetching:
+    // https://developer.mozilla.org/en-US/docs/Web/Performance/dns-prefetch
+
     const staticPreconnectUrls = [
         `${CDN}`,
         `https://i.guim.co.uk`,
-        `https://interactive.guim.co.uk`,
-        `https://www.google-analytics.com`,
-    ];
-
-    // Information on prefetching:
-    // https://developer.mozilla.org/en-US/docs/Web/Performance/dns-prefetch
-    const staticPrefetchUrls = [
-        `${CDN}`,
-        `https://i.guim.co.uk`,
-        `https://api.nextgen.guardianapps.co.uk`,
-        `https://hits-secure.theguardian.com`,
+        `https://securepubads.g.doubleclick.net`,
         `https://j.ophan.co.uk`,
         `https://ophan.theguardian.com`,
-        `https://phar.gu-web.net`,
-        `https://www.google-analytics.com`,
-        `https://sb.scorecardresearch.com`,
     ];
 
-    const prefetchTags = staticPrefetchUrls.map(
-        src => `<link rel="dns-prefetch" href="${src}">`,
-    );
+    const staticPrefetchUrls = [
+        ...staticPreconnectUrls,
+        `https://ad.crwdcntrl.net`,
+        `https://api.nextgen.guardianapps.co.uk`,
+        `https://api.permutive.com`,
+        `https://cdn-gl.imrworldwide.com`,
+        `https://cdn.adsafeprotected.com`,
+        `https://cdn.brandmetrics.com`,
+        `https://cdn.permutive.com`,
+        `https://collector.brandmetrics.com`,
+        `https://confiant-integrations.global.ssl.fastly.net`,
+        `https://googleads.g.doubleclick.net`,
+        `https://hits-secure.theguardian.com`,
+        `https://ib.adnxs.com`,
+        `https://interactive.guim.co.uk`,
+        `https://ipv6.guim.co.uk`,
+        `https://pagead2.googlesyndication.com`,
+        `https://phar.gu-web.net`,
+        `https://pixel.adsafeprotected.com`,
+        `https://pubads.g.doubleclick.net`,
+        `https://sb.scorecardresearch.com`,
+        `https://secure-gl.imrworldwide.com`,
+        `https://securepubads.g.doubleclick.net`,
+        `https://static.ads-twitter.com`,
+        `https://static.theguardian.com`,
+        `https://stats.g.doubleclick.net`,
+        `https://support.theguardian.com`,
+        `https://tpc.googlesyndication.com`,
+        `https://www.facebook.com`,
+        `https://www.google-analytics.com`,
+        `https://www.google.co.uk`,
+        `https://www.google.com`,
+        `https://www.googleadservices.com`,
+    ];
 
     const preconnectTags = staticPreconnectUrls.map(
         src => `<link rel="preconnect" href="${src}">`,
+    );
+
+    const prefetchTags = staticPrefetchUrls.map(
+        src => `<link rel="dns-prefetch" href="${src}">`,
     );
 
     return `<!doctype html>

--- a/src/web/server/htmlTemplate.ts
+++ b/src/web/server/htmlTemplate.ts
@@ -117,51 +117,16 @@ export const htmlTemplate = ({
     // https://css-tricks.com/using-relpreconnect-to-establish-network-connections-early-and-increase-performance/
     // More information on prefetching:
     // https://developer.mozilla.org/en-US/docs/Web/Performance/dns-prefetch
-
-    // Preconnect links that are only necessary for ads:
-    const staticPreconnctAdUrls = isAdFreeUser
-        ? []
-        : [`https://googleads.g.doubleclick.net`];
-
-    // Prefetch links that are only necessary for ads:
-    const staticPrefetchAdUrls = isAdFreeUser
-        ? []
-        : [
-              `https://ad.crwdcntrl.net`,
-              `https://api.permutive.com`,
-              `https://cdn-gl.imrworldwide.com`,
-              `https://cdn.adsafeprotected.com`,
-              `https://cdn.brandmetrics.com`,
-              `https://cdn.permutive.com`,
-              `https://collector.brandmetrics.com`,
-              `https://confiant-integrations.global.ssl.fastly.net`,
-              `https://ib.adnxs.com`,
-              `https://pagead2.googlesyndication.com`,
-              `https://pixel.adsafeprotected.com`,
-              `https://pubads.g.doubleclick.net`,
-              `https://sb.scorecardresearch.com`,
-              `https://secure-gl.imrworldwide.com`,
-              `https://securepubads.g.doubleclick.net`,
-              `https://static.ads-twitter.com`,
-              `https://stats.g.doubleclick.net`,
-              `https://tpc.googlesyndication.com`,
-              `https://www.google.co.uk`,
-              `https://www.google.com`,
-              `https://www.googleadservices.com`,
-          ];
-
     const staticPreconnectUrls = [
         `${CDN}`,
         `https://i.guim.co.uk`,
         `https://securepubads.g.doubleclick.net`,
         `https://j.ophan.co.uk`,
         `https://ophan.theguardian.com`,
-        ...staticPreconnctAdUrls,
     ];
 
     const staticPrefetchUrls = [
         ...staticPreconnectUrls,
-        ...staticPrefetchAdUrls,
         `https://api.nextgen.guardianapps.co.uk`,
         `https://hits-secure.theguardian.com`,
         `https://interactive.guim.co.uk`,

--- a/src/web/server/htmlTemplate.ts
+++ b/src/web/server/htmlTemplate.ts
@@ -122,6 +122,7 @@ export const htmlTemplate = ({
         `https://securepubads.g.doubleclick.net`,
         `https://j.ophan.co.uk`,
         `https://ophan.theguardian.com`,
+        `https://googleads.g.doubleclick.net`,
     ];
 
     const staticPrefetchUrls = [
@@ -135,7 +136,6 @@ export const htmlTemplate = ({
         `https://cdn.permutive.com`,
         `https://collector.brandmetrics.com`,
         `https://confiant-integrations.global.ssl.fastly.net`,
-        `https://googleads.g.doubleclick.net`,
         `https://hits-secure.theguardian.com`,
         `https://ib.adnxs.com`,
         `https://interactive.guim.co.uk`,


### PR DESCRIPTION
## What does this change?
I updated the prefetch and preconnect code after doing more research into what URLs we need to connect to and when it is better to use preconnect vs prefetch. Prefetch offers less improvement but is less intensive to implement and more widely supported (IE11). Preconnect offers better performance overall, where supported, but should only be used on domains we know we need to connect to later. I did this update in consultation with Jerome.

### Before
Exact replica of dotcom platform prefetch and preconnect

### After
Longer list of prefetch domains with better documentation as to why we need them

## Why?
Performance!
