### PR TITLE
Type additional elements

### DIFF
--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -277,6 +277,11 @@ interface DocumentBlockElement {
     isMandatory: boolean;
 }
 
+interface TableBlockElement {
+    _type: 'model.dotcomrendering.pageElements.TableBlockElement';
+    isMandatory: boolean;
+}
+
 type CAPIElement =
     | TextBlockElement
     | SubheadingBlockElement
@@ -307,4 +312,5 @@ type CAPIElement =
     | AudioBlockElement
     | VideoBlockElement
     | CodeBlockElement
-    | DocumentBlockElement;
+    | DocumentBlockElement
+    | TableBlockElement;

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -272,6 +272,11 @@ interface CodeBlockElement {
     isMandatory: boolean;
 }
 
+interface DocumentBlockElement {
+    _type: 'model.dotcomrendering.pageElements.DocumentBlockElement';
+    isMandatory: boolean;
+}
+
 type CAPIElement =
     | TextBlockElement
     | SubheadingBlockElement
@@ -301,4 +306,5 @@ type CAPIElement =
     | ContentAtomElement
     | AudioBlockElement
     | VideoBlockElement
-    | CodeBlockElement;
+    | CodeBlockElement
+    | DocumentBlockElement;

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -103,6 +103,9 @@
                     },
                     {
                         "$ref": "#/definitions/DocumentBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/TableBlockElement"
                     }
                 ]
             }
@@ -1170,6 +1173,21 @@
             },
             "required": ["_type", "isMandatory"]
         },
+        "TableBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.TableBlockElement"
+                    ]
+                },
+                "isMandatory": {
+                    "type": "boolean"
+                }
+            },
+            "required": ["_type", "isMandatory"]
+        },
         "Block": {
             "type": "object",
             "properties": {
@@ -1269,6 +1287,9 @@
                             },
                             {
                                 "$ref": "#/definitions/DocumentBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/TableBlockElement"
                             }
                         ]
                     }

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -100,6 +100,9 @@
                     },
                     {
                         "$ref": "#/definitions/CodeBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/DocumentBlockElement"
                     }
                 ]
             }
@@ -1152,6 +1155,21 @@
             },
             "required": ["_type", "isMandatory"]
         },
+        "DocumentBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.DocumentBlockElement"
+                    ]
+                },
+                "isMandatory": {
+                    "type": "boolean"
+                }
+            },
+            "required": ["_type", "isMandatory"]
+        },
         "Block": {
             "type": "object",
             "properties": {
@@ -1248,6 +1266,9 @@
                             },
                             {
                                 "$ref": "#/definitions/CodeBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/DocumentBlockElement"
                             }
                         ]
                     }


### PR DESCRIPTION
## What does this change?
Adds types for `DocumentBlockElement` and `TableBlockElement`

### Before
Without these we were throwing validation errors causing 500 errors

### After
We still don't support these elements fully but we correctly return null preventing errors
