### PR TITLE
Correct mislabelled Element

### DIFF
--- a/scripts/frontend/landing/index.html
+++ b/scripts/frontend/landing/index.html
@@ -1,89 +1,135 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <style>
-        html {
-            font-family: Arial, Helvetica, sans-serif;
-            padding-left: 2em;
-        }
-        h2 {
-            margin-top: 1.5em;
-        }
-        a {
-            color: #389ddc;
-        }
-        .test-articles-list span {
-            display: inline-block;
-            width: 8em;
-            line-height: 2em;
-        }
-        .test-article-header span {
-            font-weight: bold;
-        }
-        .test-article>span:nth-child(1), .test-article-header>span:nth-child(1) {
-            width: 14em !important;
-        }
-    </style>
-</head>
-<body>
+    <head>
+        <style>
+            html {
+                font-family: Arial, Helvetica, sans-serif;
+                padding-left: 2em;
+            }
+            h2 {
+                margin-top: 1.5em;
+            }
+            a {
+                color: #389ddc;
+            }
+            .test-articles-list span {
+                display: inline-block;
+                width: 8em;
+                line-height: 2em;
+            }
+            .test-article-header span {
+                font-weight: bold;
+            }
+            .test-article > span:nth-child(1),
+            .test-article-header > span:nth-child(1) {
+                width: 14em !important;
+            }
+        </style>
+    </head>
+    <body>
+        <h2>Default Endpoints</h2>
 
-    <h2>Default Endpoints</h2>
+        <ul>
+            <li><a href="/Article">Article</a></li>
+            <li><a href="/AMPArticle">⚡️Article</a></li>
+        </ul>
 
-    <ul>
-        <li><a href="/Article">Article</a></li>
-        <li><a href="/AMPArticle">⚡️Article</a></li>
-    </ul>
+        <h2>Test Articles By Content Type</h2>
 
-    <h2>Test Articles By Content Type</h2>
-
-    <div id="test-articles-by-content" class="test-articles-list">
-
-        <div class="test-article-header">
-            <span>type</span>
-            <span>local</span>
-            <span>local-amp</span>
-            <span>production</span>
-            <span>production-amp</span>
+        <div id="test-articles-by-content" class="test-articles-list">
+            <div class="test-article-header">
+                <span>type</span>
+                <span>local</span>
+                <span>local-amp</span>
+                <span>production</span>
+                <span>production-amp</span>
+            </div>
         </div>
 
-    </div>
+        <h2>Test Articles By Element</h2>
 
-    <h2>Test Articles By Element</h2>
-
-    <div id="test-articles-by-element" class="test-articles-list">
-
-        <div class="test-article-header">
-            <span>type</span>
-            <span>local</span>
-            <span>local-amp</span>
-            <span>production</span>
-            <span>production-amp</span>
+        <div id="test-articles-by-element" class="test-articles-list">
+            <div class="test-article-header">
+                <span>type</span>
+                <span>local</span>
+                <span>local-amp</span>
+                <span>production</span>
+                <span>production-amp</span>
+            </div>
         </div>
 
-    </div>
+        <script>
+            var testContentTypes = [
+                {
+                    name: 'Live Blog',
+                    article:
+                        '/football/live/2018/jul/03/world-cup-2018-england-v-colombia-switzerland-v-sweden-buildup-live',
+                },
+                {
+                    name: 'Opinion Piece',
+                    article:
+                        '/politics/2019/jul/15/it-will-be-boris-johnson-and-it-will-certainly-be-a-disaster',
+                },
+                {
+                    name: 'Review',
+                    article: '/music/2018/aug/31/eminem-kamikaze-album-review',
+                },
+                {
+                    name: 'Paid Content',
+                    article:
+                        '/bank-australia-clean-money/2019/feb/11/three-trillion-reasons-for-australians-to-join-the-clean-money-revolution',
+                },
+            ];
 
-    <script>
+            var testArticles = [
+                {
+                    name: 'ImageBlockElement',
+                    article:
+                        '/environment/2018/dec/21/from-spectacular-orchids-to-towering-trees-2018s-top-new-plant-discoveries',
+                },
+                {
+                    name: 'ImageBlockElement (left)',
+                    article:
+                        '/film/2018/aug/30/damon-herriman-to-play-charles-manson-in-quentin-tarantino-film',
+                },
+                {
+                    name: 'TweetBlockElement',
+                    article:
+                        '/uk-news/reality-check/2015/sep/19/daily-mail-syrian-refugees-story-three-problems',
+                },
+                {
+                    name: 'RichLinkBlockElement',
+                    article:
+                        '/football/2019/jun/04/juventus-interested-paul-pogba-manchester-united',
+                },
+                {
+                    name: 'PullquoteBlockElement',
+                    article:
+                        '/world/2018/dec/28/south-koreas-sexist-sex-education',
+                },
+                {
+                    name: 'VideoYoutubeBlockElement',
+                    article:
+                        '/us-news/2017/feb/23/los-angeles-police-officer-teen-gun-video-protests',
+                },
+                {
+                    name: 'AudioBlockElement',
+                    article:
+                        '/music/2018/nov/02/the-prodigy-no-tourists-review',
+                },
+                {
+                    name: 'EmbedBlockElement',
+                    article:
+                        '/australia-news/2018/jun/12/shorten-wants-more-aged-care-spending-but-wont-back-royal-commission',
+                },
+                {
+                    name: 'ContentAtomBlockElement',
+                    article:
+                        '/world/2018/jun/18/yemen-crisis-saudi-coalition-demands-houthis-unconditional-withdrawal-from-port',
+                },
+            ];
 
-        var testContentTypes = [
-            { name: "Live Blog", article: "/football/live/2018/jul/03/world-cup-2018-england-v-colombia-switzerland-v-sweden-buildup-live" },
-            { name: "Opinion Piece", article: "/politics/2019/jul/15/it-will-be-boris-johnson-and-it-will-certainly-be-a-disaster" },
-            { name: "Review", article: "/music/2018/aug/31/eminem-kamikaze-album-review"},
-            { name: "Paid Content", article: "/bank-australia-clean-money/2019/feb/11/three-trillion-reasons-for-australians-to-join-the-clean-money-revolution"}
-        ];
-
-        var testArticles = [
-            { name: "ImageBlockElement", article: "/environment/2018/dec/21/from-spectacular-orchids-to-towering-trees-2018s-top-new-plant-discoveries" },
-            { name: "ImageBlockElement (left)", article: "/film/2018/aug/30/damon-herriman-to-play-charles-manson-in-quentin-tarantino-film" },
-            { name: "TweetBlockElement", article: "/uk-news/reality-check/2015/sep/19/daily-mail-syrian-refugees-story-three-problems" },
-            { name: "RichLinkBlockElement", article: "/football/2019/jun/04/juventus-interested-paul-pogba-manchester-united" },
-            { name: "PullquoteBlockElement", article: "/world/2018/dec/28/south-koreas-sexist-sex-education" },
-            { name: "VideoBlockElement", article: "/us-news/2017/feb/23/los-angeles-police-officer-teen-gun-video-protests" },
-            { name: "AudioBlockElement", article: "/music/2018/nov/02/the-prodigy-no-tourists-review" },
-            { name: "EmbedBlockElement", article: "/australia-news/2018/jun/12/shorten-wants-more-aged-care-spending-but-wont-back-royal-commission" },
-            { name: "ContentAtomBlockElement", article: "/world/2018/jun/18/yemen-crisis-saudi-coalition-demands-houthis-unconditional-withdrawal-from-port" }
-        ];
-
-        var makeTestArticle = (a) => `
+            var makeTestArticle = a => `
             <div class="test-article">
                 <span>${a.name}</span>
                 <span><a href="/Article?url=https://www.theguardian.com${a.article}">🔗</a> <a href="/Article?url=http://localhost:9000${a.article}">🔗(local FE)</a></span>
@@ -93,15 +139,17 @@
             </div>
         `;
 
-        testArticles.forEach((a)=>{
-            document.getElementById("test-articles-by-element").innerHTML += makeTestArticle(a);
-        });
+            testArticles.forEach(a => {
+                document.getElementById(
+                    'test-articles-by-element',
+                ).innerHTML += makeTestArticle(a);
+            });
 
-        testContentTypes.forEach((a)=>{
-            document.getElementById("test-articles-by-content").innerHTML += makeTestArticle(a);
-        });
-
-    </script>
-
-</body>
+            testContentTypes.forEach(a => {
+                document.getElementById(
+                    'test-articles-by-content',
+                ).innerHTML += makeTestArticle(a);
+            });
+        </script>
+    </body>
 </html>


### PR DESCRIPTION
## What does this change?

On our index page, while lists element types along urls, the link for `VideoBlockElement` is actually a link for `VideoYoutubeBlockElement`. This is the only meaningful change, the rest is linter having had fun with the file.  

Before:

<img width="386" alt="Screenshot 2020-05-05 at 12 26 17" src="https://user-images.githubusercontent.com/6035518/81061218-dd44cb80-8ecb-11ea-8586-73ad64098ece.png">

After:

<img width="372" alt="Screenshot 2020-05-05 at 12 26 25" src="https://user-images.githubusercontent.com/6035518/81061239-e46bd980-8ecb-11ea-9de5-8bd04819d01b.png">

