### PR TITLE
Second attempt at soundcloud embeds after merge hell

### DIFF
--- a/cypress/integration/e2e/article.elements.spec.js
+++ b/cypress/integration/e2e/article.elements.spec.js
@@ -61,5 +61,19 @@ describe('Elements', function() {
 
             getIframeBody().contains('radiolab');
         });
+        it('should render the soundcloud embed', function() {
+            const getIframeBody = () => {
+                return cy
+                    .get('div[data-cy="soundcloud-embed"] > iframe')
+                    .its('0.contentDocument.body')
+                    .should('not.be.empty')
+                    .then(cy.wrap);
+            };
+            cy.visit(
+                'Article?url=https://www.theguardian.com/music/2020/jan/31/elon-musk-edm-artist-first-track-dont-doubt-ur-vibe',
+            );
+
+            getIframeBody().contains('Cookie policy');
+        });
     });
 });

--- a/src/web/components/elements/SouncloudBlockComponent.tsx
+++ b/src/web/components/elements/SouncloudBlockComponent.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { css } from 'emotion';
+import { unescapeData } from '@root/src/lib/escapeData';
+
+const widthOverride = css`
+    iframe {
+        /* The  embed js hijacks the iframe and calculated an incorrect width, which pushed the body out */
+        width: 100%;
+    }
+`;
+
+export const SoundcloudBlockComponent: React.FC<{
+    element: SoundcloudBlockElement;
+}> = ({ element }) => {
+    return (
+        <div className={widthOverride}>
+            <div
+                data-cy="soundcloud-embed"
+                dangerouslySetInnerHTML={{ __html: unescapeData(element.html) }}
+            />
+        </div>
+    );
+};

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -10,6 +10,7 @@ import { BlockquoteComponent } from '@root/src/web/components/elements/Blockquot
 import { YouTubeComponent } from '@root/src/web/components/elements/YouTubeComponent';
 import { InstagramBlockComponent } from '@root/src/web/components/elements/InstagramBlockComponent';
 import { EmbedBlockComponent } from '@root/src/web/components/elements/EmbedBlockComponent';
+import { SoundcloudBlockComponent } from '@root/src/web/components/elements/SouncloudBlockComponent';
 
 // This is required for spacefinder to work!
 const commercialPosition = css`
@@ -60,6 +61,10 @@ export const ArticleRenderer: React.FC<{
                 case 'model.dotcomrendering.pageElements.InstagramBlockElement':
                     return (
                         <InstagramBlockComponent key={i} element={element} />
+                    );
+                case 'model.dotcomrendering.pageElements.SoundcloudBlockElement':
+                    return (
+                        <SoundcloudBlockComponent key={i} element={element} />
                     );
                 case 'model.dotcomrendering.pageElements.EmbedBlockElement':
                     return (


### PR DESCRIPTION
## What does this change?
Enables the rendering of soundcloud embeds in DCR articles. PR comes with a free reminder that Elon Musk wrote an EDM track. https://www.theguardian.com/music/2020/jan/31/elon-musk-edm-artist-first-track-dont-doubt-ur-vibe

<img width="691" alt="Screen Shot 2020-04-30 at 21 03 37" src="https://user-images.githubusercontent.com/2051501/80756098-da438700-8b29-11ea-930a-590bd1ee7428.png">

<img width="283" alt="Screen Shot 2020-04-30 at 21 03 56" src="https://user-images.githubusercontent.com/2051501/80756107-de6fa480-8b29-11ea-9f8a-ce908d3ac183.png">

