### PR TITLE
Update test name to be AMP specific

### DIFF
--- a/src/amp/experimentConfigs.ts
+++ b/src/amp/experimentConfigs.ts
@@ -2,7 +2,7 @@ import { StyledExperimentCollection } from '@root/src/amp/lib/experiment';
 
 // Variant proportions must be >0, so we set extremely low to simulate a 0% test
 export const experimentFullConfig: StyledExperimentCollection = {
-    'ab-zero-test-experiment': {
+    'ab-amp-zero-test-experiment': {
         sticky: false,
         variants: {
             treatment1: {


### PR DESCRIPTION
## What does this change?
Update the test name to be AMP specific. Matches with https://github.com/guardian/frontend/pull/22560

## Why?
Reduce risk of clashing with non-AMP experiment