### PR TITLE
Convert test name to Camel Case

### DIFF
--- a/src/amp/experimentConfigs.ts
+++ b/src/amp/experimentConfigs.ts
@@ -2,7 +2,7 @@ import { StyledExperimentCollection } from '@root/src/amp/lib/experiment';
 
 // Variant proportions must be >0, so we set extremely low to simulate a 0% test
 export const experimentFullConfig: StyledExperimentCollection = {
-    'ab-amp-zero-test-experiment': {
+    abAmpZeroTestExperiment: {
         sticky: false,
         variants: {
             treatment1: {

--- a/src/amp/server/document.test.tsx
+++ b/src/amp/server/document.test.tsx
@@ -4,7 +4,10 @@ import { CAPI } from '@root/fixtures/CAPI/CAPI';
 import { Article } from '@root/src/amp/pages/Article';
 import { extract as extractNAV } from '@root/src/model/extract-nav';
 import { AnalyticsModel } from '@root/src/amp/components/Analytics';
-import { getAllActiveExperiments } from '@root/src/amp/lib/experiment';
+import {
+    getAllActiveExperiments,
+    getAllActiveCss,
+} from '@root/src/amp/lib/experiment';
 import { experimentFullConfig } from '@root/src/amp/experimentConfigs';
 import { document } from './document';
 
@@ -12,6 +15,7 @@ test('rejects invalid AMP doc (to test validator)', async () => {
     const v = await validator.getInstance();
     const linkedData = [{}];
     const metadata = { description: '', canonicalURL: '' };
+    const abTestCss = '';
     const result = v.validateString(
         document({
             linkedData,
@@ -19,6 +23,7 @@ test('rejects invalid AMP doc (to test validator)', async () => {
             title: 'foo',
             scripts: [''],
             body: <img alt="foo" />,
+            abTestCss,
         }),
     );
     expect(result.errors.length > 0).toBe(true);
@@ -63,6 +68,7 @@ test('produces valid AMP doc', async () => {
         experimentFullConfig,
         config.switches,
     );
+    const abTestCss = getAllActiveCss(experimentFullConfig, config.switches);
 
     const body = (
         <Article
@@ -80,6 +86,7 @@ test('produces valid AMP doc', async () => {
             metadata,
             title: 'foo',
             scripts: [],
+            abTestCss,
         }),
     );
 

--- a/src/amp/server/document.tsx
+++ b/src/amp/server/document.tsx
@@ -6,9 +6,6 @@ import { cache } from 'emotion';
 import escape from 'lodash.escape';
 import resetCSS from /* preval */ '@root/src/lib/reset-css';
 import { getFontsCss } from '@root/src/lib/fonts-css';
-import { experimentFullConfig } from '@root/src/amp/experimentConfigs';
-import { getAllActiveCss } from '@root/src/amp/lib/experiment';
-import { CAPI } from '@root/fixtures/CAPI/CAPI';
 
 interface RenderToStringResult {
     html: string;
@@ -26,15 +23,15 @@ export const document = ({
     body,
     scripts,
     metadata,
+    abTestCss,
 }: {
     linkedData: object[];
     title: string;
     body: React.ReactElement<any>;
     scripts: string[];
     metadata: Metadata;
+    abTestCss: string;
 }) => {
-    const testCss = getAllActiveCss(experimentFullConfig, CAPI.config.switches);
-
     const { html, css }: RenderToStringResult = extractCritical(
         // TODO: CacheProvider can be removed when we've moved over to using @emotion/core
         renderToStaticMarkup(
@@ -89,7 +86,7 @@ export const document = ({
     <!-- AMP elements that are optional dependending on content -->
     ${scripts.join(' ')}
 
-    <style amp-custom>${testCss}${getFontsCss()}${resetCSS}${css}</style>
+    <style amp-custom>${abTestCss}${getFontsCss()}${resetCSS}${css}</style>
     </head>
     <body>
     ${html}

--- a/src/amp/server/render.tsx
+++ b/src/amp/server/render.tsx
@@ -10,7 +10,10 @@ import { validateAsCAPIType as validateV2 } from '@root/src/model/validate';
 import { findBySubsection } from '@root/src/model/article-sections';
 import { bodyJSON } from '@root/src/model/exampleBodyJSON';
 import { generatePermutivePayload } from '@root/src/amp/lib/permutive';
-import { getAllActiveExperiments } from '@root/src/amp/lib/experiment';
+import {
+    getAllActiveExperiments,
+    getAllActiveCss,
+} from '@root/src/amp/lib/experiment';
 
 export const render = ({ body }: express.Request, res: express.Response) => {
     try {
@@ -49,6 +52,11 @@ export const render = ({ body }: express.Request, res: express.Response) => {
             experimentFullConfig,
             config.switches,
         );
+        const abTestCss = getAllActiveCss(
+            experimentFullConfig,
+            config.switches,
+        );
+
         const metadata = {
             description: CAPI.trailText,
             canonicalURL: CAPI.webURL,
@@ -68,6 +76,7 @@ export const render = ({ body }: express.Request, res: express.Response) => {
                     config={config}
                 />
             ),
+            abTestCss,
         });
 
         res.status(200).send(resp);


### PR DESCRIPTION
## What does this change?
The config.switches object converts from kebeb case to camelCase. The test config needs updating to reflect this.

In addition, the `CAPI.config.switches` used by `document.tsx` was the incorrect one for this use case. Instead I've modified the code to take the active experiment CSS string as an argument into the document component and to handle the generation and extraction in `render.tsx`

## Why?
After deploying a change to the active switches on PROD frontend, I realised that  the above changes needed to be made for the AMP code to work on PROD as well. I'd previously tested against a mocked/ artificial `config.switches` object.

This has now been tested against an actual PROD config object and works.