### PR TITLE
Polyfill less in Cypress

### DIFF
--- a/cypress/integration/e2e/article.e2e.spec.js
+++ b/cypress/integration/e2e/article.e2e.spec.js
@@ -6,7 +6,7 @@ import { articles, AMPArticles } from '../../lib/articles.js';
 import { setupApiRoutes } from '../../lib/apiRoutes.js';
 
 describe('E2E Page rendering', function() {
-    beforeEach(getPolyfill);
+    before(getPolyfill);
     beforeEach(setupApiRoutes);
 
     describe('for WEB', function() {

--- a/cypress/integration/e2e/article.interactivity.spec.js
+++ b/cypress/integration/e2e/article.interactivity.spec.js
@@ -42,7 +42,7 @@ describe('Interactivity', function() {
         });
 
         describe('When most viewed is mocked', function() {
-            beforeEach(getPolyfill);
+            before(getPolyfill);
             beforeEach(mockApi);
             it('should change the list of most viewed items when a tab is clicked', function() {
                 cy.visit(`/Article?url=${articleUrl}`, fetchPolyfill);

--- a/cypress/integration/mocked/article.amp.spec.js
+++ b/cypress/integration/mocked/article.amp.spec.js
@@ -5,7 +5,7 @@ import { AMPArticles } from '../../lib/articles.js';
 import { mockApi } from '../../lib/mocks';
 
 describe('For AMP', function() {
-    beforeEach(getPolyfill);
+    before(getPolyfill);
     beforeEach(fixTime);
     beforeEach(mockApi);
 

--- a/cypress/integration/mocked/article.web.spec.js
+++ b/cypress/integration/mocked/article.web.spec.js
@@ -5,7 +5,7 @@ import { articles } from '../../lib/articles.js';
 import { mockApi } from '../../lib/mocks';
 
 describe('For WEB', function() {
-    beforeEach(getPolyfill);
+    before(getPolyfill);
     beforeEach(fixTime);
     beforeEach(mockApi);
 


### PR DESCRIPTION
## What does this change?
Only call the polyfill once per Cypress spec, not once per test

## Why?
Because if we call it repeatedly we end up getting 429 responses, which fail the test run