### PR TITLE
Rename PullQuoteComponent into PullQuoteBlockComponent

### DIFF
--- a/src/web/components/elements/PullQuoteBlockComponent.tsx
+++ b/src/web/components/elements/PullQuoteBlockComponent.tsx
@@ -126,7 +126,7 @@ function getStyles(role: string) {
     return role === 'supporting' ? supportingStyles : inlineStyles;
 }
 
-export const PullQuoteComponent: React.FC<{
+export const PullQuoteBlockComponent: React.FC<{
     html: string;
     pillar: Pillar;
     designType: DesignType;

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -5,7 +5,7 @@ import { TextBlockComponent } from '@root/src/web/components/elements/TextBlockC
 import { SubheadingBlockComponent } from '@root/src/web/components/elements/SubheadingBlockComponent';
 import { ImageBlockComponent } from '@root/src/web/components/elements/ImageBlockComponent';
 import { TweetBlockComponent } from '@root/src/web/components/elements/TweetBlockComponent';
-import { PullQuoteComponent } from '@root/src/web/components/elements/PullQuoteComponent';
+import { PullQuoteBlockComponent } from '@root/src/web/components/elements/PullQuoteBlockComponent';
 import { BlockquoteComponent } from '@root/src/web/components/elements/BlockquoteComponent';
 import { YouTubeComponent } from '@root/src/web/components/elements/YouTubeComponent';
 import { InstagramBlockComponent } from '@root/src/web/components/elements/InstagramBlockComponent';
@@ -64,7 +64,7 @@ export const ArticleRenderer: React.FC<{
                     );
                 case 'model.dotcomrendering.pageElements.PullquoteBlockElement':
                     return (
-                        <PullQuoteComponent
+                        <PullQuoteBlockComponent
                             key={i}
                             html={element.html}
                             pillar={pillar}


### PR DESCRIPTION
## What does this change?

Rename PullQuoteComponent into PullQuoteBlockComponent. See ( https://github.com/guardian/dotcom-rendering/pull/1463 )
