### PR TITLE
Rename YouTubeComponent into YouTubeBlockComponent

### DIFF
--- a/src/web/components/MainMedia.tsx
+++ b/src/web/components/MainMedia.tsx
@@ -4,7 +4,7 @@ import { css, cx } from 'emotion';
 import { until } from '@guardian/src-foundations/mq';
 
 import { ImageComponent } from '@root/src/web/components/elements/ImageComponent';
-import { YouTubeComponent } from '@root/src/web/components/elements/YouTubeComponent';
+import { YouTubeBlockComponent } from '@root/src/web/components/elements/YouTubeBlockComponent';
 
 const mainMedia = css`
     min-height: 1px;
@@ -63,7 +63,7 @@ function renderElement(
             );
         case 'model.dotcomrendering.pageElements.YoutubeBlockElement':
             return (
-                <YouTubeComponent
+                <YouTubeBlockComponent
                     display={display}
                     key={i}
                     element={element}

--- a/src/web/components/elements/YouTubeBlockComponent.stories.tsx
+++ b/src/web/components/elements/YouTubeBlockComponent.stories.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { css } from 'emotion';
 
-import { YouTubeComponent } from './YouTubeComponent';
+import { YouTubeBlockComponent } from './YouTubeBlockComponent';
 
 export default {
-    component: YouTubeComponent,
+    component: YouTubeBlockComponent,
     title: 'Components/YouTubeComponent',
 };
 
@@ -22,7 +22,7 @@ const Container = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
 export const noOverlay = () => {
     return (
         <Container>
-            <YouTubeComponent
+            <YouTubeBlockComponent
                 display="standard"
                 element={{
                     mediaTitle:

--- a/src/web/components/elements/YouTubeBlockComponent.tsx
+++ b/src/web/components/elements/YouTubeBlockComponent.tsx
@@ -14,7 +14,7 @@ type Props = {
     children?: JSX.Element | JSX.Element[];
 };
 
-export const YouTubeComponent = ({
+export const YouTubeBlockComponent = ({
     display,
     element,
     pillar,

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -7,7 +7,7 @@ import { ImageBlockComponent } from '@root/src/web/components/elements/ImageBloc
 import { TweetBlockComponent } from '@root/src/web/components/elements/TweetBlockComponent';
 import { PullQuoteComponent } from '@root/src/web/components/elements/PullQuoteComponent';
 import { BlockquoteComponent } from '@root/src/web/components/elements/BlockquoteComponent';
-import { YouTubeComponent } from '@root/src/web/components/elements/YouTubeComponent';
+import { YouTubeBlockComponent } from '@root/src/web/components/elements/YouTubeBlockComponent';
 import { InstagramBlockComponent } from '@root/src/web/components/elements/InstagramBlockComponent';
 import { EmbedBlockComponent } from '@root/src/web/components/elements/EmbedBlockComponent';
 import { SoundcloudBlockComponent } from '@root/src/web/components/elements/SouncloudBlockComponent';
@@ -99,7 +99,7 @@ export const ArticleRenderer: React.FC<{
                     return <TweetBlockComponent key={i} element={element} />;
                 case 'model.dotcomrendering.pageElements.YoutubeBlockElement':
                     return (
-                        <YouTubeComponent
+                        <YouTubeBlockComponent
                             display={display}
                             key={i}
                             element={element}


### PR DESCRIPTION
## What does this change?

Rename YouTubeComponent into YouTubeBlockComponent. See ( https://github.com/guardian/dotcom-rendering/pull/1463 )
