### PR TITLE
Bump @guardian/discussion-rendering > v2.2.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "@emotion/core": "^10.0.28",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/consent-management-platform": "^3.0.4",
-        "@guardian/discussion-rendering": "^2.2.8",
+        "@guardian/discussion-rendering": "^2.2.9",
         "@guardian/src-button": "^0.17.0",
         "@guardian/src-ed-lines": "^0.18.0-rc.0",
         "@guardian/src-foundations": "^0.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2151,10 +2151,10 @@
     js-cookie "^2.2.1"
     whatwg-fetch "^3.0.0"
 
-"@guardian/discussion-rendering@^2.2.8":
-  version "2.2.8"
-  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-2.2.8.tgz#022ff28b6d6b4b828002338f556c44bd9ed82514"
-  integrity sha512-5/RVjLXHAu+pLCNnGY4YCt8UW0t7SNAqn5ZQYYpjCvYlwui9MYR5FO+ZTR0rsZxrhk0PjGrrr8wHa51a05xREQ==
+"@guardian/discussion-rendering@^2.2.9":
+  version "2.2.9"
+  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-2.2.9.tgz#3f8f5d4e55daac8e64c669d71eb520922f8746c8"
+  integrity sha512-js6ndawG9hq2j8/oj6deY/hKMVyeD6x95e9SC3Nc2pwCcD2r8aT9/ZwDSRlEQc4y2Cnkb/wFb9vTr4TKYvFHpw==
   dependencies:
     react-focus-lock "^2.2.1"
     timeago.js "^4.0.2"


### PR DESCRIPTION
## What does this change?
Bumps discussion-rendering to v2.2.9

## Why?
Fixes the missing filters when there are no top picks and report form issues
