### PR TITLE
Rename element types

### DIFF
--- a/scripts/frontend/landing/index.html
+++ b/scripts/frontend/landing/index.html
@@ -61,9 +61,9 @@
         <h2>Test Articles By Element (Missing)</h2>
         <ul>
             <li>AtomEmbedMarkupBlockElement</li>
-            <li>AtomEmbedUrlElement</li>
+            <li>AtomEmbedUrlBlockElement</li>
             <li>BlockquoteBlockElement</li>
-            <li>ContentAtomElement</li>
+            <li>ContentAtomBlockElement</li>
             <li>DisclaimerBlockElement</li>
             <li>GuideBlockElement</li>
             <li>InteractiveMarkupBlockElement</li>

--- a/src/amp/components/elements/ContentAtom.tsx
+++ b/src/amp/components/elements/ContentAtom.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 export const ContentAtom: React.FC<{
-    element: ContentAtomElement;
+    element: ContentAtomBlockElement;
 }> = ({}) => {
     return null;
 };

--- a/src/amp/components/elements/VideoFacebook.tsx
+++ b/src/amp/components/elements/VideoFacebook.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Caption } from '@root/src/amp/components/Caption';
 
 export const VideoFacebook: React.FC<{
-    element: VideoFacebook;
+    element: VideoFacebookBlockElement;
     pillar: Pillar;
 }> = ({ element, pillar }) => {
     return (

--- a/src/amp/components/elements/VideoGuardian.tsx
+++ b/src/amp/components/elements/VideoGuardian.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Caption } from '@root/src/amp/components/Caption';
 
 export const VideoGuardian: React.FC<{
-    element: VideoGuardian;
+    element: GuVideoBlockElement;
     pillar: Pillar;
 }> = ({ element, pillar }) => {
     return (

--- a/src/amp/components/elements/VideoVimeo.tsx
+++ b/src/amp/components/elements/VideoVimeo.tsx
@@ -3,7 +3,7 @@ import { getIdFromUrl } from '@root/src/amp/lib/get-video-id';
 import { Caption } from '@root/src/amp/components/Caption';
 
 export const VideoVimeo: React.FC<{
-    element: VideoVimeo;
+    element: VideoVimeoBlockElement;
     pillar: Pillar;
 }> = ({ element, pillar }) => {
     const vimeoId = getIdFromUrl(element.url, '(\\d+)($|\\/)', true);

--- a/src/amp/components/elements/VideoYoutube.tsx
+++ b/src/amp/components/elements/VideoYoutube.tsx
@@ -3,7 +3,7 @@ import { getIdFromUrl } from '@root/src/amp/lib/get-video-id';
 import { Caption } from '@root/src/amp/components/Caption';
 
 export const VideoYoutube: React.FC<{
-    element: VideoYoutube;
+    element: VideoYoutubeBlockElement;
     pillar: Pillar;
 }> = ({ element, pillar }) => {
     const youtubeId = getIdFromUrl(

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -67,7 +67,7 @@ interface YoutubeBlockElement {
 }
 
 // Note, this is a Video Embed rather than the above Media Atom
-interface VideoYoutube {
+interface VideoYoutubeBlockElement {
     _type: 'model.dotcomrendering.pageElements.VideoYoutubeBlockElement';
     url: string;
     height: number;
@@ -75,7 +75,7 @@ interface VideoYoutube {
     caption: string;
 }
 
-interface VideoVimeo {
+interface VideoVimeoBlockElement {
     _type: 'model.dotcomrendering.pageElements.VideoVimeoBlockElement';
     url: string;
     height: number;
@@ -83,7 +83,7 @@ interface VideoVimeo {
     caption: string;
 }
 
-interface VideoFacebook {
+interface VideoFacebookBlockElement {
     _type: 'model.dotcomrendering.pageElements.VideoFacebookBlockElement';
     url: string;
     height: number;
@@ -91,7 +91,7 @@ interface VideoFacebook {
     caption: string;
 }
 
-interface VideoGuardian {
+interface GuVideoBlockElement {
     _type: 'model.dotcomrendering.pageElements.GuVideoBlockElement';
     assets: VideoAssets[];
     caption: string;
@@ -232,7 +232,7 @@ interface AtomEmbedMarkupBlockElement {
     js?: string;
 }
 
-interface AtomEmbedUrlElement {
+interface AtomEmbedUrlBlockElement {
     _type: 'model.dotcomrendering.pageElements.AtomEmbedUrlBlockElement';
     url: string;
 }
@@ -255,7 +255,7 @@ interface AudioAtomElement {
     coverUrl: string;
 }
 
-interface ContentAtomElement {
+interface ContentAtomBlockElement {
     _type: 'model.dotcomrendering.pageElements.ContentAtomBlockElement';
     atomId: string;
 }
@@ -288,10 +288,10 @@ type CAPIElement =
     | SubheadingBlockElement
     | ImageBlockElement
     | YoutubeBlockElement
-    | VideoYoutube
-    | VideoVimeo
-    | VideoFacebook
-    | VideoGuardian
+    | VideoYoutubeBlockElement
+    | VideoVimeoBlockElement
+    | VideoFacebookBlockElement
+    | GuVideoBlockElement
     | InstagramBlockElement
     | TweetBlockElement
     | RichLinkBlockElement
@@ -306,10 +306,10 @@ type CAPIElement =
     | ProfileBlockElement
     | TimelineBlockElement
     | AtomEmbedMarkupBlockElement
-    | AtomEmbedUrlElement
+    | AtomEmbedUrlBlockElement
     | MapBlockElement
     | AudioAtomElement
-    | ContentAtomElement
+    | ContentAtomBlockElement
     | AudioBlockElement
     | VideoBlockElement
     | CodeBlockElement

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -30,13 +30,13 @@
                         "$ref": "#/definitions/YoutubeBlockElement"
                     },
                     {
-                        "$ref": "#/definitions/VideoYoutube"
+                        "$ref": "#/definitions/VideoYoutubeBlockElement"
                     },
                     {
-                        "$ref": "#/definitions/VideoVimeo"
+                        "$ref": "#/definitions/VideoVimeoBlockElement"
                     },
                     {
-                        "$ref": "#/definitions/VideoFacebook"
+                        "$ref": "#/definitions/VideoFacebookBlockElement"
                     },
                     {
                         "$ref": "#/definitions/VideoGuardian"
@@ -81,7 +81,7 @@
                         "$ref": "#/definitions/AtomEmbedMarkupBlockElement"
                     },
                     {
-                        "$ref": "#/definitions/AtomEmbedUrlElement"
+                        "$ref": "#/definitions/AtomEmbedUrlBlockElement"
                     },
                     {
                         "$ref": "#/definitions/MapBlockElement"
@@ -90,7 +90,7 @@
                         "$ref": "#/definitions/AudioAtomElement"
                     },
                     {
-                        "$ref": "#/definitions/ContentAtomElement"
+                        "$ref": "#/definitions/ContentAtomBlockElement"
                     },
                     {
                         "$ref": "#/definitions/AudioBlockElement"
@@ -578,7 +578,7 @@
             },
             "required": ["_type", "assetId", "mediaTitle"]
         },
-        "VideoYoutube": {
+        "VideoYoutubeBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
@@ -602,7 +602,7 @@
             },
             "required": ["_type", "caption", "height", "url", "width"]
         },
-        "VideoVimeo": {
+        "VideoVimeoBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
@@ -626,7 +626,7 @@
             },
             "required": ["_type", "caption", "height", "url", "width"]
         },
-        "VideoFacebook": {
+        "VideoFacebookBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
@@ -1021,7 +1021,7 @@
             },
             "required": ["_type"]
         },
-        "AtomEmbedUrlElement": {
+        "AtomEmbedUrlBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
@@ -1104,7 +1104,7 @@
                 "trackUrl"
             ]
         },
-        "ContentAtomElement": {
+        "ContentAtomBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
@@ -1214,13 +1214,13 @@
                                 "$ref": "#/definitions/YoutubeBlockElement"
                             },
                             {
-                                "$ref": "#/definitions/VideoYoutube"
+                                "$ref": "#/definitions/VideoYoutubeBlockElement"
                             },
                             {
-                                "$ref": "#/definitions/VideoVimeo"
+                                "$ref": "#/definitions/VideoVimeoBlockElement"
                             },
                             {
-                                "$ref": "#/definitions/VideoFacebook"
+                                "$ref": "#/definitions/VideoFacebookBlockElement"
                             },
                             {
                                 "$ref": "#/definitions/VideoGuardian"
@@ -1265,7 +1265,7 @@
                                 "$ref": "#/definitions/AtomEmbedMarkupBlockElement"
                             },
                             {
-                                "$ref": "#/definitions/AtomEmbedUrlElement"
+                                "$ref": "#/definitions/AtomEmbedUrlBlockElement"
                             },
                             {
                                 "$ref": "#/definitions/MapBlockElement"
@@ -1274,7 +1274,7 @@
                                 "$ref": "#/definitions/AudioAtomElement"
                             },
                             {
-                                "$ref": "#/definitions/ContentAtomElement"
+                                "$ref": "#/definitions/ContentAtomBlockElement"
                             },
                             {
                                 "$ref": "#/definitions/AudioBlockElement"

--- a/src/web/components/elements/ImageComponent.tsx
+++ b/src/web/components/elements/ImageComponent.tsx
@@ -264,7 +264,7 @@ export const ImageComponent = ({
                                         captionText={element.data.caption || ''}
                                         pillar={pillar}
                                         credit={element.data.credit}
-                                        displayCredit={true}
+                                        displayCredit={element.displayCredit}
                                         shouldLimitWidth={shouldLimitWidth}
                                         isOverlayed={true}
                                     />
@@ -282,7 +282,7 @@ export const ImageComponent = ({
                         captionText={element.data.caption || ''}
                         pillar={pillar}
                         credit={element.data.credit}
-                        displayCredit={true}
+                        displayCredit={element.displayCredit}
                         shouldLimitWidth={shouldLimitWidth}
                     />
                 </Hide>
@@ -292,7 +292,7 @@ export const ImageComponent = ({
                     captionText={element.data.caption || ''}
                     pillar={pillar}
                     credit={element.data.credit}
-                    displayCredit={true}
+                    displayCredit={element.displayCredit}
                     shouldLimitWidth={shouldLimitWidth}
                 />
             )}

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -111,7 +111,26 @@ export const ArticleRenderer: React.FC<{
                             isMainMedia={false}
                         />
                     );
-                default:
+                case 'model.dotcomrendering.pageElements.AudioAtomBlockElement':
+                case 'model.dotcomrendering.pageElements.CodeBlockElement':
+                case 'model.dotcomrendering.pageElements.CommentBlockElement':
+                case 'model.dotcomrendering.pageElements.ContentAtomBlockElement':
+                case 'model.dotcomrendering.pageElements.DisclaimerBlockElement':
+                case 'model.dotcomrendering.pageElements.DocumentBlockElement':
+                case 'model.dotcomrendering.pageElements.MapBlockElement':
+                case 'model.dotcomrendering.pageElements.GuVideoBlockElement':
+                case 'model.dotcomrendering.pageElements.GuideBlockElement':
+                case 'model.dotcomrendering.pageElements.ProfileBlockElement':
+                case 'model.dotcomrendering.pageElements.QABlockElement':
+                case 'model.dotcomrendering.pageElements.TableBlockElement':
+                case 'model.dotcomrendering.pageElements.TimelineBlockElement':
+                case 'model.dotcomrendering.pageElements.VideoBlockElement':
+                case 'model.dotcomrendering.pageElements.VideoFacebookBlockElement':
+                case 'model.dotcomrendering.pageElements.VideoVimeoBlockElement':
+                case 'model.dotcomrendering.pageElements.VideoYoutubeBlockElement':
+                case 'model.dotcomrendering.pageElements.AtomEmbedMarkupBlockElement':
+                case 'model.dotcomrendering.pageElements.AtomEmbedUrlBlockElement':
+                case 'model.dotcomrendering.pageElements.AudioBlockElement':
                     return null;
             }
         })


### PR DESCRIPTION
## What does this change?
Renames the types:
```
    VideoYoutube > VideoYoutubeBlockElement
    VideoVimeo > VideoVimeoBlockElement
    VideoFacebook > VideoFacebookBlockElement
    VideoGuardian > GuVideoBlockElement
    AtomEmbedUrlElement > AtomEmbedUrlBlockElement
    ContentAtomElement > ContentAtomBlockElement
```
and then explicitly declares the case statements in `ArticleRenderer`


## Why?
To follow conventions and ensure coverage
