### PR TITLE
MultiImageBlockElement

### DIFF
--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -121,6 +121,12 @@ interface MapBlockElement {
     title: string;
 }
 
+interface MultiImageBlockElement {
+    _type: 'model.dotcomrendering.pageElements.MultiImageBlockElement';
+    images: ImageBlockElement[];
+    caption?: string;
+}
+
 interface ProfileBlockElement {
     _type: 'model.dotcomrendering.pageElements.ProfileBlockElement';
     id: string;
@@ -254,6 +260,7 @@ type CAPIElement =
     | ImageBlockElement
     | InstagramBlockElement
     | MapBlockElement
+    | MultiImageBlockElement
     | ProfileBlockElement
     | PullquoteBlockElement
     | QABlockElement

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -15,100 +15,103 @@
             "items": {
                 "anyOf": [
                     {
-                        "$ref": "#/definitions/TextBlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/SubheadingBlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/RichLinkBlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/ImageBlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/YoutubeBlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/VideoYoutubeBlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/VideoVimeoBlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/VideoFacebookBlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/VideoGuardian"
-                    },
-                    {
-                        "$ref": "#/definitions/InstagramBlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/TweetBlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/CommentBlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/SoundcloudBlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/EmbedBlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/DisclaimerBlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/PullquoteBlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/BlockquoteBlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/QABlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/GuideBlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/ProfileBlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/TimelineBlockElement"
-                    },
-                    {
                         "$ref": "#/definitions/AtomEmbedMarkupBlockElement"
                     },
                     {
                         "$ref": "#/definitions/AtomEmbedUrlBlockElement"
                     },
                     {
-                        "$ref": "#/definitions/MapBlockElement"
-                    },
-                    {
                         "$ref": "#/definitions/AudioAtomElement"
-                    },
-                    {
-                        "$ref": "#/definitions/ContentAtomBlockElement"
                     },
                     {
                         "$ref": "#/definitions/AudioBlockElement"
                     },
                     {
-                        "$ref": "#/definitions/VideoBlockElement"
+                        "$ref": "#/definitions/BlockquoteBlockElement"
                     },
                     {
                         "$ref": "#/definitions/CodeBlockElement"
                     },
                     {
+                        "$ref": "#/definitions/CommentBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/ContentAtomBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/DisclaimerBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/DividerBlockElement"
+                    },
+                    {
                         "$ref": "#/definitions/DocumentBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/EmbedBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/GuideBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/GuVideoBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/ImageBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/InstagramBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/MapBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/MultiImageBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/ProfileBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/PullquoteBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/QABlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/RichLinkBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/SoundcloudBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/SubheadingBlockElement"
                     },
                     {
                         "$ref": "#/definitions/TableBlockElement"
                     },
                     {
-                        "$ref": "#/definitions/DividerBlockElement"
+                        "$ref": "#/definitions/TextBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/TimelineBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/TweetBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/VideoBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/VideoFacebookBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/VideoVimeoBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/VideoYoutubeBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/YoutubeBlockElement"
                     }
                 ]
             }
@@ -353,383 +356,133 @@
         "webURL"
     ],
     "definitions": {
-        "TextBlockElement": {
+        "AtomEmbedMarkupBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
                     "type": "string",
                     "enum": [
-                        "model.dotcomrendering.pageElements.TextBlockElement"
+                        "model.dotcomrendering.pageElements.AtomEmbedMarkupBlockElement"
                     ]
-                },
-                "html": {
-                    "type": "string"
-                }
-            },
-            "required": ["_type", "html"]
-        },
-        "SubheadingBlockElement": {
-            "type": "object",
-            "properties": {
-                "_type": {
-                    "type": "string",
-                    "enum": [
-                        "model.dotcomrendering.pageElements.SubheadingBlockElement"
-                    ]
-                },
-                "html": {
-                    "type": "string"
-                }
-            },
-            "required": ["_type", "html"]
-        },
-        "RichLinkBlockElement": {
-            "type": "object",
-            "properties": {
-                "_type": {
-                    "type": "string",
-                    "enum": [
-                        "model.dotcomrendering.pageElements.RichLinkBlockElement"
-                    ]
-                },
-                "url": {
-                    "type": "string"
-                },
-                "text": {
-                    "type": "string"
-                },
-                "prefix": {
-                    "type": "string"
-                },
-                "role": {
-                    "$ref": "#/definitions/Weighting"
-                },
-                "richLinkIndex": {
-                    "type": "number"
-                }
-            },
-            "required": ["_type", "prefix", "text", "url"]
-        },
-        "Weighting": {
-            "enum": [
-                "halfwidth",
-                "immersive",
-                "inline",
-                "showcase",
-                "supporting",
-                "thumbnail"
-            ],
-            "type": "string"
-        },
-        "ImageBlockElement": {
-            "type": "object",
-            "properties": {
-                "_type": {
-                    "type": "string",
-                    "enum": [
-                        "model.dotcomrendering.pageElements.ImageBlockElement"
-                    ]
-                },
-                "media": {
-                    "type": "object",
-                    "properties": {
-                        "allImages": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/Image"
-                            }
-                        }
-                    },
-                    "required": ["allImages"]
-                },
-                "data": {
-                    "type": "object",
-                    "properties": {
-                        "alt": {
-                            "type": "string"
-                        },
-                        "credit": {
-                            "type": "string"
-                        },
-                        "caption": {
-                            "type": "string"
-                        },
-                        "copyright": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "imageSources": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/ImageSource"
-                    }
-                },
-                "displayCredit": {
-                    "type": "boolean"
-                },
-                "role": {
-                    "$ref": "#/definitions/RoleType"
-                }
-            },
-            "required": ["_type", "data", "imageSources", "media", "role"]
-        },
-        "Image": {
-            "type": "object",
-            "properties": {
-                "index": {
-                    "type": "number"
-                },
-                "fields": {
-                    "type": "object",
-                    "properties": {
-                        "height": {
-                            "type": "string"
-                        },
-                        "width": {
-                            "type": "string"
-                        },
-                        "isMaster": {
-                            "type": "string"
-                        }
-                    },
-                    "required": ["height", "width"]
-                },
-                "mediaType": {
-                    "type": "string"
-                },
-                "mimeType": {
-                    "type": "string"
-                },
-                "url": {
-                    "type": "string"
-                }
-            },
-            "required": ["fields", "index", "mediaType", "mimeType", "url"]
-        },
-        "ImageSource": {
-            "type": "object",
-            "properties": {
-                "weighting": {
-                    "$ref": "#/definitions/Weighting"
-                },
-                "srcSet": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/SrcSetItem"
-                    }
-                }
-            },
-            "required": ["srcSet", "weighting"]
-        },
-        "SrcSetItem": {
-            "type": "object",
-            "properties": {
-                "src": {
-                    "type": "string"
-                },
-                "width": {
-                    "type": "number"
-                }
-            },
-            "required": ["src", "width"]
-        },
-        "RoleType": {
-            "enum": [
-                "halfWidth",
-                "immersive",
-                "inline",
-                "showcase",
-                "supporting",
-                "thumbnail"
-            ],
-            "type": "string"
-        },
-        "YoutubeBlockElement": {
-            "type": "object",
-            "properties": {
-                "_type": {
-                    "type": "string",
-                    "enum": [
-                        "model.dotcomrendering.pageElements.YoutubeBlockElement"
-                    ]
-                },
-                "assetId": {
-                    "type": "string"
-                },
-                "mediaTitle": {
-                    "type": "string"
                 },
                 "id": {
                     "type": "string"
                 },
-                "channelId": {
+                "html": {
+                    "type": "string"
+                },
+                "css": {
+                    "type": "string"
+                },
+                "js": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "_type"
+            ]
+        },
+        "AtomEmbedUrlBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.AtomEmbedUrlBlockElement"
+                    ]
+                },
+                "url": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "_type",
+                "url"
+            ]
+        },
+        "AudioAtomElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.AudioAtomBlockElement"
+                    ]
+                },
+                "id": {
+                    "type": "string"
+                },
+                "kicker": {
+                    "type": "string"
+                },
+                "trackUrl": {
                     "type": "string"
                 },
                 "duration": {
                     "type": "number"
                 },
-                "posterSrc": {
-                    "type": "string"
-                },
-                "height": {
-                    "type": "string"
-                },
-                "width": {
+                "coverUrl": {
                     "type": "string"
                 }
             },
-            "required": ["_type", "assetId", "mediaTitle"]
+            "required": [
+                "_type",
+                "coverUrl",
+                "duration",
+                "id",
+                "kicker",
+                "trackUrl"
+            ]
         },
-        "VideoYoutubeBlockElement": {
+        "AudioBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
                     "type": "string",
                     "enum": [
-                        "model.dotcomrendering.pageElements.VideoYoutubeBlockElement"
+                        "model.dotcomrendering.pageElements.AudioBlockElement"
                     ]
-                },
-                "url": {
-                    "type": "string"
-                },
-                "height": {
-                    "type": "number"
-                },
-                "width": {
-                    "type": "number"
-                },
-                "caption": {
-                    "type": "string"
                 }
             },
-            "required": ["_type", "caption", "height", "url", "width"]
+            "required": [
+                "_type"
+            ]
         },
-        "VideoVimeoBlockElement": {
+        "BlockquoteBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
                     "type": "string",
                     "enum": [
-                        "model.dotcomrendering.pageElements.VideoVimeoBlockElement"
-                    ]
-                },
-                "url": {
-                    "type": "string"
-                },
-                "height": {
-                    "type": "number"
-                },
-                "width": {
-                    "type": "number"
-                },
-                "caption": {
-                    "type": "string"
-                }
-            },
-            "required": ["_type", "caption", "height", "url", "width"]
-        },
-        "VideoFacebookBlockElement": {
-            "type": "object",
-            "properties": {
-                "_type": {
-                    "type": "string",
-                    "enum": [
-                        "model.dotcomrendering.pageElements.VideoFacebookBlockElement"
-                    ]
-                },
-                "url": {
-                    "type": "string"
-                },
-                "height": {
-                    "type": "number"
-                },
-                "width": {
-                    "type": "number"
-                },
-                "caption": {
-                    "type": "string"
-                }
-            },
-            "required": ["_type", "caption", "height", "url", "width"]
-        },
-        "VideoGuardian": {
-            "type": "object",
-            "properties": {
-                "_type": {
-                    "type": "string",
-                    "enum": [
-                        "model.dotcomrendering.pageElements.GuVideoBlockElement"
-                    ]
-                },
-                "assets": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/VideoAssets"
-                    }
-                },
-                "caption": {
-                    "type": "string"
-                }
-            },
-            "required": ["_type", "assets", "caption"]
-        },
-        "VideoAssets": {
-            "type": "object",
-            "properties": {
-                "url": {
-                    "type": "string"
-                },
-                "mimeType": {
-                    "type": "string"
-                }
-            },
-            "required": ["mimeType", "url"]
-        },
-        "InstagramBlockElement": {
-            "type": "object",
-            "properties": {
-                "_type": {
-                    "type": "string",
-                    "enum": [
-                        "model.dotcomrendering.pageElements.InstagramBlockElement"
+                        "model.dotcomrendering.pageElements.BlockquoteBlockElement"
                     ]
                 },
                 "html": {
                     "type": "string"
-                },
-                "url": {
-                    "type": "string"
-                },
-                "hasCaption": {
-                    "type": "boolean"
                 }
             },
-            "required": ["_type", "hasCaption", "html", "url"]
+            "required": [
+                "_type",
+                "html"
+            ]
         },
-        "TweetBlockElement": {
+        "CodeBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
                     "type": "string",
                     "enum": [
-                        "model.dotcomrendering.pageElements.TweetBlockElement"
+                        "model.dotcomrendering.pageElements.CodeBlockElement"
                     ]
                 },
-                "html": {
-                    "type": "string"
-                },
-                "url": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "hasMedia": {
+                "isMandatory": {
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "hasMedia", "html", "id", "url"]
+            "required": [
+                "_type",
+                "isMandatory"
+            ]
         },
         "CommentBlockElement": {
             "type": "object",
@@ -769,29 +522,73 @@
                 "profileURL"
             ]
         },
-        "SoundcloudBlockElement": {
+        "ContentAtomBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
                     "type": "string",
                     "enum": [
-                        "model.dotcomrendering.pageElements.SoundcloudBlockElement"
+                        "model.dotcomrendering.pageElements.ContentAtomBlockElement"
+                    ]
+                },
+                "atomId": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "_type",
+                "atomId"
+            ]
+        },
+        "DisclaimerBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.DisclaimerBlockElement"
                     ]
                 },
                 "html": {
                     "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "isTrack": {
-                    "type": "boolean"
+                }
+            },
+            "required": [
+                "_type",
+                "html"
+            ]
+        },
+        "DividerBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.DividerBlockElement"
+                    ]
+                }
+            },
+            "required": [
+                "_type"
+            ]
+        },
+        "DocumentBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.DocumentBlockElement"
+                    ]
                 },
                 "isMandatory": {
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "html", "id", "isMandatory", "isTrack"]
+            "required": [
+                "_type",
+                "isMandatory"
+            ]
         },
         "EmbedBlockElement": {
             "type": "object",
@@ -815,85 +612,11 @@
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "html", "isMandatory"]
-        },
-        "DisclaimerBlockElement": {
-            "type": "object",
-            "properties": {
-                "_type": {
-                    "type": "string",
-                    "enum": [
-                        "model.dotcomrendering.pageElements.DisclaimerBlockElement"
-                    ]
-                },
-                "html": {
-                    "type": "string"
-                }
-            },
-            "required": ["_type", "html"]
-        },
-        "PullquoteBlockElement": {
-            "type": "object",
-            "properties": {
-                "_type": {
-                    "type": "string",
-                    "enum": [
-                        "model.dotcomrendering.pageElements.PullquoteBlockElement"
-                    ]
-                },
-                "html": {
-                    "type": "string"
-                },
-                "role": {
-                    "type": "string"
-                },
-                "attribution": {
-                    "type": "string"
-                }
-            },
-            "required": ["_type", "html", "role"]
-        },
-        "BlockquoteBlockElement": {
-            "type": "object",
-            "properties": {
-                "_type": {
-                    "type": "string",
-                    "enum": [
-                        "model.dotcomrendering.pageElements.BlockquoteBlockElement"
-                    ]
-                },
-                "html": {
-                    "type": "string"
-                }
-            },
-            "required": ["_type", "html"]
-        },
-        "QABlockElement": {
-            "type": "object",
-            "properties": {
-                "_type": {
-                    "type": "string",
-                    "enum": [
-                        "model.dotcomrendering.pageElements.QABlockElement"
-                    ]
-                },
-                "id": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "img": {
-                    "type": "string"
-                },
-                "html": {
-                    "type": "string"
-                },
-                "credit": {
-                    "type": "string"
-                }
-            },
-            "required": ["_type", "credit", "html", "id", "title"]
+            "required": [
+                "_type",
+                "html",
+                "isMandatory"
+            ]
         },
         "GuideBlockElement": {
             "type": "object",
@@ -923,121 +646,238 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "credit", "html", "id", "label", "title"]
+            "required": [
+                "_type",
+                "credit",
+                "html",
+                "id",
+                "label",
+                "title"
+            ]
         },
-        "ProfileBlockElement": {
+        "GuVideoBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
                     "type": "string",
                     "enum": [
-                        "model.dotcomrendering.pageElements.ProfileBlockElement"
+                        "model.dotcomrendering.pageElements.GuVideoBlockElement"
                     ]
                 },
-                "id": {
-                    "type": "string"
-                },
-                "label": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "img": {
-                    "type": "string"
-                },
-                "html": {
-                    "type": "string"
-                },
-                "credit": {
-                    "type": "string"
-                }
-            },
-            "required": ["_type", "credit", "html", "id", "label", "title"]
-        },
-        "TimelineBlockElement": {
-            "type": "object",
-            "properties": {
-                "_type": {
-                    "type": "string",
-                    "enum": [
-                        "model.dotcomrendering.pageElements.TimelineBlockElement"
-                    ]
-                },
-                "id": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "events": {
+                "assets": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/TimelineEvent"
+                        "$ref": "#/definitions/VideoAssets"
                     }
+                },
+                "caption": {
+                    "type": "string"
                 }
             },
-            "required": ["_type", "events", "id", "title"]
+            "required": [
+                "_type",
+                "assets",
+                "caption"
+            ]
         },
-        "TimelineEvent": {
+        "VideoAssets": {
             "type": "object",
             "properties": {
-                "title": {
+                "url": {
                     "type": "string"
                 },
-                "date": {
-                    "type": "string"
-                },
-                "body": {
-                    "type": "string"
-                },
-                "toDate": {
+                "mimeType": {
                     "type": "string"
                 }
             },
-            "required": ["date", "title"]
+            "required": [
+                "mimeType",
+                "url"
+            ]
         },
-        "AtomEmbedMarkupBlockElement": {
-            "type": "object",
-            "properties": {
-                "_type": {
-                    "type": "string",
-                    "enum": [
-                        "model.dotcomrendering.pageElements.AtomEmbedMarkupBlockElement"
-                    ]
-                },
-                "id": {
-                    "type": "string"
-                },
-                "html": {
-                    "type": "string"
-                },
-                "css": {
-                    "type": "string"
-                },
-                "js": {
-                    "type": "string"
-                }
-            },
-            "required": ["_type"]
-        },
-        "AtomEmbedUrlBlockElement": {
+        "ImageBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
                     "type": "string",
                     "enum": [
-                        "model.dotcomrendering.pageElements.AtomEmbedUrlBlockElement"
+                        "model.dotcomrendering.pageElements.ImageBlockElement"
                     ]
+                },
+                "media": {
+                    "type": "object",
+                    "properties": {
+                        "allImages": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Image"
+                            }
+                        }
+                    },
+                    "required": [
+                        "allImages"
+                    ]
+                },
+                "data": {
+                    "type": "object",
+                    "properties": {
+                        "alt": {
+                            "type": "string"
+                        },
+                        "credit": {
+                            "type": "string"
+                        },
+                        "caption": {
+                            "type": "string"
+                        },
+                        "copyright": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "imageSources": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ImageSource"
+                    }
+                },
+                "displayCredit": {
+                    "type": "boolean"
+                },
+                "role": {
+                    "$ref": "#/definitions/RoleType"
+                }
+            },
+            "required": [
+                "_type",
+                "data",
+                "imageSources",
+                "media",
+                "role"
+            ]
+        },
+        "Image": {
+            "type": "object",
+            "properties": {
+                "index": {
+                    "type": "number"
+                },
+                "fields": {
+                    "type": "object",
+                    "properties": {
+                        "height": {
+                            "type": "string"
+                        },
+                        "width": {
+                            "type": "string"
+                        },
+                        "isMaster": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "height",
+                        "width"
+                    ]
+                },
+                "mediaType": {
+                    "type": "string"
+                },
+                "mimeType": {
+                    "type": "string"
                 },
                 "url": {
                     "type": "string"
                 }
             },
-            "required": ["_type", "url"]
+            "required": [
+                "fields",
+                "index",
+                "mediaType",
+                "mimeType",
+                "url"
+            ]
+        },
+        "ImageSource": {
+            "type": "object",
+            "properties": {
+                "weighting": {
+                    "$ref": "#/definitions/Weighting"
+                },
+                "srcSet": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/SrcSetItem"
+                    }
+                }
+            },
+            "required": [
+                "srcSet",
+                "weighting"
+            ]
+        },
+        "Weighting": {
+            "enum": [
+                "halfwidth",
+                "immersive",
+                "inline",
+                "showcase",
+                "supporting",
+                "thumbnail"
+            ],
+            "type": "string"
+        },
+        "SrcSetItem": {
+            "type": "object",
+            "properties": {
+                "src": {
+                    "type": "string"
+                },
+                "width": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "src",
+                "width"
+            ]
+        },
+        "RoleType": {
+            "enum": [
+                "halfWidth",
+                "immersive",
+                "inline",
+                "showcase",
+                "supporting",
+                "thumbnail"
+            ],
+            "type": "string"
+        },
+        "InstagramBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.InstagramBlockElement"
+                    ]
+                },
+                "html": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "hasCaption": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "_type",
+                "hasCaption",
+                "html",
+                "url"
+            ]
         },
         "MapBlockElement": {
             "type": "object",
@@ -1073,108 +913,204 @@
                 "url"
             ]
         },
-        "AudioAtomElement": {
+        "MultiImageBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
                     "type": "string",
                     "enum": [
-                        "model.dotcomrendering.pageElements.AudioAtomBlockElement"
+                        "model.dotcomrendering.pageElements.MultiImageBlockElement"
                     ]
                 },
-                "id": {
-                    "type": "string"
+                "images": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ImageBlockElement"
+                    }
                 },
-                "kicker": {
-                    "type": "string"
-                },
-                "trackUrl": {
-                    "type": "string"
-                },
-                "duration": {
-                    "type": "number"
-                },
-                "coverUrl": {
+                "caption": {
                     "type": "string"
                 }
             },
             "required": [
                 "_type",
-                "coverUrl",
-                "duration",
-                "id",
-                "kicker",
-                "trackUrl"
+                "images"
             ]
         },
-        "ContentAtomBlockElement": {
+        "ProfileBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
                     "type": "string",
                     "enum": [
-                        "model.dotcomrendering.pageElements.ContentAtomBlockElement"
+                        "model.dotcomrendering.pageElements.ProfileBlockElement"
                     ]
                 },
-                "atomId": {
+                "id": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "img": {
+                    "type": "string"
+                },
+                "html": {
+                    "type": "string"
+                },
+                "credit": {
                     "type": "string"
                 }
             },
-            "required": ["_type", "atomId"]
+            "required": [
+                "_type",
+                "credit",
+                "html",
+                "id",
+                "label",
+                "title"
+            ]
         },
-        "AudioBlockElement": {
+        "PullquoteBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
                     "type": "string",
                     "enum": [
-                        "model.dotcomrendering.pageElements.AudioBlockElement"
+                        "model.dotcomrendering.pageElements.PullquoteBlockElement"
                     ]
+                },
+                "html": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string"
+                },
+                "attribution": {
+                    "type": "string"
                 }
             },
-            "required": ["_type"]
+            "required": [
+                "_type",
+                "html",
+                "role"
+            ]
         },
-        "VideoBlockElement": {
+        "QABlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
                     "type": "string",
                     "enum": [
-                        "model.dotcomrendering.pageElements.VideoBlockElement"
+                        "model.dotcomrendering.pageElements.QABlockElement"
                     ]
+                },
+                "id": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "img": {
+                    "type": "string"
+                },
+                "html": {
+                    "type": "string"
+                },
+                "credit": {
+                    "type": "string"
                 }
             },
-            "required": ["_type"]
+            "required": [
+                "_type",
+                "credit",
+                "html",
+                "id",
+                "title"
+            ]
         },
-        "CodeBlockElement": {
+        "RichLinkBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
                     "type": "string",
                     "enum": [
-                        "model.dotcomrendering.pageElements.CodeBlockElement"
+                        "model.dotcomrendering.pageElements.RichLinkBlockElement"
                     ]
+                },
+                "url": {
+                    "type": "string"
+                },
+                "text": {
+                    "type": "string"
+                },
+                "prefix": {
+                    "type": "string"
+                },
+                "role": {
+                    "$ref": "#/definitions/Weighting"
+                },
+                "richLinkIndex": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "_type",
+                "prefix",
+                "text",
+                "url"
+            ]
+        },
+        "SoundcloudBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.SoundcloudBlockElement"
+                    ]
+                },
+                "html": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "isTrack": {
+                    "type": "boolean"
                 },
                 "isMandatory": {
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "isMandatory"]
+            "required": [
+                "_type",
+                "html",
+                "id",
+                "isMandatory",
+                "isTrack"
+            ]
         },
-        "DocumentBlockElement": {
+        "SubheadingBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
                     "type": "string",
                     "enum": [
-                        "model.dotcomrendering.pageElements.DocumentBlockElement"
+                        "model.dotcomrendering.pageElements.SubheadingBlockElement"
                     ]
                 },
-                "isMandatory": {
-                    "type": "boolean"
+                "html": {
+                    "type": "string"
                 }
             },
-            "required": ["_type", "isMandatory"]
+            "required": [
+                "_type",
+                "html"
+            ]
         },
         "TableBlockElement": {
             "type": "object",
@@ -1189,19 +1125,258 @@
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "isMandatory"]
+            "required": [
+                "_type",
+                "isMandatory"
+            ]
         },
-        "DividerBlockElement": {
+        "TextBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
                     "type": "string",
                     "enum": [
-                        "model.dotcomrendering.pageElements.DividerBlockElement"
+                        "model.dotcomrendering.pageElements.TextBlockElement"
+                    ]
+                },
+                "dropCap": {
+                    "type": "boolean"
+                },
+                "html": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "_type",
+                "html"
+            ]
+        },
+        "TimelineBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.TimelineBlockElement"
+                    ]
+                },
+                "id": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "events": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/TimelineEvent"
+                    }
+                }
+            },
+            "required": [
+                "_type",
+                "events",
+                "id",
+                "title"
+            ]
+        },
+        "TimelineEvent": {
+            "type": "object",
+            "properties": {
+                "title": {
+                    "type": "string"
+                },
+                "date": {
+                    "type": "string"
+                },
+                "body": {
+                    "type": "string"
+                },
+                "toDate": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "date",
+                "title"
+            ]
+        },
+        "TweetBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.TweetBlockElement"
+                    ]
+                },
+                "html": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "hasMedia": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "_type",
+                "hasMedia",
+                "html",
+                "id",
+                "url"
+            ]
+        },
+        "VideoBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.VideoBlockElement"
                     ]
                 }
             },
-            "required": ["_type"]
+            "required": [
+                "_type"
+            ]
+        },
+        "VideoFacebookBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.VideoFacebookBlockElement"
+                    ]
+                },
+                "url": {
+                    "type": "string"
+                },
+                "height": {
+                    "type": "number"
+                },
+                "width": {
+                    "type": "number"
+                },
+                "caption": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "_type",
+                "caption",
+                "height",
+                "url",
+                "width"
+            ]
+        },
+        "VideoVimeoBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.VideoVimeoBlockElement"
+                    ]
+                },
+                "url": {
+                    "type": "string"
+                },
+                "height": {
+                    "type": "number"
+                },
+                "width": {
+                    "type": "number"
+                },
+                "caption": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "_type",
+                "caption",
+                "height",
+                "url",
+                "width"
+            ]
+        },
+        "VideoYoutubeBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.VideoYoutubeBlockElement"
+                    ]
+                },
+                "url": {
+                    "type": "string"
+                },
+                "height": {
+                    "type": "number"
+                },
+                "width": {
+                    "type": "number"
+                },
+                "caption": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "_type",
+                "caption",
+                "height",
+                "url",
+                "width"
+            ]
+        },
+        "YoutubeBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.YoutubeBlockElement"
+                    ]
+                },
+                "assetId": {
+                    "type": "string"
+                },
+                "mediaTitle": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "channelId": {
+                    "type": "string"
+                },
+                "duration": {
+                    "type": "number"
+                },
+                "posterSrc": {
+                    "type": "string"
+                },
+                "height": {
+                    "type": "string"
+                },
+                "width": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "_type",
+                "assetId",
+                "mediaTitle"
+            ]
         },
         "Block": {
             "type": "object",
@@ -1214,100 +1389,103 @@
                     "items": {
                         "anyOf": [
                             {
-                                "$ref": "#/definitions/TextBlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/SubheadingBlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/RichLinkBlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/ImageBlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/YoutubeBlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/VideoYoutubeBlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/VideoVimeoBlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/VideoFacebookBlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/VideoGuardian"
-                            },
-                            {
-                                "$ref": "#/definitions/InstagramBlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/TweetBlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/CommentBlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/SoundcloudBlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/EmbedBlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/DisclaimerBlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/PullquoteBlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/BlockquoteBlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/QABlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/GuideBlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/ProfileBlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/TimelineBlockElement"
-                            },
-                            {
                                 "$ref": "#/definitions/AtomEmbedMarkupBlockElement"
                             },
                             {
                                 "$ref": "#/definitions/AtomEmbedUrlBlockElement"
                             },
                             {
-                                "$ref": "#/definitions/MapBlockElement"
-                            },
-                            {
                                 "$ref": "#/definitions/AudioAtomElement"
-                            },
-                            {
-                                "$ref": "#/definitions/ContentAtomBlockElement"
                             },
                             {
                                 "$ref": "#/definitions/AudioBlockElement"
                             },
                             {
-                                "$ref": "#/definitions/VideoBlockElement"
+                                "$ref": "#/definitions/BlockquoteBlockElement"
                             },
                             {
                                 "$ref": "#/definitions/CodeBlockElement"
                             },
                             {
+                                "$ref": "#/definitions/CommentBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/ContentAtomBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/DisclaimerBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/DividerBlockElement"
+                            },
+                            {
                                 "$ref": "#/definitions/DocumentBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/EmbedBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/GuideBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/GuVideoBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/ImageBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/InstagramBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/MapBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/MultiImageBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/ProfileBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/PullquoteBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/QABlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/RichLinkBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/SoundcloudBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/SubheadingBlockElement"
                             },
                             {
                                 "$ref": "#/definitions/TableBlockElement"
                             },
                             {
-                                "$ref": "#/definitions/DividerBlockElement"
+                                "$ref": "#/definitions/TextBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/TimelineBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/TweetBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/VideoBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/VideoFacebookBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/VideoVimeoBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/VideoYoutubeBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/YoutubeBlockElement"
                             }
                         ]
                     }
@@ -1334,7 +1512,10 @@
                     "type": "string"
                 }
             },
-            "required": ["elements", "id"]
+            "required": [
+                "elements",
+                "id"
+            ]
         },
         "Pagination": {
             "type": "object",
@@ -1358,7 +1539,10 @@
                     "type": "string"
                 }
             },
-            "required": ["currentPage", "totalPages"]
+            "required": [
+                "currentPage",
+                "totalPages"
+            ]
         },
         "AuthorType": {
             "type": "object",
@@ -1375,7 +1559,12 @@
             }
         },
         "Edition": {
-            "enum": ["AU", "INT", "UK", "US"],
+            "enum": [
+                "AU",
+                "INT",
+                "UK",
+                "US"
+            ],
             "type": "string"
         },
         "TagType": {
@@ -1400,7 +1589,11 @@
                     "type": "string"
                 }
             },
-            "required": ["id", "title", "type"]
+            "required": [
+                "id",
+                "title",
+                "type"
+            ]
         },
         "Pillar": {
             "enum": [
@@ -1423,7 +1616,10 @@
                     "type": "string"
                 }
             },
-            "required": ["title", "url"]
+            "required": [
+                "title",
+                "url"
+            ]
         },
         "ConfigType": {
             "description": "the config model will contain useful app/site\nlevel data. Although currently derived from the config model\nconstructed in frontend and passed to dotcom-rendering\nthis data could eventually be defined in dotcom-rendering",
@@ -1622,7 +1818,12 @@
                     "$ref": "#/definitions/EditionCommercialProperties"
                 }
             },
-            "required": ["AU", "INT", "UK", "US"]
+            "required": [
+                "AU",
+                "INT",
+                "UK",
+                "US"
+            ]
         },
         "EditionCommercialProperties": {
             "type": "object",
@@ -1637,7 +1838,9 @@
                     "$ref": "#/definitions/Branding"
                 }
             },
-            "required": ["adTargeting"]
+            "required": [
+                "adTargeting"
+            ]
         },
         "AdTargetParam": {
             "type": "object",
@@ -1659,7 +1862,10 @@
                     ]
                 }
             },
-            "required": ["name", "value"]
+            "required": [
+                "name",
+                "value"
+            ]
         },
         "Branding": {
             "type": "object",
@@ -1671,7 +1877,9 @@
                             "type": "string"
                         }
                     },
-                    "required": ["name"]
+                    "required": [
+                        "name"
+                    ]
                 },
                 "sponsorName": {
                     "type": "string"
@@ -1698,10 +1906,18 @@
                                     "type": "number"
                                 }
                             },
-                            "required": ["height", "width"]
+                            "required": [
+                                "height",
+                                "width"
+                            ]
                         }
                     },
-                    "required": ["dimensions", "label", "link", "src"]
+                    "required": [
+                        "dimensions",
+                        "label",
+                        "link",
+                        "src"
+                    ]
                 },
                 "aboutThisLink": {
                     "type": "string"
@@ -1722,7 +1938,10 @@
                                     "type": "number"
                                 }
                             },
-                            "required": ["height", "width"]
+                            "required": [
+                                "height",
+                                "width"
+                            ]
                         },
                         "link": {
                             "type": "string"
@@ -1731,10 +1950,19 @@
                             "type": "string"
                         }
                     },
-                    "required": ["dimensions", "label", "link", "src"]
+                    "required": [
+                        "dimensions",
+                        "label",
+                        "link",
+                        "src"
+                    ]
                 }
             },
-            "required": ["aboutThisLink", "logo", "sponsorName"]
+            "required": [
+                "aboutThisLink",
+                "logo",
+                "sponsorName"
+            ]
         },
         "BadgeType": {
             "type": "object",
@@ -1746,7 +1974,10 @@
                     "type": "string"
                 }
             },
-            "required": ["imageUrl", "seriesTag"]
+            "required": [
+                "imageUrl",
+                "seriesTag"
+            ]
         },
         "FooterType": {
             "type": "object",
@@ -1761,7 +1992,9 @@
                     }
                 }
             },
-            "required": ["footerLinks"]
+            "required": [
+                "footerLinks"
+            ]
         },
         "FooterLink": {
             "type": "object",
@@ -1779,7 +2012,11 @@
                     "type": "string"
                 }
             },
-            "required": ["dataLinkName", "text", "url"]
+            "required": [
+                "dataLinkName",
+                "text",
+                "url"
+            ]
         }
     },
     "$schema": "http://json-schema.org/draft-07/schema#"

--- a/src/web/components/elements/ImageComponent.tsx
+++ b/src/web/components/elements/ImageComponent.tsx
@@ -213,6 +213,11 @@ export const ImageComponent = ({
             <div
                 className={css`
                     position: relative;
+
+                    img {
+                        width: 100%;
+                        object-fit: cover;
+                    }
                 `}
             >
                 <Picture
@@ -229,6 +234,11 @@ export const ImageComponent = ({
             <div
                 className={css`
                     position: relative;
+
+                    img {
+                        width: 100%;
+                        object-fit: cover;
+                    }
                 `}
             >
                 <Picture

--- a/src/web/components/elements/MultiImageBlockComponent.mocks.tsx
+++ b/src/web/components/elements/MultiImageBlockComponent.mocks.tsx
@@ -1,0 +1,1546 @@
+export const fourImages: ImageBlockElement[] = [
+    {
+        role: 'halfWidth',
+        data: {
+            copyright: '© Tommy Trenchard / Greenpeace',
+            alt:
+                'Greenpeace’s ship Arctic Sunrise hits a wave during rough weather in the South Atlantic.',
+            caption:
+                'Greenpeace’s ship Arctic Sunrise hits a wave during rough weather in the South Atlantic.',
+            credit: 'Photograph: Tommy Trenchard/Greenpeace',
+        },
+        imageSources: [
+            {
+                weighting: 'inline',
+                srcSet: [
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=f70dd057eabb09a74239f51650641c4a',
+                        width: 620,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=d492338bc4d1b857a33a7d6998e58d55',
+                        width: 1240,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=9ffe0420cf6b7a25d9fcf83066e49537',
+                        width: 605,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=c867fb62ad1a7a0e51483037f5081fc2',
+                        width: 1210,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=6f4393bb49787a9f09014f0d73f35e53',
+                        width: 445,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=3c545ae4299d83a325aa5935ebfbce11',
+                        width: 890,
+                    },
+                ],
+            },
+            {
+                weighting: 'thumbnail',
+                srcSet: [
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=140&quality=85&auto=format&fit=max&s=17a69e8ac10312b57ee185e7b5c12b06',
+                        width: 140,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=d81dd269cfa7c30e61beeaa746868972',
+                        width: 280,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=120&quality=85&auto=format&fit=max&s=bc634c596641d789f5f48dd55c8177ae',
+                        width: 120,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=33fed56e309ce3dc48241b9e511811aa',
+                        width: 240,
+                    },
+                ],
+            },
+            {
+                weighting: 'supporting',
+                srcSet: [
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=380&quality=85&auto=format&fit=max&s=783257361864e3d3a0f24dadd43ba2c8',
+                        width: 380,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=92ff97fd43ab1f8c8b0e70833028718e',
+                        width: 760,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=300&quality=85&auto=format&fit=max&s=3e52dbd6bcc1b013003e6c1995b7bb91',
+                        width: 300,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=850629dd089c10958c9b8e82c1e39c9f',
+                        width: 600,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=f70dd057eabb09a74239f51650641c4a',
+                        width: 620,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=d492338bc4d1b857a33a7d6998e58d55',
+                        width: 1240,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=9ffe0420cf6b7a25d9fcf83066e49537',
+                        width: 605,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=c867fb62ad1a7a0e51483037f5081fc2',
+                        width: 1210,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=6f4393bb49787a9f09014f0d73f35e53',
+                        width: 445,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=3c545ae4299d83a325aa5935ebfbce11',
+                        width: 890,
+                    },
+                ],
+            },
+            {
+                weighting: 'showcase',
+                srcSet: [
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=1020&quality=85&auto=format&fit=max&s=624a76f3dc9a7695e138c67610633b45',
+                        width: 1020,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=1020&quality=45&auto=format&fit=max&dpr=2&s=f85de213c16f04387749d64c9afacd5a',
+                        width: 2040,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=940&quality=85&auto=format&fit=max&s=05ed80bb6e20fa018504bb702e75218d',
+                        width: 940,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=940&quality=45&auto=format&fit=max&dpr=2&s=9dc3d27211b8be5f92defb9b912e6c81',
+                        width: 1880,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=d8bcdf73ed74f16258ecdb92400ef2c0',
+                        width: 700,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=fde8b72a040ceefcbb5ed6399a259b76',
+                        width: 1400,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=d8bcdf73ed74f16258ecdb92400ef2c0',
+                        width: 700,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=fde8b72a040ceefcbb5ed6399a259b76',
+                        width: 1400,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=660&quality=85&auto=format&fit=max&s=0879bc44ac2be63a38ced704a0604514',
+                        width: 660,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=660&quality=45&auto=format&fit=max&dpr=2&s=2090ed6fb990e98d1f87ca526353942b',
+                        width: 1320,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=fdea12cbfc6379ce2ea9c8ca6e7d2c1b',
+                        width: 645,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=482fd54191d45fe1fe775f1296b094b6',
+                        width: 1290,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=afb1030bad54d5114b7b8c3a83fb546a',
+                        width: 465,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=f4a89c4a74f00e29b2777b8a0c24a542',
+                        width: 930,
+                    },
+                ],
+            },
+            {
+                weighting: 'halfwidth',
+                srcSet: [
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=f70dd057eabb09a74239f51650641c4a',
+                        width: 620,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=d492338bc4d1b857a33a7d6998e58d55',
+                        width: 1240,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=9ffe0420cf6b7a25d9fcf83066e49537',
+                        width: 605,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=c867fb62ad1a7a0e51483037f5081fc2',
+                        width: 1210,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=6f4393bb49787a9f09014f0d73f35e53',
+                        width: 445,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=3c545ae4299d83a325aa5935ebfbce11',
+                        width: 890,
+                    },
+                ],
+            },
+            {
+                weighting: 'immersive',
+                srcSet: [
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=1300&quality=85&auto=format&fit=max&s=58e079130c99df397eefb44cd631e5fd',
+                        width: 1300,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=1300&quality=45&auto=format&fit=max&dpr=2&s=13eadd8a324cd00b82ed99e653637c64',
+                        width: 2600,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=1140&quality=85&auto=format&fit=max&s=634a10dc8c7eac24404f019342f32386',
+                        width: 1140,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=1140&quality=45&auto=format&fit=max&dpr=2&s=f6cfb13dfaaaba727ac380d48506e004',
+                        width: 2280,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=1125&quality=85&auto=format&fit=max&s=117d630bad3656bcb8644b79a51713eb',
+                        width: 1125,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=1125&quality=45&auto=format&fit=max&dpr=2&s=29a1a3e8a5b4932f2437cd608fc68b00',
+                        width: 2250,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=965&quality=85&auto=format&fit=max&s=ab81ffc4bb069288d0d031fee9f91dab',
+                        width: 965,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=965&quality=45&auto=format&fit=max&dpr=2&s=1e8031c855c745ef928b3355f831b126',
+                        width: 1930,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=725&quality=85&auto=format&fit=max&s=c11e7a2e1b27f1da9efe176edfccd2b5',
+                        width: 725,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=725&quality=45&auto=format&fit=max&dpr=2&s=e2630fb3eaab5df471b4577a08dbffeb',
+                        width: 1450,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=fdea12cbfc6379ce2ea9c8ca6e7d2c1b',
+                        width: 645,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=482fd54191d45fe1fe775f1296b094b6',
+                        width: 1290,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=afb1030bad54d5114b7b8c3a83fb546a',
+                        width: 465,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=f4a89c4a74f00e29b2777b8a0c24a542',
+                        width: 930,
+                    },
+                ],
+            },
+        ],
+        _type: 'model.dotcomrendering.pageElements.ImageBlockElement',
+        media: {
+            allImages: [
+                {
+                    index: 0,
+                    fields: {
+                        height: '1667',
+                        width: '2500',
+                    },
+                    mediaType: 'Image',
+                    mimeType: 'image/jpeg',
+                    url:
+                        'https://media.guim.co.uk/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/2500.jpg',
+                },
+                {
+                    index: 1,
+                    fields: {
+                        isMaster: 'true',
+                        height: '1667',
+                        width: '2500',
+                    },
+                    mediaType: 'Image',
+                    mimeType: 'image/jpeg',
+                    url:
+                        'https://media.guim.co.uk/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg',
+                },
+                {
+                    index: 2,
+                    fields: {
+                        height: '1334',
+                        width: '2000',
+                    },
+                    mediaType: 'Image',
+                    mimeType: 'image/jpeg',
+                    url:
+                        'https://media.guim.co.uk/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/2000.jpg',
+                },
+                {
+                    index: 3,
+                    fields: {
+                        height: '667',
+                        width: '1000',
+                    },
+                    mediaType: 'Image',
+                    mimeType: 'image/jpeg',
+                    url:
+                        'https://media.guim.co.uk/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/1000.jpg',
+                },
+                {
+                    index: 4,
+                    fields: {
+                        height: '333',
+                        width: '500',
+                    },
+                    mediaType: 'Image',
+                    mimeType: 'image/jpeg',
+                    url:
+                        'https://media.guim.co.uk/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/500.jpg',
+                },
+                {
+                    index: 5,
+                    fields: {
+                        height: '93',
+                        width: '140',
+                    },
+                    mediaType: 'Image',
+                    mimeType: 'image/jpeg',
+                    url:
+                        'https://media.guim.co.uk/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/140.jpg',
+                },
+            ],
+        },
+        displayCredit: true,
+    },
+    {
+        role: 'halfWidth',
+        data: {
+            copyright: '© Tommy Trenchard / Greenpeace',
+            alt:
+                'A vessel is seen on the radar of the Arctic Sunrise in the mid-Atlantic ocean.',
+            caption:
+                'A vessel is seen on the radar of the Arctic Sunrise in the mid-Atlantic ocean.',
+            credit: 'Photograph: Tommy Trenchard/Greenpeace',
+        },
+        imageSources: [
+            {
+                weighting: 'inline',
+                srcSet: [
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=1a1f41e93103d8f80ed96f1877cce8dd',
+                        width: 620,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=dd1a14ee43f584cfb502c871f78dcf3d',
+                        width: 1240,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=b39f8587f6de6b4882a266402b1de4fb',
+                        width: 605,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=5085ead125476d718c3b99ee8313fb3a',
+                        width: 1210,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=30b4094e41b17742d7d07b4d1942628d',
+                        width: 445,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=f5fa0b0a01a2ec6ffa214d1d979dcb36',
+                        width: 890,
+                    },
+                ],
+            },
+            {
+                weighting: 'thumbnail',
+                srcSet: [
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=140&quality=85&auto=format&fit=max&s=333a3a3814133344842bd07cf1e485f8',
+                        width: 140,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=1f60425205116b265ab692893a4da2bc',
+                        width: 280,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=120&quality=85&auto=format&fit=max&s=d4101e6e70f05ea73fc3956ab9d57633',
+                        width: 120,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=7b5db9389171ea20d54214ee34483f99',
+                        width: 240,
+                    },
+                ],
+            },
+            {
+                weighting: 'supporting',
+                srcSet: [
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=380&quality=85&auto=format&fit=max&s=1464287ceb0e09ea17729a89d973e42b',
+                        width: 380,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=d3eed1a4664033931edd676ededb9a3a',
+                        width: 760,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=300&quality=85&auto=format&fit=max&s=4368ad1138f4f2cb441c2e90319f4d42',
+                        width: 300,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=284b97a79d5485f99224a0f4d4ec6cf2',
+                        width: 600,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=1a1f41e93103d8f80ed96f1877cce8dd',
+                        width: 620,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=dd1a14ee43f584cfb502c871f78dcf3d',
+                        width: 1240,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=b39f8587f6de6b4882a266402b1de4fb',
+                        width: 605,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=5085ead125476d718c3b99ee8313fb3a',
+                        width: 1210,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=30b4094e41b17742d7d07b4d1942628d',
+                        width: 445,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=f5fa0b0a01a2ec6ffa214d1d979dcb36',
+                        width: 890,
+                    },
+                ],
+            },
+            {
+                weighting: 'showcase',
+                srcSet: [
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=1020&quality=85&auto=format&fit=max&s=a46a52f554db0e2e76170611240ce230',
+                        width: 1020,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=1020&quality=45&auto=format&fit=max&dpr=2&s=be848e3f9a6a4d104e590bc9bdc04d5d',
+                        width: 2040,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=940&quality=85&auto=format&fit=max&s=e7abe49fa4d52320be12e03e2a6afb06',
+                        width: 940,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=940&quality=45&auto=format&fit=max&dpr=2&s=8bd0c605e5bdc1af557a768500864187',
+                        width: 1880,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=3a452c9a5c3d2b313ae33506cf44961e',
+                        width: 700,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=69a79d5f3ee45439ab224208620433c9',
+                        width: 1400,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=3a452c9a5c3d2b313ae33506cf44961e',
+                        width: 700,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=69a79d5f3ee45439ab224208620433c9',
+                        width: 1400,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=660&quality=85&auto=format&fit=max&s=c035d9a260e7607443983cf093a732ad',
+                        width: 660,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=660&quality=45&auto=format&fit=max&dpr=2&s=f8e81ab0fa3af51301556780dc925a6b',
+                        width: 1320,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=f45d48bbb50e99b69db54da172d693de',
+                        width: 645,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=d1aecf02f0884aa6b462da3e292ae08c',
+                        width: 1290,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=20976fe36bdd6c7c994467081cc9854a',
+                        width: 465,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=f327ef15b32559eba8f849c0a4984eeb',
+                        width: 930,
+                    },
+                ],
+            },
+            {
+                weighting: 'halfwidth',
+                srcSet: [
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=1a1f41e93103d8f80ed96f1877cce8dd',
+                        width: 620,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=dd1a14ee43f584cfb502c871f78dcf3d',
+                        width: 1240,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=b39f8587f6de6b4882a266402b1de4fb',
+                        width: 605,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=5085ead125476d718c3b99ee8313fb3a',
+                        width: 1210,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=30b4094e41b17742d7d07b4d1942628d',
+                        width: 445,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=f5fa0b0a01a2ec6ffa214d1d979dcb36',
+                        width: 890,
+                    },
+                ],
+            },
+            {
+                weighting: 'immersive',
+                srcSet: [
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=1300&quality=85&auto=format&fit=max&s=e908ee2e8a1fb639ba7795933b6b7166',
+                        width: 1300,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=1300&quality=45&auto=format&fit=max&dpr=2&s=955ff64ffa266c77ee04a75142c445f2',
+                        width: 2600,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=1140&quality=85&auto=format&fit=max&s=dbf50cddd4b86f8da4d280b7907c378e',
+                        width: 1140,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=1140&quality=45&auto=format&fit=max&dpr=2&s=5bebfcbd7f07943acf283b6157e8eb0f',
+                        width: 2280,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=1125&quality=85&auto=format&fit=max&s=e523903e7e8ad2e51b053433eb2e4c43',
+                        width: 1125,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=1125&quality=45&auto=format&fit=max&dpr=2&s=0bfd26e45abb4232fb0a5f5bad03f1a8',
+                        width: 2250,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=965&quality=85&auto=format&fit=max&s=1007564a1513aef7346e3719c088dcbd',
+                        width: 965,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=965&quality=45&auto=format&fit=max&dpr=2&s=9c5d6595d96009b575cae135077df95b',
+                        width: 1930,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=725&quality=85&auto=format&fit=max&s=b9e6445791d64e48014a24c4b5fbe4d8',
+                        width: 725,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=725&quality=45&auto=format&fit=max&dpr=2&s=dbd6d4625d12373074b7ee71735195a9',
+                        width: 1450,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=f45d48bbb50e99b69db54da172d693de',
+                        width: 645,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=d1aecf02f0884aa6b462da3e292ae08c',
+                        width: 1290,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=20976fe36bdd6c7c994467081cc9854a',
+                        width: 465,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=f327ef15b32559eba8f849c0a4984eeb',
+                        width: 930,
+                    },
+                ],
+            },
+        ],
+        _type: 'model.dotcomrendering.pageElements.ImageBlockElement',
+        media: {
+            allImages: [
+                {
+                    index: 0,
+                    fields: {
+                        height: '1667',
+                        width: '2500',
+                    },
+                    mediaType: 'Image',
+                    mimeType: 'image/jpeg',
+                    url:
+                        'https://media.guim.co.uk/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/2500.jpg',
+                },
+                {
+                    index: 1,
+                    fields: {
+                        isMaster: 'true',
+                        height: '1667',
+                        width: '2500',
+                    },
+                    mediaType: 'Image',
+                    mimeType: 'image/jpeg',
+                    url:
+                        'https://media.guim.co.uk/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg',
+                },
+                {
+                    index: 2,
+                    fields: {
+                        height: '1334',
+                        width: '2000',
+                    },
+                    mediaType: 'Image',
+                    mimeType: 'image/jpeg',
+                    url:
+                        'https://media.guim.co.uk/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/2000.jpg',
+                },
+                {
+                    index: 3,
+                    fields: {
+                        height: '667',
+                        width: '1000',
+                    },
+                    mediaType: 'Image',
+                    mimeType: 'image/jpeg',
+                    url:
+                        'https://media.guim.co.uk/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/1000.jpg',
+                },
+                {
+                    index: 4,
+                    fields: {
+                        height: '333',
+                        width: '500',
+                    },
+                    mediaType: 'Image',
+                    mimeType: 'image/jpeg',
+                    url:
+                        'https://media.guim.co.uk/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/500.jpg',
+                },
+                {
+                    index: 5,
+                    fields: {
+                        height: '93',
+                        width: '140',
+                    },
+                    mediaType: 'Image',
+                    mimeType: 'image/jpeg',
+                    url:
+                        'https://media.guim.co.uk/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/140.jpg',
+                },
+            ],
+        },
+        displayCredit: true,
+    },
+    {
+        role: 'halfWidth',
+        data: {
+            copyright: '© Tommy Trenchard / Greenpeace',
+            alt:
+                'Second mate Helena De Carlos Watts and investigator Sophie Cooke watch the radar screen as the Arctic Sunrise approaches a vessel in the southern Atlantic Ocean.',
+            caption:
+                'Second mate Helena De Carlos Watts and investigator Sophie Cooke watch the radar screen as the Arctic Sunrise approaches a vessel in the southern Atlantic Ocean.',
+            credit: 'Photograph: Tommy Trenchard/Greenpeace',
+        },
+        imageSources: [
+            {
+                weighting: 'inline',
+                srcSet: [
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=48e15d5d34cdf2677030c6349c4a6bf2',
+                        width: 620,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=a95ecd11817238d37fd9bbbd5b8ee70e',
+                        width: 1240,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=40432b37fa1c7e4907d202078a496d15',
+                        width: 605,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=07cb72515ee014a5f6951cca0d71b631',
+                        width: 1210,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=3d194971fbccd3692587cc844457254b',
+                        width: 445,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=bba08a4952a4b24f4c85b702dea4b534',
+                        width: 890,
+                    },
+                ],
+            },
+            {
+                weighting: 'thumbnail',
+                srcSet: [
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=140&quality=85&auto=format&fit=max&s=05ce8b8c9f83ba188b134aa1621d429a',
+                        width: 140,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=f81cccbcca62f07659a3730083de645a',
+                        width: 280,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=120&quality=85&auto=format&fit=max&s=d9db4a6aeea90aca485904e70ddaccd4',
+                        width: 120,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=fb974d50ad8c90d1bb07c7b3ab4a6cd8',
+                        width: 240,
+                    },
+                ],
+            },
+            {
+                weighting: 'supporting',
+                srcSet: [
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=380&quality=85&auto=format&fit=max&s=87392954749c1fe40f9acfd7f5bce39b',
+                        width: 380,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=bcfad42ee8e729f5a29790d14c0a8c9b',
+                        width: 760,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=300&quality=85&auto=format&fit=max&s=0ee9331eac61a413ffaa7014015145e3',
+                        width: 300,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=ad0f597c419a9c869736af91f9f15acf',
+                        width: 600,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=48e15d5d34cdf2677030c6349c4a6bf2',
+                        width: 620,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=a95ecd11817238d37fd9bbbd5b8ee70e',
+                        width: 1240,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=40432b37fa1c7e4907d202078a496d15',
+                        width: 605,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=07cb72515ee014a5f6951cca0d71b631',
+                        width: 1210,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=3d194971fbccd3692587cc844457254b',
+                        width: 445,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=bba08a4952a4b24f4c85b702dea4b534',
+                        width: 890,
+                    },
+                ],
+            },
+            {
+                weighting: 'showcase',
+                srcSet: [
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=1020&quality=85&auto=format&fit=max&s=f760a24db7ea1d2228fd5689398ac2d7',
+                        width: 1020,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=1020&quality=45&auto=format&fit=max&dpr=2&s=687689ef25b440a287139ec262f35e7b',
+                        width: 2040,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=940&quality=85&auto=format&fit=max&s=c67ce0ccfdca1eef3794cc61fbf1d9f3',
+                        width: 940,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=940&quality=45&auto=format&fit=max&dpr=2&s=5482c2e538e9653b1e1dfd66e97a3fe7',
+                        width: 1880,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=68ebcc2dd6e13568cba4d7a7feffeed8',
+                        width: 700,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=e760a5833fe9b557dc45171177145a7a',
+                        width: 1400,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=68ebcc2dd6e13568cba4d7a7feffeed8',
+                        width: 700,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=e760a5833fe9b557dc45171177145a7a',
+                        width: 1400,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=660&quality=85&auto=format&fit=max&s=f49608389e051e6d3713bc6d3503b7fa',
+                        width: 660,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=660&quality=45&auto=format&fit=max&dpr=2&s=93cffd5d0a75f5885174bd38d4273f1b',
+                        width: 1320,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=95e38b41456988787c76bb9401c20835',
+                        width: 645,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=3cae4fb30b88aa1ddc6b1883e2fa5632',
+                        width: 1290,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=dedb7743d844de1e8560486fd1235619',
+                        width: 465,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=cd444a4e8ca8c9a2bd85db2aa1ed77a7',
+                        width: 930,
+                    },
+                ],
+            },
+            {
+                weighting: 'halfwidth',
+                srcSet: [
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=48e15d5d34cdf2677030c6349c4a6bf2',
+                        width: 620,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=a95ecd11817238d37fd9bbbd5b8ee70e',
+                        width: 1240,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=40432b37fa1c7e4907d202078a496d15',
+                        width: 605,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=07cb72515ee014a5f6951cca0d71b631',
+                        width: 1210,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=3d194971fbccd3692587cc844457254b',
+                        width: 445,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=bba08a4952a4b24f4c85b702dea4b534',
+                        width: 890,
+                    },
+                ],
+            },
+            {
+                weighting: 'immersive',
+                srcSet: [
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=1300&quality=85&auto=format&fit=max&s=21d5fae46f9bec0fa7ee923ef8360bae',
+                        width: 1300,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=1300&quality=45&auto=format&fit=max&dpr=2&s=bdd034c39d5d22967ac44669ff040258',
+                        width: 2600,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=1140&quality=85&auto=format&fit=max&s=dec643b163956f46820536b113ca1282',
+                        width: 1140,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=1140&quality=45&auto=format&fit=max&dpr=2&s=98ed6ad0ac33f01fc10537e16da529cd',
+                        width: 2280,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=1125&quality=85&auto=format&fit=max&s=7020ae5b3786c579ec1edc7731309fae',
+                        width: 1125,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=1125&quality=45&auto=format&fit=max&dpr=2&s=0f8c96c0b74f48eccc8e57e16338a13b',
+                        width: 2250,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=965&quality=85&auto=format&fit=max&s=651d525cf91cebecebbbbdb596474763',
+                        width: 965,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=965&quality=45&auto=format&fit=max&dpr=2&s=90278c37c184a4d7414aa593b561a1af',
+                        width: 1930,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=725&quality=85&auto=format&fit=max&s=fde24e4cf698ba9ad43245c58cd35ef1',
+                        width: 725,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=725&quality=45&auto=format&fit=max&dpr=2&s=3b8175e5793268a255ce7b9bec807668',
+                        width: 1450,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=95e38b41456988787c76bb9401c20835',
+                        width: 645,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=3cae4fb30b88aa1ddc6b1883e2fa5632',
+                        width: 1290,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=dedb7743d844de1e8560486fd1235619',
+                        width: 465,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=cd444a4e8ca8c9a2bd85db2aa1ed77a7',
+                        width: 930,
+                    },
+                ],
+            },
+        ],
+        _type: 'model.dotcomrendering.pageElements.ImageBlockElement',
+        media: {
+            allImages: [
+                {
+                    index: 0,
+                    fields: {
+                        height: '1667',
+                        width: '2500',
+                    },
+                    mediaType: 'Image',
+                    mimeType: 'image/jpeg',
+                    url:
+                        'https://media.guim.co.uk/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/2500.jpg',
+                },
+                {
+                    index: 1,
+                    fields: {
+                        isMaster: 'true',
+                        height: '1667',
+                        width: '2500',
+                    },
+                    mediaType: 'Image',
+                    mimeType: 'image/jpeg',
+                    url:
+                        'https://media.guim.co.uk/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg',
+                },
+                {
+                    index: 2,
+                    fields: {
+                        height: '1334',
+                        width: '2000',
+                    },
+                    mediaType: 'Image',
+                    mimeType: 'image/jpeg',
+                    url:
+                        'https://media.guim.co.uk/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/2000.jpg',
+                },
+                {
+                    index: 3,
+                    fields: {
+                        height: '667',
+                        width: '1000',
+                    },
+                    mediaType: 'Image',
+                    mimeType: 'image/jpeg',
+                    url:
+                        'https://media.guim.co.uk/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/1000.jpg',
+                },
+                {
+                    index: 4,
+                    fields: {
+                        height: '333',
+                        width: '500',
+                    },
+                    mediaType: 'Image',
+                    mimeType: 'image/jpeg',
+                    url:
+                        'https://media.guim.co.uk/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/500.jpg',
+                },
+                {
+                    index: 5,
+                    fields: {
+                        height: '93',
+                        width: '140',
+                    },
+                    mediaType: 'Image',
+                    mimeType: 'image/jpeg',
+                    url:
+                        'https://media.guim.co.uk/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/140.jpg',
+                },
+            ],
+        },
+        displayCredit: true,
+    },
+    {
+        role: 'halfWidth',
+        data: {
+            copyright: '© Tommy Trenchard / Greenpeace',
+            alt:
+                'A Greenpeace inflatable boat observes as frozen tuna are transferred from one ship to another in the middle of the Atlantic Ocean.',
+            caption:
+                'A Greenpeace inflatable boat observes as frozen tuna are transferred from one ship to another in the middle of the Atlantic Ocean.',
+            credit: 'Photograph: Tommy Trenchard/Greenpeace',
+        },
+        imageSources: [
+            {
+                weighting: 'inline',
+                srcSet: [
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=5f0aad213210796efce5bc6e4b36f59b',
+                        width: 620,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=e8deb95a117dfeb50e2589ba8a52659c',
+                        width: 1240,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=8da200c890a10261a96778219bafbbf7',
+                        width: 605,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=7cdad992b7f86597b5962968fe064d7a',
+                        width: 1210,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=517b6cf595a28030747904afc06ca99c',
+                        width: 445,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=cd91e3355d3b9535f03c49de18c042e9',
+                        width: 890,
+                    },
+                ],
+            },
+            {
+                weighting: 'thumbnail',
+                srcSet: [
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=140&quality=85&auto=format&fit=max&s=46f2811868440560a977d6864d49910e',
+                        width: 140,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=2a44939d4251a73f838c78e55f682c93',
+                        width: 280,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=120&quality=85&auto=format&fit=max&s=ef2feb81c3f887f850dc08c57add7a7b',
+                        width: 120,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=b347c73fa5602c1316d3cd8de2401713',
+                        width: 240,
+                    },
+                ],
+            },
+            {
+                weighting: 'supporting',
+                srcSet: [
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=380&quality=85&auto=format&fit=max&s=be2cefb415a0326466aa09d9a70e95f4',
+                        width: 380,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=32442832dd714139c8b6af3c3d263684',
+                        width: 760,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=300&quality=85&auto=format&fit=max&s=1482e95ab52e1a8a2943c22815bf53e4',
+                        width: 300,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=e364ab01ad53bf52d38f8964dcd7e43f',
+                        width: 600,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=5f0aad213210796efce5bc6e4b36f59b',
+                        width: 620,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=e8deb95a117dfeb50e2589ba8a52659c',
+                        width: 1240,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=8da200c890a10261a96778219bafbbf7',
+                        width: 605,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=7cdad992b7f86597b5962968fe064d7a',
+                        width: 1210,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=517b6cf595a28030747904afc06ca99c',
+                        width: 445,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=cd91e3355d3b9535f03c49de18c042e9',
+                        width: 890,
+                    },
+                ],
+            },
+            {
+                weighting: 'showcase',
+                srcSet: [
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=1020&quality=85&auto=format&fit=max&s=773503c05c0d2d2a5289d5135eab3bf9',
+                        width: 1020,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=1020&quality=45&auto=format&fit=max&dpr=2&s=99f61fb65f3db7331a9accd7dcaef487',
+                        width: 2040,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=940&quality=85&auto=format&fit=max&s=fc5c19b9d108d6640e027993afa24af1',
+                        width: 940,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=940&quality=45&auto=format&fit=max&dpr=2&s=4bd7f37b18f0912c852861476fc52ba5',
+                        width: 1880,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=5076e3e1d235ee37c5d8f2817d03ac23',
+                        width: 700,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=1c53bc70bb0b4f0a7c438ee616ebe810',
+                        width: 1400,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=5076e3e1d235ee37c5d8f2817d03ac23',
+                        width: 700,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=1c53bc70bb0b4f0a7c438ee616ebe810',
+                        width: 1400,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=660&quality=85&auto=format&fit=max&s=d19f425eeacd2bfceeae01dee61fe01d',
+                        width: 660,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=660&quality=45&auto=format&fit=max&dpr=2&s=2860e067ff5bd111b0fb3bdf7f53633b',
+                        width: 1320,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=427e2816ab973fe59c9a87dc9144caf6',
+                        width: 645,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=c65bbe1a99f10e53f66ef07a4fdf5c4a',
+                        width: 1290,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=b705d2cefa6d0b9bb435523649374f3d',
+                        width: 465,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=a08d573f5068f467d77c4628aa31e863',
+                        width: 930,
+                    },
+                ],
+            },
+            {
+                weighting: 'halfwidth',
+                srcSet: [
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=5f0aad213210796efce5bc6e4b36f59b',
+                        width: 620,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=e8deb95a117dfeb50e2589ba8a52659c',
+                        width: 1240,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=8da200c890a10261a96778219bafbbf7',
+                        width: 605,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=7cdad992b7f86597b5962968fe064d7a',
+                        width: 1210,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=517b6cf595a28030747904afc06ca99c',
+                        width: 445,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=cd91e3355d3b9535f03c49de18c042e9',
+                        width: 890,
+                    },
+                ],
+            },
+            {
+                weighting: 'immersive',
+                srcSet: [
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=1300&quality=85&auto=format&fit=max&s=b184a2b9e93b4083aa7a6fed6eec45c2',
+                        width: 1300,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=1300&quality=45&auto=format&fit=max&dpr=2&s=fd2a2d24f60db471a2580c85207c0f77',
+                        width: 2600,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=1140&quality=85&auto=format&fit=max&s=8cfe0ddf82131868395e69ce26f1af5f',
+                        width: 1140,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=1140&quality=45&auto=format&fit=max&dpr=2&s=7b8fa4d6d96248046e24f47796d347db',
+                        width: 2280,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=1125&quality=85&auto=format&fit=max&s=7090db5a62dcac6f9d03479f88513f73',
+                        width: 1125,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=1125&quality=45&auto=format&fit=max&dpr=2&s=51a09168635bbb6994527ec403a4da49',
+                        width: 2250,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=965&quality=85&auto=format&fit=max&s=029e623ff8dd7413cd197efb537acc71',
+                        width: 965,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=965&quality=45&auto=format&fit=max&dpr=2&s=9cefb63048efd535ef87d07d4849f4ac',
+                        width: 1930,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=725&quality=85&auto=format&fit=max&s=83b5f0e48e1cd7a9e2aea238c2aa4b13',
+                        width: 725,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=725&quality=45&auto=format&fit=max&dpr=2&s=f88f9cf18582298fdfdc5859b2edc23d',
+                        width: 1450,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=427e2816ab973fe59c9a87dc9144caf6',
+                        width: 645,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=c65bbe1a99f10e53f66ef07a4fdf5c4a',
+                        width: 1290,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=b705d2cefa6d0b9bb435523649374f3d',
+                        width: 465,
+                    },
+                    {
+                        src:
+                            'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=a08d573f5068f467d77c4628aa31e863',
+                        width: 930,
+                    },
+                ],
+            },
+        ],
+        _type: 'model.dotcomrendering.pageElements.ImageBlockElement',
+        media: {
+            allImages: [
+                {
+                    index: 0,
+                    fields: {
+                        height: '1667',
+                        width: '2500',
+                    },
+                    mediaType: 'Image',
+                    mimeType: 'image/jpeg',
+                    url:
+                        'https://media.guim.co.uk/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/2500.jpg',
+                },
+                {
+                    index: 1,
+                    fields: {
+                        isMaster: 'true',
+                        height: '1667',
+                        width: '2500',
+                    },
+                    mediaType: 'Image',
+                    mimeType: 'image/jpeg',
+                    url:
+                        'https://media.guim.co.uk/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg',
+                },
+                {
+                    index: 2,
+                    fields: {
+                        height: '1334',
+                        width: '2000',
+                    },
+                    mediaType: 'Image',
+                    mimeType: 'image/jpeg',
+                    url:
+                        'https://media.guim.co.uk/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/2000.jpg',
+                },
+                {
+                    index: 3,
+                    fields: {
+                        height: '667',
+                        width: '1000',
+                    },
+                    mediaType: 'Image',
+                    mimeType: 'image/jpeg',
+                    url:
+                        'https://media.guim.co.uk/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/1000.jpg',
+                },
+                {
+                    index: 4,
+                    fields: {
+                        height: '333',
+                        width: '500',
+                    },
+                    mediaType: 'Image',
+                    mimeType: 'image/jpeg',
+                    url:
+                        'https://media.guim.co.uk/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/500.jpg',
+                },
+                {
+                    index: 5,
+                    fields: {
+                        height: '93',
+                        width: '140',
+                    },
+                    mediaType: 'Image',
+                    mimeType: 'image/jpeg',
+                    url:
+                        'https://media.guim.co.uk/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/140.jpg',
+                },
+            ],
+        },
+        displayCredit: true,
+    },
+];

--- a/src/web/components/elements/MultiImageBlockComponent.stories.tsx
+++ b/src/web/components/elements/MultiImageBlockComponent.stories.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+
+import { MultiImageBlockComponent } from './MultiImageBlockComponent';
+
+import { fourImages } from './MultiImageBlockComponent.mocks';
+
+const oneImage = fourImages.slice(0, 1);
+const twoImages = fourImages.slice(0, 2);
+const threeImages = fourImages.slice(0, 3);
+
+export default {
+    component: MultiImageBlockComponent,
+    title: 'Components/MultiImageBlockComponent',
+};
+
+export const SingleImage = () => {
+    return (
+        <MultiImageBlockComponent
+            designType="Article"
+            pillar="news"
+            images={oneImage}
+        />
+    );
+};
+SingleImage.story = {
+    name: 'single image',
+};
+
+export const SingleImageWithCaption = () => {
+    return (
+        <MultiImageBlockComponent
+            designType="Article"
+            pillar="news"
+            images={oneImage}
+            caption="This is the caption for a single image"
+        />
+    );
+};
+SingleImageWithCaption.story = {
+    name: 'single image with caption',
+};
+
+export const SideBySide = () => {
+    return (
+        <MultiImageBlockComponent
+            designType="Article"
+            pillar="news"
+            images={twoImages}
+        />
+    );
+};
+SideBySide.story = {
+    name: 'side by side',
+};
+
+export const SideBySideWithCaption = () => {
+    return (
+        <MultiImageBlockComponent
+            designType="Article"
+            pillar="news"
+            images={twoImages}
+            caption="This is the caption for side by side"
+        />
+    );
+};
+SideBySideWithCaption.story = {
+    name: 'side by side with caption',
+};
+
+export const OneAboveTwo = () => {
+    return (
+        <MultiImageBlockComponent
+            designType="Article"
+            pillar="news"
+            images={threeImages}
+        />
+    );
+};
+OneAboveTwo.story = {
+    name: 'one above two',
+};
+
+export const OneAboveTwoWithCaption = () => {
+    return (
+        <MultiImageBlockComponent
+            designType="Article"
+            pillar="news"
+            images={threeImages}
+            caption="This is the caption for one above two"
+        />
+    );
+};
+OneAboveTwoWithCaption.story = {
+    name: 'one above two with caption',
+};
+
+export const GridOfFour = () => {
+    return (
+        <MultiImageBlockComponent
+            designType="Article"
+            pillar="news"
+            images={fourImages}
+        />
+    );
+};
+GridOfFour.story = {
+    name: 'grid of four',
+};
+
+export const GridOfFourWithCaption = () => {
+    return (
+        <MultiImageBlockComponent
+            designType="Article"
+            pillar="news"
+            images={fourImages}
+            caption="This is the caption for grid of four"
+        />
+    );
+};
+GridOfFourWithCaption.story = {
+    name: 'grid of four with caption',
+};

--- a/src/web/components/elements/MultiImageBlockComponent.tsx
+++ b/src/web/components/elements/MultiImageBlockComponent.tsx
@@ -1,0 +1,287 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { space } from '@guardian/src-foundations';
+import { from, until } from '@guardian/src-foundations/mq';
+
+import { ImageComponent } from '@root/src/web/components/elements/ImageComponent';
+import { Caption } from '@frontend/web/components/Caption';
+import { GridItem } from '@root/src/web/components/GridItem';
+
+type Props = {
+    designType: DesignType;
+    images: ImageBlockElement[];
+    caption?: string;
+    pillar: Pillar;
+};
+
+const ieFallback = css`
+    display: flex;
+    flex-direction: column;
+    ${until.leftCol} {
+        margin-left: 0px;
+    }
+    ${from.leftCol} {
+        margin-left: 151px;
+    }
+    ${from.wide} {
+        margin-left: 230px;
+    }
+`;
+
+const SideBySideGrid = ({
+    children,
+}: {
+    children: JSX.Element | JSX.Element[];
+}) => (
+    <div
+        className={css`
+            ${ieFallback}
+            @supports (display: grid) {
+                margin-left: 0;
+                margin-right: ${space[3]}px;
+                display: grid;
+                grid-gap: ${space[3]}px;
+                grid-template-columns:
+                    50% /* Left column */
+                    50%; /* Right column */
+                grid-template-areas: 'first second';
+            }
+        `}
+    >
+        {children}
+    </div>
+);
+
+const OneAboveTwoGrid = ({
+    children,
+}: {
+    children: JSX.Element | JSX.Element[];
+}) => (
+    <div
+        className={css`
+            ${ieFallback}
+            @supports (display: grid) {
+                margin-left: 0;
+                margin-right: ${space[3]}px;
+                display: grid;
+                grid-gap: ${space[3]}px;
+                grid-template-columns:
+                    50% /* Left column */
+                    50%; /* Right column */
+                grid-template-areas:
+                    'first first'
+                    'second third';
+            }
+        `}
+    >
+        {children}
+    </div>
+);
+
+const GridOfFour = ({
+    children,
+}: {
+    children: JSX.Element | JSX.Element[];
+}) => (
+    <div
+        className={css`
+            ${ieFallback}
+            @supports (display: grid) {
+                margin-left: 0;
+                margin-right: ${space[3]}px;
+                display: grid;
+                grid-gap: ${space[3]}px;
+                grid-template-columns:
+                    50% /* Left column */
+                    50%; /* Right column */
+                grid-template-areas:
+                    'first second'
+                    'third forth';
+            }
+        `}
+    >
+        {children}
+    </div>
+);
+
+export const MultiImageBlockComponent = ({
+    // designType,
+    caption,
+    images,
+    pillar,
+}: Props) => {
+    const imageCount = images.length;
+
+    switch (imageCount) {
+        case 1:
+            return (
+                <div
+                    className={css`
+                        img {
+                            object-fit: cover;
+                            width: 100%;
+                        }
+                    `}
+                >
+                    <ImageComponent
+                        display="standard"
+                        element={images[0]}
+                        pillar={pillar}
+                        hideCaption={true}
+                        role={images[0].role}
+                    />
+                    {caption && (
+                        <Caption
+                            display="standard"
+                            captionText={caption}
+                            pillar={pillar}
+                            shouldLimitWidth={false}
+                        />
+                    )}
+                </div>
+            );
+        case 2:
+            return (
+                <div
+                    className={css`
+                        img {
+                            object-fit: cover;
+                            width: 100%;
+                        }
+                    `}
+                >
+                    <SideBySideGrid>
+                        <GridItem area="first">
+                            <ImageComponent
+                                display="standard"
+                                element={images[0]}
+                                pillar={pillar}
+                                hideCaption={true}
+                                role={images[0].role}
+                            />
+                        </GridItem>
+                        <GridItem area="second">
+                            <ImageComponent
+                                display="standard"
+                                element={images[1]}
+                                pillar={pillar}
+                                hideCaption={true}
+                                role={images[1].role}
+                            />
+                        </GridItem>
+                    </SideBySideGrid>
+                    {caption && (
+                        <Caption
+                            display="standard"
+                            captionText={caption}
+                            pillar={pillar}
+                            shouldLimitWidth={false}
+                        />
+                    )}
+                </div>
+            );
+        case 3:
+            return (
+                <div className={css``}>
+                    <OneAboveTwoGrid>
+                        <GridItem area="first">
+                            <ImageComponent
+                                display="standard"
+                                element={images[0]}
+                                pillar={pillar}
+                                hideCaption={true}
+                                role={images[0].role}
+                            />
+                        </GridItem>
+                        <GridItem area="second">
+                            <ImageComponent
+                                display="standard"
+                                element={images[1]}
+                                pillar={pillar}
+                                hideCaption={true}
+                                role={images[1].role}
+                            />
+                        </GridItem>
+                        <GridItem area="third">
+                            <ImageComponent
+                                display="standard"
+                                element={images[2]}
+                                pillar={pillar}
+                                hideCaption={true}
+                                role={images[2].role}
+                            />
+                        </GridItem>
+                    </OneAboveTwoGrid>
+                    {caption && (
+                        <Caption
+                            display="standard"
+                            captionText={caption}
+                            pillar={pillar}
+                            shouldLimitWidth={false}
+                        />
+                    )}
+                </div>
+            );
+        case 4:
+            return (
+                <div
+                    className={css`
+                        img {
+                            object-fit: cover;
+                            width: 100%;
+                        }
+                    `}
+                >
+                    <GridOfFour>
+                        <GridItem area="first">
+                            <ImageComponent
+                                display="standard"
+                                element={images[0]}
+                                pillar={pillar}
+                                hideCaption={true}
+                                role={images[0].role}
+                            />
+                        </GridItem>
+                        <GridItem area="second">
+                            <ImageComponent
+                                display="standard"
+                                element={images[1]}
+                                pillar={pillar}
+                                hideCaption={true}
+                                role={images[1].role}
+                            />
+                        </GridItem>
+                        <GridItem area="third">
+                            <ImageComponent
+                                display="standard"
+                                element={images[2]}
+                                pillar={pillar}
+                                hideCaption={true}
+                                role={images[2].role}
+                            />
+                        </GridItem>
+                        <GridItem area="forth">
+                            <ImageComponent
+                                display="standard"
+                                element={images[3]}
+                                pillar={pillar}
+                                hideCaption={true}
+                                role={images[3].role}
+                            />
+                        </GridItem>
+                    </GridOfFour>
+                    {caption && (
+                        <Caption
+                            display="standard"
+                            captionText={caption}
+                            pillar={pillar}
+                            shouldLimitWidth={false}
+                        />
+                    )}
+                </div>
+            );
+        default:
+            return null;
+    }
+};

--- a/src/web/components/elements/MultiImageBlockComponent.tsx
+++ b/src/web/components/elements/MultiImageBlockComponent.tsx
@@ -183,7 +183,14 @@ export const MultiImageBlockComponent = ({
             );
         case 3:
             return (
-                <div className={css``}>
+                <div
+                    className={css`
+                        img {
+                            object-fit: cover;
+                            width: 100%;
+                        }
+                    `}
+                >
                     <OneAboveTwoGrid>
                         <GridItem area="first">
                             <ImageComponent

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -5,6 +5,7 @@ import { BlockquoteBlockComponent } from '@root/src/web/components/elements/Bloc
 import { DividerBlockComponent } from '@root/src/web/components/elements/DividerBlockComponent';
 import { EmbedBlockComponent } from '@root/src/web/components/elements/EmbedBlockComponent';
 import { ImageBlockComponent } from '@root/src/web/components/elements/ImageBlockComponent';
+import { MultiImageBlockComponent } from '@root/src/web/components/elements/MultiImageBlockComponent';
 import { InstagramBlockComponent } from '@root/src/web/components/elements/InstagramBlockComponent';
 import { PullQuoteBlockComponent } from '@root/src/web/components/elements/PullQuoteBlockComponent';
 import { SoundcloudBlockComponent } from '@root/src/web/components/elements/SoundcloudBlockComponent';
@@ -64,6 +65,16 @@ export const ArticleRenderer: React.FC<{
                 case 'model.dotcomrendering.pageElements.InstagramBlockElement':
                     return (
                         <InstagramBlockComponent key={i} element={element} />
+                    );
+                case 'model.dotcomrendering.pageElements.MultiImageBlockElement':
+                    return (
+                        <MultiImageBlockComponent
+                            designType={designType}
+                            key={i}
+                            images={element.images}
+                            caption={element.caption}
+                            pillar={pillar}
+                        />
                     );
                 case 'model.dotcomrendering.pageElements.PullquoteBlockElement':
                     return (


### PR DESCRIPTION
## What does this change?
Adds a new element type `MultiImageBlockElement` for use when multiple images should be arranged together with a single caption (optional)

### Props
```typescript
type Props = {
    designType: DesignType;
    images: ImageBlockElement[];
    caption?: string;
    pillar: Pillar;
};
```

### Element type
```typescript
interface MultiImageBlockElement {
    _type: 'model.dotcomrendering.pageElements.MultiImageBlockElement';
    images: ImageBlockElement[];
    caption?: string;
}
```

![2020-05-10 13 52 37](https://user-images.githubusercontent.com/1336821/81499728-9557e700-92c5-11ea-8ece-22705f230510.gif)



## Why?
In the short term, this prepares support for Photo Essays, in the long term it offers a more flexible api for how we insert images into an article, not just photo essays.
