### PR TITLE
Missing immersive captions

### DIFF
--- a/src/web/components/Caption.tsx
+++ b/src/web/components/Caption.tsx
@@ -104,7 +104,10 @@ export const Caption = ({
         }
     `;
 
-    if (!captionText && !displayCredit) return null;
+    const noCaption = !captionText;
+    const noCredit = !credit;
+    const hideCredit = !displayCredit;
+    if (noCaption && (noCredit || hideCredit)) return null;
 
     return (
         <figcaption

--- a/src/web/components/Caption.tsx
+++ b/src/web/components/Caption.tsx
@@ -104,7 +104,7 @@ export const Caption = ({
         }
     `;
 
-    if (!captionText) return null;
+    if (!captionText && !displayCredit) return null;
 
     return (
         <figcaption
@@ -126,14 +126,16 @@ export const Caption = ({
             >
                 <TriangleIcon />
             </span>
-            <span
-                className={captionLink}
-                // eslint-disable-next-line react/no-danger
-                dangerouslySetInnerHTML={{
-                    __html: captionText || '',
-                }}
-                key="caption"
-            />
+            {captionText && (
+                <span
+                    className={captionLink}
+                    // eslint-disable-next-line react/no-danger
+                    dangerouslySetInnerHTML={{
+                        __html: captionText || '',
+                    }}
+                    key="caption"
+                />
+            )}
             {credit && displayCredit && ` ${credit}`}
         </figcaption>
     );

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -153,6 +153,14 @@ interface Props {
     pillar: Pillar;
 }
 
+const decideCaption = (mainMedia: ImageBlockElement): string => {
+    const caption = [];
+    if (mainMedia.data.caption) caption.push(mainMedia.data.caption);
+    if (mainMedia.displayCredit && mainMedia.data.credit)
+        caption.push(mainMedia.data.credit);
+    return caption.join(' ');
+};
+
 export const ImmersiveLayout = ({
     CAPI,
     NAV,
@@ -183,7 +191,7 @@ export const ImmersiveLayout = ({
     const showComments = CAPI.isCommentable;
 
     const mainMedia = CAPI.mainMediaElements[0] as ImageBlockElement;
-    const captionText = mainMedia && mainMedia.data && mainMedia.data.caption;
+    const captionText = decideCaption(mainMedia);
 
     return (
         <>

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -155,8 +155,9 @@ interface Props {
 
 const decideCaption = (mainMedia: ImageBlockElement): string => {
     const caption = [];
-    if (mainMedia.data.caption) caption.push(mainMedia.data.caption);
-    if (mainMedia.displayCredit && mainMedia.data.credit)
+    if (mainMedia.data && mainMedia.data.caption)
+        caption.push(mainMedia.data.caption);
+    if (mainMedia.displayCredit && mainMedia.data && mainMedia.data.credit)
         caption.push(mainMedia.data.credit);
     return caption.join(' ');
 };


### PR DESCRIPTION
## What does this change?
Ensures that we display a caption, even if that text is only the credit

### Before
![Screenshot 2020-05-10 at 14 45 15](https://user-images.githubusercontent.com/1336821/81500880-e919fe80-92cc-11ea-8b3d-406640dd2ee3.jpg)


### After
![Screenshot 2020-05-10 at 14 45 29](https://user-images.githubusercontent.com/1336821/81500883-ec14ef00-92cc-11ea-9402-8e7e98a7f2d2.jpg)

## Why?
We previously thought that captions should not show at all if there was now caption text, even if there was a credit. But it's now clear that sometimes the text can be wholy made up of just the credit
