### PR TITLE
PhotoEssay Type

### DIFF
--- a/fixtures/CAPI/comment.ts
+++ b/fixtures/CAPI/comment.ts
@@ -2605,6 +2605,7 @@ export const comment: CAPIType = {
         discussionApiClientHeader: 'testClientHeader',
         ampIframeUrl:
             'https://assets.guim.co.uk/data/vendor/a994b749adae30cd58f0e84c8fa28013/amp-iframe.html',
+        isPhotoEssay: false,
     },
     sectionLabel: 'Conservatives',
 };

--- a/fixtures/CAPI/review/showcaseReview.ts
+++ b/fixtures/CAPI/review/showcaseReview.ts
@@ -2711,6 +2711,7 @@ export const showcaseReviewCAPI: CAPIType = {
             'https://assets.guim.co.uk/data/vendor/a994b749adae30cd58f0e84c8fa28013/amp-iframe.html',
         discussionD2Uid: 'testD2Header',
         discussionApiClientHeader: 'testClientHeader',
+        isPhotoEssay: false,
     },
     sectionLabel: 'TV comedy',
 };

--- a/fixtures/CAPI/review/standardReview.ts
+++ b/fixtures/CAPI/review/standardReview.ts
@@ -2388,6 +2388,7 @@ export const standardReviewCAPI: CAPIType = {
             'https://assets.guim.co.uk/data/vendor/a994b749adae30cd58f0e84c8fa28013/amp-iframe.html',
         discussionD2Uid: 'testD2Header',
         discussionApiClientHeader: 'testClientHeader',
+        isPhotoEssay: false,
     },
     sectionLabel: 'Theatre',
 };

--- a/fixtures/CAPI/richLink.ts
+++ b/fixtures/CAPI/richLink.ts
@@ -2820,6 +2820,7 @@ export const richLink: CAPIType = {
             'https://assets.guim.co.uk/data/vendor/a994b749adae30cd58f0e84c8fa28013/amp-iframe.html',
         discussionD2Uid: 'testD2Header',
         discussionApiClientHeader: 'testClientHeader',
+        isPhotoEssay: false,
     },
     sectionLabel: 'Eminem',
     contributionsServiceUrl: 'https://contributions.guardianapis.com',

--- a/fixtures/articles/AdvertisementFeature.ts
+++ b/fixtures/articles/AdvertisementFeature.ts
@@ -2557,6 +2557,7 @@ export const AdvertisementFeature: CAPIType = {
         discussionApiClientHeader: 'testClientHeader',
         ampIframeUrl:
             'https://assets.guim.co.uk/data/vendor/a994b749adae30cd58f0e84c8fa28013/amp-iframe.html',
+        isPhotoEssay: false,
     },
     sectionLabel: 'The power of firsts',
 };

--- a/fixtures/articles/Analysis.ts
+++ b/fixtures/articles/Analysis.ts
@@ -3007,6 +3007,7 @@ export const Analysis: CAPIType = {
         discussionApiClientHeader: 'testClientHeader',
         ampIframeUrl:
             'https://assets.guim.co.uk/data/vendor/a994b749adae30cd58f0e84c8fa28013/amp-iframe.html',
+        isPhotoEssay: false,
     },
     sectionLabel: 'Ireland',
 };

--- a/fixtures/articles/Article.ts
+++ b/fixtures/articles/Article.ts
@@ -3345,6 +3345,7 @@ export const Article: CAPIType = {
         discussionApiClientHeader: 'testClientHeader',
         ampIframeUrl:
             'https://assets.guim.co.uk/data/vendor/a994b749adae30cd58f0e84c8fa28013/amp-iframe.html',
+        isPhotoEssay: false,
     },
     sectionLabel: 'Climate change',
 };

--- a/fixtures/articles/Comment.ts
+++ b/fixtures/articles/Comment.ts
@@ -3194,6 +3194,7 @@ export const Comment: CAPIType = {
         discussionApiClientHeader: 'testClientHeader',
         ampIframeUrl:
             'https://assets.guim.co.uk/data/vendor/a994b749adae30cd58f0e84c8fa28013/amp-iframe.html',
+        isPhotoEssay: false,
     },
     sectionLabel: 'Austerity',
 };

--- a/fixtures/articles/Feature.ts
+++ b/fixtures/articles/Feature.ts
@@ -3045,6 +3045,7 @@ export const Feature: CAPIType = {
         discussionApiClientHeader: 'testClientHeader',
         ampIframeUrl:
             'https://assets.guim.co.uk/data/vendor/a994b749adae30cd58f0e84c8fa28013/amp-iframe.html',
+        isPhotoEssay: false,
     },
     sectionLabel: 'Oscars 2020',
 };

--- a/fixtures/articles/GuardianView.ts
+++ b/fixtures/articles/GuardianView.ts
@@ -3016,6 +3016,7 @@ export const GuardianView: CAPIType = {
         discussionApiClientHeader: 'testClientHeader',
         ampIframeUrl:
             'https://assets.guim.co.uk/data/vendor/a994b749adae30cd58f0e84c8fa28013/amp-iframe.html',
+        isPhotoEssay: false,
     },
     sectionLabel: 'Trump impeachment',
 };

--- a/fixtures/articles/Immersive.ts
+++ b/fixtures/articles/Immersive.ts
@@ -4835,6 +4835,7 @@ export const Immersive: CAPIType = {
         discussionApiClientHeader: 'testClientHeader',
         ampIframeUrl:
             'https://assets.guim.co.uk/data/vendor/a994b749adae30cd58f0e84c8fa28013/amp-iframe.html',
+        isPhotoEssay: false,
     },
     sectionLabel: 'Christopher Eccleston',
 };

--- a/fixtures/articles/Interview.ts
+++ b/fixtures/articles/Interview.ts
@@ -6041,6 +6041,7 @@ export const Interview: CAPIType = {
         discussionApiClientHeader: 'testClientHeader',
         ampIframeUrl:
             'https://assets.guim.co.uk/data/vendor/a994b749adae30cd58f0e84c8fa28013/amp-iframe.html',
+        isPhotoEssay: false,
     },
     sectionLabel: 'Models',
 };

--- a/fixtures/articles/MatchReport.ts
+++ b/fixtures/articles/MatchReport.ts
@@ -2842,6 +2842,7 @@ export const MatchReport: CAPIType = {
         discussionApiClientHeader: 'testClientHeader',
         ampIframeUrl:
             'https://assets.guim.co.uk/data/vendor/a994b749adae30cd58f0e84c8fa28013/amp-iframe.html',
+        isPhotoEssay: false,
     },
     sectionLabel: 'Six Nations 2020',
 };

--- a/fixtures/articles/PhotoEssay.ts
+++ b/fixtures/articles/PhotoEssay.ts
@@ -1,0 +1,9336 @@
+export const PhotoEssay: CAPIType = {
+    shouldHideReaderRevenue: false,
+    slotMachineFlags: '',
+    isAdFreeUser: false,
+    main:
+        '<figure class="element element-image" data-media-id="87ae80fa40c8ceab7ba864e69d921c6588b2ca45"> <img src="https://media.guim.co.uk/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/1000.jpg" alt="A shark is hauled into the hold of a longliner." width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">Every year 100 million sharks are killed.</span> <span class="element-image__credit">Photograph: Tommy Trenchard/Greenpeace</span> </figcaption> </figure>',
+    subMetaSectionLinks: [
+        {
+            url: '/environment/series/seascape-the-state-of-our-oceans',
+            title: 'Seascape: the state of our oceans',
+        },
+    ],
+    commercialProperties: {
+        UK: {
+            branding: {
+                brandingType: { name: 'foundation' },
+                sponsorName: 'The David and Lucile Packard Foundation',
+                logo: {
+                    src:
+                        'https://static.theguardian.com/commercial/sponsor/17/Sep/2018/25703364-a145-46b0-bcd0-bcd1dd5f571b-seascape-color-logo.png',
+                    dimensions: { width: 140, height: 90 },
+                    link: 'https://www.packard.org/',
+                    label: 'Seascape: the state of our oceans is supported by',
+                },
+                logoForDarkBackground: {
+                    src:
+                        'https://static.theguardian.com/commercial/sponsor/17/Sep/2018/046ec8e1-d643-4be8-b2f1-8873d7b105e9-seascape-mono-logo.png',
+                    dimensions: { width: 140, height: 90 },
+                    link: 'https://www.packard.org/',
+                    label: 'Seascape: the state of our oceans is supported by',
+                },
+                aboutThisLink:
+                    'https://www.theguardian.com/environment/2018/sep/16/about-seascape-the-state-of-our-oceans-a-guardian-series',
+            },
+            adTargeting: [
+                { name: 'edition', value: 'uk' },
+                {
+                    name: 'k',
+                    value: [
+                        'wildlife',
+                        'fishing',
+                        'animals',
+                        'environment',
+                        'marine-life',
+                        'conservation',
+                    ],
+                },
+                { name: 'se', value: ['seascape-the-state-of-our-oceans'] },
+                { name: 'sh', value: 'https://gu.com/p/cqjf5' },
+                { name: 'co', value: ['sophiecooke'] },
+                { name: 'su', value: ['0'] },
+                { name: 'ct', value: 'article' },
+                { name: 'p', value: 'ng' },
+                { name: 'br', value: 'f' },
+                {
+                    name: 'url',
+                    value:
+                        '/environment/2020/jan/29/i-witnessed-a-shark-attack-its-not-what-you-imagine-photo-essay',
+                },
+            ],
+        },
+        US: {
+            branding: {
+                brandingType: { name: 'foundation' },
+                sponsorName: 'The David and Lucile Packard Foundation',
+                logo: {
+                    src:
+                        'https://static.theguardian.com/commercial/sponsor/17/Sep/2018/25703364-a145-46b0-bcd0-bcd1dd5f571b-seascape-color-logo.png',
+                    dimensions: { width: 140, height: 90 },
+                    link: 'https://www.packard.org/',
+                    label: 'Seascape: the state of our oceans is supported by',
+                },
+                logoForDarkBackground: {
+                    src:
+                        'https://static.theguardian.com/commercial/sponsor/17/Sep/2018/046ec8e1-d643-4be8-b2f1-8873d7b105e9-seascape-mono-logo.png',
+                    dimensions: { width: 140, height: 90 },
+                    link: 'https://www.packard.org/',
+                    label: 'Seascape: the state of our oceans is supported by',
+                },
+                aboutThisLink:
+                    'https://www.theguardian.com/environment/2018/sep/16/about-seascape-the-state-of-our-oceans-a-guardian-series',
+            },
+            adTargeting: [
+                {
+                    name: 'k',
+                    value: [
+                        'wildlife',
+                        'fishing',
+                        'animals',
+                        'environment',
+                        'marine-life',
+                        'conservation',
+                    ],
+                },
+                { name: 'se', value: ['seascape-the-state-of-our-oceans'] },
+                { name: 'sh', value: 'https://gu.com/p/cqjf5' },
+                { name: 'co', value: ['sophiecooke'] },
+                { name: 'su', value: ['0'] },
+                { name: 'ct', value: 'article' },
+                { name: 'p', value: 'ng' },
+                { name: 'edition', value: 'us' },
+                { name: 'br', value: 'f' },
+                {
+                    name: 'url',
+                    value:
+                        '/environment/2020/jan/29/i-witnessed-a-shark-attack-its-not-what-you-imagine-photo-essay',
+                },
+            ],
+        },
+        AU: {
+            branding: {
+                brandingType: { name: 'foundation' },
+                sponsorName: 'The David and Lucile Packard Foundation',
+                logo: {
+                    src:
+                        'https://static.theguardian.com/commercial/sponsor/17/Sep/2018/25703364-a145-46b0-bcd0-bcd1dd5f571b-seascape-color-logo.png',
+                    dimensions: { width: 140, height: 90 },
+                    link: 'https://www.packard.org/',
+                    label: 'Seascape: the state of our oceans is supported by',
+                },
+                logoForDarkBackground: {
+                    src:
+                        'https://static.theguardian.com/commercial/sponsor/17/Sep/2018/046ec8e1-d643-4be8-b2f1-8873d7b105e9-seascape-mono-logo.png',
+                    dimensions: { width: 140, height: 90 },
+                    link: 'https://www.packard.org/',
+                    label: 'Seascape: the state of our oceans is supported by',
+                },
+                aboutThisLink:
+                    'https://www.theguardian.com/environment/2018/sep/16/about-seascape-the-state-of-our-oceans-a-guardian-series',
+            },
+            adTargeting: [
+                {
+                    name: 'k',
+                    value: [
+                        'wildlife',
+                        'fishing',
+                        'animals',
+                        'environment',
+                        'marine-life',
+                        'conservation',
+                    ],
+                },
+                { name: 'se', value: ['seascape-the-state-of-our-oceans'] },
+                { name: 'sh', value: 'https://gu.com/p/cqjf5' },
+                { name: 'co', value: ['sophiecooke'] },
+                { name: 'su', value: ['0'] },
+                { name: 'ct', value: 'article' },
+                { name: 'p', value: 'ng' },
+                { name: 'br', value: 'f' },
+                {
+                    name: 'url',
+                    value:
+                        '/environment/2020/jan/29/i-witnessed-a-shark-attack-its-not-what-you-imagine-photo-essay',
+                },
+                { name: 'edition', value: 'au' },
+            ],
+        },
+        INT: {
+            branding: {
+                brandingType: { name: 'foundation' },
+                sponsorName: 'The David and Lucile Packard Foundation',
+                logo: {
+                    src:
+                        'https://static.theguardian.com/commercial/sponsor/17/Sep/2018/25703364-a145-46b0-bcd0-bcd1dd5f571b-seascape-color-logo.png',
+                    dimensions: { width: 140, height: 90 },
+                    link: 'https://www.packard.org/',
+                    label: 'Seascape: the state of our oceans is supported by',
+                },
+                logoForDarkBackground: {
+                    src:
+                        'https://static.theguardian.com/commercial/sponsor/17/Sep/2018/046ec8e1-d643-4be8-b2f1-8873d7b105e9-seascape-mono-logo.png',
+                    dimensions: { width: 140, height: 90 },
+                    link: 'https://www.packard.org/',
+                    label: 'Seascape: the state of our oceans is supported by',
+                },
+                aboutThisLink:
+                    'https://www.theguardian.com/environment/2018/sep/16/about-seascape-the-state-of-our-oceans-a-guardian-series',
+            },
+            adTargeting: [
+                {
+                    name: 'k',
+                    value: [
+                        'wildlife',
+                        'fishing',
+                        'animals',
+                        'environment',
+                        'marine-life',
+                        'conservation',
+                    ],
+                },
+                { name: 'se', value: ['seascape-the-state-of-our-oceans'] },
+                { name: 'sh', value: 'https://gu.com/p/cqjf5' },
+                { name: 'co', value: ['sophiecooke'] },
+                { name: 'edition', value: 'int' },
+                { name: 'su', value: ['0'] },
+                { name: 'ct', value: 'article' },
+                { name: 'p', value: 'ng' },
+                { name: 'br', value: 'f' },
+                {
+                    name: 'url',
+                    value:
+                        '/environment/2020/jan/29/i-witnessed-a-shark-attack-its-not-what-you-imagine-photo-essay',
+                },
+            ],
+        },
+    },
+    pageFooter: {
+        footerLinks: [
+            [
+                {
+                    text: 'About us',
+                    url: '/about',
+                    dataLinkName: 'uk : footer : about us',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Contact us',
+                    url: '/help/contact-us',
+                    dataLinkName: 'uk : footer : contact us',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Complaints & corrections',
+                    url: '/info/complaints-and-corrections',
+                    dataLinkName: 'complaints',
+                    extraClasses: '',
+                },
+                {
+                    text: 'SecureDrop',
+                    url: 'https://www.theguardian.com/securedrop',
+                    dataLinkName: 'securedrop',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Work for us',
+                    url: 'https://workforus.theguardian.com',
+                    dataLinkName: 'uk : footer : work for us',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Privacy policy',
+                    url: '/info/privacy',
+                    dataLinkName: 'privacy',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Cookie policy',
+                    url: '/info/cookies',
+                    dataLinkName: 'cookie',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Terms & conditions',
+                    url: '/help/terms-of-service',
+                    dataLinkName: 'terms',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Help',
+                    url: '/help',
+                    dataLinkName: 'uk : footer : tech feedback',
+                    extraClasses: 'js-tech-feedback-report',
+                },
+            ],
+            [
+                {
+                    text: 'All topics',
+                    url: '/index/subjects/a',
+                    dataLinkName: 'uk : footer : all topics',
+                    extraClasses: '',
+                },
+                {
+                    text: 'All writers',
+                    url: '/index/contributors',
+                    dataLinkName: 'uk : footer : all contributors',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Modern Slavery Act',
+                    url:
+                        '/info/2016/jul/27/modern-slavery-and-our-supply-chains?INTCMP=NGW_FOOTER_UK_GU_MODERN_SLAVERY_ACT',
+                    dataLinkName: 'uk : footer : modern slavery act statement',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Digital newspaper archive',
+                    url: 'https://theguardian.newspapers.com',
+                    dataLinkName: 'digital newspaper archive',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Facebook',
+                    url: 'https://www.facebook.com/theguardian',
+                    dataLinkName: 'uk : footer : facebook',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Twitter',
+                    url: 'https://twitter.com/guardian',
+                    dataLinkName: 'uk: footer : twitter',
+                    extraClasses: '',
+                },
+            ],
+            [
+                {
+                    text: 'Advertise with us',
+                    url: 'https://advertising.theguardian.com',
+                    dataLinkName: 'uk : footer : advertise with us',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Guardian Labs',
+                    url: '/guardian-labs',
+                    dataLinkName: 'uk : footer : guardian labs',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Search jobs',
+                    url:
+                        'https://jobs.theguardian.com?INTCMP=NGW_FOOTER_UK_GU_JOBS',
+                    dataLinkName: 'uk : footer : jobs',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Dating',
+                    url:
+                        'https://soulmates.theguardian.com?INTCMP=NGW_FOOTER_UK_GU_SOULMATES',
+                    dataLinkName: 'uk : footer : soulmates',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Patrons',
+                    url:
+                        'https://patrons.theguardian.com?INTCMP=footer_patrons',
+                    dataLinkName: 'uk : footer : patrons',
+                    extraClasses: '',
+                },
+                {
+                    text: 'Discount Codes',
+                    url: 'https://discountcode.theguardian.com/',
+                    dataLinkName: 'uk: footer : discount code',
+                    extraClasses: 'js-discount-code-link',
+                },
+            ],
+        ],
+    },
+    twitterData: {
+        'twitter:app:id:iphone': '409128287',
+        'twitter:app:name:googleplay': 'The Guardian',
+        'twitter:app:name:ipad': 'The Guardian',
+        'twitter:image':
+            'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctZGVmYXVsdC5wbmc&s=df2ce220ec7766f8635edf4fe205c488',
+        'twitter:site': '@guardian',
+        'twitter:app:url:ipad':
+            'gnmguardian://environment/2020/jan/29/i-witnessed-a-shark-attack-its-not-what-you-imagine-photo-essay?contenttype=Article&source=twitter',
+        'twitter:card': 'summary_large_image',
+        'twitter:app:name:iphone': 'The Guardian',
+        'twitter:app:id:ipad': '409128287',
+        'twitter:app:id:googleplay': 'com.guardian',
+        'twitter:app:url:googleplay':
+            'guardian://www.theguardian.com/environment/2020/jan/29/i-witnessed-a-shark-attack-its-not-what-you-imagine-photo-essay',
+        'twitter:app:url:iphone':
+            'gnmguardian://environment/2020/jan/29/i-witnessed-a-shark-attack-its-not-what-you-imagine-photo-essay?contenttype=Article&source=twitter',
+    },
+    beaconURL: '//phar.gu-web.net',
+    sectionName: 'environment',
+    editionLongForm: 'UK edition',
+    hasRelated: true,
+    pageType: {
+        hasShowcaseMainElement: false,
+        isFront: false,
+        isLiveblog: false,
+        isMinuteArticle: false,
+        isPaidContent: false,
+        isPreview: false,
+        isSensitive: false,
+    },
+    hasStoryPackage: false,
+    contributionsServiceUrl: 'https://contributions.guardianapis.com',
+    publication: 'theguardian.com',
+    trailText:
+        'Greenpeace investigator Sophie Cooke spent a month at sea observing the hidden practices behind many of the deaths of 100 million sharks every year',
+    subMetaKeywordLinks: [
+        { url: '/world/animals', title: 'Animals' },
+        { url: '/environment/conservation', title: 'Conservation' },
+        { url: '/environment/marine-life', title: 'Marine life' },
+        { url: '/environment/wildlife', title: 'Wildlife' },
+    ],
+    contentType: 'Article',
+    headline: 'We fear sharks, but humans are the real predators – photo essay',
+    nav: {
+        currentUrl: '/environment/wildlife',
+        pillars: [
+            {
+                title: 'News',
+                url: '/',
+                longTitle: 'Headlines',
+                iconName: 'home',
+                children: [
+                    {
+                        title: 'UK',
+                        url: '/uk-news',
+                        longTitle: 'UK news',
+                        iconName: '',
+                        children: [
+                            {
+                                title: 'UK politics',
+                                url: '/politics',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Education',
+                                url: '/education',
+                                longTitle: '',
+                                iconName: '',
+                                children: [
+                                    {
+                                        title: 'Schools',
+                                        url: '/education/schools',
+                                        longTitle: '',
+                                        iconName: '',
+                                        children: [],
+                                        classList: [],
+                                    },
+                                    {
+                                        title: 'Teachers',
+                                        url: '/teacher-network',
+                                        longTitle: '',
+                                        iconName: '',
+                                        children: [],
+                                        classList: [],
+                                    },
+                                    {
+                                        title: 'Universities',
+                                        url: '/education/universities',
+                                        longTitle: '',
+                                        iconName: '',
+                                        children: [],
+                                        classList: [],
+                                    },
+                                    {
+                                        title: 'Students',
+                                        url: '/education/students',
+                                        longTitle: '',
+                                        iconName: '',
+                                        children: [],
+                                        classList: [],
+                                    },
+                                ],
+                                classList: [],
+                            },
+                            {
+                                title: 'Media',
+                                url: '/media',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Society',
+                                url: '/society',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Law',
+                                url: '/law',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Scotland',
+                                url: '/uk/scotland',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Wales',
+                                url: '/uk/wales',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Northern Ireland',
+                                url: '/uk/northernireland',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                        ],
+                        classList: [],
+                    },
+                    {
+                        title: 'World',
+                        url: '/world',
+                        longTitle: 'World news',
+                        iconName: '',
+                        children: [
+                            {
+                                title: 'Europe',
+                                url: '/world/europe-news',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'US',
+                                url: '/us-news',
+                                longTitle: 'US news',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Americas',
+                                url: '/world/americas',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Asia',
+                                url: '/world/asia',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Australia',
+                                url: '/australia-news',
+                                longTitle: 'Australia news',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Middle East',
+                                url: '/world/middleeast',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Africa',
+                                url: '/world/africa',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Inequality',
+                                url: '/inequality',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Global development',
+                                url: '/global-development',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                        ],
+                        classList: [],
+                    },
+                    {
+                        title: 'Business',
+                        url: '/business',
+                        longTitle: '',
+                        iconName: '',
+                        children: [
+                            {
+                                title: 'Economics',
+                                url: '/business/economics',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Banking',
+                                url: '/business/banking',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Money',
+                                url: '/money',
+                                longTitle: '',
+                                iconName: '',
+                                children: [
+                                    {
+                                        title: 'Property',
+                                        url: '/money/property',
+                                        longTitle: '',
+                                        iconName: '',
+                                        children: [],
+                                        classList: [],
+                                    },
+                                    {
+                                        title: 'Pensions',
+                                        url: '/money/pensions',
+                                        longTitle: '',
+                                        iconName: '',
+                                        children: [],
+                                        classList: [],
+                                    },
+                                    {
+                                        title: 'Savings',
+                                        url: '/money/savings',
+                                        longTitle: '',
+                                        iconName: '',
+                                        children: [],
+                                        classList: [],
+                                    },
+                                    {
+                                        title: 'Borrowing',
+                                        url: '/money/debt',
+                                        longTitle: '',
+                                        iconName: '',
+                                        children: [],
+                                        classList: [],
+                                    },
+                                    {
+                                        title: 'Careers',
+                                        url: '/money/work-and-careers',
+                                        longTitle: '',
+                                        iconName: '',
+                                        children: [],
+                                        classList: [],
+                                    },
+                                ],
+                                classList: [],
+                            },
+                            {
+                                title: 'Markets',
+                                url: '/business/stock-markets',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Project Syndicate',
+                                url:
+                                    '/business/series/project-syndicate-economists',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'B2B',
+                                url: '/business-to-business',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Retail',
+                                url: '/business/retail',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                        ],
+                        classList: [],
+                    },
+                    {
+                        title: 'Coronavirus',
+                        url: '/world/coronavirus-outbreak',
+                        longTitle: 'Coronavirus',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Football',
+                        url: '/football',
+                        longTitle: '',
+                        iconName: '',
+                        children: [
+                            {
+                                title: 'Live scores',
+                                url: '/football/live',
+                                longTitle: 'football/live',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Tables',
+                                url: '/football/tables',
+                                longTitle: 'football/tables',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Fixtures',
+                                url: '/football/fixtures',
+                                longTitle: 'football/fixtures',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Results',
+                                url: '/football/results',
+                                longTitle: 'football/results',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Competitions',
+                                url: '/football/competitions',
+                                longTitle: 'football/competitions',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Clubs',
+                                url: '/football/teams',
+                                longTitle: 'football/teams',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                        ],
+                        classList: [],
+                    },
+                    {
+                        title: 'Environment',
+                        url: '/environment',
+                        longTitle: '',
+                        iconName: '',
+                        children: [
+                            {
+                                title: 'Climate change',
+                                url: '/environment/climate-change',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Wildlife',
+                                url: '/environment/wildlife',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Energy',
+                                url: '/environment/energy',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Pollution',
+                                url: '/environment/pollution',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                        ],
+                        classList: [],
+                    },
+                    {
+                        title: 'UK politics',
+                        url: '/politics',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Education',
+                        url: '/education',
+                        longTitle: '',
+                        iconName: '',
+                        children: [
+                            {
+                                title: 'Schools',
+                                url: '/education/schools',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Teachers',
+                                url: '/teacher-network',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Universities',
+                                url: '/education/universities',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Students',
+                                url: '/education/students',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                        ],
+                        classList: [],
+                    },
+                    {
+                        title: 'Society',
+                        url: '/society',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Science',
+                        url: '/science',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Tech',
+                        url: '/technology',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Global development',
+                        url: '/global-development',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Obituaries',
+                        url: '/tone/obituaries',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                ],
+                classList: [],
+            },
+            {
+                title: 'Opinion',
+                url: '/commentisfree',
+                longTitle: 'Opinion home',
+                iconName: 'home',
+                children: [
+                    {
+                        title: 'The Guardian view',
+                        url: '/profile/editorial',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Columnists',
+                        url: '/index/contributors',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Cartoons',
+                        url: '/cartoons/archive',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Opinion videos',
+                        url: '/type/video+tone/comment',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Letters',
+                        url: '/tone/letters',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                ],
+                classList: [],
+            },
+            {
+                title: 'Sport',
+                url: '/sport',
+                longTitle: 'Sport home',
+                iconName: 'home',
+                children: [
+                    {
+                        title: 'Football',
+                        url: '/football',
+                        longTitle: '',
+                        iconName: '',
+                        children: [
+                            {
+                                title: 'Live scores',
+                                url: '/football/live',
+                                longTitle: 'football/live',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Tables',
+                                url: '/football/tables',
+                                longTitle: 'football/tables',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Fixtures',
+                                url: '/football/fixtures',
+                                longTitle: 'football/fixtures',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Results',
+                                url: '/football/results',
+                                longTitle: 'football/results',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Competitions',
+                                url: '/football/competitions',
+                                longTitle: 'football/competitions',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Clubs',
+                                url: '/football/teams',
+                                longTitle: 'football/teams',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                        ],
+                        classList: [],
+                    },
+                    {
+                        title: 'Cricket',
+                        url: '/sport/cricket',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Rugby union',
+                        url: '/sport/rugby-union',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Tennis',
+                        url: '/sport/tennis',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Cycling',
+                        url: '/sport/cycling',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'F1',
+                        url: '/sport/formulaone',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Golf',
+                        url: '/sport/golf',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Boxing',
+                        url: '/sport/boxing',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Rugby league',
+                        url: '/sport/rugbyleague',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Racing',
+                        url: '/sport/horse-racing',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'US sports',
+                        url: '/sport/us-sport',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                ],
+                classList: [],
+            },
+            {
+                title: 'Culture',
+                url: '/culture',
+                longTitle: 'Culture home',
+                iconName: 'home',
+                children: [
+                    {
+                        title: 'Film',
+                        url: '/film',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Music',
+                        url: '/music',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'TV & radio',
+                        url: '/tv-and-radio',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Books',
+                        url: '/books',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Art & design',
+                        url: '/artanddesign',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Stage',
+                        url: '/stage',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Games',
+                        url: '/games',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Classical',
+                        url: '/music/classicalmusicandopera',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                ],
+                classList: [],
+            },
+            {
+                title: 'Lifestyle',
+                url: '/lifeandstyle',
+                longTitle: 'Lifestyle home',
+                iconName: 'home',
+                children: [
+                    {
+                        title: 'Fashion',
+                        url: '/fashion',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Food',
+                        url: '/food',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Recipes',
+                        url: '/tone/recipes',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Travel',
+                        url: '/travel',
+                        longTitle: '',
+                        iconName: '',
+                        children: [
+                            {
+                                title: 'UK',
+                                url: '/travel/uk',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Europe',
+                                url: '/travel/europe',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'US',
+                                url: '/travel/usa',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                        ],
+                        classList: [],
+                    },
+                    {
+                        title: 'Health & fitness',
+                        url: '/lifeandstyle/health-and-wellbeing',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Women',
+                        url: '/lifeandstyle/women',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Men',
+                        url: '/lifeandstyle/men',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Love & sex',
+                        url: '/lifeandstyle/love-and-sex',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Beauty',
+                        url: '/fashion/beauty',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Home & garden',
+                        url: '/lifeandstyle/home-and-garden',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Money',
+                        url: '/money',
+                        longTitle: '',
+                        iconName: '',
+                        children: [
+                            {
+                                title: 'Property',
+                                url: '/money/property',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Pensions',
+                                url: '/money/pensions',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Savings',
+                                url: '/money/savings',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Borrowing',
+                                url: '/money/debt',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                            {
+                                title: 'Careers',
+                                url: '/money/work-and-careers',
+                                longTitle: '',
+                                iconName: '',
+                                children: [],
+                                classList: [],
+                            },
+                        ],
+                        classList: [],
+                    },
+                    {
+                        title: 'Cars',
+                        url: '/technology/motoring',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                ],
+                classList: [],
+            },
+        ],
+        otherLinks: [
+            {
+                title: 'The Guardian app',
+                url:
+                    'https://www.theguardian.com/mobile/2014/may/29/the-guardian-for-mobile-and-tablet',
+                longTitle: '',
+                iconName: '',
+                children: [],
+                classList: [],
+            },
+            {
+                title: 'Video',
+                url: '/video',
+                longTitle: '',
+                iconName: '',
+                children: [],
+                classList: [],
+            },
+            {
+                title: 'Podcasts',
+                url: '/podcasts',
+                longTitle: '',
+                iconName: '',
+                children: [],
+                classList: [],
+            },
+            {
+                title: 'Pictures',
+                url: '/inpictures',
+                longTitle: '',
+                iconName: '',
+                children: [],
+                classList: [],
+            },
+            {
+                title: 'Newsletters',
+                url: '/email-newsletters',
+                longTitle: '',
+                iconName: '',
+                children: [],
+                classList: [],
+            },
+            {
+                title: "Today's paper",
+                url: '/theguardian',
+                longTitle: '',
+                iconName: '',
+                children: [
+                    {
+                        title: 'Obituaries',
+                        url: '/tone/obituaries',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'G2',
+                        url: '/theguardian/g2',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Weekend',
+                        url: '/theguardian/weekend',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'The Guide',
+                        url: '/theguardian/theguide',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Saturday review',
+                        url: '/theguardian/guardianreview',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                ],
+                classList: [],
+            },
+            {
+                title: 'Inside the Guardian',
+                url: 'https://www.theguardian.com/membership',
+                longTitle: '',
+                iconName: '',
+                children: [],
+                classList: [],
+            },
+            {
+                title: 'The Observer',
+                url: '/observer',
+                longTitle: '',
+                iconName: '',
+                children: [
+                    {
+                        title: 'Comment',
+                        url: '/theobserver/news/comment',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'The New Review',
+                        url: '/theobserver/new-review',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Observer Magazine',
+                        url: '/theobserver/magazine',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                ],
+                classList: [],
+            },
+            {
+                title: 'Guardian Weekly',
+                url:
+                    'https://www.theguardian.com/weekly?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_UK',
+                longTitle: '',
+                iconName: '',
+                children: [],
+                classList: [],
+            },
+            {
+                title: 'Professional networks',
+                url: '/guardian-professional',
+                longTitle: '',
+                iconName: '',
+                children: [],
+                classList: [],
+            },
+            {
+                title: 'Crosswords',
+                url: '/crosswords',
+                longTitle: '',
+                iconName: '',
+                children: [
+                    {
+                        title: 'Blog',
+                        url: '/crosswords/crossword-blog',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Editor',
+                        url: '/crosswords/series/crossword-editor-update',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Quick',
+                        url: '/crosswords/series/quick',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Cryptic',
+                        url: '/crosswords/series/cryptic',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Prize',
+                        url: '/crosswords/series/prize',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Weekend',
+                        url: '/crosswords/series/weekend-crossword',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Quiptic',
+                        url: '/crosswords/series/quiptic',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Genius',
+                        url: '/crosswords/series/genius',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Speedy',
+                        url: '/crosswords/series/speedy',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Everyman',
+                        url: '/crosswords/series/everyman',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Azed',
+                        url: '/crosswords/series/azed',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                ],
+                classList: [],
+            },
+        ],
+        brandExtensions: [
+            {
+                title: 'Search jobs',
+                url:
+                    'https://jobs.theguardian.com?INTCMP=jobs_uk_web_newheader_dropdown',
+                longTitle: '',
+                iconName: '',
+                children: [],
+                classList: [],
+            },
+            {
+                title: 'Dating',
+                url:
+                    'https://soulmates.theguardian.com?INTCMP=soulmates_uk_web_newheader_dropdown',
+                longTitle: '',
+                iconName: '',
+                children: [],
+                classList: [],
+            },
+            {
+                title: 'Holidays',
+                url:
+                    'https://holidays.theguardian.com?INTCMP=holidays_uk_web_newheader',
+                longTitle: '',
+                iconName: '',
+                children: [],
+                classList: [],
+            },
+            {
+                title: 'Live events',
+                url:
+                    'https://membership.theguardian.com/events?INTCMP=live_uk_header_dropdown',
+                longTitle: '',
+                iconName: '',
+                children: [],
+                classList: [],
+            },
+            {
+                title: 'Masterclasses',
+                url: '/guardian-masterclasses',
+                longTitle: '',
+                iconName: '',
+                children: [],
+                classList: [],
+            },
+            {
+                title: 'Digital Archive',
+                url: 'https://theguardian.newspapers.com',
+                longTitle: '',
+                iconName: '',
+                children: [],
+                classList: [],
+            },
+            {
+                title: 'Guardian Print Shop',
+                url: '/artanddesign/series/gnm-print-sales',
+                longTitle: '',
+                iconName: '',
+                children: [],
+                classList: [],
+            },
+            {
+                title: 'Patrons',
+                url: 'https://patrons.theguardian.com/?INTCMP=header_patrons',
+                longTitle: '',
+                iconName: '',
+                children: [],
+                classList: [],
+            },
+            {
+                title: 'Discount Codes',
+                url: 'https://discountcode.theguardian.com',
+                longTitle: '',
+                iconName: '',
+                children: [],
+                classList: ['js-discount-code-link'],
+            },
+            {
+                title: 'Guardian Puzzles app',
+                url: 'https://puzzles.theguardian.com/download',
+                longTitle: '',
+                iconName: '',
+                children: [],
+                classList: [],
+            },
+        ],
+        currentNavLink: {
+            title: 'Wildlife',
+            url: '/environment/wildlife',
+            longTitle: '',
+            iconName: '',
+            children: [],
+            classList: [],
+        },
+        currentParent: {
+            title: 'Environment',
+            url: '/environment',
+            longTitle: '',
+            iconName: '',
+            children: [
+                {
+                    title: 'Climate change',
+                    url: '/environment/climate-change',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Wildlife',
+                    url: '/environment/wildlife',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Energy',
+                    url: '/environment/energy',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Pollution',
+                    url: '/environment/pollution',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+            ],
+            classList: [],
+        },
+        currentPillar: {
+            title: 'News',
+            url: '/',
+            longTitle: 'Headlines',
+            iconName: 'home',
+            children: [
+                {
+                    title: 'UK',
+                    url: '/uk-news',
+                    longTitle: 'UK news',
+                    iconName: '',
+                    children: [
+                        {
+                            title: 'UK politics',
+                            url: '/politics',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Education',
+                            url: '/education',
+                            longTitle: '',
+                            iconName: '',
+                            children: [
+                                {
+                                    title: 'Schools',
+                                    url: '/education/schools',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Teachers',
+                                    url: '/teacher-network',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Universities',
+                                    url: '/education/universities',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Students',
+                                    url: '/education/students',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                            ],
+                            classList: [],
+                        },
+                        {
+                            title: 'Media',
+                            url: '/media',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Society',
+                            url: '/society',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Law',
+                            url: '/law',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Scotland',
+                            url: '/uk/scotland',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Wales',
+                            url: '/uk/wales',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Northern Ireland',
+                            url: '/uk/northernireland',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                    ],
+                    classList: [],
+                },
+                {
+                    title: 'World',
+                    url: '/world',
+                    longTitle: 'World news',
+                    iconName: '',
+                    children: [
+                        {
+                            title: 'Europe',
+                            url: '/world/europe-news',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'US',
+                            url: '/us-news',
+                            longTitle: 'US news',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Americas',
+                            url: '/world/americas',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Asia',
+                            url: '/world/asia',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Australia',
+                            url: '/australia-news',
+                            longTitle: 'Australia news',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Middle East',
+                            url: '/world/middleeast',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Africa',
+                            url: '/world/africa',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Inequality',
+                            url: '/inequality',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Global development',
+                            url: '/global-development',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                    ],
+                    classList: [],
+                },
+                {
+                    title: 'Business',
+                    url: '/business',
+                    longTitle: '',
+                    iconName: '',
+                    children: [
+                        {
+                            title: 'Economics',
+                            url: '/business/economics',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Banking',
+                            url: '/business/banking',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Money',
+                            url: '/money',
+                            longTitle: '',
+                            iconName: '',
+                            children: [
+                                {
+                                    title: 'Property',
+                                    url: '/money/property',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Pensions',
+                                    url: '/money/pensions',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Savings',
+                                    url: '/money/savings',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Borrowing',
+                                    url: '/money/debt',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                                {
+                                    title: 'Careers',
+                                    url: '/money/work-and-careers',
+                                    longTitle: '',
+                                    iconName: '',
+                                    children: [],
+                                    classList: [],
+                                },
+                            ],
+                            classList: [],
+                        },
+                        {
+                            title: 'Markets',
+                            url: '/business/stock-markets',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Project Syndicate',
+                            url:
+                                '/business/series/project-syndicate-economists',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'B2B',
+                            url: '/business-to-business',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Retail',
+                            url: '/business/retail',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                    ],
+                    classList: [],
+                },
+                {
+                    title: 'Coronavirus',
+                    url: '/world/coronavirus-outbreak',
+                    longTitle: 'Coronavirus',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Football',
+                    url: '/football',
+                    longTitle: '',
+                    iconName: '',
+                    children: [
+                        {
+                            title: 'Live scores',
+                            url: '/football/live',
+                            longTitle: 'football/live',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Tables',
+                            url: '/football/tables',
+                            longTitle: 'football/tables',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Fixtures',
+                            url: '/football/fixtures',
+                            longTitle: 'football/fixtures',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Results',
+                            url: '/football/results',
+                            longTitle: 'football/results',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Competitions',
+                            url: '/football/competitions',
+                            longTitle: 'football/competitions',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Clubs',
+                            url: '/football/teams',
+                            longTitle: 'football/teams',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                    ],
+                    classList: [],
+                },
+                {
+                    title: 'Environment',
+                    url: '/environment',
+                    longTitle: '',
+                    iconName: '',
+                    children: [
+                        {
+                            title: 'Climate change',
+                            url: '/environment/climate-change',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Wildlife',
+                            url: '/environment/wildlife',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Energy',
+                            url: '/environment/energy',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Pollution',
+                            url: '/environment/pollution',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                    ],
+                    classList: [],
+                },
+                {
+                    title: 'UK politics',
+                    url: '/politics',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Education',
+                    url: '/education',
+                    longTitle: '',
+                    iconName: '',
+                    children: [
+                        {
+                            title: 'Schools',
+                            url: '/education/schools',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Teachers',
+                            url: '/teacher-network',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Universities',
+                            url: '/education/universities',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                        {
+                            title: 'Students',
+                            url: '/education/students',
+                            longTitle: '',
+                            iconName: '',
+                            children: [],
+                            classList: [],
+                        },
+                    ],
+                    classList: [],
+                },
+                {
+                    title: 'Society',
+                    url: '/society',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Science',
+                    url: '/science',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Tech',
+                    url: '/technology',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Global development',
+                    url: '/global-development',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Obituaries',
+                    url: '/tone/obituaries',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+            ],
+            classList: [],
+        },
+        subNavSections: {
+            parent: {
+                title: 'Environment',
+                url: '/environment',
+                longTitle: '',
+                iconName: '',
+                children: [
+                    {
+                        title: 'Climate change',
+                        url: '/environment/climate-change',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Wildlife',
+                        url: '/environment/wildlife',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Energy',
+                        url: '/environment/energy',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                    {
+                        title: 'Pollution',
+                        url: '/environment/pollution',
+                        longTitle: '',
+                        iconName: '',
+                        children: [],
+                        classList: [],
+                    },
+                ],
+                classList: [],
+            },
+            links: [
+                {
+                    title: 'Climate change',
+                    url: '/environment/climate-change',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Wildlife',
+                    url: '/environment/wildlife',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Energy',
+                    url: '/environment/energy',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+                {
+                    title: 'Pollution',
+                    url: '/environment/pollution',
+                    longTitle: '',
+                    iconName: '',
+                    children: [],
+                    classList: [],
+                },
+            ],
+        },
+        readerRevenueLinks: {
+            header: {
+                contribute:
+                    'https://support.theguardian.com/contribute?INTCMP=header_support_contribute&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support_contribute%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+                subscribe:
+                    'https://support.theguardian.com/subscribe?INTCMP=header_support_subscribe&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support_subscribe%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+                support:
+                    'https://support.theguardian.com?INTCMP=header_support&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+            },
+            footer: {
+                contribute:
+                    'https://support.theguardian.com/contribute?INTCMP=footer_support_contribute&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22footer_support_contribute%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+                subscribe:
+                    'https://support.theguardian.com/subscribe?INTCMP=footer_support_subscribe&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22footer_support_subscribe%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+                support:
+                    'https://support.theguardian.com?INTCMP=footer_support&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22footer_support%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+            },
+            sideMenu: {
+                contribute:
+                    'https://support.theguardian.com/contribute?INTCMP=side_menu_support_contribute&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22side_menu_support_contribute%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+                subscribe:
+                    'https://support.theguardian.com/subscribe?INTCMP=side_menu_support_subscribe&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22side_menu_support_subscribe%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+                support:
+                    'https://support.theguardian.com?INTCMP=side_menu_support&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22side_menu_support%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+            },
+            ampHeader: {
+                contribute:
+                    'https://support.theguardian.com/contribute?INTCMP=header_support_contribute&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support_contribute%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+                subscribe:
+                    'https://support.theguardian.com/subscribe?INTCMP=header_support_subscribe&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support_subscribe%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+                support:
+                    'https://support.theguardian.com?INTCMP=amp_header_support&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22amp_header_support%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+            },
+            ampFooter: {
+                contribute:
+                    'https://support.theguardian.com/contribute?INTCMP=amp_footer_support_contribute&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22amp_footer_support_contribute%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+                subscribe:
+                    'https://support.theguardian.com/subscribe?INTCMP=amp_footer_support_subscribe&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22amp_footer_support_subscribe%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+                support:
+                    'https://support.theguardian.com?INTCMP=footer_support&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22footer_support%22,%22source%22:%22GUARDIAN_WEB%22%7D',
+            },
+        },
+    },
+    guardianBaseURL: 'https://www.theguardian.com',
+    mainMediaElements: [
+        {
+            role: 'inline',
+            data: {
+                copyright: '© Tommy Trenchard / Greenpeace',
+                alt: 'A shark is hauled into the hold of a longliner.',
+                caption: 'Every year 100 million sharks are killed.',
+                credit: 'Photograph: Tommy Trenchard/Greenpeace',
+            },
+            imageSources: [
+                {
+                    weighting: 'inline',
+                    srcSet: [
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=620&quality=85&auto=format&fit=max&s=59c14a5f5dd82b5c259bc20ebf221027',
+                            width: 620,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=c2bf5b76cc19d899e3bab5c37cd5ef26',
+                            width: 1240,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=605&quality=85&auto=format&fit=max&s=07f5237db090f2703789483bf91d0383',
+                            width: 605,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=80e6e82f8cc5d51ff4da0a19719298e1',
+                            width: 1210,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=445&quality=85&auto=format&fit=max&s=870d1db1d388c4f152ed44304599d654',
+                            width: 445,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=27f1140964c02f72a93259dec894f9ea',
+                            width: 890,
+                        },
+                    ],
+                },
+                {
+                    weighting: 'thumbnail',
+                    srcSet: [
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=140&quality=85&auto=format&fit=max&s=8482743c105124eca57c111b41e40938',
+                            width: 140,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=2954de58d05f38691b54a60e445f4e0d',
+                            width: 280,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=120&quality=85&auto=format&fit=max&s=fdafaa132ac103b69cae4b9dbbf78731',
+                            width: 120,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=1958a31562aa9fe2fc52f0d16b6f3a68',
+                            width: 240,
+                        },
+                    ],
+                },
+                {
+                    weighting: 'supporting',
+                    srcSet: [
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=380&quality=85&auto=format&fit=max&s=7912c7a52b5091206c7dae0744ce8f88',
+                            width: 380,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=a9b6392dc7ef805279d51f01da22fdbf',
+                            width: 760,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=300&quality=85&auto=format&fit=max&s=df7c5cc78edd93da9f708207809e5eed',
+                            width: 300,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=63d3c7831e7d5a74876164b1a7d96642',
+                            width: 600,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=620&quality=85&auto=format&fit=max&s=59c14a5f5dd82b5c259bc20ebf221027',
+                            width: 620,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=c2bf5b76cc19d899e3bab5c37cd5ef26',
+                            width: 1240,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=605&quality=85&auto=format&fit=max&s=07f5237db090f2703789483bf91d0383',
+                            width: 605,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=80e6e82f8cc5d51ff4da0a19719298e1',
+                            width: 1210,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=445&quality=85&auto=format&fit=max&s=870d1db1d388c4f152ed44304599d654',
+                            width: 445,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=27f1140964c02f72a93259dec894f9ea',
+                            width: 890,
+                        },
+                    ],
+                },
+                {
+                    weighting: 'showcase',
+                    srcSet: [
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=1020&quality=85&auto=format&fit=max&s=9cb7b9b95ddf816090fdeadb341b6115',
+                            width: 1020,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=1020&quality=45&auto=format&fit=max&dpr=2&s=ca46a83e73439b090f24e222af912239',
+                            width: 2040,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=940&quality=85&auto=format&fit=max&s=eec125e8fcb258de36077a9b11dc5b17',
+                            width: 940,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=940&quality=45&auto=format&fit=max&dpr=2&s=55a71c4544da82095ec614a02f578226',
+                            width: 1880,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=700&quality=85&auto=format&fit=max&s=a43370c722f283b44ccc72a62e2fa265',
+                            width: 700,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=2d4abdde5dfce7211d04759e270cad65',
+                            width: 1400,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=700&quality=85&auto=format&fit=max&s=a43370c722f283b44ccc72a62e2fa265',
+                            width: 700,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=2d4abdde5dfce7211d04759e270cad65',
+                            width: 1400,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=660&quality=85&auto=format&fit=max&s=e14980ea864670528176726e1e3a9ebb',
+                            width: 660,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=660&quality=45&auto=format&fit=max&dpr=2&s=4a60a58e7cef143e23037dfd44325471',
+                            width: 1320,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=645&quality=85&auto=format&fit=max&s=09ca055b7f629f0511d245d2330528f2',
+                            width: 645,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=cc92a27689312ca3c97890ef9b8acb02',
+                            width: 1290,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=465&quality=85&auto=format&fit=max&s=5fdede12c4165686317b4a6041e93060',
+                            width: 465,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=34ebff519ebc7e9d298c6d3e38f928f5',
+                            width: 930,
+                        },
+                    ],
+                },
+                {
+                    weighting: 'halfwidth',
+                    srcSet: [
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=620&quality=85&auto=format&fit=max&s=59c14a5f5dd82b5c259bc20ebf221027',
+                            width: 620,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=c2bf5b76cc19d899e3bab5c37cd5ef26',
+                            width: 1240,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=605&quality=85&auto=format&fit=max&s=07f5237db090f2703789483bf91d0383',
+                            width: 605,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=80e6e82f8cc5d51ff4da0a19719298e1',
+                            width: 1210,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=445&quality=85&auto=format&fit=max&s=870d1db1d388c4f152ed44304599d654',
+                            width: 445,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=27f1140964c02f72a93259dec894f9ea',
+                            width: 890,
+                        },
+                    ],
+                },
+                {
+                    weighting: 'immersive',
+                    srcSet: [
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=1300&quality=85&auto=format&fit=max&s=1553c52a0744a1ee7b4803ec1d9d884c',
+                            width: 1300,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=1300&quality=45&auto=format&fit=max&dpr=2&s=1cf8b9afee65d7f2e7eb4c38d3ff1351',
+                            width: 2600,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=1140&quality=85&auto=format&fit=max&s=f141ac2d064d8aaa838450fd0d24f84e',
+                            width: 1140,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=1140&quality=45&auto=format&fit=max&dpr=2&s=62968b4eb0e3801e8041f64981c80a23',
+                            width: 2280,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=1125&quality=85&auto=format&fit=max&s=615ac5c898da8f7f6caa9c99b2a3262e',
+                            width: 1125,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=1125&quality=45&auto=format&fit=max&dpr=2&s=9b4cdf0335c4d483404a6e6b9c1d5244',
+                            width: 2250,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=965&quality=85&auto=format&fit=max&s=8ec27aa88a7a93a5febb568d9d4a8d9d',
+                            width: 965,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=965&quality=45&auto=format&fit=max&dpr=2&s=3bb885b6c2b49bcb87665a5488f67d7f',
+                            width: 1930,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=725&quality=85&auto=format&fit=max&s=a02bff89057a6f8baef8338efe9f31b8',
+                            width: 725,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=725&quality=45&auto=format&fit=max&dpr=2&s=619a51ba9099a12b6de53207aae1e35f',
+                            width: 1450,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=645&quality=85&auto=format&fit=max&s=09ca055b7f629f0511d245d2330528f2',
+                            width: 645,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=cc92a27689312ca3c97890ef9b8acb02',
+                            width: 1290,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=465&quality=85&auto=format&fit=max&s=5fdede12c4165686317b4a6041e93060',
+                            width: 465,
+                        },
+                        {
+                            src:
+                                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=34ebff519ebc7e9d298c6d3e38f928f5',
+                            width: 930,
+                        },
+                    ],
+                },
+            ],
+            _type: 'model.dotcomrendering.pageElements.ImageBlockElement',
+            media: {
+                allImages: [
+                    {
+                        index: 0,
+                        fields: { height: '1200', width: '2000' },
+                        mediaType: 'Image',
+                        mimeType: 'image/jpeg',
+                        url:
+                            'https://media.guim.co.uk/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/2000.jpg',
+                    },
+                    {
+                        index: 1,
+                        fields: { height: '600', width: '1000' },
+                        mediaType: 'Image',
+                        mimeType: 'image/jpeg',
+                        url:
+                            'https://media.guim.co.uk/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/1000.jpg',
+                    },
+                    {
+                        index: 2,
+                        fields: { height: '300', width: '500' },
+                        mediaType: 'Image',
+                        mimeType: 'image/jpeg',
+                        url:
+                            'https://media.guim.co.uk/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/500.jpg',
+                    },
+                    {
+                        index: 3,
+                        fields: { height: '84', width: '140' },
+                        mediaType: 'Image',
+                        mimeType: 'image/jpeg',
+                        url:
+                            'https://media.guim.co.uk/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/140.jpg',
+                    },
+                    {
+                        index: 4,
+                        fields: { height: '1321', width: '2203' },
+                        mediaType: 'Image',
+                        mimeType: 'image/jpeg',
+                        url:
+                            'https://media.guim.co.uk/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/2203.jpg',
+                    },
+                    {
+                        index: 5,
+                        fields: {
+                            isMaster: 'true',
+                            height: '1321',
+                            width: '2203',
+                        },
+                        mediaType: 'Image',
+                        mimeType: 'image/jpeg',
+                        url:
+                            'https://media.guim.co.uk/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg',
+                    },
+                ],
+            },
+            displayCredit: true,
+        },
+    ],
+    webPublicationDate: '2020-01-29T13:37:43.000Z',
+    author: { byline: 'Sophie Cooke' },
+    designType: 'Article',
+    blocks: [
+        {
+            id: '5df3cc848f087e8308e5db6f',
+            elements: [
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>On the end of a hook is a shark much larger than me. Its white belly gleams clean and sleek against the rusty hull of the ship as it is hauled out of the ocean, thrashing about trying to escape. They kill it by severing its spine with a knife.</p>',
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>For a generation, the film <a href="https://www.theguardian.com/film/2015/may/31/jaws-40-years-on-truly-great-lasting-classics-of-america-cinema">Jaws</a> was the source of an irrational fear of sharks, which has probably made it harder for many to connect to their plight. People see it almost as a kill or be killed response. On the high seas, however, it’s clear who the real predators are.</p>',
+                },
+                {
+                    role: 'inline',
+                    data: {
+                        copyright: '© Tommy Trenchard / Greenpeace',
+                        alt:
+                            'A shark is hauled onboard a longliner targeting swordfish in the southeast Atlantic.',
+                        caption:
+                            'A shark is hauled onboard a longliner targeting swordfish in the southeast Atlantic.',
+                        credit: 'Photograph: Tommy Trenchard/Greenpeace',
+                    },
+                    imageSources: [
+                        {
+                            weighting: 'inline',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=082c87fb08c1d7c3bdcf309b406f8733',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=fddb3a1f4634b55f64975ca9a6859546',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=49a644545e0d362a03011fe69eebd959',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=b013750242712b89461df874bf931085',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=5ef45c8b714c94e03a895f13e8c28816',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=7d7a5fc9bcf077d150ce54757e61294d',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'thumbnail',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=140&quality=85&auto=format&fit=max&s=8604fd47cf541daa236cb157183e3744',
+                                    width: 140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=17a6e658daf40517d4c6a8c59bd9d27c',
+                                    width: 280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=120&quality=85&auto=format&fit=max&s=44beb65a2b10a95f546842e7700fb283',
+                                    width: 120,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=952f941778441acbb97f0d46f58d9e7c',
+                                    width: 240,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'supporting',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=380&quality=85&auto=format&fit=max&s=868784209f96408e16578b823933616a',
+                                    width: 380,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=a32e59c8915a89881dcb9d310b11478c',
+                                    width: 760,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=300&quality=85&auto=format&fit=max&s=1402d23e2838004b3c4b42b571192ef8',
+                                    width: 300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=99590c997b209ff30d22399627092d91',
+                                    width: 600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=082c87fb08c1d7c3bdcf309b406f8733',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=fddb3a1f4634b55f64975ca9a6859546',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=49a644545e0d362a03011fe69eebd959',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=b013750242712b89461df874bf931085',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=5ef45c8b714c94e03a895f13e8c28816',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=7d7a5fc9bcf077d150ce54757e61294d',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'showcase',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=1020&quality=85&auto=format&fit=max&s=c78cd863d442afb67eb0bb106f80317d',
+                                    width: 1020,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=1020&quality=45&auto=format&fit=max&dpr=2&s=12c23f20b1007c7a65ee3c8ef5ebadde',
+                                    width: 2040,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=940&quality=85&auto=format&fit=max&s=14246e9907a3a5cb6d8dcd0cd782c604',
+                                    width: 940,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=940&quality=45&auto=format&fit=max&dpr=2&s=96bc466e06b52146749218c5f1edea39',
+                                    width: 1880,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=20be19aab76ea316bad88e482823534b',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=b1844cd3981e10db28de4a730b577e23',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=20be19aab76ea316bad88e482823534b',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=b1844cd3981e10db28de4a730b577e23',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=660&quality=85&auto=format&fit=max&s=c6fd7e99bfbf87011b7a950ef4280b11',
+                                    width: 660,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=660&quality=45&auto=format&fit=max&dpr=2&s=ec688181d97aa0888b2f260dc61968c0',
+                                    width: 1320,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=f5aeda45fd2b8d5ec190211dc86d5212',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=9aab59793ddb83bcf0afbb7b1429d786',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=511bffbfbd688acb2c3a10dfce418bc4',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=777b5d09ac34f917981aef058d841940',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'halfwidth',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=082c87fb08c1d7c3bdcf309b406f8733',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=fddb3a1f4634b55f64975ca9a6859546',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=49a644545e0d362a03011fe69eebd959',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=b013750242712b89461df874bf931085',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=5ef45c8b714c94e03a895f13e8c28816',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=7d7a5fc9bcf077d150ce54757e61294d',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'immersive',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=1300&quality=85&auto=format&fit=max&s=bdab487fe0fdd2417d30e988c3fa064d',
+                                    width: 1300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=1300&quality=45&auto=format&fit=max&dpr=2&s=846c9e49dfff425782c5431953b4d288',
+                                    width: 2600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=1140&quality=85&auto=format&fit=max&s=83ce4458a0d52bf6968b6ead48682da4',
+                                    width: 1140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=1140&quality=45&auto=format&fit=max&dpr=2&s=dbc94302d3cd33cc900503bc2ec531d0',
+                                    width: 2280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=1125&quality=85&auto=format&fit=max&s=3a30fcf0d41adeee11e7203de11c2132',
+                                    width: 1125,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=1125&quality=45&auto=format&fit=max&dpr=2&s=12644c6d4f115a4e1096f71f686dc09c',
+                                    width: 2250,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=965&quality=85&auto=format&fit=max&s=71f9acd16096d6589999714976dbb594',
+                                    width: 965,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=965&quality=45&auto=format&fit=max&dpr=2&s=f626fe45299d52777baaf21e2d34fe98',
+                                    width: 1930,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=725&quality=85&auto=format&fit=max&s=8bf181d5c6d528bfed38494187eaccef',
+                                    width: 725,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=725&quality=45&auto=format&fit=max&dpr=2&s=1cac870277f85abbcffab91f3986f454',
+                                    width: 1450,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=f5aeda45fd2b8d5ec190211dc86d5212',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=9aab59793ddb83bcf0afbb7b1429d786',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=511bffbfbd688acb2c3a10dfce418bc4',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=777b5d09ac34f917981aef058d841940',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                    ],
+                    _type:
+                        'model.dotcomrendering.pageElements.ImageBlockElement',
+                    media: {
+                        allImages: [
+                            {
+                                index: 0,
+                                fields: { height: '1667', width: '2500' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/2500.jpg',
+                            },
+                            {
+                                index: 1,
+                                fields: {
+                                    isMaster: 'true',
+                                    height: '1667',
+                                    width: '2500',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/master/2500.jpg',
+                            },
+                            {
+                                index: 2,
+                                fields: { height: '1334', width: '2000' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/2000.jpg',
+                            },
+                            {
+                                index: 3,
+                                fields: { height: '667', width: '1000' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/1000.jpg',
+                            },
+                            {
+                                index: 4,
+                                fields: { height: '333', width: '500' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/500.jpg',
+                            },
+                            {
+                                index: 5,
+                                fields: { height: '93', width: '140' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/3b2c68f22cbc81b7d17245453eb7247bbe0cbbbc/0_0_2500_1667/140.jpg',
+                            },
+                        ],
+                    },
+                    displayCredit: true,
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>Sharks are under attack all over the world. The statistics are grim: <a href="https://www.sciencedirect.com/science/article/pii/S0308597X13000055">100 million sharks are killed every year</a>. Here I was, face to face with one of them, as it was hauled out of the water and cut to pieces.</p>',
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>In September, Greenpeace took its ship the Arctic Sunrise on to the high seas of the South Atlantic to expose the fishing vessels emptying our oceans and to draw attention to why we want a <a href="https://www.greenpeace.org.uk/wp-content/uploads/2019/06/Why-we-need-a-Global-Ocean-Treaty-1.pdf">Global Ocean Treaty </a>that can create huge sanctuaries free from this kind of pillaging.</p>',
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>Here, ships operate out of sight and out of mind: a system enabled by the fragmented governance of our global oceans – a space bigger than every continent combined but managed by a patchwork of regional bodies dominated by industrial fishing interests. It’s a peculiar system for the “blue planet”, almost half of which is covered by ocean beyond national borders that by rights belongs to us all.</p>',
+                },
+                {
+                    role: 'halfWidth',
+                    data: {
+                        copyright: '© Tommy Trenchard / Greenpeace',
+                        alt:
+                            'A crew bring in their lines in the mid-Atlantic ocean.',
+                        caption:
+                            'A crew bring in their lines in the mid-Atlantic ocean.',
+                        credit: 'Photograph: Tommy Trenchard/Greenpeace',
+                    },
+                    imageSources: [
+                        {
+                            weighting: 'inline',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=fb31a2207fc4e1332357d9fea721f67a',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=03108401df08ef2031553a59f6965a6d',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=3599efdddbfb224ff72c31929936bdb3',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=f25c8713efed61b5dfec96982b1e6700',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=895ed6c87e64adb71593a609bb63be80',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=5809dc7a45033432f60e6d6c0552aad5',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'thumbnail',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=140&quality=85&auto=format&fit=max&s=8a44febfd59d44877df02e1b6525a54b',
+                                    width: 140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=ebcd54e0df37761e53429c3364d0c7f4',
+                                    width: 280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=120&quality=85&auto=format&fit=max&s=37a46041743756690614adf24db288ff',
+                                    width: 120,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=fa47fb7c87a1c8aadac95e9e7d7d1025',
+                                    width: 240,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'supporting',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=380&quality=85&auto=format&fit=max&s=b08192b2246351d5976e69e789f2d984',
+                                    width: 380,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=8c5959c60e17551e53dad03e408b088c',
+                                    width: 760,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=300&quality=85&auto=format&fit=max&s=a77cb4c883c9e5df9d3b216fa8d93446',
+                                    width: 300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=7181e8d0163ca96e2fabd396f2843489',
+                                    width: 600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=fb31a2207fc4e1332357d9fea721f67a',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=03108401df08ef2031553a59f6965a6d',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=3599efdddbfb224ff72c31929936bdb3',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=f25c8713efed61b5dfec96982b1e6700',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=895ed6c87e64adb71593a609bb63be80',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=5809dc7a45033432f60e6d6c0552aad5',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'showcase',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=1020&quality=85&auto=format&fit=max&s=52687d76e03cf68fb12c1e3d64c6a037',
+                                    width: 1020,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=1020&quality=45&auto=format&fit=max&dpr=2&s=fa425aabb6b68a4f7b43cf7cf3965eb9',
+                                    width: 2040,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=940&quality=85&auto=format&fit=max&s=99209dd74cf6976718cf067b548b06f4',
+                                    width: 940,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=940&quality=45&auto=format&fit=max&dpr=2&s=dfed964aa16795d9d124f92421645111',
+                                    width: 1880,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=2772b5e88098bd4afca88ec693aedb97',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=26930807b691adeeb078e7c1b33713b1',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=2772b5e88098bd4afca88ec693aedb97',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=26930807b691adeeb078e7c1b33713b1',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=660&quality=85&auto=format&fit=max&s=ade748e27e01134b73c6ee5b982590f1',
+                                    width: 660,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=660&quality=45&auto=format&fit=max&dpr=2&s=a6a9f00d7cd50b9d0e840db379b3e316',
+                                    width: 1320,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=8fdfd5f1159c6472b2220b7673822076',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=c5f6735fa66510a5aa46411aa1f432c1',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=50b7fb2dedb47e59fb54d9f78caedc0d',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=5f5c99789059a9896604393b95ed4707',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'halfwidth',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=fb31a2207fc4e1332357d9fea721f67a',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=03108401df08ef2031553a59f6965a6d',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=3599efdddbfb224ff72c31929936bdb3',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=f25c8713efed61b5dfec96982b1e6700',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=895ed6c87e64adb71593a609bb63be80',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=5809dc7a45033432f60e6d6c0552aad5',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'immersive',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=1300&quality=85&auto=format&fit=max&s=c2450e1242527c0b13480519a0ff6f28',
+                                    width: 1300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=1300&quality=45&auto=format&fit=max&dpr=2&s=38856465d2ddc2cb66b3dd47dbfc2c94',
+                                    width: 2600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=1140&quality=85&auto=format&fit=max&s=8895e6caf4134e56f4c7878736a17c49',
+                                    width: 1140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=1140&quality=45&auto=format&fit=max&dpr=2&s=72aac437ad890082ba4f68667c0834e6',
+                                    width: 2280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=1125&quality=85&auto=format&fit=max&s=aec38d76637a332c3f35499c623ac9f6',
+                                    width: 1125,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=1125&quality=45&auto=format&fit=max&dpr=2&s=ec34019a63e9282a57377fe2b352886c',
+                                    width: 2250,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=965&quality=85&auto=format&fit=max&s=1f77bd46586928b1518f9cbb2dea0014',
+                                    width: 965,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=965&quality=45&auto=format&fit=max&dpr=2&s=6bdf521fc7acc620f3d526d35484e5a9',
+                                    width: 1930,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=725&quality=85&auto=format&fit=max&s=4ac8e30054b4fdb11839f57252de331f',
+                                    width: 725,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=725&quality=45&auto=format&fit=max&dpr=2&s=9fba175e0115eafc4a690dae111715ad',
+                                    width: 1450,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=8fdfd5f1159c6472b2220b7673822076',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=c5f6735fa66510a5aa46411aa1f432c1',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=50b7fb2dedb47e59fb54d9f78caedc0d',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=5f5c99789059a9896604393b95ed4707',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                    ],
+                    _type:
+                        'model.dotcomrendering.pageElements.ImageBlockElement',
+                    media: {
+                        allImages: [
+                            {
+                                index: 0,
+                                fields: { height: '1667', width: '2500' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/2500.jpg',
+                            },
+                            {
+                                index: 1,
+                                fields: {
+                                    isMaster: 'true',
+                                    height: '1667',
+                                    width: '2500',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/master/2500.jpg',
+                            },
+                            {
+                                index: 2,
+                                fields: { height: '1334', width: '2000' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/2000.jpg',
+                            },
+                            {
+                                index: 3,
+                                fields: { height: '667', width: '1000' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/1000.jpg',
+                            },
+                            {
+                                index: 4,
+                                fields: { height: '333', width: '500' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/500.jpg',
+                            },
+                            {
+                                index: 5,
+                                fields: { height: '93', width: '140' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/9f33a2a5afa97ad182742afd4b3abd88ec06592e/0_0_2500_1667/140.jpg',
+                            },
+                        ],
+                    },
+                    displayCredit: true,
+                },
+                {
+                    role: 'halfWidth',
+                    data: {
+                        copyright: '© Tommy Trenchard / Greenpeace',
+                        alt:
+                            'The crew a longliner bring in their lines in the mid-Atlantic ocean.',
+                        caption:
+                            'Greenpeace tracked the activities of fishing vessels for a month.',
+                        credit: 'Photograph: Tommy Trenchard/Greenpeace',
+                    },
+                    imageSources: [
+                        {
+                            weighting: 'inline',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=7c6cbce636fc2fdab2d7bd59ff216b56',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=f70c82e1aeb29200dead6bc75fa7e62e',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=ba3ec5fa9208484991f3558e28405987',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=276e233d30466a81925526a2f70c9dad',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=d7059c11a153e594bcc85b01ddcf3081',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=12e2c5782985bf7e1d8f67511b58bab5',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'thumbnail',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=140&quality=85&auto=format&fit=max&s=36612131f02d7a5beec68d077e718f58',
+                                    width: 140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=1336b29d9bbad731744d69a4af111e11',
+                                    width: 280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=120&quality=85&auto=format&fit=max&s=03120f845583ad0aea5048c63a8aa78f',
+                                    width: 120,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=7f07472f052d95f612a1fbc3e63c6016',
+                                    width: 240,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'supporting',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=380&quality=85&auto=format&fit=max&s=4362c1bd78e0a5ffb51b4230f84fefeb',
+                                    width: 380,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=8c9c334a0fd23160d6668e7f0ced1aaa',
+                                    width: 760,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=300&quality=85&auto=format&fit=max&s=8a935752bbae7332942b07e562404fe3',
+                                    width: 300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=ecb5fecfeacc7b9acc4c9fe14bd52b0d',
+                                    width: 600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=7c6cbce636fc2fdab2d7bd59ff216b56',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=f70c82e1aeb29200dead6bc75fa7e62e',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=ba3ec5fa9208484991f3558e28405987',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=276e233d30466a81925526a2f70c9dad',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=d7059c11a153e594bcc85b01ddcf3081',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=12e2c5782985bf7e1d8f67511b58bab5',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'showcase',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=1020&quality=85&auto=format&fit=max&s=1663aad9cc45852b2d066321b8e48c65',
+                                    width: 1020,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=1020&quality=45&auto=format&fit=max&dpr=2&s=34eb8885917e18b91d296ca75e69ade8',
+                                    width: 2040,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=940&quality=85&auto=format&fit=max&s=72c0700f538955bea8b2bc36ba812ce8',
+                                    width: 940,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=940&quality=45&auto=format&fit=max&dpr=2&s=09a090f5f02684d2bceca21f413a4edd',
+                                    width: 1880,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=f666bb563dbf40ff93a050079d1fe2d8',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=187be3b1019693d35d5be31c348d1f04',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=f666bb563dbf40ff93a050079d1fe2d8',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=187be3b1019693d35d5be31c348d1f04',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=660&quality=85&auto=format&fit=max&s=8d328fe84d53a92b69a0ca09a229f085',
+                                    width: 660,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=660&quality=45&auto=format&fit=max&dpr=2&s=82ab684d4d4a7e4d73cae9af1affabbc',
+                                    width: 1320,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=3e2d149cb7801f5b8d8405e6e47fae21',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=c4f7c30db8911427af9123d21d3123fc',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=8a05f563448491c7eb0f697a86eda073',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=79f9d17d0313fe82f9b86e1b80245cc1',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'halfwidth',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=7c6cbce636fc2fdab2d7bd59ff216b56',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=f70c82e1aeb29200dead6bc75fa7e62e',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=ba3ec5fa9208484991f3558e28405987',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=276e233d30466a81925526a2f70c9dad',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=d7059c11a153e594bcc85b01ddcf3081',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=12e2c5782985bf7e1d8f67511b58bab5',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'immersive',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=1300&quality=85&auto=format&fit=max&s=dd6a7ed0b77273e510e3913fb6d2b6f8',
+                                    width: 1300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=1300&quality=45&auto=format&fit=max&dpr=2&s=9993d054f50ce9b7b50a20c57d07b5c2',
+                                    width: 2600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=1140&quality=85&auto=format&fit=max&s=a1d012ec1870d60036af209cba676d66',
+                                    width: 1140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=1140&quality=45&auto=format&fit=max&dpr=2&s=82d8d0656f48aa46a13e95e015c519b3',
+                                    width: 2280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=1125&quality=85&auto=format&fit=max&s=b565a90a235f7409893c9c89db5ae4a6',
+                                    width: 1125,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=1125&quality=45&auto=format&fit=max&dpr=2&s=56f55fb59456819b9089a0047d0a01fb',
+                                    width: 2250,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=965&quality=85&auto=format&fit=max&s=4be8fc6eed4069fab0b9f90ab9e52f96',
+                                    width: 965,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=965&quality=45&auto=format&fit=max&dpr=2&s=7eed95bd8e746d2682e4074fe032794d',
+                                    width: 1930,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=725&quality=85&auto=format&fit=max&s=44924f821552a9a70845fade7bc69fa5',
+                                    width: 725,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=725&quality=45&auto=format&fit=max&dpr=2&s=d733eae936cd0d388a3fb6d9a84b1cea',
+                                    width: 1450,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=3e2d149cb7801f5b8d8405e6e47fae21',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=c4f7c30db8911427af9123d21d3123fc',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=8a05f563448491c7eb0f697a86eda073',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=79f9d17d0313fe82f9b86e1b80245cc1',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                    ],
+                    _type:
+                        'model.dotcomrendering.pageElements.ImageBlockElement',
+                    media: {
+                        allImages: [
+                            {
+                                index: 0,
+                                fields: { height: '1667', width: '2500' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/2500.jpg',
+                            },
+                            {
+                                index: 1,
+                                fields: {
+                                    isMaster: 'true',
+                                    height: '1667',
+                                    width: '2500',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/master/2500.jpg',
+                            },
+                            {
+                                index: 2,
+                                fields: { height: '1334', width: '2000' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/2000.jpg',
+                            },
+                            {
+                                index: 3,
+                                fields: { height: '667', width: '1000' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/1000.jpg',
+                            },
+                            {
+                                index: 4,
+                                fields: { height: '333', width: '500' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/500.jpg',
+                            },
+                            {
+                                index: 5,
+                                fields: { height: '93', width: '140' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/07726157d8982dd1089d26ff3deb3b109852dfd7/0_0_2500_1667/140.jpg',
+                            },
+                        ],
+                    },
+                    displayCredit: true,
+                },
+                {
+                    role: 'halfWidth',
+                    data: {
+                        copyright: '© Tommy Trenchard / Greenpeace',
+                        alt:
+                            'A shark is hauled into the hold of a longliner targeting swordfish in the south Atlantic ocean.',
+                        caption:
+                            'Longliners use a single line that can extend 100 nautical miles and carry thousands of hooks.',
+                        credit: 'Photograph: Tommy Trenchard/Greenpeace',
+                    },
+                    imageSources: [
+                        {
+                            weighting: 'inline',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=1aaaf0e909b3837aeb06f17d5d25da9b',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=dc817f4d115b1e8d67a9b6c33b427add',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=48b5dcb06e23dde6f7e12c5d2e98f640',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=b6a70e4be15637771f1bba47f7e6648d',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=6e50c4cb906b0d17077480e4a2a96a30',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=0c40b1e583da4c94a5a43c4cc3aab7bb',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'thumbnail',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=140&quality=85&auto=format&fit=max&s=82ec865d9daf16d43f7353f0a82f0f66',
+                                    width: 140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=8412b8e31822cef7b6da8d0b1333d655',
+                                    width: 280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=120&quality=85&auto=format&fit=max&s=027eb5d8bf74b45dbdb9c4732e2ffdae',
+                                    width: 120,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=3e917d576572adc52371c2af08bc6850',
+                                    width: 240,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'supporting',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=380&quality=85&auto=format&fit=max&s=fd79fd64f6de6fd74180bce99e5ba529',
+                                    width: 380,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=1abf7e194f8bc0349c89afaafeb3cc08',
+                                    width: 760,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=300&quality=85&auto=format&fit=max&s=9674258ecc5cc9463b326fbebc377d62',
+                                    width: 300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=c0a1c4360539bc0055a9f299012b4bf3',
+                                    width: 600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=1aaaf0e909b3837aeb06f17d5d25da9b',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=dc817f4d115b1e8d67a9b6c33b427add',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=48b5dcb06e23dde6f7e12c5d2e98f640',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=b6a70e4be15637771f1bba47f7e6648d',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=6e50c4cb906b0d17077480e4a2a96a30',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=0c40b1e583da4c94a5a43c4cc3aab7bb',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'showcase',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=1020&quality=85&auto=format&fit=max&s=b6db7a9a5464e4f81a699e811faa0370',
+                                    width: 1020,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=1020&quality=45&auto=format&fit=max&dpr=2&s=9cdc79f30eb3d4971f9e5695a989146b',
+                                    width: 2040,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=940&quality=85&auto=format&fit=max&s=09c9c144f2dafba32299354f8c32d743',
+                                    width: 940,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=940&quality=45&auto=format&fit=max&dpr=2&s=80d7890f82b89d799e32fb9b006f032c',
+                                    width: 1880,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=389541ba189b352617a8a93a696cf967',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=a27cebbdca518e8e8fb7968f60af451b',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=389541ba189b352617a8a93a696cf967',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=a27cebbdca518e8e8fb7968f60af451b',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=660&quality=85&auto=format&fit=max&s=bad39bcb155edabd68fd802d560a5866',
+                                    width: 660,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=660&quality=45&auto=format&fit=max&dpr=2&s=433933f7d9a86556f6e3561188b1a223',
+                                    width: 1320,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=a5a583059003ff83e215c36b4329cc3d',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=bdd6f7290effd2db6699a94a7f1a6d9b',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=821f407cdeaa148d49b4b8dca9691d1f',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=a51cf023e0c0922519f42d434f333046',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'halfwidth',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=1aaaf0e909b3837aeb06f17d5d25da9b',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=dc817f4d115b1e8d67a9b6c33b427add',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=48b5dcb06e23dde6f7e12c5d2e98f640',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=b6a70e4be15637771f1bba47f7e6648d',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=6e50c4cb906b0d17077480e4a2a96a30',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=0c40b1e583da4c94a5a43c4cc3aab7bb',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'immersive',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=1300&quality=85&auto=format&fit=max&s=386e47e9f369beffe36a1ec2dbc0c4dc',
+                                    width: 1300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=1300&quality=45&auto=format&fit=max&dpr=2&s=2ae03c2b0adb2991f13964a858b5035b',
+                                    width: 2600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=1140&quality=85&auto=format&fit=max&s=a2ac291022987443ea62b0e43058eb6a',
+                                    width: 1140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=1140&quality=45&auto=format&fit=max&dpr=2&s=f20baadb6e91634fd84a29e53b00ac3c',
+                                    width: 2280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=1125&quality=85&auto=format&fit=max&s=faf06ef7049d9236658e9d431f6073ab',
+                                    width: 1125,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=1125&quality=45&auto=format&fit=max&dpr=2&s=ca965ad75a2ce3bd1ec78139a5d5b725',
+                                    width: 2250,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=965&quality=85&auto=format&fit=max&s=75b7422288509ae4580283a68c663c35',
+                                    width: 965,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=965&quality=45&auto=format&fit=max&dpr=2&s=e038f3d2ef9c63a0cafb28a31632f325',
+                                    width: 1930,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=725&quality=85&auto=format&fit=max&s=7213106ddfe8f055ef24b95f084b776b',
+                                    width: 725,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=725&quality=45&auto=format&fit=max&dpr=2&s=f312a3fa334712878a9d1b0efa46b3d1',
+                                    width: 1450,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=a5a583059003ff83e215c36b4329cc3d',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=bdd6f7290effd2db6699a94a7f1a6d9b',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=821f407cdeaa148d49b4b8dca9691d1f',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=a51cf023e0c0922519f42d434f333046',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                    ],
+                    _type:
+                        'model.dotcomrendering.pageElements.ImageBlockElement',
+                    media: {
+                        allImages: [
+                            {
+                                index: 0,
+                                fields: { height: '1667', width: '2500' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/2500.jpg',
+                            },
+                            {
+                                index: 1,
+                                fields: {
+                                    isMaster: 'true',
+                                    height: '1667',
+                                    width: '2500',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/master/2500.jpg',
+                            },
+                            {
+                                index: 2,
+                                fields: { height: '1334', width: '2000' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/2000.jpg',
+                            },
+                            {
+                                index: 3,
+                                fields: { height: '667', width: '1000' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/1000.jpg',
+                            },
+                            {
+                                index: 4,
+                                fields: { height: '333', width: '500' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/500.jpg',
+                            },
+                            {
+                                index: 5,
+                                fields: { height: '93', width: '140' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/e39bd86fd6664603f10f46b3f41c21573b97a06f/0_0_2500_1667/140.jpg',
+                            },
+                        ],
+                    },
+                    displayCredit: true,
+                },
+                {
+                    role: 'halfWidth',
+                    data: {
+                        copyright: '© Tommy Trenchard / Greenpeace',
+                        alt: 'A swordfish being stabbed with a gaff pole.',
+                        caption:
+                            'A gaff pole is used to stab large fish and lift them on to boats.',
+                        credit: 'Photograph: Tommy Trenchard/Greenpeace',
+                    },
+                    imageSources: [
+                        {
+                            weighting: 'inline',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=ee5ce3fa1851ffff2a770d6a6185b294',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=daacdd0b337d811ebab9d89040f47bbc',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=689f259a9f9090478bf6e3be9bfa19ef',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=6d5e0f97c860fbee991b6658603320ce',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=5b084a5dd94ba98dee6d419b57b6f96e',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=7590351d540229448837f81d92de85bc',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'thumbnail',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=140&quality=85&auto=format&fit=max&s=10494b3c339ca0569953c0bafe0e6ffb',
+                                    width: 140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=288f06a02b24ba95e9c443cfcdaa253d',
+                                    width: 280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=120&quality=85&auto=format&fit=max&s=9b47711eba9e0d38201787cb6a111d26',
+                                    width: 120,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=03fe02f5d785cf69a19fd0fce229454a',
+                                    width: 240,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'supporting',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=380&quality=85&auto=format&fit=max&s=848a372f0d9aa74e2047feb8a2648966',
+                                    width: 380,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=74c5b369c6f91356b4eab6ef12f505a0',
+                                    width: 760,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=300&quality=85&auto=format&fit=max&s=8a8f91e7b777dc828967a517db8f5197',
+                                    width: 300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=07c980d4a93d5a31224427fe9517a2db',
+                                    width: 600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=ee5ce3fa1851ffff2a770d6a6185b294',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=daacdd0b337d811ebab9d89040f47bbc',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=689f259a9f9090478bf6e3be9bfa19ef',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=6d5e0f97c860fbee991b6658603320ce',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=5b084a5dd94ba98dee6d419b57b6f96e',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=7590351d540229448837f81d92de85bc',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'showcase',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=1020&quality=85&auto=format&fit=max&s=8e03d8196b4e9925df024949a62ba638',
+                                    width: 1020,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=1020&quality=45&auto=format&fit=max&dpr=2&s=2da69699e3ec4c2629d58f6684997c89',
+                                    width: 2040,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=940&quality=85&auto=format&fit=max&s=78f651308901af0aa73f4c017a266db5',
+                                    width: 940,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=940&quality=45&auto=format&fit=max&dpr=2&s=b84727bb5bd13e724d4d816c11345a23',
+                                    width: 1880,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=66108aeb2ea14b327932faaf4c107608',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=a51fa07a1b099dc982ca0c89fea0af2b',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=66108aeb2ea14b327932faaf4c107608',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=a51fa07a1b099dc982ca0c89fea0af2b',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=660&quality=85&auto=format&fit=max&s=8a1ab71c8f2aefdee9b072e25c502911',
+                                    width: 660,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=660&quality=45&auto=format&fit=max&dpr=2&s=e181445d3d3f419d67b832acc78f4224',
+                                    width: 1320,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=ceb329c7c8e2ca0ab68f9fe4b3a2239c',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=1607b651d5dd44cae147545c69cd5993',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=73ef50b68cd5701832b629b650242ef0',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=fcc544e9418c391eda7f4002f79314a0',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'halfwidth',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=ee5ce3fa1851ffff2a770d6a6185b294',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=daacdd0b337d811ebab9d89040f47bbc',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=689f259a9f9090478bf6e3be9bfa19ef',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=6d5e0f97c860fbee991b6658603320ce',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=5b084a5dd94ba98dee6d419b57b6f96e',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=7590351d540229448837f81d92de85bc',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'immersive',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=1300&quality=85&auto=format&fit=max&s=6f6a920fc8a0c580fba9741af4b06ff9',
+                                    width: 1300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=1300&quality=45&auto=format&fit=max&dpr=2&s=6b4aabee4f91aac23d2f746d79c4bcc7',
+                                    width: 2600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=1140&quality=85&auto=format&fit=max&s=5610664df9302899cd7e288ce54106dd',
+                                    width: 1140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=1140&quality=45&auto=format&fit=max&dpr=2&s=6f3e469a71dbd03ab4584bbdb3c90d8a',
+                                    width: 2280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=1125&quality=85&auto=format&fit=max&s=adee9a14578015ed60e39a8455946533',
+                                    width: 1125,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=1125&quality=45&auto=format&fit=max&dpr=2&s=583500bee1fb531e7caca07a9b9f5fdf',
+                                    width: 2250,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=965&quality=85&auto=format&fit=max&s=bb8bf921616a85d789af844b6b56495e',
+                                    width: 965,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=965&quality=45&auto=format&fit=max&dpr=2&s=981787afb23043c73c5214b280ec9329',
+                                    width: 1930,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=725&quality=85&auto=format&fit=max&s=99f3213b76b0a467e4c3ef22cf26fcee',
+                                    width: 725,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=725&quality=45&auto=format&fit=max&dpr=2&s=64a8b56bb17164a111de87e7974b707b',
+                                    width: 1450,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=ceb329c7c8e2ca0ab68f9fe4b3a2239c',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=1607b651d5dd44cae147545c69cd5993',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=73ef50b68cd5701832b629b650242ef0',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=fcc544e9418c391eda7f4002f79314a0',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                    ],
+                    _type:
+                        'model.dotcomrendering.pageElements.ImageBlockElement',
+                    media: {
+                        allImages: [
+                            {
+                                index: 0,
+                                fields: { height: '1667', width: '2500' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/2500.jpg',
+                            },
+                            {
+                                index: 1,
+                                fields: {
+                                    isMaster: 'true',
+                                    height: '1667',
+                                    width: '2500',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/master/2500.jpg',
+                            },
+                            {
+                                index: 2,
+                                fields: { height: '1334', width: '2000' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/2000.jpg',
+                            },
+                            {
+                                index: 3,
+                                fields: { height: '667', width: '1000' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/1000.jpg',
+                            },
+                            {
+                                index: 4,
+                                fields: { height: '333', width: '500' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/500.jpg',
+                            },
+                            {
+                                index: 5,
+                                fields: { height: '93', width: '140' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/0d285664aca2e05b8fd7c9d3bf75884c0b9ffd0f/0_0_2500_1667/140.jpg',
+                            },
+                        ],
+                    },
+                    displayCredit: true,
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>Some vessels even hide from what little regulation there is by turning off satellite tracking systems, “going dark”. Some offload cargo to refrigerated ships (or “reefers”) allowing them to remain at sea for months at a time. This “transshipment” has been linked to some of the worst environmental and labour abuses. </p>',
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>Using innovative reconnaissance techniques, Greenpeace set out to find these ships and document the damage they are doing to our oceans.</p>',
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>We spent more than a month at sea between Senegal and the tip of South Africa, observing a dozen longliners in the South Atlantic. Longliners use a single long line that can extend 100 nautical miles and carry thousands of hooks.</p>',
+                },
+                {
+                    role: 'immersive',
+                    data: {
+                        copyright: '© Greenpeace',
+                        alt:
+                            'Frozen tuna and shark being transferred from one ship to another.',
+                        caption:
+                            'Frozen tuna and shark being transferred from one ship to another.',
+                        credit: 'Photograph: Greenpeace',
+                    },
+                    imageSources: [
+                        {
+                            weighting: 'inline',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=4a743fcb4179775be27db07d6e1b88af',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=db4edc5504b0505b1fb01883093cfef6',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=1b1bdd5d55d1f88f73d94c4e254a53c6',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=0c47ba32adbd92a34e10e8603d022b62',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=47c41151816df0afff7a94f9b0d63311',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=09873ab0a7386a9aad2ea7e2fc4da0fd',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'thumbnail',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=140&quality=85&auto=format&fit=max&s=313587b9516c6c18139552addb42a8a9',
+                                    width: 140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=196e3e3de8336ef6ba32103d3105069e',
+                                    width: 280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=120&quality=85&auto=format&fit=max&s=6438563892ce7caf4d9b5a73e84a9687',
+                                    width: 120,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=5edb6553660e4395fa17920dd6f55316',
+                                    width: 240,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'supporting',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=380&quality=85&auto=format&fit=max&s=41864f08aa9ca4500ba0ccb10ea0a09f',
+                                    width: 380,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=b0f02cf344d79db92a5b0148ff2bb6cf',
+                                    width: 760,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=300&quality=85&auto=format&fit=max&s=d79bf5718421004357f7601f59201948',
+                                    width: 300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=819b1f510c6563bc153defd84560b3cd',
+                                    width: 600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=4a743fcb4179775be27db07d6e1b88af',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=db4edc5504b0505b1fb01883093cfef6',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=1b1bdd5d55d1f88f73d94c4e254a53c6',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=0c47ba32adbd92a34e10e8603d022b62',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=47c41151816df0afff7a94f9b0d63311',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=09873ab0a7386a9aad2ea7e2fc4da0fd',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'showcase',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=1020&quality=85&auto=format&fit=max&s=f2663d36c4c821b32aca31950b9d32cf',
+                                    width: 1020,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=1020&quality=45&auto=format&fit=max&dpr=2&s=6d180a944f57d322ad9c32f06820442f',
+                                    width: 2040,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=940&quality=85&auto=format&fit=max&s=6e8f342754b9393196cbd4c84bf0ff08',
+                                    width: 940,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=940&quality=45&auto=format&fit=max&dpr=2&s=33dc1a6da0e10b4be6bb4a1cffca9dc4',
+                                    width: 1880,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=a6e20935fac07e130290217db5559d32',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=5c64bdd8e32144fb81103cf2f5a629dd',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=a6e20935fac07e130290217db5559d32',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=5c64bdd8e32144fb81103cf2f5a629dd',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=660&quality=85&auto=format&fit=max&s=77dc68c6c46190aaf7d3d382c97afa74',
+                                    width: 660,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=660&quality=45&auto=format&fit=max&dpr=2&s=c59b6c617e95898213bb3910cb7ac003',
+                                    width: 1320,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=ed930d53261f398f020835e0c6771ec0',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=e018c020d9e086944f3d71e469ba4954',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=39a8da56361c5e3883ad6db5eb2c9050',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=13388ccbce0caa08c9a5ac8916df9bd9',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'halfwidth',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=4a743fcb4179775be27db07d6e1b88af',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=db4edc5504b0505b1fb01883093cfef6',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=1b1bdd5d55d1f88f73d94c4e254a53c6',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=0c47ba32adbd92a34e10e8603d022b62',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=47c41151816df0afff7a94f9b0d63311',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=09873ab0a7386a9aad2ea7e2fc4da0fd',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'immersive',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=1300&quality=85&auto=format&fit=max&s=da3d2ee95ae7a1215794889fb4a1d523',
+                                    width: 1300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=1300&quality=45&auto=format&fit=max&dpr=2&s=6c103dfcf77eeeef5cb58ab374eaaebe',
+                                    width: 2600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=1140&quality=85&auto=format&fit=max&s=6e20b10816880ed594dbb54d51e48314',
+                                    width: 1140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=1140&quality=45&auto=format&fit=max&dpr=2&s=0c225bb68e0e0fb524ef40dd5cf67b96',
+                                    width: 2280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=1125&quality=85&auto=format&fit=max&s=52741f7848406949a300a3be346f850f',
+                                    width: 1125,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=1125&quality=45&auto=format&fit=max&dpr=2&s=e07933c0ae81602bb5864ecc46655ce2',
+                                    width: 2250,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=965&quality=85&auto=format&fit=max&s=0182a80c11743e73a3037eb79e761f51',
+                                    width: 965,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=965&quality=45&auto=format&fit=max&dpr=2&s=a930caba6b4b6ef97a878f6ad7944112',
+                                    width: 1930,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=725&quality=85&auto=format&fit=max&s=324e1cb897462bc026f46172292bb109',
+                                    width: 725,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=725&quality=45&auto=format&fit=max&dpr=2&s=d9ed1d91c0eba0927449ce545fb2dafb',
+                                    width: 1450,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=ed930d53261f398f020835e0c6771ec0',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=e018c020d9e086944f3d71e469ba4954',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=39a8da56361c5e3883ad6db5eb2c9050',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=13388ccbce0caa08c9a5ac8916df9bd9',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                    ],
+                    _type:
+                        'model.dotcomrendering.pageElements.ImageBlockElement',
+                    media: {
+                        allImages: [
+                            {
+                                index: 0,
+                                fields: { height: '1500', width: '2500' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/2500.jpg',
+                            },
+                            {
+                                index: 1,
+                                fields: {
+                                    isMaster: 'true',
+                                    height: '1500',
+                                    width: '2500',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/master/2500.jpg',
+                            },
+                            {
+                                index: 2,
+                                fields: { height: '1200', width: '2000' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/2000.jpg',
+                            },
+                            {
+                                index: 3,
+                                fields: { height: '600', width: '1000' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/1000.jpg',
+                            },
+                            {
+                                index: 4,
+                                fields: { height: '300', width: '500' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/500.jpg',
+                            },
+                            {
+                                index: 5,
+                                fields: { height: '84', width: '140' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/5e04ee6f25d43beeef312b7df529e0c3848a5889/0_228_2500_1500/140.jpg',
+                            },
+                        ],
+                    },
+                    displayCredit: true,
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>The Atlantic longline fleet officially targets tuna and swordfish, but time and time again the bulk of their catch is sharks. Studies have shown that some fisheries are even <a href="https://www.greenpeace.org/international/press-release/22754/thousands-of-endangered-sharks-slaughtered-by-overfishing-new-report-reveals/">catching</a> tens of thousands of endangered sharks, such as shortfin mako, every year.</p>',
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>Most sharks don’t have the same protection as tuna or swordfish, and for every tuna or swordfish caught, we saw them hauling up around six sharks. These were primarily blue sharks, deemed “near threatened” by the International Union for Conservation of Nature.</p>',
+                },
+                {
+                    role: 'inline',
+                    data: {
+                        copyright: '© Robert Marc Lehmann / Greenpeace',
+                        alt: 'A blue shark swims near the Azores.',
+                        caption:
+                            'Blue sharks are deemed ‘near threatened’ by the International Union for Conservation of Nature.',
+                        credit: 'Photograph: Robert Marc Lehmann/Greenpeace',
+                    },
+                    imageSources: [
+                        {
+                            weighting: 'inline',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=eaf1071c9b5d730e23683be84d1076c7',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=3e70e42a72890927352bbd7a21f22415',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=0606d38e6756a1cb62b7c00c748ae7be',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=fa0636e1df5fb7e0141bacb990e49c97',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=1f8b9eea2097c494ee48d903df086bc8',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=d42590c10fd400d4f84265c5e78e0600',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'thumbnail',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=140&quality=85&auto=format&fit=max&s=45eeabacd2b9ec876176baa2877565d9',
+                                    width: 140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=caadf495226fc2209b2ab10a11289d7f',
+                                    width: 280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=120&quality=85&auto=format&fit=max&s=a2d0d9161ed6fc056d6fb574970195d3',
+                                    width: 120,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=edfb1781ef3ac6b66aa0952051a32aeb',
+                                    width: 240,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'supporting',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=380&quality=85&auto=format&fit=max&s=054b724657422344908bd6115ecb0c84',
+                                    width: 380,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=3ee17ebe6f860e65f7316f418a0a7f70',
+                                    width: 760,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=300&quality=85&auto=format&fit=max&s=4daa4d220747eeb9ce81325f1d1d1494',
+                                    width: 300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=9390f62e84d640007adb3f25336cdc9c',
+                                    width: 600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=eaf1071c9b5d730e23683be84d1076c7',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=3e70e42a72890927352bbd7a21f22415',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=0606d38e6756a1cb62b7c00c748ae7be',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=fa0636e1df5fb7e0141bacb990e49c97',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=1f8b9eea2097c494ee48d903df086bc8',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=d42590c10fd400d4f84265c5e78e0600',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'showcase',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=1020&quality=85&auto=format&fit=max&s=3271bd8e995650c50ebce3adf8961936',
+                                    width: 1020,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=1020&quality=45&auto=format&fit=max&dpr=2&s=49c562a38335694e716cd5f11cfe8afb',
+                                    width: 2040,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=940&quality=85&auto=format&fit=max&s=f13a13694148c46d39ab9aeb35efd4da',
+                                    width: 940,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=940&quality=45&auto=format&fit=max&dpr=2&s=c707f446cb9ca71ccd212b8242ca7343',
+                                    width: 1880,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=6c80035c7d5f58be92ff30847a916779',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=1b1a2363b6a7c95fdbddf6f11ac3998e',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=6c80035c7d5f58be92ff30847a916779',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=1b1a2363b6a7c95fdbddf6f11ac3998e',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=660&quality=85&auto=format&fit=max&s=ec47105355893707c06980ea569d2346',
+                                    width: 660,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=660&quality=45&auto=format&fit=max&dpr=2&s=70b0d9fb5fd61fb44420b41e67916f57',
+                                    width: 1320,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=b561ba343500fea9117d5ef18588255b',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=c891d9704dac139da5c611e1700a0cf8',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=07401516d4d6072949cb134fcec0b993',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=81c6db0a5c8e83c5c9c8fad570552e12',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'halfwidth',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=eaf1071c9b5d730e23683be84d1076c7',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=3e70e42a72890927352bbd7a21f22415',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=0606d38e6756a1cb62b7c00c748ae7be',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=fa0636e1df5fb7e0141bacb990e49c97',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=1f8b9eea2097c494ee48d903df086bc8',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=d42590c10fd400d4f84265c5e78e0600',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'immersive',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=1300&quality=85&auto=format&fit=max&s=f8f2539f6e9eacc64604673ef92e468f',
+                                    width: 1300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=1300&quality=45&auto=format&fit=max&dpr=2&s=d0b6df89a89bc6a6eb015f7411238904',
+                                    width: 2600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=1140&quality=85&auto=format&fit=max&s=a54f3127960af47eb1aa74da0db562d2',
+                                    width: 1140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=1140&quality=45&auto=format&fit=max&dpr=2&s=d3bf35beabdb45b3236523a783448dec',
+                                    width: 2280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=1125&quality=85&auto=format&fit=max&s=b3653e6ec1dde342bbc6c56e7c9335d9',
+                                    width: 1125,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=1125&quality=45&auto=format&fit=max&dpr=2&s=a23aa74e320e414d85507439b87e9c00',
+                                    width: 2250,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=965&quality=85&auto=format&fit=max&s=7ff9e7ab62cecdaf65dcb74fa2742457',
+                                    width: 965,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=965&quality=45&auto=format&fit=max&dpr=2&s=bbfef7e796ad755da39bf1ade0abee65',
+                                    width: 1930,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=725&quality=85&auto=format&fit=max&s=40438e717eebf412b40adf88cf64e9b3',
+                                    width: 725,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=725&quality=45&auto=format&fit=max&dpr=2&s=e9ca1982064bfb03b196460bb6b8d162',
+                                    width: 1450,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=b561ba343500fea9117d5ef18588255b',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=c891d9704dac139da5c611e1700a0cf8',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=07401516d4d6072949cb134fcec0b993',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=81c6db0a5c8e83c5c9c8fad570552e12',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                    ],
+                    _type:
+                        'model.dotcomrendering.pageElements.ImageBlockElement',
+                    media: {
+                        allImages: [
+                            {
+                                index: 0,
+                                fields: { height: '1667', width: '2500' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/2500.jpg',
+                            },
+                            {
+                                index: 1,
+                                fields: {
+                                    isMaster: 'true',
+                                    height: '1667',
+                                    width: '2500',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/master/2500.jpg',
+                            },
+                            {
+                                index: 2,
+                                fields: { height: '1334', width: '2000' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/2000.jpg',
+                            },
+                            {
+                                index: 3,
+                                fields: { height: '667', width: '1000' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/1000.jpg',
+                            },
+                            {
+                                index: 4,
+                                fields: { height: '333', width: '500' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/500.jpg',
+                            },
+                            {
+                                index: 5,
+                                fields: { height: '93', width: '140' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/5ad81c7a1fd17f6059d2a02f98d73996d48b202b/0_0_2500_1667/140.jpg',
+                            },
+                        ],
+                    },
+                    displayCredit: true,
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>We saw one vessel hauling up a particularly large shark. The captain saw our cameras, and started motioning to the crew to cut the line. The shark swam free, hook in its mouth and line dragging behind. This left us wondering which species it was, and what its fate might have been if witnesses had not been there.</p>',
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>Another of the ships we intercepted, the Hung Yu 212, was <a href="https://www.nytimes.com/2015/11/09/world/asia/philippines-fishing-ships-illegal-manning-agencies.html">previously investigated</a> after a crew member was returned dead to his home, covered in bruises and with one of his eyes and his pancreas missing. No one was held accountable for his death, and I wondered if the crew we saw working the decks knew about this. When there are no repercussions, what’s to stop environmental or human rights abuses?</p>',
+                },
+                {
+                    role: 'halfWidth',
+                    data: {
+                        copyright: '© Tommy Trenchard / Greenpeace',
+                        alt:
+                            'Greenpeace’s ship Arctic Sunrise hits a wave during rough weather in the South Atlantic.',
+                        caption:
+                            'Greenpeace’s ship Arctic Sunrise hits a wave during rough weather in the South Atlantic.',
+                        credit: 'Photograph: Tommy Trenchard/Greenpeace',
+                    },
+                    imageSources: [
+                        {
+                            weighting: 'inline',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=f70dd057eabb09a74239f51650641c4a',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=d492338bc4d1b857a33a7d6998e58d55',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=9ffe0420cf6b7a25d9fcf83066e49537',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=c867fb62ad1a7a0e51483037f5081fc2',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=6f4393bb49787a9f09014f0d73f35e53',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=3c545ae4299d83a325aa5935ebfbce11',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'thumbnail',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=140&quality=85&auto=format&fit=max&s=17a69e8ac10312b57ee185e7b5c12b06',
+                                    width: 140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=d81dd269cfa7c30e61beeaa746868972',
+                                    width: 280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=120&quality=85&auto=format&fit=max&s=bc634c596641d789f5f48dd55c8177ae',
+                                    width: 120,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=33fed56e309ce3dc48241b9e511811aa',
+                                    width: 240,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'supporting',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=380&quality=85&auto=format&fit=max&s=783257361864e3d3a0f24dadd43ba2c8',
+                                    width: 380,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=92ff97fd43ab1f8c8b0e70833028718e',
+                                    width: 760,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=300&quality=85&auto=format&fit=max&s=3e52dbd6bcc1b013003e6c1995b7bb91',
+                                    width: 300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=850629dd089c10958c9b8e82c1e39c9f',
+                                    width: 600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=f70dd057eabb09a74239f51650641c4a',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=d492338bc4d1b857a33a7d6998e58d55',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=9ffe0420cf6b7a25d9fcf83066e49537',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=c867fb62ad1a7a0e51483037f5081fc2',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=6f4393bb49787a9f09014f0d73f35e53',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=3c545ae4299d83a325aa5935ebfbce11',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'showcase',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=1020&quality=85&auto=format&fit=max&s=624a76f3dc9a7695e138c67610633b45',
+                                    width: 1020,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=1020&quality=45&auto=format&fit=max&dpr=2&s=f85de213c16f04387749d64c9afacd5a',
+                                    width: 2040,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=940&quality=85&auto=format&fit=max&s=05ed80bb6e20fa018504bb702e75218d',
+                                    width: 940,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=940&quality=45&auto=format&fit=max&dpr=2&s=9dc3d27211b8be5f92defb9b912e6c81',
+                                    width: 1880,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=d8bcdf73ed74f16258ecdb92400ef2c0',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=fde8b72a040ceefcbb5ed6399a259b76',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=d8bcdf73ed74f16258ecdb92400ef2c0',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=fde8b72a040ceefcbb5ed6399a259b76',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=660&quality=85&auto=format&fit=max&s=0879bc44ac2be63a38ced704a0604514',
+                                    width: 660,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=660&quality=45&auto=format&fit=max&dpr=2&s=2090ed6fb990e98d1f87ca526353942b',
+                                    width: 1320,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=fdea12cbfc6379ce2ea9c8ca6e7d2c1b',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=482fd54191d45fe1fe775f1296b094b6',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=afb1030bad54d5114b7b8c3a83fb546a',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=f4a89c4a74f00e29b2777b8a0c24a542',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'halfwidth',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=f70dd057eabb09a74239f51650641c4a',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=d492338bc4d1b857a33a7d6998e58d55',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=9ffe0420cf6b7a25d9fcf83066e49537',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=c867fb62ad1a7a0e51483037f5081fc2',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=6f4393bb49787a9f09014f0d73f35e53',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=3c545ae4299d83a325aa5935ebfbce11',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'immersive',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=1300&quality=85&auto=format&fit=max&s=58e079130c99df397eefb44cd631e5fd',
+                                    width: 1300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=1300&quality=45&auto=format&fit=max&dpr=2&s=13eadd8a324cd00b82ed99e653637c64',
+                                    width: 2600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=1140&quality=85&auto=format&fit=max&s=634a10dc8c7eac24404f019342f32386',
+                                    width: 1140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=1140&quality=45&auto=format&fit=max&dpr=2&s=f6cfb13dfaaaba727ac380d48506e004',
+                                    width: 2280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=1125&quality=85&auto=format&fit=max&s=117d630bad3656bcb8644b79a51713eb',
+                                    width: 1125,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=1125&quality=45&auto=format&fit=max&dpr=2&s=29a1a3e8a5b4932f2437cd608fc68b00',
+                                    width: 2250,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=965&quality=85&auto=format&fit=max&s=ab81ffc4bb069288d0d031fee9f91dab',
+                                    width: 965,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=965&quality=45&auto=format&fit=max&dpr=2&s=1e8031c855c745ef928b3355f831b126',
+                                    width: 1930,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=725&quality=85&auto=format&fit=max&s=c11e7a2e1b27f1da9efe176edfccd2b5',
+                                    width: 725,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=725&quality=45&auto=format&fit=max&dpr=2&s=e2630fb3eaab5df471b4577a08dbffeb',
+                                    width: 1450,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=fdea12cbfc6379ce2ea9c8ca6e7d2c1b',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=482fd54191d45fe1fe775f1296b094b6',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=afb1030bad54d5114b7b8c3a83fb546a',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=f4a89c4a74f00e29b2777b8a0c24a542',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                    ],
+                    _type:
+                        'model.dotcomrendering.pageElements.ImageBlockElement',
+                    media: {
+                        allImages: [
+                            {
+                                index: 0,
+                                fields: { height: '1667', width: '2500' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/2500.jpg',
+                            },
+                            {
+                                index: 1,
+                                fields: {
+                                    isMaster: 'true',
+                                    height: '1667',
+                                    width: '2500',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg',
+                            },
+                            {
+                                index: 2,
+                                fields: { height: '1334', width: '2000' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/2000.jpg',
+                            },
+                            {
+                                index: 3,
+                                fields: { height: '667', width: '1000' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/1000.jpg',
+                            },
+                            {
+                                index: 4,
+                                fields: { height: '333', width: '500' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/500.jpg',
+                            },
+                            {
+                                index: 5,
+                                fields: { height: '93', width: '140' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/140.jpg',
+                            },
+                        ],
+                    },
+                    displayCredit: true,
+                },
+                {
+                    role: 'halfWidth',
+                    data: {
+                        copyright: '© Tommy Trenchard / Greenpeace',
+                        alt:
+                            'A vessel is seen on the radar of the Arctic Sunrise in the mid-Atlantic ocean.',
+                        caption:
+                            'A vessel is seen on the radar of the Arctic Sunrise in the mid-Atlantic ocean.',
+                        credit: 'Photograph: Tommy Trenchard/Greenpeace',
+                    },
+                    imageSources: [
+                        {
+                            weighting: 'inline',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=1a1f41e93103d8f80ed96f1877cce8dd',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=dd1a14ee43f584cfb502c871f78dcf3d',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=b39f8587f6de6b4882a266402b1de4fb',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=5085ead125476d718c3b99ee8313fb3a',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=30b4094e41b17742d7d07b4d1942628d',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=f5fa0b0a01a2ec6ffa214d1d979dcb36',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'thumbnail',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=140&quality=85&auto=format&fit=max&s=333a3a3814133344842bd07cf1e485f8',
+                                    width: 140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=1f60425205116b265ab692893a4da2bc',
+                                    width: 280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=120&quality=85&auto=format&fit=max&s=d4101e6e70f05ea73fc3956ab9d57633',
+                                    width: 120,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=7b5db9389171ea20d54214ee34483f99',
+                                    width: 240,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'supporting',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=380&quality=85&auto=format&fit=max&s=1464287ceb0e09ea17729a89d973e42b',
+                                    width: 380,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=d3eed1a4664033931edd676ededb9a3a',
+                                    width: 760,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=300&quality=85&auto=format&fit=max&s=4368ad1138f4f2cb441c2e90319f4d42',
+                                    width: 300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=284b97a79d5485f99224a0f4d4ec6cf2',
+                                    width: 600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=1a1f41e93103d8f80ed96f1877cce8dd',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=dd1a14ee43f584cfb502c871f78dcf3d',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=b39f8587f6de6b4882a266402b1de4fb',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=5085ead125476d718c3b99ee8313fb3a',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=30b4094e41b17742d7d07b4d1942628d',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=f5fa0b0a01a2ec6ffa214d1d979dcb36',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'showcase',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=1020&quality=85&auto=format&fit=max&s=a46a52f554db0e2e76170611240ce230',
+                                    width: 1020,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=1020&quality=45&auto=format&fit=max&dpr=2&s=be848e3f9a6a4d104e590bc9bdc04d5d',
+                                    width: 2040,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=940&quality=85&auto=format&fit=max&s=e7abe49fa4d52320be12e03e2a6afb06',
+                                    width: 940,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=940&quality=45&auto=format&fit=max&dpr=2&s=8bd0c605e5bdc1af557a768500864187',
+                                    width: 1880,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=3a452c9a5c3d2b313ae33506cf44961e',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=69a79d5f3ee45439ab224208620433c9',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=3a452c9a5c3d2b313ae33506cf44961e',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=69a79d5f3ee45439ab224208620433c9',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=660&quality=85&auto=format&fit=max&s=c035d9a260e7607443983cf093a732ad',
+                                    width: 660,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=660&quality=45&auto=format&fit=max&dpr=2&s=f8e81ab0fa3af51301556780dc925a6b',
+                                    width: 1320,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=f45d48bbb50e99b69db54da172d693de',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=d1aecf02f0884aa6b462da3e292ae08c',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=20976fe36bdd6c7c994467081cc9854a',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=f327ef15b32559eba8f849c0a4984eeb',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'halfwidth',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=1a1f41e93103d8f80ed96f1877cce8dd',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=dd1a14ee43f584cfb502c871f78dcf3d',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=b39f8587f6de6b4882a266402b1de4fb',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=5085ead125476d718c3b99ee8313fb3a',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=30b4094e41b17742d7d07b4d1942628d',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=f5fa0b0a01a2ec6ffa214d1d979dcb36',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'immersive',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=1300&quality=85&auto=format&fit=max&s=e908ee2e8a1fb639ba7795933b6b7166',
+                                    width: 1300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=1300&quality=45&auto=format&fit=max&dpr=2&s=955ff64ffa266c77ee04a75142c445f2',
+                                    width: 2600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=1140&quality=85&auto=format&fit=max&s=dbf50cddd4b86f8da4d280b7907c378e',
+                                    width: 1140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=1140&quality=45&auto=format&fit=max&dpr=2&s=5bebfcbd7f07943acf283b6157e8eb0f',
+                                    width: 2280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=1125&quality=85&auto=format&fit=max&s=e523903e7e8ad2e51b053433eb2e4c43',
+                                    width: 1125,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=1125&quality=45&auto=format&fit=max&dpr=2&s=0bfd26e45abb4232fb0a5f5bad03f1a8',
+                                    width: 2250,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=965&quality=85&auto=format&fit=max&s=1007564a1513aef7346e3719c088dcbd',
+                                    width: 965,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=965&quality=45&auto=format&fit=max&dpr=2&s=9c5d6595d96009b575cae135077df95b',
+                                    width: 1930,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=725&quality=85&auto=format&fit=max&s=b9e6445791d64e48014a24c4b5fbe4d8',
+                                    width: 725,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=725&quality=45&auto=format&fit=max&dpr=2&s=dbd6d4625d12373074b7ee71735195a9',
+                                    width: 1450,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=f45d48bbb50e99b69db54da172d693de',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=d1aecf02f0884aa6b462da3e292ae08c',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=20976fe36bdd6c7c994467081cc9854a',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=f327ef15b32559eba8f849c0a4984eeb',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                    ],
+                    _type:
+                        'model.dotcomrendering.pageElements.ImageBlockElement',
+                    media: {
+                        allImages: [
+                            {
+                                index: 0,
+                                fields: { height: '1667', width: '2500' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/2500.jpg',
+                            },
+                            {
+                                index: 1,
+                                fields: {
+                                    isMaster: 'true',
+                                    height: '1667',
+                                    width: '2500',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg',
+                            },
+                            {
+                                index: 2,
+                                fields: { height: '1334', width: '2000' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/2000.jpg',
+                            },
+                            {
+                                index: 3,
+                                fields: { height: '667', width: '1000' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/1000.jpg',
+                            },
+                            {
+                                index: 4,
+                                fields: { height: '333', width: '500' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/500.jpg',
+                            },
+                            {
+                                index: 5,
+                                fields: { height: '93', width: '140' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/140.jpg',
+                            },
+                        ],
+                    },
+                    displayCredit: true,
+                },
+                {
+                    role: 'halfWidth',
+                    data: {
+                        copyright: '© Tommy Trenchard / Greenpeace',
+                        alt:
+                            'Second mate Helena De Carlos Watts and investigator Sophie Cooke watch the radar screen as the Arctic Sunrise approaches a vessel in the southern Atlantic Ocean.',
+                        caption:
+                            'Second mate Helena De Carlos Watts and investigator Sophie Cooke watch the radar screen as the Arctic Sunrise approaches a vessel in the southern Atlantic Ocean.',
+                        credit: 'Photograph: Tommy Trenchard/Greenpeace',
+                    },
+                    imageSources: [
+                        {
+                            weighting: 'inline',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=48e15d5d34cdf2677030c6349c4a6bf2',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=a95ecd11817238d37fd9bbbd5b8ee70e',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=40432b37fa1c7e4907d202078a496d15',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=07cb72515ee014a5f6951cca0d71b631',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=3d194971fbccd3692587cc844457254b',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=bba08a4952a4b24f4c85b702dea4b534',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'thumbnail',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=140&quality=85&auto=format&fit=max&s=05ce8b8c9f83ba188b134aa1621d429a',
+                                    width: 140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=f81cccbcca62f07659a3730083de645a',
+                                    width: 280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=120&quality=85&auto=format&fit=max&s=d9db4a6aeea90aca485904e70ddaccd4',
+                                    width: 120,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=fb974d50ad8c90d1bb07c7b3ab4a6cd8',
+                                    width: 240,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'supporting',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=380&quality=85&auto=format&fit=max&s=87392954749c1fe40f9acfd7f5bce39b',
+                                    width: 380,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=bcfad42ee8e729f5a29790d14c0a8c9b',
+                                    width: 760,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=300&quality=85&auto=format&fit=max&s=0ee9331eac61a413ffaa7014015145e3',
+                                    width: 300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=ad0f597c419a9c869736af91f9f15acf',
+                                    width: 600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=48e15d5d34cdf2677030c6349c4a6bf2',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=a95ecd11817238d37fd9bbbd5b8ee70e',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=40432b37fa1c7e4907d202078a496d15',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=07cb72515ee014a5f6951cca0d71b631',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=3d194971fbccd3692587cc844457254b',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=bba08a4952a4b24f4c85b702dea4b534',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'showcase',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=1020&quality=85&auto=format&fit=max&s=f760a24db7ea1d2228fd5689398ac2d7',
+                                    width: 1020,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=1020&quality=45&auto=format&fit=max&dpr=2&s=687689ef25b440a287139ec262f35e7b',
+                                    width: 2040,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=940&quality=85&auto=format&fit=max&s=c67ce0ccfdca1eef3794cc61fbf1d9f3',
+                                    width: 940,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=940&quality=45&auto=format&fit=max&dpr=2&s=5482c2e538e9653b1e1dfd66e97a3fe7',
+                                    width: 1880,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=68ebcc2dd6e13568cba4d7a7feffeed8',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=e760a5833fe9b557dc45171177145a7a',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=68ebcc2dd6e13568cba4d7a7feffeed8',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=e760a5833fe9b557dc45171177145a7a',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=660&quality=85&auto=format&fit=max&s=f49608389e051e6d3713bc6d3503b7fa',
+                                    width: 660,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=660&quality=45&auto=format&fit=max&dpr=2&s=93cffd5d0a75f5885174bd38d4273f1b',
+                                    width: 1320,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=95e38b41456988787c76bb9401c20835',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=3cae4fb30b88aa1ddc6b1883e2fa5632',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=dedb7743d844de1e8560486fd1235619',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=cd444a4e8ca8c9a2bd85db2aa1ed77a7',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'halfwidth',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=48e15d5d34cdf2677030c6349c4a6bf2',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=a95ecd11817238d37fd9bbbd5b8ee70e',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=40432b37fa1c7e4907d202078a496d15',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=07cb72515ee014a5f6951cca0d71b631',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=3d194971fbccd3692587cc844457254b',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=bba08a4952a4b24f4c85b702dea4b534',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'immersive',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=1300&quality=85&auto=format&fit=max&s=21d5fae46f9bec0fa7ee923ef8360bae',
+                                    width: 1300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=1300&quality=45&auto=format&fit=max&dpr=2&s=bdd034c39d5d22967ac44669ff040258',
+                                    width: 2600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=1140&quality=85&auto=format&fit=max&s=dec643b163956f46820536b113ca1282',
+                                    width: 1140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=1140&quality=45&auto=format&fit=max&dpr=2&s=98ed6ad0ac33f01fc10537e16da529cd',
+                                    width: 2280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=1125&quality=85&auto=format&fit=max&s=7020ae5b3786c579ec1edc7731309fae',
+                                    width: 1125,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=1125&quality=45&auto=format&fit=max&dpr=2&s=0f8c96c0b74f48eccc8e57e16338a13b',
+                                    width: 2250,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=965&quality=85&auto=format&fit=max&s=651d525cf91cebecebbbbdb596474763',
+                                    width: 965,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=965&quality=45&auto=format&fit=max&dpr=2&s=90278c37c184a4d7414aa593b561a1af',
+                                    width: 1930,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=725&quality=85&auto=format&fit=max&s=fde24e4cf698ba9ad43245c58cd35ef1',
+                                    width: 725,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=725&quality=45&auto=format&fit=max&dpr=2&s=3b8175e5793268a255ce7b9bec807668',
+                                    width: 1450,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=95e38b41456988787c76bb9401c20835',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=3cae4fb30b88aa1ddc6b1883e2fa5632',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=dedb7743d844de1e8560486fd1235619',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=cd444a4e8ca8c9a2bd85db2aa1ed77a7',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                    ],
+                    _type:
+                        'model.dotcomrendering.pageElements.ImageBlockElement',
+                    media: {
+                        allImages: [
+                            {
+                                index: 0,
+                                fields: { height: '1667', width: '2500' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/2500.jpg',
+                            },
+                            {
+                                index: 1,
+                                fields: {
+                                    isMaster: 'true',
+                                    height: '1667',
+                                    width: '2500',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg',
+                            },
+                            {
+                                index: 2,
+                                fields: { height: '1334', width: '2000' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/2000.jpg',
+                            },
+                            {
+                                index: 3,
+                                fields: { height: '667', width: '1000' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/1000.jpg',
+                            },
+                            {
+                                index: 4,
+                                fields: { height: '333', width: '500' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/500.jpg',
+                            },
+                            {
+                                index: 5,
+                                fields: { height: '93', width: '140' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/140.jpg',
+                            },
+                        ],
+                    },
+                    displayCredit: true,
+                },
+                {
+                    role: 'halfWidth',
+                    data: {
+                        copyright: '© Tommy Trenchard / Greenpeace',
+                        alt:
+                            'A Greenpeace inflatable boat observes as frozen tuna are transferred from one ship to another in the middle of the Atlantic Ocean.',
+                        caption:
+                            'A Greenpeace inflatable boat observes as frozen tuna are transferred from one ship to another in the middle of the Atlantic Ocean.',
+                        credit: 'Photograph: Tommy Trenchard/Greenpeace',
+                    },
+                    imageSources: [
+                        {
+                            weighting: 'inline',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=5f0aad213210796efce5bc6e4b36f59b',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=e8deb95a117dfeb50e2589ba8a52659c',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=8da200c890a10261a96778219bafbbf7',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=7cdad992b7f86597b5962968fe064d7a',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=517b6cf595a28030747904afc06ca99c',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=cd91e3355d3b9535f03c49de18c042e9',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'thumbnail',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=140&quality=85&auto=format&fit=max&s=46f2811868440560a977d6864d49910e',
+                                    width: 140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=2a44939d4251a73f838c78e55f682c93',
+                                    width: 280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=120&quality=85&auto=format&fit=max&s=ef2feb81c3f887f850dc08c57add7a7b',
+                                    width: 120,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=b347c73fa5602c1316d3cd8de2401713',
+                                    width: 240,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'supporting',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=380&quality=85&auto=format&fit=max&s=be2cefb415a0326466aa09d9a70e95f4',
+                                    width: 380,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=32442832dd714139c8b6af3c3d263684',
+                                    width: 760,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=300&quality=85&auto=format&fit=max&s=1482e95ab52e1a8a2943c22815bf53e4',
+                                    width: 300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=e364ab01ad53bf52d38f8964dcd7e43f',
+                                    width: 600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=5f0aad213210796efce5bc6e4b36f59b',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=e8deb95a117dfeb50e2589ba8a52659c',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=8da200c890a10261a96778219bafbbf7',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=7cdad992b7f86597b5962968fe064d7a',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=517b6cf595a28030747904afc06ca99c',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=cd91e3355d3b9535f03c49de18c042e9',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'showcase',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=1020&quality=85&auto=format&fit=max&s=773503c05c0d2d2a5289d5135eab3bf9',
+                                    width: 1020,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=1020&quality=45&auto=format&fit=max&dpr=2&s=99f61fb65f3db7331a9accd7dcaef487',
+                                    width: 2040,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=940&quality=85&auto=format&fit=max&s=fc5c19b9d108d6640e027993afa24af1',
+                                    width: 940,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=940&quality=45&auto=format&fit=max&dpr=2&s=4bd7f37b18f0912c852861476fc52ba5',
+                                    width: 1880,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=5076e3e1d235ee37c5d8f2817d03ac23',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=1c53bc70bb0b4f0a7c438ee616ebe810',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=5076e3e1d235ee37c5d8f2817d03ac23',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=1c53bc70bb0b4f0a7c438ee616ebe810',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=660&quality=85&auto=format&fit=max&s=d19f425eeacd2bfceeae01dee61fe01d',
+                                    width: 660,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=660&quality=45&auto=format&fit=max&dpr=2&s=2860e067ff5bd111b0fb3bdf7f53633b',
+                                    width: 1320,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=427e2816ab973fe59c9a87dc9144caf6',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=c65bbe1a99f10e53f66ef07a4fdf5c4a',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=b705d2cefa6d0b9bb435523649374f3d',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=a08d573f5068f467d77c4628aa31e863',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'halfwidth',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=5f0aad213210796efce5bc6e4b36f59b',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=e8deb95a117dfeb50e2589ba8a52659c',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=8da200c890a10261a96778219bafbbf7',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=7cdad992b7f86597b5962968fe064d7a',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=517b6cf595a28030747904afc06ca99c',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=cd91e3355d3b9535f03c49de18c042e9',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'immersive',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=1300&quality=85&auto=format&fit=max&s=b184a2b9e93b4083aa7a6fed6eec45c2',
+                                    width: 1300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=1300&quality=45&auto=format&fit=max&dpr=2&s=fd2a2d24f60db471a2580c85207c0f77',
+                                    width: 2600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=1140&quality=85&auto=format&fit=max&s=8cfe0ddf82131868395e69ce26f1af5f',
+                                    width: 1140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=1140&quality=45&auto=format&fit=max&dpr=2&s=7b8fa4d6d96248046e24f47796d347db',
+                                    width: 2280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=1125&quality=85&auto=format&fit=max&s=7090db5a62dcac6f9d03479f88513f73',
+                                    width: 1125,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=1125&quality=45&auto=format&fit=max&dpr=2&s=51a09168635bbb6994527ec403a4da49',
+                                    width: 2250,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=965&quality=85&auto=format&fit=max&s=029e623ff8dd7413cd197efb537acc71',
+                                    width: 965,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=965&quality=45&auto=format&fit=max&dpr=2&s=9cefb63048efd535ef87d07d4849f4ac',
+                                    width: 1930,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=725&quality=85&auto=format&fit=max&s=83b5f0e48e1cd7a9e2aea238c2aa4b13',
+                                    width: 725,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=725&quality=45&auto=format&fit=max&dpr=2&s=f88f9cf18582298fdfdc5859b2edc23d',
+                                    width: 1450,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=427e2816ab973fe59c9a87dc9144caf6',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=c65bbe1a99f10e53f66ef07a4fdf5c4a',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=b705d2cefa6d0b9bb435523649374f3d',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=a08d573f5068f467d77c4628aa31e863',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                    ],
+                    _type:
+                        'model.dotcomrendering.pageElements.ImageBlockElement',
+                    media: {
+                        allImages: [
+                            {
+                                index: 0,
+                                fields: { height: '1667', width: '2500' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/2500.jpg',
+                            },
+                            {
+                                index: 1,
+                                fields: {
+                                    isMaster: 'true',
+                                    height: '1667',
+                                    width: '2500',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg',
+                            },
+                            {
+                                index: 2,
+                                fields: { height: '1334', width: '2000' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/2000.jpg',
+                            },
+                            {
+                                index: 3,
+                                fields: { height: '667', width: '1000' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/1000.jpg',
+                            },
+                            {
+                                index: 4,
+                                fields: { height: '333', width: '500' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/500.jpg',
+                            },
+                            {
+                                index: 5,
+                                fields: { height: '93', width: '140' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/140.jpg',
+                            },
+                        ],
+                    },
+                    displayCredit: true,
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>Demand for shark is a complex issue and the infamous shark fin soup is by no means the only threat. The global industry is now <a href="http://www.fao.org/3/a-i4795e.pdf">valued at up to $1bn</a> (£0.8bn) with a growing demand for shark meat, as well as the use of shark in consumer products such as liver oils.</p>',
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>Back at sea, we saw another shark caught on the line about to be lifted to the ship. But something went wrong when the fisherman tried to slip a noose around its neck. The shark struggled, twisted its body and the hook came loose.</p>',
+                },
+                {
+                    role: 'immersive',
+                    data: {
+                        copyright: '© Tommy Trenchard / Greenpeace',
+                        alt:
+                            'Crew on a longliner gaff a swordfish while hauling in their line in the South Atlantic ocean.',
+                        caption:
+                            'Crew on a longliner gaff a swordfish while hauling in their line in the South Atlantic ocean.',
+                        credit: 'Photograph: Tommy Trenchard/Greenpeace',
+                    },
+                    imageSources: [
+                        {
+                            weighting: 'inline',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=d64879f9b695e3d0f7ac510e1f5821f4',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=bca86bf5618ae8723896070b91db13c5',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=414baf5e0de1c002990408d098b3982e',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=81ce6dc7b8b5f412a3a8e50fb28fa2fb',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=95c255d78e1f997f2036b26cc74e3cb9',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=a74830302598cb4bba4a0b1d8aa651dd',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'thumbnail',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=140&quality=85&auto=format&fit=max&s=6e5e8ce3b96907e0d08daece83eaddfe',
+                                    width: 140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=2a726e828d1fed3846d538225116720d',
+                                    width: 280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=120&quality=85&auto=format&fit=max&s=b8a50b42376f7f90e0ebdec4af535337',
+                                    width: 120,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=e4157ebb2c19b4799b5d8ad98fde25e6',
+                                    width: 240,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'supporting',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=380&quality=85&auto=format&fit=max&s=862656ecdbd8a0cf29bc2e91013504c2',
+                                    width: 380,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=b112e06e1cf0a1e49d6d79db97253a1e',
+                                    width: 760,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=300&quality=85&auto=format&fit=max&s=9eaf73506a78ade176b65e2e7f1fe932',
+                                    width: 300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=6e1b7678d27ecd06e22ea7345e12bf6d',
+                                    width: 600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=d64879f9b695e3d0f7ac510e1f5821f4',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=bca86bf5618ae8723896070b91db13c5',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=414baf5e0de1c002990408d098b3982e',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=81ce6dc7b8b5f412a3a8e50fb28fa2fb',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=95c255d78e1f997f2036b26cc74e3cb9',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=a74830302598cb4bba4a0b1d8aa651dd',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'showcase',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=1020&quality=85&auto=format&fit=max&s=7ae12c4c69b9e8973391ca792e53c0bd',
+                                    width: 1020,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=1020&quality=45&auto=format&fit=max&dpr=2&s=0ad3f7a43074615c15c46fce30b06a80',
+                                    width: 2040,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=940&quality=85&auto=format&fit=max&s=9e9433313207e707186ae82f83345d0b',
+                                    width: 940,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=940&quality=45&auto=format&fit=max&dpr=2&s=eba289f45d024fe428105a7c94277444',
+                                    width: 1880,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=43c46189a3ccfddb950401f0fcc4108c',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=1fbcfe1c298cc452dc839090d27e0973',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=43c46189a3ccfddb950401f0fcc4108c',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=1fbcfe1c298cc452dc839090d27e0973',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=660&quality=85&auto=format&fit=max&s=30f69e8ee55f097cc9bb05eb7d142097',
+                                    width: 660,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=660&quality=45&auto=format&fit=max&dpr=2&s=d675c06722e265e646553a0a5aa49d8d',
+                                    width: 1320,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=65d656f15165e3e99fd658b24f090845',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=47ad02e150b4009d66044244b93916f3',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=a0e8a7a18f1a026e931eec36030b5803',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=a8a0bcfdaf87a979e638d3260c0e21d8',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'halfwidth',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=d64879f9b695e3d0f7ac510e1f5821f4',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=bca86bf5618ae8723896070b91db13c5',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=414baf5e0de1c002990408d098b3982e',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=81ce6dc7b8b5f412a3a8e50fb28fa2fb',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=95c255d78e1f997f2036b26cc74e3cb9',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=a74830302598cb4bba4a0b1d8aa651dd',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'immersive',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=1300&quality=85&auto=format&fit=max&s=ef16de3786fb1242f32961e1ad8cf3ad',
+                                    width: 1300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=1300&quality=45&auto=format&fit=max&dpr=2&s=676942d7f6f72f870744b41356fd5099',
+                                    width: 2600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=1140&quality=85&auto=format&fit=max&s=13dde4beba3632dbb81824d416f9d1e2',
+                                    width: 1140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=1140&quality=45&auto=format&fit=max&dpr=2&s=c7ea3331bd05e725448cc4270e1a07d7',
+                                    width: 2280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=1125&quality=85&auto=format&fit=max&s=539cb79319ffd267b278583bb21dc7d7',
+                                    width: 1125,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=1125&quality=45&auto=format&fit=max&dpr=2&s=9c6435fc7bccfb4677675f7ee4684b16',
+                                    width: 2250,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=965&quality=85&auto=format&fit=max&s=e101690229e965453a178f55e89cc9e9',
+                                    width: 965,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=965&quality=45&auto=format&fit=max&dpr=2&s=a82092372290e69962f8a0ce0252b9af',
+                                    width: 1930,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=725&quality=85&auto=format&fit=max&s=f1fe94fccb8e00ab93aeda443afcf34e',
+                                    width: 725,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=725&quality=45&auto=format&fit=max&dpr=2&s=91d1629208c6f4b3859c191afa14974a',
+                                    width: 1450,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=65d656f15165e3e99fd658b24f090845',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=47ad02e150b4009d66044244b93916f3',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=a0e8a7a18f1a026e931eec36030b5803',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=a8a0bcfdaf87a979e638d3260c0e21d8',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                    ],
+                    _type:
+                        'model.dotcomrendering.pageElements.ImageBlockElement',
+                    media: {
+                        allImages: [
+                            {
+                                index: 0,
+                                fields: { height: '1667', width: '2500' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/2500.jpg',
+                            },
+                            {
+                                index: 1,
+                                fields: {
+                                    isMaster: 'true',
+                                    height: '1667',
+                                    width: '2500',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/master/2500.jpg',
+                            },
+                            {
+                                index: 2,
+                                fields: { height: '1334', width: '2000' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/2000.jpg',
+                            },
+                            {
+                                index: 3,
+                                fields: { height: '667', width: '1000' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/1000.jpg',
+                            },
+                            {
+                                index: 4,
+                                fields: { height: '333', width: '500' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/500.jpg',
+                            },
+                            {
+                                index: 5,
+                                fields: { height: '93', width: '140' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/e1e20b6c1b5d96d69b722881d0bc05ab3a689fba/0_0_2500_1667/140.jpg',
+                            },
+                        ],
+                    },
+                    displayCredit: true,
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>The fisherman missed his chance, but the shark didn’t. It darted away, and towards our small boat, before stopping right beside us. I could have touched its fin if I had dared. After a while, the shark regained its strength and dived under our boat, descending into the deep.</p>',
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>I saw so much killing, but it helps to remember the one that got away. Our oceans can recover if we only give them a chance.</p>',
+                },
+                {
+                    role: 'halfWidth',
+                    data: {
+                        copyright: '© Tommy Trenchard / Greenpeace',
+                        alt:
+                            'A crew bring in their lines in the mid-Atlantic ocean.',
+                        caption:
+                            'A crew bring in their lines in the mid-Atlantic ocean.',
+                        credit: 'Photograph: Tommy Trenchard/Greenpeace',
+                    },
+                    imageSources: [
+                        {
+                            weighting: 'inline',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=2476dc48df433a66fe03df304780eda3',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=d2814db1e9f9fed9a526ae22a3a3a797',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=d6e54a4d9e5405a830f868223e75bc2a',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=0c23eff279e505868a3c3c0d08f820fe',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=47fb2daa98d79124a4c0790909603f09',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=ae734e0771f89ceb9e5eb2f83b4f9753',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'thumbnail',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=140&quality=85&auto=format&fit=max&s=296d52df58a68a84e250c66c083989c9',
+                                    width: 140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=04f8152313f9333346c6903bfb7c7d73',
+                                    width: 280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=120&quality=85&auto=format&fit=max&s=0ed0c7e7a3b34cafbfed8145f741b159',
+                                    width: 120,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=e5e7e148e89857c36a46275ef6634355',
+                                    width: 240,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'supporting',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=380&quality=85&auto=format&fit=max&s=78f47fe6d5a419107dfb04a5daf163da',
+                                    width: 380,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=554d5d4c16f53076e4619c85dc93230b',
+                                    width: 760,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=300&quality=85&auto=format&fit=max&s=c258ea6c936aacaf11c90413b8d1d902',
+                                    width: 300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=5e84b57a5445c908a86b0467195930f5',
+                                    width: 600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=2476dc48df433a66fe03df304780eda3',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=d2814db1e9f9fed9a526ae22a3a3a797',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=d6e54a4d9e5405a830f868223e75bc2a',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=0c23eff279e505868a3c3c0d08f820fe',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=47fb2daa98d79124a4c0790909603f09',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=ae734e0771f89ceb9e5eb2f83b4f9753',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'showcase',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=1020&quality=85&auto=format&fit=max&s=9987dae7b6f3ccbb0fe8aa2b3f6b763d',
+                                    width: 1020,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=1020&quality=45&auto=format&fit=max&dpr=2&s=e91014f6e76084be483b7238a026c90a',
+                                    width: 2040,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=940&quality=85&auto=format&fit=max&s=b04ecf5e004a533ceeebc1b86db87c39',
+                                    width: 940,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=940&quality=45&auto=format&fit=max&dpr=2&s=8f2253d7d6041140186319c8952fd9cd',
+                                    width: 1880,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=da7d69422e10e52cb7a381c2c8d092ec',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=34e349f65a118399cea07a46ec3b5da6',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=da7d69422e10e52cb7a381c2c8d092ec',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=34e349f65a118399cea07a46ec3b5da6',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=660&quality=85&auto=format&fit=max&s=ef19c5025feabc048a6853b35af2776d',
+                                    width: 660,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=660&quality=45&auto=format&fit=max&dpr=2&s=8c43f3774ef69e2f461d175c63cfdc19',
+                                    width: 1320,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=97dca2ce53cbfa5a0aa3cb95843f0879',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=44768d19436cc3529ce78ee59ef179aa',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=e34b8340b4d53d32e178b22a0f35d59c',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=0bff0f3a3c372bd7c30981b91b8ae03b',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'halfwidth',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=2476dc48df433a66fe03df304780eda3',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=d2814db1e9f9fed9a526ae22a3a3a797',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=d6e54a4d9e5405a830f868223e75bc2a',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=0c23eff279e505868a3c3c0d08f820fe',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=47fb2daa98d79124a4c0790909603f09',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=ae734e0771f89ceb9e5eb2f83b4f9753',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'immersive',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=1300&quality=85&auto=format&fit=max&s=7a117f62c3b10032a267ecb562b6c751',
+                                    width: 1300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=1300&quality=45&auto=format&fit=max&dpr=2&s=57f6a724dd830fea2fdda837d78e2148',
+                                    width: 2600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=1140&quality=85&auto=format&fit=max&s=24ffe8bf9c907fc6f41776847c44f952',
+                                    width: 1140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=1140&quality=45&auto=format&fit=max&dpr=2&s=9aaf3858251a32a5e519aaa591a6f896',
+                                    width: 2280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=1125&quality=85&auto=format&fit=max&s=ecdf4e34afcb5eca07d588fc27d3f975',
+                                    width: 1125,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=1125&quality=45&auto=format&fit=max&dpr=2&s=e53ca99bc56b631e31db72b7aeda09b0',
+                                    width: 2250,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=965&quality=85&auto=format&fit=max&s=d2cb034df24e43db2d90714346e6d564',
+                                    width: 965,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=965&quality=45&auto=format&fit=max&dpr=2&s=922cb44c2f54b74584e219034f05faf0',
+                                    width: 1930,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=725&quality=85&auto=format&fit=max&s=d68bb87dc4aef8ba185b6cb2b3d3b8a0',
+                                    width: 725,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=725&quality=45&auto=format&fit=max&dpr=2&s=7c01c2834c58077bffc3722d0416582b',
+                                    width: 1450,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=97dca2ce53cbfa5a0aa3cb95843f0879',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=44768d19436cc3529ce78ee59ef179aa',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=e34b8340b4d53d32e178b22a0f35d59c',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=0bff0f3a3c372bd7c30981b91b8ae03b',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                    ],
+                    _type:
+                        'model.dotcomrendering.pageElements.ImageBlockElement',
+                    media: {
+                        allImages: [
+                            {
+                                index: 0,
+                                fields: { height: '1667', width: '2500' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/2500.jpg',
+                            },
+                            {
+                                index: 1,
+                                fields: {
+                                    isMaster: 'true',
+                                    height: '1667',
+                                    width: '2500',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/master/2500.jpg',
+                            },
+                            {
+                                index: 2,
+                                fields: { height: '1334', width: '2000' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/2000.jpg',
+                            },
+                            {
+                                index: 3,
+                                fields: { height: '667', width: '1000' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/1000.jpg',
+                            },
+                            {
+                                index: 4,
+                                fields: { height: '333', width: '500' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/500.jpg',
+                            },
+                            {
+                                index: 5,
+                                fields: { height: '93', width: '140' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/6263bfac7765f647ac2082ccff70707a1386045c/0_0_2500_1667/140.jpg',
+                            },
+                        ],
+                    },
+                    displayCredit: true,
+                },
+                {
+                    role: 'halfWidth',
+                    data: {
+                        copyright: '© Tommy Trenchard / Greenpeace',
+                        alt:
+                            'Crew members of a ship in the mid-Atlantic lower a tuna into the hold.',
+                        caption:
+                            'Crew members of a ship in the mid-Atlantic lower a tuna into the hold.',
+                        credit: 'Photograph: Tommy Trenchard/Greenpeace',
+                    },
+                    imageSources: [
+                        {
+                            weighting: 'inline',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=b3a5aec11286d61a66a6a37c146e7249',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=8b9c8f0035cf91c416b402d1ce1e13d2',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=edf2b3d05832a04f99bad6ce3a6a3e8b',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=66fdfed9c9b27f1e405c9ef7737ca0cc',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=fe108b5ebb9949bfbb9233d215fbd3e0',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=f1e5463e16009618f279bc41c1cf1fc9',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'thumbnail',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=140&quality=85&auto=format&fit=max&s=45bdd32b68c2b705ccb7d12b221ff894',
+                                    width: 140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=3f322c5319a52b78069932e0de1066c8',
+                                    width: 280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=120&quality=85&auto=format&fit=max&s=c1d58ecd4fd71d61b946050a5253451f',
+                                    width: 120,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=8134df3dc33959a087582c2a3b8437f0',
+                                    width: 240,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'supporting',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=380&quality=85&auto=format&fit=max&s=f9d9076d589990c344c8d254a8084785',
+                                    width: 380,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=24267136f1599b34e30c62c168ff5825',
+                                    width: 760,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=300&quality=85&auto=format&fit=max&s=d7435a79deccc28a877ac88e3eccb0f9',
+                                    width: 300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=6eadecc79e99f79cc2777c2e510e60f5',
+                                    width: 600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=b3a5aec11286d61a66a6a37c146e7249',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=8b9c8f0035cf91c416b402d1ce1e13d2',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=edf2b3d05832a04f99bad6ce3a6a3e8b',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=66fdfed9c9b27f1e405c9ef7737ca0cc',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=fe108b5ebb9949bfbb9233d215fbd3e0',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=f1e5463e16009618f279bc41c1cf1fc9',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'showcase',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=1020&quality=85&auto=format&fit=max&s=35e513776f55aaac2f394bf0d4d58993',
+                                    width: 1020,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=1020&quality=45&auto=format&fit=max&dpr=2&s=26c3edef968c33d71676cf1ea4843ed7',
+                                    width: 2040,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=940&quality=85&auto=format&fit=max&s=34f429a2c2341e54989166f132a6e2f9',
+                                    width: 940,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=940&quality=45&auto=format&fit=max&dpr=2&s=86847d6057bd116bf6f60388eebf2850',
+                                    width: 1880,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=528573985a72391ace2c64e4900cd8b0',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=11319410c328405b9476896b233b3171',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=528573985a72391ace2c64e4900cd8b0',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=11319410c328405b9476896b233b3171',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=660&quality=85&auto=format&fit=max&s=c8694d3bcd2365136c4f971d0545ad36',
+                                    width: 660,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=660&quality=45&auto=format&fit=max&dpr=2&s=3b1ac3cb8f192d02d38c169ad7f0c9b3',
+                                    width: 1320,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=54fd4effaba2a017b3924df228e57bd2',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=ca52d564c6233cc909c0134ab9fe5e99',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=759601d8a3f9618248952c8d1ae1c020',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=e66584f55ae98f4d84298747722d2631',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'halfwidth',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=b3a5aec11286d61a66a6a37c146e7249',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=8b9c8f0035cf91c416b402d1ce1e13d2',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=edf2b3d05832a04f99bad6ce3a6a3e8b',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=66fdfed9c9b27f1e405c9ef7737ca0cc',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=fe108b5ebb9949bfbb9233d215fbd3e0',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=f1e5463e16009618f279bc41c1cf1fc9',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'immersive',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=1300&quality=85&auto=format&fit=max&s=0bbd0e62e43d5bb52dbbe4762ea973ca',
+                                    width: 1300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=1300&quality=45&auto=format&fit=max&dpr=2&s=e9433ace2ae754246df479b78586bbeb',
+                                    width: 2600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=1140&quality=85&auto=format&fit=max&s=0da8435d7697a29af69160145a625975',
+                                    width: 1140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=1140&quality=45&auto=format&fit=max&dpr=2&s=d82ba2757ea16a3e3bd96ed0b4bb37b1',
+                                    width: 2280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=1125&quality=85&auto=format&fit=max&s=9df1511c17ced63e5da5fa1f917aa5b6',
+                                    width: 1125,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=1125&quality=45&auto=format&fit=max&dpr=2&s=b520b065c0a7c4e658451487e71dd27a',
+                                    width: 2250,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=965&quality=85&auto=format&fit=max&s=e2a0835e90e278cc1734e430c682e274',
+                                    width: 965,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=965&quality=45&auto=format&fit=max&dpr=2&s=ff955b2ad4e27ac00de772ffa6fa5efa',
+                                    width: 1930,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=725&quality=85&auto=format&fit=max&s=f3e3ee1b04dc72612afdc3ab2ac18c0b',
+                                    width: 725,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=725&quality=45&auto=format&fit=max&dpr=2&s=b3b9ed2143ae32b47445d27f2f7e130f',
+                                    width: 1450,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=54fd4effaba2a017b3924df228e57bd2',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=ca52d564c6233cc909c0134ab9fe5e99',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=759601d8a3f9618248952c8d1ae1c020',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=e66584f55ae98f4d84298747722d2631',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                    ],
+                    _type:
+                        'model.dotcomrendering.pageElements.ImageBlockElement',
+                    media: {
+                        allImages: [
+                            {
+                                index: 0,
+                                fields: { height: '1667', width: '2500' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/2500.jpg',
+                            },
+                            {
+                                index: 1,
+                                fields: {
+                                    isMaster: 'true',
+                                    height: '1667',
+                                    width: '2500',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/master/2500.jpg',
+                            },
+                            {
+                                index: 2,
+                                fields: { height: '1334', width: '2000' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/2000.jpg',
+                            },
+                            {
+                                index: 3,
+                                fields: { height: '667', width: '1000' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/1000.jpg',
+                            },
+                            {
+                                index: 4,
+                                fields: { height: '333', width: '500' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/500.jpg',
+                            },
+                            {
+                                index: 5,
+                                fields: { height: '93', width: '140' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/69b6a57cdd3dbcbac140e015036f03ed15a39e15/0_0_2500_1667/140.jpg',
+                            },
+                        ],
+                    },
+                    displayCredit: true,
+                },
+                {
+                    role: 'halfWidth',
+                    data: {
+                        copyright: '© Tommy Trenchard / Greenpeace',
+                        alt: 'Frozen sharks are stacked in the hold of a ship.',
+                        caption:
+                            'Frozen sharks are stacked in the hold of a ship.',
+                        credit: 'Photograph: Tommy Trenchard/Greenpeace',
+                    },
+                    imageSources: [
+                        {
+                            weighting: 'inline',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=f3697fef29182e234c6e57b51ecfd44f',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=3f779adba3bc215f4661e3dbed8e1a79',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=377c628562dd9251118b5435333b707c',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=a2b51c7ed6ba4760fb33eda6063f3236',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=5b95b3aaddcdb112ebd63b73f17c9cf6',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=046a76ae5517c142afab08e6dc0b75b2',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'thumbnail',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=140&quality=85&auto=format&fit=max&s=ec21b5d8a9f4ff4cc94427f75b8d1f35',
+                                    width: 140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=ca9e5c23859a6dd2f83fff48f6df11e5',
+                                    width: 280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=120&quality=85&auto=format&fit=max&s=491979607b920c71f60a9a4cbe1f7371',
+                                    width: 120,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=0b95fc0551bc042d7d56ab9d4bd713e9',
+                                    width: 240,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'supporting',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=380&quality=85&auto=format&fit=max&s=47ef04a7dcf507ad5840c4f1bbc3e1ce',
+                                    width: 380,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=33933c5852d1b661f9d86ee690ca4517',
+                                    width: 760,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=300&quality=85&auto=format&fit=max&s=e7ad6131a2ab84a1526605c7e4bdb01b',
+                                    width: 300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=55c7159790f068d939fc8835543fcfb5',
+                                    width: 600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=f3697fef29182e234c6e57b51ecfd44f',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=3f779adba3bc215f4661e3dbed8e1a79',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=377c628562dd9251118b5435333b707c',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=a2b51c7ed6ba4760fb33eda6063f3236',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=5b95b3aaddcdb112ebd63b73f17c9cf6',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=046a76ae5517c142afab08e6dc0b75b2',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'showcase',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=1020&quality=85&auto=format&fit=max&s=122a7158fb8c68f46f63062bae84cc8e',
+                                    width: 1020,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=1020&quality=45&auto=format&fit=max&dpr=2&s=9cec7d1cc20792f84d732d66db30298e',
+                                    width: 2040,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=940&quality=85&auto=format&fit=max&s=2b4947f65a024b1bfccfea0cec827a23',
+                                    width: 940,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=940&quality=45&auto=format&fit=max&dpr=2&s=2175efcfe7450e0c75d6bec1ee75c7e0',
+                                    width: 1880,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=142c38c38a1a092ad77b06ba5ab63681',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=3f4abfd88f173a6c61ae93080b1571cc',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=142c38c38a1a092ad77b06ba5ab63681',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=3f4abfd88f173a6c61ae93080b1571cc',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=660&quality=85&auto=format&fit=max&s=c6a86a509375ce89888812b61e070288',
+                                    width: 660,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=660&quality=45&auto=format&fit=max&dpr=2&s=b633a4879cc6c4296d8b8b51adcb6fe0',
+                                    width: 1320,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=9e2d14a4c4e03382de5fa2d9aed44027',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=f220070971574594fe2b41efb74a8bdd',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=20558b7c0a1598b816b0dcbca46dcf83',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=a975e2f3bf2a70db408a4ce610bdd173',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'halfwidth',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=f3697fef29182e234c6e57b51ecfd44f',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=3f779adba3bc215f4661e3dbed8e1a79',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=377c628562dd9251118b5435333b707c',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=a2b51c7ed6ba4760fb33eda6063f3236',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=5b95b3aaddcdb112ebd63b73f17c9cf6',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=046a76ae5517c142afab08e6dc0b75b2',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'immersive',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=1300&quality=85&auto=format&fit=max&s=d69531bcb5063767bf62f9f4b09f15b3',
+                                    width: 1300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=1300&quality=45&auto=format&fit=max&dpr=2&s=3c027c2b9d620d068faf1c7bbd04e2a5',
+                                    width: 2600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=1140&quality=85&auto=format&fit=max&s=4420e60dcbb32cc72afd462f066d24f4',
+                                    width: 1140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=1140&quality=45&auto=format&fit=max&dpr=2&s=c6b9fdc907744553e4277532de889ff1',
+                                    width: 2280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=1125&quality=85&auto=format&fit=max&s=72a55dd0aa8c7707827803818e75062a',
+                                    width: 1125,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=1125&quality=45&auto=format&fit=max&dpr=2&s=a27b1b93137f7d02461b5f496f586c6c',
+                                    width: 2250,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=965&quality=85&auto=format&fit=max&s=594f365fa70da2de6f53b9f389828c8c',
+                                    width: 965,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=965&quality=45&auto=format&fit=max&dpr=2&s=f16ba1687aa9d30b5c1147b603b8b315',
+                                    width: 1930,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=725&quality=85&auto=format&fit=max&s=6d877f18063bd8aecc1ab17d6797f654',
+                                    width: 725,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=725&quality=45&auto=format&fit=max&dpr=2&s=c569d0dcaf47707fec64d09fb1090aef',
+                                    width: 1450,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=9e2d14a4c4e03382de5fa2d9aed44027',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=f220070971574594fe2b41efb74a8bdd',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=20558b7c0a1598b816b0dcbca46dcf83',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=a975e2f3bf2a70db408a4ce610bdd173',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                    ],
+                    _type:
+                        'model.dotcomrendering.pageElements.ImageBlockElement',
+                    media: {
+                        allImages: [
+                            {
+                                index: 0,
+                                fields: { height: '1667', width: '2500' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/2500.jpg',
+                            },
+                            {
+                                index: 1,
+                                fields: {
+                                    isMaster: 'true',
+                                    height: '1667',
+                                    width: '2500',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/master/2500.jpg',
+                            },
+                            {
+                                index: 2,
+                                fields: { height: '1334', width: '2000' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/2000.jpg',
+                            },
+                            {
+                                index: 3,
+                                fields: { height: '667', width: '1000' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/1000.jpg',
+                            },
+                            {
+                                index: 4,
+                                fields: { height: '333', width: '500' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/500.jpg',
+                            },
+                            {
+                                index: 5,
+                                fields: { height: '93', width: '140' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/99367d325a6319ad01ed829836affd4f2bf3cf86/0_0_2500_1667/140.jpg',
+                            },
+                        ],
+                    },
+                    displayCredit: true,
+                },
+                {
+                    role: 'halfWidth',
+                    data: {
+                        copyright: '© Tommy Trenchard / Greenpeace',
+                        alt:
+                            'Frozen tuna are transferred from one ship to another in the middle of the Atlantic Ocean.',
+                        caption:
+                            'Frozen tuna are transferred from one ship to another in the middle of the Atlantic Ocean.',
+                        credit: 'Photograph: Tommy Trenchard/Greenpeace',
+                    },
+                    imageSources: [
+                        {
+                            weighting: 'inline',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=1ba8bd42fb134d94b9c2c7ac3530461e',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=4206fa1de883ee50fce583ab04d359fa',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=5db955974310a310937ec5a836a4b81a',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=6153e894473b82fa6bd2eaba25277562',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=c92fcb4708c9b38d0b470b81f125a398',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=a50975a8e46c66a09162e98d61e7d2fc',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'thumbnail',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=140&quality=85&auto=format&fit=max&s=1e6e4754f08cf6a475c5410359e8bf4e',
+                                    width: 140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=2e3fcbaf28efe231836a194622b6c262',
+                                    width: 280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=120&quality=85&auto=format&fit=max&s=fe7e7992d9571c9907261859f1876719',
+                                    width: 120,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=d06371a2b14a2643e14d1c0d05a8b1ea',
+                                    width: 240,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'supporting',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=380&quality=85&auto=format&fit=max&s=8f2d01f5a3c9647a4ab365db9c4299c3',
+                                    width: 380,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=29e2aeba1c905245f93ff81df4b48593',
+                                    width: 760,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=300&quality=85&auto=format&fit=max&s=743e1eeef03097822bec1505e6ab953b',
+                                    width: 300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=2d5094d24a66739aa4372d25481a2265',
+                                    width: 600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=1ba8bd42fb134d94b9c2c7ac3530461e',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=4206fa1de883ee50fce583ab04d359fa',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=5db955974310a310937ec5a836a4b81a',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=6153e894473b82fa6bd2eaba25277562',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=c92fcb4708c9b38d0b470b81f125a398',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=a50975a8e46c66a09162e98d61e7d2fc',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'showcase',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=1020&quality=85&auto=format&fit=max&s=2cba0cf676ef0ac1e9f6d4cbc0570d4a',
+                                    width: 1020,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=1020&quality=45&auto=format&fit=max&dpr=2&s=756e8acbee0ef360d3f7f95d5f2fad20',
+                                    width: 2040,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=940&quality=85&auto=format&fit=max&s=58cf3dc182081f396da24b1f4143fe2d',
+                                    width: 940,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=940&quality=45&auto=format&fit=max&dpr=2&s=887e98c06f0b1baac415c4fc45521502',
+                                    width: 1880,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=efb38be8ab29c46aadc19020a686d0cf',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=81b91b0bdf9f33f9bd1c9c9e2306e8ef',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=efb38be8ab29c46aadc19020a686d0cf',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=81b91b0bdf9f33f9bd1c9c9e2306e8ef',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=660&quality=85&auto=format&fit=max&s=1013342594d738b472511de543b5b1b8',
+                                    width: 660,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=660&quality=45&auto=format&fit=max&dpr=2&s=e43a10922e8b87be4394cffcef01424f',
+                                    width: 1320,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=01de381cee149b58d8445a5d2cda617a',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=f1066153db38056a649edd484c216979',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=eb3db1898852502a7fbb9d9391599e2f',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=77bbd347a5b58f7e84dfa80954780d76',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'halfwidth',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=1ba8bd42fb134d94b9c2c7ac3530461e',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=4206fa1de883ee50fce583ab04d359fa',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=5db955974310a310937ec5a836a4b81a',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=6153e894473b82fa6bd2eaba25277562',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=c92fcb4708c9b38d0b470b81f125a398',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=a50975a8e46c66a09162e98d61e7d2fc',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'immersive',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=1300&quality=85&auto=format&fit=max&s=970ef78f93a3adced156eb4ed7741d80',
+                                    width: 1300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=1300&quality=45&auto=format&fit=max&dpr=2&s=aa54a2d550ca9c8c676800f93862ea4a',
+                                    width: 2600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=1140&quality=85&auto=format&fit=max&s=579ebf1f4757a254b49e8b3b0e0dbeda',
+                                    width: 1140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=1140&quality=45&auto=format&fit=max&dpr=2&s=5b14ea81875586799c9ae17cafbada3e',
+                                    width: 2280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=1125&quality=85&auto=format&fit=max&s=7d4acd6c338621de9ccf65b7c4f880ba',
+                                    width: 1125,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=1125&quality=45&auto=format&fit=max&dpr=2&s=2f56aaf3418d4b74631960da243e94e9',
+                                    width: 2250,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=965&quality=85&auto=format&fit=max&s=da83e98a472828c6b09c6809fe3cda04',
+                                    width: 965,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=965&quality=45&auto=format&fit=max&dpr=2&s=68075270954434874cf851755d53d520',
+                                    width: 1930,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=725&quality=85&auto=format&fit=max&s=ce74d7054a8aee8bf10c2e96f32c2dcd',
+                                    width: 725,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=725&quality=45&auto=format&fit=max&dpr=2&s=df3cabacb25b9a8e4b93b539287f9421',
+                                    width: 1450,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=01de381cee149b58d8445a5d2cda617a',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=f1066153db38056a649edd484c216979',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=eb3db1898852502a7fbb9d9391599e2f',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=77bbd347a5b58f7e84dfa80954780d76',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                    ],
+                    _type:
+                        'model.dotcomrendering.pageElements.ImageBlockElement',
+                    media: {
+                        allImages: [
+                            {
+                                index: 0,
+                                fields: { height: '1667', width: '2500' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/2500.jpg',
+                            },
+                            {
+                                index: 1,
+                                fields: {
+                                    isMaster: 'true',
+                                    height: '1667',
+                                    width: '2500',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/master/2500.jpg',
+                            },
+                            {
+                                index: 2,
+                                fields: { height: '1334', width: '2000' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/2000.jpg',
+                            },
+                            {
+                                index: 3,
+                                fields: { height: '667', width: '1000' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/1000.jpg',
+                            },
+                            {
+                                index: 4,
+                                fields: { height: '333', width: '500' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/500.jpg',
+                            },
+                            {
+                                index: 5,
+                                fields: { height: '93', width: '140' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/2e75b2a105dc131ab42de371bf225ac4aa2dec65/0_0_2500_1667/140.jpg',
+                            },
+                        ],
+                    },
+                    displayCredit: true,
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>Just a glimpse of these gruesome acts gave a sense of the scale of this industry and made clear to me that our system for looking after our oceans is entirely broken. We are utterly failing to protect marine life from the destructive practices of industrial fishing.</p>',
+                },
+                {
+                    _type:
+                        'model.dotcomrendering.pageElements.TextBlockElement',
+                    html:
+                        '<p>Millions of people worldwide are calling for governments to agree a strong Global Ocean Treaty when they <a href="https://oceanconference.un.org/">meet at the UN</a> in spring 2020. This would replace our weak ocean regulation and could pave the way for a network of ocean sanctuaries, off-limits to harmful human activity, which would properly protect marine life. It cannot wait. Longliners are out at sea now reeling in shark after shark, marking our countdown to protect the oceans.</p>',
+                },
+                {
+                    role: 'immersive',
+                    data: {
+                        copyright: '© Tommy Trenchard / Greenpeace',
+                        alt:
+                            'A crew member stabs a shark behind the gills with a knife, working the blade around the back of the head, to kill it as it’s hauled onboard.',
+                        caption:
+                            'A crew member stabs a shark behind the gills with a knife, working the blade around the back of the head, to kill it as it’s hauled onboard.',
+                        credit: 'Photograph: Tommy Trenchard/Greenpeace',
+                    },
+                    imageSources: [
+                        {
+                            weighting: 'inline',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=5343f09d693b4a2b3f4266dfe57630d5',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=874cc791c92872e3baadc8514df039a0',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=9b65b19e1d35dc045825f51ee4e6854b',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=58e3d69a6ca83daf55f776f75861fe4a',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=2188aa7860562f0e9e0d0901752eac2a',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=2511bec9b860c81cb4743590e7f978c3',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'thumbnail',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=140&quality=85&auto=format&fit=max&s=eb6ad90ea1326a443aa0e3c11beecf3e',
+                                    width: 140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=c9d78d19ac07894e8091383e307405eb',
+                                    width: 280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=120&quality=85&auto=format&fit=max&s=6b9e5c22e898fed709bd7f5c050bf389',
+                                    width: 120,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=6bb0264174eb4e001cc3e5c4b43623b5',
+                                    width: 240,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'supporting',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=380&quality=85&auto=format&fit=max&s=556786132ecb55632ea8ee82bbb95b34',
+                                    width: 380,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=26298592b5cd2a24c51621b3daac8699',
+                                    width: 760,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=300&quality=85&auto=format&fit=max&s=24569b9ace2714c744162f3231a1631b',
+                                    width: 300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=2a844d7b27448c3449c96f8e9eb447d1',
+                                    width: 600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=5343f09d693b4a2b3f4266dfe57630d5',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=874cc791c92872e3baadc8514df039a0',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=9b65b19e1d35dc045825f51ee4e6854b',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=58e3d69a6ca83daf55f776f75861fe4a',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=2188aa7860562f0e9e0d0901752eac2a',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=2511bec9b860c81cb4743590e7f978c3',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'showcase',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=1020&quality=85&auto=format&fit=max&s=cad7740f227461f8590e7d84ee4777a4',
+                                    width: 1020,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=1020&quality=45&auto=format&fit=max&dpr=2&s=18ffc5fc556d97f8ceee15003afed0d2',
+                                    width: 2040,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=940&quality=85&auto=format&fit=max&s=878ed97bd2cd17adae7d3c6712084610',
+                                    width: 940,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=940&quality=45&auto=format&fit=max&dpr=2&s=5249ee4956b95d5fb7e54260f679fa89',
+                                    width: 1880,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=68761938611e65edacf7ec2e8f5661ae',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=0a6b83f87a0c35beb319a12c7db81b57',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=68761938611e65edacf7ec2e8f5661ae',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=0a6b83f87a0c35beb319a12c7db81b57',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=660&quality=85&auto=format&fit=max&s=83a10c201e7d397a05124a6f46c93c7c',
+                                    width: 660,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=660&quality=45&auto=format&fit=max&dpr=2&s=4d7c1ae7eabfd8ac34c4164d8745610c',
+                                    width: 1320,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=b55f87e3c878668d2b184f5a5994417f',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=14d6159eecfd8c22cd3aea60022dd42b',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=d9564bb2ec0e016952a25116e5bda2a5',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=e3b9ad6e2053583db72aeefc27ab243b',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'halfwidth',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=5343f09d693b4a2b3f4266dfe57630d5',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=874cc791c92872e3baadc8514df039a0',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=9b65b19e1d35dc045825f51ee4e6854b',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=58e3d69a6ca83daf55f776f75861fe4a',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=2188aa7860562f0e9e0d0901752eac2a',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=2511bec9b860c81cb4743590e7f978c3',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'immersive',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=1300&quality=85&auto=format&fit=max&s=7d6eeacac784a514b42f2f667c4d6447',
+                                    width: 1300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=1300&quality=45&auto=format&fit=max&dpr=2&s=47a11bc914c2a8e0bafa49836679c435',
+                                    width: 2600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=1140&quality=85&auto=format&fit=max&s=bcd60ab99f8f1a3c3c2720cda1341df5',
+                                    width: 1140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=1140&quality=45&auto=format&fit=max&dpr=2&s=b8c7bf49a5ca9367bf3d688ab69ecea5',
+                                    width: 2280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=1125&quality=85&auto=format&fit=max&s=de918ebce2d0bd8c85bd22678a083e0a',
+                                    width: 1125,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=1125&quality=45&auto=format&fit=max&dpr=2&s=e4f694ab59a919ab54f1c0eff3416fe8',
+                                    width: 2250,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=965&quality=85&auto=format&fit=max&s=e4ae6dd7d0446f491a23f1b4c3dfccd8',
+                                    width: 965,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=965&quality=45&auto=format&fit=max&dpr=2&s=e8f4c3717e2e4126bfba201658306079',
+                                    width: 1930,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=725&quality=85&auto=format&fit=max&s=d96673170dac32ac5d838f4d5d8dec97',
+                                    width: 725,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=725&quality=45&auto=format&fit=max&dpr=2&s=5eaf398aaebcae38920810b91c89b148',
+                                    width: 1450,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=b55f87e3c878668d2b184f5a5994417f',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=14d6159eecfd8c22cd3aea60022dd42b',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=d9564bb2ec0e016952a25116e5bda2a5',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=e3b9ad6e2053583db72aeefc27ab243b',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                    ],
+                    _type:
+                        'model.dotcomrendering.pageElements.ImageBlockElement',
+                    media: {
+                        allImages: [
+                            {
+                                index: 0,
+                                fields: { height: '1667', width: '2500' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/2500.jpg',
+                            },
+                            {
+                                index: 1,
+                                fields: {
+                                    isMaster: 'true',
+                                    height: '1667',
+                                    width: '2500',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/master/2500.jpg',
+                            },
+                            {
+                                index: 2,
+                                fields: { height: '1334', width: '2000' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/2000.jpg',
+                            },
+                            {
+                                index: 3,
+                                fields: { height: '667', width: '1000' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/1000.jpg',
+                            },
+                            {
+                                index: 4,
+                                fields: { height: '333', width: '500' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/500.jpg',
+                            },
+                            {
+                                index: 5,
+                                fields: { height: '93', width: '140' },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/a5f48db7f2fd4f61a702590c29610ddc9158f104/0_0_2500_1667/140.jpg',
+                            },
+                        ],
+                    },
+                    displayCredit: true,
+                },
+            ],
+            createdOn: 1576258692000,
+            createdOnDisplay: '17:38 GMT',
+            lastUpdated: 1580305053000,
+            lastUpdatedDisplay: '13:37 GMT',
+            firstPublished: 1576258694000,
+            firstPublishedDisplay: '17:38 GMT',
+        },
+    ],
+    linkedData: [
+        {
+            '@type': 'NewsArticle',
+            '@context': 'https://schema.org',
+            '@id':
+                'https://amp.theguardian.comenvironment/2020/jan/29/i-witnessed-a-shark-attack-its-not-what-you-imagine-photo-essay',
+            publisher: {
+                '@type': 'Organization',
+                '@context': 'https://schema.org',
+                '@id': 'https://www.theguardian.com#publisher',
+                name: 'The Guardian',
+                url: 'https://www.theguardian.com/',
+                logo: {
+                    '@type': 'ImageObject',
+                    url:
+                        'https://uploads.guim.co.uk/2018/01/31/TheGuardian_AMP.png',
+                    width: 190,
+                    height: 60,
+                },
+                sameAs: [
+                    'https://www.facebook.com/theguardian',
+                    'https://twitter.com/guardian',
+                    'https://www.youtube.com/user/TheGuardian',
+                ],
+            },
+            isAccessibleForFree: true,
+            isPartOf: {
+                '@type': ['CreativeWork', 'Product'],
+                name: 'The Guardian',
+                productID: 'theguardian.com:basic',
+            },
+            image: [
+                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctZGVmYXVsdC5wbmc&enable=upscale&s=0534b40e422942dacdda9afaf1693a99',
+                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=1200&height=1200&quality=85&auto=format&fit=crop&s=37421e011f52e2cd7c4fc0a80cfcf4e7',
+                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=1200&height=900&quality=85&auto=format&fit=crop&s=db77b079c4773df855ed1ea1afdc3977',
+                'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=1200&quality=85&auto=format&fit=max&s=93e414122620a0805dad9cb35c7a5647',
+            ],
+            author: [
+                {
+                    '@type': 'Person',
+                    name: 'Sophie Cooke',
+                    sameAs: 'https://www.theguardian.com/profile/sophiecooke',
+                },
+            ],
+            datePublished: '2020-01-29T13:37:43.000Z',
+            headline:
+                'We fear sharks, but humans are the real predators – photo essay',
+            dateModified: '2020-01-29T13:39:25.000Z',
+            mainEntityOfPage:
+                'https://www.theguardian.com/environment/2020/jan/29/i-witnessed-a-shark-attack-its-not-what-you-imagine-photo-essay',
+        },
+        {
+            '@type': 'WebPage',
+            '@context': 'https://schema.org',
+            '@id':
+                'https://www.theguardian.com/environment/2020/jan/29/i-witnessed-a-shark-attack-its-not-what-you-imagine-photo-essay',
+            potentialAction: {
+                '@type': 'ViewAction',
+                target:
+                    'android-app://com.guardian/https/www.theguardian.com/environment/2020/jan/29/i-witnessed-a-shark-attack-its-not-what-you-imagine-photo-essay',
+            },
+        },
+    ],
+    editionId: 'UK',
+    webPublicationDateDisplay: 'Wed 29 Jan 2020 13.37 GMT',
+    shouldHideAds: false,
+    standfirst:
+        '<p>Greenpeace investigator Sophie Cooke spent a month at sea observing the hidden practices behind many of the deaths of 100 million sharks every year</p>',
+    openGraphData: {
+        'og:url':
+            'http://www.theguardian.com/environment/2020/jan/29/i-witnessed-a-shark-attack-its-not-what-you-imagine-photo-essay',
+        'article:author': 'https://www.theguardian.com/profile/sophiecooke',
+        'og:image:height': '720',
+        'og:description':
+            'Greenpeace investigator Sophie Cooke spent a month at sea observing the hidden practices behind many of the deaths of 100 million sharks every year',
+        'og:image:width': '1200',
+        'og:image':
+            'https://i.guim.co.uk/img/media/87ae80fa40c8ceab7ba864e69d921c6588b2ca45/297_213_2203_1321/master/2203.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctZGVmYXVsdC5wbmc&enable=upscale&s=0534b40e422942dacdda9afaf1693a99',
+        'al:ios:url':
+            'gnmguardian://environment/2020/jan/29/i-witnessed-a-shark-attack-its-not-what-you-imagine-photo-essay?contenttype=Article&source=applinks',
+        'article:publisher': 'https://www.facebook.com/theguardian',
+        'og:type': 'article',
+        'al:ios:app_store_id': '409128287',
+        'article:section': 'Environment',
+        'article:published_time': '2020-01-29T13:37:43.000Z',
+        'og:title':
+            'We fear sharks, but humans are the real predators – photo essay',
+        'fb:app_id': '180444840287',
+        'article:tag':
+            'Fishing,Animals,Conservation,Environment,Marine life,Wildlife',
+        'al:ios:app_name': 'The Guardian',
+        'og:site_name': 'the Guardian',
+        'article:modified_time': '2020-01-29T13:39:25.000Z',
+    },
+    webTitle: 'We fear sharks, but humans are the real predators – photo essay',
+    sectionUrl: 'environment/fishing',
+    pageId:
+        'environment/2020/jan/29/i-witnessed-a-shark-attack-its-not-what-you-imagine-photo-essay',
+    version: 3,
+    tags: [
+        {
+            id: 'environment/series/seascape-the-state-of-our-oceans',
+            type: 'Series',
+            title: 'Seascape: the state of our oceans',
+        },
+        { id: 'environment/fishing', type: 'Keyword', title: 'Fishing' },
+        { id: 'world/animals', type: 'Keyword', title: 'Animals' },
+        {
+            id: 'environment/conservation',
+            type: 'Keyword',
+            title: 'Conservation',
+        },
+        {
+            id: 'environment/environment',
+            type: 'Keyword',
+            title: 'Environment',
+        },
+        {
+            id: 'environment/marine-life',
+            type: 'Keyword',
+            title: 'Marine life',
+        },
+        { id: 'environment/wildlife', type: 'Keyword', title: 'Wildlife' },
+        { id: 'type/article', type: 'Type', title: 'Article' },
+        {
+            id: 'profile/sophiecooke',
+            type: 'Contributor',
+            title: 'Sophie Cooke',
+        },
+        {
+            id: 'tracking/commissioningdesk/global-development',
+            type: 'Tracking',
+            title: 'UK Global Development',
+        },
+    ],
+    pillar: 'news',
+    isCommentable: false,
+    webURL:
+        'https://www.theguardian.com/environment/2020/jan/29/i-witnessed-a-shark-attack-its-not-what-you-imagine-photo-essay',
+    keyEvents: [],
+    showBottomSocialButtons: true,
+    isImmersive: true,
+    config: {
+        ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
+        discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
+        sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
+        sentryHost: 'app.getsentry.com/35463',
+        dcrSentryDsn:
+            'https://1937ab71c8804b2b8438178dfdd6468f@sentry.io/1377847',
+        switches: {},
+        shortUrlId: '/p/4k83z',
+        abTests: {},
+        dfpAccountId: '',
+        commercialBundleUrl:
+            'https://assets.guim.co.uk/javascripts/3d3cbc5f29df7c0cdd65/graun.dotcom-rendering-commercial.js',
+        revisionNumber: '62cf0d6e4609276d37e09fd596430fbf8b629418',
+        isDev: false,
+        googletagUrl: '//www.googletagservices.com/tag/js/gpt.js',
+        stage: 'DEV',
+        frontendAssetsFullURL: 'https://assets.guim.co.uk/',
+        hbImpl: {
+            prebid: false,
+            a9: false,
+        },
+        adUnit: '/59666047/theguardian.com/film/article/ng',
+        isSensitive: false,
+        videoDuration: 0,
+        edition: '',
+        section: '',
+        sharedAdTargeting: {},
+        keywordIds: '',
+        showRelatedContent: false,
+        pageId: '',
+        webPublicationDate: 1579185778186,
+        headline: '',
+        author: '',
+        keywords: '',
+        series: '',
+        contentType: '',
+        isPaidContent: false,
+        discussionD2Uid: 'testD2Header',
+        discussionApiClientHeader: 'testClientHeader',
+        ampIframeUrl:
+            'https://assets.guim.co.uk/data/vendor/a994b749adae30cd58f0e84c8fa28013/amp-iframe.html',
+        isPhotoEssay: true,
+    },
+    sectionLabel: 'Fishing',
+};

--- a/fixtures/articles/Quiz.ts
+++ b/fixtures/articles/Quiz.ts
@@ -3084,6 +3084,7 @@ export const Quiz: CAPIType = {
         discussionApiClientHeader: 'testClientHeader',
         ampIframeUrl:
             'https://assets.guim.co.uk/data/vendor/a994b749adae30cd58f0e84c8fa28013/amp-iframe.html',
+        isPhotoEssay: false,
     },
     sectionLabel: 'Life and style',
 };

--- a/fixtures/articles/Recipe.ts
+++ b/fixtures/articles/Recipe.ts
@@ -5108,6 +5108,7 @@ export const Recipe: CAPIType = {
         discussionApiClientHeader: 'testClientHeader',
         ampIframeUrl:
             'https://assets.guim.co.uk/data/vendor/a994b749adae30cd58f0e84c8fa28013/amp-iframe.html',
+        isPhotoEssay: false,
     },
     sectionLabel: 'Food',
 };

--- a/fixtures/articles/Review.ts
+++ b/fixtures/articles/Review.ts
@@ -2711,6 +2711,7 @@ export const Review: CAPIType = {
         discussionApiClientHeader: 'testClientHeader',
         ampIframeUrl:
             'https://assets.guim.co.uk/data/vendor/a994b749adae30cd58f0e84c8fa28013/amp-iframe.html',
+        isPhotoEssay: false,
     },
     sectionLabel: 'TV comedy',
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,7 +28,8 @@ type DesignType =
     | 'GuardianView'
     | 'GuardianLabs'
     | 'Quiz'
-    | 'AdvertisementFeature';
+    | 'AdvertisementFeature'
+    | 'PhotoEssay';
 
 // This is an object that allows you Type defaults of the designTypes.
 // The return type looks like: { Feature: any, Live: any, ...}
@@ -334,6 +335,7 @@ type CAPIBrowserType = {
     };
     contributionsServiceUrl: string;
     isImmersive: boolean;
+    isPhotoEssay: boolean;
 };
 
 interface TagType {
@@ -527,6 +529,7 @@ interface ConfigType extends CommercialConfigType {
     discussionApiUrl: string;
     discussionD2Uid: string;
     discussionApiClientHeader: string;
+    isPhotoEssay: boolean;
 }
 
 interface GADataType {

--- a/src/lib/designTypes.ts
+++ b/src/lib/designTypes.ts
@@ -15,6 +15,7 @@ export const designTypes: DesignType[] = [
     'GuardianLabs',
     'Quiz',
     'AdvertisementFeature',
+    'PhotoEssay',
 ];
 
 // Return an object of all designTypes that uses the defaultVal

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -15,100 +15,100 @@
             "items": {
                 "anyOf": [
                     {
-                        "$ref": "#/definitions/TextBlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/SubheadingBlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/RichLinkBlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/ImageBlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/YoutubeBlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/VideoYoutubeBlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/VideoVimeoBlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/VideoFacebookBlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/VideoGuardian"
-                    },
-                    {
-                        "$ref": "#/definitions/InstagramBlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/TweetBlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/CommentBlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/SoundcloudBlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/EmbedBlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/DisclaimerBlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/PullquoteBlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/BlockquoteBlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/QABlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/GuideBlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/ProfileBlockElement"
-                    },
-                    {
-                        "$ref": "#/definitions/TimelineBlockElement"
-                    },
-                    {
                         "$ref": "#/definitions/AtomEmbedMarkupBlockElement"
                     },
                     {
                         "$ref": "#/definitions/AtomEmbedUrlBlockElement"
                     },
                     {
-                        "$ref": "#/definitions/MapBlockElement"
-                    },
-                    {
                         "$ref": "#/definitions/AudioAtomElement"
-                    },
-                    {
-                        "$ref": "#/definitions/ContentAtomBlockElement"
                     },
                     {
                         "$ref": "#/definitions/AudioBlockElement"
                     },
                     {
-                        "$ref": "#/definitions/VideoBlockElement"
+                        "$ref": "#/definitions/BlockquoteBlockElement"
                     },
                     {
                         "$ref": "#/definitions/CodeBlockElement"
                     },
                     {
+                        "$ref": "#/definitions/CommentBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/ContentAtomBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/DisclaimerBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/DividerBlockElement"
+                    },
+                    {
                         "$ref": "#/definitions/DocumentBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/EmbedBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/GuideBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/GuVideoBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/ImageBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/InstagramBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/MapBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/ProfileBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/PullquoteBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/QABlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/RichLinkBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/SoundcloudBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/SubheadingBlockElement"
                     },
                     {
                         "$ref": "#/definitions/TableBlockElement"
                     },
                     {
-                        "$ref": "#/definitions/DividerBlockElement"
+                        "$ref": "#/definitions/TextBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/TimelineBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/TweetBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/VideoBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/VideoFacebookBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/VideoVimeoBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/VideoYoutubeBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/YoutubeBlockElement"
                     }
                 ]
             }
@@ -353,383 +353,133 @@
         "webURL"
     ],
     "definitions": {
-        "TextBlockElement": {
+        "AtomEmbedMarkupBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
                     "type": "string",
                     "enum": [
-                        "model.dotcomrendering.pageElements.TextBlockElement"
+                        "model.dotcomrendering.pageElements.AtomEmbedMarkupBlockElement"
                     ]
-                },
-                "html": {
-                    "type": "string"
-                }
-            },
-            "required": ["_type", "html"]
-        },
-        "SubheadingBlockElement": {
-            "type": "object",
-            "properties": {
-                "_type": {
-                    "type": "string",
-                    "enum": [
-                        "model.dotcomrendering.pageElements.SubheadingBlockElement"
-                    ]
-                },
-                "html": {
-                    "type": "string"
-                }
-            },
-            "required": ["_type", "html"]
-        },
-        "RichLinkBlockElement": {
-            "type": "object",
-            "properties": {
-                "_type": {
-                    "type": "string",
-                    "enum": [
-                        "model.dotcomrendering.pageElements.RichLinkBlockElement"
-                    ]
-                },
-                "url": {
-                    "type": "string"
-                },
-                "text": {
-                    "type": "string"
-                },
-                "prefix": {
-                    "type": "string"
-                },
-                "role": {
-                    "$ref": "#/definitions/Weighting"
-                },
-                "richLinkIndex": {
-                    "type": "number"
-                }
-            },
-            "required": ["_type", "prefix", "text", "url"]
-        },
-        "Weighting": {
-            "enum": [
-                "halfwidth",
-                "immersive",
-                "inline",
-                "showcase",
-                "supporting",
-                "thumbnail"
-            ],
-            "type": "string"
-        },
-        "ImageBlockElement": {
-            "type": "object",
-            "properties": {
-                "_type": {
-                    "type": "string",
-                    "enum": [
-                        "model.dotcomrendering.pageElements.ImageBlockElement"
-                    ]
-                },
-                "media": {
-                    "type": "object",
-                    "properties": {
-                        "allImages": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/Image"
-                            }
-                        }
-                    },
-                    "required": ["allImages"]
-                },
-                "data": {
-                    "type": "object",
-                    "properties": {
-                        "alt": {
-                            "type": "string"
-                        },
-                        "credit": {
-                            "type": "string"
-                        },
-                        "caption": {
-                            "type": "string"
-                        },
-                        "copyright": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "imageSources": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/ImageSource"
-                    }
-                },
-                "displayCredit": {
-                    "type": "boolean"
-                },
-                "role": {
-                    "$ref": "#/definitions/RoleType"
-                }
-            },
-            "required": ["_type", "data", "imageSources", "media", "role"]
-        },
-        "Image": {
-            "type": "object",
-            "properties": {
-                "index": {
-                    "type": "number"
-                },
-                "fields": {
-                    "type": "object",
-                    "properties": {
-                        "height": {
-                            "type": "string"
-                        },
-                        "width": {
-                            "type": "string"
-                        },
-                        "isMaster": {
-                            "type": "string"
-                        }
-                    },
-                    "required": ["height", "width"]
-                },
-                "mediaType": {
-                    "type": "string"
-                },
-                "mimeType": {
-                    "type": "string"
-                },
-                "url": {
-                    "type": "string"
-                }
-            },
-            "required": ["fields", "index", "mediaType", "mimeType", "url"]
-        },
-        "ImageSource": {
-            "type": "object",
-            "properties": {
-                "weighting": {
-                    "$ref": "#/definitions/Weighting"
-                },
-                "srcSet": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/SrcSetItem"
-                    }
-                }
-            },
-            "required": ["srcSet", "weighting"]
-        },
-        "SrcSetItem": {
-            "type": "object",
-            "properties": {
-                "src": {
-                    "type": "string"
-                },
-                "width": {
-                    "type": "number"
-                }
-            },
-            "required": ["src", "width"]
-        },
-        "RoleType": {
-            "enum": [
-                "halfWidth",
-                "immersive",
-                "inline",
-                "showcase",
-                "supporting",
-                "thumbnail"
-            ],
-            "type": "string"
-        },
-        "YoutubeBlockElement": {
-            "type": "object",
-            "properties": {
-                "_type": {
-                    "type": "string",
-                    "enum": [
-                        "model.dotcomrendering.pageElements.YoutubeBlockElement"
-                    ]
-                },
-                "assetId": {
-                    "type": "string"
-                },
-                "mediaTitle": {
-                    "type": "string"
                 },
                 "id": {
                     "type": "string"
                 },
-                "channelId": {
+                "html": {
+                    "type": "string"
+                },
+                "css": {
+                    "type": "string"
+                },
+                "js": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "_type"
+            ]
+        },
+        "AtomEmbedUrlBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.AtomEmbedUrlBlockElement"
+                    ]
+                },
+                "url": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "_type",
+                "url"
+            ]
+        },
+        "AudioAtomElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.AudioAtomBlockElement"
+                    ]
+                },
+                "id": {
+                    "type": "string"
+                },
+                "kicker": {
+                    "type": "string"
+                },
+                "trackUrl": {
                     "type": "string"
                 },
                 "duration": {
                     "type": "number"
                 },
-                "posterSrc": {
-                    "type": "string"
-                },
-                "height": {
-                    "type": "string"
-                },
-                "width": {
+                "coverUrl": {
                     "type": "string"
                 }
             },
-            "required": ["_type", "assetId", "mediaTitle"]
+            "required": [
+                "_type",
+                "coverUrl",
+                "duration",
+                "id",
+                "kicker",
+                "trackUrl"
+            ]
         },
-        "VideoYoutubeBlockElement": {
+        "AudioBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
                     "type": "string",
                     "enum": [
-                        "model.dotcomrendering.pageElements.VideoYoutubeBlockElement"
+                        "model.dotcomrendering.pageElements.AudioBlockElement"
                     ]
-                },
-                "url": {
-                    "type": "string"
-                },
-                "height": {
-                    "type": "number"
-                },
-                "width": {
-                    "type": "number"
-                },
-                "caption": {
-                    "type": "string"
                 }
             },
-            "required": ["_type", "caption", "height", "url", "width"]
+            "required": [
+                "_type"
+            ]
         },
-        "VideoVimeoBlockElement": {
+        "BlockquoteBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
                     "type": "string",
                     "enum": [
-                        "model.dotcomrendering.pageElements.VideoVimeoBlockElement"
-                    ]
-                },
-                "url": {
-                    "type": "string"
-                },
-                "height": {
-                    "type": "number"
-                },
-                "width": {
-                    "type": "number"
-                },
-                "caption": {
-                    "type": "string"
-                }
-            },
-            "required": ["_type", "caption", "height", "url", "width"]
-        },
-        "VideoFacebookBlockElement": {
-            "type": "object",
-            "properties": {
-                "_type": {
-                    "type": "string",
-                    "enum": [
-                        "model.dotcomrendering.pageElements.VideoFacebookBlockElement"
-                    ]
-                },
-                "url": {
-                    "type": "string"
-                },
-                "height": {
-                    "type": "number"
-                },
-                "width": {
-                    "type": "number"
-                },
-                "caption": {
-                    "type": "string"
-                }
-            },
-            "required": ["_type", "caption", "height", "url", "width"]
-        },
-        "VideoGuardian": {
-            "type": "object",
-            "properties": {
-                "_type": {
-                    "type": "string",
-                    "enum": [
-                        "model.dotcomrendering.pageElements.GuVideoBlockElement"
-                    ]
-                },
-                "assets": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/VideoAssets"
-                    }
-                },
-                "caption": {
-                    "type": "string"
-                }
-            },
-            "required": ["_type", "assets", "caption"]
-        },
-        "VideoAssets": {
-            "type": "object",
-            "properties": {
-                "url": {
-                    "type": "string"
-                },
-                "mimeType": {
-                    "type": "string"
-                }
-            },
-            "required": ["mimeType", "url"]
-        },
-        "InstagramBlockElement": {
-            "type": "object",
-            "properties": {
-                "_type": {
-                    "type": "string",
-                    "enum": [
-                        "model.dotcomrendering.pageElements.InstagramBlockElement"
+                        "model.dotcomrendering.pageElements.BlockquoteBlockElement"
                     ]
                 },
                 "html": {
                     "type": "string"
-                },
-                "url": {
-                    "type": "string"
-                },
-                "hasCaption": {
-                    "type": "boolean"
                 }
             },
-            "required": ["_type", "hasCaption", "html", "url"]
+            "required": [
+                "_type",
+                "html"
+            ]
         },
-        "TweetBlockElement": {
+        "CodeBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
                     "type": "string",
                     "enum": [
-                        "model.dotcomrendering.pageElements.TweetBlockElement"
+                        "model.dotcomrendering.pageElements.CodeBlockElement"
                     ]
                 },
-                "html": {
-                    "type": "string"
-                },
-                "url": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "hasMedia": {
+                "isMandatory": {
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "hasMedia", "html", "id", "url"]
+            "required": [
+                "_type",
+                "isMandatory"
+            ]
         },
         "CommentBlockElement": {
             "type": "object",
@@ -769,29 +519,73 @@
                 "profileURL"
             ]
         },
-        "SoundcloudBlockElement": {
+        "ContentAtomBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
                     "type": "string",
                     "enum": [
-                        "model.dotcomrendering.pageElements.SoundcloudBlockElement"
+                        "model.dotcomrendering.pageElements.ContentAtomBlockElement"
+                    ]
+                },
+                "atomId": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "_type",
+                "atomId"
+            ]
+        },
+        "DisclaimerBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.DisclaimerBlockElement"
                     ]
                 },
                 "html": {
                     "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "isTrack": {
-                    "type": "boolean"
+                }
+            },
+            "required": [
+                "_type",
+                "html"
+            ]
+        },
+        "DividerBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.DividerBlockElement"
+                    ]
+                }
+            },
+            "required": [
+                "_type"
+            ]
+        },
+        "DocumentBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.DocumentBlockElement"
+                    ]
                 },
                 "isMandatory": {
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "html", "id", "isMandatory", "isTrack"]
+            "required": [
+                "_type",
+                "isMandatory"
+            ]
         },
         "EmbedBlockElement": {
             "type": "object",
@@ -815,85 +609,11 @@
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "html", "isMandatory"]
-        },
-        "DisclaimerBlockElement": {
-            "type": "object",
-            "properties": {
-                "_type": {
-                    "type": "string",
-                    "enum": [
-                        "model.dotcomrendering.pageElements.DisclaimerBlockElement"
-                    ]
-                },
-                "html": {
-                    "type": "string"
-                }
-            },
-            "required": ["_type", "html"]
-        },
-        "PullquoteBlockElement": {
-            "type": "object",
-            "properties": {
-                "_type": {
-                    "type": "string",
-                    "enum": [
-                        "model.dotcomrendering.pageElements.PullquoteBlockElement"
-                    ]
-                },
-                "html": {
-                    "type": "string"
-                },
-                "role": {
-                    "type": "string"
-                },
-                "attribution": {
-                    "type": "string"
-                }
-            },
-            "required": ["_type", "html", "role"]
-        },
-        "BlockquoteBlockElement": {
-            "type": "object",
-            "properties": {
-                "_type": {
-                    "type": "string",
-                    "enum": [
-                        "model.dotcomrendering.pageElements.BlockquoteBlockElement"
-                    ]
-                },
-                "html": {
-                    "type": "string"
-                }
-            },
-            "required": ["_type", "html"]
-        },
-        "QABlockElement": {
-            "type": "object",
-            "properties": {
-                "_type": {
-                    "type": "string",
-                    "enum": [
-                        "model.dotcomrendering.pageElements.QABlockElement"
-                    ]
-                },
-                "id": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "img": {
-                    "type": "string"
-                },
-                "html": {
-                    "type": "string"
-                },
-                "credit": {
-                    "type": "string"
-                }
-            },
-            "required": ["_type", "credit", "html", "id", "title"]
+            "required": [
+                "_type",
+                "html",
+                "isMandatory"
+            ]
         },
         "GuideBlockElement": {
             "type": "object",
@@ -923,121 +643,238 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "credit", "html", "id", "label", "title"]
+            "required": [
+                "_type",
+                "credit",
+                "html",
+                "id",
+                "label",
+                "title"
+            ]
         },
-        "ProfileBlockElement": {
+        "GuVideoBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
                     "type": "string",
                     "enum": [
-                        "model.dotcomrendering.pageElements.ProfileBlockElement"
+                        "model.dotcomrendering.pageElements.GuVideoBlockElement"
                     ]
                 },
-                "id": {
-                    "type": "string"
-                },
-                "label": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "img": {
-                    "type": "string"
-                },
-                "html": {
-                    "type": "string"
-                },
-                "credit": {
-                    "type": "string"
-                }
-            },
-            "required": ["_type", "credit", "html", "id", "label", "title"]
-        },
-        "TimelineBlockElement": {
-            "type": "object",
-            "properties": {
-                "_type": {
-                    "type": "string",
-                    "enum": [
-                        "model.dotcomrendering.pageElements.TimelineBlockElement"
-                    ]
-                },
-                "id": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "events": {
+                "assets": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/TimelineEvent"
+                        "$ref": "#/definitions/VideoAssets"
                     }
+                },
+                "caption": {
+                    "type": "string"
                 }
             },
-            "required": ["_type", "events", "id", "title"]
+            "required": [
+                "_type",
+                "assets",
+                "caption"
+            ]
         },
-        "TimelineEvent": {
+        "VideoAssets": {
             "type": "object",
             "properties": {
-                "title": {
+                "url": {
                     "type": "string"
                 },
-                "date": {
-                    "type": "string"
-                },
-                "body": {
-                    "type": "string"
-                },
-                "toDate": {
+                "mimeType": {
                     "type": "string"
                 }
             },
-            "required": ["date", "title"]
+            "required": [
+                "mimeType",
+                "url"
+            ]
         },
-        "AtomEmbedMarkupBlockElement": {
-            "type": "object",
-            "properties": {
-                "_type": {
-                    "type": "string",
-                    "enum": [
-                        "model.dotcomrendering.pageElements.AtomEmbedMarkupBlockElement"
-                    ]
-                },
-                "id": {
-                    "type": "string"
-                },
-                "html": {
-                    "type": "string"
-                },
-                "css": {
-                    "type": "string"
-                },
-                "js": {
-                    "type": "string"
-                }
-            },
-            "required": ["_type"]
-        },
-        "AtomEmbedUrlBlockElement": {
+        "ImageBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
                     "type": "string",
                     "enum": [
-                        "model.dotcomrendering.pageElements.AtomEmbedUrlBlockElement"
+                        "model.dotcomrendering.pageElements.ImageBlockElement"
                     ]
+                },
+                "media": {
+                    "type": "object",
+                    "properties": {
+                        "allImages": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Image"
+                            }
+                        }
+                    },
+                    "required": [
+                        "allImages"
+                    ]
+                },
+                "data": {
+                    "type": "object",
+                    "properties": {
+                        "alt": {
+                            "type": "string"
+                        },
+                        "credit": {
+                            "type": "string"
+                        },
+                        "caption": {
+                            "type": "string"
+                        },
+                        "copyright": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "imageSources": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ImageSource"
+                    }
+                },
+                "displayCredit": {
+                    "type": "boolean"
+                },
+                "role": {
+                    "$ref": "#/definitions/RoleType"
+                }
+            },
+            "required": [
+                "_type",
+                "data",
+                "imageSources",
+                "media",
+                "role"
+            ]
+        },
+        "Image": {
+            "type": "object",
+            "properties": {
+                "index": {
+                    "type": "number"
+                },
+                "fields": {
+                    "type": "object",
+                    "properties": {
+                        "height": {
+                            "type": "string"
+                        },
+                        "width": {
+                            "type": "string"
+                        },
+                        "isMaster": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "height",
+                        "width"
+                    ]
+                },
+                "mediaType": {
+                    "type": "string"
+                },
+                "mimeType": {
+                    "type": "string"
                 },
                 "url": {
                     "type": "string"
                 }
             },
-            "required": ["_type", "url"]
+            "required": [
+                "fields",
+                "index",
+                "mediaType",
+                "mimeType",
+                "url"
+            ]
+        },
+        "ImageSource": {
+            "type": "object",
+            "properties": {
+                "weighting": {
+                    "$ref": "#/definitions/Weighting"
+                },
+                "srcSet": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/SrcSetItem"
+                    }
+                }
+            },
+            "required": [
+                "srcSet",
+                "weighting"
+            ]
+        },
+        "Weighting": {
+            "enum": [
+                "halfwidth",
+                "immersive",
+                "inline",
+                "showcase",
+                "supporting",
+                "thumbnail"
+            ],
+            "type": "string"
+        },
+        "SrcSetItem": {
+            "type": "object",
+            "properties": {
+                "src": {
+                    "type": "string"
+                },
+                "width": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "src",
+                "width"
+            ]
+        },
+        "RoleType": {
+            "enum": [
+                "halfWidth",
+                "immersive",
+                "inline",
+                "showcase",
+                "supporting",
+                "thumbnail"
+            ],
+            "type": "string"
+        },
+        "InstagramBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.InstagramBlockElement"
+                    ]
+                },
+                "html": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "hasCaption": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "_type",
+                "hasCaption",
+                "html",
+                "url"
+            ]
         },
         "MapBlockElement": {
             "type": "object",
@@ -1073,108 +910,180 @@
                 "url"
             ]
         },
-        "AudioAtomElement": {
+        "ProfileBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
                     "type": "string",
                     "enum": [
-                        "model.dotcomrendering.pageElements.AudioAtomBlockElement"
+                        "model.dotcomrendering.pageElements.ProfileBlockElement"
                     ]
                 },
                 "id": {
                     "type": "string"
                 },
-                "kicker": {
+                "label": {
                     "type": "string"
                 },
-                "trackUrl": {
+                "title": {
                     "type": "string"
                 },
-                "duration": {
-                    "type": "number"
+                "img": {
+                    "type": "string"
                 },
-                "coverUrl": {
+                "html": {
+                    "type": "string"
+                },
+                "credit": {
                     "type": "string"
                 }
             },
             "required": [
                 "_type",
-                "coverUrl",
-                "duration",
+                "credit",
+                "html",
                 "id",
-                "kicker",
-                "trackUrl"
+                "label",
+                "title"
             ]
         },
-        "ContentAtomBlockElement": {
+        "PullquoteBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
                     "type": "string",
                     "enum": [
-                        "model.dotcomrendering.pageElements.ContentAtomBlockElement"
+                        "model.dotcomrendering.pageElements.PullquoteBlockElement"
                     ]
                 },
-                "atomId": {
+                "html": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string"
+                },
+                "attribution": {
                     "type": "string"
                 }
             },
-            "required": ["_type", "atomId"]
+            "required": [
+                "_type",
+                "html",
+                "role"
+            ]
         },
-        "AudioBlockElement": {
+        "QABlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
                     "type": "string",
                     "enum": [
-                        "model.dotcomrendering.pageElements.AudioBlockElement"
+                        "model.dotcomrendering.pageElements.QABlockElement"
                     ]
+                },
+                "id": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "img": {
+                    "type": "string"
+                },
+                "html": {
+                    "type": "string"
+                },
+                "credit": {
+                    "type": "string"
                 }
             },
-            "required": ["_type"]
+            "required": [
+                "_type",
+                "credit",
+                "html",
+                "id",
+                "title"
+            ]
         },
-        "VideoBlockElement": {
+        "RichLinkBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
                     "type": "string",
                     "enum": [
-                        "model.dotcomrendering.pageElements.VideoBlockElement"
+                        "model.dotcomrendering.pageElements.RichLinkBlockElement"
                     ]
+                },
+                "url": {
+                    "type": "string"
+                },
+                "text": {
+                    "type": "string"
+                },
+                "prefix": {
+                    "type": "string"
+                },
+                "role": {
+                    "$ref": "#/definitions/Weighting"
+                },
+                "richLinkIndex": {
+                    "type": "number"
                 }
             },
-            "required": ["_type"]
+            "required": [
+                "_type",
+                "prefix",
+                "text",
+                "url"
+            ]
         },
-        "CodeBlockElement": {
+        "SoundcloudBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
                     "type": "string",
                     "enum": [
-                        "model.dotcomrendering.pageElements.CodeBlockElement"
+                        "model.dotcomrendering.pageElements.SoundcloudBlockElement"
                     ]
+                },
+                "html": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "isTrack": {
+                    "type": "boolean"
                 },
                 "isMandatory": {
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "isMandatory"]
+            "required": [
+                "_type",
+                "html",
+                "id",
+                "isMandatory",
+                "isTrack"
+            ]
         },
-        "DocumentBlockElement": {
+        "SubheadingBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
                     "type": "string",
                     "enum": [
-                        "model.dotcomrendering.pageElements.DocumentBlockElement"
+                        "model.dotcomrendering.pageElements.SubheadingBlockElement"
                     ]
                 },
-                "isMandatory": {
-                    "type": "boolean"
+                "html": {
+                    "type": "string"
                 }
             },
-            "required": ["_type", "isMandatory"]
+            "required": [
+                "_type",
+                "html"
+            ]
         },
         "TableBlockElement": {
             "type": "object",
@@ -1189,19 +1098,258 @@
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "isMandatory"]
+            "required": [
+                "_type",
+                "isMandatory"
+            ]
         },
-        "DividerBlockElement": {
+        "TextBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
                     "type": "string",
                     "enum": [
-                        "model.dotcomrendering.pageElements.DividerBlockElement"
+                        "model.dotcomrendering.pageElements.TextBlockElement"
+                    ]
+                },
+                "dropCap": {
+                    "type": "boolean"
+                },
+                "html": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "_type",
+                "html"
+            ]
+        },
+        "TimelineBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.TimelineBlockElement"
+                    ]
+                },
+                "id": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "events": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/TimelineEvent"
+                    }
+                }
+            },
+            "required": [
+                "_type",
+                "events",
+                "id",
+                "title"
+            ]
+        },
+        "TimelineEvent": {
+            "type": "object",
+            "properties": {
+                "title": {
+                    "type": "string"
+                },
+                "date": {
+                    "type": "string"
+                },
+                "body": {
+                    "type": "string"
+                },
+                "toDate": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "date",
+                "title"
+            ]
+        },
+        "TweetBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.TweetBlockElement"
+                    ]
+                },
+                "html": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "hasMedia": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "_type",
+                "hasMedia",
+                "html",
+                "id",
+                "url"
+            ]
+        },
+        "VideoBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.VideoBlockElement"
                     ]
                 }
             },
-            "required": ["_type"]
+            "required": [
+                "_type"
+            ]
+        },
+        "VideoFacebookBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.VideoFacebookBlockElement"
+                    ]
+                },
+                "url": {
+                    "type": "string"
+                },
+                "height": {
+                    "type": "number"
+                },
+                "width": {
+                    "type": "number"
+                },
+                "caption": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "_type",
+                "caption",
+                "height",
+                "url",
+                "width"
+            ]
+        },
+        "VideoVimeoBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.VideoVimeoBlockElement"
+                    ]
+                },
+                "url": {
+                    "type": "string"
+                },
+                "height": {
+                    "type": "number"
+                },
+                "width": {
+                    "type": "number"
+                },
+                "caption": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "_type",
+                "caption",
+                "height",
+                "url",
+                "width"
+            ]
+        },
+        "VideoYoutubeBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.VideoYoutubeBlockElement"
+                    ]
+                },
+                "url": {
+                    "type": "string"
+                },
+                "height": {
+                    "type": "number"
+                },
+                "width": {
+                    "type": "number"
+                },
+                "caption": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "_type",
+                "caption",
+                "height",
+                "url",
+                "width"
+            ]
+        },
+        "YoutubeBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.YoutubeBlockElement"
+                    ]
+                },
+                "assetId": {
+                    "type": "string"
+                },
+                "mediaTitle": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "channelId": {
+                    "type": "string"
+                },
+                "duration": {
+                    "type": "number"
+                },
+                "posterSrc": {
+                    "type": "string"
+                },
+                "height": {
+                    "type": "string"
+                },
+                "width": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "_type",
+                "assetId",
+                "mediaTitle"
+            ]
         },
         "Block": {
             "type": "object",
@@ -1214,100 +1362,100 @@
                     "items": {
                         "anyOf": [
                             {
-                                "$ref": "#/definitions/TextBlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/SubheadingBlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/RichLinkBlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/ImageBlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/YoutubeBlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/VideoYoutubeBlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/VideoVimeoBlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/VideoFacebookBlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/VideoGuardian"
-                            },
-                            {
-                                "$ref": "#/definitions/InstagramBlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/TweetBlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/CommentBlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/SoundcloudBlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/EmbedBlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/DisclaimerBlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/PullquoteBlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/BlockquoteBlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/QABlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/GuideBlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/ProfileBlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/TimelineBlockElement"
-                            },
-                            {
                                 "$ref": "#/definitions/AtomEmbedMarkupBlockElement"
                             },
                             {
                                 "$ref": "#/definitions/AtomEmbedUrlBlockElement"
                             },
                             {
-                                "$ref": "#/definitions/MapBlockElement"
-                            },
-                            {
                                 "$ref": "#/definitions/AudioAtomElement"
-                            },
-                            {
-                                "$ref": "#/definitions/ContentAtomBlockElement"
                             },
                             {
                                 "$ref": "#/definitions/AudioBlockElement"
                             },
                             {
-                                "$ref": "#/definitions/VideoBlockElement"
+                                "$ref": "#/definitions/BlockquoteBlockElement"
                             },
                             {
                                 "$ref": "#/definitions/CodeBlockElement"
                             },
                             {
+                                "$ref": "#/definitions/CommentBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/ContentAtomBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/DisclaimerBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/DividerBlockElement"
+                            },
+                            {
                                 "$ref": "#/definitions/DocumentBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/EmbedBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/GuideBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/GuVideoBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/ImageBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/InstagramBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/MapBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/ProfileBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/PullquoteBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/QABlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/RichLinkBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/SoundcloudBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/SubheadingBlockElement"
                             },
                             {
                                 "$ref": "#/definitions/TableBlockElement"
                             },
                             {
-                                "$ref": "#/definitions/DividerBlockElement"
+                                "$ref": "#/definitions/TextBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/TimelineBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/TweetBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/VideoBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/VideoFacebookBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/VideoVimeoBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/VideoYoutubeBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/YoutubeBlockElement"
                             }
                         ]
                     }
@@ -1334,7 +1482,10 @@
                     "type": "string"
                 }
             },
-            "required": ["elements", "id"]
+            "required": [
+                "elements",
+                "id"
+            ]
         },
         "Pagination": {
             "type": "object",
@@ -1358,7 +1509,10 @@
                     "type": "string"
                 }
             },
-            "required": ["currentPage", "totalPages"]
+            "required": [
+                "currentPage",
+                "totalPages"
+            ]
         },
         "AuthorType": {
             "type": "object",
@@ -1375,7 +1529,12 @@
             }
         },
         "Edition": {
-            "enum": ["AU", "INT", "UK", "US"],
+            "enum": [
+                "AU",
+                "INT",
+                "UK",
+                "US"
+            ],
             "type": "string"
         },
         "TagType": {
@@ -1400,7 +1559,11 @@
                     "type": "string"
                 }
             },
-            "required": ["id", "title", "type"]
+            "required": [
+                "id",
+                "title",
+                "type"
+            ]
         },
         "Pillar": {
             "enum": [
@@ -1423,7 +1586,10 @@
                     "type": "string"
                 }
             },
-            "required": ["title", "url"]
+            "required": [
+                "title",
+                "url"
+            ]
         },
         "ConfigType": {
             "description": "the config model will contain useful app/site\nlevel data. Although currently derived from the config model\nconstructed in frontend and passed to dotcom-rendering\nthis data could eventually be defined in dotcom-rendering",
@@ -1529,6 +1695,9 @@
                 "discussionApiClientHeader": {
                     "type": "string"
                 },
+                "isPhotoEssay": {
+                    "type": "boolean"
+                },
                 "pageId": {
                     "type": "string"
                 },
@@ -1570,6 +1739,7 @@
                 "frontendAssetsFullURL",
                 "googletagUrl",
                 "hbImpl",
+                "isPhotoEssay",
                 "isSensitive",
                 "keywordIds",
                 "pageId",
@@ -1599,6 +1769,7 @@
                 "Live",
                 "MatchReport",
                 "Media",
+                "PhotoEssay",
                 "Quiz",
                 "Recipe",
                 "Review",
@@ -1622,7 +1793,12 @@
                     "$ref": "#/definitions/EditionCommercialProperties"
                 }
             },
-            "required": ["AU", "INT", "UK", "US"]
+            "required": [
+                "AU",
+                "INT",
+                "UK",
+                "US"
+            ]
         },
         "EditionCommercialProperties": {
             "type": "object",
@@ -1637,7 +1813,9 @@
                     "$ref": "#/definitions/Branding"
                 }
             },
-            "required": ["adTargeting"]
+            "required": [
+                "adTargeting"
+            ]
         },
         "AdTargetParam": {
             "type": "object",
@@ -1659,7 +1837,10 @@
                     ]
                 }
             },
-            "required": ["name", "value"]
+            "required": [
+                "name",
+                "value"
+            ]
         },
         "Branding": {
             "type": "object",
@@ -1671,7 +1852,9 @@
                             "type": "string"
                         }
                     },
-                    "required": ["name"]
+                    "required": [
+                        "name"
+                    ]
                 },
                 "sponsorName": {
                     "type": "string"
@@ -1698,10 +1881,18 @@
                                     "type": "number"
                                 }
                             },
-                            "required": ["height", "width"]
+                            "required": [
+                                "height",
+                                "width"
+                            ]
                         }
                     },
-                    "required": ["dimensions", "label", "link", "src"]
+                    "required": [
+                        "dimensions",
+                        "label",
+                        "link",
+                        "src"
+                    ]
                 },
                 "aboutThisLink": {
                     "type": "string"
@@ -1722,7 +1913,10 @@
                                     "type": "number"
                                 }
                             },
-                            "required": ["height", "width"]
+                            "required": [
+                                "height",
+                                "width"
+                            ]
                         },
                         "link": {
                             "type": "string"
@@ -1731,10 +1925,19 @@
                             "type": "string"
                         }
                     },
-                    "required": ["dimensions", "label", "link", "src"]
+                    "required": [
+                        "dimensions",
+                        "label",
+                        "link",
+                        "src"
+                    ]
                 }
             },
-            "required": ["aboutThisLink", "logo", "sponsorName"]
+            "required": [
+                "aboutThisLink",
+                "logo",
+                "sponsorName"
+            ]
         },
         "BadgeType": {
             "type": "object",
@@ -1746,7 +1949,10 @@
                     "type": "string"
                 }
             },
-            "required": ["imageUrl", "seriesTag"]
+            "required": [
+                "imageUrl",
+                "seriesTag"
+            ]
         },
         "FooterType": {
             "type": "object",
@@ -1761,7 +1967,9 @@
                     }
                 }
             },
-            "required": ["footerLinks"]
+            "required": [
+                "footerLinks"
+            ]
         },
         "FooterLink": {
             "type": "object",
@@ -1779,7 +1987,11 @@
                     "type": "string"
                 }
             },
-            "required": ["dataLinkName", "text", "url"]
+            "required": [
+                "dataLinkName",
+                "text",
+                "url"
+            ]
         }
     },
     "$schema": "http://json-schema.org/draft-07/schema#"

--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -140,6 +140,7 @@ export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
         },
         contributionsServiceUrl: CAPI.contributionsServiceUrl,
         isImmersive: CAPI.isImmersive,
+        isPhotoEssay: CAPI.config.isPhotoEssay,
     };
 };
 

--- a/src/web/components/ArticleHeadline.stories.tsx
+++ b/src/web/components/ArticleHeadline.stories.tsx
@@ -248,6 +248,26 @@ export const AdvertisementFeature = () => (
 );
 AdvertisementFeature.story = { name: 'AdvertisementFeature' };
 
+export const PhotoEssay = () => (
+    <Section>
+        <Flex>
+            <LeftColumn>
+                <></>
+            </LeftColumn>
+            <ArticleContainer>
+                <ArticleHeadline
+                    headlineString="This is the headline you see when design type is PhotoEssay"
+                    display="standard"
+                    designType="PhotoEssay"
+                    pillar="news"
+                    tags={[]}
+                />
+            </ArticleContainer>
+        </Flex>
+    </Section>
+);
+PhotoEssay.story = { name: 'PhotoEssay' };
+
 export const Quiz = () => (
     <Section>
         <Flex>

--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -185,6 +185,7 @@ export const ArticleHeadline = ({
         case 'Immersive':
         case 'Article':
         case 'Media':
+        case 'PhotoEssay':
         case 'Live':
         case 'SpecialReport':
         case 'MatchReport':

--- a/src/web/components/ArticleHeadlinePadding.tsx
+++ b/src/web/components/ArticleHeadlinePadding.tsx
@@ -18,6 +18,7 @@ const determinPadding = (designType: DesignType) => {
     switch (designType) {
         case 'Article':
         case 'Media':
+        case 'PhotoEssay':
         case 'Live':
         case 'SpecialReport':
         case 'Recipe':

--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -104,6 +104,7 @@ const shouldShowAvatar = (designType: DesignType, display: Display) => {
             return true;
         case 'Live':
         case 'Media':
+        case 'PhotoEssay':
         case 'Analysis':
         case 'Article':
         case 'SpecialReport':
@@ -132,6 +133,7 @@ const shouldShowContributor = (designType: DesignType, display: Display) => {
         case 'Review':
         case 'Live':
         case 'Media':
+        case 'PhotoEssay':
         case 'Interview':
         case 'Analysis':
         case 'Article':

--- a/src/web/components/Byline.tsx
+++ b/src/web/components/Byline.tsx
@@ -49,6 +49,7 @@ const colourStyles = (designType: DesignType, pillar: Pillar) => {
         case 'Interview':
         case 'Article':
         case 'Media':
+        case 'PhotoEssay':
         case 'Review':
         case 'Live':
         case 'SpecialReport':

--- a/src/web/components/Card/components/CardAge.tsx
+++ b/src/web/components/Card/components/CardAge.tsx
@@ -43,6 +43,7 @@ const colourStyles = (designType: DesignType, pillar: Pillar) => {
         case 'Feature':
         case 'Interview':
         case 'Media':
+        case 'PhotoEssay':
         case 'Analysis':
         case 'Article':
         case 'Review':

--- a/src/web/components/Card/components/CardLink.tsx
+++ b/src/web/components/Card/components/CardLink.tsx
@@ -70,6 +70,7 @@ const linkStyles = (designType: DesignType, pillar: Pillar) => {
             `;
         case 'Article':
         case 'Review':
+        case 'PhotoEssay':
         case 'SpecialReport':
         case 'Recipe':
         case 'MatchReport':

--- a/src/web/components/CardCommentCount.tsx
+++ b/src/web/components/CardCommentCount.tsx
@@ -74,6 +74,7 @@ const colourStyles = (designType: DesignType, pillar: Pillar) => {
         case 'Feature':
         case 'Interview':
         case 'Media':
+        case 'PhotoEssay':
         case 'Analysis':
         case 'Article':
         case 'Review':

--- a/src/web/components/CardHeadline.tsx
+++ b/src/web/components/CardHeadline.tsx
@@ -79,6 +79,7 @@ const headlineStyles = (designType: DesignType, pillar: Pillar) => {
         case 'Live':
             return colourStyles(neutral[97]);
         case 'Analysis':
+        case 'PhotoEssay':
         case 'Article':
         case 'Review':
         case 'SpecialReport':

--- a/src/web/components/DropCap.tsx
+++ b/src/web/components/DropCap.tsx
@@ -33,6 +33,7 @@ const outerStyles = (pillar: Pillar, designType: DesignType) => {
         case 'Interview':
         case 'Article':
         case 'Media':
+        case 'PhotoEssay':
         case 'Review':
         case 'Live':
         case 'SpecialReport':
@@ -71,6 +72,7 @@ const innerStyles = (designType: DesignType) => {
         case 'Interview':
         case 'Article':
         case 'Media':
+        case 'PhotoEssay':
         case 'Review':
         case 'Live':
         case 'SpecialReport':

--- a/src/web/components/HeadlineByline.tsx
+++ b/src/web/components/HeadlineByline.tsx
@@ -120,6 +120,7 @@ export const HeadlineByline = ({
         case 'Feature':
         case 'Article':
         case 'Media':
+        case 'PhotoEssay':
         case 'Review':
         case 'Live':
         case 'SpecialReport':

--- a/src/web/components/Kicker.tsx
+++ b/src/web/components/Kicker.tsx
@@ -37,6 +37,7 @@ const decideColour = (
                 ? pillarPalette[pillar].bright
                 : pillarPalette[pillar].main;
         case 'Feature':
+        case 'PhotoEssay':
         case 'Interview':
         case 'Analysis':
         case 'Article':

--- a/src/web/components/Standfirst.stories.tsx
+++ b/src/web/components/Standfirst.stories.tsx
@@ -216,3 +216,16 @@ export const AdvertisementFeature = () => {
     );
 };
 AdvertisementFeature.story = { name: 'AdvertisementFeature' };
+
+export const PhotoEssay = () => {
+    return (
+        <Section>
+            <Standfirst
+                display="standard"
+                designType="PhotoEssay"
+                standfirst="This is how PhotoEssay standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
+            />
+        </Section>
+    );
+};
+PhotoEssay.story = { name: 'PhotoEssay' };

--- a/src/web/components/Standfirst.tsx
+++ b/src/web/components/Standfirst.tsx
@@ -80,6 +80,7 @@ const standfirstStyles = (designType: DesignType, display: Display) => {
             `;
         case 'Immersive':
         case 'Media':
+        case 'PhotoEssay':
         case 'SpecialReport':
         case 'MatchReport':
         case 'AdvertisementFeature':

--- a/src/web/components/elements/TextBlockComponent.tsx
+++ b/src/web/components/elements/TextBlockComponent.tsx
@@ -63,6 +63,7 @@ const shouldShowDropCap = ({
         case 'Comment':
         case 'Review':
         case 'Interview':
+        case 'PhotoEssay':
         case 'Recipe':
             return true;
         case 'Article':

--- a/src/web/layouts/DecideLayout.tsx
+++ b/src/web/layouts/DecideLayout.tsx
@@ -47,6 +47,7 @@ export const DecideLayout = ({ CAPI, NAV }: Props) => {
                 case 'Interview':
                 case 'Live':
                 case 'Media':
+                case 'PhotoEssay':
                 case 'Analysis':
                 case 'Article':
                 case 'SpecialReport':
@@ -86,6 +87,7 @@ export const DecideLayout = ({ CAPI, NAV }: Props) => {
                 case 'Interview':
                 case 'Live':
                 case 'Media':
+                case 'PhotoEssay':
                 case 'Analysis':
                 case 'Article':
                 case 'SpecialReport':
@@ -125,6 +127,7 @@ export const DecideLayout = ({ CAPI, NAV }: Props) => {
                 case 'Interview':
                 case 'Live':
                 case 'Media':
+                case 'PhotoEssay':
                 case 'Analysis':
                 case 'Article':
                 case 'SpecialReport':

--- a/src/web/layouts/Immersive.stories.tsx
+++ b/src/web/layouts/Immersive.stories.tsx
@@ -3,6 +3,7 @@ import React, { useEffect } from 'react';
 import { makeGuardianBrowserCAPI } from '@root/src/model/window-guardian';
 import { Article } from '@root/fixtures/articles/Article';
 import { AdvertisementFeature } from '@root/fixtures/articles/AdvertisementFeature';
+import { PhotoEssay } from '@root/fixtures/articles/PhotoEssay';
 import { Review } from '@root/fixtures/articles/Review';
 import { Analysis } from '@root/fixtures/articles/Analysis';
 import { Feature } from '@root/fixtures/articles/Feature';
@@ -74,6 +75,12 @@ export const AdvertisementFeatureStory = () => {
     return <HydratedLayout ServerCAPI={ServerCAPI} />;
 };
 AdvertisementFeatureStory.story = { name: 'AdvertisementFeature' };
+
+export const PhotoEssayStory = () => {
+    const ServerCAPI = convertToImmersive(PhotoEssay);
+    return <HydratedLayout ServerCAPI={ServerCAPI} />;
+};
+PhotoEssayStory.story = { name: 'PhotoEssay' };
 
 export const AnalysisStory = () => {
     const ServerCAPI = convertToImmersive(Analysis);

--- a/src/web/layouts/Showcase.stories.tsx
+++ b/src/web/layouts/Showcase.stories.tsx
@@ -3,6 +3,7 @@ import React, { useEffect } from 'react';
 import { makeGuardianBrowserCAPI } from '@root/src/model/window-guardian';
 import { Article } from '@root/fixtures/articles/Article';
 import { AdvertisementFeature } from '@root/fixtures/articles/AdvertisementFeature';
+import { PhotoEssay } from '@root/fixtures/articles/PhotoEssay';
 import { Review } from '@root/fixtures/articles/Review';
 import { Analysis } from '@root/fixtures/articles/Analysis';
 import { Feature } from '@root/fixtures/articles/Feature';
@@ -74,6 +75,12 @@ export const AdvertisementFeatureStory = () => {
     return <HydratedLayout ServerCAPI={ServerCAPI} />;
 };
 AdvertisementFeatureStory.story = { name: 'AdvertisementFeature' };
+
+export const PhotoEssayStory = () => {
+    const ServerCAPI = convertToShowcase(PhotoEssay);
+    return <HydratedLayout ServerCAPI={ServerCAPI} />;
+};
+PhotoEssayStory.story = { name: 'PhotoEssay' };
 
 export const AnalysisStory = () => {
     const ServerCAPI = convertToShowcase(Analysis);

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -189,6 +189,7 @@ const PositionHeadline = ({
         case 'Immersive':
         case 'Article':
         case 'Media':
+        case 'PhotoEssay':
         case 'Review':
         case 'Live':
         case 'SpecialReport':

--- a/src/web/layouts/Standard.stories.tsx
+++ b/src/web/layouts/Standard.stories.tsx
@@ -3,6 +3,7 @@ import React, { useEffect } from 'react';
 import { makeGuardianBrowserCAPI } from '@root/src/model/window-guardian';
 import { Article } from '@root/fixtures/articles/Article';
 import { AdvertisementFeature } from '@root/fixtures/articles/AdvertisementFeature';
+import { PhotoEssay } from '@root/fixtures/articles/PhotoEssay';
 import { Review } from '@root/fixtures/articles/Review';
 import { Analysis } from '@root/fixtures/articles/Analysis';
 import { Feature } from '@root/fixtures/articles/Feature';
@@ -74,6 +75,12 @@ export const AdvertisementFeatureStory = () => {
     return <HydratedLayout ServerCAPI={ServerCAPI} />;
 };
 AdvertisementFeatureStory.story = { name: 'AdvertisementFeature' };
+
+export const PhotoEssayStory = () => {
+    const ServerCAPI = convertToStandard(PhotoEssay);
+    return <HydratedLayout ServerCAPI={ServerCAPI} />;
+};
+PhotoEssayStory.story = { name: 'PhotoEssay' };
 
 export const AnalysisStory = () => {
     const ServerCAPI = convertToStandard(Analysis);

--- a/src/web/lib/layoutHelpers.ts
+++ b/src/web/lib/layoutHelpers.ts
@@ -16,6 +16,7 @@ export const decideLineEffect = (
         case 'Interview':
         case 'Live':
         case 'Media':
+        case 'PhotoEssay':
         case 'Analysis':
         case 'Article':
         case 'SpecialReport':


### PR DESCRIPTION
## What does this change?
Adds the `photoEssay` design type

## Why a design type and not a display?
Articles become photo essays in Composer using a display hint so it would be natural to carry that over into DCR. However, it works better to represent photo essays as a DesignType, for several reasons:

1. By using a design type, we could potentially have a showcase or a standard photo essay, we're not forced to make every photo essay immersive.

2. The relationship between `immersive` and photo essays is confusing and mainly so because we need to use lots of OR statements when trying to handle the logic. Creating this new design type removes the need for that logic and makes things more declarative.

3. As part of the support for photo essays we are going to have to have new versions of several components. Caption, Standfirst, PullQuotes, etc. all have special styles for photo essays. It's a lot more logical to make this branch based on designType because we already use the same value for all out other design branches.
