### PR TITLE
Dynamic imports foundations

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,8 +1,8 @@
 module.exports = {
     plugins: [
+        '@babel/plugin-syntax-dynamic-import',
         '@babel/plugin-transform-react-jsx',
         'babel-plugin-preval',
-        'babel-plugin-dynamic-import-node',
         [
             '@babel/plugin-proposal-object-rest-spread',
             {

--- a/index.d.ts
+++ b/index.d.ts
@@ -285,6 +285,7 @@ type CAPIBrowserType = {
     designType: DesignType;
     pillar: Pillar;
     config: {
+        frontendAssetsFullURL: string;
         isDev: boolean;
         ajaxUrl: string;
         shortUrlId: string;

--- a/package.json
+++ b/package.json
@@ -135,7 +135,6 @@
         "babel-core": "^7.0.0-bridge.0",
         "babel-jest": "^24.8.0",
         "babel-loader": "^8.0.6",
-        "babel-plugin-dynamic-import-node": "^2.3.0",
         "babel-plugin-emotion": "^10.0.14",
         "babel-plugin-module-resolver": "^3.2.0",
         "babel-plugin-preval": "^3.0.0",

--- a/scripts/frontend/dev-server.js
+++ b/scripts/frontend/dev-server.js
@@ -40,7 +40,7 @@ const go = () => {
         webpackDevMiddleware(compiler, {
             serverSideRender: true,
             logLevel: 'silent',
-            publicPath: '/assets/javascript/',
+            publicPath: '/assets/',
             ignored: [/node_modules([\\]+|\/)+(?!@guardian)/],
         }),
     );

--- a/scripts/webpack/frontend.js
+++ b/scripts/webpack/frontend.js
@@ -12,7 +12,6 @@ const commonConfigs = ({ platform }) => ({
     name: platform,
     mode: process.env.NODE_ENV,
     output: {
-        publicPath: '/assets/',
         path: dist,
     },
     stats: 'errors-only',

--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -15,6 +15,7 @@ try {
     // do nothing
 }
 
+// TODO: this should be removed in favor of `frontendAssetsFullURL` defined in CAPI
 // GU_STAGE is set in cloudformation.yml, so will be undefined locally
 const stage =
     typeof process.env.GU_STAGE === 'string'

--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -88,6 +88,7 @@ export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
         designType: CAPI.designType,
         pillar: CAPI.pillar,
         config: {
+            frontendAssetsFullURL: CAPI.config.frontendAssetsFullURL,
             isDev: process.env.NODE_ENV !== 'production',
             ajaxUrl: CAPI.config.ajaxUrl,
             shortUrlId: CAPI.config.shortUrlId,

--- a/src/web/browser/ga/init.ts
+++ b/src/web/browser/ga/init.ts
@@ -1,3 +1,4 @@
+import '../webpackPublicPath';
 import { startup } from '@root/src/web/browser/startup';
 import { init as initGa, sendPageView } from './ga';
 

--- a/src/web/browser/initPerf.ts
+++ b/src/web/browser/initPerf.ts
@@ -1,0 +1,20 @@
+export const initPerf = (name: string) => {
+    const perf = window.performance;
+    const startKey = `${name}-start`;
+    const endKey = `${name}-end`;
+
+    const start = () => {
+        perf.mark(startKey);
+    };
+    const end = () => {
+        perf.mark(endKey);
+        perf.measure(name, startKey, endKey);
+        // eslint-disable-next-line no-console
+        console.log(JSON.stringify(perf.getEntriesByName(name)));
+    };
+
+    return {
+        start,
+        end,
+    };
+};

--- a/src/web/browser/lotame/init.ts
+++ b/src/web/browser/lotame/init.ts
@@ -1,3 +1,4 @@
+import '../webpackPublicPath';
 import { startup } from '@root/src/web/browser/startup';
 
 const shouldServeLotame = (window: Window) => {

--- a/src/web/browser/ophan/init.ts
+++ b/src/web/browser/ophan/init.ts
@@ -1,3 +1,4 @@
+import '../webpackPublicPath';
 import { startup } from '@root/src/web/browser/startup';
 import { sendOphanPlatformRecord, recordPerformance } from './ophan';
 

--- a/src/web/browser/react/init.ts
+++ b/src/web/browser/react/init.ts
@@ -1,3 +1,4 @@
+import '../webpackPublicPath';
 import { hydrate as hydrateCSS } from 'emotion';
 
 import { startup } from '@root/src/web/browser/startup';

--- a/src/web/browser/startup.ts
+++ b/src/web/browser/startup.ts
@@ -2,28 +2,39 @@ export interface Reporter {
     report: (err: Error, tags: { [key: string]: string }) => void;
 }
 
-const measure = (name: string, task: () => Promise<void>): void => {
+export const initPerf = (name: string) => {
     const perf = window.performance;
-    const start = `${name}-start`;
-    const end = `${name}-end`;
+    const startKey = `${name}-start`;
+    const endKey = `${name}-end`;
 
-    perf.mark(start);
-
-    function markEnd() {
-        perf.mark(end);
-        perf.measure(name, start, end);
-
+    const start = () => {
+        perf.mark(startKey);
+    };
+    const end = () => {
+        perf.mark(endKey);
+        perf.measure(name, startKey, endKey);
         // eslint-disable-next-line no-console
         console.log(JSON.stringify(perf.getEntriesByName(name)));
-    }
+    };
+
+    return {
+        start,
+        end,
+    };
+};
+
+const measure = (name: string, task: () => Promise<void>): void => {
+    const { start, end } = initPerf(name);
+
+    start();
 
     task()
         // You could use 'finally' here to prevent this duplication but finally isn't supported
         // in Chrome 59 which is used by Cypress in headless mode so if you do it will
         // break the Cypress tests on CI
         // See: https://github.com/cypress-io/cypress/issues/2651#issuecomment-432698837
-        .then(markEnd)
-        .catch(markEnd);
+        .then(end)
+        .catch(end);
 };
 
 export const startup = <A>(

--- a/src/web/browser/startup.ts
+++ b/src/web/browser/startup.ts
@@ -1,27 +1,8 @@
+import { initPerf } from './initPerf';
+
 export interface Reporter {
     report: (err: Error, tags: { [key: string]: string }) => void;
 }
-
-export const initPerf = (name: string) => {
-    const perf = window.performance;
-    const startKey = `${name}-start`;
-    const endKey = `${name}-end`;
-
-    const start = () => {
-        perf.mark(startKey);
-    };
-    const end = () => {
-        perf.mark(endKey);
-        perf.measure(name, startKey, endKey);
-        // eslint-disable-next-line no-console
-        console.log(JSON.stringify(perf.getEntriesByName(name)));
-    };
-
-    return {
-        start,
-        end,
-    };
-};
 
 const measure = (name: string, task: () => Promise<void>): void => {
     const { start, end } = initPerf(name);

--- a/src/web/browser/webpackPublicPath.ts
+++ b/src/web/browser/webpackPublicPath.ts
@@ -1,0 +1,8 @@
+// allows us to define public path dynamically
+// dynamic imports will use this as the base to find their assets
+// https://webpack.js.org/guides/public-path/#on-the-fly
+// eslint-disable-next-line @typescript-eslint/camelcase
+__webpack_public_path__ =
+    window.location.hostname === 'localhost'
+        ? '/assets/'
+        : `${window.guardian.app.data.CAPI.config.frontendAssetsFullURL}assets/`;


### PR DESCRIPTION
## What does this change?
Support Dynamic imports without implementing any dynamic imports

## Why?
Currently we are unable to support dynamic imports because:

- Client does not know what the correct path of the asset is. We set `__webpack_public_path__` on the client end using `frontendAssetsFullURL` to achieve this. We also have removed `publicPath` from being set in the webpack config to allowing it to be dynamically set client side

- Does not work with `babel-plugin-dynamic-import-node`, as this babel plugin replaces all references of `import` and converts them to CommonJS `require`. We simply need to remove it as Typescript handles the conversion of `import` to `require` for the code that runs on Node

- Change `measure` to `initPerf` which will allow us to measure performance of dynamic imports in future PRs