### PR TITLE
Dynamic import consent management platform utilities

### DIFF
--- a/src/web/components/CMP.tsx
+++ b/src/web/components/CMP.tsx
@@ -1,24 +1,31 @@
 import React, { useState, useEffect } from 'react';
-import {
-    shouldShow,
-    setErrorHandler,
-} from '@guardian/consent-management-platform';
+
 import { ConsentManagementPlatform } from '@guardian/consent-management-platform/lib/ConsentManagementPlatform';
+import { initPerf } from '@root/src/web/browser/initPerf';
 
 export const CMP = () => {
     const [show, setShow] = useState(false);
 
     useEffect(() => {
-        if (shouldShow()) {
-            setShow(true);
+        const { start, end } = initPerf(
+            'consent-management-platform-utilities',
+        );
+        start();
+        import(
+            /* webpackChunkName: "consent-management-platform-utilities" */ '@guardian/consent-management-platform'
+        ).then(({ shouldShow, setErrorHandler }) => {
+            end();
+            if (shouldShow()) {
+                setShow(true);
 
-            // setErrorHandler takes function to be called on errors in the CMP UI
-            setErrorHandler((errMsg: string): void => {
-                const err = new Error(errMsg);
+                // setErrorHandler takes function to be called on errors in the CMP UI
+                setErrorHandler((errMsg: string): void => {
+                    const err = new Error(errMsg);
 
-                window.guardian.modules.sentry.reportError(err, 'cmp');
-            });
-        }
+                    window.guardian.modules.sentry.reportError(err, 'cmp');
+                });
+            }
+        });
     }, []);
 
     return (


### PR DESCRIPTION
## What does this change?
Dynamic import for utilities used in '@guardian/consent-management-platform'

### Before
`shouldShow` and `setErrorHandler` where bundled as part of the `react.js` bundle

### After
`shouldShow` and `setErrorHandler` removed from `react.js` and are loaded dynamically when `CAPI.config.cmpUi` is true.

## Why?
`shouldShow` and `setErrorHandler` are some of the larger parts of '@guardian/consent-management-platform'. We can use webpack's dynamic import functionality to break them out of the bundle.

## Note
`shouldShow` and `setErrorHandler` are needed when `CAPI.config.cmpUi` is true. This is known on the server, so it may be worth splitting out and importing server side?