### PR TITLE
@guardian/discussion-rendering@2.2.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "@emotion/core": "^10.0.28",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/consent-management-platform": "^3.0.4",
-        "@guardian/discussion-rendering": "^2.2.10",
+        "@guardian/discussion-rendering": "^2.2.11",
         "@guardian/src-button": "^0.17.0",
         "@guardian/src-ed-lines": "^0.18.0-rc.0",
         "@guardian/src-foundations": "^0.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2151,10 +2151,10 @@
     js-cookie "^2.2.1"
     whatwg-fetch "^3.0.0"
 
-"@guardian/discussion-rendering@^2.2.10":
-  version "2.2.10"
-  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-2.2.10.tgz#e53bff8fa1a7d93de4848a2ca980634f8b1fe376"
-  integrity sha512-OeZBkUmpX0KUuOmhv3CwYtCQ7uHykl/ZlE0d3AOXRgf9+h350TWygql+430PO7NujniAiWpgTzYrdfxT+cbqeg==
+"@guardian/discussion-rendering@^2.2.11":
+  version "2.2.11"
+  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-2.2.11.tgz#c8cc4b63b02bd14c64c87d158af4113d0b50ec06"
+  integrity sha512-h5q8cq7Ur9wwv1bimwgXxteIjSuzdXVI033IPTG+2uDLyZdFFM+QiJttSDRP51VE9vK9zNg5shDo5slGXprW8g==
   dependencies:
     react-focus-lock "^2.2.1"
     timeago.js "^4.0.2"


### PR DESCRIPTION
## What does this change?
verion bump to 2.2.11 of discussion-rendering

## Why?
Fix responses API call