### PR TITLE
Fix comment width pre-expand

### DIFF
--- a/src/web/components/CommentsLayout.tsx
+++ b/src/web/components/CommentsLayout.tsx
@@ -6,7 +6,6 @@ import { App as Comments } from '@guardian/discussion-rendering';
 import { LeftColumn } from '@frontend/web/components/LeftColumn';
 import { SignedInAs } from '@frontend/web/components/SignedInAs';
 import { Hide } from '@frontend/web/components/Hide';
-import { Flex } from '@frontend/web/components/Flex';
 
 type Props = {
     user?: UserProfile;
@@ -40,6 +39,16 @@ const bottomPadding = css`
     padding-bottom: ${space[2]}px;
 `;
 
+const flexRowWrapper = css`
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    /* Fixes IE 10/11 bug that collapses this container by default: */
+    /* stylelint-disable-next-line property-no-vendor-prefix */
+    -ms-flex-positive: 1;
+`;
+
 export const CommentsLayout = ({
     user,
     pillar,
@@ -57,7 +66,7 @@ export const CommentsLayout = ({
     commentToScrollTo,
     onPermalinkClick,
 }: Props) => (
-    <Flex direction="row">
+    <div className={flexRowWrapper}>
         <LeftColumn showRightBorder={false}>
             <SignedInAs
                 pillar={pillar}
@@ -100,5 +109,5 @@ export const CommentsLayout = ({
                 apiKey="dotcom-rendering"
             />
         </div>
-    </Flex>
+    </div>
 );

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -465,7 +465,12 @@ export const CommentLayout = ({
                     {showComments && (
                         <Section sectionId="comments">
                             <Flex>
-                                <div id="comments-root" />
+                                <div
+                                    id="comments-root"
+                                    className={css`
+                                        width: 100%;
+                                    `}
+                                />
                                 <RightColumn>
                                     <AdSlot
                                         asps={namedAdSlotParameters('comments')}

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -387,7 +387,12 @@ export const ImmersiveLayout = ({
                     {showComments && (
                         <Section sectionId="comments">
                             <Flex>
-                                <div id="comments-root" />
+                                <div
+                                    id="comments-root"
+                                    className={css`
+                                        width: 100%;
+                                    `}
+                                />
                                 <RightColumn>
                                     <AdSlot
                                         asps={namedAdSlotParameters('comments')}

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -508,7 +508,12 @@ export const ShowcaseLayout = ({
                     {showComments && (
                         <Section sectionId="comments">
                             <Flex>
-                                <div id="comments-root" />
+                                <div
+                                    id="comments-root"
+                                    className={css`
+                                        width: 100%;
+                                    `}
+                                />
                                 <RightColumn>
                                     <AdSlot
                                         asps={namedAdSlotParameters('comments')}

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -493,7 +493,12 @@ export const StandardLayout = ({
                     {showComments && (
                         <Section sectionId="comments">
                             <Flex>
-                                <div id="comments-root" />
+                                <div
+                                    id="comments-root"
+                                    className={css`
+                                        width: 100%;
+                                    `}
+                                />
                                 <RightColumn>
                                     <AdSlot
                                         asps={namedAdSlotParameters('comments')}


### PR DESCRIPTION
## What does this change?
Makes sure that comment layout is full width before expand

### Before
<img width="1000" alt="Screenshot 2020-05-12 at 15 48 52" src="https://user-images.githubusercontent.com/8831403/81707766-c15f9d80-9468-11ea-8a33-2646885c7109.png">

### After
<img width="1016" alt="Screenshot 2020-05-12 at 15 49 05" src="https://user-images.githubusercontent.com/8831403/81707804-c6245180-9468-11ea-92a1-8e0b2e428122.png">

## Why?
Width was incorrect, causing it to jump when the user click on the expand button

## Ticket
https://trello.com/c/luHoc4q1/1655-comment-width-pre-expand