### PR TITLE
Guard against undefined main media

### DIFF
--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -158,9 +158,14 @@ interface Props {
 
 const decideCaption = (mainMedia: ImageBlockElement): string => {
     const caption = [];
-    if (mainMedia.data && mainMedia.data.caption)
+    if (mainMedia && mainMedia.data && mainMedia.data.caption)
         caption.push(mainMedia.data.caption);
-    if (mainMedia.displayCredit && mainMedia.data && mainMedia.data.credit)
+    if (
+        mainMedia &&
+        mainMedia.displayCredit &&
+        mainMedia.data &&
+        mainMedia.data.credit
+    )
         caption.push(mainMedia.data.credit);
     return caption.join(' ');
 };


### PR DESCRIPTION
## What does this change?
Adds a check to make sure the main media object as read from the array is in fact defined.

## Why?
Because it turns out in some cases it isn't and we were trying to access it causing errors

Example: https://www.theguardian.com/artanddesign/2019/sep/17/buy-a-classic-sport-photograph-jumping-in-the-fog-at-white-hart-lane