### PR TITLE
Immersive sans main media

### DIFF
--- a/src/web/components/ArticleHeadline.stories.tsx
+++ b/src/web/components/ArticleHeadline.stories.tsx
@@ -328,6 +328,47 @@ export const Recipe = () => (
 );
 Recipe.story = { name: 'Recipe' };
 
+export const Immersive = () => (
+    <Section>
+        <Flex>
+            <LeftColumn>
+                <></>
+            </LeftColumn>
+            <ArticleContainer>
+                <ArticleHeadline
+                    headlineString="This is the headline you see when display type is Immersive"
+                    display="immersive"
+                    designType="Article"
+                    pillar="news"
+                    tags={[]}
+                />
+            </ArticleContainer>
+        </Flex>
+    </Section>
+);
+Immersive.story = { name: 'Immersive' };
+
+export const ImmersiveNoMainMedia = () => (
+    <Section>
+        <Flex>
+            <LeftColumn>
+                <></>
+            </LeftColumn>
+            <ArticleContainer>
+                <ArticleHeadline
+                    headlineString="This is the headline you see when display type is Immersive, but with no main media"
+                    display="immersive"
+                    designType="Article"
+                    pillar="news"
+                    tags={[]}
+                    noMainMedia={true}
+                />
+            </ArticleContainer>
+        </Flex>
+    </Section>
+);
+ImmersiveNoMainMedia.story = { name: 'Immersive (with no main media)' };
+
 export const GuardianView = () => (
     <Section>
         <Flex>

--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -17,6 +17,8 @@ type Props = {
     byline?: string;
     tags: TagType[];
     isShowcase?: boolean; // Used for Interviews to change headline position
+    noMainMedia?: boolean; // Used for Immersives where the headline styles
+    // change when there is no main media
 };
 
 const curly = (x: any) => x;
@@ -160,14 +162,11 @@ export const ArticleHeadline = ({
     pillar,
     tags,
     byline,
+    noMainMedia,
 }: Props) => {
-    const isPrintShop = tags.find(
-        tag => tag.id === 'artanddesign/series/guardian-print-shop',
-    );
-
-    if (isPrintShop) {
+    if (display === 'immersive' && noMainMedia) {
         return (
-            // Immersive headlines are larger than normal
+            // Immersive headlines have two versions, with main media, and (this one) without
             <h1
                 className={cx(
                     jumboFont,
@@ -183,8 +182,8 @@ export const ArticleHeadline = ({
 
     if (display === 'immersive') {
         return (
-            // Immersive headlines are large and inverted and have their black background
-            // extended to the right
+            // Immersive headlines with main media present, are large and inverted with
+            // a black background
             <h1 className={cx(invertedWrapper, blackBackground)}>
                 <span
                     className={cx(

--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -161,6 +161,26 @@ export const ArticleHeadline = ({
     tags,
     byline,
 }: Props) => {
+    const isPrintShop = tags.find(
+        tag => tag.id === 'artanddesign/series/guardian-print-shop',
+    );
+
+    if (isPrintShop) {
+        return (
+            // Immersive headlines are larger than normal
+            <h1
+                className={cx(
+                    jumboFont,
+                    maxWidth,
+                    immersiveStyles,
+                    displayBlock,
+                )}
+            >
+                {curly(headlineString)}
+            </h1>
+        );
+    }
+
     if (display === 'immersive') {
         return (
             // Immersive headlines are large and inverted and have their black background

--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -182,18 +182,6 @@ export const ArticleHeadline = ({
     }
 
     switch (designType) {
-        case 'Immersive':
-        case 'Article':
-        case 'Media':
-        case 'PhotoEssay':
-        case 'Live':
-        case 'SpecialReport':
-        case 'MatchReport':
-        case 'GuardianLabs':
-        case 'Quiz':
-        case 'AdvertisementFeature':
-            return <h1 className={standardFont}>{curly(headlineString)}</h1>;
-
         case 'Review':
         case 'Recipe':
         case 'Feature':
@@ -260,5 +248,17 @@ export const ArticleHeadline = ({
                     )}
                 </div>
             );
+        case 'Immersive':
+        case 'Article':
+        case 'Media':
+        case 'PhotoEssay':
+        case 'Live':
+        case 'SpecialReport':
+        case 'MatchReport':
+        case 'GuardianLabs':
+        case 'Quiz':
+        case 'AdvertisementFeature':
+        default:
+            return <h1 className={standardFont}>{curly(headlineString)}</h1>;
     }
 };

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -207,7 +207,7 @@ export const ImmersiveLayout = ({
                 className={css`
                     display: flex;
                     flex-direction: column;
-                    min-height: 100vh;
+                    min-height: ${mainMedia && '100vh'};
                 `}
             >
                 <Section
@@ -226,26 +226,28 @@ export const ImmersiveLayout = ({
                         edition={CAPI.editionId}
                     />
                 </Section>
-                <div
-                    className={css`
-                        flex: 1;
-                        min-height: 31.25rem;
-                        position: relative;
-                    `}
-                >
-                    <MainMedia
-                        display={display}
-                        elements={CAPI.mainMediaElements}
-                        pillar={pillar}
-                        adTargeting={adTargeting}
-                        starRating={
-                            CAPI.designType === 'Review' && CAPI.starRating
-                                ? CAPI.starRating
-                                : undefined
-                        }
-                        hideCaption={true}
-                    />
-                </div>
+                {mainMedia && (
+                    <div
+                        className={css`
+                            flex: 1;
+                            min-height: 31.25rem;
+                            position: relative;
+                        `}
+                    >
+                        <MainMedia
+                            display={display}
+                            elements={CAPI.mainMediaElements}
+                            pillar={pillar}
+                            adTargeting={adTargeting}
+                            starRating={
+                                CAPI.designType === 'Review' && CAPI.starRating
+                                    ? CAPI.starRating
+                                    : undefined
+                            }
+                            hideCaption={true}
+                        />
+                    </div>
+                )}
             </div>
 
             <ImmersiveHeadline

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -4,12 +4,14 @@ import { css } from 'emotion';
 import {
     neutral,
     brandBackground,
+    brandAltBackground,
     brandBorder,
 } from '@guardian/src-foundations/palette';
 import { from, until } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
 
 import { namedAdSlotParameters } from '@root/src/model/advertisement';
+import { StarRating } from '@root/src/web/components/StarRating/StarRating';
 import { ArticleBody } from '@root/src/web/components/ArticleBody';
 import { RightColumn } from '@root/src/web/components/RightColumn';
 import { ArticleContainer } from '@root/src/web/components/ArticleContainer';
@@ -17,6 +19,9 @@ import { ArticleMeta } from '@root/src/web/components/ArticleMeta';
 import { GuardianLines } from '@root/src/web/components/GuardianLines';
 import { SubMeta } from '@root/src/web/components/SubMeta';
 import { MainMedia } from '@root/src/web/components/MainMedia';
+import { ArticleTitle } from '@root/src/web/components/ArticleTitle';
+import { ArticleHeadline } from '@root/src/web/components/ArticleHeadline';
+import { ArticleHeadlinePadding } from '@root/src/web/components/ArticleHeadlinePadding';
 import { ArticleStandfirst } from '@root/src/web/components/ArticleStandfirst';
 import { Footer } from '@root/src/web/components/Footer';
 import { SubNav } from '@root/src/web/components/SubNav/SubNav';
@@ -29,9 +34,11 @@ import { Flex } from '@root/src/web/components/Flex';
 import { Caption } from '@root/src/web/components/Caption';
 import { HeadlineByline } from '@root/src/web/components/HeadlineByline';
 import { ImmersiveHeadline } from '@root/src/web/components/ImmersiveHeadline';
+import { AgeWarning } from '@root/src/web/components/AgeWarning';
 
 import { buildAdTargeting } from '@root/src/lib/ad-targeting';
 import { parse } from '@frontend/lib/slot-machine-flags';
+import { getAgeWarning } from '@root/src/lib/age-warning';
 
 import {
     decideLineCount,
@@ -73,7 +80,9 @@ const ImmersiveGrid = ({
                         1fr /* Main content */
                         300px; /* Right Column */
                     grid-template-areas:
-                        'caption    border      standfirst  right-column'
+                        'caption    border      title       right-column'
+                        '.          border      headline    right-column'
+                        '.          border      standfirst  right-column'
                         '.          border      byline      right-column'
                         'lines      border      body        right-column'
                         'meta       border      body        right-column'
@@ -90,6 +99,8 @@ const ImmersiveGrid = ({
                         1fr /* Main content */
                         300px; /* Right Column */
                     grid-template-areas:
+                        '.          border      title       right-column'
+                        '.          border      headline    right-column'
                         '.          border      standfirst  right-column'
                         '.          border      byline      right-column'
                         'lines      border      body        right-column'
@@ -105,6 +116,8 @@ const ImmersiveGrid = ({
                         1fr /* Main content */
                         300px; /* Right Column */
                     grid-template-areas:
+                        'title       right-column'
+                        'headline    right-column'
                         'standfirst  right-column'
                         'byline      right-column'
                         'caption     right-column'
@@ -117,6 +130,8 @@ const ImmersiveGrid = ({
                     grid-column-gap: 0px;
                     grid-template-columns: 1fr; /* Main content */
                     grid-template-areas:
+                        'title'
+                        'headline'
                         'standfirst'
                         'byline'
                         'caption'
@@ -145,6 +160,40 @@ const stretchLines = css`
     ${until.mobileLandscape} {
         margin-left: -10px;
         margin-right: -10px;
+    }
+`;
+
+const starWrapper = css`
+    margin-bottom: 18px;
+    margin-top: 6px;
+    background-color: ${brandAltBackground.primary};
+    display: inline-block;
+
+    ${until.phablet} {
+        padding-left: 20px;
+        margin-left: -20px;
+    }
+    ${until.leftCol} {
+        padding-left: 0px;
+        margin-left: -0px;
+    }
+
+    padding-left: 10px;
+    margin-left: -10px;
+`;
+
+const ageWarningMargins = css`
+    margin-top: 12px;
+    margin-left: -10px;
+    margin-bottom: 6px;
+
+    ${from.tablet} {
+        margin-left: -20px;
+    }
+
+    ${from.leftCol} {
+        margin-left: -10px;
+        margin-top: 0;
     }
 `;
 
@@ -201,6 +250,12 @@ export const ImmersiveLayout = ({
     const mainMedia = CAPI.mainMediaElements[0] as ImageBlockElement;
     const captionText = decideCaption(mainMedia);
 
+    const age = getAgeWarning(CAPI.tags, CAPI.webPublicationDate);
+
+    const isPrintShop = CAPI.tags.find(
+        tag => tag.id === 'artanddesign/series/guardian-print-shop',
+    );
+
     return (
         <>
             <div
@@ -250,19 +305,21 @@ export const ImmersiveLayout = ({
                 )}
             </div>
 
-            <ImmersiveHeadline
-                display={display}
-                designType={designType}
-                tags={CAPI.tags}
-                author={CAPI.author}
-                headline={CAPI.headline}
-                sectionLabel={CAPI.sectionLabel}
-                sectionUrl={CAPI.sectionUrl}
-                guardianBaseURL={CAPI.guardianBaseURL}
-                pillar={CAPI.pillar}
-                captionText={captionText}
-                badge={CAPI.badge}
-            />
+            {!isPrintShop && (
+                <ImmersiveHeadline
+                    display={display}
+                    designType={designType}
+                    tags={CAPI.tags}
+                    author={CAPI.author}
+                    headline={CAPI.headline}
+                    sectionLabel={CAPI.sectionLabel}
+                    sectionUrl={CAPI.sectionUrl}
+                    guardianBaseURL={CAPI.guardianBaseURL}
+                    pillar={CAPI.pillar}
+                    captionText={captionText}
+                    badge={CAPI.badge}
+                />
+            )}
 
             <Section showTopBorder={false} showSideBorders={false}>
                 <ImmersiveGrid>
@@ -281,6 +338,70 @@ export const ImmersiveLayout = ({
                     </GridItem>
                     <GridItem area="border">
                         <Border />
+                    </GridItem>
+                    <GridItem area="title">
+                        <>
+                            {isPrintShop && (
+                                <div
+                                    className={css`
+                                        margin-top: -3px;
+                                        margin-left: -10px;
+                                    `}
+                                >
+                                    <ArticleTitle
+                                        display={display}
+                                        tags={CAPI.tags}
+                                        sectionLabel={CAPI.sectionLabel}
+                                        sectionUrl={CAPI.sectionUrl}
+                                        guardianBaseURL={CAPI.guardianBaseURL}
+                                        pillar={pillar}
+                                        badge={CAPI.badge}
+                                    />
+                                </div>
+                            )}
+                        </>
+                    </GridItem>
+                    <GridItem area="headline">
+                        <>
+                            {isPrintShop && (
+                                <div className={maxWidth}>
+                                    <ArticleHeadlinePadding
+                                        designType={designType}
+                                    >
+                                        {age && (
+                                            <div className={ageWarningMargins}>
+                                                <AgeWarning age={age} />
+                                            </div>
+                                        )}
+                                        <ArticleHeadline
+                                            display={display}
+                                            headlineString={CAPI.headline}
+                                            designType={designType}
+                                            pillar={pillar}
+                                            tags={CAPI.tags}
+                                            byline={CAPI.author.byline}
+                                        />
+                                        {age && (
+                                            <AgeWarning
+                                                age={age}
+                                                isScreenReader={true}
+                                            />
+                                        )}
+                                    </ArticleHeadlinePadding>
+                                </div>
+                            )}
+                            {isPrintShop &&
+                            (CAPI.starRating || CAPI.starRating === 0) ? (
+                                <div className={starWrapper}>
+                                    <StarRating
+                                        rating={CAPI.starRating}
+                                        size="large"
+                                    />
+                                </div>
+                            ) : (
+                                <></>
+                            )}
+                        </>
                     </GridItem>
                     <GridItem area="standfirst">
                         <ArticleStandfirst
@@ -364,13 +485,21 @@ export const ImmersiveLayout = ({
                     </GridItem>
                     <GridItem area="right-column">
                         <RightColumn>
-                            <div
-                                className={css`
-                                    margin-top: ${space[4]}px;
-                                `}
-                            >
-                                <AdSlot asps={namedAdSlotParameters('right')} />
-                            </div>
+                            <>
+                                {!isPrintShop && (
+                                    <div
+                                        className={css`
+                                            margin-top: ${space[4]}px;
+                                        `}
+                                    >
+                                        <AdSlot
+                                            asps={namedAdSlotParameters(
+                                                'right',
+                                            )}
+                                        />
+                                    </div>
+                                )}
+                            </>
                         </RightColumn>
                     </GridItem>
                 </ImmersiveGrid>

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -212,10 +212,6 @@ export const ImmersiveLayout = ({
     const mainMedia = CAPI.mainMediaElements[0] as ImageBlockElement;
     const captionText = decideCaption(mainMedia);
 
-    const isPrintShop = CAPI.tags.find(
-        tag => tag.id === 'artanddesign/series/guardian-print-shop',
-    );
-
     return (
         <>
             <div
@@ -265,7 +261,7 @@ export const ImmersiveLayout = ({
                 )}
             </div>
 
-            {!isPrintShop && (
+            {mainMedia && (
                 <ImmersiveHeadline
                     display={display}
                     designType={designType}
@@ -301,11 +297,15 @@ export const ImmersiveLayout = ({
                     </GridItem>
                     <GridItem area="title">
                         <>
-                            {isPrintShop && (
+                            {!mainMedia && (
                                 <div
                                     className={css`
                                         margin-top: -3px;
                                         margin-left: -10px;
+
+                                        ${until.tablet} {
+                                            margin-left: -20px;
+                                        }
                                     `}
                                 >
                                     <ArticleTitle
@@ -323,7 +323,7 @@ export const ImmersiveLayout = ({
                     </GridItem>
                     <GridItem area="headline">
                         <>
-                            {isPrintShop && (
+                            {!mainMedia && (
                                 <div className={maxWidth}>
                                     <ArticleHeadlinePadding
                                         designType={designType}
@@ -335,6 +335,7 @@ export const ImmersiveLayout = ({
                                             pillar={pillar}
                                             tags={CAPI.tags}
                                             byline={CAPI.author.byline}
+                                            noMainMedia={true}
                                         />
                                     </ArticleHeadlinePadding>
                                 </div>
@@ -424,7 +425,7 @@ export const ImmersiveLayout = ({
                     <GridItem area="right-column">
                         <RightColumn>
                             <>
-                                {!isPrintShop && (
+                                {mainMedia && (
                                     <div
                                         className={css`
                                             margin-top: ${space[4]}px;

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -4,14 +4,12 @@ import { css } from 'emotion';
 import {
     neutral,
     brandBackground,
-    brandAltBackground,
     brandBorder,
 } from '@guardian/src-foundations/palette';
 import { from, until } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
 
 import { namedAdSlotParameters } from '@root/src/model/advertisement';
-import { StarRating } from '@root/src/web/components/StarRating/StarRating';
 import { ArticleBody } from '@root/src/web/components/ArticleBody';
 import { RightColumn } from '@root/src/web/components/RightColumn';
 import { ArticleContainer } from '@root/src/web/components/ArticleContainer';
@@ -34,11 +32,9 @@ import { Flex } from '@root/src/web/components/Flex';
 import { Caption } from '@root/src/web/components/Caption';
 import { HeadlineByline } from '@root/src/web/components/HeadlineByline';
 import { ImmersiveHeadline } from '@root/src/web/components/ImmersiveHeadline';
-import { AgeWarning } from '@root/src/web/components/AgeWarning';
 
 import { buildAdTargeting } from '@root/src/lib/ad-targeting';
 import { parse } from '@frontend/lib/slot-machine-flags';
-import { getAgeWarning } from '@root/src/lib/age-warning';
 
 import {
     decideLineCount,
@@ -163,40 +159,6 @@ const stretchLines = css`
     }
 `;
 
-const starWrapper = css`
-    margin-bottom: 18px;
-    margin-top: 6px;
-    background-color: ${brandAltBackground.primary};
-    display: inline-block;
-
-    ${until.phablet} {
-        padding-left: 20px;
-        margin-left: -20px;
-    }
-    ${until.leftCol} {
-        padding-left: 0px;
-        margin-left: -0px;
-    }
-
-    padding-left: 10px;
-    margin-left: -10px;
-`;
-
-const ageWarningMargins = css`
-    margin-top: 12px;
-    margin-left: -10px;
-    margin-bottom: 6px;
-
-    ${from.tablet} {
-        margin-left: -20px;
-    }
-
-    ${from.leftCol} {
-        margin-left: -10px;
-        margin-top: 0;
-    }
-`;
-
 interface Props {
     CAPI: CAPIType;
     NAV: NavType;
@@ -249,8 +211,6 @@ export const ImmersiveLayout = ({
 
     const mainMedia = CAPI.mainMediaElements[0] as ImageBlockElement;
     const captionText = decideCaption(mainMedia);
-
-    const age = getAgeWarning(CAPI.tags, CAPI.webPublicationDate);
 
     const isPrintShop = CAPI.tags.find(
         tag => tag.id === 'artanddesign/series/guardian-print-shop',
@@ -368,11 +328,6 @@ export const ImmersiveLayout = ({
                                     <ArticleHeadlinePadding
                                         designType={designType}
                                     >
-                                        {age && (
-                                            <div className={ageWarningMargins}>
-                                                <AgeWarning age={age} />
-                                            </div>
-                                        )}
                                         <ArticleHeadline
                                             display={display}
                                             headlineString={CAPI.headline}
@@ -381,25 +336,8 @@ export const ImmersiveLayout = ({
                                             tags={CAPI.tags}
                                             byline={CAPI.author.byline}
                                         />
-                                        {age && (
-                                            <AgeWarning
-                                                age={age}
-                                                isScreenReader={true}
-                                            />
-                                        )}
                                     </ArticleHeadlinePadding>
                                 </div>
-                            )}
-                            {isPrintShop &&
-                            (CAPI.starRating || CAPI.starRating === 0) ? (
-                                <div className={starWrapper}>
-                                    <StarRating
-                                        rating={CAPI.starRating}
-                                        size="large"
-                                    />
-                                </div>
-                            ) : (
-                                <></>
                             )}
                         </>
                     </GridItem>


### PR DESCRIPTION
## What does this change?
Adds support for Immersive articles without main media

https://www.theguardian.com/artanddesign/2020/may/12/buy-a-classic-sport-photograph-euphoria-at-the-1966-world-cup

These are special articles that:

- Have `isImmersive: true`
- Have `DesignType: Immersive`
- Empty main media
- Don't show the top right ad slot

### Before
![Screenshot 2020-05-13 at 10 45 18](https://user-images.githubusercontent.com/1336821/81797568-e30f6200-9506-11ea-8d57-b9c99bc60367.jpg)

### After
![Screenshot 2020-05-13 at 10 44 25](https://user-images.githubusercontent.com/1336821/81797593-e9054300-9506-11ea-8a29-8daa8e5a433a.jpg)

