### PR TITLE
Auto rich links

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -312,6 +312,7 @@ type CAPIBrowserType = {
         discussionApiClientHeader: string;
     };
     richLinks: RichLinkBlockElementBrowser[];
+    referencesRichLink: ReferenceRichLinkBlockElementBrowser[];
     editionId: Edition;
     contentType: string;
     sectionName?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -502,7 +502,7 @@ interface ConfigType extends CommercialConfigType {
     ajaxUrl: string;
     sentryPublicApiKey: string;
     sentryHost: string;
-    references: { [key: string]: string }[];
+    references?: { [key: string]: string }[];
     dcrSentryDsn: string;
     switches: { [key: string]: boolean };
     abTests: { [key: string]: string };

--- a/index.d.ts
+++ b/index.d.ts
@@ -311,7 +311,7 @@ type CAPIBrowserType = {
         discussionD2Uid: string;
         discussionApiClientHeader: string;
     };
-    richLinks: RichLinkBlockElement[];
+    richLinks: RichLinkBlockElementBrowser[];
     editionId: Edition;
     contentType: string;
     sectionName?: string;
@@ -502,6 +502,7 @@ interface ConfigType extends CommercialConfigType {
     ajaxUrl: string;
     sentryPublicApiKey: string;
     sentryHost: string;
+    references: { [key: string]: string }[];
     dcrSentryDsn: string;
     switches: { [key: string]: boolean };
     abTests: { [key: string]: string };

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -167,6 +167,10 @@ interface RichLinkBlockElementBrowser {
     richLinkIndex: number;
 }
 
+interface ReferenceRichLinkBlockElementBrowser {
+    url: string;
+}
+
 interface SoundcloudBlockElement {
     _type: 'model.dotcomrendering.pageElements.SoundcloudBlockElement';
     html: string;

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -162,6 +162,11 @@ interface RichLinkBlockElement {
     richLinkIndex?: number;
 }
 
+interface RichLinkBlockElementBrowser {
+    url: string;
+    richLinkIndex: number;
+}
+
 interface SoundcloudBlockElement {
     _type: 'model.dotcomrendering.pageElements.SoundcloudBlockElement';
     html: string;

--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -86,7 +86,7 @@ export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
     );
 
     // references with the key `rich-link` work similar to RichLinkBlockElement
-    // however we do care about thier index, as we will use spaceFinder to determin thier location
+    // however we do care about their index, as we will use spaceFinder to determine their location
     const referencesRichLink: ReferenceRichLinkBlockElementBrowser[] = CAPI
         .config.references
         ? CAPI.config.references.reduce(

--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -89,7 +89,12 @@ export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
         .references
         ? CAPI.config.references.reduce(
               (acc, reference, index) => {
-                  if (reference.hasOwnProperty('rich-link')) {
+                  if (
+                      Object.prototype.hasOwnProperty.call(
+                          reference,
+                          'rich-link',
+                      )
+                  ) {
                       acc.push({
                           url: reference['rich-link'],
                           richLinkIndex: index,

--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -76,6 +76,7 @@ export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
             ) {
                 acc.push({
                     url: element.url,
+                    // It is important to pass down the index of rich links as well as the component itself
                     richLinkIndex: index,
                 } as RichLinkBlockElementBrowser);
             }
@@ -83,12 +84,13 @@ export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
         },
         [] as RichLinkBlockElementBrowser[],
     );
+
     // references with the key `rich-link` work similar to RichLinkBlockElement
-    // however thier structure is different so we filter them out sperartly
-    const referencesRichLink: RichLinkBlockElementBrowser[] = CAPI.config
-        .references
+    // however we do care about thier index, as we will use spaceFinder to determin thier location
+    const referencesRichLink: ReferenceRichLinkBlockElementBrowser[] = CAPI
+        .config.references
         ? CAPI.config.references.reduce(
-              (acc, reference, index) => {
+              (acc, reference) => {
                   if (
                       Object.prototype.hasOwnProperty.call(
                           reference,
@@ -97,21 +99,13 @@ export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
                   ) {
                       acc.push({
                           url: reference['rich-link'],
-                          richLinkIndex: index,
-                      } as RichLinkBlockElementBrowser);
+                      } as ReferenceRichLinkBlockElementBrowser);
                   }
                   return acc;
               },
-              [] as RichLinkBlockElementBrowser[],
+              [] as ReferenceRichLinkBlockElementBrowser[],
           )
         : [];
-
-    // It is important to pass down the index of rich links as well as the component itself
-    // We assume that richLinks should start ealier in the index
-    const richLinksWithIndex: RichLinkBlockElementBrowser[] = [
-        ...richLinks,
-        ...referencesRichLink,
-    ];
 
     return {
         designType: CAPI.designType,
@@ -146,7 +140,8 @@ export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
             discussionD2Uid: CAPI.config.discussionD2Uid,
             discussionApiClientHeader: CAPI.config.discussionApiClientHeader,
         },
-        richLinks: richLinksWithIndex,
+        richLinks,
+        referencesRichLink,
         editionId: CAPI.editionId,
         contentType: CAPI.contentType,
         sectionName: CAPI.sectionName,

--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -85,18 +85,21 @@ export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
     );
     // references with the key `rich-link` work similar to RichLinkBlockElement
     // however thier structure is different so we filter them out sperartly
-    const referencesRichLink: RichLinkBlockElementBrowser[] = CAPI.config.references.reduce(
-        (acc, reference, index) => {
-            if (reference.hasOwnProperty('rich-link')) {
-                acc.push({
-                    url: reference['rich-link'],
-                    richLinkIndex: index,
-                } as RichLinkBlockElementBrowser);
-            }
-            return acc;
-        },
-        [] as RichLinkBlockElementBrowser[],
-    );
+    const referencesRichLink: RichLinkBlockElementBrowser[] = CAPI.config
+        .references
+        ? CAPI.config.references.reduce(
+              (acc, reference, index) => {
+                  if (reference.hasOwnProperty('rich-link')) {
+                      acc.push({
+                          url: reference['rich-link'],
+                          richLinkIndex: index,
+                      } as RichLinkBlockElementBrowser);
+                  }
+                  return acc;
+              },
+              [] as RichLinkBlockElementBrowser[],
+          )
+        : [];
 
     // It is important to pass down the index of rich links as well as the component itself
     // We assume that richLinks should start ealier in the index

--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -66,35 +66,36 @@ const makeWindowGuardianConfig = (
     } as WindowGuardianConfig;
 };
 
-type richLinkURL = { url: string };
 export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
     // filter out RichLinkBlockElement from elements
-    const richLinks: richLinkURL[] = CAPI.blocks[0].elements.reduce(
-        (acc, element) => {
+    const richLinks: RichLinkBlockElementBrowser[] = CAPI.blocks[0].elements.reduce(
+        (acc, element, index) => {
             if (
                 element._type ===
                 'model.dotcomrendering.pageElements.RichLinkBlockElement'
             ) {
                 acc.push({
                     url: element.url,
-                } as richLinkURL);
+                    richLinkIndex: index,
+                } as RichLinkBlockElementBrowser);
             }
             return acc;
         },
-        [] as richLinkURL[],
+        [] as RichLinkBlockElementBrowser[],
     );
     // references with the key `rich-link` work similar to RichLinkBlockElement
     // however thier structure is different so we filter them out sperartly
-    const referencesRichLink: richLinkURL[] = CAPI.config.references.reduce(
-        (acc, reference) => {
+    const referencesRichLink: RichLinkBlockElementBrowser[] = CAPI.config.references.reduce(
+        (acc, reference, index) => {
             if (reference.hasOwnProperty('rich-link')) {
                 acc.push({
                     url: reference['rich-link'],
-                } as richLinkURL);
+                    richLinkIndex: index,
+                } as RichLinkBlockElementBrowser);
             }
             return acc;
         },
-        [] as richLinkURL[],
+        [] as RichLinkBlockElementBrowser[],
     );
 
     // It is important to pass down the index of rich links as well as the component itself
@@ -102,10 +103,7 @@ export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
     const richLinksWithIndex: RichLinkBlockElementBrowser[] = [
         ...richLinks,
         ...referencesRichLink,
-    ].map((element, index) => ({
-        url: element.url,
-        richLinkIndex: index,
-    }));
+    ];
 
     return {
         designType: CAPI.designType,

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -201,6 +201,8 @@ export const App = ({ CAPI, NAV }: Props) => {
                     </>
                 </Hydrate>
             )}
+            {console.log('CAPI.richLinks')}
+            {console.log(CAPI.richLinks)}
             {CAPI.richLinks.map((link, index) => (
                 <Portal
                     key={index}

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -201,8 +201,6 @@ export const App = ({ CAPI, NAV }: Props) => {
                     </>
                 </Hydrate>
             )}
-            {console.log('CAPI.richLinks')}
-            {console.log(CAPI.richLinks)}
             {CAPI.richLinks.map((link, index) => (
                 <Portal
                     key={index}

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -201,6 +201,7 @@ export const App = ({ CAPI, NAV }: Props) => {
                     </>
                 </Hydrate>
             )}
+            {/* TODO: CAPI.referencesRichLink requires spaceFinder */}
             {CAPI.richLinks.map((link, index) => (
                 <Portal
                     key={index}

--- a/src/web/components/elements/RichLinkComponent.tsx
+++ b/src/web/components/elements/RichLinkComponent.tsx
@@ -291,16 +291,16 @@ const RichLinkBody: React.FC<{ richLink: RichLink }> = ({ richLink }) => {
     );
 };
 
-const buildUrl: (element: RichLinkBlockElement, ajaxUrl: string) => string = (
-    element,
-    ajaxUrl,
-) => {
+const buildUrl: (
+    element: RichLinkBlockElementBrowser,
+    ajaxUrl: string,
+) => string = (element, ajaxUrl) => {
     const path = new URL(element.url).pathname;
     return `${ajaxUrl}/embed/card${path}.json?dcr=true`;
 };
 
 export const RichLinkComponent: React.FC<{
-    element: RichLinkBlockElement;
+    element: RichLinkBlockElementBrowser;
     pillar: Pillar;
     ajaxEndpoint: string;
     richLinkIndex: number;


### PR DESCRIPTION
## What does this change?
Extract `rich-link` from references object and pass down, `referencesRichLink` as a new object to CAPI.

## Why?
Some rich links can be found in `CAPI.config.references`, if the object contains the key `rich-link` it means the value should be a URL path to the json of that rich link. This PR extracts this data out of the the CAPI sent to the server. 

## Note
Unlike rich links found in the elements array, which use their position index to calculate, there is not index position for auto rich links. Normally we would use spaceFinder to determine their position, however we do not currently have access to that function
