### PR TITLE
Epic in AMP articles

### DIFF
--- a/src/amp/components/BodyArticle.tsx
+++ b/src/amp/components/BodyArticle.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import { css } from 'emotion';
+
 import { InnerContainer } from '@root/src/amp/components/InnerContainer';
 import { Elements } from '@root/src/amp/components/Elements';
-import { css } from 'emotion';
 import { ArticleModel } from '@root/src/amp/types/ArticleModel';
 import { TopMeta } from '@root/src/amp/components/topMeta/TopMeta';
 import { SubMeta } from '@root/src/amp/components/SubMeta';
@@ -13,7 +14,7 @@ import { WithAds } from '@root/src/amp/components/WithAds';
 import { findAdSlots } from '@root/src/amp/lib/find-adslots';
 import { getSharingUrls } from '@root/src/lib/sharing-urls';
 import { buildAdTargeting } from '@root/src/lib/ad-targeting';
-import {Epic} from "@root/src/amp/components/Epic";
+import { Epic } from "@root/src/amp/components/Epic";
 
 const bulletStyle = (pillar: Pillar) => css`
     .bullet {

--- a/src/amp/components/BodyArticle.tsx
+++ b/src/amp/components/BodyArticle.tsx
@@ -101,7 +101,7 @@ export const Body: React.FC<{
     );
 
     const epicTestPageId = "science/2015/sep/28/nasa-scientists-find-evidence-flowing-water-mars"
-    const epic = (data.pageId === epicTestPageId) ? <Epic /> : null
+    const epic = (data.pageId === epicTestPageId) && !data.shouldHideReaderRevenue ? <Epic /> : null
 
     return (
         <InnerContainer className={body(pillar, designType)}>

--- a/src/amp/components/BodyArticle.tsx
+++ b/src/amp/components/BodyArticle.tsx
@@ -109,7 +109,7 @@ export const Body: React.FC<{
 
             {elements}
 
-            <Epic/>
+            <Epic />
 
             <SubMeta
                 sections={data.subMetaSectionLinks}

--- a/src/amp/components/BodyArticle.tsx
+++ b/src/amp/components/BodyArticle.tsx
@@ -98,6 +98,7 @@ export const Body: React.FC<{
             adInfo={adInfo}
         />
     );
+
     return (
         <InnerContainer className={body(pillar, designType)}>
             <TopMeta
@@ -109,7 +110,7 @@ export const Body: React.FC<{
 
             {elements}
 
-            <Epic />
+            <Epic pageId={data.pageId} />
 
             <SubMeta
                 sections={data.subMetaSectionLinks}

--- a/src/amp/components/BodyArticle.tsx
+++ b/src/amp/components/BodyArticle.tsx
@@ -13,6 +13,7 @@ import { WithAds } from '@root/src/amp/components/WithAds';
 import { findAdSlots } from '@root/src/amp/lib/find-adslots';
 import { getSharingUrls } from '@root/src/lib/sharing-urls';
 import { buildAdTargeting } from '@root/src/lib/ad-targeting';
+import {Epic} from "@root/src/amp/components/Epic";
 
 const bulletStyle = (pillar: Pillar) => css`
     .bullet {
@@ -107,6 +108,8 @@ export const Body: React.FC<{
             />
 
             {elements}
+
+            <Epic/>
 
             <SubMeta
                 sections={data.subMetaSectionLinks}

--- a/src/amp/components/BodyArticle.tsx
+++ b/src/amp/components/BodyArticle.tsx
@@ -100,6 +100,9 @@ export const Body: React.FC<{
         />
     );
 
+    const epicTestPageId = "science/2015/sep/28/nasa-scientists-find-evidence-flowing-water-mars"
+    const epic = (data.pageId === epicTestPageId) ? <Epic /> : null
+
     return (
         <InnerContainer className={body(pillar, designType)}>
             <TopMeta
@@ -111,7 +114,7 @@ export const Body: React.FC<{
 
             {elements}
 
-            <Epic pageId={data.pageId} />
+            {epic}
 
             <SubMeta
                 sections={data.subMetaSectionLinks}

--- a/src/amp/components/Epic.tsx
+++ b/src/amp/components/Epic.tsx
@@ -108,15 +108,12 @@ const acceptedPaymentMethodsWrapper = css`
     display: block;
 `;
 
-export const Epic: React.FC<{
-    pageId: string
-}> = ({pageId}) => {
-    const testArticleId = 'science/2015/sep/28/nasa-scientists-find-evidence-flowing-water-mars'
+export const Epic: React.FC<{}> = ({}) => {
     const epicUrl = process.env.NODE_ENV === 'production' ?
         'https://contributions.guardianapis.com/amp/epic' :
         'https://contributions.code.dev-guardianapis.com/amp/epic';
 
-    return (pageId === testArticleId) ? (
+    return (
         <amp-list
             layout="fixed-height"
             // This means that if the user refreshes at the end of the article while the epic is in view then the epic
@@ -165,5 +162,5 @@ export const Epic: React.FC<{
                 </div>
             </MoustacheTemplate>
         </amp-list>
-    ) : null;
+    )
 };

--- a/src/amp/components/Epic.tsx
+++ b/src/amp/components/Epic.tsx
@@ -33,7 +33,7 @@ const epicParagraph = css`
     display: block;
     margin-block-start: 0.5rem;
     margin-block-end: 0.5rem;
-    
+
     ${body.medium()};
     text-rendering: optimizeLegibility;
     font-kerning: normal;
@@ -107,12 +107,15 @@ const acceptedPaymentMethodsWrapper = css`
     display: block;
 `;
 
-export const Epic: React.FC<{}> = ({}) => {
+export const Epic: React.FC<{
+    pageId: string
+}> = ({pageId}) => {
+    const testArticleId = 'science/2015/sep/28/nasa-scientists-find-evidence-flowing-water-mars'
     const epicUrl = process.env.NODE_ENV === 'production' ?
         'https://contributions.guardianapis.com/amp/epic' :
         'https://contributions.code.dev-guardianapis.com/amp/epic';
 
-    return (
+    return (pageId === testArticleId) ? (
         <amp-list
             layout="fixed-height"
             // This means that if the user refreshes at the end of the article while the epic is in view then the epic
@@ -161,5 +164,5 @@ export const Epic: React.FC<{}> = ({}) => {
                 </div>
             </MoustacheTemplate>
         </amp-list>
-    );
+    ) : null;
 };

--- a/src/amp/components/Epic.tsx
+++ b/src/amp/components/Epic.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { palette } from '@guardian/src-foundations';
+import { headline, body, textSans } from '@guardian/src-foundations/typography';
 import {css} from "emotion";
 
 const epic = css`
@@ -13,7 +14,7 @@ const epic = css`
 const epicHeader = css `
     font-size: 1.25rem;
     line-height: 1.4375rem;
-    font-family: "Guardian Egyptian Web",Georgia,serif;
+    ${headline.xxsmall()};
     text-rendering: optimizeLegibility;
     font-kerning: normal;
     font-variant-ligatures: common-ligatures;
@@ -27,7 +28,7 @@ const epicParagraph = css`
     margin-block-start: 1em;
     margin-block-end: 1em;
     margin-bottom: 0.5rem;
-    font-family: "Guardian Text Egyptian Web",Georgia,serif;
+    ${body.medium()};
     text-rendering: optimizeLegibility;
     font-kerning: normal;
     font-variant-ligatures: common-ligatures;
@@ -45,7 +46,7 @@ const highlightedText = css`
     font-weight: bold;
     margin-left: 5px;
     color: ${palette.neutral[7]};
-    font-family: "Guardian Text Egyptian Web",Georgia,serif;
+    ${body.medium()};
     text-rendering: optimizeLegibility;
     font-kerning: normal;
     font-variant-ligatures: common-ligatures;
@@ -57,7 +58,7 @@ const supportButton = css`
     background-color: ${palette.brandYellow.main};
     color: ${palette.neutral[7]};
     display: inline-block;
-    font-family: "Guardian Text Sans Web","Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif;
+    ${textSans.medium()};
     text-rendering: optimizeLegibility;
     font-kerning: normal;
     font-variant-ligatures: common-ligatures;
@@ -91,11 +92,9 @@ const arrow = css`
     color: ${palette.neutral[7]};
     vertical-align: sub;
 `;
-const acceptedPaymentMethods = css`
+const acceptedPaymentMethodsWrapper = css`
     margin-top: .5rem;
-    margin-left: .25rem;
-    width: 32.5%;
-    height: auto;
+    margin-left: .5rem;
     display: block;
 `;
 
@@ -105,6 +104,8 @@ export const Epic: React.FC<{}> = ({}) => {
     return (
         <amp-list
             layout="responsive"
+            height="0"
+            width="0"
             src="https://contributions.guardianapis.com/amp/epic"
             credentials="include"
         >
@@ -157,11 +158,15 @@ export const Epic: React.FC<{}> = ({}) => {
                         <path d="M20 9.35l-9.08 8.54-.86-.81 6.54-7.31H0V8.12h16.6L10.06.81l.86-.81L20 8.51v.84z" />
                     </svg>
                 </a>
-                <img
-                    src="https://assets.guim.co.uk/images/acquisitions/2db3a266287f452355b68d4240df8087/payment-methods.png"
-                    alt="Accepted payment methods: Visa, Mastercard, American Express and PayPal"
-                    className={acceptedPaymentMethods}
-                />
+                <div className={acceptedPaymentMethodsWrapper}>
+                    <amp-img
+                        layout="fixed"
+                        height="25px"
+                        width="176px"
+                        src="https://assets.guim.co.uk/images/acquisitions/2db3a266287f452355b68d4240df8087/payment-methods.png"
+                        alt="Accepted payment methods: Visa, Mastercard, American Express and PayPal"
+                    />
+                </div>
             </div>
         </amp-list>
     );

--- a/src/amp/components/Epic.tsx
+++ b/src/amp/components/Epic.tsx
@@ -4,25 +4,170 @@ import {
     MoustacheTemplate,
     MoustacheVariable,
 } from "@root/src/amp/components/moustache";
+import {css} from "emotion";
+import {headline} from "@guardian/src-foundations/typography";
 
-export const Epic: React.FC<{}> = ({}) =>
-    (
+const epic = css`
+    border-top: 0.0625rem solid #ffe500;
+    background-color: #f6f6f6;
+    clear: left;
+    margin-top: 1.5rem;
+    margin-bottom: 1.5rem;
+    padding: 0.25rem 0.3125rem 0.75rem;
+`;
+const epicHeader = css `
+    font-size: 1.25rem;
+    line-height: 1.4375rem;
+    font-family: "Guardian Egyptian Web",Georgia,serif;
+    text-rendering: optimizeLegibility;
+    font-kerning: normal;
+    font-variant-ligatures: common-ligatures;
+    font-weight: 900;
+    margin-bottom: 0.75rem;
+    -webkit-font-smoothing: antialiased;
+`;
+const epicParagraph = css`
+    font-size: 1.1rem;
+    display: block;
+    margin-block-start: 1em;
+    margin-block-end: 1em;
+    margin-bottom: 0.5rem;
+    font-family: "Guardian Text Egyptian Web",Georgia,serif;
+    text-rendering: optimizeLegibility;
+    font-kerning: normal;
+    font-variant-ligatures: common-ligatures;
+    -webkit-font-smoothing: antialiased;
+    vertical-align: 0%;
+    line-height: 1.5;
+`;
+const highlightedText = css`
+    font-size: 1.1rem;
+    background-color: #ffe500;
+    padding: 0.125rem;
+    font-weight: bold;
+    padding: 0.125rem;
+    margin-left: 5px;
+    color: #121212;
+    font-family: "Guardian Text Egyptian Web",Georgia,serif;
+    text-rendering: optimizeLegibility;
+    font-kerning: normal;
+    font-variant-ligatures: common-ligatures;
+    -webkit-font-smoothing: antialiased;
+    vertical-align: 0%;
+    line-height: 1.5;
+`;
+const supportButton = css`
+    background-color: #ffe500;
+    color: #121212;
+    display: inline-block;
+    line-height: 1.375rem;
+    font-family: "Guardian Text Sans Web","Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif;
+    text-rendering: optimizeLegibility;
+    font-kerning: normal;
+    font-variant-ligatures: common-ligatures;
+    -webkit-font-smoothing: antialiased;
+    align-items: center;
+    text-decoration: none;
+    font-weight: 700;
+    font-size: 1.1rem;
+    height: 2.625rem;
+    min-height: 2.625rem;
+    padding: 0 1.3125rem;
+    border: 0;
+    border-radius: 1.3125rem;
+    box-sizing: border-box;
+    cursor: pointer;
+    margin: 2rem 0.625rem 0.25rem 0;
+    vertical-align: base;
+    line-height: 2.625rem;
+    transition: background-color .3s;
+    text-align: centre;
+
+    :hover {
+        background-color: #FFBB51;
+    }
+`;
+const arrow = css`
+    margin-left: .5rem;
+    position: relative;
+    width: 1.3125rem;
+    height: auto;
+    display: inline;
+    color: #121212;
+    vertical-align: sub;
+`;
+const acceptedPaymentMethods = css`
+    margin-top: .5rem;
+    margin-left: .25rem;
+    width: 32.5%;
+    height: auto;
+    display: block;
+`;
+
+const supportUrl = "https://support.theguardian.com/uk/contribute"
+
+export const Epic: React.FC<{}> = ({}) => {
+    return (
         <amp-list
-            layout="fixed-height"
-            height="184px"
-            src={"https://interactive.guim.co.uk/docsdata/1fy0JolB1bf1IEFLHGHfUYWx-niad7vR9K954OpTOvjE.json"}
+            layout="responsive"
+            src="https://contributions.guardianapis.com/amp/epic"
             credentials="include"
         >
-            <MoustacheTemplate>
-                <MoustacheSection name="sheets">
-                    <MoustacheSection name="control">
-                        <MoustacheSection name="heading">
-                            <MoustacheVariable name="heading" />
-                        </MoustacheSection>
-
-                        <MoustacheVariable name="paragraphs" />
-                    </MoustacheSection>
-                </MoustacheSection>
-            </MoustacheTemplate>
+            <div className={epic}>
+                <h2 className={epicHeader}>News is under threat …</h2>
+                <p className={epicParagraph}>
+                    … just when we need it the most. Millions of readers around the world are flocking to the
+                    Guardian in search of honest, authoritative, fact-based reporting that can help them
+                    understand the biggest challenge we have faced in our lifetime. But at this crucial moment,
+                    news organisations are facing a cruel financial double blow: with fewer people able to leave
+                    their homes, and fewer news vendors in operation, we’re seeing a reduction in newspaper
+                    sales across the UK. Advertising revenue continues to fall steeply meanwhile as businesses
+                    feel the pinch. We need you to help fill the gap.
+                </p>
+                <p className={epicParagraph}>
+                    We believe every one of us deserves equal access to quality news and measured explanation.
+                    So, unlike many others, we made a different choice: to keep Guardian journalism open for all,
+                    regardless of where they live or what they can afford to pay. This would not be possible without
+                    financial contributions from our readers, who now support our work from 180 countries around
+                    the world.
+                </p>
+                <p className={epicParagraph}>
+                    We have upheld our editorial independence in the face of the disintegration of traditional
+                    media – with social platforms giving rise to misinformation, the seemingly unstoppable rise of
+                    big tech and independent voices being squashed by commercial ownership. The Guardian’s
+                    independence means we can set our own agenda and voice our own opinions. Our journalism is free
+                    from commercial and political bias – never influenced by billionaire owners or shareholders.
+                    This makes us different. It means we can challenge the powerful without fear and give a voice to
+                    those less heard.
+                </p>
+                <p className={epicParagraph}>
+                    Reader financial support has meant we can keep investigating, disentangling and interrogating.
+                    It has protected our independence, which has never been so critical. We are so grateful.
+                </p>
+                <p className={epicParagraph}>
+                    We need your support so we can keep delivering quality journalism that’s open and independent.
+                    And that is here for the long term. Every reader contribution, however big or small, is so valuable.
+                    <span className={highlightedText}>Support the Guardian from as little as £1 – and it only takes a minute. Thank you.</span>
+                </p>
+                <a href={supportUrl} className={supportButton}>
+                    Support the Guardian
+                    <svg
+                        className={arrow}
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 20 17.89"
+                        preserveAspectRatio="xMinYMid"
+                        aria-hidden="true"
+                        focusable="false"
+                    >
+                        <path d="M20 9.35l-9.08 8.54-.86-.81 6.54-7.31H0V8.12h16.6L10.06.81l.86-.81L20 8.51v.84z" />
+                    </svg>
+                </a>
+                <img
+                    src="https://assets.guim.co.uk/images/acquisitions/2db3a266287f452355b68d4240df8087/payment-methods.png"
+                    alt="Accepted payment methods: Visa, Mastercard, American Express and PayPal"
+                    className={acceptedPaymentMethods}
+                />
+            </div>
         </amp-list>
     );
+}

--- a/src/amp/components/Epic.tsx
+++ b/src/amp/components/Epic.tsx
@@ -1,11 +1,5 @@
 import React from 'react';
-import {
-    MoustacheSection,
-    MoustacheTemplate,
-    MoustacheVariable,
-} from "@root/src/amp/components/moustache";
 import {css} from "emotion";
-import {headline} from "@guardian/src-foundations/typography";
 
 const epic = css`
     border-top: 0.0625rem solid #ffe500;
@@ -45,7 +39,6 @@ const highlightedText = css`
     background-color: #ffe500;
     padding: 0.125rem;
     font-weight: bold;
-    padding: 0.125rem;
     margin-left: 5px;
     color: #121212;
     font-family: "Guardian Text Egyptian Web",Georgia,serif;
@@ -60,7 +53,6 @@ const supportButton = css`
     background-color: #ffe500;
     color: #121212;
     display: inline-block;
-    line-height: 1.375rem;
     font-family: "Guardian Text Sans Web","Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif;
     text-rendering: optimizeLegibility;
     font-kerning: normal;

--- a/src/amp/components/Epic.tsx
+++ b/src/amp/components/Epic.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import { palette } from '@guardian/src-foundations';
 import {css} from "emotion";
 
 const epic = css`
-    border-top: 0.0625rem solid #ffe500;
-    background-color: #f6f6f6;
+    border-top: 0.0625rem solid ${palette.brandYellow.main};
+    background-color: ${palette.neutral[97]};
     clear: left;
     margin-top: 1.5rem;
     margin-bottom: 1.5rem;
@@ -33,14 +34,17 @@ const epicParagraph = css`
     -webkit-font-smoothing: antialiased;
     vertical-align: 0%;
     line-height: 1.5;
+    &::selection {
+        background-color: ${palette.brandYellow.main};
+    }
 `;
 const highlightedText = css`
     font-size: 1.1rem;
-    background-color: #ffe500;
+    background-color: ${palette.brandYellow.main};
     padding: 0.125rem;
     font-weight: bold;
     margin-left: 5px;
-    color: #121212;
+    color: ${palette.neutral[7]};
     font-family: "Guardian Text Egyptian Web",Georgia,serif;
     text-rendering: optimizeLegibility;
     font-kerning: normal;
@@ -50,8 +54,8 @@ const highlightedText = css`
     line-height: 1.5;
 `;
 const supportButton = css`
-    background-color: #ffe500;
-    color: #121212;
+    background-color: ${palette.brandYellow.main};
+    color: ${palette.neutral[7]};
     display: inline-block;
     font-family: "Guardian Text Sans Web","Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif;
     text-rendering: optimizeLegibility;
@@ -74,8 +78,7 @@ const supportButton = css`
     line-height: 2.625rem;
     transition: background-color .3s;
     text-align: centre;
-
-    :hover {
+    &:hover {
         background-color: #FFBB51;
     }
 `;
@@ -85,7 +88,7 @@ const arrow = css`
     width: 1.3125rem;
     height: auto;
     display: inline;
-    color: #121212;
+    color: ${palette.neutral[7]};
     vertical-align: sub;
 `;
 const acceptedPaymentMethods = css`

--- a/src/amp/components/Epic.tsx
+++ b/src/amp/components/Epic.tsx
@@ -79,7 +79,7 @@ const supportButton = css`
     transition: background-color .3s;
     text-align: centre;
     &:hover {
-        background-color: #FFBB51;
+        background-color: ${palette.opinion[600]};
     }
 `;
 const arrow = css`

--- a/src/amp/components/Epic.tsx
+++ b/src/amp/components/Epic.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import {
+    MoustacheSection,
+    MoustacheTemplate,
+    MoustacheVariable,
+} from "@root/src/amp/components/moustache";
+
+export const Epic: React.FC<{}> = ({}) =>
+    (
+        <amp-list
+            layout="fixed-height"
+            height="184px"
+            src={"https://interactive.guim.co.uk/docsdata/1fy0JolB1bf1IEFLHGHfUYWx-niad7vR9K954OpTOvjE.json"}
+            credentials="include"
+        >
+            <MoustacheTemplate>
+                <MoustacheSection name="sheets">
+                    <MoustacheSection name="control">
+                        <MoustacheSection name="heading">
+                            <MoustacheVariable name="heading" />
+                        </MoustacheSection>
+
+                        <MoustacheVariable name="paragraphs" />
+                    </MoustacheSection>
+                </MoustacheSection>
+            </MoustacheTemplate>
+        </amp-list>
+    );

--- a/src/amp/components/Epic.tsx
+++ b/src/amp/components/Epic.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
-import { palette } from '@guardian/src-foundations';
-import { headline, body, textSans } from '@guardian/src-foundations/typography';
-import {css} from "emotion";
+import { css } from 'emotion';
+
 import {
     MoustacheSection,
+    MoustacheVariable,
     MoustacheTemplate,
     moustacheVariable,
-    MoustacheVariable
-} from "@root/src/amp/components/moustache";
+} from '@root/src/amp/components/moustache';
+import { palette } from '@guardian/src-foundations';
+import { headline, body, textSans } from '@guardian/src-foundations/typography';
 
 const epic = css`
     border-top: 0.0625rem solid ${palette.brandYellow.main};

--- a/src/amp/components/Epic.tsx
+++ b/src/amp/components/Epic.tsx
@@ -2,6 +2,12 @@ import React from 'react';
 import { palette } from '@guardian/src-foundations';
 import { headline, body, textSans } from '@guardian/src-foundations/typography';
 import {css} from "emotion";
+import {
+    MoustacheSection,
+    MoustacheTemplate,
+    moustacheVariable,
+    MoustacheVariable
+} from "@root/src/amp/components/moustache";
 
 const epic = css`
     border-top: 0.0625rem solid ${palette.brandYellow.main};
@@ -9,7 +15,7 @@ const epic = css`
     clear: left;
     margin-top: 1.5rem;
     margin-bottom: 1.5rem;
-    padding: 0.25rem 0.3125rem 0.75rem;
+    padding: 0.25rem 0.3125rem 1rem;
 `;
 const epicHeader = css `
     font-size: 1.25rem;
@@ -25,9 +31,9 @@ const epicHeader = css `
 const epicParagraph = css`
     font-size: 1.1rem;
     display: block;
-    margin-block-start: 1em;
-    margin-block-end: 1em;
-    margin-bottom: 0.5rem;
+    margin-block-start: 0.5rem;
+    margin-block-end: 0.5rem;
+    
     ${body.medium()};
     text-rendering: optimizeLegibility;
     font-kerning: normal;
@@ -38,21 +44,24 @@ const epicParagraph = css`
     &::selection {
         background-color: ${palette.brandYellow.main};
     }
+    &:last-of-type {
+      display: inline;
+    }
 `;
 const highlightedText = css`
     font-size: 1.1rem;
     background-color: ${palette.brandYellow.main};
     padding: 0.125rem;
-    font-weight: bold;
     margin-left: 5px;
     color: ${palette.neutral[7]};
-    ${body.medium()};
+    ${headline.xxxsmall({fontWeight: "bold"})};
     text-rendering: optimizeLegibility;
     font-kerning: normal;
     font-variant-ligatures: common-ligatures;
     -webkit-font-smoothing: antialiased;
     vertical-align: 0%;
     line-height: 1.5;
+    display: inline;
 `;
 const supportButton = css`
     background-color: ${palette.brandYellow.main};
@@ -98,76 +107,59 @@ const acceptedPaymentMethodsWrapper = css`
     display: block;
 `;
 
-const supportUrl = "https://support.theguardian.com/uk/contribute"
-
 export const Epic: React.FC<{}> = ({}) => {
+    const epicUrl = process.env.NODE_ENV === 'production' ?
+        'https://contributions.guardianapis.com/amp/epic' :
+        'https://contributions.code.dev-guardianapis.com/amp/epic';
+
     return (
         <amp-list
-            layout="responsive"
-            height="0"
-            width="0"
-            src="https://contributions.guardianapis.com/amp/epic"
+            layout="fixed-height"
+            // This means that if the user refreshes at the end of the article while the epic is in view then the epic
+            // will not display. This is such an edge case that we can live with it, and in general it will fill the
+            // space.
+            height="1px"
+            src={epicUrl}
             credentials="include"
         >
-            <div className={epic}>
-                <h2 className={epicHeader}>News is under threat …</h2>
-                <p className={epicParagraph}>
-                    … just when we need it the most. Millions of readers around the world are flocking to the
-                    Guardian in search of honest, authoritative, fact-based reporting that can help them
-                    understand the biggest challenge we have faced in our lifetime. But at this crucial moment,
-                    news organisations are facing a cruel financial double blow: with fewer people able to leave
-                    their homes, and fewer news vendors in operation, we’re seeing a reduction in newspaper
-                    sales across the UK. Advertising revenue continues to fall steeply meanwhile as businesses
-                    feel the pinch. We need you to help fill the gap.
-                </p>
-                <p className={epicParagraph}>
-                    We believe every one of us deserves equal access to quality news and measured explanation.
-                    So, unlike many others, we made a different choice: to keep Guardian journalism open for all,
-                    regardless of where they live or what they can afford to pay. This would not be possible without
-                    financial contributions from our readers, who now support our work from 180 countries around
-                    the world.
-                </p>
-                <p className={epicParagraph}>
-                    We have upheld our editorial independence in the face of the disintegration of traditional
-                    media – with social platforms giving rise to misinformation, the seemingly unstoppable rise of
-                    big tech and independent voices being squashed by commercial ownership. The Guardian’s
-                    independence means we can set our own agenda and voice our own opinions. Our journalism is free
-                    from commercial and political bias – never influenced by billionaire owners or shareholders.
-                    This makes us different. It means we can challenge the powerful without fear and give a voice to
-                    those less heard.
-                </p>
-                <p className={epicParagraph}>
-                    Reader financial support has meant we can keep investigating, disentangling and interrogating.
-                    It has protected our independence, which has never been so critical. We are so grateful.
-                </p>
-                <p className={epicParagraph}>
-                    We need your support so we can keep delivering quality journalism that’s open and independent.
-                    And that is here for the long term. Every reader contribution, however big or small, is so valuable.
-                    <span className={highlightedText}>Support the Guardian from as little as £1 – and it only takes a minute. Thank you.</span>
-                </p>
-                <a href={supportUrl} className={supportButton}>
-                    Support the Guardian
-                    <svg
-                        className={arrow}
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 20 17.89"
-                        preserveAspectRatio="xMinYMid"
-                        aria-hidden="true"
-                        focusable="false"
-                    >
-                        <path d="M20 9.35l-9.08 8.54-.86-.81 6.54-7.31H0V8.12h16.6L10.06.81l.86-.81L20 8.51v.84z" />
-                    </svg>
-                </a>
-                <div className={acceptedPaymentMethodsWrapper}>
-                    <amp-img
-                        layout="fixed"
-                        height="25px"
-                        width="176px"
-                        src="https://assets.guim.co.uk/images/acquisitions/2db3a266287f452355b68d4240df8087/payment-methods.png"
-                        alt="Accepted payment methods: Visa, Mastercard, American Express and PayPal"
-                    />
+            <MoustacheTemplate>
+                <div className={epic}>
+                    <h2 className={epicHeader}>
+                        <MoustacheVariable name="heading" />
+                    </h2>
+                    <MoustacheSection name="paragraphs">
+                        <p className={epicParagraph}>
+                            <MoustacheVariable name="." />
+                        </p>
+                    </MoustacheSection>
+                    <span className={highlightedText}><MoustacheVariable name="highlightedText" /></span>
+                    <br />
+                    <MoustacheSection name="cta">
+                        <a href={moustacheVariable('baseUrl')} className={supportButton}>
+                            <MoustacheVariable name="text" />
+                            <svg
+                                className={arrow}
+                                xmlns="http://www.w3.org/2000/svg"
+                                viewBox="0 0 20 17.89"
+                                preserveAspectRatio="xMinYMid"
+                                aria-hidden="true"
+                                focusable="false"
+                            >
+                                <path d="M20 9.35l-9.08 8.54-.86-.81 6.54-7.31H0V8.12h16.6L10.06.81l.86-.81L20 8.51v.84z" />
+                            </svg>
+                        </a>
+                        <div className={acceptedPaymentMethodsWrapper}>
+                            <amp-img
+                                layout="fixed"
+                                height="25px"
+                                width="176px"
+                                src="https://assets.guim.co.uk/images/acquisitions/2db3a266287f452355b68d4240df8087/payment-methods.png"
+                                alt="Accepted payment methods: Visa, Mastercard, American Express and PayPal"
+                            />
+                        </div>
+                    </MoustacheSection>
                 </div>
-            </div>
+            </MoustacheTemplate>
         </amp-list>
     );
-}
+};

--- a/src/amp/components/OnwardContainer.tsx
+++ b/src/amp/components/OnwardContainer.tsx
@@ -167,7 +167,6 @@ export const OnwardContainer: React.FC<{
                                         <MoustacheSection name="isComment">
                                             <div>
                                                 <MoustacheVariable name="byline" />
-                                                <MoustacheVariable name="byline" />
                                             </div>
                                         </MoustacheSection>
                                     </div>

--- a/src/amp/components/OnwardContainer.tsx
+++ b/src/amp/components/OnwardContainer.tsx
@@ -69,12 +69,10 @@ const headlineCSS = css`
     word-wrap: break-word;
     ${headline.xxxsmall()};
 `;
-
 const description = css`
     ${headline.xxxsmall()};
     margin-bottom: 16px;
 `;
-
 const iconCSS = css`
     svg {
         fill: ${palette.neutral[7]};
@@ -83,7 +81,6 @@ const iconCSS = css`
         width: 16px;
     }
 `;
-
 const quoteIconCSS = css`
     svg {
         fill: ${palette.neutral[60]};
@@ -92,13 +89,11 @@ const quoteIconCSS = css`
         width: 16px;
     }
 `;
-
 const ageWarning = css`
     color: ${palette.neutral[20]};
     fill: ${palette.neutral[20]};
     ${textSans.xsmall()};
 `;
-
 const showMore = css`
     background-color: ${palette.neutral[100]};
     &[overflow] {
@@ -171,6 +166,7 @@ export const OnwardContainer: React.FC<{
                                         </h2>
                                         <MoustacheSection name="isComment">
                                             <div>
+                                                <MoustacheVariable name="byline" />
                                                 <MoustacheVariable name="byline" />
                                             </div>
                                         </MoustacheSection>

--- a/src/amp/pages/Article.tsx
+++ b/src/amp/pages/Article.tsx
@@ -14,6 +14,7 @@ import { AnalyticsIframe } from '@root/src/amp/components/AnalyticsIframe';
 import { getPillar } from '@root/src/lib/pillars';
 import { palette } from '@guardian/src-foundations';
 import { ArticleModel } from '@root/src/amp/types/ArticleModel';
+import {Epic} from "@root/src/amp/components/Epic";
 
 const backgroundColour = css`
     background-color: ${palette.neutral[97]};

--- a/src/amp/pages/Article.tsx
+++ b/src/amp/pages/Article.tsx
@@ -14,7 +14,6 @@ import { AnalyticsIframe } from '@root/src/amp/components/AnalyticsIframe';
 import { getPillar } from '@root/src/lib/pillars';
 import { palette } from '@guardian/src-foundations';
 import { ArticleModel } from '@root/src/amp/types/ArticleModel';
-import {Epic} from "@root/src/amp/components/Epic";
 
 const backgroundColour = css`
     background-color: ${palette.neutral[97]};

--- a/src/amp/types/ArticleModel.tsx
+++ b/src/amp/types/ArticleModel.tsx
@@ -19,6 +19,7 @@ export interface ArticleModel {
     subMetaKeywordLinks: SimpleLinkType[];
     webURL: string;
     shouldHideAds: boolean;
+    shouldHideReaderRevenue: boolean;
     guardianBaseURL: string;
     hasRelated: boolean;
     hasStoryPackage: boolean;


### PR DESCRIPTION
Adds the epic to AMP articles. Tested extensively locally, and also on CODE. Currently, and for checking in PROD purposes, the `Epic` component is only rendered on [this one specific article from 2015](https://www.theguardian.com/science/2015/sep/28/nasa-scientists-find-evidence-flowing-water-mars). 

Once checked in PROD, a subsequent PR will remove this condition and the Epic will then behave as it does elsewhere.

Please see the screenshot below, taken using Firefox Dev Edition, emulating an iPhone X
<br />
<img src="https://user-images.githubusercontent.com/25020231/81834050-609f9600-9538-11ea-9e7e-772cb6ba9d33.png" alt="AMP epic screenshot" height="50%" width="50%">
