### PR TITLE
Bring immersive onwards in line with other layouts

### DIFF
--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -383,11 +383,13 @@ export const ImmersiveLayout = ({
                 <AdSlot asps={namedAdSlotParameters('merchandising-high')} />
             </Section>
 
-            <Section sectionId="onwards-upper" />
-
             {!isPaidContent && (
                 <>
-                    {showOnwardsLower && <Section sectionId="onwards-lower" />}
+                    {/* Onwards (when signed IN) */}
+                    <Section sectionId="onwards-upper-whensignedin" />
+                    {showOnwardsLower && (
+                        <Section sectionId="onwards-lower-whensignedin" />
+                    )}
 
                     {showComments && (
                         <Section sectionId="comments">
@@ -400,6 +402,15 @@ export const ImmersiveLayout = ({
                                 </RightColumn>
                             </Flex>
                         </Section>
+                    )}
+
+                    {/* Onwards (when signed OUT) */}
+                    <Section
+                        sectionId="onwards-upper-whensignedout"
+                        showTopBorder={false}
+                    />
+                    {showOnwardsLower && (
+                        <Section sectionId="onwards-lower-whensignedout" />
                     )}
 
                     <Section sectionId="most-viewed-footer" />


### PR DESCRIPTION
## What does this change?
Updates `ImmersiveLayout` to include the correct root ids for onwards content

## Why?
These were updated earlier to allow onward sections to be positioned differently when the reader is logged in or not but this update had not been carried into the immersive layout because it was still being developed at that time.

We should now see onwards content rendered for Immersive articles