### PR TITLE
Fixes #1484 - Drop Caps obscure links

### DIFF
--- a/src/web/components/DropCap.tsx
+++ b/src/web/components/DropCap.tsx
@@ -19,7 +19,6 @@ const outerStyles = (pillar: Pillar, designType: DesignType) => {
         text-transform: uppercase;
         box-sizing: border-box;
         margin-right: 4px;
-        pointer-events: none;
     `;
 
     switch (designType) {
@@ -59,6 +58,7 @@ const innerStyles = (designType: DesignType) => {
 
         display: inline-block;
         vertical-align: text-top;
+        pointer-events: none;
     `;
 
     switch (designType) {

--- a/src/web/components/DropCap.tsx
+++ b/src/web/components/DropCap.tsx
@@ -19,6 +19,7 @@ const outerStyles = (pillar: Pillar, designType: DesignType) => {
         text-transform: uppercase;
         box-sizing: border-box;
         margin-right: 4px;
+        pointer-events: none;
     `;
 
     switch (designType) {


### PR DESCRIPTION
## What does this change?
Prevents drop caps from obscuring the click area for links near them

### Before
![2020-05-13 21 40 12](https://user-images.githubusercontent.com/1336821/81862941-601bf500-9562-11ea-83fe-7db3e13285ba.gif)

### After
![2020-05-13 21 37 49](https://user-images.githubusercontent.com/1336821/81862953-6316e580-9562-11ea-9339-88a27437764b.gif)

