### PR TITLE
Refactor stickiness

### DIFF
--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -3,6 +3,7 @@ import { css, cx } from 'emotion';
 
 import {
     neutral,
+    border,
     brandBorder,
     brandBackground,
     brandLine,
@@ -36,6 +37,7 @@ import { GridItem } from '@root/src/web/components/GridItem';
 import { Flex } from '@root/src/web/components/Flex';
 import { AgeWarning } from '@root/src/web/components/AgeWarning';
 
+import { getZIndex } from '@frontend/web/lib/getZIndex';
 import { buildAdTargeting } from '@root/src/lib/ad-targeting';
 import { parse } from '@frontend/lib/slot-machine-flags';
 import { getAgeWarning } from '@root/src/lib/age-warning';
@@ -180,6 +182,25 @@ const headlinePadding = css`
     padding-bottom: 43px;
 `;
 
+// The advert is stuck to the top of the container as we scroll
+// until we hit the bottom of the wrapper that contains
+// the top banner and the header/navigation
+// We apply sticky positioning and z-indexes, the stickAdWrapper and headerWrapper
+// classes are tightly coupled.
+
+const stickyAdWrapper = css`
+    background-color: white;
+    border-bottom: 0.0625rem solid ${border.secondary};
+    position: sticky;
+    top: 0;
+    ${getZIndex('stickyAdWrapper')}
+`;
+
+const headerWrapper = css`
+    position: relative;
+    ${getZIndex('headerWrapper')}
+`;
+
 const ageWarningMargins = css`
     margin-top: 12px;
     margin-left: -10px;
@@ -242,62 +263,70 @@ export const CommentLayout = ({
 
     return (
         <>
-            <Section
-                showTopBorder={false}
-                showSideBorders={false}
-                padded={false}
-            >
-                <HeaderAdSlot
-                    isAdFreeUser={CAPI.isAdFreeUser}
-                    shouldHideAds={CAPI.shouldHideAds}
-                />
-            </Section>
-            <Section
-                showTopBorder={false}
-                showSideBorders={false}
-                padded={false}
-                backgroundColour={brandBackground.primary}
-            >
-                <Header edition={CAPI.editionId} />
-            </Section>
+            <div>
+                <div className={stickyAdWrapper}>
+                    <Section
+                        showTopBorder={false}
+                        showSideBorders={false}
+                        padded={false}
+                    >
+                        <HeaderAdSlot
+                            isAdFreeUser={CAPI.isAdFreeUser}
+                            shouldHideAds={CAPI.shouldHideAds}
+                        />
+                    </Section>
+                </div>
+                <div className={headerWrapper}>
+                    <Section
+                        showTopBorder={false}
+                        showSideBorders={false}
+                        padded={false}
+                        backgroundColour={brandBackground.primary}
+                    >
+                        <Header edition={CAPI.editionId} />
+                    </Section>
 
-            <Section
-                showSideBorders={true}
-                borderColour={brandLine.primary}
-                showTopBorder={false}
-                padded={false}
-                backgroundColour={brandBackground.primary}
-            >
-                <Nav
-                    pillar={getCurrentPillar(CAPI)}
-                    nav={NAV}
-                    display={display}
-                    subscribeUrl={CAPI.nav.readerRevenueLinks.header.subscribe}
-                    edition={CAPI.editionId}
-                />
-            </Section>
+                    <Section
+                        showSideBorders={true}
+                        borderColour={brandLine.primary}
+                        showTopBorder={false}
+                        padded={false}
+                        backgroundColour={brandBackground.primary}
+                    >
+                        <Nav
+                            pillar={getCurrentPillar(CAPI)}
+                            nav={NAV}
+                            display={display}
+                            subscribeUrl={
+                                CAPI.nav.readerRevenueLinks.header.subscribe
+                            }
+                            edition={CAPI.editionId}
+                        />
+                    </Section>
 
-            {NAV.subNavSections && (
-                <Section
-                    backgroundColour={opinion[800]}
-                    padded={false}
-                    sectionId="sub-nav-root"
-                >
-                    <SubNav
-                        subNavSections={NAV.subNavSections}
-                        currentNavLink={NAV.currentNavLink}
-                        pillar={pillar}
-                    />
-                </Section>
-            )}
+                    {NAV.subNavSections && (
+                        <Section
+                            backgroundColour={opinion[800]}
+                            padded={false}
+                            sectionId="sub-nav-root"
+                        >
+                            <SubNav
+                                subNavSections={NAV.subNavSections}
+                                currentNavLink={NAV.currentNavLink}
+                                pillar={pillar}
+                            />
+                        </Section>
+                    )}
 
-            <Section
-                backgroundColour={opinion[800]}
-                padded={false}
-                showTopBorder={false}
-            >
-                <GuardianLines count={4} pillar={pillar} />
-            </Section>
+                    <Section
+                        backgroundColour={opinion[800]}
+                        padded={false}
+                        showTopBorder={false}
+                    >
+                        <GuardianLines count={4} pillar={pillar} />
+                    </Section>
+                </div>
+            </div>
 
             <Section showTopBorder={false} backgroundColour={opinion[800]}>
                 <StandardGrid>

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -3,7 +3,6 @@ import { css, cx } from 'emotion';
 
 import {
     neutral,
-    border,
     brandBorder,
     brandBackground,
     brandLine,
@@ -37,11 +36,11 @@ import { GridItem } from '@root/src/web/components/GridItem';
 import { Flex } from '@root/src/web/components/Flex';
 import { AgeWarning } from '@root/src/web/components/AgeWarning';
 
-import { getZIndex } from '@frontend/web/lib/getZIndex';
 import { buildAdTargeting } from '@root/src/lib/ad-targeting';
 import { parse } from '@frontend/lib/slot-machine-flags';
 import { getAgeWarning } from '@root/src/lib/age-warning';
 import { getCurrentPillar } from '@root/src/web/lib/layoutHelpers';
+import { Stuck, SendToBack } from '@root/src/web/layouts/lib/stickiness';
 
 const StandardGrid = ({
     children,
@@ -182,25 +181,6 @@ const headlinePadding = css`
     padding-bottom: 43px;
 `;
 
-// The advert is stuck to the top of the container as we scroll
-// until we hit the bottom of the wrapper that contains
-// the top banner and the header/navigation
-// We apply sticky positioning and z-indexes, the stickAdWrapper and headerWrapper
-// classes are tightly coupled.
-
-const stickyAdWrapper = css`
-    background-color: white;
-    border-bottom: 0.0625rem solid ${border.secondary};
-    position: sticky;
-    top: 0;
-    ${getZIndex('stickyAdWrapper')}
-`;
-
-const headerWrapper = css`
-    position: relative;
-    ${getZIndex('headerWrapper')}
-`;
-
 const ageWarningMargins = css`
     margin-top: 12px;
     margin-left: -10px;
@@ -264,7 +244,7 @@ export const CommentLayout = ({
     return (
         <>
             <div>
-                <div className={stickyAdWrapper}>
+                <Stuck>
                     <Section
                         showTopBorder={false}
                         showSideBorders={false}
@@ -275,8 +255,8 @@ export const CommentLayout = ({
                             shouldHideAds={CAPI.shouldHideAds}
                         />
                     </Section>
-                </div>
-                <div className={headerWrapper}>
+                </Stuck>
+                <SendToBack>
                     <Section
                         showTopBorder={false}
                         showSideBorders={false}
@@ -325,7 +305,7 @@ export const CommentLayout = ({
                     >
                         <GuardianLines count={4} pillar={pillar} />
                     </Section>
-                </div>
+                </SendToBack>
             </div>
 
             <Section showTopBorder={false} backgroundColour={opinion[800]}>

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -3,7 +3,6 @@ import { css } from 'emotion';
 
 import {
     neutral,
-    border,
     background,
     brandBackground,
     brandLine,
@@ -34,8 +33,6 @@ import { Border } from '@root/src/web/components/Border';
 import { GridItem } from '@root/src/web/components/GridItem';
 import { Flex } from '@root/src/web/components/Flex';
 import { AgeWarning } from '@root/src/web/components/AgeWarning';
-
-import { getZIndex } from '@frontend/web/lib/getZIndex';
 import { buildAdTargeting } from '@root/src/lib/ad-targeting';
 import { parse } from '@frontend/lib/slot-machine-flags';
 import { getAgeWarning } from '@root/src/lib/age-warning';
@@ -44,6 +41,7 @@ import {
     decideLineEffect,
     getCurrentPillar,
 } from '@root/src/web/lib/layoutHelpers';
+import { Stuck, SendToBack } from '@root/src/web/layouts/lib/stickiness';
 
 const ShowcaseGrid = ({
     children,
@@ -211,25 +209,6 @@ const PositionHeadline = ({
     }
 };
 
-// The advert is stuck to the top of the container as we scroll
-// until we hit the bottom of the wrapper that contains
-// the top banner and the header/navigation
-// We apply sticky positioning and z-indexes, the stickAdWrapper and headerWrapper
-// classes are tightly coupled.
-
-const stickyAdWrapper = css`
-    background-color: white;
-    border-bottom: 0.0625rem solid ${border.secondary};
-    position: sticky;
-    top: 0;
-    ${getZIndex('stickyAdWrapper')}
-`;
-
-const headerWrapper = css`
-    position: relative;
-    ${getZIndex('headerWrapper')}
-`;
-
 const ageWarningMargins = css`
     margin-top: 12px;
     margin-left: -10px;
@@ -286,7 +265,7 @@ export const ShowcaseLayout = ({
     return (
         <>
             <div>
-                <div className={stickyAdWrapper}>
+                <Stuck>
                     <Section
                         showTopBorder={false}
                         showSideBorders={false}
@@ -297,8 +276,8 @@ export const ShowcaseLayout = ({
                             shouldHideAds={CAPI.shouldHideAds}
                         />
                     </Section>
-                </div>
-                <div className={headerWrapper}>
+                </Stuck>
+                <SendToBack>
                     <Section
                         showTopBorder={false}
                         showSideBorders={false}
@@ -347,7 +326,7 @@ export const ShowcaseLayout = ({
                     >
                         <GuardianLines count={4} pillar={pillar} />
                     </Section>
-                </div>
+                </SendToBack>
             </div>
 
             <Section showTopBorder={false}>

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -3,7 +3,6 @@ import { css } from 'emotion';
 
 import {
     neutral,
-    border,
     background,
     brandAltBackground,
     brandBackground,
@@ -41,13 +40,13 @@ import { AgeWarning } from '@root/src/web/components/AgeWarning';
 
 import { buildAdTargeting } from '@root/src/lib/ad-targeting';
 import { parse } from '@frontend/lib/slot-machine-flags';
-import { getZIndex } from '@frontend/web/lib/getZIndex';
 import { getAgeWarning } from '@root/src/lib/age-warning';
 import {
     decideLineCount,
     decideLineEffect,
     getCurrentPillar,
 } from '@root/src/web/lib/layoutHelpers';
+import { Stuck, SendToBack } from '@root/src/web/layouts/lib/stickiness';
 
 const StandardGrid = ({
     children,
@@ -195,25 +194,6 @@ const starWrapper = css`
     margin-left: -10px;
 `;
 
-// The advert is stuck to the top of the container as we scroll
-// until we hit the bottom of the wrapper that contains
-// the top banner and the header/navigation
-// We apply sticky positioning and z-indexes, the stickAdWrapper and headerWrapper
-// classes are tightly coupled.
-
-const stickyAdWrapper = css`
-    background-color: white;
-    border-bottom: 0.0625rem solid ${border.secondary};
-    position: sticky;
-    top: 0;
-    ${getZIndex('stickyAdWrapper')}
-`;
-
-const headerWrapper = css`
-    position: relative;
-    ${getZIndex('headerWrapper')}
-`;
-
 const ageWarningMargins = css`
     margin-top: 12px;
     margin-left: -10px;
@@ -270,7 +250,7 @@ export const StandardLayout = ({
     return (
         <>
             <div>
-                <div className={stickyAdWrapper}>
+                <Stuck>
                     <Section
                         showTopBorder={false}
                         showSideBorders={false}
@@ -281,8 +261,8 @@ export const StandardLayout = ({
                             shouldHideAds={CAPI.shouldHideAds}
                         />
                     </Section>
-                </div>
-                <div className={headerWrapper}>
+                </Stuck>
+                <SendToBack>
                     <Section
                         showTopBorder={false}
                         showSideBorders={false}
@@ -331,7 +311,7 @@ export const StandardLayout = ({
                     >
                         <GuardianLines count={4} pillar={pillar} />
                     </Section>
-                </div>
+                </SendToBack>
             </div>
 
             <Section showTopBorder={false}>

--- a/src/web/layouts/lib/stickiness.tsx
+++ b/src/web/layouts/lib/stickiness.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { border } from '@guardian/src-foundations/palette';
+
+import { getZIndex } from '@frontend/web/lib/getZIndex';
+
+type Props = {
+    children: React.ReactNode;
+};
+
+// The advert is stuck to the top of the container as we scroll
+// until we hit the bottom of the wrapper that contains
+// the top banner and the header/navigation
+// We apply sticky positioning and z-indexes, the stickAdWrapper and headerWrapper
+// classes are tightly coupled.
+const stickyAdWrapper = css`
+    background-color: white;
+    border-bottom: 0.0625rem solid ${border.secondary};
+    position: sticky;
+    top: 0;
+    ${getZIndex('stickyAdWrapper')}
+`;
+
+const headerWrapper = css`
+    position: relative;
+    ${getZIndex('headerWrapper')}
+`;
+
+export const Stuck = ({ children }: Props) => (
+    <div className={stickyAdWrapper}>{children}</div>
+);
+
+export const SendToBack = ({ children }: Props) => (
+    <div className={headerWrapper}>{children}</div>
+);


### PR DESCRIPTION
## What does this change?
Makes the top above nav slot on Comment pieces sticky

Also refactors how we make the header sticky by abstracting the logic into a lib.

## Why?
We repeat this code in three places now and it's deemed unlikely that we would want to stick the advert in a different manner in different layouts so an abstraction makes sense in this case.