### PR TITLE
Ensure MV section name is capitalised

### DIFF
--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterGrid.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterGrid.tsx
@@ -133,6 +133,9 @@ export const MostViewedFooterGrid = ({ data, sectionName, pillar }: Props) => {
                                     Most viewed{' '}
                                 </span>
                                 <span
+                                    className={css`
+                                        text-transform: capitalize;
+                                    `}
                                     // "Across The Guardian" has a non-breaking space entity between "The" and "Guardian"
                                     dangerouslySetInnerHTML={{
                                         __html: tab.heading,


### PR DESCRIPTION
## What does this change?
Capitalises the name of each Most Viewed tab

### Before
![Screenshot 2020-05-17 at 07 36 59](https://user-images.githubusercontent.com/1336821/82137547-35a39380-9811-11ea-96c1-66d7f14f6038.jpg)


### After
![Screenshot 2020-05-17 at 07 32 51](https://user-images.githubusercontent.com/1336821/82137543-2886a480-9811-11ea-9720-e3b7914a8d3d.jpg)

## Why?
Because we want titles to use title case
