### PR TITLE
Use title case for Most viewed

### DIFF
--- a/cypress/integration/e2e/article.e2e.spec.js
+++ b/cypress/integration/e2e/article.e2e.spec.js
@@ -30,7 +30,7 @@ describe('E2E Page rendering', function() {
                         expect(xhr.response.body).to.have.property('heading');
                         expect(xhr.status).to.be.equal(200);
 
-                        cy.contains('most viewed');
+                        cy.contains('Most viewed');
                     });
                 }
 

--- a/src/web/components/MostViewed/MostViewedRight/MostViewedRight.tsx
+++ b/src/web/components/MostViewed/MostViewedRight/MostViewedRight.tsx
@@ -37,7 +37,7 @@ export const MostViewedRight = ({ pillar, limitItems = 5 }: Props) => {
         return (
             <div className={wrapperStyles} data-component="geo-most-popular">
                 <GuardianLines count={4} pillar={pillar} />
-                <h3 className={headingStyles}>most viewed</h3>
+                <h3 className={headingStyles}>Most viewed</h3>
                 <ul data-link-name="Right hand most popular geo GB">
                     {(data.trails || [])
                         .slice(0, limitItems)


### PR DESCRIPTION
## What does this change?
'most viewed' > 'Most viewed'

### Before
![Screenshot 2020-05-17 at 08 06 58](https://user-images.githubusercontent.com/1336821/82138064-65549a80-9815-11ea-82c5-8310a82022ca.jpg)

### After
![Screenshot 2020-05-17 at 08 06 34](https://user-images.githubusercontent.com/1336821/82138060-5bcb3280-9815-11ea-92a8-00894225bac8.jpg)

## Why?
> During a conversation with Duarte, it's been pointed out that all section name headings throughout the site are meant to be using the capitalisation pattern of the 2018 redesign - i.e. 'Most viewed', 'Around the world', 'Take part' etc. This is mostly already in place, but there's a few instances where the old capitalisation is still in place (all lowercase).
>
> We should go through the section headings in DCR and double check they're capitalising the name correctly, consistently and following the 2018 convention.
