### PR TITLE
Filter more network errors from Sentry

### DIFF
--- a/src/web/browser/sentry/sentry.tsx
+++ b/src/web/browser/sentry/sentry.tsx
@@ -21,6 +21,8 @@ const ignoreErrors = [
     'Failed to fetch',
     'This video is no longer available.',
     'UnknownError',
+    'TypeError: Failed to fetch',
+    'TypeError: NetworkError when attempting to fetch resource',
 ];
 
 export const initialiseSentry = (adBlockInUse: boolean) => {


### PR DESCRIPTION
## What does this change?
We already filter several variations of fetch network errors from Sentry. Here we add 2 more:

```typescript
        'TypeError: Failed to fetch',
        'TypeError: NetworkError when attempting to fetch resource',
```

The trigger for this change was errors seen when making calls for CMP to get the vendorList.json file but we also want to ignore network requests in principle because we have no control over them. This error in particular is [known to occur](https://forum.sentry.io/t/typeerror-failed-to-fetch-reported-over-and-overe/8447) when the user navigates away from the page early.
