### PR TITLE
Increase test coverage for different image roles

### DIFF
--- a/cypress/integration/e2e/article.e2e.spec.js
+++ b/cypress/integration/e2e/article.e2e.spec.js
@@ -16,7 +16,7 @@ describe('E2E Page rendering', function() {
             it(`It should load ${designType} articles under the ${pillar} pillar`, function() {
                 cy.visit(`Article?url=${url}`, fetchPolyfill);
                 cy.scrollTo('bottom', { duration: 100 });
-                cy.contains('Sign in');
+                cy.contains('Lifestyle');
 
                 cy.wait('@getMostRead').then(xhr => {
                     expect(xhr.response.body).to.have.property('tabs');

--- a/cypress/lib/articles.js
+++ b/cypress/lib/articles.js
@@ -17,6 +17,14 @@ export const articles = [
     },
     {
         url:
+            'https://www.theguardian.com/artanddesign/2019/may/21/inside-huawei-a-photo-essay',
+        pillar: 'culture',
+        designType: 'PhotoEssay',
+        hasRichLinks: true,
+        hideMostViewed: true,
+    },
+    {
+        url:
             'https://www.theguardian.com/politics/2019/nov/20/jeremy-corbyn-boris-johnson-tv-debate-watched-by-67-million-people',
         pillar: 'news',
         designType: 'Article',

--- a/fixtures/articles/Article.ts
+++ b/fixtures/articles/Article.ts
@@ -2713,6 +2713,393 @@ export const Article: CAPIType = {
                         '<p>Meanwhile, large areas of Spain, Portugal and France would be grappling with desertification, with the worst-affected zones experiencing a two and half-fold increase in droughts under the worst-case scenario.</p>',
                 },
                 {
+                    role: 'showcase',
+                    data: {
+                        copyright: 'AFP or licensors',
+                        alt:
+                            'Lovechild of a pretzel … Vessel by Thomas Heatherwick.',
+                        caption:
+                            'Lovechild of a pretzel … Vessel by Thomas Heatherwick.',
+                        credit: 'Photograph: Timothy A Clary/AFP/Getty',
+                    },
+                    imageSources: [
+                        {
+                            weighting: 'inline',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=620&quality=85&auto=format&fit=max&s=11b920f01b52d8c4aa146bf90efdb806',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=aef7ec1e05b3a906d54fd781afd09b02',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=605&quality=85&auto=format&fit=max&s=1ae06edd667c151dd4076443e0e2d62d',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=597328d26278467b51380655fe528930',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=445&quality=85&auto=format&fit=max&s=19a94a13726050044c4281696a94e520',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=625240e86ded7a4464ea2687ce4a735d',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'thumbnail',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=140&quality=85&auto=format&fit=max&s=1eb288c630d5f26bd61aff018a123713',
+                                    width: 140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=f6cc65b0956d9330e035e785c733749a',
+                                    width: 280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=120&quality=85&auto=format&fit=max&s=31cc61e609f8073b6c5694a022bf8b28',
+                                    width: 120,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=d9a5fca7f8a30e18cc20dd95010762f9',
+                                    width: 240,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'supporting',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=380&quality=85&auto=format&fit=max&s=b84e92b77bd4ddbf3277f809fa7829b4',
+                                    width: 380,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=294550d628f6bfc729fd5b3a0ba66070',
+                                    width: 760,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=300&quality=85&auto=format&fit=max&s=6166f93bc76ecb11c889b869dede4dcc',
+                                    width: 300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=3182c32997da6ebae030b4b2d2b44e6a',
+                                    width: 600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=620&quality=85&auto=format&fit=max&s=11b920f01b52d8c4aa146bf90efdb806',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=aef7ec1e05b3a906d54fd781afd09b02',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=605&quality=85&auto=format&fit=max&s=1ae06edd667c151dd4076443e0e2d62d',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=597328d26278467b51380655fe528930',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=445&quality=85&auto=format&fit=max&s=19a94a13726050044c4281696a94e520',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=625240e86ded7a4464ea2687ce4a735d',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'showcase',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=1020&quality=85&auto=format&fit=max&s=82a29f8be6e3d028bc683d17f4785c37',
+                                    width: 1020,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=1020&quality=45&auto=format&fit=max&dpr=2&s=9f39ce2e27e61ad41b67680081b5a768',
+                                    width: 2040,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=940&quality=85&auto=format&fit=max&s=d9f86968016039811c4b30d886f73451',
+                                    width: 940,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=940&quality=45&auto=format&fit=max&dpr=2&s=5b20fd1d47751d647e915bd9264ae3aa',
+                                    width: 1880,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=700&quality=85&auto=format&fit=max&s=25d2540be33071ef5a5c68a195b630e9',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=ef76196ae2833a1f56e94044a1f3cf75',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=700&quality=85&auto=format&fit=max&s=25d2540be33071ef5a5c68a195b630e9',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=ef76196ae2833a1f56e94044a1f3cf75',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=660&quality=85&auto=format&fit=max&s=64e6a7979c7a116e3de15ef80359a586',
+                                    width: 660,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=660&quality=45&auto=format&fit=max&dpr=2&s=c3c8081dd2c4b1abf69822f5d7b66978',
+                                    width: 1320,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=645&quality=85&auto=format&fit=max&s=007d1dab11d5047a31296fe53a15344e',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=a569d3631b6f27aa58c4c2336f39451f',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=465&quality=85&auto=format&fit=max&s=59a118d67f82f691762c54e362317c6f',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=9c667855de065c1dcc1d45c80f664fe1',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'halfwidth',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=620&quality=85&auto=format&fit=max&s=11b920f01b52d8c4aa146bf90efdb806',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=aef7ec1e05b3a906d54fd781afd09b02',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=605&quality=85&auto=format&fit=max&s=1ae06edd667c151dd4076443e0e2d62d',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=597328d26278467b51380655fe528930',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=445&quality=85&auto=format&fit=max&s=19a94a13726050044c4281696a94e520',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=625240e86ded7a4464ea2687ce4a735d',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'immersive',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=1300&quality=85&auto=format&fit=max&s=6fede08b1a0fbb3ce1abb5084aac625d',
+                                    width: 1300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=1300&quality=45&auto=format&fit=max&dpr=2&s=db675e7c6486708c5dce62b87d3d81be',
+                                    width: 2600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=1140&quality=85&auto=format&fit=max&s=e8c653e7c6483f56d9e37f465617088e',
+                                    width: 1140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=1140&quality=45&auto=format&fit=max&dpr=2&s=88c378e1b607de892afb16d7884c6b41',
+                                    width: 2280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=1125&quality=85&auto=format&fit=max&s=f2ddad6e79939957fd7da027cfbc7226',
+                                    width: 1125,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=1125&quality=45&auto=format&fit=max&dpr=2&s=ed8a47bcbdfea603cd8a39a1bd18f87a',
+                                    width: 2250,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=965&quality=85&auto=format&fit=max&s=4bf449ecaa24cc24d26c79fabf21b6be',
+                                    width: 965,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=965&quality=45&auto=format&fit=max&dpr=2&s=e39a6d963c1ef9a3965b2ef9c947bdca',
+                                    width: 1930,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=725&quality=85&auto=format&fit=max&s=33e71a4933b69e9121695a52e7593ecd',
+                                    width: 725,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=725&quality=45&auto=format&fit=max&dpr=2&s=eb70135ca471280fce4adce5ef2f862f',
+                                    width: 1450,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=645&quality=85&auto=format&fit=max&s=007d1dab11d5047a31296fe53a15344e',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=a569d3631b6f27aa58c4c2336f39451f',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=465&quality=85&auto=format&fit=max&s=59a118d67f82f691762c54e362317c6f',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=9c667855de065c1dcc1d45c80f664fe1',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                    ],
+                    _type:
+                        'model.dotcomrendering.pageElements.ImageBlockElement',
+                    media: {
+                        allImages: [
+                            {
+                                index: 0,
+                                fields: {
+                                    height: '3726',
+                                    width: '5712',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/5712.jpg',
+                            },
+                            {
+                                index: 1,
+                                fields: {
+                                    isMaster: 'true',
+                                    height: '3726',
+                                    width: '5712',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg',
+                            },
+                            {
+                                index: 2,
+                                fields: {
+                                    height: '1305',
+                                    width: '2000',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/2000.jpg',
+                            },
+                            {
+                                index: 3,
+                                fields: {
+                                    height: '652',
+                                    width: '1000',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/1000.jpg',
+                            },
+                            {
+                                index: 4,
+                                fields: {
+                                    height: '326',
+                                    width: '500',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/500.jpg',
+                            },
+                            {
+                                index: 5,
+                                fields: {
+                                    height: '91',
+                                    width: '140',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/140.jpg',
+                            },
+                        ],
+                    },
+                    displayCredit: true,
+                },
+                {
                     _type:
                         'model.dotcomrendering.pageElements.TextBlockElement',
                     html:

--- a/fixtures/articles/Feature.ts
+++ b/fixtures/articles/Feature.ts
@@ -2003,6 +2003,393 @@ export const Feature: CAPIType = {
                         '<p><strong>… on dairy products<br></strong>“I think we’ve become very disconnected from the natural world, many of us are guilty of an egocentric worldview and we believe that we’re the centre of the universe. We go into the natural world and we plunder it for its resources, we feel entitled to artificially inseminate a cow and steal her baby even though her cries of anguish are unmistakeable. Then we take her milk intended for her calf and we put it in our coffee and our cereal.”</p>',
                 },
                 {
+                    role: 'showcase',
+                    data: {
+                        copyright: 'AFP or licensors',
+                        alt:
+                            'Lovechild of a pretzel … Vessel by Thomas Heatherwick.',
+                        caption:
+                            'Lovechild of a pretzel … Vessel by Thomas Heatherwick.',
+                        credit: 'Photograph: Timothy A Clary/AFP/Getty',
+                    },
+                    imageSources: [
+                        {
+                            weighting: 'inline',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=620&quality=85&auto=format&fit=max&s=11b920f01b52d8c4aa146bf90efdb806',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=aef7ec1e05b3a906d54fd781afd09b02',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=605&quality=85&auto=format&fit=max&s=1ae06edd667c151dd4076443e0e2d62d',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=597328d26278467b51380655fe528930',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=445&quality=85&auto=format&fit=max&s=19a94a13726050044c4281696a94e520',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=625240e86ded7a4464ea2687ce4a735d',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'thumbnail',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=140&quality=85&auto=format&fit=max&s=1eb288c630d5f26bd61aff018a123713',
+                                    width: 140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=f6cc65b0956d9330e035e785c733749a',
+                                    width: 280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=120&quality=85&auto=format&fit=max&s=31cc61e609f8073b6c5694a022bf8b28',
+                                    width: 120,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=d9a5fca7f8a30e18cc20dd95010762f9',
+                                    width: 240,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'supporting',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=380&quality=85&auto=format&fit=max&s=b84e92b77bd4ddbf3277f809fa7829b4',
+                                    width: 380,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=294550d628f6bfc729fd5b3a0ba66070',
+                                    width: 760,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=300&quality=85&auto=format&fit=max&s=6166f93bc76ecb11c889b869dede4dcc',
+                                    width: 300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=3182c32997da6ebae030b4b2d2b44e6a',
+                                    width: 600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=620&quality=85&auto=format&fit=max&s=11b920f01b52d8c4aa146bf90efdb806',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=aef7ec1e05b3a906d54fd781afd09b02',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=605&quality=85&auto=format&fit=max&s=1ae06edd667c151dd4076443e0e2d62d',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=597328d26278467b51380655fe528930',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=445&quality=85&auto=format&fit=max&s=19a94a13726050044c4281696a94e520',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=625240e86ded7a4464ea2687ce4a735d',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'showcase',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=1020&quality=85&auto=format&fit=max&s=82a29f8be6e3d028bc683d17f4785c37',
+                                    width: 1020,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=1020&quality=45&auto=format&fit=max&dpr=2&s=9f39ce2e27e61ad41b67680081b5a768',
+                                    width: 2040,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=940&quality=85&auto=format&fit=max&s=d9f86968016039811c4b30d886f73451',
+                                    width: 940,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=940&quality=45&auto=format&fit=max&dpr=2&s=5b20fd1d47751d647e915bd9264ae3aa',
+                                    width: 1880,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=700&quality=85&auto=format&fit=max&s=25d2540be33071ef5a5c68a195b630e9',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=ef76196ae2833a1f56e94044a1f3cf75',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=700&quality=85&auto=format&fit=max&s=25d2540be33071ef5a5c68a195b630e9',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=ef76196ae2833a1f56e94044a1f3cf75',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=660&quality=85&auto=format&fit=max&s=64e6a7979c7a116e3de15ef80359a586',
+                                    width: 660,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=660&quality=45&auto=format&fit=max&dpr=2&s=c3c8081dd2c4b1abf69822f5d7b66978',
+                                    width: 1320,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=645&quality=85&auto=format&fit=max&s=007d1dab11d5047a31296fe53a15344e',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=a569d3631b6f27aa58c4c2336f39451f',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=465&quality=85&auto=format&fit=max&s=59a118d67f82f691762c54e362317c6f',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=9c667855de065c1dcc1d45c80f664fe1',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'halfwidth',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=620&quality=85&auto=format&fit=max&s=11b920f01b52d8c4aa146bf90efdb806',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=aef7ec1e05b3a906d54fd781afd09b02',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=605&quality=85&auto=format&fit=max&s=1ae06edd667c151dd4076443e0e2d62d',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=597328d26278467b51380655fe528930',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=445&quality=85&auto=format&fit=max&s=19a94a13726050044c4281696a94e520',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=625240e86ded7a4464ea2687ce4a735d',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'immersive',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=1300&quality=85&auto=format&fit=max&s=6fede08b1a0fbb3ce1abb5084aac625d',
+                                    width: 1300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=1300&quality=45&auto=format&fit=max&dpr=2&s=db675e7c6486708c5dce62b87d3d81be',
+                                    width: 2600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=1140&quality=85&auto=format&fit=max&s=e8c653e7c6483f56d9e37f465617088e',
+                                    width: 1140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=1140&quality=45&auto=format&fit=max&dpr=2&s=88c378e1b607de892afb16d7884c6b41',
+                                    width: 2280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=1125&quality=85&auto=format&fit=max&s=f2ddad6e79939957fd7da027cfbc7226',
+                                    width: 1125,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=1125&quality=45&auto=format&fit=max&dpr=2&s=ed8a47bcbdfea603cd8a39a1bd18f87a',
+                                    width: 2250,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=965&quality=85&auto=format&fit=max&s=4bf449ecaa24cc24d26c79fabf21b6be',
+                                    width: 965,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=965&quality=45&auto=format&fit=max&dpr=2&s=e39a6d963c1ef9a3965b2ef9c947bdca',
+                                    width: 1930,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=725&quality=85&auto=format&fit=max&s=33e71a4933b69e9121695a52e7593ecd',
+                                    width: 725,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=725&quality=45&auto=format&fit=max&dpr=2&s=eb70135ca471280fce4adce5ef2f862f',
+                                    width: 1450,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=645&quality=85&auto=format&fit=max&s=007d1dab11d5047a31296fe53a15344e',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=a569d3631b6f27aa58c4c2336f39451f',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=465&quality=85&auto=format&fit=max&s=59a118d67f82f691762c54e362317c6f',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=9c667855de065c1dcc1d45c80f664fe1',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                    ],
+                    _type:
+                        'model.dotcomrendering.pageElements.ImageBlockElement',
+                    media: {
+                        allImages: [
+                            {
+                                index: 0,
+                                fields: {
+                                    height: '3726',
+                                    width: '5712',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/5712.jpg',
+                            },
+                            {
+                                index: 1,
+                                fields: {
+                                    isMaster: 'true',
+                                    height: '3726',
+                                    width: '5712',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/master/5712.jpg',
+                            },
+                            {
+                                index: 2,
+                                fields: {
+                                    height: '1305',
+                                    width: '2000',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/2000.jpg',
+                            },
+                            {
+                                index: 3,
+                                fields: {
+                                    height: '652',
+                                    width: '1000',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/1000.jpg',
+                            },
+                            {
+                                index: 4,
+                                fields: {
+                                    height: '326',
+                                    width: '500',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/500.jpg',
+                            },
+                            {
+                                index: 5,
+                                fields: {
+                                    height: '91',
+                                    width: '140',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/c3474cdfcf69f37ffa370ea3fe9320b0fddfa3c7/0_0_5712_3726/140.jpg',
+                            },
+                        ],
+                    },
+                    displayCredit: true,
+                },
+                {
                     _type:
                         'model.dotcomrendering.pageElements.TextBlockElement',
                     html:

--- a/fixtures/articles/Interview.ts
+++ b/fixtures/articles/Interview.ts
@@ -4367,6 +4367,393 @@ export const Interview: CAPIType = {
                         '<p>She does have certain requirements, such as a pop-up tent in which to change backstage at shows, but she says she’s never been uncomfortably set apart, or made to feel othered. She remembers her experience of walking for Yeezy at New York fashion week in 2017, her breakout year, as a watershed moment. The first outfit she was presented with “was just not going to work,” she says, gesturing above her knee – too short. “Even then I knew: walking away when something doesn’t fit is always better than feeling you need to force something.”</p>',
                 },
                 {
+                    role: 'immersive',
+                    data: {
+                        copyright: 'Christopher Thomond',
+                        alt:
+                            'Zippy, George, Bungle, Tom and Jerry, five alpacas who live on the slopes of the hill.',
+                        caption:
+                            'Zippy, George, Bungle, Tom and Jerry: five alpacas who live on the slopes of the hill.',
+                        credit: 'Photograph: Christopher Thomond/The Guardian',
+                    },
+                    imageSources: [
+                        {
+                            weighting: 'inline',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=620&quality=85&auto=format&fit=max&s=16750be620eae62752d30ab8b29cf1d6',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=14e417ff80fc5740ffb692722bf6aca0',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=605&quality=85&auto=format&fit=max&s=f8cca1932c3d4148d2658b0387dd0517',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=2fc791f0abcb538408c4b12df8bf6f90',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=445&quality=85&auto=format&fit=max&s=89294e06de636910cfc7df38b1eb61ae',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=1cb870a1b57dab73ad949ec18f45a37e',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'thumbnail',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=140&quality=85&auto=format&fit=max&s=d3d74082a0dd0b86dc711936661009f1',
+                                    width: 140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=0adb6af4f9156ff72924dbfc8e654bea',
+                                    width: 280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=120&quality=85&auto=format&fit=max&s=1aa188e8d818a967c613a6b6b05fcf37',
+                                    width: 120,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=203b9af6057ccfe06b59172d9ed64c32',
+                                    width: 240,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'supporting',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=380&quality=85&auto=format&fit=max&s=f394ad2658d243becb76c6c0578b7fc9',
+                                    width: 380,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=3d8813ea242cbe469880b19890cea383',
+                                    width: 760,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=300&quality=85&auto=format&fit=max&s=eca093857dcf35c0667552bb228d3513',
+                                    width: 300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=7c03e9f5a73880471e92933079fadf74',
+                                    width: 600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=620&quality=85&auto=format&fit=max&s=16750be620eae62752d30ab8b29cf1d6',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=14e417ff80fc5740ffb692722bf6aca0',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=605&quality=85&auto=format&fit=max&s=f8cca1932c3d4148d2658b0387dd0517',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=2fc791f0abcb538408c4b12df8bf6f90',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=445&quality=85&auto=format&fit=max&s=89294e06de636910cfc7df38b1eb61ae',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=1cb870a1b57dab73ad949ec18f45a37e',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'showcase',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=1020&quality=85&auto=format&fit=max&s=53c3d6837db8d7babfd394f0358fa859',
+                                    width: 1020,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=1020&quality=45&auto=format&fit=max&dpr=2&s=d48649fe69a1413dbdbb6e53eeb18ada',
+                                    width: 2040,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=940&quality=85&auto=format&fit=max&s=7603a414dfceeb85a757630da07d30a4',
+                                    width: 940,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=940&quality=45&auto=format&fit=max&dpr=2&s=bbec6321e766aab3120994bec78cbd64',
+                                    width: 1880,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=700&quality=85&auto=format&fit=max&s=b4fbed60d29c70bb0f7e386e425b3b96',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=aa3e80994176d2b23360fe8da68fffe5',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=700&quality=85&auto=format&fit=max&s=b4fbed60d29c70bb0f7e386e425b3b96',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=aa3e80994176d2b23360fe8da68fffe5',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=660&quality=85&auto=format&fit=max&s=7234263b94d080c46847ab5e9bc8be51',
+                                    width: 660,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=660&quality=45&auto=format&fit=max&dpr=2&s=62ea12e09df9c0675659b6a14fb8d833',
+                                    width: 1320,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=645&quality=85&auto=format&fit=max&s=0a8f28bd54f0dabf9f1049d256af204e',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=d433a84ed06163f46bc936ae4baa642d',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=465&quality=85&auto=format&fit=max&s=6f528b9ff1e7bb2cfefa3a50f95c8ea3',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=88b761f91c6a7aef94d44d09aa45309f',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'halfwidth',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=620&quality=85&auto=format&fit=max&s=16750be620eae62752d30ab8b29cf1d6',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=14e417ff80fc5740ffb692722bf6aca0',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=605&quality=85&auto=format&fit=max&s=f8cca1932c3d4148d2658b0387dd0517',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=2fc791f0abcb538408c4b12df8bf6f90',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=445&quality=85&auto=format&fit=max&s=89294e06de636910cfc7df38b1eb61ae',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=1cb870a1b57dab73ad949ec18f45a37e',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'immersive',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=1300&quality=85&auto=format&fit=max&s=ae7e9a1b91b603b5244afc15db448ee5',
+                                    width: 1300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=1300&quality=45&auto=format&fit=max&dpr=2&s=efff21a58fb65b8d0e7b749a74592892',
+                                    width: 2600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=1140&quality=85&auto=format&fit=max&s=9f0e36097c54cf48069e68b707a510ce',
+                                    width: 1140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=1140&quality=45&auto=format&fit=max&dpr=2&s=0f590572fb418024506b02eb2f60657f',
+                                    width: 2280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=1125&quality=85&auto=format&fit=max&s=ec674d5279c570a46a864c34287b5ad8',
+                                    width: 1125,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=1125&quality=45&auto=format&fit=max&dpr=2&s=bf54957b78457e1364a74cbf9bcea17e',
+                                    width: 2250,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=965&quality=85&auto=format&fit=max&s=4e88a6bd4c365fe4ce3214d3c3a510e6',
+                                    width: 965,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=965&quality=45&auto=format&fit=max&dpr=2&s=3378f27b45b15a5863da9717451d4b5b',
+                                    width: 1930,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=725&quality=85&auto=format&fit=max&s=a5db37ecfb812b732d689d8cbee95b79',
+                                    width: 725,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=725&quality=45&auto=format&fit=max&dpr=2&s=ee3cc64e4876c1f361d0886357a01073',
+                                    width: 1450,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=645&quality=85&auto=format&fit=max&s=0a8f28bd54f0dabf9f1049d256af204e',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=d433a84ed06163f46bc936ae4baa642d',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=465&quality=85&auto=format&fit=max&s=6f528b9ff1e7bb2cfefa3a50f95c8ea3',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=88b761f91c6a7aef94d44d09aa45309f',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                    ],
+                    _type:
+                        'model.dotcomrendering.pageElements.ImageBlockElement',
+                    media: {
+                        allImages: [
+                            {
+                                index: 0,
+                                fields: {
+                                    height: '4388',
+                                    width: '6582',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/6582.jpg',
+                            },
+                            {
+                                index: 1,
+                                fields: {
+                                    isMaster: 'true',
+                                    height: '4388',
+                                    width: '6582',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/master/6582.jpg',
+                            },
+                            {
+                                index: 2,
+                                fields: {
+                                    height: '1333',
+                                    width: '2000',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/2000.jpg',
+                            },
+                            {
+                                index: 3,
+                                fields: {
+                                    height: '667',
+                                    width: '1000',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/1000.jpg',
+                            },
+                            {
+                                index: 4,
+                                fields: {
+                                    height: '333',
+                                    width: '500',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/500.jpg',
+                            },
+                            {
+                                index: 5,
+                                fields: {
+                                    height: '93',
+                                    width: '140',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/jpeg',
+                                url:
+                                    'https://media.guim.co.uk/87dd77e72ff61df8454b3dd86863ef220866fc57/0_0_6582_4388/140.jpg',
+                            },
+                        ],
+                    },
+                    displayCredit: true,
+                },
+                {
                     _type:
                         'model.dotcomrendering.pageElements.TextBlockElement',
                     html:

--- a/fixtures/articles/Recipe.ts
+++ b/fixtures/articles/Recipe.ts
@@ -2921,6 +2921,356 @@ export const Recipe: CAPIType = {
                         '<p>Pasta is all about the dough, worked by hand until it turns silky under your palms and starts to spring back when poked. Most recipes require at least 10 minutes of knead time – the push-smoosh-turn action creates elasticity, which is crucial for a stretchy, al dente texture.</p>',
                 },
                 {
+                    role: 'thumbnail',
+                    data: {
+                        alt: '2',
+                        credit: 'Composite: GW Composite',
+                    },
+                    imageSources: [
+                        {
+                            weighting: 'inline',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=620&quality=85&auto=format&fit=max&s=32e94499b35fbfbf33983baa156c4019',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=620&quality=45&auto=format&fit=max&dpr=2&s=bd8fd767aed79e684e3fef302aa27b9d',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=605&quality=85&auto=format&fit=max&s=568b051daaecf114113a5ce485c035de',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=605&quality=45&auto=format&fit=max&dpr=2&s=6def35afa69972eb6abf7913812e3228',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=445&quality=85&auto=format&fit=max&s=d2c311f876a909dae5f2b2e9e687655e',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=445&quality=45&auto=format&fit=max&dpr=2&s=1f8f477aa44cef5b01354ec5b6644300',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'thumbnail',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=140&quality=85&auto=format&fit=max&s=b3cfd9a5cf1fbebf7e11b1df0ed0dc74',
+                                    width: 140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=140&quality=45&auto=format&fit=max&dpr=2&s=aa8e8d3fb76b02752c590ec7742db325',
+                                    width: 280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=120&quality=85&auto=format&fit=max&s=253c49433b934e1ce43184511e44ee99',
+                                    width: 120,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=120&quality=45&auto=format&fit=max&dpr=2&s=58266c3dce1dfff847390f090938ce50',
+                                    width: 240,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'supporting',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=380&quality=85&auto=format&fit=max&s=03b205636ff0b6eca474c96e704290e8',
+                                    width: 380,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=380&quality=45&auto=format&fit=max&dpr=2&s=1c12bf7881ad4bc9906bbed7d5251629',
+                                    width: 760,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=300&quality=85&auto=format&fit=max&s=fdd04f81706f07f5f3eb6b87ed482ccc',
+                                    width: 300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=300&quality=45&auto=format&fit=max&dpr=2&s=2828ad3311ad34038ca5491ab8e5cddb',
+                                    width: 600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=620&quality=85&auto=format&fit=max&s=32e94499b35fbfbf33983baa156c4019',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=620&quality=45&auto=format&fit=max&dpr=2&s=bd8fd767aed79e684e3fef302aa27b9d',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=605&quality=85&auto=format&fit=max&s=568b051daaecf114113a5ce485c035de',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=605&quality=45&auto=format&fit=max&dpr=2&s=6def35afa69972eb6abf7913812e3228',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=445&quality=85&auto=format&fit=max&s=d2c311f876a909dae5f2b2e9e687655e',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=445&quality=45&auto=format&fit=max&dpr=2&s=1f8f477aa44cef5b01354ec5b6644300',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'showcase',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=1020&quality=85&auto=format&fit=max&s=c6fdaf0fc3bfc736e26e84e35f91c171',
+                                    width: 1020,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=1020&quality=45&auto=format&fit=max&dpr=2&s=81a8d0edb9b944f1af71bdbabecfcb6e',
+                                    width: 2040,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=940&quality=85&auto=format&fit=max&s=89f5ad906bbc656fb866cc3af5239cee',
+                                    width: 940,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=940&quality=45&auto=format&fit=max&dpr=2&s=103ff4f0a790df1cf14323261d05b78d',
+                                    width: 1880,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=700&quality=85&auto=format&fit=max&s=2c439d90b03f9a276db8f6a8ee1ecfaf',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=700&quality=45&auto=format&fit=max&dpr=2&s=26ff1cdf6ed2ba0a9876615ea76a8e0c',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=700&quality=85&auto=format&fit=max&s=2c439d90b03f9a276db8f6a8ee1ecfaf',
+                                    width: 700,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=700&quality=45&auto=format&fit=max&dpr=2&s=26ff1cdf6ed2ba0a9876615ea76a8e0c',
+                                    width: 1400,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=660&quality=85&auto=format&fit=max&s=511d1ff8e2e92a5902b016f511501eaa',
+                                    width: 660,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=660&quality=45&auto=format&fit=max&dpr=2&s=3e2407c7284a385b8260ea69152ed2cc',
+                                    width: 1320,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=645&quality=85&auto=format&fit=max&s=e49bf8b917887617a96ac5636f24147d',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=645&quality=45&auto=format&fit=max&dpr=2&s=35643c50ff5dc80b17d27d4f8a9dd0b1',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=465&quality=85&auto=format&fit=max&s=7835760db9979f0a7c997a7a7d695943',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=465&quality=45&auto=format&fit=max&dpr=2&s=218e18617974685bf31ef54fbc7666d1',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'halfwidth',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=620&quality=85&auto=format&fit=max&s=32e94499b35fbfbf33983baa156c4019',
+                                    width: 620,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=620&quality=45&auto=format&fit=max&dpr=2&s=bd8fd767aed79e684e3fef302aa27b9d',
+                                    width: 1240,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=605&quality=85&auto=format&fit=max&s=568b051daaecf114113a5ce485c035de',
+                                    width: 605,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=605&quality=45&auto=format&fit=max&dpr=2&s=6def35afa69972eb6abf7913812e3228',
+                                    width: 1210,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=445&quality=85&auto=format&fit=max&s=d2c311f876a909dae5f2b2e9e687655e',
+                                    width: 445,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=445&quality=45&auto=format&fit=max&dpr=2&s=1f8f477aa44cef5b01354ec5b6644300',
+                                    width: 890,
+                                },
+                            ],
+                        },
+                        {
+                            weighting: 'immersive',
+                            srcSet: [
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=1300&quality=85&auto=format&fit=max&s=4d07079596baefd9d4ba5615e60ab1bc',
+                                    width: 1300,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=1300&quality=45&auto=format&fit=max&dpr=2&s=1b583301b69ec56e26976d1de7de5d00',
+                                    width: 2600,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=1140&quality=85&auto=format&fit=max&s=00b9ff8e52a419760d2e276dd958428a',
+                                    width: 1140,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=1140&quality=45&auto=format&fit=max&dpr=2&s=b72541ae46d5b12ccbfb8b39c93aa926',
+                                    width: 2280,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=1125&quality=85&auto=format&fit=max&s=55be922e02167de4fa92934b0d877783',
+                                    width: 1125,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=1125&quality=45&auto=format&fit=max&dpr=2&s=e6d0128ca8639811b9494d469ca77f63',
+                                    width: 2250,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=965&quality=85&auto=format&fit=max&s=4f920bde1504cb07e80a9a8dea66cf05',
+                                    width: 965,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=965&quality=45&auto=format&fit=max&dpr=2&s=d1ad51877334594c2e28129d37f46cf4',
+                                    width: 1930,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=725&quality=85&auto=format&fit=max&s=b5b59fe7bbcec6fa161efb0670ae896f',
+                                    width: 725,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=725&quality=45&auto=format&fit=max&dpr=2&s=1add271304ffa69f2c08e4aa046f1479',
+                                    width: 1450,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=645&quality=85&auto=format&fit=max&s=e49bf8b917887617a96ac5636f24147d',
+                                    width: 645,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=645&quality=45&auto=format&fit=max&dpr=2&s=35643c50ff5dc80b17d27d4f8a9dd0b1',
+                                    width: 1290,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=465&quality=85&auto=format&fit=max&s=7835760db9979f0a7c997a7a7d695943',
+                                    width: 465,
+                                },
+                                {
+                                    src:
+                                        'https://i.guim.co.uk/img/media/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png?width=465&quality=45&auto=format&fit=max&dpr=2&s=218e18617974685bf31ef54fbc7666d1',
+                                    width: 930,
+                                },
+                            ],
+                        },
+                    ],
+                    _type:
+                        'model.dotcomrendering.pageElements.ImageBlockElement',
+                    media: {
+                        allImages: [
+                            {
+                                index: 0,
+                                fields: {
+                                    height: '368',
+                                    width: '405',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/png',
+                                url:
+                                    'https://media.guim.co.uk/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/405.png',
+                            },
+                            {
+                                index: 1,
+                                fields: {
+                                    isMaster: 'true',
+                                    height: '368',
+                                    width: '405',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/png',
+                                url:
+                                    'https://media.guim.co.uk/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/master/405.png',
+                            },
+                            {
+                                index: 2,
+                                fields: {
+                                    height: '127',
+                                    width: '140',
+                                },
+                                mediaType: 'Image',
+                                mimeType: 'image/png',
+                                url:
+                                    'https://media.guim.co.uk/4b3f214b056a1a8b317ba14c99e2a1dd191bff12/0_0_405_368/140.png',
+                            },
+                        ],
+                    },
+                    displayCredit: false,
+                },
+                {
                     _type:
                         'model.dotcomrendering.pageElements.TextBlockElement',
                     html:


### PR DESCRIPTION
## What does this change?
Inserts additional image elements into the fixtures used for Storybook and also adds a new article url to the list used for Cypress

## Why?
To increase test coverage of the different image types. We've previously seen how changes to the image logic can cause issues in DCR when an article has a speific image type so we wanted to be sure to have all types covered
