### PR TITLE
discussion-rendering@2.2.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "@emotion/core": "^10.0.28",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/consent-management-platform": "^3.0.4",
-        "@guardian/discussion-rendering": "^2.2.15",
+        "@guardian/discussion-rendering": "^2.2.16",
         "@guardian/src-button": "^0.17.0",
         "@guardian/src-ed-lines": "^0.18.0-rc.0",
         "@guardian/src-foundations": "^0.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2151,10 +2151,10 @@
     js-cookie "^2.2.1"
     whatwg-fetch "^3.0.0"
 
-"@guardian/discussion-rendering@^2.2.15":
-  version "2.2.15"
-  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-2.2.15.tgz#35ff70035e9331c572436415adcb710759ff210c"
-  integrity sha512-CAcLc447SbgR6NRPhA7yIdZ0BZLZC4UOcWm4JgZVD25dnJDtBGhTk5xAyAKfzGGKzt2o5bH5FxOPIlSa6SYSiQ==
+"@guardian/discussion-rendering@^2.2.16":
+  version "2.2.16"
+  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-2.2.16.tgz#65100db47e218b42b70e091f0a47e2eedca1eea0"
+  integrity sha512-0ViB5rf3cyc2y7Vfjht81es+4b4kvBAGUgJVAbjk90u7bfge+eX93rVSqwGcrnyPM8qedhbwDBs9y/ZC/WBRKQ==
   dependencies:
     react-focus-lock "^2.2.1"
     timeago.js "^4.0.2"


### PR DESCRIPTION
## What does this change?
Bumps `@guardian/discussion-rendering` to `v2.2.16`

## Why?
Includes [a fix](https://github.com/guardian/discussion-rendering/pull/268) to display the post comment form at the bottom of the comments list as well as the top
