### PR TITLE
Add referrerUrl to AMP epic

### DIFF
--- a/src/amp/components/BodyArticle.tsx
+++ b/src/amp/components/BodyArticle.tsx
@@ -100,7 +100,7 @@ export const Body: React.FC<{
         />
     );
 
-    const epic = data.shouldHideReaderRevenue ? null : <Epic />
+    const epic = data.shouldHideReaderRevenue ? null : <Epic webURL={data.webURL} />;
 
     return (
         <InnerContainer className={body(pillar, designType)}>

--- a/src/amp/components/Epic.tsx
+++ b/src/amp/components/Epic.tsx
@@ -108,7 +108,18 @@ const acceptedPaymentMethodsWrapper = css`
     display: block;
 `;
 
-export const Epic: React.FC<{}> = ({}) => {
+const buildUrl = (contributionsUrl: string, articleUrl: string, campaignCode: string, componentId: string): string => {
+    const acquisitionData = {
+        source: "GOOGLE_AMP",
+        componentType: "ACQUISITIONS_EPIC",
+        componentId,
+        campaignCode,
+        referrerUrl: articleUrl
+    };
+    return `${contributionsUrl}?INTCMP=${campaignCode}&acquisitionData=${JSON.stringify(acquisitionData)}`;
+};
+
+export const Epic: React.FC<{webURL: string}> = ({webURL}) => {
     const epicUrl = process.env.NODE_ENV === 'production' ?
         'https://contributions.guardianapis.com/amp/epic' :
         'https://contributions.code.dev-guardianapis.com/amp/epic';
@@ -136,7 +147,17 @@ export const Epic: React.FC<{}> = ({}) => {
                     <span className={highlightedText}><MoustacheVariable name="highlightedText" /></span>
                     <br />
                     <MoustacheSection name="cta">
-                        <a href={moustacheVariable('baseUrl')} className={supportButton}>
+                        <a
+                            href={
+                                buildUrl(
+                                    moustacheVariable('url'),
+                                    webURL,
+                                    moustacheVariable('campaignCode'),
+                                    moustacheVariable('componentId')
+                                )
+                            }
+                            className={supportButton}
+                        >
                             <MoustacheVariable name="text" />
                             <svg
                                 className={arrow}


### PR DESCRIPTION
## What does this change?
Adds a new field to the AMP epic link's tracking params: `referrerUrl`. This is so that we can track which articles contributors were on.

The `contributions-service` response was updated here: https://github.com/guardian/contributions-service/pull/137
Previously we returned the full epic link url, with tracking params, as `baseUrl` (which is not a very good name for it, but I used the existing cta model).

But we want the client to be able to insert a `referrerUrl` field into the tracking params. The proper way to do this is to have `contributions-service` return the parts that make up the tracking params, and let the client construct the url query string itself.

Here's the contributions page redux store, with `referrerUrl`:
![Screen Shot 2020-05-19 at 08 50 53](https://user-images.githubusercontent.com/1513454/82302203-2ce9c380-99b1-11ea-80e6-4b9f573fcc5b.png)
