### PR TITLE
Top above ad not showing on mobile

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -594,7 +594,8 @@ type IslandType =
     | 'onwards-lower-whensignedout'
     | 'rich-link'
     | 'links-root'
-    | 'comments';
+    | 'comments'
+    | 'header-ad-slot-root';
 
 interface TrailType {
     designType: DesignType;

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -10,6 +10,7 @@ import { SlotBodyEnd } from '@frontend/web/components/SlotBodyEnd';
 import { Links } from '@frontend/web/components/Links';
 import { SubNav } from '@frontend/web/components/SubNav/SubNav';
 import { CommentsLayout } from '@frontend/web/components/CommentsLayout';
+import { HeaderAdSlot } from '@root/src/web/components/HeaderAdSlot';
 import { incrementWeeklyArticleCount } from '@guardian/automat-client';
 
 import { Portal } from '@frontend/web/components/Portal';
@@ -215,6 +216,12 @@ export const App = ({ CAPI, NAV }: Props) => {
             </Portal>
             <Hydrate root="links-root">
                 <Links userId={user ? user.userId : undefined} />
+            </Hydrate>
+            <Hydrate root="header-ad-slot-root">
+                <HeaderAdSlot
+                    isAdFreeUser={CAPI.isAdFreeUser}
+                    shouldHideAds={CAPI.shouldHideAds}
+                />
             </Hydrate>
             <Hydrate root="edition-root">
                 <EditionDropdown

--- a/src/web/components/HeaderAdSlot.tsx
+++ b/src/web/components/HeaderAdSlot.tsx
@@ -35,19 +35,31 @@ export const HeaderAdSlot: React.FC<{
     isAdFreeUser: boolean;
     shouldHideAds: boolean;
 }> = ({ isAdFreeUser, shouldHideAds }) => (
-    <div className={headerWrapper}>
-        <Hide when="below" breakpoint="tablet">
-            <div
-                className={cx({
-                    [headerAdWrapper]: true,
-                    [headerAdWrapperHidden]: isAdFreeUser || shouldHideAds,
-                })}
-            >
-                <AdSlot
-                    asps={namedAdSlotParameters('top-above-nav')}
-                    localStyles={adSlotAboveNav}
-                />
+    <>
+        {/*
+            Commercial script does not render this ad slot on mobile width
+            if the element exists in the DOM. Therefore we need to remove it
+            from the DOM
+            TODO: find better work around working with commerical logic
+        */}
+        {/* 740 is the px width of tablet */}
+        {document.documentElement.clientWidth >= 740 && (
+            <div className={headerWrapper}>
+                <Hide when="below" breakpoint="tablet">
+                    <div
+                        className={cx({
+                            [headerAdWrapper]: true,
+                            [headerAdWrapperHidden]:
+                                isAdFreeUser || shouldHideAds,
+                        })}
+                    >
+                        <AdSlot
+                            asps={namedAdSlotParameters('top-above-nav')}
+                            localStyles={adSlotAboveNav}
+                        />
+                    </div>
+                </Hide>
             </div>
-        </Hide>
-    </div>
+        )}
+    </>
 );

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -29,7 +29,6 @@ import { Footer } from '@root/src/web/components/Footer';
 import { SubNav } from '@root/src/web/components/SubNav/SubNav';
 import { Section } from '@root/src/web/components/Section';
 import { Nav } from '@root/src/web/components/Nav/Nav';
-import { HeaderAdSlot } from '@root/src/web/components/HeaderAdSlot';
 import { MobileStickyContainer, AdSlot } from '@root/src/web/components/AdSlot';
 import { Border } from '@root/src/web/components/Border';
 import { GridItem } from '@root/src/web/components/GridItem';
@@ -252,10 +251,7 @@ export const CommentLayout = ({
                         showSideBorders={false}
                         padded={false}
                     >
-                        <HeaderAdSlot
-                            isAdFreeUser={CAPI.isAdFreeUser}
-                            shouldHideAds={CAPI.shouldHideAds}
-                        />
+                        <div id="header-ad-slot-root" />
                     </Section>
                 </Stuck>
                 <SendToBack>

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -27,7 +27,6 @@ import { Footer } from '@root/src/web/components/Footer';
 import { SubNav } from '@root/src/web/components/SubNav/SubNav';
 import { Section } from '@root/src/web/components/Section';
 import { Nav } from '@root/src/web/components/Nav/Nav';
-import { HeaderAdSlot } from '@root/src/web/components/HeaderAdSlot';
 import { MobileStickyContainer, AdSlot } from '@root/src/web/components/AdSlot';
 import { Border } from '@root/src/web/components/Border';
 import { GridItem } from '@root/src/web/components/GridItem';
@@ -272,10 +271,7 @@ export const ShowcaseLayout = ({
                         showSideBorders={false}
                         padded={false}
                     >
-                        <HeaderAdSlot
-                            isAdFreeUser={CAPI.isAdFreeUser}
-                            shouldHideAds={CAPI.shouldHideAds}
-                        />
+                        <div id="header-ad-slot-root" />
                     </Section>
                 </Stuck>
                 <SendToBack>

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -31,7 +31,6 @@ import { Footer } from '@root/src/web/components/Footer';
 import { SubNav } from '@root/src/web/components/SubNav/SubNav';
 import { Section } from '@root/src/web/components/Section';
 import { Nav } from '@root/src/web/components/Nav/Nav';
-import { HeaderAdSlot } from '@root/src/web/components/HeaderAdSlot';
 import { MobileStickyContainer, AdSlot } from '@root/src/web/components/AdSlot';
 import { Border } from '@root/src/web/components/Border';
 import { GridItem } from '@root/src/web/components/GridItem';
@@ -258,10 +257,7 @@ export const StandardLayout = ({
                         showSideBorders={false}
                         padded={false}
                     >
-                        <HeaderAdSlot
-                            isAdFreeUser={CAPI.isAdFreeUser}
-                            shouldHideAds={CAPI.shouldHideAds}
-                        />
+                        <div id="header-ad-slot-root" />
                     </Section>
                 </Stuck>
                 <SendToBack>


### PR DESCRIPTION
## What does this change?
We hydrate the rendering of the header as slot. We also conditionally render the Ad based on the page width.

## Why?
The header ad slot is rendered in body on widths lower than tablet. Previously we used CSS display to hide this element, however the commercial script would still identify the DOM element and assume this element is already being rendered.

Therefore we need to avoid rendering this DOM element at lower widths. The commercial script will then auto generate the new header ad
