### PR TITLE
Fix Sentry by adding dcrSentryDsn and editionLongForm to the browser window

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -311,9 +311,11 @@ type CAPIBrowserType = {
         discussionApiUrl: string;
         discussionD2Uid: string;
         discussionApiClientHeader: string;
+        dcrSentryDsn: string;
     };
     richLinks: RichLinkBlockElement[];
     editionId: Edition;
+    editionLongForm: string;
     contentType: string;
     sectionName?: string;
     shouldHideReaderRevenue: boolean;

--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -116,9 +116,12 @@ export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
             discussionApiUrl: CAPI.config.discussionApiUrl,
             discussionD2Uid: CAPI.config.discussionD2Uid,
             discussionApiClientHeader: CAPI.config.discussionApiClientHeader,
+
+            dcrSentryDsn: CAPI.config.dcrSentryDsn,
         },
         richLinks: richLinksWithIndex,
         editionId: CAPI.editionId,
+        editionLongForm: CAPI.editionLongForm,
         contentType: CAPI.contentType,
         sectionName: CAPI.sectionName,
         shouldHideReaderRevenue: CAPI.shouldHideReaderRevenue,

--- a/src/web/browser/sentry/sentry.tsx
+++ b/src/web/browser/sentry/sentry.tsx
@@ -26,12 +26,12 @@ const ignoreErrors = [
 ];
 
 export const initialiseSentry = (adBlockInUse: boolean) => {
-    const CAPIbrowser: CAPIBrowserType = window.guardian.app.data.CAPI;
+    const CAPIBrowser: CAPIBrowserType = window.guardian.app.data.CAPI;
     const {
         editionLongForm,
         contentType,
         config: { isDev, enableSentryReporting, dcrSentryDsn },
-    } = CAPIbrowser;
+    } = CAPIBrowser;
 
     Sentry.init({
         ignoreErrors,

--- a/src/web/browser/sentry/sentry.tsx
+++ b/src/web/browser/sentry/sentry.tsx
@@ -26,11 +26,12 @@ const ignoreErrors = [
 ];
 
 export const initialiseSentry = (adBlockInUse: boolean) => {
+    const CAPIbrowser: CAPIBrowserType = window.guardian.app.data.CAPI;
     const {
         editionLongForm,
         contentType,
         config: { isDev, enableSentryReporting, dcrSentryDsn },
-    } = window.guardian.app.data.CAPI;
+    } = CAPIbrowser;
 
     Sentry.init({
         ignoreErrors,


### PR DESCRIPTION
## What does this change?

As title, but adds typing to the value being used so that we can more clearly see what's missing.

![Screen Shot 2020-05-19 at 17 11 33](https://user-images.githubusercontent.com/638051/82352704-419c7a80-99f6-11ea-9be9-c0d91f021564.png)
![Screen Shot 2020-05-19 at 17 29 29](https://user-images.githubusercontent.com/638051/82352753-54af4a80-99f6-11ea-973c-d888accc2a2b.png)


## Why?
Sentry errors are useful.

## Note

This is just *fixing* sentry, not setting up the lazy loading (wanna make sure this works first)