### PR TITLE
Do not notify Sentry when there’s no epic to show

### DIFF
--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -172,16 +172,18 @@ const MemoisedInner = ({
             .then(checkForErrors)
             .then(response => response.json())
             .then(json => {
-                setData({
-                    slot: {
-                        html: json.data.html,
-                        css: json.data.css,
-                        js: json.data.js,
-                        meta: json.data.meta,
-                    },
-                });
+                if (json.data) {
+                    setData({
+                        slot: {
+                            html: json.data.html,
+                            css: json.data.css,
+                            js: json.data.js,
+                            meta: json.data.meta,
+                        },
+                    });
 
-                sendOphanEpicEvent('INSERT', json.data.meta);
+                    sendOphanEpicEvent('INSERT', json.data.meta);
+                }
             })
             .catch(error =>
                 window.guardian.modules.sentry.reportError(


### PR DESCRIPTION
## What does this change?

It is expected that the data property of the contributions service response can be `null`. Because our accessing of downstream properties (html, css etc.) wasn’t wrapped in a condition we were causing an exception which was then being passed to Sentry unnecessarily.

### Before

Sentry exceptions when the contributions service returns `null` for the data property (no epic to show, based on business rules).

### After

These Sentry exceptions go away! 👋 

## Why?

Unnecessary exceptions clutter up Sentry and potentially push us towards the limit of our plan.