### PR TITLE
Show a fallback message when error.statusText isn't present

### DIFF
--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -18,7 +18,7 @@ type HasBeenSeen = [boolean, (el: HTMLDivElement) => void];
 
 const checkForErrors = (response: any) => {
     if (!response.ok) {
-        throw Error(response.statusText);
+        throw Error(response.statusText || `SlotBodyEnd | An api call returned HTTP status ${response.status}`);
     }
     return response;
 };

--- a/src/web/lib/api.tsx
+++ b/src/web/lib/api.tsx
@@ -25,7 +25,11 @@ interface FetchOptions {
 
 function checkForErrors(response: any) {
     if (!response.ok) {
-        throw Error(response.statusText);
+        console.log(response);
+        throw Error(
+            response.statusText ||
+                `useApi | An api call returned HTTP status ${response.status}`,
+        );
     }
     return response;
 }

--- a/src/web/lib/api.tsx
+++ b/src/web/lib/api.tsx
@@ -25,7 +25,6 @@ interface FetchOptions {
 
 function checkForErrors(response: any) {
     if (!response.ok) {
-        console.log(response);
         throw Error(
             response.statusText ||
                 `useApi | An api call returned HTTP status ${response.status}`,

--- a/src/web/lib/getCommentContext.ts
+++ b/src/web/lib/getCommentContext.ts
@@ -100,7 +100,10 @@ export const getCommentContext = async (
     return fetch(url + objAsParams(params))
         .then(response => {
             if (!response.ok) {
-                throw Error(response.statusText);
+                throw Error(
+                    response.statusText ||
+                        `getCommentContext | An api call returned HTTP status ${response.status}`,
+                );
             }
             return response;
         })

--- a/src/web/lib/getCountryCode.ts
+++ b/src/web/lib/getCountryCode.ts
@@ -26,7 +26,10 @@ export const getCountryCode = async () => {
         )
             .then(response => {
                 if (!response.ok) {
-                    throw Error(response.statusText);
+                    throw Error(
+                        response.statusText ||
+                            `getCountryCode | An api call returned HTTP status ${response.status}`,
+                    );
                 }
                 return response;
             })

--- a/src/web/lib/getDiscussion.ts
+++ b/src/web/lib/getDiscussion.ts
@@ -58,7 +58,10 @@ export const getDiscussion = async (
     return fetch(url)
         .then(response => {
             if (!response.ok) {
-                throw Error(response.statusText);
+                throw Error(
+                    response.statusText ||
+                        `getDiscussion | An api call returned HTTP status ${response.status}`,
+                );
             }
             return response;
         })

--- a/src/web/lib/getUser.ts
+++ b/src/web/lib/getUser.ts
@@ -7,7 +7,10 @@ export const getUser = async (ajaxUrl: string): Promise<UserProfile> => {
     })
         .then(response => {
             if (!response.ok) {
-                throw Error(response.statusText);
+                throw Error(
+                    response.statusText ||
+                        `getUser | An api call returned HTTP status ${response.status}`,
+                );
             }
             return response;
         })


### PR DESCRIPTION
## What does this change?
Often when getting a 500 for an api call we don't see any `statusText` value. In these cases we're currently logging an undefined error message. Here we use a more useful fallback message

## Why?
This update helps with Sentry error messages like this
![Screenshot 2020-05-21 at 11 10 10](https://user-images.githubusercontent.com/1336821/82548783-c51fae00-9b53-11ea-9b35-247765c25009.jpg)

The fallback error message doesn't add any additional conext, it's present in the error page, but it does surface it sooner, which is useful
