### PR TITLE
Update to Twitter embed script

### DIFF
--- a/src/web/components/elements/TweetBlockComponent.tsx
+++ b/src/web/components/elements/TweetBlockComponent.tsx
@@ -47,7 +47,7 @@ export const TweetBlockComponent: React.FC<{
             />
             <script
                 async={true}
-                src="https://platform.twitter.com/widgets.js"
+                src="https://ton.twimg.com/syndication/widgetsjs/partner/widgets.js"
             />
         </div>
     );


### PR DESCRIPTION
## What does this change?
Updates the Twitter embed script to use a new partner version for publishers. Also seems to fix an issue with tweets displaying incorrectly.

### Before
<img width="707" alt="Screen Shot 2020-05-21 at 21 39 27" src="https://user-images.githubusercontent.com/2051501/82604056-9503f980-9bab-11ea-8890-e070eee3da05.png">

### After
<img width="707" alt="Screen Shot 2020-05-21 at 21 37 47" src="https://user-images.githubusercontent.com/2051501/82604007-81f12980-9bab-11ea-80d0-9d07839d7eca.png">

## Why?
Better tweets
