### PR TITLE
discussion-rendering@2.2.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "@emotion/core": "^10.0.28",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/consent-management-platform": "^3.0.4",
-        "@guardian/discussion-rendering": "^2.2.18",
+        "@guardian/discussion-rendering": "^2.2.20",
         "@guardian/src-button": "^0.17.0",
         "@guardian/src-ed-lines": "^0.18.0-rc.0",
         "@guardian/src-foundations": "^0.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2151,10 +2151,10 @@
     js-cookie "^2.2.1"
     whatwg-fetch "^3.0.0"
 
-"@guardian/discussion-rendering@^2.2.18":
-  version "2.2.18"
-  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-2.2.18.tgz#b3f03cf16a34a59e3c48c99f7d91eb55f76d7a3b"
-  integrity sha512-ZHrHX5zsJcpdeVroxc4+4DX9bULyr7ihuc8gf4eHHTALFHJaHnHq0f6yq5c9jJTjVX0d8GIIn8noSJEVOczjkA==
+"@guardian/discussion-rendering@^2.2.20":
+  version "2.2.20"
+  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-2.2.20.tgz#251433ff46d5b52dacc270cc7105f8d3cb49076c"
+  integrity sha512-FuCbBDaIuro1hhdCYoeSU+CEk3JWT2aA5G1s2ftIBG6v5oQF7RSTkN3emLXQEDrE3ydBeCw+QFpsyG8dmJDLXA==
   dependencies:
     react-focus-lock "^2.2.1"
     timeago.js "^4.0.2"


### PR DESCRIPTION
## What does this change?
Bumps discussion rendering to [v2.2.20](https://github.com/guardian/discussion-rendering/pull/273)