### PR TITLE
discussion-rendering@2.2.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "@emotion/core": "^10.0.28",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/consent-management-platform": "^3.0.4",
-        "@guardian/discussion-rendering": "^2.2.20",
+        "@guardian/discussion-rendering": "^2.2.21",
         "@guardian/src-button": "^0.17.0",
         "@guardian/src-ed-lines": "^0.18.0-rc.0",
         "@guardian/src-foundations": "^0.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2151,10 +2151,10 @@
     js-cookie "^2.2.1"
     whatwg-fetch "^3.0.0"
 
-"@guardian/discussion-rendering@^2.2.20":
-  version "2.2.20"
-  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-2.2.20.tgz#251433ff46d5b52dacc270cc7105f8d3cb49076c"
-  integrity sha512-FuCbBDaIuro1hhdCYoeSU+CEk3JWT2aA5G1s2ftIBG6v5oQF7RSTkN3emLXQEDrE3ydBeCw+QFpsyG8dmJDLXA==
+"@guardian/discussion-rendering@^2.2.21":
+  version "2.2.21"
+  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-2.2.21.tgz#3176b2a64a1b895ffa88e4ef95b79d398cd6d484"
+  integrity sha512-sIpH04NvEaVMvcJ+U8IDzZGMGIHYWAOAAP/V9+yM783uKUdv3E73zJZfOaY9lyLAnf6nhywY5mRb5WRJL799SQ==
   dependencies:
     react-focus-lock "^2.2.1"
     timeago.js "^4.0.2"


### PR DESCRIPTION
## What does this change?
Bumps dicussion-rendering to [v2.2.21](https://github.com/guardian/discussion-rendering/pull/273)
