### PR TITLE
Introduce ExplainerAtomBlockElement

### DIFF
--- a/docs/atoms.md
+++ b/docs/atoms.md
@@ -131,3 +131,6 @@ case class ExplainerAtomBlockElement(
 ) extends PageElement
 ```
 
+AMP: Currently not supported.
+
+WEB: Currently not supported. Awaiting new Atom library. 🚧

--- a/docs/atoms.md
+++ b/docs/atoms.md
@@ -88,7 +88,9 @@ TimelineBlockElement
     -> [amp] TimelineBlockComponent
 ```
 
-### Atom Documentation
+## Atom Documentation
+
+### AudioAtom
 
 `AudioAtomBlockElement`
 
@@ -102,5 +104,30 @@ TimelineBlockElement
 	    contentId: String
 	) extends PageElement
 	```
-	
-Example: [www](https://www.theguardian.com/football/blog/2020/may/06/bundesliga-football-puts-its-reputation-on-the-line-with-return-in-late-may), [data](https://www.theguardian.com/football/blog/2020/may/06/bundesliga-football-puts-its-reputation-on-the-line-with-return-in-late-may.json?dcr).
+
+AMP: See `AudioAtomBlockComponent` ✅
+
+WEB: Currently not supported. Awaiting new Atom library. 🚧
+
+### ChartAtom
+
+Comes to DCR as `AtomEmbedUrlBlockElement` 
+
+AMP: See `AtomEmbedUrlBlockComponent` ✅
+
+WEB: Currently not supported. Should be rendered using an iframe as it is treated as interactive. 🚧
+
+### CommonsDivision
+
+I question whether we should be supporting it in the first place given how very rare it is.
+
+### ExplainerAtom
+```
+case class ExplainerAtomBlockElement(
+    id: String, 
+    title: String, 
+    body: String, 
+    displayType: String
+) extends PageElement
+```
+

--- a/docs/atoms.md
+++ b/docs/atoms.md
@@ -134,3 +134,94 @@ case class ExplainerAtomBlockElement(
 AMP: Currently not supported.
 
 WEB: Currently not supported. Awaiting new Atom library. 🚧
+
+### InteractiveAtom
+
+```
+case class AtomEmbedUrlBlockElement(
+	url: String
+) extends PageElement
+```
+
+AMP: AtomEmbedUrlBlockComponent ✅
+
+WEB: Currently not supported. Should be rendered using an iframe. 🚧
+
+### GuideAtom
+
+```
+case class ProfileBlockElement(
+	id: String, 
+	label: String, 
+	title: String, 
+	img: Option[String], 
+	html: String, 
+	credit: String
+) extends PageElement
+```
+
+AMP: Expandable (Component) ✅
+
+WEB: Currently not supported. Awaiting new Atom library. 🚧
+
+### MediaAtom
+
+The MediaAtom is sent to DCR either as `YoutubeBlockElement` or `HTMLFallbackBlockElement`.
+
+```
+case class YoutubeBlockElement(
+	id: String, 
+	assetId: String, 
+	channelId: Option[String], 
+	mediaTitle: String
+) extends PageElement
+```
+
+AMP: YoutubeBlockComponent ✅
+
+WEB: YoutubeBlockComponent ✅
+
+### ProfileAtom
+
+```
+case class ProfileBlockElement(
+	id: String, 
+	label: String, 
+	title: String, 
+	img: Option[String], 
+	html: String, 
+	credit: String
+) extends PageElement
+```
+
+AMP: Expandable (Component) ✅
+
+WEB: Currently not supported. Awaiting new Atom library. 🚧
+
+### QuandaAtom
+
+```
+case class QABlockElement(
+	id: String, 
+	title: String, 
+	img: Option[String], 
+	html: String, 
+	credit: String
+) extends PageElement
+```
+
+AMP: Expandable (Component) ✅
+
+WEB: Currently not supported. Awaiting new Atom library. 🚧
+
+### QuizAtom
+
+Undocumented for the moment 🚧 ‼️
+
+### RecipeAtom
+
+I am not sure it's ever been used. ‼️
+
+### ReviewAtom
+
+Not found in AtomWorkshop ‼️

--- a/docs/atoms.md
+++ b/docs/atoms.md
@@ -88,12 +88,9 @@ TimelineBlockElement
     -> [amp] TimelineBlockComponent
 ```
 
+### Atom Documentation
 
-### Todo
-
-This section contains all the work that need to be done as part of this atom migration.
-
-- Build a DCR component that utilises the AudioAtom data passed to DCR by the backend carried by `AudioAtomBlockElement`
+`AudioAtomBlockElement`
 
 	```
 	case class AudioAtomBlockElement(
@@ -106,4 +103,4 @@ This section contains all the work that need to be done as part of this atom mig
 	) extends PageElement
 	```
 	
-	And example of a page with an AudioAtom is [here](https://www.theguardian.com/football/blog/2020/may/06/bundesliga-football-puts-its-reputation-on-the-line-with-return-in-late-may), and the data is already is the [data sent to DCR](https://www.theguardian.com/football/blog/2020/may/06/bundesliga-football-puts-its-reputation-on-the-line-with-return-in-late-may.json?dcr).
+Example: [www](https://www.theguardian.com/football/blog/2020/may/06/bundesliga-football-puts-its-reputation-on-the-line-with-return-in-late-may), [data](https://www.theguardian.com/football/blog/2020/may/06/bundesliga-football-puts-its-reputation-on-the-line-with-return-in-late-may.json?dcr).

--- a/docs/atoms.md
+++ b/docs/atoms.md
@@ -224,4 +224,4 @@ I am not sure it's ever been used. ‼️
 
 ### ReviewAtom
 
-Not found in AtomWorkshop ‼️
+Not found in AtomWorkshop ‼️ (According to Alex W. there actually isn't one.)

--- a/scripts/frontend/landing/index.html
+++ b/scripts/frontend/landing/index.html
@@ -229,6 +229,11 @@
                     article:
                         '/football/blog/2020/may/06/bundesliga-football-puts-its-reputation-on-the-line-with-return-in-late-may',
                 },
+                {
+                    name: 'ChartAtom',
+                    article:
+                        '/australia-news/2020/apr/07/coronavirus-crisis-has-had-staggering-impact-on-australian-businesses-data-reveals',
+                },
             ];
 
             var makeTestArticle = a => `

--- a/scripts/frontend/landing/index.html
+++ b/scripts/frontend/landing/index.html
@@ -234,6 +234,16 @@
                     article:
                         '/australia-news/2020/apr/07/coronavirus-crisis-has-had-staggering-impact-on-australian-businesses-data-reveals',
                 },
+                {
+                    name: 'ExplainerAtom',
+                    article:
+                        '/books/2020/may/07/poems-to-get-us-through-the-ghosts-of-cricketing-summers-knock-kit-wright-for-six-carol-ann-duffy-roller',
+                },
+                {
+                    name: 'GuideAtom',
+                    article:
+                        '/sport/2020/may/19/pinatubo-has-probably-trained-on-for-the-2000-guineas-says-charlie-appleby',
+                },
             ];
 
             var makeTestArticle = a => `

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -75,6 +75,14 @@ interface EmbedBlockElement {
     isMandatory: boolean;
 }
 
+interface ExplainerAtomBlockElement {
+    _type: 'model.dotcomrendering.pageElements.ExplainerAtomBlockElement';
+    id: string;
+    title: string;
+    body: string;
+    displayType: string;
+}
+
 interface GuideBlockElement {
     _type: 'model.dotcomrendering.pageElements.GuideBlockElement';
     id: string;
@@ -255,6 +263,7 @@ type CAPIElement =
     | DividerBlockElement
     | DocumentBlockElement
     | EmbedBlockElement
+    | ExplainerAtomBlockElement
     | GuideBlockElement
     | GuVideoBlockElement
     | ImageBlockElement

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -378,9 +378,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type"
-            ]
+            "required": ["_type"]
         },
         "AtomEmbedUrlBlockElement": {
             "type": "object",
@@ -395,10 +393,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "url"
-            ]
+            "required": ["_type", "url"]
         },
         "AudioAtomElement": {
             "type": "object",
@@ -444,9 +439,7 @@
                     ]
                 }
             },
-            "required": [
-                "_type"
-            ]
+            "required": ["_type"]
         },
         "BlockquoteBlockElement": {
             "type": "object",
@@ -461,10 +454,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "html"
-            ]
+            "required": ["_type", "html"]
         },
         "CodeBlockElement": {
             "type": "object",
@@ -479,10 +469,7 @@
                     "type": "boolean"
                 }
             },
-            "required": [
-                "_type",
-                "isMandatory"
-            ]
+            "required": ["_type", "isMandatory"]
         },
         "CommentBlockElement": {
             "type": "object",
@@ -535,10 +522,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "atomId"
-            ]
+            "required": ["_type", "atomId"]
         },
         "DisclaimerBlockElement": {
             "type": "object",
@@ -553,10 +537,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "html"
-            ]
+            "required": ["_type", "html"]
         },
         "DividerBlockElement": {
             "type": "object",
@@ -568,9 +549,7 @@
                     ]
                 }
             },
-            "required": [
-                "_type"
-            ]
+            "required": ["_type"]
         },
         "DocumentBlockElement": {
             "type": "object",
@@ -585,10 +564,7 @@
                     "type": "boolean"
                 }
             },
-            "required": [
-                "_type",
-                "isMandatory"
-            ]
+            "required": ["_type", "isMandatory"]
         },
         "EmbedBlockElement": {
             "type": "object",
@@ -612,11 +588,31 @@
                     "type": "boolean"
                 }
             },
-            "required": [
-                "_type",
-                "html",
-                "isMandatory"
-            ]
+            "required": ["_type", "html", "isMandatory"]
+        },
+        "ExplainerAtomBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.ExplainerAtomBlockElement"
+                    ]
+                },
+                "id": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "body": {
+                    "type": "string"
+                },
+                "displayType": {
+                    "type": "string"
+                }
+            },
+            "required": ["_type", "id", "title", "body", "displayType"]
         },
         "GuideBlockElement": {
             "type": "object",
@@ -646,14 +642,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "credit",
-                "html",
-                "id",
-                "label",
-                "title"
-            ]
+            "required": ["_type", "credit", "html", "id", "label", "title"]
         },
         "GuVideoBlockElement": {
             "type": "object",
@@ -674,11 +663,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "assets",
-                "caption"
-            ]
+            "required": ["_type", "assets", "caption"]
         },
         "VideoAssets": {
             "type": "object",
@@ -690,10 +675,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "mimeType",
-                "url"
-            ]
+            "required": ["mimeType", "url"]
         },
         "ImageBlockElement": {
             "type": "object",
@@ -714,9 +696,7 @@
                             }
                         }
                     },
-                    "required": [
-                        "allImages"
-                    ]
+                    "required": ["allImages"]
                 },
                 "data": {
                     "type": "object",
@@ -748,13 +728,7 @@
                     "$ref": "#/definitions/RoleType"
                 }
             },
-            "required": [
-                "_type",
-                "data",
-                "imageSources",
-                "media",
-                "role"
-            ]
+            "required": ["_type", "data", "imageSources", "media", "role"]
         },
         "Image": {
             "type": "object",
@@ -775,10 +749,7 @@
                             "type": "string"
                         }
                     },
-                    "required": [
-                        "height",
-                        "width"
-                    ]
+                    "required": ["height", "width"]
                 },
                 "mediaType": {
                     "type": "string"
@@ -790,13 +761,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "fields",
-                "index",
-                "mediaType",
-                "mimeType",
-                "url"
-            ]
+            "required": ["fields", "index", "mediaType", "mimeType", "url"]
         },
         "ImageSource": {
             "type": "object",
@@ -811,10 +776,7 @@
                     }
                 }
             },
-            "required": [
-                "srcSet",
-                "weighting"
-            ]
+            "required": ["srcSet", "weighting"]
         },
         "Weighting": {
             "enum": [
@@ -837,10 +799,7 @@
                     "type": "number"
                 }
             },
-            "required": [
-                "src",
-                "width"
-            ]
+            "required": ["src", "width"]
         },
         "RoleType": {
             "enum": [
@@ -872,12 +831,7 @@
                     "type": "boolean"
                 }
             },
-            "required": [
-                "_type",
-                "hasCaption",
-                "html",
-                "url"
-            ]
+            "required": ["_type", "hasCaption", "html", "url"]
         },
         "MapBlockElement": {
             "type": "object",
@@ -932,10 +886,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "images"
-            ]
+            "required": ["_type", "images"]
         },
         "ProfileBlockElement": {
             "type": "object",
@@ -965,14 +916,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "credit",
-                "html",
-                "id",
-                "label",
-                "title"
-            ]
+            "required": ["_type", "credit", "html", "id", "label", "title"]
         },
         "PullquoteBlockElement": {
             "type": "object",
@@ -993,11 +937,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "html",
-                "role"
-            ]
+            "required": ["_type", "html", "role"]
         },
         "QABlockElement": {
             "type": "object",
@@ -1024,13 +964,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "credit",
-                "html",
-                "id",
-                "title"
-            ]
+            "required": ["_type", "credit", "html", "id", "title"]
         },
         "RichLinkBlockElement": {
             "type": "object",
@@ -1057,12 +991,7 @@
                     "type": "number"
                 }
             },
-            "required": [
-                "_type",
-                "prefix",
-                "text",
-                "url"
-            ]
+            "required": ["_type", "prefix", "text", "url"]
         },
         "SoundcloudBlockElement": {
             "type": "object",
@@ -1086,13 +1015,7 @@
                     "type": "boolean"
                 }
             },
-            "required": [
-                "_type",
-                "html",
-                "id",
-                "isMandatory",
-                "isTrack"
-            ]
+            "required": ["_type", "html", "id", "isMandatory", "isTrack"]
         },
         "SubheadingBlockElement": {
             "type": "object",
@@ -1107,10 +1030,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "html"
-            ]
+            "required": ["_type", "html"]
         },
         "TableBlockElement": {
             "type": "object",
@@ -1125,10 +1045,7 @@
                     "type": "boolean"
                 }
             },
-            "required": [
-                "_type",
-                "isMandatory"
-            ]
+            "required": ["_type", "isMandatory"]
         },
         "TextBlockElement": {
             "type": "object",
@@ -1146,10 +1063,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "html"
-            ]
+            "required": ["_type", "html"]
         },
         "TimelineBlockElement": {
             "type": "object",
@@ -1176,12 +1090,7 @@
                     }
                 }
             },
-            "required": [
-                "_type",
-                "events",
-                "id",
-                "title"
-            ]
+            "required": ["_type", "events", "id", "title"]
         },
         "TimelineEvent": {
             "type": "object",
@@ -1199,10 +1108,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "date",
-                "title"
-            ]
+            "required": ["date", "title"]
         },
         "TweetBlockElement": {
             "type": "object",
@@ -1226,13 +1132,7 @@
                     "type": "boolean"
                 }
             },
-            "required": [
-                "_type",
-                "hasMedia",
-                "html",
-                "id",
-                "url"
-            ]
+            "required": ["_type", "hasMedia", "html", "id", "url"]
         },
         "VideoBlockElement": {
             "type": "object",
@@ -1244,9 +1144,7 @@
                     ]
                 }
             },
-            "required": [
-                "_type"
-            ]
+            "required": ["_type"]
         },
         "VideoFacebookBlockElement": {
             "type": "object",
@@ -1270,13 +1168,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "caption",
-                "height",
-                "url",
-                "width"
-            ]
+            "required": ["_type", "caption", "height", "url", "width"]
         },
         "VideoVimeoBlockElement": {
             "type": "object",
@@ -1300,13 +1192,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "caption",
-                "height",
-                "url",
-                "width"
-            ]
+            "required": ["_type", "caption", "height", "url", "width"]
         },
         "VideoYoutubeBlockElement": {
             "type": "object",
@@ -1330,13 +1216,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "caption",
-                "height",
-                "url",
-                "width"
-            ]
+            "required": ["_type", "caption", "height", "url", "width"]
         },
         "YoutubeBlockElement": {
             "type": "object",
@@ -1372,11 +1252,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "assetId",
-                "mediaTitle"
-            ]
+            "required": ["_type", "assetId", "mediaTitle"]
         },
         "Block": {
             "type": "object",
@@ -1512,10 +1388,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "elements",
-                "id"
-            ]
+            "required": ["elements", "id"]
         },
         "Pagination": {
             "type": "object",
@@ -1539,10 +1412,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "currentPage",
-                "totalPages"
-            ]
+            "required": ["currentPage", "totalPages"]
         },
         "AuthorType": {
             "type": "object",
@@ -1559,12 +1429,7 @@
             }
         },
         "Edition": {
-            "enum": [
-                "AU",
-                "INT",
-                "UK",
-                "US"
-            ],
+            "enum": ["AU", "INT", "UK", "US"],
             "type": "string"
         },
         "TagType": {
@@ -1589,11 +1454,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "id",
-                "title",
-                "type"
-            ]
+            "required": ["id", "title", "type"]
         },
         "Pillar": {
             "enum": [
@@ -1616,10 +1477,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "title",
-                "url"
-            ]
+            "required": ["title", "url"]
         },
         "ConfigType": {
             "description": "the config model will contain useful app/site\nlevel data. Although currently derived from the config model\nconstructed in frontend and passed to dotcom-rendering\nthis data could eventually be defined in dotcom-rendering",
@@ -1823,12 +1681,7 @@
                     "$ref": "#/definitions/EditionCommercialProperties"
                 }
             },
-            "required": [
-                "AU",
-                "INT",
-                "UK",
-                "US"
-            ]
+            "required": ["AU", "INT", "UK", "US"]
         },
         "EditionCommercialProperties": {
             "type": "object",
@@ -1843,9 +1696,7 @@
                     "$ref": "#/definitions/Branding"
                 }
             },
-            "required": [
-                "adTargeting"
-            ]
+            "required": ["adTargeting"]
         },
         "AdTargetParam": {
             "type": "object",
@@ -1867,10 +1718,7 @@
                     ]
                 }
             },
-            "required": [
-                "name",
-                "value"
-            ]
+            "required": ["name", "value"]
         },
         "Branding": {
             "type": "object",
@@ -1882,9 +1730,7 @@
                             "type": "string"
                         }
                     },
-                    "required": [
-                        "name"
-                    ]
+                    "required": ["name"]
                 },
                 "sponsorName": {
                     "type": "string"
@@ -1911,18 +1757,10 @@
                                     "type": "number"
                                 }
                             },
-                            "required": [
-                                "height",
-                                "width"
-                            ]
+                            "required": ["height", "width"]
                         }
                     },
-                    "required": [
-                        "dimensions",
-                        "label",
-                        "link",
-                        "src"
-                    ]
+                    "required": ["dimensions", "label", "link", "src"]
                 },
                 "aboutThisLink": {
                     "type": "string"
@@ -1943,10 +1781,7 @@
                                     "type": "number"
                                 }
                             },
-                            "required": [
-                                "height",
-                                "width"
-                            ]
+                            "required": ["height", "width"]
                         },
                         "link": {
                             "type": "string"
@@ -1955,19 +1790,10 @@
                             "type": "string"
                         }
                     },
-                    "required": [
-                        "dimensions",
-                        "label",
-                        "link",
-                        "src"
-                    ]
+                    "required": ["dimensions", "label", "link", "src"]
                 }
             },
-            "required": [
-                "aboutThisLink",
-                "logo",
-                "sponsorName"
-            ]
+            "required": ["aboutThisLink", "logo", "sponsorName"]
         },
         "BadgeType": {
             "type": "object",
@@ -1979,10 +1805,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "imageUrl",
-                "seriesTag"
-            ]
+            "required": ["imageUrl", "seriesTag"]
         },
         "FooterType": {
             "type": "object",
@@ -1997,9 +1820,7 @@
                     }
                 }
             },
-            "required": [
-                "footerLinks"
-            ]
+            "required": ["footerLinks"]
         },
         "FooterLink": {
             "type": "object",
@@ -2017,11 +1838,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "dataLinkName",
-                "text",
-                "url"
-            ]
+            "required": ["dataLinkName", "text", "url"]
         }
     },
     "$schema": "http://json-schema.org/draft-07/schema#"

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -53,6 +53,8 @@ export const ArticleRenderer: React.FC<{
                             alt={element.alt}
                         />
                     );
+                case 'model.dotcomrendering.pageElements.ExplainerAtomBlockElement':
+                    return null; // awaiting the coming atom support (wip)
                 case 'model.dotcomrendering.pageElements.ImageBlockElement':
                     return (
                         <ImageBlockComponent


### PR DESCRIPTION
## What does this change?

This introduces the type `ExplainerAtomBlockElement` which is missing in DCR as well as additional documentation about the content atoms. The documentation is to help with the current article migration and the building of a dedicated library.  Also the index page atom index is updated.