### PR TITLE
Remove displayType as attribute of ExplainerAtomBlockElement

### DIFF
--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -80,7 +80,6 @@ interface ExplainerAtomBlockElement {
     id: string;
     title: string;
     body: string;
-    displayType: string;
 }
 
 interface GuideBlockElement {

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -607,9 +607,6 @@
                 },
                 "body": {
                     "type": "string"
-                },
-                "displayType": {
-                    "type": "string"
                 }
             },
             "required": ["_type", "id", "title", "body", "displayType"]


### PR DESCRIPTION
## What does this change?

Remove `displayType` as attribute of `ExplainerAtomBlockElement`. It appears that it's actually not being used. 
