### PR TITLE
Explainer atom

### DIFF
--- a/fixtures/articles/Feature.ts
+++ b/fixtures/articles/Feature.ts
@@ -1998,6 +1998,14 @@ export const Feature: CAPIType = {
                 },
                 {
                     _type:
+                        'model.dotcomrendering.pageElements.ExplainerAtomBlockElement',
+                    id: 'abc123',
+                    title: 'Cranes Lean In by Imtiaz Dharker',
+                    body:
+                        '<p>Cranes lean in, waiting for an all-clear<br>that will not come.&nbsp;</p><p>Forehead pressed to glass,<br>phone at my ear, I learn</p><p>to sail on your voice<br>over a sadness of building sites,&nbsp;</p><p>past King’s Cross, St Pancras,<br>to the place where you are.</p><p>You say nothing<br>is too far, mothers</p><p>will find their daughters,<br>strangers will be neighbours,</p><p>even saviours<br>will have names.</p><p>You are all flame<br>in a red dress.&nbsp;&nbsp;</p><p>Petals brush my face.<br>You say at last</p><p>the cherry blossom<br>has arrived</p><p>as if that is what<br>we were really waiting for.</p>',
+                },
+                {
+                    _type:
                         'model.dotcomrendering.pageElements.TextBlockElement',
                     html:
                         '<p><strong>… on dairy products<br></strong>“I think we’ve become very disconnected from the natural world, many of us are guilty of an egocentric worldview and we believe that we’re the centre of the universe. We go into the natural world and we plunder it for its resources, we feel entitled to artificially inseminate a cow and steal her baby even though her cries of anguish are unmistakeable. Then we take her milk intended for her calf and we put it in our coffee and our cereal.”</p>',

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "dependencies": {
         "@babel/runtime": "^7.9.2",
         "@emotion/core": "^10.0.28",
+        "@guardian/atoms-rendering": "^1.2.0",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/consent-management-platform": "^3.0.4",
         "@guardian/discussion-rendering": "^2.2.20",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dependencies": {
         "@babel/runtime": "^7.9.2",
         "@emotion/core": "^10.0.28",
-        "@guardian/atoms-rendering": "^1.2.0",
+        "@guardian/atoms-rendering": "^1.3.3",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/consent-management-platform": "^3.0.4",
         "@guardian/discussion-rendering": "^2.2.20",

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -36,7 +36,6 @@ export const ArticleRenderer: React.FC<{
 
     const output = elements
         .map((element, i) => {
-            console.log({ element });
             switch (element._type) {
                 case 'model.dotcomrendering.pageElements.BlockquoteBlockElement':
                     return (

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -14,6 +14,8 @@ import { TextBlockComponent } from '@root/src/web/components/elements/TextBlockC
 import { TweetBlockComponent } from '@root/src/web/components/elements/TweetBlockComponent';
 import { YoutubeBlockComponent } from '@root/src/web/components/elements/YoutubeBlockComponent';
 
+import { ExplainerAtom } from '@guardian/atoms-rendering';
+
 // This is required for spacefinder to work!
 const commercialPosition = css`
     position: relative;
@@ -34,6 +36,7 @@ export const ArticleRenderer: React.FC<{
 
     const output = elements
         .map((element, i) => {
+            console.log({ element });
             switch (element._type) {
                 case 'model.dotcomrendering.pageElements.BlockquoteBlockElement':
                     return (
@@ -54,7 +57,14 @@ export const ArticleRenderer: React.FC<{
                         />
                     );
                 case 'model.dotcomrendering.pageElements.ExplainerAtomBlockElement':
-                    return null; // awaiting the coming atom support (wip)
+                    return (
+                        <ExplainerAtom
+                            key={i}
+                            id={element.id}
+                            title={element.title}
+                            html={element.body}
+                        />
+                    );
                 case 'model.dotcomrendering.pageElements.ImageBlockElement':
                     return (
                         <ImageBlockComponent

--- a/yarn.lock
+++ b/yarn.lock
@@ -2137,10 +2137,10 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
-"@guardian/atoms-rendering@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-1.2.0.tgz#057bd790bb92fc0f5269414902b53c2e6d5eac2a"
-  integrity sha512-eFftfnmuAEyLWOj7opatVHW+feL8bS9b6g+YnkfRiNCzg+7BJNdvlKXXf1qYmUqF55n9SplkrtmqHYZlTUmUYQ==
+"@guardian/atoms-rendering@^1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-1.3.3.tgz#5142fc6bfb8cf90024edad09c3aee039c3e75f38"
+  integrity sha512-Uug54iosZNTOcoSsRQ4GyEIUUiA5Dg+0ikrkQJOP+wSFdGhoYKBGcS39COXZ0V8xcij/hnopiIJeOVxMW3x5Uw==
 
 "@guardian/automat-client@^0.2.16":
   version "0.2.16"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2137,6 +2137,11 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
+"@guardian/atoms-rendering@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-1.2.0.tgz#057bd790bb92fc0f5269414902b53c2e6d5eac2a"
+  integrity sha512-eFftfnmuAEyLWOj7opatVHW+feL8bS9b6g+YnkfRiNCzg+7BJNdvlKXXf1qYmUqF55n9SplkrtmqHYZlTUmUYQ==
+
 "@guardian/automat-client@^0.2.16":
   version "0.2.16"
   resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.16.tgz#3ef47e7f49e633aea51c67f061d8d313a26fa9bc"


### PR DESCRIPTION
## What does this change?
Adds support for rendering Explainer Atoms

This PR is just plumbing. It brings together work in [atoms-rendering](https://github.com/guardian/atoms-rendering) to render the component and is pending the backend changes to bring the data down to DCR in the expected format.

```typescript
interface ExplainerAtomBlockElement {
    _type: 'model.dotcomrendering.pageElements.ExplainerAtomBlockElement';
    id: string;
    title: string;
    body: string;
}
```

![Screenshot 2020-05-29 at 17 20 06](https://user-images.githubusercontent.com/1336821/83281874-a9aa4800-a1d0-11ea-9be9-6641a8d7ce7f.jpg)
