### PR TITLE
Update pullquote element to be full width at low breakpoint

### DIFF
--- a/src/web/components/elements/PullQuoteBlockComponent.tsx
+++ b/src/web/components/elements/PullQuoteBlockComponent.tsx
@@ -4,7 +4,7 @@ import { QuoteIcon } from '@frontend/web/components/QuoteIcon';
 import { pillarPalette } from '@root/src/lib/pillars';
 import { neutral } from '@guardian/src-foundations/palette';
 import { headline } from '@guardian/src-foundations/typography';
-import { from } from '@guardian/src-foundations/mq';
+import { from, until } from '@guardian/src-foundations/mq';
 import { unescapeData } from '@root/src/lib/escapeData';
 
 const gutter = 20;
@@ -72,6 +72,10 @@ const supportingStyles = css`
     margin-right: 0.6rem;
     clear: left;
     float: left;
+
+    ${until.mobileMedium} {
+        width: 100%;
+    }
 
     ${from.leftCol} {
         margin-left: -${gutter / 2 + gsSpan(3) / 2}px;


### PR DESCRIPTION
## What does this change?
Makes the pullquote element full width on lowest breakpoint

### Before
<img width="194" alt="Screen Shot 2020-06-01 at 10 37 56" src="https://user-images.githubusercontent.com/2051501/83397212-24ec4380-a3f5-11ea-90de-8ee3c43f572e.png">

### After
<img width="194" alt="Screen Shot 2020-06-01 at 10 37 28" src="https://user-images.githubusercontent.com/2051501/83397223-2a498e00-a3f5-11ea-9868-67ee6b57b1aa.png">

## Why?
For parity with frontend, and because it looked a  bit borked
https://trello.com/c/BL5qIg8d/1575-pullquotes-should-be-full-width-on-mobile
