### PR TITLE
Add support for supported by badging

### DIFF
--- a/src/web/components/ArticleMeta.stories.tsx
+++ b/src/web/components/ArticleMeta.stories.tsx
@@ -65,6 +65,46 @@ export const ArticleStory = () => {
         </Container>
     );
 };
+
+export const BrandingStory = () => {
+    return (
+        <Container>
+            <ArticleMeta
+                branding={{
+                    sponsorName: 'Humanity United',
+                    logo: {
+                        src:
+                            'https://static.theguardian.com/commercial/sponsor/14/May/2018/533d381b-ac99-4e10-83be-8b64a1da9710-hu.png',
+                        dimensions: { width: 140, height: 90 },
+                        link: 'http://www.humanityunited.org/ ',
+                        label: 'Supported by',
+                    },
+                    logoForDarkBackground: {
+                        src:
+                            'https://static.theguardian.com/commercial/sponsor/14/May/2018/4192d462-d794-4f07-a43c-6b546f4dcd93-hu-white.png',
+                        dimensions: { width: 140, height: 39 },
+                        link: 'http://www.humanityunited.org/ ',
+                        label: 'Supported by',
+                    },
+                    aboutThisLink:
+                        'https://www.theguardian.com/info/2016/jan/25/content-funding',
+                }}
+                display="standard"
+                designType="Article"
+                pillar="news"
+                pageId=""
+                webTitle=""
+                author={{
+                    byline: 'Lanre Bakare',
+                    twitterHandle: 'lanre_bakare',
+                }}
+                tags={tagsWithBylineImage}
+                webPublicationDateDisplay="Sun 12 Jan 2020 18.00 GMT"
+            />
+        </Container>
+    );
+};
+
 ArticleStory.story = { name: 'Article' };
 
 export const FeatureStory = () => {

--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -6,12 +6,15 @@ import { Contributor } from '@root/src/web/components/Contributor';
 import { Avatar } from '@root/src/web/components/Avatar';
 
 import { getSharingUrls } from '@root/src/lib/sharing-urls';
+import { Branding } from '@root/src/web/components/Branding';
 import { SharingIcons } from './ShareIcons';
 import { Dateline } from './Dateline';
 
 type Props = {
+    branding: Branding;
     display: Display;
     designType: DesignType;
+    editionCommercialProperties: EditionCommercialProperties;
     pillar: Pillar;
     pageId: string;
     webTitle: string;
@@ -120,6 +123,14 @@ const shouldShowAvatar = (designType: DesignType, display: Display) => {
     }
 };
 
+const shouldShowBranding = (
+    editionCommercialProperties: EditionCommercialProperties,
+) => {
+    if (editionCommercialProperties.branding !== undefined) {
+        return true;
+    }
+};
+
 const shouldShowContributor = (designType: DesignType, display: Display) => {
     if (display === 'immersive') {
         return false;
@@ -197,8 +208,10 @@ const RowBelowLeftCol = ({
 );
 
 export const ArticleMeta = ({
+    branding,
     display,
     designType,
+    editionCommercialProperties,
     pillar,
     pageId,
     webTitle,
@@ -230,6 +243,10 @@ export const ArticleMeta = ({
                                 />
                             </AvatarContainer>
                         )}
+                        {shouldShowBranding && (
+                            <Branding branding={branding} pillar={pillar} />
+                        )}
+
                         <div>
                             {shouldShowContributor(designType, display) && (
                                 <Contributor

--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -221,6 +221,7 @@ export const ArticleMeta = ({
     return (
         <div className={metaContainer}>
             <div className={cx(meta)}>
+                {branding && <Branding branding={branding} pillar={pillar} />}
                 <RowBelowLeftCol>
                     <>
                         {showAvatar && bylineImageUrl && (
@@ -232,10 +233,6 @@ export const ArticleMeta = ({
                                 />
                             </AvatarContainer>
                         )}
-                        {branding && (
-                            <Branding branding={branding} pillar={pillar} />
-                        )}
-
                         <div>
                             {shouldShowContributor(designType, display) && (
                                 <Contributor

--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -11,16 +11,15 @@ import { SharingIcons } from './ShareIcons';
 import { Dateline } from './Dateline';
 
 type Props = {
-    branding: Branding;
     display: Display;
     designType: DesignType;
-    editionCommercialProperties: EditionCommercialProperties;
     pillar: Pillar;
     pageId: string;
     webTitle: string;
     author: AuthorType;
     tags: TagType[];
     webPublicationDateDisplay: string;
+    branding?: Branding;
 };
 
 const meta = css`
@@ -123,14 +122,6 @@ const shouldShowAvatar = (designType: DesignType, display: Display) => {
     }
 };
 
-const shouldShowBranding = (
-    editionCommercialProperties: EditionCommercialProperties,
-) => {
-    if (editionCommercialProperties.branding !== undefined) {
-        return true;
-    }
-};
-
 const shouldShowContributor = (designType: DesignType, display: Display) => {
     if (display === 'immersive') {
         return false;
@@ -211,7 +202,6 @@ export const ArticleMeta = ({
     branding,
     display,
     designType,
-    editionCommercialProperties,
     pillar,
     pageId,
     webTitle,
@@ -228,7 +218,6 @@ export const ArticleMeta = ({
 
     const showAvatar =
         onlyOneContributor && shouldShowAvatar(designType, display);
-
     return (
         <div className={metaContainer}>
             <div className={cx(meta)}>
@@ -243,7 +232,7 @@ export const ArticleMeta = ({
                                 />
                             </AvatarContainer>
                         )}
-                        {shouldShowBranding && (
+                        {branding && (
                             <Branding branding={branding} pillar={pillar} />
                         )}
 

--- a/src/web/components/Branding.tsx
+++ b/src/web/components/Branding.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { LinkStyle } from '@root/src/amp/components/elements/TextBlockComponent';
 import { textSans } from '@guardian/src-foundations/typography';
 import { css } from 'emotion';
-import { ImageWrapper } from './Card/components/ImageWrapper';
 
 const brandingStyle = (pillar: Pillar) => css`
     padding: 10px 0;

--- a/src/web/components/Branding.tsx
+++ b/src/web/components/Branding.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { LinkStyle } from '@root/src/amp/components/elements/TextBlockComponent';
 import { textSans } from '@guardian/src-foundations/typography';
+
 import { css } from 'emotion';
+import { palette } from '@guardian/src-foundations';
 
 const brandingStyle = (pillar: Pillar) => css`
-    padding: 10px 0;
+    padding-bottom: 10px;
     ${LinkStyle(pillar)}
 
     a, a:hover {
@@ -16,6 +18,8 @@ const brandingStyle = (pillar: Pillar) => css`
 
 const brandingLabelStyle = css`
     ${textSans.xsmall()};
+    color: ${palette.neutral[46]};
+    font-weight: bold;
 `;
 
 const brandingLogoStyle = css`

--- a/src/web/components/Branding.tsx
+++ b/src/web/components/Branding.tsx
@@ -27,6 +27,7 @@ export const Branding: React.FC<{
     branding: Branding;
     pillar: Pillar;
 }> = ({ branding, pillar }) => {
+    if (!branding) return null;
     return (
         <div className={brandingStyle(pillar)}>
             <div className={brandingLabelStyle}>{branding.logo.label}</div>
@@ -37,14 +38,12 @@ export const Branding: React.FC<{
                 rel="nofollow"
                 aria-label={`Visit the ${branding.sponsorName} website`}
             >
-                <ImageWrapper>
-                    <img
-                        src={branding.logo.src}
-                        width={branding.logo.dimensions.width}
-                        height={branding.logo.dimensions.height}
-                        alt={branding.sponsorName}
-                    />
-                </ImageWrapper>
+                <img
+                    src={branding.logo.src}
+                    width={branding.logo.dimensions.width}
+                    height={branding.logo.dimensions.height}
+                    alt={branding.sponsorName}
+                />
             </a>
             <a href={branding.aboutThisLink}>About this content</a>
         </div>

--- a/src/web/components/Branding.tsx
+++ b/src/web/components/Branding.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { LinkStyle } from '@root/src/amp/components/elements/TextBlockComponent';
+import { textSans } from '@guardian/src-foundations/typography';
+import { css } from 'emotion';
+import { ImageWrapper } from './Card/components/ImageWrapper';
+
+const brandingStyle = (pillar: Pillar) => css`
+    padding: 10px 0;
+    ${LinkStyle(pillar)}
+
+    a, a:hover {
+        display: block;
+        border-bottom: none;
+        ${textSans.xsmall()}
+    }
+`;
+
+const brandingLabelStyle = css`
+    ${textSans.xsmall()};
+`;
+
+const brandingLogoStyle = css`
+    padding: 10px 0;
+`;
+
+export const Branding: React.FC<{
+    branding: Branding;
+    pillar: Pillar;
+}> = ({ branding, pillar }) => {
+    return (
+        <div className={brandingStyle(pillar)}>
+            <div className={brandingLabelStyle}>{branding.logo.label}</div>
+            <a
+                className={brandingLogoStyle}
+                href={branding.logo.link}
+                data-sponsor={branding.sponsorName.toLowerCase()}
+                rel="nofollow"
+                aria-label={`Visit the ${branding.sponsorName} website`}
+            >
+                <ImageWrapper>
+                    <img
+                        src={branding.logo.src}
+                        width={branding.logo.dimensions.width}
+                        height={branding.logo.dimensions.height}
+                        alt={branding.sponsorName}
+                    />
+                </ImageWrapper>
+            </a>
+            <a href={branding.aboutThisLink}>About this content</a>
+        </div>
+    );
+};

--- a/src/web/components/Branding.tsx
+++ b/src/web/components/Branding.tsx
@@ -1,29 +1,31 @@
 import React from 'react';
-import { LinkStyle } from '@root/src/amp/components/elements/TextBlockComponent';
 import { textSans } from '@guardian/src-foundations/typography';
 
 import { css } from 'emotion';
-import { palette } from '@guardian/src-foundations';
+import { neutral } from '@guardian/src-foundations';
+import { pillarPalette } from '@root/src/lib/pillars';
 
-const brandingStyle = (pillar: Pillar) => css`
+const brandingStyle = css`
     padding-bottom: 10px;
-    ${LinkStyle(pillar)}
-
-    a, a:hover {
-        display: block;
-        border-bottom: none;
-        ${textSans.xsmall()}
-    }
 `;
 
 const brandingLabelStyle = css`
-    ${textSans.xsmall()};
-    color: ${palette.neutral[46]};
-    font-weight: bold;
+    ${textSans.xsmall({ fontWeight: 'bold' })};
+    color: ${neutral[46]};
 `;
 
 const brandingLogoStyle = css`
     padding: 10px 0;
+`;
+
+const brandingAboutLink = (pillar: Pillar) => css`
+    color: ${pillarPalette[pillar].main};
+    ${textSans.xsmall()}
+    display: block;
+    text-decoration: none;
+    &:hover {
+        text-decoration: underline;
+    }
 `;
 
 export const Branding: React.FC<{
@@ -32,7 +34,7 @@ export const Branding: React.FC<{
 }> = ({ branding, pillar }) => {
     if (!branding) return null;
     return (
-        <div className={brandingStyle(pillar)}>
+        <div className={brandingStyle}>
             <div className={brandingLabelStyle}>{branding.logo.label}</div>
             <a
                 className={brandingLogoStyle}
@@ -48,7 +50,12 @@ export const Branding: React.FC<{
                     alt={branding.sponsorName}
                 />
             </a>
-            <a href={branding.aboutThisLink}>About this content</a>
+            <a
+                href={branding.aboutThisLink}
+                className={brandingAboutLink(pillar)}
+            >
+                About this content
+            </a>
         </div>
     );
 };

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -243,6 +243,8 @@ export const CommentLayout = ({
 
     const age = getAgeWarning(CAPI.tags, CAPI.webPublicationDate);
 
+    const { branding } = CAPI.commercialProperties[CAPI.editionId];
+
     return (
         <>
             <div>
@@ -403,6 +405,7 @@ export const CommentLayout = ({
                     <GridItem area="meta">
                         <div className={maxWidth}>
                             <ArticleMeta
+                                branding={branding}
                                 display={display}
                                 designType={designType}
                                 pillar={pillar}

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -211,6 +211,7 @@ export const ImmersiveLayout = ({
 
     const mainMedia = CAPI.mainMediaElements[0] as ImageBlockElement;
     const captionText = decideCaption(mainMedia);
+    const { branding } = CAPI.commercialProperties[CAPI.editionId];
 
     return (
         <>
@@ -378,6 +379,7 @@ export const ImmersiveLayout = ({
                     <GridItem area="meta">
                         <div className={maxWidth}>
                             <ArticleMeta
+                                branding={branding}
                                 display={display}
                                 designType={designType}
                                 pillar={pillar}

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -263,6 +263,8 @@ export const ShowcaseLayout = ({
 
     const age = getAgeWarning(CAPI.tags, CAPI.webPublicationDate);
 
+    const { branding } = CAPI.commercialProperties[CAPI.editionId];
+
     return (
         <>
             <div>
@@ -415,6 +417,7 @@ export const ShowcaseLayout = ({
                     <GridItem area="meta">
                         <div className={maxWidth}>
                             <ArticleMeta
+                                branding={branding}
                                 display={display}
                                 designType={designType}
                                 pillar={pillar}

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -251,8 +251,6 @@ export const StandardLayout = ({
 
     const { branding } = CAPI.commercialProperties[CAPI.editionId];
 
-    console.log(branding);
-
     return (
         <>
             <div>

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -249,6 +249,10 @@ export const StandardLayout = ({
 
     const age = getAgeWarning(CAPI.tags, CAPI.webPublicationDate);
 
+    const { branding } = CAPI.commercialProperties[CAPI.editionId];
+
+    console.log(branding);
+
     return (
         <>
             <div>
@@ -402,6 +406,7 @@ export const StandardLayout = ({
                     <GridItem area="meta">
                         <div className={maxWidth}>
                             <ArticleMeta
+                                branding={branding}
                                 display={display}
                                 designType={designType}
                                 pillar={pillar}


### PR DESCRIPTION
## What does this change?
Adds the rendering of 'commercial' badges to Web. 'Commercial' happens to handle all the badging for articles, regardless of whether or not it's actually a commercial sponsorship.



### Frontend
<img width="336" alt="Screen Shot 2020-06-02 at 14 01 25" src="https://user-images.githubusercontent.com/2051501/83523234-c8168900-a4d9-11ea-9a79-23cc3a24728f.png">
<img width="379" alt="Screen Shot 2020-06-02 at 14 02 18" src="https://user-images.githubusercontent.com/2051501/83523261-d49ae180-a4d9-11ea-981b-72dd668e7ada.png">


### DCR
<img width="336" alt="Screen Shot 2020-06-02 at 14 01 56" src="https://user-images.githubusercontent.com/2051501/83523236-c947b600-a4d9-11ea-8c1d-69e86401306c.png">
<img width="379" alt="Screen Shot 2020-06-02 at 14 02 27" src="https://user-images.githubusercontent.com/2051501/83523295-e11f3a00-a4d9-11ea-878d-975167c7ceae.png">

## Why?
https://trello.com/c/znrv4cCk/1674-add-support-for-supported-by-badging
