### PR TITLE
White Headline

### DIFF
--- a/src/web/components/ArticleHeadline.stories.tsx
+++ b/src/web/components/ArticleHeadline.stories.tsx
@@ -369,6 +369,30 @@ export const ImmersiveNoMainMedia = () => (
 );
 ImmersiveNoMainMedia.story = { name: 'Immersive (with no main media)' };
 
+export const ImmersiveComment = () => (
+    <Section
+        showSideBorders={false}
+        showTopBorder={false}
+        backgroundColour="orange"
+    >
+        <Flex>
+            <LeftColumn>
+                <></>
+            </LeftColumn>
+            <ArticleContainer>
+                <ArticleHeadline
+                    headlineString="This is the headline you see when display type is Immersive and designType Comment"
+                    display="immersive"
+                    designType="Comment"
+                    pillar="news"
+                    tags={[]}
+                />
+            </ArticleContainer>
+        </Flex>
+    </Section>
+);
+ImmersiveComment.story = { name: 'Immersive opinion piece' };
+
 export const GuardianView = () => (
     <Section>
         <Flex>

--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -133,6 +133,13 @@ const blackBackground = css`
     background-color: black;
 `;
 
+const invertedText = css`
+    color: white;
+    white-space: pre-wrap;
+    padding-bottom: ${space[1]}px;
+    padding-right: ${space[1]}px;
+`;
+
 const maxWidth = css`
     ${from.desktop} {
         max-width: 620px;
@@ -166,38 +173,75 @@ export const ArticleHeadline = ({
 }: Props) => {
     switch (display) {
         case 'immersive': {
-            if (noMainMedia) {
-                return (
-                    // Immersive headlines have two versions, with main media, and (this one) without
-                    <h1
-                        className={cx(
-                            jumboFont,
-                            maxWidth,
-                            immersiveStyles,
-                            displayBlock,
-                        )}
-                    >
-                        {curly(headlineString)}
-                    </h1>
-                );
+            switch (designType) {
+                case 'Comment':
+                case 'GuardianView':
+                    return (
+                        <>
+                            <h1 className={cx(lightFont, invertedText)}>
+                                {curly(headlineString)}
+                            </h1>
+                            {byline && (
+                                <HeadlineByline
+                                    display={display}
+                                    designType={designType}
+                                    pillar={pillar}
+                                    byline={byline}
+                                    tags={tags}
+                                />
+                            )}
+                        </>
+                    );
+                case 'Review':
+                case 'Recipe':
+                case 'Feature':
+                case 'Analysis':
+                case 'Interview':
+                case 'Live':
+                case 'Media':
+                case 'PhotoEssay':
+                case 'Article':
+                case 'SpecialReport':
+                case 'MatchReport':
+                case 'GuardianLabs':
+                case 'Quiz':
+                case 'AdvertisementFeature':
+                case 'Immersive':
+                default:
+                    if (noMainMedia) {
+                        return (
+                            // Immersive headlines have two versions, with main media, and (this one) without
+                            <h1
+                                className={cx(
+                                    jumboFont,
+                                    maxWidth,
+                                    immersiveStyles,
+                                    displayBlock,
+                                )}
+                            >
+                                {curly(headlineString)}
+                            </h1>
+                        );
+                    }
+                    return (
+                        // Immersive headlines with main media present, are large and inverted with
+                        // a black background
+                        <h1 className={cx(invertedWrapper, blackBackground)}>
+                            <span
+                                className={cx(
+                                    jumboFont,
+                                    maxWidth,
+                                    invertedStyles,
+                                    immersiveStyles,
+                                    displayBlock,
+                                )}
+                            >
+                                {curly(headlineString)}
+                            </span>
+                        </h1>
+                    );
             }
-            return (
-                // Immersive headlines with main media present, are large and inverted with
-                // a black background
-                <h1 className={cx(invertedWrapper, blackBackground)}>
-                    <span
-                        className={cx(
-                            jumboFont,
-                            maxWidth,
-                            invertedStyles,
-                            immersiveStyles,
-                            displayBlock,
-                        )}
-                    >
-                        {curly(headlineString)}
-                    </span>
-                </h1>
-            );
+            break;
         }
         case 'showcase':
         case 'standard': {


### PR DESCRIPTION
## What does this change?
Show a white headline for immersive comment pieces

### Before
![Screenshot 2020-06-03 at 19 48 43](https://user-images.githubusercontent.com/1336821/83676872-4145d700-a5d3-11ea-91fa-7b7e31ba2984.jpg)


### After
![Screenshot 2020-06-03 at 19 47 26](https://user-images.githubusercontent.com/1336821/83676756-16f41980-a5d3-11ea-9162-30abeba501d0.jpg)

## Why?
In preparation for the new immersive comment layout
![Screenshot 2020-06-03 at 19 49 13](https://user-images.githubusercontent.com/1336821/83676917-51f64d00-a5d3-11ea-9376-3925eefd326c.jpg)

### Why does it look broken?
Because this PR only adds partial support for the new layout. Further work is pending but because these styles aren't surfaced (there are no immersive comment pieces) we can release the code as it is
