### PR TITLE
White Byline

### DIFF
--- a/src/web/components/HeadlineByline.stories.tsx
+++ b/src/web/components/HeadlineByline.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-
+import { css } from 'emotion';
 import { HeadlineByline } from './HeadlineByline';
 
 export default {
@@ -51,6 +51,32 @@ export const immersiveStory = () => {
     );
 };
 immersiveStory.story = { name: 'Immersive' };
+
+export const ImmersiveComment = () => {
+    return (
+        <div
+            className={css`
+                background-color: lightgray;
+                padding: 20px;
+            `}
+        >
+            <HeadlineByline
+                display="immersive"
+                designType="Comment"
+                pillar="lifestyle"
+                byline="Jane Smith"
+                tags={[
+                    {
+                        id: '1',
+                        type: 'Contributor',
+                        title: 'Jane Smith',
+                    },
+                ]}
+            />
+        </div>
+    );
+};
+ImmersiveComment.story = { name: 'Immersive Comment' };
 
 export const MultipleStory = () => {
     return (

--- a/src/web/components/HeadlineByline.tsx
+++ b/src/web/components/HeadlineByline.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'emotion';
+import { css, cx } from 'emotion';
 import { brandAltBackground } from '@guardian/src-foundations/palette';
 import { headline } from '@guardian/src-foundations/typography';
 import { space } from '@guardian/src-foundations';
@@ -52,6 +52,10 @@ const opinionStyles = (pillar: Pillar) => css`
     }
 `;
 
+const whiteText = css`
+    color: white;
+`;
+
 const immersiveStyles = css`
     ${headline.xsmall({
         fontWeight: 'light',
@@ -89,14 +93,39 @@ export const HeadlineByline = ({
 }: Props) => {
     switch (display) {
         case 'immersive': {
-            return (
-                <div className={immersiveStyles}>
-                    by{' '}
-                    <span className={immersiveLinkStyles(pillar)}>
-                        <BylineLink byline={byline} tags={tags} />
-                    </span>
-                </div>
-            );
+            switch (designType) {
+                case 'GuardianView':
+                case 'Comment':
+                    return (
+                        <div className={cx(opinionStyles(pillar), whiteText)}>
+                            <BylineLink byline={byline} tags={tags} />
+                        </div>
+                    );
+                case 'Interview':
+                case 'Immersive':
+                case 'Analysis':
+                case 'Feature':
+                case 'Article':
+                case 'Media':
+                case 'PhotoEssay':
+                case 'Review':
+                case 'Live':
+                case 'SpecialReport':
+                case 'Recipe':
+                case 'MatchReport':
+                case 'GuardianLabs':
+                case 'Quiz':
+                case 'AdvertisementFeature':
+                default:
+                    return (
+                        <div className={immersiveStyles}>
+                            by{' '}
+                            <span className={immersiveLinkStyles(pillar)}>
+                                <BylineLink byline={byline} tags={tags} />
+                            </span>
+                        </div>
+                    );
+            }
         }
         case 'showcase':
         case 'standard': {


### PR DESCRIPTION
## What does this change?
Show white byline text for immersive comment pieces

### Before
![Screenshot 2020-06-03 at 20 08 53](https://user-images.githubusercontent.com/1336821/83678708-10b36c80-a5d6-11ea-9038-4e2f6b5e304e.jpg)

### After
![Screenshot 2020-06-03 at 20 08 04](https://user-images.githubusercontent.com/1336821/83678642-f8dbe880-a5d5-11ea-96bf-928c8b630d4b.jpg)

## Why?
In preparation for the new immersive comment layout
![Screenshot 2020-06-03 at 19 49 13](https://user-images.githubusercontent.com/1336821/83676917-51f64d00-a5d3-11ea-9376-3925eefd326c.jpg)

### Why does it look broken?
Because this PR only adds partial support for the new layout. Further work is pending but because these styles aren't surfaced (there are no immersive comment pieces) we can release the code as it is
