### PR TITLE
Refactored Article Title

### DIFF
--- a/src/web/components/ArticleTitle.stories.tsx
+++ b/src/web/components/ArticleTitle.stories.tsx
@@ -18,6 +18,8 @@ const CAPI = {
     guardianBaseURL: 'https://theguardian.com',
     inLeftCol: true,
     fallbackToSection: true,
+    sectionLabel: 'Section label',
+    sectionUrl: '/section_url',
 };
 const brexitCAPI = {
     ...CAPI,
@@ -53,8 +55,13 @@ export default {
 export const defaultStory = () => {
     return (
         <Container>
-            {/* eslint-disable-next-line react/jsx-props-no-spreading */}
-            <ArticleTitle {...brexitCAPI} display="standard" pillar="sport" />
+            <ArticleTitle
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                {...brexitCAPI}
+                display="standard"
+                pillar="sport"
+                designType="Article"
+            />
         </Container>
     );
 };
@@ -68,8 +75,159 @@ export const beyondTheBlade = () => {
                 {...beyondTheBladeCAPI}
                 display="standard"
                 pillar="news"
+                designType="Article"
             />
         </Container>
     );
 };
 beyondTheBlade.story = { name: 'Beyond the blade badge' };
+
+export const immersiveComment = () => {
+    return (
+        <div
+            className={css`
+                background-color: lightgray;
+                padding: 20px;
+            `}
+        >
+            <ArticleTitle
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                {...brexitCAPI}
+                display="immersive"
+                pillar="sport"
+                designType="Comment"
+            />
+        </div>
+    );
+};
+immersiveComment.story = { name: 'Immersive comment piece' };
+
+export const immersiveCommentTag = () => {
+    return (
+        <div
+            className={css`
+                background-color: lightgray;
+                padding: 20px;
+            `}
+        >
+            <ArticleTitle
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                {...CAPI}
+                display="immersive"
+                pillar="sport"
+                designType="Comment"
+                tags={[
+                    {
+                        id: '',
+                        title: 'Tag title',
+                        type: 'Blog',
+                    },
+                ]}
+            />
+        </div>
+    );
+};
+immersiveCommentTag.story = { name: 'Immersive comment piece with Blog tag' };
+
+export const ImmersiveSeriesTag = () => {
+    return (
+        <Container>
+            <ArticleTitle
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                {...CAPI}
+                display="immersive"
+                pillar="sport"
+                designType="Review"
+                tags={[
+                    {
+                        id: '',
+                        title: 'Series title',
+                        type: 'Series',
+                    },
+                ]}
+            />
+        </Container>
+    );
+};
+ImmersiveSeriesTag.story = { name: 'Immersive with a Series tag' };
+
+export const ArticleBlogTag = () => {
+    return (
+        <Container>
+            <ArticleTitle
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                {...CAPI}
+                display="standard"
+                pillar="sport"
+                designType="Article"
+                tags={[
+                    {
+                        id: '',
+                        title: 'Blog title',
+                        type: 'Blog',
+                    },
+                ]}
+            />
+        </Container>
+    );
+};
+ArticleBlogTag.story = { name: 'Article with a Blog tag' };
+
+export const ArticleOpinionTag = () => {
+    return (
+        <Container>
+            <ArticleTitle
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                {...CAPI}
+                display="standard"
+                pillar="sport"
+                designType="Article"
+                tags={[
+                    {
+                        id: '',
+                        title: 'Opinion title',
+                        type: 'Opinion',
+                    },
+                ]}
+            />
+        </Container>
+    );
+};
+ArticleOpinionTag.story = { name: 'Article with a Opinion tag' };
+
+export const ArticleSeriesTag = () => {
+    return (
+        <Container>
+            <ArticleTitle
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                {...CAPI}
+                display="standard"
+                pillar="sport"
+                designType="Article"
+                tags={[
+                    {
+                        id: '',
+                        title: 'Series title',
+                        type: 'Series',
+                    },
+                ]}
+            />
+        </Container>
+    );
+};
+ArticleSeriesTag.story = { name: 'Article with a Series tag' };
+
+export const ArticleNoTags = () => {
+    return (
+        <Container>
+            <ArticleTitle
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                {...CAPI}
+                display="standard"
+                pillar="culture"
+                designType="Article"
+            />
+        </Container>
+    );
+};
+ArticleNoTags.story = { name: 'Article with no tags' };

--- a/src/web/components/ArticleTitle.tsx
+++ b/src/web/components/ArticleTitle.tsx
@@ -7,6 +7,7 @@ import { SeriesSectionLink } from './SeriesSectionLink';
 
 type Props = {
     display: Display;
+    designType: DesignType;
     tags: TagType[];
     sectionLabel: string;
     sectionUrl: string;
@@ -49,6 +50,7 @@ const marginBottom = css`
 
 export const ArticleTitle = ({
     display,
+    designType,
     tags,
     sectionLabel,
     sectionUrl,
@@ -70,6 +72,7 @@ export const ArticleTitle = ({
         >
             <SeriesSectionLink
                 display={display}
+                designType={designType}
                 tags={tags}
                 sectionLabel={sectionLabel}
                 sectionUrl={sectionUrl}

--- a/src/web/components/ImmersiveHeadline.tsx
+++ b/src/web/components/ImmersiveHeadline.tsx
@@ -123,6 +123,7 @@ export const ImmersiveHeadline = ({
                     <PositionHeadline>
                         <ArticleTitle
                             display={display}
+                            designType={designType}
                             tags={tags}
                             sectionLabel={sectionLabel}
                             sectionUrl={sectionUrl}

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -123,7 +123,7 @@ export const SeriesSectionLink = ({
                         // We have a tag, we're not immersive, show both series and section titles
                         return (
                             // Sometimes the tags/titles are shown inline, sometimes stacked
-                            <div className={marginBottom}>
+                            <div className={cx(!badge && rowBelowLeftCol)}>
                                 <a
                                     href={`${guardianBaseURL}/${tag.id}`}
                                     className={cx(
@@ -156,18 +156,20 @@ export const SeriesSectionLink = ({
                     }
                     // There's no tag so fallback to section title
                     return (
-                        <a
-                            href={`${guardianBaseURL}/${sectionUrl}`}
-                            className={cx(
-                                sectionLabelLink,
-                                primaryStyle,
-                                whiteFont,
-                            )}
-                            data-component="section"
-                            data-link-name="article section"
-                        >
-                            <span>{sectionLabel}</span>
-                        </a>
+                        <div className={marginBottom}>
+                            <a
+                                href={`${guardianBaseURL}/${sectionUrl}`}
+                                className={cx(
+                                    sectionLabelLink,
+                                    primaryStyle,
+                                    whiteFont,
+                                )}
+                                data-component="section"
+                                data-link-name="article section"
+                            >
+                                <span>{sectionLabel}</span>
+                            </a>
+                        </div>
                     );
                 }
                 case 'Feature':

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -10,6 +10,7 @@ import { Hide } from '@frontend/web/components/Hide';
 
 type Props = {
     display: Display;
+    designType: DesignType;
     tags: TagType[];
     sectionLabel: string;
     sectionUrl: string;
@@ -78,6 +79,15 @@ const invertedStyle = (pillar: Pillar) => css`
     padding-bottom: ${space[1]}px;
 `;
 
+const whiteFont = css`
+    font-weight: 700;
+    ${headline.xxxsmall({ fontWeight: 'bold' })};
+    ${from.leftCol} {
+        ${headline.xxsmall({ fontWeight: 'bold' })};
+    }
+    color: ${neutral[100]};
+`;
+
 const secondaryStyle = css`
     ${headline.xxxsmall({ fontWeight: 'regular' })};
     display: block;
@@ -85,6 +95,7 @@ const secondaryStyle = css`
 
 export const SeriesSectionLink = ({
     display,
+    designType,
     tags,
     sectionLabel,
     sectionUrl,
@@ -102,93 +113,175 @@ export const SeriesSectionLink = ({
     );
 
     const hasSeriesTag = tag && tag.type === 'Series';
-    const isImmersive = display === 'immersive';
 
-    if (isImmersive && !hasSeriesTag) {
-        // Immersives show nothing at all if there's no series tag
-        return null;
-    }
+    switch (display) {
+        case 'immersive': {
+            switch (designType) {
+                case 'Comment':
+                case 'GuardianView': {
+                    if (tag) {
+                        // We have a tag, we're not immersive, show both series and section titles
+                        return (
+                            // Sometimes the tags/titles are shown inline, sometimes stacked
+                            <div className={marginBottom}>
+                                <a
+                                    href={`${guardianBaseURL}/${tag.id}`}
+                                    className={cx(
+                                        sectionLabelLink,
+                                        primaryStyle,
+                                        whiteFont,
+                                    )}
+                                    data-component="series"
+                                    data-link-name="article series"
+                                >
+                                    <span>{tag.title}</span>
+                                </a>
 
-    if (isImmersive && hasSeriesTag) {
-        // If it is immersive and has a series tag, show this
-        if (!tag) return null;
-        return (
-            <a
-                href={`${guardianBaseURL}/${tag.id}`}
-                className={cx(
-                    sectionLabelLink,
-                    pillarColours[pillar],
-                    invertedStyle(pillar),
-                )}
-                data-component="series"
-                data-link-name="article series"
-            >
-                <span>{tag.title}</span>
-            </a>
-        );
-    }
-
-    if (!tag) {
-        // There's no tag so fallback to section title
-        return (
-            <a
-                href={`${guardianBaseURL}/${sectionUrl}`}
-                className={cx(
-                    sectionLabelLink,
-                    pillarColours[pillar],
-                    primaryStyle,
-                )}
-                data-component="section"
-                data-link-name="article section"
-            >
-                <span>{sectionLabel}</span>
-            </a>
-        );
-    }
-
-    if (tag) {
-        // We have a tag, we're not immersive, show both series and section titles
-        return (
-            // Sometimes the tags/titles are shown inline, sometimes stacked
-            <div
-                className={cx(
-                    !badge && display !== 'immersive' && rowBelowLeftCol,
-                    display === 'immersive' && marginBottom,
-                )}
-            >
-                <a
-                    href={`${guardianBaseURL}/${tag.id}`}
-                    className={cx(
-                        sectionLabelLink,
-                        pillarColours[pillar],
-                        primaryStyle,
-                        isSpecial && yellowBackground,
-                    )}
-                    data-component="series"
-                    data-link-name="article series"
-                >
-                    <span>{tag.title}</span>
-                </a>
-
-                {display !== 'immersive' && (
-                    <Hide when="below" breakpoint="tablet">
+                                <Hide when="below" breakpoint="tablet">
+                                    <a
+                                        href={`${guardianBaseURL}/${sectionUrl}`}
+                                        className={cx(
+                                            sectionLabelLink,
+                                            secondaryStyle,
+                                            whiteFont,
+                                        )}
+                                        data-component="section"
+                                        data-link-name="article section"
+                                    >
+                                        <span>{sectionLabel}</span>
+                                    </a>
+                                </Hide>
+                            </div>
+                        );
+                    }
+                    // There's no tag so fallback to section title
+                    return (
                         <a
                             href={`${guardianBaseURL}/${sectionUrl}`}
                             className={cx(
                                 sectionLabelLink,
-                                pillarColours[pillar],
-                                secondaryStyle,
+                                primaryStyle,
+                                whiteFont,
                             )}
                             data-component="section"
                             data-link-name="article section"
                         >
                             <span>{sectionLabel}</span>
                         </a>
-                    </Hide>
-                )}
-            </div>
-        );
-    }
+                    );
+                }
+                case 'Feature':
+                case 'Review':
+                case 'Interview':
+                case 'Live':
+                case 'Media':
+                case 'PhotoEssay':
+                case 'Analysis':
+                case 'Article':
+                case 'SpecialReport':
+                case 'Recipe':
+                case 'MatchReport':
+                case 'GuardianLabs':
+                case 'Quiz':
+                case 'AdvertisementFeature':
+                case 'Immersive':
+                default: {
+                    if (hasSeriesTag) {
+                        if (!tag) return null; // Just to keep ts happy
+                        return (
+                            <a
+                                href={`${guardianBaseURL}/${tag.id}`}
+                                className={cx(
+                                    sectionLabelLink,
+                                    pillarColours[pillar],
+                                    invertedStyle(pillar),
+                                )}
+                                data-component="series"
+                                data-link-name="article series"
+                            >
+                                <span>{tag.title}</span>
+                            </a>
+                        );
+                    }
+                    // Immersives show nothing at all if there's no series tag
+                    return null;
+                }
+            }
+        }
+        case 'showcase':
+        case 'standard': {
+            switch (designType) {
+                case 'Comment':
+                case 'GuardianView':
+                case 'Feature':
+                case 'Review':
+                case 'Interview':
+                case 'Live':
+                case 'Media':
+                case 'PhotoEssay':
+                case 'Analysis':
+                case 'Article':
+                case 'SpecialReport':
+                case 'Recipe':
+                case 'MatchReport':
+                case 'GuardianLabs':
+                case 'Quiz':
+                case 'AdvertisementFeature':
+                case 'Immersive':
+                default: {
+                    if (tag) {
+                        // We have a tag, we're not immersive, show both series and section titles
+                        return (
+                            // Sometimes the tags/titles are shown inline, sometimes stacked
+                            <div className={cx(!badge && rowBelowLeftCol)}>
+                                <a
+                                    href={`${guardianBaseURL}/${tag.id}`}
+                                    className={cx(
+                                        sectionLabelLink,
+                                        pillarColours[pillar],
+                                        primaryStyle,
+                                        isSpecial && yellowBackground,
+                                    )}
+                                    data-component="series"
+                                    data-link-name="article series"
+                                >
+                                    <span>{tag.title}</span>
+                                </a>
 
-    return null;
+                                <Hide when="below" breakpoint="tablet">
+                                    <a
+                                        href={`${guardianBaseURL}/${sectionUrl}`}
+                                        className={cx(
+                                            sectionLabelLink,
+                                            pillarColours[pillar],
+                                            secondaryStyle,
+                                        )}
+                                        data-component="section"
+                                        data-link-name="article section"
+                                    >
+                                        <span>{sectionLabel}</span>
+                                    </a>
+                                </Hide>
+                            </div>
+                        );
+                    }
+                    // There's no tag so fallback to section title
+                    return (
+                        <a
+                            href={`${guardianBaseURL}/${sectionUrl}`}
+                            className={cx(
+                                sectionLabelLink,
+                                pillarColours[pillar],
+                                primaryStyle,
+                            )}
+                            data-component="section"
+                            data-link-name="article section"
+                        >
+                            <span>{sectionLabel}</span>
+                        </a>
+                    );
+                }
+            }
+        }
+    }
 };

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -317,6 +317,7 @@ export const CommentLayout = ({
                     <GridItem area="title">
                         <ArticleTitle
                             display={display}
+                            designType={designType}
                             tags={CAPI.tags}
                             sectionLabel={CAPI.sectionLabel}
                             sectionUrl={CAPI.sectionUrl}

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -311,6 +311,7 @@ export const ImmersiveLayout = ({
                                 >
                                     <ArticleTitle
                                         display={display}
+                                        designType={designType}
                                         tags={CAPI.tags}
                                         sectionLabel={CAPI.sectionLabel}
                                         sectionUrl={CAPI.sectionUrl}

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -337,6 +337,7 @@ export const ShowcaseLayout = ({
                     <GridItem area="title">
                         <ArticleTitle
                             display={display}
+                            designType={designType}
                             tags={CAPI.tags}
                             sectionLabel={CAPI.sectionLabel}
                             sectionUrl={CAPI.sectionUrl}

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -323,6 +323,7 @@ export const StandardLayout = ({
                     <GridItem area="title">
                         <ArticleTitle
                             display={display}
+                            designType={designType}
                             tags={CAPI.tags}
                             sectionLabel={CAPI.sectionLabel}
                             sectionUrl={CAPI.sectionUrl}


### PR DESCRIPTION
## What does this change?
Refactors article title / section links

## Why?
The code here needs to handle several use cases and, because we needed to add one more, needed cleaning up.

I added the `designType` prop to the component so we can act differently for comment pieces (so we can support white test for immersive opinion pieces) and then replaced the series of if statements we had before with a nested switch statement based on `display` and `designType`.

From here there is still some branching based on what type of tag is available but it is hopefully more readable.