### PR TITLE
Don't absolute position main media for immersive opinion

### DIFF
--- a/src/web/components/ArticleHeadline.stories.tsx
+++ b/src/web/components/ArticleHeadline.stories.tsx
@@ -106,6 +106,7 @@ export const ShowcaseInterview = () => (
                 </div>
                 <MainMedia
                     display="standard"
+                    designType="Article"
                     hideCaption={true}
                     elements={mainMediaElements}
                     pillar="news"
@@ -138,6 +139,7 @@ export const Interview = () => (
                 />
                 <MainMedia
                     display="standard"
+                    designType="Article"
                     hideCaption={true}
                     elements={mainMediaElements}
                     pillar="news"

--- a/src/web/components/ImmersiveHeadline.stories.tsx
+++ b/src/web/components/ImmersiveHeadline.stories.tsx
@@ -19,6 +19,7 @@ export const Short = () => (
         >
             <MainMedia
                 display="immersive"
+                designType="Article"
                 hideCaption={true}
                 elements={mainMediaElements}
                 pillar="news"
@@ -49,6 +50,7 @@ export const Long = () => (
         >
             <MainMedia
                 display="immersive"
+                designType="Article"
                 hideCaption={true}
                 elements={mainMediaElements}
                 pillar="news"

--- a/src/web/components/MainMedia.tsx
+++ b/src/web/components/MainMedia.tsx
@@ -40,6 +40,7 @@ const noGutters = css`
 
 function renderElement(
     display: Display,
+    designType: DesignType,
     element: CAPIElement,
     pillar: Pillar,
     i: number,
@@ -52,6 +53,7 @@ function renderElement(
             return (
                 <ImageComponent
                     display={display}
+                    designType={designType}
                     key={i}
                     element={element}
                     pillar={pillar}
@@ -86,16 +88,26 @@ function renderElement(
 
 export const MainMedia: React.FC<{
     display: Display;
+    designType: DesignType;
     elements: CAPIElement[];
     pillar: Pillar;
     hideCaption?: boolean;
     adTargeting?: AdTargeting;
     starRating?: number;
-}> = ({ display, elements, pillar, hideCaption, adTargeting, starRating }) => (
+}> = ({
+    display,
+    designType,
+    elements,
+    pillar,
+    hideCaption,
+    adTargeting,
+    starRating,
+}) => (
     <div className={cx(mainMedia, display !== 'immersive' && noGutters)}>
         {elements.map((element, i) =>
             renderElement(
                 display,
+                designType,
                 element,
                 pillar,
                 i,

--- a/src/web/components/elements/ImageBlockComponent.tsx
+++ b/src/web/components/elements/ImageBlockComponent.tsx
@@ -6,6 +6,7 @@ import { from } from '@guardian/src-foundations/mq';
 
 type Props = {
     display: Display;
+    designType: DesignType;
     element: ImageBlockElement;
     pillar: Pillar;
     hideCaption?: boolean;
@@ -112,6 +113,7 @@ const decidePosition = (role: RoleType) => {
 
 export const ImageBlockComponent = ({
     display,
+    designType,
     element,
     pillar,
     hideCaption,
@@ -121,6 +123,7 @@ export const ImageBlockComponent = ({
         <div className={decidePosition(role)}>
             <ImageComponent
                 display={display}
+                designType={designType}
                 element={element}
                 pillar={pillar}
                 hideCaption={hideCaption}

--- a/src/web/components/elements/ImageComponent.tsx
+++ b/src/web/components/elements/ImageComponent.tsx
@@ -11,6 +11,7 @@ import { StarRating } from '@root/src/web/components/StarRating/StarRating';
 
 type Props = {
     display: Display;
+    designType: DesignType;
     element: ImageBlockElement;
     pillar: Pillar;
     hideCaption?: boolean;
@@ -168,6 +169,7 @@ const CaptionToggle = () => (
 
 export const ImageComponent = ({
     display,
+    designType,
     element,
     pillar,
     hideCaption,
@@ -180,8 +182,10 @@ export const ImageComponent = ({
     const shouldLimitWidth =
         !isMainMedia &&
         (role === 'showcase' || role === 'supporting' || role === 'immersive');
+    const isNotOpinion =
+        designType !== 'Comment' && designType !== 'GuardianView';
 
-    if (isMainMedia && display === 'immersive') {
+    if (isMainMedia && display === 'immersive' && isNotOpinion) {
         return (
             <div
                 className={css`

--- a/src/web/components/elements/MultiImageBlockComponent.tsx
+++ b/src/web/components/elements/MultiImageBlockComponent.tsx
@@ -126,6 +126,7 @@ export const MultiImageBlockComponent = ({
                 >
                     <ImageComponent
                         display="standard"
+                        designType="Article"
                         element={images[0]}
                         pillar={pillar}
                         hideCaption={true}
@@ -155,6 +156,7 @@ export const MultiImageBlockComponent = ({
                         <GridItem area="first">
                             <ImageComponent
                                 display="standard"
+                                designType="Article"
                                 element={images[0]}
                                 pillar={pillar}
                                 hideCaption={true}
@@ -164,6 +166,7 @@ export const MultiImageBlockComponent = ({
                         <GridItem area="second">
                             <ImageComponent
                                 display="standard"
+                                designType="Article"
                                 element={images[1]}
                                 pillar={pillar}
                                 hideCaption={true}
@@ -195,6 +198,7 @@ export const MultiImageBlockComponent = ({
                         <GridItem area="first">
                             <ImageComponent
                                 display="standard"
+                                designType="Article"
                                 element={images[0]}
                                 pillar={pillar}
                                 hideCaption={true}
@@ -204,6 +208,7 @@ export const MultiImageBlockComponent = ({
                         <GridItem area="second">
                             <ImageComponent
                                 display="standard"
+                                designType="Article"
                                 element={images[1]}
                                 pillar={pillar}
                                 hideCaption={true}
@@ -213,6 +218,7 @@ export const MultiImageBlockComponent = ({
                         <GridItem area="third">
                             <ImageComponent
                                 display="standard"
+                                designType="Article"
                                 element={images[2]}
                                 pillar={pillar}
                                 hideCaption={true}
@@ -244,6 +250,7 @@ export const MultiImageBlockComponent = ({
                         <GridItem area="first">
                             <ImageComponent
                                 display="standard"
+                                designType="Article"
                                 element={images[0]}
                                 pillar={pillar}
                                 hideCaption={true}
@@ -253,6 +260,7 @@ export const MultiImageBlockComponent = ({
                         <GridItem area="second">
                             <ImageComponent
                                 display="standard"
+                                designType="Article"
                                 element={images[1]}
                                 pillar={pillar}
                                 hideCaption={true}
@@ -262,6 +270,7 @@ export const MultiImageBlockComponent = ({
                         <GridItem area="third">
                             <ImageComponent
                                 display="standard"
+                                designType="Article"
                                 element={images[2]}
                                 pillar={pillar}
                                 hideCaption={true}
@@ -271,6 +280,7 @@ export const MultiImageBlockComponent = ({
                         <GridItem area="forth">
                             <ImageComponent
                                 display="standard"
+                                designType="Article"
                                 element={images[3]}
                                 pillar={pillar}
                                 hideCaption={true}

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -397,6 +397,7 @@ export const CommentLayout = ({
                         <div className={maxWidth}>
                             <MainMedia
                                 display={display}
+                                designType={designType}
                                 elements={CAPI.mainMediaElements}
                                 pillar={pillar}
                                 adTargeting={adTargeting}

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -248,6 +248,7 @@ export const ImmersiveLayout = ({
                     >
                         <MainMedia
                             display={display}
+                            designType={designType}
                             elements={CAPI.mainMediaElements}
                             pillar={pillar}
                             adTargeting={adTargeting}

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -382,6 +382,7 @@ export const ShowcaseLayout = ({
                         <div className={mainMediaWrapper}>
                             <MainMedia
                                 display={display}
+                                designType={designType}
                                 elements={CAPI.mainMediaElements}
                                 pillar={pillar}
                                 adTargeting={adTargeting}

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -382,6 +382,7 @@ export const StandardLayout = ({
                         <div className={maxWidth}>
                             <MainMedia
                                 display={display}
+                                designType={designType}
                                 elements={CAPI.mainMediaElements}
                                 pillar={pillar}
                                 adTargeting={adTargeting}

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -68,6 +68,7 @@ export const ArticleRenderer: React.FC<{
                     return (
                         <ImageBlockComponent
                             display={display}
+                            designType={designType}
                             key={i}
                             element={element}
                             pillar={pillar}


### PR DESCRIPTION
## What does this change?
To ensure the main media image is correctly positioned full width and matches the viewport height we use absolute positioning when `display` is immersive. But now that we have a new layout for immersive comment pieces we need to adjust this logic, based on `designType`

Most of the changes here are around prop drilling `designType`. The actual logic change is in `ImageComponent` and fairly straight forward.

