### PR TITLE
Add bwid getCookieValue

### DIFF
--- a/src/web/server/htmlTemplate.ts
+++ b/src/web/server/htmlTemplate.ts
@@ -207,6 +207,31 @@ export const htmlTemplate = ({
                     };
                 </script>
 
+                <script>
+                    // Set the browserId from the bwid cookie on the ophan object created above
+                    // This will need to be replaced later with an async request to an endpoint
+                    (function (window, document) {
+
+                        function getCookieValue(name) {
+                            var nameEq = name + "=",
+                                cookies = document.cookie.split(';'),
+                                value = null;
+                            cookies.forEach(function (cookie) {
+                                while (cookie.charAt(0) === ' ') {
+                                    cookie = cookie.substring(1, cookie.length);
+                                }
+                                if (cookie.indexOf(nameEq) === 0) {
+                                    value = cookie.substring(nameEq.length, cookie.length);
+                                }
+                            });
+                            return value;
+                        }
+
+                        window.guardian.config.ophan.browserId = getCookieValue("bwid");
+
+                    })(window, document);
+                </script>
+
                 <script>${prepareCmpString}</script>
 
                 <noscript>


### PR DESCRIPTION
## What does this change?

Adds an inline script to get the Ophan browserID needed for commercial from the bwid cookie.

Copied directly from https://github.com/guardian/frontend/blob/88cfa609c73545085c3e5f3921631ec344a3eb83/common/app/templates/inlineJS/nonBlocking/ophanConfig.scala.js#L5

Will be obselete soon as we will need to fetch the browser ID from the ophan bwid endpoint, but this needs defining.