### PR TITLE
Remove dynamic imports for CMP

### DIFF
--- a/src/web/components/CMP.tsx
+++ b/src/web/components/CMP.tsx
@@ -1,41 +1,24 @@
 import React, { useState, useEffect, Suspense } from 'react';
-
-import { initPerf } from '@root/src/web/browser/initPerf';
-
-const ConsentManagementPlatform = React.lazy(() => {
-    const { start, end } = initPerf('ConsentManagementPlatform');
-    start();
-    return import(
-        /* webpackChunkName: "ConsentManagementPlatform" */ '@guardian/consent-management-platform/lib/ConsentManagementPlatform'
-    ).then(module => {
-        end();
-        return { default: module.ConsentManagementPlatform };
-    });
-});
+import { ConsentManagementPlatform } from '@guardian/consent-management-platform/lib/ConsentManagementPlatform';
+import {
+    shouldShow,
+    setErrorHandler,
+} from '@guardian/consent-management-platform';
 
 export const CMP = () => {
     const [show, setShow] = useState(false);
 
     useEffect(() => {
-        const { start, end } = initPerf(
-            'consent-management-platform-utilities',
-        );
-        start();
-        import(
-            /* webpackChunkName: "consent-management-platform-utilities" */ '@guardian/consent-management-platform'
-        ).then(({ shouldShow, setErrorHandler }) => {
-            end();
-            if (shouldShow()) {
-                setShow(true);
+        if (shouldShow()) {
+            setShow(true);
 
-                // setErrorHandler takes function to be called on errors in the CMP UI
-                setErrorHandler((errMsg: string): void => {
-                    const err = new Error(errMsg);
+            // setErrorHandler takes function to be called on errors in the CMP UI
+            setErrorHandler((errMsg: string): void => {
+                const err = new Error(errMsg);
 
-                    window.guardian.modules.sentry.reportError(err, 'cmp');
-                });
-            }
-        });
+                window.guardian.modules.sentry.reportError(err, 'cmp');
+            });
+        }
     }, []);
 
     return (


### PR DESCRIPTION
## What does this change?

Refactors out the dynamic imports for CMP so they are a part of the main bundle.

## Why?

We noticed that there was a significant increase in the Largest Contentful Paint on DCR, which coincides with dynamic imports of the CMP - this makes sense as the CMP is the largest item on the page once loaded. As the CMP is on the 'critical path' we need to try and load it as early as possible (but, in the future, as little as possible).

On my fast machine, the CMP loads half a second faster on localhost.

![image](https://user-images.githubusercontent.com/638051/83844519-10fb5700-a6ff-11ea-9c9e-beb4db9f6442.png)


## What Next

We should think about a holistic that allows us to make reasonable choices server side on whether to load the CMP early or dynamically import - if we have dynamic imports in place, but choose whether to *also* load the CMP bundle early in some cases - like if the user *is not* an `adFreeUser`, we can include the CMP bundle into the page so it's ready for the import immediately.
