### PR TITLE
Delay Cypress check for Most Popular

### DIFF
--- a/cypress/integration/e2e/article.e2e.spec.js
+++ b/cypress/integration/e2e/article.e2e.spec.js
@@ -43,6 +43,11 @@ describe('E2E Page rendering', function() {
                     });
                 }
 
+                // We scroll again here because not all the content at the bottom of the page loads
+                // when you first touch bottom, you sometimes need to scroll once more to trigger
+                // lazy loading Most Popular
+                cy.scrollTo('bottom', { duration: 100 });
+
                 cy.wait('@getMostRead', { timeout: 5000 }).then(xhr => {
                     expect(xhr.response.body).to.have.property('tabs');
                     expect(xhr.status).to.be.equal(200);

--- a/cypress/integration/e2e/article.e2e.spec.js
+++ b/cypress/integration/e2e/article.e2e.spec.js
@@ -18,13 +18,6 @@ describe('E2E Page rendering', function() {
                 cy.scrollTo('bottom', { duration: 100 });
                 cy.contains('Lifestyle');
 
-                cy.wait('@getMostRead').then(xhr => {
-                    expect(xhr.response.body).to.have.property('tabs');
-                    expect(xhr.status).to.be.equal(200);
-
-                    cy.contains('Most popular');
-                });
-
                 if (!article.hideMostViewed) {
                     cy.wait('@getMostReadGeo').then(xhr => {
                         expect(xhr.response.body).to.have.property('heading');
@@ -49,6 +42,13 @@ describe('E2E Page rendering', function() {
                         cy.contains('Read more');
                     });
                 }
+
+                cy.wait('@getMostRead', { timeout: 5000 }).then(xhr => {
+                    expect(xhr.response.body).to.have.property('tabs');
+                    expect(xhr.status).to.be.equal(200);
+
+                    cy.contains('Most popular');
+                });
             });
         });
     });

--- a/cypress/integration/e2e/article.e2e.spec.js
+++ b/cypress/integration/e2e/article.e2e.spec.js
@@ -15,11 +15,11 @@ describe('E2E Page rendering', function() {
 
             it(`It should load ${designType} articles under the ${pillar} pillar`, function() {
                 cy.visit(`Article?url=${url}`, fetchPolyfill);
-                cy.scrollTo('bottom', { duration: 100 });
+                cy.scrollTo('bottom', { duration: 500 });
                 cy.contains('Lifestyle');
 
                 if (!article.hideMostViewed) {
-                    cy.wait('@getMostReadGeo').then(xhr => {
+                    cy.wait('@getMostReadGeo', { timeout: 8000 }).then(xhr => {
                         expect(xhr.response.body).to.have.property('heading');
                         expect(xhr.status).to.be.equal(200);
 
@@ -46,9 +46,9 @@ describe('E2E Page rendering', function() {
                 // We scroll again here because not all the content at the bottom of the page loads
                 // when you first touch bottom, you sometimes need to scroll once more to trigger
                 // lazy loading Most Popular
-                cy.scrollTo('bottom', { duration: 100 });
+                cy.scrollTo('bottom', { duration: 500 });
 
-                cy.wait('@getMostRead', { timeout: 5000 }).then(xhr => {
+                cy.wait('@getMostRead', { timeout: 8000 }).then(xhr => {
                     expect(xhr.response.body).to.have.property('tabs');
                     expect(xhr.status).to.be.equal(200);
 

--- a/cypress/integration/e2e/article.interactivity.spec.js
+++ b/cypress/integration/e2e/article.interactivity.spec.js
@@ -36,7 +36,9 @@ describe('Interactivity', function() {
             beforeEach(mockApi);
             it('should change the list of most viewed items when a tab is clicked', function() {
                 cy.visit(`/Article?url=${articleUrl}`, fetchPolyfill);
-                cy.scrollTo('bottom', { duration: 500 });
+                cy.scrollTo('bottom', { duration: 300 });
+                cy.contains('Lifestyle');
+                cy.scrollTo('bottom', { duration: 300 });
                 cy.get('[data-cy=tab-body-0]').should('be.visible');
                 cy.get('[data-cy=tab-body-1]').should('not.be.visible');
                 cy.get('[data-cy=tab-heading-1]').click();

--- a/cypress/integration/e2e/article.interactivity.spec.js
+++ b/cypress/integration/e2e/article.interactivity.spec.js
@@ -22,7 +22,7 @@ describe('Interactivity', function() {
         });
         it('should display all the rich links for an article', function() {
             cy.visit(`/Article?url=${articleUrl}`);
-            cy.scrollTo('bottom', { duration: 100 });
+            cy.scrollTo('bottom', { duration: 300 });
             cy.get('[data-component=rich-link]')
                 .should('exist')
                 .its('length')
@@ -36,7 +36,7 @@ describe('Interactivity', function() {
             beforeEach(mockApi);
             it('should change the list of most viewed items when a tab is clicked', function() {
                 cy.visit(`/Article?url=${articleUrl}`, fetchPolyfill);
-                cy.scrollTo('bottom', { duration: 100 });
+                cy.scrollTo('bottom', { duration: 500 });
                 cy.get('[data-cy=tab-body-0]').should('be.visible');
                 cy.get('[data-cy=tab-body-1]').should('not.be.visible');
                 cy.get('[data-cy=tab-heading-1]').click();


### PR DESCRIPTION
## What does this change?
Moves the check to see if the Most Popular component rendered to the end of the test so that it has a chance to load. We also add an additoinal scoll event to mimic real user behaviour and to make sure the lazy load is triggered.

### Before
Broken build

### After
Working build

