### PR TITLE
Refactor getIndex()

### DIFF
--- a/src/web/components/Links.tsx
+++ b/src/web/components/Links.tsx
@@ -14,28 +14,6 @@ type Props = {
     userId?: string;
 };
 
-const search = css`
-    :after {
-        content: '';
-        display: inline-block;
-        width: 5px;
-        height: 5px;
-        transform: translateY(-2px) rotate(45deg);
-        border-width: 1px;
-        border-style: solid;
-        border-color: currentColor;
-        border-left: none;
-        border-top: none;
-        margin-left: 5px;
-        vertical-align: middle;
-        backface-visibility: hidden;
-        transition: transform 250ms ease-out;
-    }
-    :hover:after {
-        transform: translateY(0) rotate(45deg);
-    }
-`;
-
 const linkStyles = css`
     ${textSans.medium()};
     color: ${brandText.primary};
@@ -110,11 +88,7 @@ const Search = ({
     dataLinkName: string;
     children: JSXElements;
 }) => (
-    <a
-        href={href}
-        className={cx(search, className)}
-        data-link-name={dataLinkName}
-    >
+    <a href={href} className={className} data-link-name={dataLinkName}>
         {children}
     </a>
 );

--- a/src/web/components/Links.tsx
+++ b/src/web/components/Links.tsx
@@ -8,7 +8,9 @@ import { textSans } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 
 import { DropdownLinkType, Dropdown } from '@root/src/web/components/Dropdown';
+
 import ProfileIcon from '@frontend/static/icons/profile.svg';
+import { getZIndex } from '@frontend/web/lib/getZIndex';
 
 type Props = {
     userId?: string;
@@ -114,6 +116,8 @@ const linksStyles = css`
     ${from.wide} {
         right: 342px;
     }
+
+    ${getZIndex('headerLinks')}
 `;
 
 export const Links = ({ userId }: Props) => {

--- a/src/web/components/Logo.tsx
+++ b/src/web/components/Logo.tsx
@@ -6,6 +6,7 @@ import { from } from '@guardian/src-foundations/mq';
 import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 
 import TheGuardianLogoSVG from '@frontend/static/logos/the-guardian.svg';
+import { getZIndex } from '@frontend/web/lib/getZIndex';
 
 const link = css`
     float: right;
@@ -23,11 +24,12 @@ const link = css`
         margin-top: 5px;
         margin-bottom: 15px;
         position: relative;
-        z-index: 1071;
     }
     ${from.wide} {
         margin-right: 96px;
     }
+
+    ${getZIndex('TheGuardian')}
 `;
 
 const style = css`

--- a/src/web/lib/getZIndex.test.tsx
+++ b/src/web/lib/getZIndex.test.tsx
@@ -6,6 +6,9 @@ describe('getZIndex', () => {
 
         expect(getZIndex('bodyArea')).toBe('z-index: 2;');
 
-        expect(getZIndex('stickyAdWrapper')).toBe('z-index: 4;');
+        expect(getZIndex('TheGuardian')).toBe('z-index: 3;');
+        expect(getZIndex('headerLinks')).toBe('z-index: 4;');
+
+        expect(getZIndex('stickyAdWrapper')).toBe('z-index: 6;');
     });
 });

--- a/src/web/lib/getZIndex.tsx
+++ b/src/web/lib/getZIndex.tsx
@@ -1,23 +1,57 @@
-// The z-indexes will be applied in order from 1 -> length of the array.
-// The later in the array, the higher the z-index will be
-// All indexes will be adjusted when new elements are added
+/**
+ * How do I get a z-index for my new item?
+ *
+ * Decide a meaningful name for your item and then insert it
+ * in the indices array below. The higher up your item visually,
+ * then the higher it will be in the z-index stack,
+ * 'higher' means _earlier_ in the array.
+ *
+ * Eg. stickyAdWrapper will be given a higher z-index than bodyArea
+ *
+ * Once inserted in the array, use getZIndex() to return the css
+ *
+ * Eg.
+ *
+ * import { getZIndex } from '@frontend/web/lib/getZIndex';
+ *
+ * const myCss = css`
+ *    color: blue;
+ *    ${getZIndex('TheGuardian')}
+ * `;
+ *
+ * As new items are added, all z-indexes are adjusted
+ */
 const indices = [
-    // Body
-    'rightColumnArea',
-    'bodyArea',
-
-    // Header links (should be above The Guardian svg)
-    'TheGuardian',
-    'headerLinks',
+    // Modals will go here at the top
 
     // Header
-    'headerWrapper',
     'stickyAdWrapper',
+    'headerWrapper',
 
-    // Modals will go here at the top
-] as const;
+    // Header links (should be above The Guardian svg)
+    'headerLinks',
+    'TheGuardian',
 
+    // Body
+    'bodyArea',
+    'rightColumnArea',
+];
+
+//
+// Implementation code  - you don't need to change this to get a new index
 type ZIndex = typeof indices[number];
 
+function reverseArray(array: any[]) {
+    return array.map((item, index) => array[array.length - 1 - index]);
+}
+
+const decideIndex = (name: string): number | null => {
+    let decided;
+    reverseArray(indices).forEach((item, index) => {
+        if (item === name) decided = index + 1;
+    });
+    return decided || null;
+};
+
 export const getZIndex = (zIndex: ZIndex): string =>
-    `z-index: ${indices.indexOf(zIndex) + 1};`;
+    `z-index: ${decideIndex(zIndex)};`;

--- a/src/web/lib/getZIndex.tsx
+++ b/src/web/lib/getZIndex.tsx
@@ -6,6 +6,10 @@ const indices = [
     'rightColumnArea',
     'bodyArea',
 
+    // Header links (should be above The Guardian svg)
+    'TheGuardian',
+    'headerLinks',
+
     // Header
     'headerWrapper',
     'stickyAdWrapper',


### PR DESCRIPTION
After using `getZIndex()` in another PR I suddenly realised how great this function is! I really like how it solves the z index ducks in a row problem. But one thing that confused me was the order of the `indices` array. My strong instinct was that the stack of items should visually represent the actual z index stack and that the items at the top of the array should be at the top of the stack. Even after working out it was reversed I still made the mistake of inserting my item in the wrong place.

So here I refactor the function to work the way my brain insists that it does. This actually adds more complexity to the implementation but by paying this price of extra code, we offer future developers a more intuitive experience.