### PR TITLE
Refactor Search link

### DIFF
--- a/src/web/components/Links.tsx
+++ b/src/web/components/Links.tsx
@@ -14,28 +14,6 @@ type Props = {
     userId?: string;
 };
 
-const search = css`
-    :after {
-        content: '';
-        display: inline-block;
-        width: 5px;
-        height: 5px;
-        transform: translateY(-2px) rotate(45deg);
-        border-width: 1px;
-        border-style: solid;
-        border-color: currentColor;
-        border-left: none;
-        border-top: none;
-        margin-left: 5px;
-        vertical-align: middle;
-        backface-visibility: hidden;
-        transition: transform 250ms ease-out;
-    }
-    :hover:after {
-        transform: translateY(0) rotate(45deg);
-    }
-`;
-
 const linkStyles = css`
     ${textSans.medium()};
     color: ${brandText.primary};
@@ -110,11 +88,7 @@ const Search = ({
     dataLinkName: string;
     children: JSXElements;
 }) => (
-    <a
-        href={href}
-        className={cx(search, className)}
-        data-link-name={dataLinkName}
-    >
+    <a href={href} className={className} data-link-name={dataLinkName}>
         {children}
     </a>
 );

--- a/src/web/components/Links.tsx
+++ b/src/web/components/Links.tsx
@@ -8,7 +8,9 @@ import { textSans } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 
 import { DropdownLinkType, Dropdown } from '@root/src/web/components/Dropdown';
+
 import ProfileIcon from '@frontend/static/icons/profile.svg';
+import { getZIndex } from '@frontend/web/lib/getZIndex';
 
 type Props = {
     userId?: string;
@@ -114,6 +116,8 @@ const linksStyles = css`
     ${from.wide} {
         right: 342px;
     }
+
+    ${getZIndex('headerLinks')}
 `;
 
 export const Links = ({ userId }: Props) => {

--- a/src/web/components/Logo.tsx
+++ b/src/web/components/Logo.tsx
@@ -6,6 +6,7 @@ import { from } from '@guardian/src-foundations/mq';
 import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 
 import TheGuardianLogoSVG from '@frontend/static/logos/the-guardian.svg';
+import { getZIndex } from '@frontend/web/lib/getZIndex';
 
 const link = css`
     float: right;
@@ -23,11 +24,12 @@ const link = css`
         margin-top: 5px;
         margin-bottom: 15px;
         position: relative;
-        z-index: 1071;
     }
     ${from.wide} {
         margin-right: 96px;
     }
+
+    ${getZIndex('TheGuardian')}
 `;
 
 const style = css`

--- a/src/web/lib/getZIndex.test.tsx
+++ b/src/web/lib/getZIndex.test.tsx
@@ -6,6 +6,9 @@ describe('getZIndex', () => {
 
         expect(getZIndex('bodyArea')).toBe('z-index: 2;');
 
-        expect(getZIndex('stickyAdWrapper')).toBe('z-index: 4;');
+        expect(getZIndex('TheGuardian')).toBe('z-index: 3;');
+        expect(getZIndex('headerLinks')).toBe('z-index: 4;');
+
+        expect(getZIndex('stickyAdWrapper')).toBe('z-index: 6;');
     });
 });

--- a/src/web/lib/getZIndex.tsx
+++ b/src/web/lib/getZIndex.tsx
@@ -6,6 +6,10 @@ const indices = [
     'rightColumnArea',
     'bodyArea',
 
+    // Header links (should be above The Guardian svg)
+    'TheGuardian',
+    'headerLinks',
+
     // Header
     'headerWrapper',
     'stickyAdWrapper',


### PR DESCRIPTION
## What does this change?
Fixes a couple of problems with the Search link in the Header

### Before
1. We were showing the dropdown down chevron suggesting a dropdown would appear. This is the case on Frontend but in DCR we link out to an external page

2. The Guardian logo was obscuring the link surface of the Search link, preventing hover styling and hijacking clicks

![2020-06-06 11 21 37](https://user-images.githubusercontent.com/1336821/83942010-efc26580-a7e7-11ea-8b91-e3e54d430f3b.gif)


### After
No chevron, better clicks
![2020-06-06 11 20 41](https://user-images.githubusercontent.com/1336821/83941994-d5888780-a7e7-11ea-8f85-04cb07157944.gif)
