### PR TITLE
Placeholder

### DIFF
--- a/src/web/components/Placeholder.stories.tsx
+++ b/src/web/components/Placeholder.stories.tsx
@@ -93,3 +93,12 @@ export const Root = () => {
     );
 };
 Root.story = { name: 'with rootId set' };
+
+export const NoShimmer = () => {
+    return (
+        <Container>
+            <Placeholder height={200} shouldShimmer={false} />
+        </Container>
+    );
+};
+NoShimmer.story = { name: 'without shimmer' };

--- a/src/web/components/Placeholder.stories.tsx
+++ b/src/web/components/Placeholder.stories.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { Placeholder } from './Placeholder';
+
+const Container = ({ children }: { children: React.ReactNode }) => (
+    <div
+        className={css`
+            width: 620px;
+            padding: 20px;
+        `}
+    >
+        {children}
+    </div>
+);
+
+const Row = ({ children }: { children: React.ReactNode }) => (
+    <div
+        className={css`
+            display: flex;
+            flex-direction: row;
+        `}
+    >
+        {children}
+    </div>
+);
+
+const Column = ({ children }: { children: React.ReactNode }) => (
+    <div
+        className={css`
+            display: flex;
+            flex-direction: column;
+        `}
+    >
+        {children}
+    </div>
+);
+
+export default {
+    component: Placeholder,
+    title: 'Components/Placeholder',
+};
+
+export const Basic = () => {
+    return (
+        <Container>
+            <Placeholder height={200} />
+        </Container>
+    );
+};
+Basic.story = { name: 'with 200px height' };
+
+export const Square = () => {
+    return (
+        <Container>
+            <Placeholder height={200} width={200} />
+        </Container>
+    );
+};
+Square.story = { name: 'with equal height and width' };
+
+export const InARow = () => {
+    return (
+        <Container>
+            <Row>
+                <Placeholder height={200} width={200} spaceLeft={2} />
+                <Placeholder height={200} width={200} spaceLeft={2} />
+                <Placeholder height={200} width={200} spaceLeft={2} />
+            </Row>
+        </Container>
+    );
+};
+InARow.story = { name: 'with elements in a row' };
+
+export const Stacked = () => {
+    return (
+        <Container>
+            <Column>
+                <Placeholder height={200} spaceBelow={5} />
+                <Placeholder height={200} spaceBelow={5} />
+                <Placeholder height={200} spaceBelow={5} />
+            </Column>
+        </Container>
+    );
+};
+Stacked.story = { name: 'with elements stacked' };
+
+export const Root = () => {
+    return (
+        <Container>
+            <Placeholder height={200} rootId="usedWithPortals" />
+        </Container>
+    );
+};
+Root.story = { name: 'with rootId set' };

--- a/src/web/components/Placeholder.tsx
+++ b/src/web/components/Placeholder.tsx
@@ -12,6 +12,7 @@ type Props = {
     width?: number;
     spaceBelow?: 1 | 2 | 3 | 4 | 5 | 6 | 9;
     spaceLeft?: 1 | 2 | 3 | 4 | 5 | 6 | 9;
+    shouldShimmer?: boolean;
 };
 
 const shimmer = keyframes`
@@ -40,6 +41,7 @@ export const Placeholder = ({
     width,
     spaceBelow,
     spaceLeft,
+    shouldShimmer = true,
 }: Props) => (
     <div id={rootId}>
         <div
@@ -50,7 +52,7 @@ export const Placeholder = ({
                 margin-left: ${spaceLeft && space[spaceLeft]}px;
                 background-color: ${BACKGROUND_COLOUR};
 
-                ${shimmerStyles}
+                ${shouldShimmer && shimmerStyles}
             `}
         />
     </div>

--- a/src/web/components/Placeholder.tsx
+++ b/src/web/components/Placeholder.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { css, keyframes } from 'emotion';
+
+import { space } from '@guardian/src-foundations';
+import { neutral } from '@guardian/src-foundations/palette';
+
+const BACKGROUND_COLOUR = neutral[93];
+
+type Props = {
+    height: number;
+    rootId?: string;
+    width?: number;
+    spaceBelow?: 1 | 2 | 3 | 4 | 5 | 6 | 9;
+    spaceLeft?: 1 | 2 | 3 | 4 | 5 | 6 | 9;
+};
+
+const shimmer = keyframes`
+  0% {
+    background-position: -1500px 0;
+  }
+  100% {
+    background-position: 1500px 0;
+  }
+`;
+
+const shimmerStyles = css`
+    animation: ${shimmer} 2s infinite linear;
+    background: linear-gradient(
+        to right,
+        ${BACKGROUND_COLOUR} 4%,
+        ${neutral[86]} 25%,
+        ${BACKGROUND_COLOUR} 36%
+    );
+    background-size: 1500px 100%;
+`;
+
+export const Placeholder = ({
+    height,
+    rootId,
+    width,
+    spaceBelow,
+    spaceLeft,
+}: Props) => (
+    <div id={rootId}>
+        <div
+            className={css`
+                height: ${height}px;
+                width: ${width ? `${width}px` : '100%'};
+                margin-bottom: ${spaceBelow && space[spaceBelow]}px;
+                margin-left: ${spaceLeft && space[spaceLeft]}px;
+                background-color: ${BACKGROUND_COLOUR};
+
+                ${shimmerStyles}
+            `}
+        />
+    </div>
+);


### PR DESCRIPTION
## What does this change?
Adds the `Placeholder` component

```typescript
type Props = {
    height: number;
    rootId?: string;
    width?: number;
    spaceBelow?: 1 | 2 | 3 | 4 | 5 | 6 | 9;
    spaceLeft?: 1 | 2 | 3 | 4 | 5 | 6 | 9;
    shouldShimmer?: boolean;
};

```

![2020-06-09 09 24 35](https://user-images.githubusercontent.com/1336821/84124615-5f786080-aa33-11ea-99a1-494c57ec9b85.gif)


## Why?
So we have a generic grey box with a shimmer effect that can be used to build loading skeletons with the aim of reducing our [Cumulative Layout Shift](https://web.dev/cls/)
