### PR TITLE
Fix Twitter embeds

### DIFF
--- a/src/web/components/elements/TweetBlockComponent.tsx
+++ b/src/web/components/elements/TweetBlockComponent.tsx
@@ -19,17 +19,6 @@ const noJSStyling = css`
         padding-bottom: 10px;
     }
 
-    /* Why are we using important here? Because this is the only way to override
-    the inline styles of the twitter-widget element and for some reason twitter
-    is adding display: block and width: 500px on this embed causing it to overflow.
-    I did think this might be caused by
-    https://stackoverflow.com/questions/36247140/why-dont-flex-items-shrink-past-content-size
-    but the solutions posted there did not help. Checking other sites with twitter embeds
-    like the BBC, we saw that this important override was being used as well. */
-    .twitter-tweet-rendered {
-        display: inline !important;
-    }
-
     a {
         /* stylelint-disable-next-line color-no-hex */
         color: #2b7bb9;


### PR DESCRIPTION
## What does this change?
Removes some css overrides that we needed before to manage the fixed width Twitter was using

### Before
![Screenshot 2020-06-09 at 13 47 22](https://user-images.githubusercontent.com/1336821/84150483-d6285480-aa59-11ea-9864-37fafe66dfcd.jpg)


### After
![Screenshot 2020-06-09 at 14 02 49](https://user-images.githubusercontent.com/1336821/84150552-eb9d7e80-aa59-11ea-8971-63e84e6fcea5.jpg)

## Why?
The css we were overriding has gone and our css is actually causing tweets to show incorrectly
