### PR TITLE
Normalize callout CAPI data

### DIFF
--- a/fixtures/calloutCampaign.ts
+++ b/fixtures/calloutCampaign.ts
@@ -10,7 +10,7 @@ export const calloutCampaign: CalloutBlockElement = {
         '<p>If you attended one of these events and believe you may have been infected by coronavirus, we\'d like to hear from you. You can get in touch by filling in the form below, or by contacting us&nbsp;<a href="https://www.theguardian.com/info/2015/aug/12/whatsapp-sharing-stories-with-the-guardian">via WhatsApp</a>&nbsp;by&nbsp;<a href="https://api.whatsapp.com/send?phone=447867825056">clicking here&nbsp;</a>or adding the contact +44(0)7867825056. Only the Guardian can see your contributions and one of our journalists may contact you to discuss further. </p>',
     formFields: [
         {
-            text_size: 50,
+            textSize: 50,
             name: 'name',
             description: 'You can use your first name only',
             hideLabel: false,
@@ -20,7 +20,7 @@ export const calloutCampaign: CalloutBlockElement = {
             required: true,
         },
         {
-            text_size: 50,
+            textSize: 50,
             name: 'where_do_you_live',
             description: 'Town or area is fine',
             hideLabel: false,
@@ -30,7 +30,7 @@ export const calloutCampaign: CalloutBlockElement = {
             required: true,
         },
         {
-            text_size: 50,
+            textSize: 50,
             name: 'tell_us_a_bit_about_yourself_age_and_what_you_do_etc',
             hideLabel: false,
             label: 'Tell us a bit about yourself (age and what you do etc.)',
@@ -39,7 +39,7 @@ export const calloutCampaign: CalloutBlockElement = {
             required: false,
         },
         {
-            text_size: 50,
+            textSize: 50,
             name: 'which_event_did_you_attend_and_when',
             hideLabel: false,
             label: 'Which event did you attend and when?',
@@ -119,7 +119,7 @@ export const calloutCampaign: CalloutBlockElement = {
             required: true,
         },
         {
-            text_size: 50,
+            textSize: 50,
             name: 'email_address_',
             description:
                 'Your contact details are helpful so we can contact you for more information. They will only be seen by the Guardian.',
@@ -130,7 +130,7 @@ export const calloutCampaign: CalloutBlockElement = {
             required: true,
         },
         {
-            text_size: 50,
+            textSize: 50,
             name: 'phone_number',
             description:
                 'Your contact details are helpful so we can contact you for more information. They will only be seen by the Guardian.',
@@ -177,7 +177,7 @@ export const calloutCampaign: CalloutBlockElement = {
     ],
 };
 
-export const preNormalizedCalloutCampaign = {
+export const preNormalizedCalloutCampaign: preNormalizedCampaignType = {
     id: '14d1b1bc-8983-43fb-8f2e-8ca08a711944',
     name: 'CALLOUT: early coronavirus events',
     rules: [],

--- a/fixtures/calloutCampaign.ts
+++ b/fixtures/calloutCampaign.ts
@@ -5,7 +5,7 @@ export const calloutCampaign: CalloutBlockElement = {
     activeFrom: 1588118400000,
     displayOnSensitive: false,
     formId: 3860296,
-    calloutTitle: 'Were you infected at this time?',
+    title: 'Were you infected at this time?',
     description:
         '<p>If you attended one of these events and believe you may have been infected by coronavirus, we\'d like to hear from you. You can get in touch by filling in the form below, or by contacting us&nbsp;<a href="https://www.theguardian.com/info/2015/aug/12/whatsapp-sharing-stories-with-the-guardian">via WhatsApp</a>&nbsp;by&nbsp;<a href="https://api.whatsapp.com/send?phone=447867825056">clicking here&nbsp;</a>or adding the contact +44(0)7867825056. Only the Guardian can see your contributions and one of our journalists may contact you to discuss further. </p>',
     formFields: [

--- a/index.d.ts
+++ b/index.d.ts
@@ -564,6 +564,7 @@ interface ConfigType extends CommercialConfigType {
     discussionD2Uid: string;
     discussionApiClientHeader: string;
     isPhotoEssay: boolean;
+    campaigns?: preNormalizedCampaignType[];
 }
 
 interface GADataType {

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -295,7 +295,8 @@ type CAPIElement =
     | VideoFacebookBlockElement
     | VideoVimeoBlockElement
     | VideoYoutubeBlockElement
-    | YoutubeBlockElement;
+    | YoutubeBlockElement
+    | CalloutBlockElement;
 
 // -------------------------------------
 // Misc

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -255,7 +255,7 @@ interface CalloutBlockElement {
     activeFrom: number;
     displayOnSensitive: boolean;
     formId: number;
-    calloutTitle: string;
+    title: string;
     description: string;
     tagName: string;
     formFields: CampaignFieldType[];

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -476,18 +476,7 @@ type preNormalizedCampaignFieldType =
     | preNormalizedCampaignFieldSelect;
 
 type preNormalizedCampaignFieldText = {
-    text_size: number;
-    name: string;
-    description?: string;
-    hide_label: string;
-    label: string;
-    id: string;
-    type: 'textarea';
-    required: string;
-};
-
-type preNormalizedCampaignFieldTextArea = {
-    text_size: string;
+    text_size?: number;
     name: string;
     description?: string;
     hide_label: string;
@@ -497,8 +486,19 @@ type preNormalizedCampaignFieldTextArea = {
     required: string;
 };
 
+type preNormalizedCampaignFieldTextArea = {
+    text_size?: number;
+    name: string;
+    description?: string;
+    hide_label: string;
+    label: string;
+    id: string;
+    type: 'textarea';
+    required: string;
+};
+
 type preNormalizedCampaignFieldFile = {
-    text_size: string;
+    text_size?: string;
     name: string;
     hide_label: string;
     label: string;

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -372,22 +372,22 @@ type CampaignFieldType =
 
 interface CampaignFieldText {
     id: number;
-    type: 'textarea';
+    type: 'text';
     name: string;
     description?: string;
     required: boolean;
-    text_size?: number;
+    textSize?: number;
     hideLabel: boolean;
     label: string;
 }
 
 interface CampaignFieldTextArea {
     id: number;
-    type: 'text';
+    type: 'textarea';
     name: string;
     description?: string;
     required: boolean;
-    text_size?: number;
+    textSize?: number;
     hideLabel: boolean;
     label: string;
 }
@@ -398,6 +398,7 @@ interface CampaignFieldFile {
     name: string;
     description?: string;
     required: boolean;
+    textSize?: number;
     hideLabel: boolean;
     label: string;
 }
@@ -443,3 +444,103 @@ interface CampaignFieldSelect {
     hideLabel: boolean;
     label: string;
 }
+
+// -------------------------------------
+// preNormalisedCampaign callout types
+// -------------------------------------
+
+type preNormalizedCampaignType = {
+    id: string;
+    name: string;
+    rules: [];
+    priority: number;
+    activeFrom: number;
+    displayOnSensitive: boolean;
+    fields: {
+        formId: number;
+        callout: string;
+        _type: string;
+        description: string;
+        tagName: string;
+        formFields: preNormalizedCampaignFieldType[];
+    };
+};
+
+type preNormalizedCampaignFieldType =
+    | preNormalizedCampaignFieldText
+    | preNormalizedCampaignFieldTextArea
+    | preNormalizedCampaignFieldFile
+    | preNormalizedCampaignFieldRadio
+    | preNormalizedCampaignFieldCheckbox
+    | preNormalizedCampaignFieldSelect;
+
+type preNormalizedCampaignFieldText = {
+    text_size: number;
+    name: string;
+    description?: string;
+    hide_label: string;
+    label: string;
+    id: string;
+    type: 'textarea';
+    required: string;
+};
+
+type preNormalizedCampaignFieldTextArea = {
+    text_size: string;
+    name: string;
+    description?: string;
+    hide_label: string;
+    label: string;
+    id: string;
+    type: 'text';
+    required: string;
+};
+
+type preNormalizedCampaignFieldFile = {
+    text_size: string;
+    name: string;
+    hide_label: string;
+    label: string;
+    id: string;
+    type: 'file';
+    required: string;
+};
+
+type preNormalizedCampaignFieldRadio = {
+    name: string;
+    options: {
+        label: string;
+        value: string;
+    }[];
+    hide_label: string;
+    label: string;
+    id: string;
+    type: 'radio';
+    required: string;
+};
+
+type preNormalizedCampaignFieldCheckbox = {
+    name: string;
+    options: {
+        label: string;
+        value: string;
+    }[];
+    hide_label: string;
+    label: string;
+    id: string;
+    type: 'checkbox';
+    required: string;
+};
+
+type preNormalizedCampaignFieldSelect = {
+    name: string;
+    options: {
+        label: string;
+        value: string;
+    }[];
+    hide_label: string;
+    label: string;
+    id: string;
+    type: 'select';
+    required: string;
+};

--- a/src/model/normalizeCallout.test.ts
+++ b/src/model/normalizeCallout.test.ts
@@ -268,6 +268,21 @@ describe('Normalize callout campaigne data', () => {
                             isMandatory: false,
                         },
                         {
+                            alt: 'Callout should-not-be-removed',
+                            _type:
+                                'model.dotcomrendering.pageElements.EmbedBlockElement',
+                            html:
+                                '<div data-callout-tagname="should-not-be-removed">          \n                               <h2>Callout</h2>\n                               <p>should-not-be-removed</p>\n                           </div>',
+                            isMandatory: false,
+                        },
+                        {
+                            _type:
+                                'model.dotcomrendering.pageElements.EmbedBlockElement',
+                            html:
+                                '<div data-callout-tagname="should-not-be-removed">          \n                               <h2>Callout</h2>\n                               <p>should-not-be-removed</p>\n                           </div>',
+                            isMandatory: false,
+                        },
+                        {
                             _type:
                                 'model.dotcomrendering.pageElements.TextBlockElement',
                             html: '<p>I should not be edited.</p>',
@@ -287,6 +302,21 @@ describe('Normalize callout campaigne data', () => {
                 {
                     elements: [
                         postNormalizedCampaign,
+                        {
+                            alt: 'Callout should-not-be-removed',
+                            _type:
+                                'model.dotcomrendering.pageElements.EmbedBlockElement',
+                            html:
+                                '<div data-callout-tagname="should-not-be-removed">          \n                               <h2>Callout</h2>\n                               <p>should-not-be-removed</p>\n                           </div>',
+                            isMandatory: false,
+                        },
+                        {
+                            _type:
+                                'model.dotcomrendering.pageElements.EmbedBlockElement',
+                            html:
+                                '<div data-callout-tagname="should-not-be-removed">          \n                               <h2>Callout</h2>\n                               <p>should-not-be-removed</p>\n                           </div>',
+                            isMandatory: false,
+                        },
                         {
                             _type:
                                 'model.dotcomrendering.pageElements.TextBlockElement',

--- a/src/model/normalizeCallout.test.ts
+++ b/src/model/normalizeCallout.test.ts
@@ -1,0 +1,306 @@
+import { normalizeCallout } from './normalizeCallout';
+import { bodyJSON } from './exampleBodyJSON';
+
+const example = JSON.parse(bodyJSON);
+
+const preNormalizedCampaign: preNormalizedCampaignType = {
+    id: '14d1b1bc-8983-43fb-8f2e-8ca08a711944',
+    name: 'CALLOUT: early coronavirus events',
+    rules: [],
+    priority: 0,
+    activeFrom: 1588118400000,
+    displayOnSensitive: false,
+    fields: {
+        formId: 3860296,
+        callout: 'Were you infected at this time?',
+        _type: 'callout',
+        description:
+            '<p>If you attended one of these events and believe you may have been infected by coronavirus, we\'d like to hear from you. You can get in touch by filling in the form below, or by contacting us&nbsp;<a href="https://www.theguardian.com/info/2015/aug/12/whatsapp-sharing-stories-with-the-guardian">via WhatsApp</a>&nbsp;by&nbsp;<a href="https://api.whatsapp.com/send?phone=447867825056">clicking here&nbsp;</a>or adding the contact +44(0)7867825056. Only the Guardian can see your contributions and one of our journalists may contact you to discuss further. </p>',
+        formFields: [
+            {
+                text_size: 50,
+                name: 'name',
+                description: 'You can use your first name only',
+                hide_label: '0',
+                label: 'Name',
+                id: '91884870',
+                type: 'text',
+                required: '1',
+            },
+            {
+                name: 'share_your_experiences_here',
+                description: 'Please include as much detail as possible',
+                hide_label: '0',
+                label: 'Share your experiences here',
+                id: '91884874',
+                type: 'textarea',
+                required: '1',
+            },
+            {
+                name:
+                    'you_can_upload_a_photo_here_if_you_think_it_will_add_to_your_story',
+                hide_label: '0',
+                label:
+                    'You can upload a photo here if you think it will add to your story',
+                id: '91884877',
+                type: 'file',
+                required: '0',
+            },
+            {
+                name: 'can_we_publish_your_response',
+                options: [
+                    {
+                        label: 'Yes, entirely',
+                        value: 'Yes, entirely',
+                    },
+                    {
+                        label: 'Yes, but please keep me anonymous',
+                        value: 'Yes, but please keep me anonymous',
+                    },
+                    {
+                        label: 'Yes, but please contact me first',
+                        value: 'Yes, but please contact me first',
+                    },
+                    {
+                        label: 'No, this is information only',
+                        value: 'No, this is information only',
+                    },
+                ],
+                hide_label: '0',
+                label: 'Can we publish your response?',
+                id: '91884878',
+                type: 'radio',
+                required: '0',
+            },
+            {
+                name: 'can_we_publish_your_response',
+                options: [
+                    {
+                        label: 'Yes, entirely',
+                        value: 'Yes, entirely',
+                    },
+                    {
+                        label: 'Yes, but please keep me anonymous',
+                        value: 'Yes, but please keep me anonymous',
+                    },
+                    {
+                        label: 'Yes, but please contact me first',
+                        value: 'Yes, but please contact me first',
+                    },
+                    {
+                        label: 'No, this is information only',
+                        value: 'No, this is information only',
+                    },
+                ],
+                hide_label: '0',
+                label: 'Can we publish your response?',
+                id: '918848785',
+                type: 'checkbox',
+                required: '1',
+            },
+            {
+                name: 'do_you_have_anything_else_to_add',
+                hide_label: '0',
+                label: 'Do you have anything else to add?',
+                id: '91884881',
+                type: 'select',
+                options: [
+                    {
+                        label: 'Yes, entirely',
+                        value: 'Yes, entirely',
+                    },
+                    {
+                        label: 'Yes, but please keep me anonymous',
+                        value: 'Yes, but please keep me anonymous',
+                    },
+                    {
+                        label: 'Yes, but please contact me first',
+                        value: 'Yes, but please contact me first',
+                    },
+                    {
+                        label: 'No, this is information only',
+                        value: 'No, this is information only',
+                    },
+                ],
+                required: '0',
+            },
+        ],
+        tagName: 'callout-early-coronavirus-events',
+    },
+};
+
+const postNormalizedCampaign: CalloutBlockElement = {
+    _type: 'model.dotcomrendering.pageElements.CalloutBlockElement',
+    id: '14d1b1bc-8983-43fb-8f2e-8ca08a711944',
+    activeFrom: 1588118400000,
+    displayOnSensitive: false,
+    formId: 3860296,
+    title: 'Were you infected at this time?',
+    description:
+        '<p>If you attended one of these events and believe you may have been infected by coronavirus, we\'d like to hear from you. You can get in touch by filling in the form below, or by contacting us&nbsp;<a href="https://www.theguardian.com/info/2015/aug/12/whatsapp-sharing-stories-with-the-guardian">via WhatsApp</a>&nbsp;by&nbsp;<a href="https://api.whatsapp.com/send?phone=447867825056">clicking here&nbsp;</a>or adding the contact +44(0)7867825056. Only the Guardian can see your contributions and one of our journalists may contact you to discuss further. </p>',
+    tagName: 'callout-early-coronavirus-events',
+    formFields: [
+        {
+            textSize: 50,
+            name: 'name',
+            description: 'You can use your first name only',
+            hideLabel: false,
+            label: 'Name',
+            id: 91884870,
+            type: 'text',
+            required: true,
+        },
+        {
+            textSize: undefined,
+            name: 'share_your_experiences_here',
+            description: 'Please include as much detail as possible',
+            hideLabel: false,
+            label: 'Share your experiences here',
+            id: 91884874,
+            type: 'textarea',
+            required: true,
+        },
+        {
+            name:
+                'you_can_upload_a_photo_here_if_you_think_it_will_add_to_your_story',
+            hideLabel: false,
+            label:
+                'You can upload a photo here if you think it will add to your story',
+            id: 91884877,
+            type: 'file',
+            required: false,
+        },
+        {
+            name: 'can_we_publish_your_response',
+            options: [
+                {
+                    label: 'Yes, entirely',
+                    value: 'Yes, entirely',
+                },
+                {
+                    label: 'Yes, but please keep me anonymous',
+                    value: 'Yes, but please keep me anonymous',
+                },
+                {
+                    label: 'Yes, but please contact me first',
+                    value: 'Yes, but please contact me first',
+                },
+                {
+                    label: 'No, this is information only',
+                    value: 'No, this is information only',
+                },
+            ],
+            hideLabel: false,
+            label: 'Can we publish your response?',
+            id: 91884878,
+            type: 'radio',
+            required: false,
+        },
+        {
+            name: 'can_we_publish_your_response',
+            options: [
+                {
+                    label: 'Yes, entirely',
+                    value: 'Yes, entirely',
+                },
+                {
+                    label: 'Yes, but please keep me anonymous',
+                    value: 'Yes, but please keep me anonymous',
+                },
+                {
+                    label: 'Yes, but please contact me first',
+                    value: 'Yes, but please contact me first',
+                },
+                {
+                    label: 'No, this is information only',
+                    value: 'No, this is information only',
+                },
+            ],
+            hideLabel: false,
+            label: 'Can we publish your response?',
+            id: 918848785,
+            type: 'checkbox',
+            required: true,
+        },
+        {
+            name: 'do_you_have_anything_else_to_add',
+            hideLabel: false,
+            label: 'Do you have anything else to add?',
+            id: 91884881,
+            type: 'select',
+            options: [
+                {
+                    label: 'Yes, entirely',
+                    value: 'Yes, entirely',
+                },
+                {
+                    label: 'Yes, but please keep me anonymous',
+                    value: 'Yes, but please keep me anonymous',
+                },
+                {
+                    label: 'Yes, but please contact me first',
+                    value: 'Yes, but please contact me first',
+                },
+                {
+                    label: 'No, this is information only',
+                    value: 'No, this is information only',
+                },
+            ],
+            required: false,
+        },
+    ],
+};
+
+// We are assuming that there will only be 1 callout per page
+describe('Normalize callout campaigne data', () => {
+    it('convert relavant EmbedBlockElement to CalloutBlockElement', () => {
+        const input = {
+            ...example,
+            blocks: [
+                {
+                    elements: [
+                        {
+                            alt: 'Callout callout-early-coronavirus-events',
+                            _type:
+                                'model.dotcomrendering.pageElements.EmbedBlockElement',
+                            html:
+                                '<div data-callout-tagname="callout-early-coronavirus-events">          \n                               <h2>Callout</h2>\n                               <p>callout-early-coronavirus-events</p>\n                           </div>',
+                            isMandatory: false,
+                        },
+                        {
+                            _type:
+                                'model.dotcomrendering.pageElements.TextBlockElement',
+                            html: '<p>I should not be edited.</p>',
+                        },
+                    ],
+                },
+            ],
+            config: {
+                ...example.config,
+                campaigns: [{ name: 'should-not-edit' }, preNormalizedCampaign],
+            },
+        };
+
+        const expectedOutput = {
+            ...example,
+            blocks: [
+                {
+                    elements: [
+                        postNormalizedCampaign,
+                        {
+                            _type:
+                                'model.dotcomrendering.pageElements.TextBlockElement',
+                            html: '<p>I should not be edited.</p>',
+                        },
+                    ],
+                },
+            ],
+            config: {
+                ...example.config,
+                campaigns: [{ name: 'should-not-edit' }, preNormalizedCampaign],
+            },
+        };
+
+        expect(normalizeCallout(input)).toEqual(expectedOutput);
+    });
+});

--- a/src/model/normalizeCallout.ts
+++ b/src/model/normalizeCallout.ts
@@ -108,9 +108,8 @@ export const normalizeCallout = (body: CAPIType): CAPIType => {
             // This is made a little complex due to the fact that we are handling multiple arrys.
             // Furthermore there is no clear way of checking if a EmbedBlockElement is a CalloutBlockElement
             // currently `alt` and `html` in the EmbedBlockElement to search for a string mathcing the calloutElements tagName
-            blocks: body.blocks.map(block => ({
-                ...block,
-                elements: block.elements.map(block => {
+            blocks: body.blocks.map(block => {
+                const elements = block.elements.map(block => {
                     if (
                         block._type ===
                         'model.dotcomrendering.pageElements.EmbedBlockElement'
@@ -122,37 +121,37 @@ export const normalizeCallout = (body: CAPIType): CAPIType => {
                                 // as doing such a search can be costly
                                 if (block.alt) {
                                     return block.alt.search(ele.fields.tagName);
-                                } else {
-                                    return block.html.search(
-                                        ele.fields.tagName,
-                                    );
                                 }
+                                return block.html.search(ele.fields.tagName);
                             },
                         );
 
                         // TODO: throw warning if we have more than 1 match
-                        if (relatedCalloutElement.length > 1)
+                        if (relatedCalloutElement.length > 1) {
+                            // eslint-disable-next-line no-console
                             console.warn(
                                 'More than one callout block match candidate, need to investigate and mitigate issue',
                             );
+                        }
 
                         // if we find a match we should remove that EmbedBlockElement with a CalloutBlockElement
                         if (relatedCalloutElement.length) {
                             return formatCalloutObject(
                                 relatedCalloutElement[0],
                             );
-                        } else {
-                            return block;
                         }
-                    } else {
                         return block;
                     }
-                }),
-            })),
+                    return block;
+                });
 
+                return {
+                    ...block,
+                    elements,
+                };
+            }),
             // TODO: we can potentually remove callout campaigns from configs?
         };
-    } else {
-        return body;
     }
+    return body;
 };

--- a/src/model/normalizeCallout.ts
+++ b/src/model/normalizeCallout.ts
@@ -121,9 +121,14 @@ export const normalizeCallout = (body: CAPIType): CAPIType => {
                                 // if `alt` is defined we should use that in favor of HTML
                                 // as doing such a search can be costly
                                 if (block.alt) {
-                                    return block.alt.search(ele.fields.tagName);
+                                    return (
+                                        block.alt.search(ele.fields.tagName) !==
+                                        -1
+                                    );
                                 }
-                                return block.html.search(ele.fields.tagName);
+                                return (
+                                    block.html.search(ele.fields.tagName) !== -1
+                                );
                             },
                         );
 

--- a/src/model/normalizeCallout.ts
+++ b/src/model/normalizeCallout.ts
@@ -108,8 +108,9 @@ export const normalizeCallout = (body: CAPIType): CAPIType => {
             // This is made a little complex due to the fact that we are handling multiple arrys.
             // Furthermore there is no clear way of checking if a EmbedBlockElement is a CalloutBlockElement
             // currently `alt` and `html` in the EmbedBlockElement to search for a string mathcing the calloutElements tagName
-            blocks: body.blocks.map(block => {
-                const elements = block.elements.map(block => {
+            blocks: body.blocks.map(({ elements, ...rest }) => ({
+                ...rest,
+                elements: elements.map(block => {
                     if (
                         block._type ===
                         'model.dotcomrendering.pageElements.EmbedBlockElement'
@@ -143,13 +144,8 @@ export const normalizeCallout = (body: CAPIType): CAPIType => {
                         return block;
                     }
                     return block;
-                });
-
-                return {
-                    ...block,
-                    elements,
-                };
-            }),
+                }),
+            })),
             // TODO: we can potentually remove callout campaigns from configs?
         };
     }

--- a/src/model/normalizeCallout.ts
+++ b/src/model/normalizeCallout.ts
@@ -146,6 +146,7 @@ export const normalizeCallout = (body: CAPIType): CAPIType => {
                     return block;
                 }),
             })),
+
             // TODO: we can potentually remove callout campaigns from configs?
         };
     }

--- a/src/model/normalizeCallout.ts
+++ b/src/model/normalizeCallout.ts
@@ -1,0 +1,158 @@
+const formatCalloutObject = (
+    calloutObject: preNormalizedCampaignType,
+): CalloutBlockElement => ({
+    // this is a type suggestion for EmbedBlockElement that are acctually callout
+    _type: 'model.dotcomrendering.pageElements.CalloutBlockElement',
+    id: calloutObject.id,
+    activeFrom: calloutObject.activeFrom,
+    displayOnSensitive: calloutObject.displayOnSensitive,
+    formId: calloutObject.fields.formId,
+    title: calloutObject.fields.callout,
+    description: calloutObject.fields.description,
+    tagName: calloutObject.fields.tagName,
+    formFields: calloutObject.fields.formFields.map(
+        (field: preNormalizedCampaignFieldType): CampaignFieldType => {
+            switch (field.type) {
+                case 'text':
+                    return {
+                        id: Number(field.id),
+                        type: 'text',
+                        name: field.name,
+                        description: field.description,
+                        required: field.required === '1',
+                        textSize: field.text_size
+                            ? Number(field.text_size)
+                            : undefined,
+                        hideLabel: field.hide_label === '1',
+                        label: field.label,
+                    } as CampaignFieldText;
+                case 'textarea':
+                    return {
+                        id: Number(field.id),
+                        type: 'textarea',
+                        name: field.name,
+                        description: field.description,
+                        required: field.required === '1',
+                        textSize: field.text_size
+                            ? Number(field.text_size)
+                            : undefined,
+                        hideLabel: field.hide_label === '1',
+                        label: field.label,
+                    } as CampaignFieldTextArea;
+                case 'file':
+                    return {
+                        id: Number(field.id),
+                        type: 'file',
+                        name: field.name,
+                        required: field.required === '1',
+                        hideLabel: field.hide_label === '1',
+                        label: field.label,
+                    } as CampaignFieldFile;
+                case 'radio':
+                    return {
+                        id: Number(field.id),
+                        type: 'radio',
+                        name: field.name,
+                        required: field.required === '1',
+                        options: field.options.map(option => ({
+                            label: option.label,
+                            value: option.value,
+                        })),
+                        hideLabel: field.hide_label === '1',
+                        label: field.label,
+                    } as CampaignFieldRadio;
+                case 'checkbox':
+                    return {
+                        id: Number(field.id),
+                        type: 'checkbox',
+                        name: field.name,
+                        required: field.required === '1',
+                        options: field.options.map(option => ({
+                            label: option.label,
+                            value: option.value,
+                        })),
+                        hideLabel: field.hide_label === '1',
+                        label: field.label,
+                    } as CampaignFieldCheckbox;
+                case 'select':
+                    return {
+                        id: Number(field.id),
+                        type: 'select',
+                        name: field.name,
+                        required: field.required === '1',
+                        options: field.options.map(option => ({
+                            label: option.label,
+                            value: option.value,
+                        })),
+                        hideLabel: field.hide_label === '1',
+                        label: field.label,
+                    } as CampaignFieldSelect;
+            }
+        },
+    ),
+});
+
+// Convert callout campaigns from EmbedBlockElement to CalloutBlockElement
+export const normalizeCallout = (body: CAPIType): CAPIType => {
+    const calloutElements: preNormalizedCampaignType[] = body.config.campaigns
+        ? body.config.campaigns.filter(
+              ele => ele && ele.fields && ele.fields._type === 'callout',
+          )
+        : [];
+
+    if (calloutElements.length) {
+        return {
+            ...body,
+
+            // Need to convert EmbedBlockElement to relavant CalloutBlockElement
+            // This is made a little complex due to the fact that we are handling multiple arrys.
+            // Furthermore there is no clear way of checking if a EmbedBlockElement is a CalloutBlockElement
+            // currently `alt` and `html` in the EmbedBlockElement to search for a string mathcing the calloutElements tagName
+            blocks: body.blocks.map(block => ({
+                ...block,
+                elements: block.elements.map(block => {
+                    if (
+                        block._type ===
+                        'model.dotcomrendering.pageElements.EmbedBlockElement'
+                    ) {
+                        // need to determin if EmbedBlockElement is a callout
+                        const relatedCalloutElement = calloutElements.filter(
+                            ele => {
+                                // if `alt` is defined we should use that in favor of HTML
+                                // as doing such a search can be costly
+                                if (block.alt) {
+                                    return block.alt.search(ele.fields.tagName);
+                                } else {
+                                    return block.html.search(
+                                        ele.fields.tagName,
+                                    );
+                                }
+                            },
+                        );
+
+                        // TODO: throw warning if we have more than 1 match
+                        if (relatedCalloutElement.length > 1)
+                            console.warn(
+                                'More than one callout block match candidate, need to investigate and mitigate issue',
+                            );
+
+                        // if we find a match we should remove that EmbedBlockElement with a CalloutBlockElement
+                        if (relatedCalloutElement.length) {
+                            return formatCalloutObject(
+                                relatedCalloutElement[0],
+                            );
+                        } else {
+                            return block;
+                        }
+                    } else {
+                        return block;
+                    }
+                }),
+            })),
+
+            // TODO: we can potentually remove callout campaigns from configs?
+        };
+    } else {
+        return body;
+    }
+};


### PR DESCRIPTION
## What does this change?
We convert `EmbedBlockElement` to `CalloutBlockElement` if callout campaign tag name is found matches contents of `EmbedBlockElement`

## Why?
Currently there is no way to distinguish between `EmbedBlockElement` that are callouts. Also all the data relevant to rendering the callout campaign form is found in the CAPI `config.campaigns` key.

This PR will make it easier to handle these block elements, and enable us to SSR render them.