### PR TITLE
Show black title text for MatchReports

### DIFF
--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -88,6 +88,10 @@ const whiteFont = css`
     color: ${neutral[100]};
 `;
 
+const blackText = css`
+    color: ${neutral[0]};
+`;
+
 const secondaryStyle = css`
     ${headline.xxxsmall({ fontWeight: 'regular' })};
     display: block;
@@ -240,7 +244,9 @@ export const SeriesSectionLink = ({
                                     href={`${guardianBaseURL}/${tag.id}`}
                                     className={cx(
                                         sectionLabelLink,
-                                        pillarColours[pillar],
+                                        designType === 'MatchReport'
+                                            ? blackText
+                                            : pillarColours[pillar],
                                         primaryStyle,
                                         isSpecial && yellowBackground,
                                     )}
@@ -255,7 +261,9 @@ export const SeriesSectionLink = ({
                                         href={`${guardianBaseURL}/${sectionUrl}`}
                                         className={cx(
                                             sectionLabelLink,
-                                            pillarColours[pillar],
+                                            designType === 'MatchReport'
+                                                ? blackText
+                                                : pillarColours[pillar],
                                             secondaryStyle,
                                         )}
                                         data-component="section"
@@ -273,7 +281,9 @@ export const SeriesSectionLink = ({
                             href={`${guardianBaseURL}/${sectionUrl}`}
                             className={cx(
                                 sectionLabelLink,
-                                pillarColours[pillar],
+                                designType === 'MatchReport'
+                                    ? blackText
+                                    : pillarColours[pillar],
                                 primaryStyle,
                             )}
                             data-component="section"


### PR DESCRIPTION
## What does this change?
If `designType === 'MatchReport' set the title text colour to black

## Why?
Because MatchReports have a yellow background behind the title and the pilar colour looks off in this situation
