### PR TITLE
Type portal children as ReactNodes

### DIFF
--- a/src/web/components/Portal.tsx
+++ b/src/web/components/Portal.tsx
@@ -2,7 +2,7 @@ import ReactDOM from 'react-dom';
 
 type Props = {
     root: IslandType;
-    children: JSX.Element;
+    children: React.ReactNode;
     richLinkIndex?: number;
 };
 


### PR DESCRIPTION
## What does this change?
Changes the type used for portal children from `JSX.Element` to `React.ReactNode`

## Why?
To prevent typescript errors if null is passed