### PR TITLE
Remove nested dropcap span

### DIFF
--- a/src/web/components/DropCap.tsx
+++ b/src/web/components/DropCap.tsx
@@ -10,49 +10,15 @@ type Props = {
     designType: DesignType;
 };
 
-const outerStyles = (pillar: Pillar, designType: DesignType) => {
+const dropCapStyles = (pillar: Pillar, designType: DesignType) => {
     const baseStyles = css`
         ${headline.large({
             fontWeight: 'light',
         })}
-        float: left;
         text-transform: uppercase;
         box-sizing: border-box;
         margin-right: 4px;
-    `;
 
-    switch (designType) {
-        case 'GuardianView':
-        case 'Comment':
-            return css`
-                ${baseStyles};
-                color: ${opinion[400]};
-            `;
-        case 'Analysis':
-        case 'Feature':
-        case 'Interview':
-        case 'Article':
-        case 'Media':
-        case 'PhotoEssay':
-        case 'Review':
-        case 'Live':
-        case 'SpecialReport':
-        case 'Recipe':
-        case 'MatchReport':
-        case 'GuardianLabs':
-        case 'Quiz':
-        case 'AdvertisementFeature':
-        case 'Immersive':
-        default:
-            return css`
-                ${baseStyles};
-                color: ${pillarPalette[pillar].dark};
-            `;
-    }
-};
-
-const innerStyles = (designType: DesignType) => {
-    const baseStyles = css`
         font-size: 109px;
         line-height: 90px;
 
@@ -66,6 +32,7 @@ const innerStyles = (designType: DesignType) => {
         case 'Comment':
             return css`
                 ${baseStyles};
+                color: ${opinion[400]};
                 font-weight: 200;
             `;
         case 'Analysis':
@@ -86,13 +53,12 @@ const innerStyles = (designType: DesignType) => {
         default:
             return css`
                 ${baseStyles};
+                color: ${pillarPalette[pillar].dark};
                 font-weight: 700;
             `;
     }
 };
 
 export const DropCap = ({ letter, pillar, designType }: Props) => (
-    <span className={outerStyles(pillar, designType)}>
-        <span className={innerStyles(designType)}>{letter}</span>
-    </span>
+    <span className={dropCapStyles(pillar, designType)}>{letter}</span>
 );


### PR DESCRIPTION
## What does this change?

Remove the nested `span` and apply all styles to the single `span` element in DropCaps component.

## Why?

Google crawlers do not understand that the nested span is still part of the same paragraph. Therefore when showing a preview of the article, it only includes the drop cap character and not the rest of the sentence.

example:
![image_(5)](https://user-images.githubusercontent.com/8831403/84379514-da7d7a80-abdd-11ea-9972-3e11658fdc6a.png)

## Note
- these changes need to be made on frontend as well
- there is no clear way to test this, so we need to keep an eye out for articles in news with drop cap