### PR TITLE
Atoms documentation update

### DIFF
--- a/docs/atoms.md
+++ b/docs/atoms.md
@@ -74,6 +74,7 @@ AudioAtomBlockElement
 
 AtomEmbedUrlBlockElement
     -> [amp] AtomEmbedUrlBlockComponent
+    -> [web] InteractiveAtom (atoms-rendering)
 
 ExplainerAtomBlockElement
 	 -> [web] ExplainerAtom (atoms-rendering)


### PR DESCRIPTION
## What does this change?

Atoms documentation update to indicate that the `InteractiveAtom` which is carried from frontend to DCR by a `AtomEmbedUrlBlockElement` will be rendered on [web] with the `InteractiveAtom` atoms-rendering component.

This will be fine for the moment, but a future refactoring should ensure that distinct atoms are carried by distinct `BlockElement`s so that DCR uses the right atoms-rendering component to render them.
