### PR TITLE
Use InteractiveAtom from atoms-rendering at DCR [web] [WIP]

### DIFF
--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -12,6 +12,7 @@ interface AtomEmbedMarkupBlockElement {
 
 interface AtomEmbedUrlBlockElement {
     _type: 'model.dotcomrendering.pageElements.AtomEmbedUrlBlockElement';
+    id: string;
     url: string;
 }
 

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -14,7 +14,7 @@ import { TextBlockComponent } from '@root/src/web/components/elements/TextBlockC
 import { TweetBlockComponent } from '@root/src/web/components/elements/TweetBlockComponent';
 import { YoutubeBlockComponent } from '@root/src/web/components/elements/YoutubeBlockComponent';
 
-import { ExplainerAtom } from '@guardian/atoms-rendering';
+import { ExplainerAtom, InteractiveAtom } from '@guardian/atoms-rendering';
 
 // This is required for spacefinder to work!
 const commercialPosition = css`
@@ -37,6 +37,10 @@ export const ArticleRenderer: React.FC<{
     const output = elements
         .map((element, i) => {
             switch (element._type) {
+                case 'model.dotcomrendering.pageElements.AtomEmbedUrlBlockElement':
+                    return (
+                        <InteractiveAtom id={element.id} url={element.url} />
+                    );
                 case 'model.dotcomrendering.pageElements.BlockquoteBlockElement':
                     return (
                         <BlockquoteBlockComponent
@@ -138,7 +142,6 @@ export const ArticleRenderer: React.FC<{
                         />
                     );
                 case 'model.dotcomrendering.pageElements.AtomEmbedMarkupBlockElement':
-                case 'model.dotcomrendering.pageElements.AtomEmbedUrlBlockElement':
                 case 'model.dotcomrendering.pageElements.AudioBlockElement':
                 case 'model.dotcomrendering.pageElements.AudioAtomBlockElement':
                 case 'model.dotcomrendering.pageElements.CodeBlockElement':


### PR DESCRIPTION
## What does this change?

Use InteractiveAtom from atoms-rendering at DCR [web]. 

Current state: 

<img width="836" alt="Screenshot 2020-06-13 at 22 19 03" src="https://user-images.githubusercontent.com/6035518/84579244-34d83000-adc4-11ea-864c-eaab5a65496e.png">

