### PR TITLE
Introduce the ChartAtomBlockElement in DCR

### DIFF
--- a/docs/atoms.md
+++ b/docs/atoms.md
@@ -31,7 +31,7 @@ AudioAtom
     -> AudioAtomBlockElement
 
 ChartAtom
-    -> AtomEmbedUrlBlockElement
+    -> ChartAtomBlockElement
 
 CommonsDivisionAtom
 
@@ -75,6 +75,9 @@ AudioAtomBlockElement
 AtomEmbedUrlBlockElement
     -> [amp] AtomEmbedUrlBlockComponent
     -> [web] InteractiveAtom (atoms-rendering)
+
+ChartAtomBlockElement
+    -> [web] ChartAtom (atoms-rendering)
 
 ExplainerAtomBlockElement
 	 -> [web] ExplainerAtom (atoms-rendering)

--- a/src/amp/components/Elements.tsx
+++ b/src/amp/components/Elements.tsx
@@ -57,6 +57,8 @@ export const Elements = (
                         pillar={pillar}
                     />
                 );
+            case 'model.dotcomrendering.pageElements.ChartAtomBlockElement':
+                return <AtomEmbedUrlBlockComponent url={element.url} />;
             case 'model.dotcomrendering.pageElements.CommentBlockElement':
                 return <CommentBlockComponent key={i} element={element} />;
             case 'model.dotcomrendering.pageElements.ContentAtomBlockElement':

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -33,6 +33,12 @@ interface BlockquoteBlockElement {
     html: string;
 }
 
+interface ChartAtomBlockElement {
+    _type: 'model.dotcomrendering.pageElements.ChartAtomBlockElement';
+    id: string;
+    url: string;
+}
+
 interface CodeBlockElement {
     _type: 'model.dotcomrendering.pageElements.CodeBlockElement';
     isMandatory: boolean;
@@ -267,6 +273,7 @@ type CAPIElement =
     | AudioAtomElement
     | AudioBlockElement
     | BlockquoteBlockElement
+    | ChartAtomBlockElement
     | CodeBlockElement
     | CommentBlockElement
     | ContentAtomBlockElement

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -30,6 +30,9 @@
                         "$ref": "#/definitions/BlockquoteBlockElement"
                     },
                     {
+                        "$ref": "#/definitions/ChartAtomBlockElement"
+                    },
+                    {
                         "$ref": "#/definitions/CodeBlockElement"
                     },
                     {
@@ -381,9 +384,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type"
-            ]
+            "required": ["_type"]
         },
         "AtomEmbedUrlBlockElement": {
             "type": "object",
@@ -398,10 +399,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "url"
-            ]
+            "required": ["_type", "url"]
         },
         "AudioAtomElement": {
             "type": "object",
@@ -447,9 +445,7 @@
                     ]
                 }
             },
-            "required": [
-                "_type"
-            ]
+            "required": ["_type"]
         },
         "BlockquoteBlockElement": {
             "type": "object",
@@ -464,10 +460,25 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "html"
-            ]
+            "required": ["_type", "html"]
+        },
+        "ChartAtomBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.ChartAtomBlockElement"
+                    ]
+                },
+                "id": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            },
+            "required": ["_type", "id", "url"]
         },
         "CodeBlockElement": {
             "type": "object",
@@ -482,10 +493,7 @@
                     "type": "boolean"
                 }
             },
-            "required": [
-                "_type",
-                "isMandatory"
-            ]
+            "required": ["_type", "isMandatory"]
         },
         "CommentBlockElement": {
             "type": "object",
@@ -538,10 +546,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "atomId"
-            ]
+            "required": ["_type", "atomId"]
         },
         "DisclaimerBlockElement": {
             "type": "object",
@@ -556,10 +561,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "html"
-            ]
+            "required": ["_type", "html"]
         },
         "DividerBlockElement": {
             "type": "object",
@@ -571,9 +573,7 @@
                     ]
                 }
             },
-            "required": [
-                "_type"
-            ]
+            "required": ["_type"]
         },
         "DocumentBlockElement": {
             "type": "object",
@@ -588,10 +588,7 @@
                     "type": "boolean"
                 }
             },
-            "required": [
-                "_type",
-                "isMandatory"
-            ]
+            "required": ["_type", "isMandatory"]
         },
         "EmbedBlockElement": {
             "type": "object",
@@ -615,11 +612,7 @@
                     "type": "boolean"
                 }
             },
-            "required": [
-                "_type",
-                "html",
-                "isMandatory"
-            ]
+            "required": ["_type", "html", "isMandatory"]
         },
         "ExplainerAtomBlockElement": {
             "type": "object",
@@ -640,12 +633,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "body",
-                "id",
-                "title"
-            ]
+            "required": ["_type", "body", "id", "title"]
         },
         "GuideAtomBlockElement": {
             "type": "object",
@@ -675,14 +663,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "credit",
-                "html",
-                "id",
-                "label",
-                "title"
-            ]
+            "required": ["_type", "credit", "html", "id", "label", "title"]
         },
         "GuVideoBlockElement": {
             "type": "object",
@@ -703,11 +684,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "assets",
-                "caption"
-            ]
+            "required": ["_type", "assets", "caption"]
         },
         "VideoAssets": {
             "type": "object",
@@ -719,10 +696,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "mimeType",
-                "url"
-            ]
+            "required": ["mimeType", "url"]
         },
         "ImageBlockElement": {
             "type": "object",
@@ -743,9 +717,7 @@
                             }
                         }
                     },
-                    "required": [
-                        "allImages"
-                    ]
+                    "required": ["allImages"]
                 },
                 "data": {
                     "type": "object",
@@ -777,13 +749,7 @@
                     "$ref": "#/definitions/RoleType"
                 }
             },
-            "required": [
-                "_type",
-                "data",
-                "imageSources",
-                "media",
-                "role"
-            ]
+            "required": ["_type", "data", "imageSources", "media", "role"]
         },
         "Image": {
             "type": "object",
@@ -804,10 +770,7 @@
                             "type": "string"
                         }
                     },
-                    "required": [
-                        "height",
-                        "width"
-                    ]
+                    "required": ["height", "width"]
                 },
                 "mediaType": {
                     "type": "string"
@@ -819,13 +782,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "fields",
-                "index",
-                "mediaType",
-                "mimeType",
-                "url"
-            ]
+            "required": ["fields", "index", "mediaType", "mimeType", "url"]
         },
         "ImageSource": {
             "type": "object",
@@ -840,10 +797,7 @@
                     }
                 }
             },
-            "required": [
-                "srcSet",
-                "weighting"
-            ]
+            "required": ["srcSet", "weighting"]
         },
         "Weighting": {
             "enum": [
@@ -866,10 +820,7 @@
                     "type": "number"
                 }
             },
-            "required": [
-                "src",
-                "width"
-            ]
+            "required": ["src", "width"]
         },
         "RoleType": {
             "enum": [
@@ -901,12 +852,7 @@
                     "type": "boolean"
                 }
             },
-            "required": [
-                "_type",
-                "hasCaption",
-                "html",
-                "url"
-            ]
+            "required": ["_type", "hasCaption", "html", "url"]
         },
         "MapBlockElement": {
             "type": "object",
@@ -961,10 +907,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "images"
-            ]
+            "required": ["_type", "images"]
         },
         "ProfileAtomBlockElement": {
             "type": "object",
@@ -994,14 +937,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "credit",
-                "html",
-                "id",
-                "label",
-                "title"
-            ]
+            "required": ["_type", "credit", "html", "id", "label", "title"]
         },
         "PullquoteBlockElement": {
             "type": "object",
@@ -1022,11 +958,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "html",
-                "role"
-            ]
+            "required": ["_type", "html", "role"]
         },
         "QABlockElement": {
             "type": "object",
@@ -1053,13 +985,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "credit",
-                "html",
-                "id",
-                "title"
-            ]
+            "required": ["_type", "credit", "html", "id", "title"]
         },
         "RichLinkBlockElement": {
             "type": "object",
@@ -1086,12 +1012,7 @@
                     "type": "number"
                 }
             },
-            "required": [
-                "_type",
-                "prefix",
-                "text",
-                "url"
-            ]
+            "required": ["_type", "prefix", "text", "url"]
         },
         "SoundcloudBlockElement": {
             "type": "object",
@@ -1115,13 +1036,7 @@
                     "type": "boolean"
                 }
             },
-            "required": [
-                "_type",
-                "html",
-                "id",
-                "isMandatory",
-                "isTrack"
-            ]
+            "required": ["_type", "html", "id", "isMandatory", "isTrack"]
         },
         "SubheadingBlockElement": {
             "type": "object",
@@ -1136,10 +1051,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "html"
-            ]
+            "required": ["_type", "html"]
         },
         "TableBlockElement": {
             "type": "object",
@@ -1154,10 +1066,7 @@
                     "type": "boolean"
                 }
             },
-            "required": [
-                "_type",
-                "isMandatory"
-            ]
+            "required": ["_type", "isMandatory"]
         },
         "TextBlockElement": {
             "type": "object",
@@ -1175,10 +1084,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "html"
-            ]
+            "required": ["_type", "html"]
         },
         "TimelineBlockElement": {
             "type": "object",
@@ -1205,12 +1111,7 @@
                     }
                 }
             },
-            "required": [
-                "_type",
-                "events",
-                "id",
-                "title"
-            ]
+            "required": ["_type", "events", "id", "title"]
         },
         "TimelineEvent": {
             "type": "object",
@@ -1228,10 +1129,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "date",
-                "title"
-            ]
+            "required": ["date", "title"]
         },
         "TweetBlockElement": {
             "type": "object",
@@ -1255,13 +1153,7 @@
                     "type": "boolean"
                 }
             },
-            "required": [
-                "_type",
-                "hasMedia",
-                "html",
-                "id",
-                "url"
-            ]
+            "required": ["_type", "hasMedia", "html", "id", "url"]
         },
         "VideoBlockElement": {
             "type": "object",
@@ -1273,9 +1165,7 @@
                     ]
                 }
             },
-            "required": [
-                "_type"
-            ]
+            "required": ["_type"]
         },
         "VideoFacebookBlockElement": {
             "type": "object",
@@ -1299,13 +1189,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "caption",
-                "height",
-                "url",
-                "width"
-            ]
+            "required": ["_type", "caption", "height", "url", "width"]
         },
         "VideoVimeoBlockElement": {
             "type": "object",
@@ -1329,13 +1213,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "caption",
-                "height",
-                "url",
-                "width"
-            ]
+            "required": ["_type", "caption", "height", "url", "width"]
         },
         "VideoYoutubeBlockElement": {
             "type": "object",
@@ -1359,13 +1237,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "caption",
-                "height",
-                "url",
-                "width"
-            ]
+            "required": ["_type", "caption", "height", "url", "width"]
         },
         "YoutubeBlockElement": {
             "type": "object",
@@ -1401,11 +1273,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "assetId",
-                "mediaTitle"
-            ]
+            "required": ["_type", "assetId", "mediaTitle"]
         },
         "Block": {
             "type": "object",
@@ -1431,6 +1299,9 @@
                             },
                             {
                                 "$ref": "#/definitions/BlockquoteBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/ChartAtomBlockElement"
                             },
                             {
                                 "$ref": "#/definitions/CodeBlockElement"
@@ -1544,10 +1415,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "elements",
-                "id"
-            ]
+            "required": ["elements", "id"]
         },
         "Pagination": {
             "type": "object",
@@ -1571,10 +1439,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "currentPage",
-                "totalPages"
-            ]
+            "required": ["currentPage", "totalPages"]
         },
         "AuthorType": {
             "type": "object",
@@ -1591,12 +1456,7 @@
             }
         },
         "Edition": {
-            "enum": [
-                "AU",
-                "INT",
-                "UK",
-                "US"
-            ],
+            "enum": ["AU", "INT", "UK", "US"],
             "type": "string"
         },
         "TagType": {
@@ -1621,11 +1481,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "id",
-                "title",
-                "type"
-            ]
+            "required": ["id", "title", "type"]
         },
         "Pillar": {
             "enum": [
@@ -1648,10 +1504,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "title",
-                "url"
-            ]
+            "required": ["title", "url"]
         },
         "ConfigType": {
             "description": "the config model will contain useful app/site\nlevel data. Although currently derived from the config model\nconstructed in frontend and passed to dotcom-rendering\nthis data could eventually be defined in dotcom-rendering",
@@ -1855,12 +1708,7 @@
                     "$ref": "#/definitions/EditionCommercialProperties"
                 }
             },
-            "required": [
-                "AU",
-                "INT",
-                "UK",
-                "US"
-            ]
+            "required": ["AU", "INT", "UK", "US"]
         },
         "EditionCommercialProperties": {
             "type": "object",
@@ -1875,9 +1723,7 @@
                     "$ref": "#/definitions/Branding"
                 }
             },
-            "required": [
-                "adTargeting"
-            ]
+            "required": ["adTargeting"]
         },
         "AdTargetParam": {
             "type": "object",
@@ -1899,10 +1745,7 @@
                     ]
                 }
             },
-            "required": [
-                "name",
-                "value"
-            ]
+            "required": ["name", "value"]
         },
         "Branding": {
             "type": "object",
@@ -1914,9 +1757,7 @@
                             "type": "string"
                         }
                     },
-                    "required": [
-                        "name"
-                    ]
+                    "required": ["name"]
                 },
                 "sponsorName": {
                     "type": "string"
@@ -1943,18 +1784,10 @@
                                     "type": "number"
                                 }
                             },
-                            "required": [
-                                "height",
-                                "width"
-                            ]
+                            "required": ["height", "width"]
                         }
                     },
-                    "required": [
-                        "dimensions",
-                        "label",
-                        "link",
-                        "src"
-                    ]
+                    "required": ["dimensions", "label", "link", "src"]
                 },
                 "aboutThisLink": {
                     "type": "string"
@@ -1975,10 +1808,7 @@
                                     "type": "number"
                                 }
                             },
-                            "required": [
-                                "height",
-                                "width"
-                            ]
+                            "required": ["height", "width"]
                         },
                         "link": {
                             "type": "string"
@@ -1987,19 +1817,10 @@
                             "type": "string"
                         }
                     },
-                    "required": [
-                        "dimensions",
-                        "label",
-                        "link",
-                        "src"
-                    ]
+                    "required": ["dimensions", "label", "link", "src"]
                 }
             },
-            "required": [
-                "aboutThisLink",
-                "logo",
-                "sponsorName"
-            ]
+            "required": ["aboutThisLink", "logo", "sponsorName"]
         },
         "BadgeType": {
             "type": "object",
@@ -2011,10 +1832,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "imageUrl",
-                "seriesTag"
-            ]
+            "required": ["imageUrl", "seriesTag"]
         },
         "FooterType": {
             "type": "object",
@@ -2029,9 +1847,7 @@
                     }
                 }
             },
-            "required": [
-                "footerLinks"
-            ]
+            "required": ["footerLinks"]
         },
         "FooterLink": {
             "type": "object",
@@ -2049,11 +1865,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "dataLinkName",
-                "text",
-                "url"
-            ]
+            "required": ["dataLinkName", "text", "url"]
         }
     },
     "$schema": "http://json-schema.org/draft-07/schema#"

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -47,6 +47,8 @@ export const ArticleRenderer: React.FC<{
                     );
                 case 'model.dotcomrendering.pageElements.DividerBlockElement':
                     return <DividerBlockComponent />;
+                case 'model.dotcomrendering.pageElements.ChartAtomBlockElement':
+                    return null; // will be filled shortly with the ChartAtom from atoms-rendering
                 case 'model.dotcomrendering.pageElements.EmbedBlockElement':
                     return (
                         <EmbedBlockComponent


### PR DESCRIPTION
## What does this change?

This introduce the ChartAtomBlockElement in DCR. 

## Why?

In order for `ChartAtom`s coming from the backend to use the corresponding atoms-rendering `ChartAtom` component they need to be carried by their own `BlockElement`. Currently they are carried by a `AtomEmbedUrlBlockElement`, which is shared by several atoms and doesn't allow for discrimination on DCR (and therefore doesn't allow for choosing the right Atom component).

This is the first of three PRs, in the second we will switch to `ChartAtomBlockElement` in the backend, and in the third will use the ChartAtom component in DCR. 

ps: Similar transformations will have to be done for other Atom which are sharing the same backend `BlockElement`s