### PR TITLE
Adding support for football table embeds

### DIFF
--- a/cypress/integration/e2e/article.elements.spec.js
+++ b/cypress/integration/e2e/article.elements.spec.js
@@ -75,5 +75,19 @@ describe('Elements', function() {
 
             getIframeBody().contains('Cookie policy');
         });
+
+        it('should render the football embed', function() {
+            const getBody = () => {
+                return cy
+                    .get('div[data-cy="football-table-embed"]')
+                    .should('not.be.empty')
+                    .then(cy.wrap);
+            };
+            cy.visit(
+                'Article?url=https://www.theguardian.com/football/2020/jun/10/premier-league-restart-preview-no-5-burnley',
+            );
+
+            getBody().contains('Liverpool');
+        });
     });
 });

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -191,6 +191,7 @@ interface SubheadingBlockElement {
 interface TableBlockElement {
     _type: 'model.dotcomrendering.pageElements.TableBlockElement';
     isMandatory: boolean;
+    html: string;
 }
 
 interface TextBlockElement {

--- a/src/web/components/elements/TableBlockComponent.tsx
+++ b/src/web/components/elements/TableBlockComponent.tsx
@@ -6,7 +6,6 @@ import { textSans } from '@guardian/src-foundations/typography';
 
 const tableEmbed = css`
     .table--football {
-        /* The  embed js hijacks the iframe and calculated an incorrect width, which pushed the body out */
         width: 100%;
         background: ${palette.background.secondary};
         border-top: 0.0625rem solid ${border.focusHalo};
@@ -43,6 +42,8 @@ const tableEmbed = css`
             width: 100%;
         }
     }
+
+    margin-bottom: 16px;
 `;
 
 export const TableBlockComponent: React.FC<{

--- a/src/web/components/elements/TableBlockComponent.tsx
+++ b/src/web/components/elements/TableBlockComponent.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { css } from 'emotion';
+import { unescapeData } from '@root/src/lib/escapeData';
+import { palette, border } from '@guardian/src-foundations';
+import { textSans } from '@guardian/src-foundations/typography';
+
+const tableEmbed = css`
+    .table--football {
+        /* The  embed js hijacks the iframe and calculated an incorrect width, which pushed the body out */
+        width: 100%;
+        background: ${palette.background.secondary};
+        border-top: 0.0625rem solid ${border.focusHalo};
+        border-collapse: inherit;
+
+        tr:nth-child(odd) > td {
+            background-color: ${palette.neutral[93]};
+        }
+
+        th {
+            padding: 0.5rem;
+        }
+
+        td {
+            padding: 0.5rem;
+        }
+
+        tr {
+            ${textSans.xsmall()};
+        }
+
+        thead {
+            tr {
+                font-weight: 800;
+                text-align: left;
+            }
+        }
+
+        tr > th:first-child,
+        td:first-child {
+            color: ${palette.text.supporting};
+        }
+        .table-column--main {
+            width: 100%;
+        }
+    }
+`;
+
+export const TableBlockComponent: React.FC<{
+    element: TableBlockElement;
+}> = ({ element }) => {
+    return (
+        <div
+            className={tableEmbed}
+            data-cy="football-table-embed"
+            dangerouslySetInnerHTML={{ __html: unescapeData(element.html) }}
+        />
+    );
+};

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -10,6 +10,7 @@ import { InstagramBlockComponent } from '@root/src/web/components/elements/Insta
 import { PullQuoteBlockComponent } from '@root/src/web/components/elements/PullQuoteBlockComponent';
 import { SoundcloudBlockComponent } from '@root/src/web/components/elements/SoundcloudBlockComponent';
 import { SubheadingBlockComponent } from '@root/src/web/components/elements/SubheadingBlockComponent';
+import { TableBlockComponent } from '@root/src/web/components/elements/TableBlockComponent';
 import { TextBlockComponent } from '@root/src/web/components/elements/TextBlockComponent';
 import { TweetBlockComponent } from '@root/src/web/components/elements/TweetBlockComponent';
 import { YoutubeBlockComponent } from '@root/src/web/components/elements/YoutubeBlockComponent';
@@ -111,6 +112,8 @@ export const ArticleRenderer: React.FC<{
                     return (
                         <SubheadingBlockComponent key={i} html={element.html} />
                     );
+                case 'model.dotcomrendering.pageElements.TableBlockElement':
+                    return <TableBlockComponent element={element} />;
                 case 'model.dotcomrendering.pageElements.TextBlockElement':
                     return (
                         <TextBlockComponent
@@ -153,7 +156,6 @@ export const ArticleRenderer: React.FC<{
                 case 'model.dotcomrendering.pageElements.GuideAtomBlockElement':
                 case 'model.dotcomrendering.pageElements.ProfileAtomBlockElement':
                 case 'model.dotcomrendering.pageElements.QABlockElement':
-                case 'model.dotcomrendering.pageElements.TableBlockElement':
                 case 'model.dotcomrendering.pageElements.TimelineBlockElement':
                 case 'model.dotcomrendering.pageElements.VideoBlockElement':
                 case 'model.dotcomrendering.pageElements.VideoFacebookBlockElement':


### PR DESCRIPTION
## What does this change?
Adds the support for rendering football table embeds. E.g. https://www.theguardian.com/football/2020/jun/10/premier-league-restart-preview-no-5-burnley.

Source does not have the same font-size available, so there is a slight visual discrepancy

### Frontend
<img width="793" alt="Screen Shot 2020-06-14 at 21 49 01" src="https://user-images.githubusercontent.com/2051501/84603835-71219400-ae89-11ea-8ec2-1b365cc96202.png">

### DCR
<img width="793" alt="Screen Shot 2020-06-14 at 21 48 39" src="https://user-images.githubusercontent.com/2051501/84603832-6f57d080-ae89-11ea-8579-a47ea6acf1a3.png">

### Why?
https://trello.com/c/5eyG4hWH/1258-tableblockelement
