### PR TITLE
Drop caps are black on photo essays

### DIFF
--- a/src/web/components/DropCap.tsx
+++ b/src/web/components/DropCap.tsx
@@ -28,12 +28,15 @@ const outerStyles = (pillar: Pillar, designType: DesignType) => {
                 ${baseStyles};
                 color: ${opinion[400]};
             `;
+        case 'PhotoEssay':
+            return css`
+                ${baseStyles};
+            `;
         case 'Analysis':
         case 'Feature':
         case 'Interview':
         case 'Article':
         case 'Media':
-        case 'PhotoEssay':
         case 'Review':
         case 'Live':
         case 'SpecialReport':


### PR DESCRIPTION
## What does this change?
Prevents pillar colour being applied if `designType` is 'PhotoEssay'

## Why?
Because photo essays have black dropcaps
