### PR TITLE
update 'My account' dropdown links following 'Account overview' overhaul in MMA

### DIFF
--- a/src/web/components/Links.tsx
+++ b/src/web/components/Links.tsx
@@ -123,39 +123,34 @@ const linksStyles = css`
 export const Links = ({ userId }: Props) => {
     const identityLinks: DropdownLinkType[] = [
         {
-            url: `https://profile.theguardian.com/user/id/${userId}`,
-            title: 'Comments and replies',
-            dataLinkName: 'nav2 : topbar : comment activity',
+            url: `https://manage.theguardian.com/`,
+            title: 'Account overview',
+            dataLinkName: 'nav2 : topbar : account overview',
         },
         {
-            url: `https://profile.theguardian.com/public/edit`,
-            title: 'Public profile',
+            url: `https://profile.theguardian.com/public-settings`,
+            title: 'Profile',
             dataLinkName: 'nav2 : topbar : edit profile',
         },
         {
-            url: `https://profile.theguardian.com/account/edit`,
-            title: 'Account details',
-            dataLinkName: 'nav2 : topbar : account details',
-        },
-        {
-            url: `https://profile.theguardian.com/email-prefs`,
-            title: 'Emails and marketing',
+            url: `https://manage.theguardian.com/email-prefs`,
+            title: 'Emails & marketing',
             dataLinkName: 'nav2 : topbar : email prefs',
         },
         {
-            url: `https://profile.theguardian.com/membership/edit`,
-            title: 'Membership',
-            dataLinkName: 'nav2 : topbar : membership',
+            url: `https://manage.theguardian.com/account-settings`,
+            title: 'Settings',
+            dataLinkName: 'nav2 : topbar : settings',
         },
         {
-            url: `https://profile.theguardian.com/contribution/recurring/edit`,
-            title: 'Contributions',
-            dataLinkName: 'nav2 : topbar : contributions',
+            url: `https://manage.theguardian.com/help`,
+            title: 'Help',
+            dataLinkName: 'nav2 : topbar : help',
         },
         {
-            url: `https://profile.theguardian.com/digitalpack/edit`,
-            title: 'Digital pack',
-            dataLinkName: 'nav2 : topbar : subscriptions',
+            url: `https://profile.theguardian.com/user/id/${userId}`,
+            title: 'Comments & replies',
+            dataLinkName: 'nav2 : topbar : comment activity',
         },
         {
             url: `https://profile.theguardian.com/signout`,


### PR DESCRIPTION
**_Accompanying https://github.com/guardian/frontend/pull/22695_**

Following the 'Account overview' overhaul in MMA (as presented by Jian in the all-hands on Thu 11 June 2020) the links in the 'My account' dropdown navigation on theguardian.com need to respect the new structure in MMA (see https://github.com/guardian/manage-frontend/pull/438).

## What does this change?
**For now this just changes the JSON for the list items following the MMA re-structure.**

There are some style/layout inconsistencies between this and the implementation in [`manage-frontend`](https://github.com/guardian/manage-frontend) and when working on this change it became obvious this should become a design systems component 😄 . Having spoken to @SiAdcock and @akemitakagi moves are afoot to make this happen and myself and @rBangay are committed to doing this properly as part of the _'Reader Revenue Source'_ - see https://trello.com/c/w6eE74rG/1409-my-account-dropdown-as-a-design-systems-component.

It's also worth noting that there are some style/layout inconsistencies between this and the implementation in [`frontend`](https://github.com/guardian/frontend) which isn't ideal but is beyond the scope of this ticket.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/19289579/84807090-9e438300-affe-11ea-831d-1f4f915182dd.png) |  ![image](https://user-images.githubusercontent.com/19289579/84806920-5ae91480-affe-11ea-873b-36ed331fec22.png)|

_it's worth pointing out that the **'Digital pack' item was well out of date** and should've been 'Subscriptions' since Jan 2019 (https://github.com/guardian/frontend/pull/20991) - not sure where it was copied from in the early days of DCR_

## Why?
https://trello.com/c/09kqpMhF/1207-update-my-account-navigation-drop-down-on-dotcom