### PR TITLE
Vimeo block element support

### DIFF
--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -227,7 +227,6 @@ interface VideoVimeoBlockElement {
     height: number;
     width: number;
     caption: string;
-    html: string;
     credit: string;
     title: string;
     description: string;

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -226,7 +226,7 @@ interface VideoVimeoBlockElement {
     url: string;
     height: number;
     width: number;
-    caption: string;
+    caption?: string;
     credit: string;
     title: string;
     description: string;

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -228,6 +228,9 @@ interface VideoVimeoBlockElement {
     width: number;
     caption: string;
     html: string;
+    credit: string;
+    title: string;
+    description: string;
 }
 
 interface VideoYoutubeBlockElement {

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -227,6 +227,7 @@ interface VideoVimeoBlockElement {
     height: number;
     width: number;
     caption: string;
+    html: string;
 }
 
 interface VideoYoutubeBlockElement {

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -1340,7 +1340,6 @@
             },
             "required": [
                 "_type",
-                "caption",
                 "credit",
                 "description",
                 "height",

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -381,7 +381,9 @@
                     "type": "string"
                 }
             },
-            "required": ["_type"]
+            "required": [
+                "_type"
+            ]
         },
         "AtomEmbedUrlBlockElement": {
             "type": "object",
@@ -396,7 +398,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "url"]
+            "required": [
+                "_type",
+                "url"
+            ]
         },
         "AudioAtomElement": {
             "type": "object",
@@ -442,7 +447,9 @@
                     ]
                 }
             },
-            "required": ["_type"]
+            "required": [
+                "_type"
+            ]
         },
         "BlockquoteBlockElement": {
             "type": "object",
@@ -457,7 +464,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "html"]
+            "required": [
+                "_type",
+                "html"
+            ]
         },
         "CodeBlockElement": {
             "type": "object",
@@ -472,7 +482,10 @@
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "isMandatory"]
+            "required": [
+                "_type",
+                "isMandatory"
+            ]
         },
         "CommentBlockElement": {
             "type": "object",
@@ -525,7 +538,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "atomId"]
+            "required": [
+                "_type",
+                "atomId"
+            ]
         },
         "DisclaimerBlockElement": {
             "type": "object",
@@ -540,7 +556,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "html"]
+            "required": [
+                "_type",
+                "html"
+            ]
         },
         "DividerBlockElement": {
             "type": "object",
@@ -552,7 +571,9 @@
                     ]
                 }
             },
-            "required": ["_type"]
+            "required": [
+                "_type"
+            ]
         },
         "DocumentBlockElement": {
             "type": "object",
@@ -567,7 +588,10 @@
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "isMandatory"]
+            "required": [
+                "_type",
+                "isMandatory"
+            ]
         },
         "EmbedBlockElement": {
             "type": "object",
@@ -591,7 +615,11 @@
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "html", "isMandatory"]
+            "required": [
+                "_type",
+                "html",
+                "isMandatory"
+            ]
         },
         "ExplainerAtomBlockElement": {
             "type": "object",
@@ -612,7 +640,12 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "body", "id", "title"]
+            "required": [
+                "_type",
+                "body",
+                "id",
+                "title"
+            ]
         },
         "GuideAtomBlockElement": {
             "type": "object",
@@ -642,7 +675,14 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "credit", "html", "id", "label", "title"]
+            "required": [
+                "_type",
+                "credit",
+                "html",
+                "id",
+                "label",
+                "title"
+            ]
         },
         "GuVideoBlockElement": {
             "type": "object",
@@ -663,7 +703,11 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "assets", "caption"]
+            "required": [
+                "_type",
+                "assets",
+                "caption"
+            ]
         },
         "VideoAssets": {
             "type": "object",
@@ -675,7 +719,10 @@
                     "type": "string"
                 }
             },
-            "required": ["mimeType", "url"]
+            "required": [
+                "mimeType",
+                "url"
+            ]
         },
         "ImageBlockElement": {
             "type": "object",
@@ -696,7 +743,9 @@
                             }
                         }
                     },
-                    "required": ["allImages"]
+                    "required": [
+                        "allImages"
+                    ]
                 },
                 "data": {
                     "type": "object",
@@ -728,7 +777,13 @@
                     "$ref": "#/definitions/RoleType"
                 }
             },
-            "required": ["_type", "data", "imageSources", "media", "role"]
+            "required": [
+                "_type",
+                "data",
+                "imageSources",
+                "media",
+                "role"
+            ]
         },
         "Image": {
             "type": "object",
@@ -749,7 +804,10 @@
                             "type": "string"
                         }
                     },
-                    "required": ["height", "width"]
+                    "required": [
+                        "height",
+                        "width"
+                    ]
                 },
                 "mediaType": {
                     "type": "string"
@@ -761,7 +819,13 @@
                     "type": "string"
                 }
             },
-            "required": ["fields", "index", "mediaType", "mimeType", "url"]
+            "required": [
+                "fields",
+                "index",
+                "mediaType",
+                "mimeType",
+                "url"
+            ]
         },
         "ImageSource": {
             "type": "object",
@@ -776,7 +840,10 @@
                     }
                 }
             },
-            "required": ["srcSet", "weighting"]
+            "required": [
+                "srcSet",
+                "weighting"
+            ]
         },
         "Weighting": {
             "enum": [
@@ -799,7 +866,10 @@
                     "type": "number"
                 }
             },
-            "required": ["src", "width"]
+            "required": [
+                "src",
+                "width"
+            ]
         },
         "RoleType": {
             "enum": [
@@ -831,7 +901,12 @@
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "hasCaption", "html", "url"]
+            "required": [
+                "_type",
+                "hasCaption",
+                "html",
+                "url"
+            ]
         },
         "MapBlockElement": {
             "type": "object",
@@ -886,7 +961,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "images"]
+            "required": [
+                "_type",
+                "images"
+            ]
         },
         "ProfileAtomBlockElement": {
             "type": "object",
@@ -916,7 +994,14 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "credit", "html", "id", "label", "title"]
+            "required": [
+                "_type",
+                "credit",
+                "html",
+                "id",
+                "label",
+                "title"
+            ]
         },
         "PullquoteBlockElement": {
             "type": "object",
@@ -937,7 +1022,11 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "html", "role"]
+            "required": [
+                "_type",
+                "html",
+                "role"
+            ]
         },
         "QABlockElement": {
             "type": "object",
@@ -964,7 +1053,13 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "credit", "html", "id", "title"]
+            "required": [
+                "_type",
+                "credit",
+                "html",
+                "id",
+                "title"
+            ]
         },
         "RichLinkBlockElement": {
             "type": "object",
@@ -991,7 +1086,12 @@
                     "type": "number"
                 }
             },
-            "required": ["_type", "prefix", "text", "url"]
+            "required": [
+                "_type",
+                "prefix",
+                "text",
+                "url"
+            ]
         },
         "SoundcloudBlockElement": {
             "type": "object",
@@ -1015,7 +1115,13 @@
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "html", "id", "isMandatory", "isTrack"]
+            "required": [
+                "_type",
+                "html",
+                "id",
+                "isMandatory",
+                "isTrack"
+            ]
         },
         "SubheadingBlockElement": {
             "type": "object",
@@ -1030,7 +1136,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "html"]
+            "required": [
+                "_type",
+                "html"
+            ]
         },
         "TableBlockElement": {
             "type": "object",
@@ -1045,7 +1154,10 @@
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "isMandatory"]
+            "required": [
+                "_type",
+                "isMandatory"
+            ]
         },
         "TextBlockElement": {
             "type": "object",
@@ -1063,7 +1175,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "html"]
+            "required": [
+                "_type",
+                "html"
+            ]
         },
         "TimelineBlockElement": {
             "type": "object",
@@ -1090,7 +1205,12 @@
                     }
                 }
             },
-            "required": ["_type", "events", "id", "title"]
+            "required": [
+                "_type",
+                "events",
+                "id",
+                "title"
+            ]
         },
         "TimelineEvent": {
             "type": "object",
@@ -1108,7 +1228,10 @@
                     "type": "string"
                 }
             },
-            "required": ["date", "title"]
+            "required": [
+                "date",
+                "title"
+            ]
         },
         "TweetBlockElement": {
             "type": "object",
@@ -1132,7 +1255,13 @@
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "hasMedia", "html", "id", "url"]
+            "required": [
+                "_type",
+                "hasMedia",
+                "html",
+                "id",
+                "url"
+            ]
         },
         "VideoBlockElement": {
             "type": "object",
@@ -1144,7 +1273,9 @@
                     ]
                 }
             },
-            "required": ["_type"]
+            "required": [
+                "_type"
+            ]
         },
         "VideoFacebookBlockElement": {
             "type": "object",
@@ -1168,7 +1299,13 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "caption", "height", "url", "width"]
+            "required": [
+                "_type",
+                "caption",
+                "height",
+                "url",
+                "width"
+            ]
         },
         "VideoVimeoBlockElement": {
             "type": "object",
@@ -1190,9 +1327,27 @@
                 },
                 "caption": {
                     "type": "string"
+                },
+                "credit": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
                 }
             },
-            "required": ["_type", "caption", "height", "url", "width"]
+            "required": [
+                "_type",
+                "caption",
+                "credit",
+                "description",
+                "height",
+                "title",
+                "url",
+                "width"
+            ]
         },
         "VideoYoutubeBlockElement": {
             "type": "object",
@@ -1216,7 +1371,13 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "caption", "height", "url", "width"]
+            "required": [
+                "_type",
+                "caption",
+                "height",
+                "url",
+                "width"
+            ]
         },
         "YoutubeBlockElement": {
             "type": "object",
@@ -1252,7 +1413,11 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "assetId", "mediaTitle"]
+            "required": [
+                "_type",
+                "assetId",
+                "mediaTitle"
+            ]
         },
         "Block": {
             "type": "object",
@@ -1391,7 +1556,10 @@
                     "type": "string"
                 }
             },
-            "required": ["elements", "id"]
+            "required": [
+                "elements",
+                "id"
+            ]
         },
         "Pagination": {
             "type": "object",
@@ -1415,7 +1583,10 @@
                     "type": "string"
                 }
             },
-            "required": ["currentPage", "totalPages"]
+            "required": [
+                "currentPage",
+                "totalPages"
+            ]
         },
         "AuthorType": {
             "type": "object",
@@ -1432,7 +1603,12 @@
             }
         },
         "Edition": {
-            "enum": ["AU", "INT", "UK", "US"],
+            "enum": [
+                "AU",
+                "INT",
+                "UK",
+                "US"
+            ],
             "type": "string"
         },
         "TagType": {
@@ -1457,7 +1633,11 @@
                     "type": "string"
                 }
             },
-            "required": ["id", "title", "type"]
+            "required": [
+                "id",
+                "title",
+                "type"
+            ]
         },
         "Pillar": {
             "enum": [
@@ -1480,7 +1660,10 @@
                     "type": "string"
                 }
             },
-            "required": ["title", "url"]
+            "required": [
+                "title",
+                "url"
+            ]
         },
         "ConfigType": {
             "description": "the config model will contain useful app/site\nlevel data. Although currently derived from the config model\nconstructed in frontend and passed to dotcom-rendering\nthis data could eventually be defined in dotcom-rendering",
@@ -1684,7 +1867,12 @@
                     "$ref": "#/definitions/EditionCommercialProperties"
                 }
             },
-            "required": ["AU", "INT", "UK", "US"]
+            "required": [
+                "AU",
+                "INT",
+                "UK",
+                "US"
+            ]
         },
         "EditionCommercialProperties": {
             "type": "object",
@@ -1699,7 +1887,9 @@
                     "$ref": "#/definitions/Branding"
                 }
             },
-            "required": ["adTargeting"]
+            "required": [
+                "adTargeting"
+            ]
         },
         "AdTargetParam": {
             "type": "object",
@@ -1721,7 +1911,10 @@
                     ]
                 }
             },
-            "required": ["name", "value"]
+            "required": [
+                "name",
+                "value"
+            ]
         },
         "Branding": {
             "type": "object",
@@ -1733,7 +1926,9 @@
                             "type": "string"
                         }
                     },
-                    "required": ["name"]
+                    "required": [
+                        "name"
+                    ]
                 },
                 "sponsorName": {
                     "type": "string"
@@ -1760,10 +1955,18 @@
                                     "type": "number"
                                 }
                             },
-                            "required": ["height", "width"]
+                            "required": [
+                                "height",
+                                "width"
+                            ]
                         }
                     },
-                    "required": ["dimensions", "label", "link", "src"]
+                    "required": [
+                        "dimensions",
+                        "label",
+                        "link",
+                        "src"
+                    ]
                 },
                 "aboutThisLink": {
                     "type": "string"
@@ -1784,7 +1987,10 @@
                                     "type": "number"
                                 }
                             },
-                            "required": ["height", "width"]
+                            "required": [
+                                "height",
+                                "width"
+                            ]
                         },
                         "link": {
                             "type": "string"
@@ -1793,10 +1999,19 @@
                             "type": "string"
                         }
                     },
-                    "required": ["dimensions", "label", "link", "src"]
+                    "required": [
+                        "dimensions",
+                        "label",
+                        "link",
+                        "src"
+                    ]
                 }
             },
-            "required": ["aboutThisLink", "logo", "sponsorName"]
+            "required": [
+                "aboutThisLink",
+                "logo",
+                "sponsorName"
+            ]
         },
         "BadgeType": {
             "type": "object",
@@ -1808,7 +2023,10 @@
                     "type": "string"
                 }
             },
-            "required": ["imageUrl", "seriesTag"]
+            "required": [
+                "imageUrl",
+                "seriesTag"
+            ]
         },
         "FooterType": {
             "type": "object",
@@ -1823,7 +2041,9 @@
                     }
                 }
             },
-            "required": ["footerLinks"]
+            "required": [
+                "footerLinks"
+            ]
         },
         "FooterLink": {
             "type": "object",
@@ -1841,7 +2061,11 @@
                     "type": "string"
                 }
             },
-            "required": ["dataLinkName", "text", "url"]
+            "required": [
+                "dataLinkName",
+                "text",
+                "url"
+            ]
         }
     },
     "$schema": "http://json-schema.org/draft-07/schema#"

--- a/src/web/components/elements/VimeoBlockComponent.stories.tsx
+++ b/src/web/components/elements/VimeoBlockComponent.stories.tsx
@@ -56,3 +56,22 @@ export const largeAspectRatio = () => {
     );
 };
 largeAspectRatio.story = { name: 'with large aspect ratio' };
+
+export const verticalAspectRatio = () => {
+    return (
+        <Container>
+            <p>abc</p>
+            <VimeoBlockComponent
+                url="https://player.vimeo.com/video/265111898?app_id=122963"
+                pillar="news"
+                height={818}
+                width={460}
+                caption="blah"
+                credit=""
+                title=""
+            />
+            <p>abc</p>
+        </Container>
+    );
+};
+verticalAspectRatio.story = { name: 'with vertical aspect ratio' };

--- a/src/web/components/elements/VimeoBlockComponent.stories.tsx
+++ b/src/web/components/elements/VimeoBlockComponent.stories.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { VimeoBlockComponent } from './VimeoBlockComponent';
+
+export default {
+    component: VimeoBlockComponent,
+    title: 'Components/VimeoComponent',
+};
+
+const Container = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
+    <div
+        className={css`
+            width: 620px;
+            padding: 20px;
+        `}
+    >
+        {children}
+    </div>
+);
+
+export const noOverlay = () => {
+    return (
+        <Container>
+            <p>abc</p>
+            <VimeoBlockComponent
+                url="https://player.vimeo.com/video/327310297?app_id=122963"
+                pillar="news"
+                height={460}
+                width={259}
+                caption="blah"
+                credit=""
+                title=""
+            />
+            <p>abc</p>
+        </Container>
+    );
+};
+noOverlay.story = { name: 'with no overlay' };

--- a/src/web/components/elements/VimeoBlockComponent.stories.tsx
+++ b/src/web/components/elements/VimeoBlockComponent.stories.tsx
@@ -19,15 +19,15 @@ const Container = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
     </div>
 );
 
-export const noOverlay = () => {
+export const smallAspectRatio = () => {
     return (
         <Container>
             <p>abc</p>
             <VimeoBlockComponent
                 url="https://player.vimeo.com/video/327310297?app_id=122963"
                 pillar="news"
-                height={460}
-                width={259}
+                height={250}
+                width={250}
                 caption="blah"
                 credit=""
                 title=""
@@ -36,4 +36,23 @@ export const noOverlay = () => {
         </Container>
     );
 };
-noOverlay.story = { name: 'with no overlay' };
+smallAspectRatio.story = { name: 'with small aspect ratio' };
+
+export const largeAspectRatio = () => {
+    return (
+        <Container>
+            <p>abc</p>
+            <VimeoBlockComponent
+                url="https://player.vimeo.com/video/327310297?app_id=122963"
+                pillar="news"
+                height={259}
+                width={460}
+                caption="blah"
+                credit=""
+                title=""
+            />
+            <p>abc</p>
+        </Container>
+    );
+};
+largeAspectRatio.story = { name: 'with large aspect ratio' };

--- a/src/web/components/elements/VimeoBlockComponent.tsx
+++ b/src/web/components/elements/VimeoBlockComponent.tsx
@@ -1,22 +1,17 @@
 import React from 'react';
 import { css } from 'emotion';
-// import { border } from '@guardian/src-foundations/palette';
-// import { body } from '@guardian/src-foundations/typography';
 import { Caption } from '@root/src/web/components/Caption';
 
 const widthOverride = css`
     width: 100%;
-    max-width: 1800px;
 `;
 
-const inner = css`
-    width: 100%;
-    position: relative;
-
+const inner = (maxWidth: number) => css`
     iframe {
         width: 100%;
         height: 400px;
     }
+    max-width: ${maxWidth}px;
 `;
 export const VimeoBlockComponent: React.FC<{
     pillar: Pillar;
@@ -26,11 +21,16 @@ export const VimeoBlockComponent: React.FC<{
     caption: string;
     credit: string;
     title: string;
-}> = ({ url, caption, title, pillar }) => {
+}> = ({ url, caption, title, pillar, width, height }) => {
+    // maxHeight is a value copied from frontend, which is the full height on an iphone X
+    const maxHeight = 812;
+    const aspectRatio = width / height;
+    const maxWidth = maxHeight * aspectRatio;
+
     return (
         <div className={widthOverride}>
-            <div className={inner}>
-                <iframe src={url} title={title} />
+            <div className={inner(maxWidth)}>
+                <iframe src={url} title={title} height={height} width={width} />
             </div>
             {caption && (
                 <Caption

--- a/src/web/components/elements/VimeoBlockComponent.tsx
+++ b/src/web/components/elements/VimeoBlockComponent.tsx
@@ -1,29 +1,40 @@
 import React from 'react';
-import { unescapeData } from '@root/src/lib/escapeData';
 import { css } from 'emotion';
 // import { border } from '@guardian/src-foundations/palette';
 // import { body } from '@guardian/src-foundations/typography';
 import { Caption } from '@root/src/web/components/Caption';
 
 const widthOverride = css`
+    width: 100%;
+    max-width: 1800px;
+`;
+
+const inner = css`
+    width: 100%;
+    position: relative;
+
     iframe {
-        /* The instagram embed js hijacks the iframe and calculated an incorrect width, which pushed the body out */
-        max-width: 620px !important;
+        width: 100%;
+        height: 400px;
     }
 `;
 export const VimeoBlockComponent: React.FC<{
-    element: VideoVimeoBlockElement;
     pillar: Pillar;
-}> = ({ element, pillar }) => {
+    url: string;
+    height: number;
+    width: number;
+    caption: string;
+    credit: string;
+    title: string;
+}> = ({ url, caption, title, pillar }) => {
     return (
-        <div>
-            <div
-                className={widthOverride}
-                dangerouslySetInnerHTML={{ __html: unescapeData(element.html) }}
-            />
-            {element.caption && (
+        <div className={widthOverride}>
+            <div className={inner}>
+                <iframe src={url} title={title} />
+            </div>
+            {caption && (
                 <Caption
-                    captionText={element.caption}
+                    captionText={caption}
                     pillar={pillar}
                     display="standard"
                 />

--- a/src/web/components/elements/VimeoBlockComponent.tsx
+++ b/src/web/components/elements/VimeoBlockComponent.tsx
@@ -19,7 +19,7 @@ export const VimeoBlockComponent: React.FC<{
     url: string;
     height: number;
     width: number;
-    caption: string;
+    caption?: string;
     credit: string;
     title: string;
 }> = ({ url, caption, title, pillar, width, height }) => {

--- a/src/web/components/elements/VimeoBlockComponent.tsx
+++ b/src/web/components/elements/VimeoBlockComponent.tsx
@@ -23,7 +23,7 @@ export const VimeoBlockComponent: React.FC<{
     credit: string;
     title: string;
 }> = ({ url, caption, title, pillar, width, height }) => {
-    // 812 is the full height on an iphone X
+    // 812 is the full height on an iphone X. This ensures that the embed doesn't display any larger than the available viewport
     const maxHeight = 812;
     const aspectRatio = width / height;
     const maxWidth = maxHeight * aspectRatio;

--- a/src/web/components/elements/VimeoBlockComponent.tsx
+++ b/src/web/components/elements/VimeoBlockComponent.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { unescapeData } from '@root/src/lib/escapeData';
+import { css } from 'emotion';
+// import { border } from '@guardian/src-foundations/palette';
+// import { body } from '@guardian/src-foundations/typography';
+import { Caption } from '@root/src/web/components/Caption';
+
+const widthOverride = css`
+    iframe {
+        /* The instagram embed js hijacks the iframe and calculated an incorrect width, which pushed the body out */
+        max-width: 620px !important;
+    }
+`;
+export const VimeoBlockComponent: React.FC<{
+    element: VideoVimeoBlockElement;
+    pillar: Pillar;
+}> = ({ element, pillar }) => {
+    return (
+        <div>
+            <div
+                className={widthOverride}
+                dangerouslySetInnerHTML={{ __html: unescapeData(element.html) }}
+            />
+            {element.caption && (
+                <Caption
+                    captionText={element.caption}
+                    pillar={pillar}
+                    display="standard"
+                />
+            )}
+        </div>
+    );
+};

--- a/src/web/components/elements/VimeoBlockComponent.tsx
+++ b/src/web/components/elements/VimeoBlockComponent.tsx
@@ -24,8 +24,10 @@ export const VimeoBlockComponent: React.FC<{
     title: string;
 }> = ({ url, caption, title, pillar, width, height }) => {
     // 812 is the full height on an iphone X. This ensures that the embed doesn't display any larger than the available viewport
-    const maxHeight = 812;
-    const aspectRatio = width / height;
+	// Constrain iframe embeds with a width to their natural width 
+	// rather than stretch them to the container using
+	// a max that would prevent portrait videos from being taller than an iphone X (baseline)
+	// More context: https://github.com/guardian/frontend/pull/17902
     const maxWidth = maxHeight * aspectRatio;
 
     return (

--- a/src/web/components/elements/VimeoBlockComponent.tsx
+++ b/src/web/components/elements/VimeoBlockComponent.tsx
@@ -2,16 +2,17 @@ import React from 'react';
 import { css } from 'emotion';
 import { Caption } from '@root/src/web/components/Caption';
 
-const widthOverride = css`
-    width: 100%;
-`;
-
-const inner = (maxWidth: number) => css`
+const responsiveAspectRatio = (height: number, width: number) => css`
+    /* https://css-tricks.com/aspect-ratio-boxes/ */
+    padding-bottom: ${(height / width) * 100}%;
+    position: relative;
     iframe {
         width: 100%;
-        height: 400px;
+        height: 100%;
+        position: absolute;
+        top: 0;
+        left: 0;
     }
-    max-width: ${maxWidth}px;
 `;
 export const VimeoBlockComponent: React.FC<{
     pillar: Pillar;
@@ -22,15 +23,26 @@ export const VimeoBlockComponent: React.FC<{
     credit: string;
     title: string;
 }> = ({ url, caption, title, pillar, width, height }) => {
-    // maxHeight is a value copied from frontend, which is the full height on an iphone X
+    // 812 is the full height on an iphone X
     const maxHeight = 812;
     const aspectRatio = width / height;
     const maxWidth = maxHeight * aspectRatio;
 
     return (
-        <div className={widthOverride}>
-            <div className={inner(maxWidth)}>
-                <iframe src={url} title={title} height={height} width={width} />
+        <div
+            className={css`
+                max-width: ${maxWidth}px;
+                width: 100%;
+            `}
+        >
+            <div className={responsiveAspectRatio(height, width)}>
+                <iframe
+                    src={url}
+                    title={title}
+                    height={height}
+                    width={width}
+                    allowFullScreen={true}
+                />
             </div>
             {caption && (
                 <Caption

--- a/src/web/components/elements/VimeoBlockComponent.tsx
+++ b/src/web/components/elements/VimeoBlockComponent.tsx
@@ -24,10 +24,12 @@ export const VimeoBlockComponent: React.FC<{
     title: string;
 }> = ({ url, caption, title, pillar, width, height }) => {
     // 812 is the full height on an iphone X. This ensures that the embed doesn't display any larger than the available viewport
-	// Constrain iframe embeds with a width to their natural width 
-	// rather than stretch them to the container using
-	// a max that would prevent portrait videos from being taller than an iphone X (baseline)
-	// More context: https://github.com/guardian/frontend/pull/17902
+    // Constrain iframe embeds with a width to their natural width
+    // rather than stretch them to the container using
+    // a max that would prevent portrait videos from being taller than an iphone X (baseline)
+    // More context: https://github.com/guardian/frontend/pull/17902
+    const maxHeight = 812;
+    const aspectRatio = width / height;
     const maxWidth = maxHeight * aspectRatio;
 
     return (

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -128,7 +128,7 @@ export const ArticleRenderer: React.FC<{
                     return (
                         <VimeoBlockComponent
                             pillar={pillar}
-                            url="https://player.vimeo.com/video/327310297?app_id=122963"
+                            url={element.url}
                             height={element.height}
                             width={element.width}
                             caption={element.caption}

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -127,8 +127,13 @@ export const ArticleRenderer: React.FC<{
                 case 'model.dotcomrendering.pageElements.VideoVimeoBlockElement':
                     return (
                         <VimeoBlockComponent
-                            element={element}
                             pillar={pillar}
+                            url={element.url}
+                            height={element.height}
+                            width={element.width}
+                            caption={element.caption}
+                            credit={element.credit}
+                            title={element.title}
                         />
                     );
                 case 'model.dotcomrendering.pageElements.YoutubeBlockElement':

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -12,6 +12,7 @@ import { SoundcloudBlockComponent } from '@root/src/web/components/elements/Soun
 import { SubheadingBlockComponent } from '@root/src/web/components/elements/SubheadingBlockComponent';
 import { TextBlockComponent } from '@root/src/web/components/elements/TextBlockComponent';
 import { TweetBlockComponent } from '@root/src/web/components/elements/TweetBlockComponent';
+import { VimeoBlockComponent } from '@root/src/web/components/elements/VimeoBlockComponent';
 import { YoutubeBlockComponent } from '@root/src/web/components/elements/YoutubeBlockComponent';
 
 import { ExplainerAtom } from '@guardian/atoms-rendering';
@@ -123,6 +124,13 @@ export const ArticleRenderer: React.FC<{
                     );
                 case 'model.dotcomrendering.pageElements.TweetBlockElement':
                     return <TweetBlockComponent key={i} element={element} />;
+                case 'model.dotcomrendering.pageElements.VideoVimeoBlockElement':
+                    return (
+                        <VimeoBlockComponent
+                            element={element}
+                            pillar={pillar}
+                        />
+                    );
                 case 'model.dotcomrendering.pageElements.YoutubeBlockElement':
                     return (
                         <YoutubeBlockComponent
@@ -155,7 +163,6 @@ export const ArticleRenderer: React.FC<{
                 case 'model.dotcomrendering.pageElements.TimelineBlockElement':
                 case 'model.dotcomrendering.pageElements.VideoBlockElement':
                 case 'model.dotcomrendering.pageElements.VideoFacebookBlockElement':
-                case 'model.dotcomrendering.pageElements.VideoVimeoBlockElement':
                 case 'model.dotcomrendering.pageElements.VideoYoutubeBlockElement':
                     return null;
             }

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -128,7 +128,7 @@ export const ArticleRenderer: React.FC<{
                     return (
                         <VimeoBlockComponent
                             pillar={pillar}
-                            url={element.url}
+                            url="https://player.vimeo.com/video/327310297?app_id=122963"
                             height={element.height}
                             width={element.width}
                             caption={element.caption}


### PR DESCRIPTION
## What does this change?
Adds DCR support for the vimeo block elements. Does include a bit of a tricksy css workaround that @oliverlloyd managed to solve. 

### DCR
<img width="793" alt="Screen Shot 2020-06-16 at 21 07 38" src="https://user-images.githubusercontent.com/2051501/84828807-8da30500-b01e-11ea-86fd-27d1d165a5e9.png">

### Frontend
<img width="793" alt="Screen Shot 2020-06-16 at 22 13 31" src="https://user-images.githubusercontent.com/2051501/84828866-a90e1000-b01e-11ea-84dd-3a14033269dc.png">

