### PR TITLE
Essay caption

### DIFF
--- a/src/web/components/ArticleBody.tsx
+++ b/src/web/components/ArticleBody.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 
-import { text, neutral, border } from '@guardian/src-foundations/palette';
+import { neutral, border } from '@guardian/src-foundations/palette';
 import { textSans, headline } from '@guardian/src-foundations/typography';
 import { from, between } from '@guardian/src-foundations/mq';
 import { pillarMap, pillarPalette } from '@root/src/lib/pillars';
@@ -24,24 +24,6 @@ const pillarColours = pillarMap(
         `,
 );
 
-// TODO refactor  to use in Caption.tsx
-// const pillarFigCaptionIconColor = pillarMap(
-//     pillar =>
-//         css`
-//             figcaption {
-//                 &::before {
-//                     border-color: transparent transparent
-//                         ${pillarPalette[pillar].main} transparent;
-//                 }
-//             }
-//         `,
-// );
-
-const captionFont = css`
-    ${textSans.xsmall()};
-    color: ${text.supporting};
-`;
-
 const bodyStyle = (display: Display) => css`
     ${between.tablet.and.desktop} {
         padding-right: 80px;
@@ -60,10 +42,6 @@ const bodyStyle = (display: Display) => css`
     img {
         width: 100%;
         height: auto;
-    }
-
-    figcaption {
-        ${captionFont};
     }
 
     figure {

--- a/src/web/components/Caption.stories.tsx
+++ b/src/web/components/Caption.stories.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+
+import { Section } from '@frontend/web/components/Section';
+import { Caption } from '@frontend/web/components/Caption';
+
+export default {
+    component: Caption,
+    title: 'Components/Caption',
+};
+
+/**
+    display: Display;
+    designType: DesignType;
+    captionText?: string;
+    pillar: Pillar;
+    padCaption?: boolean;
+    credit?: string;
+    displayCredit?: boolean;
+    shouldLimitWidth?: boolean;
+    isOverlayed?: boolean; // Not tested here as this option only works in the context of the ImageComponent
+ */
+
+export const Article = () => (
+    <Section showTopBorder={false} showSideBorders={false}>
+        <Caption
+            display="standard"
+            designType="Article"
+            captionText="This is how an Article caption looks"
+            pillar="news"
+        />
+    </Section>
+);
+Article.story = { name: 'Article' };
+
+export const Analysis = () => (
+    <Section showTopBorder={false} showSideBorders={false}>
+        <Caption
+            display="standard"
+            designType="Analysis"
+            captionText="This is how an Analysis caption looks"
+            pillar="news"
+        />
+    </Section>
+);
+Analysis.story = { name: 'Analysis' };
+
+export const PhotoEssay = () => (
+    <Section showTopBorder={false} showSideBorders={false}>
+        <Caption
+            display="standard"
+            designType="PhotoEssay"
+            captionText="This is how a PhotoEssay caption looks"
+            pillar="news"
+        />
+    </Section>
+);
+PhotoEssay.story = { name: 'PhotoEssay' };
+
+export const PhotoEssayLimitedWidth = () => (
+    <Section showTopBorder={false} showSideBorders={false}>
+        <Caption
+            display="standard"
+            designType="PhotoEssay"
+            captionText="This is how a PhotoEssay caption looks when width is limited"
+            pillar="news"
+            shouldLimitWidth={true}
+        />
+    </Section>
+);
+PhotoEssayLimitedWidth.story = { name: 'PhotoEssay with width limited' };
+
+export const Credit = () => (
+    <Section showTopBorder={false} showSideBorders={false}>
+        <Caption
+            display="standard"
+            designType="Feature"
+            captionText="This is how a Feature caption looks with credit showing"
+            pillar="news"
+            credit="Credited to Able Jones"
+            displayCredit={true}
+        />
+    </Section>
+);
+Credit.story = { name: 'with credit' };
+
+export const WidthLimited = () => (
+    <Section showTopBorder={false} showSideBorders={false}>
+        <Caption
+            display="standard"
+            designType="Article"
+            captionText="This is how a caption looks with width limited"
+            pillar="news"
+            shouldLimitWidth={true}
+        />
+    </Section>
+);
+WidthLimited.story = { name: 'with width limited' };
+
+export const Padded = () => (
+    <Section showTopBorder={false} showSideBorders={false}>
+        <Caption
+            display="standard"
+            designType="Article"
+            captionText="This is how a caption looks when padded"
+            pillar="news"
+            padCaption={true}
+        />
+    </Section>
+);
+Padded.story = { name: 'when padded' };

--- a/src/web/components/Caption.tsx
+++ b/src/web/components/Caption.tsx
@@ -9,6 +9,7 @@ import TriangleIcon from '@frontend/static/icons/triangle.svg';
 
 type Props = {
     display: Display;
+    designType: DesignType;
     captionText?: string;
     pillar: Pillar;
     padCaption?: boolean;

--- a/src/web/components/Caption.tsx
+++ b/src/web/components/Caption.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
-import { text } from '@guardian/src-foundations/palette';
+import { text, brandBackground } from '@guardian/src-foundations/palette';
 import { from, until } from '@guardian/src-foundations/mq';
 import { textSans } from '@guardian/src-foundations/typography';
+import { space } from '@guardian/src-foundations';
 import { css, cx } from 'emotion';
 import { pillarPalette } from '@root/src/lib/pillars';
 import TriangleIcon from '@frontend/static/icons/triangle.svg';
@@ -20,6 +21,7 @@ type Props = {
 };
 
 const captionStyle = css`
+    ${textSans.xsmall()};
     padding-top: 6px;
     ${textSans.xsmall()};
     word-wrap: break-word;
@@ -66,9 +68,25 @@ const limitedWidth = css`
     }
 `;
 
+const veryLimitedWidth = css`
+    ${from.leftCol} {
+        width: 104px;
+        /* use absolute position here to allow the article text to push up alongside
+           the caption when it is limited in width */
+        position: absolute;
+    }
+    ${from.wide} {
+        width: 184px;
+    }
+`;
+
 const captionPadding = css`
     padding-left: 8px;
     padding-right: 8px;
+`;
+
+const leftMargin = css`
+    margin-left: ${space[9]}px;
 `;
 
 const hideIconBelowLeftCol = css`
@@ -77,8 +95,27 @@ const hideIconBelowLeftCol = css`
     }
 `;
 
+const iconStyle = (pillar: Pillar) => css`
+    fill: ${pillarPalette[pillar].main};
+    padding-right: 3px;
+`;
+
+const captionLink = (pillar: Pillar) => css`
+    a {
+        color: ${pillarPalette[pillar].main};
+        text-decoration: none;
+    }
+    a:hover {
+        text-decoration: underline;
+    }
+    strong {
+        font-weight: bold;
+    }
+`;
+
 export const Caption = ({
     display,
+    designType,
     captionText,
     pillar,
     padCaption = false,
@@ -87,60 +124,83 @@ export const Caption = ({
     shouldLimitWidth = false,
     isOverlayed,
 }: Props) => {
-    const iconStyle = css`
-        fill: ${pillarPalette[pillar].main};
-        padding-right: 3px;
-    `;
-
-    const captionLink = css`
-        a {
-            color: ${pillarPalette[pillar].main};
-            text-decoration: none;
-        }
-        a:hover {
-            text-decoration: underline;
-        }
-        strong {
-            font-weight: bold;
-        }
-    `;
-
     const noCaption = !captionText;
     const noCredit = !credit;
     const hideCredit = !displayCredit;
     if (noCaption && (noCredit || hideCredit)) return null;
 
-    return (
-        <figcaption
-            className={cx(
-                captionStyle,
-                shouldLimitWidth && limitedWidth,
-                !isOverlayed && bottomMargin,
-                isOverlayed && overlayedStyles,
-                {
-                    [captionPadding]: padCaption,
-                },
-            )}
-        >
-            <span
-                className={cx(
-                    iconStyle,
-                    display === 'immersive' && hideIconBelowLeftCol,
-                )}
-            >
-                <TriangleIcon />
-            </span>
-            {captionText && (
-                <span
-                    className={captionLink}
-                    // eslint-disable-next-line react/no-danger
-                    dangerouslySetInnerHTML={{
-                        __html: captionText || '',
-                    }}
-                    key="caption"
-                />
-            )}
-            {credit && displayCredit && ` ${credit}`}
-        </figcaption>
-    );
+    switch (designType) {
+        case 'PhotoEssay':
+            return (
+                <figcaption
+                    className={cx(
+                        css`
+                            ${textSans.xsmall()};
+                            color: ${brandBackground.primary};
+                            width: 100%;
+                            line-height: ${space[5]}px;
+                            margin-top: ${space[2]}px;
+                            padding-top: ${space[1]}px;
+                            border-top: 1px solid ${brandBackground.primary};
+                        `,
+                        bottomMargin,
+                        padCaption && captionPadding,
+                        shouldLimitWidth && veryLimitedWidth,
+                        shouldLimitWidth && leftMargin,
+                    )}
+                >
+                    {captionText}
+                    {credit && displayCredit && ` ${credit}`}
+                </figcaption>
+            );
+        case 'Article':
+        case 'Media':
+        case 'Live':
+        case 'SpecialReport':
+        case 'Recipe':
+        case 'MatchReport':
+        case 'GuardianView':
+        case 'GuardianLabs':
+        case 'Quiz':
+        case 'AdvertisementFeature':
+        case 'Feature':
+        case 'Comment':
+        case 'Analysis':
+        case 'Review':
+        case 'Immersive':
+        case 'Interview':
+            return (
+                <figcaption
+                    className={cx(
+                        captionStyle,
+                        shouldLimitWidth && limitedWidth,
+                        !isOverlayed && bottomMargin,
+                        isOverlayed && overlayedStyles,
+                        {
+                            [captionPadding]: padCaption,
+                        },
+                    )}
+                >
+                    <span
+                        className={cx(
+                            iconStyle(pillar),
+                            display === 'immersive' && hideIconBelowLeftCol,
+                        )}
+                    >
+                        <TriangleIcon />
+                    </span>
+                    {captionText && (
+                        <span
+                            className={captionLink(pillar)}
+                            // eslint-disable-next-line react/no-danger
+                            dangerouslySetInnerHTML={{
+                                __html: captionText || '',
+                            }}
+                            key="caption"
+                        />
+                    )}
+                    {credit && displayCredit && ` ${credit}`}
+                </figcaption>
+            );
+    }
 };

--- a/src/web/components/ImmersiveHeadline.tsx
+++ b/src/web/components/ImmersiveHeadline.tsx
@@ -115,6 +115,7 @@ export const ImmersiveHeadline = ({
                     <LeftColumn showRightBorder={false}>
                         <Caption
                             display={display}
+                            designType={designType}
                             captionText={captionText}
                             pillar={pillar}
                             shouldLimitWidth={true}

--- a/src/web/components/MainMedia.tsx
+++ b/src/web/components/MainMedia.tsx
@@ -67,6 +67,7 @@ function renderElement(
             return (
                 <YoutubeBlockComponent
                     display={display}
+                    designType={designType}
                     key={i}
                     element={element}
                     pillar={pillar}

--- a/src/web/components/elements/ImageComponent.tsx
+++ b/src/web/components/elements/ImageComponent.tsx
@@ -275,6 +275,7 @@ export const ImageComponent = ({
                                 <div id="the-caption">
                                     <Caption
                                         display={display}
+                                        designType={designType}
                                         captionText={element.data.caption || ''}
                                         pillar={pillar}
                                         credit={element.data.credit}
@@ -293,6 +294,7 @@ export const ImageComponent = ({
                 <Hide when="below" breakpoint="tablet">
                     <Caption
                         display={display}
+                        designType={designType}
                         captionText={element.data.caption || ''}
                         pillar={pillar}
                         credit={element.data.credit}
@@ -303,6 +305,7 @@ export const ImageComponent = ({
             ) : (
                 <Caption
                     display={display}
+                    designType={designType}
                     captionText={element.data.caption || ''}
                     pillar={pillar}
                     credit={element.data.credit}

--- a/src/web/components/elements/MultiImageBlockComponent.tsx
+++ b/src/web/components/elements/MultiImageBlockComponent.tsx
@@ -106,7 +106,7 @@ const GridOfFour = ({
 );
 
 export const MultiImageBlockComponent = ({
-    // designType,
+    designType,
     caption,
     images,
     pillar,
@@ -126,7 +126,7 @@ export const MultiImageBlockComponent = ({
                 >
                     <ImageComponent
                         display="standard"
-                        designType="Article"
+                        designType={designType}
                         element={images[0]}
                         pillar={pillar}
                         hideCaption={true}
@@ -135,6 +135,7 @@ export const MultiImageBlockComponent = ({
                     {caption && (
                         <Caption
                             display="standard"
+                            designType={designType}
                             captionText={caption}
                             pillar={pillar}
                             shouldLimitWidth={false}
@@ -177,6 +178,7 @@ export const MultiImageBlockComponent = ({
                     {caption && (
                         <Caption
                             display="standard"
+                            designType={designType}
                             captionText={caption}
                             pillar={pillar}
                             shouldLimitWidth={false}
@@ -229,6 +231,7 @@ export const MultiImageBlockComponent = ({
                     {caption && (
                         <Caption
                             display="standard"
+                            designType={designType}
                             captionText={caption}
                             pillar={pillar}
                             shouldLimitWidth={false}
@@ -291,6 +294,7 @@ export const MultiImageBlockComponent = ({
                     {caption && (
                         <Caption
                             display="standard"
+                            designType={designType}
                             captionText={caption}
                             pillar={pillar}
                             shouldLimitWidth={false}

--- a/src/web/components/elements/YoutubeBlockComponent.stories.tsx
+++ b/src/web/components/elements/YoutubeBlockComponent.stories.tsx
@@ -24,6 +24,7 @@ export const noOverlay = () => {
         <Container>
             <YoutubeBlockComponent
                 display="standard"
+                designType="Article"
                 element={{
                     mediaTitle:
                         "Prince Harry and Meghan's 'bombshell' plans explained – video",

--- a/src/web/components/elements/YoutubeBlockComponent.tsx
+++ b/src/web/components/elements/YoutubeBlockComponent.tsx
@@ -5,6 +5,7 @@ import { YouTubeEmbed } from '@root/src/web/components/YouTubeEmbed';
 
 type Props = {
     display: Display;
+    designType: DesignType;
     element: YoutubeBlockElement;
     pillar: Pillar;
     hideCaption?: boolean;
@@ -16,6 +17,7 @@ type Props = {
 
 export const YoutubeBlockComponent = ({
     display,
+    designType,
     element,
     pillar,
     hideCaption,
@@ -49,6 +51,7 @@ export const YoutubeBlockComponent = ({
             />
             <Caption
                 display={display}
+                designType={designType}
                 captionText={element.mediaTitle || ''}
                 pillar={pillar}
                 displayCredit={false}

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -288,6 +288,7 @@ export const ImmersiveLayout = ({
                         <Hide when="above" breakpoint="leftCol">
                             <Caption
                                 display={display}
+                                designType={designType}
                                 captionText={captionText}
                                 pillar={pillar}
                                 shouldLimitWidth={false}

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -132,6 +132,7 @@ export const ArticleRenderer: React.FC<{
                     return (
                         <YoutubeBlockComponent
                             display={display}
+                            designType={designType}
                             key={i}
                             element={element}
                             pillar={pillar}


### PR DESCRIPTION
## What does this change?
Adds support for the version ofthe caption that appears on Photo Essays

![Screenshot 2020-06-17 at 09 24 03](https://user-images.githubusercontent.com/1336821/84874285-4d726f80-b07c-11ea-92ba-428dc766294e.jpg)
![Screenshot 2020-06-17 at 09 23 30](https://user-images.githubusercontent.com/1336821/84874288-4ea39c80-b07c-11ea-9703-67801978fb65.jpg)

This PR includes the following changes:

1. `designType` is passed down the stack into `Caption`
2. The switch on designType pattern is added to `Caption`
3. Branched styling for `PhotoEssay` has been added
4. `AticleBody` was edited to remove the global css selector on `figcaption`
