### PR TITLE
Added preceding / to Badge link

### DIFF
--- a/src/web/components/Badge.tsx
+++ b/src/web/components/Badge.tsx
@@ -29,10 +29,13 @@ type Props = {
     seriesTag: string;
 };
 
-export const Badge = ({ imageUrl, seriesTag }: Props) => (
-    <div className={badgeWrapper}>
-        <a href={'/' + seriesTag} className={badgeLink} role="button">
-            <img className={imageStyles} src={imageUrl} alt="" />
-        </a>
-    </div>
-);
+export const Badge = ({ imageUrl, seriesTag }: Props) => {
+    const urlPath = `/${seriesTag}`;
+    return (
+        <div className={badgeWrapper}>
+            <a href={urlPath} className={badgeLink} role="button">
+                <img className={imageStyles} src={imageUrl} alt="" />
+            </a>
+        </div>
+    );
+};

--- a/src/web/components/Badge.tsx
+++ b/src/web/components/Badge.tsx
@@ -31,7 +31,7 @@ type Props = {
 
 export const Badge = ({ imageUrl, seriesTag }: Props) => (
     <div className={badgeWrapper}>
-        <a href={seriesTag} className={badgeLink} role="button">
+        <a href={'/' + seriesTag} className={badgeLink} role="button">
             <img className={imageStyles} src={imageUrl} alt="" />
         </a>
     </div>


### PR DESCRIPTION
The badge href now has a '/' appended to the link to fix the 404 issue.

## What does this change?
The href of the badge passed through the props.

### Before
The original prop link was used

### After
Now it is '/'prop link

## Why?
Fixes a 404 error from an incorrect link