### PR TITLE
Ophan tracking on the RR banner

### DIFF
--- a/src/web/browser/ophan/ophan.ts
+++ b/src/web/browser/ophan/ophan.ts
@@ -7,6 +7,39 @@ interface ABTestPayload {
     abTestRegister: { [key: string]: ABTestRecord };
 }
 
+export type OphanAction = 'INSERT' | 'VIEW';
+
+export type OphanComponentType = 'ACQUISITIONS_EPIC' | 'ACQUISITIONS_ENGAGEMENT_BANNER';
+
+export type TestMeta = {
+    abTestName: string;
+    abTestVariant: string;
+    campaignCode: string;
+    campaignId?: string;
+};
+
+export const sendOphanContributionsComponentEvent = (
+    action: OphanAction,
+    testMeta: TestMeta,
+    componentType: OphanComponentType
+): void => {
+    const componentEvent = {
+        component: {
+            componentType,
+            products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
+            campaignCode: testMeta.campaignCode,
+            id: testMeta.campaignId || testMeta.campaignCode,
+        },
+        abTest: {
+            name: testMeta.abTestName,
+            variant: testMeta.abTestVariant,
+        },
+        action,
+    };
+
+    window.guardian.ophan.record({ componentEvent });
+};
+
 export const abTestPayload = (tests: {
     [key: string]: string;
 }): ABTestPayload => {

--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -14,6 +14,7 @@ import {
     getLastOneOffContributionDate,
 } from '@root/src/web/lib/contributions';
 import { initPerf } from '@root/src/web/browser/initPerf';
+import {sendOphanContributionsComponentEvent, TestMeta} from "@root/src/web/browser/ophan/ophan";
 import { getCookie } from '../browser/cookie';
 import { useHasBeenSeen } from '../lib/useHasBeenSeen';
 
@@ -29,33 +30,6 @@ const checkForErrors = (response: any) => {
         );
     }
     return response;
-};
-
-type OphanAction = 'INSERT' | 'VIEW';
-
-type TestMeta = {
-    abTestName: string;
-    abTestVariant: string;
-    campaignCode: string;
-    campaignId: string;
-};
-
-const sendOphanEpicEvent = (action: OphanAction, testMeta: TestMeta): void => {
-    const componentEvent = {
-        component: {
-            componentType: 'ACQUISITIONS_EPIC',
-            products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
-            campaignCode: testMeta.campaignCode,
-            id: testMeta.campaignId,
-        },
-        abTest: {
-            name: testMeta.abTestName,
-            variant: testMeta.abTestVariant,
-        },
-        action,
-    };
-
-    window.guardian.ophan.record({ componentEvent });
 };
 
 const sendOphanReminderEvent = (componentId: string): void => {
@@ -205,7 +179,7 @@ const MemoisedInner = ({
                             onReminderOpen: sendOphanReminderOpenEvent,
                         });
                         setEpic(() => epicModule.ContributionsEpic); // useState requires functions to be wrapped
-                        sendOphanEpicEvent('INSERT', meta);
+                        sendOphanContributionsComponentEvent('INSERT', meta, 'ACQUISITIONS_EPIC');
                     })
                     // eslint-disable-next-line no-console
                     .catch(error => console.log(`epic - error is: ${error}`));
@@ -217,7 +191,7 @@ const MemoisedInner = ({
     useEffect(() => {
         if (hasBeenSeen && epicMeta) {
             logView(epicMeta.abTestName);
-            sendOphanEpicEvent('VIEW', epicMeta);
+            sendOphanContributionsComponentEvent('VIEW', epicMeta, 'ACQUISITIONS_EPIC');
         }
     }, [hasBeenSeen, epicMeta]);
 

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -23,7 +23,6 @@ type TestMeta = {
     abTestName: string;
     abTestVariant: string;
     campaignCode: string;
-    campaignId: string;
 };
 
 const sendOphanBannerEvent = (action: OphanAction, testMeta: TestMeta): void => {
@@ -32,7 +31,7 @@ const sendOphanBannerEvent = (action: OphanAction, testMeta: TestMeta): void => 
             componentType: 'ACQUISITIONS_BANNER',
             products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
             campaignCode: testMeta.campaignCode,
-            id: testMeta.campaignId,
+            id: testMeta.campaignCode,
         },
         abTest: {
             name: testMeta.abTestName,

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { css } from 'emotion';
 import * as emotion from 'emotion';
 import * as emotionCore from '@emotion/core';
 import * as emotionTheming from 'emotion-theming';
@@ -87,7 +88,6 @@ const MemoisedInner = ({
     const [bannerMeta, setBannerMeta] = useState<TestMeta>();
 
     const [hasBeenSeen, setNode] = useHasBeenSeen({
-        rootMargin: '-18px',
         threshold: 0,
         debounce: true,
     }) as HasBeenSeen;
@@ -158,7 +158,8 @@ const MemoisedInner = ({
 
     if (Banner) {
         return (
-            <div ref={setNode}>
+            // The css here is necessary to put the container div in view, so that we can track the view
+            <div ref={setNode} className={css`position: fixed; bottom: -1px;`}>
                 hello
                 {/* eslint-disable-next-line react/jsx-props-no-spreading */}
                 <Banner {...bannerProps} />

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -6,6 +6,7 @@ import {useHasBeenSeen} from "@root/src/web/lib/useHasBeenSeen";
 import {logView} from "@root/node_modules/@guardian/automat-client";
 import {shouldShowSupportMessaging} from "@root/src/web/lib/contributions";
 import {getCookie} from "@root/src/web/browser/cookie";
+import {sendOphanContributionsComponentEvent, TestMeta} from "@root/src/web/browser/ophan/ophan";
 
 const checkForErrors = (response: any) => {
     if (!response.ok) {
@@ -18,32 +19,6 @@ const checkForErrors = (response: any) => {
 };
 
 type HasBeenSeen = [boolean, (el: HTMLDivElement) => void];
-
-type OphanAction = 'INSERT' | 'VIEW';
-
-type TestMeta = {
-    abTestName: string;
-    abTestVariant: string;
-    campaignCode: string;
-};
-
-const sendOphanBannerEvent = (action: OphanAction, testMeta: TestMeta): void => {
-    const componentEvent = {
-        component: {
-            componentType: 'ACQUISITIONS_BANNER',
-            products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
-            campaignCode: testMeta.campaignCode,
-            id: testMeta.campaignCode,
-        },
-        abTest: {
-            name: testMeta.abTestName,
-            variant: testMeta.abTestVariant,
-        },
-        action,
-    };
-
-    window.guardian.ophan.record({ componentEvent });
-};
 
 type Props = {
     isSignedIn?: boolean;
@@ -156,7 +131,7 @@ const MemoisedInner = ({
                         });
                         setBanner(() => bannerModule.Banner); // useState requires functions to be wrapped
                         setBannerMeta(meta);
-                        sendOphanBannerEvent('INSERT', meta);
+                        sendOphanContributionsComponentEvent('INSERT', meta, 'ACQUISITIONS_ENGAGEMENT_BANNER');
                     })
                     // eslint-disable-next-line no-console
                     .catch(error => console.log(`banner - error is: ${error}`));
@@ -168,7 +143,7 @@ const MemoisedInner = ({
     useEffect(() => {
         if (hasBeenSeen && bannerMeta) {
             logView(bannerMeta.abTestName);
-            sendOphanBannerEvent('VIEW', bannerMeta);
+            sendOphanContributionsComponentEvent('VIEW', bannerMeta, 'ACQUISITIONS_ENGAGEMENT_BANNER');
         }
     }, [hasBeenSeen, bannerMeta]);
 

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -3,13 +3,7 @@ import * as emotion from 'emotion';
 import * as emotionCore from '@emotion/core';
 import * as emotionTheming from 'emotion-theming';
 import {useHasBeenSeen} from "@root/src/web/lib/useHasBeenSeen";
-import {getViewLog, getWeeklyArticleHistory, logView} from "@root/node_modules/@guardian/automat-client";
-import {
-    getLastOneOffContributionDate,
-    isRecurringContributor,
-    shouldShowSupportMessaging
-} from "@root/src/web/lib/contributions";
-import {getCookie} from "@root/src/web/browser/cookie";
+import {logView} from "@root/node_modules/@guardian/automat-client";
 
 const checkForErrors = (response: any) => {
     if (!response.ok) {

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import { css } from 'emotion';
 import * as emotion from 'emotion';
 import * as emotionCore from '@emotion/core';
 import * as emotionTheming from 'emotion-theming';
@@ -184,7 +183,7 @@ const MemoisedInner = ({
     if (Banner) {
         return (
             // The css here is necessary to put the container div in view, so that we can track the view
-            <div ref={setNode} className={css`position: fixed; bottom: -1px;`}>
+            <div ref={setNode} className={emotion.css`position: fixed; bottom: -1px;`}>
                 hello
                 {/* eslint-disable-next-line react/jsx-props-no-spreading */}
                 <Banner {...bannerProps} />

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -67,29 +67,11 @@ type Props = {
 const buildPayload = (props: Props) => {
     return {
         tracking: {
-            ophanPageId: window.guardian.config.ophan.pageViewId,
-            ophanComponentId: 'ACQUISITIONS_BANNER',
-            platformId: 'GUARDIAN_WEB',
-            clientName: 'dcr',
-            referrerUrl: window.location.origin + window.location.pathname,
+            // TODO stub
         },
         targeting: {
-            contentType: props.contentType,
-            sectionName: props.sectionName || '', // TODO update client to reflect that this is optional
-            shouldHideReaderRevenue: props.shouldHideReaderRevenue,
-            isMinuteArticle: props.isMinuteArticle,
-            isPaidContent: props.isPaidContent,
-            isSensitive: props.isSensitive,
-            tags: props.tags,
-            showSupportMessaging: shouldShowSupportMessaging(),
-            isRecurringContributor: isRecurringContributor(
-                props.isSignedIn || false,
-            ),
-            lastOneOffContributionDate: getLastOneOffContributionDate(),
-            epicViewLog: getViewLog(),
-            weeklyArticleHistory: getWeeklyArticleHistory(),
-            mvtId: Number(getCookie('GU_mvt_id')),
-            countryCode: props.countryCode,
+            ...props,
+            // TODO stub
         },
     };
 };

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -150,7 +150,6 @@ const MemoisedInner = ({
 
     // Should only run once
     useEffect(() => {
-        console.log("seen?",hasBeenSeen, bannerMeta)
         if (hasBeenSeen && bannerMeta) {
             logView(bannerMeta.abTestName);
             sendOphanBannerEvent('VIEW', bannerMeta);

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -4,7 +4,13 @@ import * as emotion from 'emotion';
 import * as emotionCore from '@emotion/core';
 import * as emotionTheming from 'emotion-theming';
 import {useHasBeenSeen} from "@root/src/web/lib/useHasBeenSeen";
-import {logView} from "@root/node_modules/@guardian/automat-client";
+import {getViewLog, getWeeklyArticleHistory, logView} from "@root/node_modules/@guardian/automat-client";
+import {
+    getLastOneOffContributionDate,
+    isRecurringContributor,
+    shouldShowSupportMessaging
+} from "@root/src/web/lib/contributions";
+import {getCookie} from "@root/src/web/browser/cookie";
 
 const checkForErrors = (response: any) => {
     if (!response.ok) {
@@ -62,14 +68,33 @@ type Props = {
 const buildPayload = (props: Props) => {
     return {
         tracking: {
-            // TODO stub
+            ophanPageId: window.guardian.config.ophan.pageViewId,
+            ophanComponentId: 'ACQUISITIONS_BANNER',
+            platformId: 'GUARDIAN_WEB',
+            clientName: 'dcr',
+            referrerUrl: window.location.origin + window.location.pathname,
         },
         targeting: {
-            ...props,
-            // TODO stub
+            contentType: props.contentType,
+            sectionName: props.sectionName || '', // TODO update client to reflect that this is optional
+            shouldHideReaderRevenue: props.shouldHideReaderRevenue,
+            isMinuteArticle: props.isMinuteArticle,
+            isPaidContent: props.isPaidContent,
+            isSensitive: props.isSensitive,
+            tags: props.tags,
+            showSupportMessaging: shouldShowSupportMessaging(),
+            isRecurringContributor: isRecurringContributor(
+                props.isSignedIn || false,
+            ),
+            lastOneOffContributionDate: getLastOneOffContributionDate(),
+            epicViewLog: getViewLog(),
+            weeklyArticleHistory: getWeeklyArticleHistory(),
+            mvtId: Number(getCookie('GU_mvt_id')),
+            countryCode: props.countryCode,
         },
     };
 };
+
 
 const MemoisedInner = ({
     isSignedIn,


### PR DESCRIPTION
## What does this change?
Implements ophan tracking events for the reader revenue banner.
We use the INSERT and VIEW componentEvents. For the click it's enough to track the user's arrival on support.theguardian.com.

Note - there's some mostly duplicated code taken from the epic (`SlotBodyEnd.tsx`), I'm not sure where the best place to put this is.

![Screen Shot 2020-06-18 at 11 05 50](https://user-images.githubusercontent.com/1513454/85007630-b37df600-b153-11ea-8835-f7dcdee7b78b.png)
![Screen Shot 2020-06-18 at 11 05 55](https://user-images.githubusercontent.com/1513454/85007637-b4af2300-b153-11ea-9db3-d8874ab7f31e.png)

