### PR TITLE
Use embedly embed card for embeds with url

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -742,6 +742,7 @@ declare namespace JSX {
         'amp-live-list': any;
         'amp-audio': any;
         'amp-embed': any;
+        'amp-embedly-card': any;
     }
     /* eslint-enable @typescript-eslint/no-explicit-any */
 }

--- a/src/amp/components/elements/EmbedBlockComponent.tsx
+++ b/src/amp/components/elements/EmbedBlockComponent.tsx
@@ -3,9 +3,26 @@ import React from 'react';
 export const EmbedBlockComponent: React.FC<{
     element: EmbedBlockElement;
 }> = ({ element }) => {
-    if (element.isMandatory) {
+    if (element.isMandatory && !element.url) {
         throw new Error(
             'This page cannot be rendered due to incompatible content that is marked as mandatory.',
+        );
+    }
+    if (element.url) {
+        return (
+            <figure>
+                <script
+                    async={true}
+                    custom-element="amp-embedly-card"
+                    src="https://cdn.ampproject.org/v0/amp-embedly-card-0.1.js"
+                />
+                <amp-embedly-card
+                    data-url={element.url}
+                    layout="responsive"
+                    height="100"
+                    width="320"
+                />
+            </figure>
         );
     }
     return null;

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -78,6 +78,7 @@ interface EmbedBlockElement {
     safe?: boolean;
     alt?: string;
     html: string;
+    url?: string;
     isMandatory: boolean;
 }
 


### PR DESCRIPTION
Note: requires the model to update https://github.com/guardian/frontend/blob/master/common/app/model/dotcomrendering/pageElements/PageElement.scala#L69 to support the 'source url' passed through with embeds. 

Also, need to check that this it is ok to show the 'powered by embedly' link. 

## What does this change?
Adds [embedly cards](https://amp.dev/documentation/components/amp-embedly-card/) for embeds that we don't support natively through the amp components (we support twitter, instagram etc for example). Tik tok is an example of one we don't support natively, nor does it have an amp component to actually support it.

### Before
Either doesn't show or errors if mandatory.

### After

![Screen Shot 2020-06-18 at 12 04 26](https://user-images.githubusercontent.com/638051/85013216-225f4d00-b15c-11ea-9b31-5f091662416e.png)

## Why?
This will vastly increase the amount of embeds we can support and the UX of the pages where the embeds are not mandatory.