### PR TITLE
Add missing Props for Caption within Vimeo block

### DIFF
--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -234,9 +234,8 @@ interface VideoVimeoBlockElement {
     height: number;
     width: number;
     caption?: string;
-    credit: string;
-    title: string;
-    description: string;
+    credit?: string;
+    title?: string;
 }
 
 interface VideoYoutubeBlockElement {

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -488,7 +488,11 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "id", "url"]
+            "required": [
+                "_type",
+                "id",
+                "url"
+            ]
         },
         "CodeBlockElement": {
             "type": "object",
@@ -1173,10 +1177,14 @@
                 },
                 "isMandatory": {
                     "type": "boolean"
+                },
+                "html": {
+                    "type": "string"
                 }
             },
             "required": [
                 "_type",
+                "html",
                 "isMandatory"
             ]
         },
@@ -1354,17 +1362,11 @@
                 },
                 "title": {
                     "type": "string"
-                },
-                "description": {
-                    "type": "string"
                 }
             },
             "required": [
                 "_type",
-                "credit",
-                "description",
                 "height",
-                "title",
                 "url",
                 "width"
             ]

--- a/src/web/components/elements/VimeoBlockComponent.stories.tsx
+++ b/src/web/components/elements/VimeoBlockComponent.stories.tsx
@@ -32,6 +32,7 @@ export const smallAspectRatio = () => {
                 credit=""
                 title=""
                 display="standard"
+                designType="Article"
             />
             <p>abc</p>
         </Container>
@@ -52,6 +53,7 @@ export const largeAspectRatio = () => {
                 credit=""
                 title=""
                 display="standard"
+                designType="Article"
             />
             <p>abc</p>
         </Container>
@@ -72,6 +74,7 @@ export const verticalAspectRatio = () => {
                 credit=""
                 title=""
                 display="standard"
+                designType="Article"
             />
             <p>abc</p>
         </Container>

--- a/src/web/components/elements/VimeoBlockComponent.stories.tsx
+++ b/src/web/components/elements/VimeoBlockComponent.stories.tsx
@@ -31,6 +31,7 @@ export const smallAspectRatio = () => {
                 caption="blah"
                 credit=""
                 title=""
+                display="standard"
             />
             <p>abc</p>
         </Container>
@@ -50,6 +51,7 @@ export const largeAspectRatio = () => {
                 caption="blah"
                 credit=""
                 title=""
+                display="standard"
             />
             <p>abc</p>
         </Container>
@@ -69,6 +71,7 @@ export const verticalAspectRatio = () => {
                 caption="blah"
                 credit=""
                 title=""
+                display="standard"
             />
             <p>abc</p>
         </Container>

--- a/src/web/components/elements/VimeoBlockComponent.tsx
+++ b/src/web/components/elements/VimeoBlockComponent.tsx
@@ -22,7 +22,8 @@ export const VimeoBlockComponent: React.FC<{
     caption?: string;
     credit: string;
     title: string;
-}> = ({ url, caption, title, pillar, width, height }) => {
+    display: Display;
+}> = ({ url, caption, title, pillar, width, height, display }) => {
     // 812 is the full height on an iphone X. This ensures that the embed doesn't display any larger than the available viewport
     // Constrain iframe embeds with a width to their natural width
     // rather than stretch them to the container using
@@ -52,7 +53,7 @@ export const VimeoBlockComponent: React.FC<{
                 <Caption
                     captionText={caption}
                     pillar={pillar}
-                    display="standard"
+                    display={display}
                 />
             )}
         </div>

--- a/src/web/components/elements/VimeoBlockComponent.tsx
+++ b/src/web/components/elements/VimeoBlockComponent.tsx
@@ -20,10 +20,21 @@ export const VimeoBlockComponent: React.FC<{
     height: number;
     width: number;
     caption?: string;
-    credit: string;
-    title: string;
+    credit?: string;
+    title?: string;
     display: Display;
-}> = ({ url, caption, title, pillar, width, height, display }) => {
+    designType: DesignType;
+}> = ({
+    url,
+    caption,
+    title,
+    pillar,
+    width,
+    height,
+    display,
+    designType,
+    credit,
+}) => {
     // 812 is the full height on an iphone X. This ensures that the embed doesn't display any larger than the available viewport
     // Constrain iframe embeds with a width to their natural width
     // rather than stretch them to the container using
@@ -52,8 +63,10 @@ export const VimeoBlockComponent: React.FC<{
             {caption && (
                 <Caption
                     captionText={caption}
+                    designType={designType}
                     pillar={pillar}
                     display={display}
+                    credit={credit}
                 />
             )}
         </div>

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -139,6 +139,7 @@ export const ArticleRenderer: React.FC<{
                             caption={element.caption}
                             credit={element.credit}
                             title={element.title}
+                            display={display}
                         />
                     );
                 case 'model.dotcomrendering.pageElements.YoutubeBlockElement':

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -133,7 +133,7 @@ export const ArticleRenderer: React.FC<{
                     return (
                         <VimeoBlockComponent
                             pillar={pillar}
-                            url="https://player.vimeo.com/video/327310297?app_id=122963"
+                            url={element.url}
                             height={element.height}
                             width={element.width}
                             caption={element.caption}

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -133,13 +133,14 @@ export const ArticleRenderer: React.FC<{
                     return (
                         <VimeoBlockComponent
                             pillar={pillar}
-                            url={element.url}
+                            url="https://player.vimeo.com/video/327310297?app_id=122963"
                             height={element.height}
                             width={element.width}
                             caption={element.caption}
                             credit={element.credit}
                             title={element.title}
                             display={display}
+                            designType={designType}
                         />
                     );
                 case 'model.dotcomrendering.pageElements.YoutubeBlockElement':


### PR DESCRIPTION
## What does this change?
Adds the required props for the caption component imported into the Vimeo block.
