### PR TITLE
Send banner payload to contributions-service

### DIFF
--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -31,7 +31,7 @@ type Props = {
     tags: TagType[];
     contributionsServiceUrl: string;
     alreadyVisitedCount: number;
-    engagementBannerLastClosedAt: Date | null,
+    engagementBannerLastClosedAt?: string,
 };
 
 // TODO specify return type (need to update client to provide this first)

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from 'react';
 import * as emotion from 'emotion';
 import * as emotionCore from '@emotion/core';
 import * as emotionTheming from 'emotion-theming';
+import {shouldShowSupportMessaging} from "@root/src/web/lib/contributions";
+import {getCookie} from "@root/src/web/browser/cookie";
 
 const checkForErrors = (response: any) => {
     if (!response.ok) {
@@ -28,17 +30,28 @@ type Props = {
     isSensitive: boolean;
     tags: TagType[];
     contributionsServiceUrl: string;
+    alreadyVisitedCount: number;
+    engagementBannerLastClosedAt: Date | null,
 };
 
 // TODO specify return type (need to update client to provide this first)
 const buildPayload = (props: Props) => {
     return {
         tracking: {
-            // TODO stub
+            ophanPageId: window.guardian.config.ophan.pageViewId,
+            ophanComponentId: 'ACQUISITIONS_BANNER',
+            platformId: 'GUARDIAN_WEB',
+            clientName: 'dcr',
+            referrerUrl: window.location.origin + window.location.pathname,
         },
         targeting: {
-            ...props,
-            // TODO stub
+            alreadyVisitedCount: props.alreadyVisitedCount,
+            shouldHideReaderRevenue: props.shouldHideReaderRevenue,
+            isPaidContent: props.isPaidContent,
+            showSupportMessaging: shouldShowSupportMessaging(),
+            engagementBannerLastClosedAt: props.engagementBannerLastClosedAt,
+            mvtId: Number(getCookie('GU_mvt_id')),
+            countryCode: props.countryCode,
         },
     };
 };
@@ -54,6 +67,8 @@ const MemoisedInner = ({
     isSensitive,
     tags,
     contributionsServiceUrl,
+    alreadyVisitedCount,
+    engagementBannerLastClosedAt,
 }: Props) => {
     const [Banner, setBanner] = useState<React.FC>();
     const [bannerProps, setBannerProps] = useState<{}>();
@@ -70,6 +85,8 @@ const MemoisedInner = ({
             tags,
             contributionsServiceUrl,
             isSensitive,
+            alreadyVisitedCount,
+            engagementBannerLastClosedAt,
         });
 
         window.guardian.automat = {
@@ -134,6 +151,8 @@ export const ReaderRevenueBanner = ({
     isSensitive,
     tags,
     contributionsServiceUrl,
+    alreadyVisitedCount,
+    engagementBannerLastClosedAt,
 }: Props) => {
     if (isSignedIn === undefined || countryCode === undefined) {
         return null;
@@ -153,6 +172,8 @@ export const ReaderRevenueBanner = ({
             isSensitive={isSensitive}
             tags={tags}
             contributionsServiceUrl={contributionsServiceUrl}
+            alreadyVisitedCount={alreadyVisitedCount}
+            engagementBannerLastClosedAt={engagementBannerLastClosedAt}
         />
     );
 };

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -39,7 +39,7 @@ const buildPayload = (props: Props) => {
     return {
         tracking: {
             ophanPageId: window.guardian.config.ophan.pageViewId,
-            ophanComponentId: 'ACQUISITIONS_BANNER',
+            ophanComponentId: 'ACQUISITIONS_ENGAGEMENT_BANNER',
             platformId: 'GUARDIAN_WEB',
             clientName: 'dcr',
             referrerUrl: window.location.origin + window.location.pathname,

--- a/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -42,7 +42,7 @@ export const StickyBottomBanner = ({
     }
 
     // Temporary flag to toggle RR banner while it is in development
-    const showRRBanner = true;
+    const showRRBanner = false;
 
     return (
         <>

--- a/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -16,9 +16,8 @@ const getAlreadyVisitedCount = (): number => {
     return !Number.isNaN(alreadyVisited) ? alreadyVisited : 0;
 };
 
-const getEngagementBannerLastClosedAt = (): Date | null => {
-    const engagementBannerLastClosedAt = localStorage.getItem('engagementBannerLastClosedAt');
-    return engagementBannerLastClosedAt ? new Date(engagementBannerLastClosedAt) : null;
+const getEngagementBannerLastClosedAt = (): string | undefined => {
+    return localStorage.getItem('engagementBannerLastClosedAt') || undefined;
 };
 
 export const StickyBottomBanner = ({

--- a/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -11,9 +11,8 @@ type Props = {
     CAPI: CAPIBrowserType;
 };
 
-//engagementBannerLastClosedAt
 const getAlreadyVisitedCount = (): number => {
-    const alreadyVisited = parseInt(localStorage.getItem('gu.alreadyVisited') ?? "");
+    const alreadyVisited = parseInt(localStorage.getItem('gu.alreadyVisited') ?? "", 10);
     return !Number.isNaN(alreadyVisited) ? alreadyVisited : 0;
 };
 

--- a/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -11,6 +11,17 @@ type Props = {
     CAPI: CAPIBrowserType;
 };
 
+//engagementBannerLastClosedAt
+const getAlreadyVisitedCount = (): number => {
+    const alreadyVisited = parseInt(localStorage.getItem('gu.alreadyVisited') ?? "");
+    return !Number.isNaN(alreadyVisited) ? alreadyVisited : 0;
+};
+
+const getEngagementBannerLastClosedAt = (): Date | null => {
+    const engagementBannerLastClosedAt = localStorage.getItem('engagementBannerLastClosedAt');
+    return engagementBannerLastClosedAt ? new Date(engagementBannerLastClosedAt) : null;
+};
+
 export const StickyBottomBanner = ({
     isSignedIn,
     countryCode,
@@ -32,7 +43,7 @@ export const StickyBottomBanner = ({
     }
 
     // Temporary flag to toggle RR banner while it is in development
-    const showRRBanner = false;
+    const showRRBanner = true;
 
     return (
         <>
@@ -51,6 +62,8 @@ export const StickyBottomBanner = ({
                         isSensitive={CAPI.config.isSensitive}
                         tags={CAPI.tags}
                         contributionsServiceUrl={CAPI.contributionsServiceUrl}
+                        alreadyVisitedCount={getAlreadyVisitedCount()}
+                        engagementBannerLastClosedAt={getEngagementBannerLastClosedAt()}
                     />
                 )
             )}

--- a/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -12,7 +12,7 @@ type Props = {
 };
 
 const getAlreadyVisitedCount = (): number => {
-    const alreadyVisited = parseInt(localStorage.getItem('gu.alreadyVisited') ?? "", 10);
+    const alreadyVisited = parseInt(localStorage.getItem('gu.alreadyVisited') || "", 10);
     return !Number.isNaN(alreadyVisited) ? alreadyVisited : 0;
 };
 


### PR DESCRIPTION
## What does this change?
Sends the relevant data to the new banner service. This is needed for the banner `canShow` logic.
![Screen Shot 2020-06-18 at 14 01 36](https://user-images.githubusercontent.com/1513454/85023288-6d815c00-b16c-11ea-889f-bef3f055be13.png)
