### PR TITLE
Adding tone to Permutive

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -527,6 +527,7 @@ interface CommercialConfigType {
     section?: string;
     edition?: string;
     series?: string;
+    toneIds?: string;
     contentType: string;
     ampIframeUrl: string;
 }

--- a/src/amp/lib/permutive.test.ts
+++ b/src/amp/lib/permutive.test.ts
@@ -11,7 +11,7 @@ describe('generatePermutivePayload', () => {
             keywords: 'keyword1,keyword2',
             edition: 'UK',
             webPublicationDate: 1578926460000,
-            toneIds: 'tone/advertisement-features',
+            toneIds: 'tone/advertisement-features,tone/minutebyminute',
         };
 
         const expected = {
@@ -22,7 +22,7 @@ describe('generatePermutivePayload', () => {
             'properties.content.authors!list[string]': 'author name',
             'properties.content.keywords!list[string]': 'keyword1,keyword2',
             'properties.content.publishedAt': '2020-01-13T14:41:00.000Z',
-            'properties.content.tone': 'tone/advertisement-features',
+            'properties.content.tone!list[string]': 'tone/advertisement-features,tone/minutebyminute',
             'properties.user.edition': 'UK',
         };
         expect(generatePermutivePayload(config as ConfigType)).toStrictEqual(
@@ -56,16 +56,19 @@ describe('generatePermutivePayload', () => {
         ).toStrictEqual(expected);
     });
 
-    test('generates the right payload given untrimmed keywords or authors', () => {
+    test('generates the right payload given untrimmed keywords, authors or tone', () => {
         const config = {
             author: 'author 1 , author 2 ,author3, author 4  ',
             keywords: ' keyword1,  keyword2  ,keyword3',
+            toneIds: ' tone/world,  tone/worldnews    ,tone/minutebyminute',
         };
         const expected = {
             'properties.content.authors!list[string]':
                 'author 1,author 2,author3,author 4',
             'properties.content.keywords!list[string]':
                 'keyword1,keyword2,keyword3',
+            'properties.content.tone!list[string]':
+                'tone/world,tone/worldnews,tone/minutebyminute',
         };
 
         expect(

--- a/src/amp/lib/permutive.test.ts
+++ b/src/amp/lib/permutive.test.ts
@@ -11,6 +11,7 @@ describe('generatePermutivePayload', () => {
             keywords: 'keyword1,keyword2',
             edition: 'UK',
             webPublicationDate: 1578926460000,
+            toneIds: 'tone/advertisement-features',
         };
 
         const expected = {
@@ -21,6 +22,7 @@ describe('generatePermutivePayload', () => {
             'properties.content.authors!list[string]': 'author name',
             'properties.content.keywords!list[string]': 'keyword1,keyword2',
             'properties.content.publishedAt': '2020-01-13T14:41:00.000Z',
+            'properties.content.tone': 'tone/advertisement-features',
             'properties.user.edition': 'UK',
         };
         expect(generatePermutivePayload(config as ConfigType)).toStrictEqual(

--- a/src/amp/lib/permutive.ts
+++ b/src/amp/lib/permutive.ts
@@ -32,6 +32,13 @@ export const generatePermutivePayload = (
                   .map(s => s.trim())
                   .join()
             : null;
+    const toneIds =
+        rawConfig.toneIds && typeof rawConfig.toneIds === 'string'
+            ? rawConfig.toneIds
+                  .split(',')
+                  .map(s => s.trim())
+                  .join()
+            : null;
     const config: { [key: string]: any } = {
         'properties.content.premium': rawConfig.isPaidContent,
         'properties.content.type': rawConfig.contentType,
@@ -42,7 +49,7 @@ export const generatePermutivePayload = (
         'properties.content.authors!list[string]': authors,
         'properties.content.keywords!list[string]': keywords,
         'properties.content.publishedAt': publishedAt,
-        'properties.content.tone': rawConfig.toneIds,
+        'properties.content.tone!list[string]': toneIds,
         'properties.user.edition': rawConfig.edition,
     };
 

--- a/src/amp/lib/permutive.ts
+++ b/src/amp/lib/permutive.ts
@@ -6,6 +6,7 @@ export interface PermutivePayload {
     'properties.content.authors!'?: string;
     'properties.content.keywords!'?: string;
     'properties.content.publishedAt'?: string;
+    'properties.content.tone'?: string;
     'properties.user.edition'?: string;
 }
 
@@ -41,6 +42,7 @@ export const generatePermutivePayload = (
         'properties.content.authors!list[string]': authors,
         'properties.content.keywords!list[string]': keywords,
         'properties.content.publishedAt': publishedAt,
+        'properties.content.tone': rawConfig.toneIds,
         'properties.user.edition': rawConfig.edition,
     };
 


### PR DESCRIPTION
## What does this change?

Adding `tone` to Permutive and `toneIds` to rawConfig

### Before

`toneIds` is not part of CommercialConfigType, only GADataType

### After

`toneIds` is now part of CommercialConfigType

## Why?

This change was made in frontend ([See PR](https://github.com/guardian/frontend/pull/22704)), so brought here, too.