### PR TITLE
Return 404 for pages with mandatory content we don't support

### DIFF
--- a/src/amp/components/Elements.tsx
+++ b/src/amp/components/Elements.tsx
@@ -218,7 +218,7 @@ export const Elements = (
                 console.log('Unsupported Element', JSON.stringify(element));
                 if ((element as { isMandatory?: boolean }).isMandatory) {
                     throw new Error(
-                        'This page cannot be rendered due to incompatible content that is marked as mandatory.',
+                        '404: This page cannot be rendered due to incompatible content that is marked as mandatory.',
                     );
                 }
                 return null;

--- a/src/amp/components/elements/EmbedBlockComponent.tsx
+++ b/src/amp/components/elements/EmbedBlockComponent.tsx
@@ -5,7 +5,7 @@ export const EmbedBlockComponent: React.FC<{
 }> = ({ element }) => {
     if (element.isMandatory) {
         throw new Error(
-            'This page cannot be rendered due to incompatible content that is marked as mandatory.',
+            '404: This page cannot be rendered due to incompatible content that is marked as mandatory.',
         );
     }
     return null;

--- a/src/amp/server/render.tsx
+++ b/src/amp/server/render.tsx
@@ -65,8 +65,11 @@ export const render = ({ body }: express.Request, res: express.Response) => {
 
         res.status(200).send(resp);
     } catch (e) {
-        // a validation error
-        if (e instanceof TypeError) {
+        if (e.message.startsWith('404')) {
+            // Message starts with 404 (mandatory content)
+            res.status(404).send(`<pre>${e.message}</pre>`);
+        } else if (e instanceof TypeError) {
+            // a validation error
             res.status(400).send(`<pre>${e.message}</pre>`);
         } else {
             res.status(500).send(`<pre>${e.message}</pre>`);

--- a/src/app/server.ts
+++ b/src/app/server.ts
@@ -161,7 +161,8 @@ if (process.env.NODE_ENV === 'production') {
     });
 
     // express requires all 4 args here:
-    app.use((err: any, req: any, res: any) => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    app.use((err: any, req: any, res: any, next: any) => {
         res.status(500).send(`<pre>${err.stack}</pre>`);
     });
 


### PR DESCRIPTION
Note: needs testing, not sure if this will work as expected through Fastly.

## What does this change?

Returns 404 for pages with mandatory content that isn't supported - mainly embeds.

### Before
Returned a 500 error.

### After
Returns a 404.

![image](https://user-images.githubusercontent.com/638051/85048975-fb207400-b18b-11ea-9d30-845a7544f3b8.png)

## Why?
We were caching the error in fastly which meant that the page was not purged.

Detailed info here: https://chat.google.com/room/AAAAPTsU18A/xGbM-gEDr5o