### PR TITLE
Style Standfirsts for Photo Essays

### DIFF
--- a/src/web/components/Standfirst.tsx
+++ b/src/web/components/Standfirst.tsx
@@ -51,20 +51,46 @@ const nestedStyles = css`
 const standfirstStyles = (designType: DesignType, display: Display) => {
     switch (display) {
         case 'immersive':
-            return css`
-                ${headline.xsmall({
-                    fontWeight: 'light',
-                })};
-                padding-top: ${space[4]}px;
+            switch (designType) {
+                case 'PhotoEssay':
+                    return css`
+                        ${headline.xxxsmall({})};
+                        margin-top: ${space[2]}px;
+                        margin-bottom: ${space[3]}px;
+                        line-height: 22px;
+                    `;
+                case 'Comment':
+                case 'GuardianView':
+                case 'Feature':
+                case 'Recipe':
+                case 'Review':
+                case 'Immersive':
+                case 'Media':
+                case 'SpecialReport':
+                case 'MatchReport':
+                case 'AdvertisementFeature':
+                case 'GuardianLabs':
+                case 'Quiz':
+                case 'Article':
+                case 'Live':
+                case 'Analysis':
+                case 'Interview':
+                default:
+                    return css`
+                        ${headline.xsmall({
+                            fontWeight: 'light',
+                        })};
+                        padding-top: ${space[4]}px;
 
-                max-width: 280px;
-                ${from.tablet} {
-                    max-width: 400px;
-                }
-                ${from.tablet} {
-                    max-width: 460px;
-                }
-            `;
+                        max-width: 280px;
+                        ${from.tablet} {
+                            max-width: 400px;
+                        }
+                        ${from.tablet} {
+                            max-width: 460px;
+                        }
+                    `;
+            }
 
         case 'showcase':
         case 'standard': {


### PR DESCRIPTION
## What does this change?
Adds special styling for the standfirst in photo essays

### Before
![Screenshot 2020-06-19 at 07 15 40](https://user-images.githubusercontent.com/1336821/85102496-b2ed6a00-b1fc-11ea-8b53-616bf6739941.jpg)

### After
![Screenshot 2020-06-19 at 07 15 08](https://user-images.githubusercontent.com/1336821/85102470-a5d07b00-b1fc-11ea-8d11-7ff3a8c287a8.jpg)


## Why?
For parity of how the standfirst looks but also to maintain parity with space finder and ad placement.
