### PR TITLE
Fix banner z-index, use module name

### DIFF
--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -129,7 +129,7 @@ const MemoisedInner = ({
                         setBannerProps({
                             ...module.props,
                         });
-                        setBanner(() => bannerModule.Banner); // useState requires functions to be wrapped
+                        setBanner(() => bannerModule[module.name]); // useState requires functions to be wrapped
                         setBannerMeta(meta);
                         sendOphanContributionsComponentEvent('INSERT', meta, 'ACQUISITIONS_ENGAGEMENT_BANNER');
                     })
@@ -150,8 +150,7 @@ const MemoisedInner = ({
     if (Banner) {
         return (
             // The css here is necessary to put the container div in view, so that we can track the view
-            <div ref={setNode} className={emotion.css`position: fixed; bottom: -1px;`}>
-                hello
+            <div ref={setNode} className={emotion.css`position: fixed; bottom: -1px; width: 100%; z-index: 999`}>
                 {/* eslint-disable-next-line react/jsx-props-no-spreading */}
                 <Banner {...bannerProps} />
             </div>

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -7,6 +7,7 @@ import {logView} from "@root/node_modules/@guardian/automat-client";
 import {shouldShowSupportMessaging} from "@root/src/web/lib/contributions";
 import {getCookie} from "@root/src/web/browser/cookie";
 import {sendOphanContributionsComponentEvent, TestMeta} from "@root/src/web/browser/ophan/ophan";
+import {getZIndex} from "@root/src/web/lib/getZIndex";
 
 const checkForErrors = (response: any) => {
     if (!response.ok) {
@@ -150,7 +151,7 @@ const MemoisedInner = ({
     if (Banner) {
         return (
             // The css here is necessary to put the container div in view, so that we can track the view
-            <div ref={setNode} className={emotion.css`position: fixed; bottom: -1px; width: 100%; z-index: 999`}>
+            <div ref={setNode} className={emotion.css`position: fixed; bottom: -1px; width: 100%; ${getZIndex('banner')}`}>
                 {/* eslint-disable-next-line react/jsx-props-no-spreading */}
                 <Banner {...bannerProps} />
             </div>

--- a/src/web/lib/getZIndex.tsx
+++ b/src/web/lib/getZIndex.tsx
@@ -24,6 +24,8 @@
 const indices = [
     // Modals will go here at the top
 
+    'banner',
+
     // Header
     'stickyAdWrapper',
     'headerWrapper',


### PR DESCRIPTION
1. Brings the banner to the front
2. Uses the name of the module after fetching it (this is configured per-test, server-side)