### PR TITLE
Stretch immersive images

### DIFF
--- a/src/web/components/elements/ImageBlockComponent.tsx
+++ b/src/web/components/elements/ImageBlockComponent.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 import { ImageComponent } from '@root/src/web/components/elements/ImageComponent';
 
-import { from } from '@guardian/src-foundations/mq';
+import { from, until } from '@guardian/src-foundations/mq';
 
 type Props = {
     display: Display;
@@ -39,6 +39,17 @@ const imageCss = {
     `,
 
     immersive: css`
+        margin-top: 12px;
+        margin-bottom: 12px;
+
+        ${until.tablet} {
+            margin-left: -20px;
+            margin-right: -20px;
+        }
+        ${until.mobileLandscape} {
+            margin-left: -10px;
+            margin-right: -10px;
+        }
         ${from.tablet} {
             margin-left: 0px;
             margin-right: -100px;

--- a/src/web/layouts/Immersive.stories.tsx
+++ b/src/web/layouts/Immersive.stories.tsx
@@ -92,7 +92,21 @@ export const PhotoEssayStory = () => {
     const ServerCAPI = convertToImmersive(PhotoEssay);
     return <HydratedLayout ServerCAPI={ServerCAPI} />;
 };
-PhotoEssayStory.story = { name: 'PhotoEssay' };
+PhotoEssayStory.story = {
+    name: 'PhotoEssay',
+};
+
+export const MobilePhotoEssay = () => {
+    const ServerCAPI = convertToImmersive(PhotoEssay);
+    return <HydratedLayout ServerCAPI={ServerCAPI} />;
+};
+MobilePhotoEssay.story = {
+    name: 'MobilePhotoEssay',
+    parameters: {
+        viewport: { defaultViewport: 'mobileMedium' },
+        chromatic: { viewports: [375] },
+    },
+};
 
 export const AnalysisStory = () => {
     const ServerCAPI = convertToImmersive(Analysis);


### PR DESCRIPTION
## What does this change?
Adds negative side margins to images with the role `immersive` so they are stretched to the full page width

## Why
For styling parity and to give them a bit more pop
