### PR TITLE
Maintain gu.alreadyVisited count

### DIFF
--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -25,6 +25,7 @@ import { getDiscussion } from '@root/src/web/lib/getDiscussion';
 import { getUser } from '@root/src/web/lib/getUser';
 import { getCommentContext } from '@root/src/web/lib/getCommentContext';
 import { FocusStyleManager } from '@guardian/src-foundations/utils';
+import {incrementAlreadyVisited} from "@root/src/web/lib/alreadyVisited";
 
 // *******************************
 // ****** Dynamic imports ********
@@ -154,6 +155,10 @@ export const App = ({ CAPI, NAV }: Props) => {
         CAPI.config.shortUrlId,
         CAPI.isCommentable,
     ]);
+
+    useEffect(() => {
+        incrementAlreadyVisited();
+    }, []);
 
     // Log an article view using the Slot Machine client lib
     // This function must be called once per article serving.

--- a/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -4,16 +4,12 @@ import {
     shouldShow as shouldShowCMP,
 } from '@root/src/web/components/StickyBottomBanner/CMP';
 import { ReaderRevenueBanner } from '@root/src/web/components/StickyBottomBanner/ReaderRevenueBanner';
+import {getAlreadyVisitedCount} from "@root/src/web/lib/alreadyVisited";
 
 type Props = {
     isSignedIn?: boolean;
     countryCode?: string;
     CAPI: CAPIBrowserType;
-};
-
-const getAlreadyVisitedCount = (): number => {
-    const alreadyVisited = parseInt(localStorage.getItem('gu.alreadyVisited') || "", 10);
-    return !Number.isNaN(alreadyVisited) ? alreadyVisited : 0;
 };
 
 const getEngagementBannerLastClosedAt = (): string | undefined => {

--- a/src/web/lib/alreadyVisited.ts
+++ b/src/web/lib/alreadyVisited.ts
@@ -1,0 +1,11 @@
+const AlreadyVisitedKey = 'gu.alreadyVisited';
+
+export const getAlreadyVisitedCount = (): number => {
+    const alreadyVisited = parseInt(localStorage.getItem(AlreadyVisitedKey) || "", 10);
+    return !Number.isNaN(alreadyVisited) ? alreadyVisited : 0;
+};
+
+export const incrementAlreadyVisited = () => {
+    const alreadyVisited = getAlreadyVisitedCount();
+    localStorage.setItem(AlreadyVisitedKey, `${alreadyVisited + 1}`);
+};


### PR DESCRIPTION
## What does this change?
In frontend we increment the `gu.alreadyVisited` local storage value on each page view, and it's used to decide when to show banners.

This value is passed to the new remotely-imported banner component, see https://github.com/guardian/dotcom-rendering/blob/master/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx#L50