### PR TITLE
Type OnwardsResponse data

### DIFF
--- a/src/web/components/Onwards/OnwardsData.tsx
+++ b/src/web/components/Onwards/OnwardsData.tsx
@@ -10,8 +10,14 @@ type Props = {
     ophanComponentName: OphanComponentName;
 };
 
+type OnwardsResponse = {
+    trails: [];
+    heading: string;
+    displayname: string;
+};
+
 export const OnwardsData = ({ url, limit, ophanComponentName }: Props) => {
-    const { data } = useApi(url);
+    const { data } = useApi<OnwardsResponse>(url);
     const onwardSections: OnwardsType[] = [];
     if (data && data.trails) {
         onwardSections.push({


### PR DESCRIPTION
## What does this change?

Adds the OnwardsResponse type as the API data response is `any` and that causes the build in https://github.com/guardian/dotcom-rendering/pull/1607 to fail, for some reason.