### PR TITLE
Rename dynamic import polyfill to be directly on the window

### DIFF
--- a/docs/architecture/023-dynamic-imports.md
+++ b/docs/architecture/023-dynamic-imports.md
@@ -15,7 +15,7 @@ Browser-support is high (~90%) but not enough to forgo a polyfill.
 Support `import` via polyfills for browsers that need them.
 
 As it is not possible to directly override `import`, dynamic import is exposed
-via `window.guardian.functions.import`.
+via `window.guardianPolyfilledImport`.
 
 ## Status
 

--- a/src/web/browser/dynamicImport/init.ts
+++ b/src/web/browser/dynamicImport/init.ts
@@ -9,13 +9,13 @@ import { startup } from '@root/src/web/browser/startup';
 // browsers that cut the mustard (support modules).**
 const initialiseDynamicImport = () => {
     try {
-        window.guardian.functions.import = new Function(
+        window.guardianPolyfilledImport = new Function(
             'url',
             `return import(url)`,
         ) as (url: string) => Promise<any>;
     } catch (e) {
         dynamicImportPolyfill.initialize({
-            importFunctionName: 'guardian.functions.import',
+            importFunctionName: 'guardianPolyfilledImport', // must be a direct property of the window
         });
     }
 };
@@ -26,18 +26,16 @@ const initialiseDynamicImportLegacy = () => {
     return import(/* webpackChunkName: "shimport" */ '@guardian/shimport').then(
         shimport => {
             shimport.initialise(); // note this adds a __shimport__ global
-            window.guardian.functions.import = shimport.load;
+            window.guardianPolyfilledImport = shimport.load;
         },
     );
 };
 
 const init = (): Promise<void> => {
-    window.guardian.functions = {
-        import: (url: string) =>
-            Promise.reject(
-                new Error(`import not polyfilled; attempted import(${url})`),
-            ),
-    };
+    window.guardianPolyfilledImport = (url: string) =>
+        Promise.reject(
+            new Error(`import not polyfilled; attempted import(${url})`),
+        );
 
     if (window.guardian.mustardCut) {
         return Promise.resolve(initialiseDynamicImport());

--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -14,7 +14,10 @@ import {
     getLastOneOffContributionDate,
 } from '@root/src/web/lib/contributions';
 import { initPerf } from '@root/src/web/browser/initPerf';
-import {sendOphanContributionsComponentEvent, TestMeta} from "@root/src/web/browser/ophan/ophan";
+import {
+    sendOphanContributionsComponentEvent,
+    TestMeta,
+} from '@root/src/web/browser/ophan/ophan';
 import { getCookie } from '../browser/cookie';
 import { useHasBeenSeen } from '../lib/useHasBeenSeen';
 
@@ -169,8 +172,8 @@ const MemoisedInner = ({
                 modulePerf.start();
 
                 // eslint-disable-next-line no-restricted-globals
-                window.guardian.functions
-                    .import(module.url)
+                window
+                    .guardianPolyfilledImport(module.url)
                     .then(epicModule => {
                         modulePerf.end();
                         setEpicMeta(meta);
@@ -179,7 +182,11 @@ const MemoisedInner = ({
                             onReminderOpen: sendOphanReminderOpenEvent,
                         });
                         setEpic(() => epicModule.ContributionsEpic); // useState requires functions to be wrapped
-                        sendOphanContributionsComponentEvent('INSERT', meta, 'ACQUISITIONS_EPIC');
+                        sendOphanContributionsComponentEvent(
+                            'INSERT',
+                            meta,
+                            'ACQUISITIONS_EPIC',
+                        );
                     })
                     // eslint-disable-next-line no-console
                     .catch(error => console.log(`epic - error is: ${error}`));
@@ -191,7 +198,11 @@ const MemoisedInner = ({
     useEffect(() => {
         if (hasBeenSeen && epicMeta) {
             logView(epicMeta.abTestName);
-            sendOphanContributionsComponentEvent('VIEW', epicMeta, 'ACQUISITIONS_EPIC');
+            sendOphanContributionsComponentEvent(
+                'VIEW',
+                epicMeta,
+                'ACQUISITIONS_EPIC',
+            );
         }
     }, [hasBeenSeen, epicMeta]);
 

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -125,8 +125,9 @@ const MemoisedInner = ({
 
                 const { module, meta } = json.data;
 
-                import(/* webpackIgnore: true */ module.url)
-                    .then(bannerModule => {
+                window
+                    .guardianPolyfilledImport(module.url)
+                    .then((bannerModule) => {
                         setBannerProps({
                             ...module.props,
                         });

--- a/window.guardian.d.ts
+++ b/window.guardian.d.ts
@@ -31,9 +31,6 @@ declare global {
                     reportError: (error: Error, feature: string) => void;
                 };
             };
-            functions: {
-                import: (url: string) => Promise<any>;
-            };
             // TODO expose as type from Automat client lib
             automat: {
                 react: any;
@@ -44,6 +41,7 @@ declare global {
         };
         GoogleAnalyticsObject: string;
         ga: UniversalAnalytics.ga;
+        guardianPolyfilledImport: (url: string) => Promise<any>; // can't be nested beyond top level
     }
 }
 /* ~ this line is required as per TypeScript's global-modifying-module.d.ts instructions */

--- a/window.guardian.d.ts
+++ b/window.guardian.d.ts
@@ -41,6 +41,16 @@ declare global {
         };
         GoogleAnalyticsObject: string;
         ga: UniversalAnalytics.ga;
+        /**
+         * ES6 module import, possibly polyfilled depending on the current
+         * browser. There are three categories:
+         *
+         * 1. Full support out of the box
+         * 2. ES6 module support but not dynamic modules
+         * 3. No module support
+         *
+         * This gives support across all 3 cases.
+         */
         guardianPolyfilledImport: (url: string) => Promise<any>; // can't be nested beyond top level
     }
 }


### PR DESCRIPTION
## What does this change?

Make the dynamic import polyfill available directly on the window, not nested under `window.guardian.functions`. This is because the "lighter" Google polyfill for import doesn't support making it available under a nested path (passing in a path with dot notation didn't have the effect of nesting). The light polyfill is used by browsers which support native imports but not dynamic imports (e.g. Chrome 62 and Edge 17).

### Before

Banner and epic not rendered on affected browsers.

### After

Chrome 62:

<img width="1250" alt="Screenshot 2020-06-24 at 09 55 00" src="https://user-images.githubusercontent.com/379839/85527756-131c4b80-b603-11ea-81b7-f69b2836208c.png">

Edge 17:

<img width="1389" alt="Screenshot 2020-06-24 at 10 04 43" src="https://user-images.githubusercontent.com/379839/85527799-1d3e4a00-b603-11ea-988d-df6a2ec7cbb6.png">

## Why?

The new banner and epic both use dynamic imports to render the relevant component. This adds support for some older browsers which don't support dynamic imports out the box.