### PR TITLE
Put banner behind a switch

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -314,6 +314,7 @@ type CAPIBrowserType = {
         discussionD2Uid: string;
         discussionApiClientHeader: string;
         dcrSentryDsn: string;
+        remoteBanner: boolean;
     };
     richLinks: RichLinkBlockElement[];
     editionId: Edition;

--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -105,6 +105,7 @@ export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
             permutive: CAPI.config.switches.permutive,
             enableSentryReporting: CAPI.config.switches.enableSentryReporting,
             enableDiscussionSwitch: CAPI.config.switches.enableDiscussionSwitch,
+            remoteBanner: CAPI.config.switches.remoteBanner,
 
             // used by lib/ad-targeting.ts
             isSensitive: CAPI.config.isSensitive,

--- a/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -36,8 +36,7 @@ export const StickyBottomBanner = ({
         return null;
     }
 
-    // Temporary flag to toggle RR banner while it is in development
-    const showRRBanner = false;
+    const showRRBanner = CAPI.config.remoteBanner;
 
     return (
         <>


### PR DESCRIPTION
The contributions banner will be fetched remotely from contributions-service.
This change makes DCR use the same switch as frontend for enabling this feature - https://github.com/guardian/frontend/pull/22722/files