### PR TITLE
HighlightBlockElement

### DIFF
--- a/scripts/frontend/landing/index.html
+++ b/scripts/frontend/landing/index.html
@@ -152,6 +152,11 @@
                     article: '/film/2013/feb/14/keanu-reeves-future-of-cinema',
                 },
                 {
+                    name: 'HighlightBlockElement',
+                    article:
+                        '/uk-news/2020/apr/22/eddies-last-farewell-a-funeral-in-the-time-of-coronavirus-photo-essay',
+                },
+                {
                     name: 'ImageBlockElement',
                     article:
                         '/environment/2018/dec/21/from-spectacular-orchids-to-towering-trees-2018s-top-new-plant-discoveries',

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -104,6 +104,11 @@ interface GuVideoBlockElement {
     caption: string;
 }
 
+interface HighlightBlockElement {
+    _type: 'model.dotcomrendering.pageElements.HighlightBlockElement';
+    html: string;
+}
+
 interface ImageBlockElement {
     _type: 'model.dotcomrendering.pageElements.ImageBlockElement';
     media: { allImages: Image[] };
@@ -287,6 +292,7 @@ type CAPIElement =
     | ExplainerAtomBlockElement
     | GuideAtomBlockElement
     | GuVideoBlockElement
+    | HighlightBlockElement
     | ImageBlockElement
     | InstagramBlockElement
     | MapBlockElement

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -63,6 +63,9 @@
                         "$ref": "#/definitions/GuVideoBlockElement"
                     },
                     {
+                        "$ref": "#/definitions/HighlightBlockElement"
+                    },
+                    {
                         "$ref": "#/definitions/ImageBlockElement"
                     },
                     {
@@ -313,6 +316,9 @@
                 "isPreview",
                 "isSensitive"
             ]
+        },
+        "matchUrl": {
+            "type": "string"
         }
     },
     "required": [
@@ -747,6 +753,24 @@
             "required": [
                 "mimeType",
                 "url"
+            ]
+        },
+        "HighlightBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.HighlightBlockElement"
+                    ]
+                },
+                "html": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "_type",
+                "html"
             ]
         },
         "ImageBlockElement": {
@@ -1500,6 +1524,9 @@
                                 "$ref": "#/definitions/GuVideoBlockElement"
                             },
                             {
+                                "$ref": "#/definitions/HighlightBlockElement"
+                            },
+                            {
                                 "$ref": "#/definitions/ImageBlockElement"
                             },
                             {
@@ -1797,6 +1824,15 @@
                 "isPhotoEssay": {
                     "type": "boolean"
                 },
+                "references": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "pageId": {
                     "type": "string"
                 },
@@ -1813,6 +1849,9 @@
                     "type": "string"
                 },
                 "series": {
+                    "type": "string"
+                },
+                "toneIds": {
                     "type": "string"
                 },
                 "contentType": {

--- a/src/web/components/elements/BlockquoteBlockComponent.stories.tsx
+++ b/src/web/components/elements/BlockquoteBlockComponent.stories.tsx
@@ -24,3 +24,16 @@ export const defaultStory = () => {
     );
 };
 defaultStory.story = { name: 'default' };
+
+export const Unquoted = () => {
+    return (
+        <div className={containerStyles}>
+            <BlockquoteBlockComponent
+                html={html}
+                pillar="news"
+                quoted={false}
+            />
+        </div>
+    );
+};
+Unquoted.story = { name: 'with quoted false' };

--- a/src/web/components/elements/BlockquoteBlockComponent.stories.tsx
+++ b/src/web/components/elements/BlockquoteBlockComponent.stories.tsx
@@ -24,16 +24,3 @@ export const defaultStory = () => {
     );
 };
 defaultStory.story = { name: 'default' };
-
-export const Unquoted = () => {
-    return (
-        <div className={containerStyles}>
-            <BlockquoteBlockComponent
-                html={html}
-                pillar="news"
-                quoted={false}
-            />
-        </div>
-    );
-};
-Unquoted.story = { name: 'with quoted false' };

--- a/src/web/components/elements/BlockquoteBlockComponent.tsx
+++ b/src/web/components/elements/BlockquoteBlockComponent.tsx
@@ -5,15 +5,16 @@ import { body } from '@guardian/src-foundations/typography';
 import { unwrapHtml } from '@root/src/model/unwrapHtml';
 import { RewrappedComponent } from '@root/src/web/components/elements/RewrappedComponent';
 import { pillarPalette } from '@root/src/lib/pillars';
-import { neutral } from '@guardian/src-foundations/palette';
+import { neutral, background } from '@guardian/src-foundations/palette';
 import { QuoteIcon } from '@root/src/web/components/QuoteIcon';
 
 type Props = {
     html: string;
     pillar: Pillar;
+    quoted?: boolean;
 };
 
-const Row = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
+const Row = ({ children }: { children: React.ReactNode }) => (
     <div
         className={css`
             display: flex;
@@ -31,23 +32,35 @@ const blockquoteStyles = css`
     color: ${neutral[46]};
 `;
 
+const blockStyles = css`
+    ${body.medium({ lineHeight: 'tight' })};
+    background-color: ${background.secondary};
+    padding-top: 8px;
+    padding-bottom: 16px;
+    padding-left: 12px;
+    padding-right: 12px;
+`;
+
 export const BlockquoteBlockComponent: React.FC<Props> = ({
     html,
     pillar,
+    quoted = true,
 }: Props) => {
     const { willUnwrap: isUnwrapped, unwrappedHtml } = unwrapHtml({
-        prefix: '<blockquote class="quted">',
+        prefix: '<blockquote>',
         suffix: '</blockquote>',
         html,
     });
 
     return (
         <Row>
-            <QuoteIcon colour={pillarPalette[pillar].main} size="large" />
+            {quoted && (
+                <QuoteIcon colour={pillarPalette[pillar].main} size="large" />
+            )}
             <RewrappedComponent
                 isUnwrapped={isUnwrapped}
                 html={unwrappedHtml}
-                elCss={blockquoteStyles}
+                elCss={quoted ? blockquoteStyles : blockStyles}
                 tagName="blockquote"
             />
         </Row>

--- a/src/web/components/elements/BlockquoteBlockComponent.tsx
+++ b/src/web/components/elements/BlockquoteBlockComponent.tsx
@@ -5,13 +5,12 @@ import { body } from '@guardian/src-foundations/typography';
 import { unwrapHtml } from '@root/src/model/unwrapHtml';
 import { RewrappedComponent } from '@root/src/web/components/elements/RewrappedComponent';
 import { pillarPalette } from '@root/src/lib/pillars';
-import { neutral, background } from '@guardian/src-foundations/palette';
+import { neutral } from '@guardian/src-foundations/palette';
 import { QuoteIcon } from '@root/src/web/components/QuoteIcon';
 
 type Props = {
     html: string;
     pillar: Pillar;
-    quoted?: boolean;
 };
 
 const Row = ({ children }: { children: React.ReactNode }) => (
@@ -25,26 +24,9 @@ const Row = ({ children }: { children: React.ReactNode }) => (
     </div>
 );
 
-const blockquoteStyles = css`
-    margin-bottom: 16px;
-    ${body.medium()};
-    font-style: italic;
-    color: ${neutral[46]};
-`;
-
-const blockStyles = css`
-    ${body.medium({ lineHeight: 'tight' })};
-    background-color: ${background.secondary};
-    padding-top: 8px;
-    padding-bottom: 16px;
-    padding-left: 12px;
-    padding-right: 12px;
-`;
-
 export const BlockquoteBlockComponent: React.FC<Props> = ({
     html,
     pillar,
-    quoted = true,
 }: Props) => {
     const { willUnwrap: isUnwrapped, unwrappedHtml } = unwrapHtml({
         prefix: '<blockquote>',
@@ -54,13 +36,16 @@ export const BlockquoteBlockComponent: React.FC<Props> = ({
 
     return (
         <Row>
-            {quoted && (
-                <QuoteIcon colour={pillarPalette[pillar].main} size="large" />
-            )}
+            <QuoteIcon colour={pillarPalette[pillar].main} size="large" />
             <RewrappedComponent
                 isUnwrapped={isUnwrapped}
                 html={unwrappedHtml}
-                elCss={quoted ? blockquoteStyles : blockStyles}
+                elCss={css`
+                    margin-bottom: 16px;
+                    ${body.medium()};
+                    font-style: italic;
+                    color: ${neutral[46]};
+                `}
                 tagName="blockquote"
             />
         </Row>

--- a/src/web/components/elements/HighlightBlockComponent.stories.tsx
+++ b/src/web/components/elements/HighlightBlockComponent.stories.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { HighlightBlockComponent } from '@frontend/web/components/elements/HighlightBlockComponent';
+
+const html =
+    '<p>We’ve now got evidence that under <a href="https://www.theguardian.com/politics/boris-johnson">Boris Johnson</a> the NHS is on the table and will be up for sale. He tried to cover it up in a secret agenda but today it’s been exposed.</p>';
+
+export default {
+    component: HighlightBlockComponent,
+    title: 'Components/HighlightBlockComponent',
+};
+
+const containerStyles = css`
+    max-width: 620px;
+    margin: 20px;
+`;
+
+export const defaultStory = () => {
+    return (
+        <div className={containerStyles}>
+            <HighlightBlockComponent html={html} />
+        </div>
+    );
+};
+defaultStory.story = { name: 'default' };

--- a/src/web/components/elements/HighlightBlockComponent.tsx
+++ b/src/web/components/elements/HighlightBlockComponent.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { body } from '@guardian/src-foundations/typography';
+import { unwrapHtml } from '@root/src/model/unwrapHtml';
+import { RewrappedComponent } from '@root/src/web/components/elements/RewrappedComponent';
+import { background } from '@guardian/src-foundations/palette';
+
+type Props = {
+    html: string;
+};
+
+export const HighlightBlockComponent: React.FC<Props> = ({ html }: Props) => {
+    const { willUnwrap: isUnwrapped, unwrappedHtml } = unwrapHtml({
+        prefix: '<p>',
+        suffix: '</p>',
+        html,
+    });
+
+    return (
+        <RewrappedComponent
+            isUnwrapped={isUnwrapped}
+            html={unwrappedHtml}
+            elCss={css`
+                ${body.medium({ lineHeight: 'tight' })};
+                background-color: ${background.secondary};
+                padding-top: 8px;
+                padding-bottom: 16px;
+                padding-left: 12px;
+                padding-right: 12px;
+            `}
+            tagName="p"
+        />
+    );
+};

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -4,6 +4,7 @@ import { css } from 'emotion';
 import { BlockquoteBlockComponent } from '@root/src/web/components/elements/BlockquoteBlockComponent';
 import { DividerBlockComponent } from '@root/src/web/components/elements/DividerBlockComponent';
 import { EmbedBlockComponent } from '@root/src/web/components/elements/EmbedBlockComponent';
+import { HighlightBlockComponent } from '@root/src/web/components/elements/HighlightBlockComponent';
 import { ImageBlockComponent } from '@root/src/web/components/elements/ImageBlockComponent';
 import { MultiImageBlockComponent } from '@root/src/web/components/elements/MultiImageBlockComponent';
 import { InstagramBlockComponent } from '@root/src/web/components/elements/InstagramBlockComponent';
@@ -67,6 +68,10 @@ export const ArticleRenderer: React.FC<{
                             title={element.title}
                             html={element.body}
                         />
+                    );
+                case 'model.dotcomrendering.pageElements.HighlightBlockElement':
+                    return (
+                        <HighlightBlockComponent key={i} html={element.html} />
                     );
                 case 'model.dotcomrendering.pageElements.ImageBlockElement':
                     return (


### PR DESCRIPTION
## What does this change?
Adds a new element `HighlightBlockComponent` to  support unquoted blockquote text

```typescript
type Props = {
    html: string;
};
```

![Screenshot 2020-06-24 at 07 47 59](https://user-images.githubusercontent.com/1336821/85510286-0e4d9c80-b5ef-11ea-8402-6b690b65dad4.jpg)

We've branched from the style in frontend slightly here to align better with Source

Example: https://www.theguardian.com/uk-news/2020/apr/22/eddies-last-farewell-a-funeral-in-the-time-of-coronavirus-photo-essay?dcr=false

## Why?
Because we sometimes want to highlight a piece of text but it might not be a quote
