### PR TITLE
CaptionBlockComponent

### DIFF
--- a/scripts/frontend/landing/index.html
+++ b/scripts/frontend/landing/index.html
@@ -75,6 +75,7 @@
             <li>AtomEmbedMarkupBlockElement</li>
             <li>AtomEmbedUrlBlockElement</li>
             <li>BlockquoteBlockElement</li>
+            <li>CaptionBlockElement</li>
             <li>ContentAtomBlockElement</li>
             <li>DisclaimerBlockElement</li>
             <li>GuideAtomBlockElement</li>

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -33,6 +33,19 @@ interface BlockquoteBlockElement {
     html: string;
 }
 
+interface CaptionBlockElement {
+    _type: 'model.dotcomrendering.pageElements.CaptionBlockElement';
+    display: Display;
+    designType: DesignType;
+    captionText?: string;
+    pillar: Pillar;
+    padCaption?: boolean;
+    credit?: string;
+    displayCredit?: boolean;
+    shouldLimitWidth?: boolean;
+    isOverlayed?: boolean;
+}
+
 interface ChartAtomBlockElement {
     _type: 'model.dotcomrendering.pageElements.ChartAtomBlockElement';
     id: string;
@@ -276,6 +289,7 @@ type CAPIElement =
     | AudioAtomElement
     | AudioBlockElement
     | BlockquoteBlockElement
+    | CaptionBlockElement
     | ChartAtomBlockElement
     | CodeBlockElement
     | CommentBlockElement

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -313,6 +313,9 @@
                 "isPreview",
                 "isSensitive"
             ]
+        },
+        "matchUrl": {
+            "type": "string"
         }
     },
     "required": [
@@ -1797,6 +1800,15 @@
                 "isPhotoEssay": {
                     "type": "boolean"
                 },
+                "references": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "pageId": {
                     "type": "string"
                 },
@@ -1813,6 +1825,9 @@
                     "type": "string"
                 },
                 "series": {
+                    "type": "string"
+                },
+                "toneIds": {
                     "type": "string"
                 },
                 "contentType": {

--- a/src/web/components/elements/CaptionBlockComponent.stories.tsx
+++ b/src/web/components/elements/CaptionBlockComponent.stories.tsx
@@ -1,0 +1,171 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { Section } from '../Section';
+import { Flex } from '../Flex';
+import { LeftColumn } from '../LeftColumn';
+import { RightColumn } from '../RightColumn';
+
+import { CaptionBlockComponent } from './CaptionBlockComponent';
+
+export default {
+    component: CaptionBlockComponent,
+    title: 'Components/CaptionBlockComponent',
+};
+
+/*
+    type Props = {
+        display: Display;
+        designType: DesignType;
+        captionText?: string;
+        pillar: Pillar;
+        padCaption?: boolean;
+        credit?: string;
+        displayCredit?: boolean;
+        shouldLimitWidth?: boolean;
+        isOverlayed?: boolean;
+    };
+ */
+
+const Container = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
+    <Section showTopBorder={false}>
+        <Flex>
+            <LeftColumn>
+                <></>
+            </LeftColumn>
+            <div
+                className={css`
+                    width: 620px;
+                    padding: 20px;
+                    flex-grow: 1;
+                `}
+            >
+                {children}
+            </div>
+            <RightColumn>
+                <></>
+            </RightColumn>
+        </Flex>
+    </Section>
+);
+
+export const StandardArticle = () => {
+    return (
+        <Container>
+            <CaptionBlockComponent
+                display="standard"
+                designType="Article"
+                captionText="Caption text"
+                pillar="news"
+            />
+        </Container>
+    );
+};
+StandardArticle.story = {
+    name: 'with defaults',
+};
+
+export const PhotoEssay = () => {
+    return (
+        <Container>
+            <CaptionBlockComponent
+                display="immersive"
+                designType="PhotoEssay"
+                captionText="Caption text"
+                pillar="lifestyle"
+                padCaption={false}
+                credit="Credit text"
+                displayCredit={false}
+                shouldLimitWidth={false}
+                isOverlayed={false}
+            />
+        </Container>
+    );
+};
+PhotoEssay.story = {
+    name: 'PhotoEssay',
+};
+
+export const Padded = () => {
+    return (
+        <Container>
+            <CaptionBlockComponent
+                display="standard"
+                designType="Analysis"
+                captionText="Caption text"
+                pillar="culture"
+                padCaption={true}
+                credit="Credit text"
+                displayCredit={false}
+                shouldLimitWidth={false}
+                isOverlayed={false}
+            />
+        </Container>
+    );
+};
+Padded.story = {
+    name: 'when padded',
+};
+
+export const WidthLimited = () => {
+    return (
+        <Container>
+            <CaptionBlockComponent
+                display="standard"
+                designType="Review"
+                captionText="Caption textQuas repellat sapiente nobis vel. Expedita veniam ut officiis. Omnis tempore natus est distinctio sapiente aliquid dolores soluta. Vel facere vitae velit et non. Eveniet omnis impedit mollitia voluptas omnis sit"
+                pillar="culture"
+                padCaption={false}
+                credit="Credit text"
+                displayCredit={false}
+                shouldLimitWidth={true}
+                isOverlayed={false}
+            />
+        </Container>
+    );
+};
+WidthLimited.story = {
+    name: 'with width limited',
+};
+
+export const Credited = () => {
+    return (
+        <Container>
+            <CaptionBlockComponent
+                display="standard"
+                designType="MatchReport"
+                captionText="Caption textQuas repellat sapiente nobis vel. Expedita veniam ut officiis. Omnis tempore natus est distinctio sapiente aliquid dolores soluta. Vel facere vitae velit et non. Eveniet omnis impedit mollitia voluptas omnis sit"
+                pillar="culture"
+                padCaption={false}
+                credit="Credit text"
+                displayCredit={true}
+                shouldLimitWidth={false}
+                isOverlayed={false}
+            />
+        </Container>
+    );
+};
+Credited.story = {
+    name: 'with credit',
+};
+
+export const Overlayed = () => {
+    return (
+        <Container>
+            <CaptionBlockComponent
+                display="showcase"
+                designType="Comment"
+                captionText="Caption textQuas repellat sapiente nobis vel. Expedita veniam ut officiis. Omnis tempore natus est distinctio sapiente aliquid dolores soluta. Vel facere vitae velit et non. Eveniet omnis impedit mollitia voluptas omnis sit"
+                pillar="sport"
+                padCaption={false}
+                credit="Credit text"
+                displayCredit={false}
+                shouldLimitWidth={false}
+                isOverlayed={true}
+            />
+        </Container>
+    );
+};
+Overlayed.story = {
+    name: 'when overlayed',
+};

--- a/src/web/components/elements/CaptionBlockComponent.tsx
+++ b/src/web/components/elements/CaptionBlockComponent.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+// import { css } from 'emotion';
+import { Caption } from '@frontend/web/components/Caption';
+
+type Props = {
+    display: Display;
+    designType: DesignType;
+    captionText?: string;
+    pillar: Pillar;
+    padCaption?: boolean;
+    credit?: string;
+    displayCredit?: boolean;
+    shouldLimitWidth?: boolean;
+    isOverlayed?: boolean;
+};
+
+export const CaptionBlockComponent = ({
+    display,
+    designType,
+    captionText,
+    pillar,
+    padCaption = false,
+    credit,
+    displayCredit = true,
+    shouldLimitWidth = false,
+    isOverlayed,
+}: Props) => (
+    <Caption
+        display={display}
+        designType={designType}
+        captionText={captionText}
+        pillar={pillar}
+        padCaption={padCaption}
+        credit={credit}
+        displayCredit={displayCredit}
+        shouldLimitWidth={shouldLimitWidth}
+        isOverlayed={isOverlayed}
+    />
+);

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 import { BlockquoteBlockComponent } from '@root/src/web/components/elements/BlockquoteBlockComponent';
+import { CaptionBlockComponent } from '@root/src/web/components/elements/CaptionBlockComponent';
 import { DividerBlockComponent } from '@root/src/web/components/elements/DividerBlockComponent';
 import { EmbedBlockComponent } from '@root/src/web/components/elements/EmbedBlockComponent';
 import { ImageBlockComponent } from '@root/src/web/components/elements/ImageBlockComponent';
@@ -45,6 +46,21 @@ export const ArticleRenderer: React.FC<{
                             key={i}
                             html={element.html}
                             pillar={pillar}
+                        />
+                    );
+                case 'model.dotcomrendering.pageElements.CaptionBlockElement':
+                    return (
+                        <CaptionBlockComponent
+                            key={i}
+                            display={display}
+                            designType={designType}
+                            pillar={pillar}
+                            captionText={element.captionText}
+                            padCaption={element.padCaption}
+                            credit={element.credit}
+                            displayCredit={element.displayCredit}
+                            shouldLimitWidth={element.shouldLimitWidth}
+                            isOverlayed={element.isOverlayed}
                         />
                     );
                 case 'model.dotcomrendering.pageElements.DividerBlockElement':


### PR DESCRIPTION
## What does this change?
Adds a separate `CaptionBlockComponent` for standalone captions

## Why?
Because sometimes captions can appear out of context of a specific image. This is currently only happening in photo essays but by having a separate element we allow this pattern to be used anywhere, adding flexibility.

If Composer were to be updated to allow stand alone captions at any point, this is the element and the props that would support that.