### PR TITLE
Remote banner - use shouldHideSupportMessaging

### DIFF
--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -89,7 +89,7 @@ const buildPayload = (props: Props) => {
             isPaidContent: props.isPaidContent,
             isSensitive: props.isSensitive,
             tags: props.tags,
-            showSupportMessaging: shouldHideSupportMessaging(props.isSignedIn || false),
+            showSupportMessaging: !shouldHideSupportMessaging(props.isSignedIn || false),
             isRecurringContributor: isRecurringContributor(
                 props.isSignedIn || false,
             ),

--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -9,9 +9,8 @@ import {
     getWeeklyArticleHistory,
 } from '@guardian/automat-client';
 import {
-    shouldShowSupportMessaging,
     isRecurringContributor,
-    getLastOneOffContributionDate,
+    getLastOneOffContributionDate, shouldHideSupportMessaging,
 } from '@root/src/web/lib/contributions';
 import { initPerf } from '@root/src/web/browser/initPerf';
 import {sendOphanContributionsComponentEvent, TestMeta} from "@root/src/web/browser/ophan/ophan";
@@ -90,7 +89,7 @@ const buildPayload = (props: Props) => {
             isPaidContent: props.isPaidContent,
             isSensitive: props.isSensitive,
             tags: props.tags,
-            showSupportMessaging: shouldShowSupportMessaging(),
+            showSupportMessaging: shouldHideSupportMessaging(props.isSignedIn || false),
             isRecurringContributor: isRecurringContributor(
                 props.isSignedIn || false,
             ),

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -50,7 +50,7 @@ const buildPayload = (props: Props) => {
             alreadyVisitedCount: props.alreadyVisitedCount,
             shouldHideReaderRevenue: props.shouldHideReaderRevenue,
             isPaidContent: props.isPaidContent,
-            showSupportMessaging: shouldHideSupportMessaging(props.isSignedIn),
+            showSupportMessaging: !shouldHideSupportMessaging(props.isSignedIn),
             engagementBannerLastClosedAt: props.engagementBannerLastClosedAt,
             mvtId: Number(getCookie('GU_mvt_id')),
             countryCode: props.countryCode,

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -4,7 +4,7 @@ import * as emotionCore from '@emotion/core';
 import * as emotionTheming from 'emotion-theming';
 import {useHasBeenSeen} from "@root/src/web/lib/useHasBeenSeen";
 import {logView} from "@root/node_modules/@guardian/automat-client";
-import {shouldShowSupportMessaging} from "@root/src/web/lib/contributions";
+import {shouldHideSupportMessaging} from "@root/src/web/lib/contributions";
 import {getCookie} from "@root/src/web/browser/cookie";
 import {sendOphanContributionsComponentEvent, TestMeta} from "@root/src/web/browser/ophan/ophan";
 import {getZIndex} from "@root/src/web/lib/getZIndex";
@@ -50,7 +50,7 @@ const buildPayload = (props: Props) => {
             alreadyVisitedCount: props.alreadyVisitedCount,
             shouldHideReaderRevenue: props.shouldHideReaderRevenue,
             isPaidContent: props.isPaidContent,
-            showSupportMessaging: shouldShowSupportMessaging(),
+            showSupportMessaging: shouldHideSupportMessaging(props.isSignedIn),
             engagementBannerLastClosedAt: props.engagementBannerLastClosedAt,
             mvtId: Number(getCookie('GU_mvt_id')),
             countryCode: props.countryCode,

--- a/src/web/lib/contributions.test.ts
+++ b/src/web/lib/contributions.test.ts
@@ -1,6 +1,7 @@
 import { addCookie } from '../browser/cookie';
 import {
     getLastOneOffContributionDate,
+    isRecentOneOffContributor,
     ONE_OFF_CONTRIBUTION_DATE_COOKIE,
     SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE,
 } from './contributions';
@@ -61,3 +62,31 @@ describe('getLastOneOffContributionDate', () => {
         expect(lastOneOffContributionDate).toBeUndefined();
     });
 });
+
+/* eslint-disable @typescript-eslint/unbound-method */
+describe('isRecentOneOffContributor', () => {
+   beforeEach(clearAllCookies);
+
+    it('returns false if there is no one-off contribution cookie', () => {
+        expect(isRecentOneOffContributor()).toBe(false);
+    });
+
+    it('returns true if there are 5 days between the last contribution date and now', () => {
+        addCookie(ONE_OFF_CONTRIBUTION_DATE_COOKIE, '2018-08-01');
+        global.Date.now = jest.fn(() => Date.parse('2018-08-07T10:50:34'));
+        expect(isRecentOneOffContributor()).toBe(true);
+    });
+
+    it('returns true if there are 0 days between the last contribution date and now', () => {
+        addCookie(ONE_OFF_CONTRIBUTION_DATE_COOKIE, '2018-08-01');
+        global.Date.now = jest.fn(() => Date.parse('2018-08-01T13:00:30'));
+        expect(isRecentOneOffContributor()).toBe(true);
+    });
+
+    it('returns false if the one-off contribution was more than 3 months ago', () => {
+        addCookie(ONE_OFF_CONTRIBUTION_DATE_COOKIE, '2018-08-01');
+        global.Date.now = jest.fn(() => Date.parse('2019-08-01T13:00:30'));
+        expect(isRecentOneOffContributor()).toBe(false);
+    });
+});
+/* eslint-enable @typescript-eslint/unbound-method  */

--- a/src/web/lib/contributions.tsx
+++ b/src/web/lib/contributions.tsx
@@ -18,7 +18,7 @@ export const SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE =
 // including but not limited to recurring & one-off contributions,
 // paper & digital subscriptions, as well as user tiers (GU supporters/staff/partners/patrons).
 // https://github.com/guardian/members-data-api/blob/3a72dc00b9389968d91e5930686aaf34d8040c52/membership-attribute-service/app/models/Attributes.scala
-export const shouldShowSupportMessaging = (): boolean => {
+const shouldShowSupportMessagingCookie = (): boolean => {
     const hideSupportMessaging =
         getCookie(HIDE_SUPPORT_MESSAGING_COOKIE) === 'true';
 
@@ -85,3 +85,27 @@ export const getLastOneOffContributionDate = (): number | undefined => {
 
     return parsedDateFromSupport || undefined; // This guards against 'parsedDateFromSupport' being NaN
 };
+
+const dateDiffDays = (from: number, to: number): number => {
+    const oneDayMs = 1000 * 60 * 60 * 24;
+    const diffMs = to - from;
+    return Math.floor(diffMs / oneDayMs);
+};
+
+const AskPauseDays = 90;
+
+export const isRecentOneOffContributor = () => {
+    const lastContributionDate = getLastOneOffContributionDate();
+    if (lastContributionDate) {
+        const now = Date.now();
+        return dateDiffDays(lastContributionDate, now) <= AskPauseDays;
+    }
+
+    return false;
+};
+
+export const shouldHideSupportMessaging = (isSignedIn: boolean = false): boolean =>
+    !shouldShowSupportMessagingCookie() &&
+    isRecurringContributor(isSignedIn) &&
+    isRecentOneOffContributor();
+

--- a/src/web/lib/contributions.tsx
+++ b/src/web/lib/contributions.tsx
@@ -18,7 +18,7 @@ export const SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE =
 // including but not limited to recurring & one-off contributions,
 // paper & digital subscriptions, as well as user tiers (GU supporters/staff/partners/patrons).
 // https://github.com/guardian/members-data-api/blob/3a72dc00b9389968d91e5930686aaf34d8040c52/membership-attribute-service/app/models/Attributes.scala
-const shouldShowSupportMessagingCookie = (): boolean => {
+const shouldShowSupportMessaging = (): boolean => {
     const hideSupportMessaging =
         getCookie(HIDE_SUPPORT_MESSAGING_COOKIE) === 'true';
 
@@ -105,7 +105,7 @@ export const isRecentOneOffContributor = () => {
 };
 
 export const shouldHideSupportMessaging = (isSignedIn: boolean = false): boolean =>
-    !shouldShowSupportMessagingCookie() &&
-    isRecurringContributor(isSignedIn) &&
+    !shouldShowSupportMessaging() ||
+    isRecurringContributor(isSignedIn) ||
     isRecentOneOffContributor();
 


### PR DESCRIPTION
This follows the same logic as frontend, see https://github.com/guardian/frontend/pull/22730
`isSupporter` should check the contributor cookies as well