### PR TITLE
Display As Const Enum - Version 2

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,12 +9,6 @@ type RealPillars = 'news' | 'opinion' | 'sport' | 'culture' | 'lifestyle';
 type FakePillars = 'labs';
 type Pillar = RealPillars | FakePillars;
 
-declare const enum Display {
-    Standard,
-    Immersive,
-    Showcase,
-}
-
 // https://github.com/guardian/content-api-scala-client/blob/master/client/src/main/scala/com.gu.contentapi.client/utils/DesignType.scala
 type DesignType =
     | 'Article'

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,11 @@ type RealPillars = 'news' | 'opinion' | 'sport' | 'culture' | 'lifestyle';
 type FakePillars = 'labs';
 type Pillar = RealPillars | FakePillars;
 
-type Display = 'standard' | 'immersive' | 'showcase';
+declare const enum Display {
+    Standard,
+    Immersive,
+    Showcase,
+}
 
 // https://github.com/guardian/content-api-scala-client/blob/master/client/src/main/scala/com.gu.contentapi.client/utils/DesignType.scala
 type DesignType =

--- a/src/lib/display.ts
+++ b/src/lib/display.ts
@@ -1,0 +1,5 @@
+export const enum Display {
+    Standard,
+    Immersive,
+    Showcase,
+}

--- a/src/web/components/ArticleBody.tsx
+++ b/src/web/components/ArticleBody.tsx
@@ -6,6 +6,7 @@ import { headline } from '@guardian/src-foundations/typography';
 import { between } from '@guardian/src-foundations/mq';
 import { pillarMap, pillarPalette } from '@root/src/lib/pillars';
 import { ArticleRenderer } from '@root/src/web/lib/ArticleRenderer';
+import { Display } from '@root/src/lib/display';
 
 type Props = {
     pillar: Pillar;

--- a/src/web/components/ArticleBody.tsx
+++ b/src/web/components/ArticleBody.tsx
@@ -30,7 +30,7 @@ const bodyStyle = (display: Display) => css`
     }
 
     h2 {
-        ${display === 'immersive'
+        ${display === Display.Immersive
             ? headline.medium({ fontWeight: 'light' })
             : headline.xxsmall({ fontWeight: 'bold' })};
     }

--- a/src/web/components/ArticleHeadline.stories.tsx
+++ b/src/web/components/ArticleHeadline.stories.tsx
@@ -24,7 +24,7 @@ export const ArticleStory = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is how the default headline looks"
-                    display="standard"
+                    display={Display.Standard}
                     designType="Article"
                     pillar="news"
                     tags={[]}
@@ -44,7 +44,7 @@ export const oldHeadline = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is an old headline"
-                    display="standard"
+                    display={Display.Standard}
                     designType="Article"
                     pillar="news"
                     tags={[
@@ -71,7 +71,7 @@ export const Feature = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is a Feature headline, it has colour applied based on pillar"
-                    display="standard"
+                    display={Display.Standard}
                     designType="Feature"
                     pillar="lifestyle"
                     tags={[]}
@@ -96,7 +96,7 @@ export const ShowcaseInterview = () => (
                 >
                     <ArticleHeadline
                         headlineString="This is an Interview headline. It has a black background, white text and overlays the image below it (as a sibling)"
-                        display="showcase"
+                        display={Display.Showcase}
                         designType="Interview"
                         pillar="culture"
                         tags={[]}
@@ -105,7 +105,7 @@ export const ShowcaseInterview = () => (
                     />
                 </div>
                 <MainMedia
-                    display="standard"
+                    display={Display.Standard}
                     designType="Article"
                     hideCaption={true}
                     elements={mainMediaElements}
@@ -126,19 +126,19 @@ export const Interview = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is an Interview headline. It has a black background, white text and overlays the image below it (as a sibling)"
-                    display="standard"
+                    display={Display.Standard}
                     designType="Interview"
                     pillar="culture"
                     tags={[]}
                     byline="Byline text"
                 />
                 <Standfirst
-                    display="standard"
+                    display={Display.Standard}
                     designType="Interview"
                     standfirst="This is the standfirst text. We include here to demonstrate spacing in this case where we have a Interview type article that does not have a showcase main media element"
                 />
                 <MainMedia
-                    display="standard"
+                    display={Display.Standard}
                     designType="Article"
                     hideCaption={true}
                     elements={mainMediaElements}
@@ -159,7 +159,7 @@ export const Comment = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="Yes, the billionaire club is one we really need to shut down"
-                    display="standard"
+                    display={Display.Standard}
                     designType="Comment"
                     pillar="opinion"
                     tags={[]}
@@ -179,7 +179,7 @@ export const Analysis = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is an Analysis headline, it's underlined. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor"
-                    display="standard"
+                    display={Display.Standard}
                     designType="Analysis"
                     pillar="news"
                     tags={[]}
@@ -199,7 +199,7 @@ export const Media = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is the headline you see when design type is Media"
-                    display="standard"
+                    display={Display.Standard}
                     designType="Media"
                     pillar="news"
                     tags={[]}
@@ -219,7 +219,7 @@ export const Review = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is the headline you see when design type is Review"
-                    display="standard"
+                    display={Display.Standard}
                     designType="Review"
                     pillar="news"
                     tags={[]}
@@ -239,7 +239,7 @@ export const AdvertisementFeature = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is the headline you see when design type is AdvertisementFeature"
-                    display="standard"
+                    display={Display.Standard}
                     designType="AdvertisementFeature"
                     pillar="news"
                     tags={[]}
@@ -259,7 +259,7 @@ export const PhotoEssay = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is the headline you see when design type is PhotoEssay"
-                    display="standard"
+                    display={Display.Standard}
                     designType="PhotoEssay"
                     pillar="news"
                     tags={[]}
@@ -279,7 +279,7 @@ export const Quiz = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is the headline you see when design type is Quiz"
-                    display="standard"
+                    display={Display.Standard}
                     designType="Quiz"
                     pillar="news"
                     tags={[]}
@@ -299,7 +299,7 @@ export const GuardianLabs = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is the headline you see when design type is GuardianLabs"
-                    display="standard"
+                    display={Display.Standard}
                     designType="GuardianLabs"
                     pillar="news"
                     tags={[]}
@@ -319,7 +319,7 @@ export const Recipe = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is the headline you see when design type is Recipe"
-                    display="standard"
+                    display={Display.Standard}
                     designType="Recipe"
                     pillar="news"
                     tags={[]}
@@ -339,7 +339,7 @@ export const Immersive = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is the headline you see when display type is Immersive"
-                    display="immersive"
+                    display={Display.Immersive}
                     designType="Article"
                     pillar="news"
                     tags={[]}
@@ -359,7 +359,7 @@ export const ImmersiveNoMainMedia = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is the headline you see when display type is Immersive, but with no main media"
-                    display="immersive"
+                    display={Display.Immersive}
                     designType="Article"
                     pillar="news"
                     tags={[]}
@@ -384,7 +384,7 @@ export const ImmersiveComment = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is the headline you see when display type is Immersive and designType Comment"
-                    display="immersive"
+                    display={Display.Immersive}
                     designType="Comment"
                     pillar="news"
                     tags={[]}
@@ -404,7 +404,7 @@ export const GuardianView = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is the headline you see when design type is GuardianView"
-                    display="standard"
+                    display={Display.Standard}
                     designType="GuardianView"
                     pillar="news"
                     tags={[]}
@@ -424,7 +424,7 @@ export const MatchReport = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is the headline you see when design type is MatchReport"
-                    display="standard"
+                    display={Display.Standard}
                     designType="MatchReport"
                     pillar="news"
                     tags={[]}
@@ -444,7 +444,7 @@ export const SpecialReport = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is the headline you see when design type is SpecialReport"
-                    display="standard"
+                    display={Display.Standard}
                     designType="SpecialReport"
                     pillar="news"
                     tags={[]}
@@ -464,7 +464,7 @@ export const Live = () => (
             <ArticleContainer>
                 <ArticleHeadline
                     headlineString="This is the headline you see when design type is Live"
-                    display="standard"
+                    display={Display.Standard}
                     designType="Live"
                     pillar="news"
                     tags={[]}

--- a/src/web/components/ArticleHeadline.stories.tsx
+++ b/src/web/components/ArticleHeadline.stories.tsx
@@ -9,6 +9,7 @@ import { ArticleContainer } from './ArticleContainer';
 import { MainMedia } from './MainMedia';
 import { Standfirst } from './Standfirst';
 import { mainMediaElements } from './ArticleHeadline.mocks';
+import { Display } from '@root/src/lib/display';
 
 export default {
     component: ArticleHeadline,

--- a/src/web/components/ArticleHeadline.stories.tsx
+++ b/src/web/components/ArticleHeadline.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 
+import { Display } from '@root/src/lib/display';
 import { Section } from './Section';
 import { ArticleHeadline } from './ArticleHeadline';
 import { Flex } from './Flex';
@@ -9,7 +10,6 @@ import { ArticleContainer } from './ArticleContainer';
 import { MainMedia } from './MainMedia';
 import { Standfirst } from './Standfirst';
 import { mainMediaElements } from './ArticleHeadline.mocks';
-import { Display } from '@root/src/lib/display';
 
 export default {
     component: ArticleHeadline,

--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -172,7 +172,7 @@ export const ArticleHeadline = ({
     noMainMedia,
 }: Props) => {
     switch (display) {
-        case 'immersive': {
+        case Display.Immersive: {
             switch (designType) {
                 case 'Comment':
                 case 'GuardianView':
@@ -243,8 +243,9 @@ export const ArticleHeadline = ({
             }
             break;
         }
-        case 'showcase':
-        case 'standard': {
+        case Display.Showcase:
+        case Display.Standard:
+        default: {
             switch (designType) {
                 case 'Review':
                 case 'Recipe':

--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -8,6 +8,7 @@ import { HeadlineByline } from '@root/src/web/components/HeadlineByline';
 import { headline } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
+import { Display } from '@root/src/lib/display';
 
 type Props = {
     headlineString: string;

--- a/src/web/components/ArticleMeta.stories.tsx
+++ b/src/web/components/ArticleMeta.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 import { ArticleMeta } from './ArticleMeta';
+import { Display } from '@root/src/lib/display';
 
 const Container = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
     <div

--- a/src/web/components/ArticleMeta.stories.tsx
+++ b/src/web/components/ArticleMeta.stories.tsx
@@ -50,7 +50,7 @@ export const ArticleStory = () => {
     return (
         <Container>
             <ArticleMeta
-                display="standard"
+                display={Display.Standard}
                 designType="Article"
                 pillar="news"
                 pageId=""
@@ -89,7 +89,7 @@ export const BrandingStory = () => {
                     aboutThisLink:
                         'https://www.theguardian.com/info/2016/jan/25/content-funding',
                 }}
-                display="standard"
+                display={Display.Standard}
                 designType="Article"
                 pillar="news"
                 pageId=""
@@ -111,7 +111,7 @@ export const FeatureStory = () => {
     return (
         <Container>
             <ArticleMeta
-                display="standard"
+                display={Display.Standard}
                 designType="Feature"
                 pillar="culture"
                 pageId=""
@@ -132,7 +132,7 @@ export const CommentStory = () => {
     return (
         <Container>
             <ArticleMeta
-                display="standard"
+                display={Display.Standard}
                 designType="Comment"
                 pillar="opinion"
                 pageId=""
@@ -153,7 +153,7 @@ export const InterviewStory = () => {
     return (
         <Container>
             <ArticleMeta
-                display="standard"
+                display={Display.Standard}
                 designType="Interview"
                 pillar="lifestyle"
                 pageId=""
@@ -174,7 +174,7 @@ export const ImmersiveStory = () => {
     return (
         <Container>
             <ArticleMeta
-                display="immersive"
+                display={Display.Immersive}
                 designType="Immersive"
                 pillar="news"
                 pageId=""
@@ -195,7 +195,7 @@ export const TwoContributorsStory = () => {
     return (
         <Container>
             <ArticleMeta
-                display="standard"
+                display={Display.Standard}
                 designType="Feature"
                 pillar="sport"
                 pageId=""

--- a/src/web/components/ArticleMeta.stories.tsx
+++ b/src/web/components/ArticleMeta.stories.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { css } from 'emotion';
 
-import { ArticleMeta } from './ArticleMeta';
 import { Display } from '@root/src/lib/display';
+import { ArticleMeta } from './ArticleMeta';
 
 const Container = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
     <div

--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -80,9 +80,9 @@ const metaContainer = ({
     designType: DesignType;
 }) => {
     switch (display) {
-        case 'immersive':
-        case 'showcase':
-        case 'standard': {
+        case Display.Immersive:
+        case Display.Showcase:
+        case Display.Standard: {
             switch (designType) {
                 case 'PhotoEssay':
                     return css`
@@ -142,10 +142,10 @@ const getAuthorName = (tags: TagType[]) => {
 
 const shouldShowAvatar = (designType: DesignType, display: Display) => {
     switch (display) {
-        case 'immersive':
+        case Display.Immersive:
             return false;
-        case 'showcase':
-        case 'standard': {
+        case Display.Showcase:
+        case Display.Standard: {
             switch (designType) {
                 case 'Feature':
                 case 'Review':
@@ -174,10 +174,10 @@ const shouldShowAvatar = (designType: DesignType, display: Display) => {
 
 const shouldShowContributor = (designType: DesignType, display: Display) => {
     switch (display) {
-        case 'immersive':
+        case Display.Immersive:
             return false;
-        case 'showcase':
-        case 'standard': {
+        case Display.Showcase:
+        case Display.Standard: {
             switch (designType) {
                 case 'Comment':
                 case 'GuardianView':

--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -9,6 +9,7 @@ import { getSharingUrls } from '@root/src/lib/sharing-urls';
 import { Branding } from '@root/src/web/components/Branding';
 import { SharingIcons } from './ShareIcons';
 import { Dateline } from './Dateline';
+import { Display } from '@root/src/lib/display';
 
 type Props = {
     display: Display;

--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -7,9 +7,9 @@ import { Avatar } from '@root/src/web/components/Avatar';
 
 import { getSharingUrls } from '@root/src/lib/sharing-urls';
 import { Branding } from '@root/src/web/components/Branding';
+import { Display } from '@root/src/lib/display';
 import { SharingIcons } from './ShareIcons';
 import { Dateline } from './Dateline';
-import { Display } from '@root/src/lib/display';
 
 type Props = {
     display: Display;

--- a/src/web/components/ArticleStandfirst.stories.tsx
+++ b/src/web/components/ArticleStandfirst.stories.tsx
@@ -21,7 +21,7 @@ export const defaultStory = () => {
                 </LeftColumn>
                 <ArticleContainer>
                     <ArticleStandfirst
-                        display="standard"
+                        display={Display.Standard}
                         designType="Article"
                         standfirst="This the default standfirst text. Aut explicabo officia delectus omnis repellendus voluptas"
                         pillar="news"

--- a/src/web/components/ArticleStandfirst.stories.tsx
+++ b/src/web/components/ArticleStandfirst.stories.tsx
@@ -6,6 +6,7 @@ import { ArticleStandfirst } from './ArticleStandfirst';
 import { Flex } from './Flex';
 import { LeftColumn } from './LeftColumn';
 import { ArticleContainer } from './ArticleContainer';
+import { Display } from '@root/src/lib/display';
 
 export default {
     component: ArticleStandfirst,

--- a/src/web/components/ArticleStandfirst.stories.tsx
+++ b/src/web/components/ArticleStandfirst.stories.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
+import { Display } from '@root/src/lib/display';
 import { Section } from './Section';
 
 import { ArticleStandfirst } from './ArticleStandfirst';
 import { Flex } from './Flex';
 import { LeftColumn } from './LeftColumn';
 import { ArticleContainer } from './ArticleContainer';
-import { Display } from '@root/src/lib/display';
 
 export default {
     component: ArticleStandfirst,

--- a/src/web/components/ArticleStandfirst.tsx
+++ b/src/web/components/ArticleStandfirst.tsx
@@ -4,6 +4,7 @@ import { pillarMap, pillarPalette } from '@root/src/lib/pillars';
 import { border } from '@guardian/src-foundations/palette';
 
 import { Standfirst } from '@frontend/web/components/Standfirst';
+import { Display } from '@root/src/lib/display';
 
 const standfirstStyles = css`
     max-width: 540px;

--- a/src/web/components/ArticleTitle.stories.tsx
+++ b/src/web/components/ArticleTitle.stories.tsx
@@ -58,7 +58,7 @@ export const defaultStory = () => {
             <ArticleTitle
                 // eslint-disable-next-line react/jsx-props-no-spreading
                 {...brexitCAPI}
-                display="standard"
+                display={Display.Standard}
                 pillar="sport"
                 designType="Article"
             />
@@ -73,7 +73,7 @@ export const beyondTheBlade = () => {
             <ArticleTitle
                 // eslint-disable-next-line react/jsx-props-no-spreading
                 {...beyondTheBladeCAPI}
-                display="standard"
+                display={Display.Standard}
                 pillar="news"
                 designType="Article"
             />
@@ -93,7 +93,7 @@ export const immersiveComment = () => {
             <ArticleTitle
                 // eslint-disable-next-line react/jsx-props-no-spreading
                 {...brexitCAPI}
-                display="immersive"
+                display={Display.Immersive}
                 pillar="sport"
                 designType="Comment"
             />
@@ -113,7 +113,7 @@ export const immersiveCommentTag = () => {
             <ArticleTitle
                 // eslint-disable-next-line react/jsx-props-no-spreading
                 {...CAPI}
-                display="immersive"
+                display={Display.Immersive}
                 pillar="sport"
                 designType="Comment"
                 tags={[
@@ -135,7 +135,7 @@ export const ImmersiveSeriesTag = () => {
             <ArticleTitle
                 // eslint-disable-next-line react/jsx-props-no-spreading
                 {...CAPI}
-                display="immersive"
+                display={Display.Immersive}
                 pillar="sport"
                 designType="Review"
                 tags={[
@@ -157,7 +157,7 @@ export const ArticleBlogTag = () => {
             <ArticleTitle
                 // eslint-disable-next-line react/jsx-props-no-spreading
                 {...CAPI}
-                display="standard"
+                display={Display.Standard}
                 pillar="sport"
                 designType="Article"
                 tags={[
@@ -179,7 +179,7 @@ export const ArticleOpinionTag = () => {
             <ArticleTitle
                 // eslint-disable-next-line react/jsx-props-no-spreading
                 {...CAPI}
-                display="standard"
+                display={Display.Standard}
                 pillar="sport"
                 designType="Article"
                 tags={[
@@ -201,7 +201,7 @@ export const ArticleSeriesTag = () => {
             <ArticleTitle
                 // eslint-disable-next-line react/jsx-props-no-spreading
                 {...CAPI}
-                display="standard"
+                display={Display.Standard}
                 pillar="sport"
                 designType="Article"
                 tags={[
@@ -223,7 +223,7 @@ export const ArticleNoTags = () => {
             <ArticleTitle
                 // eslint-disable-next-line react/jsx-props-no-spreading
                 {...CAPI}
-                display="standard"
+                display={Display.Standard}
                 pillar="culture"
                 designType="Article"
             />

--- a/src/web/components/ArticleTitle.stories.tsx
+++ b/src/web/components/ArticleTitle.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 import { ArticleTitle } from './ArticleTitle';
+import { Display } from '@root/src/lib/display';
 
 const Container = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
     <div

--- a/src/web/components/ArticleTitle.stories.tsx
+++ b/src/web/components/ArticleTitle.stories.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { css } from 'emotion';
 
-import { ArticleTitle } from './ArticleTitle';
 import { Display } from '@root/src/lib/display';
+import { ArticleTitle } from './ArticleTitle';
 
 const Container = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
     <div

--- a/src/web/components/ArticleTitle.tsx
+++ b/src/web/components/ArticleTitle.tsx
@@ -59,7 +59,7 @@ export const ArticleTitle = ({
     badge,
 }: Props) => (
     <div className={cx(sectionStyles, badge && badgeContainer)}>
-        {badge && display !== 'immersive' && (
+        {badge && display !== Display.Immersive && (
             <div className={titleBadgeWrapper}>
                 <Badge imageUrl={badge.imageUrl} seriesTag={badge.seriesTag} />
             </div>
@@ -67,7 +67,7 @@ export const ArticleTitle = ({
         <div
             className={cx(
                 badge && marginTop,
-                display === 'immersive' && marginBottom,
+                display === Display.Immersive && marginBottom,
             )}
         >
             <SeriesSectionLink

--- a/src/web/components/ArticleTitle.tsx
+++ b/src/web/components/ArticleTitle.tsx
@@ -4,6 +4,7 @@ import { css, cx } from 'emotion';
 import { from, until } from '@guardian/src-foundations/mq';
 import { Badge } from '@frontend/web/components/Badge';
 import { SeriesSectionLink } from './SeriesSectionLink';
+import { Display } from '@root/src/lib/display';
 
 type Props = {
     display: Display;

--- a/src/web/components/ArticleTitle.tsx
+++ b/src/web/components/ArticleTitle.tsx
@@ -3,8 +3,8 @@ import { css, cx } from 'emotion';
 
 import { from, until } from '@guardian/src-foundations/mq';
 import { Badge } from '@frontend/web/components/Badge';
-import { SeriesSectionLink } from './SeriesSectionLink';
 import { Display } from '@root/src/lib/display';
+import { SeriesSectionLink } from './SeriesSectionLink';
 
 type Props = {
     display: Display;

--- a/src/web/components/Caption.stories.tsx
+++ b/src/web/components/Caption.stories.tsx
@@ -23,7 +23,7 @@ export default {
 export const Article = () => (
     <Section showTopBorder={false} showSideBorders={false}>
         <Caption
-            display="standard"
+            display={Display.Standard}
             designType="Article"
             captionText="This is how an Article caption looks"
             pillar="news"
@@ -35,7 +35,7 @@ Article.story = { name: 'Article' };
 export const Analysis = () => (
     <Section showTopBorder={false} showSideBorders={false}>
         <Caption
-            display="standard"
+            display={Display.Standard}
             designType="Analysis"
             captionText="This is how an Analysis caption looks"
             pillar="news"
@@ -47,7 +47,7 @@ Analysis.story = { name: 'Analysis' };
 export const PhotoEssay = () => (
     <Section showTopBorder={false} showSideBorders={false}>
         <Caption
-            display="standard"
+            display={Display.Standard}
             designType="PhotoEssay"
             captionText="This is how a PhotoEssay caption looks"
             pillar="news"
@@ -59,7 +59,7 @@ PhotoEssay.story = { name: 'PhotoEssay' };
 export const PhotoEssayLimitedWidth = () => (
     <Section showTopBorder={false} showSideBorders={false}>
         <Caption
-            display="standard"
+            display={Display.Standard}
             designType="PhotoEssay"
             captionText="This is how a PhotoEssay caption looks when width is limited"
             pillar="news"
@@ -72,7 +72,7 @@ PhotoEssayLimitedWidth.story = { name: 'PhotoEssay with width limited' };
 export const Credit = () => (
     <Section showTopBorder={false} showSideBorders={false}>
         <Caption
-            display="standard"
+            display={Display.Standard}
             designType="Feature"
             captionText="This is how a Feature caption looks with credit showing"
             pillar="news"
@@ -86,7 +86,7 @@ Credit.story = { name: 'with credit' };
 export const WidthLimited = () => (
     <Section showTopBorder={false} showSideBorders={false}>
         <Caption
-            display="standard"
+            display={Display.Standard}
             designType="Article"
             captionText="This is how a caption looks with width limited"
             pillar="news"
@@ -99,7 +99,7 @@ WidthLimited.story = { name: 'with width limited' };
 export const Padded = () => (
     <Section showTopBorder={false} showSideBorders={false}>
         <Caption
-            display="standard"
+            display={Display.Standard}
             designType="Article"
             captionText="This is how a caption looks when padded"
             pillar="news"

--- a/src/web/components/Caption.stories.tsx
+++ b/src/web/components/Caption.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { Section } from '@frontend/web/components/Section';
 import { Caption } from '@frontend/web/components/Caption';
+import { Display } from '@root/src/lib/display';
 
 export default {
     component: Caption,

--- a/src/web/components/Caption.tsx
+++ b/src/web/components/Caption.tsx
@@ -7,6 +7,7 @@ import { space } from '@guardian/src-foundations';
 import { css, cx } from 'emotion';
 import { pillarPalette } from '@root/src/lib/pillars';
 import TriangleIcon from '@frontend/static/icons/triangle.svg';
+import { Display } from '@root/src/lib/display';
 
 type Props = {
     display: Display;

--- a/src/web/components/Caption.tsx
+++ b/src/web/components/Caption.tsx
@@ -211,7 +211,7 @@ export const Caption = ({
                     <span
                         className={cx(
                             iconStyle(pillar),
-                            display === 'immersive' && hideIconBelowLeftCol,
+                            display === Display.Immersive && hideIconBelowLeftCol,
                         )}
                     >
                         <TriangleIcon />

--- a/src/web/components/Footer.tsx
+++ b/src/web/components/Footer.tsx
@@ -212,7 +212,7 @@ export const Footer: React.FC<{
     <footer className={footer} data-link-name="footer" data-component="footer">
         <div className={pillarWrap}>
             <Pillars
-                display="standard"
+                display={Display.Standard}
                 pillars={pillars}
                 pillar={pillar}
                 showLastPillarDivider={false}

--- a/src/web/components/Footer.tsx
+++ b/src/web/components/Footer.tsx
@@ -13,6 +13,7 @@ import { from, until } from '@guardian/src-foundations/mq';
 import { clearFix } from '@root/src/lib/mixins';
 import { Pillars, pillarWidth, firstPillarWidth } from './Pillars';
 import { BackToTop } from './BackToTop';
+import { Display } from '@root/src/lib/display';
 
 // CSS vars
 const emailSignupSideMargins = 10;

--- a/src/web/components/Footer.tsx
+++ b/src/web/components/Footer.tsx
@@ -11,9 +11,9 @@ import { textSans } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
 
 import { clearFix } from '@root/src/lib/mixins';
+import { Display } from '@root/src/lib/display';
 import { Pillars, pillarWidth, firstPillarWidth } from './Pillars';
 import { BackToTop } from './BackToTop';
-import { Display } from '@root/src/lib/display';
 
 // CSS vars
 const emailSignupSideMargins = 10;

--- a/src/web/components/HeadlineByline.stories.tsx
+++ b/src/web/components/HeadlineByline.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 import { HeadlineByline } from './HeadlineByline';
+import { Display } from '@root/src/lib/display';
 
 export default {
     component: HeadlineByline,

--- a/src/web/components/HeadlineByline.stories.tsx
+++ b/src/web/components/HeadlineByline.stories.tsx
@@ -10,7 +10,7 @@ export default {
 export const interviewStory = () => {
     return (
         <HeadlineByline
-            display="standard"
+            display={Display.Standard}
             designType="Interview"
             pillar="culture"
             byline="Jane Smith"
@@ -23,7 +23,7 @@ interviewStory.story = { name: 'Interview' };
 export const commentStory = () => {
     return (
         <HeadlineByline
-            display="standard"
+            display={Display.Standard}
             designType="Comment"
             pillar="sport"
             byline="Jane Smith"
@@ -36,7 +36,7 @@ commentStory.story = { name: 'Comment' };
 export const immersiveStory = () => {
     return (
         <HeadlineByline
-            display="immersive"
+            display={Display.Immersive}
             designType="Immersive"
             pillar="lifestyle"
             byline="Jane Smith"
@@ -61,7 +61,7 @@ export const ImmersiveComment = () => {
             `}
         >
             <HeadlineByline
-                display="immersive"
+                display={Display.Immersive}
                 designType="Comment"
                 pillar="lifestyle"
                 byline="Jane Smith"
@@ -81,7 +81,7 @@ ImmersiveComment.story = { name: 'Immersive Comment' };
 export const MultipleStory = () => {
     return (
         <HeadlineByline
-            display="immersive"
+            display={Display.Immersive}
             designType="Immersive"
             pillar="lifestyle"
             byline="Jane Smith, John Doe and Nae Bevan"

--- a/src/web/components/HeadlineByline.stories.tsx
+++ b/src/web/components/HeadlineByline.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
-import { HeadlineByline } from './HeadlineByline';
 import { Display } from '@root/src/lib/display';
+import { HeadlineByline } from './HeadlineByline';
 
 export default {
     component: HeadlineByline,

--- a/src/web/components/HeadlineByline.tsx
+++ b/src/web/components/HeadlineByline.tsx
@@ -92,7 +92,7 @@ export const HeadlineByline = ({
     tags,
 }: Props) => {
     switch (display) {
-        case 'immersive': {
+        case Display.Immersive: {
             switch (designType) {
                 case 'GuardianView':
                 case 'Comment':
@@ -127,8 +127,9 @@ export const HeadlineByline = ({
                     );
             }
         }
-        case 'showcase':
-        case 'standard': {
+        case Display.Showcase:
+        case Display.Standard:
+        default: {
             switch (designType) {
                 case 'Interview':
                     return (

--- a/src/web/components/HeadlineByline.tsx
+++ b/src/web/components/HeadlineByline.tsx
@@ -6,6 +6,7 @@ import { space } from '@guardian/src-foundations';
 
 import { BylineLink } from '@root/src/web/components/BylineLink';
 import { pillarPalette } from '@frontend/lib/pillars';
+import { Display } from '@root/src/lib/display';
 
 const wrapperStyles = css`
     margin-left: 6px;

--- a/src/web/components/ImmersiveHeadline.stories.tsx
+++ b/src/web/components/ImmersiveHeadline.stories.tsx
@@ -4,6 +4,7 @@ import { css } from 'emotion';
 import { MainMedia } from './MainMedia';
 import { mainMediaElements } from './ArticleHeadline.mocks';
 import { ImmersiveHeadline } from './ImmersiveHeadline';
+import { Display } from '@root/src/lib/display';
 
 export default {
     component: ImmersiveHeadline,

--- a/src/web/components/ImmersiveHeadline.stories.tsx
+++ b/src/web/components/ImmersiveHeadline.stories.tsx
@@ -18,7 +18,7 @@ export const Short = () => (
             `}
         >
             <MainMedia
-                display="immersive"
+                display={Display.Immersive}
                 designType="Article"
                 hideCaption={true}
                 elements={mainMediaElements}
@@ -27,7 +27,7 @@ export const Short = () => (
         </div>
 
         <ImmersiveHeadline
-            display="immersive"
+            display={Display.Immersive}
             designType="Immersive"
             tags={[]}
             author={{}}
@@ -49,7 +49,7 @@ export const Long = () => (
             `}
         >
             <MainMedia
-                display="immersive"
+                display={Display.Immersive}
                 designType="Article"
                 hideCaption={true}
                 elements={mainMediaElements}
@@ -58,7 +58,7 @@ export const Long = () => (
         </div>
 
         <ImmersiveHeadline
-            display="immersive"
+            display={Display.Immersive}
             designType="Immersive"
             tags={[]}
             author={{}}

--- a/src/web/components/ImmersiveHeadline.stories.tsx
+++ b/src/web/components/ImmersiveHeadline.stories.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { css } from 'emotion';
 
+import { Display } from '@root/src/lib/display';
 import { MainMedia } from './MainMedia';
 import { mainMediaElements } from './ArticleHeadline.mocks';
 import { ImmersiveHeadline } from './ImmersiveHeadline';
-import { Display } from '@root/src/lib/display';
 
 export default {
     component: ImmersiveHeadline,

--- a/src/web/components/ImmersiveHeadline.tsx
+++ b/src/web/components/ImmersiveHeadline.tsx
@@ -8,6 +8,7 @@ import { ArticleHeadline } from '@root/src/web/components/ArticleHeadline';
 import { LeftColumn } from '@root/src/web/components/LeftColumn';
 import { Flex } from '@root/src/web/components/Flex';
 import { Caption } from '@root/src/web/components/Caption';
+import { Display } from '@root/src/lib/display';
 
 type Props = {
     display: Display;

--- a/src/web/components/MainMedia.tsx
+++ b/src/web/components/MainMedia.tsx
@@ -5,6 +5,7 @@ import { until } from '@guardian/src-foundations/mq';
 
 import { ImageComponent } from '@root/src/web/components/elements/ImageComponent';
 import { YoutubeBlockComponent } from '@root/src/web/components/elements/YoutubeBlockComponent';
+import { Display } from '@root/src/lib/display';
 
 const mainMedia = css`
     min-height: 1px;

--- a/src/web/components/MainMedia.tsx
+++ b/src/web/components/MainMedia.tsx
@@ -104,7 +104,7 @@ export const MainMedia: React.FC<{
     adTargeting,
     starRating,
 }) => (
-    <div className={cx(mainMedia, display !== 'immersive' && noGutters)}>
+    <div className={cx(mainMedia, display !== Display.Immersive && noGutters)}>
         {elements.map((element, i) =>
             renderElement(
                 display,

--- a/src/web/components/Nav/ExpandedMenu/ExpandedMenu.tsx
+++ b/src/web/components/Nav/ExpandedMenu/ExpandedMenu.tsx
@@ -9,6 +9,7 @@ import { ShowMoreMenu } from './ShowMoreMenu';
 import { VeggieBurgerMenu } from './VeggieBurgerMenu';
 import { Columns } from './Columns';
 import { navInputCheckboxId } from '../config';
+import { Display } from '@root/src/lib/display';
 
 const mainMenuStyles = css`
     background-color: ${brandBackground.primary};

--- a/src/web/components/Nav/ExpandedMenu/ExpandedMenu.tsx
+++ b/src/web/components/Nav/ExpandedMenu/ExpandedMenu.tsx
@@ -5,11 +5,11 @@ import { brandBackground } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
 
+import { Display } from '@root/src/lib/display';
 import { ShowMoreMenu } from './ShowMoreMenu';
 import { VeggieBurgerMenu } from './VeggieBurgerMenu';
 import { Columns } from './Columns';
 import { navInputCheckboxId } from '../config';
-import { Display } from '@root/src/lib/display';
 
 const mainMenuStyles = css`
     background-color: ${brandBackground.primary};

--- a/src/web/components/Nav/ExpandedMenu/ShowMoreMenu.tsx
+++ b/src/web/components/Nav/ExpandedMenu/ShowMoreMenu.tsx
@@ -65,7 +65,7 @@ const openExpandedMenuStyles = (display: Display) => css`
     padding-right: 20px;
     ${from.desktop} {
         display: block;
-        padding-top: ${display === 'immersive' ? '9px' : '5px'};
+        padding-top: ${display === Display.Immersive ? '9px' : '5px'};
         height: 42px;
     }
     :hover,

--- a/src/web/components/Nav/ExpandedMenu/ShowMoreMenu.tsx
+++ b/src/web/components/Nav/ExpandedMenu/ShowMoreMenu.tsx
@@ -7,6 +7,7 @@ import { headline } from '@guardian/src-foundations/typography';
 import { brandText, brandAlt } from '@guardian/src-foundations/palette';
 
 import { navInputCheckboxId, showMoreButtonId } from '../config';
+import { Display } from '@root/src/lib/display';
 
 const screenReadable = css`
     ${visuallyHidden};

--- a/src/web/components/Nav/ExpandedMenu/ShowMoreMenu.tsx
+++ b/src/web/components/Nav/ExpandedMenu/ShowMoreMenu.tsx
@@ -6,8 +6,8 @@ import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 import { headline } from '@guardian/src-foundations/typography';
 import { brandText, brandAlt } from '@guardian/src-foundations/palette';
 
-import { navInputCheckboxId, showMoreButtonId } from '../config';
 import { Display } from '@root/src/lib/display';
+import { navInputCheckboxId, showMoreButtonId } from '../config';
 
 const screenReadable = css`
     ${visuallyHidden};

--- a/src/web/components/Nav/ExpandedMenu/VeggieBurgerMenu.tsx
+++ b/src/web/components/Nav/ExpandedMenu/VeggieBurgerMenu.tsx
@@ -85,7 +85,7 @@ const veggieBurgerStyles = (display: Display) => css`
     right: 5px;
     bottom: 48px;
     ${from.mobileMedium} {
-        bottom: ${display === 'immersive' ? '3px' : '-3px'};
+        bottom: ${display === Display.Immersive ? '3px' : '-3px'};
         right: 5px;
     }
     ${from.mobileLandscape} {

--- a/src/web/components/Nav/ExpandedMenu/VeggieBurgerMenu.tsx
+++ b/src/web/components/Nav/ExpandedMenu/VeggieBurgerMenu.tsx
@@ -6,6 +6,7 @@ import { from } from '@guardian/src-foundations/mq';
 import { brandAlt, neutral } from '@guardian/src-foundations/palette';
 
 import { navInputCheckboxId, veggieBurgerId } from '../config';
+import { Display } from '@root/src/lib/display';
 
 const screenReadable = css`
     ${visuallyHidden};

--- a/src/web/components/Nav/ExpandedMenu/VeggieBurgerMenu.tsx
+++ b/src/web/components/Nav/ExpandedMenu/VeggieBurgerMenu.tsx
@@ -5,8 +5,8 @@ import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 import { from } from '@guardian/src-foundations/mq';
 import { brandAlt, neutral } from '@guardian/src-foundations/palette';
 
-import { navInputCheckboxId, veggieBurgerId } from '../config';
 import { Display } from '@root/src/lib/display';
+import { navInputCheckboxId, veggieBurgerId } from '../config';
 
 const screenReadable = css`
     ${visuallyHidden};

--- a/src/web/components/Nav/Nav.stories.tsx
+++ b/src/web/components/Nav/Nav.stories.tsx
@@ -8,6 +8,7 @@ import { Section } from '@frontend/web/components/Section';
 
 import { nav } from './Nav.mock';
 import { Nav } from './Nav';
+import { Display } from '@root/src/lib/display';
 
 export default {
     component: Nav,

--- a/src/web/components/Nav/Nav.stories.tsx
+++ b/src/web/components/Nav/Nav.stories.tsx
@@ -25,7 +25,7 @@ export const StandardStory = () => {
         >
             <Nav
                 pillar="news"
-                display="standard"
+                display={Display.Standard}
                 nav={nav}
                 subscribeUrl=""
                 edition="UK"
@@ -46,7 +46,7 @@ export const ImmersiveStory = () => {
         >
             <Nav
                 pillar="news"
-                display="immersive"
+                display={Display.Immersive}
                 nav={nav}
                 subscribeUrl=""
                 edition="UK"

--- a/src/web/components/Nav/Nav.stories.tsx
+++ b/src/web/components/Nav/Nav.stories.tsx
@@ -6,9 +6,9 @@ import {
 
 import { Section } from '@frontend/web/components/Section';
 
+import { Display } from '@root/src/lib/display';
 import { nav } from './Nav.mock';
 import { Nav } from './Nav';
-import { Display } from '@root/src/lib/display';
 
 export default {
     component: Nav,

--- a/src/web/components/Nav/Nav.test.tsx
+++ b/src/web/components/Nav/Nav.test.tsx
@@ -11,7 +11,7 @@ describe('Nav', () => {
             <Nav
                 pillar="news"
                 nav={nav}
-                display="standard"
+                display={Display.Standard}
                 subscribeUrl=""
                 edition="UK"
             />,
@@ -29,7 +29,7 @@ describe('Nav', () => {
             <Nav
                 pillar="news"
                 nav={nav}
-                display="standard"
+                display={Display.Standard}
                 subscribeUrl=""
                 edition="UK"
             />,

--- a/src/web/components/Nav/Nav.test.tsx
+++ b/src/web/components/Nav/Nav.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, within } from '@testing-library/react';
 import { Nav } from './Nav';
 import { nav } from './Nav.mock';
+import { Display } from '@root/src/lib/display';
 
 // type Pillar = "news" | "opinion" | "sport" | "culture" | "lifestyle" | "labs"
 

--- a/src/web/components/Nav/Nav.test.tsx
+++ b/src/web/components/Nav/Nav.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { render, within } from '@testing-library/react';
+import { Display } from '@root/src/lib/display';
 import { Nav } from './Nav';
 import { nav } from './Nav.mock';
-import { Display } from '@root/src/lib/display';
 
 // type Pillar = "news" | "opinion" | "sport" | "culture" | "lifestyle" | "labs"
 

--- a/src/web/components/Nav/Nav.tsx
+++ b/src/web/components/Nav/Nav.tsx
@@ -160,13 +160,13 @@ export const Nav = ({ display, pillar, nav, subscribeUrl, edition }: Props) => {
                 className={cx(
                     clearFixStyle,
                     rowStyles,
-                    display === 'immersive' && minHeight,
+                    display === Display.Immersive && minHeight,
                 )}
                 role="navigation"
                 aria-label="Guardian sections"
                 data-component="nav2"
             >
-                {display === 'immersive' && (
+                {display === Display.Immersive && (
                     <Hide when="above" breakpoint="tablet">
                         <ThemeProvider theme={buttonReaderRevenueBrand}>
                             <PositionButton>
@@ -215,7 +215,7 @@ export const Nav = ({ display, pillar, nav, subscribeUrl, edition }: Props) => {
                 />
                 <ExpandedMenu nav={nav} display={display} />
             </nav>
-            {display === 'immersive' && (
+            {display === Display.Immersive && (
                 <PositionRoundel>
                     <GuardianRoundel />
                 </PositionRoundel>

--- a/src/web/components/Nav/Nav.tsx
+++ b/src/web/components/Nav/Nav.tsx
@@ -16,6 +16,7 @@ import { clearFix } from '@root/src/lib/mixins';
 
 import { navInputCheckboxId, showMoreButtonId, veggieBurgerId } from './config';
 import { ExpandedMenu } from './ExpandedMenu/ExpandedMenu';
+import { Display } from '@root/src/lib/display';
 
 type Props = {
     pillar: Pillar;

--- a/src/web/components/Nav/Nav.tsx
+++ b/src/web/components/Nav/Nav.tsx
@@ -14,9 +14,9 @@ import { Hide } from '@frontend/web/components/Hide';
 
 import { clearFix } from '@root/src/lib/mixins';
 
+import { Display } from '@root/src/lib/display';
 import { navInputCheckboxId, showMoreButtonId, veggieBurgerId } from './config';
 import { ExpandedMenu } from './ExpandedMenu/ExpandedMenu';
-import { Display } from '@root/src/lib/display';
 
 type Props = {
     pillar: Pillar;

--- a/src/web/components/Pillars.tsx
+++ b/src/web/components/Pillars.tsx
@@ -19,7 +19,7 @@ export const preDesktopPillarWidth = 'auto';
 // CSS
 const pillarsStyles = (display: Display) => css`
     ${until.tablet} {
-        display: ${display === 'immersive' && 'none'};
+        display: ${display === Display.Immersive && 'none'};
     }
     clear: right;
     margin: 0;
@@ -49,13 +49,13 @@ const pillarsStyles = (display: Display) => css`
         bottom: 0;
         left: 0;
         right: 0;
-        height: ${display === 'immersive' ? '49px' : '37px'};
+        height: ${display === Display.Immersive ? '49px' : '37px'};
         ${from.tablet} {
             border-bottom: 0;
             height: 49px;
         }
         ${from.desktop} {
-            height: ${display === 'immersive' ? '49px' : '43px'};
+            height: ${display === Display.Immersive ? '49px' : '43px'};
         }
     }
 `;
@@ -138,44 +138,44 @@ const linkStyle = (display: Display) => css`
     cursor: pointer;
     display: block;
     font-size: 15.4px;
-    height: ${display === 'immersive' ? '48px' : '36px'};
-    padding-top: ${display === 'immersive' ? '10px' : '9px'};
-    padding-right: ${display === 'immersive' ? '5px' : '5px'};
-    padding-bottom: ${display === 'immersive' ? '0' : '0'};
-    padding-left: ${display === 'immersive' ? '5px' : '5px'};
+    height: ${display === Display.Immersive ? '48px' : '36px'};
+    padding-top: ${display === Display.Immersive ? '10px' : '9px'};
+    padding-right: ${display === Display.Immersive ? '5px' : '5px'};
+    padding-bottom: ${display === Display.Immersive ? '0' : '0'};
+    padding-left: ${display === Display.Immersive ? '5px' : '5px'};
     position: relative;
     overflow: hidden;
     text-decoration: none;
     z-index: 1;
     ${from.mobileMedium} {
         font-size: 15.7px;
-        padding-top: ${display === 'immersive' ? '9px' : '9px'};
-        padding-right: ${display === 'immersive' ? '5px' : '5px'};
-        padding-bottom: ${display === 'immersive' ? '0' : '0'};
-        padding-left: ${display === 'immersive' ? '5px' : '5px'};
+        padding-top: ${display === Display.Immersive ? '9px' : '9px'};
+        padding-right: ${display === Display.Immersive ? '5px' : '5px'};
+        padding-bottom: ${display === Display.Immersive ? '0' : '0'};
+        padding-left: ${display === Display.Immersive ? '5px' : '5px'};
     }
     ${from.mobileLandscape} {
         font-size: 18px;
-        padding-top: ${display === 'immersive' ? '9px' : '9px'};
-        padding-right: ${display === 'immersive' ? '5px' : '5px'};
-        padding-bottom: ${display === 'immersive' ? '0' : '0'};
-        padding-left: ${display === 'immersive' ? '5px' : '5px'};
+        padding-top: ${display === Display.Immersive ? '9px' : '9px'};
+        padding-right: ${display === Display.Immersive ? '5px' : '5px'};
+        padding-bottom: ${display === Display.Immersive ? '0' : '0'};
+        padding-left: ${display === Display.Immersive ? '5px' : '5px'};
     }
     ${from.tablet} {
         font-size: 22px;
         height: 48px;
-        padding-top: ${display === 'immersive' ? '9px' : '9px'};
-        padding-right: ${display === 'immersive' ? '20px' : '20px'};
-        padding-bottom: ${display === 'immersive' ? '0' : '0'};
-        padding-left: ${display === 'immersive' ? '9px' : '9px'};
+        padding-top: ${display === Display.Immersive ? '9px' : '9px'};
+        padding-right: ${display === Display.Immersive ? '20px' : '20px'};
+        padding-bottom: ${display === Display.Immersive ? '0' : '0'};
+        padding-left: ${display === Display.Immersive ? '9px' : '9px'};
     }
     ${from.desktop} {
-        padding-top: ${display === 'immersive' ? '9px' : '5px'};
-        height: ${display === 'immersive' ? '48px' : '42px'};
+        padding-top: ${display === Display.Immersive ? '9px' : '5px'};
+        height: ${display === Display.Immersive ? '48px' : '42px'};
     }
 
     ${from.wide} {
-        padding-top: ${display === 'immersive' ? '10px' : '7px'};
+        padding-top: ${display === Display.Immersive ? '10px' : '7px'};
         font-size: 24px;
     }
 

--- a/src/web/components/Pillars.tsx
+++ b/src/web/components/Pillars.tsx
@@ -7,6 +7,7 @@ import { from, until } from '@guardian/src-foundations/mq';
 
 import { pillarMap, pillarPalette } from '@root/src/lib/pillars';
 import { navInputCheckboxId } from './Nav/config';
+import { Display } from '@root/src/lib/display';
 
 // CSS Vars
 

--- a/src/web/components/Pillars.tsx
+++ b/src/web/components/Pillars.tsx
@@ -6,8 +6,8 @@ import { headline } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
 
 import { pillarMap, pillarPalette } from '@root/src/lib/pillars';
-import { navInputCheckboxId } from './Nav/config';
 import { Display } from '@root/src/lib/display';
+import { navInputCheckboxId } from './Nav/config';
 
 // CSS Vars
 

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -119,7 +119,7 @@ export const SeriesSectionLink = ({
     const hasSeriesTag = tag && tag.type === 'Series';
 
     switch (display) {
-        case 'immersive': {
+        case Display.Immersive: {
             switch (designType) {
                 case 'Comment':
                 case 'GuardianView': {
@@ -214,8 +214,9 @@ export const SeriesSectionLink = ({
                 }
             }
         }
-        case 'showcase':
-        case 'standard': {
+        case Display.Showcase:
+        case Display.Standard:
+        default: {
             switch (designType) {
                 case 'Comment':
                 case 'GuardianView':

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -7,6 +7,7 @@ import { from, until } from '@guardian/src-foundations/mq';
 import { space, neutral, brandAltBackground } from '@guardian/src-foundations';
 
 import { Hide } from '@frontend/web/components/Hide';
+import { Display } from '@root/src/lib/display';
 
 type Props = {
     display: Display;

--- a/src/web/components/Standfirst.stories.tsx
+++ b/src/web/components/Standfirst.stories.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Section } from './Section';
 
 import { Standfirst } from './Standfirst';
+import { Display } from '@root/src/lib/display';
 
 export default {
     component: Standfirst,

--- a/src/web/components/Standfirst.stories.tsx
+++ b/src/web/components/Standfirst.stories.tsx
@@ -13,7 +13,7 @@ export const Article = () => {
     return (
         <Section>
             <Standfirst
-                display="standard"
+                display={Display.Standard}
                 designType="Article"
                 standfirst="This is how Article standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
             />
@@ -26,7 +26,7 @@ export const Comment = () => {
     return (
         <Section>
             <Standfirst
-                display="standard"
+                display={Display.Standard}
                 designType="Comment"
                 standfirst="This is how Comment standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
             />
@@ -39,7 +39,7 @@ export const Feature = () => {
     return (
         <Section>
             <Standfirst
-                display="standard"
+                display={Display.Standard}
                 designType="Feature"
                 standfirst="This is how Feature standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
             />
@@ -52,7 +52,7 @@ export const Immersive = () => {
     return (
         <Section>
             <Standfirst
-                display="immersive"
+                display={Display.Immersive}
                 designType="Immersive"
                 standfirst="This is how Immersive standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
             />
@@ -65,7 +65,7 @@ export const Review = () => {
     return (
         <Section>
             <Standfirst
-                display="standard"
+                display={Display.Standard}
                 designType="Review"
                 standfirst="This is how Review standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
             />
@@ -78,7 +78,7 @@ export const Live = () => {
     return (
         <Section>
             <Standfirst
-                display="standard"
+                display={Display.Standard}
                 designType="Live"
                 standfirst="This is how Live standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
             />
@@ -91,7 +91,7 @@ export const Interview = () => {
     return (
         <Section>
             <Standfirst
-                display="standard"
+                display={Display.Standard}
                 designType="Interview"
                 standfirst="This is how Interview standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
             />
@@ -104,7 +104,7 @@ export const Analysis = () => {
     return (
         <Section>
             <Standfirst
-                display="standard"
+                display={Display.Standard}
                 designType="Analysis"
                 standfirst="This is how Analysis standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
             />
@@ -117,7 +117,7 @@ export const Media = () => {
     return (
         <Section>
             <Standfirst
-                display="standard"
+                display={Display.Standard}
                 designType="Media"
                 standfirst="This is how Media standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
             />
@@ -130,7 +130,7 @@ export const Recipe = () => {
     return (
         <Section>
             <Standfirst
-                display="standard"
+                display={Display.Standard}
                 designType="Recipe"
                 standfirst="This is how Recipe standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
             />
@@ -143,7 +143,7 @@ export const MatchReport = () => {
     return (
         <Section>
             <Standfirst
-                display="standard"
+                display={Display.Standard}
                 designType="MatchReport"
                 standfirst="This is how MatchReport standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
             />
@@ -156,7 +156,7 @@ export const Quiz = () => {
     return (
         <Section>
             <Standfirst
-                display="standard"
+                display={Display.Standard}
                 designType="Quiz"
                 standfirst="This is how Quiz standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
             />
@@ -169,7 +169,7 @@ export const SpecialReport = () => {
     return (
         <Section>
             <Standfirst
-                display="standard"
+                display={Display.Standard}
                 designType="SpecialReport"
                 standfirst="This is how SpecialReport standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
             />
@@ -182,7 +182,7 @@ export const GuardianView = () => {
     return (
         <Section>
             <Standfirst
-                display="standard"
+                display={Display.Standard}
                 designType="GuardianView"
                 standfirst="This is how GuardianView standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
             />
@@ -195,7 +195,7 @@ export const GuardianLabs = () => {
     return (
         <Section>
             <Standfirst
-                display="standard"
+                display={Display.Standard}
                 designType="GuardianLabs"
                 standfirst="This is how GuardianLabs standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
             />
@@ -208,7 +208,7 @@ export const AdvertisementFeature = () => {
     return (
         <Section>
             <Standfirst
-                display="standard"
+                display={Display.Standard}
                 designType="AdvertisementFeature"
                 standfirst="This is how AdvertisementFeature standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
             />
@@ -221,7 +221,7 @@ export const PhotoEssay = () => {
     return (
         <Section>
             <Standfirst
-                display="standard"
+                display={Display.Standard}
                 designType="PhotoEssay"
                 standfirst="This is how PhotoEssay standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
             />

--- a/src/web/components/Standfirst.stories.tsx
+++ b/src/web/components/Standfirst.stories.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
+import { Display } from '@root/src/lib/display';
 import { Section } from './Section';
 
 import { Standfirst } from './Standfirst';
-import { Display } from '@root/src/lib/display';
 
 export default {
     component: Standfirst,

--- a/src/web/components/Standfirst.tsx
+++ b/src/web/components/Standfirst.tsx
@@ -50,7 +50,7 @@ const nestedStyles = css`
 
 const standfirstStyles = (designType: DesignType, display: Display) => {
     switch (display) {
-        case 'immersive':
+        case Display.Immersive:
             switch (designType) {
                 case 'PhotoEssay':
                     return css`
@@ -92,8 +92,8 @@ const standfirstStyles = (designType: DesignType, display: Display) => {
                     `;
             }
 
-        case 'showcase':
-        case 'standard': {
+        case Display.Showcase:
+        case Display.Standard: {
             switch (designType) {
                 case 'Comment':
                 case 'GuardianView':

--- a/src/web/components/Standfirst.tsx
+++ b/src/web/components/Standfirst.tsx
@@ -4,6 +4,7 @@ import { neutral } from '@guardian/src-foundations/palette';
 import { space } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { headline, textSans } from '@guardian/src-foundations/typography';
+import { Display } from '@root/src/lib/display';
 
 type Props = {
     display: Display;

--- a/src/web/components/elements/ImageBlockComponent.stories.tsx
+++ b/src/web/components/elements/ImageBlockComponent.stories.tsx
@@ -9,6 +9,7 @@ import { RightColumn } from '../RightColumn';
 import { ImageBlockComponent } from './ImageBlockComponent';
 
 import { image } from './ImageBlockComponent.mocks';
+import { Display } from '@root/src/lib/display';
 
 export default {
     component: ImageBlockComponent,

--- a/src/web/components/elements/ImageBlockComponent.stories.tsx
+++ b/src/web/components/elements/ImageBlockComponent.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 
+import { Display } from '@root/src/lib/display';
 import { Section } from '../Section';
 import { Flex } from '../Flex';
 import { LeftColumn } from '../LeftColumn';
@@ -9,7 +10,6 @@ import { RightColumn } from '../RightColumn';
 import { ImageBlockComponent } from './ImageBlockComponent';
 
 import { image } from './ImageBlockComponent.mocks';
-import { Display } from '@root/src/lib/display';
 
 export default {
     component: ImageBlockComponent,

--- a/src/web/components/elements/ImageBlockComponent.stories.tsx
+++ b/src/web/components/elements/ImageBlockComponent.stories.tsx
@@ -51,7 +51,7 @@ export const StandardArticle = () => {
     return (
         <Container>
             <ImageBlockComponent
-                display="standard"
+                display={Display.Standard}
                 designType="Article"
                 element={{ ...image, role: 'inline' }}
                 pillar="news"
@@ -67,7 +67,7 @@ export const Immersive = () => {
     return (
         <Container>
             <ImageBlockComponent
-                display="standard"
+                display={Display.Standard}
                 designType="Article"
                 element={{ ...image, role: 'immersive' }}
                 pillar="news"
@@ -83,7 +83,7 @@ export const Showcase = () => {
     return (
         <Container>
             <ImageBlockComponent
-                display="standard"
+                display={Display.Standard}
                 designType="Article"
                 element={{ ...image, role: 'showcase' }}
                 pillar="news"
@@ -99,7 +99,7 @@ export const Thumbnail = () => {
     return (
         <Container>
             <ImageBlockComponent
-                display="standard"
+                display={Display.Standard}
                 designType="Article"
                 element={{ ...image, role: 'thumbnail' }}
                 pillar="news"
@@ -115,7 +115,7 @@ export const Supporting = () => {
     return (
         <Container>
             <ImageBlockComponent
-                display="standard"
+                display={Display.Standard}
                 designType="Article"
                 element={{ ...image, role: 'supporting' }}
                 pillar="news"
@@ -131,7 +131,7 @@ export const HideCaption = () => {
     return (
         <Container>
             <ImageBlockComponent
-                display="standard"
+                display={Display.Standard}
                 designType="Article"
                 element={{ ...image, role: 'inline' }}
                 pillar="news"
@@ -148,7 +148,7 @@ export const InlineTitle = () => {
     return (
         <Container>
             <ImageBlockComponent
-                display="standard"
+                display={Display.Standard}
                 designType="Article"
                 element={{ ...image, role: 'inline' }}
                 pillar="news"
@@ -170,7 +170,7 @@ export const InlineTitleMobile = () => {
     return (
         <Container>
             <ImageBlockComponent
-                display="standard"
+                display={Display.Standard}
                 designType="Article"
                 element={{ ...image, role: 'inline' }}
                 pillar="news"
@@ -192,7 +192,7 @@ export const ImmersiveTitle = () => {
     return (
         <Container>
             <ImageBlockComponent
-                display="standard"
+                display={Display.Standard}
                 designType="Article"
                 element={{ ...image, role: 'immersive' }}
                 pillar="news"
@@ -210,7 +210,7 @@ export const ShowcaseTitle = () => {
     return (
         <Container>
             <ImageBlockComponent
-                display="standard"
+                display={Display.Standard}
                 designType="Article"
                 element={{ ...image, role: 'showcase' }}
                 pillar="news"
@@ -252,7 +252,7 @@ export const HalfWidth = () => {
                 mollit anim id est laborum.
             </p>
             <ImageBlockComponent
-                display="standard"
+                display={Display.Standard}
                 designType="Article"
                 element={{ ...image, role: 'halfWidth' }}
                 pillar="news"
@@ -308,7 +308,7 @@ export const HalfWidthMobile = () => {
                 mollit anim id est laborum.
             </p>
             <ImageBlockComponent
-                display="standard"
+                display={Display.Standard}
                 designType="Article"
                 element={{ ...image, role: 'halfWidth' }}
                 pillar="news"
@@ -364,7 +364,7 @@ export const HalfWidthWide = () => {
                 deserunt mollit anim id est laborum.
             </p>
             <ImageBlockComponent
-                display="standard"
+                display={Display.Standard}
                 designType="Article"
                 element={{ ...image, role: 'halfWidth' }}
                 pillar="news"

--- a/src/web/components/elements/ImageBlockComponent.tsx
+++ b/src/web/components/elements/ImageBlockComponent.tsx
@@ -3,6 +3,7 @@ import { css } from 'emotion';
 import { ImageComponent } from '@root/src/web/components/elements/ImageComponent';
 
 import { from, until } from '@guardian/src-foundations/mq';
+import { Display } from '@root/src/lib/display';
 
 type Props = {
     display: Display;

--- a/src/web/components/elements/ImageComponent.tsx
+++ b/src/web/components/elements/ImageComponent.tsx
@@ -10,6 +10,7 @@ import { Picture, PictureSource } from '@root/src/web/components/Picture';
 import { Caption } from '@root/src/web/components/Caption';
 import { Hide } from '@root/src/web/components/Hide';
 import { StarRating } from '@root/src/web/components/StarRating/StarRating';
+import { Display } from '@root/src/lib/display';
 
 type Props = {
     display: Display;

--- a/src/web/components/elements/ImageComponent.tsx
+++ b/src/web/components/elements/ImageComponent.tsx
@@ -291,7 +291,7 @@ export const ImageComponent = ({
     const isNotOpinion =
         designType !== 'Comment' && designType !== 'GuardianView';
 
-    if (isMainMedia && display === 'immersive' && isNotOpinion) {
+    if (isMainMedia && display === Display.Immersive && isNotOpinion) {
         return (
             <div
                 className={css`

--- a/src/web/components/elements/MultiImageBlockComponent.tsx
+++ b/src/web/components/elements/MultiImageBlockComponent.tsx
@@ -127,7 +127,7 @@ export const MultiImageBlockComponent = ({
                     `}
                 >
                     <ImageComponent
-                        display="standard"
+                        display={Display.Standard}
                         designType={designType}
                         element={images[0]}
                         pillar={pillar}
@@ -136,7 +136,7 @@ export const MultiImageBlockComponent = ({
                     />
                     {caption && (
                         <Caption
-                            display="standard"
+                            display={Display.Standard}
                             designType={designType}
                             captionText={caption}
                             pillar={pillar}
@@ -161,7 +161,7 @@ export const MultiImageBlockComponent = ({
                     <SideBySideGrid>
                         <GridItem area="first">
                             <ImageComponent
-                                display="standard"
+                                display={Display.Standard}
                                 designType="Article"
                                 element={images[0]}
                                 pillar={pillar}
@@ -171,7 +171,7 @@ export const MultiImageBlockComponent = ({
                         </GridItem>
                         <GridItem area="second">
                             <ImageComponent
-                                display="standard"
+                                display={Display.Standard}
                                 designType="Article"
                                 element={images[1]}
                                 pillar={pillar}
@@ -182,7 +182,7 @@ export const MultiImageBlockComponent = ({
                     </SideBySideGrid>
                     {caption && (
                         <Caption
-                            display="standard"
+                            display={Display.Standard}
                             designType={designType}
                             captionText={caption}
                             pillar={pillar}
@@ -207,7 +207,7 @@ export const MultiImageBlockComponent = ({
                     <OneAboveTwoGrid>
                         <GridItem area="first">
                             <ImageComponent
-                                display="standard"
+                                display={Display.Standard}
                                 designType="Article"
                                 element={images[0]}
                                 pillar={pillar}
@@ -217,7 +217,7 @@ export const MultiImageBlockComponent = ({
                         </GridItem>
                         <GridItem area="second">
                             <ImageComponent
-                                display="standard"
+                                display={Display.Standard}
                                 designType="Article"
                                 element={images[1]}
                                 pillar={pillar}
@@ -227,7 +227,7 @@ export const MultiImageBlockComponent = ({
                         </GridItem>
                         <GridItem area="third">
                             <ImageComponent
-                                display="standard"
+                                display={Display.Standard}
                                 designType="Article"
                                 element={images[2]}
                                 pillar={pillar}
@@ -238,7 +238,7 @@ export const MultiImageBlockComponent = ({
                     </OneAboveTwoGrid>
                     {caption && (
                         <Caption
-                            display="standard"
+                            display={Display.Standard}
                             designType={designType}
                             captionText={caption}
                             pillar={pillar}
@@ -262,7 +262,7 @@ export const MultiImageBlockComponent = ({
                     <GridOfFour>
                         <GridItem area="first">
                             <ImageComponent
-                                display="standard"
+                                display={Display.Standard}
                                 designType="Article"
                                 element={images[0]}
                                 pillar={pillar}
@@ -272,7 +272,7 @@ export const MultiImageBlockComponent = ({
                         </GridItem>
                         <GridItem area="second">
                             <ImageComponent
-                                display="standard"
+                                display={Display.Standard}
                                 designType="Article"
                                 element={images[1]}
                                 pillar={pillar}
@@ -282,7 +282,7 @@ export const MultiImageBlockComponent = ({
                         </GridItem>
                         <GridItem area="third">
                             <ImageComponent
-                                display="standard"
+                                display={Display.Standard}
                                 designType="Article"
                                 element={images[2]}
                                 pillar={pillar}
@@ -292,7 +292,7 @@ export const MultiImageBlockComponent = ({
                         </GridItem>
                         <GridItem area="forth">
                             <ImageComponent
-                                display="standard"
+                                display={Display.Standard}
                                 designType="Article"
                                 element={images[3]}
                                 pillar={pillar}
@@ -303,7 +303,7 @@ export const MultiImageBlockComponent = ({
                     </GridOfFour>
                     {caption && (
                         <Caption
-                            display="standard"
+                            display={Display.Standard}
                             designType={designType}
                             captionText={caption}
                             pillar={pillar}

--- a/src/web/components/elements/MultiImageBlockComponent.tsx
+++ b/src/web/components/elements/MultiImageBlockComponent.tsx
@@ -7,6 +7,7 @@ import { from, until } from '@guardian/src-foundations/mq';
 import { ImageComponent } from '@root/src/web/components/elements/ImageComponent';
 import { Caption } from '@frontend/web/components/Caption';
 import { GridItem } from '@root/src/web/components/GridItem';
+import { Display } from '@root/src/lib/display';
 
 type Props = {
     designType: DesignType;

--- a/src/web/components/elements/TextBlockComponent.stories.tsx
+++ b/src/web/components/elements/TextBlockComponent.stories.tsx
@@ -29,7 +29,7 @@ export const defaultStory = () => {
                 html={html}
                 pillar="news"
                 designType="Article"
-                display="standard"
+                display={Display.Standard}
                 isFirstParagraph={false}
             />
         </div>
@@ -45,7 +45,7 @@ export const DropCap = () => {
                 pillar="culture"
                 forceDropCap={true}
                 designType="Article"
-                display="immersive"
+                display={Display.Immersive}
                 isFirstParagraph={false}
             />
         </div>
@@ -61,7 +61,7 @@ export const QuotedDropCap = () => {
                 pillar="opinion"
                 forceDropCap={false}
                 designType="Comment"
-                display="standard"
+                display={Display.Standard}
                 isFirstParagraph={true}
             />
         </div>
@@ -77,7 +77,7 @@ export const ShortText = () => {
                 pillar="news"
                 forceDropCap={true}
                 designType="Article"
-                display="standard"
+                display={Display.Standard}
                 isFirstParagraph={false}
             />
         </div>
@@ -93,7 +93,7 @@ export const NoTags = () => {
                 pillar="news"
                 forceDropCap={true}
                 designType="Article"
-                display="standard"
+                display={Display.Standard}
                 isFirstParagraph={false}
             />
         </div>
@@ -109,7 +109,7 @@ export const FeatureDropCap = () => {
                 pillar="culture"
                 forceDropCap={false}
                 designType="Feature"
-                display="standard"
+                display={Display.Standard}
                 isFirstParagraph={true}
             />
         </div>

--- a/src/web/components/elements/TextBlockComponent.stories.tsx
+++ b/src/web/components/elements/TextBlockComponent.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 import { TextBlockComponent } from '@frontend/web/components/elements/TextBlockComponent';
+import { Display } from '@root/src/lib/display';
 
 const html =
     '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesquepharetra libero nec varius feugiat. Nulla commodo sagittis erat amalesuada. Ut iaculis interdum eros, et tristique ex. In veldignissim arcu. Nulla nisi urna, laoreet a aliquam at, viverra eueros. Proin imperdiet pellentesque turpis sed luctus. Donecdignissim lacus in risus fermentum maximus eu vel justo. Duis nontortor ac elit dapibus imperdiet ut at risus. Etiam pretium, odioeget accumsan venenatis, tortor mi aliquet nisl, vel ullamcorperneque nulla vel elit. Etiam porta mauris nec sagittis luctus.</p>';

--- a/src/web/components/elements/TextBlockComponent.tsx
+++ b/src/web/components/elements/TextBlockComponent.tsx
@@ -10,6 +10,7 @@ import { unwrapHtml } from '@root/src/model/unwrapHtml';
 import { RewrappedComponent } from '@root/src/web/components/elements/RewrappedComponent';
 
 import { DropCap } from '@frontend/web/components/DropCap';
+import { Display } from '@root/src/lib/display';
 
 type Props = {
     html: string;

--- a/src/web/components/elements/TextBlockComponent.tsx
+++ b/src/web/components/elements/TextBlockComponent.tsx
@@ -58,7 +58,7 @@ const shouldShowDropCap = ({
     // Otherwise, we're only interested in marking the first para as a drop cap
     if (!isFirstParagraph) return false;
     // If immersive, we show drop caps for the first para
-    if (display === 'immersive') return true;
+    if (display === Display.Immersive) return true;
     // The first para has a drop cap for these design types
     switch (designType) {
         case 'Feature':

--- a/src/web/components/elements/VimeoBlockComponent.stories.tsx
+++ b/src/web/components/elements/VimeoBlockComponent.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 import { VimeoBlockComponent } from './VimeoBlockComponent';
+import { Display } from '@root/src/lib/display';
 
 export default {
     component: VimeoBlockComponent,

--- a/src/web/components/elements/VimeoBlockComponent.stories.tsx
+++ b/src/web/components/elements/VimeoBlockComponent.stories.tsx
@@ -31,7 +31,7 @@ export const smallAspectRatio = () => {
                 caption="blah"
                 credit=""
                 title=""
-                display="standard"
+                display={Display.Standard}
                 designType="Article"
             />
             <p>abc</p>
@@ -52,7 +52,7 @@ export const largeAspectRatio = () => {
                 caption="blah"
                 credit=""
                 title=""
-                display="standard"
+                display={Display.Standard}
                 designType="Article"
             />
             <p>abc</p>
@@ -73,7 +73,7 @@ export const verticalAspectRatio = () => {
                 caption="blah"
                 credit=""
                 title=""
-                display="standard"
+                display={Display.Standard}
                 designType="Article"
             />
             <p>abc</p>

--- a/src/web/components/elements/VimeoBlockComponent.stories.tsx
+++ b/src/web/components/elements/VimeoBlockComponent.stories.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { css } from 'emotion';
 
-import { VimeoBlockComponent } from './VimeoBlockComponent';
 import { Display } from '@root/src/lib/display';
+import { VimeoBlockComponent } from './VimeoBlockComponent';
 
 export default {
     component: VimeoBlockComponent,

--- a/src/web/components/elements/VimeoBlockComponent.tsx
+++ b/src/web/components/elements/VimeoBlockComponent.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 import { Caption } from '@root/src/web/components/Caption';
+import { Display } from '@root/src/lib/display';
 
 const responsiveAspectRatio = (height: number, width: number) => css`
     /* https://css-tricks.com/aspect-ratio-boxes/ */

--- a/src/web/components/elements/YoutubeBlockComponent.stories.tsx
+++ b/src/web/components/elements/YoutubeBlockComponent.stories.tsx
@@ -44,7 +44,7 @@ export const noOverlay = () => {
                 nisi ut aliquip ex ea commodo consequat.{' '}
             </p>
             <YoutubeBlockComponent
-                display="standard"
+                display={Display.Standard}
                 designType="Article"
                 element={{
                     mediaTitle:

--- a/src/web/components/elements/YoutubeBlockComponent.stories.tsx
+++ b/src/web/components/elements/YoutubeBlockComponent.stories.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { css } from 'emotion';
 
+import { Display } from '@root/src/lib/display';
 import { Section } from '../Section';
 import { Flex } from '../Flex';
 import { LeftColumn } from '../LeftColumn';
 import { RightColumn } from '../RightColumn';
 
 import { YoutubeBlockComponent } from './YoutubeBlockComponent';
-import { Display } from '@root/src/lib/display';
 
 export default {
     component: YoutubeBlockComponent,
@@ -81,7 +81,7 @@ export const Vertical = () => {
                 nisi ut aliquip ex ea commodo consequat.{' '}
             </p>
             <YoutubeBlockComponent
-                display="standard"
+                display={Display.Standard}
                 designType="Article"
                 element={{
                     mediaTitle:

--- a/src/web/components/elements/YoutubeBlockComponent.stories.tsx
+++ b/src/web/components/elements/YoutubeBlockComponent.stories.tsx
@@ -7,6 +7,7 @@ import { LeftColumn } from '../LeftColumn';
 import { RightColumn } from '../RightColumn';
 
 import { YoutubeBlockComponent } from './YoutubeBlockComponent';
+import { Display } from '@root/src/lib/display';
 
 export default {
     component: YoutubeBlockComponent,

--- a/src/web/components/elements/YoutubeBlockComponent.tsx
+++ b/src/web/components/elements/YoutubeBlockComponent.tsx
@@ -5,6 +5,7 @@ import { YouTubeOverlay } from '@frontend/web/components/YouTubeOverlay';
 import { MaintainAspectRatio } from '@frontend/web/components/MaintainAspectRatio';
 
 import { constructQuery } from '@root/src/lib/querystring';
+import { Display } from '@root/src/lib/display';
 
 type Props = {
     display: Display;

--- a/src/web/components/elements/YoutubeEmbedBlockComponent.stories.tsx
+++ b/src/web/components/elements/YoutubeEmbedBlockComponent.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 
+import { Display } from '@root/src/lib/display';
 import { YoutubeEmbedBlockComponent } from './YoutubeEmbedBlockComponent';
 
 export default {
@@ -31,7 +32,7 @@ export const standardAspectRatio = () => {
                 caption="blah"
                 credit=""
                 title=""
-                display="standard"
+                display={Display.Standard}
                 designType="Article"
             />
             <p>abc</p>

--- a/src/web/components/elements/YoutubeEmbedBlockComponent.tsx
+++ b/src/web/components/elements/YoutubeEmbedBlockComponent.tsx
@@ -3,6 +3,7 @@ import { css } from 'emotion';
 
 import { Caption } from '@root/src/web/components/Caption';
 import { MaintainAspectRatio } from '@frontend/web/components/MaintainAspectRatio';
+import { Display } from '@root/src/lib/display';
 
 export const YoutubeEmbedBlockComponent: React.FC<{
     pillar: Pillar;

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -41,6 +41,7 @@ import { parse } from '@frontend/lib/slot-machine-flags';
 import { getAgeWarning } from '@root/src/lib/age-warning';
 import { getCurrentPillar } from '@root/src/web/lib/layoutHelpers';
 import { Stuck, SendToBack } from '@root/src/web/layouts/lib/stickiness';
+import { Display } from '@root/src/lib/display';
 
 const MOSTVIEWED_STICKY_HEIGHT = 1059;
 

--- a/src/web/layouts/DecideLayout.tsx
+++ b/src/web/layouts/DecideLayout.tsx
@@ -11,9 +11,9 @@ type Props = {
 };
 
 const decideDisplay = (CAPI: CAPIType): Display => {
-    if (CAPI.isImmersive) return 'immersive';
-    if (CAPI.pageType.hasShowcaseMainElement) return 'showcase';
-    return 'standard';
+    if (CAPI.isImmersive) return Display.Immersive;
+    if (CAPI.pageType.hasShowcaseMainElement) return Display.Showcase;
+    return Display.Standard;
 };
 
 const decidePillar = (CAPI: CAPIType): Pillar => {
@@ -29,7 +29,7 @@ export const DecideLayout = ({ CAPI, NAV }: Props) => {
     const { designType } = CAPI;
 
     switch (display) {
-        case 'immersive': {
+        case Display.Immersive: {
             switch (designType) {
                 case 'Comment':
                 case 'GuardianView':
@@ -37,7 +37,7 @@ export const DecideLayout = ({ CAPI, NAV }: Props) => {
                         <ImmersiveLayout
                             CAPI={CAPI}
                             NAV={NAV}
-                            display="immersive"
+                            display={Display.Immersive}
                             designType={designType}
                             pillar={pillar}
                         />
@@ -61,7 +61,7 @@ export const DecideLayout = ({ CAPI, NAV }: Props) => {
                         <ImmersiveLayout
                             CAPI={CAPI}
                             NAV={NAV}
-                            display="immersive"
+                            display={Display.Immersive}
                             designType={designType}
                             pillar={pillar}
                         />
@@ -69,7 +69,7 @@ export const DecideLayout = ({ CAPI, NAV }: Props) => {
             }
             break;
         }
-        case 'showcase': {
+        case Display.Showcase: {
             switch (designType) {
                 case 'Comment':
                 case 'GuardianView':
@@ -77,7 +77,7 @@ export const DecideLayout = ({ CAPI, NAV }: Props) => {
                         <CommentLayout
                             CAPI={CAPI}
                             NAV={NAV}
-                            display="showcase"
+                            display={Display.Showcase}
                             designType={designType}
                             pillar={pillar}
                         />
@@ -101,7 +101,7 @@ export const DecideLayout = ({ CAPI, NAV }: Props) => {
                         <ShowcaseLayout
                             CAPI={CAPI}
                             NAV={NAV}
-                            display="showcase"
+                            display={Display.Showcase}
                             designType={designType}
                             pillar={pillar}
                         />
@@ -109,7 +109,8 @@ export const DecideLayout = ({ CAPI, NAV }: Props) => {
             }
             break;
         }
-        case 'standard': {
+        case Display.Standard:
+        default: {
             switch (designType) {
                 case 'Comment':
                 case 'GuardianView':
@@ -117,7 +118,7 @@ export const DecideLayout = ({ CAPI, NAV }: Props) => {
                         <CommentLayout
                             CAPI={CAPI}
                             NAV={NAV}
-                            display="standard"
+                            display={Display.Standard}
                             designType={designType}
                             pillar={pillar}
                         />
@@ -141,7 +142,7 @@ export const DecideLayout = ({ CAPI, NAV }: Props) => {
                         <StandardLayout
                             CAPI={CAPI}
                             NAV={NAV}
-                            display="standard"
+                            display={Display.Standard}
                             designType={designType}
                             pillar={pillar}
                         />

--- a/src/web/layouts/DecideLayout.tsx
+++ b/src/web/layouts/DecideLayout.tsx
@@ -4,6 +4,7 @@ import { StandardLayout } from './StandardLayout';
 import { ShowcaseLayout } from './ShowcaseLayout';
 import { CommentLayout } from './CommentLayout';
 import { ImmersiveLayout } from './ImmersiveLayout';
+import { Display } from '@root/src/lib/display';
 
 type Props = {
     CAPI: CAPIType;

--- a/src/web/layouts/DecideLayout.tsx
+++ b/src/web/layouts/DecideLayout.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
+import { Display } from '@root/src/lib/display';
 import { StandardLayout } from './StandardLayout';
 import { ShowcaseLayout } from './ShowcaseLayout';
 import { CommentLayout } from './CommentLayout';
 import { ImmersiveLayout } from './ImmersiveLayout';
-import { Display } from '@root/src/lib/display';
 
 type Props = {
     CAPI: CAPIType;

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -42,6 +42,7 @@ import {
     getCurrentPillar,
 } from '@root/src/web/lib/layoutHelpers';
 import { Hide } from '../components/Hide';
+import { Display } from '@root/src/lib/display';
 
 const ImmersiveGrid = ({
     children,

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -41,8 +41,8 @@ import {
     decideLineEffect,
     getCurrentPillar,
 } from '@root/src/web/lib/layoutHelpers';
-import { Hide } from '../components/Hide';
 import { Display } from '@root/src/lib/display';
+import { Hide } from '../components/Hide';
 
 const ImmersiveGrid = ({
     children,

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -43,6 +43,7 @@ import {
     getCurrentPillar,
 } from '@root/src/web/lib/layoutHelpers';
 import { Stuck, SendToBack } from '@root/src/web/layouts/lib/stickiness';
+import { Display } from '@root/src/lib/display';
 
 const ShowcaseGrid = ({
     children,

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -48,6 +48,7 @@ import {
     getCurrentPillar,
 } from '@root/src/web/lib/layoutHelpers';
 import { Stuck, SendToBack } from '@root/src/web/layouts/lib/stickiness';
+import { Display } from '@root/src/lib/display';
 
 const MOSTVIEWED_STICKY_HEIGHT = 1059;
 

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -18,6 +18,7 @@ import { YoutubeEmbedBlockComponent } from '@root/src/web/components/elements/Yo
 import { YoutubeBlockComponent } from '@root/src/web/components/elements/YoutubeBlockComponent';
 
 import { ExplainerAtom } from '@guardian/atoms-rendering';
+import { Display } from '@root/src/lib/display';
 
 // This is required for spacefinder to work!
 const commercialPosition = css`


### PR DESCRIPTION
## What does this change?

The explanation is mostly the same as #1606. The main difference is that I've split `Display` out into a `.ts` file, rather than putting it in `index.d.ts`. That didn't work when used in conjunction with `transpileOnly`, because it requires project-level type information to extract and inline the `const enum`. The result was a compilation that passed, but an error at runtime (see #1655).

Ideally we'd remove `transpileOnly` for production builds to benefit from reduced bundle size due to inlined `const enum`s. However, I'm having trouble getting that to work, so for now this behaviour remains as before, and `const enum`s are included in the output bundle, much like standard `enum`s. This should allow us to share the same `const enum`s as AR, even if DCR doesn't get the bundle size reduction just yet.

**Note:** This branch was created using a GitHub revert on #1655, which is why the first commit is marked as being from @oliverlloyd (for a repo ownership reason possibly).

### Before

See #1606.

### After

All of #1606 + `Display` now lives in `display.ts` and is imported as needed.

## Why?

Again, see #1606 + this shouldn't runtime error.
