### PR TITLE
Don’t request the RR banner if not in AU

### DIFF
--- a/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -36,7 +36,7 @@ export const StickyBottomBanner = ({
         return null;
     }
 
-    const showRRBanner = CAPI.config.remoteBanner;
+    const showRRBanner = CAPI.config.remoteBanner && countryCode === 'AU';
 
     return (
         <>


### PR DESCRIPTION
## What does this change?

Only make a request to the contributions service for the RR banner if the reader is in AU.

## Why?

This will reduce the overall number of requests, bringing down costs.