### PR TITLE
Fix Display In CaptionBlock

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,12 @@ type RealPillars = 'news' | 'opinion' | 'sport' | 'culture' | 'lifestyle';
 type FakePillars = 'labs';
 type Pillar = RealPillars | FakePillars;
 
+declare const enum Display {
+    Standard,
+    Immersive,
+    Showcase,
+}
+
 // https://github.com/guardian/content-api-scala-client/blob/master/client/src/main/scala/com.gu.contentapi.client/utils/DesignType.scala
 type DesignType =
     | 'Article'

--- a/src/web/components/Caption.stories.tsx
+++ b/src/web/components/Caption.stories.tsx
@@ -48,9 +48,9 @@ Analysis.story = { name: 'Analysis' };
 export const PhotoEssay = () => (
     <Section showTopBorder={false} showSideBorders={false}>
         <Caption
-            display={Display.Standard}
+            display={Display.Immersive}
             designType="PhotoEssay"
-            captionText="This is how a PhotoEssay caption looks"
+            captionText="<ul><li>This is how a PhotoEssay caption looks</li></ul>"
             pillar="news"
         />
     </Section>
@@ -60,9 +60,9 @@ PhotoEssay.story = { name: 'PhotoEssay' };
 export const PhotoEssayLimitedWidth = () => (
     <Section showTopBorder={false} showSideBorders={false}>
         <Caption
-            display={Display.Standard}
+            display={Display.Immersive}
             designType="PhotoEssay"
-            captionText="This is how a PhotoEssay caption looks when width is limited"
+            captionText="<ul><li>This is how a PhotoEssay caption looks when width is limited</li></ul>"
             pillar="news"
             shouldLimitWidth={true}
         />

--- a/src/web/components/elements/CaptionBlockComponent.stories.tsx
+++ b/src/web/components/elements/CaptionBlockComponent.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 
+import { Display } from '@root/src/lib/display';
 import { Section } from '../Section';
 import { Flex } from '../Flex';
 import { LeftColumn } from '../LeftColumn';
@@ -53,7 +54,7 @@ export const StandardArticle = () => {
     return (
         <Container>
             <CaptionBlockComponent
-                display="standard"
+                display={Display.Standard}
                 designType="Article"
                 captionText="Caption text"
                 pillar="news"
@@ -69,7 +70,7 @@ export const PhotoEssay = () => {
     return (
         <Container>
             <CaptionBlockComponent
-                display="immersive"
+                display={Display.Immersive}
                 designType="PhotoEssay"
                 captionText="Caption text"
                 pillar="lifestyle"
@@ -90,7 +91,7 @@ export const Padded = () => {
     return (
         <Container>
             <CaptionBlockComponent
-                display="standard"
+                display={Display.Standard}
                 designType="Analysis"
                 captionText="Caption text"
                 pillar="culture"
@@ -111,7 +112,7 @@ export const WidthLimited = () => {
     return (
         <Container>
             <CaptionBlockComponent
-                display="standard"
+                display={Display.Standard}
                 designType="Review"
                 captionText="Caption textQuas repellat sapiente nobis vel. Expedita veniam ut officiis. Omnis tempore natus est distinctio sapiente aliquid dolores soluta. Vel facere vitae velit et non. Eveniet omnis impedit mollitia voluptas omnis sit"
                 pillar="culture"
@@ -132,7 +133,7 @@ export const Credited = () => {
     return (
         <Container>
             <CaptionBlockComponent
-                display="standard"
+                display={Display.Standard}
                 designType="MatchReport"
                 captionText="Caption textQuas repellat sapiente nobis vel. Expedita veniam ut officiis. Omnis tempore natus est distinctio sapiente aliquid dolores soluta. Vel facere vitae velit et non. Eveniet omnis impedit mollitia voluptas omnis sit"
                 pillar="culture"
@@ -153,7 +154,7 @@ export const Overlayed = () => {
     return (
         <Container>
             <CaptionBlockComponent
-                display="showcase"
+                display={Display.Showcase}
                 designType="Comment"
                 captionText="Caption textQuas repellat sapiente nobis vel. Expedita veniam ut officiis. Omnis tempore natus est distinctio sapiente aliquid dolores soluta. Vel facere vitae velit et non. Eveniet omnis impedit mollitia voluptas omnis sit"
                 pillar="sport"

--- a/src/web/components/elements/CaptionBlockComponent.stories.tsx
+++ b/src/web/components/elements/CaptionBlockComponent.stories.tsx
@@ -87,6 +87,27 @@ PhotoEssay.story = {
     name: 'PhotoEssay',
 };
 
+export const PhotoEssayHTML = () => {
+    return (
+        <Container>
+            <CaptionBlockComponent
+                display={Display.Immersive}
+                designType="PhotoEssay"
+                captionText="<ul><li>Line 1 text</li><li>Line 2 text</li><li>Line 3 text</li></ul>"
+                pillar="sport"
+                padCaption={false}
+                credit="Credit text"
+                displayCredit={false}
+                shouldLimitWidth={false}
+                isOverlayed={false}
+            />
+        </Container>
+    );
+};
+PhotoEssayHTML.story = {
+    name: 'PhotoEssay using html',
+};
+
 export const Padded = () => {
     return (
         <Container>

--- a/src/web/components/elements/CaptionBlockComponent.tsx
+++ b/src/web/components/elements/CaptionBlockComponent.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 // import { css } from 'emotion';
 import { Caption } from '@frontend/web/components/Caption';
+import { Display } from '@root/src/lib/display';
 
 type Props = {
     display: Display;


### PR DESCRIPTION
## What does this change?

### Before

Strings used for `Display` in `CaptionBlockComponent`.

### After

`Display` enum used. Also introduced a `Display` declaration in `index.d.ts` to support the reference to `Display` in `content.d.ts`.

## Why?

Merging #1656 caused conflicts with #1652 that meant master failed to build. This fixes forward.
