### PR TITLE
Use Highlights for non quoted blockquotes

### DIFF
--- a/src/model/add-highlights.test.ts
+++ b/src/model/add-highlights.test.ts
@@ -1,0 +1,157 @@
+import { addHighlights } from './add-highlights';
+import { bodyJSON } from './exampleBodyJSON';
+
+const example = JSON.parse(bodyJSON);
+
+describe('Drop Caps', () => {
+    it('creates an identical but new object when no changes are needed', () => {
+        expect(addHighlights(example)).not.toBe(example); // We created a new object
+        expect(addHighlights(example)).toEqual(example); // The new object is what we expect
+    });
+
+    it('creates highlight elements as expected', () => {
+        const input = {
+            ...example,
+            blocks: [
+                {
+                    elements: [
+                        {
+                            _type:
+                                'model.dotcomrendering.pageElements.BlockquoteBlockElement',
+                            html: '<blockquote>This is not a quote</blockquote>',
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const expectedOutput = {
+            ...example,
+            blocks: [
+                {
+                    elements: [
+                        {
+                            _type:
+                                'model.dotcomrendering.pageElements.HighlightBlockElement',
+                            html: '<blockquote>This is not a quote</blockquote>',
+                        },
+                    ],
+                },
+            ],
+        };
+
+        expect(addHighlights(input)).toEqual(expectedOutput);
+    });
+
+    it('creates passes through quotes as expected', () => {
+        const input = {
+            ...example,
+            blocks: [
+                {
+                    elements: [
+                        {
+                            _type:
+                                'model.dotcomrendering.pageElements.BlockquoteBlockElement',
+                            html: '<blockquote class="quoted">This is a quote</blockquote>',
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const expectedOutput = {
+            ...example,
+            blocks: [
+                {
+                    elements: [
+                        {
+                            _type:
+                                'model.dotcomrendering.pageElements.BlockquoteBlockElement',
+                            html: '<blockquote class="quoted">This is a quote</blockquote>',
+                        },
+                    ],
+                },
+            ],
+        };
+
+        expect(addHighlights(input)).toEqual(expectedOutput);
+    });
+
+    it('ignores blockquotes with other classnames, still creating highlight elements', () => {
+        const input = {
+            ...example,
+            blocks: [
+                {
+                    elements: [
+                        {
+                            _type:
+                                'model.dotcomrendering.pageElements.BlockquoteBlockElement',
+                            html: '<blockquote class="somethingelse">This is not a quote</blockquote>',
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const expectedOutput = {
+            ...example,
+            blocks: [
+                {
+                    elements: [
+                        {
+                            _type:
+                                'model.dotcomrendering.pageElements.HighlightBlockElement',
+                            html: '<blockquote class="somethingelse">This is not a quote</blockquote>',
+                        },
+                    ],
+                },
+            ],
+        };
+
+        expect(addHighlights(input)).toEqual(expectedOutput);
+    });
+
+    it('handles both highlights and blockquotes in the same array', () => {
+        const input = {
+            ...example,
+            blocks: [
+                {
+                    elements: [
+                        {
+                            _type:
+                                'model.dotcomrendering.pageElements.BlockquoteBlockElement',
+                            html: '<blockquote class="quoted">This is a quote</blockquote>',
+                        },
+                        {
+                            _type:
+                                'model.dotcomrendering.pageElements.BlockquoteBlockElement',
+                            html: '<blockquote>This is not a quote</blockquote>',
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const expectedOutput = {
+            ...example,
+            blocks: [
+                {
+                    elements: [
+                        {
+                            _type:
+                                'model.dotcomrendering.pageElements.BlockquoteBlockElement',
+                            html: '<blockquote class="quoted">This is a quote</blockquote>',
+                        },
+                        {
+                            _type:
+                                'model.dotcomrendering.pageElements.HighlightBlockElement',
+                            html: '<blockquote>This is not a quote</blockquote>',
+                        },
+                    ],
+                },
+            ],
+        };
+
+        expect(addHighlights(input)).toEqual(expectedOutput);
+    });
+});

--- a/src/model/add-highlights.ts
+++ b/src/model/add-highlights.ts
@@ -1,0 +1,51 @@
+import { JSDOM } from 'jsdom';
+
+const isHighlight = (element: BlockquoteBlockElement): boolean => {
+    // A highlight blockquote: <blockquote><p>Blah</p></blockquote>
+    // A quoted blockquote: <blockquote class="quoted"><p>Blah</p></blockquote>
+    console.log(element.html)
+    const frag = JSDOM.fragment(element.html);
+    if (!frag) return false; // Not anything
+    const isQuoted = !!frag.querySelector('.quoted');
+    if (isQuoted) return false; // This blockquote is a quote
+    return true; // This blockquote is not a quote, so it's a highlight
+};
+
+const checkForHighlights = (elements: CAPIElement[]): CAPIElement[] => {
+    // checkForHighlights loops the array of article elements looking for
+    // BlockquoteBlockElements. If the element has the class "quoted" it
+    // is left as a BlockquoteBlockElement but if not then it is transformed
+    // into a HighlightBlockElement
+    const enhanced: CAPIElement[] = [];
+    elements.forEach((element, i) => {
+        switch (element._type) {
+            case 'model.dotcomrendering.pageElements.BlockquoteBlockElement':
+                if (isHighlight(element)) {
+                    enhanced.push({
+                        _type: 'model.dotcomrendering.pageElements.HighlightBlockElement',
+                        html: element.html,
+                    });
+                } else {
+                    enhanced.push(element);
+                }
+                break;
+            default:
+                enhanced.push(element);
+        }
+    });
+    return enhanced;
+};
+
+export const addHighlights = (data: CAPIType): CAPIType => {
+    const enhancedBlocks = data.blocks.map((block: Block) => {
+        return {
+            ...block,
+            elements: checkForHighlights(block.elements),
+        };
+    });
+
+    return {
+        ...data,
+        blocks: enhancedBlocks,
+    } as CAPIType;
+};

--- a/src/model/add-highlights.ts
+++ b/src/model/add-highlights.ts
@@ -16,7 +16,7 @@ const checkForHighlights = (elements: CAPIElement[]): CAPIElement[] => {
     // is left as a BlockquoteBlockElement but if not then it is transformed
     // into a HighlightBlockElement
     const enhanced: CAPIElement[] = [];
-    elements.forEach((element, i) => {
+    elements.forEach(element => {
         switch (element._type) {
             case 'model.dotcomrendering.pageElements.BlockquoteBlockElement':
                 if (isHighlight(element)) {

--- a/src/model/add-highlights.ts
+++ b/src/model/add-highlights.ts
@@ -3,7 +3,6 @@ import { JSDOM } from 'jsdom';
 const isHighlight = (element: BlockquoteBlockElement): boolean => {
     // A highlight blockquote: <blockquote><p>Blah</p></blockquote>
     // A quoted blockquote: <blockquote class="quoted"><p>Blah</p></blockquote>
-    console.log(element.html)
     const frag = JSDOM.fragment(element.html);
     if (!frag) return false; // Not anything
     const isQuoted = !!frag.querySelector('.quoted');

--- a/src/web/server/render.ts
+++ b/src/web/server/render.ts
@@ -4,6 +4,7 @@ import { extract as extractNAV } from '@root/src/model/extract-nav';
 import { document } from '@root/src/web/server/document';
 import { validateAsCAPIType } from '@root/src/model/validate';
 import { addDropCaps } from '@root/src/model/add-dropcaps';
+import { addHighlights } from '@root/src/model/add-highlights';
 import { enhancePhotoEssay } from '@root/src/model/enhance-photoessay';
 import { extract as extractGA } from '@root/src/model/extract-ga';
 import { bodyJSON } from '@root/src/model/exampleBodyJSON';
@@ -11,7 +12,8 @@ import { bodyJSON } from '@root/src/model/exampleBodyJSON';
 export const render = ({ body }: express.Request, res: express.Response) => {
     try {
         const withDropCaps: CAPIType = addDropCaps(body);
-        const withEssayEnhancement: CAPIType = enhancePhotoEssay(withDropCaps);
+        const withHighlights: CAPIType = addHighlights(withDropCaps);
+        const withEssayEnhancement: CAPIType = enhancePhotoEssay(withHighlights);
         const CAPI: CAPIType = validateAsCAPIType(withEssayEnhancement);
 
         const resp = document({


### PR DESCRIPTION
## What does this change?
Replaces blockquotes with highlights when not quoted

https://www.theguardian.com/world/2020/feb/21/how-italy-blends-culture-with-cuisine-a-photo-essay

## Why?
Because there's a `quoted` class on the `blockquote` element as passed down from CAPI which denotes that the text is in fact a quote and we should show quote marks. When this class is missing the text should be styled differently, and for better semantics, placed into a new element, the `HighlightBlockElement`