### PR TITLE
Hide revenue links when logged in

### DIFF
--- a/src/web/components/ReaderRevenueLinks.test.tsx
+++ b/src/web/components/ReaderRevenueLinks.test.tsx
@@ -17,6 +17,9 @@ jest.mock('@frontend/web/browser/cookie', () => ({
 describe('ReaderRevenueLinks', () => {
     const contributionsCookie = 'gu.contributions.contrib-timestamp';
     const payingMemberCookie = 'gu_paying_member';
+    const digitalSubscriberCookie = 'gu_digital_subscriber';
+    const recentContributorCookie = 'gu.contributions.contrib-timestamp';
+
     const urls = {
         contribute: 'https://www.theguardian.com/contribute',
         subscribe: 'https://www.theguardian.com/subscribe',
@@ -49,8 +52,11 @@ describe('ReaderRevenueLinks', () => {
         // expect nothing to be rendered
         await wait(() => expect(container.firstChild).toBeNull());
 
-        expect(getCookie).toHaveBeenCalledTimes(2);
+        expect(getCookie).toHaveBeenCalledTimes(4);
         expect(getCookie).toHaveBeenCalledWith(contributionsCookie);
+        expect(getCookie).toHaveBeenCalledWith(digitalSubscriberCookie);
+        expect(getCookie).toHaveBeenCalledWith(payingMemberCookie);
+        expect(getCookie).toHaveBeenCalledWith(recentContributorCookie);
     });
 
     it('should not render correctly if paying member', async () => {
@@ -76,9 +82,11 @@ describe('ReaderRevenueLinks', () => {
         // expect nothing to be rendered
         await wait(() => expect(container.firstChild).toBeNull());
 
-        expect(getCookie).toHaveBeenCalledTimes(2);
+        expect(getCookie).toHaveBeenCalledTimes(4);
         expect(getCookie).toHaveBeenCalledWith(contributionsCookie);
         expect(getCookie).toHaveBeenCalledWith(payingMemberCookie);
+        expect(getCookie).toHaveBeenCalledWith(digitalSubscriberCookie);
+        expect(getCookie).toHaveBeenCalledWith(recentContributorCookie);
     });
 
     it('should render if neither paying member or recent contributor', async () => {
@@ -104,8 +112,10 @@ describe('ReaderRevenueLinks', () => {
         await wait(() => expect(container.firstChild).not.toBeNull());
 
         expect(getByText('Support The Guardian')).toBeInTheDocument();
-        expect(getCookie).toHaveBeenCalledTimes(2);
+        expect(getCookie).toHaveBeenCalledTimes(4);
         expect(getCookie).toHaveBeenCalledWith(contributionsCookie);
         expect(getCookie).toHaveBeenCalledWith(payingMemberCookie);
+        expect(getCookie).toHaveBeenCalledWith(digitalSubscriberCookie);
+        expect(getCookie).toHaveBeenCalledWith(recentContributorCookie);
     });
 });

--- a/src/web/components/ReaderRevenueLinks.tsx
+++ b/src/web/components/ReaderRevenueLinks.tsx
@@ -132,7 +132,15 @@ export const ReaderRevenueLinks: React.FC<Props> = ({
     dataLinkNamePrefix,
     inHeader,
 }) => {
+    const [isDigitalSubscriber, setIsDigitalSubscriber] = useState<boolean>(
+        false,
+    );
+    const [hideSupportMessage, setShouldHideSupportMessage] = useState<boolean>(
+        false,
+    );
+
     const [isPayingMember, setIsPayingMember] = useState<boolean>(false);
+
     const [isRecentContributor, setIsRecentContributor] = useState<boolean>(
         false,
     );
@@ -140,24 +148,65 @@ export const ReaderRevenueLinks: React.FC<Props> = ({
     useEffect(() => {
         // Is paying member?
         setIsPayingMember(getCookie('gu_paying_member') === 'true');
+
+        // Should the support messages be shown
+        setShouldHideSupportMessage(
+            getCookie('gu_hide_support_messaging') === 'true',
+        );
+
         // Is recent contributor?
         setIsRecentContributor(decideIfRecentContributor());
+
+        // Is digital subscriber?
+        setIsDigitalSubscriber(getCookie('gu_digital_subscriber') === 'true');
     }, []);
 
-    if (!isPayingMember && !isRecentContributor) {
-        return (
-            <div className={cx(inHeader && paddingStyles)}>
-                <div
-                    className={cx({
-                        [hiddenUntilTablet]: inHeader,
-                    })}
+    /*
+        Changed to OR statement as it's likely that at least one will will be false.
+        Default response is to show the banners
+    */
+    if (
+        isDigitalSubscriber ||
+        isPayingMember ||
+        isRecentContributor ||
+        hideSupportMessage
+    ) {
+        return null;
+    }
+    return (
+        <div className={cx(inHeader && paddingStyles)}>
+            <div
+                className={cx({
+                    [hiddenUntilTablet]: inHeader,
+                })}
+            >
+                <div className={messageStyles}>Support The&nbsp;Guardian</div>
+                <div className={subMessageStyles}>
+                    Available for everyone, funded by readers
+                </div>
+                <a
+                    className={linkStyles}
+                    href={urls.contribute}
+                    data-link-name={`${dataLinkNamePrefix}contribute-cta`}
                 >
-                    <div className={messageStyles}>
-                        Support The&nbsp;Guardian
-                    </div>
-                    <div className={subMessageStyles}>
-                        Available for everyone, funded by readers
-                    </div>
+                    Contribute <ArrowRightIcon />
+                </a>
+                <a
+                    className={linkStyles}
+                    href={urls.subscribe}
+                    data-link-name={`${dataLinkNamePrefix}subscribe-cta`}
+                >
+                    Subscribe <ArrowRightIcon />
+                </a>
+            </div>
+
+            <div
+                className={cx({
+                    [hiddenFromTablet]: inHeader,
+                    [hidden]: !inHeader,
+                })}
+            >
+                {edition === 'UK' ? (
                     <a
                         className={linkStyles}
                         href={urls.contribute}
@@ -165,41 +214,16 @@ export const ReaderRevenueLinks: React.FC<Props> = ({
                     >
                         Contribute <ArrowRightIcon />
                     </a>
+                ) : (
                     <a
                         className={linkStyles}
-                        href={urls.subscribe}
-                        data-link-name={`${dataLinkNamePrefix}subscribe-cta`}
+                        href={urls.support}
+                        data-link-name={`${dataLinkNamePrefix}support-cta`}
                     >
-                        Subscribe <ArrowRightIcon />
+                        Support us <ArrowRightIcon />
                     </a>
-                </div>
-
-                <div
-                    className={cx({
-                        [hiddenFromTablet]: inHeader,
-                        [hidden]: !inHeader,
-                    })}
-                >
-                    {edition === 'UK' ? (
-                        <a
-                            className={linkStyles}
-                            href={urls.contribute}
-                            data-link-name={`${dataLinkNamePrefix}contribute-cta`}
-                        >
-                            Contribute <ArrowRightIcon />
-                        </a>
-                    ) : (
-                        <a
-                            className={linkStyles}
-                            href={urls.support}
-                            data-link-name={`${dataLinkNamePrefix}support-cta`}
-                        >
-                            Support us <ArrowRightIcon />
-                        </a>
-                    )}
-                </div>
+                )}
             </div>
-        );
-    }
-    return null;
+        </div>
+    );
 };


### PR DESCRIPTION
## What does this change?

The reader revenue links are now hidden when the user is logged in and a:

 - Paying Member
 - Digital Subscriber
 - Recent contributor
 - Hide support message is true

This will need optimisation as the links appear for a few milliseconds and then are removed

### Before

![image](https://user-images.githubusercontent.com/35331926/85858294-4bfb2280-b7b3-11ea-87e2-db0849fb6178.png)

### After

![image](https://user-images.githubusercontent.com/35331926/85858436-8a90dd00-b7b3-11ea-8648-85aef2f98a58.png)


