### PR TITLE
Enables video embeds to use new field from frontend

### DIFF
--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -254,7 +254,7 @@ interface VideoFacebookBlockElement {
 
 interface VideoVimeoBlockElement {
     _type: 'model.dotcomrendering.pageElements.VideoVimeoBlockElement';
-    url: string;
+    embedUrl: string;
     height: number;
     width: number;
     caption?: string;
@@ -264,7 +264,7 @@ interface VideoVimeoBlockElement {
 
 interface VideoYoutubeBlockElement {
     _type: 'model.dotcomrendering.pageElements.VideoYoutubeBlockElement';
-    url: string;
+    embedUrl: string;
     height: number;
     width: number;
     caption?: string;

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -254,7 +254,7 @@ interface VideoFacebookBlockElement {
 
 interface VideoVimeoBlockElement {
     _type: 'model.dotcomrendering.pageElements.VideoVimeoBlockElement';
-    embedUrl: string;
+    embedUrl?: string;
     url: string;
     height: number;
     width: number;
@@ -265,7 +265,7 @@ interface VideoVimeoBlockElement {
 
 interface VideoYoutubeBlockElement {
     _type: 'model.dotcomrendering.pageElements.VideoYoutubeBlockElement';
-    embedUrl: string;
+    embedUrl?: string;
     url: string;
     height: number;
     width: number;

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -255,6 +255,7 @@ interface VideoFacebookBlockElement {
 interface VideoVimeoBlockElement {
     _type: 'model.dotcomrendering.pageElements.VideoVimeoBlockElement';
     embedUrl: string;
+    url: string;
     height: number;
     width: number;
     caption?: string;
@@ -265,6 +266,7 @@ interface VideoVimeoBlockElement {
 interface VideoYoutubeBlockElement {
     _type: 'model.dotcomrendering.pageElements.VideoYoutubeBlockElement';
     embedUrl: string;
+    url: string;
     height: number;
     width: number;
     caption?: string;

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -1574,7 +1574,6 @@
             },
             "required": [
                 "_type",
-                "embedUrl",
                 "height",
                 "url",
                 "width"
@@ -1613,7 +1612,6 @@
             },
             "required": [
                 "_type",
-                "embedUrl",
                 "height",
                 "url",
                 "width"

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -1553,6 +1553,9 @@
                 "embedUrl": {
                     "type": "string"
                 },
+                "url": {
+                    "type": "string"
+                },
                 "height": {
                     "type": "number"
                 },
@@ -1573,6 +1576,7 @@
                 "_type",
                 "embedUrl",
                 "height",
+                "url",
                 "width"
             ]
         },
@@ -1588,6 +1592,9 @@
                 "embedUrl": {
                     "type": "string"
                 },
+                "url": {
+                    "type": "string"
+                },
                 "height": {
                     "type": "number"
                 },
@@ -1608,6 +1615,7 @@
                 "_type",
                 "embedUrl",
                 "height",
+                "url",
                 "width"
             ]
         },

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -1550,7 +1550,7 @@
                         "model.dotcomrendering.pageElements.VideoVimeoBlockElement"
                     ]
                 },
-                "url": {
+                "embedUrl": {
                     "type": "string"
                 },
                 "height": {
@@ -1571,8 +1571,8 @@
             },
             "required": [
                 "_type",
+                "embedUrl",
                 "height",
-                "url",
                 "width"
             ]
         },
@@ -1585,7 +1585,7 @@
                         "model.dotcomrendering.pageElements.VideoYoutubeBlockElement"
                     ]
                 },
-                "url": {
+                "embedUrl": {
                     "type": "string"
                 },
                 "height": {
@@ -1606,8 +1606,8 @@
             },
             "required": [
                 "_type",
+                "embedUrl",
                 "height",
-                "url",
                 "width"
             ]
         },

--- a/src/web/components/elements/VimeoBlockComponent.stories.tsx
+++ b/src/web/components/elements/VimeoBlockComponent.stories.tsx
@@ -25,7 +25,7 @@ export const smallAspectRatio = () => {
         <Container>
             <p>abc</p>
             <VimeoBlockComponent
-                url="https://player.vimeo.com/video/327310297?app_id=122963"
+                embedUrl="https://player.vimeo.com/video/327310297?app_id=122963"
                 pillar="news"
                 height={250}
                 width={250}
@@ -46,7 +46,7 @@ export const largeAspectRatio = () => {
         <Container>
             <p>abc</p>
             <VimeoBlockComponent
-                url="https://player.vimeo.com/video/327310297?app_id=122963"
+                embedUrl="https://player.vimeo.com/video/327310297?app_id=122963"
                 pillar="news"
                 height={259}
                 width={460}
@@ -67,7 +67,7 @@ export const verticalAspectRatio = () => {
         <Container>
             <p>abc</p>
             <VimeoBlockComponent
-                url="https://player.vimeo.com/video/265111898?app_id=122963"
+                embedUrl="https://player.vimeo.com/video/265111898?app_id=122963"
                 pillar="news"
                 height={818}
                 width={460}

--- a/src/web/components/elements/VimeoBlockComponent.tsx
+++ b/src/web/components/elements/VimeoBlockComponent.tsx
@@ -17,7 +17,7 @@ const responsiveAspectRatio = (height: number, width: number) => css`
 `;
 export const VimeoBlockComponent: React.FC<{
     pillar: Pillar;
-    embedUrl: string;
+    embedUrl?: string;
     height: number;
     width: number;
     caption?: string;

--- a/src/web/components/elements/VimeoBlockComponent.tsx
+++ b/src/web/components/elements/VimeoBlockComponent.tsx
@@ -17,7 +17,7 @@ const responsiveAspectRatio = (height: number, width: number) => css`
 `;
 export const VimeoBlockComponent: React.FC<{
     pillar: Pillar;
-    url: string;
+    embedUrl: string;
     height: number;
     width: number;
     caption?: string;
@@ -26,7 +26,7 @@ export const VimeoBlockComponent: React.FC<{
     display: Display;
     designType: DesignType;
 }> = ({
-    url,
+    embedUrl,
     caption,
     title,
     pillar,
@@ -54,7 +54,7 @@ export const VimeoBlockComponent: React.FC<{
         >
             <div className={responsiveAspectRatio(height, width)}>
                 <iframe
-                    src={url}
+                    src={embedUrl}
                     title={title}
                     height={height}
                     width={width}

--- a/src/web/components/elements/YoutubeEmbedBlockComponent.stories.tsx
+++ b/src/web/components/elements/YoutubeEmbedBlockComponent.stories.tsx
@@ -25,7 +25,7 @@ export const standardAspectRatio = () => {
         <Container>
             <p>abc</p>
             <YoutubeEmbedBlockComponent
-                url="https://www.youtube-nocookie.com/embed/79fzeNUqQbQ?wmode=opaque&feature=oembed"
+                embedUrl="https://www.youtube-nocookie.com/embed/79fzeNUqQbQ?wmode=opaque&feature=oembed"
                 pillar="news"
                 height={259}
                 width={460}

--- a/src/web/components/elements/YoutubeEmbedBlockComponent.tsx
+++ b/src/web/components/elements/YoutubeEmbedBlockComponent.tsx
@@ -7,7 +7,7 @@ import { Display } from '@root/src/lib/display';
 
 export const YoutubeEmbedBlockComponent: React.FC<{
     pillar: Pillar;
-    embedUrl: string;
+    embedUrl?: string;
     height: number;
     width: number;
     caption?: string;

--- a/src/web/components/elements/YoutubeEmbedBlockComponent.tsx
+++ b/src/web/components/elements/YoutubeEmbedBlockComponent.tsx
@@ -7,7 +7,7 @@ import { Display } from '@root/src/lib/display';
 
 export const YoutubeEmbedBlockComponent: React.FC<{
     pillar: Pillar;
-    url: string;
+    embedUrl: string;
     height: number;
     width: number;
     caption?: string;
@@ -16,7 +16,7 @@ export const YoutubeEmbedBlockComponent: React.FC<{
     display: Display;
     designType: DesignType;
 }> = ({
-    url,
+    embedUrl,
     caption,
     title,
     pillar,
@@ -44,7 +44,7 @@ export const YoutubeEmbedBlockComponent: React.FC<{
         >
             <MaintainAspectRatio height={height} width={width}>
                 <iframe
-                    src={url}
+                    src={embedUrl}
                     title={title}
                     height={height}
                     width={width}

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -157,7 +157,7 @@ export const ArticleRenderer: React.FC<{
                     return (
                         <VimeoBlockComponent
                             pillar={pillar}
-                            url={element.url}
+                            embedUrl={element.embedUrl}
                             height={element.height}
                             width={element.width}
                             caption={element.caption}
@@ -171,7 +171,7 @@ export const ArticleRenderer: React.FC<{
                     return (
                         <YoutubeEmbedBlockComponent
                             pillar={pillar}
-                            url={element.url}
+                            embedUrl={element.embedUrl}
                             height={element.height}
                             width={element.width}
                             caption={element.caption}
@@ -217,7 +217,7 @@ export const ArticleRenderer: React.FC<{
                     return null;
             }
         })
-        .filter((_) => _ != null);
+        .filter(_ => _ != null);
 
     return (
         <div


### PR DESCRIPTION
## What does this change?
Youtube and Vimeo will be able to use the new field from frontend in order to create the iframes for the components.

Depends on https://github.com/guardian/frontend/pull/22740