### PR TITLE
Using contributions library for revenue link logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,4 +134,4 @@ We recommend you update your workspace settings to automatically fix formatting 
 
 <a href="https://www.chromaticqa.com/"><img src="https://cdn-images-1.medium.com/letterbox/147/36/50/50/1*oHHjTjInDOBxIuYHDY2gFA.png?source=logoAvatar-d7276495b101---37816ec27d7a" width="120"/></a>
 
-Thanks to [Chromatic](https://www.chromaticqa.com/) for providing the visual testing platform that helps us catch unexpected changes on time.
+Thanks to [Chromatic](https://www.chromaticqa.com/) for providing the visual testing platform that helps us catch unexpected changes on time

--- a/scripts/git-hooks/post-merge
+++ b/scripts/git-hooks/post-merge
@@ -4,9 +4,11 @@ const execa = require('execa');
 const chalk = require('chalk');
 const fs = require('fs');
 
-execa
-    .shell('git diff-tree -r --name-only --no-commit-id HEAD@{1} HEAD')
-    .then(result => {
+// execa
+execa('git diff-tree -r --name-only --no-commit-id HEAD@{1} HEAD', {
+    shell: true,
+})
+    .then((result) => {
         const changedFiles = result.stdout.split('\n');
 
         if (changedFiles.includes('.nvmrc')) {
@@ -14,14 +16,14 @@ execa
 
             console.log(
                 `${chalk.red(
-                    `This application now requires Node v${nvmrcVersion}. Switch to the latest version using \`nvm install\` or download from nodejs.org. Then run \`make reinstall\`.`
-                )}`
+                    `This application now requires Node v${nvmrcVersion}. Switch to the latest version using \`nvm install\` or download from nodejs.org. Then run \`make reinstall\`.`,
+                )}`,
             );
         } else if (changedFiles.includes('yarn.lock')) {
             console.log(
                 `${chalk.red(
-                    'This application has new dependencies. Running `make install`...'
-                )}`
+                    'This application has new dependencies. Running `make install`...',
+                )}`,
             );
 
             return execa('make', ['install'], {
@@ -31,7 +33,7 @@ execa
 
         return Promise.resolve();
     })
-    .catch(e => {
+    .catch((e) => {
         console.log(`\n${e}\n`);
         process.exit(1);
     });

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -261,6 +261,7 @@ interface VideoFacebookBlockElement {
     height: number;
     width: number;
     caption: string;
+    embedUrl?: string;
 }
 
 interface VideoVimeoBlockElement {

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -39,6 +39,23 @@ interface CaptionBlockElement {
     shouldLimitWidth?: boolean;
     isOverlayed?: boolean;
 }
+
+interface CalloutBlockElement {
+    _type: 'model.dotcomrendering.pageElements.CalloutBlockElement';
+    id: string;
+    activeFrom: number;
+    displayOnSensitive: boolean;
+    formId: number;
+    title: string;
+    description: string;
+    tagName: string;
+    formFields: CampaignFieldType[];
+}
+
+interface CalloutBlockElementXp {
+    _type: 'model.dotcomrendering.pageElements.CalloutBlockElementXp';
+}
+
 interface ChartAtomBlockElement extends InteractiveAtomBlockElementBase {
     _type: 'model.dotcomrendering.pageElements.ChartAtomBlockElement';
 }
@@ -280,23 +297,13 @@ interface YoutubeBlockElement {
     width?: string;
 }
 
-interface CalloutBlockElement {
-    _type: 'model.dotcomrendering.pageElements.CalloutBlockElement';
-    id: string;
-    activeFrom: number;
-    displayOnSensitive: boolean;
-    formId: number;
-    title: string;
-    description: string;
-    tagName: string;
-    formFields: CampaignFieldType[];
-}
-
 type CAPIElement =
     | AudioAtomElement
     | AudioBlockElement
     | BlockquoteBlockElement
     | CaptionBlockElement
+    | CalloutBlockElement
+    | CalloutBlockElementXp
     | ChartAtomBlockElement
     | CodeBlockElement
     | CommentBlockElement

--- a/src/model/add-highlights.test.ts
+++ b/src/model/add-highlights.test.ts
@@ -1,0 +1,157 @@
+import { addHighlights } from './add-highlights';
+import { bodyJSON } from './exampleBodyJSON';
+
+const example = JSON.parse(bodyJSON);
+
+describe('Drop Caps', () => {
+    it('creates an identical but new object when no changes are needed', () => {
+        expect(addHighlights(example)).not.toBe(example); // We created a new object
+        expect(addHighlights(example)).toEqual(example); // The new object is what we expect
+    });
+
+    it('creates highlight elements as expected', () => {
+        const input = {
+            ...example,
+            blocks: [
+                {
+                    elements: [
+                        {
+                            _type:
+                                'model.dotcomrendering.pageElements.BlockquoteBlockElement',
+                            html: '<blockquote>This is not a quote</blockquote>',
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const expectedOutput = {
+            ...example,
+            blocks: [
+                {
+                    elements: [
+                        {
+                            _type:
+                                'model.dotcomrendering.pageElements.HighlightBlockElement',
+                            html: '<blockquote>This is not a quote</blockquote>',
+                        },
+                    ],
+                },
+            ],
+        };
+
+        expect(addHighlights(input)).toEqual(expectedOutput);
+    });
+
+    it('creates passes through quotes as expected', () => {
+        const input = {
+            ...example,
+            blocks: [
+                {
+                    elements: [
+                        {
+                            _type:
+                                'model.dotcomrendering.pageElements.BlockquoteBlockElement',
+                            html: '<blockquote class="quoted">This is a quote</blockquote>',
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const expectedOutput = {
+            ...example,
+            blocks: [
+                {
+                    elements: [
+                        {
+                            _type:
+                                'model.dotcomrendering.pageElements.BlockquoteBlockElement',
+                            html: '<blockquote class="quoted">This is a quote</blockquote>',
+                        },
+                    ],
+                },
+            ],
+        };
+
+        expect(addHighlights(input)).toEqual(expectedOutput);
+    });
+
+    it('ignores blockquotes with other classnames, still creating highlight elements', () => {
+        const input = {
+            ...example,
+            blocks: [
+                {
+                    elements: [
+                        {
+                            _type:
+                                'model.dotcomrendering.pageElements.BlockquoteBlockElement',
+                            html: '<blockquote class="somethingelse">This is not a quote</blockquote>',
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const expectedOutput = {
+            ...example,
+            blocks: [
+                {
+                    elements: [
+                        {
+                            _type:
+                                'model.dotcomrendering.pageElements.HighlightBlockElement',
+                            html: '<blockquote class="somethingelse">This is not a quote</blockquote>',
+                        },
+                    ],
+                },
+            ],
+        };
+
+        expect(addHighlights(input)).toEqual(expectedOutput);
+    });
+
+    it('handles both highlights and blockquotes in the same array', () => {
+        const input = {
+            ...example,
+            blocks: [
+                {
+                    elements: [
+                        {
+                            _type:
+                                'model.dotcomrendering.pageElements.BlockquoteBlockElement',
+                            html: '<blockquote class="quoted">This is a quote</blockquote>',
+                        },
+                        {
+                            _type:
+                                'model.dotcomrendering.pageElements.BlockquoteBlockElement',
+                            html: '<blockquote>This is not a quote</blockquote>',
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const expectedOutput = {
+            ...example,
+            blocks: [
+                {
+                    elements: [
+                        {
+                            _type:
+                                'model.dotcomrendering.pageElements.BlockquoteBlockElement',
+                            html: '<blockquote class="quoted">This is a quote</blockquote>',
+                        },
+                        {
+                            _type:
+                                'model.dotcomrendering.pageElements.HighlightBlockElement',
+                            html: '<blockquote>This is not a quote</blockquote>',
+                        },
+                    ],
+                },
+            ],
+        };
+
+        expect(addHighlights(input)).toEqual(expectedOutput);
+    });
+});

--- a/src/model/add-highlights.ts
+++ b/src/model/add-highlights.ts
@@ -1,0 +1,50 @@
+import { JSDOM } from 'jsdom';
+
+const isHighlight = (element: BlockquoteBlockElement): boolean => {
+    // A highlight blockquote: <blockquote><p>Blah</p></blockquote>
+    // A quoted blockquote: <blockquote class="quoted"><p>Blah</p></blockquote>
+    const frag = JSDOM.fragment(element.html);
+    if (!frag) return false; // Not anything
+    const isQuoted = !!frag.querySelector('.quoted');
+    if (isQuoted) return false; // This blockquote is a quote
+    return true; // This blockquote is not a quote, so it's a highlight
+};
+
+const checkForHighlights = (elements: CAPIElement[]): CAPIElement[] => {
+    // checkForHighlights loops the array of article elements looking for
+    // BlockquoteBlockElements. If the element has the class "quoted" it
+    // is left as a BlockquoteBlockElement but if not then it is transformed
+    // into a HighlightBlockElement
+    const enhanced: CAPIElement[] = [];
+    elements.forEach(element => {
+        switch (element._type) {
+            case 'model.dotcomrendering.pageElements.BlockquoteBlockElement':
+                if (isHighlight(element)) {
+                    enhanced.push({
+                        _type: 'model.dotcomrendering.pageElements.HighlightBlockElement',
+                        html: element.html,
+                    });
+                } else {
+                    enhanced.push(element);
+                }
+                break;
+            default:
+                enhanced.push(element);
+        }
+    });
+    return enhanced;
+};
+
+export const addHighlights = (data: CAPIType): CAPIType => {
+    const enhancedBlocks = data.blocks.map((block: Block) => {
+        return {
+            ...block,
+            elements: checkForHighlights(block.elements),
+        };
+    });
+
+    return {
+        ...data,
+        blocks: enhancedBlocks,
+    } as CAPIType;
+};

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -27,6 +27,12 @@
                         "$ref": "#/definitions/CaptionBlockElement"
                     },
                     {
+                        "$ref": "#/definitions/CalloutBlockElement"
+                    },
+                    {
+                        "$ref": "#/definitions/CalloutBlockElementXp"
+                    },
+                    {
                         "$ref": "#/definitions/ChartAtomBlockElement"
                     },
                     {
@@ -521,6 +527,385 @@
                 "sport"
             ],
             "type": "string"
+        },
+        "CalloutBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.CalloutBlockElement"
+                    ]
+                },
+                "id": {
+                    "type": "string"
+                },
+                "activeFrom": {
+                    "type": "number"
+                },
+                "displayOnSensitive": {
+                    "type": "boolean"
+                },
+                "formId": {
+                    "type": "number"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "tagName": {
+                    "type": "string"
+                },
+                "formFields": {
+                    "type": "array",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/CampaignFieldText"
+                            },
+                            {
+                                "$ref": "#/definitions/CampaignFieldTextArea"
+                            },
+                            {
+                                "$ref": "#/definitions/CampaignFieldFile"
+                            },
+                            {
+                                "$ref": "#/definitions/CampaignFieldRadio"
+                            },
+                            {
+                                "$ref": "#/definitions/CampaignFieldCheckbox"
+                            },
+                            {
+                                "$ref": "#/definitions/CampaignFieldSelect"
+                            }
+                        ]
+                    }
+                }
+            },
+            "required": [
+                "_type",
+                "activeFrom",
+                "description",
+                "displayOnSensitive",
+                "formFields",
+                "formId",
+                "id",
+                "tagName",
+                "title"
+            ]
+        },
+        "CampaignFieldText": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "textarea"
+                    ]
+                },
+                "id": {
+                    "type": "number"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean"
+                },
+                "textSize": {
+                    "type": "number"
+                },
+                "hideLabel": {
+                    "type": "boolean"
+                },
+                "label": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "hideLabel",
+                "id",
+                "label",
+                "name",
+                "required",
+                "type"
+            ]
+        },
+        "CampaignFieldTextArea": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "text"
+                    ]
+                },
+                "id": {
+                    "type": "number"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean"
+                },
+                "textSize": {
+                    "type": "number"
+                },
+                "hideLabel": {
+                    "type": "boolean"
+                },
+                "label": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "hideLabel",
+                "id",
+                "label",
+                "name",
+                "required",
+                "type"
+            ]
+        },
+        "CampaignFieldFile": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "file"
+                    ]
+                },
+                "id": {
+                    "type": "number"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean"
+                },
+                "textSize": {
+                    "type": "number"
+                },
+                "hideLabel": {
+                    "type": "boolean"
+                },
+                "label": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "hideLabel",
+                "id",
+                "label",
+                "name",
+                "required",
+                "type"
+            ]
+        },
+        "CampaignFieldRadio": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "radio"
+                    ]
+                },
+                "options": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "label": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "label",
+                            "value"
+                        ]
+                    }
+                },
+                "id": {
+                    "type": "number"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean"
+                },
+                "textSize": {
+                    "type": "number"
+                },
+                "hideLabel": {
+                    "type": "boolean"
+                },
+                "label": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "hideLabel",
+                "id",
+                "label",
+                "name",
+                "options",
+                "required",
+                "type"
+            ]
+        },
+        "CampaignFieldCheckbox": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "checkbox"
+                    ]
+                },
+                "options": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "label": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "label",
+                            "value"
+                        ]
+                    }
+                },
+                "id": {
+                    "type": "number"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean"
+                },
+                "textSize": {
+                    "type": "number"
+                },
+                "hideLabel": {
+                    "type": "boolean"
+                },
+                "label": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "hideLabel",
+                "id",
+                "label",
+                "name",
+                "options",
+                "required",
+                "type"
+            ]
+        },
+        "CampaignFieldSelect": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "select"
+                    ]
+                },
+                "options": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "label": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "label",
+                            "value"
+                        ]
+                    }
+                },
+                "id": {
+                    "type": "number"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean"
+                },
+                "textSize": {
+                    "type": "number"
+                },
+                "hideLabel": {
+                    "type": "boolean"
+                },
+                "label": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "hideLabel",
+                "id",
+                "label",
+                "name",
+                "options",
+                "required",
+                "type"
+            ]
+        },
+        "CalloutBlockElementXp": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.CalloutBlockElementXp"
+                    ]
+                }
+            },
+            "required": [
+                "_type"
+            ]
         },
         "ChartAtomBlockElement": {
             "type": "object",
@@ -1612,6 +1997,12 @@
                             },
                             {
                                 "$ref": "#/definitions/CaptionBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/CalloutBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/CalloutBlockElementXp"
                             },
                             {
                                 "$ref": "#/definitions/ChartAtomBlockElement"

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -1850,6 +1850,9 @@
                 },
                 "caption": {
                     "type": "string"
+                },
+                "embedUrl": {
+                    "type": "string"
                 }
             },
             "required": [

--- a/src/web/components/ReaderRevenueLinks.test.tsx
+++ b/src/web/components/ReaderRevenueLinks.test.tsx
@@ -17,8 +17,6 @@ jest.mock('@frontend/web/browser/cookie', () => ({
 describe('ReaderRevenueLinks', () => {
     const contributionsCookie = 'gu.contributions.contrib-timestamp';
     const payingMemberCookie = 'gu_paying_member';
-    const digitalSubscriberCookie = 'gu_digital_subscriber';
-    const recentContributorCookie = 'gu.contributions.contrib-timestamp';
 
     const urls = {
         contribute: 'https://www.theguardian.com/contribute',
@@ -50,13 +48,7 @@ describe('ReaderRevenueLinks', () => {
         );
 
         // expect nothing to be rendered
-        await wait(() => expect(container.firstChild).toBeNull());
-
-        expect(getCookie).toHaveBeenCalledTimes(4);
-        expect(getCookie).toHaveBeenCalledWith(contributionsCookie);
-        expect(getCookie).toHaveBeenCalledWith(digitalSubscriberCookie);
-        expect(getCookie).toHaveBeenCalledWith(payingMemberCookie);
-        expect(getCookie).toHaveBeenCalledWith(recentContributorCookie);
+        await wait(() => expect(container.firstChild).toBeTruthy());
     });
 
     it('should not render correctly if paying member', async () => {
@@ -80,13 +72,7 @@ describe('ReaderRevenueLinks', () => {
         );
 
         // expect nothing to be rendered
-        await wait(() => expect(container.firstChild).toBeNull());
-
-        expect(getCookie).toHaveBeenCalledTimes(4);
-        expect(getCookie).toHaveBeenCalledWith(contributionsCookie);
-        expect(getCookie).toHaveBeenCalledWith(payingMemberCookie);
-        expect(getCookie).toHaveBeenCalledWith(digitalSubscriberCookie);
-        expect(getCookie).toHaveBeenCalledWith(recentContributorCookie);
+        await wait(() => expect(container.firstChild).toBeTruthy());
     });
 
     it('should render if neither paying member or recent contributor', async () => {
@@ -112,10 +98,5 @@ describe('ReaderRevenueLinks', () => {
         await wait(() => expect(container.firstChild).not.toBeNull());
 
         expect(getByText('Support The Guardian')).toBeInTheDocument();
-        expect(getCookie).toHaveBeenCalledTimes(4);
-        expect(getCookie).toHaveBeenCalledWith(contributionsCookie);
-        expect(getCookie).toHaveBeenCalledWith(payingMemberCookie);
-        expect(getCookie).toHaveBeenCalledWith(digitalSubscriberCookie);
-        expect(getCookie).toHaveBeenCalledWith(recentContributorCookie);
     });
 });

--- a/src/web/components/ReaderRevenueLinks.test.tsx
+++ b/src/web/components/ReaderRevenueLinks.test.tsx
@@ -1,23 +1,15 @@
 import React from 'react';
 import { render, wait } from '@testing-library/react';
-import {
-    getCookie as getCookie_,
-    addCookie as addCookie_,
-} from '@root/src/web/browser/cookie';
+import { shouldHideSupportMessaging as shouldHideSupportMessaging_ } from '@root/src/web/lib/contributions';
 import { ReaderRevenueLinks } from './ReaderRevenueLinks';
 
-const getCookie: any = getCookie_;
-const addCookie: any = addCookie_;
+const shouldHideSupportMessaging: any = shouldHideSupportMessaging_;
 
-jest.mock('@frontend/web/browser/cookie', () => ({
-    getCookie: jest.fn(() => null),
-    addCookie: jest.fn(() => null),
+jest.mock('@root/src/web/lib/contributions', () => ({
+    shouldHideSupportMessaging: jest.fn(() => true),
 }));
 
 describe('ReaderRevenueLinks', () => {
-    const contributionsCookie = 'gu.contributions.contrib-timestamp';
-    const payingMemberCookie = 'gu_paying_member';
-
     const urls = {
         contribute: 'https://www.theguardian.com/contribute',
         subscribe: 'https://www.theguardian.com/subscribe',
@@ -25,18 +17,8 @@ describe('ReaderRevenueLinks', () => {
     };
     const edition: Edition = 'UK';
 
-    beforeEach(() => {
-        addCookie.mockReset();
-        getCookie.mockReset();
-    });
-
-    it('should not render if recent contributor', async () => {
-        const contributionDate = new Date();
-
-        // set a contribution date of 1 week ago
-        contributionDate.setDate(contributionDate.getDate() - 7);
-
-        getCookie.mockReturnValue(contributionDate);
+    it('should not render if shouldHideSupportMessaging() returns true', async () => {
+        shouldHideSupportMessaging.mockReturnValue(true);
 
         const { container } = render(
             <ReaderRevenueLinks
@@ -48,19 +30,11 @@ describe('ReaderRevenueLinks', () => {
         );
 
         // expect nothing to be rendered
-        await wait(() => expect(container.firstChild).toBeTruthy());
+        await wait(() => expect(container.firstChild).toBeNull());
     });
 
-    it('should not render correctly if paying member', async () => {
-        const contributionDate = new Date();
-
-        // set a contribution date of 1 year ago
-        contributionDate.setDate(contributionDate.getDate() - 365);
-
-        getCookie.mockImplementation((name: string) => {
-            if (name === contributionsCookie) return contributionDate;
-            if (name === payingMemberCookie) return 'true';
-        });
+    it('should render if shouldHideSupportMessaging() returns false', async () => {
+        shouldHideSupportMessaging.mockReturnValue(false);
 
         const { container } = render(
             <ReaderRevenueLinks
@@ -71,32 +45,7 @@ describe('ReaderRevenueLinks', () => {
             />,
         );
 
-        // expect nothing to be rendered
-        await wait(() => expect(container.firstChild).toBeTruthy());
-    });
-
-    it('should render if neither paying member or recent contributor', async () => {
-        const contributionDate = new Date();
-
-        // set a contribution date of 1 year ago
-        contributionDate.setDate(contributionDate.getDate() - 365);
-
-        getCookie
-            .mockReturnValueOnce(contributionDate)
-            .mockReturnValueOnce('false');
-
-        const { container, getByText } = render(
-            <ReaderRevenueLinks
-                urls={urls}
-                edition={edition}
-                dataLinkNamePrefix="nav2 : "
-                inHeader={true}
-            />,
-        );
-
-        // expect something to be rendered
+        // expect links to be rendered
         await wait(() => expect(container.firstChild).not.toBeNull());
-
-        expect(getByText('Support The Guardian')).toBeInTheDocument();
     });
 });

--- a/src/web/components/ReaderRevenueLinks.tsx
+++ b/src/web/components/ReaderRevenueLinks.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { css, cx } from 'emotion';
 
 import ArrowRightIcon from '@frontend/static/icons/arrow-right.svg';
@@ -10,7 +10,7 @@ import {
 import { textSans, headline } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
 
-import { getCookie } from '@root/src/web/browser/cookie';
+import { shouldHideSupportMessaging } from '@root/src/web/lib/contributions';
 
 type Props = {
     edition: Edition;
@@ -112,65 +112,16 @@ const subMessageStyles = css`
     margin-bottom: 5px;
 `;
 
-const decideIfRecentContributor: () => boolean = () => {
-    const cookieValue = getCookie('gu.contributions.contrib-timestamp');
-
-    if (!cookieValue) {
-        return false;
-    }
-
-    const now = new Date().getTime();
-    const lastContribution = new Date(cookieValue).getTime();
-    const diffDays = Math.ceil((now - lastContribution) / (1000 * 3600 * 24));
-
-    return diffDays <= 180;
-};
-
 export const ReaderRevenueLinks: React.FC<Props> = ({
     edition,
     urls,
     dataLinkNamePrefix,
     inHeader,
 }) => {
-    const [isDigitalSubscriber, setIsDigitalSubscriber] = useState<boolean>(
-        false,
-    );
-    const [hideSupportMessage, setShouldHideSupportMessage] = useState<boolean>(
-        false,
-    );
-
-    const [isPayingMember, setIsPayingMember] = useState<boolean>(false);
-
-    const [isRecentContributor, setIsRecentContributor] = useState<boolean>(
-        false,
-    );
-
-    useEffect(() => {
-        // Is paying member?
-        setIsPayingMember(getCookie('gu_paying_member') === 'true');
-
-        // Should the support messages be shown
-        setShouldHideSupportMessage(
-            getCookie('gu_hide_support_messaging') === 'true',
-        );
-
-        // Is recent contributor?
-        setIsRecentContributor(decideIfRecentContributor());
-
-        // Is digital subscriber?
-        setIsDigitalSubscriber(getCookie('gu_digital_subscriber') === 'true');
-    }, []);
-
     /*
-        Changed to OR statement as it's likely that at least one will will be false.
-        Default response is to show the banners
+        Updated to now use Reader Revenue shouldHideSupportMessaging()
     */
-    if (
-        isDigitalSubscriber ||
-        isPayingMember ||
-        isRecentContributor ||
-        hideSupportMessage
-    ) {
+    if (shouldHideSupportMessaging()) {
         return null;
     }
     return (

--- a/src/web/components/StickyBottomBanner/CMP.tsx
+++ b/src/web/components/StickyBottomBanner/CMP.tsx
@@ -1,11 +1,30 @@
 import React, { useState, useEffect, Suspense } from 'react';
 import { ConsentManagementPlatform } from '@guardian/consent-management-platform/dist/ConsentManagementPlatform';
 import {
-    shouldShow as shouldShow_,
+    init as initCCPA,
+    shouldShow,
     setErrorHandler,
+    checkWillShowUi as checkWillShowCCPAUi,
 } from '@guardian/consent-management-platform';
+import { ccpaApplies } from '@root/src/web/lib/ccpaApplies';
 
-export const shouldShow = shouldShow_;
+// this is the wrong place to be doing this, but it's temporary
+// until we remove the old react CMP component and go 100% sourcepoint
+export const willShowNewCMP = async () => {
+    const useCCPA = await ccpaApplies();
+
+    if (useCCPA) {
+        initCCPA({
+            useCcpa: true,
+        });
+        return checkWillShowCCPAUi();
+    }
+
+    return false;
+};
+
+export const shouldShowOldCMP = async () =>
+    (await ccpaApplies()) ? false : shouldShow();
 
 export const CMP = () => {
     const [show, setShow] = useState(false);

--- a/src/web/components/elements/VideoFacebookBlockComponent.stories.tsx
+++ b/src/web/components/elements/VideoFacebookBlockComponent.stories.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { Display } from '@root/src/lib/display';
+import { VideoFacebookBlockComponent } from './VideoFacebookBlockComponent';
+
+export default {
+    component: VideoFacebookBlockComponent,
+    title: 'Components/VideoFacebookComponent',
+};
+
+const Container = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
+    <div
+        className={css`
+            max-width: 620px;
+            padding: 20px;
+        `}
+    >
+        {children}
+    </div>
+);
+
+export const largeAspectRatio = () => {
+    return (
+        <Container>
+            <p>abc</p>
+            <VideoFacebookBlockComponent
+                embedUrl="https://www.facebook.com/video/embed?video_id=10155703704626323\"
+                pillar="news"
+                height={281}
+                width={500}
+                caption="blah"
+                credit=""
+                title=""
+                display={Display.Standard}
+                designType="Article"
+            />
+            <p>abc</p>
+        </Container>
+    );
+};
+largeAspectRatio.story = { name: 'with large aspect ratio' };
+
+export const verticalAspectRatio = () => {
+    return (
+        <Container>
+            <p>abc</p>
+            <VideoFacebookBlockComponent
+                embedUrl="https://www.facebook.com/video/embed?video_id=10155591097456323\"
+                pillar="news"
+                height={889}
+                width={500}
+                caption="blah"
+                credit=""
+                title=""
+                display={Display.Standard}
+                designType="Article"
+            />
+            <p>abc</p>
+        </Container>
+    );
+};
+verticalAspectRatio.story = { name: 'with vertical aspect ratio' };

--- a/src/web/components/elements/VideoFacebookBlockComponent.tsx
+++ b/src/web/components/elements/VideoFacebookBlockComponent.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { Caption } from '@root/src/web/components/Caption';
+import { MaintainAspectRatio } from '@frontend/web/components/MaintainAspectRatio';
+import { Display } from '@root/src/lib/display';
+
+export const VideoFacebookBlockComponent: React.FC<{
+    pillar: Pillar;
+    embedUrl?: string;
+    height: number;
+    width: number;
+    caption?: string;
+    credit?: string;
+    title?: string;
+    display: Display;
+    designType: DesignType;
+}> = ({
+    embedUrl,
+    caption,
+    title,
+    pillar,
+    width,
+    height,
+    display,
+    designType,
+    credit,
+}) => {
+    // 812 is the full height on an iphone X. This ensures that the embed doesn't display any larger than the available viewport
+    // Constrain iframe embeds with a width to their natural width
+    // rather than stretch them to the container using
+    // a max that would prevent portrait videos from being taller than an iphone X (baseline)
+    // More context: https://github.com/guardian/frontend/pull/17902
+    const maxHeight = 812;
+    const aspectRatio = width / height;
+    const maxWidth = maxHeight * aspectRatio;
+
+    return (
+        <div
+            className={css`
+                max-width: ${maxWidth}px;
+                width: 100%;
+            `}
+        >
+            <MaintainAspectRatio height={height} width={width}>
+                <iframe
+                    src={embedUrl}
+                    title={title}
+                    height={height}
+                    width={width}
+                    allowFullScreen={true}
+                />
+            </MaintainAspectRatio>
+            {caption && (
+                <Caption
+                    captionText={caption}
+                    designType={designType}
+                    pillar={pillar}
+                    display={display}
+                    credit={credit}
+                />
+            )}
+        </div>
+    );
+};

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -15,6 +15,7 @@ import { SubheadingBlockComponent } from '@root/src/web/components/elements/Subh
 import { TableBlockComponent } from '@root/src/web/components/elements/TableBlockComponent';
 import { TextBlockComponent } from '@root/src/web/components/elements/TextBlockComponent';
 import { TweetBlockComponent } from '@root/src/web/components/elements/TweetBlockComponent';
+import { VideoFacebookBlockComponent } from '@root/src/web/components/elements/VideoFacebookBlockComponent';
 import { VimeoBlockComponent } from '@root/src/web/components/elements/VimeoBlockComponent';
 import { YoutubeEmbedBlockComponent } from '@root/src/web/components/elements/YoutubeEmbedBlockComponent';
 import { YoutubeBlockComponent } from '@root/src/web/components/elements/YoutubeBlockComponent';
@@ -153,6 +154,20 @@ export const ArticleRenderer: React.FC<{
                     );
                 case 'model.dotcomrendering.pageElements.TweetBlockElement':
                     return <TweetBlockComponent key={i} element={element} />;
+                case 'model.dotcomrendering.pageElements.VideoFacebookBlockElement':
+                    return (
+                        <VideoFacebookBlockComponent
+                            pillar={pillar}
+                            embedUrl={element.embedUrl}
+                            height={element.height}
+                            width={element.width}
+                            caption={element.caption}
+                            display={display}
+                            designType={designType}
+                            credit={element.caption}
+                            title={element.caption}
+                        />
+                    );
                 case 'model.dotcomrendering.pageElements.VideoVimeoBlockElement':
                     return (
                         <VimeoBlockComponent
@@ -215,11 +230,10 @@ export const ArticleRenderer: React.FC<{
                 case 'model.dotcomrendering.pageElements.QABlockElement':
                 case 'model.dotcomrendering.pageElements.TimelineBlockElement':
                 case 'model.dotcomrendering.pageElements.VideoBlockElement':
-                case 'model.dotcomrendering.pageElements.VideoFacebookBlockElement':
                     return null;
             }
         })
-        .filter(_ => _ != null);
+        .filter((_) => _ != null);
 
     return (
         <div

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -199,6 +199,8 @@ export const ArticleRenderer: React.FC<{
 
                 case 'model.dotcomrendering.pageElements.AudioBlockElement':
                 case 'model.dotcomrendering.pageElements.AudioAtomBlockElement':
+                case 'model.dotcomrendering.pageElements.CalloutBlockElement':
+                case 'model.dotcomrendering.pageElements.CalloutBlockElementXp':
                 case 'model.dotcomrendering.pageElements.CodeBlockElement':
                 case 'model.dotcomrendering.pageElements.CommentBlockElement':
                 case 'model.dotcomrendering.pageElements.ContentAtomBlockElement':

--- a/src/web/lib/ccpaApplies.ts
+++ b/src/web/lib/ccpaApplies.ts
@@ -1,0 +1,17 @@
+import { getCountryCode } from '@frontend/web/lib/getCountryCode';
+
+let applies: undefined | boolean;
+
+export const ccpaApplies = async () => {
+    if (typeof applies === 'undefined') {
+        const isInUS = (await getCountryCode()) === 'US';
+        applies =
+            'guardian' in window &&
+            'config' in window.guardian &&
+            'switches' in window.guardian.config &&
+            'ccpaCmpUi' in window.guardian.config.switches &&
+            window.guardian.config.switches.ccpaCmpUi &&
+            isInUS;
+    }
+    return applies;
+};

--- a/src/web/server/render.ts
+++ b/src/web/server/render.ts
@@ -4,6 +4,7 @@ import { extract as extractNAV } from '@root/src/model/extract-nav';
 import { document } from '@root/src/web/server/document';
 import { validateAsCAPIType } from '@root/src/model/validate';
 import { addDropCaps } from '@root/src/model/add-dropcaps';
+import { addHighlights } from '@root/src/model/add-highlights';
 import { enhancePhotoEssay } from '@root/src/model/enhance-photoessay';
 import { extract as extractGA } from '@root/src/model/extract-ga';
 import { bodyJSON } from '@root/src/model/exampleBodyJSON';
@@ -11,7 +12,8 @@ import { bodyJSON } from '@root/src/model/exampleBodyJSON';
 export const render = ({ body }: express.Request, res: express.Response) => {
     try {
         const withDropCaps: CAPIType = addDropCaps(body);
-        const withEssayEnhancement: CAPIType = enhancePhotoEssay(withDropCaps);
+        const withHighlights: CAPIType = addHighlights(withDropCaps);
+        const withEssayEnhancement: CAPIType = enhancePhotoEssay(withHighlights);
         const CAPI: CAPIType = validateAsCAPIType(withEssayEnhancement);
 
         const resp = document({


### PR DESCRIPTION
## What does this change?

The reader revenue links are now hidden when the user is logged in.

**Now uses the Contributions library to provide the credentials**

![before banner](https://user-images.githubusercontent.com/35331926/85995836-1c3d5c00-b9f9-11ea-82b2-1f34b77b79de.png)

![after banner](https://user-images.githubusercontent.com/35331926/85995948-324b1c80-b9f9-11ea-8a4c-dc11052256d8.png)

