### PR TITLE
Facebook video embeds

### DIFF
--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -261,6 +261,7 @@ interface VideoFacebookBlockElement {
     height: number;
     width: number;
     caption: string;
+    embedUrl?: string;
 }
 
 interface VideoVimeoBlockElement {

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -33,6 +33,9 @@
                         "$ref": "#/definitions/CalloutBlockElementXp"
                     },
                     {
+                        "$ref": "#/definitions/CaptionBlockElement"
+                    },
+                    {
                         "$ref": "#/definitions/ChartAtomBlockElement"
                     },
                     {
@@ -906,6 +909,91 @@
             "required": [
                 "_type"
             ]
+        },
+        "CaptionBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.CaptionBlockElement"
+                    ]
+                },
+                "display": {
+                    "$ref": "#/definitions/Display"
+                },
+                "designType": {
+                    "$ref": "#/definitions/DesignType"
+                },
+                "captionText": {
+                    "type": "string"
+                },
+                "pillar": {
+                    "$ref": "#/definitions/Pillar"
+                },
+                "padCaption": {
+                    "type": "boolean"
+                },
+                "credit": {
+                    "type": "string"
+                },
+                "displayCredit": {
+                    "type": "boolean"
+                },
+                "shouldLimitWidth": {
+                    "type": "boolean"
+                },
+                "isOverlayed": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "_type",
+                "designType",
+                "display",
+                "pillar"
+            ]
+        },
+        "Display": {
+            "type": "number",
+            "enum": [
+                0,
+                1,
+                2
+            ]
+        },
+        "DesignType": {
+            "enum": [
+                "AdvertisementFeature",
+                "Analysis",
+                "Article",
+                "Comment",
+                "Feature",
+                "GuardianLabs",
+                "GuardianView",
+                "Immersive",
+                "Interview",
+                "Live",
+                "MatchReport",
+                "Media",
+                "PhotoEssay",
+                "Quiz",
+                "Recipe",
+                "Review",
+                "SpecialReport"
+            ],
+            "type": "string"
+        },
+        "Pillar": {
+            "enum": [
+                "culture",
+                "labs",
+                "lifestyle",
+                "news",
+                "opinion",
+                "sport"
+            ],
+            "type": "string"
         },
         "ChartAtomBlockElement": {
             "type": "object",
@@ -1850,6 +1938,9 @@
                 },
                 "caption": {
                     "type": "string"
+                },
+                "embedUrl": {
+                    "type": "string"
                 }
             },
             "required": [
@@ -2003,6 +2094,9 @@
                             },
                             {
                                 "$ref": "#/definitions/CalloutBlockElementXp"
+                            },
+                            {
+                                "$ref": "#/definitions/CaptionBlockElement"
                             },
                             {
                                 "$ref": "#/definitions/ChartAtomBlockElement"

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -33,9 +33,6 @@
                         "$ref": "#/definitions/CalloutBlockElementXp"
                     },
                     {
-                        "$ref": "#/definitions/CaptionBlockElement"
-                    },
-                    {
                         "$ref": "#/definitions/ChartAtomBlockElement"
                     },
                     {
@@ -909,91 +906,6 @@
             "required": [
                 "_type"
             ]
-        },
-        "CaptionBlockElement": {
-            "type": "object",
-            "properties": {
-                "_type": {
-                    "type": "string",
-                    "enum": [
-                        "model.dotcomrendering.pageElements.CaptionBlockElement"
-                    ]
-                },
-                "display": {
-                    "$ref": "#/definitions/Display"
-                },
-                "designType": {
-                    "$ref": "#/definitions/DesignType"
-                },
-                "captionText": {
-                    "type": "string"
-                },
-                "pillar": {
-                    "$ref": "#/definitions/Pillar"
-                },
-                "padCaption": {
-                    "type": "boolean"
-                },
-                "credit": {
-                    "type": "string"
-                },
-                "displayCredit": {
-                    "type": "boolean"
-                },
-                "shouldLimitWidth": {
-                    "type": "boolean"
-                },
-                "isOverlayed": {
-                    "type": "boolean"
-                }
-            },
-            "required": [
-                "_type",
-                "designType",
-                "display",
-                "pillar"
-            ]
-        },
-        "Display": {
-            "type": "number",
-            "enum": [
-                0,
-                1,
-                2
-            ]
-        },
-        "DesignType": {
-            "enum": [
-                "AdvertisementFeature",
-                "Analysis",
-                "Article",
-                "Comment",
-                "Feature",
-                "GuardianLabs",
-                "GuardianView",
-                "Immersive",
-                "Interview",
-                "Live",
-                "MatchReport",
-                "Media",
-                "PhotoEssay",
-                "Quiz",
-                "Recipe",
-                "Review",
-                "SpecialReport"
-            ],
-            "type": "string"
-        },
-        "Pillar": {
-            "enum": [
-                "culture",
-                "labs",
-                "lifestyle",
-                "news",
-                "opinion",
-                "sport"
-            ],
-            "type": "string"
         },
         "ChartAtomBlockElement": {
             "type": "object",
@@ -2094,9 +2006,6 @@
                             },
                             {
                                 "$ref": "#/definitions/CalloutBlockElementXp"
-                            },
-                            {
-                                "$ref": "#/definitions/CaptionBlockElement"
                             },
                             {
                                 "$ref": "#/definitions/ChartAtomBlockElement"

--- a/src/web/components/elements/VideoFacebookBlockComponent.stories.tsx
+++ b/src/web/components/elements/VideoFacebookBlockComponent.stories.tsx
@@ -25,7 +25,7 @@ export const largeAspectRatio = () => {
         <Container>
             <p>abc</p>
             <VideoFacebookBlockComponent
-                url="https://www.facebook.com/video/embed?video_id=10155703704626323\"
+                embedUrl="https://www.facebook.com/video/embed?video_id=10155703704626323\"
                 pillar="news"
                 height={281}
                 width={500}
@@ -46,7 +46,7 @@ export const verticalAspectRatio = () => {
         <Container>
             <p>abc</p>
             <VideoFacebookBlockComponent
-                url="https://www.facebook.com/video/embed?video_id=10155591097456323\"
+                embedUrl="https://www.facebook.com/video/embed?video_id=10155591097456323\"
                 pillar="news"
                 height={889}
                 width={500}

--- a/src/web/components/elements/VideoFacebookBlockComponent.stories.tsx
+++ b/src/web/components/elements/VideoFacebookBlockComponent.stories.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { Display } from '@root/src/lib/display';
+import { VideoFacebookBlockComponent } from './VideoFacebookBlockComponent';
+
+export default {
+    component: VideoFacebookBlockComponent,
+    title: 'Components/VideoFacebookComponent',
+};
+
+const Container = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
+    <div
+        className={css`
+            max-width: 620px;
+            padding: 20px;
+        `}
+    >
+        {children}
+    </div>
+);
+
+export const largeAspectRatio = () => {
+    return (
+        <Container>
+            <p>abc</p>
+            <VideoFacebookBlockComponent
+                url="https://www.facebook.com/video/embed?video_id=10155703704626323\"
+                pillar="news"
+                height={281}
+                width={500}
+                caption="blah"
+                credit=""
+                title=""
+                display={Display.Standard}
+                designType="Article"
+            />
+            <p>abc</p>
+        </Container>
+    );
+};
+largeAspectRatio.story = { name: 'with large aspect ratio' };
+
+export const verticalAspectRatio = () => {
+    return (
+        <Container>
+            <p>abc</p>
+            <VideoFacebookBlockComponent
+                url="https://www.facebook.com/video/embed?video_id=10155591097456323\"
+                pillar="news"
+                height={889}
+                width={500}
+                caption="blah"
+                credit=""
+                title=""
+                display={Display.Standard}
+                designType="Article"
+            />
+            <p>abc</p>
+        </Container>
+    );
+};
+verticalAspectRatio.story = { name: 'with vertical aspect ratio' };

--- a/src/web/components/elements/VideoFacebookBlockComponent.tsx
+++ b/src/web/components/elements/VideoFacebookBlockComponent.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { Caption } from '@root/src/web/components/Caption';
+import { MaintainAspectRatio } from '@frontend/web/components/MaintainAspectRatio';
+import { Display } from '@root/src/lib/display';
+
+export const VideoFacebookBlockComponent: React.FC<{
+    pillar: Pillar;
+    url: string;
+    height: number;
+    width: number;
+    caption?: string;
+    credit?: string;
+    title?: string;
+    display: Display;
+    designType: DesignType;
+}> = ({
+    url,
+    caption,
+    title,
+    pillar,
+    width,
+    height,
+    display,
+    designType,
+    credit,
+}) => {
+    // 812 is the full height on an iphone X. This ensures that the embed doesn't display any larger than the available viewport
+    // Constrain iframe embeds with a width to their natural width
+    // rather than stretch them to the container using
+    // a max that would prevent portrait videos from being taller than an iphone X (baseline)
+    // More context: https://github.com/guardian/frontend/pull/17902
+    const maxHeight = 812;
+    const aspectRatio = width / height;
+    const maxWidth = maxHeight * aspectRatio;
+
+    return (
+        <div
+            className={css`
+                max-width: ${maxWidth}px;
+                width: 100%;
+            `}
+        >
+            <MaintainAspectRatio height={height} width={width}>
+                <iframe
+                    src={url}
+                    title={title}
+                    height={height}
+                    width={width}
+                    allowFullScreen={true}
+                />
+            </MaintainAspectRatio>
+            {caption && (
+                <Caption
+                    captionText={caption}
+                    designType={designType}
+                    pillar={pillar}
+                    display={display}
+                    credit={credit}
+                />
+            )}
+        </div>
+    );
+};

--- a/src/web/components/elements/VideoFacebookBlockComponent.tsx
+++ b/src/web/components/elements/VideoFacebookBlockComponent.tsx
@@ -7,7 +7,7 @@ import { Display } from '@root/src/lib/display';
 
 export const VideoFacebookBlockComponent: React.FC<{
     pillar: Pillar;
-    url: string;
+    embedUrl?: string;
     height: number;
     width: number;
     caption?: string;
@@ -16,7 +16,7 @@ export const VideoFacebookBlockComponent: React.FC<{
     display: Display;
     designType: DesignType;
 }> = ({
-    url,
+    embedUrl,
     caption,
     title,
     pillar,
@@ -44,7 +44,7 @@ export const VideoFacebookBlockComponent: React.FC<{
         >
             <MaintainAspectRatio height={height} width={width}>
                 <iframe
-                    src={url}
+                    src={embedUrl}
                     title={title}
                     height={height}
                     width={width}

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -158,7 +158,7 @@ export const ArticleRenderer: React.FC<{
                     return (
                         <VideoFacebookBlockComponent
                             pillar={pillar}
-                            url={element.url}
+                            embedUrl={element.embedUrl}
                             height={element.height}
                             width={element.width}
                             caption={element.caption}
@@ -233,7 +233,7 @@ export const ArticleRenderer: React.FC<{
                     return null;
             }
         })
-        .filter(_ => _ != null);
+        .filter((_) => _ != null);
 
     return (
         <div

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -15,6 +15,7 @@ import { SubheadingBlockComponent } from '@root/src/web/components/elements/Subh
 import { TableBlockComponent } from '@root/src/web/components/elements/TableBlockComponent';
 import { TextBlockComponent } from '@root/src/web/components/elements/TextBlockComponent';
 import { TweetBlockComponent } from '@root/src/web/components/elements/TweetBlockComponent';
+import { VideoFacebookBlockComponent } from '@root/src/web/components/elements/VideoFacebookBlockComponent';
 import { VimeoBlockComponent } from '@root/src/web/components/elements/VimeoBlockComponent';
 import { YoutubeEmbedBlockComponent } from '@root/src/web/components/elements/YoutubeEmbedBlockComponent';
 import { YoutubeBlockComponent } from '@root/src/web/components/elements/YoutubeBlockComponent';
@@ -153,6 +154,20 @@ export const ArticleRenderer: React.FC<{
                     );
                 case 'model.dotcomrendering.pageElements.TweetBlockElement':
                     return <TweetBlockComponent key={i} element={element} />;
+                case 'model.dotcomrendering.pageElements.VideoFacebookBlockElement':
+                    return (
+                        <VideoFacebookBlockComponent
+                            pillar={pillar}
+                            url={element.url}
+                            height={element.height}
+                            width={element.width}
+                            caption={element.caption}
+                            display={display}
+                            designType={designType}
+                            credit={element.caption}
+                            title={element.caption}
+                        />
+                    );
                 case 'model.dotcomrendering.pageElements.VideoVimeoBlockElement':
                     return (
                         <VimeoBlockComponent
@@ -215,7 +230,6 @@ export const ArticleRenderer: React.FC<{
                 case 'model.dotcomrendering.pageElements.QABlockElement':
                 case 'model.dotcomrendering.pageElements.TimelineBlockElement':
                 case 'model.dotcomrendering.pageElements.VideoBlockElement':
-                case 'model.dotcomrendering.pageElements.VideoFacebookBlockElement':
                     return null;
             }
         })


### PR DESCRIPTION
## What does this change?
Adds the ability to render facebook videos in DCR. Due to the scarcity of them and the way the data comes through(as VideoBlockElement), it was not possible to find an example, so these have been built using storybook.

<img width="447" alt="Screen Shot 2020-06-29 at 21 32 26" src="https://user-images.githubusercontent.com/2051501/86053749-e1671280-ba50-11ea-8313-daa079457339.png">
<img width="638" alt="Screen Shot 2020-06-29 at 21 36 53" src="https://user-images.githubusercontent.com/2051501/86053753-e5933000-ba50-11ea-9877-35cc9ff01d12.png">
