### PR TITLE
Fix execa shell post merge

### DIFF
--- a/scripts/git-hooks/post-merge
+++ b/scripts/git-hooks/post-merge
@@ -4,9 +4,11 @@ const execa = require('execa');
 const chalk = require('chalk');
 const fs = require('fs');
 
-execa
-    .shell('git diff-tree -r --name-only --no-commit-id HEAD@{1} HEAD')
-    .then(result => {
+// execa
+execa('git diff-tree -r --name-only --no-commit-id HEAD@{1} HEAD', {
+    shell: true,
+})
+    .then((result) => {
         const changedFiles = result.stdout.split('\n');
 
         if (changedFiles.includes('.nvmrc')) {
@@ -14,14 +16,14 @@ execa
 
             console.log(
                 `${chalk.red(
-                    `This application now requires Node v${nvmrcVersion}. Switch to the latest version using \`nvm install\` or download from nodejs.org. Then run \`make reinstall\`.`
-                )}`
+                    `This application now requires Node v${nvmrcVersion}. Switch to the latest version using \`nvm install\` or download from nodejs.org. Then run \`make reinstall\`.`,
+                )}`,
             );
         } else if (changedFiles.includes('yarn.lock')) {
             console.log(
                 `${chalk.red(
-                    'This application has new dependencies. Running `make install`...'
-                )}`
+                    'This application has new dependencies. Running `make install`...',
+                )}`,
             );
 
             return execa('make', ['install'], {
@@ -31,7 +33,7 @@ execa
 
         return Promise.resolve();
     })
-    .catch(e => {
+    .catch((e) => {
         console.log(`\n${e}\n`);
         process.exit(1);
     });


### PR DESCRIPTION
## What does this change?
changes `execa` to make sure it is run as shell using the options param

## Why?
When running `post-merge` we would get the error `execa.shell` does not exist. This is because the latest version (which dependabot updated) had a breaking change, requiring execa to be written like `execa(xxx, { options })` 