### PR TITLE
Add sourcepoint privacy link

### DIFF
--- a/src/web/components/StickyBottomBanner/CMP.tsx
+++ b/src/web/components/StickyBottomBanner/CMP.tsx
@@ -7,6 +7,7 @@ import {
     checkWillShowUi as checkWillShowCCPAUi,
 } from '@guardian/consent-management-platform';
 import { ccpaApplies } from '@root/src/web/lib/ccpaApplies';
+import { addPrivacySettingsLink } from './CMPPrivacyLink';
 
 // this is the wrong place to be doing this, but it's temporary
 // until we remove the old react CMP component and go 100% sourcepoint
@@ -17,6 +18,7 @@ export const willShowNewCMP = async () => {
         initCCPA({
             useCcpa: true,
         });
+        addPrivacySettingsLink();
         return checkWillShowCCPAUi();
     }
 

--- a/src/web/components/StickyBottomBanner/CMPPrivacyLink.ts
+++ b/src/web/components/StickyBottomBanner/CMPPrivacyLink.ts
@@ -1,0 +1,60 @@
+import { ccpaApplies } from '@root/src/web/lib/ccpaApplies';
+import { showPrivacyManager } from '@guardian/consent-management-platform';
+
+const show = (forceModal?: boolean) => {
+    ccpaApplies().then((useCCPA) => {
+        if (useCCPA) {
+            if (forceModal) {
+                showPrivacyManager();
+            }
+        }
+    });
+};
+
+export const addPrivacySettingsLink = (): void => {
+    if (
+        'guardian' in window &&
+        'config' in window.guardian &&
+        'switches' in window.guardian.config &&
+        'cmpUi' in window.guardian.config.switches &&
+        !window.guardian.config.switches.cmpUi
+    ) {
+        return;
+    }
+
+    const privacyLink = document.querySelector('a[data-link-name=privacy]');
+
+    if (privacyLink) {
+        const privacyLinkListItem = privacyLink.parentElement;
+
+        if (privacyLinkListItem) {
+            ccpaApplies().then((useCCPA) => {
+                const newPrivacyLink = privacyLink.cloneNode(false) as Element;
+
+                newPrivacyLink.setAttribute(
+                    'data-link-name',
+                    'privacy-settings',
+                );
+                newPrivacyLink.setAttribute('href', '#');
+                newPrivacyLink.innerHTML = useCCPA
+                    ? 'California resident – Do Not Sell'
+                    : 'Privacy settings';
+
+                const newPrivacyLinkListItem = privacyLinkListItem.cloneNode(
+                    false,
+                ) as Element;
+
+                newPrivacyLinkListItem.appendChild(newPrivacyLink);
+
+                privacyLinkListItem.insertAdjacentElement(
+                    'beforebegin',
+                    newPrivacyLinkListItem,
+                );
+
+                newPrivacyLink.addEventListener('click', () => {
+                    show(true);
+                });
+            });
+        }
+    }
+};

--- a/src/web/components/StickyBottomBanner/CMPPrivacyLink.ts
+++ b/src/web/components/StickyBottomBanner/CMPPrivacyLink.ts
@@ -3,10 +3,8 @@ import { showPrivacyManager } from '@guardian/consent-management-platform';
 
 const show = (forceModal?: boolean) => {
     ccpaApplies().then((useCCPA) => {
-        if (useCCPA) {
-            if (forceModal) {
-                showPrivacyManager();
-            }
+        if (useCCPA && forceModal) {
+			showPrivacyManager();
         }
     });
 };


### PR DESCRIPTION
## What does this change?

injects a link into the footer once CCPA CMP is initialised

#### nb
- a subsequent PR will add an equivalent TCFv1 link (it's more complex)
- in a few weeks we will remove this react component entirely, at which point `src/web/components/StickyBottomBanner/CMPPrivacyLink.ts` will also get a new home. it seems like the wrong place for this code but it keeps it together. happy to move it if @guardian/dotcom-platform prefer it elsewhere

## Why?

this link is a legal requirement

