### PR TITLE
Fix engagementBannerLastClosedAt value in remote banner request

### DIFF
--- a/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -14,8 +14,9 @@ type Props = {
 };
 
 const getEngagementBannerLastClosedAt = (): string | undefined => {
+    const item = localStorage.getItem('gu.prefs.engagementBannerLastClosedAt');
     return (
-        localStorage.getItem('gu.prefs.engagementBannerLastClosedAt') ||
+        (item && JSON.parse(item).value) ||
         undefined
     );
 };


### PR DESCRIPTION
We send `engagementBannerLastClosedAt` to the backend to decide if the banner should be displayed.
This localstorage value has the format:
`{"value":"2020-06-30T14:44:22.355Z"}`
The client is currently sending this raw value, when it should actually be sending the field `value`.

The impact was that the banner was never displaying for DCR users if they have _ever_ closed the banner. So the banner redeploy logic wasn't working for DCR.

Note - this _does_ work for frontend