### PR TITLE
Ma/reader revenue links using contributions rebased

### DIFF
--- a/src/web/components/ReaderRevenueLinks.test.tsx
+++ b/src/web/components/ReaderRevenueLinks.test.tsx
@@ -17,8 +17,6 @@ jest.mock('@frontend/web/browser/cookie', () => ({
 describe('ReaderRevenueLinks', () => {
     const contributionsCookie = 'gu.contributions.contrib-timestamp';
     const payingMemberCookie = 'gu_paying_member';
-    const digitalSubscriberCookie = 'gu_digital_subscriber';
-    const recentContributorCookie = 'gu.contributions.contrib-timestamp';
 
     const urls = {
         contribute: 'https://www.theguardian.com/contribute',
@@ -50,13 +48,7 @@ describe('ReaderRevenueLinks', () => {
         );
 
         // expect nothing to be rendered
-        await wait(() => expect(container.firstChild).toBeNull());
-
-        expect(getCookie).toHaveBeenCalledTimes(4);
-        expect(getCookie).toHaveBeenCalledWith(contributionsCookie);
-        expect(getCookie).toHaveBeenCalledWith(digitalSubscriberCookie);
-        expect(getCookie).toHaveBeenCalledWith(payingMemberCookie);
-        expect(getCookie).toHaveBeenCalledWith(recentContributorCookie);
+        await wait(() => expect(container.firstChild).toBeTruthy());
     });
 
     it('should not render correctly if paying member', async () => {
@@ -80,13 +72,7 @@ describe('ReaderRevenueLinks', () => {
         );
 
         // expect nothing to be rendered
-        await wait(() => expect(container.firstChild).toBeNull());
-
-        expect(getCookie).toHaveBeenCalledTimes(4);
-        expect(getCookie).toHaveBeenCalledWith(contributionsCookie);
-        expect(getCookie).toHaveBeenCalledWith(payingMemberCookie);
-        expect(getCookie).toHaveBeenCalledWith(digitalSubscriberCookie);
-        expect(getCookie).toHaveBeenCalledWith(recentContributorCookie);
+        await wait(() => expect(container.firstChild).toBeTruthy());
     });
 
     it('should render if neither paying member or recent contributor', async () => {
@@ -112,10 +98,5 @@ describe('ReaderRevenueLinks', () => {
         await wait(() => expect(container.firstChild).not.toBeNull());
 
         expect(getByText('Support The Guardian')).toBeInTheDocument();
-        expect(getCookie).toHaveBeenCalledTimes(4);
-        expect(getCookie).toHaveBeenCalledWith(contributionsCookie);
-        expect(getCookie).toHaveBeenCalledWith(payingMemberCookie);
-        expect(getCookie).toHaveBeenCalledWith(digitalSubscriberCookie);
-        expect(getCookie).toHaveBeenCalledWith(recentContributorCookie);
     });
 });

--- a/src/web/components/ReaderRevenueLinks.test.tsx
+++ b/src/web/components/ReaderRevenueLinks.test.tsx
@@ -1,23 +1,15 @@
 import React from 'react';
 import { render, wait } from '@testing-library/react';
-import {
-    getCookie as getCookie_,
-    addCookie as addCookie_,
-} from '@root/src/web/browser/cookie';
+import { shouldHideSupportMessaging as shouldHideSupportMessaging_ } from '@root/src/web/lib/contributions';
 import { ReaderRevenueLinks } from './ReaderRevenueLinks';
 
-const getCookie: any = getCookie_;
-const addCookie: any = addCookie_;
+const shouldHideSupportMessaging: any = shouldHideSupportMessaging_;
 
-jest.mock('@frontend/web/browser/cookie', () => ({
-    getCookie: jest.fn(() => null),
-    addCookie: jest.fn(() => null),
+jest.mock('@root/src/web/lib/contributions', () => ({
+    shouldHideSupportMessaging: jest.fn(() => true),
 }));
 
 describe('ReaderRevenueLinks', () => {
-    const contributionsCookie = 'gu.contributions.contrib-timestamp';
-    const payingMemberCookie = 'gu_paying_member';
-
     const urls = {
         contribute: 'https://www.theguardian.com/contribute',
         subscribe: 'https://www.theguardian.com/subscribe',
@@ -25,18 +17,8 @@ describe('ReaderRevenueLinks', () => {
     };
     const edition: Edition = 'UK';
 
-    beforeEach(() => {
-        addCookie.mockReset();
-        getCookie.mockReset();
-    });
-
-    it('should not render if recent contributor', async () => {
-        const contributionDate = new Date();
-
-        // set a contribution date of 1 week ago
-        contributionDate.setDate(contributionDate.getDate() - 7);
-
-        getCookie.mockReturnValue(contributionDate);
+    it('should not render if shouldHideSupportMessaging() returns true', async () => {
+        shouldHideSupportMessaging.mockReturnValue(true);
 
         const { container } = render(
             <ReaderRevenueLinks
@@ -48,19 +30,11 @@ describe('ReaderRevenueLinks', () => {
         );
 
         // expect nothing to be rendered
-        await wait(() => expect(container.firstChild).toBeTruthy());
+        await wait(() => expect(container.firstChild).toBeNull());
     });
 
-    it('should not render correctly if paying member', async () => {
-        const contributionDate = new Date();
-
-        // set a contribution date of 1 year ago
-        contributionDate.setDate(contributionDate.getDate() - 365);
-
-        getCookie.mockImplementation((name: string) => {
-            if (name === contributionsCookie) return contributionDate;
-            if (name === payingMemberCookie) return 'true';
-        });
+    it('should render if shouldHideSupportMessaging() returns false', async () => {
+        shouldHideSupportMessaging.mockReturnValue(false);
 
         const { container } = render(
             <ReaderRevenueLinks
@@ -71,32 +45,7 @@ describe('ReaderRevenueLinks', () => {
             />,
         );
 
-        // expect nothing to be rendered
-        await wait(() => expect(container.firstChild).toBeTruthy());
-    });
-
-    it('should render if neither paying member or recent contributor', async () => {
-        const contributionDate = new Date();
-
-        // set a contribution date of 1 year ago
-        contributionDate.setDate(contributionDate.getDate() - 365);
-
-        getCookie
-            .mockReturnValueOnce(contributionDate)
-            .mockReturnValueOnce('false');
-
-        const { container, getByText } = render(
-            <ReaderRevenueLinks
-                urls={urls}
-                edition={edition}
-                dataLinkNamePrefix="nav2 : "
-                inHeader={true}
-            />,
-        );
-
-        // expect something to be rendered
+        // expect links to be rendered
         await wait(() => expect(container.firstChild).not.toBeNull());
-
-        expect(getByText('Support The Guardian')).toBeInTheDocument();
     });
 });

--- a/src/web/components/ReaderRevenueLinks.tsx
+++ b/src/web/components/ReaderRevenueLinks.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { css, cx } from 'emotion';
 
 import ArrowRightIcon from '@frontend/static/icons/arrow-right.svg';
@@ -10,7 +10,7 @@ import {
 import { textSans, headline } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
 
-import { getCookie } from '@root/src/web/browser/cookie';
+import { shouldHideSupportMessaging } from '@root/src/web/lib/contributions';
 
 type Props = {
     edition: Edition;
@@ -112,65 +112,16 @@ const subMessageStyles = css`
     margin-bottom: 5px;
 `;
 
-const decideIfRecentContributor: () => boolean = () => {
-    const cookieValue = getCookie('gu.contributions.contrib-timestamp');
-
-    if (!cookieValue) {
-        return false;
-    }
-
-    const now = new Date().getTime();
-    const lastContribution = new Date(cookieValue).getTime();
-    const diffDays = Math.ceil((now - lastContribution) / (1000 * 3600 * 24));
-
-    return diffDays <= 180;
-};
-
 export const ReaderRevenueLinks: React.FC<Props> = ({
     edition,
     urls,
     dataLinkNamePrefix,
     inHeader,
 }) => {
-    const [isDigitalSubscriber, setIsDigitalSubscriber] = useState<boolean>(
-        false,
-    );
-    const [hideSupportMessage, setShouldHideSupportMessage] = useState<boolean>(
-        false,
-    );
-
-    const [isPayingMember, setIsPayingMember] = useState<boolean>(false);
-
-    const [isRecentContributor, setIsRecentContributor] = useState<boolean>(
-        false,
-    );
-
-    useEffect(() => {
-        // Is paying member?
-        setIsPayingMember(getCookie('gu_paying_member') === 'true');
-
-        // Should the support messages be shown
-        setShouldHideSupportMessage(
-            getCookie('gu_hide_support_messaging') === 'true',
-        );
-
-        // Is recent contributor?
-        setIsRecentContributor(decideIfRecentContributor());
-
-        // Is digital subscriber?
-        setIsDigitalSubscriber(getCookie('gu_digital_subscriber') === 'true');
-    }, []);
-
     /*
-        Changed to OR statement as it's likely that at least one will will be false.
-        Default response is to show the banners
+        Updated to now use Reader Revenue shouldHideSupportMessaging()
     */
-    if (
-        isDigitalSubscriber ||
-        isPayingMember ||
-        isRecentContributor ||
-        hideSupportMessage
-    ) {
+    if (shouldHideSupportMessaging()) {
         return null;
     }
     return (


### PR DESCRIPTION
## What does this change?

It removes the reader revenue links using confirmation received from the `contributions` library via the `shouldHideSupportMessaging` flag.

ReaderRevenueLinks tests have been updated to reflect the new methodology.

This is a rebased branch to avoid confusion!

### Before

![image](https://user-images.githubusercontent.com/35331926/86220138-0c4d8580-bb7b-11ea-876c-1d420bd3b97b.png)

### After

![image](https://user-images.githubusercontent.com/35331926/86220167-14a5c080-bb7b-11ea-8275-ba490dcdbe3b.png)

