### PR TITLE
integrate InteractiveAtomBlockElement

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@babel/runtime": "^7.9.2",
         "@emotion/core": "^10.0.28",
-        "@guardian/atoms-rendering": "^1.3.3",
+        "@guardian/atoms-rendering": "^1.3.4",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/consent-management-platform": "^3.4.3",
         "@guardian/discussion-rendering": "^2.2.23",

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -158,6 +158,10 @@ interface InstagramBlockElement {
 
 interface InteractiveAtomBlockElement extends InteractiveAtomBlockElementBase {
     _type: 'model.dotcomrendering.pageElements.InteractiveAtomBlockElement';
+    id: string;
+    js: string;
+    html?: string;
+    css?: string;
 }
 
 interface MapBlockElement {

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -19,7 +19,7 @@ import { VimeoBlockComponent } from '@root/src/web/components/elements/VimeoBloc
 import { YoutubeEmbedBlockComponent } from '@root/src/web/components/elements/YoutubeEmbedBlockComponent';
 import { YoutubeBlockComponent } from '@root/src/web/components/elements/YoutubeBlockComponent';
 
-import { ExplainerAtom } from '@guardian/atoms-rendering';
+import { ExplainerAtom, InteractiveAtom } from '@guardian/atoms-rendering';
 import { Display } from '@root/src/lib/display';
 
 // This is required for spacefinder to work!
@@ -196,6 +196,15 @@ export const ArticleRenderer: React.FC<{
                             isMainMedia={false}
                         />
                     );
+                case 'model.dotcomrendering.pageElements.InteractiveAtomBlockElement':
+                    return (
+                        <InteractiveAtom
+                            id={element.id}
+                            html={element.html}
+                            js={element.js}
+                            css={element.css}
+                        />
+                    );
 
                 case 'model.dotcomrendering.pageElements.AudioBlockElement':
                 case 'model.dotcomrendering.pageElements.AudioAtomBlockElement':
@@ -209,7 +218,6 @@ export const ArticleRenderer: React.FC<{
                 case 'model.dotcomrendering.pageElements.GenericAtomBlockElement':
                 case 'model.dotcomrendering.pageElements.GuVideoBlockElement':
                 case 'model.dotcomrendering.pageElements.GuideAtomBlockElement':
-                case 'model.dotcomrendering.pageElements.InteractiveAtomBlockElement':
                 case 'model.dotcomrendering.pageElements.MapBlockElement':
                 case 'model.dotcomrendering.pageElements.ProfileAtomBlockElement':
                 case 'model.dotcomrendering.pageElements.QABlockElement':
@@ -219,7 +227,7 @@ export const ArticleRenderer: React.FC<{
                     return null;
             }
         })
-        .filter(_ => _ != null);
+        .filter((_) => _ != null);
 
     return (
         <div

--- a/yarn.lock
+++ b/yarn.lock
@@ -2347,10 +2347,10 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
-"@guardian/atoms-rendering@^1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-1.3.3.tgz#5142fc6bfb8cf90024edad09c3aee039c3e75f38"
-  integrity sha512-Uug54iosZNTOcoSsRQ4GyEIUUiA5Dg+0ikrkQJOP+wSFdGhoYKBGcS39COXZ0V8xcij/hnopiIJeOVxMW3x5Uw==
+"@guardian/atoms-rendering@^1.3.4":
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-1.3.4.tgz#13e8336d11d5a7847d66e658ede3d0b31de5d4f7"
+  integrity sha512-rpCaa9dx7GuBztcpx3g+sHX/EiOQDM2HKycHFRUw8NblZXIMTOESmdTOZ2hIORH4FplYHSysn1F1ETKERBWSkQ==
 
 "@guardian/automat-client@^0.2.16":
   version "0.2.16"


### PR DESCRIPTION
## What does this change?
Update `atoms-rendering` and support `InteractiveAtomBlockElement`

### Before
<img width="664" alt="Screenshot 2020-07-01 at 15 08 15" src="https://user-images.githubusercontent.com/8831403/86247521-dfb26180-bbac-11ea-9646-d4dae1914082.png">


### After
<img width="671" alt="Screenshot 2020-07-01 at 15 07 09" src="https://user-images.githubusercontent.com/8831403/86247366-a37f0100-bbac-11ea-848e-173bb51f7bb5.png">


## Why?

Because InteractiveAtomBlockElement is now supported thanks to the new release
