### PR TITLE
Remove CalloutBlockElementXp

### DIFF
--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -52,10 +52,6 @@ interface CalloutBlockElement {
     formFields: CampaignFieldType[];
 }
 
-interface CalloutBlockElementXp {
-    _type: 'model.dotcomrendering.pageElements.CalloutBlockElementXp';
-}
-
 interface ChartAtomBlockElement extends InteractiveAtomBlockElementBase {
     _type: 'model.dotcomrendering.pageElements.ChartAtomBlockElement';
 }
@@ -308,7 +304,6 @@ type CAPIElement =
     | BlockquoteBlockElement
     | CaptionBlockElement
     | CalloutBlockElement
-    | CalloutBlockElementXp
     | ChartAtomBlockElement
     | CodeBlockElement
     | CommentBlockElement

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -30,9 +30,6 @@
                         "$ref": "#/definitions/CalloutBlockElement"
                     },
                     {
-                        "$ref": "#/definitions/CalloutBlockElementXp"
-                    },
-                    {
                         "$ref": "#/definitions/ChartAtomBlockElement"
                     },
                     {
@@ -421,9 +418,7 @@
                     ]
                 }
             },
-            "required": [
-                "_type"
-            ]
+            "required": ["_type"]
         },
         "BlockquoteBlockElement": {
             "type": "object",
@@ -438,10 +433,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "html"
-            ]
+            "required": ["_type", "html"]
         },
         "CaptionBlockElement": {
             "type": "object",
@@ -480,20 +472,11 @@
                     "type": "boolean"
                 }
             },
-            "required": [
-                "_type",
-                "designType",
-                "display",
-                "pillar"
-            ]
+            "required": ["_type", "designType", "display", "pillar"]
         },
         "Display": {
             "type": "number",
-            "enum": [
-                0,
-                1,
-                2
-            ]
+            "enum": [0, 1, 2]
         },
         "DesignType": {
             "enum": [
@@ -601,9 +584,7 @@
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": [
-                        "textarea"
-                    ]
+                    "enum": ["textarea"]
                 },
                 "id": {
                     "type": "string"
@@ -627,23 +608,14 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "hideLabel",
-                "id",
-                "label",
-                "name",
-                "required",
-                "type"
-            ]
+            "required": ["hideLabel", "id", "label", "name", "required", "type"]
         },
         "CampaignFieldTextArea": {
             "type": "object",
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": [
-                        "text"
-                    ]
+                    "enum": ["text"]
                 },
                 "id": {
                     "type": "string"
@@ -667,23 +639,14 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "hideLabel",
-                "id",
-                "label",
-                "name",
-                "required",
-                "type"
-            ]
+            "required": ["hideLabel", "id", "label", "name", "required", "type"]
         },
         "CampaignFieldFile": {
             "type": "object",
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": [
-                        "file"
-                    ]
+                    "enum": ["file"]
                 },
                 "id": {
                     "type": "string"
@@ -707,23 +670,14 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "hideLabel",
-                "id",
-                "label",
-                "name",
-                "required",
-                "type"
-            ]
+            "required": ["hideLabel", "id", "label", "name", "required", "type"]
         },
         "CampaignFieldRadio": {
             "type": "object",
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": [
-                        "radio"
-                    ]
+                    "enum": ["radio"]
                 },
                 "options": {
                     "type": "array",
@@ -737,10 +691,7 @@
                                 "type": "string"
                             }
                         },
-                        "required": [
-                            "label",
-                            "value"
-                        ]
+                        "required": ["label", "value"]
                     }
                 },
                 "id": {
@@ -780,9 +731,7 @@
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": [
-                        "checkbox"
-                    ]
+                    "enum": ["checkbox"]
                 },
                 "options": {
                     "type": "array",
@@ -796,10 +745,7 @@
                                 "type": "string"
                             }
                         },
-                        "required": [
-                            "label",
-                            "value"
-                        ]
+                        "required": ["label", "value"]
                     }
                 },
                 "id": {
@@ -839,9 +785,7 @@
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": [
-                        "select"
-                    ]
+                    "enum": ["select"]
                 },
                 "options": {
                     "type": "array",
@@ -855,10 +799,7 @@
                                 "type": "string"
                             }
                         },
-                        "required": [
-                            "label",
-                            "value"
-                        ]
+                        "required": ["label", "value"]
                     }
                 },
                 "id": {
@@ -893,20 +834,6 @@
                 "type"
             ]
         },
-        "CalloutBlockElementXp": {
-            "type": "object",
-            "properties": {
-                "_type": {
-                    "type": "string",
-                    "enum": [
-                        "model.dotcomrendering.pageElements.CalloutBlockElementXp"
-                    ]
-                }
-            },
-            "required": [
-                "_type"
-            ]
-        },
         "ChartAtomBlockElement": {
             "type": "object",
             "properties": {
@@ -932,10 +859,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "url"
-            ]
+            "required": ["_type", "url"]
         },
         "CodeBlockElement": {
             "type": "object",
@@ -950,10 +874,7 @@
                     "type": "boolean"
                 }
             },
-            "required": [
-                "_type",
-                "isMandatory"
-            ]
+            "required": ["_type", "isMandatory"]
         },
         "CommentBlockElement": {
             "type": "object",
@@ -1006,10 +927,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "atomId"
-            ]
+            "required": ["_type", "atomId"]
         },
         "DisclaimerBlockElement": {
             "type": "object",
@@ -1024,10 +942,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "html"
-            ]
+            "required": ["_type", "html"]
         },
         "DividerBlockElement": {
             "type": "object",
@@ -1039,9 +954,7 @@
                     ]
                 }
             },
-            "required": [
-                "_type"
-            ]
+            "required": ["_type"]
         },
         "DocumentBlockElement": {
             "type": "object",
@@ -1056,10 +969,7 @@
                     "type": "boolean"
                 }
             },
-            "required": [
-                "_type",
-                "isMandatory"
-            ]
+            "required": ["_type", "isMandatory"]
         },
         "EmbedBlockElement": {
             "type": "object",
@@ -1083,11 +993,7 @@
                     "type": "boolean"
                 }
             },
-            "required": [
-                "_type",
-                "html",
-                "isMandatory"
-            ]
+            "required": ["_type", "html", "isMandatory"]
         },
         "ExplainerAtomBlockElement": {
             "type": "object",
@@ -1108,12 +1014,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "body",
-                "id",
-                "title"
-            ]
+            "required": ["_type", "body", "id", "title"]
         },
         "GenericAtomBlockElement": {
             "type": "object",
@@ -1140,10 +1041,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "url"
-            ]
+            "required": ["_type", "url"]
         },
         "GuideAtomBlockElement": {
             "type": "object",
@@ -1173,14 +1071,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "credit",
-                "html",
-                "id",
-                "label",
-                "title"
-            ]
+            "required": ["_type", "credit", "html", "id", "label", "title"]
         },
         "GuVideoBlockElement": {
             "type": "object",
@@ -1201,11 +1092,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "assets",
-                "caption"
-            ]
+            "required": ["_type", "assets", "caption"]
         },
         "VideoAssets": {
             "type": "object",
@@ -1217,10 +1104,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "mimeType",
-                "url"
-            ]
+            "required": ["mimeType", "url"]
         },
         "HighlightBlockElement": {
             "type": "object",
@@ -1235,10 +1119,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "html"
-            ]
+            "required": ["_type", "html"]
         },
         "ImageBlockElement": {
             "type": "object",
@@ -1259,9 +1140,7 @@
                             }
                         }
                     },
-                    "required": [
-                        "allImages"
-                    ]
+                    "required": ["allImages"]
                 },
                 "data": {
                     "type": "object",
@@ -1296,13 +1175,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "data",
-                "imageSources",
-                "media",
-                "role"
-            ]
+            "required": ["_type", "data", "imageSources", "media", "role"]
         },
         "Image": {
             "type": "object",
@@ -1323,10 +1196,7 @@
                             "type": "string"
                         }
                     },
-                    "required": [
-                        "height",
-                        "width"
-                    ]
+                    "required": ["height", "width"]
                 },
                 "mediaType": {
                     "type": "string"
@@ -1338,13 +1208,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "fields",
-                "index",
-                "mediaType",
-                "mimeType",
-                "url"
-            ]
+            "required": ["fields", "index", "mediaType", "mimeType", "url"]
         },
         "ImageSource": {
             "type": "object",
@@ -1359,10 +1223,7 @@
                     }
                 }
             },
-            "required": [
-                "srcSet",
-                "weighting"
-            ]
+            "required": ["srcSet", "weighting"]
         },
         "Weighting": {
             "enum": [
@@ -1385,10 +1246,7 @@
                     "type": "number"
                 }
             },
-            "required": [
-                "src",
-                "width"
-            ]
+            "required": ["src", "width"]
         },
         "RoleType": {
             "enum": [
@@ -1420,12 +1278,7 @@
                     "type": "boolean"
                 }
             },
-            "required": [
-                "_type",
-                "hasCaption",
-                "html",
-                "url"
-            ]
+            "required": ["_type", "hasCaption", "html", "url"]
         },
         "InteractiveAtomBlockElement": {
             "type": "object",
@@ -1452,10 +1305,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "url"
-            ]
+            "required": ["_type", "url"]
         },
         "MapBlockElement": {
             "type": "object",
@@ -1510,10 +1360,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "images"
-            ]
+            "required": ["_type", "images"]
         },
         "ProfileAtomBlockElement": {
             "type": "object",
@@ -1543,14 +1390,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "credit",
-                "html",
-                "id",
-                "label",
-                "title"
-            ]
+            "required": ["_type", "credit", "html", "id", "label", "title"]
         },
         "PullquoteBlockElement": {
             "type": "object",
@@ -1571,11 +1411,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "html",
-                "role"
-            ]
+            "required": ["_type", "html", "role"]
         },
         "QABlockElement": {
             "type": "object",
@@ -1602,13 +1438,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "credit",
-                "html",
-                "id",
-                "title"
-            ]
+            "required": ["_type", "credit", "html", "id", "title"]
         },
         "RichLinkBlockElement": {
             "type": "object",
@@ -1635,12 +1465,7 @@
                     "type": "number"
                 }
             },
-            "required": [
-                "_type",
-                "prefix",
-                "text",
-                "url"
-            ]
+            "required": ["_type", "prefix", "text", "url"]
         },
         "SoundcloudBlockElement": {
             "type": "object",
@@ -1664,13 +1489,7 @@
                     "type": "boolean"
                 }
             },
-            "required": [
-                "_type",
-                "html",
-                "id",
-                "isMandatory",
-                "isTrack"
-            ]
+            "required": ["_type", "html", "id", "isMandatory", "isTrack"]
         },
         "SubheadingBlockElement": {
             "type": "object",
@@ -1685,10 +1504,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "html"
-            ]
+            "required": ["_type", "html"]
         },
         "TableBlockElement": {
             "type": "object",
@@ -1706,11 +1522,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "html",
-                "isMandatory"
-            ]
+            "required": ["_type", "html", "isMandatory"]
         },
         "TextBlockElement": {
             "type": "object",
@@ -1728,10 +1540,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "html"
-            ]
+            "required": ["_type", "html"]
         },
         "TimelineBlockElement": {
             "type": "object",
@@ -1758,12 +1567,7 @@
                     }
                 }
             },
-            "required": [
-                "_type",
-                "events",
-                "id",
-                "title"
-            ]
+            "required": ["_type", "events", "id", "title"]
         },
         "TimelineEvent": {
             "type": "object",
@@ -1781,10 +1585,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "date",
-                "title"
-            ]
+            "required": ["date", "title"]
         },
         "TweetBlockElement": {
             "type": "object",
@@ -1808,13 +1609,7 @@
                     "type": "boolean"
                 }
             },
-            "required": [
-                "_type",
-                "hasMedia",
-                "html",
-                "id",
-                "url"
-            ]
+            "required": ["_type", "hasMedia", "html", "id", "url"]
         },
         "VideoBlockElement": {
             "type": "object",
@@ -1826,9 +1621,7 @@
                     ]
                 }
             },
-            "required": [
-                "_type"
-            ]
+            "required": ["_type"]
         },
         "VideoFacebookBlockElement": {
             "type": "object",
@@ -1855,13 +1648,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "caption",
-                "height",
-                "url",
-                "width"
-            ]
+            "required": ["_type", "caption", "height", "url", "width"]
         },
         "VideoVimeoBlockElement": {
             "type": "object",
@@ -1894,12 +1681,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "height",
-                "url",
-                "width"
-            ]
+            "required": ["_type", "height", "url", "width"]
         },
         "VideoYoutubeBlockElement": {
             "type": "object",
@@ -1932,12 +1714,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "height",
-                "url",
-                "width"
-            ]
+            "required": ["_type", "height", "url", "width"]
         },
         "YoutubeBlockElement": {
             "type": "object",
@@ -1973,11 +1750,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "assetId",
-                "mediaTitle"
-            ]
+            "required": ["_type", "assetId", "mediaTitle"]
         },
         "Block": {
             "type": "object",
@@ -2003,9 +1776,6 @@
                             },
                             {
                                 "$ref": "#/definitions/CalloutBlockElement"
-                            },
-                            {
-                                "$ref": "#/definitions/CalloutBlockElementXp"
                             },
                             {
                                 "$ref": "#/definitions/ChartAtomBlockElement"
@@ -2131,10 +1901,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "elements",
-                "id"
-            ]
+            "required": ["elements", "id"]
         },
         "Pagination": {
             "type": "object",
@@ -2158,10 +1925,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "currentPage",
-                "totalPages"
-            ]
+            "required": ["currentPage", "totalPages"]
         },
         "AuthorType": {
             "type": "object",
@@ -2178,12 +1942,7 @@
             }
         },
         "Edition": {
-            "enum": [
-                "AU",
-                "INT",
-                "UK",
-                "US"
-            ],
+            "enum": ["AU", "INT", "UK", "US"],
             "type": "string"
         },
         "TagType": {
@@ -2208,11 +1967,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "id",
-                "title",
-                "type"
-            ]
+            "required": ["id", "title", "type"]
         },
         "SimpleLinkType": {
             "type": "object",
@@ -2224,10 +1979,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "title",
-                "url"
-            ]
+            "required": ["title", "url"]
         },
         "ConfigType": {
             "description": "the config model will contain useful app/site\nlevel data. Although currently derived from the config model\nconstructed in frontend and passed to dotcom-rendering\nthis data could eventually be defined in dotcom-rendering",
@@ -2421,12 +2173,7 @@
                     "$ref": "#/definitions/EditionCommercialProperties"
                 }
             },
-            "required": [
-                "AU",
-                "INT",
-                "UK",
-                "US"
-            ]
+            "required": ["AU", "INT", "UK", "US"]
         },
         "EditionCommercialProperties": {
             "type": "object",
@@ -2441,9 +2188,7 @@
                     "$ref": "#/definitions/Branding"
                 }
             },
-            "required": [
-                "adTargeting"
-            ]
+            "required": ["adTargeting"]
         },
         "AdTargetParam": {
             "type": "object",
@@ -2465,10 +2210,7 @@
                     ]
                 }
             },
-            "required": [
-                "name",
-                "value"
-            ]
+            "required": ["name", "value"]
         },
         "Branding": {
             "type": "object",
@@ -2480,9 +2222,7 @@
                             "type": "string"
                         }
                     },
-                    "required": [
-                        "name"
-                    ]
+                    "required": ["name"]
                 },
                 "sponsorName": {
                     "type": "string"
@@ -2509,18 +2249,10 @@
                                     "type": "number"
                                 }
                             },
-                            "required": [
-                                "height",
-                                "width"
-                            ]
+                            "required": ["height", "width"]
                         }
                     },
-                    "required": [
-                        "dimensions",
-                        "label",
-                        "link",
-                        "src"
-                    ]
+                    "required": ["dimensions", "label", "link", "src"]
                 },
                 "aboutThisLink": {
                     "type": "string"
@@ -2541,10 +2273,7 @@
                                     "type": "number"
                                 }
                             },
-                            "required": [
-                                "height",
-                                "width"
-                            ]
+                            "required": ["height", "width"]
                         },
                         "link": {
                             "type": "string"
@@ -2553,19 +2282,10 @@
                             "type": "string"
                         }
                     },
-                    "required": [
-                        "dimensions",
-                        "label",
-                        "link",
-                        "src"
-                    ]
+                    "required": ["dimensions", "label", "link", "src"]
                 }
             },
-            "required": [
-                "aboutThisLink",
-                "logo",
-                "sponsorName"
-            ]
+            "required": ["aboutThisLink", "logo", "sponsorName"]
         },
         "BadgeType": {
             "type": "object",
@@ -2577,10 +2297,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "imageUrl",
-                "seriesTag"
-            ]
+            "required": ["imageUrl", "seriesTag"]
         },
         "FooterType": {
             "type": "object",
@@ -2595,9 +2312,7 @@
                     }
                 }
             },
-            "required": [
-                "footerLinks"
-            ]
+            "required": ["footerLinks"]
         },
         "FooterLink": {
             "type": "object",
@@ -2615,11 +2330,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "dataLinkName",
-                "text",
-                "url"
-            ]
+            "required": ["dataLinkName", "text", "url"]
         }
     },
     "$schema": "http://json-schema.org/draft-07/schema#"

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -224,7 +224,6 @@ export const ArticleRenderer: React.FC<{
                 case 'model.dotcomrendering.pageElements.AudioBlockElement':
                 case 'model.dotcomrendering.pageElements.AudioAtomBlockElement':
                 case 'model.dotcomrendering.pageElements.CalloutBlockElement':
-                case 'model.dotcomrendering.pageElements.CalloutBlockElementXp':
                 case 'model.dotcomrendering.pageElements.CodeBlockElement':
                 case 'model.dotcomrendering.pageElements.CommentBlockElement':
                 case 'model.dotcomrendering.pageElements.ContentAtomBlockElement':


### PR DESCRIPTION
## What does this change?

Remove `CalloutBlockElementXp`, which is now un-necessary now that the backend BlockElement has been renamed ( https://github.com/guardian/frontend/pull/22764 ) 
