### PR TITLE
Label styles should apply to scroll, too

### DIFF
--- a/src/web/components/AdSlot.tsx
+++ b/src/web/components/AdSlot.tsx
@@ -6,7 +6,8 @@ import { textSans } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 
 export const labelStyles = css`
-    .ad-slot__label {
+    .ad-slot__label,
+    .ad-slot__scroll {
         ${textSans.xsmall()};
         position: relative;
         height: 24px;
@@ -20,6 +21,12 @@ export const labelStyles = css`
 
     .ad-slot__close-button {
         display: none;
+    }
+
+    .ad-slot__scroll {
+        position: fixed;
+        bottom: 0;
+        width: 100%;
     }
 `;
 const mobileStickyAdStyles = css`
@@ -104,7 +111,7 @@ export const makeClassNames = (
     optClassNames: string[],
 ): string => {
     const baseClassNames = ['js-ad-slot', 'ad-slot', `ad-slot--${name}`];
-    const adTypeClassNames = adTypes.map(adType => `ad-slot--${adType}`);
+    const adTypeClassNames = adTypes.map((adType) => `ad-slot--${adType}`);
     return baseClassNames.concat(adTypeClassNames, optClassNames).join(' ');
 };
 


### PR DESCRIPTION
## What does this change?

Adding styles of ad labels to the bottom ones (`.ad-slot__scroll`) and fixes it to the bottom of the page.

### Before

![image](https://user-images.githubusercontent.com/76776/86363327-9296c400-bc6e-11ea-8520-2e495b6a72ea.png)

### After

![image](https://user-images.githubusercontent.com/76776/86363386-ab06de80-bc6e-11ea-920f-70a06c8401af.png)

## Why?

The styling of these elements is currently off, inheriting styles from anchor elements (bright colour).