### PR TITLE
Dropcaps colour fixed for comment types

### DIFF
--- a/src/web/components/DropCap.tsx
+++ b/src/web/components/DropCap.tsx
@@ -21,13 +21,14 @@ const outerStyles = (pillar: Pillar, designType: DesignType) => {
         margin-right: 4px;
     `;
 
+    /*
+        The reason pillar type 'opinion' is forced to opinion[400] is that
+        opinion.dark is much darker so it is forced to keep with similar colour
+        tones (that's my understanding anyway!)
+    */
     switch (designType) {
         case 'GuardianView':
         case 'Comment':
-            return css`
-                ${baseStyles};
-                color: ${opinion[400]};
-            `;
         case 'PhotoEssay':
         case 'Analysis':
         case 'Feature':
@@ -46,7 +47,9 @@ const outerStyles = (pillar: Pillar, designType: DesignType) => {
         default:
             return css`
                 ${baseStyles};
-                color: ${pillarPalette[pillar].dark};
+                color: ${pillar === 'opinion'
+                    ? opinion[400]
+                    : pillarPalette[pillar].dark};
             `;
     }
 };

--- a/src/web/components/DropCap.tsx
+++ b/src/web/components/DropCap.tsx
@@ -24,7 +24,7 @@ const outerStyles = (pillar: Pillar, designType: DesignType) => {
     /*
         The reason pillar type 'opinion' is forced to opinion[400] is that
         opinion.dark is much darker so it is forced to keep with similar colour
-        tones (that's my understanding anyway!)
+        tones used on the site(that's my understanding anyway!)
     */
     switch (designType) {
         case 'GuardianView':

--- a/src/web/components/DropCap.tsx
+++ b/src/web/components/DropCap.tsx
@@ -29,6 +29,12 @@ const outerStyles = (pillar: Pillar, designType: DesignType) => {
     switch (designType) {
         case 'GuardianView':
         case 'Comment':
+            return css`
+                ${baseStyles};
+                color: ${pillar === 'opinion'
+                    ? opinion[400]
+                    : pillarPalette[pillar].dark};
+            `;
         case 'PhotoEssay':
         case 'Analysis':
         case 'Feature':
@@ -47,9 +53,7 @@ const outerStyles = (pillar: Pillar, designType: DesignType) => {
         default:
             return css`
                 ${baseStyles};
-                color: ${pillar === 'opinion'
-                    ? opinion[400]
-                    : pillarPalette[pillar].dark};
+                color: ${pillarPalette[pillar].dark};
             `;
     }
 };

--- a/src/web/components/Dropcap.stories.tsx
+++ b/src/web/components/Dropcap.stories.tsx
@@ -44,6 +44,29 @@ export const Article = () => {
 };
 Article.story = { name: 'Article | news' };
 
+export const OpinionArticle = () => {
+    return (
+        <Container>
+            <p
+                className={css`
+                    ${body.medium()};
+                `}
+            >
+                <DropCap designType="Article" letter="O" pillar="opinion" />
+                nce upon a time there was a dropcap. Lorem ipsum dolor sit amet,
+                consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+                labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+                nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+                commodo consequat. Duis aute irure dolor in reprehenderit in
+                voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                Excepteur sint occaecat cupidatat non proident, sunt in culpa
+                qui officia deserunt mollit anim id est laborum.
+            </p>
+        </Container>
+    );
+};
+OpinionArticle.story = { name: 'Article | opinion' };
+
 export const Feature = () => {
     return (
         <Container>

--- a/src/web/components/Dropcap.stories.tsx
+++ b/src/web/components/Dropcap.stories.tsx
@@ -135,3 +135,49 @@ export const Comment = () => {
     );
 };
 Comment.story = { name: 'Comment | opinion' };
+
+export const CommentSport = () => {
+    return (
+        <Container>
+            <p
+                className={css`
+                    ${body.medium()};
+                `}
+            >
+                <DropCap designType="Comment" letter="O" pillar="sport" />
+                nce upon a time there was a dropcap. Lorem ipsum dolor sit amet,
+                consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+                labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+                nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+                commodo consequat. Duis aute irure dolor in reprehenderit in
+                voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                Excepteur sint occaecat cupidatat non proident, sunt in culpa
+                qui officia deserunt mollit anim id est laborum.
+            </p>
+        </Container>
+    );
+};
+CommentSport.story = { name: 'Comment | sport' };
+
+export const CommentCulture = () => {
+    return (
+        <Container>
+            <p
+                className={css`
+                    ${body.medium()};
+                `}
+            >
+                <DropCap designType="Comment" letter="O" pillar="culture" />
+                nce upon a time there was a dropcap. Lorem ipsum dolor sit amet,
+                consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+                labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+                nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+                commodo consequat. Duis aute irure dolor in reprehenderit in
+                voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                Excepteur sint occaecat cupidatat non proident, sunt in culpa
+                qui officia deserunt mollit anim id est laborum.
+            </p>
+        </Container>
+    );
+};
+CommentCulture.story = { name: 'Comment | culture' };


### PR DESCRIPTION
## What does this change?

It stops comment Dropcaps being forced to the opinion[400] colour, it now defaults to the dark variant of the pillar type. Additional stories have been added with different comment types for verification.

There was some confusion as to why opinion comments had to be [400] and not it's dark variant but it's likely down to maintaining look and feel:

![Screenshot 2020-07-03 at 09 24 16](https://user-images.githubusercontent.com/35331926/86451588-08546b80-bd13-11ea-8da6-d66ef34f26d6.png)
`opinion[400]`

![Screenshot 2020-07-03 at 09 25 03](https://user-images.githubusercontent.com/35331926/86451646-1f935900-bd13-11ea-8cef-a368d34eb8f2.png)
`opinion dark`

**But the main changes are:** 

### Before

<img width="624" alt="Screenshot 2020-07-03 at 09 44 12" src="https://user-images.githubusercontent.com/35331926/86451729-3e91eb00-bd13-11ea-921c-5d7e9ca945a7.png">

### After

<img width="624" alt="Screenshot 2020-07-03 at 09 44 24" src="https://user-images.githubusercontent.com/35331926/86451792-51a4bb00-bd13-11ea-9cf7-5a1eab4cf999.png">
