### PR TITLE
Enable callout block

### DIFF
--- a/fixtures/calloutCampaign.ts
+++ b/fixtures/calloutCampaign.ts
@@ -1,6 +1,8 @@
 export const calloutCampaign: CalloutBlockElement = {
     _type: 'model.dotcomrendering.pageElements.CalloutBlockElement',
     id: '14d1b1bc-8983-43fb-8f2e-8ca08a711944',
+    calloutsUrl:
+        'https://callouts.code.dev-guardianapis.com/formstack-campaign/submit',
     tagName: 'callout-early-coronavirus-events',
     activeFrom: 1588118400000,
     displayOnSensitive: false,

--- a/index.d.ts
+++ b/index.d.ts
@@ -349,6 +349,7 @@ type CAPIBrowserType = {
     isImmersive: boolean;
     isPhotoEssay: boolean;
     matchUrl?: string;
+    callouts: CalloutBlockElement[];
 };
 
 interface TagType {
@@ -643,6 +644,7 @@ type IslandType =
     | 'links-root'
     | 'match-nav'
     | 'match-stats'
+    | 'callout'
     | 'comments';
 
 interface TrailType {

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
         "@storybook/react": "^5.2.5",
         "@testing-library/dom": "^7.9.0",
         "@testing-library/react": "^10.3.0",
+        "@testing-library/user-event": "^12.0.11",
         "@types/amphtml-validator": "^1.0.1",
         "@types/compose-function": "^0.0.30",
         "@types/compression": "^0.0.36",

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -51,6 +51,7 @@ interface CalloutBlockElement {
     description: string;
     tagName: string;
     formFields: CampaignFieldType[];
+    calloutIndex?: number;
 }
 
 interface ChartAtomBlockElement extends InteractiveAtomBlockElementBase {

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -43,6 +43,7 @@ interface CaptionBlockElement {
 interface CalloutBlockElement {
     _type: 'model.dotcomrendering.pageElements.CalloutBlockElement';
     id: string;
+    calloutsUrl: string;
     activeFrom: number;
     displayOnSensitive: boolean;
     formId: number;

--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -67,7 +67,7 @@ const makeWindowGuardianConfig = (
 };
 
 export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
-    // it is important to pass down the index of rich links as well as the component itself
+    // For some elements it is important key thier index in the `elements` array
     const richLinksWithIndex: RichLinkBlockElement[] = CAPI.blocks[0].elements.reduce(
         (acc, element, index: number) => {
             if (
@@ -82,6 +82,21 @@ export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
             return acc;
         },
         [] as RichLinkBlockElement[],
+    );
+    const calloutsWithIndex: CalloutBlockElement[] = CAPI.blocks[0].elements.reduce(
+        (acc, element, index: number) => {
+            if (
+                element._type ===
+                'model.dotcomrendering.pageElements.CalloutBlockElement'
+            ) {
+                acc.push({
+                    ...element,
+                    calloutIndex: index,
+                } as CalloutBlockElement);
+            }
+            return acc;
+        },
+        [] as CalloutBlockElement[],
     );
 
     return {
@@ -149,6 +164,7 @@ export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
         isImmersive: CAPI.isImmersive,
         isPhotoEssay: CAPI.config.isPhotoEssay,
         matchUrl: CAPI.matchUrl,
+        callouts: calloutsWithIndex,
     };
 };
 

--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -67,7 +67,7 @@ const makeWindowGuardianConfig = (
 };
 
 export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
-    // For some elements it is important key thier index in the `elements` array
+    // For some elements it is important to keep thier index in the `elements` array
     const richLinksWithIndex: RichLinkBlockElement[] = CAPI.blocks[0].elements.reduce(
         (acc, element, index: number) => {
             if (

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -4,6 +4,7 @@ import { EditionDropdown } from '@frontend/web/components/EditionDropdown';
 import { MostViewedFooter } from '@frontend/web/components/MostViewed/MostViewedFooter/MostViewedFooter';
 import { Counts } from '@frontend/web/components/Counts';
 import { RichLinkComponent } from '@frontend/web/components/elements/RichLinkComponent';
+import { CalloutBlockComponent } from '@root/src/web/components/elements/CalloutBlockComponent';
 import { ReaderRevenueLinks } from '@frontend/web/components/ReaderRevenueLinks';
 import { SlotBodyEnd } from '@frontend/web/components/SlotBodyEnd';
 import { Links } from '@frontend/web/components/Links';
@@ -25,7 +26,7 @@ import { getDiscussion } from '@root/src/web/lib/getDiscussion';
 import { getUser } from '@root/src/web/lib/getUser';
 import { getCommentContext } from '@root/src/web/lib/getCommentContext';
 import { FocusStyleManager } from '@guardian/src-foundations/utils';
-import {incrementAlreadyVisited} from "@root/src/web/lib/alreadyVisited";
+import { incrementAlreadyVisited } from '@root/src/web/lib/alreadyVisited';
 
 // *******************************
 // ****** Dynamic imports ********
@@ -35,7 +36,7 @@ const MostViewedRightWrapper = React.lazy(() => {
     start();
     return import(
         /* webpackChunkName: "MostViewedRightWrapper" */ '@frontend/web/components/MostViewed/MostViewedRight/MostViewedRightWrapper'
-    ).then(module => {
+    ).then((module) => {
         end();
         return { default: module.MostViewedRightWrapper };
     });
@@ -45,7 +46,7 @@ const OnwardsUpper = React.lazy(() => {
     start();
     return import(
         /* webpackChunkName: "OnwardsUpper" */ '@frontend/web/components/Onwards/OnwardsUpper'
-    ).then(module => {
+    ).then((module) => {
         end();
         return { default: module.OnwardsUpper };
     });
@@ -55,7 +56,7 @@ const OnwardsLower = React.lazy(() => {
     start();
     return import(
         /* webpackChunkName: "OnwardsLower" */ '@frontend/web/components/Onwards/OnwardsLower'
-    ).then(module => {
+    ).then((module) => {
         end();
         return { default: module.OnwardsLower };
     });
@@ -65,7 +66,7 @@ const GetMatchStats = React.lazy(() => {
     start();
     return import(
         /* webpackChunkName: "GetMatchStats" */ '@frontend/web/components/GetMatchStats'
-    ).then(module => {
+    ).then((module) => {
         end();
         return { default: module.GetMatchStats };
     });
@@ -174,7 +175,7 @@ export const App = ({ CAPI, NAV }: Props) => {
     useEffect(() => {
         if (hashCommentId) {
             getCommentContext(CAPI.config.discussionApiUrl, hashCommentId).then(
-                context => {
+                (context) => {
                     setCommentPage(context.page);
                     setCommentPageSize(context.pageSize);
                     setCommentOrderBy(context.orderBy);
@@ -269,6 +270,11 @@ export const App = ({ CAPI, NAV }: Props) => {
                         richLinkIndex={index}
                     />
                 </Portal>
+            ))}
+            {CAPI.callouts.map((callout) => (
+                <Hydrate root="callout" index={callout.calloutIndex}>
+                    <CalloutBlockComponent callout={callout} pillar={pillar} />
+                </Hydrate>
             ))}
             <Portal root="share-comment-counts">
                 {CAPI.isCommentable ? (

--- a/src/web/components/ArticleBody.tsx
+++ b/src/web/components/ArticleBody.tsx
@@ -17,7 +17,7 @@ type Props = {
 };
 
 const pillarColours = pillarMap(
-    pillar =>
+    (pillar) =>
         css`
             color: ${pillar === 'opinion' || pillar === 'culture'
                 ? pillarPalette[pillar].dark
@@ -47,7 +47,7 @@ const bodyStyle = (display: Display) => css`
 `;
 
 const linkColour = pillarMap(
-    pillar => css`
+    (pillar) => css`
         a {
             text-decoration: none;
             border-bottom: 1px solid ${border.secondary};

--- a/src/web/components/Callout/FileUpload.tsx
+++ b/src/web/components/Callout/FileUpload.tsx
@@ -1,11 +1,21 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { css } from 'emotion';
 
+import { textSans } from '@guardian/src-foundations/typography';
+import { text } from '@guardian/src-foundations/palette';
+
+import { stringifyFileBase64 } from '../../lib/stringifyFileBase64';
 import { FieldLabel } from './FieldLabel';
 
 const fileUploadInputStyles = css`
     padding-top: 10px;
     padding-bottom: 10px;
+`;
+
+const errorMessagesStyles = css`
+    padding-bottom: 10px;
+    color: ${text.error};
+    ${textSans.medium({ fontWeight: 'bold' })};
 `;
 
 type Props = {
@@ -14,21 +24,40 @@ type Props = {
     setFormData: React.Dispatch<React.SetStateAction<{ [x: string]: any }>>;
 };
 
-export const FileUpload = ({ formField, formData, setFormData }: Props) => (
-    <>
-        <FieldLabel formField={formField} />
-        <input
-            data-testid={`form-field-${formField.id}`}
-            className={fileUploadInputStyles}
-            type="file"
-            accept="image/*, .pdf"
-            required={formField.required}
-            onChange={e =>
+export const FileUpload = ({ formField, formData, setFormData }: Props) => {
+    const [error, setError] = useState('');
+    const onSelectFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+        if (e.target.files && e.target.files[0]) {
+            try {
+                setError('');
+                const stringifiedFile = await stringifyFileBase64(
+                    e.target.files[0],
+                );
                 setFormData({
                     ...formData,
-                    [formField.id]: e.target.files && e.target.files[0],
-                })}
-        />
-        <p>We accept images and pdfs. Maximum total file size: 6MB</p>
-    </>
-);
+                    [formField.id]: stringifiedFile,
+                });
+            } catch (e) {
+                console.log('dfsiuhfdsuihfdsiuyghdf');
+                console.log(e);
+                setError(e);
+            }
+        }
+    };
+
+    return (
+        <>
+            <FieldLabel formField={formField} />
+            <input
+                data-testid={`form-field-${formField.id}`}
+                className={fileUploadInputStyles}
+                type="file"
+                accept="image/*, .pdf"
+                required={formField.required}
+                onChange={onSelectFile}
+            />
+            <p>We accept images and pdfs. Maximum total file size: 6MB</p>
+            {error && <div className={errorMessagesStyles}>{error}</div>}
+        </>
+    );
+};

--- a/src/web/components/Callout/FileUpload.tsx
+++ b/src/web/components/Callout/FileUpload.tsx
@@ -26,12 +26,12 @@ type Props = {
 
 export const FileUpload = ({ formField, formData, setFormData }: Props) => {
     const [error, setError] = useState('');
-    const onSelectFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
-        if (e.target.files && e.target.files[0]) {
+    const onSelectFile = async (event: React.ChangeEvent<HTMLInputElement>) => {
+        if (event.target.files && event.target.files[0]) {
             try {
                 setError('');
                 const stringifiedFile = await stringifyFileBase64(
-                    e.target.files[0],
+                    event.target.files[0],
                 );
                 setFormData({
                     ...formData,

--- a/src/web/components/Callout/FileUpload.tsx
+++ b/src/web/components/Callout/FileUpload.tsx
@@ -38,8 +38,6 @@ export const FileUpload = ({ formField, formData, setFormData }: Props) => {
                     [formField.id]: stringifiedFile,
                 });
             } catch (e) {
-                console.log('dfsiuhfdsuihfdsiuyghdf');
-                console.log(e);
                 setError(e);
             }
         }

--- a/src/web/components/Callout/Form.test.tsx
+++ b/src/web/components/Callout/Form.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import user from '@testing-library/user-event';
 
 import { Form } from './Form';
 
@@ -22,6 +23,15 @@ const textAreaField = {
     type: 'textarea',
     required: true,
 } as CampaignFieldTextArea;
+
+const fileField = {
+    name: 'you_can_upload_a_photo_here_if_you_think_it_will_add_to_your_story',
+    hideLabel: false,
+    label: 'You can upload a photo here if you think it will add to your story',
+    id: '91884877',
+    type: 'file',
+    required: false,
+} as CampaignFieldFile;
 
 const radioField = {
     name: 'can_we_publish_your_response',
@@ -206,10 +216,27 @@ describe('Callout from', () => {
             [checkboxField.id]: ['checkbox 1', 'checkbox 3'],
         });
     });
+    test('should upload the file', () => {
+        const file = new File(['hello'], 'hello.png', { type: 'image/png' });
+        const mockSubmit = jest.fn();
+        const { queryByText } = render(
+            <Form formFields={[fileField]} onSubmit={mockSubmit} />,
+        );
 
-    // TODO:
-    // file upload unit tests are flaky to implement
-    it.todo('should allow file upload');
+        const input = screen.getByTestId(`form-field-${fileField.id}`);
+        user.upload(input, file);
+
+        expect(input.files[0]).toStrictEqual(file);
+        expect(input.files).toHaveLength(1);
+
+        const submitButton = queryByText(
+            'Share with the Guardian',
+        ) as HTMLButtonElement;
+        fireEvent.click(submitButton);
+
+        expect(mockSubmit.mock.calls.length).toBe(1);
+        // TODO: test mockSubmit internal
+    });
 
     it('should submit select', () => {
         const mockSubmit = jest.fn();

--- a/src/web/components/Callout/Form.test.tsx
+++ b/src/web/components/Callout/Form.test.tsx
@@ -228,8 +228,10 @@ describe('Callout from', () => {
         ) as HTMLInputElement;
         user.upload(input, file);
 
-        expect(input.files[0]).toStrictEqual(file);
-        expect(input.files).toHaveLength(1);
+        const inputFiles = input.files ? input.files : [];
+
+        expect(inputFiles[0]).toStrictEqual(file);
+        expect(inputFiles).toHaveLength(1);
 
         const submitButton = queryByText(
             'Share with the Guardian',

--- a/src/web/components/Callout/Form.test.tsx
+++ b/src/web/components/Callout/Form.test.tsx
@@ -223,7 +223,9 @@ describe('Callout from', () => {
             <Form formFields={[fileField]} onSubmit={mockSubmit} />,
         );
 
-        const input = screen.getByTestId(`form-field-${fileField.id}`);
+        const input = screen.getByTestId(
+            `form-field-${fileField.id}`,
+        ) as HTMLInputElement;
         user.upload(input, file);
 
         expect(input.files[0]).toStrictEqual(file);

--- a/src/web/components/Hydrate.tsx
+++ b/src/web/components/Hydrate.tsx
@@ -2,19 +2,21 @@ import ReactDOM from 'react-dom';
 
 type Props = {
     root: IslandType;
+    index?: number;
     children: JSX.Element;
 };
 
-export const Hydrate = ({ root, children }: Props) => {
-    const element = document.getElementById(root);
+export const Hydrate = ({ root, index, children }: Props) => {
+    const rootWithIndex = index ? `${root}-${index}` : root;
+    const element = document.getElementById(rootWithIndex);
     if (!element) return null;
-    window.performance.mark(`${root}-hydrate-start`);
+    window.performance.mark(`${rootWithIndex}-hydrate-start`);
     ReactDOM.hydrate(children, element);
-    window.performance.mark(`${root}-hydrate-end`);
+    window.performance.mark(`${rootWithIndex}-hydrate-end`);
     window.performance.measure(
-        `${root}-hydrate`,
-        `${root}-hydrate-start`,
-        `${root}-hydrate-end`,
+        `${rootWithIndex}-hydrate`,
+        `${rootWithIndex}-hydrate-start`,
+        `${rootWithIndex}-hydrate-end`,
     );
     return null;
 };

--- a/src/web/components/elements/CalloutBlockComponent.stories.tsx
+++ b/src/web/components/elements/CalloutBlockComponent.stories.tsx
@@ -3,11 +3,11 @@ import { css } from 'emotion';
 import fetchMock from 'fetch-mock';
 
 import { calloutCampaign } from '@root/fixtures/calloutCampaign';
-import { Callout } from './Callout';
+import { CalloutBlockComponent } from './CalloutBlockComponent';
 
 export default {
-    component: Callout,
-    title: 'Components/Callout',
+    component: CalloutBlockComponent,
+    title: 'Components/CalloutBlockComponent',
 };
 
 export const Default = () => {
@@ -27,11 +27,7 @@ export const Default = () => {
                 padding: 15px;
             `}
         >
-            <Callout
-                callout={calloutCampaign}
-                calloutsUrl="https://callouts.code.dev-guardianapis.com"
-                pillar="news"
-            />
+            <CalloutBlockComponent callout={calloutCampaign} pillar="news" />
         </div>
     );
 };

--- a/src/web/components/elements/CalloutBlockComponent.tsx
+++ b/src/web/components/elements/CalloutBlockComponent.tsx
@@ -10,6 +10,11 @@ import PlusIcon from '@frontend/static/icons/plus.svg';
 import MinusIcon from '@frontend/static/icons/minus.svg';
 import { Form } from '../Callout/Form';
 
+const wrapperStyles = css`
+    margin-bottom: 26px;
+    margin-top: 16px;
+`;
+
 const calloutDetailsStyles = css`
     border-top: 1px ${neutral[86]} solid;
     border-bottom: 1px ${neutral[86]} solid;
@@ -248,7 +253,7 @@ export const CalloutBlockComponent = ({
 
     if (submissionSuccess) {
         return (
-            <figure>
+            <figure className={wrapperStyles}>
                 <details
                     className={cx(calloutDetailsStyles, backgroundColorStyle)}
                     aria-hidden={true}
@@ -281,7 +286,7 @@ export const CalloutBlockComponent = ({
     }
 
     return (
-        <figure>
+        <figure className={wrapperStyles}>
             <details
                 className={cx(calloutDetailsStyles, {
                     [backgroundColorStyle]: isExpanded,

--- a/src/web/components/elements/CalloutBlockComponent.tsx
+++ b/src/web/components/elements/CalloutBlockComponent.tsx
@@ -8,7 +8,7 @@ import { Button } from '@guardian/src-button';
 
 import PlusIcon from '@frontend/static/icons/plus.svg';
 import MinusIcon from '@frontend/static/icons/minus.svg';
-import { Form } from './Form';
+import { Form } from '../Callout/Form';
 
 const calloutDetailsStyles = css`
     border-top: 1px ${neutral[86]} solid;
@@ -88,13 +88,11 @@ let hasFormBeenOpened = true;
 
 type formData = { [key in string]: any };
 
-export const Callout = ({
+export const CalloutBlockComponent = ({
     callout,
-    calloutsUrl,
     pillar,
 }: {
     callout: CalloutBlockElement;
-    calloutsUrl: string;
     pillar: Pillar;
 }) => {
     let expandFormButtonRef: HTMLButtonElement | null = null;
@@ -124,7 +122,7 @@ export const Callout = ({
             {},
         );
 
-        return fetch(`${calloutsUrl}/formstack-campaign/submit`, {
+        return fetch(callout.calloutsUrl, {
             method: 'POST',
             body: JSON.stringify({
                 formId: callout.formId,

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -223,10 +223,12 @@ export const ArticleRenderer: React.FC<{
                     );
                 case 'model.dotcomrendering.pageElements.CalloutBlockElement':
                     return (
-                        <CalloutBlockComponent
-                            callout={element}
-                            pillar={pillar}
-                        />
+                        <div id={`callout-${i}`}>
+                            <CalloutBlockComponent
+                                callout={element}
+                                pillar={pillar}
+                            />
+                        </div>
                     );
 
                 case 'model.dotcomrendering.pageElements.AudioBlockElement':

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -19,6 +19,7 @@ import { VideoFacebookBlockComponent } from '@root/src/web/components/elements/V
 import { VimeoBlockComponent } from '@root/src/web/components/elements/VimeoBlockComponent';
 import { YoutubeEmbedBlockComponent } from '@root/src/web/components/elements/YoutubeEmbedBlockComponent';
 import { YoutubeBlockComponent } from '@root/src/web/components/elements/YoutubeBlockComponent';
+import { CalloutBlockComponent } from '@root/src/web/components/elements/CalloutBlockComponent';
 
 import { ExplainerAtom, InteractiveAtom } from '@guardian/atoms-rendering';
 import { Display } from '@root/src/lib/display';
@@ -220,10 +221,16 @@ export const ArticleRenderer: React.FC<{
                             css={element.css}
                         />
                     );
+                case 'model.dotcomrendering.pageElements.CalloutBlockElement':
+                    return (
+                        <CalloutBlockComponent
+                            callout={element}
+                            pillar={pillar}
+                        />
+                    );
 
                 case 'model.dotcomrendering.pageElements.AudioBlockElement':
                 case 'model.dotcomrendering.pageElements.AudioAtomBlockElement':
-                case 'model.dotcomrendering.pageElements.CalloutBlockElement':
                 case 'model.dotcomrendering.pageElements.CodeBlockElement':
                 case 'model.dotcomrendering.pageElements.CommentBlockElement':
                 case 'model.dotcomrendering.pageElements.ContentAtomBlockElement':

--- a/src/web/lib/stringifyFileBase64.ts
+++ b/src/web/lib/stringifyFileBase64.ts
@@ -1,0 +1,30 @@
+export const stringifyFileBase64 = (file: File) =>
+    new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.addEventListener(
+            'load',
+            () => {
+                const fileAsBase64 =
+                    reader &&
+                    reader.result &&
+                    reader.result.toString().split(';base64,')[1];
+                // remove data:*/*;base64, from the start of the base64 string
+
+                reject(
+                    'Sorry there was a problem with the file you uploaded above. Check the size and type. We only accept images, pdfs and .doc or .docx files',
+                );
+                fileAsBase64
+                    ? resolve(fileAsBase64)
+                    : reject(
+                          'Sorry there was a problem with the file you uploaded above. Check the size and type. We only accept images, pdfs and .doc or .docx files',
+                      );
+            },
+            false,
+        );
+        reader.addEventListener('error', () => {
+            reject(
+                'Sorry there was a problem with the file you uploaded above. Check the size and type. We only accept images, pdfs and .doc or .docx files',
+            );
+        });
+        reader.readAsDataURL(file);
+    });

--- a/src/web/lib/stringifyFileBase64.ts
+++ b/src/web/lib/stringifyFileBase64.ts
@@ -11,19 +11,27 @@ export const stringifyFileBase64 = (file: File) =>
                 // remove data:*/*;base64, from the start of the base64 string
 
                 reject(
-                    'Sorry there was a problem with the file you uploaded above. Check the size and type. We only accept images, pdfs and .doc or .docx files',
+                    Error(
+                        'Sorry there was a problem with the file you uploaded above. Check the size and type. We only accept images, pdfs and .doc or .docx files',
+                    ),
                 );
-                fileAsBase64
-                    ? resolve(fileAsBase64)
-                    : reject(
-                          'Sorry there was a problem with the file you uploaded above. Check the size and type. We only accept images, pdfs and .doc or .docx files',
-                      );
+                if (fileAsBase64) {
+                    resolve(fileAsBase64);
+                } else {
+                    reject(
+                        Error(
+                            'Sorry there was a problem with the file you uploaded above. Check the size and type. We only accept images, pdfs and .doc or .docx files',
+                        ),
+                    );
+                }
             },
             false,
         );
         reader.addEventListener('error', () => {
             reject(
-                'Sorry there was a problem with the file you uploaded above. Check the size and type. We only accept images, pdfs and .doc or .docx files',
+                Error(
+                    'Sorry there was a problem with the file you uploaded above. Check the size and type. We only accept images, pdfs and .doc or .docx files',
+                ),
             );
         });
         reader.readAsDataURL(file);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3692,6 +3692,13 @@
     "@babel/runtime" "^7.10.2"
     "@testing-library/dom" "^7.14.2"
 
+"@testing-library/user-event@^12.0.11":
+  version "12.0.11"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-12.0.11.tgz#157594e6c6d73a1503003933177843648b8c7da4"
+  integrity sha512-r7QNfktLE2n8IODEl32orup/HNOMueJpoXRDeTMlvWR4nZIHJwx59+8SkLf6nqV4Ot5Xo6qNeaWrvC1KO4eOng==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
+
 "@textlint/ast-node-types@^4.0.3":
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/@textlint/ast-node-types/-/ast-node-types-4.2.4.tgz#ae569bd76364040939044d057d5a56284563a7af"


### PR DESCRIPTION
## What does this change?
- Enables `CalloutBlockElement` in `src/web/lib/ArticleRenderer.tsx`
- Add Hydration to the `CalloutBlockElement` to enable JS
- use `calloutsUrl` to determine the callout URL

### Before
<img width="665" alt="Screenshot 2020-07-08 at 14 05 54" src="https://user-images.githubusercontent.com/8831403/86916798-6c689c80-c124-11ea-828f-c07e6c082ab8.png">


### After
<img width="638" alt="Screenshot 2020-07-08 at 14 07 44" src="https://user-images.githubusercontent.com/8831403/86916805-6ecaf680-c124-11ea-88de-9f365148bc42.png">


## Why?
We want to be able to support callout embeds now. Callout blocks are part of the page element and therefore can be SSR, but as they requite some logic to convert files into base64 strings and handle accessibility logic, they need client side hydration to enable JS.
