### PR TITLE
full width top ad

### DIFF
--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -243,7 +243,7 @@ export const StandardLayout = ({
     // 2) Otherwise, ensure slot only renders if `CAPI.config.shouldHideReaderRevenue` equals false.
 
     const seriesTag = CAPI.tags.find(
-        tag => tag.type === 'Series' || tag.type === 'Blog',
+        (tag) => tag.type === 'Series' || tag.type === 'Blog',
     );
     const showOnwardsLower = seriesTag && CAPI.hasStoryPackage;
 
@@ -263,6 +263,7 @@ export const StandardLayout = ({
                         showTopBorder={false}
                         showSideBorders={false}
                         padded={false}
+                        shouldCenter={false}
                     >
                         <HeaderAdSlot
                             isAdFreeUser={CAPI.isAdFreeUser}


### PR DESCRIPTION
## What does this change?

Top ad slots should not be 'centered' and rather allowed to expand to a full-width.

### Before

![image](https://user-images.githubusercontent.com/76776/86601588-6c886100-bf99-11ea-928f-ae8153818aed.png)

### After

![image](https://user-images.githubusercontent.com/76776/86601671-845fe500-bf99-11ea-8920-1dfef43d6e45.png)

## Why?

Native ads should display identically between frontend and DCR. See associated PR: https://github.com/guardian/frontend/pull/22776