### PR TITLE
Add Legacy font family names to support interactives

### DIFF
--- a/src/lib/fonts-css.ts
+++ b/src/lib/fonts-css.ts
@@ -3,8 +3,11 @@ import { getStatic } from './assets';
 
 type FontFamily =
     | 'GH Guardian Headline'
+    | 'Guardian Egyptian Web' // Legacy of GH Guardian Headline
     | 'GuardianTextEgyptian'
-    | 'GuardianTextSans';
+    | 'Guardian Text Egyptian Web' // Legacy of GuardianTextEgyptian
+    | 'GuardianTextSans'
+    | 'Guardian Text Sans Web'; // Legacy of GuardianTextSans
 
 type FontStyle = 'normal' | 'italic';
 
@@ -18,8 +21,20 @@ interface FontDisplay {
 }
 
 const fontList: FontDisplay[] = [
+    // GH Guardian Headline, with legacy family name of Guardian Egyptian Web
     {
         family: 'GH Guardian Headline',
+        woff2:
+            'fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Light.woff2',
+        woff:
+            'fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Light.woff',
+        ttf:
+            'fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Light.ttf',
+        weight: 300,
+        style: 'normal',
+    },
+    {
+        family: 'Guardian Egyptian Web',
         woff2:
             'fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Light.woff2',
         woff:
@@ -41,7 +56,29 @@ const fontList: FontDisplay[] = [
         style: 'italic',
     },
     {
+        family: 'Guardian Egyptian Web',
+        woff2:
+            'fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-LightItalic.woff2',
+        woff:
+            'fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-LightItalic.woff',
+        ttf:
+            'fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-LightItalic.ttf',
+        weight: 300,
+        style: 'italic',
+    },
+    {
         family: 'GH Guardian Headline',
+        woff2:
+            'fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.woff2',
+        woff:
+            'fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.woff',
+        ttf:
+            'fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Medium.ttf',
+        weight: 500,
+        style: 'normal',
+    },
+    {
+        family: 'Guardian Egyptian Web',
         woff2:
             'fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.woff2',
         woff:
@@ -63,6 +100,17 @@ const fontList: FontDisplay[] = [
         style: 'italic',
     },
     {
+        family: 'Guardian Egyptian Web',
+        woff2:
+            'fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-MediumItalic.woff2',
+        woff:
+            'fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-MediumItalic.woff',
+        ttf:
+            'fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-MediumItalic.ttf',
+        weight: 500,
+        style: 'italic',
+    },
+    {
         family: 'GH Guardian Headline',
         woff2:
             'fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.woff2',
@@ -74,7 +122,30 @@ const fontList: FontDisplay[] = [
         style: 'normal',
     },
     {
+        family: 'Guardian Egyptian Web',
+        woff2:
+            'fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.woff2',
+        woff:
+            'fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Bold.woff',
+        ttf:
+            'fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Bold.ttf',
+        weight: 700,
+        style: 'normal',
+    },
+    // GuardianTextEgyptian, with legacy family name of Guardian Text Egyptian Web
+    {
         family: 'GuardianTextEgyptian',
+        woff2:
+            'fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff2',
+        woff:
+            'fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff',
+        ttf:
+            'fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-Regular.ttf',
+        weight: 400,
+        style: 'normal',
+    },
+    {
+        family: 'Guardian Text Egyptian Web',
         woff2:
             'fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff2',
         woff:
@@ -96,6 +167,17 @@ const fontList: FontDisplay[] = [
         style: 'italic',
     },
     {
+        family: 'Guardian Text Egyptian Web',
+        woff2:
+            'fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.woff2',
+        woff:
+            'fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-RegularItalic.woff',
+        ttf:
+            'fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-RegularItalic.ttf',
+        weight: 400,
+        style: 'italic',
+    },
+    {
         family: 'GuardianTextEgyptian',
         woff2:
             'fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.woff2',
@@ -107,7 +189,30 @@ const fontList: FontDisplay[] = [
         style: 'normal',
     },
     {
+        family: 'Guardian Text Egyptian Web',
+        woff2:
+            'fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.woff2',
+        woff:
+            'fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-Bold.woff',
+        ttf:
+            'fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-Bold.ttf',
+        weight: 700,
+        style: 'normal',
+    },
+    // GuardianTextSans, with legacy family name of Guardian Text Sans Web
+    {
         family: 'GuardianTextSans',
+        woff2:
+            'fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.woff2',
+        woff:
+            'fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.woff',
+        ttf:
+            'fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-Regular.ttf',
+        weight: 400,
+        style: 'normal',
+    },
+    {
+        family: 'Guardian Text Sans Web',
         woff2:
             'fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.woff2',
         woff:
@@ -129,7 +234,29 @@ const fontList: FontDisplay[] = [
         style: 'italic',
     },
     {
+        family: 'Guardian Text Sans Web',
+        woff2:
+            'fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-RegularItalic.woff2',
+        woff:
+            'fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-RegularItalic.woff',
+        ttf:
+            'fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-RegularItalic.ttf',
+        weight: 400,
+        style: 'italic',
+    },
+    {
         family: 'GuardianTextSans',
+        woff2:
+            'fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Bold.woff2',
+        woff:
+            'fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-Bold.woff',
+        ttf:
+            'fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-Bold.ttf',
+        weight: 700,
+        style: 'normal',
+    },
+    {
+        family: 'Guardian Text Sans Web',
         woff2:
             'fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Bold.woff2',
         woff:

--- a/src/web/server/htmlTemplate.ts
+++ b/src/web/server/htmlTemplate.ts
@@ -242,7 +242,7 @@ export const htmlTemplate = ({
                     ...priorityLegacyScriptTags,
                     ...priorityNonLegacyScriptTags,
                 ].join('\n')}
-                <style>${getFontsCss()}${resetCSS}${css}</style>
+                <style class="webfont">${getFontsCss()}${resetCSS}${css}</style>
 
             </head>
 


### PR DESCRIPTION
## What does this change?

Fixes font families in Interactive Atoms that are included from the parent.

The fonts changed names but existing interactives (and the interactive atom template) expect the old names in their font-family declarations. This legacy font-family names [were added to Source](https://github.com/guardian/source/pull/205/files?diff=unified&w=1) for a similar reason. 

We also add the class of 'webfont' to the fonts `<style>` element to ensure that [the script](https://github.com/guardian/atoms-rendering/blob/master/src/lib/unifyPageContent.tsx#L43) used in interactive atoms that fetches the style block from the interactive atom iframe parent works correctly.

### Before

![Screen Shot 2020-07-08 at 11 54 39](https://user-images.githubusercontent.com/638051/86910585-d461b780-c111-11ea-988a-c55e6b9f17b8.png)

### After

![Screen Shot 2020-07-08 at 11 46 30](https://user-images.githubusercontent.com/638051/86910602-daf02f00-c111-11ea-9723-42e1acae90ad.png)
