### PR TITLE
Callout File Upload

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
         "@storybook/react": "^5.3.19",
         "@testing-library/dom": "^7.9.0",
         "@testing-library/react": "^10.3.0",
+        "@testing-library/user-event": "^12.0.11",
         "@types/amphtml-validator": "^1.0.1",
         "@types/compose-function": "^0.0.30",
         "@types/compression": "^0.0.36",

--- a/src/web/components/Callout/FileUpload.tsx
+++ b/src/web/components/Callout/FileUpload.tsx
@@ -1,11 +1,21 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { css } from 'emotion';
 
+import { textSans } from '@guardian/src-foundations/typography';
+import { text } from '@guardian/src-foundations/palette';
+
+import { stringifyFileBase64 } from '../../lib/stringifyFileBase64';
 import { FieldLabel } from './FieldLabel';
 
 const fileUploadInputStyles = css`
     padding-top: 10px;
     padding-bottom: 10px;
+`;
+
+const errorMessagesStyles = css`
+    padding-bottom: 10px;
+    color: ${text.error};
+    ${textSans.medium({ fontWeight: 'bold' })};
 `;
 
 type Props = {
@@ -14,22 +24,38 @@ type Props = {
     setFormData: React.Dispatch<React.SetStateAction<{ [x: string]: any }>>;
 };
 
-export const FileUpload = ({ formField, formData, setFormData }: Props) => (
-    <>
-        <FieldLabel formField={formField} />
-        <input
-            data-testid={`form-field-${formField.id}`}
-            className={fileUploadInputStyles}
-            type="file"
-            accept="image/*, .pdf"
-            required={formField.required}
-            onChange={(e) =>
+export const FileUpload = ({ formField, formData, setFormData }: Props) => {
+    const [error, setError] = useState('');
+    const onSelectFile = async (event: React.ChangeEvent<HTMLInputElement>) => {
+        if (event.target.files && event.target.files[0]) {
+            try {
+                setError('');
+                const stringifiedFile = await stringifyFileBase64(
+                    event.target.files[0],
+                );
                 setFormData({
                     ...formData,
-                    [formField.id]: e.target.files && e.target.files[0],
-                })
+                    [formField.id]: stringifiedFile,
+                });
+            } catch (e) {
+                setError(e);
             }
-        />
-        <p>We accept images and pdfs. Maximum total file size: 6MB</p>
-    </>
-);
+        }
+    };
+
+    return (
+        <>
+            <FieldLabel formField={formField} />
+            <input
+                data-testid={`form-field-${formField.id}`}
+                className={fileUploadInputStyles}
+                type="file"
+                accept="image/*, .pdf"
+                required={formField.required}
+                onChange={onSelectFile}
+            />
+            <p>We accept images and pdfs. Maximum total file size: 6MB</p>
+            {error && <div className={errorMessagesStyles}>{error}</div>}
+        </>
+    );
+};

--- a/src/web/components/Callout/Form.test.tsx
+++ b/src/web/components/Callout/Form.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import user from '@testing-library/user-event';
 
 import { Form } from './Form';
 
@@ -22,6 +23,15 @@ const textAreaField = {
     type: 'textarea',
     required: true,
 } as CampaignFieldTextArea;
+
+const fileField = {
+    name: 'you_can_upload_a_photo_here_if_you_think_it_will_add_to_your_story',
+    hideLabel: false,
+    label: 'You can upload a photo here if you think it will add to your story',
+    id: '91884877',
+    type: 'file',
+    required: false,
+} as CampaignFieldFile;
 
 const radioField = {
     name: 'can_we_publish_your_response',
@@ -206,10 +216,31 @@ describe('Callout from', () => {
             [checkboxField.id]: ['checkbox 1', 'checkbox 3'],
         });
     });
+    test('should upload the file', () => {
+        const file = new File(['hello'], 'hello.png', { type: 'image/png' });
+        const mockSubmit = jest.fn();
+        const { queryByText } = render(
+            <Form formFields={[fileField]} onSubmit={mockSubmit} />,
+        );
 
-    // TODO:
-    // file upload unit tests are flaky to implement
-    it.todo('should allow file upload');
+        const input = screen.getByTestId(
+            `form-field-${fileField.id}`,
+        ) as HTMLInputElement;
+        user.upload(input, file);
+
+        const inputFiles = input.files ? input.files : [];
+
+        expect(inputFiles[0]).toStrictEqual(file);
+        expect(inputFiles).toHaveLength(1);
+
+        const submitButton = queryByText(
+            'Share with the Guardian',
+        ) as HTMLButtonElement;
+        fireEvent.click(submitButton);
+
+        expect(mockSubmit.mock.calls.length).toBe(1);
+        // TODO: test mockSubmit internal
+    });
 
     it('should submit select', () => {
         const mockSubmit = jest.fn();

--- a/src/web/lib/stringifyFileBase64.ts
+++ b/src/web/lib/stringifyFileBase64.ts
@@ -1,0 +1,38 @@
+export const stringifyFileBase64 = (file: File) =>
+    new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.addEventListener(
+            'load',
+            () => {
+                const fileAsBase64 =
+                    reader &&
+                    reader.result &&
+                    reader.result.toString().split(';base64,')[1];
+                // remove data:*/*;base64, from the start of the base64 string
+
+                reject(
+                    Error(
+                        'Sorry there was a problem with the file you uploaded above. Check the size and type. We only accept images, pdfs and .doc or .docx files',
+                    ),
+                );
+                if (fileAsBase64) {
+                    resolve(fileAsBase64);
+                } else {
+                    reject(
+                        Error(
+                            'Sorry there was a problem with the file you uploaded above. Check the size and type. We only accept images, pdfs and .doc or .docx files',
+                        ),
+                    );
+                }
+            },
+            false,
+        );
+        reader.addEventListener('error', () => {
+            reject(
+                Error(
+                    'Sorry there was a problem with the file you uploaded above. Check the size and type. We only accept images, pdfs and .doc or .docx files',
+                ),
+            );
+        });
+        reader.readAsDataURL(file);
+    });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3702,6 +3702,13 @@
     "@babel/runtime" "^7.10.2"
     "@testing-library/dom" "^7.14.2"
 
+"@testing-library/user-event@^12.0.11":
+  version "12.0.11"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-12.0.11.tgz#157594e6c6d73a1503003933177843648b8c7da4"
+  integrity sha512-r7QNfktLE2n8IODEl32orup/HNOMueJpoXRDeTMlvWR4nZIHJwx59+8SkLf6nqV4Ot5Xo6qNeaWrvC1KO4eOng==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
+
 "@textlint/ast-node-types@^4.0.3":
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/@textlint/ast-node-types/-/ast-node-types-4.2.4.tgz#ae569bd76364040939044d057d5a56284563a7af"


### PR DESCRIPTION
## What does this change?
Stringify the target upload file into based 64 and add it to the `formData` object

## Why?
When sending a file through the callout API call we need to stringify it into base 64. 