### PR TITLE
Re-support interactive embeds

### DIFF
--- a/src/amp/components/Elements.tsx
+++ b/src/amp/components/Elements.tsx
@@ -96,6 +96,8 @@ export const Elements = (
                 return <InstagramBlockComponent key={i} element={element} />;
             case 'model.dotcomrendering.pageElements.InteractiveAtomBlockElement':
                 return <InteractiveAtomBlockComponent url={element.url} />;
+            case 'model.dotcomrendering.pageElements.InteractiveBlockElement': // Plain Interactive Embeds
+                return <InteractiveAtomBlockComponent url={element.url} />;
             case 'model.dotcomrendering.pageElements.MapBlockElement':
                 return (
                     <MapBlockComponent

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -165,6 +165,10 @@ interface InteractiveAtomBlockElement extends InteractiveAtomBlockElementBase {
     css?: string;
 }
 
+interface InteractiveBlockElement extends InteractiveAtomBlockElementBase {
+    _type: 'model.dotcomrendering.pageElements.InteractiveBlockElement';
+}
+
 interface MapBlockElement {
     _type: 'model.dotcomrendering.pageElements.MapBlockElement';
     url: string;
@@ -325,6 +329,7 @@ type CAPIElement =
     | ImageBlockElement
     | InstagramBlockElement
     | InteractiveAtomBlockElement
+    | InteractiveBlockElement
     | MapBlockElement
     | MultiImageBlockElement
     | ProfileAtomBlockElement

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -78,6 +78,9 @@
                         "$ref": "#/definitions/InteractiveAtomBlockElement"
                     },
                     {
+                        "$ref": "#/definitions/InteractiveBlockElement"
+                    },
+                    {
                         "$ref": "#/definitions/MapBlockElement"
                     },
                     {
@@ -418,7 +421,9 @@
                     ]
                 }
             },
-            "required": ["_type"]
+            "required": [
+                "_type"
+            ]
         },
         "BlockquoteBlockElement": {
             "type": "object",
@@ -433,7 +438,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "html"]
+            "required": [
+                "_type",
+                "html"
+            ]
         },
         "CaptionBlockElement": {
             "type": "object",
@@ -472,11 +480,20 @@
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "designType", "display", "pillar"]
+            "required": [
+                "_type",
+                "designType",
+                "display",
+                "pillar"
+            ]
         },
         "Display": {
             "type": "number",
-            "enum": [0, 1, 2]
+            "enum": [
+                0,
+                1,
+                2
+            ]
         },
         "DesignType": {
             "enum": [
@@ -523,6 +540,9 @@
                 "id": {
                     "type": "string"
                 },
+                "calloutsUrl": {
+                    "type": "string"
+                },
                 "activeFrom": {
                     "type": "number"
                 },
@@ -565,11 +585,15 @@
                             }
                         ]
                     }
+                },
+                "calloutIndex": {
+                    "type": "number"
                 }
             },
             "required": [
                 "_type",
                 "activeFrom",
+                "calloutsUrl",
                 "description",
                 "displayOnSensitive",
                 "formFields",
@@ -584,7 +608,9 @@
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": ["textarea"]
+                    "enum": [
+                        "text"
+                    ]
                 },
                 "id": {
                     "type": "string"
@@ -608,14 +634,23 @@
                     "type": "string"
                 }
             },
-            "required": ["hideLabel", "id", "label", "name", "required", "type"]
+            "required": [
+                "hideLabel",
+                "id",
+                "label",
+                "name",
+                "required",
+                "type"
+            ]
         },
         "CampaignFieldTextArea": {
             "type": "object",
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": ["text"]
+                    "enum": [
+                        "textarea"
+                    ]
                 },
                 "id": {
                     "type": "string"
@@ -639,14 +674,23 @@
                     "type": "string"
                 }
             },
-            "required": ["hideLabel", "id", "label", "name", "required", "type"]
+            "required": [
+                "hideLabel",
+                "id",
+                "label",
+                "name",
+                "required",
+                "type"
+            ]
         },
         "CampaignFieldFile": {
             "type": "object",
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": ["file"]
+                    "enum": [
+                        "file"
+                    ]
                 },
                 "id": {
                     "type": "string"
@@ -670,14 +714,23 @@
                     "type": "string"
                 }
             },
-            "required": ["hideLabel", "id", "label", "name", "required", "type"]
+            "required": [
+                "hideLabel",
+                "id",
+                "label",
+                "name",
+                "required",
+                "type"
+            ]
         },
         "CampaignFieldRadio": {
             "type": "object",
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": ["radio"]
+                    "enum": [
+                        "radio"
+                    ]
                 },
                 "options": {
                     "type": "array",
@@ -691,7 +744,10 @@
                                 "type": "string"
                             }
                         },
-                        "required": ["label", "value"]
+                        "required": [
+                            "label",
+                            "value"
+                        ]
                     }
                 },
                 "id": {
@@ -731,7 +787,9 @@
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": ["checkbox"]
+                    "enum": [
+                        "checkbox"
+                    ]
                 },
                 "options": {
                     "type": "array",
@@ -745,7 +803,10 @@
                                 "type": "string"
                             }
                         },
-                        "required": ["label", "value"]
+                        "required": [
+                            "label",
+                            "value"
+                        ]
                     }
                 },
                 "id": {
@@ -785,7 +846,9 @@
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": ["select"]
+                    "enum": [
+                        "select"
+                    ]
                 },
                 "options": {
                     "type": "array",
@@ -799,7 +862,10 @@
                                 "type": "string"
                             }
                         },
-                        "required": ["label", "value"]
+                        "required": [
+                            "label",
+                            "value"
+                        ]
                     }
                 },
                 "id": {
@@ -859,7 +925,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "url"]
+            "required": [
+                "_type",
+                "url"
+            ]
         },
         "CodeBlockElement": {
             "type": "object",
@@ -874,7 +943,10 @@
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "isMandatory"]
+            "required": [
+                "_type",
+                "isMandatory"
+            ]
         },
         "CommentBlockElement": {
             "type": "object",
@@ -927,7 +999,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "atomId"]
+            "required": [
+                "_type",
+                "atomId"
+            ]
         },
         "DisclaimerBlockElement": {
             "type": "object",
@@ -942,7 +1017,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "html"]
+            "required": [
+                "_type",
+                "html"
+            ]
         },
         "DividerBlockElement": {
             "type": "object",
@@ -954,7 +1032,9 @@
                     ]
                 }
             },
-            "required": ["_type"]
+            "required": [
+                "_type"
+            ]
         },
         "DocumentBlockElement": {
             "type": "object",
@@ -978,7 +1058,12 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "embedUrl", "height", "width"]
+            "required": [
+                "_type",
+                "embedUrl",
+                "height",
+                "width"
+            ]
         },
         "EmbedBlockElement": {
             "type": "object",
@@ -1002,7 +1087,11 @@
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "html", "isMandatory"]
+            "required": [
+                "_type",
+                "html",
+                "isMandatory"
+            ]
         },
         "ExplainerAtomBlockElement": {
             "type": "object",
@@ -1023,7 +1112,12 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "body", "id", "title"]
+            "required": [
+                "_type",
+                "body",
+                "id",
+                "title"
+            ]
         },
         "GenericAtomBlockElement": {
             "type": "object",
@@ -1050,7 +1144,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "url"]
+            "required": [
+                "_type",
+                "url"
+            ]
         },
         "GuideAtomBlockElement": {
             "type": "object",
@@ -1080,7 +1177,14 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "credit", "html", "id", "label", "title"]
+            "required": [
+                "_type",
+                "credit",
+                "html",
+                "id",
+                "label",
+                "title"
+            ]
         },
         "GuVideoBlockElement": {
             "type": "object",
@@ -1101,7 +1205,11 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "assets", "caption"]
+            "required": [
+                "_type",
+                "assets",
+                "caption"
+            ]
         },
         "VideoAssets": {
             "type": "object",
@@ -1113,7 +1221,10 @@
                     "type": "string"
                 }
             },
-            "required": ["mimeType", "url"]
+            "required": [
+                "mimeType",
+                "url"
+            ]
         },
         "HighlightBlockElement": {
             "type": "object",
@@ -1128,7 +1239,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "html"]
+            "required": [
+                "_type",
+                "html"
+            ]
         },
         "ImageBlockElement": {
             "type": "object",
@@ -1149,7 +1263,9 @@
                             }
                         }
                     },
-                    "required": ["allImages"]
+                    "required": [
+                        "allImages"
+                    ]
                 },
                 "data": {
                     "type": "object",
@@ -1184,7 +1300,13 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "data", "imageSources", "media", "role"]
+            "required": [
+                "_type",
+                "data",
+                "imageSources",
+                "media",
+                "role"
+            ]
         },
         "Image": {
             "type": "object",
@@ -1205,7 +1327,10 @@
                             "type": "string"
                         }
                     },
-                    "required": ["height", "width"]
+                    "required": [
+                        "height",
+                        "width"
+                    ]
                 },
                 "mediaType": {
                     "type": "string"
@@ -1217,7 +1342,13 @@
                     "type": "string"
                 }
             },
-            "required": ["fields", "index", "mediaType", "mimeType", "url"]
+            "required": [
+                "fields",
+                "index",
+                "mediaType",
+                "mimeType",
+                "url"
+            ]
         },
         "ImageSource": {
             "type": "object",
@@ -1232,7 +1363,10 @@
                     }
                 }
             },
-            "required": ["srcSet", "weighting"]
+            "required": [
+                "srcSet",
+                "weighting"
+            ]
         },
         "Weighting": {
             "enum": [
@@ -1255,7 +1389,10 @@
                     "type": "number"
                 }
             },
-            "required": ["src", "width"]
+            "required": [
+                "src",
+                "width"
+            ]
         },
         "RoleType": {
             "enum": [
@@ -1287,7 +1424,12 @@
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "hasCaption", "html", "url"]
+            "required": [
+                "_type",
+                "hasCaption",
+                "html",
+                "url"
+            ]
         },
         "InteractiveAtomBlockElement": {
             "type": "object",
@@ -1314,7 +1456,42 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "url"]
+            "required": [
+                "_type",
+                "id",
+                "js",
+                "url"
+            ]
+        },
+        "InteractiveBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.InteractiveBlockElement"
+                    ]
+                },
+                "url": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "html": {
+                    "type": "string"
+                },
+                "css": {
+                    "type": "string"
+                },
+                "js": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "_type",
+                "url"
+            ]
         },
         "MapBlockElement": {
             "type": "object",
@@ -1369,7 +1546,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "images"]
+            "required": [
+                "_type",
+                "images"
+            ]
         },
         "ProfileAtomBlockElement": {
             "type": "object",
@@ -1399,7 +1579,14 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "credit", "html", "id", "label", "title"]
+            "required": [
+                "_type",
+                "credit",
+                "html",
+                "id",
+                "label",
+                "title"
+            ]
         },
         "PullquoteBlockElement": {
             "type": "object",
@@ -1420,7 +1607,11 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "html", "role"]
+            "required": [
+                "_type",
+                "html",
+                "role"
+            ]
         },
         "QABlockElement": {
             "type": "object",
@@ -1447,7 +1638,13 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "credit", "html", "id", "title"]
+            "required": [
+                "_type",
+                "credit",
+                "html",
+                "id",
+                "title"
+            ]
         },
         "RichLinkBlockElement": {
             "type": "object",
@@ -1474,7 +1671,12 @@
                     "type": "number"
                 }
             },
-            "required": ["_type", "prefix", "text", "url"]
+            "required": [
+                "_type",
+                "prefix",
+                "text",
+                "url"
+            ]
         },
         "SoundcloudBlockElement": {
             "type": "object",
@@ -1498,7 +1700,13 @@
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "html", "id", "isMandatory", "isTrack"]
+            "required": [
+                "_type",
+                "html",
+                "id",
+                "isMandatory",
+                "isTrack"
+            ]
         },
         "SubheadingBlockElement": {
             "type": "object",
@@ -1513,7 +1721,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "html"]
+            "required": [
+                "_type",
+                "html"
+            ]
         },
         "TableBlockElement": {
             "type": "object",
@@ -1531,7 +1742,11 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "html", "isMandatory"]
+            "required": [
+                "_type",
+                "html",
+                "isMandatory"
+            ]
         },
         "TextBlockElement": {
             "type": "object",
@@ -1549,7 +1764,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "html"]
+            "required": [
+                "_type",
+                "html"
+            ]
         },
         "TimelineBlockElement": {
             "type": "object",
@@ -1576,7 +1794,12 @@
                     }
                 }
             },
-            "required": ["_type", "events", "id", "title"]
+            "required": [
+                "_type",
+                "events",
+                "id",
+                "title"
+            ]
         },
         "TimelineEvent": {
             "type": "object",
@@ -1594,7 +1817,10 @@
                     "type": "string"
                 }
             },
-            "required": ["date", "title"]
+            "required": [
+                "date",
+                "title"
+            ]
         },
         "TweetBlockElement": {
             "type": "object",
@@ -1618,7 +1844,13 @@
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "hasMedia", "html", "id", "url"]
+            "required": [
+                "_type",
+                "hasMedia",
+                "html",
+                "id",
+                "url"
+            ]
         },
         "VideoBlockElement": {
             "type": "object",
@@ -1630,7 +1862,9 @@
                     ]
                 }
             },
-            "required": ["_type"]
+            "required": [
+                "_type"
+            ]
         },
         "VideoFacebookBlockElement": {
             "type": "object",
@@ -1657,7 +1891,13 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "caption", "height", "url", "width"]
+            "required": [
+                "_type",
+                "caption",
+                "height",
+                "url",
+                "width"
+            ]
         },
         "VideoVimeoBlockElement": {
             "type": "object",
@@ -1690,7 +1930,12 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "height", "url", "width"]
+            "required": [
+                "_type",
+                "height",
+                "url",
+                "width"
+            ]
         },
         "VideoYoutubeBlockElement": {
             "type": "object",
@@ -1723,7 +1968,12 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "height", "url", "width"]
+            "required": [
+                "_type",
+                "height",
+                "url",
+                "width"
+            ]
         },
         "YoutubeBlockElement": {
             "type": "object",
@@ -1759,7 +2009,11 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "assetId", "mediaTitle"]
+            "required": [
+                "_type",
+                "assetId",
+                "mediaTitle"
+            ]
         },
         "Block": {
             "type": "object",
@@ -1833,6 +2087,9 @@
                             },
                             {
                                 "$ref": "#/definitions/InteractiveAtomBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/InteractiveBlockElement"
                             },
                             {
                                 "$ref": "#/definitions/MapBlockElement"
@@ -1910,7 +2167,10 @@
                     "type": "string"
                 }
             },
-            "required": ["elements", "id"]
+            "required": [
+                "elements",
+                "id"
+            ]
         },
         "Pagination": {
             "type": "object",
@@ -1934,7 +2194,10 @@
                     "type": "string"
                 }
             },
-            "required": ["currentPage", "totalPages"]
+            "required": [
+                "currentPage",
+                "totalPages"
+            ]
         },
         "AuthorType": {
             "type": "object",
@@ -1951,7 +2214,12 @@
             }
         },
         "Edition": {
-            "enum": ["AU", "INT", "UK", "US"],
+            "enum": [
+                "AU",
+                "INT",
+                "UK",
+                "US"
+            ],
             "type": "string"
         },
         "TagType": {
@@ -1976,7 +2244,11 @@
                     "type": "string"
                 }
             },
-            "required": ["id", "title", "type"]
+            "required": [
+                "id",
+                "title",
+                "type"
+            ]
         },
         "SimpleLinkType": {
             "type": "object",
@@ -1988,7 +2260,10 @@
                     "type": "string"
                 }
             },
-            "required": ["title", "url"]
+            "required": [
+                "title",
+                "url"
+            ]
         },
         "ConfigType": {
             "description": "the config model will contain useful app/site\nlevel data. Although currently derived from the config model\nconstructed in frontend and passed to dotcom-rendering\nthis data could eventually be defined in dotcom-rendering",
@@ -2182,7 +2457,12 @@
                     "$ref": "#/definitions/EditionCommercialProperties"
                 }
             },
-            "required": ["AU", "INT", "UK", "US"]
+            "required": [
+                "AU",
+                "INT",
+                "UK",
+                "US"
+            ]
         },
         "EditionCommercialProperties": {
             "type": "object",
@@ -2197,7 +2477,9 @@
                     "$ref": "#/definitions/Branding"
                 }
             },
-            "required": ["adTargeting"]
+            "required": [
+                "adTargeting"
+            ]
         },
         "AdTargetParam": {
             "type": "object",
@@ -2219,7 +2501,10 @@
                     ]
                 }
             },
-            "required": ["name", "value"]
+            "required": [
+                "name",
+                "value"
+            ]
         },
         "Branding": {
             "type": "object",
@@ -2231,7 +2516,9 @@
                             "type": "string"
                         }
                     },
-                    "required": ["name"]
+                    "required": [
+                        "name"
+                    ]
                 },
                 "sponsorName": {
                     "type": "string"
@@ -2258,10 +2545,18 @@
                                     "type": "number"
                                 }
                             },
-                            "required": ["height", "width"]
+                            "required": [
+                                "height",
+                                "width"
+                            ]
                         }
                     },
-                    "required": ["dimensions", "label", "link", "src"]
+                    "required": [
+                        "dimensions",
+                        "label",
+                        "link",
+                        "src"
+                    ]
                 },
                 "aboutThisLink": {
                     "type": "string"
@@ -2282,7 +2577,10 @@
                                     "type": "number"
                                 }
                             },
-                            "required": ["height", "width"]
+                            "required": [
+                                "height",
+                                "width"
+                            ]
                         },
                         "link": {
                             "type": "string"
@@ -2291,10 +2589,19 @@
                             "type": "string"
                         }
                     },
-                    "required": ["dimensions", "label", "link", "src"]
+                    "required": [
+                        "dimensions",
+                        "label",
+                        "link",
+                        "src"
+                    ]
                 }
             },
-            "required": ["aboutThisLink", "logo", "sponsorName"]
+            "required": [
+                "aboutThisLink",
+                "logo",
+                "sponsorName"
+            ]
         },
         "BadgeType": {
             "type": "object",
@@ -2306,7 +2613,10 @@
                     "type": "string"
                 }
             },
-            "required": ["imageUrl", "seriesTag"]
+            "required": [
+                "imageUrl",
+                "seriesTag"
+            ]
         },
         "FooterType": {
             "type": "object",
@@ -2321,7 +2631,9 @@
                     }
                 }
             },
-            "required": ["footerLinks"]
+            "required": [
+                "footerLinks"
+            ]
         },
         "FooterLink": {
             "type": "object",
@@ -2339,7 +2651,11 @@
                     "type": "string"
                 }
             },
-            "required": ["dataLinkName", "text", "url"]
+            "required": [
+                "dataLinkName",
+                "text",
+                "url"
+            ]
         }
     },
     "$schema": "http://json-schema.org/draft-07/schema#"


### PR DESCRIPTION
## What does this change?

In https://github.com/guardian/frontend/pull/22717/files#diff-5775f8f47d521441655ea7d7f0ce47d8L507 I updated the mapping of InteractiveBlockElement from `AtomMarkupBlockElement` to a specific  `InteractiveBlockElement` but did not add this to the allowed block elements.

Along with https://github.com/guardian/frontend/pull/22789 this PR allows Interactive Embeds through to DCR for AMP.

This had the effect on pages like [First Dog](https://www.theguardian.com/commentisfree/2020/jul/08/to-the-distress-of-wordists-a-dictionary-has-confirmed-the-lexical-veracity-of-irregardless) of 'allowing' the pages in AMP, but not showing the cartoon. Actually, what happens in this case is that the iframe invalidates the page but that is 'expected' and 'parity' behaviour (though not 100% desirable).

