### PR TITLE
CSS Typo: Height =/= Width

### DIFF
--- a/src/amp/components/Sidebar.tsx
+++ b/src/amp/components/Sidebar.tsx
@@ -4,7 +4,7 @@ import { palette } from '@guardian/src-foundations';
 import { headline, textSans } from '@guardian/src-foundations/typography';
 
 const sidebarStyles = css`
-    width: 80vh;
+    width: 80vw;
     background-color: ${palette.brand.main};
 
     [aria-expanded='true'] {


### PR DESCRIPTION
## What does this change?

Fixes a typo, as there is an overriding rule for: `max-width: 80vw` further down.

## Why?

The original `80vh` seemed like a typo, and this removes the horizontal scroll bar showing on AMP.