### PR TITLE
Cypress: AMP Interactive Embeds

### DIFF
--- a/cypress/integration/e2e/article.elements.spec.js
+++ b/cypress/integration/e2e/article.elements.spec.js
@@ -6,12 +6,12 @@ describe('Elements', function () {
     describe('AMP', function () {
         // Based on examples from this blog post about working with iframes in Cypress
         // https://www.cypress.io/blog/2020/02/12/working-with-iframes-in-cypress/
-        const getAmpIframeBody = () => {
+        const getAmpIframeBody = (iframeSelector) => {
             // get the iframe > document > body
             // and retry until the body element is not empty
             return (
                 cy
-                    .get('amp-iframe[data-cy="atom-embed-url"] > iframe')
+                    .get(iframeSelector)
                     .its('0.contentDocument.body')
                     .should('not.be.empty')
                     // wraps "body" DOM element to allow
@@ -21,12 +21,24 @@ describe('Elements', function () {
             );
         };
 
-        it('should render the corona embed', function () {
+        it('should render the corona interactive atom embed', function () {
             cy.visit(
                 'AMPArticle?url=https://www.theguardian.com/world/2020/apr/24/new-mother-dies-of-coronavirus-six-days-after-giving-birth',
             );
 
-            getAmpIframeBody().contains('Data from Public Health England');
+            getAmpIframeBody(
+                'amp-iframe[data-cy="atom-embed-url"] > iframe',
+            ).contains('Data from Public Health England');
+        });
+
+        it('should render the counted interactive embed', function () {
+            cy.visit(
+                'AMPArticle?url=https://www.theguardian.com/us-news/2015/nov/05/police-tasers-deaths-the-counted',
+            );
+
+            getAmpIframeBody(
+                'amp-iframe[src="https://interactive.guim.co.uk/embed/2015/10/2015-10-counted-table/"] > iframe',
+            ).contains('Deaths after Taser use: the findings');
         });
     });
 

--- a/cypress/integration/e2e/article.elements.spec.js
+++ b/cypress/integration/e2e/article.elements.spec.js
@@ -36,9 +36,14 @@ describe('Elements', function () {
                 'AMPArticle?url=https://www.theguardian.com/us-news/2015/nov/05/police-tasers-deaths-the-counted',
             );
 
-            getAmpIframeBody(
-                'amp-iframe[src="https://interactive.guim.co.uk/embed/2015/10/2015-10-counted-table/"] > iframe',
-            ).contains('Deaths after Taser use: the findings');
+            const ampIframeSelector =
+                'amp-iframe[src="https://interactive.guim.co.uk/embed/2015/10/2015-10-counted-table/"]';
+            const ampIframe = cy.get(ampIframeSelector);
+            ampIframe.scrollIntoView();
+
+            getAmpIframeBody(`${ampIframeSelector} > iframe`).contains(
+                'Deaths after Taser use: the findings',
+            );
         });
     });
 


### PR DESCRIPTION
## What does this change?

Cypress: Checks that we render AMP Interactive Embeds

## Why?

Smoke test on a regression where we lost interactive embeds.
