### PR TITLE
Only show byline image with one contributor

### DIFF
--- a/src/amp/components/topMeta/TopMetaOpinion.tsx
+++ b/src/amp/components/topMeta/TopMetaOpinion.tsx
@@ -68,6 +68,9 @@ const BylineMeta: React.SFC<{
     const contributorTag = articleData.tags.find(
         (t) => t.type === 'Contributor',
     );
+    const contributorCount = articleData.tags.filter(
+        (t) => t.type === 'Contributor',
+    ).length;
     const bylineImageUrl = contributorTag
         ? contributorTag.bylineImageUrl
         : null;
@@ -84,7 +87,7 @@ const BylineMeta: React.SFC<{
                 })}
             />
 
-            {contributorTag && bylineImageUrl && (
+            {contributorTag && bylineImageUrl && contributorCount === 1 && (
                 <amp-img
                     class={bylineImageStyle}
                     src={bylineImageUrl}


### PR DESCRIPTION
## What does this change?

If an opinion article has multiple contributors, we don't want to show the byline image.

## Why?

Prevents stuff like this (raised by Kath..)

![image](https://user-images.githubusercontent.com/638051/87144910-6697c600-c2a0-11ea-97e9-6c46928aec49.png)

