### PR TITLE
reversed sections array of donut

### DIFF
--- a/src/web/components/MatchStats.tsx
+++ b/src/web/components/MatchStats.tsx
@@ -203,7 +203,7 @@ export const MatchStats = ({ home, away }: Props) => (
                                     label: away.name.slice(0, 3).toUpperCase(),
                                     color: away.colours,
                                 },
-                            ]}
+                            ].reverse()}
                         />
                     </Center>
                     <br />


### PR DESCRIPTION
## What does this change?

Reverses array of possession donut, so `home` and `away` are aligned with the rest of the report.
[DCR now](https://www.theguardian.com/football/2020/jul/12/bournemouths-dominic-solanke-spells-double-trouble-for-10-man-leicester?dcr) matches the [frontend version](https://www.theguardian.com/football/2020/jul/12/bournemouths-dominic-solanke-spells-double-trouble-for-10-man-leicester).

### Before

![image](https://user-images.githubusercontent.com/76776/87283858-a7384f00-c4ed-11ea-9122-fc6fb5cf158d.png)

### After

![image](https://user-images.githubusercontent.com/76776/87283793-97206f80-c4ed-11ea-8238-60257cf6b6c2.png)

## Why?

The `Donut` element is filled clockwise, making the first item (`home`)of the array visually on the right, whereas it is otherwise on the left. Maybe the fill direction could be a prop?