### PR TITLE
Refactor contributions service logic in preparation for subs banners

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -319,6 +319,7 @@ type CAPIBrowserType = {
         discussionApiClientHeader: string;
         dcrSentryDsn: string;
         remoteBanner: boolean;
+        remoteSubscriptionsBanner: boolean;
         ausMoment2020Header: boolean;
     };
     richLinks: RichLinkBlockElement[];

--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -121,6 +121,8 @@ export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
             enableSentryReporting: CAPI.config.switches.enableSentryReporting,
             enableDiscussionSwitch: CAPI.config.switches.enableDiscussionSwitch,
             remoteBanner: CAPI.config.switches.remoteBanner,
+            remoteSubscriptionsBanner:
+                CAPI.config.switches.remoteSubscriptionsBanner,
             ausMoment2020Header: CAPI.config.switches.ausMoment2020Header,
 
             // used by lib/ad-targeting.ts

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -38,7 +38,7 @@ type Props = {
     alreadyVisitedCount: number;
     engagementBannerLastClosedAt?: string;
     subscriptionBannerLastClosedAt?: string;
-    switches: { [String]: boolean };
+    switches: { [key: string]: boolean };
 };
 
 // TODO specify return type (need to update client to provide this first)

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -38,7 +38,7 @@ type Props = {
     alreadyVisitedCount: number;
     engagementBannerLastClosedAt?: string;
     subscriptionBannerLastClosedAt?: string;
-    switches: { [string]: boolean };
+    switches: { [String]: boolean };
 };
 
 // TODO specify return type (need to update client to provide this first)

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -37,6 +37,8 @@ type Props = {
     contributionsServiceUrl: string;
     alreadyVisitedCount: number;
     engagementBannerLastClosedAt?: string;
+    subscriptionBannerLastClosedAt?: string;
+    switches: { [string]: boolean };
 };
 
 // TODO specify return type (need to update client to provide this first)
@@ -55,8 +57,11 @@ const buildPayload = (props: Props) => {
             isPaidContent: props.isPaidContent,
             showSupportMessaging: !shouldHideSupportMessaging(props.isSignedIn),
             engagementBannerLastClosedAt: props.engagementBannerLastClosedAt,
+            subscriptionBannerLastClosedAt:
+                props.subscriptionBannerLastClosedAt,
             mvtId: Number(getCookie('GU_mvt_id')),
             countryCode: props.countryCode,
+            switches: props.switches,
         },
     };
 };
@@ -74,6 +79,8 @@ const MemoisedInner = ({
     contributionsServiceUrl,
     alreadyVisitedCount,
     engagementBannerLastClosedAt,
+    subscriptionBannerLastClosedAt,
+    switches,
 }: Props) => {
     const [Banner, setBanner] = useState<React.FC>();
     const [bannerProps, setBannerProps] = useState<{}>();
@@ -98,6 +105,8 @@ const MemoisedInner = ({
             isSensitive,
             alreadyVisitedCount,
             engagementBannerLastClosedAt,
+            subscriptionBannerLastClosedAt,
+            switches,
         });
 
         window.guardian.automat = {
@@ -192,6 +201,8 @@ export const ReaderRevenueBanner = ({
     contributionsServiceUrl,
     alreadyVisitedCount,
     engagementBannerLastClosedAt,
+    subscriptionBannerLastClosedAt,
+    switches,
 }: Props) => {
     if (isSignedIn === undefined || countryCode === undefined) {
         return null;
@@ -213,6 +224,8 @@ export const ReaderRevenueBanner = ({
             contributionsServiceUrl={contributionsServiceUrl}
             alreadyVisitedCount={alreadyVisitedCount}
             engagementBannerLastClosedAt={engagementBannerLastClosedAt}
+            subscriptionBannerLastClosedAt={subscriptionBannerLastClosedAt}
+            switches={switches}
         />
     );
 };

--- a/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -13,8 +13,8 @@ type Props = {
     CAPI: CAPIBrowserType;
 };
 
-const getEngagementBannerLastClosedAt = (): string | undefined => {
-    const item = localStorage.getItem('gu.prefs.engagementBannerLastClosedAt');
+const getBannerLastClosedAt = (key: string): string | undefined => {
+    const item = localStorage.getItem(`gu.prefs.${key}`);
     return (item && JSON.parse(item).value) || undefined;
 };
 
@@ -44,7 +44,7 @@ export const StickyBottomBanner = ({
 
     if (showOldCMP) return <CMP />;
 
-    const showRRBanner = CAPI.config.remoteBanner && countryCode === 'AU';
+    const showRRBanner = CAPI.config.remoteBanner;
 
     if (showRRBanner)
         return (
@@ -60,7 +60,16 @@ export const StickyBottomBanner = ({
                 tags={CAPI.tags}
                 contributionsServiceUrl={CAPI.contributionsServiceUrl}
                 alreadyVisitedCount={getAlreadyVisitedCount()}
-                engagementBannerLastClosedAt={getEngagementBannerLastClosedAt()}
+                engagementBannerLastClosedAt={getBannerLastClosedAt(
+                    'engagementBannerLastClosedAt',
+                )}
+                subscriptionBannerLastClosedAt={getBannerLastClosedAt(
+                    'subscriptionBannerLastClosedAt',
+                )}
+                switches={{
+                    remoteSubscriptionsBanner: !!CAPI.config
+                        .remoteSubscriptionsBanner,
+                }}
             />
         );
 

--- a/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -44,7 +44,7 @@ export const StickyBottomBanner = ({
 
     if (showOldCMP) return <CMP />;
 
-    const showRRBanner = CAPI.config.remoteBanner;
+    const showRRBanner = CAPI.config.remoteBanner && countryCode === 'AU';
 
     if (showRRBanner)
         return (


### PR DESCRIPTION
## What does this change?

This is the DCR equivalent of the `frontend` PR: https://github.com/guardian/frontend/pull/22805

https://github.com/guardian/frontend/pull/22805 introduced a new switch `remoteSubscriptionsBanner` in `frontend`. This PR passes the value of this switch on to the `contributions-service` in the `targeting` object.

This PR also adds a new `subscriptionBannerLastClosedAt` property to the `targeting` object, this value is read from `localStorage`.

## Why?

- Sends extra info required to select the subscriptions banners
- Allows us to quickly turn off the old subscriptions banner and start using new service with the `remoteSubscriptionsBanner` switch.
