### PR TITLE
Minimum 8 instances in ASG

### DIFF
--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -60,8 +60,8 @@ Mappings:
       Value: rendering
   StageMap:
     PROD:
-      MinCapacity: 6
-      MaxCapacity: 24
+      MinCapacity: 8
+      MaxCapacity: 32
     CODE:
       MinCapacity: 1
       MaxCapacity: 4


### PR DESCRIPTION
Adds a couple more t3.small instances to the ASG as we are anticipating needing more capacity when we do an audience size increase of ~67%.

I think this should be considered a short term change - we should review more thoroughly the best configuration for running node/express efficiently (i.e. experiment with instance type, number and pm2 cluster mode).
