### PR TITLE
Use article count opt out flag

### DIFF
--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -27,11 +27,12 @@ import { getUser } from '@root/src/web/lib/getUser';
 import { getCommentContext } from '@root/src/web/lib/getCommentContext';
 import { FocusStyleManager } from '@guardian/src-foundations/utils';
 import { incrementAlreadyVisited } from '@root/src/web/lib/alreadyVisited';
-import { hasOptedOutOfArticleCount } from '../lib/contributions';
 import { incrementDailyArticleCount } from '@frontend/web/lib/dailyArticleCount';
 
 import { useAB } from '@guardian/ab-react';
 import { tests } from '@frontend/web/experiments/ab-tests';
+
+import { hasOptedOutOfArticleCount } from '../lib/contributions';
 
 // *******************************
 // ****** Dynamic imports ********

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -166,7 +166,9 @@ export const App = ({ CAPI, NAV }: Props) => {
     // We should monitor this function call to ensure it only happens within an
     // article pages when other pages are supported by DCR.
     useEffect(() => {
-        incrementWeeklyArticleCount();
+        if (getCookie('gu_article_count_opt_out') == null) {
+            incrementWeeklyArticleCount();
+        }
     }, []);
 
     // Check the url to see if there is a comment hash, e.g. ...crisis#comment-139113120

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -27,6 +27,7 @@ import { getUser } from '@root/src/web/lib/getUser';
 import { getCommentContext } from '@root/src/web/lib/getCommentContext';
 import { FocusStyleManager } from '@guardian/src-foundations/utils';
 import { incrementAlreadyVisited } from '@root/src/web/lib/alreadyVisited';
+import { hasOptedOutOfArticleCount } from '../lib/contributions';
 
 // *******************************
 // ****** Dynamic imports ********
@@ -166,7 +167,7 @@ export const App = ({ CAPI, NAV }: Props) => {
     // We should monitor this function call to ensure it only happens within an
     // article pages when other pages are supported by DCR.
     useEffect(() => {
-        if (getCookie('gu_article_count_opt_out') == null) {
+        if (!hasOptedOutOfArticleCount()) {
             incrementWeeklyArticleCount();
         }
     }, []);

--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -102,6 +102,8 @@ const buildPayload = (props: Props) => {
             lastOneOffContributionDate: getLastOneOffContributionDate(),
             epicViewLog: getViewLog(),
             weeklyArticleHistory: getWeeklyArticleHistory(),
+            hasOptedOutOfArticleCount:
+                getCookie('gu_article_count_opt_out') !== null,
             mvtId: Number(getCookie('GU_mvt_id')),
             countryCode: props.countryCode,
         },

--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -12,6 +12,7 @@ import {
     isRecurringContributor,
     getLastOneOffContributionDate,
     shouldHideSupportMessaging,
+    hasOptedOutOfArticleCount,
 } from '@root/src/web/lib/contributions';
 import { initPerf } from '@root/src/web/browser/initPerf';
 import {
@@ -102,8 +103,7 @@ const buildPayload = (props: Props) => {
             lastOneOffContributionDate: getLastOneOffContributionDate(),
             epicViewLog: getViewLog(),
             weeklyArticleHistory: getWeeklyArticleHistory(),
-            hasOptedOutOfArticleCount:
-                getCookie('gu_article_count_opt_out') !== null,
+            hasOptedOutOfArticleCount: hasOptedOutOfArticleCount(),
             mvtId: Number(getCookie('GU_mvt_id')),
             countryCode: props.countryCode,
         },

--- a/src/web/lib/contributions.tsx
+++ b/src/web/lib/contributions.tsx
@@ -4,6 +4,7 @@ import { getCookie } from '@root/src/web/browser/cookie';
 export const HIDE_SUPPORT_MESSAGING_COOKIE = 'gu_hide_support_messaging';
 export const RECURRING_CONTRIBUTOR_COOKIE = 'gu_recurring_contributor';
 export const ONE_OFF_CONTRIBUTION_DATE_COOKIE = 'gu_one_off_contribution_date';
+export const OPT_OUT_OF_ARTICLE_COUNT_COOKIE = 'gu_article_count_opt_out';
 
 // Support Frontend cookies (dropped when contribution is made)
 export const SUPPORT_RECURRING_CONTRIBUTOR_MONTHLY_COOKIE =
@@ -110,3 +111,6 @@ export const shouldHideSupportMessaging = (
     !shouldShowSupportMessaging() ||
     isRecurringContributor(isSignedIn) ||
     isRecentOneOffContributor();
+
+export const hasOptedOutOfArticleCount = (): boolean =>
+    getCookie(OPT_OUT_OF_ARTICLE_COUNT_COOKIE) !== null;


### PR DESCRIPTION
## What does this change?
We now send contributions service a flag indicating if the user has opted out of article counts. This allows contributions service to send the correct epic. Additionally, only increment the article count when this flag isn't set.
