### PR TITLE
Revert #1733 and fix dailyArticleCount unshift issue

### DIFF
--- a/scripts/jest/setup.ts
+++ b/scripts/jest/setup.ts
@@ -52,3 +52,30 @@ const windowGuardian = {
 
 // Stub global Guardian object
 window.guardian = windowGuardian;
+
+// Mock Local Storage
+// See: https://github.com/facebook/jest/issues/2098#issuecomment-260733457
+// eslint-disable-next-line func-names
+const localStorageMock = (function () {
+    let store: {
+        [key: string]: string;
+    } = {};
+    return {
+        getItem(key: string) {
+            return store[key] || null;
+        },
+        setItem(key: string, value: string) {
+            store[key] = value.toString();
+        },
+        removeItem(key: string) {
+            delete store[key];
+        },
+        clear() {
+            store = {};
+        },
+    };
+})();
+
+Object.defineProperty(window, 'localStorage', {
+    value: localStorageMock,
+});

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -27,6 +27,7 @@ import { getUser } from '@root/src/web/lib/getUser';
 import { getCommentContext } from '@root/src/web/lib/getCommentContext';
 import { FocusStyleManager } from '@guardian/src-foundations/utils';
 import { incrementAlreadyVisited } from '@root/src/web/lib/alreadyVisited';
+import { incrementDailyArticleCount } from '@frontend/web/lib/dailyArticleCount';
 
 import { useAB } from '@guardian/ab-react';
 import { tests } from '@frontend/web/experiments/ab-tests';
@@ -174,6 +175,10 @@ export const App = ({ CAPI, NAV }: Props) => {
 
     useEffect(() => {
         incrementAlreadyVisited();
+    }, []);
+
+    useEffect(() => {
+        incrementDailyArticleCount();
     }, []);
 
     // Log an article view using the Slot Machine client lib

--- a/src/web/lib/dailyArticleCount.test.ts
+++ b/src/web/lib/dailyArticleCount.test.ts
@@ -1,0 +1,135 @@
+import {
+    DailyArticleCount,
+    DailyArticleCountKey,
+    getDailyArticleCount,
+    incrementDailyArticleCount,
+} from './dailyArticleCount';
+
+const today = Math.floor(Date.now() / 86400000);
+
+const validDailyArticleCount: DailyArticleCount = [
+    {
+        day: today,
+        count: 3,
+    },
+    {
+        day: today - 1,
+        count: 2,
+    },
+    {
+        day: today - 2,
+        count: 1,
+    },
+];
+
+describe('dailyArticleCount', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    it('gets an empty array of daily article counts by default', () => {
+        const output = getDailyArticleCount();
+
+        expect(output).toEqual([]);
+    });
+
+    it('returns array of valid daily article counts if they exist', () => {
+        localStorage.setItem(
+            DailyArticleCountKey,
+            JSON.stringify(validDailyArticleCount),
+        );
+
+        const output = getDailyArticleCount();
+
+        expect(output).toEqual(validDailyArticleCount);
+    });
+
+    it('returns empty array of daily article counts if failed to parse local storage, and remove the key from localStorage', () => {
+        localStorage.setItem(DailyArticleCountKey, 'not a valid json string');
+
+        const output = getDailyArticleCount();
+
+        expect(output).toEqual([]);
+        expect(localStorage.getItem(DailyArticleCountKey)).toBeNull();
+    });
+
+    it('increments daily article count for today if daily article count does not exist', () => {
+        // set localstorage to mock daily count
+        incrementDailyArticleCount();
+
+        const expected = [
+            {
+                day: today,
+                count: 1,
+            },
+        ];
+
+        const output = getDailyArticleCount();
+
+        expect(output).toEqual(expected);
+    });
+
+    it('increments daily article count if it exists for today', () => {
+        // set localstorage to mock daily count
+        localStorage.setItem(
+            DailyArticleCountKey,
+            JSON.stringify(validDailyArticleCount),
+        );
+
+        // increment article view
+        incrementDailyArticleCount();
+
+        // set up expected object (views for today should be incremented)
+        const expected = [...validDailyArticleCount];
+        expected[0].count += 1;
+
+        const output = getDailyArticleCount();
+
+        expect(output).toEqual(expected);
+    });
+
+    it('increments daily article count for today if daily article count exists, but not for day', () => {
+        // valid daily article count without first element (today removed)
+        const [, ...mocked] = validDailyArticleCount;
+
+        // set localstorage to mock daily count
+        localStorage.setItem(DailyArticleCountKey, JSON.stringify(mocked));
+
+        // increment article view
+        incrementDailyArticleCount();
+
+        // set up expected object (views for today should be 1)
+        const expected = [...validDailyArticleCount];
+        expected[0].count = 1;
+
+        const output = getDailyArticleCount();
+
+        expect(output).toEqual(expected);
+    });
+
+    it('increments daily article for today if it does not exist, and removes any older than 60 days', () => {
+        // valid daily article count with some older than 60 days
+        const [, ...withoutToday] = validDailyArticleCount;
+        const mocked: DailyArticleCount = [
+            ...withoutToday,
+            ...[
+                { day: today - 61, count: 1 },
+                { day: today - 62, count: 2 },
+            ],
+        ];
+
+        // set localstorage to mock daily count
+        localStorage.setItem(DailyArticleCountKey, JSON.stringify(mocked));
+
+        // increment article view
+        incrementDailyArticleCount();
+
+        // set up expected object (views for today should be incremented, older than 60 days removed)
+        const expected = [...validDailyArticleCount];
+        expected[0].count = 1;
+
+        const output = getDailyArticleCount();
+
+        expect(output).toEqual(expected);
+    });
+});

--- a/src/web/lib/dailyArticleCount.test.ts
+++ b/src/web/lib/dailyArticleCount.test.ts
@@ -36,7 +36,7 @@ describe('dailyArticleCount', () => {
     it('returns array of valid daily article counts if they exist', () => {
         localStorage.setItem(
             DailyArticleCountKey,
-            JSON.stringify(validDailyArticleCount),
+            JSON.stringify({ value: validDailyArticleCount }),
         );
 
         const output = getDailyArticleCount();
@@ -46,6 +46,18 @@ describe('dailyArticleCount', () => {
 
     it('returns empty array of daily article counts if failed to parse local storage, and remove the key from localStorage', () => {
         localStorage.setItem(DailyArticleCountKey, 'not a valid json string');
+
+        const output = getDailyArticleCount();
+
+        expect(output).toEqual([]);
+        expect(localStorage.getItem(DailyArticleCountKey)).toBeNull();
+    });
+
+    it('returns empty array of daily article counts if invalid json format, and removes the key from localStorage', () => {
+        localStorage.setItem(
+            DailyArticleCountKey,
+            JSON.stringify(validDailyArticleCount), // invalid format (array only, not it { value: array } format)
+        );
 
         const output = getDailyArticleCount();
 
@@ -73,7 +85,7 @@ describe('dailyArticleCount', () => {
         // set localstorage to mock daily count
         localStorage.setItem(
             DailyArticleCountKey,
-            JSON.stringify(validDailyArticleCount),
+            JSON.stringify({ value: validDailyArticleCount }),
         );
 
         // increment article view
@@ -93,7 +105,10 @@ describe('dailyArticleCount', () => {
         const [, ...mocked] = validDailyArticleCount;
 
         // set localstorage to mock daily count
-        localStorage.setItem(DailyArticleCountKey, JSON.stringify(mocked));
+        localStorage.setItem(
+            DailyArticleCountKey,
+            JSON.stringify({ value: mocked }),
+        );
 
         // increment article view
         incrementDailyArticleCount();
@@ -119,7 +134,10 @@ describe('dailyArticleCount', () => {
         ];
 
         // set localstorage to mock daily count
-        localStorage.setItem(DailyArticleCountKey, JSON.stringify(mocked));
+        localStorage.setItem(
+            DailyArticleCountKey,
+            JSON.stringify({ value: mocked }),
+        );
 
         // increment article view
         incrementDailyArticleCount();

--- a/src/web/lib/dailyArticleCount.ts
+++ b/src/web/lib/dailyArticleCount.ts
@@ -5,6 +5,11 @@ interface DailyArticle {
 
 export type DailyArticleCount = Array<DailyArticle>;
 
+// in localStorage, has format {"value":[{"day":18459,"count":1},{"day":18457,"count":1},{"day":18446,"count":1}]} to match frontend
+interface DailyArticleCountLocalStorage {
+    value: DailyArticleCount;
+}
+
 export const DailyArticleCountKey = 'gu.history.dailyArticleCount';
 
 export const getDailyArticleCount = (): DailyArticleCount => {
@@ -15,7 +20,14 @@ export const getDailyArticleCount = (): DailyArticleCount => {
     }
 
     try {
-        return JSON.parse(dailyCount);
+        const { value }: DailyArticleCountLocalStorage = JSON.parse(dailyCount);
+
+        // check if value parsed correctly
+        if (!value || !value.length) {
+            throw new Error('Invalid gu.history.dailyArticleCount value');
+        }
+
+        return value;
     } catch (e) {
         // error parsing the string, so remove the key
         localStorage.removeItem(DailyArticleCountKey);
@@ -57,6 +69,8 @@ export const incrementDailyArticleCount = (): void => {
     // set the latest article count
     localStorage.setItem(
         DailyArticleCountKey,
-        JSON.stringify(dailyArticleCount),
+        JSON.stringify({
+            value: dailyArticleCount,
+        } as DailyArticleCountLocalStorage),
     );
 };

--- a/src/web/lib/dailyArticleCount.ts
+++ b/src/web/lib/dailyArticleCount.ts
@@ -1,0 +1,62 @@
+interface DailyArticle {
+    day: number;
+    count: number;
+}
+
+export type DailyArticleCount = Array<DailyArticle>;
+
+export const DailyArticleCountKey = 'gu.history.dailyArticleCount';
+
+export const getDailyArticleCount = (): DailyArticleCount => {
+    const dailyCount = localStorage.getItem(DailyArticleCountKey);
+
+    if (!dailyCount) {
+        return [];
+    }
+
+    try {
+        return JSON.parse(dailyCount);
+    } catch (e) {
+        // error parsing the string, so remove the key
+        localStorage.removeItem(DailyArticleCountKey);
+        // return empty array
+        return [];
+    }
+};
+
+export const incrementDailyArticleCount = (): void => {
+    // get the daily article count from local storage
+    const dailyArticleCount = getDailyArticleCount();
+
+    // calculate days since unix epoch for today date
+    const today = Math.floor(Date.now() / 86400000);
+
+    // check if latest day is today and increment if so
+    if (
+        dailyArticleCount[0] &&
+        dailyArticleCount[0].day &&
+        dailyArticleCount[0].day === today
+    ) {
+        dailyArticleCount[0].count += 1;
+    } else {
+        // else set new day
+        dailyArticleCount.unshift({ day: today, count: 1 });
+
+        // remove any days older than 60
+        const cutOff = today - 60;
+
+        const firstOldDayIndex = dailyArticleCount.findIndex(
+            (dailyCount) => dailyCount.day && dailyCount.day < cutOff,
+        );
+
+        if (firstOldDayIndex > 0) {
+            dailyArticleCount.splice(firstOldDayIndex);
+        }
+    }
+
+    // set the latest article count
+    localStorage.setItem(
+        DailyArticleCountKey,
+        JSON.stringify(dailyArticleCount),
+    );
+};

--- a/src/web/lib/getCountryCode.test.ts
+++ b/src/web/lib/getCountryCode.test.ts
@@ -2,30 +2,6 @@ import fetchMock from 'fetch-mock';
 
 import { getCountryCode } from './getCountryCode';
 
-// Mock Local Storage
-// See: https://github.com/facebook/jest/issues/2098#issuecomment-260733457
-// eslint-disable-next-line func-names
-const localStorageMock = (function () {
-    let store: {
-        [key: string]: string;
-    } = {};
-    return {
-        getItem(key: string) {
-            return store[key] || null;
-        },
-        setItem(key: string, value: string) {
-            store[key] = value.toString();
-        },
-        clear() {
-            store = {};
-        },
-    };
-})();
-
-Object.defineProperty(window, 'localStorage', {
-    value: localStorageMock,
-});
-
 const expectedCountry = 'GB';
 const COUNTRY_CODE_KEY = 'gu.geolocation';
 const TEN_DAYS = 60 * 60 * 24 * 10;


### PR DESCRIPTION
## What does this change?
- Reverts #1733 
- Fixes issue introduced in #1730 

In #1730 I introduced the `dailyArticleCount` to the `localStorage` based on code from `frontend`. However the format I added the JSON to localStorage was different to that in frontend.

In frontend the `gu.history.dailyArticleCount` key was in the following JSON format:
```json
{
   "value": [
      {
         "day":18459,
         "count":1
      },
      {
         "day":18457,
         "count":1
      },
      {
         "day":18446,
         "count":1
      }
   ]
}
```
However in my previous PR I had stored it into local storage as an array instead:
```json
[
      {
         "day":18459,
         "count":1
      },
      {
         "day":18457,
         "count":1
      },
      {
         "day":18446,
         "count":1
      }
 ]
```
This caused an issue when merged into production where if a browser already had the dailyArticleCount in the `{ value: ... }` format, it would parse this into an object okay, but when trying to increment (using `unshift` see #1733 ) it was unable to do so, as it was parsed as an object.

I've now changed this so that in DCR to it also adds the JSON to the localStorage in the same format as frontend so that it's compatible.