### PR TITLE
Migrate legacy colour names to new colour names

### DIFF
--- a/src/amp/components/AdConsent.tsx
+++ b/src/amp/components/AdConsent.tsx
@@ -52,7 +52,7 @@ const buttonStyle = css`
 const acceptStyle = css`
     border-radius: 20px;
     border: 1px solid rgba(255, 255, 255, 0.3);
-    background: ${palette.brandYellow.main};
+    background: ${palette.brandAlt[400]};
     color: ${palette.neutral[7]};
     padding: 5px 20px;
     font-weight: bold;

--- a/src/amp/components/BodyArticle.tsx
+++ b/src/amp/components/BodyArticle.tsx
@@ -42,7 +42,7 @@ const body = (pillar: Pillar, designType: DesignType) => {
     // Extend defaultStyles with custom styles for some designTypes
     const designTypeStyle: DesignTypesObj = {
         ...defaultStyles,
-        Comment: palette.opinion.faded,
+        Comment: palette.opinion[800],
         AdvertisementFeature: palette.neutral[86],
     };
 

--- a/src/amp/components/BodyLiveblog.tsx
+++ b/src/amp/components/BodyLiveblog.tsx
@@ -47,7 +47,7 @@ const updateButtonStyle = css`
         height: 36px;
         padding: 0 12px;
 
-        background-color: ${palette.news.main};
+        background-color: ${palette.news[400]};
         color: ${palette.neutral[100]};
         font-weight: bold;
         ${textSans.xsmall()};

--- a/src/amp/components/Epic.tsx
+++ b/src/amp/components/Epic.tsx
@@ -11,7 +11,7 @@ import { palette } from '@guardian/src-foundations';
 import { headline, body, textSans } from '@guardian/src-foundations/typography';
 
 const epic = css`
-    border-top: 0.0625rem solid ${palette.brandYellow.main};
+    border-top: 0.0625rem solid ${palette.brandAlt[400]};
     background-color: ${palette.neutral[97]};
     clear: left;
     margin-top: 1.5rem;
@@ -43,7 +43,7 @@ const epicParagraph = css`
     vertical-align: 0%;
     line-height: 1.5;
     &::selection {
-        background-color: ${palette.brandYellow.main};
+        background-color: ${palette.brandAlt[400]};
     }
     &:last-of-type {
         display: inline;
@@ -51,7 +51,7 @@ const epicParagraph = css`
 `;
 const highlightedText = css`
     font-size: 1.1rem;
-    background-color: ${palette.brandYellow.main};
+    background-color: ${palette.brandAlt[400]};
     padding: 0.125rem;
     margin-left: 5px;
     color: ${palette.neutral[7]};
@@ -65,7 +65,7 @@ const highlightedText = css`
     display: inline;
 `;
 const supportButton = css`
-    background-color: ${palette.brandYellow.main};
+    background-color: ${palette.brandAlt[400]};
     color: ${palette.neutral[7]};
     display: inline-block;
     ${textSans.medium()};

--- a/src/amp/components/Footer.tsx
+++ b/src/amp/components/Footer.tsx
@@ -12,7 +12,7 @@ import { ReaderRevenueButton } from '@root/src/amp/components/ReaderRevenueButto
 import { InnerContainer } from './InnerContainer';
 
 const footer = css`
-    background-color: ${palette.brand.main};
+    background-color: ${palette.brand[400]};
     color: ${palette.neutral[86]};
     ${textSans.medium()};
     margin-top: 20px;
@@ -30,7 +30,7 @@ const footerLink = css`
     display: block;
 
     :hover {
-        color: ${palette.brandYellow.main};
+        color: ${palette.brandAlt[400]};
     }
 `;
 
@@ -92,7 +92,7 @@ const icon = css`
         left: 0;
         right: 0;
         margin: auto;
-        border: 2px solid ${palette.brand.main};
+        border: 2px solid ${palette.brand[400]};
         border-bottom: 0;
         border-right: 0;
         content: '';
@@ -104,7 +104,7 @@ const icon = css`
 
 const backToTopLink = css`
     position: absolute;
-    background-color: ${palette.brand.main};
+    background-color: ${palette.brand[400]};
     color: ${palette.neutral[100]};
     font-weight: 700;
     top: -14px;
@@ -119,7 +119,7 @@ const backToTopText = css`
 `;
 
 const supportLink = css`
-    color: ${palette.brandYellow.main};
+    color: ${palette.brandAlt[400]};
     ${body.medium()};
     padding-bottom: 0.375rem;
 `;

--- a/src/amp/components/Header.tsx
+++ b/src/amp/components/Header.tsx
@@ -9,7 +9,7 @@ import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 import { ReaderRevenueButton } from '@root/src/amp/components/ReaderRevenueButton';
 
 const headerStyles = css`
-    background-color: ${palette.brand.main};
+    background-color: ${palette.brand[400]};
 `;
 
 const row = css`
@@ -112,7 +112,7 @@ const pillarLinkStyle = (pillar: Pillar) => css`
 `;
 
 const veggieStyles = css`
-    background-color: ${palette.brandYellow.main};
+    background-color: ${palette.brandAlt[400]};
     color: ${palette.neutral[97]};
     height: 42px;
     min-width: 42px;

--- a/src/amp/components/KeyEvents.tsx
+++ b/src/amp/components/KeyEvents.tsx
@@ -53,7 +53,7 @@ const wrapper = css`
 const eventLinkStyle = css`
     display: block;
     text-decoration: none;
-    color: ${palette.sport.dark};
+    color: ${palette.sport[300]};
     :hover {
         text-decoration: underline;
     }

--- a/src/amp/components/ReaderRevenueButton.tsx
+++ b/src/amp/components/ReaderRevenueButton.tsx
@@ -8,7 +8,7 @@ import { until } from '@guardian/src-foundations/mq';
 
 const supportStyles = css`
     align-self: flex-start;
-    background-color: ${palette.brandYellow.main};
+    background-color: ${palette.brandAlt[400]};
     border-radius: 20px;
     display: flex;
     align-items: center;

--- a/src/amp/components/Sidebar.tsx
+++ b/src/amp/components/Sidebar.tsx
@@ -5,7 +5,7 @@ import { headline, textSans } from '@guardian/src-foundations/typography';
 
 const sidebarStyles = css`
     width: 80vh;
-    background-color: ${palette.brand.main};
+    background-color: ${palette.brand[400]};
 
     [aria-expanded='true'] {
         i {
@@ -75,7 +75,7 @@ const link = css`
 `;
 
 const subLinks = css`
-    background-color: ${palette.brand.dark};
+    background-color: ${palette.brand[300]};
     padding-bottom: 12px;
 
     a {
@@ -92,7 +92,7 @@ const otherLinks = css`
 const membershipLinks = css`
     a {
         font-weight: 700;
-        color: ${palette.brandYellow.main};
+        color: ${palette.brandAlt[400]};
     }
 `;
 

--- a/src/amp/components/StarRating.tsx
+++ b/src/amp/components/StarRating.tsx
@@ -4,7 +4,7 @@ import Star from '@frontend/static/icons/star.svg';
 import { palette } from '@guardian/src-foundations';
 
 const ratingsWrapper = css`
-    background-color: ${palette.brandYellow.main};
+    background-color: ${palette.brandAlt[400]};
     display: inline-block;
 `;
 

--- a/src/amp/components/elements/CommentBlockComponent.tsx
+++ b/src/amp/components/elements/CommentBlockComponent.tsx
@@ -22,7 +22,7 @@ const avatar = css`
 
 const metaLink = css`
     border-bottom: 1px solid ${palette.neutral[86]};
-    color: ${palette.news.main};
+    color: ${palette.news[400]};
     text-decoration: none;
     ${textSans.xsmall()};
 `;

--- a/src/amp/components/elements/TimelineBlockComponent.tsx
+++ b/src/amp/components/elements/TimelineBlockComponent.tsx
@@ -18,7 +18,7 @@ const eventStyle = css`
 `;
 
 const highlight = css`
-    background-color: ${palette.brandYellow.main};
+    background-color: ${palette.brandAlt[400]};
 `;
 
 const eventIconStyle = css`

--- a/src/amp/components/topMeta/PaidForBand.tsx
+++ b/src/amp/components/topMeta/PaidForBand.tsx
@@ -23,7 +23,7 @@ const headerStyle = css`
 `;
 
 const focusColor = css`
-    outline-color: ${palette.brandYellow.main};
+    outline-color: ${palette.brandAlt[400]};
 `;
 
 const metaStyle = css`

--- a/src/lib/pillars.ts
+++ b/src/lib/pillars.ts
@@ -1,14 +1,36 @@
 import {
-    news,
-    opinion,
-    sport,
-    culture,
-    lifestyle,
+    news as _news,
+    opinion as _opinion,
+    sport as _sport,
+    culture as _culture,
+    lifestyle as _lifestyle,
     labs,
     border,
 } from '@guardian/src-foundations/palette';
 
 type colour = string;
+
+const [news, opinion, sport, culture, lifestyle] = [
+    _news,
+    _opinion,
+    _sport,
+    _culture,
+    _lifestyle,
+].map((p) => ({
+    // maps legacy colour names to new names in Source
+    dark: p[300],
+    main: p[400],
+    bright: p[500],
+    pastel: p[600],
+    faded: p[800],
+
+    // continue to expose the new names too!
+    300: p[300],
+    400: p[400],
+    500: p[500],
+    600: p[600],
+    800: p[800],
+}));
 
 interface PillarColours {
     dark: colour;
@@ -16,6 +38,11 @@ interface PillarColours {
     bright: colour;
     pastel: colour;
     faded: colour;
+    300: colour;
+    400: colour;
+    500: colour;
+    600: colour;
+    800: colour;
 }
 
 export const pillarNames: Pillar[] = [
@@ -33,6 +60,11 @@ export const augmentedLabs: PillarColours = {
     bright: '#69d1ca', // bright teal
     pastel: '', // TODO
     faded: '#65a897', // dark teal
+    300: labs[300],
+    400: labs[400],
+    500: '#69d1ca', // bright teal
+    600: '', // TODO
+    800: '#65a897', // dark teal
 };
 
 export const pillarPalette: Record<Pillar, PillarColours> = {

--- a/src/web/components/MatchNav.tsx
+++ b/src/web/components/MatchNav.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 
-import { brandYellow, background } from '@guardian/src-foundations/palette';
+import { brandAlt, background } from '@guardian/src-foundations/palette';
 import { headline, textSans } from '@guardian/src-foundations/typography';
 import { space } from '@guardian/src-foundations';
 import { until } from '@guardian/src-foundations/mq';
@@ -45,7 +45,7 @@ const StretchBackground = ({ children }: { children: React.ReactNode }) => (
             justify-content: space-between;
             position: relative;
             padding: ${space[2]}px;
-            background-color: ${brandYellow.main};
+            background-color: ${brandAlt[400]};
 
             :before {
                 content: '';
@@ -57,7 +57,7 @@ const StretchBackground = ({ children }: { children: React.ReactNode }) => (
                 ${until.desktop} {
                     left: calc((100vw - 46rem) / -2);
                 }
-                background-color: ${brandYellow.main};
+                background-color: ${brandAlt[400]};
                 z-index: -1;
             }
         `}

--- a/src/web/components/RichLink.tsx
+++ b/src/web/components/RichLink.tsx
@@ -87,7 +87,7 @@ const richLinkPillarColour: (pillar: Pillar) => colour = (pillar) => {
     if (pillar) {
         return pillarPalette[pillar].main;
     }
-    return pillarPalette.news.main;
+    return pillarPalette.news[400];
 };
 
 const pillarBackground: (pillar: Pillar) => colour = (pillar) => {

--- a/src/web/components/SubNav/SubNav.tsx
+++ b/src/web/components/SubNav/SubNav.tsx
@@ -95,7 +95,7 @@ const showMoreStyle = css`
     color: ${text.supporting};
 
     :hover {
-        color: ${news.main};
+        color: ${news[400]};
     }
 
     ${from.desktop} {


### PR DESCRIPTION
## What does this change?

This change migrates dotcom-rendering from the old colour naming system to the new one.

To facilitate this, I've amended the type definition of `PillarColours` to support both legacy and new names for the time being. There are around 150 instances of `pillarPalette` being called with the legacy names, and I didn't want raise a sprawling change that updates all of them! 😅 

## Why?

Source's [global colour names](https://www.theguardian.design/2a1e5182b/p/492a30-light-palette) have changed from semantic words to numbers representing approximate lightness values. This approach was considered more scalable. The word-based names are deprecated and the number-based names have been available for some time.

With 2.0.0 we have decided to declutter the API and delete the old names. 

As a result of this change, upgrading to Source v2.0.0 should be less of a hassle!

## Before / After

There are no UI changes, and Chromatic will catch us out if there are.

Typecheck passes so the colours I have used here at least exist 🎉  The worst case is that I have mistakenly replaced a colour with a colour that makes content less accessible or less aesthetically pleasing.
