### PR TITLE
Update uwraphtml to support multiple html elements

### DIFF
--- a/cypress/integration/e2e/article.e2e.spec.js
+++ b/cypress/integration/e2e/article.e2e.spec.js
@@ -15,7 +15,8 @@ describe('E2E Page rendering', function () {
 
             it(`It should load ${designType} articles under the ${pillar} pillar`, function () {
                 cy.visit(`Article?url=${url}`, fetchPolyfill);
-                cy.scrollTo('bottom', { duration: 500 });
+                const roughLoadPositionOfMostView = 1400;
+                cy.scrollTo(0, roughLoadPositionOfMostView, { duration: 500 });
                 cy.contains('Lifestyle');
 
                 if (!article.hideMostViewed) {
@@ -31,6 +32,7 @@ describe('E2E Page rendering', function () {
                     );
                 }
 
+                cy.scrollTo('bottom', { duration: 500 });
                 cy.wait('@getShareCount').then((xhr) => {
                     expect(xhr.status).to.be.equal(200);
                     expect(xhr.response.body).to.have.property('path');
@@ -56,7 +58,7 @@ describe('E2E Page rendering', function () {
                     expect(xhr.response.body).to.have.property('tabs');
                     expect(xhr.status).to.be.equal(200);
 
-                    cy.contains('Most popular');
+                    cy.contains('Most commented');
                 });
             });
         });

--- a/src/model/unwrapHtml.test.ts
+++ b/src/model/unwrapHtml.test.ts
@@ -5,8 +5,12 @@ describe('unwrapHtml', () => {
         // Blockquote, elements inside
         const bqUnwrap = {
             html: '<blockquote class="quote"><p>inner</p></blockquote>',
-            prefix: '<blockquote class="quote">',
-            suffix: '</blockquote>',
+            fixes: [
+                {
+                    prefix: '<blockquote class="quote">',
+                    suffix: '</blockquote>',
+                },
+            ],
         };
 
         const {
@@ -17,8 +21,12 @@ describe('unwrapHtml', () => {
         // Paragraph, no elements inside
         const pUnwrap = {
             html: '<p>inner</p>',
-            prefix: '<p>',
-            suffix: '</p>',
+            fixes: [
+                {
+                    prefix: '<p>',
+                    suffix: '</p>',
+                },
+            ],
         };
         const {
             willUnwrap: pIsUnwrapped,
@@ -35,12 +43,96 @@ describe('unwrapHtml', () => {
     it('Returns non-unwrapped HTML if prefix and suffix do not match', () => {
         const bqUnwrap = {
             html: '<blockquote><p>inner</p></blockquote>',
-            prefix: '<blockquote class="quote">',
-            suffix: '</blockquote>',
+            fixes: [
+                {
+                    prefix: '<blockquote class="quote">',
+                    suffix: '</blockquote>',
+                },
+            ],
         };
         const { willUnwrap: isUnwrapped, unwrappedHtml } = unwrapHtml(bqUnwrap);
 
         expect(isUnwrapped).toBeFalsy();
         expect(unwrappedHtml).toBe(bqUnwrap.html);
+    });
+
+    it('Returns wrapped HTML if prefix and suffix of one "fix" match from multiple options', () => {
+        const bqUnwrap = {
+            html: '<blockquote><p>inner</p></blockquote>',
+            fixes: [
+                {
+                    prefix: '<blockquote>',
+                    suffix: '</blockquote>',
+                    unwrappedElement: 'blockquote',
+                },
+                {
+                    prefix: '<p>',
+                    suffix: '</p>',
+                    unwrappedElement: 'p',
+                },
+            ],
+        };
+
+        const {
+            willUnwrap: bqIsUnwrapped,
+            unwrappedHtml: bqUnwrappedHtml,
+            unwrappedElement: bqUnwrappedElement,
+        } = unwrapHtml(bqUnwrap);
+
+        const pUnwrap = {
+            html: '<p>inner</p>',
+            fixes: [
+                {
+                    prefix: '<p>',
+                    suffix: '</p>',
+                    unwrappedElement: 'p',
+                },
+                {
+                    prefix: '<ul>',
+                    suffix: '</ul>',
+                    unwrappedElement: 'ul',
+                },
+            ],
+        };
+        const {
+            willUnwrap: pIsUnwrapped,
+            unwrappedHtml: pUnwrappedHtml,
+            unwrappedElement: pUnwrappedElement,
+        } = unwrapHtml(pUnwrap);
+
+        const ulUnwrap = {
+            html: '<ul><li>Test</li><li>test2</li></ul>',
+            fixes: [
+                {
+                    prefix: '<p>',
+                    suffix: '</p>',
+                    unwrappedElement: 'p',
+                },
+                {
+                    prefix: '<ul>',
+                    suffix: '</ul>',
+                    unwrappedElement: 'ul',
+                },
+            ],
+        };
+
+        // Unwrap Unordered lists
+        const {
+            willUnwrap: ulIsUnwrapped,
+            unwrappedHtml: ulUnwrappedHtml,
+            unwrappedElement: ulUnwrappedElement,
+        } = unwrapHtml(ulUnwrap);
+
+        expect(bqIsUnwrapped).toBeTruthy();
+        expect(bqUnwrappedHtml).toBe('<p>inner</p>');
+        expect(bqUnwrappedElement).toBe('blockquote');
+
+        expect(pIsUnwrapped).toBeTruthy();
+        expect(pUnwrappedHtml).toBe('inner');
+        expect(pUnwrappedElement).toBe('p');
+
+        expect(ulIsUnwrapped).toBeTruthy();
+        expect(ulUnwrappedHtml).toBe('<li>Test</li><li>test2</li>');
+        expect(ulUnwrappedElement).toBe('ul');
     });
 });

--- a/src/model/unwrapHtml.ts
+++ b/src/model/unwrapHtml.ts
@@ -2,18 +2,47 @@ const stripTags = (html: string, prefix: string, suffix: string) => {
     return html.slice(prefix.length, html.length - suffix.length);
 };
 
+/**
+unwrapHtml will check whether the html passed in starts with any of the prefixes
+and ends with the suffixes and will then return the html with the prefix and
+suffix stripped off, as well as the matching element that we want to 'rewrap'
+the html in
+ */
 export const unwrapHtml = ({
-    prefix,
-    suffix,
+    fixes,
     html,
 }: {
-    prefix: string;
-    suffix: string;
+    fixes: { prefix: string; suffix: string; unwrappedElement?: string }[];
     html: string;
-}): { unwrappedHtml: string; willUnwrap: boolean } => {
-    const willUnwrap = html.startsWith(prefix) && html.endsWith(suffix);
+}): {
+    unwrappedHtml: string;
+    willUnwrap: boolean;
+    unwrappedElement: string;
+} => {
+    const fixFilteredToMatchingHtmlTags = fixes.filter(
+        ({ prefix, suffix }) =>
+            html.startsWith(prefix) && html.endsWith(suffix),
+    );
 
-    const unwrappedHtml = willUnwrap ? stripTags(html, prefix, suffix) : html;
+    // We only unwrap if we have a match on the start and end html tags to one of the passed 'fixes'
+    const willUnwrap = fixFilteredToMatchingHtmlTags.length === 1;
+    const matchingFix =
+        fixFilteredToMatchingHtmlTags && fixFilteredToMatchingHtmlTags[0];
 
-    return { unwrappedHtml, willUnwrap };
+    const unwrappedHtml =
+        (willUnwrap &&
+            matchingFix &&
+            // Chop off the start and end tags if we have matches to unwrap the html
+            stripTags(html, matchingFix.prefix, matchingFix.suffix)) ||
+        html;
+
+    // span is the default unwrappedElement
+    const unwrappedElement =
+        (willUnwrap && matchingFix && matchingFix.unwrappedElement) || 'span';
+
+    return {
+        unwrappedHtml,
+        willUnwrap,
+        unwrappedElement,
+    };
 };

--- a/src/web/components/elements/BlockquoteBlockComponent.tsx
+++ b/src/web/components/elements/BlockquoteBlockComponent.tsx
@@ -29,8 +29,7 @@ export const BlockquoteBlockComponent: React.FC<Props> = ({
     pillar,
 }: Props) => {
     const { willUnwrap: isUnwrapped, unwrappedHtml } = unwrapHtml({
-        prefix: '<blockquote>',
-        suffix: '</blockquote>',
+        fixes: [{ prefix: '<blockquote>', suffix: '</blockquote>' }],
         html,
     });
 

--- a/src/web/components/elements/HighlightBlockComponent.tsx
+++ b/src/web/components/elements/HighlightBlockComponent.tsx
@@ -12,8 +12,7 @@ type Props = {
 
 export const HighlightBlockComponent: React.FC<Props> = ({ html }: Props) => {
     const { willUnwrap: isUnwrapped, unwrappedHtml } = unwrapHtml({
-        prefix: '<p>',
-        suffix: '</p>',
+        fixes: [{ prefix: '<p>', suffix: '</p>' }],
         html,
     });
 

--- a/src/web/components/elements/SubheadingBlockComponent.tsx
+++ b/src/web/components/elements/SubheadingBlockComponent.tsx
@@ -6,8 +6,7 @@ export const SubheadingBlockComponent: React.FC<{ html: string }> = ({
     html,
 }) => {
     const { willUnwrap: isUnwrapped, unwrappedHtml } = unwrapHtml({
-        prefix: '<h2>',
-        suffix: '</h2>',
+        fixes: [{ prefix: '<h2>', suffix: '</h2>' }],
         html,
     });
 

--- a/src/web/components/elements/TextBlockComponent.stories.tsx
+++ b/src/web/components/elements/TextBlockComponent.stories.tsx
@@ -12,6 +12,8 @@ const shortHtml =
     '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesquepharetra libero </p>';
 const differentWrapperTags =
     '<span><p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesquepharetra libero nec varius feugiat. Nulla commodo sagittis erat amalesuada. Ut iaculis interdum eros, et tristique ex. In veldignissim arcu. Nulla nisi urna, laoreet a aliquam at, viverra eueros. Proin imperdiet pellentesque turpis sed luctus. Donecdignissim lacus in risus fermentum maximus eu vel justo. Duis nontortor ac elit dapibus imperdiet ut at risus. Etiam pretium, odioeget accumsan venenatis, tortor mi aliquet nisl, vel ullamcorperneque nulla vel elit. Etiam porta mauris nec sagittis luctus.</p></span>';
+const aListHtml =
+    '<ul><li>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesquepharetra libero nec varius feugiat.</li><li>Nulla commodo sagittis erat amalesuada. Ut iaculis interdum eros, et tristique ex. In veldignissim arcu. Nulla nisi urna, laoreet a aliquam at, viverra eueros. Proin imperdiet pellentesque turpis sed luctus. Donecdignissim lacus in risus fermentum maximus eu vel justo. Duis nontortor ac elit dapibus imperdiet ut at risus. Etiam pretium, odioeget accumsan venenatis, tortor mi aliquet nisl, vel ullamcorperneque nulla vel elit. Etiam porta mauris nec sagittis luctus.</li></ul>';
 
 const containerStyles = css`
     max-width: 620px;
@@ -117,3 +119,19 @@ export const FeatureDropCap = () => {
     );
 };
 FeatureDropCap.story = { name: 'with designType of Feature' };
+
+export const AList = () => {
+    return (
+        <div className={containerStyles}>
+            <TextBlockComponent
+                html={aListHtml}
+                pillar="news"
+                forceDropCap={true}
+                designType="Article"
+                display={Display.Standard}
+                isFirstParagraph={false}
+            />
+        </div>
+    );
+};
+NoTags.story = { name: 'with a list' };

--- a/src/web/components/elements/TextBlockComponent.tsx
+++ b/src/web/components/elements/TextBlockComponent.tsx
@@ -108,9 +108,23 @@ export const TextBlockComponent: React.FC<Props> = ({
     forceDropCap,
     isFirstParagraph,
 }: Props) => {
-    const { willUnwrap: isUnwrapped, unwrappedHtml } = unwrapHtml({
-        prefix: '<p>',
-        suffix: '</p>',
+    const {
+        willUnwrap: isUnwrapped,
+        unwrappedHtml,
+        unwrappedElement,
+    } = unwrapHtml({
+        fixes: [
+            {
+                unwrappedElement: 'p',
+                prefix: '<p>',
+                suffix: '</p>',
+            },
+            {
+                unwrappedElement: 'ul',
+                prefix: '<ul>',
+                suffix: '</ul>',
+            },
+        ],
         html,
     });
 
@@ -187,7 +201,7 @@ export const TextBlockComponent: React.FC<Props> = ({
             isUnwrapped={isUnwrapped}
             html={sanitise(unwrappedHtml, sanitiserOptions)}
             elCss={paraStyles}
-            tagName="p"
+            tagName={unwrappedElement || 'p'}
         />
     );
 };

--- a/src/web/components/elements/TextBlockComponent.tsx
+++ b/src/web/components/elements/TextBlockComponent.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 import { neutral } from '@guardian/src-foundations/palette';
-import { textSans, body } from '@guardian/src-foundations/typography';
+import { body } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 import { sanitise } from '@frontend/lib/sanitise-html';
 
@@ -143,7 +143,6 @@ export const TextBlockComponent: React.FC<Props> = ({
         }
 
         li {
-            ${textSans.medium()};
             margin-bottom: 6px;
             padding-left: 20px;
 


### PR DESCRIPTION
## What does this change?

In order to support different element types in `textBlockComponent` - ie: `<ul>` elements, and not have to wrap them in a span, then we need to support multiple checks in the `unwrapHtml` utility.

The underlying issue being fixed here is lack of styling for UL elements because they were nested within a span. Ensuring that we don't do this is more semantic markup. 

### Before
![image](https://user-images.githubusercontent.com/638051/88160233-4a801700-cc06-11ea-80cf-1c85ebbdab19.png)

![image](https://user-images.githubusercontent.com/638051/88160297-5cfa5080-cc06-11ea-8536-609259a605ac.png)

### After

![image](https://user-images.githubusercontent.com/638051/88160199-3f2ceb80-cc06-11ea-9a17-b535e2aa6f0a.png)

![image](https://user-images.githubusercontent.com/638051/88160331-684d7c00-cc06-11ea-95b1-20c6e71f00b3.png)



## Why?
ul - Styling and semantic markup.

There's likely other elements where this is useful, so extending out to allow multiple 'fixes' ensures that we can re-use the utility effectively.