### PR TITLE
Add padding to slot body end between tablet and desktop

### DIFF
--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -8,6 +8,7 @@ import {
     logView,
     getWeeklyArticleHistory,
 } from '@guardian/automat-client';
+import { between } from '@guardian/src-foundations/mq';
 import {
     isRecurringContributor,
     getLastOneOffContributionDate,
@@ -61,6 +62,10 @@ const sendOphanReminderOpenEvent = ({ buttonCopyAsString }: OpenProps) => {
 
 const wrapperMargins = css`
     margin: 18px 0;
+
+    ${between.tablet.and.desktop} {
+        padding-right: 80px;
+    }
 `;
 
 type Props = {


### PR DESCRIPTION
## What does this change?
Add some padding to the slot body end component between tablet and desktop. 

### Before
<img width="981" alt="Screenshot 2020-07-22 at 11 57 42" src="https://user-images.githubusercontent.com/17720442/88171046-95098f80-cc16-11ea-9a03-d3ee69e3ec39.png">

### After
<img width="981" alt="Screenshot 2020-07-22 at 11 58 03" src="https://user-images.githubusercontent.com/17720442/88171327-0cd7ba00-cc17-11ea-95bc-ebd2201a558d.png">

## Why?
This aligns the article body with the slot body end at this breakpoint.