### PR TITLE
Remove hardcoded contributions-service tracking props

### DIFF
--- a/src/web/browser/ophan/ophan.ts
+++ b/src/web/browser/ophan/ophan.ts
@@ -11,30 +11,46 @@ export type OphanAction = 'INSERT' | 'VIEW';
 
 export type OphanComponentType =
     | 'ACQUISITIONS_EPIC'
-    | 'ACQUISITIONS_ENGAGEMENT_BANNER';
+    | 'ACQUISITIONS_ENGAGEMENT_BANNER'
+    | 'ACQUISITIONS_SUBSCRIPTIONS_BANNER';
+
+export type OphanProduct =
+    | 'CONTRIBUTION'
+    | 'MEMBERSHIP_SUPPORTER'
+    | 'DIGITAL_SUBSCRIPTION'
+    | 'PRINT_SUBSCRIPTION';
 
 export type TestMeta = {
     abTestName: string;
     abTestVariant: string;
     campaignCode: string;
     campaignId?: string;
+    componentType: OphanComponentType;
+    products?: OphanProduct[];
 };
 
-export const sendOphanContributionsComponentEvent = (
+export const sendOphanComponentEvent = (
     action: OphanAction,
     testMeta: TestMeta,
-    componentType: OphanComponentType,
 ): void => {
+    const {
+        abTestName,
+        abTestVariant,
+        componentType,
+        products = [],
+        campaignCode,
+    } = testMeta;
+
     const componentEvent = {
         component: {
             componentType,
-            products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
-            campaignCode: testMeta.campaignCode,
+            products,
+            campaignCode,
             id: testMeta.campaignId || testMeta.campaignCode,
         },
         abTest: {
-            name: testMeta.abTestName,
-            variant: testMeta.abTestVariant,
+            name: abTestName,
+            variant: abTestVariant,
         },
         action,
     };

--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -16,7 +16,7 @@ import {
 } from '@root/src/web/lib/contributions';
 import { initPerf } from '@root/src/web/browser/initPerf';
 import {
-    sendOphanContributionsComponentEvent,
+    sendOphanComponentEvent,
     TestMeta,
 } from '@root/src/web/browser/ophan/ophan';
 import { getCookie } from '../browser/cookie';
@@ -81,7 +81,7 @@ const buildPayload = (props: Props) => {
     return {
         tracking: {
             ophanPageId: window.guardian.config.ophan.pageViewId,
-            ophanComponentId: 'ACQUISITIONS_EPIC',
+            ophanComponentId: '', // TODO: Remove ophanComponentId from @guardian/automat-client/dist/types.d.ts Tracking type
             platformId: 'GUARDIAN_WEB',
             clientName: 'dcr',
             referrerUrl: window.location.origin + window.location.pathname,
@@ -186,11 +186,7 @@ const MemoisedInner = ({
                             onReminderOpen: sendOphanReminderOpenEvent,
                         });
                         setEpic(() => epicModule.ContributionsEpic); // useState requires functions to be wrapped
-                        sendOphanContributionsComponentEvent(
-                            'INSERT',
-                            meta,
-                            'ACQUISITIONS_EPIC',
-                        );
+                        sendOphanComponentEvent('INSERT', meta);
                     })
                     // eslint-disable-next-line no-console
                     .catch((error) => console.log(`epic - error is: ${error}`));
@@ -201,12 +197,11 @@ const MemoisedInner = ({
     // Should only run once
     useEffect(() => {
         if (hasBeenSeen && epicMeta) {
-            logView(epicMeta.abTestName);
-            sendOphanContributionsComponentEvent(
-                'VIEW',
-                epicMeta,
-                'ACQUISITIONS_EPIC',
-            );
+            const { abTestName } = epicMeta;
+
+            logView(abTestName);
+
+            sendOphanComponentEvent('VIEW', epicMeta);
         }
     }, [hasBeenSeen, epicMeta]);
 

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -7,7 +7,7 @@ import { logView } from '@root/node_modules/@guardian/automat-client';
 import { shouldHideSupportMessaging } from '@root/src/web/lib/contributions';
 import { getCookie } from '@root/src/web/browser/cookie';
 import {
-    sendOphanContributionsComponentEvent,
+    sendOphanComponentEvent,
     TestMeta,
 } from '@root/src/web/browser/ophan/ophan';
 import { getZIndex } from '@root/src/web/lib/getZIndex';
@@ -46,7 +46,6 @@ const buildPayload = (props: Props) => {
     return {
         tracking: {
             ophanPageId: window.guardian.config.ophan.pageViewId,
-            ophanComponentId: 'ACQUISITIONS_ENGAGEMENT_BANNER',
             platformId: 'GUARDIAN_WEB',
             clientName: 'dcr',
             referrerUrl: window.location.origin + window.location.pathname,
@@ -144,11 +143,7 @@ const MemoisedInner = ({
                         });
                         setBanner(() => bannerModule[module.name]); // useState requires functions to be wrapped
                         setBannerMeta(meta);
-                        sendOphanContributionsComponentEvent(
-                            'INSERT',
-                            meta,
-                            'ACQUISITIONS_ENGAGEMENT_BANNER',
-                        );
+                        sendOphanComponentEvent('INSERT', meta);
                     })
                     // eslint-disable-next-line no-console
                     .catch((error) =>
@@ -161,12 +156,11 @@ const MemoisedInner = ({
     // Should only run once
     useEffect(() => {
         if (hasBeenSeen && bannerMeta) {
-            logView(bannerMeta.abTestName);
-            sendOphanContributionsComponentEvent(
-                'VIEW',
-                bannerMeta,
-                'ACQUISITIONS_ENGAGEMENT_BANNER',
-            );
+            const { abTestName } = bannerMeta;
+
+            logView(abTestName);
+
+            sendOphanComponentEvent('VIEW', bannerMeta);
         }
     }, [hasBeenSeen, bannerMeta]);
 


### PR DESCRIPTION
## What does this change?

Frontend equivalent of this PR: https://github.com/guardian/frontend/pull/22828

We want to start using the `contributions-service` to start serving subscriptions banners, in order to do this we have updated the `contributions-service`. The `contributions-service` was previously setup to receive tracking props in the request payloads sent to the `/epic` and `/banner` routes, these props were hardcoded and were relevant to the Epic and Contributions Banner only. 

The `contributions-service` was updated in https://github.com/guardian/contributions-service/pull/190 to no longer use these hardcoded props but to instead use props associated to the various Banner and Epic components defined in the service instead. These tracking props are now returned in the response from the the `/epic` and `/banner` routes and are fed back into the Components as props at the point they're rendered. The props can also be used in the `view` and `insert` events triggered on `frontend` and `dotcom-rendering`.

This PR makes the relevant changes to stop sending the hardcoded `ophanComponentId` to the service, and to now read the new tracking props when triggering the `view` and `insert` events.

## What is the value of this and can you measure success?

We can track various banners served from the `contribution-service` following this change.