### PR TITLE
Default the element to paragraph for textblockcomponent

### DIFF
--- a/src/model/unwrapHtml.ts
+++ b/src/model/unwrapHtml.ts
@@ -38,7 +38,7 @@ export const unwrapHtml = ({
 
     // span is the default unwrappedElement
     const unwrappedElement =
-        (willUnwrap && matchingFix && matchingFix.unwrappedElement) || 'span';
+        (willUnwrap && matchingFix && matchingFix.unwrappedElement) || 'p';
 
     return {
         unwrappedHtml,

--- a/src/web/components/elements/TextBlockComponent.stories.tsx
+++ b/src/web/components/elements/TextBlockComponent.stories.tsx
@@ -14,6 +14,8 @@ const differentWrapperTags =
     '<span><p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesquepharetra libero nec varius feugiat. Nulla commodo sagittis erat amalesuada. Ut iaculis interdum eros, et tristique ex. In veldignissim arcu. Nulla nisi urna, laoreet a aliquam at, viverra eueros. Proin imperdiet pellentesque turpis sed luctus. Donecdignissim lacus in risus fermentum maximus eu vel justo. Duis nontortor ac elit dapibus imperdiet ut at risus. Etiam pretium, odioeget accumsan venenatis, tortor mi aliquet nisl, vel ullamcorperneque nulla vel elit. Etiam porta mauris nec sagittis luctus.</p></span>';
 const aListHtml =
     '<ul><li>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesquepharetra libero nec varius feugiat.</li><li>Nulla commodo sagittis erat amalesuada. Ut iaculis interdum eros, et tristique ex. In veldignissim arcu. Nulla nisi urna, laoreet a aliquam at, viverra eueros. Proin imperdiet pellentesque turpis sed luctus. Donecdignissim lacus in risus fermentum maximus eu vel justo. Duis nontortor ac elit dapibus imperdiet ut at risus. Etiam pretium, odioeget accumsan venenatis, tortor mi aliquet nisl, vel ullamcorperneque nulla vel elit. Etiam porta mauris nec sagittis luctus.</li></ul>';
+const badMarkup =
+    '<html>\n <head></head>\n <body>\n  <p>In its <a href="https://www.admiral.com/magazine/guides/home/the-jargon-free-guide-to-bicycle-insurance" title="">guide to protecting your bike</a>, the insurer Admiral cites the Kryptonite New York M18 U-lock as being good quality. It costs <a href="http://go.theguardian.com/?id=114047X1572903&amp;url=https%3A%2F%2Fwww.wiggle.co.uk%2Fkryptonite-new-york-m18-u-lock&amp;sref=https://www.theguardian.com/money/2020/jul/18/bike-theft-uk-cycle-sales-best-locks-insurance-bicycle.json?dcr" title="">£82.99 at Wiggle.co.uk</a>. Add a <a href="http://go.theguardian.com/?id=114047X1572903&amp;url=https%3A%2F%2Fwww.wiggle.co.uk%2Fkryptonite-kryptoflex-7-foot-cable-bike-lock%2F&amp;sref=https://www.theguardian.com/money/2020/jul/18/bike-theft-uk-cycle-sales-best-locks-insurance-bicycle.json?dcr" title="">cable</a> for another tenner, so you can loop it through the wheels and secure them, too.</p>\n </body>\n</html>';
 
 const containerStyles = css`
     max-width: 620px;
@@ -135,3 +137,19 @@ export const AList = () => {
     );
 };
 NoTags.story = { name: 'with a list' };
+
+export const BadMarkup = () => {
+    return (
+        <div className={containerStyles}>
+            <TextBlockComponent
+                html={badMarkup}
+                pillar="news"
+                forceDropCap={false}
+                designType="Article"
+                display={Display.Standard}
+                isFirstParagraph={false}
+            />
+        </div>
+    );
+};
+NoTags.story = { name: 'with a bad markup' };


### PR DESCRIPTION
## What does this change?

I had previously made the default element for unwrapped components a `span` but they should be paragraphs.

### Before


![Screen Shot 2020-07-23 at 14 31 00](https://user-images.githubusercontent.com/638051/88292312-66acb280-ccf1-11ea-9d88-b71f5ba54955.png)


### After


![Screen Shot 2020-07-23 at 14 30 53](https://user-images.githubusercontent.com/638051/88294519-416d7380-ccf4-11ea-8c96-cc76a4c40c04.png)
## Why?

In this case, the markup we get through is super odd, so we need to fix that root issue but this more gracefully handles badmarkup

![Screen Shot 2020-07-23 at 14 33 20](https://user-images.githubusercontent.com/638051/88292389-804dfa00-ccf1-11ea-88de-39348e9a4b53.png)
