### PR TITLE
Pass submitComponentEvent prop to remote banner as a prop

### DIFF
--- a/src/web/browser/ophan/ophan.ts
+++ b/src/web/browser/ophan/ophan.ts
@@ -29,6 +29,31 @@ export type TestMeta = {
     products?: OphanProduct[];
 };
 
+export type OphanComponent = {
+    componentType: OphanComponentType;
+    id?: string;
+    products?: OphanProduct[];
+    campaignCode?: string;
+    labels?: string[];
+};
+
+export type OphanComponentEvent = {
+    component: OphanComponent;
+    action: OphanAction;
+    value?: string;
+    id?: string;
+    abTest?: {
+        name: string;
+        variant: string;
+    };
+};
+
+export const submitComponentEvent = (
+    componentEvent: OphanComponentEvent,
+): void => {
+    window.guardian.ophan.record({ componentEvent });
+};
+
 export const sendOphanComponentEvent = (
     action: OphanAction,
     testMeta: TestMeta,
@@ -41,7 +66,7 @@ export const sendOphanComponentEvent = (
         campaignCode,
     } = testMeta;
 
-    const componentEvent = {
+    const componentEvent: OphanComponentEvent = {
         component: {
             componentType,
             products,
@@ -55,7 +80,7 @@ export const sendOphanComponentEvent = (
         action,
     };
 
-    window.guardian.ophan.record({ componentEvent });
+    submitComponentEvent(componentEvent);
 };
 
 export const abTestPayload = (tests: {

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -9,6 +9,7 @@ import { getCookie } from '@root/src/web/browser/cookie';
 import {
     sendOphanComponentEvent,
     TestMeta,
+    submitComponentEvent,
 } from '@root/src/web/browser/ophan/ophan';
 import { getZIndex } from '@root/src/web/lib/getZIndex';
 
@@ -139,6 +140,7 @@ const MemoisedInner = ({
                     .guardianPolyfilledImport(module.url)
                     .then((bannerModule) => {
                         setBannerProps({
+                            submitComponentEvent,
                             ...module.props,
                         });
                         setBanner(() => bannerModule[module.name]); // useState requires functions to be wrapped


### PR DESCRIPTION
## What does this change?

This PR passes the `submitComponentEvent` function as prop to remote Banner components as a prop. This means we can track Ophan "actions" from our Banners, such as click events.

Related PRs:

`frontend`: https://github.com/guardian/frontend/pull/22832
`contributions-service`: https://github.com/guardian/contributions-service/pull/196
