### PR TITLE
Add lighthouse ci github action

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,18 @@
+name: Run Lighthouse CI
+on: [push]
+jobs:
+    lhci:
+        name: Lighthouse CI
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v1
+            - name: Use Node.js 10.15.3
+              uses: actions/setup-node@v1
+              with:
+                  node-version: 10.15.3
+            - run: make build
+            - name: Install and run Lighthouse CI
+              run: |
+                  npm install -g @lhci/cli@0.4.x
+                  lhci autorun

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -2,7 +2,7 @@ name: Run Lighthouse CI
 on: [push]
 jobs:
     lhci:
-        name: Lighthouse CI
+        name: run
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -1,0 +1,11 @@
+module.exports = {
+  ci: {
+    collect: {
+      url: ['http://localhost:9000/Article?url=https://www.theguardian.com/commentisfree/2020/feb/08/hungary-now-for-the-new-right-what-venezuela-once-was-for-the-left'],
+      startServerCommand: 'NODE_ENV=production node dist/frontend.server.js',
+    },
+    upload: {
+      target: 'temporary-public-storage',
+    },
+  },
+};

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -2,7 +2,7 @@ module.exports = {
   ci: {
     collect: {
       url: ['http://localhost:9000/Article?url=https://www.theguardian.com/commentisfree/2020/feb/08/hungary-now-for-the-new-right-what-venezuela-once-was-for-the-left'],
-      startServerCommand: 'NODE_ENV=production node dist/frontend.server.js',
+      startServerCommand: 'NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true node dist/frontend.server.js',
     },
     upload: {
       target: 'temporary-public-storage',

--- a/src/app/logging.ts
+++ b/src/app/logging.ts
@@ -3,7 +3,7 @@ import { configure, getLogger, addLayout, shutdown } from 'log4js';
 
 const logLocation =
     process.env.NODE_ENV === 'production'
-        ? '/var/log/dotcom-rendering/dotcom-rendering.log'
+        ? `${path.resolve('logs')}/dotcom-rendering.log`
         : `${path.resolve('logs')}/dotcom-rendering.log`;
 
 const logFields = (logEvent: any): any => {

--- a/src/app/logging.ts
+++ b/src/app/logging.ts
@@ -25,7 +25,7 @@ addLayout('json', () => {
     };
 });
 
-const log4js_disabled = {
+const disableLog4js = {
     appenders: {
         console: { type: 'console' },
     },
@@ -35,7 +35,7 @@ const log4js_disabled = {
     },
 };
 
-const log4js_enabled = {
+const enableLog4j = {
     appenders: {
         console: { type: 'console' },
         fileAppender: {
@@ -56,10 +56,10 @@ const log4js_enabled = {
 };
 
 if (process.env.DISABLE_LOGGING_AND_METRICS === "true") {
-    configure(log4js_disabled);
+    configure(disableLog4js);
 }
 else {
-    configure(log4js_enabled);
+    configure(enableLog4j);
 }
 
 // We do this to ensure no memory leaks during development as hot reloading

--- a/src/app/logging.ts
+++ b/src/app/logging.ts
@@ -66,5 +66,3 @@ export const logger =
     process.env.NODE_ENV === 'development'
         ? getLogger('development')
         : getLogger();
-
-logger.level = 'info';

--- a/src/app/logging.ts
+++ b/src/app/logging.ts
@@ -2,6 +2,9 @@ import path from 'path';
 import { configure, getLogger, addLayout, shutdown } from 'log4js';
 
 const logLocation =
+    process.env.DISABLE_LOGGING_AND_METRICS === 'true'
+        ? `${path.resolve('logs')}/dotcom-rendering.log`
+        :
     process.env.NODE_ENV === 'production'
         ? '/var/log/dotcom-rendering/dotcom-rendering.log'
         : `${path.resolve('logs')}/dotcom-rendering.log`;

--- a/src/app/logging.ts
+++ b/src/app/logging.ts
@@ -3,7 +3,7 @@ import { configure, getLogger, addLayout, shutdown } from 'log4js';
 
 const logLocation =
     process.env.NODE_ENV === 'production'
-        ? `${path.resolve('logs')}/dotcom-rendering.log`
+        ? '/var/log/dotcom-rendering/dotcom-rendering.log'
         : `${path.resolve('logs')}/dotcom-rendering.log`;
 
 const logFields = (logEvent: any): any => {
@@ -40,6 +40,7 @@ configure({
     categories: {
         default: { appenders: ['fileAppender'], level: 'info' },
         development: { appenders: ['console'], level: 'info' },
+        off: { appenders: ['console'], level: 'off' },
     },
     pm2: true,
 });
@@ -56,6 +57,9 @@ if (process.env.NODE_ENV === 'development') {
 }
 
 export const logger =
+    process.env.DISABLE_LOGGING_AND_METRICS === 'true'
+        ? getLogger('off')
+        :
     process.env.NODE_ENV === 'development'
         ? getLogger('development')
         : getLogger();

--- a/src/app/server.ts
+++ b/src/app/server.ts
@@ -54,6 +54,7 @@ const buildUrlFromPath = (req: Request) => {
 // this is the actual production server
 if (process.env.NODE_ENV === 'production') {
     logger.info('dotcom-rendering is GO.');
+    if(false)
     getGuardianConfiguration('prod')
         .then((config: GuardianConfiguration) => {
             log(`loaded ${config.size()} configuration parameters`);
@@ -144,27 +145,12 @@ if (process.env.NODE_ENV === 'production') {
         }
     });
 
-    app.get('*', async (req: Request, res: Response) => {
-        // Eg. http://localhost:9000/commentisfree/...
-        try {
-            const url = buildUrlFromPath(req);
-            const { html, ...config } = await fetch(url).then((article) =>
-                article.json(),
-            );
-
-            req.body = config;
-            return renderArticle(req, res);
-        } catch (error) {
-            // eslint-disable-next-line no-console
-            console.error(error);
-        }
-    });
-
     // express requires all 4 args here:
-    app.use((err: any, req: any, res: any) => {
+    app.use((err: any, req: any, res: any, next: any) => {
         res.status(500).send(`<pre>${err.stack}</pre>`);
     });
 
+if(false)
     setInterval(() => {
         recordBaselineCloudWatchMetrics();
     }, 10 * 1000);
@@ -172,4 +158,5 @@ if (process.env.NODE_ENV === 'production') {
     app.listen(port);
     // eslint-disable-next-line no-console
     console.log(`Started production server on port ${port}`);
+    console.log('ready');
 }

--- a/src/app/server.ts
+++ b/src/app/server.ts
@@ -146,6 +146,7 @@ if (process.env.NODE_ENV === 'production') {
     });
 
     // express requires all 4 args here:
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     app.use((err: any, req: any, res: any, next: any) => {
         res.status(500).send(`<pre>${err.stack}</pre>`);
     });

--- a/src/app/server.ts
+++ b/src/app/server.ts
@@ -47,15 +47,17 @@ const buildUrlFromQueryParam = (req: Request) => {
 // this is the actual production server
 if (process.env.NODE_ENV === 'production') {
     logger.info('dotcom-rendering is GO.');
-    if(false) // eslint-disable-line 
-    getGuardianConfiguration('prod')
-        .then((config: GuardianConfiguration) => {
-            log(`loaded ${config.size()} configuration parameters`);
-        })
-        .catch((err: any) => {
-            warn('Failed to get configuration. Bad AWS credentials?');
-            warn(err);
-        });
+
+    if (process.env.ENABLE_LOGGING_AND_METRICS !== "false") {
+       getGuardianConfiguration('prod')
+           .then((config: GuardianConfiguration) => {
+               log(`loaded ${config.size()} configuration parameters`);
+           })
+           .catch((err: any) => {
+               warn('Failed to get configuration. Bad AWS credentials?');
+               warn(err);
+           });
+    }
 
     const app = express();
 
@@ -144,10 +146,11 @@ if (process.env.NODE_ENV === 'production') {
         res.status(500).send(`<pre>${err.stack}</pre>`);
     });
 
-if(false) // eslint-disable-line 
-    setInterval(() => {
-        recordBaselineCloudWatchMetrics();
-    }, 10 * 1000);
+    if (process.env.ENABLE_LOGGING_AND_METRICS !== "false") {
+        setInterval(() => {
+            recordBaselineCloudWatchMetrics();
+        }, 10 * 1000);
+    }
 
     app.listen(port);
     // eslint-disable-next-line no-console

--- a/src/app/server.ts
+++ b/src/app/server.ts
@@ -48,7 +48,7 @@ const buildUrlFromQueryParam = (req: Request) => {
 if (process.env.NODE_ENV === 'production') {
     logger.info('dotcom-rendering is GO.');
 
-    if (process.env.ENABLE_LOGGING_AND_METRICS !== "false") {
+    if (process.env.DISABLE_LOGGING_AND_METRICS !== "true") {
        getGuardianConfiguration('prod')
            .then((config: GuardianConfiguration) => {
                log(`loaded ${config.size()} configuration parameters`);
@@ -146,7 +146,7 @@ if (process.env.NODE_ENV === 'production') {
         res.status(500).send(`<pre>${err.stack}</pre>`);
     });
 
-    if (process.env.ENABLE_LOGGING_AND_METRICS !== "false") {
+    if (process.env.DISABLE_LOGGING_AND_METRICS !== "true") {
         setInterval(() => {
             recordBaselineCloudWatchMetrics();
         }, 10 * 1000);

--- a/src/app/server.ts
+++ b/src/app/server.ts
@@ -154,6 +154,5 @@ if (process.env.NODE_ENV === 'production') {
 
     app.listen(port);
     // eslint-disable-next-line no-console
-    console.log(`Started production server on port ${port}`);
-    console.log('ready');
+    console.log(`Started production server on port ${port}\nready`);
 }

--- a/src/app/server.ts
+++ b/src/app/server.ts
@@ -47,7 +47,7 @@ const buildUrlFromQueryParam = (req: Request) => {
 // this is the actual production server
 if (process.env.NODE_ENV === 'production') {
     logger.info('dotcom-rendering is GO.');
-    if(false)
+    if(false) // eslint-disable-line 
     getGuardianConfiguration('prod')
         .then((config: GuardianConfiguration) => {
             log(`loaded ${config.size()} configuration parameters`);
@@ -144,7 +144,7 @@ if (process.env.NODE_ENV === 'production') {
         res.status(500).send(`<pre>${err.stack}</pre>`);
     });
 
-if(false)
+if(false) // eslint-disable-line 
     setInterval(() => {
         recordBaselineCloudWatchMetrics();
     }, 10 * 1000);

--- a/src/app/server.ts
+++ b/src/app/server.ts
@@ -44,13 +44,6 @@ const buildUrlFromQueryParam = (req: Request) => {
     return `${url.origin}${url.pathname}.json?dcr=true&${searchparams}`;
 };
 
-const buildUrlFromPath = (req: Request) => {
-    // Supports urls such as:
-    // http://localhost:9000/tv-and-radio/2020/apr/26/normal-people-review-sally-rooney-bbc-hulu
-    // Note. Defaults to using production frontend
-    return `https://www.theguardian.com${req.url}.json?dcr=true`;
-};
-
 // this is the actual production server
 if (process.env.NODE_ENV === 'production') {
     logger.info('dotcom-rendering is GO.');


### PR DESCRIPTION
## What does this change?

Adds lighthouse-ci as a github action

<img width="480" alt="jorgeazevedo_dotcom-rendering_at_ja-gh-test" src="https://user-images.githubusercontent.com/1672034/88410355-2ff89a00-cdce-11ea-92eb-70845cf5e339.png">

## Why?

We want to be able to measure performance at the PR level!

I had to patch the prod server to make this work, and would appreciate feedback on at least 2 fronts:

* I had to fix a few routing problems that were causing lighthouse to fail. Since this is the prod server, I'm looking to understand if my fixes actually didn't break anything else! Also, if I can get rid of one of the routes
* I need to make some functionality optional, but it feels a bit clunky. I'm looking for feedback on how best to make it optional!

### Fixes

There's two main fixes

First, adding `next` back to `app.use((err: any`. This was removed during a rollout of linting since the argument is unused., but that fourth argument is not optional. Without it, the `res` argument will change and the server will throw the following error

```
TypeError: res.status is not a function
```

Second, removing ` app.get('*'`. AFAIK This was added to facilitate lighthouse ci, but it actually makes the server throw a bunch of errors that ultimately break lighthouse. Joshua report the issue to google [here](https://github.com/GoogleChrome/lighthouse-ci/issues/313), but it's actually due to our server misconfiguration. 

Basically, that generic route will swallow up calls to `assets` and other paths. This will make a cascade of errors like

```
{ FetchError: invalid json response body at https://www.theguardian.com/assets/dynamicImport.d6662415116a9da9a585.js.json?dcr=true reason: Unexpected token < in JSON at position 0
    at /Users/jorge_azevedo/code/dotcom-rendering/node_modules/node-fetch/lib/index.js:272:32
    at process._tickCallback (internal/process/next_tick.js:68:7)
  message:
   'invalid json response body at https://www.theguardian.com/assets/dynamicImport.d6662415116a9da9a585.js.json?dcr=true reason: Unexpected token < in JSON at position 0',
  type: 'invalid-json' }
```

And others paths such as `https://www.theguardian.com/asset-manifest.json` and `https://www.theguardian.com/robots.txt`. This breaks lighthouse, like literally when you run it in the chrome UI, not just the CI tool.

### Optionals

For our production server to run in the github action virtual environment, we need to
- Not log to `/var/log/dotcom-rendering/dotcom-rendering.log` since we won't have the permissions
- Not request aws credentials
- Not push metrics to cloudwatch

I've ended going for a somewhat verbose env variable DISABLE_LOGGING_AND_METRICS to turn both metric collection and log4js off, instead of keeping log4js logging to a file that the CI environment can access.