### PR TITLE
Pass submitComponentEvent prop to remote banner

### DIFF
--- a/src/web/browser/ophan/ophan.ts
+++ b/src/web/browser/ophan/ophan.ts
@@ -87,7 +87,15 @@ export type TestMeta = {
 export const submitComponentEvent = (
     componentEvent: OphanComponentEvent,
 ): void => {
-    window.guardian.ophan.record({ componentEvent });
+    if (
+        window.guardian &&
+        window.guardian.ophan &&
+        window.guardian.ophan.record
+    ) {
+        window.guardian.ophan.record({ componentEvent });
+    } else {
+        throw new Error("window.guardian.ophan.record doesn't exist");
+    }
 };
 
 export const sendOphanComponentEvent = (

--- a/src/web/browser/ophan/ophan.ts
+++ b/src/web/browser/ophan/ophan.ts
@@ -84,6 +84,12 @@ export type TestMeta = {
     products?: OphanProduct[];
 };
 
+export const submitComponentEvent = (
+    componentEvent: OphanComponentEvent,
+): void => {
+    window.guardian.ophan.record({ componentEvent });
+};
+
 export const sendOphanComponentEvent = (
     action: OphanAction,
     testMeta: TestMeta,
@@ -96,7 +102,7 @@ export const sendOphanComponentEvent = (
         campaignCode,
     } = testMeta;
 
-    const componentEvent = {
+    const componentEvent: OphanComponentEvent = {
         component: {
             componentType,
             products,
@@ -110,7 +116,7 @@ export const sendOphanComponentEvent = (
         action,
     };
 
-    window.guardian.ophan.record({ componentEvent });
+    submitComponentEvent(componentEvent);
 };
 
 export const abTestPayload = (tests: {

--- a/src/web/browser/ophan/ophan.ts
+++ b/src/web/browser/ophan/ophan.ts
@@ -84,18 +84,22 @@ export type TestMeta = {
     products?: OphanProduct[];
 };
 
-export const submitComponentEvent = (
-    componentEvent: OphanComponentEvent,
-): void => {
+const record = (event: {}): void => {
     if (
         window.guardian &&
         window.guardian.ophan &&
         window.guardian.ophan.record
     ) {
-        window.guardian.ophan.record({ componentEvent });
+        window.guardian.ophan.record(event);
     } else {
         throw new Error("window.guardian.ophan.record doesn't exist");
     }
+};
+
+export const submitComponentEvent = (
+    componentEvent: OphanComponentEvent,
+): void => {
+    record({ componentEvent });
 };
 
 export const sendOphanComponentEvent = (
@@ -142,20 +146,17 @@ export const abTestPayload = (tests: {
 };
 
 export const sendOphanPlatformRecord = () => {
+    record({ experiences: 'dotcom-rendering' });
+
+    // Record server-side AB test variants (i.e. control or variant)
     if (
         window.guardian &&
-        window.guardian.ophan &&
-        window.guardian.ophan.record
+        window.guardian.config &&
+        window.guardian.config.tests
     ) {
-        window.guardian.ophan.record({ experiences: 'dotcom-rendering' });
+        const { tests } = window.guardian.config;
 
-        // Record server-side AB test variants (i.e. control or variant)
-        if (window.guardian.config.tests) {
-            const { tests } = window.guardian.config;
-            window.guardian.ophan.record(abTestPayload(tests));
-        }
-    } else {
-        throw new Error("window.guardian.ophan.record doesn't exist");
+        record(abTestPayload(tests));
     }
 };
 
@@ -184,7 +185,7 @@ export const recordPerformance = () => {
         redirectCount: performanceAPI.navigation.redirectCount,
     };
 
-    window.guardian.ophan.record({
+    record({
         performance,
     });
 };

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -9,6 +9,7 @@ import { getCookie } from '@root/src/web/browser/cookie';
 import {
     sendOphanComponentEvent,
     TestMeta,
+    submitComponentEvent,
 } from '@root/src/web/browser/ophan/ophan';
 import { getZIndex } from '@root/src/web/lib/getZIndex';
 
@@ -139,6 +140,7 @@ const MemoisedInner = ({
                     .guardianPolyfilledImport(module.url)
                     .then((bannerModule) => {
                         setBannerProps({
+                            submitComponentEvent,
                             ...module.props,
                         });
                         setBanner(() => bannerModule[module.name]); // useState requires functions to be wrapped


### PR DESCRIPTION
## What does this change?

This PR passes the `submitComponentEvent` function as prop to remote Banner components as a prop. This means we can track Ophan "actions" from our Banners, such as click events.

Related PRs:

`frontend`: https://github.com/guardian/frontend/pull/22832
`contributions-service`: https://github.com/guardian/contributions-service/pull/196

NOTE: The original PR https://github.com/guardian/dotcom-rendering/pull/1743 was reverted due to changes going into master after it had been raised which conflicted with it's changes causing the validation Github actions to fail.