### PR TITLE
Update aus header

### DIFF
--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -252,7 +252,6 @@ export const App = ({ CAPI, NAV }: Props) => {
                     edition={CAPI.editionId}
                     dataLinkNamePrefix="nav2 : "
                     inHeader={true}
-                    enableAusMoment2020Header={CAPI.config.ausMoment2020Header}
                 />
             </Portal>
             <Hydrate root="links-root">
@@ -430,7 +429,6 @@ export const App = ({ CAPI, NAV }: Props) => {
                         edition={CAPI.editionId}
                         dataLinkNamePrefix="footer : "
                         inHeader={false}
-                        enableAusMoment2020Header={false}
                     />
                 </Lazy>
             </Portal>

--- a/src/web/components/ReaderRevenueLinks.stories.tsx
+++ b/src/web/components/ReaderRevenueLinks.stories.tsx
@@ -38,7 +38,6 @@ export const Header = () => {
                 urls={revenueUrls}
                 dataLinkNamePrefix=""
                 inHeader={true}
-                enableAusMoment2020Header={false}
             />
         </Container>
     );
@@ -59,7 +58,6 @@ export const HeaderMobile = () => {
                 urls={revenueUrls}
                 dataLinkNamePrefix=""
                 inHeader={true}
-                enableAusMoment2020Header={false}
             />
         </Container>
     );
@@ -80,7 +78,6 @@ export const Footer = () => {
                 urls={revenueUrls}
                 dataLinkNamePrefix=""
                 inHeader={false}
-                enableAusMoment2020Header={false}
             />
         </Container>
     );
@@ -101,7 +98,6 @@ export const FooterMobile = () => {
                 urls={revenueUrls}
                 dataLinkNamePrefix=""
                 inHeader={false}
-                enableAusMoment2020Header={false}
             />
         </Container>
     );

--- a/src/web/components/ReaderRevenueLinks.test.tsx
+++ b/src/web/components/ReaderRevenueLinks.test.tsx
@@ -26,7 +26,6 @@ describe('ReaderRevenueLinks', () => {
                 edition={edition}
                 dataLinkNamePrefix="nav2 : "
                 inHeader={true}
-                enableAusMoment2020Header={false}
             />,
         );
 
@@ -43,7 +42,6 @@ describe('ReaderRevenueLinks', () => {
                 edition={edition}
                 dataLinkNamePrefix="nav2 : "
                 inHeader={true}
-                enableAusMoment2020Header={false}
             />,
         );
 

--- a/src/web/components/ReaderRevenueLinks.tsx
+++ b/src/web/components/ReaderRevenueLinks.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { css, cx } from 'emotion';
 
 import ArrowRightIcon from '@frontend/static/icons/arrow-right.svg';
@@ -11,15 +11,7 @@ import { textSans, headline } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
 import { LinkButton , buttonBrand } from '@guardian/src-button';
 
-
-
 import { shouldHideSupportMessaging } from '@root/src/web/lib/contributions';
-import {
-    fetchTickerData,
-    TickerCountType,
-    TickerData,
-} from '@root/src/lib/fetchTickerData';
-import { addForMinutes, getCookie } from '@root/src/web/browser/cookie';
 import {ThemeProvider} from "@root/node_modules/emotion-theming";
 
 type Props = {
@@ -31,7 +23,6 @@ type Props = {
     };
     dataLinkNamePrefix: string;
     inHeader: boolean;
-    enableAusMoment2020Header: boolean;
 };
 
 const paddingStyles = css`
@@ -120,48 +111,16 @@ const hiddenFromTablet = css`
 const subMessageStyles = css`
     color: ${brandText.primary};
     ${textSans.medium()};
-    margin-bottom: 5px;
+    margin: 5px 0;
 `;
-
-const headerYellowHighlight = css`
-    color: ${brandAlt[400]};
-    font-weight: 700;
-`;
-
-const AUS_MOMENT_SUPPORTER_COUNT_COOKIE_NAME = 'gu_aus_moment_supporter_count';
 
 export const ReaderRevenueLinks: React.FC<Props> = ({
     edition,
     urls,
     dataLinkNamePrefix,
     inHeader,
-    enableAusMoment2020Header,
 }) => {
-    const [numberOfSupporters, setnumberOfSupporters] = useState<string>('');
-    const showAusMomentHeader = edition === 'AU' && enableAusMoment2020Header;
-
-    useEffect(() => {
-        if (showAusMomentHeader) {
-            const cookieValue = getCookie(
-                AUS_MOMENT_SUPPORTER_COUNT_COOKIE_NAME,
-            );
-
-            if (cookieValue) {
-                setnumberOfSupporters(cookieValue.toLocaleString());
-            } else {
-                fetchTickerData(TickerCountType.people).then(
-                    (td: TickerData) => {
-                        addForMinutes(
-                            AUS_MOMENT_SUPPORTER_COUNT_COOKIE_NAME,
-                            `${td.total}`,
-                            60,
-                        );
-                        setnumberOfSupporters(td.total.toLocaleString());
-                    },
-                );
-            }
-        }
-    }, [showAusMomentHeader]);
+    const showAusMomentHeader = edition === 'AU';
 
     if (shouldHideSupportMessaging()) {
         if (showAusMomentHeader) {
@@ -175,12 +134,6 @@ export const ReaderRevenueLinks: React.FC<Props> = ({
                         <div className={messageStyles}>Thank you</div>
 
                         <div className={subMessageStyles}>
-                            We&apos;re funded by
-                            <span className={headerYellowHighlight}>
-                                {` ${numberOfSupporters} `}
-                            </span>
-                            readers across Australia.
-                            <br />
                             <ThemeProvider theme={buttonBrand}>
                                 <LinkButton
                                     priority="secondary"
@@ -207,17 +160,7 @@ export const ReaderRevenueLinks: React.FC<Props> = ({
             >
                 <div className={messageStyles}>Support The&nbsp;Guardian</div>
                 <div className={subMessageStyles}>
-                    {showAusMomentHeader ? (
-                        <div>
-                            We&apos;re funded by
-                            <span className={headerYellowHighlight}>
-                                {` ${numberOfSupporters} `}
-                            </span>
-                            readers across Australia.
-                        </div>
-                    ) : (
-                        <div> Available for everyone, funded by readers</div>
-                    )}
+                    <div> Available for everyone, funded by readers</div>
                 </div>
                 <a
                     className={linkStyles}

--- a/src/web/components/ReaderRevenueLinks.tsx
+++ b/src/web/components/ReaderRevenueLinks.tsx
@@ -141,7 +141,7 @@ export const ReaderRevenueLinks: React.FC<Props> = ({
                                     size="small"
                                     href="https://support.theguardian.com/aus-2020-map?INTCMP=Aus_moment_2020_frontend_header"
                                 >
-                                    Hear from our supporters
+                                    Hear from other supporters
                                 </LinkButton>
                             </ThemeProvider>
                         </div>


### PR DESCRIPTION
We have been showing a special header to AU users.
Now that the 'moment' is over, we will remove it for non-supporters, and modify it for supporters.
This is now a permanent feature so I've removed the switch.
([frontend version](https://github.com/guardian/frontend/pull/22839))

- Non-supporters: back to the standard header (seen by all regions)
![Screen Shot 2020-07-27 at 14 57 50](https://user-images.githubusercontent.com/1513454/88550881-19468300-d01a-11ea-87f8-173ccc0bf82a.png)

- Supporters: still have a special header (on desktop), but we've removed the line with the ticker value:
![Screen Shot 2020-07-27 at 14 57 36](https://user-images.githubusercontent.com/1513454/88550892-1cda0a00-d01a-11ea-81fb-cc5df2ddde30.png)
