### PR TITLE
Fix author head over the byline

### DIFF
--- a/src/web/components/HeadlineByline.tsx
+++ b/src/web/components/HeadlineByline.tsx
@@ -77,6 +77,17 @@ const immersiveLinkStyles = (pillar: Pillar) => css`
     }
 `;
 
+// If there is an image reduce the width of the author div
+const mobileCommentAuthor = css`
+    @media (max-width: 400px) {
+        width: 65%;
+    }
+`;
+
+function hasBylineImage(item: TagType) {
+    return item.bylineImageUrl;
+}
+
 type Props = {
     display: Display;
     designType: DesignType;
@@ -142,8 +153,14 @@ export const HeadlineByline = ({
                     );
                 case 'GuardianView':
                 case 'Comment':
+                    // Check if there is an image for the author
+                    const hasImage = tags.find(hasBylineImage);
                     return (
-                        <div className={opinionStyles(pillar)}>
+                        <div
+                            className={`${opinionStyles(pillar)} ${
+                                hasImage ? mobileCommentAuthor : ''
+                            }`}
+                        >
                             <BylineLink byline={byline} tags={tags} />
                         </div>
                     );

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -163,9 +163,14 @@ const minHeightWithAvatar = css`
     min-height: 259px;
 `;
 
+// If in mobile increase the margin top and margin right deficit
 const avatarPositionStyles = css`
     display: flex;
     justify-content: flex-end;
+    ${from.mobile} {
+        margin-right: -1.85rem;
+        margin-top: -50px;
+    }
     ${from.mobileLandscape} {
         margin-right: -1.25rem;
     }


### PR DESCRIPTION
## What does this change?

This reduces the width of the div containing the authors name when an image is displayed. This stops the problem of images appearing over text when on a mobile.

### Before

![Screenshot 2020-07-27 at 12 17 37](https://user-images.githubusercontent.com/35331926/88551638-fec0d980-d01a-11ea-889f-4e2ff2cab4ba.png)

### After

![Screenshot 2020-07-27 at 12 17 52](https://user-images.githubusercontent.com/35331926/88551697-0e402280-d01b-11ea-9932-218380b04a5b.png)

![Screenshot 2020-07-27 at 14 56 31](https://user-images.githubusercontent.com/35331926/88551718-14ce9a00-d01b-11ea-9dd1-ef9e0a9a325d.png)

