### PR TITLE
Prepare for automat interface change

### DIFF
--- a/scripts/jest/setup.ts
+++ b/scripts/jest/setup.ts
@@ -44,6 +44,7 @@ const windowGuardian = {
     },
     automat: {
         react: undefined,
+        preact: undefined,
         emotion: undefined,
         emotionCore: undefined,
         emotionTheming: undefined,

--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -148,6 +148,7 @@ const MemoisedInner = ({
 
         window.guardian.automat = {
             react: React,
+            preact: React, // temp while we deploy newer contributions-service at which point client-lib does this for us
             emotionCore,
             emotionTheming,
             emotion,

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -111,6 +111,7 @@ const MemoisedInner = ({
 
         window.guardian.automat = {
             react: React,
+            preact: React,
             emotionCore,
             emotionTheming,
             emotion,

--- a/window.guardian.d.ts
+++ b/window.guardian.d.ts
@@ -34,6 +34,7 @@ declare global {
             // TODO expose as type from Automat client lib
             automat: {
                 react: any;
+                preact: any;
                 emotion: any;
                 emotionCore: any;
                 emotionTheming: any;


### PR DESCRIPTION
## What

Add `preact` to the `window.guardian.automat` object.

## Why?

The API for the automat window object is changing. Specifically, rather than 'react' it will expect 'preact' going forward. To
prepare for this we expose both to keep things working during the migration.

Once the contributions-service is updated (see https://github.com/guardian/contributions-service/pull/194) we can switch to the new automat client (see https://github.com/guardian/automat-client-v2/blob/master/src/modules/index.tsx#L19) which handles the `window.guardian.automat` logic itself, so we can remove all of that behaviour in DCR. It also supports shadow-dom, giving us improved isolation for most browsers.