### PR TITLE
Track (remote) subscriptions banner view event in GA

### DIFF
--- a/src/web/browser/ga/ga.ts
+++ b/src/web/browser/ga/ga.ts
@@ -182,10 +182,17 @@ export const trackNonClickInteraction = (actionName: string): void => {
         const send = `${tracker.name}.send`;
 
         ga(send, 'event', 'Interaction', actionName, {
-            nonInteraction: true, // to avoid affecting bounce rate
+            /**
+             * set nonInteraction to avoid affecting bounce rate
+             * https://support.google.com/analytics/answer/1033068#NonInteractionEvents
+             */
+            nonInteraction: true,
         });
     } else {
         const error = new Error("window.ga doesn't exist");
-        window.guardian.modules.sentry.reportError(error);
+        window.guardian.modules.sentry.reportError(
+            error,
+            'trackNonClickInteraction',
+        );
     }
 };

--- a/src/web/browser/ga/ga.ts
+++ b/src/web/browser/ga/ga.ts
@@ -176,9 +176,13 @@ export const sendPageView = (): void => {
 };
 
 export const trackNonClickInteraction = (actionName: string): void => {
-    const send = `${tracker.name}.send`;
+    const { ga } = window;
 
-    window.ga(send, 'event', 'Interaction', actionName, {
-        nonInteraction: true, // to avoid affecting bounce rate
-    });
+    if (ga) {
+        const send = `${tracker.name}.send`;
+
+        ga(send, 'event', 'Interaction', actionName, {
+            nonInteraction: true, // to avoid affecting bounce rate
+        });
+    }
 };

--- a/src/web/browser/ga/ga.ts
+++ b/src/web/browser/ga/ga.ts
@@ -184,5 +184,8 @@ export const trackNonClickInteraction = (actionName: string): void => {
         ga(send, 'event', 'Interaction', actionName, {
             nonInteraction: true, // to avoid affecting bounce rate
         });
+    } else {
+        const error = new Error("window.ga doesn't exist");
+        window.guardian.modules.sentry.reportError(error);
     }
 };

--- a/src/web/browser/ga/ga.ts
+++ b/src/web/browser/ga/ga.ts
@@ -174,3 +174,11 @@ export const sendPageView = (): void => {
 
     trackLCP(send);
 };
+
+export const trackNonClickInteraction = (actionName: string): void => {
+    const send = `${tracker.name}.send`;
+
+    window.ga(send, 'event', 'Interaction', actionName, {
+        nonInteraction: true, // to avoid affecting bounce rate
+    });
+};

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -11,7 +11,7 @@ import {
     TestMeta,
 } from '@root/src/web/browser/ophan/ophan';
 import { getZIndex } from '@root/src/web/lib/getZIndex';
-import { trackNonClickInteraction } from '../../browser/ga/ga';
+import { trackNonClickInteraction } from '@root/src/web/browser/ga/ga';
 
 const checkForErrors = (response: any) => {
     if (!response.ok) {

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -11,7 +11,7 @@ import {
     TestMeta,
 } from '@root/src/web/browser/ophan/ophan';
 import { getZIndex } from '@root/src/web/lib/getZIndex';
-import { trackNonClickInteraction } from './ga';
+import { trackNonClickInteraction } from '../../browser/ga/ga';
 
 const checkForErrors = (response: any) => {
     if (!response.ok) {

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -11,6 +11,7 @@ import {
     TestMeta,
 } from '@root/src/web/browser/ophan/ophan';
 import { getZIndex } from '@root/src/web/lib/getZIndex';
+import { trackNonClickInteraction } from './ga';
 
 const checkForErrors = (response: any) => {
     if (!response.ok) {
@@ -156,11 +157,16 @@ const MemoisedInner = ({
     // Should only run once
     useEffect(() => {
         if (hasBeenSeen && bannerMeta) {
-            const { abTestName } = bannerMeta;
+            const { abTestName, componentType } = bannerMeta;
 
             logView(abTestName);
 
             sendOphanComponentEvent('VIEW', bannerMeta);
+
+            // track banner view event in Google Analytics for subscriptions banner
+            if (componentType === 'ACQUISITIONS_SUBSCRIPTIONS_BANNER') {
+                trackNonClickInteraction('subscription-banner : display');
+            }
         }
     }, [hasBeenSeen, bannerMeta]);
 


### PR DESCRIPTION
## What does this change?

This PR adds a tracking call to Google Analytics (GA) that's fired when a subscriptions banner served from the remote `contributions-service` has been seen. This event is currently recorded in GA for subscriptions banners that are NOT served from the remote `contributions-service`, so we're just making sure we retain this data, as requested by the stakeholder.

To achieve this I've introduced the `trackNonClickInteraction` function into the `ga` module, the same implementation is used in `frontend`.

**frontend equivalent PR:** https://github.com/guardian/frontend/pull/22842
