### PR TITLE
Branding image should not be enlarged

### DIFF
--- a/src/web/components/Branding.tsx
+++ b/src/web/components/Branding.tsx
@@ -52,7 +52,12 @@ export const Branding: React.FC<{
                     rel="nofollow"
                     aria-label={`Visit the ${branding.sponsorName} website`}
                 >
-                    <img src={branding.logo.src} alt={branding.sponsorName} />
+                    <img
+                        src={branding.logo.src}
+                        alt={branding.sponsorName}
+                        height={branding.logo.dimensions.height}
+                        width={branding.logo.dimensions.width}
+                    />
                 </a>
             </div>
 

--- a/src/web/components/Branding.tsx
+++ b/src/web/components/Branding.tsx
@@ -4,7 +4,6 @@ import { textSans } from '@guardian/src-foundations/typography';
 import { css } from 'emotion';
 import { neutral } from '@guardian/src-foundations';
 import { pillarPalette } from '@root/src/lib/pillars';
-import { MaintainAspectRatio } from '@frontend/web/components/MaintainAspectRatio';
 import { until } from '@guardian/src-foundations/mq';
 
 const brandingStyle = css`
@@ -23,6 +22,9 @@ const brandingLogoStyle = css`
     max-width: 220px;
     width: 100%;
     padding: 10px 0;
+    img {
+        max-width: 100%;
+    }
 `;
 
 const brandingAboutLink = (pillar: Pillar) => css`
@@ -44,22 +46,14 @@ export const Branding: React.FC<{
         <div className={brandingStyle}>
             <div className={brandingLabelStyle}>{branding.logo.label}</div>
             <div className={brandingLogoStyle}>
-                <MaintainAspectRatio
-                    height={branding.logo.dimensions.height}
-                    width={branding.logo.dimensions.width}
+                <a
+                    href={branding.logo.link}
+                    data-sponsor={branding.sponsorName.toLowerCase()}
+                    rel="nofollow"
+                    aria-label={`Visit the ${branding.sponsorName} website`}
                 >
-                    <a
-                        href={branding.logo.link}
-                        data-sponsor={branding.sponsorName.toLowerCase()}
-                        rel="nofollow"
-                        aria-label={`Visit the ${branding.sponsorName} website`}
-                    >
-                        <img
-                            src={branding.logo.src}
-                            alt={branding.sponsorName}
-                        />
-                    </a>
-                </MaintainAspectRatio>
+                    <img src={branding.logo.src} alt={branding.sponsorName} />
+                </a>
             </div>
 
             <a

--- a/src/web/components/MaintainAspectRatio.tsx
+++ b/src/web/components/MaintainAspectRatio.tsx
@@ -15,8 +15,7 @@ export const MaintainAspectRatio = ({ height, width, children }: Props) => (
             position: relative;
             padding-bottom: ${(height / width) * 100}%;
 
-            iframe,
-            img {
+            iframe {
                 width: 100%;
                 height: 100%;
                 position: absolute;


### PR DESCRIPTION
## What does this change?
Removes the usage of MaintainAspectRatio for branding images, because images do that natively (if I understand what that's for). Instead we control the max width of the image by setting to 100% and let the image's dimensions dictate the width below that threshold. This means we're not enlarging low resolution images that get used for branding.

### Before
![image](https://user-images.githubusercontent.com/8754692/88640058-688dc180-d0b5-11ea-9386-bdd330f63496.png)


### After
![image](https://user-images.githubusercontent.com/8754692/88640135-7e9b8200-d0b5-11ea-9b3a-52c697f0391a.png)


## Why?
Spotted by editorial that images were blurry and too large.