### PR TITLE
Remove height/width to avoid change to aspect ratio

### DIFF
--- a/src/web/components/Branding.tsx
+++ b/src/web/components/Branding.tsx
@@ -52,12 +52,7 @@ export const Branding: React.FC<{
                     rel="nofollow"
                     aria-label={`Visit the ${branding.sponsorName} website`}
                 >
-                    <img
-                        src={branding.logo.src}
-                        alt={branding.sponsorName}
-                        height={branding.logo.dimensions.height}
-                        width={branding.logo.dimensions.width}
-                    />
+                    <img src={branding.logo.src} alt={branding.sponsorName} />
                 </a>
             </div>
 


### PR DESCRIPTION
## What does this change?
I neglected to test #1760 as thoroughly after making a late change and it turns out that including the width/height parameters will warp the aspect ratio undesirably when we restrict the width for larger images.

### Before
![image](https://user-images.githubusercontent.com/8754692/88661239-1b6b1900-d0d0-11ea-9e85-d9441eac6410.png)


### After
![image](https://user-images.githubusercontent.com/8754692/88661304-32117000-d0d0-11ea-9ca4-78fa4ec6d7f5.png)


## Why?
