### PR TITLE
Fix Overflow X issue on Opinion articles and test it

### DIFF
--- a/cypress/integration/e2e/article.elements.spec.js
+++ b/cypress/integration/e2e/article.elements.spec.js
@@ -52,6 +52,40 @@ describe('Elements', function () {
     });
 
     describe('WEB', function () {
+        it.only('should render the page as expected', function () {
+            cy.viewport('iphone-x');
+            const iphoneXWidth = 375;
+            let hasElementTooWide = false;
+
+            cy.visit(
+                'Article?url=https://www.theguardian.com/commentisfree/2020/jun/30/conservatives-cowboy-builders-boris-johnson',
+            );
+
+            const pageHasXOverflow = (docWidth) => {
+                const scrollbarWidth = 15; // Chrome scrollbar is 15px...
+                return cy.get('*').each(($el) => {
+                    if (
+                        !$el.is('script') && // Remove script elements from check...
+                        $el.outerWidth() > docWidth - scrollbarWidth
+                    ) {
+                        // This is brittle but if we're in here then we're trouble anyway
+                        // hopefully it shows some context for where the problem comes from
+                        // but you probably are going to want to be running Cypress locally
+                        cy.log(
+                            `Element is wider than document: ${$el[0].classList[0]} in parent ${$el[0].parentElement.classList[0]}`,
+                        );
+                        hasElementTooWide = true;
+                    }
+                });
+            };
+
+            cy.wrap(null).then(() =>
+                pageHasXOverflow(iphoneXWidth).then(
+                    () => expect(hasElementTooWide).to.be.false,
+                ),
+            );
+        });
+
         it('should render the instagram embed', function () {
             // https://www.cypress.io/blog/2020/02/12/working-with-iframes-in-cypress/
             const getIframeBody = () => {

--- a/src/web/components/HeadlineByline.stories.tsx
+++ b/src/web/components/HeadlineByline.stories.tsx
@@ -34,6 +34,29 @@ export const commentStory = () => {
 };
 commentStory.story = { name: 'Comment' };
 
+export const commentWithBylineImageStory = () => {
+    // Not visibly different in storybook but will apply a width
+    return (
+        <HeadlineByline
+            display={Display.Standard}
+            designType="Comment"
+            pillar="sport"
+            byline="Jane Smith"
+            tags={[
+                {
+                    id: 'profile/marinahyde',
+                    type: 'Contributor',
+                    title: 'Marina Hyde',
+                    twitterHandle: 'MarinaHyde',
+                    bylineImageUrl:
+                        'https://i.guim.co.uk/img/uploads/2018/01/10/Marina_Hyde,_L.png?width=300&quality=85&auto=format&fit=max&s=6476202195914952e48ef41aadb116ff',
+                },
+            ]}
+        />
+    );
+};
+commentWithBylineImageStory.story = { name: 'Comment with byline image' };
+
 export const immersiveStory = () => {
     return (
         <HeadlineByline

--- a/src/web/components/HeadlineByline.tsx
+++ b/src/web/components/HeadlineByline.tsx
@@ -84,10 +84,6 @@ const mobileCommentAuthor = css`
     }
 `;
 
-function hasBylineImage(item: TagType) {
-    return item.bylineImageUrl;
-}
-
 type Props = {
     display: Display;
     designType: DesignType;
@@ -153,12 +149,12 @@ export const HeadlineByline = ({
                     );
                 case 'GuardianView':
                 case 'Comment':
-                    // Check if there is an image for the author
-                    const hasImage = tags.find(hasBylineImage);
                     return (
                         <div
                             className={`${opinionStyles(pillar)} ${
-                                hasImage ? mobileCommentAuthor : ''
+                                tags.find((tag) => tag.bylineImageUrl)
+                                    ? mobileCommentAuthor
+                                    : ''
                             }`}
                         >
                             <BylineLink byline={byline} tags={tags} />

--- a/src/web/components/MainMedia.tsx
+++ b/src/web/components/MainMedia.tsx
@@ -35,7 +35,7 @@ const noGutters = css`
 
     ${until.mobileLandscape} {
         margin-left: -10px;
-        margin-right: -11px;
+        margin-right: -10px;
     }
 `;
 

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -167,15 +167,35 @@ const minHeightWithAvatar = css`
 const avatarPositionStyles = css`
     display: flex;
     justify-content: flex-end;
+    overflow: hidden;
+    margin-bottom: -29px;
+    margin-top: -50px;
+
+    /*  Why target img element?
+
+        Because only in this context, where we have overflow: hidden
+        and the margin-bottom and margin-top of avatarPositionStyles
+        do we also want to apply our margin-right. These styles
+        are tightly coupled in this context, and so it does not
+        make sense to move them to the avatar component.
+
+        It's imperfect from the perspective of DCR, the alternative is to bust
+        the combined elements into a separate component (with the
+        relevant stories) and couple them that way, which might be what
+        you want to do if you find yourself adding more styles
+        to this section. For now, this works without making me 🤢.
+    */
+
     ${from.mobile} {
-        margin-right: -1.85rem;
-        margin-top: -50px;
+        img {
+            margin-right: -1.85rem;
+        }
     }
     ${from.mobileLandscape} {
-        margin-right: -1.25rem;
+        img {
+            margin-right: -1.25rem;
+        }
     }
-    margin-top: -36px;
-    margin-bottom: -29px;
 `;
 
 const pushToBottom = css`


### PR DESCRIPTION
## What does this change?

- Ensures the negative margins on main media are correct and don't trigger X scroll
- Ensures the negative margins on opinion avatar do not trigger X scroll
- Add a story for the above
- Adds a Cypress test to ensure that no elements are wider that the document width (and thus trigger X scroll)

### Before

Cypress test reporting offending element and element's parent (this is actually one element, main media, and all it's children)

![Screen Shot 2020-07-28 at 14 11 27](https://user-images.githubusercontent.com/638051/88673032-0dbd8f80-d0e0-11ea-93c6-6bdcfca64a82.png)



### After

![Screen Shot 2020-07-28 at 14 11 56](https://user-images.githubusercontent.com/638051/88672722-b0c1d980-d0df-11ea-8150-5cdde125e10a.png)


## Why?

Horizontal scroll on the body is the devil's work.
