### PR TITLE
Auth component tracking for Identity Authentication

### DIFF
--- a/src/amp/components/Sidebar.tsx
+++ b/src/amp/components/Sidebar.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { css, cx } from 'emotion';
 import { palette } from '@guardian/src-foundations';
 import { headline, textSans } from '@guardian/src-foundations/typography';
+import { createAuthenticationEventParams } from "@root/src/lib/identity-component-event";
 
 const sidebarStyles = css`
     width: 80vh;
@@ -158,7 +159,7 @@ const template = `
 {{ /readerRevenueLinks }}
 
 <li>
-    <a href="https://profile.theguardian.com/signin?INTCMP=DOTCOM_NEWHEADER_SIGNIN&ABCMP=ab-sign-in"
+    <a href="https://profile.theguardian.com/signin?INTCMP=DOTCOM_NEWHEADER_SIGNIN&ABCMP=ab-sign-in&${createAuthenticationEventParams('amp_sidebar_signin')}"
         data-link-name="amp : nav : sign in">
         Sign in / Register
     </a>

--- a/src/lib/identity-component-event.test.ts
+++ b/src/lib/identity-component-event.test.ts
@@ -1,0 +1,10 @@
+import { createAuthenticationEventParams } from "./identity-component-event";
+
+describe('createAuthenticationEventParams', () => {
+    it('creates authentication event params given a component Id', () => {
+        expect(createAuthenticationEventParams('amp_sidebar_signin')).toBe('componentEventParams=componentType%3Didentityauthentication%26componentId%3Damp_sidebar_signin')
+    });
+    it('creates authentication event params given a component Id and a page view Id', () => {
+        expect(createAuthenticationEventParams('amp_sidebar_signin', 'pageViewId')).toBe('componentEventParams=componentType%3Didentityauthentication%26componentId%3Damp_sidebar_signin%26viewId%3DpageViewId')
+    });
+});

--- a/src/lib/identity-component-event.ts
+++ b/src/lib/identity-component-event.ts
@@ -1,0 +1,22 @@
+import { constructQuery } from "@root/src/lib/querystring";
+
+export type AuthenticationComponentId = 'amp_sidebar_signin' | 'guardian_signin_header' | 'signin_to_comment' | 'register_to_comment'
+
+type AuthenticationEventParams = {
+    componentType: string,
+    componentId: AuthenticationComponentId,
+    viewId?: string
+}
+
+export const createAuthenticationEventParams = (componentId: AuthenticationComponentId, pageViewId?: string) => {
+    const params: AuthenticationEventParams = {
+        componentType: 'identityauthentication',
+        componentId,
+    };
+
+    if (pageViewId) {
+        params.viewId = pageViewId;
+    }
+
+    return `componentEventParams=${encodeURIComponent(constructQuery(params))}`;
+};

--- a/src/web/components/Links.tsx
+++ b/src/web/components/Links.tsx
@@ -11,6 +11,7 @@ import { DropdownLinkType, Dropdown } from '@root/src/web/components/Dropdown';
 
 import ProfileIcon from '@frontend/static/icons/profile.svg';
 import { getZIndex } from '@frontend/web/lib/getZIndex';
+import { createAuthenticationEventParams } from "@root/src/lib/identity-component-event";
 
 type Props = {
     userId?: string;
@@ -183,7 +184,7 @@ export const Links = ({ userId }: Props) => {
             ) : (
                 <a
                     className={linkStyles}
-                    href="https://profile.theguardian.com/signin?INTCMP=DOTCOM_NEWHEADER_SIGNIN&ABCMP=ab-sign-in"
+                    href={`https://profile.theguardian.com/signin?INTCMP=DOTCOM_NEWHEADER_SIGNIN&ABCMP=ab-sign-in&${createAuthenticationEventParams('guardian_signin_header')}`}
                     data-link-name="nav2 : topbar : signin"
                 >
                     <ProfileIcon /> Sign in

--- a/src/web/components/SignedInAs.tsx
+++ b/src/web/components/SignedInAs.tsx
@@ -6,6 +6,7 @@ import { headline, textSans } from '@guardian/src-foundations/typography';
 import { space } from '@guardian/src-foundations';
 import { until } from '@guardian/src-foundations/mq';
 import { pillarPalette } from '@frontend/lib/pillars';
+import { createAuthenticationEventParams } from "@root/src/lib/identity-component-event";
 
 type Props = {
     commentCount: number;
@@ -153,14 +154,14 @@ export const SignedInAs = ({
             {!user && (
                 <span className={headlineStyles}>
                     <a
-                        href="https://profile.theguardian.com/signin?INTCMP=DOTCOM_COMMENTS_SIGNIN"
+                        href={`https://profile.theguardian.com/signin?INTCMP=DOTCOM_COMMENTS_SIGNIN&${createAuthenticationEventParams('signin_to_comment')}`}
                         className={linkStyles(pillar)}
                     >
                         Sign in
                     </a>{' '}
                     or{' '}
                     <a
-                        href="https://profile.theguardian.com/register?INTCMP=DOTCOM_COMMENTS_REG"
+                        href={`https://profile.theguardian.com/register?INTCMP=DOTCOM_COMMENTS_REG&${createAuthenticationEventParams('register_to_comment')}`}
                         className={linkStyles(pillar)}
                     >
                         create your Guardian account


### PR DESCRIPTION
## What does this change?

Pass component event parameters for all signin referrers. These parameters get propagated from /signin to IDAPI which sends the component events on behalf of the user. IDAPI sends the component event to Ophan using the /signin page view ID and the new SC_GU_U cookie. This means the /signin pageview entry has session information associated and the component ID used for signing in.

## Why?

This will allow data analysts to track how many users are using different sign in mechanisms to authenticate using the Guardian website.
