### PR TITLE
Test for existence of ophan to resolve IE11 issue

### DIFF
--- a/src/web/components/HydrateApp.tsx
+++ b/src/web/components/HydrateApp.tsx
@@ -23,7 +23,10 @@ export const HydrateApp = ({ CAPI, NAV }: Props) => {
     }
 
     const ophanRecordFunc =
-        window && window.guardian && window.guardian.ophan.record;
+        window &&
+        window.guardian &&
+        window.guardian.ophan &&
+        window.guardian.ophan.record;
 
     ReactDOM.render(
         <ABProvider


### PR DESCRIPTION
## What does this change?
Adds an extra check for window.guardian.ophan before referencing it, which appears to be a problem on IE11 specifically.
The polyfill for Promise isn't available when ophan script is run (not sure why, but it isn't guaranteed) so ophan fails to load.

### Before
JS doesn't run on IE11 due to an error

### After
JS runs, although I'm not sure this is an improvement on IE

## Why?
Reported to userhelp
