### PR TITLE
Fix broken README links to concept documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,11 @@ You can see a _web only_ architecture diagram by running `make arch-diagram`. It
 
 There are some concepts to learn, that will make working with Dotcom Rendering clearer:
 
--   Design and Display Types use the [Switch Pattern](docs/contributing/switch-on-display-design.md)
--   [DecideLayout](docs/contributing/decide-layout.md)
+-   Design and Display Types use the [Switch Pattern](docs/patterns/switch-on-display-design.md)
+-   [DecideLayout](docs/patterns/decide-layout.md)
 -   [Prop Drilling](https://kentcdodds.com/blog/prop-drilling/) (and [why we don't use React Context](docs/architecture/018-react-context-api.md))
 -   Dynamic imports
--   [EnhanceCAPI](docs/contributing/enhance-capi.md)
+-   [EnhanceCAPI](docs/patterns/enhance-capi.md)
 -   Data generated in Frontend
 
 ### Feedback


### PR DESCRIPTION
## What does this change?

README links to concept documentation.

### Before

Links result in a 404 Page Not Found

### After

Links result in a 2XX response

## Why?

Fixing a regression introduced by:

- 1a2a7f8
- 4709f5a
- d8e52ef