### PR TITLE
Change the ordering of comments and onward journey components 

### DIFF
--- a/docs/patterns/decide-layout.md
+++ b/docs/patterns/decide-layout.md
@@ -1,4 +1,5 @@
-#  DecideLayout
+# DecideLayout
+
 The [DecideLayout](/src/web/layouts/DecideLayout.tsx) component is the point of entry when server side rendering an article. It is meant to make one decision: which layout file should be used for this article?
 
-It uses the [switch pattern](docs/contributing/switch-on-display-design.md) for Display and Design type to keep the code scalable as we add more layout types and the decision gets more complicated.
+It uses the [switch pattern](switch-on-display-design.md) for Display and Design type to keep the code scalable as we add more layout types and the decision gets more complicated.

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -501,10 +501,13 @@ export const CommentLayout = ({
 
             {!isPaidContent && (
                 <>
-                    {/* Onwards (when signed IN) */}
-                    <Section sectionId="onwards-upper-whensignedin" />
+                    {/* Onwards (when signed OUT) */}
+                    <Section
+                        sectionId="onwards-upper-whensignedout"
+                        showTopBorder={false}
+                    />
                     {showOnwardsLower && (
-                        <Section sectionId="onwards-lower-whensignedin" />
+                        <Section sectionId="onwards-lower-whensignedout" />
                     )}
 
                     {showComments && (
@@ -526,13 +529,10 @@ export const CommentLayout = ({
                         </Section>
                     )}
 
-                    {/* Onwards (when signed OUT) */}
-                    <Section
-                        sectionId="onwards-upper-whensignedout"
-                        showTopBorder={false}
-                    />
+                    {/* Onwards (when signed IN) */}
+                    <Section sectionId="onwards-upper-whensignedin" />
                     {showOnwardsLower && (
-                        <Section sectionId="onwards-lower-whensignedout" />
+                        <Section sectionId="onwards-lower-whensignedin" />
                     )}
 
                     <Section sectionId="most-viewed-footer" />

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -465,10 +465,13 @@ export const ImmersiveLayout = ({
 
             {!isPaidContent && (
                 <>
-                    {/* Onwards (when signed IN) */}
-                    <Section sectionId="onwards-upper-whensignedin" />
+                    {/* Onwards (when signed OUT) */}
+                    <Section
+                        sectionId="onwards-upper-whensignedout"
+                        showTopBorder={false}
+                    />
                     {showOnwardsLower && (
-                        <Section sectionId="onwards-lower-whensignedin" />
+                        <Section sectionId="onwards-lower-whensignedout" />
                     )}
 
                     {showComments && (
@@ -490,13 +493,10 @@ export const ImmersiveLayout = ({
                         </Section>
                     )}
 
-                    {/* Onwards (when signed OUT) */}
-                    <Section
-                        sectionId="onwards-upper-whensignedout"
-                        showTopBorder={false}
-                    />
+                    {/* Onwards (when signed IN) */}
+                    <Section sectionId="onwards-upper-whensignedin" />
                     {showOnwardsLower && (
-                        <Section sectionId="onwards-lower-whensignedout" />
+                        <Section sectionId="onwards-lower-whensignedin" />
                     )}
 
                     <Section sectionId="most-viewed-footer" />

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -485,10 +485,13 @@ export const ShowcaseLayout = ({
 
             {!isPaidContent && (
                 <>
-                    {/* Onwards (when signed IN) */}
-                    <Section sectionId="onwards-upper-whensignedin" />
+                    {/* Onwards (when signed OUT) */}
+                    <Section
+                        sectionId="onwards-upper-whensignedout"
+                        showTopBorder={false}
+                    />
                     {showOnwardsLower && (
-                        <Section sectionId="onwards-lower-whensignedin" />
+                        <Section sectionId="onwards-lower-whensignedout" />
                     )}
 
                     {showComments && (
@@ -510,13 +513,10 @@ export const ShowcaseLayout = ({
                         </Section>
                     )}
 
-                    {/* Onwards (when signed OUT) */}
-                    <Section
-                        sectionId="onwards-upper-whensignedout"
-                        showTopBorder={false}
-                    />
+                    {/* Onwards (when signed IN) */}
+                    <Section sectionId="onwards-upper-whensignedin" />
                     {showOnwardsLower && (
-                        <Section sectionId="onwards-lower-whensignedout" />
+                        <Section sectionId="onwards-lower-whensignedin" />
                     )}
 
                     <Section sectionId="most-viewed-footer" />

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -483,10 +483,13 @@ export const StandardLayout = ({
 
             {!isPaidContent && (
                 <>
-                    {/* Onwards (when signed IN) */}
-                    <Section sectionId="onwards-upper-whensignedin" />
+                    {/* Onwards (when signed OUT) */}
+                    <Section
+                        sectionId="onwards-upper-whensignedout"
+                        showTopBorder={false}
+                    />
                     {showOnwardsLower && (
-                        <Section sectionId="onwards-lower-whensignedin" />
+                        <Section sectionId="onwards-lower-whensignedout" />
                     )}
 
                     {showComments && (
@@ -508,13 +511,10 @@ export const StandardLayout = ({
                         </Section>
                     )}
 
-                    {/* Onwards (when signed OUT) */}
-                    <Section
-                        sectionId="onwards-upper-whensignedout"
-                        showTopBorder={false}
-                    />
+                    {/* Onwards (when signed IN) */}
+                    <Section sectionId="onwards-upper-whensignedin" />
                     {showOnwardsLower && (
-                        <Section sectionId="onwards-lower-whensignedout" />
+                        <Section sectionId="onwards-lower-whensignedin" />
                     )}
 
                     <Section sectionId="most-viewed-footer" />


### PR DESCRIPTION
This changes the ordering of comments and onward journey components to match frontend. The desired ordering is for comments to be above onwards components (upper and lower) for signed in users, and below onwards components for signed out users. (see [this](https://trello.com/c/HECtqqeB/1882-discussion-vs-onwards-journey-ordering-is-different-on-frontend-dcr-for-logged-in-users) Trello ticket)

### Before
Signed in (onwards above comments):
![image](https://user-images.githubusercontent.com/9820960/88814093-97895d80-d1b1-11ea-918a-3940a78b097e.png)

Signed out (comments above onwards):
![image](https://user-images.githubusercontent.com/9820960/88814225-bbe53a00-d1b1-11ea-8b4a-886399747a9b.png)

### After
Signed in (comments above onwards):
![image](https://user-images.githubusercontent.com/9820960/88814337-d7e8db80-d1b1-11ea-9a80-44ec712ad309.png)

Signed out (onwards above comments):
![image](https://user-images.githubusercontent.com/9820960/88814416-f8189a80-d1b1-11ea-8ea8-133166e72438.png)

## Why?
I'd be interested to look at the data for onwards/comment engagement to see why this ordering is preferred, we may have accidentally managed to run a test serving DCR with this difference. 