### PR TITLE
Add disclaimer block for articles containing affiliate links

### DIFF
--- a/cypress/integration/e2e/article.elements.spec.js
+++ b/cypress/integration/e2e/article.elements.spec.js
@@ -144,5 +144,19 @@ describe('Elements', function () {
 
             getBody().contains('Liverpool');
         });
+
+        it('should render the affiliate disclaimer block', function () {
+            const getBody = () => {
+                return cy
+                    .get('div[data-cy="affiiate-disclaimer"]')
+                    .should('not.be.empty')
+                    .then(cy.wrap);
+            };
+            cy.visit(
+                'Article?url=https://www.theguardian.com/music/2020/jun/15/pet-shop-boys-where-to-start-in-their-back-catalogue',
+            );
+
+            getBody().contains('affiliate links');
+        });
     });
 });

--- a/src/web/components/elements/DisclaimerBlockComponent.tsx
+++ b/src/web/components/elements/DisclaimerBlockComponent.tsx
@@ -11,7 +11,7 @@ const style = (pillar: Pillar) => css`
     }
 
     sup {
-        font-size: 12.75px;
+        font-size: 85%;
     }
 `;
 
@@ -19,8 +19,9 @@ export const DisclaimerBlockComponent: React.FC<{
     html: string;
     pillar: Pillar;
 }> = ({ html, pillar }) => (
-    <div
+    <span
         className={style(pillar)}
+        data-cy="affiliate-disclaimer"
         dangerouslySetInnerHTML={{
             __html: html,
         }}

--- a/src/web/components/elements/DisclaimerBlockComponent.tsx
+++ b/src/web/components/elements/DisclaimerBlockComponent.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { body } from '@guardian/src-foundations/typography';
+import { pillarPalette } from '@root/src/lib/pillars';
+import { css } from 'emotion';
+
+const style = (pillar: Pillar) => css`
+    ${body.small()};
+
+    a {
+        color: ${pillarPalette[pillar].dark};
+    }
+
+    sup {
+        font-size: 12.75px;
+    }
+`;
+
+export const DisclaimerBlockComponent: React.FC<{
+    html: string;
+    pillar: Pillar;
+}> = ({ html, pillar }) => (
+    <div
+        className={style(pillar)}
+        dangerouslySetInnerHTML={{
+            __html: html,
+        }}
+    />
+);

--- a/src/web/components/elements/DisclaimerBlockComponent.tsx
+++ b/src/web/components/elements/DisclaimerBlockComponent.tsx
@@ -13,13 +13,15 @@ const style = (pillar: Pillar) => css`
     sup {
         font-size: 85%;
     }
+
+    margin-bottom: 16px;
 `;
 
 export const DisclaimerBlockComponent: React.FC<{
     html: string;
     pillar: Pillar;
 }> = ({ html, pillar }) => (
-    <span
+    <footer
         className={style(pillar)}
         data-cy="affiliate-disclaimer"
         dangerouslySetInnerHTML={{

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -4,6 +4,7 @@ import { css } from 'emotion';
 import { BlockquoteBlockComponent } from '@root/src/web/components/elements/BlockquoteBlockComponent';
 import { CaptionBlockComponent } from '@root/src/web/components/elements/CaptionBlockComponent';
 import { DocumentBlockComponent } from '@root/src/web/components/elements/DocumentBlockComponent';
+import { DisclaimerBlockComponent } from '@root/src/web/components/elements/DisclaimerBlockComponent';
 import { DividerBlockComponent } from '@root/src/web/components/elements/DividerBlockComponent';
 import { EmbedBlockComponent } from '@root/src/web/components/elements/EmbedBlockComponent';
 import { HighlightBlockComponent } from '@root/src/web/components/elements/HighlightBlockComponent';
@@ -67,6 +68,13 @@ export const ArticleRenderer: React.FC<{
                             displayCredit={element.displayCredit}
                             shouldLimitWidth={element.shouldLimitWidth}
                             isOverlayed={element.isOverlayed}
+                        />
+                    );
+                case 'model.dotcomrendering.pageElements.DisclaimerBlockElement':
+                    return (
+                        <DisclaimerBlockComponent
+                            html={element.html}
+                            pillar={pillar}
                         />
                     );
                 case 'model.dotcomrendering.pageElements.DividerBlockElement':
@@ -250,7 +258,6 @@ export const ArticleRenderer: React.FC<{
                 case 'model.dotcomrendering.pageElements.CodeBlockElement':
                 case 'model.dotcomrendering.pageElements.CommentBlockElement':
                 case 'model.dotcomrendering.pageElements.ContentAtomBlockElement':
-                case 'model.dotcomrendering.pageElements.DisclaimerBlockElement':
                 case 'model.dotcomrendering.pageElements.GenericAtomBlockElement':
                 case 'model.dotcomrendering.pageElements.GuVideoBlockElement':
                 case 'model.dotcomrendering.pageElements.GuideAtomBlockElement':


### PR DESCRIPTION
## What does this change?
Adds the disclaimer block for when we have an article that contains affiliate links. The font-size is unfortunately magic number, but there's no existing size within the design system to enable it otherwise.

### Frontend
<img width="1101" alt="Screen Shot 2020-07-29 at 16 39 41" src="https://user-images.githubusercontent.com/2051501/88822587-f522a780-d1bb-11ea-82af-827740f7b4b9.png">

### DCR
<img width="1101" alt="Screen Shot 2020-07-29 at 16 39 23" src="https://user-images.githubusercontent.com/2051501/88822578-f2c04d80-d1bb-11ea-82d9-df383b8d23ad.png">

## Why?
https://trello.com/c/yI6FAg1H/1679-support-affiliate-links
