### PR TITLE
Tidy up pullquote shark fin 

### DIFF
--- a/src/web/components/elements/PullQuoteBlockComponent.tsx
+++ b/src/web/components/elements/PullQuoteBlockComponent.tsx
@@ -31,7 +31,7 @@ const partiallyLeft = css`
         ${from.leftCol} {
             border-radius: 0 0 0 25px;
             left: 0;
-            margin-left: 140px;
+            margin-left: 85px;
         }
     }
 `;


### PR DESCRIPTION
## What does this change?
Alters the position of the shark fin on the 'supporting pullquote'.

### Before
<img width="375" alt="Screen Shot 2020-07-31 at 12 02 16" src="https://user-images.githubusercontent.com/2051501/89029185-c6284500-d325-11ea-894e-39dc018dfb1c.png">

### After
<img width="375" alt="Screen Shot 2020-07-31 at 11 03 56" src="https://user-images.githubusercontent.com/2051501/89029082-83666d00-d325-11ea-88a2-560dc8126dc6.png">

## Why?
Parity with frontend