### PR TITLE
Introduce the SpotifyBlockComponent

### DIFF
--- a/src/web/components/elements/SpotifyBlockComponent.tsx
+++ b/src/web/components/elements/SpotifyBlockComponent.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { css } from 'emotion';
+import { unescapeData } from '@root/src/lib/escapeData';
+
+const widthOverride = css`
+    iframe {
+        /* The  embed js hijacks the iframe and calculated an incorrect width, which pushed the body out */
+        width: 100%;
+    }
+`;
+
+export const SpotifyBlockComponent: React.FC<{
+    element: SpotifyBlockElement;
+}> = ({ element }) => {
+    return (
+        <div className={widthOverride}>
+            <div
+                data-cy="spotify-embed"
+                dangerouslySetInnerHTML={{ __html: unescapeData(element.html) }}
+            />
+        </div>
+    );
+};

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 import { BlockquoteBlockComponent } from '@root/src/web/components/elements/BlockquoteBlockComponent';
+import { CalloutBlockComponent } from '@root/src/web/components/elements/CalloutBlockComponent';
 import { CaptionBlockComponent } from '@root/src/web/components/elements/CaptionBlockComponent';
 import { DocumentBlockComponent } from '@root/src/web/components/elements/DocumentBlockComponent';
 import { DisclaimerBlockComponent } from '@root/src/web/components/elements/DisclaimerBlockComponent';
@@ -9,10 +10,11 @@ import { DividerBlockComponent } from '@root/src/web/components/elements/Divider
 import { EmbedBlockComponent } from '@root/src/web/components/elements/EmbedBlockComponent';
 import { HighlightBlockComponent } from '@root/src/web/components/elements/HighlightBlockComponent';
 import { ImageBlockComponent } from '@root/src/web/components/elements/ImageBlockComponent';
-import { MultiImageBlockComponent } from '@root/src/web/components/elements/MultiImageBlockComponent';
 import { InstagramBlockComponent } from '@root/src/web/components/elements/InstagramBlockComponent';
+import { MultiImageBlockComponent } from '@root/src/web/components/elements/MultiImageBlockComponent';
 import { PullQuoteBlockComponent } from '@root/src/web/components/elements/PullQuoteBlockComponent';
 import { SoundcloudBlockComponent } from '@root/src/web/components/elements/SoundcloudBlockComponent';
+import { SpotifyBlockComponent } from '@root/src/web/components/elements/SpotifyBlockComponent';
 import { SubheadingBlockComponent } from '@root/src/web/components/elements/SubheadingBlockComponent';
 import { TableBlockComponent } from '@root/src/web/components/elements/TableBlockComponent';
 import { TextBlockComponent } from '@root/src/web/components/elements/TextBlockComponent';
@@ -21,7 +23,6 @@ import { VideoFacebookBlockComponent } from '@root/src/web/components/elements/V
 import { VimeoBlockComponent } from '@root/src/web/components/elements/VimeoBlockComponent';
 import { YoutubeEmbedBlockComponent } from '@root/src/web/components/elements/YoutubeEmbedBlockComponent';
 import { YoutubeBlockComponent } from '@root/src/web/components/elements/YoutubeBlockComponent';
-import { CalloutBlockComponent } from '@root/src/web/components/elements/CalloutBlockComponent';
 
 import {
     ExplainerAtom,
@@ -191,7 +192,7 @@ export const ArticleRenderer: React.FC<{
                         <SoundcloudBlockComponent key={i} element={element} />
                     );
                 case 'model.dotcomrendering.pageElements.SpotifyBlockElement':
-                    return null;
+                    return <SpotifyBlockComponent element={element} />;
                 case 'model.dotcomrendering.pageElements.SubheadingBlockElement':
                     return (
                         <SubheadingBlockComponent key={i} html={element.html} />

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -190,6 +190,8 @@ export const ArticleRenderer: React.FC<{
                     return (
                         <SoundcloudBlockComponent key={i} element={element} />
                     );
+                case 'model.dotcomrendering.pageElements.SpotifyBlockElement':
+                    return null;
                 case 'model.dotcomrendering.pageElements.SubheadingBlockElement':
                     return (
                         <SubheadingBlockComponent key={i} html={element.html} />
@@ -281,7 +283,6 @@ export const ArticleRenderer: React.FC<{
                 case 'model.dotcomrendering.pageElements.GuideAtomBlockElement':
                 case 'model.dotcomrendering.pageElements.MapBlockElement':
                 case 'model.dotcomrendering.pageElements.ProfileAtomBlockElement':
-                case 'model.dotcomrendering.pageElements.SpotifyBlockElement':
                 case 'model.dotcomrendering.pageElements.TimelineBlockElement':
                 case 'model.dotcomrendering.pageElements.VideoBlockElement':
                     return null;


### PR DESCRIPTION
## What does this change?

Introduce the SpotifyBlockComponent. We are not yet showing the caption and title.

### Before

<img width="676" alt="Screenshot 2020-08-03 at 13 37 07" src="https://user-images.githubusercontent.com/6035518/89183131-b3647900-d58e-11ea-9f1f-ff7353916c8f.png">

### After

<img width="660" alt="Screenshot 2020-08-03 at 13 37 21" src="https://user-images.githubusercontent.com/6035518/89183142-b6f80000-d58e-11ea-816b-aa4e307ce605.png">

