### PR TITLE
Correct SpotifyBlockElement definition

### DIFF
--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -1559,7 +1559,7 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "html", "title", "caption"]
+            "required": ["_type", "html"]
         },
         "SubheadingBlockElement": {
             "type": "object",


### PR DESCRIPTION
## What does this change?

Correct `SpotifyBlockElement` definition. `title` and `caption` are only optional. ( see: https://github.com/guardian/frontend/blob/213db84920508d17e2faad70ff5fb4d64cad25b8/common/app/model/dotcomrendering/pageElements/PageElement.scala#L99 )
