### PR TITLE
Remove extra quote marks in Picture source

### DIFF
--- a/src/web/components/Picture.tsx
+++ b/src/web/components/Picture.tsx
@@ -10,8 +10,8 @@ export interface PictureSource {
 
 const mq: (source: PictureSource) => string = (source) =>
     source.hidpi
-        ? `(min-width: ${source.minWidth}px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: ${source.minWidth}px) and (min-resolution: 120dpi)"`
-        : `(min-width: ${source.minWidth}px)"`;
+        ? `(min-width: ${source.minWidth}px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: ${source.minWidth}px) and (min-resolution: 120dpi)`
+        : `(min-width: ${source.minWidth}px)`;
 
 const forSource: (source: PictureSource) => string = (source) =>
     ` <source media="${mq(source)}" sizes="${source.width}px" srcset="${


### PR DESCRIPTION
## What does this change?
The `mq` function is called like `media="${mq(source)}"` so the quote mark at the end of the returned string is invalid markup.