### PR TITLE
Identity | Sign In Gate | Fix issue with Component ID not reporting correctly

### DIFF
--- a/src/web/components/SignInGate/SignInGate.stories.tsx
+++ b/src/web/components/SignInGate/SignInGate.stories.tsx
@@ -19,7 +19,7 @@ export const mainStandalone = () => {
                 guUrl="https://theguardian.com"
                 signInUrl="https://profile.theguardian.com/"
                 dismissGate={() => {}}
-                component="test"
+                ophanComponentId="test"
             />
         </Section>
     );
@@ -33,7 +33,7 @@ export const mainPatientia = () => {
                 guUrl="https://theguardian.com"
                 signInUrl="https://profile.theguardian.com/"
                 dismissGate={() => {}}
-                component="test"
+                ophanComponentId="test"
             />
         </Section>
     );

--- a/src/web/components/SignInGate/SignInGateSelector.tsx
+++ b/src/web/components/SignInGate/SignInGateSelector.tsx
@@ -96,7 +96,7 @@ const generateSignInUrl = (
     // set the component event params to be included in the query
     const queryParams: ComponentEventParams = {
         componentType: 'signingate',
-        componentId: testIdToComponentId[currentTest.name],
+        componentId: testIdToComponentId[currentTest.id],
         abTestName: currentTest.name,
         abTestVariant: currentTest.variant,
         viewId: window.guardian.ophan.viewId,
@@ -124,7 +124,7 @@ const ShowSignInGate = ({
     // use effect hook to fire view event tracking only on initial render
     useEffect(() => {
         submitViewEventTracking({
-            component: withComponentId(testIdToComponentId[abTest.name]),
+            component: withComponentId(testIdToComponentId[abTest.id]),
             abTest,
         });
     }, [abTest]);
@@ -141,7 +141,7 @@ const ShowSignInGate = ({
                 dismissGate(setShowGate, abTest);
             },
             abTest,
-            component: componentName,
+            ophanComponentId: testIdToComponentId[abTest.id],
             isComment:
                 CAPI.designType === 'Comment' ||
                 CAPI.designType === 'GuardianView',
@@ -161,6 +161,7 @@ export const SignInGateSelector = ({
     const [currentTest, setCurrentTest] = useState<CurrentABTest>({
         name: '',
         variant: '',
+        id: '',
     });
 
     const ab = useAB();
@@ -171,6 +172,7 @@ export const SignInGateSelector = ({
         setCurrentTest({
             name: test?.dataLinkNames || test?.id || '',
             variant: test?.variantToRun.id || '',
+            id: test?.id || '',
         });
     }, [ab]);
 

--- a/src/web/components/SignInGate/componentEventTracking.tsx
+++ b/src/web/components/SignInGate/componentEventTracking.tsx
@@ -64,6 +64,7 @@ export const trackLink = (
     abTest?: CurrentABTest,
 ): void => {
     const component = withComponentId(componentId);
+
     submitClickEventTracking({
         component,
         abTest,

--- a/src/web/components/SignInGate/gateDesigns/SignInGateMain.tsx
+++ b/src/web/components/SignInGate/gateDesigns/SignInGateMain.tsx
@@ -7,7 +7,6 @@ import { space, palette, opinion } from '@guardian/src-foundations';
 import { LinkButton } from '@guardian/src-button';
 import { Link } from '@guardian/src-link';
 import { ConsentManagementPlatform } from '@guardian/consent-management-platform/dist/ConsentManagementPlatform';
-import { OphanComponent } from '@frontend/web/browser/ophan/ophan';
 import { trackLink } from '@frontend/web/components/SignInGate/componentEventTracking';
 import { SignInGateProps } from './types';
 
@@ -135,20 +134,12 @@ const hideElementsCss = `
     }
     `;
 
-// set the ophan component tracking vars
-export const withComponentId: (id: string) => OphanComponent = (
-    id: string = '',
-) => ({
-    componentType: 'SIGN_IN_GATE',
-    id,
-});
-
 export const SignInGateMain = ({
     signInUrl,
     guUrl,
     dismissGate,
     abTest,
-    component,
+    ophanComponentId,
     isComment,
 }: SignInGateProps) => {
     const [showCpmUi, setShowCmpUi] = useState(false);
@@ -179,7 +170,7 @@ export const SignInGateMain = ({
                     className={privacyLink}
                     onClick={() => {
                         setShowCmpUi(!showCpmUi);
-                        trackLink(component, 'privacy', abTest);
+                        trackLink(ophanComponentId, 'privacy', abTest);
                     }}
                 >
                     privacy settings
@@ -194,7 +185,7 @@ export const SignInGateMain = ({
                     size="small"
                     href={signInUrl}
                     onClick={() => {
-                        trackLink(component, 'register-link', abTest);
+                        trackLink(ophanComponentId, 'register-link', abTest);
                     }}
                 >
                     Register for free
@@ -207,7 +198,7 @@ export const SignInGateMain = ({
                     size="small"
                     onClick={() => {
                         dismissGate();
-                        trackLink(component, 'not-now', abTest);
+                        trackLink(ophanComponentId, 'not-now', abTest);
                     }}
                 >
                     I’ll do it later
@@ -223,7 +214,7 @@ export const SignInGateMain = ({
                 className={signInLink}
                 href={signInUrl}
                 onClick={() => {
-                    trackLink(component, 'sign-in-link', abTest);
+                    trackLink(ophanComponentId, 'sign-in-link', abTest);
                 }}
             >
                 Sign In
@@ -233,7 +224,7 @@ export const SignInGateMain = ({
                 <Link
                     href={`${guUrl}/membership/2019/dec/20/signing-in-to-the-guardian`}
                     onClick={() => {
-                        trackLink(component, 'how-link', abTest);
+                        trackLink(ophanComponentId, 'how-link', abTest);
                     }}
                 >
                     Why register & how does it help?
@@ -242,7 +233,7 @@ export const SignInGateMain = ({
                 <Link
                     href={`${guUrl}/info/2014/nov/03/why-your-data-matters-to-us-full-text`}
                     onClick={() => {
-                        trackLink(component, 'why-link', abTest);
+                        trackLink(ophanComponentId, 'why-link', abTest);
                     }}
                 >
                     How will my information & data be used?
@@ -251,7 +242,7 @@ export const SignInGateMain = ({
                 <Link
                     href={`${guUrl}/help/identity-faq`}
                     onClick={() => {
-                        trackLink(component, 'help-link', abTest);
+                        trackLink(ophanComponentId, 'help-link', abTest);
                     }}
                 >
                     Get help with registering or signing in

--- a/src/web/components/SignInGate/gateDesigns/SignInGatePatientia.tsx
+++ b/src/web/components/SignInGate/gateDesigns/SignInGatePatientia.tsx
@@ -7,7 +7,6 @@ import { space, palette, opinion } from '@guardian/src-foundations';
 import { LinkButton } from '@guardian/src-button';
 import { Link } from '@guardian/src-link';
 import { ConsentManagementPlatform } from '@guardian/consent-management-platform/dist/ConsentManagementPlatform';
-import { OphanComponent } from '@frontend/web/browser/ophan/ophan';
 import { trackLink } from '@frontend/web/components/SignInGate/componentEventTracking';
 import { SignInGateProps } from './types';
 
@@ -120,20 +119,12 @@ const hideElementsCss = `
     }
     `;
 
-// set the ophan component tracking vars
-export const withComponentId: (id: string) => OphanComponent = (
-    id: string = '',
-) => ({
-    componentType: 'SIGN_IN_GATE',
-    id,
-});
-
 export const SignInGatePatientia = ({
     signInUrl,
     guUrl,
     dismissGate,
     abTest,
-    component,
+    ophanComponentId,
     isComment,
 }: SignInGateProps) => {
     const [showCpmUi, setShowCmpUi] = useState(false);
@@ -160,7 +151,7 @@ export const SignInGatePatientia = ({
                     size="small"
                     href={signInUrl}
                     onClick={() => {
-                        trackLink(component, 'register-link', abTest);
+                        trackLink(ophanComponentId, 'register-link', abTest);
                     }}
                 >
                     Register for free
@@ -172,7 +163,7 @@ export const SignInGatePatientia = ({
                     size="small"
                     onClick={() => {
                         dismissGate();
-                        trackLink(component, 'not-now', abTest);
+                        trackLink(ophanComponentId, 'not-now', abTest);
                     }}
                 >
                     Not Now
@@ -185,7 +176,7 @@ export const SignInGatePatientia = ({
                     className={signInLink}
                     href={signInUrl}
                     onClick={() => {
-                        trackLink(component, 'sign-in-link', abTest);
+                        trackLink(ophanComponentId, 'sign-in-link', abTest);
                     }}
                 >
                     Sign In
@@ -196,7 +187,7 @@ export const SignInGatePatientia = ({
                 <Link
                     href={`${guUrl}/membership/2019/dec/20/signing-in-to-the-guardian`}
                     onClick={() => {
-                        trackLink(component, 'how-link', abTest);
+                        trackLink(ophanComponentId, 'how-link', abTest);
                     }}
                 >
                     Why register & how does it help?
@@ -205,7 +196,7 @@ export const SignInGatePatientia = ({
                 <Link
                     href={`${guUrl}/info/2014/nov/03/why-your-data-matters-to-us-full-text`}
                     onClick={() => {
-                        trackLink(component, 'why-link', abTest);
+                        trackLink(ophanComponentId, 'why-link', abTest);
                     }}
                 >
                     How will my information & data be used?
@@ -214,7 +205,7 @@ export const SignInGatePatientia = ({
                 <Link
                     href={`${guUrl}/help/identity-faq`}
                     onClick={() => {
-                        trackLink(component, 'help-link', abTest);
+                        trackLink(ophanComponentId, 'help-link', abTest);
                     }}
                 >
                     Get help with registering or signing in

--- a/src/web/components/SignInGate/gateDesigns/types.ts
+++ b/src/web/components/SignInGate/gateDesigns/types.ts
@@ -11,7 +11,7 @@ export interface SignInGateProps {
     signInUrl: string;
     guUrl: string;
     dismissGate: () => void;
-    component: string;
+    ophanComponentId: string;
     isComment?: boolean;
     abTest?: CurrentABTest;
 }
@@ -19,4 +19,5 @@ export interface SignInGateProps {
 export type CurrentABTest = {
     name: string;
     variant: string;
+    id: string;
 };

--- a/src/web/components/SignInGate/gates/main-variant.tsx
+++ b/src/web/components/SignInGate/gates/main-variant.tsx
@@ -40,11 +40,18 @@ const canShow = (
     !isIOS9();
 
 export const signInGateComponent: SignInGateComponent = {
-    gate: ({ component, dismissGate, guUrl, signInUrl, abTest, isComment }) => (
+    gate: ({
+        ophanComponentId,
+        dismissGate,
+        guUrl,
+        signInUrl,
+        abTest,
+        isComment,
+    }) => (
         <Lazy margin={300}>
             <Suspense fallback={<></>}>
                 <SignInGateMain
-                    component={component}
+                    ophanComponentId={ophanComponentId}
                     dismissGate={dismissGate}
                     guUrl={guUrl}
                     signInUrl={signInUrl}

--- a/src/web/components/SignInGate/gates/patientia-variant.tsx
+++ b/src/web/components/SignInGate/gates/patientia-variant.tsx
@@ -40,11 +40,18 @@ const SignInGatePatientia = React.lazy(() => {
 });
 
 export const signInGateComponent: SignInGateComponent = {
-    gate: ({ component, dismissGate, guUrl, signInUrl, abTest, isComment }) => (
+    gate: ({
+        ophanComponentId,
+        dismissGate,
+        guUrl,
+        signInUrl,
+        abTest,
+        isComment,
+    }) => (
         <Lazy margin={300}>
             <Suspense fallback={<></>}>
                 <SignInGatePatientia
-                    component={component}
+                    ophanComponentId={ophanComponentId}
                     dismissGate={dismissGate}
                     guUrl={guUrl}
                     signInUrl={signInUrl}


### PR DESCRIPTION
## What does this change?
- Maps the component id in the `testIdToComponentId` object using the AB test ID now, rather than the name, since the name may not be the AB test ID as it could be the AB test `dataLinkName` instead
  - This is because `dataLinkName` is used to combine multiple tests under one reporting name, but the component id for each of those tests may be different
- Renamed `component` to `ophanComponentId` in the `SignInGateProps` type, as that better reflects the name

## Why?
- In the data lake the component id for that particular component in the data lake was sometimes reporting as `undefined` due to this issue, which may cause issues with reporting if segmenting by the component id
  - It's still possible to segment by the AB test variant, which is unique, so using the variant is actually a better way of doing it, but this was still a bug which may cause confusion