### PR TITLE
AB Tests | Register AB Tests with Ophan

### DIFF
--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -133,6 +133,7 @@ export const App = ({ CAPI, NAV }: Props) => {
     const ABTestAPI = useAB();
     useEffect(() => {
         const allRunnableTests = ABTestAPI.allRunnableTests(tests);
+        ABTestAPI.trackABTests(allRunnableTests);
         ABTestAPI.registerImpressionEvents(allRunnableTests);
         ABTestAPI.registerCompleteEvents(allRunnableTests);
     }, [ABTestAPI]);


### PR DESCRIPTION
## What does this change?
- Fire the `ABTestAPI.trackABTests` method when setting up the AB tests which registers AB tests with the pageview in Ophan and therefore the data lake.

## Why?
This method was accidentally left out when setting up the AB test framework in DCR, but it required to correctly report on page views with AB tests.

## Screenshot
![chrome_eQsKThw5XO](https://user-images.githubusercontent.com/13315440/89307208-b895f680-d668-11ea-9110-8663596990cc.png)

