### PR TITLE
Track Core Vitals to Google Analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,8 @@
         "prettier-eslint": "^11.0.0",
         "pretty-bytes": "^4.0.2",
         "reset-css": "^5.0.1",
-        "sanitize-html": "^1.27.0"
+        "sanitize-html": "^1.27.0",
+        "web-vitals": "^0.2.4"
     },
     "devDependencies": {
         "@babel/core": "^7.5.5",

--- a/src/web/browser/ga/ga.ts
+++ b/src/web/browser/ga/ga.ts
@@ -1,3 +1,4 @@
+import { getCLS, getFID, getLCP } from 'web-vitals';
 import { getCookie } from './cookie';
 
 interface TrackerConfig {
@@ -13,6 +14,8 @@ const tracker: TrackerConfig = {
     sampleRate: 100,
     siteSpeedSampleRate: 1, // TODO Should be set to 0.1 when rolling out to wider audience
 };
+const set = `${tracker.name}.set`;
+const send = `${tracker.name}.send`;
 
 const getQueryParam = (
     key: string,
@@ -42,65 +45,39 @@ export const init = (): void => {
     });
 };
 
-// Adapted from https://web.dev/lcp/#measure-lcp-in-javascript
-const trackLCP = (send: string) => {
+type coreVitalsArgs = {
+    name: string;
+    delta: number;
+    id: string;
+};
+// https://www.npmjs.com/package/web-vitals#using-analyticsjs
+const sendCoreVital = ({ name, delta, id }: coreVitalsArgs): void => {
     const { ga } = window;
-    // Create a variable to hold the latest LCP value (since it can change).
-    let lcp: number;
 
-    if (!window.PerformanceObserver) {
+    if (!ga) {
         return;
     }
 
-    // Create the PerformanceObserver instance.
-    const po = new window.PerformanceObserver((entryList) => {
-        const entries = entryList.getEntries();
-        const lastEntry = entries[entries.length - 1];
 
-        // Update `lcp` to the latest value, using `renderTime` if it's available,
-        // otherwise using `loadTime`. (Note: `renderTime` may not be available if
-        // the element is an image and it's loaded cross-origin without the
-        // `Timing-Allow-Origin` header.)
-        lcp = lastEntry.renderTime || lastEntry.loadTime;
+    ga(send, 'event', {
+        eventCategory: 'Web Vitals',
+        eventAction: name,
+        // Google Analytics metrics must be integers, so the value is rounded.
+        // For CLS the value is first multiplied by 1000 for greater precision
+        // (note: increase the multiplier for greater precision if needed).
+        eventValue: Math.round(name === 'CLS' ? delta * 1000 : delta),
+        // The `id` value will be unique to the current page load. When sending
+        // multiple values from the same page (e.g. for CLS), Google Analytics can
+        // compute a total by grouping on this ID (note: requires `eventLabel` to
+        // be a dimension in your report).
+        eventLabel: id,
+        // Use a non-interaction event to avoid affecting bounce rate.
+        nonInteraction: true,
     });
-
-    // Observe entries of type `largest-contentful-paint`, including buffered
-    // entries, i.e. entries that occurred before calling `observe()`.
-    try {
-        // This inexplicably fires off an error instead of just ignoring a type it doesn't understand
-        // until fairly recent browsers.
-        // https://github.com/w3c/performance-timeline/issues/87
-        // If we can't observer LCP, catch and return early.
-        po.observe({ type: 'largest-contentful-paint', buffered: true });
-    } catch {
-        return;
-    }
-
-    // Send the latest LCP value to your analytics server once the user
-    // leaves the tab.
-    window.addEventListener(
-        'visibilitychange',
-        function fn() {
-            if (lcp && document.visibilityState === 'hidden') {
-                ga(
-                    send,
-                    'timing',
-                    'Javascript Load', // Matches Frontend
-                    'LCP', // Largest Contentful Paint (We can filter to DCR with the Dimension 43 segment)
-                    Math.round(lcp),
-                    'Largest Contentful Paint',
-                );
-                window.removeEventListener('visibilitychange', fn, true);
-            }
-        },
-        true,
-    );
 };
 
 export const sendPageView = (): void => {
     const { GA } = window.guardian.app.data;
-    const set = `${tracker.name}.set`;
-    const send = `${tracker.name}.send`;
     const userCookie = getCookie('GU_U');
     const { ga } = window;
 
@@ -172,15 +149,24 @@ export const sendPageView = (): void => {
         },
     });
 
-    trackLCP(send);
+    // //////////////////////
+    // Core Vitals Reporting
+    // Supported only in Chromium but npm module tested in all our supported browsers
+    // https://www.npmjs.com/package/web-vitals#browser-support
+
+    // CLS and LCP are captured when the page lifecycle changes to 'hidden'.
+    // https://developers.google.com/web/updates/2018/07/page-lifecycle-api#advice-hidden
+    getCLS(sendCoreVital); // https://github.com/GoogleChrome/web-vitals#getcls (This is actually DCLS, as doesn't track CLS in iframes, see https://github.com/WICG/layout-instability#cumulative-scores)
+    getLCP(sendCoreVital); // https://github.com/GoogleChrome/web-vitals#getlcp
+
+    // FID is captured when a user interacts with the page
+    getFID(sendCoreVital); // https://github.com/GoogleChrome/web-vitals#getfid
 };
 
 export const trackNonClickInteraction = (actionName: string): void => {
     const { ga } = window;
 
     if (ga) {
-        const send = `${tracker.name}.send`;
-
         ga(send, 'event', 'Interaction', actionName, {
             /**
              * set nonInteraction to avoid affecting bounce rate

--- a/yarn.lock
+++ b/yarn.lock
@@ -19103,6 +19103,11 @@ wcwidth@^1.0.0:
   dependencies:
     defaults "^1.0.3"
 
+web-vitals@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-0.2.4.tgz#ec3df43c834a207fd7cdefd732b2987896e08511"
+  integrity sha512-6BjspCO9VriYy12z356nL6JBS0GYeEcA457YyRzD+dD6XYCQ75NKhcOHUMHentOE7OcVCIXXDvOm0jKFfQG2Gg==
+
 webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"


### PR DESCRIPTION
## What does this change?

Implements the official [GoogleChrome web-vitals](https://github.com/GoogleChrome/web-vitals) metrics module reporting the results to Google Analytics.

The library is small (with easy to read code) and well tested, it makes more sense than implementing these ourselves. Reporting to GA is simple and matches how we were previously reporting LCP.

We are reporting:

- *Largest Contentful Paint* when page lifecycle becomes 'hidden'
- *Cumulative Layout Shift* when page lifecycle becomes 'hidden'
- *First Input Delay* on a user interaction

I am limiting the data to these three for now to avoid sending many more events to GA. We may want to expand on this in the future, this library in particular also tracks FCP and TTFB which are not automatically tracked by GA.

## Why?

Tracking core vitals at RUM is required to allow us to measure pages that are damaging to user experience and web performance. We can see Core Vitals at a RUM level using the CrUX report which feeds into the Google Search Console but capturing the data ourselves here (and later, maybe, Ophan) means we can better segment the data to pages, sections and platforms.

Be aware: the data is only available for Chromium browsers.