### PR TITLE
Refactor AudioAtomBlockElement

### DIFF
--- a/src/amp/components/Elements.tsx
+++ b/src/amp/components/Elements.tsx
@@ -37,7 +37,7 @@ export const Elements = (
     const output = cleanedElements.map((element, i) => {
         switch (element._type) {
             case 'model.dotcomrendering.pageElements.AudioAtomBlockElement':
-                return <AudioAtomBlockComponent element={element} />;
+                return <AudioAtomBlockComponent element={element.amp} />;
             case 'model.dotcomrendering.pageElements.BlockquoteBlockElement':
                 return (
                     <TextBlockComponent

--- a/src/amp/components/elements/AudioAtomBlockComponent.tsx
+++ b/src/amp/components/elements/AudioAtomBlockComponent.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 export const AudioAtomBlockComponent: React.FC<{
-    element: AudioAtomElement;
+    element: AudioAtomBlockElementAMP;
 }> = ({ element }) => {
     return (
         <amp-audio src={element.trackUrl} title={element.kicker}>

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -9,13 +9,17 @@ interface InteractiveAtomBlockElementBase {
     js?: string;
 }
 
-interface AudioAtomElement {
-    _type: 'model.dotcomrendering.pageElements.AudioAtomBlockElement';
+interface AudioAtomBlockElementAMP {
     id: string;
     kicker: string;
     trackUrl: string;
     duration: number;
     coverUrl: string;
+}
+
+interface AudioAtomBlockElement {
+    _type: 'model.dotcomrendering.pageElements.AudioAtomBlockElement';
+    amp: AudioAtomBlockElementAMP;
 }
 
 interface AudioBlockElement {
@@ -316,7 +320,7 @@ interface YoutubeBlockElement {
 }
 
 type CAPIElement =
-    | AudioAtomElement
+    | AudioAtomBlockElement
     | AudioBlockElement
     | BlockquoteBlockElement
     | CaptionBlockElement

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -15,7 +15,7 @@
             "items": {
                 "anyOf": [
                     {
-                        "$ref": "#/definitions/AudioAtomElement"
+                        "$ref": "#/definitions/AudioAtomBlockElement"
                     },
                     {
                         "$ref": "#/definitions/AudioBlockElement"
@@ -380,7 +380,7 @@
         "webURL"
     ],
     "definitions": {
-        "AudioAtomElement": {
+        "AudioAtomBlockElement": {
             "type": "object",
             "properties": {
                 "_type": {
@@ -389,30 +389,11 @@
                         "model.dotcomrendering.pageElements.AudioAtomBlockElement"
                     ]
                 },
-                "id": {
-                    "type": "string"
-                },
-                "kicker": {
-                    "type": "string"
-                },
-                "trackUrl": {
-                    "type": "string"
-                },
-                "duration": {
-                    "type": "number"
-                },
-                "coverUrl": {
-                    "type": "string"
+                "amp": {
+                    "type": "object"
                 }
             },
-            "required": [
-                "_type",
-                "coverUrl",
-                "duration",
-                "id",
-                "kicker",
-                "trackUrl"
-            ]
+            "required": ["_type", "amp"]
         },
         "AudioBlockElement": {
             "type": "object",
@@ -1833,7 +1814,7 @@
                     "items": {
                         "anyOf": [
                             {
-                                "$ref": "#/definitions/AudioAtomElement"
+                                "$ref": "#/definitions/AudioAtomBlockElement"
                             },
                             {
                                 "$ref": "#/definitions/AudioBlockElement"


### PR DESCRIPTION
## What does this change?

This both repairs and refactors the `AudioAtomElement` in AMP

The `AudioAtomElement`, now renamed `AudioAtomBlockElement` was not showing up in AMP using the `AudioAtomBlockComponent`, because the backend has not been sending the `AudioAtomBlockElement` for a few months.

The backend is going to start sending the data again, but a slightly modified version from before. The backend is moving from 

this:

```
    {
      "coverUrl": "https://media.guim.co.uk/95972cd44af49b3a457f95c36e7ddfdde1116d14/0_346_5618_3373/500.jpg",
      "duration": 849,
      "contentId": "_no_ids",
      "_type": "model.dotcomrendering.pageElements.AudioAtomBlockElement",
      "id": "d6d509cf-ca10-407f-8913-e16a3712f415",
      "trackUrl": "https://audio.guim.co.uk/2020/05/05-61553-gnl.fw.200505.jf.ch7DW.mp3",
      "kicker": "Football Weekly Extra Extra"
    },
```

to this

```
    {
      "amp": {
        "id": "d6d509cf-ca10-407f-8913-e16a3712f415",
        "kicker": "Football Weekly Extra Extra",
        "coverUrl": "https://media.guim.co.uk/95972cd44af49b3a457f95c36e7ddfdde1116d14/0_346_5618_3373/500.jpg",
        "trackUrl": "https://audio.guim.co.uk/2020/05/05-61553-gnl.fw.200505.jf.ch7DW.mp3",
        "duration": 849,
        "contentId": "_no_ids"
      },
      "_type": "model.dotcomrendering.pageElements.AudioAtomBlockElement"
    },
```

Hence the update in the DCR definition. The change in the backend schema is part of a current effort to send audio data to DCR web.