### PR TITLE
Support reader revenue bookmarklets

### DIFF
--- a/scripts/jest/setup.ts
+++ b/scripts/jest/setup.ts
@@ -49,6 +49,13 @@ const windowGuardian = {
         emotionCore: undefined,
         emotionTheming: undefined,
     },
+    readerRevenue: {
+        changeGeolocation: () => {},
+        showMeTheEpic: () => {},
+        showMeTheBanner: () => {},
+        showNextVariant: () => {},
+        showPreviousVariant: () => {},
+    }
 };
 
 // Stub global Guardian object

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -238,12 +238,14 @@ export const App = ({ CAPI, NAV }: Props) => {
                 .catch(error => console.log('Error loading readerRevenueDevUtils', error));
                 /* eslint-enable no-console */
 
-        window.guardian.readerRevenue = {
-            changeGeolocation: loadAndRun('changeGeolocation'),
-            showMeTheEpic: loadAndRun('showMeTheEpic'),
-            showMeTheBanner: loadAndRun('showMeTheBanner'),
-            showNextVariant: loadAndRun('showNextVariant'),
-            showPreviousVariant: loadAndRun('showPreviousVariant'),
+        if (window && window.guardian) {
+            window.guardian.readerRevenue = {
+                changeGeolocation: loadAndRun('changeGeolocation'),
+                showMeTheEpic: loadAndRun('showMeTheEpic'),
+                showMeTheBanner: loadAndRun('showMeTheBanner'),
+                showNextVariant: loadAndRun('showNextVariant'),
+                showPreviousVariant: loadAndRun('showPreviousVariant'),
+            }
         }
     }, [CAPI.shouldHideReaderRevenue]);
 

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -35,6 +35,7 @@ import { incrementAlreadyVisited } from '@root/src/web/lib/alreadyVisited';
 import { incrementDailyArticleCount } from '@frontend/web/lib/dailyArticleCount';
 
 import { hasOptedOutOfArticleCount } from '@frontend/web/lib/contributions';
+import { init as initReaderRevenueDevUtils } from '@root/src/web/lib/readerRevenueDevUtils';
 
 import {
     submitComponentEvent,
@@ -227,6 +228,10 @@ export const App = ({ CAPI, NAV }: Props) => {
     useEffect(() => {
         FocusStyleManager.onlyShowFocusOnTabs();
     }, []);
+
+    useEffect(() => {
+        initReaderRevenueDevUtils(CAPI.shouldHideReaderRevenue);
+    }, [CAPI.shouldHideReaderRevenue]);
 
     const pillar = decidePillar(CAPI);
 

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -36,11 +36,11 @@ import { incrementDailyArticleCount } from '@frontend/web/lib/dailyArticleCount'
 
 import { hasOptedOutOfArticleCount } from '@frontend/web/lib/contributions';
 
+import {ReaderRevenueDevUtils} from "@root/src/web/lib/readerRevenueDevUtils";
 import {
     submitComponentEvent,
     OphanComponentEvent,
 } from '../browser/ophan/ophan';
-import {ReaderRevenueDevUtils} from "@root/src/web/lib/readerRevenueDevUtils";
 
 // *******************************
 // ****** Dynamic imports ********
@@ -234,7 +234,9 @@ export const App = ({ CAPI, NAV }: Props) => {
         const loadAndRun = <K extends keyof ReaderRevenueDevUtils>(key: K) => (asExistingSupporter: boolean) =>
             import(/* webpackChunkName: "readerRevenueDevUtils" */ '@frontend/web/lib/readerRevenueDevUtils')
                 .then(utils => utils[key](asExistingSupporter, CAPI.shouldHideReaderRevenue))
+                /* eslint-disable no-console */
                 .catch(error => console.log('Error loading readerRevenueDevUtils', error));
+                /* eslint-enable no-console */
 
         window.guardian.readerRevenue = {
             changeGeolocation: loadAndRun('changeGeolocation'),

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -35,12 +35,12 @@ import { incrementAlreadyVisited } from '@root/src/web/lib/alreadyVisited';
 import { incrementDailyArticleCount } from '@frontend/web/lib/dailyArticleCount';
 
 import { hasOptedOutOfArticleCount } from '@frontend/web/lib/contributions';
-import { init as initReaderRevenueDevUtils } from '@root/src/web/lib/readerRevenueDevUtils';
 
 import {
     submitComponentEvent,
     OphanComponentEvent,
 } from '../browser/ophan/ophan';
+import {ReaderRevenueDevUtils} from "@root/src/web/lib/readerRevenueDevUtils";
 
 // *******************************
 // ****** Dynamic imports ********
@@ -230,7 +230,19 @@ export const App = ({ CAPI, NAV }: Props) => {
     }, []);
 
     useEffect(() => {
-        initReaderRevenueDevUtils(CAPI.shouldHideReaderRevenue);
+        // Used internally only, so only import each function on demand
+        const loadAndRun = <K extends keyof ReaderRevenueDevUtils>(key: K) => (asExistingSupporter: boolean) =>
+            import(/* webpackChunkName: "readerRevenueDevUtils" */ '@frontend/web/lib/readerRevenueDevUtils')
+                .then(utils => utils[key](asExistingSupporter, CAPI.shouldHideReaderRevenue))
+                .catch(error => console.log('Error loading readerRevenueDevUtils', error));
+
+        window.guardian.readerRevenue = {
+            changeGeolocation: loadAndRun('changeGeolocation'),
+            showMeTheEpic: loadAndRun('showMeTheEpic'),
+            showMeTheBanner: loadAndRun('showMeTheBanner'),
+            showNextVariant: loadAndRun('showNextVariant'),
+            showPreviousVariant: loadAndRun('showPreviousVariant'),
+        }
     }, [CAPI.shouldHideReaderRevenue]);
 
     const pillar = decidePillar(CAPI);

--- a/src/web/lib/alreadyVisited.ts
+++ b/src/web/lib/alreadyVisited.ts
@@ -8,7 +8,11 @@ export const getAlreadyVisitedCount = (): number => {
     return !Number.isNaN(alreadyVisited) ? alreadyVisited : 0;
 };
 
+export const setAlreadyVisited = (count: number): void => {
+    localStorage.setItem(AlreadyVisitedKey, count.toString());
+};
+
 export const incrementAlreadyVisited = () => {
     const alreadyVisited = getAlreadyVisitedCount();
-    localStorage.setItem(AlreadyVisitedKey, `${alreadyVisited + 1}`);
+    setAlreadyVisited(alreadyVisited + 1)
 };

--- a/src/web/lib/getCountryCode.ts
+++ b/src/web/lib/getCountryCode.ts
@@ -3,14 +3,37 @@ type LocalCountryCodeType = {
     expires: number;
 };
 
+const COUNTRY_CODE_KEY = 'gu.geolocation';
+const TEN_DAYS = 60 * 60 * 24 * 10;
+
 function hasExpired(whenItExpires: number) {
     return new Date().getTime() > whenItExpires;
 }
 
-export const getCountryCode = async () => {
-    const TEN_DAYS = 60 * 60 * 24 * 10;
-    const COUNTRY_CODE_KEY = 'gu.geolocation';
+export const setCountryCode = (countryCode: string): void => {
+    // What's this setTimeout business?
+    // localStorage calls are syncronous and we don't need to wait for this
+    // one so we use setTimeout to put this step on the end of the event queue
+    // for later, letting the thread continue
+    setTimeout(() => {
+        if (countryCode) {
+            try {
+                localStorage.setItem(
+                    COUNTRY_CODE_KEY,
+                    JSON.stringify({
+                        value: countryCode,
+                        expires: new Date().getTime() + TEN_DAYS,
+                    }),
+                );
+            } catch (error) {
+                // We tried, it failed. Often local storage is not available and we
+                // need to live with that
+            }
+        }
+    });
+};
 
+export const getCountryCode = async () => {
     // Read local storage to see if we already have a value
     let localCountryCode: LocalCountryCodeType | null;
     try {
@@ -42,26 +65,9 @@ export const getCountryCode = async () => {
                 );
             });
 
-        // What's this setTimeout business?
-        // localStorage calls are syncronous and we don't need to wait for this
-        // one so we use setTimeout to put this step on the end of the event queue
-        // for later, letting the thread continue
-        setTimeout(() => {
-            if (countryCode) {
-                try {
-                    localStorage.setItem(
-                        COUNTRY_CODE_KEY,
-                        JSON.stringify({
-                            value: countryCode,
-                            expires: new Date().getTime() + TEN_DAYS,
-                        }),
-                    );
-                } catch (error) {
-                    // We tried, it failed. Often local storage is not available and we
-                    // need to live with that
-                }
-            }
-        });
+        if (countryCode) {
+            setCountryCode(countryCode);
+        }
         // Return the country value that we got from our fetch call
         return countryCode;
     }

--- a/src/web/lib/readerRevenueDevUtils.ts
+++ b/src/web/lib/readerRevenueDevUtils.ts
@@ -104,13 +104,15 @@ const init = (shouldHideReaderRevenue: boolean) => {
         })
     };
 
-    window.guardian.readerRevenue = {
-        changeGeolocation,
-        showMeTheEpic,
-        showMeTheBanner,
-        showNextVariant,
-        showPreviousVariant
-    };
+    if (window && window.guardian) {
+        window.guardian.readerRevenue = {
+            changeGeolocation,
+            showMeTheEpic,
+            showMeTheBanner,
+            showNextVariant,
+            showPreviousVariant
+        };
+    }
 };
 
 export {

--- a/src/web/lib/readerRevenueDevUtils.ts
+++ b/src/web/lib/readerRevenueDevUtils.ts
@@ -1,0 +1,118 @@
+import {setCountryCode, getCountryCode} from "@root/src/web/lib/getCountryCode";
+import {
+    HIDE_SUPPORT_MESSAGING_COOKIE,
+    RECURRING_CONTRIBUTOR_COOKIE, SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE, SUPPORT_RECURRING_CONTRIBUTOR_ANNUAL_COOKIE,
+    SUPPORT_RECURRING_CONTRIBUTOR_MONTHLY_COOKIE
+} from "@root/src/web/lib/contributions";
+import {addCookie, getCookie, removeCookie} from "@root/src/web/browser/cookie";
+import {setAlreadyVisited} from "@root/src/web/lib/alreadyVisited";
+
+const readerRevenueCookies = [
+    HIDE_SUPPORT_MESSAGING_COOKIE,
+    RECURRING_CONTRIBUTOR_COOKIE,
+    SUPPORT_RECURRING_CONTRIBUTOR_MONTHLY_COOKIE,
+    SUPPORT_RECURRING_CONTRIBUTOR_ANNUAL_COOKIE,
+    SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE,
+];
+
+const clearEpicViewLog = (): void => localStorage.removeItem('gu.contributions.views');
+const clearBannerLastClosedAt = (): void => localStorage.removeItem('engagementBannerLastClosedAt');
+
+const fakeOneOffContributor = (): void =>
+    addCookie(SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE, Date.now().toString());
+
+const MULTIVARIATE_ID_COOKIE = 'GU_mvt_id';
+const MAX_CLIENT_MVT_ID = 1000000;
+const incrementMvtCookie = (): void => {
+    const mvtId = parseInt(getCookie(MULTIVARIATE_ID_COOKIE) || '1', 10);
+    if (mvtId) {
+        if (mvtId === MAX_CLIENT_MVT_ID) {
+            // Wrap back to 1 if it would exceed the max
+            addCookie(MULTIVARIATE_ID_COOKIE, '1');
+        } else {
+            addCookie(MULTIVARIATE_ID_COOKIE, `${mvtId + 1}`);
+        }
+    }
+};
+const decrementMvtCookie = (): void => {
+    const mvtId = parseInt(getCookie(MULTIVARIATE_ID_COOKIE) || '1', 10);
+    if (mvtId) {
+        if (mvtId === 0) {
+            // Wrap back to max if it would be less than 0
+            addCookie(MULTIVARIATE_ID_COOKIE, MAX_CLIENT_MVT_ID.toString());
+        } else {
+            addCookie(MULTIVARIATE_ID_COOKIE, `${mvtId - 1}`);
+        }
+    }
+};
+
+const init = (shouldHideReaderRevenue: boolean) => {
+
+    const clearCommonReaderRevenueStateAndReload = (asExistingSupporter: boolean): void => {
+        if (shouldHideReaderRevenue) {
+            /* eslint-disable no-alert */
+            alert(
+                'This page has "Prevent membership/contribution appeals" ticked in Composer. Please try a different page'
+            );
+            /* eslint-enable no-alert */
+            return;
+        }
+
+        readerRevenueCookies.forEach(cookie => removeCookie(cookie));
+        clearEpicViewLog();
+
+        if (asExistingSupporter) {
+            fakeOneOffContributor();
+        }
+
+        window.location.reload();
+    };
+
+    const showMeTheEpic = (asExistingSupporter: boolean = false): void => {
+        clearCommonReaderRevenueStateAndReload(asExistingSupporter);
+    };
+
+    const showMeTheBanner = (asExistingSupporter: boolean = false): void => {
+        clearBannerLastClosedAt();
+        setAlreadyVisited(2);
+        clearCommonReaderRevenueStateAndReload(asExistingSupporter);
+    };
+
+    const showNextVariant = (asExistingSupporter: boolean = false): void => {
+        incrementMvtCookie();
+        clearCommonReaderRevenueStateAndReload(asExistingSupporter);
+    };
+
+    const showPreviousVariant = (asExistingSupporter: boolean = false): void => {
+        decrementMvtCookie();
+        clearCommonReaderRevenueStateAndReload(asExistingSupporter);
+    };
+
+    const changeGeolocation = (asExistingSupporter: boolean = false): void => {
+        getCountryCode().then(current => {
+            /* eslint-disable no-alert */
+            const geo = window.prompt(
+                `Enter two-letter geolocation code (e.g. GB, US, AU). Current is ${current}.`
+            );
+            if (geo === 'UK') {
+                alert(`'UK' is not a valid geolocation - please use 'GB' instead!`);
+            } else if (geo) {
+                setCountryCode(geo);
+                clearCommonReaderRevenueStateAndReload(asExistingSupporter);
+            }
+            /* eslint-enable no-alert */
+        })
+    };
+
+    window.guardian.readerRevenue = {
+        changeGeolocation,
+        showMeTheEpic,
+        showMeTheBanner,
+        showNextVariant,
+        showPreviousVariant
+    };
+};
+
+export {
+    init
+}

--- a/src/web/lib/readerRevenueDevUtils.ts
+++ b/src/web/lib/readerRevenueDevUtils.ts
@@ -46,75 +46,76 @@ const decrementMvtCookie = (): void => {
     }
 };
 
-const init = (shouldHideReaderRevenue: boolean) => {
 
-    const clearCommonReaderRevenueStateAndReload = (asExistingSupporter: boolean): void => {
-        if (shouldHideReaderRevenue) {
-            /* eslint-disable no-alert */
-            alert(
-                'This page has "Prevent membership/contribution appeals" ticked in Composer. Please try a different page'
-            );
-            /* eslint-enable no-alert */
-            return;
-        }
-
-        readerRevenueCookies.forEach(cookie => removeCookie(cookie));
-        clearEpicViewLog();
-
-        if (asExistingSupporter) {
-            fakeOneOffContributor();
-        }
-
-        window.location.reload();
-    };
-
-    const showMeTheEpic = (asExistingSupporter: boolean = false): void => {
-        clearCommonReaderRevenueStateAndReload(asExistingSupporter);
-    };
-
-    const showMeTheBanner = (asExistingSupporter: boolean = false): void => {
-        clearBannerLastClosedAt();
-        setAlreadyVisited(2);
-        clearCommonReaderRevenueStateAndReload(asExistingSupporter);
-    };
-
-    const showNextVariant = (asExistingSupporter: boolean = false): void => {
-        incrementMvtCookie();
-        clearCommonReaderRevenueStateAndReload(asExistingSupporter);
-    };
-
-    const showPreviousVariant = (asExistingSupporter: boolean = false): void => {
-        decrementMvtCookie();
-        clearCommonReaderRevenueStateAndReload(asExistingSupporter);
-    };
-
-    const changeGeolocation = (asExistingSupporter: boolean = false): void => {
-        getCountryCode().then(current => {
-            /* eslint-disable no-alert */
-            const geo = window.prompt(
-                `Enter two-letter geolocation code (e.g. GB, US, AU). Current is ${current}.`
-            );
-            if (geo === 'UK') {
-                alert(`'UK' is not a valid geolocation - please use 'GB' instead!`);
-            } else if (geo) {
-                setCountryCode(geo);
-                clearCommonReaderRevenueStateAndReload(asExistingSupporter);
-            }
-            /* eslint-enable no-alert */
-        })
-    };
-
-    if (window && window.guardian) {
-        window.guardian.readerRevenue = {
-            changeGeolocation,
-            showMeTheEpic,
-            showMeTheBanner,
-            showNextVariant,
-            showPreviousVariant
-        };
+const clearCommonReaderRevenueStateAndReload = (asExistingSupporter: boolean, shouldHideReaderRevenue: boolean): void => {
+    if (shouldHideReaderRevenue) {
+        /* eslint-disable no-alert */
+        alert(
+            'This page has "Prevent membership/contribution appeals" ticked in Composer. Please try a different page'
+        );
+        /* eslint-enable no-alert */
+        return;
     }
+
+    readerRevenueCookies.forEach(cookie => removeCookie(cookie));
+    clearEpicViewLog();
+
+    if (asExistingSupporter) {
+        fakeOneOffContributor();
+    }
+
+    window.location.reload();
 };
 
-export {
-    init
+const showMeTheEpic = (asExistingSupporter: boolean = false, shouldHideReaderRevenue: boolean): void => {
+    clearCommonReaderRevenueStateAndReload(asExistingSupporter, shouldHideReaderRevenue);
+};
+
+const showMeTheBanner = (asExistingSupporter: boolean = false, shouldHideReaderRevenue: boolean): void => {
+    clearBannerLastClosedAt();
+    setAlreadyVisited(2);
+    clearCommonReaderRevenueStateAndReload(asExistingSupporter, shouldHideReaderRevenue);
+};
+
+const showNextVariant = (asExistingSupporter: boolean = false, shouldHideReaderRevenue: boolean): void => {
+    incrementMvtCookie();
+    clearCommonReaderRevenueStateAndReload(asExistingSupporter, shouldHideReaderRevenue);
+};
+
+const showPreviousVariant = (asExistingSupporter: boolean = false, shouldHideReaderRevenue: boolean): void => {
+    decrementMvtCookie();
+    clearCommonReaderRevenueStateAndReload(asExistingSupporter, shouldHideReaderRevenue);
+};
+
+const changeGeolocation = (asExistingSupporter: boolean = false, shouldHideReaderRevenue: boolean): void => {
+    getCountryCode().then(current => {
+        /* eslint-disable no-alert */
+        const geo = window.prompt(
+            `Enter two-letter geolocation code (e.g. GB, US, AU). Current is ${current}.`
+        );
+        if (geo === 'UK') {
+            alert(`'UK' is not a valid geolocation - please use 'GB' instead!`);
+        } else if (geo) {
+            setCountryCode(geo);
+            clearCommonReaderRevenueStateAndReload(asExistingSupporter, shouldHideReaderRevenue);
+        }
+        /* eslint-enable no-alert */
+    })
+};
+
+type ReaderRevenueDevUtil = (asExistingSupporter: boolean, shouldHideReaderRevenue: boolean) => void;
+export interface ReaderRevenueDevUtils {
+    changeGeolocation: ReaderRevenueDevUtil;
+    showMeTheEpic: ReaderRevenueDevUtil;
+    showMeTheBanner: ReaderRevenueDevUtil;
+    showNextVariant: ReaderRevenueDevUtil;
+    showPreviousVariant: ReaderRevenueDevUtil;
 }
+
+export {
+    changeGeolocation,
+    showMeTheEpic,
+    showMeTheBanner,
+    showNextVariant,
+    showPreviousVariant
+};

--- a/window.guardian.d.ts
+++ b/window.guardian.d.ts
@@ -1,4 +1,5 @@
 import { WindowGuardianConfig } from '@root/src/model/window-guardian';
+import {ReaderRevenueDevUtils} from "@root/src/web/lib/readerRevenueDevUtils";
 
 declare global {
     /* ~ Here, declare things that go in the global namespace, or augment
@@ -39,13 +40,7 @@ declare global {
                 emotionCore: any;
                 emotionTheming: any;
             };
-            readerRevenue: {
-                changeGeolocation: (asExistingSupporter: boolean) => void;
-                showMeTheEpic: (asExistingSupporter: boolean) => void;
-                showMeTheBanner: (asExistingSupporter: boolean) => void;
-                showNextVariant: (asExistingSupporter: boolean) => void;
-                showPreviousVariant: (asExistingSupporter: boolean) => void;
-            }
+            readerRevenue: ReaderRevenueDevUtils;
         };
         GoogleAnalyticsObject: string;
         ga: UniversalAnalytics.ga;

--- a/window.guardian.d.ts
+++ b/window.guardian.d.ts
@@ -39,6 +39,13 @@ declare global {
                 emotionCore: any;
                 emotionTheming: any;
             };
+            readerRevenue: {
+                changeGeolocation: (asExistingSupporter: boolean) => void;
+                showMeTheEpic: (asExistingSupporter: boolean) => void;
+                showMeTheBanner: (asExistingSupporter: boolean) => void;
+                showNextVariant: (asExistingSupporter: boolean) => void;
+                showPreviousVariant: (asExistingSupporter: boolean) => void;
+            }
         };
         GoogleAnalyticsObject: string;
         ga: UniversalAnalytics.ga;


### PR DESCRIPTION
## What does this change?
Re-implements the logic from frontend here: https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/common/modules/commercial/reader-revenue-dev-utils.js

These functions support the [bookmarklets](http://reader-revenue-bookmarklets.s3-website-eu-west-1.amazonaws.com/), which are used heavily by lots of people for viewing epics/banners.
