### PR TITLE
Return of the old AMP specific Audio Atom definition

### DIFF
--- a/src/amp/components/Elements.tsx
+++ b/src/amp/components/Elements.tsx
@@ -37,7 +37,7 @@ export const Elements = (
     const output = cleanedElements.map((element, i) => {
         switch (element._type) {
             case 'model.dotcomrendering.pageElements.AudioAtomBlockElement':
-                // return <AudioAtomBlockComponent element={element.amp} />;
+                // return <AudioAtomBlockComponent element={element} />;
                 return null;
             case 'model.dotcomrendering.pageElements.BlockquoteBlockElement':
                 return (

--- a/src/amp/components/elements/AudioAtomBlockComponent.tsx
+++ b/src/amp/components/elements/AudioAtomBlockComponent.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 export const AudioAtomBlockComponent: React.FC<{
-    element: AudioAtomBlockElementAMP;
+    element: AudioAtomBlockElement;
 }> = ({ element }) => {
     return (
         <amp-audio src={element.trackUrl} title={element.kicker}>

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -9,17 +9,13 @@ interface InteractiveAtomBlockElementBase {
     js?: string;
 }
 
-interface AudioAtomBlockElementAMP {
+interface AudioAtomBlockElement {
+    _type: 'model.dotcomrendering.pageElements.AudioAtomBlockElement';
     id: string;
     kicker: string;
     trackUrl: string;
     duration: number;
     coverUrl: string;
-}
-
-interface AudioAtomBlockElement {
-    _type: 'model.dotcomrendering.pageElements.AudioAtomBlockElement';
-    amp: AudioAtomBlockElementAMP;
 }
 
 interface AudioBlockElement {

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -389,11 +389,30 @@
                         "model.dotcomrendering.pageElements.AudioAtomBlockElement"
                     ]
                 },
-                "amp": {
-                    "type": "object"
+                "id": {
+                    "type": "string"
+                },
+                "kicker": {
+                    "type": "string"
+                },
+                "trackUrl": {
+                    "type": "string"
+                },
+                "duration": {
+                    "type": "number"
+                },
+                "coverUrl": {
+                    "type": "string"
                 }
             },
-            "required": ["_type", "amp"]
+            "required": [
+                "_type",
+                "coverUrl",
+                "duration",
+                "id",
+                "kicker",
+                "trackUrl"
+            ]
         },
         "AudioBlockElement": {
             "type": "object",


### PR DESCRIPTION
## What does this change?

After https://github.com/guardian/dotcom-rendering/pull/1800, this brings back the previous AMP specific definition of the AudioAtomBlockElement. Note that it wasn't a good idea to just revert https://github.com/guardian/dotcom-rendering/pull/1794 , because we would have ended up with an incorrect BlockElement name. This is part of a backend driven refactoring sequence to bring the atom to web rendering in DCR.


