### PR TITLE
Spotify block component refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Frontend rendering framework for theguardian.com. It uses [React](https://reactj
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 <!-- Automatically created with yarn run createtoc and on push hook -->
 
-- [Chat](#chat)
 - [Quick start](#quick-start)
   - [Install Node.js](#install-nodejs)
   - [Running instructions](#running-instructions)

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -234,9 +234,10 @@ interface SoundcloudBlockElement {
 
 interface SpotifyBlockElement {
     _type: 'model.dotcomrendering.pageElements.SpotifyBlockElement';
-    html: string;
+    embedUrl: string;
     title: string;
-    caption: string;
+    height: number;
+    width: number;
 }
 
 interface SubheadingBlockElement {

--- a/src/web/components/elements/SpotifyBlockComponent.tsx
+++ b/src/web/components/elements/SpotifyBlockComponent.tsx
@@ -1,22 +1,28 @@
 import React from 'react';
 import { css } from 'emotion';
-import { unescapeData } from '@root/src/lib/escapeData';
-
-const widthOverride = css`
-    iframe {
-        /* The  embed js hijacks the iframe and calculated an incorrect width, which pushed the body out */
-        width: 100%;
-    }
-`;
 
 export const SpotifyBlockComponent: React.FC<{
-    element: SpotifyBlockElement;
-}> = ({ element }) => {
+    embedUrl: string;
+    height: number;
+    width: number;
+    title: string;
+}> = ({ embedUrl, width, height, title }) => {
     return (
-        <div className={widthOverride}>
-            <div
-                data-cy="spotify-embed"
-                dangerouslySetInnerHTML={{ __html: unescapeData(element.html) }}
+        <div
+            className={css`
+                iframe {
+                    width: 100%;
+                }
+                margin-bottom: 16px;
+            `}
+            data-cy="spotify-embed"
+        >
+            <iframe
+                src={embedUrl}
+                title={title}
+                height={height}
+                width={width}
+                allowFullScreen={true}
             />
         </div>
     );

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -192,7 +192,14 @@ export const ArticleRenderer: React.FC<{
                         <SoundcloudBlockComponent key={i} element={element} />
                     );
                 case 'model.dotcomrendering.pageElements.SpotifyBlockElement':
-                    return <SpotifyBlockComponent element={element} />;
+                    return (
+                        <SpotifyBlockComponent
+                            embedUrl={element.embedUrl}
+                            height={element.height}
+                            width={element.width}
+                            title={element.title}
+                        />
+                    );
                 case 'model.dotcomrendering.pageElements.SubheadingBlockElement':
                     return (
                         <SubheadingBlockComponent key={i} html={element.html} />


### PR DESCRIPTION
Requires - https://github.com/guardian/frontend/pull/22874

## What does this change?

Update the DCR SpotifyBlockElement following the corresponding schema update in the backend. 