### PR TITLE
Post lighthouse results as a status check

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -13,6 +13,8 @@ jobs:
                   node-version: 10.15.3
             - run: make build
             - name: Install and run Lighthouse CI
+              env:
+                  LHCI_GITHUB_TOKEN: ${{ secrets.LHCI_GITHUB_TOKEN }}
               run: |
                   npm install -g @lhci/cli@0.4.x
                   lhci autorun


### PR DESCRIPTION
## What does this change?

This make lighthouse CI post the performance test results back as a separate status check. 

This is the new one

<img width="484" alt="Comparing_master___ja-test_·_guardian_dotcom-rendering" src="https://user-images.githubusercontent.com/1672034/89889775-2347b480-dbca-11ea-981d-489b6d897920.png">

that will show up along side the existing one

<img width="484" alt="Comparing_master___ja-test_·_guardian_dotcom-rendering" src="https://user-images.githubusercontent.com/1672034/89889838-42464680-dbca-11ea-9de9-bb02c6f609a5.png">

I've used the teamcity github token instead of setting up a github app because it requires reviewing and accepting their terms of service.

## Why?

Lighthouse ci prints the URL in the log, which is very inconvenient. This is also a required step to write an assertion that makes the check fail is performance drops below a threshold.