### PR TITLE
Add twitter privacy meta tags

### DIFF
--- a/src/web/server/htmlTemplate.ts
+++ b/src/web/server/htmlTemplate.ts
@@ -100,7 +100,13 @@ export const htmlTemplate = ({
     };
 
     const openGraphMetaTags = generateMetaTags(openGraphData, 'property');
-
+    
+    // Opt out of having information from our website used for personalization of content and suggestions for Twitter users, including ads
+    // Display twitter widget with restricted capabilities (even if our own CSP may allow more)
+    // See https://developer.twitter.com/en/docs/twitter-for-websites/webpage-properties/overview
+    const twitterSecAndPrivacyMetaTags = `<meta name="twitter:dnt" content="on">
+                                          <meta name="twitter:widgets:csp" content="on">`;
+    
     const twitterMetaTags = generateMetaTags(twitterData, 'name');
 
     // Duplicated prefetch and preconnect tags from DCP:
@@ -165,7 +171,9 @@ export const htmlTemplate = ({
                 ${fontPreloadTags.join('\n')}
 
                 ${openGraphMetaTags}
-
+                
+                ${twitterSecAndPrivacyMetaTags}
+                
                 ${twitterMetaTags}
 
                 <script>

--- a/src/web/server/htmlTemplate.ts
+++ b/src/web/server/htmlTemplate.ts
@@ -102,10 +102,8 @@ export const htmlTemplate = ({
     const openGraphMetaTags = generateMetaTags(openGraphData, 'property');
     
     // Opt out of having information from our website used for personalization of content and suggestions for Twitter users, including ads
-    // Display twitter widget with restricted capabilities (even if our own CSP may allow more)
     // See https://developer.twitter.com/en/docs/twitter-for-websites/webpage-properties/overview
-    const twitterSecAndPrivacyMetaTags = `<meta name="twitter:dnt" content="on">
-                                          <meta name="twitter:widgets:csp" content="on">`;
+    const twitterSecAndPrivacyMetaTags = `<meta name="twitter:dnt" content="on">`;
     
     const twitterMetaTags = generateMetaTags(twitterData, 'name');
 


### PR DESCRIPTION
## What does this change?

In a similar way to what we have done for [current frontend rendering](https://github.com/guardian/frontend/pull/17810), indicate that we do not consent for sharing information about content being read with Twitter. When guardian reader see twitter products integrated into our website `Twitter may receive information including the web page you visited, your IP address, browser type, operating system, and cookie information. This information helps us to improve our products and services, including personalized suggestions and personalized ads` see https://developer.twitter.com/en/docs/twitter-for-websites/privacy

## Why?

Better privacy
