### PR TITLE
Correct SpotifyBlockElement's type

### DIFF
--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -230,10 +230,11 @@ interface SoundcloudBlockElement {
 
 interface SpotifyBlockElement {
     _type: 'model.dotcomrendering.pageElements.SpotifyBlockElement';
-    embedUrl: string;
-    title: string;
-    height: number;
-    width: number;
+    embedUrl?: string;
+    title?: string;
+    height?: number;
+    width?: number;
+    caption?: string;
 }
 
 interface SubheadingBlockElement {

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -424,9 +424,7 @@
                     ]
                 }
             },
-            "required": [
-                "_type"
-            ]
+            "required": ["_type"]
         },
         "BlockquoteBlockElement": {
             "type": "object",
@@ -441,10 +439,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "html"
-            ]
+            "required": ["_type", "html"]
         },
         "CaptionBlockElement": {
             "type": "object",
@@ -483,20 +478,11 @@
                     "type": "boolean"
                 }
             },
-            "required": [
-                "_type",
-                "designType",
-                "display",
-                "pillar"
-            ]
+            "required": ["_type", "designType", "display", "pillar"]
         },
         "Display": {
             "type": "number",
-            "enum": [
-                0,
-                1,
-                2
-            ]
+            "enum": [0, 1, 2]
         },
         "DesignType": {
             "enum": [
@@ -611,9 +597,7 @@
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": [
-                        "text"
-                    ]
+                    "enum": ["text"]
                 },
                 "id": {
                     "type": "string"
@@ -637,23 +621,14 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "hideLabel",
-                "id",
-                "label",
-                "name",
-                "required",
-                "type"
-            ]
+            "required": ["hideLabel", "id", "label", "name", "required", "type"]
         },
         "CampaignFieldTextArea": {
             "type": "object",
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": [
-                        "textarea"
-                    ]
+                    "enum": ["textarea"]
                 },
                 "id": {
                     "type": "string"
@@ -677,23 +652,14 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "hideLabel",
-                "id",
-                "label",
-                "name",
-                "required",
-                "type"
-            ]
+            "required": ["hideLabel", "id", "label", "name", "required", "type"]
         },
         "CampaignFieldFile": {
             "type": "object",
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": [
-                        "file"
-                    ]
+                    "enum": ["file"]
                 },
                 "id": {
                     "type": "string"
@@ -717,23 +683,14 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "hideLabel",
-                "id",
-                "label",
-                "name",
-                "required",
-                "type"
-            ]
+            "required": ["hideLabel", "id", "label", "name", "required", "type"]
         },
         "CampaignFieldRadio": {
             "type": "object",
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": [
-                        "radio"
-                    ]
+                    "enum": ["radio"]
                 },
                 "options": {
                     "type": "array",
@@ -747,10 +704,7 @@
                                 "type": "string"
                             }
                         },
-                        "required": [
-                            "label",
-                            "value"
-                        ]
+                        "required": ["label", "value"]
                     }
                 },
                 "id": {
@@ -790,9 +744,7 @@
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": [
-                        "checkbox"
-                    ]
+                    "enum": ["checkbox"]
                 },
                 "options": {
                     "type": "array",
@@ -806,10 +758,7 @@
                                 "type": "string"
                             }
                         },
-                        "required": [
-                            "label",
-                            "value"
-                        ]
+                        "required": ["label", "value"]
                     }
                 },
                 "id": {
@@ -849,9 +798,7 @@
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": [
-                        "select"
-                    ]
+                    "enum": ["select"]
                 },
                 "options": {
                     "type": "array",
@@ -865,10 +812,7 @@
                                 "type": "string"
                             }
                         },
-                        "required": [
-                            "label",
-                            "value"
-                        ]
+                        "required": ["label", "value"]
                     }
                 },
                 "id": {
@@ -928,10 +872,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "url"
-            ]
+            "required": ["_type", "url"]
         },
         "CodeBlockElement": {
             "type": "object",
@@ -946,10 +887,7 @@
                     "type": "boolean"
                 }
             },
-            "required": [
-                "_type",
-                "isMandatory"
-            ]
+            "required": ["_type", "isMandatory"]
         },
         "CommentBlockElement": {
             "type": "object",
@@ -1002,10 +940,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "atomId"
-            ]
+            "required": ["_type", "atomId"]
         },
         "DisclaimerBlockElement": {
             "type": "object",
@@ -1020,10 +955,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "html"
-            ]
+            "required": ["_type", "html"]
         },
         "DividerBlockElement": {
             "type": "object",
@@ -1035,9 +967,7 @@
                     ]
                 }
             },
-            "required": [
-                "_type"
-            ]
+            "required": ["_type"]
         },
         "DocumentBlockElement": {
             "type": "object",
@@ -1061,12 +991,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "embedUrl",
-                "height",
-                "width"
-            ]
+            "required": ["_type", "embedUrl", "height", "width"]
         },
         "EmbedBlockElement": {
             "type": "object",
@@ -1090,11 +1015,7 @@
                     "type": "boolean"
                 }
             },
-            "required": [
-                "_type",
-                "html",
-                "isMandatory"
-            ]
+            "required": ["_type", "html", "isMandatory"]
         },
         "ExplainerAtomBlockElement": {
             "type": "object",
@@ -1115,12 +1036,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "body",
-                "id",
-                "title"
-            ]
+            "required": ["_type", "body", "id", "title"]
         },
         "GenericAtomBlockElement": {
             "type": "object",
@@ -1147,10 +1063,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "url"
-            ]
+            "required": ["_type", "url"]
         },
         "GuideAtomBlockElement": {
             "type": "object",
@@ -1180,14 +1093,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "credit",
-                "html",
-                "id",
-                "label",
-                "title"
-            ]
+            "required": ["_type", "credit", "html", "id", "label", "title"]
         },
         "GuVideoBlockElement": {
             "type": "object",
@@ -1208,11 +1114,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "assets",
-                "caption"
-            ]
+            "required": ["_type", "assets", "caption"]
         },
         "VideoAssets": {
             "type": "object",
@@ -1224,10 +1126,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "mimeType",
-                "url"
-            ]
+            "required": ["mimeType", "url"]
         },
         "HighlightBlockElement": {
             "type": "object",
@@ -1242,10 +1141,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "html"
-            ]
+            "required": ["_type", "html"]
         },
         "ImageBlockElement": {
             "type": "object",
@@ -1266,9 +1162,7 @@
                             }
                         }
                     },
-                    "required": [
-                        "allImages"
-                    ]
+                    "required": ["allImages"]
                 },
                 "data": {
                     "type": "object",
@@ -1303,13 +1197,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "data",
-                "imageSources",
-                "media",
-                "role"
-            ]
+            "required": ["_type", "data", "imageSources", "media", "role"]
         },
         "Image": {
             "type": "object",
@@ -1330,10 +1218,7 @@
                             "type": "string"
                         }
                     },
-                    "required": [
-                        "height",
-                        "width"
-                    ]
+                    "required": ["height", "width"]
                 },
                 "mediaType": {
                     "type": "string"
@@ -1345,13 +1230,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "fields",
-                "index",
-                "mediaType",
-                "mimeType",
-                "url"
-            ]
+            "required": ["fields", "index", "mediaType", "mimeType", "url"]
         },
         "ImageSource": {
             "type": "object",
@@ -1366,10 +1245,7 @@
                     }
                 }
             },
-            "required": [
-                "srcSet",
-                "weighting"
-            ]
+            "required": ["srcSet", "weighting"]
         },
         "Weighting": {
             "enum": [
@@ -1392,10 +1268,7 @@
                     "type": "number"
                 }
             },
-            "required": [
-                "src",
-                "width"
-            ]
+            "required": ["src", "width"]
         },
         "RoleType": {
             "enum": [
@@ -1427,12 +1300,7 @@
                     "type": "boolean"
                 }
             },
-            "required": [
-                "_type",
-                "hasCaption",
-                "html",
-                "url"
-            ]
+            "required": ["_type", "hasCaption", "html", "url"]
         },
         "InteractiveAtomBlockElement": {
             "type": "object",
@@ -1459,12 +1327,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "id",
-                "js",
-                "url"
-            ]
+            "required": ["_type", "id", "js", "url"]
         },
         "InteractiveBlockElement": {
             "type": "object",
@@ -1491,10 +1354,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "url"
-            ]
+            "required": ["_type", "url"]
         },
         "MapBlockElement": {
             "type": "object",
@@ -1549,10 +1409,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "images"
-            ]
+            "required": ["_type", "images"]
         },
         "ProfileAtomBlockElement": {
             "type": "object",
@@ -1582,14 +1439,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "credit",
-                "html",
-                "id",
-                "label",
-                "title"
-            ]
+            "required": ["_type", "credit", "html", "id", "label", "title"]
         },
         "PullquoteBlockElement": {
             "type": "object",
@@ -1610,11 +1460,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "html",
-                "role"
-            ]
+            "required": ["_type", "html", "role"]
         },
         "QABlockElement": {
             "type": "object",
@@ -1644,13 +1490,7 @@
                     "type": "number"
                 }
             },
-            "required": [
-                "_type",
-                "credit",
-                "html",
-                "id",
-                "title"
-            ]
+            "required": ["_type", "credit", "html", "id", "title"]
         },
         "RichLinkBlockElement": {
             "type": "object",
@@ -1677,12 +1517,7 @@
                     "type": "number"
                 }
             },
-            "required": [
-                "_type",
-                "prefix",
-                "text",
-                "url"
-            ]
+            "required": ["_type", "prefix", "text", "url"]
         },
         "SoundcloudBlockElement": {
             "type": "object",
@@ -1706,13 +1541,7 @@
                     "type": "boolean"
                 }
             },
-            "required": [
-                "_type",
-                "html",
-                "id",
-                "isMandatory",
-                "isTrack"
-            ]
+            "required": ["_type", "html", "id", "isMandatory", "isTrack"]
         },
         "SpotifyBlockElement": {
             "type": "object",
@@ -1739,9 +1568,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type"
-            ]
+            "required": ["_type"]
         },
         "SubheadingBlockElement": {
             "type": "object",
@@ -1756,10 +1583,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "html"
-            ]
+            "required": ["_type", "html"]
         },
         "TableBlockElement": {
             "type": "object",
@@ -1777,11 +1601,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "html",
-                "isMandatory"
-            ]
+            "required": ["_type", "html", "isMandatory"]
         },
         "TextBlockElement": {
             "type": "object",
@@ -1799,10 +1619,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "html"
-            ]
+            "required": ["_type", "html"]
         },
         "TimelineBlockElement": {
             "type": "object",
@@ -1829,12 +1646,7 @@
                     }
                 }
             },
-            "required": [
-                "_type",
-                "events",
-                "id",
-                "title"
-            ]
+            "required": ["_type", "events", "id", "title"]
         },
         "TimelineEvent": {
             "type": "object",
@@ -1852,10 +1664,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "date",
-                "title"
-            ]
+            "required": ["date", "title"]
         },
         "TweetBlockElement": {
             "type": "object",
@@ -1879,13 +1688,7 @@
                     "type": "boolean"
                 }
             },
-            "required": [
-                "_type",
-                "hasMedia",
-                "html",
-                "id",
-                "url"
-            ]
+            "required": ["_type", "hasMedia", "html", "id", "url"]
         },
         "VideoBlockElement": {
             "type": "object",
@@ -1897,9 +1700,7 @@
                     ]
                 }
             },
-            "required": [
-                "_type"
-            ]
+            "required": ["_type"]
         },
         "VideoFacebookBlockElement": {
             "type": "object",
@@ -1926,13 +1727,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "caption",
-                "height",
-                "url",
-                "width"
-            ]
+            "required": ["_type", "caption", "height", "url", "width"]
         },
         "VideoVimeoBlockElement": {
             "type": "object",
@@ -1965,12 +1760,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "height",
-                "url",
-                "width"
-            ]
+            "required": ["_type", "height", "url", "width"]
         },
         "VideoYoutubeBlockElement": {
             "type": "object",
@@ -2003,12 +1793,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "height",
-                "url",
-                "width"
-            ]
+            "required": ["_type", "height", "url", "width"]
         },
         "YoutubeBlockElement": {
             "type": "object",
@@ -2044,11 +1829,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "_type",
-                "assetId",
-                "mediaTitle"
-            ]
+            "required": ["_type", "assetId", "mediaTitle"]
         },
         "Block": {
             "type": "object",
@@ -2205,10 +1986,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "elements",
-                "id"
-            ]
+            "required": ["elements", "id"]
         },
         "Pagination": {
             "type": "object",
@@ -2232,10 +2010,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "currentPage",
-                "totalPages"
-            ]
+            "required": ["currentPage", "totalPages"]
         },
         "AuthorType": {
             "type": "object",
@@ -2252,12 +2027,7 @@
             }
         },
         "Edition": {
-            "enum": [
-                "AU",
-                "INT",
-                "UK",
-                "US"
-            ],
+            "enum": ["AU", "INT", "UK", "US"],
             "type": "string"
         },
         "TagType": {
@@ -2282,11 +2052,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "id",
-                "title",
-                "type"
-            ]
+            "required": ["id", "title", "type"]
         },
         "SimpleLinkType": {
             "type": "object",
@@ -2298,10 +2064,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "title",
-                "url"
-            ]
+            "required": ["title", "url"]
         },
         "ConfigType": {
             "description": "the config model will contain useful app/site\nlevel data. Although currently derived from the config model\nconstructed in frontend and passed to dotcom-rendering\nthis data could eventually be defined in dotcom-rendering",
@@ -2501,12 +2264,7 @@
                     "$ref": "#/definitions/EditionCommercialProperties"
                 }
             },
-            "required": [
-                "AU",
-                "INT",
-                "UK",
-                "US"
-            ]
+            "required": ["AU", "INT", "UK", "US"]
         },
         "EditionCommercialProperties": {
             "type": "object",
@@ -2521,9 +2279,7 @@
                     "$ref": "#/definitions/Branding"
                 }
             },
-            "required": [
-                "adTargeting"
-            ]
+            "required": ["adTargeting"]
         },
         "AdTargetParam": {
             "type": "object",
@@ -2545,10 +2301,7 @@
                     ]
                 }
             },
-            "required": [
-                "name",
-                "value"
-            ]
+            "required": ["name", "value"]
         },
         "Branding": {
             "type": "object",
@@ -2560,9 +2313,7 @@
                             "type": "string"
                         }
                     },
-                    "required": [
-                        "name"
-                    ]
+                    "required": ["name"]
                 },
                 "sponsorName": {
                     "type": "string"
@@ -2589,18 +2340,10 @@
                                     "type": "number"
                                 }
                             },
-                            "required": [
-                                "height",
-                                "width"
-                            ]
+                            "required": ["height", "width"]
                         }
                     },
-                    "required": [
-                        "dimensions",
-                        "label",
-                        "link",
-                        "src"
-                    ]
+                    "required": ["dimensions", "label", "link", "src"]
                 },
                 "aboutThisLink": {
                     "type": "string"
@@ -2621,10 +2364,7 @@
                                     "type": "number"
                                 }
                             },
-                            "required": [
-                                "height",
-                                "width"
-                            ]
+                            "required": ["height", "width"]
                         },
                         "link": {
                             "type": "string"
@@ -2633,19 +2373,10 @@
                             "type": "string"
                         }
                     },
-                    "required": [
-                        "dimensions",
-                        "label",
-                        "link",
-                        "src"
-                    ]
+                    "required": ["dimensions", "label", "link", "src"]
                 }
             },
-            "required": [
-                "aboutThisLink",
-                "logo",
-                "sponsorName"
-            ]
+            "required": ["aboutThisLink", "logo", "sponsorName"]
         },
         "BadgeType": {
             "type": "object",
@@ -2657,10 +2388,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "imageUrl",
-                "seriesTag"
-            ]
+            "required": ["imageUrl", "seriesTag"]
         },
         "FooterType": {
             "type": "object",
@@ -2675,9 +2403,7 @@
                     }
                 }
             },
-            "required": [
-                "footerLinks"
-            ]
+            "required": ["footerLinks"]
         },
         "FooterLink": {
             "type": "object",
@@ -2695,11 +2421,7 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "dataLinkName",
-                "text",
-                "url"
-            ]
+            "required": ["dataLinkName", "text", "url"]
         }
     },
     "$schema": "http://json-schema.org/draft-07/schema#"

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -424,7 +424,9 @@
                     ]
                 }
             },
-            "required": ["_type"]
+            "required": [
+                "_type"
+            ]
         },
         "BlockquoteBlockElement": {
             "type": "object",
@@ -439,7 +441,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "html"]
+            "required": [
+                "_type",
+                "html"
+            ]
         },
         "CaptionBlockElement": {
             "type": "object",
@@ -478,11 +483,20 @@
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "designType", "display", "pillar"]
+            "required": [
+                "_type",
+                "designType",
+                "display",
+                "pillar"
+            ]
         },
         "Display": {
             "type": "number",
-            "enum": [0, 1, 2]
+            "enum": [
+                0,
+                1,
+                2
+            ]
         },
         "DesignType": {
             "enum": [
@@ -597,7 +611,9 @@
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": ["text"]
+                    "enum": [
+                        "text"
+                    ]
                 },
                 "id": {
                     "type": "string"
@@ -621,14 +637,23 @@
                     "type": "string"
                 }
             },
-            "required": ["hideLabel", "id", "label", "name", "required", "type"]
+            "required": [
+                "hideLabel",
+                "id",
+                "label",
+                "name",
+                "required",
+                "type"
+            ]
         },
         "CampaignFieldTextArea": {
             "type": "object",
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": ["textarea"]
+                    "enum": [
+                        "textarea"
+                    ]
                 },
                 "id": {
                     "type": "string"
@@ -652,14 +677,23 @@
                     "type": "string"
                 }
             },
-            "required": ["hideLabel", "id", "label", "name", "required", "type"]
+            "required": [
+                "hideLabel",
+                "id",
+                "label",
+                "name",
+                "required",
+                "type"
+            ]
         },
         "CampaignFieldFile": {
             "type": "object",
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": ["file"]
+                    "enum": [
+                        "file"
+                    ]
                 },
                 "id": {
                     "type": "string"
@@ -683,14 +717,23 @@
                     "type": "string"
                 }
             },
-            "required": ["hideLabel", "id", "label", "name", "required", "type"]
+            "required": [
+                "hideLabel",
+                "id",
+                "label",
+                "name",
+                "required",
+                "type"
+            ]
         },
         "CampaignFieldRadio": {
             "type": "object",
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": ["radio"]
+                    "enum": [
+                        "radio"
+                    ]
                 },
                 "options": {
                     "type": "array",
@@ -704,7 +747,10 @@
                                 "type": "string"
                             }
                         },
-                        "required": ["label", "value"]
+                        "required": [
+                            "label",
+                            "value"
+                        ]
                     }
                 },
                 "id": {
@@ -744,7 +790,9 @@
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": ["checkbox"]
+                    "enum": [
+                        "checkbox"
+                    ]
                 },
                 "options": {
                     "type": "array",
@@ -758,7 +806,10 @@
                                 "type": "string"
                             }
                         },
-                        "required": ["label", "value"]
+                        "required": [
+                            "label",
+                            "value"
+                        ]
                     }
                 },
                 "id": {
@@ -798,7 +849,9 @@
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": ["select"]
+                    "enum": [
+                        "select"
+                    ]
                 },
                 "options": {
                     "type": "array",
@@ -812,7 +865,10 @@
                                 "type": "string"
                             }
                         },
-                        "required": ["label", "value"]
+                        "required": [
+                            "label",
+                            "value"
+                        ]
                     }
                 },
                 "id": {
@@ -872,7 +928,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "url"]
+            "required": [
+                "_type",
+                "url"
+            ]
         },
         "CodeBlockElement": {
             "type": "object",
@@ -887,7 +946,10 @@
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "isMandatory"]
+            "required": [
+                "_type",
+                "isMandatory"
+            ]
         },
         "CommentBlockElement": {
             "type": "object",
@@ -940,7 +1002,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "atomId"]
+            "required": [
+                "_type",
+                "atomId"
+            ]
         },
         "DisclaimerBlockElement": {
             "type": "object",
@@ -955,7 +1020,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "html"]
+            "required": [
+                "_type",
+                "html"
+            ]
         },
         "DividerBlockElement": {
             "type": "object",
@@ -967,7 +1035,9 @@
                     ]
                 }
             },
-            "required": ["_type"]
+            "required": [
+                "_type"
+            ]
         },
         "DocumentBlockElement": {
             "type": "object",
@@ -991,7 +1061,12 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "embedUrl", "height", "width"]
+            "required": [
+                "_type",
+                "embedUrl",
+                "height",
+                "width"
+            ]
         },
         "EmbedBlockElement": {
             "type": "object",
@@ -1015,7 +1090,11 @@
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "html", "isMandatory"]
+            "required": [
+                "_type",
+                "html",
+                "isMandatory"
+            ]
         },
         "ExplainerAtomBlockElement": {
             "type": "object",
@@ -1036,7 +1115,12 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "body", "id", "title"]
+            "required": [
+                "_type",
+                "body",
+                "id",
+                "title"
+            ]
         },
         "GenericAtomBlockElement": {
             "type": "object",
@@ -1063,7 +1147,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "url"]
+            "required": [
+                "_type",
+                "url"
+            ]
         },
         "GuideAtomBlockElement": {
             "type": "object",
@@ -1093,7 +1180,14 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "credit", "html", "id", "label", "title"]
+            "required": [
+                "_type",
+                "credit",
+                "html",
+                "id",
+                "label",
+                "title"
+            ]
         },
         "GuVideoBlockElement": {
             "type": "object",
@@ -1114,7 +1208,11 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "assets", "caption"]
+            "required": [
+                "_type",
+                "assets",
+                "caption"
+            ]
         },
         "VideoAssets": {
             "type": "object",
@@ -1126,7 +1224,10 @@
                     "type": "string"
                 }
             },
-            "required": ["mimeType", "url"]
+            "required": [
+                "mimeType",
+                "url"
+            ]
         },
         "HighlightBlockElement": {
             "type": "object",
@@ -1141,7 +1242,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "html"]
+            "required": [
+                "_type",
+                "html"
+            ]
         },
         "ImageBlockElement": {
             "type": "object",
@@ -1162,7 +1266,9 @@
                             }
                         }
                     },
-                    "required": ["allImages"]
+                    "required": [
+                        "allImages"
+                    ]
                 },
                 "data": {
                     "type": "object",
@@ -1197,7 +1303,13 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "data", "imageSources", "media", "role"]
+            "required": [
+                "_type",
+                "data",
+                "imageSources",
+                "media",
+                "role"
+            ]
         },
         "Image": {
             "type": "object",
@@ -1218,7 +1330,10 @@
                             "type": "string"
                         }
                     },
-                    "required": ["height", "width"]
+                    "required": [
+                        "height",
+                        "width"
+                    ]
                 },
                 "mediaType": {
                     "type": "string"
@@ -1230,7 +1345,13 @@
                     "type": "string"
                 }
             },
-            "required": ["fields", "index", "mediaType", "mimeType", "url"]
+            "required": [
+                "fields",
+                "index",
+                "mediaType",
+                "mimeType",
+                "url"
+            ]
         },
         "ImageSource": {
             "type": "object",
@@ -1245,7 +1366,10 @@
                     }
                 }
             },
-            "required": ["srcSet", "weighting"]
+            "required": [
+                "srcSet",
+                "weighting"
+            ]
         },
         "Weighting": {
             "enum": [
@@ -1268,7 +1392,10 @@
                     "type": "number"
                 }
             },
-            "required": ["src", "width"]
+            "required": [
+                "src",
+                "width"
+            ]
         },
         "RoleType": {
             "enum": [
@@ -1300,7 +1427,12 @@
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "hasCaption", "html", "url"]
+            "required": [
+                "_type",
+                "hasCaption",
+                "html",
+                "url"
+            ]
         },
         "InteractiveAtomBlockElement": {
             "type": "object",
@@ -1327,7 +1459,12 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "id", "js", "url"]
+            "required": [
+                "_type",
+                "id",
+                "js",
+                "url"
+            ]
         },
         "InteractiveBlockElement": {
             "type": "object",
@@ -1354,7 +1491,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "url"]
+            "required": [
+                "_type",
+                "url"
+            ]
         },
         "MapBlockElement": {
             "type": "object",
@@ -1409,7 +1549,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "images"]
+            "required": [
+                "_type",
+                "images"
+            ]
         },
         "ProfileAtomBlockElement": {
             "type": "object",
@@ -1439,7 +1582,14 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "credit", "html", "id", "label", "title"]
+            "required": [
+                "_type",
+                "credit",
+                "html",
+                "id",
+                "label",
+                "title"
+            ]
         },
         "PullquoteBlockElement": {
             "type": "object",
@@ -1460,7 +1610,11 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "html", "role"]
+            "required": [
+                "_type",
+                "html",
+                "role"
+            ]
         },
         "QABlockElement": {
             "type": "object",
@@ -1485,9 +1639,18 @@
                 },
                 "credit": {
                     "type": "string"
+                },
+                "qandaIndex": {
+                    "type": "number"
                 }
             },
-            "required": ["_type", "credit", "html", "id", "title"]
+            "required": [
+                "_type",
+                "credit",
+                "html",
+                "id",
+                "title"
+            ]
         },
         "RichLinkBlockElement": {
             "type": "object",
@@ -1514,7 +1677,12 @@
                     "type": "number"
                 }
             },
-            "required": ["_type", "prefix", "text", "url"]
+            "required": [
+                "_type",
+                "prefix",
+                "text",
+                "url"
+            ]
         },
         "SoundcloudBlockElement": {
             "type": "object",
@@ -1538,7 +1706,13 @@
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "html", "id", "isMandatory", "isTrack"]
+            "required": [
+                "_type",
+                "html",
+                "id",
+                "isMandatory",
+                "isTrack"
+            ]
         },
         "SpotifyBlockElement": {
             "type": "object",
@@ -1549,17 +1723,25 @@
                         "model.dotcomrendering.pageElements.SpotifyBlockElement"
                     ]
                 },
-                "html": {
+                "embedUrl": {
                     "type": "string"
                 },
                 "title": {
                     "type": "string"
                 },
+                "height": {
+                    "type": "number"
+                },
+                "width": {
+                    "type": "number"
+                },
                 "caption": {
                     "type": "string"
                 }
             },
-            "required": ["_type", "html"]
+            "required": [
+                "_type"
+            ]
         },
         "SubheadingBlockElement": {
             "type": "object",
@@ -1574,7 +1756,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "html"]
+            "required": [
+                "_type",
+                "html"
+            ]
         },
         "TableBlockElement": {
             "type": "object",
@@ -1592,7 +1777,11 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "html", "isMandatory"]
+            "required": [
+                "_type",
+                "html",
+                "isMandatory"
+            ]
         },
         "TextBlockElement": {
             "type": "object",
@@ -1610,7 +1799,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "html"]
+            "required": [
+                "_type",
+                "html"
+            ]
         },
         "TimelineBlockElement": {
             "type": "object",
@@ -1637,7 +1829,12 @@
                     }
                 }
             },
-            "required": ["_type", "events", "id", "title"]
+            "required": [
+                "_type",
+                "events",
+                "id",
+                "title"
+            ]
         },
         "TimelineEvent": {
             "type": "object",
@@ -1655,7 +1852,10 @@
                     "type": "string"
                 }
             },
-            "required": ["date", "title"]
+            "required": [
+                "date",
+                "title"
+            ]
         },
         "TweetBlockElement": {
             "type": "object",
@@ -1679,7 +1879,13 @@
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "hasMedia", "html", "id", "url"]
+            "required": [
+                "_type",
+                "hasMedia",
+                "html",
+                "id",
+                "url"
+            ]
         },
         "VideoBlockElement": {
             "type": "object",
@@ -1691,7 +1897,9 @@
                     ]
                 }
             },
-            "required": ["_type"]
+            "required": [
+                "_type"
+            ]
         },
         "VideoFacebookBlockElement": {
             "type": "object",
@@ -1718,7 +1926,13 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "caption", "height", "url", "width"]
+            "required": [
+                "_type",
+                "caption",
+                "height",
+                "url",
+                "width"
+            ]
         },
         "VideoVimeoBlockElement": {
             "type": "object",
@@ -1751,7 +1965,12 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "height", "url", "width"]
+            "required": [
+                "_type",
+                "height",
+                "url",
+                "width"
+            ]
         },
         "VideoYoutubeBlockElement": {
             "type": "object",
@@ -1784,7 +2003,12 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "height", "url", "width"]
+            "required": [
+                "_type",
+                "height",
+                "url",
+                "width"
+            ]
         },
         "YoutubeBlockElement": {
             "type": "object",
@@ -1820,7 +2044,11 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "assetId", "mediaTitle"]
+            "required": [
+                "_type",
+                "assetId",
+                "mediaTitle"
+            ]
         },
         "Block": {
             "type": "object",
@@ -1917,10 +2145,10 @@
                                 "$ref": "#/definitions/RichLinkBlockElement"
                             },
                             {
-                                "$ref": "#/definitions/SpotifyBlockElement"
+                                "$ref": "#/definitions/SoundcloudBlockElement"
                             },
                             {
-                                "$ref": "#/definitions/SoundcloudBlockElement"
+                                "$ref": "#/definitions/SpotifyBlockElement"
                             },
                             {
                                 "$ref": "#/definitions/SubheadingBlockElement"
@@ -1977,7 +2205,10 @@
                     "type": "string"
                 }
             },
-            "required": ["elements", "id"]
+            "required": [
+                "elements",
+                "id"
+            ]
         },
         "Pagination": {
             "type": "object",
@@ -2001,7 +2232,10 @@
                     "type": "string"
                 }
             },
-            "required": ["currentPage", "totalPages"]
+            "required": [
+                "currentPage",
+                "totalPages"
+            ]
         },
         "AuthorType": {
             "type": "object",
@@ -2018,7 +2252,12 @@
             }
         },
         "Edition": {
-            "enum": ["AU", "INT", "UK", "US"],
+            "enum": [
+                "AU",
+                "INT",
+                "UK",
+                "US"
+            ],
             "type": "string"
         },
         "TagType": {
@@ -2043,7 +2282,11 @@
                     "type": "string"
                 }
             },
-            "required": ["id", "title", "type"]
+            "required": [
+                "id",
+                "title",
+                "type"
+            ]
         },
         "SimpleLinkType": {
             "type": "object",
@@ -2055,7 +2298,10 @@
                     "type": "string"
                 }
             },
-            "required": ["title", "url"]
+            "required": [
+                "title",
+                "url"
+            ]
         },
         "ConfigType": {
             "description": "the config model will contain useful app/site\nlevel data. Although currently derived from the config model\nconstructed in frontend and passed to dotcom-rendering\nthis data could eventually be defined in dotcom-rendering",
@@ -2173,6 +2419,12 @@
                         }
                     }
                 },
+                "host": {
+                    "type": "string"
+                },
+                "idUrl": {
+                    "type": "string"
+                },
                 "pageId": {
                     "type": "string"
                 },
@@ -2249,7 +2501,12 @@
                     "$ref": "#/definitions/EditionCommercialProperties"
                 }
             },
-            "required": ["AU", "INT", "UK", "US"]
+            "required": [
+                "AU",
+                "INT",
+                "UK",
+                "US"
+            ]
         },
         "EditionCommercialProperties": {
             "type": "object",
@@ -2264,7 +2521,9 @@
                     "$ref": "#/definitions/Branding"
                 }
             },
-            "required": ["adTargeting"]
+            "required": [
+                "adTargeting"
+            ]
         },
         "AdTargetParam": {
             "type": "object",
@@ -2286,7 +2545,10 @@
                     ]
                 }
             },
-            "required": ["name", "value"]
+            "required": [
+                "name",
+                "value"
+            ]
         },
         "Branding": {
             "type": "object",
@@ -2298,7 +2560,9 @@
                             "type": "string"
                         }
                     },
-                    "required": ["name"]
+                    "required": [
+                        "name"
+                    ]
                 },
                 "sponsorName": {
                     "type": "string"
@@ -2325,10 +2589,18 @@
                                     "type": "number"
                                 }
                             },
-                            "required": ["height", "width"]
+                            "required": [
+                                "height",
+                                "width"
+                            ]
                         }
                     },
-                    "required": ["dimensions", "label", "link", "src"]
+                    "required": [
+                        "dimensions",
+                        "label",
+                        "link",
+                        "src"
+                    ]
                 },
                 "aboutThisLink": {
                     "type": "string"
@@ -2349,7 +2621,10 @@
                                     "type": "number"
                                 }
                             },
-                            "required": ["height", "width"]
+                            "required": [
+                                "height",
+                                "width"
+                            ]
                         },
                         "link": {
                             "type": "string"
@@ -2358,10 +2633,19 @@
                             "type": "string"
                         }
                     },
-                    "required": ["dimensions", "label", "link", "src"]
+                    "required": [
+                        "dimensions",
+                        "label",
+                        "link",
+                        "src"
+                    ]
                 }
             },
-            "required": ["aboutThisLink", "logo", "sponsorName"]
+            "required": [
+                "aboutThisLink",
+                "logo",
+                "sponsorName"
+            ]
         },
         "BadgeType": {
             "type": "object",
@@ -2373,7 +2657,10 @@
                     "type": "string"
                 }
             },
-            "required": ["imageUrl", "seriesTag"]
+            "required": [
+                "imageUrl",
+                "seriesTag"
+            ]
         },
         "FooterType": {
             "type": "object",
@@ -2388,7 +2675,9 @@
                     }
                 }
             },
-            "required": ["footerLinks"]
+            "required": [
+                "footerLinks"
+            ]
         },
         "FooterLink": {
             "type": "object",
@@ -2406,7 +2695,11 @@
                     "type": "string"
                 }
             },
-            "required": ["dataLinkName", "text", "url"]
+            "required": [
+                "dataLinkName",
+                "text",
+                "url"
+            ]
         }
     },
     "$schema": "http://json-schema.org/draft-07/schema#"

--- a/src/web/components/elements/SpotifyBlockComponent.tsx
+++ b/src/web/components/elements/SpotifyBlockComponent.tsx
@@ -6,24 +6,28 @@ export const SpotifyBlockComponent: React.FC<{
     title?: string;
     height?: number;
     width?: number;
-}> = ({ embedUrl, width, height, title }) => {
+}> = ({ embedUrl, title, width, height }) => {
     return (
-        <div
-            className={css`
-                iframe {
-                    width: 100%;
-                }
-                margin-bottom: 16px;
-            `}
-            data-cy="spotify-embed"
-        >
-            <iframe
-                src={embedUrl}
-                title={title}
-                height={height}
-                width={width}
-                allowFullScreen={true}
-            />
-        </div>
+        <>
+            {embedUrl && title && width && height && (
+                <div
+                    className={css`
+                        iframe {
+                            width: 100%;
+                        }
+                        margin-bottom: 16px;
+                    `}
+                    data-cy="spotify-embed"
+                >
+                    <iframe
+                        src={embedUrl}
+                        title={title}
+                        height={height}
+                        width={width}
+                        allowFullScreen={true}
+                    />
+                </div>
+            )}
+        </>
     );
 };

--- a/src/web/components/elements/SpotifyBlockComponent.tsx
+++ b/src/web/components/elements/SpotifyBlockComponent.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { css } from 'emotion';
 
 export const SpotifyBlockComponent: React.FC<{
-    embedUrl: string;
-    height: number;
-    width: number;
-    title: string;
+    embedUrl?: string;
+    title?: string;
+    height?: number;
+    width?: number;
 }> = ({ embedUrl, width, height, title }) => {
     return (
         <div


### PR DESCRIPTION
## What does this change?

Correct SpotifyBlockElement's type. To align it with the backend type: https://github.com/guardian/frontend/blob/0e6b2252b80d555961315278f47307edc15789ba/common/app/model/dotcomrendering/pageElements/PageElement.scala#L111
