### PR TITLE
Fix the spelling of affiliate to make sure we're showing the disclaimer

### DIFF
--- a/cypress/integration/e2e/article.elements.spec.js
+++ b/cypress/integration/e2e/article.elements.spec.js
@@ -145,10 +145,10 @@ describe('Elements', function () {
             getBody().contains('Liverpool');
         });
 
-        it('should render the affiliate disclaimer block', function () {
+        it.only('should render the affiliate disclaimer block', function () {
             const getBody = () => {
                 return cy
-                    .get('div[data-cy="affiiate-disclaimer"]')
+                    .get('[data-cy="affiliate-disclaimer"]')
                     .should('not.be.empty')
                     .then(cy.wrap);
             };


### PR DESCRIPTION
As title - fixes the cypress test.