### PR TITLE
Fix the most popular cypress tests (and remove focused tests)

### DIFF
--- a/cypress/integration/e2e/article.elements.spec.js
+++ b/cypress/integration/e2e/article.elements.spec.js
@@ -52,7 +52,7 @@ describe('Elements', function () {
     });
 
     describe('WEB', function () {
-        it.only('should render the page as expected', function () {
+        it('should render the page as expected', function () {
             cy.viewport('iphone-x');
             const iphoneXWidth = 375;
             let hasElementTooWide = false;
@@ -145,7 +145,7 @@ describe('Elements', function () {
             getBody().contains('Liverpool');
         });
 
-        it.only('should render the affiliate disclaimer block', function () {
+        it('should render the affiliate disclaimer block', function () {
             const getBody = () => {
                 return cy
                     .get('[data-cy="affiliate-disclaimer"]')

--- a/cypress/integration/e2e/article.interactivity.spec.js
+++ b/cypress/integration/e2e/article.interactivity.spec.js
@@ -3,6 +3,7 @@
 import { getPolyfill } from '../../lib/polyfill';
 import { mockApi } from '../../lib/mocks';
 import { fetchPolyfill } from '../../lib/config';
+import { setupApiRoutes } from '../../lib/apiRoutes.js';
 
 const READER_REVENUE_TITLE_TEXT = 'Support The';
 const articleUrl =
@@ -34,11 +35,15 @@ describe('Interactivity', function () {
         describe('When most viewed is mocked', function () {
             before(getPolyfill);
             beforeEach(mockApi);
+            beforeEach(setupApiRoutes);
             it('should change the list of most viewed items when a tab is clicked', function () {
                 cy.visit(`/Article?url=${articleUrl}`, fetchPolyfill);
-                cy.scrollTo('bottom', { duration: 300 });
                 cy.contains('Lifestyle');
-                cy.scrollTo('bottom', { duration: 300 });
+                cy.get('[data-component="most-popular"]').scrollIntoView({
+                    duration: 300,
+                    offset: { top: -30 },
+                });
+                cy.wait('@getMostRead');
                 cy.get('[data-cy=tab-body-0]').should('be.visible');
                 cy.get('[data-cy=tab-body-1]').should('not.be.visible');
                 cy.get('[data-cy=tab-heading-1]').click();


### PR DESCRIPTION
There were some `it.only` left in (whoops) and the Most Popular kept failing because `cy.get` seems to block requests and therefore it never made the network request. Waiting on the request fixes this.