### PR TITLE
Send browserId in pubData to SourcePoint via CMP

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "@guardian/ab-react": "1.0.0-next.0",
         "@guardian/atoms-rendering": "^1.5.0",
         "@guardian/automat-client": "^0.2.16",
-        "@guardian/consent-management-platform": "4.0.0-12",
+        "@guardian/consent-management-platform": "4.0.0-13",
         "@guardian/discussion-rendering": "^2.6.0",
         "@guardian/shimport": "^1.0.2",
         "@guardian/src-button": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "@guardian/ab-react": "1.0.0-next.0",
         "@guardian/atoms-rendering": "^1.5.0",
         "@guardian/automat-client": "^0.2.16",
-        "@guardian/consent-management-platform": "4.0.0-13",
+        "@guardian/consent-management-platform": "4.0.0-14",
         "@guardian/discussion-rendering": "^2.6.0",
         "@guardian/shimport": "^1.0.2",
         "@guardian/src-button": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "@guardian/ab-react": "1.0.0-next.0",
         "@guardian/atoms-rendering": "^1.5.0",
         "@guardian/automat-client": "^0.2.16",
-        "@guardian/consent-management-platform": "4.0.0-10",
+        "@guardian/consent-management-platform": "4.0.0-11",
         "@guardian/discussion-rendering": "^2.6.0",
         "@guardian/shimport": "^1.0.2",
         "@guardian/src-button": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "@guardian/ab-react": "1.0.0-next.0",
         "@guardian/atoms-rendering": "^1.5.0",
         "@guardian/automat-client": "^0.2.16",
-        "@guardian/consent-management-platform": "4.0.0-9",
+        "@guardian/consent-management-platform": "4.0.0-10",
         "@guardian/discussion-rendering": "^2.6.0",
         "@guardian/shimport": "^1.0.2",
         "@guardian/src-button": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "@guardian/ab-react": "1.0.0-next.0",
         "@guardian/atoms-rendering": "^1.5.0",
         "@guardian/automat-client": "^0.2.16",
-        "@guardian/consent-management-platform": "4.0.0-11",
+        "@guardian/consent-management-platform": "4.0.0-12",
         "@guardian/discussion-rendering": "^2.6.0",
         "@guardian/shimport": "^1.0.2",
         "@guardian/src-button": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "@guardian/ab-react": "1.0.0-next.0",
         "@guardian/atoms-rendering": "^1.5.0",
         "@guardian/automat-client": "^0.2.16",
-        "@guardian/consent-management-platform": "4.0.0-14",
+        "@guardian/consent-management-platform": "4.0.0-beta.0",
         "@guardian/discussion-rendering": "^2.6.0",
         "@guardian/shimport": "^1.0.2",
         "@guardian/src-button": "^1.5.0",

--- a/src/web/components/StickyBottomBanner/CMP.tsx
+++ b/src/web/components/StickyBottomBanner/CMP.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, Suspense } from 'react';
 import { cmp, oldCmp } from '@guardian/consent-management-platform';
 import { getCountryCode } from '@root/src/web/lib/getCountryCode';
 import { getPrivacyFramework } from '@root/src/web/lib/getPrivacyFramework';
+import { getCookie } from '@frontend/web/browser/cookie';
 import { addPrivacySettingsLink } from './CMPPrivacyLink';
 
 export const willShowCMP = async () => {
@@ -13,7 +14,12 @@ export const willShowCMP = async () => {
     }
 
     const isInUsa = (await getCountryCode()) === 'US';
+    const browserId: string | undefined = getCookie('bwid') || undefined;
+    const pubData: { browserId?: string } | undefined = browserId
+        ? { browserId }
+        : undefined;
     cmp.init({
+        pubData,
         isInUsa,
     });
     addPrivacySettingsLink();

--- a/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -29,7 +29,7 @@ export const StickyBottomBanner = ({
     );
 
     useEffect(() => {
-        shouldShowOldCMP().then(shouldShowOld =>
+        shouldShowOldCMP().then((shouldShowOld) =>
             setShowOldCMP(shouldShowOld && CAPI.config.cmpUi),
         );
         willShowCMP().then(setCMPWillShow);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2355,10 +2355,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.16.tgz#3ef47e7f49e633aea51c67f061d8d313a26fa9bc"
   integrity sha512-SgNU2bgiyQaXNfqanx4SDmxqAhXW6QBCTk4tRnCgV9Ht6noRl7UsDfx4I0u+M4H3TRnK4I/i2mmlJBtnuwhxEg==
 
-"@guardian/consent-management-platform@4.0.0-10":
-  version "4.0.0-10"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-4.0.0-10.tgz#d34fafcd8c4dfd2fe301df3fbb283fa8007ad0d3"
-  integrity sha512-YwQVc1vNzA0YmXzbwQmW8MJmXKVkWR/clPTeV/eyaiK54d8ryydtEeFj3WU/3qTZapLy8x1mNAtfcaWeh078VA==
+"@guardian/consent-management-platform@4.0.0-12":
+  version "4.0.0-12"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-4.0.0-12.tgz#88d891e51adb196e3f1612cc4496ec69a994c7bd"
+  integrity sha512-9vPFjBXSOD3AwJm0nLiAHwSommGHGJWWiwOFi7d5aS/JJhp+5x7BQMK8zQix7mEWM3XM8qrXvC6I9ui1cRPsKA==
   dependencies:
     "@guardian/old-cmp" "npm:@guardian/consent-management-platform@^3.4.10"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2355,10 +2355,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.16.tgz#3ef47e7f49e633aea51c67f061d8d313a26fa9bc"
   integrity sha512-SgNU2bgiyQaXNfqanx4SDmxqAhXW6QBCTk4tRnCgV9Ht6noRl7UsDfx4I0u+M4H3TRnK4I/i2mmlJBtnuwhxEg==
 
-"@guardian/consent-management-platform@4.0.0-12":
-  version "4.0.0-12"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-4.0.0-12.tgz#88d891e51adb196e3f1612cc4496ec69a994c7bd"
-  integrity sha512-9vPFjBXSOD3AwJm0nLiAHwSommGHGJWWiwOFi7d5aS/JJhp+5x7BQMK8zQix7mEWM3XM8qrXvC6I9ui1cRPsKA==
+"@guardian/consent-management-platform@4.0.0-13":
+  version "4.0.0-13"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-4.0.0-13.tgz#38319f88f7848daa48c1365c5cd4f3f12c9d1726"
+  integrity sha512-HEM36wERJ47zgCLKBVZVtGU7LgC3/gjwIbnRF/RBeHxhEqSHocN8o5rlriMGqoyovMMVgljGRMMcTx4RTgO46w==
   dependencies:
     "@guardian/old-cmp" "npm:@guardian/consent-management-platform@^3.4.10"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2355,12 +2355,12 @@
   resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.16.tgz#3ef47e7f49e633aea51c67f061d8d313a26fa9bc"
   integrity sha512-SgNU2bgiyQaXNfqanx4SDmxqAhXW6QBCTk4tRnCgV9Ht6noRl7UsDfx4I0u+M4H3TRnK4I/i2mmlJBtnuwhxEg==
 
-"@guardian/consent-management-platform@4.0.0-9":
-  version "4.0.0-9"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-4.0.0-9.tgz#9335485e5b98c7771498dee2bb892a5f94e27b19"
-  integrity sha512-JL2LpgbUcYz488kBAmCAAn0t8NtmT8s4LDXd2sVvRhZAThG4evGyJDD1fI9FhBmwvhAukRaet2SPr52hxt7zUQ==
+"@guardian/consent-management-platform@4.0.0-10":
+  version "4.0.0-10"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-4.0.0-10.tgz#d34fafcd8c4dfd2fe301df3fbb283fa8007ad0d3"
+  integrity sha512-YwQVc1vNzA0YmXzbwQmW8MJmXKVkWR/clPTeV/eyaiK54d8ryydtEeFj3WU/3qTZapLy8x1mNAtfcaWeh078VA==
   dependencies:
-    "@guardian/old-cmp" "npm:@guardian/consent-management-platform@^3.4.9"
+    "@guardian/old-cmp" "npm:@guardian/consent-management-platform@^3.4.10"
 
 "@guardian/discussion-rendering@^2.6.0":
   version "2.6.0"
@@ -2373,7 +2373,7 @@
     react-focus-lock "^2.2.1"
     timeago.js "^4.0.2"
 
-"@guardian/old-cmp@npm:@guardian/consent-management-platform@^3.4.9":
+"@guardian/old-cmp@npm:@guardian/consent-management-platform@^3.4.10":
   version "3.4.10"
   resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-3.4.10.tgz#604e71d27c6bfa4664c83c55578a8aa73ff09d82"
   integrity sha512-P3dTf9EqYhpH7JQ+Bg9MNoIQ08U4yD5j+s5epO9mNTaIBiX1BeOF3RcI3KNj/dBxSggaut0rBdQ82GN54Bg4jA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2355,10 +2355,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.16.tgz#3ef47e7f49e633aea51c67f061d8d313a26fa9bc"
   integrity sha512-SgNU2bgiyQaXNfqanx4SDmxqAhXW6QBCTk4tRnCgV9Ht6noRl7UsDfx4I0u+M4H3TRnK4I/i2mmlJBtnuwhxEg==
 
-"@guardian/consent-management-platform@4.0.0-13":
-  version "4.0.0-13"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-4.0.0-13.tgz#38319f88f7848daa48c1365c5cd4f3f12c9d1726"
-  integrity sha512-HEM36wERJ47zgCLKBVZVtGU7LgC3/gjwIbnRF/RBeHxhEqSHocN8o5rlriMGqoyovMMVgljGRMMcTx4RTgO46w==
+"@guardian/consent-management-platform@4.0.0-beta.0":
+  version "4.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-4.0.0-beta.0.tgz#d09d9ce569aa08b85ad97a342e95b8916f7b2fe7"
+  integrity sha512-2dwfDyewIv7c3/c3F5t6MX0fd7O+OCP3kcXZ6WZXwPaDs3aFomHwgTKDIXMf0ZFGOlTCItHVopL6xPOMMDXJeA==
   dependencies:
     "@guardian/old-cmp" "npm:@guardian/consent-management-platform@^3.4.10"
 


### PR DESCRIPTION
## What does this change?

This adds adding the `browserId` to the `pubData` object that can be passed to the `init` of the CMP.

## Why?

We would like to report on the consent each pageview has; in order to do this we would like to associate the current `browserId` with a consent signal from the CMP.

@guardian/commercial-dev