### PR TITLE
Add Sign In Gate Dismiss Window test

### DIFF
--- a/cypress/integration/e2e/sign-in-gate.spec.js
+++ b/cypress/integration/e2e/sign-in-gate.spec.js
@@ -1,56 +1,79 @@
 /* eslint-disable no-undef */
 /* eslint-disable func-names */
 
-describe('Sign In Gate Tests', function() {
+describe('Sign In Gate Tests', function () {
     const setArticleCount = (n) => {
         // set article count for today to be n
-        localStorage.setItem('gu.history.dailyArticleCount', JSON.stringify({ value: [{ day: Math.floor(Date.now() / 86400000), count: n }] }));
-    }
+        localStorage.setItem(
+            'gu.history.dailyArticleCount',
+            JSON.stringify({
+                value: [
+                    {
+                        day: Math.floor(Date.now() / 86400000),
+                        count: n,
+                    },
+                ],
+            }),
+        );
+    };
 
     const setMvtCookie = (str) => {
         cy.setCookie('GU_mvt_id_local', str, {
-            log: true
-        })
-    }
+            log: true,
+        });
+    };
 
     // helper method over the cypress visit method to avoid having to repeat the same url by setting a default
     // can override the parameter if required
-    const visitArticle = (url = 'https://www.theguardian.com/games/2018/aug/23/nier-automata-yoko-taro-interview') => {
-        cy.visit(
-            `Article?url=${url}`,
-        );
-    }
+    const visitArticle = (
+        url = 'https://www.theguardian.com/games/2018/aug/23/nier-automata-yoko-taro-interview',
+    ) => {
+        cy.visit(`Article?url=${url}`);
+    };
 
     // as the sign in gate is lazy loaded, we need to scroll to the rough position where it
     // will be inserted to make it visible
     // can override position if required
     const scrollToGateForLazyLoading = (roughPosition = 1000) => {
         cy.scrollTo(0, roughPosition, { duration: 500 });
-    }
+    };
 
     // we call visit and scroll for most test, so this wrapper combines the two
     // while preserving the ability to set the parameters if required
-    const visitArticleAndScrollToGateForLazyLoad = ({ url, roughPosition } = {}) => {
+    const visitArticleAndScrollToGateForLazyLoad = ({
+        url,
+        roughPosition,
+    } = {}) => {
         visitArticle(url);
         scrollToGateForLazyLoading(roughPosition);
-    }
+    };
 
-    describe('SignInGateMain', function() {
-        beforeEach(function() {
+    const getCMPiFrame = () => {
+        return cy
+            .get('#sp_message_container_106842')
+            .then(cy.wrap)
+            .get('iframe')
+            .its('2.contentDocument.body')
+            .should('not.be.empty')
+            .then(cy.wrap);
+    };
+
+    describe('SignInGateMain', function () {
+        beforeEach(function () {
             // sign in gate main runs from 0-900000 MVT IDs, so 500 forces user into test
             setMvtCookie('500');
 
             // set article count to be min number to view gate
             setArticleCount(3);
-        })
+        });
 
-        it('should load the sign in gate', function() {
+        it('should load the sign in gate', function () {
             visitArticleAndScrollToGateForLazyLoad();
 
             cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
         });
 
-        it('should not load the sign in gate if the user has not read at least 3 article in a day', function() {
+        it('should not load the sign in gate if the user has not read at least 3 article in a day', function () {
             setArticleCount(1);
 
             visitArticleAndScrollToGateForLazyLoad();
@@ -58,11 +81,15 @@ describe('Sign In Gate Tests', function() {
             cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
         });
 
-        it('should not load the sign in gate if the user is signed in', function() {
+        it('should not load the sign in gate if the user is signed in', function () {
             // use GU_U cookie to determine if user is signed in
-            cy.setCookie('GU_U', 'MCwCFHbDHWevL_GqgH0CcbeDWp4N9kR5AhQ2lD3zMjjbKJAgC7FUDtc18Ac8BA', { log: true });
+            cy.setCookie(
+                'GU_U',
+                'MCwCFHbDHWevL_GqgH0CcbeDWp4N9kR5AhQ2lD3zMjjbKJAgC7FUDtc18Ac8BA',
+                { log: true },
+            );
 
-            visitArticleAndScrollToGateForLazyLoad()
+            visitArticleAndScrollToGateForLazyLoad();
 
             // when using GU_U cookie, there is an issue with the commercial.dcr.js bundle
             // causing a URI Malformed error in cypress
@@ -70,40 +97,50 @@ describe('Sign In Gate Tests', function() {
             cy.on('uncaught:exception', () => {
                 done();
                 return false;
-            })
+            });
 
             cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
         });
 
-        it('should not load the sign in gate if the user has already dismissed the gate', function() {
-            localStorage.setItem('gu.prefs.sign-in-gate', '{"SignInGateMain-main-variant-1":"2020-07-22T08:25:05.567Z"}')
+        it('should not load the sign in gate if the user has already dismissed the gate', function () {
+            localStorage.setItem(
+                'gu.prefs.sign-in-gate',
+                '{"SignInGateMain-main-variant-1":"2020-07-22T08:25:05.567Z"}',
+            );
 
             visitArticleAndScrollToGateForLazyLoad();
 
             cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
         });
 
-        it('should not load the sign in gate if the article is not a valid section (membership)', function() {
-            visitArticleAndScrollToGateForLazyLoad({ url: 'https://www.theguardian.com/membership/2018/nov/15/support-guardian-readers-future-journalism' })
+        it('should not load the sign in gate if the article is not a valid section (membership)', function () {
+            visitArticleAndScrollToGateForLazyLoad({
+                url:
+                    'https://www.theguardian.com/membership/2018/nov/15/support-guardian-readers-future-journalism',
+            });
 
             cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
         });
 
-        it('should not load the sign in gate on a device with an ios9 user agent string', function() {
+        it('should not load the sign in gate on a device with an ios9 user agent string', function () {
             // can't use visitArticleAndScrollToGateForLazyLoad for this method as overriding user agent
-            cy.visit('Article?url=https://www.theguardian.com/games/2018/aug/23/nier-automata-yoko-taro-interview', {
-                onBeforeLoad: win => {
-                    Object.defineProperty(win.navigator, 'userAgent', {
-                        value: 'Mozilla/5.0 (iPad; CPU OS 9_0 like Mac OS X) AppleWebKit/601.1.17 (KHTML, like Gecko) Version/8.0 Mobile/13A175 Safari/600.1.4',
-                    });
+            cy.visit(
+                'Article?url=https://www.theguardian.com/games/2018/aug/23/nier-automata-yoko-taro-interview',
+                {
+                    onBeforeLoad: (win) => {
+                        Object.defineProperty(win.navigator, 'userAgent', {
+                            value:
+                                'Mozilla/5.0 (iPad; CPU OS 9_0 like Mac OS X) AppleWebKit/601.1.17 (KHTML, like Gecko) Version/8.0 Mobile/13A175 Safari/600.1.4',
+                        });
+                    },
                 },
-            });
+            );
             scrollToGateForLazyLoading();
 
             cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
         });
 
-        it('should remove gate when the dismiss button is clicked', function() {
+        it('should remove gate when the dismiss button is clicked', function () {
             visitArticleAndScrollToGateForLazyLoad();
 
             cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
@@ -113,26 +150,27 @@ describe('Sign In Gate Tests', function() {
             cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
         });
 
-        it('register button should contain profile.theguardian.com href', function() {
+        it('register button should contain profile.theguardian.com href', function () {
             visitArticleAndScrollToGateForLazyLoad();
 
             cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
 
             cy.get('[data-cy=sign-in-gate-main_register]')
-                .invoke('attr', 'href').should('contains', 'profile.theguardian.com');
+                .invoke('attr', 'href')
+                .should('contains', 'profile.theguardian.com');
         });
 
-        it('sign in link should contain profile.theguardian.com href', function() {
+        it('sign in link should contain profile.theguardian.com href', function () {
             visitArticleAndScrollToGateForLazyLoad();
 
             cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
 
-
             cy.get('[data-cy=sign-in-gate-main_signin]')
-                .invoke('attr', 'href').should('contains', 'profile.theguardian.com');
+                .invoke('attr', 'href')
+                .should('contains', 'profile.theguardian.com');
         });
 
-        it('should show cmp ui when privacy settings link is clicked', function() {
+        it('should show cmp ui when privacy settings link is clicked', function () {
             visitArticleAndScrollToGateForLazyLoad();
 
             cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
@@ -143,8 +181,236 @@ describe('Sign In Gate Tests', function() {
         });
     });
 
-    describe('SignInGatePatientia', function() {
-        beforeEach(function() {
+    describe('SignInGateDismissWindow - control', function () {
+        beforeEach(function () {
+            setMvtCookie('876000');
+
+            // set article count to be min number to view gate
+            setArticleCount(3);
+        });
+
+        it('should load the sign in gate', function () {
+            visitArticleAndScrollToGateForLazyLoad();
+
+            cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+        });
+
+        it('should not load the sign in gate if the user has not read at least 3 article in a day', function () {
+            setArticleCount(1);
+
+            visitArticleAndScrollToGateForLazyLoad();
+
+            cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
+        });
+
+        it('should not load the sign in gate if the user is signed in', function () {
+            // use GU_U cookie to determine if user is signed in
+            cy.setCookie(
+                'GU_U',
+                'MCwCFHbDHWevL_GqgH0CcbeDWp4N9kR5AhQ2lD3zMjjbKJAgC7FUDtc18Ac8BA',
+                {
+                    log: true,
+                },
+            );
+
+            visitArticleAndScrollToGateForLazyLoad();
+
+            // when using GU_U cookie, there is an issue with the commercial.dcr.js bundle
+            // causing a URI Malformed error in cypress
+            // we use this uncaught exception in this test to catch this and continue the rest of the test
+            cy.on('uncaught:exception', () => {
+                done();
+                return false;
+            });
+
+            cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
+        });
+
+        it('should not load the sign in gate if the user has already dismissed the gate', function () {
+            localStorage.setItem(
+                'gu.prefs.sign-in-gate',
+                '{"SignInGateDismissWindow-dismiss-window-control":"2020-07-22T08:25:05.567Z"}',
+            );
+
+            visitArticleAndScrollToGateForLazyLoad();
+
+            cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
+        });
+        it('should not load the sign in gate if the article is not a valid section (membership)', function () {
+            visitArticleAndScrollToGateForLazyLoad({
+                url:
+                    'https://www.theguardian.com/membership/2018/nov/15/support-guardian-readers-future-journalism',
+            });
+
+            cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
+        });
+
+        it('should not load the sign in gate on a device with an ios9 user agent string', function () {
+            // can't use visitArticleAndScrollToGateForLazyLoad for this method as overriding user agent
+            cy.visit(
+                'Article?url=https://www.theguardian.com/games/2018/aug/23/nier-automata-yoko-taro-interview',
+                {
+                    onBeforeLoad: (win) => {
+                        Object.defineProperty(win.navigator, 'userAgent', {
+                            value:
+                                'Mozilla/5.0 (iPad; CPU OS 9_0 like Mac OS X) AppleWebKit/601.1.17 (KHTML, like Gecko) Version/8.0 Mobile/13A175 Safari/600.1.4',
+                        });
+                    },
+                },
+            );
+            scrollToGateForLazyLoading();
+
+            cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
+        });
+
+        it('should remove gate when the dismiss button is clicked', function () {
+            visitArticleAndScrollToGateForLazyLoad();
+
+            cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+
+            cy.get('[data-cy=sign-in-gate-main_dismiss]').click();
+
+            cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
+        });
+
+        it('register button should contain profile.theguardian.com href', function () {
+            visitArticleAndScrollToGateForLazyLoad();
+
+            cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+
+            cy.get('[data-cy=sign-in-gate-main_register]')
+                .invoke('attr', 'href')
+                .should('contains', 'profile.theguardian.com');
+        });
+
+        it('sign in link should contain profile.theguardian.com href', function () {
+            visitArticleAndScrollToGateForLazyLoad();
+
+            cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+
+            cy.get('[data-cy=sign-in-gate-main_signin]')
+                .invoke('attr', 'href')
+                .should('contains', 'profile.theguardian.com');
+        });
+
+        it('should show cmp ui when privacy settings link is clicked', function () {
+            visitArticleAndScrollToGateForLazyLoad();
+
+            cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+
+            cy.get('[data-cy=sign-in-gate-main_privacy]').click();
+
+            cy.contains('privacy settings');
+        });
+    });
+
+    describe('SignInGateDismissWindow - variant 1 - article', function () {
+        beforeEach(function () {
+            setMvtCookie('877000');
+
+            // set article count to be min number to view gate
+            setArticleCount(3);
+        });
+
+        it('should load the sign in gate', function () {
+            visitArticleAndScrollToGateForLazyLoad();
+
+            cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+        });
+
+        it('should remove gate when the dismiss button is clicked', function () {
+            visitArticleAndScrollToGateForLazyLoad();
+
+            cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+
+            cy.get('[data-cy=sign-in-gate-main_dismiss]').click();
+
+            cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
+        });
+
+        it('should load the sign in gate even if the user has already dismissed the gate', function () {
+            localStorage.setItem(
+                'gu.prefs.sign-in-gate',
+                '{"SignInGateDismissWindow-variant-1-article":"2020-07-22T08:25:05.567Z"}',
+            );
+
+            visitArticleAndScrollToGateForLazyLoad();
+
+            cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+        });
+
+        it('should reshow the sign in gate if the user has already dismissed the gate but navigates to a new article', function () {
+            visitArticleAndScrollToGateForLazyLoad();
+
+            cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+
+            cy.get('[data-cy=sign-in-gate-main_dismiss]').click();
+
+            cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
+
+            visitArticleAndScrollToGateForLazyLoad();
+
+            cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+        });
+    });
+
+    describe('SignInGateDismissWindow - variant 2 - day', function () {
+        beforeEach(function () {
+            setMvtCookie('878000');
+
+            // set article count to be min number to view gate
+            setArticleCount(3);
+        });
+
+        it('should load the sign in gate', function () {
+            visitArticleAndScrollToGateForLazyLoad();
+
+            cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+        });
+
+        it('should remove gate when the dismiss button is clicked', function () {
+            visitArticleAndScrollToGateForLazyLoad();
+
+            cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+
+            cy.get('[data-cy=sign-in-gate-main_dismiss]').click();
+
+            cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
+        });
+
+        it('should not load the sign in gate if the user has dismissed the gate in last 24hrs', function () {
+            const lessThanADayAgo = new Date();
+            lessThanADayAgo.setHours(lessThanADayAgo.getHours() - 16);
+            localStorage.setItem(
+                'gu.prefs.sign-in-gate',
+                JSON.stringify({
+                    'SignInGateDismissWindow-dismiss-window-variant-2-day': lessThanADayAgo.toISOString(),
+                }),
+            );
+
+            visitArticleAndScrollToGateForLazyLoad();
+
+            cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
+        });
+
+        it('should load the sign in gate if the user has dismissed the gate more than 24hrs ago', function () {
+            const moreThanADayAgo = new Date();
+            moreThanADayAgo.setHours(moreThanADayAgo.getHours() - 48);
+            localStorage.setItem(
+                'gu.prefs.sign-in-gate',
+                JSON.stringify({
+                    'SignInGateDismissWindow-dismiss-window-variant-2-day': moreThanADayAgo.toISOString(),
+                }),
+            );
+
+            visitArticleAndScrollToGateForLazyLoad();
+
+            cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+        });
+    });
+
+    describe('SignInGatePatientia', function () {
+        beforeEach(function () {
             // sign in gate patientia runs from 999901-1000000 MVT IDs, so 999901 forces user into test variant
             setMvtCookie('999901');
 
@@ -152,13 +418,13 @@ describe('Sign In Gate Tests', function() {
             setArticleCount(3);
         });
 
-        it('should load the sign in gate', function() {
+        it('should load the sign in gate', function () {
             visitArticleAndScrollToGateForLazyLoad();
 
             cy.get('[data-cy=sign-in-gate-patientia]').should('be.visible');
         });
 
-        it('should remove gate when the dismiss button is clicked', function() {
+        it('should remove gate when the dismiss button is clicked', function () {
             visitArticleAndScrollToGateForLazyLoad();
 
             cy.get('[data-cy=sign-in-gate-patientia]').should('be.visible');
@@ -167,5 +433,5 @@ describe('Sign In Gate Tests', function() {
 
             cy.get('[data-cy=sign-in-gate-patientia]').should('not.be.visible');
         });
-    })
+    });
 });

--- a/src/web/components/SignInGate/README.md
+++ b/src/web/components/SignInGate/README.md
@@ -8,8 +8,9 @@
 4. If the test needs a design, make it in the `gateDesigns` folder
 5. Set up individual variants in the `gates` folder, exports the `SignInGateComponent` type. Display rules defined here in the `canShow` method. Helpers in `displayRule.ts`.
 6. Import the `SignInGateComponent` in `SignInGateSelector.tsx` by mapping the variant name to the `SignInGateComponent` in the `testVariantToGateMapping` array.
-7. Add it to Storybook by modifying `SignInGate.stories.tsx`
-8. Update Cypress tests in the `cypress/integration/e2e/sign-in-gate.spec.js`, and any unit tests e.g. `displayRule.test.ts`
+7. Add a value for the new test to `testIdToComponentId` map (for tracking).
+8. If there is a new gate design, add the component to Storybook by modifying `SignInGate.stories.tsx`
+9. Update Cypress tests in the `cypress/integration/e2e/sign-in-gate.spec.js`, and any unit tests e.g. `displayRule.test.ts`
 
 ## Full Guide
 
@@ -275,6 +276,8 @@ To view it in storybook simply run `yarn storybook` which will launch a storyboo
 
 Once the test has been set up, you may want to force yourself into the test to manually check that it's working as expected.
 
+First, ensure you are running `frontend` locally, and the AB test switch has been switched on eg. `safeState=On` - do not commit this change.
+
 Currently there are 2 ways of doing this.
 
 **A)** Set the `GU_mvt_id_local` cookie in your browser.
@@ -310,9 +313,20 @@ The disadvantage of this method is that it's a bit tricky to work out exactly wh
 </ABProvider>
 ```
 
-The advantage of using the forcedTestVariant is that you don't have to work out the value of the mvt_id to set, and that if the audience size or offset has changed it will automatically be picked up.
+The advantages of using the forcedTestVariant:
 
-The disadvantage of this is that you have to make sure that you **DO NOT** commit the `forcedTestVariant` to master, and that if the `id` or variant id changes, you have to make sure to change it here too.
+-   you don't have to work out the value of the mvt_id to set, and that if the audience size or offset has changed it will automatically be picked up.
+-   you can technically run it without running `frontend` locally by manually switchi on your AB test switch:
+
+```tsx
+ abTestSwitches={{
+       ...{ abAbTestTest: true },
+       ...CAPI.config.switches,
+       ...{ abSignInGateSwitchName: true }, // DO NOT COMMIT THIS!!
+   }}
+```
+
+The disadvantage of this is that you have to make sure that you **DO NOT** commit the `forcedTestVariant` or `abTestSwitches` change to master, and that if the `id` or variant id changes, you have to make sure to change it here too.
 
 #### Cypress Integration Tests
 

--- a/src/web/components/SignInGate/README.md
+++ b/src/web/components/SignInGate/README.md
@@ -328,6 +328,17 @@ The advantages of using the forcedTestVariant:
 
 The disadvantage of this is that you have to make sure that you **DO NOT** commit the `forcedTestVariant` or `abTestSwitches` change to master, and that if the `id` or variant id changes, you have to make sure to change it here too.
 
+#### Testing in CODE
+
+To test in CODE you will need to:
+
+1. Ensure the AB test is deployed in Frontend CODE and switched ON here: https://frontend.code.dev-gutools.co.uk/dev/switchboard
+2. Ensure the AB test experiment file with audience offsets are depolyed to Frontend CODE and check here: https://frontend.code.devv-gutools.co.uk/analytics/abtests (These test files should be identical in DCR and Frontend)
+3. Deploy you DCR branch to CODE.
+4. In chrome dev tools, set the value of the `GU_mvt_id` for the `dev-theguardian.com` cookie to one that will be captured by your desired test bucket (use https://ab-tests.netlify.app/)
+5. Navigate to an article page and trigger DCR by adding `?dcr` to the url
+6. Verify you are in the correct test bucket by looking at the `abtest` value sent to Ophan in the network tab.
+
 #### Cypress Integration Tests
 
 The Cypress tests for the sign in gate are found in `cypress/integration/e2e/sign-in-gate.spec.js`. We use cypress to test that the functionality of the gate works as expected in a browser. Each test that shows a gate **must** be tested individually, as well as any display rules to show that gate (unless the display rules are shared).

--- a/src/web/components/SignInGate/SignInGateSelector.tsx
+++ b/src/web/components/SignInGate/SignInGateSelector.tsx
@@ -14,12 +14,16 @@ import { getCookie } from '@frontend/web/browser/cookie';
 import { signInGatePatientia } from '@frontend/web/experiments/tests/sign-in-gate-patientia';
 import { signInGateMainVariant } from '@root/src/web/experiments/tests/sign-in-gate-main-variant';
 import { signInGateMainControl } from '@root/src/web/experiments/tests/sign-in-gate-main-control';
+import { signInGateDismissWindow } from '@root/src/web/experiments/tests/sign-in-gate-dismiss-window';
 
 // Sign in Gate Types
 import { signInGateComponent as gateMainVariant } from '@root/src/web/components/SignInGate/gates/main-variant';
 import { signInGateComponent as gateMainControl } from '@root/src/web/components/SignInGate/gates/main-control';
 import { signInGateComponent as gatePatientiaControl } from '@root/src/web/components/SignInGate/gates/patientia-control';
 import { signInGateComponent as gatePatientiaVariant } from '@root/src/web/components/SignInGate/gates/patientia-variant';
+import { signInGateComponent as gateDismissWindowControl } from '@root/src/web/components/SignInGate/gates/dismiss-window-control';
+import { signInGateComponent as gateDismissWindowVariant1Article } from '@root/src/web/components/SignInGate/gates/dismiss-window-variant-1-article';
+import { signInGateComponent as gateDismissWindowVariant2Day } from '@root/src/web/components/SignInGate/gates/dismiss-window-variant-2-day';
 
 import {
     ComponentEventParams,
@@ -69,6 +73,7 @@ const tests: ReadonlyArray<ABTest> = [
     signInGatePatientia,
     signInGateMainVariant,
     signInGateMainControl,
+    signInGateDismissWindow,
 ];
 
 const testVariantToGateMapping: GateTestMap = {
@@ -76,12 +81,16 @@ const testVariantToGateMapping: GateTestMap = {
     'patientia-variant-1': gatePatientiaVariant,
     'main-control-1': gateMainControl,
     'main-variant-1': gateMainVariant,
+    'dismiss-window-control': gateDismissWindowControl,
+    'dismiss-window-variant-1-article': gateDismissWindowVariant1Article,
+    'dismiss-window-variant-2-day': gateDismissWindowVariant2Day,
 };
 
 const testIdToComponentId: { [key: string]: string } = {
     SignInGateMainVariant: 'main_variant_1',
     SignInGateMainControl: 'main_control_1',
     SignInGatePatientia: 'patientia_test',
+    SignInGateDismissWindow: 'dismiss_window_test',
 };
 
 // function to generate the profile.theguardian.com url with tracking params

--- a/src/web/components/SignInGate/dismissGate.test.ts
+++ b/src/web/components/SignInGate/dismissGate.test.ts
@@ -1,4 +1,4 @@
-import { hasUserDismissedGate, setUserDismissedGate } from './dismissGate';
+import { hasUserDismissedGate, setUserDismissedGate, unsetUserDismissedGate } from './dismissGate';
 
 describe('SignInGate - dismissGate methods', () => {
     beforeEach(() => {
@@ -62,6 +62,53 @@ describe('SignInGate - dismissGate methods', () => {
 
             expect(output).toBe(false);
         });
+
+        test('user has dismissed gate within time window', () => {
+            const lessThanADayAgo = new Date();
+            lessThanADayAgo.setHours(lessThanADayAgo.getHours() - 1);
+            localStorage.setItem(
+                'gu.prefs.sign-in-gate',
+                JSON.stringify({
+                    'SignInGateCurrent-variant-name': lessThanADayAgo.toISOString(),
+                }),
+            );
+            const output = hasUserDismissedGate(
+                'variant-name',
+                'SignInGateCurrent',
+                24
+            );
+
+            expect(output).toBe(true);
+        });
+
+        test('user has not dismissed gate within time window', () => {
+            const moreThanADayAgo = new Date();
+            moreThanADayAgo.setHours(moreThanADayAgo.getHours() - 48);
+            localStorage.setItem(
+                'gu.prefs.sign-in-gate',
+                JSON.stringify({
+                    'SignInGateCurrent-variant-name': moreThanADayAgo.toISOString(),
+                }),
+            );
+
+            const output = hasUserDismissedGate(
+                'variant-name',
+                'SignInGateCurrent',
+                24
+            );
+
+            expect(output).toBe(false);
+        });
+
+        test('returns false if window is checked but there is no dismissal time for the varian in local storage', () => {
+            const output = hasUserDismissedGate(
+                'variant-name',
+                'SignInGateCurrent',
+                24
+            );
+
+            expect(output).toBe(false);
+        });
     });
 
     describe('setUserDismissedGate', () => {
@@ -85,6 +132,21 @@ describe('SignInGate - dismissGate methods', () => {
 
             expect(output1).toBe(true);
             expect(output2).toBe(true);
+        });
+    });
+
+    describe('unsetUserDismissedGate', () => {
+        test('unsets dismissed sign in gate for correct test and variant', () => {
+            setUserDismissedGate('variant-1', 'test-1');
+            setUserDismissedGate('variant-2', 'test-2');
+            unsetUserDismissedGate('variant-2', 'test-2');
+
+            const output1 = hasUserDismissedGate('variant-1', 'test-1');
+            const output2 = hasUserDismissedGate('variant-2', 'test-2');
+
+            expect(output1).toBe(true);
+            expect(output2).toBe(false);
+
         });
     });
 });

--- a/src/web/components/SignInGate/dismissGate.ts
+++ b/src/web/components/SignInGate/dismissGate.ts
@@ -5,29 +5,6 @@ const localStorageLookupKey = (variant: string, name: string): string => {
     return `${name}-${variant}`;
 };
 
-// Check if the user has dismissed the gate by checking the user preferences,
-// name is optional, but can be used to differentiate between multiple sign in gate tests
-//
-// This is set in local storage with the following shape:
-//
-// key:   gu.prefs.sign-in-gate
-// value: {"testVariantName":"2020-07-01T10:55:09.085Z"}
-//
-// We extract the value using the key, which remains constant
-// and the from within the value object we look up the variant we are looking for
-
-export const hasUserDismissedGate = (
-    variant: string,
-    name: string,
-): boolean => {
-    try {
-        const prefs = JSON.parse(localStorage.getItem(localStorageKey) || '{}');
-        return !!prefs[localStorageLookupKey(variant, name)];
-    } catch (error) {
-        // Alas, sometimes localstorage isn't available. Please have a sign in gate as an apology
-        return false;
-    }
-};
 
 // set in user preferences that the user has dismissed the gate, set the value to the current ISO date string
 // name is optional, but can be used to differentiate between multiple sign in gate tests
@@ -48,4 +25,59 @@ export const setUserDismissedGate = (variant: string, name: string): void => {
     } catch (error) {
         // Alas, sometimes localstorage isn't available
     }
+};
+
+export const unsetUserDismissedGate = (variant: string, name: string): void => {
+    try {
+        const prefs = JSON.parse(localStorage.getItem(localStorageKey) || '{}');
+        delete prefs[localStorageLookupKey(variant, name)]
+        localStorage.setItem(localStorageKey, JSON.stringify(prefs));
+    } catch (error) {
+        // Alas, sometimes localstorage isn't available
+    }
+};
+
+
+// Check if the user has dismissed the gate by checking the user preferences,
+// name is optional, but can be used to differentiate between multiple sign in gate tests
+//
+// This is set in local storage with the following shape:
+//
+// key:   gu.prefs.sign-in-gate
+// value: {"testVariantName":"2020-07-01T10:55:09.085Z"}
+//
+// We extract the value using the key, which remains constant
+// and the from within the value object we look up the variant we are looking for
+export const hasUserDismissedGate = (
+    variant: string,
+    name: string,
+    window?: number, // represents hours - only use if the gate should reshow after X hrs (dismissal window)
+): boolean => {
+    try {
+        const prefs = JSON.parse(localStorage.getItem(localStorageKey) || '{}');
+
+        // checks if a dismissal occured within a given window timeframe in hours
+        if (window) {
+            // checks if prefs is empty, ie. the user has not dismissed gate before.
+            if (!prefs[localStorageLookupKey(variant, name)]) {
+
+                return false;
+            }
+
+            const dismissalTZ = Date.parse(prefs[localStorageLookupKey(variant, name)]);
+            const hours = (Date.now() - dismissalTZ) / 36e5; //  36e5 is the scientific notation for 60*60*1000, which converts the milliseconds difference into hours.
+
+            if (hours >= window) {
+                unsetUserDismissedGate(variant, name)
+                return false
+            }
+            return true
+        }
+
+        return !!prefs[localStorageLookupKey(variant, name)];
+    } catch (error) {
+        // Alas, sometimes localstorage isn't available. Please have a sign in gate as an apology
+        return false;
+    }
+
 };

--- a/src/web/components/SignInGate/gates/dismiss-window-control.tsx
+++ b/src/web/components/SignInGate/gates/dismiss-window-control.tsx
@@ -1,0 +1,66 @@
+import React, { Suspense } from 'react';
+import { Lazy } from '@root/src/web/components/Lazy';
+
+import {
+    SignInGateComponent,
+    CurrentABTest,
+} from '@frontend/web/components/SignInGate/gateDesigns/types';
+import {
+    isNPageOrHigherPageView,
+    isValidContentType,
+    isValidSection,
+    isIOS9,
+} from '@frontend/web/components/SignInGate/displayRule';
+import { initPerf } from '@root/src/web/browser/initPerf';
+import { hasUserDismissedGate } from '../dismissGate';
+
+const SignInGateMain = React.lazy(() => {
+    const { start, end } = initPerf('SignInGateMain');
+    start();
+    return import(
+        /* webpackChunkName: "SignInGateMain" */ '../gateDesigns/SignInGateMain'
+    ).then((module) => {
+        end();
+        return { default: module.SignInGateMain };
+    });
+});
+
+const canShow = (
+    CAPI: CAPIBrowserType,
+    isSignedIn: boolean,
+    currentTest: CurrentABTest,
+): boolean => {
+    return (
+        !isSignedIn &&
+        !hasUserDismissedGate(currentTest.variant, currentTest.name) &&
+        isNPageOrHigherPageView(3) &&
+        isValidContentType(CAPI) &&
+        isValidSection(CAPI) &&
+        !isIOS9()
+    );
+};
+
+export const signInGateComponent: SignInGateComponent = {
+    gate: ({
+        ophanComponentId,
+        dismissGate,
+        guUrl,
+        signInUrl,
+        abTest,
+        isComment,
+    }) => (
+        <Lazy margin={300}>
+            <Suspense fallback={<></>}>
+                <SignInGateMain
+                    ophanComponentId={ophanComponentId}
+                    dismissGate={dismissGate}
+                    guUrl={guUrl}
+                    signInUrl={signInUrl}
+                    abTest={abTest}
+                    isComment={isComment}
+                />
+            </Suspense>
+        </Lazy>
+    ),
+    canShow,
+};

--- a/src/web/components/SignInGate/gates/dismiss-window-variant-1-article.tsx
+++ b/src/web/components/SignInGate/gates/dismiss-window-variant-1-article.tsx
@@ -1,0 +1,68 @@
+import React, { Suspense } from 'react';
+import { Lazy } from '@root/src/web/components/Lazy';
+
+import {
+    SignInGateComponent,
+    CurrentABTest,
+} from '@frontend/web/components/SignInGate/gateDesigns/types';
+import {
+    isNPageOrHigherPageView,
+    isValidContentType,
+    isValidSection,
+    isIOS9,
+} from '@frontend/web/components/SignInGate/displayRule';
+import { initPerf } from '@root/src/web/browser/initPerf';
+import { unsetUserDismissedGate } from '../dismissGate';
+
+const SignInGateMain = React.lazy(() => {
+    const { start, end } = initPerf('SignInGateMain');
+    start();
+    return import(
+        /* webpackChunkName: "SignInGateMain" */ '../gateDesigns/SignInGateMain'
+    ).then((module) => {
+        end();
+        return { default: module.SignInGateMain };
+    });
+});
+
+const canShow = (
+    CAPI: CAPIBrowserType,
+    isSignedIn: boolean,
+    currentTest: CurrentABTest,
+): boolean => {
+    unsetUserDismissedGate(currentTest.variant, currentTest.name); // clears gate dismissal from local storage
+
+    return (
+        // do not check for gate dismissal as gate should show on every article
+        !isSignedIn &&
+        isNPageOrHigherPageView(3) &&
+        isValidContentType(CAPI) &&
+        isValidSection(CAPI) &&
+        !isIOS9()
+    );
+};
+
+export const signInGateComponent: SignInGateComponent = {
+    gate: ({
+        ophanComponentId,
+        dismissGate,
+        guUrl,
+        signInUrl,
+        abTest,
+        isComment,
+    }) => (
+        <Lazy margin={300}>
+            <Suspense fallback={<></>}>
+                <SignInGateMain
+                    ophanComponentId={ophanComponentId}
+                    dismissGate={dismissGate}
+                    guUrl={guUrl}
+                    signInUrl={signInUrl}
+                    abTest={abTest}
+                    isComment={isComment}
+                />
+            </Suspense>
+        </Lazy>
+    ),
+    canShow,
+};

--- a/src/web/components/SignInGate/gates/dismiss-window-variant-2-day.tsx
+++ b/src/web/components/SignInGate/gates/dismiss-window-variant-2-day.tsx
@@ -1,0 +1,64 @@
+import React, { Suspense } from 'react';
+import { Lazy } from '@root/src/web/components/Lazy';
+
+import {
+    SignInGateComponent,
+    CurrentABTest,
+} from '@frontend/web/components/SignInGate/gateDesigns/types';
+import {
+    isNPageOrHigherPageView,
+    isValidContentType,
+    isValidSection,
+    isIOS9,
+} from '@frontend/web/components/SignInGate/displayRule';
+import { initPerf } from '@root/src/web/browser/initPerf';
+import { hasUserDismissedGate } from '../dismissGate';
+
+const SignInGateMain = React.lazy(() => {
+    const { start, end } = initPerf('SignInGateDismissWindow');
+    start();
+    return import(
+        /* webpackChunkName: "SignInGateMain" */ '../gateDesigns/SignInGateMain'
+    ).then((module) => {
+        end();
+        return { default: module.SignInGateMain };
+    });
+});
+
+const canShow = (
+    CAPI: CAPIBrowserType,
+    isSignedIn: boolean,
+    currentTest: CurrentABTest,
+): boolean =>
+    !isSignedIn &&
+    // will return false if user has dimissed gate more than 24 hrs ago, so we can reshow
+    !hasUserDismissedGate(currentTest.variant, currentTest.name, 0.01) &&
+    isNPageOrHigherPageView(3) &&
+    isValidContentType(CAPI) &&
+    isValidSection(CAPI) &&
+    !isIOS9();
+
+export const signInGateComponent: SignInGateComponent = {
+    gate: ({
+        ophanComponentId,
+        dismissGate,
+        guUrl,
+        signInUrl,
+        abTest,
+        isComment,
+    }) => (
+        <Lazy margin={300}>
+            <Suspense fallback={<></>}>
+                <SignInGateMain
+                    ophanComponentId={ophanComponentId}
+                    dismissGate={dismissGate}
+                    guUrl={guUrl}
+                    signInUrl={signInUrl}
+                    abTest={abTest}
+                    isComment={isComment}
+                />
+            </Suspense>
+        </Lazy>
+    ),
+    canShow,
+};

--- a/src/web/components/SignInGate/gates/dismiss-window-variant-2-day.tsx
+++ b/src/web/components/SignInGate/gates/dismiss-window-variant-2-day.tsx
@@ -15,7 +15,7 @@ import { initPerf } from '@root/src/web/browser/initPerf';
 import { hasUserDismissedGate } from '../dismissGate';
 
 const SignInGateMain = React.lazy(() => {
-    const { start, end } = initPerf('SignInGateDismissWindow');
+    const { start, end } = initPerf('SignInGateMain');
     start();
     return import(
         /* webpackChunkName: "SignInGateMain" */ '../gateDesigns/SignInGateMain'
@@ -32,7 +32,7 @@ const canShow = (
 ): boolean =>
     !isSignedIn &&
     // will return false if user has dimissed gate more than 24 hrs ago, so we can reshow
-    !hasUserDismissedGate(currentTest.variant, currentTest.name, 0.01) &&
+    !hasUserDismissedGate(currentTest.variant, currentTest.name, 24) &&
     isNPageOrHigherPageView(3) &&
     isValidContentType(CAPI) &&
     isValidSection(CAPI) &&

--- a/src/web/experiments/ab-tests.ts
+++ b/src/web/experiments/ab-tests.ts
@@ -3,10 +3,12 @@ import { abTestTest } from '@frontend/web/experiments/tests/ab-test-test';
 import { signInGateMainVariant } from '@root/src/web/experiments/tests/sign-in-gate-main-variant';
 import { signInGateMainControl } from '@root/src/web/experiments/tests/sign-in-gate-main-control';
 import { signInGatePatientia } from '@frontend/web/experiments/tests/sign-in-gate-patientia';
+import { signInGateDismissWindow } from '@frontend/web/experiments/tests/sign-in-gate-dismiss-window';
 
 export const tests: ABTest[] = [
     abTestTest,
     signInGateMainVariant,
     signInGateMainControl,
     signInGatePatientia,
+    signInGateDismissWindow,
 ];

--- a/src/web/experiments/tests/sign-in-gate-dismiss-window.ts
+++ b/src/web/experiments/tests/sign-in-gate-dismiss-window.ts
@@ -1,0 +1,35 @@
+import { ABTest } from '@guardian/ab-core';
+
+export const signInGateDismissWindow: ABTest = {
+    id: 'SignInGateDismissWindow',
+    start: '2020-08-12',
+    expiry: '2020-12-01',
+    author: 'vlbee',
+    description:
+        'Dismiss Window sign in gate test on 3nd article view of simple article templates, with higher priority over banners and epic',
+    audience: 0.025,
+    audienceOffset: 0.875,
+    successMeasure:
+        'More users who previously dismissed the gate sign in or create a Guardian account',
+    audienceCriteria:
+        '3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics. Control group will no longer see gate after first dismissal, Variant 1 will see gate on every article after first dimissal, Variant 2 will see gate again after 24hrs first dimissal in same session',
+    dataLinkNames: 'SignInGateDismissWindow',
+    idealOutcome:
+        'Conversion to sign in is higher with increased gate impressions after initial dismissal, with no sustained negative impact to engagement levels or supporter acquisition',
+    showForSensitive: false,
+    canRun: () => true,
+    variants: [
+        {
+            id: 'dismiss-window-control',
+            test: (): void => { },
+        },
+        {
+            id: 'dismiss-window-variant-1-article',
+            test: (): void => { },
+        },
+        {
+            id: 'dismiss-window-variant-2-day',
+            test: (): void => { },
+        },
+    ],
+};

--- a/src/web/experiments/tests/sign-in-gate-main-control.ts
+++ b/src/web/experiments/tests/sign-in-gate-main-control.ts
@@ -7,7 +7,7 @@ export const signInGateMainControl: ABTest = {
     author: 'Mahesh Makani',
     description:
         'Show sign in gate to 100% of users on 3rd article view of simple article templates, with higher priority over banners and epic. Control Audience.',
-    audience: 0.09,
+    audience: 0.0999,
     audienceOffset: 0.9,
     successMeasure: 'N/A - User does not see gate, only to compare to variant.',
     audienceCriteria:
@@ -20,7 +20,7 @@ export const signInGateMainControl: ABTest = {
     variants: [
         {
             id: 'main-control-1',
-            test: (): void => {},
+            test: (): void => { },
         },
     ],
 };

--- a/src/web/experiments/tests/sign-in-gate-main-variant.ts
+++ b/src/web/experiments/tests/sign-in-gate-main-variant.ts
@@ -7,7 +7,7 @@ export const signInGateMainVariant: ABTest = {
     author: 'Mahesh Makani',
     description:
         'Show sign in gate to 100% of users on 3rd article view of simple article templates, with higher priority over banners and epic. Main/Variant Audience.',
-    audience: 0.9,
+    audience: 0.875,
     audienceOffset: 0.0,
     successMeasure: 'Users sign in or create a Guardian account',
     audienceCriteria:
@@ -20,7 +20,7 @@ export const signInGateMainVariant: ABTest = {
     variants: [
         {
             id: 'main-variant-1',
-            test: (): void => {},
+            test: (): void => { },
         },
     ],
 };

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -33,6 +33,7 @@ import {
     TimelineAtom,
 } from '@guardian/atoms-rendering';
 import { Display } from '@root/src/lib/display';
+import { withSignInGateSlot } from '@root/src/web/lib/withSignInGateSlot';
 
 // This is required for spacefinder to work!
 const commercialPosition = css`
@@ -256,8 +257,6 @@ export const ArticleRenderer: React.FC<{
                                 designType={designType}
                                 forceDropCap={element.dropCap}
                             />
-                            {/* Insert the placeholder for the sign in gate on the 2nd paragrah */}
-                            {i === 1 && <span id="sign-in-gate" />}
                         </>
                     );
                 case 'model.dotcomrendering.pageElements.TweetBlockElement':
@@ -351,7 +350,8 @@ export const ArticleRenderer: React.FC<{
         <div
             className={`article-body-commercial-selector ${commercialPosition}`}
         >
-            {output}
+            {/* Insert the placeholder for the sign in gate on the 2nd article element */}
+            {withSignInGateSlot(output)}
         </div>
     ); // classname that space finder is going to target for in-body ads in DCR
 };

--- a/src/web/lib/withSignInGateSlot.tsx
+++ b/src/web/lib/withSignInGateSlot.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+// This span is used to insert the sign in gate into the appropirate location within body of an article,
+// if the SignInGateSector determines a gate should be rendered.
+
+const SignInGateSlot = <span id="sign-in-gate" />;
+
+export const withSignInGateSlot = (
+    articleElements: (JSX.Element | null | undefined)[],
+): (JSX.Element | null | undefined)[] => {
+    return articleElements.map((element, i) => {
+        return (
+            <>
+                {element}
+                {i === 1 && SignInGateSlot}
+            </>
+        );
+    });
+};


### PR DESCRIPTION
## What does this change?

- Adds a new AB(C) test for different dismiss windows on the Sign In Gate before reshowing gate to users. 
- Updates the README
- Adds the option to add a dismissal window (in hours) to the `hadUserDismissedGate` function
- Adds new `unsetUserDismissedGate` function
- Fixes how the sign in gate placeholder div is inserted into the Article html, as before it would only work if the second article element was a text block. 

Uses same gate UI as the current main variant

### TODO

Cypress integration tests

## Why?

Because
