### PR TITLE
Fix byline image when viewing full size screen

### DIFF
--- a/src/web/components/HeadlineByline.tsx
+++ b/src/web/components/HeadlineByline.tsx
@@ -78,10 +78,8 @@ const immersiveLinkStyles = (pillar: Pillar) => css`
 `;
 
 // If there is an image reduce the width of the author div
-const mobileCommentAuthor = css`
-    @media (max-width: 400px) {
-        width: 65%;
-    }
+const authorBylineWithImage = css`
+    width: 68%;
 `;
 
 type Props = {
@@ -152,8 +150,9 @@ export const HeadlineByline = ({
                     return (
                         <div
                             className={`${opinionStyles(pillar)} ${
-                                tags.find((tag) => tag.bylineImageUrl)
-                                    ? mobileCommentAuthor
+                                tags.filter((tag) => tag.type === 'Contributor')
+                                    .length === 1
+                                    ? authorBylineWithImage
                                     : ''
                             }`}
                         >


### PR DESCRIPTION
## What does this change?
If there is more than one contributor it defaults the byline width to 100%, if there is only 1 it limits it to 68% to accommodate an image. 

This is a temporary fix.

### Before

![Screenshot 2020-08-13 at 12 10 20](https://user-images.githubusercontent.com/35331926/90127965-fdebaf80-dd5d-11ea-9c1a-59d262f7d4ad.png)


### After

![Screenshot 2020-08-13 at 12 05 44](https://user-images.githubusercontent.com/35331926/90128003-0c39cb80-dd5e-11ea-8c46-ce294a328269.png)

![Screenshot 2020-08-13 at 12 05 53](https://user-images.githubusercontent.com/35331926/90128023-14920680-dd5e-11ea-975f-dcb0635bb309.png)


