### PR TITLE
Introduce Banner Picker to DCR

### DIFF
--- a/src/web/browser/ophan/ophan.ts
+++ b/src/web/browser/ophan/ophan.ts
@@ -84,7 +84,7 @@ export type TestMeta = {
     products?: OphanProduct[];
 };
 
-const record = (event: {}): void => {
+export const record = (event: {}): void => {
     if (
         window.guardian &&
         window.guardian.ophan &&

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -134,6 +134,13 @@ export const App = ({ CAPI, NAV }: Props) => {
     const [isSignedIn, setIsSignedIn] = useState<boolean>();
     const [user, setUser] = useState<UserProfile>();
     const [countryCode, setCountryCode] = useState<string>();
+    // This is an async version of the countryCode state value defined above.
+    // This can be used where you've got logic which depends on countryCode but
+    // don't want to block on it becoming available, as you would with the
+    // non-async version (this is the case in the banner picker where some
+    // banners need countryCode but we don't want to block all banners from
+    // executing their canShow logic until countryCode is available):
+    const [asyncCountryCode, setAsyncCountryCode] = useState<Promise<string>>();
     const [commentCount, setCommentCount] = useState<number>(0);
     const [isClosedForComments, setIsClosedForComments] = useState<boolean>(
         true,
@@ -176,8 +183,11 @@ export const App = ({ CAPI, NAV }: Props) => {
     }, [isSignedIn, CAPI.config.discussionApiUrl]);
 
     useEffect(() => {
-        const callFetch = async () =>
-            setCountryCode((await getCountryCode()) || '');
+        const callFetch = () => {
+            const countryCodePromise = getCountryCode();
+            setAsyncCountryCode(countryCodePromise);
+            countryCodePromise.then((cc) => setCountryCode(cc || ''));
+        };
         callFetch();
     }, []);
 
@@ -605,7 +615,7 @@ export const App = ({ CAPI, NAV }: Props) => {
             <Portal root="bottom-banner">
                 <StickyBottomBanner
                     isSignedIn={isSignedIn}
-                    countryCode={countryCode}
+                    asyncCountryCode={asyncCountryCode}
                     CAPI={CAPI}
                 />
             </Portal>

--- a/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -4,12 +4,16 @@ import {
     shouldShowOldCMP,
     CMP,
 } from '@root/src/web/components/StickyBottomBanner/CMP';
-import { ReaderRevenueBanner } from '@root/src/web/components/StickyBottomBanner/ReaderRevenueBanner';
+import {
+    canShow as canShowRRBanner,
+    ReaderRevenueBanner,
+} from '@root/src/web/components/StickyBottomBanner/ReaderRevenueBanner';
 import { getAlreadyVisitedCount } from '@root/src/web/lib/alreadyVisited';
+import { pickBanner, BannerConfig, MaybeFC, Banner } from './bannerPicker';
 
 type Props = {
     isSignedIn?: boolean;
-    countryCode?: string;
+    asyncCountryCode?: Promise<string>;
     CAPI: CAPIBrowserType;
 };
 
@@ -18,63 +22,99 @@ const getBannerLastClosedAt = (key: string): string | undefined => {
     return (item && JSON.parse(item).value) || undefined;
 };
 
-export const StickyBottomBanner = ({
-    isSignedIn,
-    countryCode,
-    CAPI,
-}: Props) => {
-    const [showOldCMP, setShowOldCMP] = useState<boolean | null>(null);
-    const [CMPWillShow, setCMPWillShow] = useState<boolean | undefined>(
-        undefined,
-    );
+const DEFAULT_BANNER_TIMEOUT_MILLIS = 2000;
 
-    useEffect(() => {
-        shouldShowOldCMP().then((shouldShowOld) =>
-            setShowOldCMP(shouldShowOld && CAPI.config.cmpUi),
-        );
-        willShowCMP().then(setCMPWillShow);
-    }, [CAPI.config.cmpUi]);
+const buildNewCmpBannerConfig = (): Banner => {
+    return {
+        id: 'cmpUi',
+        canShow: () => willShowCMP().then((result) => ({ result: !!result })),
+        // New CMP is not a react component and is shown outside of react's world
+        // so render nothing if it will show
+        show: () => null,
+        timeoutMillis: null,
+    };
+};
 
-    // Don't render anything until we know whether we can show the CMP
-    if (showOldCMP === null || CMPWillShow === null) {
-        return null;
-    }
+const buildOldCmpBannerConfig = (CAPI: CAPIBrowserType): Banner => {
+    return {
+        id: 'cmpUi',
+        canShow: () =>
+            shouldShowOldCMP().then((shouldShowOld) => ({
+                result: shouldShowOld && CAPI.config.cmpUi,
+            })),
+        show: () => CMP,
+        timeoutMillis: null,
+    };
+};
 
-    // New CMP is not a react component and is shown outside of react's world
-    // so render nothing if it will show
-    if (CMPWillShow) return null;
-
-    if (showOldCMP) return <CMP />;
-
-    const showRRBanner = CAPI.config.remoteBanner;
-
-    if (showRRBanner)
-        return (
-            <ReaderRevenueBanner
-                isSignedIn={isSignedIn}
-                countryCode={countryCode}
-                contentType={CAPI.contentType}
-                sectionName={CAPI.sectionName}
-                shouldHideReaderRevenue={CAPI.shouldHideReaderRevenue}
-                isMinuteArticle={CAPI.pageType.isMinuteArticle}
-                isPaidContent={CAPI.pageType.isPaidContent}
-                isSensitive={CAPI.config.isSensitive}
-                tags={CAPI.tags}
-                contributionsServiceUrl={CAPI.contributionsServiceUrl}
-                alreadyVisitedCount={getAlreadyVisitedCount()}
-                engagementBannerLastClosedAt={getBannerLastClosedAt(
+const buildReaderRevenueBannerConfig = (
+    CAPI: CAPIBrowserType,
+    isSignedIn: boolean,
+    asyncCountryCode: Promise<string>,
+): Banner => {
+    return {
+        id: 'reader-revenue-banner',
+        canShow: () =>
+            canShowRRBanner({
+                remoteBannerConfig: CAPI.config.remoteBanner,
+                isSignedIn,
+                asyncCountryCode,
+                contentType: CAPI.contentType,
+                sectionName: CAPI.sectionName,
+                shouldHideReaderRevenue: CAPI.shouldHideReaderRevenue,
+                isMinuteArticle: CAPI.pageType.isMinuteArticle,
+                isPaidContent: CAPI.pageType.isPaidContent,
+                isSensitive: CAPI.config.isSensitive,
+                tags: CAPI.tags,
+                contributionsServiceUrl: CAPI.contributionsServiceUrl,
+                alreadyVisitedCount: getAlreadyVisitedCount(),
+                engagementBannerLastClosedAt: getBannerLastClosedAt(
                     'engagementBannerLastClosedAt',
-                )}
-                subscriptionBannerLastClosedAt={getBannerLastClosedAt(
+                ),
+                subscriptionBannerLastClosedAt: getBannerLastClosedAt(
                     'subscriptionBannerLastClosedAt',
-                )}
-                switches={{
+                ),
+                switches: {
                     remoteSubscriptionsBanner: !!CAPI.config
                         .remoteSubscriptionsBanner,
-                }}
-            />
-        );
+                },
+            }),
+        /* eslint-disable-next-line react/jsx-props-no-spreading */
+        show: (meta: any) => () => <ReaderRevenueBanner {...meta} />,
+        timeoutMillis: DEFAULT_BANNER_TIMEOUT_MILLIS,
+    };
+};
 
-    // Nothing applies, so do nothing.
+export const StickyBottomBanner = ({
+    isSignedIn,
+    asyncCountryCode,
+    CAPI,
+}: Props) => {
+    const [SelectedBanner, setSelectedBanner] = useState<React.FC | null>(null);
+
+    useEffect(() => {
+        if (isSignedIn === undefined || asyncCountryCode === undefined) {
+            return;
+        }
+
+        const newCmp = buildNewCmpBannerConfig();
+        const oldCmp = buildOldCmpBannerConfig(CAPI);
+        const readerRevenue = buildReaderRevenueBannerConfig(
+            CAPI,
+            isSignedIn,
+            asyncCountryCode,
+        );
+        const bannerConfig: BannerConfig = [newCmp, oldCmp, readerRevenue];
+
+        pickBanner(bannerConfig).then((PickedBanner: () => MaybeFC) =>
+            setSelectedBanner(PickedBanner),
+        );
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isSignedIn, asyncCountryCode]);
+
+    if (SelectedBanner) {
+        return <SelectedBanner />;
+    }
+
     return null;
 };

--- a/src/web/components/StickyBottomBanner/bannerPicker.test.tsx
+++ b/src/web/components/StickyBottomBanner/bannerPicker.test.tsx
@@ -1,0 +1,195 @@
+import React from 'react';
+import { record } from '@root/src/web/browser/ophan/ophan';
+import { pickBanner, CanShowResult } from './bannerPicker';
+
+jest.mock('@root/src/web/browser/ophan/ophan', () => ({
+    record: jest.fn(),
+}));
+
+jest.useFakeTimers();
+
+// Wait for all unsettled promises to complete before finishing the test. Not
+// doing this results in a warning from Jest. Note that it's actually expected
+// that there may be outstanding promises when a test completes becuase the the
+// banner picker returns when the canShow of a banner resolves, even if there
+// are lower priority banners still pending.
+const flushPromises = () => new Promise(setImmediate);
+afterEach(async () => {
+    await flushPromises();
+});
+
+describe('pickBanner', () => {
+    it('resolves with the highest priority banner which can show', async () => {
+        const MockComponent = () => <div />;
+        const ChosenMockComponent = () => <div />;
+        const config = [
+            {
+                id: 'banner-1',
+                canShow: () => Promise.resolve({ result: false }),
+                show: () => MockComponent,
+                timeoutMillis: null,
+            },
+            {
+                id: 'banner-2',
+                canShow: () => Promise.resolve({ result: true }),
+                show: () => ChosenMockComponent,
+                timeoutMillis: null,
+            },
+            {
+                id: 'banner-3',
+                canShow: () => Promise.resolve({ result: true }),
+                show: () => MockComponent,
+                timeoutMillis: null,
+            },
+        ];
+
+        const got = await pickBanner(config);
+
+        expect(got()).toEqual(ChosenMockComponent);
+    });
+
+    it('resolves with null if no banners can show', async () => {
+        const MockComponent = () => <div />;
+
+        const config = [
+            {
+                id: 'banner-1',
+                canShow: () => Promise.resolve({ result: false }),
+                show: () => MockComponent,
+                timeoutMillis: null,
+            },
+            {
+                id: 'banner-2',
+                canShow: () => Promise.resolve({ result: false }),
+                show: () => MockComponent,
+                timeoutMillis: null,
+            },
+        ];
+
+        const got = await pickBanner(config);
+
+        expect(got()).toEqual(null);
+    });
+
+    it('falls through to a lower priority banner when a higher one times out', async () => {
+        const MockComponent = () => <div />;
+        const ChosenMockComponent = () => <div />;
+        const config = [
+            {
+                id: 'banner-1',
+                canShow: (): Promise<CanShowResult> =>
+                    new Promise((resolve) =>
+                        setTimeout(() => resolve({ result: true }), 500),
+                    ),
+                show: () => MockComponent,
+                timeoutMillis: 250,
+            },
+            {
+                id: 'banner-2',
+                canShow: () => Promise.resolve({ result: true }),
+                show: () => ChosenMockComponent,
+                timeoutMillis: null,
+            },
+        ];
+
+        const bannerPromise = pickBanner(config);
+        jest.advanceTimersByTime(260);
+        const got = await bannerPromise;
+
+        expect(got()).toEqual(ChosenMockComponent);
+    });
+
+    it('resolves with null if all banners time out', async () => {
+        const MockComponent = () => <div />;
+        let timer1;
+        let timer2;
+        const config = [
+            {
+                id: 'banner-1',
+                canShow: (): Promise<CanShowResult> =>
+                    new Promise((resolve) => {
+                        timer1 = setTimeout(
+                            () => resolve({ result: true }),
+                            500,
+                        );
+                    }),
+                show: () => MockComponent,
+                timeoutMillis: 250,
+            },
+            {
+                id: 'banner-2',
+                canShow: (): Promise<CanShowResult> =>
+                    new Promise((resolve) => {
+                        timer2 = setTimeout(
+                            () => resolve({ result: true }),
+                            500,
+                        );
+                    }),
+                show: () => MockComponent,
+                timeoutMillis: 250,
+            },
+        ];
+
+        const bannerPromise = pickBanner(config);
+        jest.advanceTimersByTime(260);
+        const got = await bannerPromise;
+
+        expect(got()).toEqual(null);
+
+        clearTimeout(timer1);
+        clearTimeout(timer2);
+    });
+
+    it('passes metadata returned by canShow to show', async () => {
+        const renderComponent = jest.fn(() => () => <div />);
+        const meta = { extra: 'info' };
+        const config = [
+            {
+                id: 'banner-1',
+                canShow: () =>
+                    Promise.resolve({
+                        result: true,
+                        meta,
+                    }),
+                show: renderComponent,
+                timeoutMillis: null,
+            },
+        ];
+
+        const show = await pickBanner(config);
+        show();
+
+        expect(renderComponent).toHaveBeenCalledWith(meta);
+    });
+
+    it('sends a message to ophan when a banner canShow times out', async () => {
+        const MockComponent = () => <div />;
+        let timer;
+        const config = [
+            {
+                id: 'example-banner',
+                canShow: (): Promise<CanShowResult> =>
+                    new Promise((resolve) => {
+                        timer = setTimeout(
+                            () => resolve({ result: true }),
+                            300,
+                        );
+                    }),
+                show: () => MockComponent,
+                timeoutMillis: 200,
+            },
+        ];
+
+        const bannerPromise = pickBanner(config);
+        jest.advanceTimersByTime(250);
+        const got = await bannerPromise;
+
+        expect(got()).toEqual(null);
+        expect(record).toHaveBeenCalledWith({
+            component: 'banner-picker-timeout-dcr',
+            value: config[0].id,
+        });
+
+        clearTimeout(timer);
+    });
+});

--- a/src/web/components/StickyBottomBanner/bannerPicker.ts
+++ b/src/web/components/StickyBottomBanner/bannerPicker.ts
@@ -1,0 +1,95 @@
+import { record } from '@root/src/web/browser/ophan/ophan';
+
+export type MaybeFC = React.FC | null;
+type ShowBanner = (meta?: any) => MaybeFC;
+
+export type CanShowResult = {
+    result: boolean;
+    meta?: any;
+};
+
+export type Banner = {
+    id: string;
+    show: ShowBanner;
+    canShow: () => Promise<CanShowResult>;
+    timeoutMillis: number | null;
+};
+
+type BannerWithTimeout = Banner & {
+    cancelTimeout: () => void;
+};
+
+export type BannerConfig = Banner[];
+
+const recordBannerTimeoutInOphan = (bannerId: string) =>
+    record({
+        component: 'banner-picker-timeout-dcr',
+        value: bannerId,
+    });
+
+const timeoutify = (banner: Banner): BannerWithTimeout => {
+    let timer: number | undefined;
+
+    const canShow = (): Promise<CanShowResult> =>
+        new Promise((resolve) => {
+            if (banner.timeoutMillis) {
+                timer = window.setTimeout(() => {
+                    recordBannerTimeoutInOphan(banner.id);
+                    resolve({ result: false });
+                }, banner.timeoutMillis);
+            }
+
+            banner.canShow().then((result) => resolve(result));
+        });
+
+    const cancelTimeout = () => timer && clearTimeout(timer);
+
+    return {
+        ...banner,
+        canShow,
+        cancelTimeout,
+    };
+};
+
+const clearAllTimeouts = (banners: BannerWithTimeout[]) =>
+    banners.map((b) => b.cancelTimeout());
+
+const defaultShow = () => null;
+
+type WinningBanner = {
+    idx: number;
+    meta?: any;
+};
+
+export const pickBanner = (banners: BannerConfig): Promise<() => MaybeFC> =>
+    new Promise((resolve) => {
+        const bannersWithTimeout = banners.map(timeoutify);
+        const results = bannersWithTimeout.map((banner) => banner.canShow());
+
+        const winner: Promise<WinningBanner> = results.reduce(
+            async (winningBannerSoFar, canShow, idx) => {
+                const runningIdx = (await winningBannerSoFar).idx;
+                if (runningIdx >= 0) {
+                    return winningBannerSoFar;
+                }
+
+                const result = await canShow;
+                bannersWithTimeout[idx].cancelTimeout();
+                if (result.result) {
+                    return { idx, meta: result.meta };
+                }
+
+                return winningBannerSoFar;
+            },
+            Promise.resolve({ idx: -1 }),
+        );
+
+        winner.then(({ idx, meta }: WinningBanner) => {
+            clearAllTimeouts(bannersWithTimeout);
+            resolve(
+                idx === -1
+                    ? defaultShow
+                    : () => bannersWithTimeout[idx].show(meta),
+            );
+        });
+    });


### PR DESCRIPTION
## What does this change?

This introduces banner picker logic similar to frontend on DCR. We provide a list of banners in priority order and concurrently ask each whether they can show in the current context. The highest priority banner which answers "yes" gets displayed.

It's also possible to give each banner a timeout, which they must respond within otherwise they lose their opportunity. This can be configured per banner, if we want to give some more leeway than others (I noticed that right now we'll wait indefinitely for the CMP to decide, before moving on to the next priority, and didn't want to break that).

<img width="1552" alt="Screenshot 2020-08-13 at 16 18 19" src="https://user-images.githubusercontent.com/379839/90156699-ac0a5000-dd84-11ea-9aa5-978e98a8bf31.png">

<img width="1552" alt="Screenshot 2020-08-13 at 16 18 29" src="https://user-images.githubusercontent.com/379839/90156725-b4628b00-dd84-11ea-857a-3c2dd0d179f9.png">

### Before

The existing setup of either showing the CMP, or otherwise falling back on the Reader Revenue banner service (or nothing) is fairly baked in, which makes it harder to introduce new banners.

### After

A clearer path for adding new banners with their own `canShow` and rendering functionality.

## Why?

We're planning on using Braze to display messages to users on the web, using the banner as the format of the first one. So we need to be able to extend the current banner selection logic to integrate the new banner.

## Notes

* ~~I've not yet split apart the true canShow logic for the RR banner and the show part. At the moment the canShow just considers the switch value, but really it should take into account the first (data) call to the contributions service, which is the real canShow logic. Right now that happens downstream of show. This only works because the RR banner is bottom of the priority list, it wouldn't if there were other candidates after it.~~

* ~~A more fundamental issue that I ran into was how to handle dependencies for the canShow logic. Two props, `countryCode` and `isSignedIn` are needed for the canShow logic of the banner. These aren't guaranteed to be set by the time we first render `StickyBottomBanner`. For now I've made them both dependencies for the effect in which we kick off the banner selection logic. But that doesn't seem reasonable since we're potentially holding up the CMP (and any other future banners) until those props are set, even though it doesn't care about them.~~ We worked around this by creating a `Promise` which wraps the country code so we pass that down to the `ReaderRevenueBanner` and it no longer blocks the banner picking code. I left `isSignedIn` as is. Technically that does still block the banner picking code but it seems so fast that it's not a problem, and not worth introducing extra complexity to work around. I measured like this, and in consistently reports 0 on my laptop:

```js
    useEffect(() => {
        const startTime = new Date().getTime();
        const guCookie = getCookie('GU_U');
        const endTime = new Date().getTime();
        console.log('Reading GU_U took', endTime - startTime);
        setIsSignedIn(!!guCookie);
    }, []);
```

That'll be slower on on older devices, but presumably not hugely?

* ~~It was suggested by Gareth that we might want to have timeouts be opt-out rather than opt-in which sounds like a good suggestion. So for the CMP if that shouldn't have a timeout we explicitly configure that, but others get a default (presumably of 2 seconds, like frontend).~~

* Previously we always waited to get a response from the CMP before asking the contributions service about the reader revenue banner. That's now changed, and we'll kick off all `canShow` requests concurrently (like frontend). This means that there are scenarios where we send the request to the contributions service but don't end up using it because the CMP says yes. I need to check this with the RR team (since it will result in additional requests to the service).