### PR TITLE
Bump Ophan Tracker JS to trim huge component names

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
         "lodash.get": "^4.4.2",
         "log4js": "4.2.0",
         "minify-css-string": "^1.0.0",
-        "ophan-tracker-js": "^1.3.21",
+        "ophan-tracker-js": "^1.3.22",
         "pm2": "^4.3.0",
         "polished": "^1.9.2",
         "preact": "^10.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14138,10 +14138,10 @@ openurl@^1.1.1:
   resolved "https://registry.yarnpkg.com/openurl/-/openurl-1.1.1.tgz#3875b4b0ef7a52c156f0db41d4609dbb0f94b387"
   integrity sha1-OHW0sO96UsFW8NtB1GCduw+Us4c=
 
-ophan-tracker-js@^1.3.21:
-  version "1.3.21"
-  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.3.21.tgz#b81463c1b96249e32f28ff42aa433ed00f143cc0"
-  integrity sha512-hroyMjdQbx3ywDJmYsCpY2Qcff1aYmH5M0wZSi56smSPUHP0SziRaMJx34G9rEKR8UL6EBUO6KIHSYyKcto5hg==
+ophan-tracker-js@^1.3.22:
+  version "1.3.22"
+  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.3.22.tgz#1ce0ce5066ff8230edc97c2105f9b52b95c1efb4"
+  integrity sha512-UNTMjo/cEyHy7BfsrAs250Q7ujElYd6RqmAIb/+aoAT9oduHZ2giJ9nJMcd5qC83U4EP8adh9gcY+dGgJsEEBQ==
 
 optimist@^0.6.1:
   version "0.6.1"


### PR DESCRIPTION
## What does this change?

With this [PR](guardian/ophan#3903) in the Ophan repo, we trim `renderedComponent` names that are greater than 50 characters, to keep the ophan.theguardian.com URLs shorter than the 2,000 character limit enforced by Akka HTTP.

The updated Ophan Tracker JS library has been published on [NPM](https://www.npmjs.com/package/ophan-tracker-js/v/1.3.22), and I've opened a [pull request](https://github.com/guardian/frontend/pull/22895) to update the Tracker JS version number in Frontend.