### PR TITLE
Document how to force DCR on or off using `?dcr`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Frontend rendering framework for theguardian.com. It uses [React](https://reactj
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 <!-- Automatically created with yarn run createtoc and on push hook -->
 
+- [Where can I see Dotcom Rendering in Production?](#where-can-i-see-dotcom-rendering-in-production)
 - [Quick start](#quick-start)
   - [Install Node.js](#install-nodejs)
   - [Running instructions](#running-instructions)
@@ -21,6 +22,28 @@ Frontend rendering framework for theguardian.com. It uses [React](https://reactj
 - [Thanks](#thanks)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Where can I see Dotcom Rendering in Production?
+
+Add `?dcr` to the URL of a Production (or CODE) article to see it rendered with Dotcom Rendering:
+
+```
+https://www.theguardian.com/info/developer-blog/2016/dec/14/mirrors-lights-sawdust-lasers?dcr
+```
+
+You can force DCR on or off explicitly with
+[`?dcr=true` or `?dcr=false`](https://github.com/guardian/frontend/pull/21753).
+
+One way to verify whether the article you're looking at is being rendered by DCR or not is to
+[View Page Source](view-source:https://www.theguardian.com/info/developer-blog/2016/dec/14/mirrors-lights-sawdust-lasers)
+and search for the presence of DCR's
+[`react-root`](https://github.com/guardian/dotcom-rendering/blob/c90bbc20eac321d83f4337e1320d1667e264d55d/src/web/server/htmlTemplate.ts#L255-L256):
+in the `<body>` tag:
+
+```html
+<body>
+<div id="react-root"></div>
+```
 
 ## Quick start
 


### PR DESCRIPTION
## Why?

https://github.com/guardian/frontend/pull/21753 made `?dcr` the way to control whether or not a given article is rendered by DCR, but this was not documented in DCR's README.md, and not immediately obvious... thanks to @shtukas for filling us in!

![image](https://user-images.githubusercontent.com/52038/90505144-08d18600-e14a-11ea-8b14-e72e77bef410.png)

Apologies for the shameless self-promotion of choosing one of my own articles! It's always tricky working out how to use articles that are not triggering in some way, and I often choose examples from the Digital Blog.