### PR TITLE
Atoms-rendering bump to 1.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "@emotion/core": "^10.0.28",
         "@guardian/ab-core": "1.1.0-next.0",
         "@guardian/ab-react": "1.0.0-next.0",
-        "@guardian/atoms-rendering": "^1.8.1",
+        "@guardian/atoms-rendering": "^1.8.2",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/consent-management-platform": "4.0.2",
         "@guardian/discussion-rendering": "^2.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2343,10 +2343,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-1.0.0-next.0.tgz#f5e070b112616b32663a2bebb202106604d87b48"
   integrity sha512-2B9zDSz89ZYLBHXpnUFuCoT6biJZFGII+fkuKmdO6g3DbGgOfLKcZNZmdmQlxwLsHRHWCiNY+0cyvh8Bbr3EkQ==
 
-"@guardian/atoms-rendering@^1.8.1":
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-1.8.1.tgz#9cd5dfbbe7df47aebd484ff44c8413ee3ccadd6a"
-  integrity sha512-+GJkbRLXp1YKGCg8+6WuhbcQUbB77ncGiG9fJDGzKiA/7S9yWrL9eXbR9J4BLjaJlVS18Vn6fA/DXQYXyANCZA==
+"@guardian/atoms-rendering@^1.8.2":
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-1.8.2.tgz#df13f3b1333976ba5855c15959ca32e51e404b7e"
+  integrity sha512-2b3muMkENCqHgMQoUFAkJdqynmx+DYD1sCV0gZQkGmQrnkTOsBq5dagh0Q+MUYsCe8Mll1OIJ+Rmhd0vyFxrAw==
 
 "@guardian/automat-client@^0.2.16":
   version "0.2.16"


### PR DESCRIPTION
## What does this change?
This bumps the atoms-rendering version to 1.8.2 to include an emotion illegal escape string fix.