### PR TITLE
PR deployments

### DIFF
--- a/.github/workflows/pr-deployment.yml
+++ b/.github/workflows/pr-deployment.yml
@@ -25,4 +25,4 @@ jobs:
                   timeout 5h ngrok http 9000 -log=stdout | \
                     grep --line-buffered -o 'https://.*' | \
                     xargs -L1 -I{} -t \
-                      curl -X POST -H 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.sha }} -d "{\"state\":\"success\", \"target_url\":\"{}\", \"context\":\"PR deployment\", \"description\":\"This PR is now live until `date -d "+5 hour" "+%a %H:%M"`. Click details to access it ->\"}"
+                      curl -X POST -H 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} -d "{\"state\":\"success\", \"target_url\":\"{}\", \"context\":\"PR deployment\", \"description\":\"This PR is now live until `date -d "+5 hour" "+%a %H:%M"`. Click details to access it ->\"}"


### PR DESCRIPTION
## What does this change?

This adds a new action called `PR deployment`, which deploys every open PR to a public URL.

It has two main components:

A main action. While this action is running, the DCR server is running and accessible

<img width="721" alt="PR_deployments_by_jorgeazevedo_·_Pull_Request__1841_·_guardian_dotcom-rendering" src="https://user-images.githubusercontent.com/1672034/90804093-a6c37d00-e311-11ea-9c5b-37b0cc41bad7.png">

A status check. When the main action has successfully compiled and booted the node server, it announces it's ready by posting this check with the public URL.

<img width="711" alt="PR_deployments_by_jorgeazevedo_·_Pull_Request__1841_·_guardian_dotcom-rendering" src="https://user-images.githubusercontent.com/1672034/90881353-eb96f480-e3a1-11ea-97ea-5e2e3204e077.png">


## Why?

Part of this quarter's work to improve performance. It makes it easy to use external tools like [pagespeed insights](https://developers.google.com/speed/pagespeed/insights/),  the [structured data testing tool](https://search.google.com/structured-data/testing-tool/u/0/) etc

## Notes

- This is not set to run against every branch pushed to the repository - only against PRs when they are _opened_ or _synchronized_ (which is what github calls it when you push to the PR's branch)

- It uses an action called `workflow-run-cleanup-action` to cancel any other PR deployments on the branch. When you push to a branch it will trigger a new PR deployment, but **github does not cancel the old one** so they can quickly accumulate. The action works fine as a workaround, but it generates email alerts for every cancelation. Not ideal 😕 it's easy to disable github actions notifications though.

- The script will auto exit after 5 hours by using `timeout`. This is to preempt github canceling it after 6 and putting a big red cross next to the commit.

- The workflow for using this will be really based on manually re-running the main action to bring the server back online. If the feature proves useful and the manual re-run too painful, the automation route is quite possible!

<img width="786" alt="PR_deployments_by_jorgeazevedo_·_Pull_Request__1841_·_guardian_dotcom-rendering" src="https://user-images.githubusercontent.com/1672034/90881548-4cbec800-e3a2-11ea-9e21-ce4bcb00c8c2.png">
