### PR TITLE
Add Subcript and Superscript styles

### DIFF
--- a/src/web/components/elements/TextBlockComponent.stories.tsx
+++ b/src/web/components/elements/TextBlockComponent.stories.tsx
@@ -153,3 +153,21 @@ export const BadMarkup = () => {
     );
 };
 BadMarkup.story = { name: 'with a bad markup' };
+
+export const SubSupscript = () => {
+    return (
+        <div className={containerStyles}>
+            <TextBlockComponent
+                html={
+                    '<p><strong>P<sub>kj</sub> = (1-r<sub>j</sub>)C<sup>kj</sup> + r<sub>j</sub>(C<sub>kj</sub> + q<sub>kj</sub> - p<sub>kj</sub>)</strong></p><p><var>a<sup>2</sup></var> + <var>b<sup>2</sup></var> = <var>c<sup>2</sup></var></p>'
+                }
+                pillar="news"
+                forceDropCap={false}
+                designType="Article"
+                display={Display.Standard}
+                isFirstParagraph={false}
+            />
+        </div>
+    );
+};
+SubSupscript.story = { name: 'with a sub and sup' };

--- a/src/web/components/elements/TextBlockComponent.tsx
+++ b/src/web/components/elements/TextBlockComponent.tsx
@@ -161,6 +161,23 @@ export const TextBlockComponent: React.FC<Props> = ({
             background-color: ${neutral[86]};
             margin-left: -20px;
         }
+
+        /* Subscript and Superscript styles */
+        sub {
+            bottom: -0.25em;
+        }
+
+        sup {
+            top: -0.5em;
+        }
+
+        sub,
+        sup {
+            font-size: 75%;
+            line-height: 0;
+            position: relative;
+            vertical-align: baseline;
+        }
     `;
 
     const firstLetter = decideDropCapLetter(unwrappedHtml);


### PR DESCRIPTION
# What does this change?

Adds the missing `sub` and `sup` styles to textBlockComponent.

Note, this will just fix in-article within textblock components. Further review will be required for other places like captions or headlines to see if it's possible to use these html elements there.

### Before

![Screen Shot 2020-08-24 at 17 07 28](https://user-images.githubusercontent.com/638051/91068899-d84b8980-e62c-11ea-8380-d7432e45fc00.png)


### After

![Screen Shot 2020-08-24 at 17 07 13](https://user-images.githubusercontent.com/638051/91068907-dc77a700-e62c-11ea-84f4-2cad30380d29.png)


