### PR TITLE
Refactor bundle loading

### DIFF
--- a/scripts/webpack/browser.js
+++ b/scripts/webpack/browser.js
@@ -45,6 +45,7 @@ module.exports = ({ isLegacyJS }) => ({
         react: scriptPath('react'),
         lotame: scriptPath('lotame'),
         dynamicImport: scriptPath('dynamicImport'),
+        commercial: scriptPath('commercial'),
     },
     output: {
         filename: generateName(isLegacyJS),

--- a/scripts/webpack/browser.js
+++ b/scripts/webpack/browser.js
@@ -1,8 +1,8 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
 const webpack = require('webpack');
 const AssetsManifest = require('webpack-assets-manifest');
 const FriendlyErrorsWebpackPlugin = require('friendly-errors-webpack-plugin');
 const chalk = require('chalk');
-const { siteName } = require('../frontend/config');
 
 const friendlyErrorsWebpackPlugin = () =>
     new FriendlyErrorsWebpackPlugin({

--- a/scripts/webpack/browser.js
+++ b/scripts/webpack/browser.js
@@ -45,7 +45,6 @@ module.exports = ({ isLegacyJS }) => ({
         react: scriptPath('react'),
         lotame: scriptPath('lotame'),
         dynamicImport: scriptPath('dynamicImport'),
-        commercial: scriptPath('commercial'),
     },
     output: {
         filename: generateName(isLegacyJS),

--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -17,6 +17,29 @@ interface RenderToStringResult {
     ids: string[];
 }
 
+const generateScriptTags = (
+    scripts: Array<{ src: string; module?: boolean }>,
+) =>
+    scripts.reduce((scriptTags, script) => {
+        if (script.module) {
+            scriptTags.push(
+                `<script defer module src="${getDist({
+                    path: script.src,
+                    legacy: false,
+                })}"></script>`,
+            );
+            scriptTags.push(
+                `<script defer nomodule src="${getDist({
+                    path: script.src,
+                    legacy: true,
+                })}"></script>`,
+            );
+        } else {
+            scriptTags.push(`<script defer src="${script.src}"></script>`);
+        }
+        return scriptTags;
+    }, [] as string[]);
+
 export const document = ({ data }: Props) => {
     const { CAPI, NAV, linkedData } = data;
     const title = `${CAPI.headline} | ${CAPI.sectionLabel} | The Guardian`;
@@ -59,20 +82,16 @@ export const document = ({ data }: Props) => {
      * Please talk to the dotcom platform team before adding more.
      * Scripts will be executed in the order they appear in this array
      */
-    const priorityScripts = [
-        polyfillIO,
-        CAPI.config && CAPI.config.commercialBundleUrl,
-    ];
-    const priorityLegacyScripts = [
-        getDist({ path: 'sentry.js', legacy: true }),
-        getDist({ path: 'dynamicImport.js', legacy: true }),
-        getDist({ path: 'react.js', legacy: true }),
-    ];
-    const priorityNonLegacyScripts = [
-        getDist({ path: 'sentry.js', legacy: false }),
-        getDist({ path: 'dynamicImport.js', legacy: false }),
-        getDist({ path: 'react.js', legacy: false }),
-    ];
+    const priorityScriptTags = generateScriptTags(
+        [
+            { src: polyfillIO },
+            { src: 'commercial.js', module: true },
+            CAPI.config && { src: CAPI.config.commercialBundleUrl },
+            { src: 'sentry.js', module: true },
+            { src: 'dynamicImport.js', module: true },
+            { src: 'react.js', module: true },
+        ].filter(Boolean),
+    );
 
     /**
      * Low priority scripts. These scripts will be requested
@@ -81,19 +100,12 @@ export const document = ({ data }: Props) => {
      * *before* the high priority scripts, although this is very
      * unlikely.
      */
-    const lowPriorityScripts = [
-        'https://www.google-analytics.com/analytics.js',
-    ];
-    const lowPriorityLegacyScripts = [
-        getDist({ path: 'ga.js', legacy: true }),
-        getDist({ path: 'ophan.js', legacy: true }),
-        getDist({ path: 'lotame.js', legacy: true }),
-    ];
-    const lowPriorityNonLegacyScripts = [
-        getDist({ path: 'ga.js', legacy: false }),
-        getDist({ path: 'ophan.js', legacy: false }),
-        getDist({ path: 'lotame.js', legacy: false }),
-    ];
+    const lowPriorityScriptTags = generateScriptTags([
+        { src: 'https://www.google-analytics.com/analytics.js' },
+        { src: 'ga.js', module: true },
+        { src: 'ophan.js', module: true },
+        { src: 'lotame.js', module: true },
+    ]);
 
     /**
      * We escape windowGuardian here to prevent errors when the data
@@ -118,13 +130,9 @@ export const document = ({ data }: Props) => {
     return htmlTemplate({
         linkedData,
 
-        priorityScripts,
-        priorityLegacyScripts,
-        priorityNonLegacyScripts,
+        priorityScriptTags,
 
-        lowPriorityScripts,
-        lowPriorityLegacyScripts,
-        lowPriorityNonLegacyScripts,
+        lowPriorityScriptTags,
 
         css,
         html,

--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -85,7 +85,6 @@ export const document = ({ data }: Props) => {
     const priorityScriptTags = generateScriptTags(
         [
             { src: polyfillIO },
-            { src: 'commercial.js', module: true },
             CAPI.config && { src: CAPI.config.commercialBundleUrl },
             { src: 'sentry.js', module: true },
             { src: 'dynamicImport.js', module: true },

--- a/src/web/server/htmlTemplate.ts
+++ b/src/web/server/htmlTemplate.ts
@@ -9,12 +9,8 @@ export const htmlTemplate = ({
     title = 'The Guardian',
     description,
     linkedData,
-    priorityScripts,
-    priorityLegacyScripts,
-    priorityNonLegacyScripts,
-    lowPriorityScripts,
-    lowPriorityLegacyScripts,
-    lowPriorityNonLegacyScripts,
+    priorityScriptTags,
+    lowPriorityScriptTags,
     css,
     html,
     windowGuardian,
@@ -27,12 +23,8 @@ export const htmlTemplate = ({
     title?: string;
     description: string;
     linkedData: object;
-    priorityScripts: string[];
-    priorityLegacyScripts: string[];
-    priorityNonLegacyScripts: string[];
-    lowPriorityScripts: string[];
-    lowPriorityLegacyScripts: string[];
-    lowPriorityNonLegacyScripts: string[];
+    priorityScriptTags: string[];
+    lowPriorityScriptTags: string[];
     css: string;
     html: string;
     fontFiles?: string[];
@@ -46,36 +38,6 @@ export const htmlTemplate = ({
         process.env.NODE_ENV === 'production'
             ? 'favicon-32x32.ico'
             : 'favicon-32x32-dev-yellow.ico';
-
-    // ********************************
-    // ****** high priority script ****
-    // ********************************
-    const priorityScriptTags = priorityScripts.map(
-        (src) => `<script defer src="${src}"></script>`,
-    );
-    // transpiled with preset-env
-    const priorityLegacyScriptTags = priorityLegacyScripts.map(
-        (src) => `<script defer nomodule src="${src}"></script>`,
-    );
-    // transpiled with preset-modules
-    const priorityNonLegacyScriptTags = priorityNonLegacyScripts.map(
-        (src) => `<script defer type="module" src="${src}"></script>`,
-    );
-
-    // ********************************
-    // **** low priority scripts ******
-    // ********************************
-    const lowPriorityScriptTags = lowPriorityScripts.map(
-        (src) => `<script async src="${src}"></script>`,
-    );
-    // transpiled with preset-env
-    const lowPriorityLegacyScriptTags = lowPriorityLegacyScripts.map(
-        (src) => `<script async nomodule src="${src}"></script>`,
-    );
-    // transpiled with preset-modules
-    const lowPriorityNonLegacyScriptTags = lowPriorityNonLegacyScripts.map(
-        (src) => `<script async type="module" src="${src}"></script>`,
-    );
 
     const fontPreloadTags = fontFiles.map(
         (fontFile) =>
@@ -243,11 +205,7 @@ export const htmlTemplate = ({
                 <noscript>
                     <img src="https://sb.scorecardresearch.com/p?c1=2&c2=6035250&cv=2.0&cj=1&cs_ucfr=0&comscorekw=${keywords}" />
                 </noscript>
-                ${[
-                    ...priorityScriptTags,
-                    ...priorityLegacyScriptTags,
-                    ...priorityNonLegacyScriptTags,
-                ].join('\n')}
+                ${[...priorityScriptTags].join('\n')}
                 <style class="webfont">${getFontsCss()}${resetCSS}${css}</style>
 
             </head>
@@ -255,11 +213,7 @@ export const htmlTemplate = ({
             <body>
                 <div id="react-root"></div>
                 ${html}
-                ${[
-                    ...lowPriorityScriptTags,
-                    ...lowPriorityLegacyScriptTags,
-                    ...lowPriorityNonLegacyScriptTags,
-                ].join('\n')}
+                ${[...lowPriorityScriptTags].join('\n')}
             </body>
         </html>`;
 };


### PR DESCRIPTION
# What does this change?

- refactors bundle loading so that guardian bundles and 3rd party scripts can be easily interleaved while priority is maintained

## Why?

should make it easier to add new bundles of different types to the page while maintaining a global order

_was part of #1511 but then became unneeded – is it still useful?_