### PR TITLE
Chillout yarn warning on push

### DIFF
--- a/makefile
+++ b/makefile
@@ -106,7 +106,7 @@ validate: clean-dist install tsc lint stylelint test validate-build
 	$(call log, "everything seems 👌")
 
 validate-prepush:
-	@run-p tsc lint-staged "test -- --verbose  --runInBand --onlyChanged"
+	@run-p tsc lint-staged "test --verbose  --runInBand --onlyChanged"
 
 validate-ci: install tsc lint stylelint test-ci bundlesize
 	$(call log, "everything seems 👌")


### PR DESCRIPTION
## What does this change?

remove use of `--` to pass options to yarn

### Before

![image](https://user-images.githubusercontent.com/867233/91170968-97f21700-e6d1-11ea-888f-a1689e60e298.png)


### After

![image](https://user-images.githubusercontent.com/867233/91170997-a5a79c80-e6d1-11ea-90d2-af3c1a5b79f5.png)


## Why?

easier to spot errors
