### PR TITLE
Use Trail Text for the meta description

### DIFF
--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -105,8 +105,6 @@ export const document = ({ data }: Props) => {
 
     const ampLink = `https://amp.theguardian.com/${data.CAPI.pageId}`;
 
-    const description = `${CAPI.headline} | ${CAPI.sectionLabel} | The Guardian`;
-
     const { openGraphData } = CAPI;
     const { twitterData } = CAPI;
     const keywords =
@@ -130,7 +128,7 @@ export const document = ({ data }: Props) => {
         html,
         fontFiles,
         title,
-        description,
+        description: CAPI.trailText,
         windowGuardian,
         ampLink,
         openGraphData,


### PR DESCRIPTION
# What does this change?

Uses trailText as per Frontend for the meta description.

I checked `og:description` which is correct. I checked AMP description meta which is correct.

Json schema doesn't exist, that requires an update on Frontend to the linkedData passed from DCR CAPI.

### Before

![Screen Shot 2020-08-25 at 13 58 25](https://user-images.githubusercontent.com/638051/91192245-9f271e00-e6ed-11ea-98ef-f98820726b7e.png)


### After

![Screen Shot 2020-08-25 at 13 57 52](https://user-images.githubusercontent.com/638051/91192264-a3533b80-e6ed-11ea-9019-76b7f9b07e9b.png)


## Why?

S EE OOOOH.