### PR TITLE
Do not make epic/banner requests if page is not compatible

### DIFF
--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -234,6 +234,11 @@ export const SlotBodyEnd = ({
         return null;
     }
 
+    if (shouldHideReaderRevenue || isPaidContent) {
+        // We never serve Reader Revenue epics in this case
+        return null;
+    }
+
     // Memoised as we only ever want to call the Slots API once, for simplicity
     // and performance reasons.
     return (

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -104,6 +104,11 @@ export const canShow = ({
 }: CanShowProps): Promise<CanShowResult> => {
     if (!remoteBannerConfig) return Promise.resolve({ result: false });
 
+    if (shouldHideReaderRevenue || isPaidContent) {
+        // We never serve Reader Revenue banners in this case
+        return Promise.resolve({ result: false });
+    }
+
     return asyncCountryCode
         .then((countryCode) =>
             buildPayload({


### PR DESCRIPTION
The backend (support-dotcom-components) never selects an epic or banner if `shouldHideReaderRevenue` or `isPaidContent` is true. So there is no need for the client to make the request in these cases.

This applies to about 2.5% of articles.