### PR TITLE
Lighthouse ci tweaks

### DIFF
--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -1,7 +1,7 @@
 module.exports = {
   ci: {
     collect: {
-      url: ['http://localhost:9000/Article?url=https://www.theguardian.com/commentisfree/2020/feb/08/hungary-now-for-the-new-right-what-venezuela-once-was-for-the-left'],
+      url: ['http://localhost:9000/Article?url=https://www.theguardian.com/commentisfree/2020/feb/08/hungary-now-for-the-new-right-what-venezuela-once-was-for-the-left#noads'],
       startServerCommand: 'NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true node dist/frontend.server.js',
     },
     upload: {

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -3,6 +3,7 @@ module.exports = {
     collect: {
       url: ['http://localhost:9000/Article?url=https://www.theguardian.com/commentisfree/2020/feb/08/hungary-now-for-the-new-right-what-venezuela-once-was-for-the-left#noads'],
       startServerCommand: 'NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true node dist/frontend.server.js',
+      numberOfRuns: '6',
     },
     upload: {
       target: 'temporary-public-storage',


### PR DESCRIPTION
## What does this change?

Disables ads and makes the final lighthouse report be an average of 6 runs. This increases the build time by 30 seconds, which I think is reasonable for the benefit

## Why?

Make our results more deterministic!