### PR TITLE
Support force-banner and force-epic in url

### DIFF
--- a/src/web/components/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd.tsx
@@ -14,6 +14,7 @@ import {
     shouldHideSupportMessaging,
     hasOptedOutOfArticleCount,
 } from '@root/src/web/lib/contributions';
+import {getForcedVariant} from "@root/src/web/lib/readerRevenueDevUtils";
 import { initPerf } from '@root/src/web/browser/initPerf';
 import {
     sendOphanComponentEvent,
@@ -21,6 +22,7 @@ import {
 } from '@root/src/web/browser/ophan/ophan';
 import { getCookie } from '../browser/cookie';
 import { useHasBeenSeen } from '../lib/useHasBeenSeen';
+
 
 const { css } = emotion;
 
@@ -157,9 +159,12 @@ const MemoisedInner = ({
         const dataPerf = initPerf('contributions-epic-data');
         dataPerf.start();
 
+        const forcedVariant = getForcedVariant('epic');
+        const queryString = forcedVariant ? `?force=${forcedVariant}` : '';
+
         getBodyEnd(
             contributionsPayload,
-            `${contributionsServiceUrl}/epic?dataOnly=true`,
+            `${contributionsServiceUrl}/epic${queryString}`,
         )
             .then((response) => {
                 dataPerf.end();

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -13,8 +13,8 @@ import {
 import { getZIndex } from '@root/src/web/lib/getZIndex';
 import { trackNonClickInteraction } from '@root/src/web/browser/ga/ga';
 import { WeeklyArticleHistory } from "@root/node_modules/@guardian/automat-client/dist/types";
-import { CanShowResult } from './bannerPicker';
 import { getForcedVariant } from "@root/src/web/lib/readerRevenueDevUtils";
+import { CanShowResult } from './bannerPicker';
 
 const checkForErrors = (response: any) => {
     if (!response.ok) {

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -14,6 +14,7 @@ import { getZIndex } from '@root/src/web/lib/getZIndex';
 import { trackNonClickInteraction } from '@root/src/web/browser/ga/ga';
 import { WeeklyArticleHistory } from "@root/node_modules/@guardian/automat-client/dist/types";
 import { CanShowResult } from './bannerPicker';
+import { getForcedVariant } from "@root/src/web/lib/readerRevenueDevUtils";
 
 const checkForErrors = (response: any) => {
     if (!response.ok) {
@@ -131,9 +132,12 @@ export const canShow = ({
                 switches,
             }),
         )
-        .then((bannerPayload) =>
-            getBanner(bannerPayload, `${contributionsServiceUrl}/banner`),
-        )
+        .then((bannerPayload) => {
+            const forcedVariant = getForcedVariant('banner');
+            const queryString = forcedVariant ? `?force=${forcedVariant}` : '';
+
+            return getBanner(bannerPayload, `${contributionsServiceUrl}/banner${queryString}`);
+        })
         .then(checkForErrors)
         .then((response) => response.json())
         .then((json) => {

--- a/src/web/lib/readerRevenueDevUtils.ts
+++ b/src/web/lib/readerRevenueDevUtils.ts
@@ -112,10 +112,23 @@ export interface ReaderRevenueDevUtils {
     showPreviousVariant: ReaderRevenueDevUtil;
 }
 
+const getForcedVariant = (type: 'epic' | 'banner'): string | null => {
+    if (URLSearchParams) {
+        const params = new URLSearchParams(window.location.search);
+        const value = params.get(`force-${type}`);
+        if (value) {
+            return value;
+        }
+    }
+
+    return null;
+};
+
 export {
     changeGeolocation,
     showMeTheEpic,
     showMeTheBanner,
     showNextVariant,
-    showPreviousVariant
+    showPreviousVariant,
+    getForcedVariant,
 };


### PR DESCRIPTION
It's helpful for staff to be able to force a specific epic/banner variant.
E.g.
`?force-banner=testName:variantName&force-epic=testName:variantName`