### PR TITLE
Identity | Sign In Gate | Exclude gnm-archive from sign in gate

### DIFF
--- a/src/web/components/SignInGate/displayRule.ts
+++ b/src/web/components/SignInGate/displayRule.ts
@@ -43,6 +43,7 @@ export const isValidSection = (CAPI: CAPIBrowserType): boolean => {
         'membership',
         'help',
         'guardian-live-australia',
+        'gnm-archive',
     ];
 
     // we check for invalid section by reducing the above array, and then NOT the result so we know


### PR DESCRIPTION
## What does this change?
- Add `gnm-archive` to excluded list of sections as we don't wait it to show up on https://www.theguardian.com/gnm-archive/2020/aug/10/could-you-help-with-the-archives-shorthand-transcription-project