### PR TITLE
Send article count to backend for banners

### DIFF
--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -3,7 +3,7 @@ import * as emotion from 'emotion';
 import * as emotionCore from '@emotion/core';
 import * as emotionTheming from 'emotion-theming';
 import { useHasBeenSeen } from '@root/src/web/lib/useHasBeenSeen';
-import { logView } from '@root/node_modules/@guardian/automat-client';
+import { getWeeklyArticleHistory, logView } from '@root/node_modules/@guardian/automat-client';
 import { shouldHideSupportMessaging } from '@root/src/web/lib/contributions';
 import { getCookie } from '@root/src/web/browser/cookie';
 import {
@@ -12,6 +12,7 @@ import {
 } from '@root/src/web/browser/ophan/ophan';
 import { getZIndex } from '@root/src/web/lib/getZIndex';
 import { trackNonClickInteraction } from '@root/src/web/browser/ga/ga';
+import { WeeklyArticleHistory } from "@root/node_modules/@guardian/automat-client/dist/types";
 import { CanShowResult } from './bannerPicker';
 
 const checkForErrors = (response: any) => {
@@ -40,6 +41,7 @@ type BaseProps = {
     engagementBannerLastClosedAt?: string;
     subscriptionBannerLastClosedAt?: string;
     switches: { [key: string]: boolean };
+    weeklyArticleHistory?: WeeklyArticleHistory;
 };
 
 type BuildPayloadProps = BaseProps & {
@@ -71,6 +73,7 @@ const buildPayload = (props: BuildPayloadProps) => {
             mvtId: Number(getCookie('GU_mvt_id')),
             countryCode: props.countryCode,
             switches: props.switches,
+            weeklyArticleHistory: getWeeklyArticleHistory(),
         },
     };
 };


### PR DESCRIPTION
This enables the backend to use article count restrictions in banner tests, as well as display the user's article count