### PR TITLE
Disable cmp in lighthouse ci

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -16,5 +16,5 @@ jobs:
               env:
                   LHCI_GITHUB_TOKEN: ${{ secrets.LHCI_GITHUB_TOKEN }}
               run: |
-                  npm install -g @lhci/cli@0.4.x
+                  npm install -g puppeteer-core@2.1.0 @lhci/cli@0.4.x
                   lhci autorun

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -4,6 +4,7 @@ module.exports = {
       url: ['http://localhost:9000/Article?url=https://www.theguardian.com/commentisfree/2020/feb/08/hungary-now-for-the-new-right-what-venezuela-once-was-for-the-left#noads'],
       startServerCommand: 'NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true node dist/frontend.server.js',
       numberOfRuns: '6',
+      puppeteerScript: './scripts/lighthouse/puppeteer-script.js',
     },
     upload: {
       target: 'temporary-public-storage',

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -5,6 +5,9 @@ module.exports = {
       startServerCommand: 'NODE_ENV=production DISABLE_LOGGING_AND_METRICS=true node dist/frontend.server.js',
       numberOfRuns: '6',
       puppeteerScript: './scripts/lighthouse/puppeteer-script.js',
+      settings: {
+        onlyCategories: "accessibility,best-practices,performance,seo",
+      }
     },
     upload: {
       target: 'temporary-public-storage',

--- a/scripts/lighthouse/puppeteer-script.js
+++ b/scripts/lighthouse/puppeteer-script.js
@@ -3,13 +3,12 @@
  * @param {{url: string, options: LHCI.CollectCommand.Options}} context
  */
 module.exports = async (browser, context) => {
-  const url = 'http://localhost:9000/Article?url=https://www.theguardian.com/commentisfree/2020/feb/08/hungary-now-for-the-new-right-what-venezuela-once-was-for-the-left#noads';
   const page = await browser.newPage();
-  await page.goto(url);
+  await page.goto(context.url);
   const cookie = {
           name: 'gu-cmp-disabled',
           value: 'true',
-          url: url,
+          url: context.url,
           'Max-Age': '31536000', //year
         };
 

--- a/scripts/lighthouse/puppeteer-script.js
+++ b/scripts/lighthouse/puppeteer-script.js
@@ -1,0 +1,17 @@
+/**
+ * @param {puppeteer.Browser} browser
+ * @param {{url: string, options: LHCI.CollectCommand.Options}} context
+ */
+module.exports = async (browser, context) => {
+  const url = 'http://localhost:9000/Article?url=https://www.theguardian.com/commentisfree/2020/feb/08/hungary-now-for-the-new-right-what-venezuela-once-was-for-the-left#noads';
+  const page = await browser.newPage();
+  await page.goto(url);
+  const cookie = {
+          name: 'gu-cmp-disabled',
+          value: 'true',
+          url: url,
+          'Max-Age': '31536000', //year
+        };
+
+  await page.setCookie(cookie);
+};


### PR DESCRIPTION
## What does this change?

This disables the consent management platform from loading during lighthouse testing by setting the following cookie `gu-cmp-disabled=true`

Unfortunately lighthouse ci only supports setting cookies in the header of the original GET request, not actually in the browser state, which is what the cmp js code will look for in runtime.

This means that the only implementation available is based on puppeteer (a chrome instrumentation tool) which will basically open the URL under test and set a cookie *before* lighthouse runs its tests.

I'm also using this PR to disable the PWA category since we don't use it!

### Before

<img width="947" alt="Banners_and_Alerts_and_Lighthouse_Report_Viewer" src="https://user-images.githubusercontent.com/1672034/91458127-12ab6580-e87d-11ea-8543-4d0b4f98c2af.png">


### After

<img width="918" alt="Lighthouse_Report_Viewer" src="https://user-images.githubusercontent.com/1672034/91458029-f9a2b480-e87c-11ea-9d91-33a6a4cf9980.png">


## Why?

The purpose is to make the results of the lighthouse tests more deterministic, but also to keep the report focused on issues introduced in this codebase