### PR TITLE
Adding support for older Guardian videos

### DIFF
--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -129,6 +129,8 @@ interface GuVideoBlockElement {
     _type: 'model.dotcomrendering.pageElements.GuVideoBlockElement';
     assets: VideoAssets[];
     caption: string;
+    html: string;
+    source: string;
 }
 
 interface HighlightBlockElement {

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -424,7 +424,9 @@
                     ]
                 }
             },
-            "required": ["_type"]
+            "required": [
+                "_type"
+            ]
         },
         "BlockquoteBlockElement": {
             "type": "object",
@@ -439,7 +441,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "html"]
+            "required": [
+                "_type",
+                "html"
+            ]
         },
         "CaptionBlockElement": {
             "type": "object",
@@ -478,11 +483,20 @@
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "designType", "display", "pillar"]
+            "required": [
+                "_type",
+                "designType",
+                "display",
+                "pillar"
+            ]
         },
         "Display": {
             "type": "number",
-            "enum": [0, 1, 2]
+            "enum": [
+                0,
+                1,
+                2
+            ]
         },
         "DesignType": {
             "enum": [
@@ -597,7 +611,9 @@
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": ["text"]
+                    "enum": [
+                        "text"
+                    ]
                 },
                 "id": {
                     "type": "string"
@@ -621,14 +637,23 @@
                     "type": "string"
                 }
             },
-            "required": ["hideLabel", "id", "label", "name", "required", "type"]
+            "required": [
+                "hideLabel",
+                "id",
+                "label",
+                "name",
+                "required",
+                "type"
+            ]
         },
         "CampaignFieldTextArea": {
             "type": "object",
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": ["textarea"]
+                    "enum": [
+                        "textarea"
+                    ]
                 },
                 "id": {
                     "type": "string"
@@ -652,14 +677,23 @@
                     "type": "string"
                 }
             },
-            "required": ["hideLabel", "id", "label", "name", "required", "type"]
+            "required": [
+                "hideLabel",
+                "id",
+                "label",
+                "name",
+                "required",
+                "type"
+            ]
         },
         "CampaignFieldFile": {
             "type": "object",
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": ["file"]
+                    "enum": [
+                        "file"
+                    ]
                 },
                 "id": {
                     "type": "string"
@@ -683,14 +717,23 @@
                     "type": "string"
                 }
             },
-            "required": ["hideLabel", "id", "label", "name", "required", "type"]
+            "required": [
+                "hideLabel",
+                "id",
+                "label",
+                "name",
+                "required",
+                "type"
+            ]
         },
         "CampaignFieldRadio": {
             "type": "object",
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": ["radio"]
+                    "enum": [
+                        "radio"
+                    ]
                 },
                 "options": {
                     "type": "array",
@@ -704,7 +747,10 @@
                                 "type": "string"
                             }
                         },
-                        "required": ["label", "value"]
+                        "required": [
+                            "label",
+                            "value"
+                        ]
                     }
                 },
                 "id": {
@@ -744,7 +790,9 @@
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": ["checkbox"]
+                    "enum": [
+                        "checkbox"
+                    ]
                 },
                 "options": {
                     "type": "array",
@@ -758,7 +806,10 @@
                                 "type": "string"
                             }
                         },
-                        "required": ["label", "value"]
+                        "required": [
+                            "label",
+                            "value"
+                        ]
                     }
                 },
                 "id": {
@@ -798,7 +849,9 @@
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": ["select"]
+                    "enum": [
+                        "select"
+                    ]
                 },
                 "options": {
                     "type": "array",
@@ -812,7 +865,10 @@
                                 "type": "string"
                             }
                         },
-                        "required": ["label", "value"]
+                        "required": [
+                            "label",
+                            "value"
+                        ]
                     }
                 },
                 "id": {
@@ -872,7 +928,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "url"]
+            "required": [
+                "_type",
+                "url"
+            ]
         },
         "CodeBlockElement": {
             "type": "object",
@@ -887,7 +946,10 @@
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "isMandatory"]
+            "required": [
+                "_type",
+                "isMandatory"
+            ]
         },
         "CommentBlockElement": {
             "type": "object",
@@ -940,7 +1002,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "atomId"]
+            "required": [
+                "_type",
+                "atomId"
+            ]
         },
         "DisclaimerBlockElement": {
             "type": "object",
@@ -955,7 +1020,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "html"]
+            "required": [
+                "_type",
+                "html"
+            ]
         },
         "DividerBlockElement": {
             "type": "object",
@@ -967,7 +1035,9 @@
                     ]
                 }
             },
-            "required": ["_type"]
+            "required": [
+                "_type"
+            ]
         },
         "DocumentBlockElement": {
             "type": "object",
@@ -991,7 +1061,12 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "embedUrl", "height", "width"]
+            "required": [
+                "_type",
+                "embedUrl",
+                "height",
+                "width"
+            ]
         },
         "EmbedBlockElement": {
             "type": "object",
@@ -1015,7 +1090,11 @@
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "html", "isMandatory"]
+            "required": [
+                "_type",
+                "html",
+                "isMandatory"
+            ]
         },
         "ExplainerAtomBlockElement": {
             "type": "object",
@@ -1036,7 +1115,12 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "body", "id", "title"]
+            "required": [
+                "_type",
+                "body",
+                "id",
+                "title"
+            ]
         },
         "GenericAtomBlockElement": {
             "type": "object",
@@ -1063,7 +1147,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "url"]
+            "required": [
+                "_type",
+                "url"
+            ]
         },
         "GuideAtomBlockElement": {
             "type": "object",
@@ -1096,7 +1183,14 @@
                     "type": "number"
                 }
             },
-            "required": ["_type", "credit", "html", "id", "label", "title"]
+            "required": [
+                "_type",
+                "credit",
+                "html",
+                "id",
+                "label",
+                "title"
+            ]
         },
         "GuVideoBlockElement": {
             "type": "object",
@@ -1115,9 +1209,21 @@
                 },
                 "caption": {
                     "type": "string"
+                },
+                "html": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
                 }
             },
-            "required": ["_type", "assets", "caption"]
+            "required": [
+                "_type",
+                "assets",
+                "caption",
+                "html",
+                "source"
+            ]
         },
         "VideoAssets": {
             "type": "object",
@@ -1129,7 +1235,10 @@
                     "type": "string"
                 }
             },
-            "required": ["mimeType", "url"]
+            "required": [
+                "mimeType",
+                "url"
+            ]
         },
         "HighlightBlockElement": {
             "type": "object",
@@ -1144,7 +1253,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "html"]
+            "required": [
+                "_type",
+                "html"
+            ]
         },
         "ImageBlockElement": {
             "type": "object",
@@ -1165,7 +1277,9 @@
                             }
                         }
                     },
-                    "required": ["allImages"]
+                    "required": [
+                        "allImages"
+                    ]
                 },
                 "data": {
                     "type": "object",
@@ -1200,7 +1314,13 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "data", "imageSources", "media", "role"]
+            "required": [
+                "_type",
+                "data",
+                "imageSources",
+                "media",
+                "role"
+            ]
         },
         "Image": {
             "type": "object",
@@ -1221,7 +1341,10 @@
                             "type": "string"
                         }
                     },
-                    "required": ["height", "width"]
+                    "required": [
+                        "height",
+                        "width"
+                    ]
                 },
                 "mediaType": {
                     "type": "string"
@@ -1233,7 +1356,13 @@
                     "type": "string"
                 }
             },
-            "required": ["fields", "index", "mediaType", "mimeType", "url"]
+            "required": [
+                "fields",
+                "index",
+                "mediaType",
+                "mimeType",
+                "url"
+            ]
         },
         "ImageSource": {
             "type": "object",
@@ -1248,7 +1377,10 @@
                     }
                 }
             },
-            "required": ["srcSet", "weighting"]
+            "required": [
+                "srcSet",
+                "weighting"
+            ]
         },
         "Weighting": {
             "enum": [
@@ -1271,7 +1403,10 @@
                     "type": "number"
                 }
             },
-            "required": ["src", "width"]
+            "required": [
+                "src",
+                "width"
+            ]
         },
         "RoleType": {
             "enum": [
@@ -1303,7 +1438,12 @@
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "hasCaption", "html", "url"]
+            "required": [
+                "_type",
+                "hasCaption",
+                "html",
+                "url"
+            ]
         },
         "InteractiveAtomBlockElement": {
             "type": "object",
@@ -1330,7 +1470,12 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "id", "js", "url"]
+            "required": [
+                "_type",
+                "id",
+                "js",
+                "url"
+            ]
         },
         "InteractiveBlockElement": {
             "type": "object",
@@ -1357,7 +1502,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "url"]
+            "required": [
+                "_type",
+                "url"
+            ]
         },
         "MapBlockElement": {
             "type": "object",
@@ -1412,7 +1560,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "images"]
+            "required": [
+                "_type",
+                "images"
+            ]
         },
         "ProfileAtomBlockElement": {
             "type": "object",
@@ -1445,7 +1596,14 @@
                     "type": "number"
                 }
             },
-            "required": ["_type", "credit", "html", "id", "label", "title"]
+            "required": [
+                "_type",
+                "credit",
+                "html",
+                "id",
+                "label",
+                "title"
+            ]
         },
         "PullquoteBlockElement": {
             "type": "object",
@@ -1466,7 +1624,11 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "html", "role"]
+            "required": [
+                "_type",
+                "html",
+                "role"
+            ]
         },
         "QABlockElement": {
             "type": "object",
@@ -1496,7 +1658,13 @@
                     "type": "number"
                 }
             },
-            "required": ["_type", "credit", "html", "id", "title"]
+            "required": [
+                "_type",
+                "credit",
+                "html",
+                "id",
+                "title"
+            ]
         },
         "RichLinkBlockElement": {
             "type": "object",
@@ -1523,7 +1691,12 @@
                     "type": "number"
                 }
             },
-            "required": ["_type", "prefix", "text", "url"]
+            "required": [
+                "_type",
+                "prefix",
+                "text",
+                "url"
+            ]
         },
         "SoundcloudBlockElement": {
             "type": "object",
@@ -1547,7 +1720,13 @@
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "html", "id", "isMandatory", "isTrack"]
+            "required": [
+                "_type",
+                "html",
+                "id",
+                "isMandatory",
+                "isTrack"
+            ]
         },
         "SpotifyBlockElement": {
             "type": "object",
@@ -1574,7 +1753,9 @@
                     "type": "string"
                 }
             },
-            "required": ["_type"]
+            "required": [
+                "_type"
+            ]
         },
         "SubheadingBlockElement": {
             "type": "object",
@@ -1589,7 +1770,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "html"]
+            "required": [
+                "_type",
+                "html"
+            ]
         },
         "TableBlockElement": {
             "type": "object",
@@ -1607,7 +1791,11 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "html", "isMandatory"]
+            "required": [
+                "_type",
+                "html",
+                "isMandatory"
+            ]
         },
         "TextBlockElement": {
             "type": "object",
@@ -1625,7 +1813,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "html"]
+            "required": [
+                "_type",
+                "html"
+            ]
         },
         "TimelineBlockElement": {
             "type": "object",
@@ -1655,7 +1846,12 @@
                     "type": "number"
                 }
             },
-            "required": ["_type", "events", "id", "title"]
+            "required": [
+                "_type",
+                "events",
+                "id",
+                "title"
+            ]
         },
         "TimelineEvent": {
             "type": "object",
@@ -1673,7 +1869,10 @@
                     "type": "string"
                 }
             },
-            "required": ["date", "title"]
+            "required": [
+                "date",
+                "title"
+            ]
         },
         "TweetBlockElement": {
             "type": "object",
@@ -1697,7 +1896,13 @@
                     "type": "boolean"
                 }
             },
-            "required": ["_type", "hasMedia", "html", "id", "url"]
+            "required": [
+                "_type",
+                "hasMedia",
+                "html",
+                "id",
+                "url"
+            ]
         },
         "VideoBlockElement": {
             "type": "object",
@@ -1709,7 +1914,9 @@
                     ]
                 }
             },
-            "required": ["_type"]
+            "required": [
+                "_type"
+            ]
         },
         "VideoFacebookBlockElement": {
             "type": "object",
@@ -1736,7 +1943,13 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "caption", "height", "url", "width"]
+            "required": [
+                "_type",
+                "caption",
+                "height",
+                "url",
+                "width"
+            ]
         },
         "VideoVimeoBlockElement": {
             "type": "object",
@@ -1769,7 +1982,12 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "height", "url", "width"]
+            "required": [
+                "_type",
+                "height",
+                "url",
+                "width"
+            ]
         },
         "VideoYoutubeBlockElement": {
             "type": "object",
@@ -1802,7 +2020,12 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "height", "url", "width"]
+            "required": [
+                "_type",
+                "height",
+                "url",
+                "width"
+            ]
         },
         "YoutubeBlockElement": {
             "type": "object",
@@ -1838,7 +2061,11 @@
                     "type": "string"
                 }
             },
-            "required": ["_type", "assetId", "mediaTitle"]
+            "required": [
+                "_type",
+                "assetId",
+                "mediaTitle"
+            ]
         },
         "Block": {
             "type": "object",
@@ -1993,9 +2220,20 @@
                 },
                 "firstPublishedDisplay": {
                     "type": "string"
+                },
+                "primaryDateLine": {
+                    "type": "string"
+                },
+                "secondaryDateLine": {
+                    "type": "string"
                 }
             },
-            "required": ["elements", "id"]
+            "required": [
+                "elements",
+                "id",
+                "primaryDateLine",
+                "secondaryDateLine"
+            ]
         },
         "Pagination": {
             "type": "object",
@@ -2019,7 +2257,10 @@
                     "type": "string"
                 }
             },
-            "required": ["currentPage", "totalPages"]
+            "required": [
+                "currentPage",
+                "totalPages"
+            ]
         },
         "AuthorType": {
             "type": "object",
@@ -2036,7 +2277,12 @@
             }
         },
         "Edition": {
-            "enum": ["AU", "INT", "UK", "US"],
+            "enum": [
+                "AU",
+                "INT",
+                "UK",
+                "US"
+            ],
             "type": "string"
         },
         "TagType": {
@@ -2061,7 +2307,11 @@
                     "type": "string"
                 }
             },
-            "required": ["id", "title", "type"]
+            "required": [
+                "id",
+                "title",
+                "type"
+            ]
         },
         "SimpleLinkType": {
             "type": "object",
@@ -2073,7 +2323,10 @@
                     "type": "string"
                 }
             },
-            "required": ["title", "url"]
+            "required": [
+                "title",
+                "url"
+            ]
         },
         "ConfigType": {
             "description": "the config model will contain useful app/site\nlevel data. Although currently derived from the config model\nconstructed in frontend and passed to dotcom-rendering\nthis data could eventually be defined in dotcom-rendering",
@@ -2273,7 +2526,12 @@
                     "$ref": "#/definitions/EditionCommercialProperties"
                 }
             },
-            "required": ["AU", "INT", "UK", "US"]
+            "required": [
+                "AU",
+                "INT",
+                "UK",
+                "US"
+            ]
         },
         "EditionCommercialProperties": {
             "type": "object",
@@ -2288,7 +2546,9 @@
                     "$ref": "#/definitions/Branding"
                 }
             },
-            "required": ["adTargeting"]
+            "required": [
+                "adTargeting"
+            ]
         },
         "AdTargetParam": {
             "type": "object",
@@ -2310,7 +2570,10 @@
                     ]
                 }
             },
-            "required": ["name", "value"]
+            "required": [
+                "name",
+                "value"
+            ]
         },
         "Branding": {
             "type": "object",
@@ -2322,7 +2585,9 @@
                             "type": "string"
                         }
                     },
-                    "required": ["name"]
+                    "required": [
+                        "name"
+                    ]
                 },
                 "sponsorName": {
                     "type": "string"
@@ -2349,10 +2614,18 @@
                                     "type": "number"
                                 }
                             },
-                            "required": ["height", "width"]
+                            "required": [
+                                "height",
+                                "width"
+                            ]
                         }
                     },
-                    "required": ["dimensions", "label", "link", "src"]
+                    "required": [
+                        "dimensions",
+                        "label",
+                        "link",
+                        "src"
+                    ]
                 },
                 "aboutThisLink": {
                     "type": "string"
@@ -2373,7 +2646,10 @@
                                     "type": "number"
                                 }
                             },
-                            "required": ["height", "width"]
+                            "required": [
+                                "height",
+                                "width"
+                            ]
                         },
                         "link": {
                             "type": "string"
@@ -2382,10 +2658,19 @@
                             "type": "string"
                         }
                     },
-                    "required": ["dimensions", "label", "link", "src"]
+                    "required": [
+                        "dimensions",
+                        "label",
+                        "link",
+                        "src"
+                    ]
                 }
             },
-            "required": ["aboutThisLink", "logo", "sponsorName"]
+            "required": [
+                "aboutThisLink",
+                "logo",
+                "sponsorName"
+            ]
         },
         "BadgeType": {
             "type": "object",
@@ -2397,7 +2682,10 @@
                     "type": "string"
                 }
             },
-            "required": ["imageUrl", "seriesTag"]
+            "required": [
+                "imageUrl",
+                "seriesTag"
+            ]
         },
         "FooterType": {
             "type": "object",
@@ -2412,7 +2700,9 @@
                     }
                 }
             },
-            "required": ["footerLinks"]
+            "required": [
+                "footerLinks"
+            ]
         },
         "FooterLink": {
             "type": "object",
@@ -2430,7 +2720,11 @@
                     "type": "string"
                 }
             },
-            "required": ["dataLinkName", "text", "url"]
+            "required": [
+                "dataLinkName",
+                "text",
+                "url"
+            ]
         }
     },
     "$schema": "http://json-schema.org/draft-07/schema#"

--- a/src/web/components/elements/GuVideoBlockComponent.tsx
+++ b/src/web/components/elements/GuVideoBlockComponent.tsx
@@ -1,0 +1,38 @@
+/* eslint-disable jsx-a11y/media-has-caption */
+import React from 'react';
+import { css } from 'emotion';
+import { unescapeData } from '@root/src/lib/escapeData';
+import { Caption } from '@root/src/web/components/Caption';
+import { Display } from '@root/src/lib/display';
+
+export const GuVideoBlockComponent: React.FC<{
+    html: string;
+    pillar: Pillar;
+    designType: DesignType;
+    display: Display;
+    credit: string;
+    caption?: string;
+}> = ({ html, pillar, designType, display, credit, caption }) => {
+    return (
+        <div
+            className={css`
+                width: 100%;
+                video {
+                    width: 100%;
+                }
+            `}
+        >
+            <div dangerouslySetInnerHTML={{ __html: unescapeData(html) }} />
+
+            {caption && (
+                <Caption
+                    captionText={caption}
+                    designType={designType}
+                    pillar={pillar}
+                    credit={credit}
+                    display={display}
+                />
+            )}
+        </div>
+    );
+};

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -34,6 +34,7 @@ import {
 } from '@guardian/atoms-rendering';
 import { Display } from '@root/src/lib/display';
 import { withSignInGateSlot } from '@root/src/web/lib/withSignInGateSlot';
+import { GuVideoBlockComponent } from '@root/src/web/components/elements/GuVideoBlockComponent';
 
 // This is required for spacefinder to work!
 const commercialPosition = css`
@@ -140,6 +141,17 @@ export const ArticleRenderer: React.FC<{
                                 expandCallback={() => {}}
                             />
                         </div>
+                    );
+                case 'model.dotcomrendering.pageElements.GuVideoBlockElement':
+                    return (
+                        <GuVideoBlockComponent
+                            html={element.html}
+                            pillar={pillar}
+                            designType={designType}
+                            display={display}
+                            credit={element.source}
+                            caption={element.caption}
+                        />
                     );
                 case 'model.dotcomrendering.pageElements.HighlightBlockElement':
                     return (
@@ -338,7 +350,6 @@ export const ArticleRenderer: React.FC<{
                 case 'model.dotcomrendering.pageElements.CommentBlockElement':
                 case 'model.dotcomrendering.pageElements.ContentAtomBlockElement':
                 case 'model.dotcomrendering.pageElements.GenericAtomBlockElement':
-                case 'model.dotcomrendering.pageElements.GuVideoBlockElement':
                 case 'model.dotcomrendering.pageElements.MapBlockElement':
                 case 'model.dotcomrendering.pageElements.VideoBlockElement':
                     return null;


### PR DESCRIPTION
### What does this change?
Adds the support for rendering older Guardian videos in DCR
<img width="637" alt="Screen Shot 2020-08-28 at 13 33 05" src="https://user-images.githubusercontent.com/2051501/91561414-73957500-e933-11ea-8045-61b431ab5d8d.png">

Requires https://github.com/guardian/frontend/pull/22951
