### PR TITLE
Banner - do not overlap footer and override ad-takeover styles

### DIFF
--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -212,7 +212,7 @@ export const ReaderRevenueBanner = ({ meta, module }: Props) => {
             // The css here is necessary to put the container div in view, so that we can track the view
             <div
                 ref={setNode}
-                className={emotion.css`position: fixed; bottom: -1px; width: 100%; ${getZIndex(
+                className={emotion.css`width: 100%; ${getZIndex(
                     'banner',
                 )}`}
             >

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -40,7 +40,7 @@ import { buildAdTargeting } from '@root/src/lib/ad-targeting';
 import { parse } from '@frontend/lib/slot-machine-flags';
 import { getAgeWarning } from '@root/src/lib/age-warning';
 import { getCurrentPillar } from '@root/src/web/lib/layoutHelpers';
-import { Stuck, SendToBack } from '@root/src/web/layouts/lib/stickiness';
+import {Stuck, SendToBack, BannerWrapper} from '@root/src/web/layouts/lib/stickiness';
 import { Display } from '@root/src/lib/display';
 
 const MOSTVIEWED_STICKY_HEIGHT = 1059;
@@ -601,7 +601,7 @@ export const CommentLayout = ({
                 />
             </Section>
 
-            <div id="bottom-banner" />
+            <BannerWrapper />
             <MobileStickyContainer />
         </>
     );

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -42,6 +42,7 @@ import {
     getCurrentPillar,
 } from '@root/src/web/lib/layoutHelpers';
 import { Display } from '@root/src/lib/display';
+import {BannerWrapper} from "@root/src/web/layouts/lib/stickiness";
 import { Hide } from '../components/Hide';
 
 const ImmersiveGrid = ({
@@ -532,7 +533,7 @@ export const ImmersiveLayout = ({
                 />
             </Section>
 
-            <div id="bottom-banner" />
+            <BannerWrapper />
             <MobileStickyContainer />
         </>
     );

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -42,7 +42,7 @@ import {
     decideLineEffect,
     getCurrentPillar,
 } from '@root/src/web/lib/layoutHelpers';
-import { Stuck, SendToBack } from '@root/src/web/layouts/lib/stickiness';
+import {Stuck, SendToBack, BannerWrapper} from '@root/src/web/layouts/lib/stickiness';
 import { Display } from '@root/src/lib/display';
 
 const ShowcaseGrid = ({
@@ -553,7 +553,7 @@ export const ShowcaseLayout = ({
                 />
             </Section>
 
-            <div id="bottom-banner" />
+            <BannerWrapper />
             <MobileStickyContainer />
         </>
     );

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -47,7 +47,7 @@ import {
     decideLineEffect,
     getCurrentPillar,
 } from '@root/src/web/lib/layoutHelpers';
-import { Stuck, SendToBack } from '@root/src/web/layouts/lib/stickiness';
+import {Stuck, SendToBack, BannerWrapper} from '@root/src/web/layouts/lib/stickiness';
 import { Display } from '@root/src/lib/display';
 
 const MOSTVIEWED_STICKY_HEIGHT = 1059;
@@ -631,7 +631,7 @@ export const StandardLayout = ({
                 />
             </Section>
 
-            <div id="bottom-banner" style={{position: 'sticky', bottom: 0, zIndex: 99999}}/>
+            <BannerWrapper />
             <MobileStickyContainer />
         </>
     );

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -631,7 +631,7 @@ export const StandardLayout = ({
                 />
             </Section>
 
-            <div id="bottom-banner" />
+            <div id="bottom-banner" style={{position: 'sticky', bottom: 0, zIndex: 99999}}/>
             <MobileStickyContainer />
         </>
     );

--- a/src/web/layouts/lib/stickiness.tsx
+++ b/src/web/layouts/lib/stickiness.tsx
@@ -31,7 +31,7 @@ const headerWrapper = css`
 const bannerWrapper = css`
     position: sticky;
     bottom: 0;
-    ${getZIndexImportant('banner')} !important
+    ${getZIndexImportant('banner')}
     
     width: 100% !important;
     background: none !important;

--- a/src/web/layouts/lib/stickiness.tsx
+++ b/src/web/layouts/lib/stickiness.tsx
@@ -31,10 +31,9 @@ const headerWrapper = css`
 const bannerWrapper = css`
     position: sticky;
     bottom: 0;
-    ${getZIndex('banner')}
+    ${getZIndex('banner')} !important
     
-    width: auto !important;
-    z-index: 999 !important;
+    width: 100% !important;
     background: none !important;
     top: auto !important;
     position: sticky !important;

--- a/src/web/layouts/lib/stickiness.tsx
+++ b/src/web/layouts/lib/stickiness.tsx
@@ -6,7 +6,7 @@ import { border } from '@guardian/src-foundations/palette';
 import { getZIndex } from '@frontend/web/lib/getZIndex';
 
 type Props = {
-    children: React.ReactNode;
+    children?: React.ReactNode;
 };
 
 // The advert is stuck to the top of the container as we scroll
@@ -27,10 +27,20 @@ const headerWrapper = css`
     ${getZIndex('headerWrapper')}
 `;
 
+const bannerWrapper = css`
+    position: sticky;
+    bottom: 0;
+    ${getZIndex('banner')}
+`;
+
 export const Stuck = ({ children }: Props) => (
     <div className={stickyAdWrapper}>{children}</div>
 );
 
 export const SendToBack = ({ children }: Props) => (
     <div className={headerWrapper}>{children}</div>
+);
+
+export const BannerWrapper = ({ children }: Props) => (
+    <div id="bottom-banner" className={bannerWrapper}>{children}</div>
 );

--- a/src/web/layouts/lib/stickiness.tsx
+++ b/src/web/layouts/lib/stickiness.tsx
@@ -29,14 +29,13 @@ const headerWrapper = css`
 
 // The css overrides here are necessary because ad-takeovers can inject css that breaks the banner
 const bannerWrapper = css`
-    position: sticky;
+    position: sticky !important;
     bottom: 0;
     ${getZIndexImportant('banner')}
     
     width: 100% !important;
     background: none !important;
     top: auto !important;
-    position: sticky !important;
 `;
 
 export const Stuck = ({ children }: Props) => (

--- a/src/web/layouts/lib/stickiness.tsx
+++ b/src/web/layouts/lib/stickiness.tsx
@@ -3,7 +3,7 @@ import { css } from 'emotion';
 
 import { border } from '@guardian/src-foundations/palette';
 
-import { getZIndex } from '@frontend/web/lib/getZIndex';
+import { getZIndex, getZIndexImportant } from '@frontend/web/lib/getZIndex';
 
 type Props = {
     children?: React.ReactNode;
@@ -31,7 +31,7 @@ const headerWrapper = css`
 const bannerWrapper = css`
     position: sticky;
     bottom: 0;
-    ${getZIndex('banner')} !important
+    ${getZIndexImportant('banner')} !important
     
     width: 100% !important;
     background: none !important;

--- a/src/web/layouts/lib/stickiness.tsx
+++ b/src/web/layouts/lib/stickiness.tsx
@@ -27,10 +27,17 @@ const headerWrapper = css`
     ${getZIndex('headerWrapper')}
 `;
 
+// The css overrides here are necessary because ad-takeovers can inject css that breaks the banner
 const bannerWrapper = css`
     position: sticky;
     bottom: 0;
     ${getZIndex('banner')}
+    
+    width: auto !important;
+    z-index: 999 !important;
+    background: none !important;
+    top: auto !important;
+    position: sticky !important;
 `;
 
 export const Stuck = ({ children }: Props) => (

--- a/src/web/lib/getZIndex.tsx
+++ b/src/web/lib/getZIndex.tsx
@@ -57,3 +57,6 @@ const decideIndex = (name: string): number | null => {
 
 export const getZIndex = (zIndex: ZIndex): string =>
     `z-index: ${decideIndex(zIndex)};`;
+
+export const getZIndexImportant = (zIndex: ZIndex): string =>
+    `z-index: ${decideIndex(zIndex)} !important;`;


### PR DESCRIPTION
Fixes 2 issues which both involve styling the parent `bottom-banner` element:
### 1. The banner currently overlaps the footer:

Current behaviour:
![Screen Shot 2020-08-28 at 14 28 04](https://user-images.githubusercontent.com/1513454/91565858-bf97e800-e93a-11ea-8bf8-d936ddc9e626.png)

Desired behaviour:
![Screen Shot 2020-08-28 at 14 28 10](https://user-images.githubusercontent.com/1513454/91565867-c45c9c00-e93a-11ea-8cbc-0b1b14012dac.png)

### 2. Ad-takeovers (which inject css into the page) break the layout:
(This is similar to the frontend fix here: https://github.com/guardian/frontend/blob/main/static/src/stylesheets/module/site-messages/_engagement-banner.scss#L223)

Current behaviour:
<img width="1670" alt="Screen Shot 2020-10-02 at 09 08 06" src="https://user-images.githubusercontent.com/1513454/94901724-f9ef2a80-048e-11eb-8565-9c1fa3c51336.png">


Desired behaviour:
<img width="1670" alt="Screen Shot 2020-10-02 at 09 09 03" src="https://user-images.githubusercontent.com/1513454/94901752-01aecf00-048f-11eb-8e2d-df87462fc955.png">


And proof that the view event still works:
![Screen Shot 2020-10-02 at 09 13 03](https://user-images.githubusercontent.com/1513454/94902071-8699e880-048f-11eb-8475-ee99331206c1.png)

And proof that the consent banner still works:
![Screen Shot 2020-10-02 at 09 18 06](https://user-images.githubusercontent.com/1513454/94902551-46873580-0490-11eb-9e79-1eec0c27b6b6.png)

