### PR TITLE
Add default rich link

### DIFF
--- a/src/web/components/RichLink.tsx
+++ b/src/web/components/RichLink.tsx
@@ -46,6 +46,7 @@ interface Props {
     tags: TagType[];
     sponsorName: string;
     contributorImage?: string;
+    isPlaceholder?: boolean; // use 'true' for server-side default prior to client-side enrichment
 }
 
 const richLinkContainer = css`
@@ -217,6 +218,35 @@ const imageStyles = css`
     height: auto;
 `;
 
+type DefaultProps = {
+    index: number;
+    headlineText: string;
+    url: string;
+    isPlaceholder?: boolean;
+};
+
+export const DefaultRichLink: React.FC<DefaultProps> = ({
+    index,
+    headlineText,
+    url,
+    isPlaceholder,
+}) => {
+    return (
+        <RichLink
+            richLinkIndex={index}
+            cardStyle="news"
+            thumbnailUrl=""
+            headlineText={headlineText}
+            contentType="article"
+            url={url}
+            pillar="news"
+            tags={[]}
+            sponsorName=""
+            isPlaceholder={isPlaceholder}
+        />
+    );
+};
+
 export const RichLink = ({
     richLinkIndex,
     cardStyle,
@@ -229,6 +259,7 @@ export const RichLink = ({
     tags,
     sponsorName,
     contributorImage,
+    isPlaceholder,
 }: Props) => {
     const linkText =
         cardStyle === 'letters' ? `${headlineText} | Letters ` : headlineText;
@@ -246,6 +277,7 @@ export const RichLink = ({
             data-link-name={`rich-link-${richLinkIndex} | ${richLinkIndex}`}
             data-component="rich-link"
             className={pillarBackground(pillar)}
+            data-name={(isPlaceholder && 'placeholder') || ''}
         >
             <div className={cx(richLinkContainer, neutralBackground)}>
                 <a className={cx(richLinkLink)} href={url}>

--- a/src/web/components/elements/RichLinkComponent.tsx
+++ b/src/web/components/elements/RichLinkComponent.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { RichLink } from '@root/src/web/components/RichLink';
+import { RichLink, DefaultRichLink } from '@root/src/web/components/RichLink';
 
 import { useApi } from '@root/src/web/lib/api';
 
@@ -53,7 +53,13 @@ export const RichLinkComponent: React.FC<{
         // Send the error to Sentry and then prevent the element from rendering
         window.guardian.modules.sentry.reportError(error, 'rich-link');
 
-        return null;
+        return (
+            <DefaultRichLink
+                index={richLinkIndex}
+                headlineText={element.text}
+                url={element.url}
+            />
+        );
     }
 
     if (loading || !data) {

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -35,6 +35,7 @@ import {
 import { Display } from '@root/src/lib/display';
 import { withSignInGateSlot } from '@root/src/web/lib/withSignInGateSlot';
 import { GuVideoBlockComponent } from '@root/src/web/components/elements/GuVideoBlockComponent';
+import { DefaultRichLink } from '../components/RichLink';
 
 // This is required for spacefinder to work!
 const commercialPosition = css`
@@ -235,7 +236,18 @@ export const ArticleRenderer: React.FC<{
                         </div>
                     );
                 case 'model.dotcomrendering.pageElements.RichLinkBlockElement':
-                    return <div key={i} id={`rich-link-${i}`} />;
+                    return (
+                        <div key={i} id={`rich-link-${i}`}>
+                            <DefaultRichLink
+                                index={i}
+                                headlineText={element.text}
+                                url={element.url}
+                                isPlaceholder={true}
+                            />
+                        </div>
+                    );
+
+                // return <div key={i} id={`rich-link-${i}`} />;
                 case 'model.dotcomrendering.pageElements.SoundcloudBlockElement':
                     return (
                         <SoundcloudBlockComponent key={i} element={element} />


### PR DESCRIPTION
## What does this change?

Show (a default) rich link even if:

* no JS
* ajax call to enrich fails

Note, we just show a 'news' default here, which is equivalent to Frontend. See:

https://github.com/guardian/frontend/blob/master/common/app/views/fragments/richLinkDefault.scala.html

### Before

(first rich link doesn't even appear when ajax call to enrich fails)

![Screenshot 2020-09-01 at 16 49 40](https://user-images.githubusercontent.com/858402/91875252-2981fb80-ec73-11ea-9d8e-1f9d884356d4.png)

### After

![Screenshot 2020-09-01 at 16 43 02](https://user-images.githubusercontent.com/858402/91875200-12430e00-ec73-11ea-933b-8e7774163e11.png)

## Why?

We want to show the rich link even if missing some of the info.
