### PR TITLE
Skip SignInGate Cypress e2e test suites if Frontend AB test switch is "off" or missing

### DIFF
--- a/cypress/integration/e2e/sign-in-gate.spec.js
+++ b/cypress/integration/e2e/sign-in-gate.spec.js
@@ -60,6 +60,16 @@ describe('Sign In Gate Tests', function () {
             .then(cy.wrap);
     };
 
+    const switchIsOn = (switchName) => {
+        const switches = Cypress.env('SWITCHES');
+        const isOn = !!switches[switchName];
+        if (!isOn)
+            console.log(
+                `${switchName} switch in Frontend does not exist or is turned off - skipping ${switchName} test suite`,
+            );
+        return isOn;
+    };
+
     /**
      * AB test switches are defined in Frontend and required to be "ON" for Cypress E2E Sign In Gate Test to successfully pass.
      * In order not to break CI builds in DCR if someone switches off a Sign In Gate AB test in the Frontend Admin tool, we run
@@ -82,401 +92,436 @@ describe('Sign In Gate Tests', function () {
         it('Check switches Cypress env var exists', function () {
             expect(Cypress.env('SWITCHES')).to.not.be.undefined;
         });
-    });
-    const switchIsOn = (switchName) => {
-        const switches = Cypress.env('SWITCHES');
-        const isOn = !!switches[switchName];
-        if (!isOn)
-            console.log(
-                `${switchName} switch in Frontend does not exist or is turned off - skipping ${switchName} test suite`,
-            );
-        return isOn;
-    };
 
-    onlyRunIf(switchIsOn('abSignInGateMainVariant'), () => {
-        describe('SignInGateMain', function () {
-            beforeEach(function () {
-                // sign in gate main runs from 0-900000 MVT IDs, so 500 forces user into test
-                setMvtCookie('500');
+        onlyRunIf(switchIsOn('abSignInGateMainVariant'), () => {
+            describe('SignInGateMain', function () {
+                beforeEach(function () {
+                    // sign in gate main runs from 0-900000 MVT IDs, so 500 forces user into test
+                    setMvtCookie('500');
 
-                // set article count to be min number to view gate
-                setArticleCount(3);
-            });
-
-            it('should load the sign in gate', function () {
-                visitArticleAndScrollToGateForLazyLoad();
-
-                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
-            });
-
-            it('should not load the sign in gate if the user has not read at least 3 article in a day', function () {
-                setArticleCount(1);
-
-                visitArticleAndScrollToGateForLazyLoad();
-
-                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
-            });
-
-            it('should not load the sign in gate if the user is signed in', function () {
-                // use GU_U cookie to determine if user is signed in
-                cy.setCookie(
-                    'GU_U',
-                    'MCwCFHbDHWevL_GqgH0CcbeDWp4N9kR5AhQ2lD3zMjjbKJAgC7FUDtc18Ac8BA',
-                    { log: true },
-                );
-
-                visitArticleAndScrollToGateForLazyLoad();
-
-                // when using GU_U cookie, there is an issue with the commercial.dcr.js bundle
-                // causing a URI Malformed error in cypress
-                // we use this uncaught exception in this test to catch this and continue the rest of the test
-                cy.on('uncaught:exception', () => {
-                    done();
-                    return false;
+                    // set article count to be min number to view gate
+                    setArticleCount(3);
                 });
 
-                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
-            });
+                it('should load the sign in gate', function () {
+                    visitArticleAndScrollToGateForLazyLoad();
 
-            it('should not load the sign in gate if the user has already dismissed the gate', function () {
-                localStorage.setItem(
-                    'gu.prefs.sign-in-gate',
-                    '{"SignInGateMain-main-variant-1":"2020-07-22T08:25:05.567Z"}',
-                );
-
-                visitArticleAndScrollToGateForLazyLoad();
-
-                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
-            });
-
-            it('should not load the sign in gate if the article is not a valid section (membership)', function () {
-                visitArticleAndScrollToGateForLazyLoad({
-                    url:
-                        'https://www.theguardian.com/membership/2018/nov/15/support-guardian-readers-future-journalism',
+                    cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
                 });
 
-                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
-            });
+                it('should not load the sign in gate if the user has not read at least 3 article in a day', function () {
+                    setArticleCount(1);
 
-            it('should not load the sign in gate on a device with an ios9 user agent string', function () {
-                // can't use visitArticleAndScrollToGateForLazyLoad for this method as overriding user agent
-                cy.visit(
-                    'Article?url=https://www.theguardian.com/games/2018/aug/23/nier-automata-yoko-taro-interview',
-                    {
-                        onBeforeLoad: (win) => {
-                            Object.defineProperty(win.navigator, 'userAgent', {
-                                value:
-                                    'Mozilla/5.0 (iPad; CPU OS 9_0 like Mac OS X) AppleWebKit/601.1.17 (KHTML, like Gecko) Version/8.0 Mobile/13A175 Safari/600.1.4',
-                            });
+                    visitArticleAndScrollToGateForLazyLoad();
+
+                    cy.get('[data-cy=sign-in-gate-main]').should(
+                        'not.be.visible',
+                    );
+                });
+
+                it('should not load the sign in gate if the user is signed in', function () {
+                    // use GU_U cookie to determine if user is signed in
+                    cy.setCookie(
+                        'GU_U',
+                        'MCwCFHbDHWevL_GqgH0CcbeDWp4N9kR5AhQ2lD3zMjjbKJAgC7FUDtc18Ac8BA',
+                        { log: true },
+                    );
+
+                    visitArticleAndScrollToGateForLazyLoad();
+
+                    // when using GU_U cookie, there is an issue with the commercial.dcr.js bundle
+                    // causing a URI Malformed error in cypress
+                    // we use this uncaught exception in this test to catch this and continue the rest of the test
+                    cy.on('uncaught:exception', () => {
+                        done();
+                        return false;
+                    });
+
+                    cy.get('[data-cy=sign-in-gate-main]').should(
+                        'not.be.visible',
+                    );
+                });
+
+                it('should not load the sign in gate if the user has already dismissed the gate', function () {
+                    localStorage.setItem(
+                        'gu.prefs.sign-in-gate',
+                        '{"SignInGateMain-main-variant-1":"2020-07-22T08:25:05.567Z"}',
+                    );
+
+                    visitArticleAndScrollToGateForLazyLoad();
+
+                    cy.get('[data-cy=sign-in-gate-main]').should(
+                        'not.be.visible',
+                    );
+                });
+
+                it('should not load the sign in gate if the article is not a valid section (membership)', function () {
+                    visitArticleAndScrollToGateForLazyLoad({
+                        url:
+                            'https://www.theguardian.com/membership/2018/nov/15/support-guardian-readers-future-journalism',
+                    });
+
+                    cy.get('[data-cy=sign-in-gate-main]').should(
+                        'not.be.visible',
+                    );
+                });
+
+                it('should not load the sign in gate on a device with an ios9 user agent string', function () {
+                    // can't use visitArticleAndScrollToGateForLazyLoad for this method as overriding user agent
+                    cy.visit(
+                        'Article?url=https://www.theguardian.com/games/2018/aug/23/nier-automata-yoko-taro-interview',
+                        {
+                            onBeforeLoad: (win) => {
+                                Object.defineProperty(
+                                    win.navigator,
+                                    'userAgent',
+                                    {
+                                        value:
+                                            'Mozilla/5.0 (iPad; CPU OS 9_0 like Mac OS X) AppleWebKit/601.1.17 (KHTML, like Gecko) Version/8.0 Mobile/13A175 Safari/600.1.4',
+                                    },
+                                );
+                            },
                         },
-                    },
-                );
-                scrollToGateForLazyLoading();
+                    );
+                    scrollToGateForLazyLoading();
 
-                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
-            });
+                    cy.get('[data-cy=sign-in-gate-main]').should(
+                        'not.be.visible',
+                    );
+                });
 
-            it('should remove gate when the dismiss button is clicked', function () {
-                visitArticleAndScrollToGateForLazyLoad();
+                it('should remove gate when the dismiss button is clicked', function () {
+                    visitArticleAndScrollToGateForLazyLoad();
 
-                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+                    cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
 
-                cy.get('[data-cy=sign-in-gate-main_dismiss]').click();
+                    cy.get('[data-cy=sign-in-gate-main_dismiss]').click();
 
-                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
-            });
+                    cy.get('[data-cy=sign-in-gate-main]').should(
+                        'not.be.visible',
+                    );
+                });
 
-            it('register button should contain profile.theguardian.com href', function () {
-                visitArticleAndScrollToGateForLazyLoad();
+                it('register button should contain profile.theguardian.com href', function () {
+                    visitArticleAndScrollToGateForLazyLoad();
 
-                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+                    cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
 
-                cy.get('[data-cy=sign-in-gate-main_register]')
-                    .invoke('attr', 'href')
-                    .should('contains', 'profile.theguardian.com');
-            });
+                    cy.get('[data-cy=sign-in-gate-main_register]')
+                        .invoke('attr', 'href')
+                        .should('contains', 'profile.theguardian.com');
+                });
 
-            it('sign in link should contain profile.theguardian.com href', function () {
-                visitArticleAndScrollToGateForLazyLoad();
+                it('sign in link should contain profile.theguardian.com href', function () {
+                    visitArticleAndScrollToGateForLazyLoad();
 
-                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+                    cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
 
-                cy.get('[data-cy=sign-in-gate-main_signin]')
-                    .invoke('attr', 'href')
-                    .should('contains', 'profile.theguardian.com');
-            });
+                    cy.get('[data-cy=sign-in-gate-main_signin]')
+                        .invoke('attr', 'href')
+                        .should('contains', 'profile.theguardian.com');
+                });
 
-            it('should show cmp ui when privacy settings link is clicked', function () {
-                visitArticleAndScrollToGateForLazyLoad();
+                it('should show cmp ui when privacy settings link is clicked', function () {
+                    visitArticleAndScrollToGateForLazyLoad();
 
-                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+                    cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
 
-                cy.get('[data-cy=sign-in-gate-main_privacy]').click();
+                    cy.get('[data-cy=sign-in-gate-main_privacy]').click();
 
-                cy.contains('privacy settings');
+                    cy.contains('privacy settings');
+                });
             });
         });
-    });
 
-    onlyRunIf(switchIsOn('abSignInGateDismissWindow'), () => {
-        describe('SignInGateDismissWindow - control', function () {
-            beforeEach(function () {
-                setMvtCookie('876000');
+        onlyRunIf(switchIsOn('abSignInGateDismissWindow'), () => {
+            describe('SignInGateDismissWindow - control', function () {
+                beforeEach(function () {
+                    setMvtCookie('876000');
 
-                // set article count to be min number to view gate
-                setArticleCount(3);
-            });
-
-            it('should load the sign in gate', function () {
-                visitArticleAndScrollToGateForLazyLoad();
-
-                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
-            });
-
-            it('should not load the sign in gate if the user has not read at least 3 article in a day', function () {
-                setArticleCount(1);
-
-                visitArticleAndScrollToGateForLazyLoad();
-
-                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
-            });
-
-            it('should not load the sign in gate if the user is signed in', function () {
-                // use GU_U cookie to determine if user is signed in
-                cy.setCookie(
-                    'GU_U',
-                    'MCwCFHbDHWevL_GqgH0CcbeDWp4N9kR5AhQ2lD3zMjjbKJAgC7FUDtc18Ac8BA',
-                    {
-                        log: true,
-                    },
-                );
-
-                visitArticleAndScrollToGateForLazyLoad();
-
-                // when using GU_U cookie, there is an issue with the commercial.dcr.js bundle
-                // causing a URI Malformed error in cypress
-                // we use this uncaught exception in this test to catch this and continue the rest of the test
-                cy.on('uncaught:exception', () => {
-                    done();
-                    return false;
+                    // set article count to be min number to view gate
+                    setArticleCount(3);
                 });
 
-                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
-            });
+                it('should load the sign in gate', function () {
+                    visitArticleAndScrollToGateForLazyLoad();
 
-            it('should not load the sign in gate if the user has already dismissed the gate', function () {
-                localStorage.setItem(
-                    'gu.prefs.sign-in-gate',
-                    '{"SignInGateDismissWindow-dismiss-window-control":"2020-07-22T08:25:05.567Z"}',
-                );
-
-                visitArticleAndScrollToGateForLazyLoad();
-
-                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
-            });
-            it('should not load the sign in gate if the article is not a valid section (membership)', function () {
-                visitArticleAndScrollToGateForLazyLoad({
-                    url:
-                        'https://www.theguardian.com/membership/2018/nov/15/support-guardian-readers-future-journalism',
+                    cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
                 });
 
-                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
-            });
+                it('should not load the sign in gate if the user has not read at least 3 article in a day', function () {
+                    setArticleCount(1);
 
-            it('should not load the sign in gate on a device with an ios9 user agent string', function () {
-                // can't use visitArticleAndScrollToGateForLazyLoad for this method as overriding user agent
-                cy.visit(
-                    'Article?url=https://www.theguardian.com/games/2018/aug/23/nier-automata-yoko-taro-interview',
-                    {
-                        onBeforeLoad: (win) => {
-                            Object.defineProperty(win.navigator, 'userAgent', {
-                                value:
-                                    'Mozilla/5.0 (iPad; CPU OS 9_0 like Mac OS X) AppleWebKit/601.1.17 (KHTML, like Gecko) Version/8.0 Mobile/13A175 Safari/600.1.4',
-                            });
+                    visitArticleAndScrollToGateForLazyLoad();
+
+                    cy.get('[data-cy=sign-in-gate-main]').should(
+                        'not.be.visible',
+                    );
+                });
+
+                it('should not load the sign in gate if the user is signed in', function () {
+                    // use GU_U cookie to determine if user is signed in
+                    cy.setCookie(
+                        'GU_U',
+                        'MCwCFHbDHWevL_GqgH0CcbeDWp4N9kR5AhQ2lD3zMjjbKJAgC7FUDtc18Ac8BA',
+                        {
+                            log: true,
                         },
-                    },
-                );
-                scrollToGateForLazyLoading();
+                    );
 
-                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
-            });
+                    visitArticleAndScrollToGateForLazyLoad();
 
-            it('should remove gate when the dismiss button is clicked', function () {
-                visitArticleAndScrollToGateForLazyLoad();
+                    // when using GU_U cookie, there is an issue with the commercial.dcr.js bundle
+                    // causing a URI Malformed error in cypress
+                    // we use this uncaught exception in this test to catch this and continue the rest of the test
+                    cy.on('uncaught:exception', () => {
+                        done();
+                        return false;
+                    });
 
-                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+                    cy.get('[data-cy=sign-in-gate-main]').should(
+                        'not.be.visible',
+                    );
+                });
 
-                cy.get('[data-cy=sign-in-gate-main_dismiss]').click();
+                it('should not load the sign in gate if the user has already dismissed the gate', function () {
+                    localStorage.setItem(
+                        'gu.prefs.sign-in-gate',
+                        '{"SignInGateDismissWindow-dismiss-window-control":"2020-07-22T08:25:05.567Z"}',
+                    );
 
-                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
-            });
+                    visitArticleAndScrollToGateForLazyLoad();
 
-            it('register button should contain profile.theguardian.com href', function () {
-                visitArticleAndScrollToGateForLazyLoad();
+                    cy.get('[data-cy=sign-in-gate-main]').should(
+                        'not.be.visible',
+                    );
+                });
+                it('should not load the sign in gate if the article is not a valid section (membership)', function () {
+                    visitArticleAndScrollToGateForLazyLoad({
+                        url:
+                            'https://www.theguardian.com/membership/2018/nov/15/support-guardian-readers-future-journalism',
+                    });
 
-                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+                    cy.get('[data-cy=sign-in-gate-main]').should(
+                        'not.be.visible',
+                    );
+                });
 
-                cy.get('[data-cy=sign-in-gate-main_register]')
-                    .invoke('attr', 'href')
-                    .should('contains', 'profile.theguardian.com');
-            });
+                it('should not load the sign in gate on a device with an ios9 user agent string', function () {
+                    // can't use visitArticleAndScrollToGateForLazyLoad for this method as overriding user agent
+                    cy.visit(
+                        'Article?url=https://www.theguardian.com/games/2018/aug/23/nier-automata-yoko-taro-interview',
+                        {
+                            onBeforeLoad: (win) => {
+                                Object.defineProperty(
+                                    win.navigator,
+                                    'userAgent',
+                                    {
+                                        value:
+                                            'Mozilla/5.0 (iPad; CPU OS 9_0 like Mac OS X) AppleWebKit/601.1.17 (KHTML, like Gecko) Version/8.0 Mobile/13A175 Safari/600.1.4',
+                                    },
+                                );
+                            },
+                        },
+                    );
+                    scrollToGateForLazyLoading();
 
-            it('sign in link should contain profile.theguardian.com href', function () {
-                visitArticleAndScrollToGateForLazyLoad();
+                    cy.get('[data-cy=sign-in-gate-main]').should(
+                        'not.be.visible',
+                    );
+                });
 
-                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+                it('should remove gate when the dismiss button is clicked', function () {
+                    visitArticleAndScrollToGateForLazyLoad();
 
-                cy.get('[data-cy=sign-in-gate-main_signin]')
-                    .invoke('attr', 'href')
-                    .should('contains', 'profile.theguardian.com');
-            });
+                    cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
 
-            it('should show cmp ui when privacy settings link is clicked', function () {
-                visitArticleAndScrollToGateForLazyLoad();
+                    cy.get('[data-cy=sign-in-gate-main_dismiss]').click();
 
-                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+                    cy.get('[data-cy=sign-in-gate-main]').should(
+                        'not.be.visible',
+                    );
+                });
 
-                cy.get('[data-cy=sign-in-gate-main_privacy]').click();
+                it('register button should contain profile.theguardian.com href', function () {
+                    visitArticleAndScrollToGateForLazyLoad();
 
-                cy.contains('privacy settings');
-            });
-        });
-    });
+                    cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
 
-    onlyRunIf(switchIsOn('abSignInGateDismissWindow'), () => {
-        describe('SignInGateDismissWindow - variant 1 - article', function () {
-            beforeEach(function () {
-                setMvtCookie('877000');
+                    cy.get('[data-cy=sign-in-gate-main_register]')
+                        .invoke('attr', 'href')
+                        .should('contains', 'profile.theguardian.com');
+                });
 
-                // set article count to be min number to view gate
-                setArticleCount(3);
-            });
-            it('should load the sign in gate', function () {
-                visitArticleAndScrollToGateForLazyLoad();
+                it('sign in link should contain profile.theguardian.com href', function () {
+                    visitArticleAndScrollToGateForLazyLoad();
 
-                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
-            });
+                    cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
 
-            it('should remove gate when the dismiss button is clicked', function () {
-                visitArticleAndScrollToGateForLazyLoad();
+                    cy.get('[data-cy=sign-in-gate-main_signin]')
+                        .invoke('attr', 'href')
+                        .should('contains', 'profile.theguardian.com');
+                });
 
-                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+                it('should show cmp ui when privacy settings link is clicked', function () {
+                    visitArticleAndScrollToGateForLazyLoad();
 
-                cy.get('[data-cy=sign-in-gate-main_dismiss]').click();
+                    cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
 
-                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
-            });
+                    cy.get('[data-cy=sign-in-gate-main_privacy]').click();
 
-            it('should load the sign in gate even if the user has already dismissed the gate', function () {
-                localStorage.setItem(
-                    'gu.prefs.sign-in-gate',
-                    '{"SignInGateDismissWindow-variant-1-article":"2020-07-22T08:25:05.567Z"}',
-                );
-
-                visitArticleAndScrollToGateForLazyLoad();
-
-                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
-            });
-
-            it('should reshow the sign in gate if the user has already dismissed the gate but navigates to a new article', function () {
-                visitArticleAndScrollToGateForLazyLoad();
-
-                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
-
-                cy.get('[data-cy=sign-in-gate-main_dismiss]').click();
-
-                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
-
-                visitArticleAndScrollToGateForLazyLoad();
-
-                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
-            });
-        });
-    });
-
-    onlyRunIf(switchIsOn('abSignInGateDismissWindow'), () => {
-        describe('SignInGateDismissWindow - variant 2 - day', function () {
-            beforeEach(function () {
-                setMvtCookie('878000');
-
-                // set article count to be min number to view gate
-                setArticleCount(3);
-            });
-
-            it('should load the sign in gate', function () {
-                visitArticleAndScrollToGateForLazyLoad();
-
-                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
-            });
-
-            it('should remove gate when the dismiss button is clicked', function () {
-                visitArticleAndScrollToGateForLazyLoad();
-
-                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
-
-                cy.get('[data-cy=sign-in-gate-main_dismiss]').click();
-
-                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
-            });
-
-            it('should not load the sign in gate if the user has dismissed the gate in last 24hrs', function () {
-                const lessThanADayAgo = new Date();
-                lessThanADayAgo.setHours(lessThanADayAgo.getHours() - 16);
-                localStorage.setItem(
-                    'gu.prefs.sign-in-gate',
-                    JSON.stringify({
-                        'SignInGateDismissWindow-dismiss-window-variant-2-day': lessThanADayAgo.toISOString(),
-                    }),
-                );
-
-                visitArticleAndScrollToGateForLazyLoad();
-
-                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
-            });
-
-            it('should load the sign in gate if the user has dismissed the gate more than 24hrs ago', function () {
-                const moreThanADayAgo = new Date();
-                moreThanADayAgo.setHours(moreThanADayAgo.getHours() - 48);
-                localStorage.setItem(
-                    'gu.prefs.sign-in-gate',
-                    JSON.stringify({
-                        'SignInGateDismissWindow-dismiss-window-variant-2-day': moreThanADayAgo.toISOString(),
-                    }),
-                );
-
-                visitArticleAndScrollToGateForLazyLoad();
-
-                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+                    cy.contains('privacy settings');
+                });
             });
         });
-    });
 
-    onlyRunIf(switchIsOn('abSignInGatePatientia'), () => {
-        describe('SignInGatePatientia', function () {
-            beforeEach(function () {
-                // sign in gate patientia runs from 999901-1000000 MVT IDs, so 999901 forces user into test variant
-                setMvtCookie('999901');
+        onlyRunIf(switchIsOn('abSignInGateDismissWindow'), () => {
+            describe('SignInGateDismissWindow - variant 1 - article', function () {
+                beforeEach(function () {
+                    setMvtCookie('877000');
 
-                // set article count to be min number to view gate
-                setArticleCount(3);
+                    // set article count to be min number to view gate
+                    setArticleCount(3);
+                });
+                it('should load the sign in gate', function () {
+                    visitArticleAndScrollToGateForLazyLoad();
+
+                    cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+                });
+
+                it('should remove gate when the dismiss button is clicked', function () {
+                    visitArticleAndScrollToGateForLazyLoad();
+
+                    cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+
+                    cy.get('[data-cy=sign-in-gate-main_dismiss]').click();
+
+                    cy.get('[data-cy=sign-in-gate-main]').should(
+                        'not.be.visible',
+                    );
+                });
+
+                it('should load the sign in gate even if the user has already dismissed the gate', function () {
+                    localStorage.setItem(
+                        'gu.prefs.sign-in-gate',
+                        '{"SignInGateDismissWindow-variant-1-article":"2020-07-22T08:25:05.567Z"}',
+                    );
+
+                    visitArticleAndScrollToGateForLazyLoad();
+
+                    cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+                });
+
+                it('should reshow the sign in gate if the user has already dismissed the gate but navigates to a new article', function () {
+                    visitArticleAndScrollToGateForLazyLoad();
+
+                    cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+
+                    cy.get('[data-cy=sign-in-gate-main_dismiss]').click();
+
+                    cy.get('[data-cy=sign-in-gate-main]').should(
+                        'not.be.visible',
+                    );
+
+                    visitArticleAndScrollToGateForLazyLoad();
+
+                    cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+                });
             });
+        });
 
-            it('should load the sign in gate', function () {
-                visitArticleAndScrollToGateForLazyLoad();
+        onlyRunIf(switchIsOn('abSignInGateDismissWindow'), () => {
+            describe('SignInGateDismissWindow - variant 2 - day', function () {
+                beforeEach(function () {
+                    setMvtCookie('878000');
 
-                cy.get('[data-cy=sign-in-gate-patientia]').should('be.visible');
+                    // set article count to be min number to view gate
+                    setArticleCount(3);
+                });
+
+                it('should load the sign in gate', function () {
+                    visitArticleAndScrollToGateForLazyLoad();
+
+                    cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+                });
+
+                it('should remove gate when the dismiss button is clicked', function () {
+                    visitArticleAndScrollToGateForLazyLoad();
+
+                    cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+
+                    cy.get('[data-cy=sign-in-gate-main_dismiss]').click();
+
+                    cy.get('[data-cy=sign-in-gate-main]').should(
+                        'not.be.visible',
+                    );
+                });
+
+                it('should not load the sign in gate if the user has dismissed the gate in last 24hrs', function () {
+                    const lessThanADayAgo = new Date();
+                    lessThanADayAgo.setHours(lessThanADayAgo.getHours() - 16);
+                    localStorage.setItem(
+                        'gu.prefs.sign-in-gate',
+                        JSON.stringify({
+                            'SignInGateDismissWindow-dismiss-window-variant-2-day': lessThanADayAgo.toISOString(),
+                        }),
+                    );
+
+                    visitArticleAndScrollToGateForLazyLoad();
+
+                    cy.get('[data-cy=sign-in-gate-main]').should(
+                        'not.be.visible',
+                    );
+                });
+
+                it('should load the sign in gate if the user has dismissed the gate more than 24hrs ago', function () {
+                    const moreThanADayAgo = new Date();
+                    moreThanADayAgo.setHours(moreThanADayAgo.getHours() - 48);
+                    localStorage.setItem(
+                        'gu.prefs.sign-in-gate',
+                        JSON.stringify({
+                            'SignInGateDismissWindow-dismiss-window-variant-2-day': moreThanADayAgo.toISOString(),
+                        }),
+                    );
+
+                    visitArticleAndScrollToGateForLazyLoad();
+
+                    cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+                });
             });
+        });
 
-            it('should remove gate when the dismiss button is clicked', function () {
-                visitArticleAndScrollToGateForLazyLoad();
+        onlyRunIf(switchIsOn('abSignInGatePatientia'), () => {
+            describe('SignInGatePatientia', function () {
+                beforeEach(function () {
+                    // sign in gate patientia runs from 999901-1000000 MVT IDs, so 999901 forces user into test variant
+                    setMvtCookie('999901');
 
-                cy.get('[data-cy=sign-in-gate-patientia]').should('be.visible');
+                    // set article count to be min number to view gate
+                    setArticleCount(3);
+                });
 
-                cy.get('[data-cy=sign-in-gate-patientia_dismiss]').click();
+                it('should load the sign in gate', function () {
+                    visitArticleAndScrollToGateForLazyLoad();
 
-                cy.get('[data-cy=sign-in-gate-patientia]').should(
-                    'not.be.visible',
-                );
+                    cy.get('[data-cy=sign-in-gate-patientia]').should(
+                        'be.visible',
+                    );
+                });
+
+                it('should remove gate when the dismiss button is clicked', function () {
+                    visitArticleAndScrollToGateForLazyLoad();
+
+                    cy.get('[data-cy=sign-in-gate-patientia]').should(
+                        'be.visible',
+                    );
+
+                    cy.get('[data-cy=sign-in-gate-patientia_dismiss]').click();
+
+                    cy.get('[data-cy=sign-in-gate-patientia]').should(
+                        'not.be.visible',
+                    );
+                });
             });
         });
     });

--- a/cypress/integration/e2e/sign-in-gate.spec.js
+++ b/cypress/integration/e2e/sign-in-gate.spec.js
@@ -1,5 +1,7 @@
 /* eslint-disable no-undef */
 /* eslint-disable func-names */
+/* eslint-disable mocha/no-setup-in-describe */
+import { onlyOn as onlyRunIf } from '@cypress/skip-test';
 
 describe('Sign In Gate Tests', function () {
     const setArticleCount = (n) => {
@@ -58,380 +60,424 @@ describe('Sign In Gate Tests', function () {
             .then(cy.wrap);
     };
 
-    describe('SignInGateMain', function () {
-        beforeEach(function () {
-            // sign in gate main runs from 0-900000 MVT IDs, so 500 forces user into test
-            setMvtCookie('500');
-
-            // set article count to be min number to view gate
-            setArticleCount(3);
+    /**
+     * AB test switches are defined in Frontend and required to be "ON" for Cypress E2E Sign In Gate Test to successfully pass.
+     * In order not to break CI builds in DCR if someone switches off a Sign In Gate AB test in the Frontend Admin tool, we run
+     * a setup test suite to load active switches from Froented into a Cypress Environment Variable available to this spec only.
+     * We use this env var to check if a switch is ON, to conditionally run relevant test suites.
+     *
+     * Warning - this means we can turn switches on/off in the Frontend Admin PROD UI without needing to make code changes to DCR,
+     * but you will need to make sure switches are ON when developing locally or in CODE.
+     *
+     * Ensure you wrap all your AB test suites with "onlyRunIf(switchIsOn('abNameOfTest', () => {})" for this to work.
+     */
+    describe('Get live Switches from Frontend', function () {
+        it('Load article and get switches', function () {
+            visitArticle();
+            cy.window().then((win) => {
+                const switches = win.guardian.config.switches;
+                Cypress.env('SWITCHES', switches);
+            });
         });
-
-        it('should load the sign in gate', function () {
-            visitArticleAndScrollToGateForLazyLoad();
-
-            cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+        it('Check switches Cypress env var exists', function () {
+            expect(Cypress.env('SWITCHES')).to.not.be.undefined;
         });
-
-        it('should not load the sign in gate if the user has not read at least 3 article in a day', function () {
-            setArticleCount(1);
-
-            visitArticleAndScrollToGateForLazyLoad();
-
-            cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
-        });
-
-        it('should not load the sign in gate if the user is signed in', function () {
-            // use GU_U cookie to determine if user is signed in
-            cy.setCookie(
-                'GU_U',
-                'MCwCFHbDHWevL_GqgH0CcbeDWp4N9kR5AhQ2lD3zMjjbKJAgC7FUDtc18Ac8BA',
-                { log: true },
+    });
+    const switchIsOn = (switchName) => {
+        const switches = Cypress.env('SWITCHES');
+        const isOn = !!switches[switchName];
+        if (!isOn)
+            console.log(
+                `${switchName} switch in Frontend does not exist or is turned off - skipping ${switchName} test suite`,
             );
+        return isOn;
+    };
 
-            visitArticleAndScrollToGateForLazyLoad();
+    onlyRunIf(switchIsOn('abSignInGateMainVariant'), () => {
+        describe('SignInGateMain', function () {
+            beforeEach(function () {
+                // sign in gate main runs from 0-900000 MVT IDs, so 500 forces user into test
+                setMvtCookie('500');
 
-            // when using GU_U cookie, there is an issue with the commercial.dcr.js bundle
-            // causing a URI Malformed error in cypress
-            // we use this uncaught exception in this test to catch this and continue the rest of the test
-            cy.on('uncaught:exception', () => {
-                done();
-                return false;
+                // set article count to be min number to view gate
+                setArticleCount(3);
             });
 
-            cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
-        });
+            it('should load the sign in gate', function () {
+                visitArticleAndScrollToGateForLazyLoad();
 
-        it('should not load the sign in gate if the user has already dismissed the gate', function () {
-            localStorage.setItem(
-                'gu.prefs.sign-in-gate',
-                '{"SignInGateMain-main-variant-1":"2020-07-22T08:25:05.567Z"}',
-            );
-
-            visitArticleAndScrollToGateForLazyLoad();
-
-            cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
-        });
-
-        it('should not load the sign in gate if the article is not a valid section (membership)', function () {
-            visitArticleAndScrollToGateForLazyLoad({
-                url:
-                    'https://www.theguardian.com/membership/2018/nov/15/support-guardian-readers-future-journalism',
+                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
             });
 
-            cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
-        });
+            it('should not load the sign in gate if the user has not read at least 3 article in a day', function () {
+                setArticleCount(1);
 
-        it('should not load the sign in gate on a device with an ios9 user agent string', function () {
-            // can't use visitArticleAndScrollToGateForLazyLoad for this method as overriding user agent
-            cy.visit(
-                'Article?url=https://www.theguardian.com/games/2018/aug/23/nier-automata-yoko-taro-interview',
-                {
-                    onBeforeLoad: (win) => {
-                        Object.defineProperty(win.navigator, 'userAgent', {
-                            value:
-                                'Mozilla/5.0 (iPad; CPU OS 9_0 like Mac OS X) AppleWebKit/601.1.17 (KHTML, like Gecko) Version/8.0 Mobile/13A175 Safari/600.1.4',
-                        });
+                visitArticleAndScrollToGateForLazyLoad();
+
+                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
+            });
+
+            it('should not load the sign in gate if the user is signed in', function () {
+                // use GU_U cookie to determine if user is signed in
+                cy.setCookie(
+                    'GU_U',
+                    'MCwCFHbDHWevL_GqgH0CcbeDWp4N9kR5AhQ2lD3zMjjbKJAgC7FUDtc18Ac8BA',
+                    { log: true },
+                );
+
+                visitArticleAndScrollToGateForLazyLoad();
+
+                // when using GU_U cookie, there is an issue with the commercial.dcr.js bundle
+                // causing a URI Malformed error in cypress
+                // we use this uncaught exception in this test to catch this and continue the rest of the test
+                cy.on('uncaught:exception', () => {
+                    done();
+                    return false;
+                });
+
+                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
+            });
+
+            it('should not load the sign in gate if the user has already dismissed the gate', function () {
+                localStorage.setItem(
+                    'gu.prefs.sign-in-gate',
+                    '{"SignInGateMain-main-variant-1":"2020-07-22T08:25:05.567Z"}',
+                );
+
+                visitArticleAndScrollToGateForLazyLoad();
+
+                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
+            });
+
+            it('should not load the sign in gate if the article is not a valid section (membership)', function () {
+                visitArticleAndScrollToGateForLazyLoad({
+                    url:
+                        'https://www.theguardian.com/membership/2018/nov/15/support-guardian-readers-future-journalism',
+                });
+
+                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
+            });
+
+            it('should not load the sign in gate on a device with an ios9 user agent string', function () {
+                // can't use visitArticleAndScrollToGateForLazyLoad for this method as overriding user agent
+                cy.visit(
+                    'Article?url=https://www.theguardian.com/games/2018/aug/23/nier-automata-yoko-taro-interview',
+                    {
+                        onBeforeLoad: (win) => {
+                            Object.defineProperty(win.navigator, 'userAgent', {
+                                value:
+                                    'Mozilla/5.0 (iPad; CPU OS 9_0 like Mac OS X) AppleWebKit/601.1.17 (KHTML, like Gecko) Version/8.0 Mobile/13A175 Safari/600.1.4',
+                            });
+                        },
                     },
-                },
-            );
-            scrollToGateForLazyLoading();
+                );
+                scrollToGateForLazyLoading();
 
-            cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
-        });
+                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
+            });
 
-        it('should remove gate when the dismiss button is clicked', function () {
-            visitArticleAndScrollToGateForLazyLoad();
+            it('should remove gate when the dismiss button is clicked', function () {
+                visitArticleAndScrollToGateForLazyLoad();
 
-            cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
 
-            cy.get('[data-cy=sign-in-gate-main_dismiss]').click();
+                cy.get('[data-cy=sign-in-gate-main_dismiss]').click();
 
-            cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
-        });
+                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
+            });
 
-        it('register button should contain profile.theguardian.com href', function () {
-            visitArticleAndScrollToGateForLazyLoad();
+            it('register button should contain profile.theguardian.com href', function () {
+                visitArticleAndScrollToGateForLazyLoad();
 
-            cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
 
-            cy.get('[data-cy=sign-in-gate-main_register]')
-                .invoke('attr', 'href')
-                .should('contains', 'profile.theguardian.com');
-        });
+                cy.get('[data-cy=sign-in-gate-main_register]')
+                    .invoke('attr', 'href')
+                    .should('contains', 'profile.theguardian.com');
+            });
 
-        it('sign in link should contain profile.theguardian.com href', function () {
-            visitArticleAndScrollToGateForLazyLoad();
+            it('sign in link should contain profile.theguardian.com href', function () {
+                visitArticleAndScrollToGateForLazyLoad();
 
-            cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
 
-            cy.get('[data-cy=sign-in-gate-main_signin]')
-                .invoke('attr', 'href')
-                .should('contains', 'profile.theguardian.com');
-        });
+                cy.get('[data-cy=sign-in-gate-main_signin]')
+                    .invoke('attr', 'href')
+                    .should('contains', 'profile.theguardian.com');
+            });
 
-        it('should show cmp ui when privacy settings link is clicked', function () {
-            visitArticleAndScrollToGateForLazyLoad();
+            it('should show cmp ui when privacy settings link is clicked', function () {
+                visitArticleAndScrollToGateForLazyLoad();
 
-            cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
 
-            cy.get('[data-cy=sign-in-gate-main_privacy]').click();
+                cy.get('[data-cy=sign-in-gate-main_privacy]').click();
 
-            cy.contains('privacy settings');
+                cy.contains('privacy settings');
+            });
         });
     });
 
-    describe('SignInGateDismissWindow - control', function () {
-        beforeEach(function () {
-            setMvtCookie('876000');
+    onlyRunIf(switchIsOn('abSignInGateDismissWindow'), () => {
+        describe('SignInGateDismissWindow - control', function () {
+            beforeEach(function () {
+                setMvtCookie('876000');
 
-            // set article count to be min number to view gate
-            setArticleCount(3);
-        });
-
-        it('should load the sign in gate', function () {
-            visitArticleAndScrollToGateForLazyLoad();
-
-            cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
-        });
-
-        it('should not load the sign in gate if the user has not read at least 3 article in a day', function () {
-            setArticleCount(1);
-
-            visitArticleAndScrollToGateForLazyLoad();
-
-            cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
-        });
-
-        it('should not load the sign in gate if the user is signed in', function () {
-            // use GU_U cookie to determine if user is signed in
-            cy.setCookie(
-                'GU_U',
-                'MCwCFHbDHWevL_GqgH0CcbeDWp4N9kR5AhQ2lD3zMjjbKJAgC7FUDtc18Ac8BA',
-                {
-                    log: true,
-                },
-            );
-
-            visitArticleAndScrollToGateForLazyLoad();
-
-            // when using GU_U cookie, there is an issue with the commercial.dcr.js bundle
-            // causing a URI Malformed error in cypress
-            // we use this uncaught exception in this test to catch this and continue the rest of the test
-            cy.on('uncaught:exception', () => {
-                done();
-                return false;
+                // set article count to be min number to view gate
+                setArticleCount(3);
             });
 
-            cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
-        });
+            it('should load the sign in gate', function () {
+                visitArticleAndScrollToGateForLazyLoad();
 
-        it('should not load the sign in gate if the user has already dismissed the gate', function () {
-            localStorage.setItem(
-                'gu.prefs.sign-in-gate',
-                '{"SignInGateDismissWindow-dismiss-window-control":"2020-07-22T08:25:05.567Z"}',
-            );
-
-            visitArticleAndScrollToGateForLazyLoad();
-
-            cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
-        });
-        it('should not load the sign in gate if the article is not a valid section (membership)', function () {
-            visitArticleAndScrollToGateForLazyLoad({
-                url:
-                    'https://www.theguardian.com/membership/2018/nov/15/support-guardian-readers-future-journalism',
+                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
             });
 
-            cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
-        });
+            it('should not load the sign in gate if the user has not read at least 3 article in a day', function () {
+                setArticleCount(1);
 
-        it('should not load the sign in gate on a device with an ios9 user agent string', function () {
-            // can't use visitArticleAndScrollToGateForLazyLoad for this method as overriding user agent
-            cy.visit(
-                'Article?url=https://www.theguardian.com/games/2018/aug/23/nier-automata-yoko-taro-interview',
-                {
-                    onBeforeLoad: (win) => {
-                        Object.defineProperty(win.navigator, 'userAgent', {
-                            value:
-                                'Mozilla/5.0 (iPad; CPU OS 9_0 like Mac OS X) AppleWebKit/601.1.17 (KHTML, like Gecko) Version/8.0 Mobile/13A175 Safari/600.1.4',
-                        });
+                visitArticleAndScrollToGateForLazyLoad();
+
+                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
+            });
+
+            it('should not load the sign in gate if the user is signed in', function () {
+                // use GU_U cookie to determine if user is signed in
+                cy.setCookie(
+                    'GU_U',
+                    'MCwCFHbDHWevL_GqgH0CcbeDWp4N9kR5AhQ2lD3zMjjbKJAgC7FUDtc18Ac8BA',
+                    {
+                        log: true,
                     },
-                },
-            );
-            scrollToGateForLazyLoading();
+                );
 
-            cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
-        });
+                visitArticleAndScrollToGateForLazyLoad();
 
-        it('should remove gate when the dismiss button is clicked', function () {
-            visitArticleAndScrollToGateForLazyLoad();
+                // when using GU_U cookie, there is an issue with the commercial.dcr.js bundle
+                // causing a URI Malformed error in cypress
+                // we use this uncaught exception in this test to catch this and continue the rest of the test
+                cy.on('uncaught:exception', () => {
+                    done();
+                    return false;
+                });
 
-            cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
+            });
 
-            cy.get('[data-cy=sign-in-gate-main_dismiss]').click();
+            it('should not load the sign in gate if the user has already dismissed the gate', function () {
+                localStorage.setItem(
+                    'gu.prefs.sign-in-gate',
+                    '{"SignInGateDismissWindow-dismiss-window-control":"2020-07-22T08:25:05.567Z"}',
+                );
 
-            cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
-        });
+                visitArticleAndScrollToGateForLazyLoad();
 
-        it('register button should contain profile.theguardian.com href', function () {
-            visitArticleAndScrollToGateForLazyLoad();
+                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
+            });
+            it('should not load the sign in gate if the article is not a valid section (membership)', function () {
+                visitArticleAndScrollToGateForLazyLoad({
+                    url:
+                        'https://www.theguardian.com/membership/2018/nov/15/support-guardian-readers-future-journalism',
+                });
 
-            cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
+            });
 
-            cy.get('[data-cy=sign-in-gate-main_register]')
-                .invoke('attr', 'href')
-                .should('contains', 'profile.theguardian.com');
-        });
+            it('should not load the sign in gate on a device with an ios9 user agent string', function () {
+                // can't use visitArticleAndScrollToGateForLazyLoad for this method as overriding user agent
+                cy.visit(
+                    'Article?url=https://www.theguardian.com/games/2018/aug/23/nier-automata-yoko-taro-interview',
+                    {
+                        onBeforeLoad: (win) => {
+                            Object.defineProperty(win.navigator, 'userAgent', {
+                                value:
+                                    'Mozilla/5.0 (iPad; CPU OS 9_0 like Mac OS X) AppleWebKit/601.1.17 (KHTML, like Gecko) Version/8.0 Mobile/13A175 Safari/600.1.4',
+                            });
+                        },
+                    },
+                );
+                scrollToGateForLazyLoading();
 
-        it('sign in link should contain profile.theguardian.com href', function () {
-            visitArticleAndScrollToGateForLazyLoad();
+                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
+            });
 
-            cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+            it('should remove gate when the dismiss button is clicked', function () {
+                visitArticleAndScrollToGateForLazyLoad();
 
-            cy.get('[data-cy=sign-in-gate-main_signin]')
-                .invoke('attr', 'href')
-                .should('contains', 'profile.theguardian.com');
-        });
+                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
 
-        it('should show cmp ui when privacy settings link is clicked', function () {
-            visitArticleAndScrollToGateForLazyLoad();
+                cy.get('[data-cy=sign-in-gate-main_dismiss]').click();
 
-            cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
+            });
 
-            cy.get('[data-cy=sign-in-gate-main_privacy]').click();
+            it('register button should contain profile.theguardian.com href', function () {
+                visitArticleAndScrollToGateForLazyLoad();
 
-            cy.contains('privacy settings');
-        });
-    });
+                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
 
-    describe('SignInGateDismissWindow - variant 1 - article', function () {
-        beforeEach(function () {
-            setMvtCookie('877000');
+                cy.get('[data-cy=sign-in-gate-main_register]')
+                    .invoke('attr', 'href')
+                    .should('contains', 'profile.theguardian.com');
+            });
 
-            // set article count to be min number to view gate
-            setArticleCount(3);
-        });
+            it('sign in link should contain profile.theguardian.com href', function () {
+                visitArticleAndScrollToGateForLazyLoad();
 
-        it('should load the sign in gate', function () {
-            visitArticleAndScrollToGateForLazyLoad();
+                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
 
-            cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
-        });
+                cy.get('[data-cy=sign-in-gate-main_signin]')
+                    .invoke('attr', 'href')
+                    .should('contains', 'profile.theguardian.com');
+            });
 
-        it('should remove gate when the dismiss button is clicked', function () {
-            visitArticleAndScrollToGateForLazyLoad();
+            it('should show cmp ui when privacy settings link is clicked', function () {
+                visitArticleAndScrollToGateForLazyLoad();
 
-            cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
 
-            cy.get('[data-cy=sign-in-gate-main_dismiss]').click();
+                cy.get('[data-cy=sign-in-gate-main_privacy]').click();
 
-            cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
-        });
-
-        it('should load the sign in gate even if the user has already dismissed the gate', function () {
-            localStorage.setItem(
-                'gu.prefs.sign-in-gate',
-                '{"SignInGateDismissWindow-variant-1-article":"2020-07-22T08:25:05.567Z"}',
-            );
-
-            visitArticleAndScrollToGateForLazyLoad();
-
-            cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
-        });
-
-        it('should reshow the sign in gate if the user has already dismissed the gate but navigates to a new article', function () {
-            visitArticleAndScrollToGateForLazyLoad();
-
-            cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
-
-            cy.get('[data-cy=sign-in-gate-main_dismiss]').click();
-
-            cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
-
-            visitArticleAndScrollToGateForLazyLoad();
-
-            cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+                cy.contains('privacy settings');
+            });
         });
     });
 
-    describe('SignInGateDismissWindow - variant 2 - day', function () {
-        beforeEach(function () {
-            setMvtCookie('878000');
+    onlyRunIf(switchIsOn('abSignInGateDismissWindow'), () => {
+        describe('SignInGateDismissWindow - variant 1 - article', function () {
+            beforeEach(function () {
+                setMvtCookie('877000');
 
-            // set article count to be min number to view gate
-            setArticleCount(3);
-        });
+                // set article count to be min number to view gate
+                setArticleCount(3);
+            });
+            it('should load the sign in gate', function () {
+                visitArticleAndScrollToGateForLazyLoad();
 
-        it('should load the sign in gate', function () {
-            visitArticleAndScrollToGateForLazyLoad();
+                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+            });
 
-            cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
-        });
+            it('should remove gate when the dismiss button is clicked', function () {
+                visitArticleAndScrollToGateForLazyLoad();
 
-        it('should remove gate when the dismiss button is clicked', function () {
-            visitArticleAndScrollToGateForLazyLoad();
+                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
 
-            cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+                cy.get('[data-cy=sign-in-gate-main_dismiss]').click();
 
-            cy.get('[data-cy=sign-in-gate-main_dismiss]').click();
+                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
+            });
 
-            cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
-        });
+            it('should load the sign in gate even if the user has already dismissed the gate', function () {
+                localStorage.setItem(
+                    'gu.prefs.sign-in-gate',
+                    '{"SignInGateDismissWindow-variant-1-article":"2020-07-22T08:25:05.567Z"}',
+                );
 
-        it('should not load the sign in gate if the user has dismissed the gate in last 24hrs', function () {
-            const lessThanADayAgo = new Date();
-            lessThanADayAgo.setHours(lessThanADayAgo.getHours() - 16);
-            localStorage.setItem(
-                'gu.prefs.sign-in-gate',
-                JSON.stringify({
-                    'SignInGateDismissWindow-dismiss-window-variant-2-day': lessThanADayAgo.toISOString(),
-                }),
-            );
+                visitArticleAndScrollToGateForLazyLoad();
 
-            visitArticleAndScrollToGateForLazyLoad();
+                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+            });
 
-            cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
-        });
+            it('should reshow the sign in gate if the user has already dismissed the gate but navigates to a new article', function () {
+                visitArticleAndScrollToGateForLazyLoad();
 
-        it('should load the sign in gate if the user has dismissed the gate more than 24hrs ago', function () {
-            const moreThanADayAgo = new Date();
-            moreThanADayAgo.setHours(moreThanADayAgo.getHours() - 48);
-            localStorage.setItem(
-                'gu.prefs.sign-in-gate',
-                JSON.stringify({
-                    'SignInGateDismissWindow-dismiss-window-variant-2-day': moreThanADayAgo.toISOString(),
-                }),
-            );
+                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
 
-            visitArticleAndScrollToGateForLazyLoad();
+                cy.get('[data-cy=sign-in-gate-main_dismiss]').click();
 
-            cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
+
+                visitArticleAndScrollToGateForLazyLoad();
+
+                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+            });
         });
     });
 
-    describe('SignInGatePatientia', function () {
-        beforeEach(function () {
-            // sign in gate patientia runs from 999901-1000000 MVT IDs, so 999901 forces user into test variant
-            setMvtCookie('999901');
+    onlyRunIf(switchIsOn('abSignInGateDismissWindow'), () => {
+        describe('SignInGateDismissWindow - variant 2 - day', function () {
+            beforeEach(function () {
+                setMvtCookie('878000');
 
-            // set article count to be min number to view gate
-            setArticleCount(3);
+                // set article count to be min number to view gate
+                setArticleCount(3);
+            });
+
+            it('should load the sign in gate', function () {
+                visitArticleAndScrollToGateForLazyLoad();
+
+                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+            });
+
+            it('should remove gate when the dismiss button is clicked', function () {
+                visitArticleAndScrollToGateForLazyLoad();
+
+                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+
+                cy.get('[data-cy=sign-in-gate-main_dismiss]').click();
+
+                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
+            });
+
+            it('should not load the sign in gate if the user has dismissed the gate in last 24hrs', function () {
+                const lessThanADayAgo = new Date();
+                lessThanADayAgo.setHours(lessThanADayAgo.getHours() - 16);
+                localStorage.setItem(
+                    'gu.prefs.sign-in-gate',
+                    JSON.stringify({
+                        'SignInGateDismissWindow-dismiss-window-variant-2-day': lessThanADayAgo.toISOString(),
+                    }),
+                );
+
+                visitArticleAndScrollToGateForLazyLoad();
+
+                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
+            });
+
+            it('should load the sign in gate if the user has dismissed the gate more than 24hrs ago', function () {
+                const moreThanADayAgo = new Date();
+                moreThanADayAgo.setHours(moreThanADayAgo.getHours() - 48);
+                localStorage.setItem(
+                    'gu.prefs.sign-in-gate',
+                    JSON.stringify({
+                        'SignInGateDismissWindow-dismiss-window-variant-2-day': moreThanADayAgo.toISOString(),
+                    }),
+                );
+
+                visitArticleAndScrollToGateForLazyLoad();
+
+                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+            });
         });
+    });
 
-        it('should load the sign in gate', function () {
-            visitArticleAndScrollToGateForLazyLoad();
+    onlyRunIf(switchIsOn('abSignInGatePatientia'), () => {
+        describe('SignInGatePatientia', function () {
+            beforeEach(function () {
+                // sign in gate patientia runs from 999901-1000000 MVT IDs, so 999901 forces user into test variant
+                setMvtCookie('999901');
 
-            cy.get('[data-cy=sign-in-gate-patientia]').should('be.visible');
-        });
+                // set article count to be min number to view gate
+                setArticleCount(3);
+            });
 
-        it('should remove gate when the dismiss button is clicked', function () {
-            visitArticleAndScrollToGateForLazyLoad();
+            it('should load the sign in gate', function () {
+                visitArticleAndScrollToGateForLazyLoad();
 
-            cy.get('[data-cy=sign-in-gate-patientia]').should('be.visible');
+                cy.get('[data-cy=sign-in-gate-patientia]').should('be.visible');
+            });
 
-            cy.get('[data-cy=sign-in-gate-patientia_dismiss]').click();
+            it('should remove gate when the dismiss button is clicked', function () {
+                visitArticleAndScrollToGateForLazyLoad();
 
-            cy.get('[data-cy=sign-in-gate-patientia]').should('not.be.visible');
+                cy.get('[data-cy=sign-in-gate-patientia]').should('be.visible');
+
+                cy.get('[data-cy=sign-in-gate-patientia_dismiss]').click();
+
+                cy.get('[data-cy=sign-in-gate-patientia]').should(
+                    'not.be.visible',
+                );
+            });
         });
     });
 });

--- a/cypress/integration/e2e/sign-in-gate.spec.js
+++ b/cypress/integration/e2e/sign-in-gate.spec.js
@@ -4,6 +4,8 @@
 import { onlyOn as onlyRunIf } from '@cypress/skip-test';
 
 describe('Sign In Gate Tests', function () {
+    console.log('tests', Cypress.env());
+
     const setArticleCount = (n) => {
         // set article count for today to be n
         localStorage.setItem(
@@ -62,7 +64,8 @@ describe('Sign In Gate Tests', function () {
 
     const switchIsOn = (switchName) => {
         const switches = Cypress.env('SWITCHES');
-        const isOn = !!switches[switchName];
+        console.log('switches from ENV in SwitchIsON', switches);
+        const isOn = !!switches && !!switches[switchName];
         if (!isOn)
             console.log(
                 `${switchName} switch in Frontend does not exist or is turned off - skipping ${switchName} test suite`,
@@ -81,447 +84,157 @@ describe('Sign In Gate Tests', function () {
      *
      * Ensure you wrap all your AB test suites with "onlyRunIf(switchIsOn('abNameOfTest', () => {})" for this to work.
      */
-    describe('Get live Switches from Frontend', function () {
-        it('Load article and get switches', function () {
-            visitArticle();
-            cy.window().then((win) => {
-                const switches = win.guardian.config.switches;
-                Cypress.env('SWITCHES', switches);
-            });
-        });
-        it('Check switches Cypress env var exists', function () {
-            expect(Cypress.env('SWITCHES')).to.not.be.undefined;
+    describe('SignInGateMain', function () {
+        beforeEach(function () {
+            // sign in gate main runs from 0-900000 MVT IDs, so 500 forces user into test
+            setMvtCookie('500');
+
+            // set article count to be min number to view gate
+            setArticleCount(3);
         });
 
         onlyRunIf(switchIsOn('abSignInGateMainVariant'), () => {
-            describe('SignInGateMain', function () {
-                beforeEach(function () {
-                    // sign in gate main runs from 0-900000 MVT IDs, so 500 forces user into test
-                    setMvtCookie('500');
+            it('should load the sign in gate', function () {
+                visitArticleAndScrollToGateForLazyLoad();
 
-                    // set article count to be min number to view gate
-                    setArticleCount(3);
+                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+            });
+
+            it('should not load the sign in gate if the user has not read at least 3 article in a day', function () {
+                setArticleCount(1);
+
+                visitArticleAndScrollToGateForLazyLoad();
+
+                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
+            });
+
+            it('should not load the sign in gate if the user is signed in', function () {
+                // use GU_U cookie to determine if user is signed in
+                cy.setCookie(
+                    'GU_U',
+                    'MCwCFHbDHWevL_GqgH0CcbeDWp4N9kR5AhQ2lD3zMjjbKJAgC7FUDtc18Ac8BA',
+                    { log: true },
+                );
+
+                visitArticleAndScrollToGateForLazyLoad();
+
+                // when using GU_U cookie, there is an issue with the commercial.dcr.js bundle
+                // causing a URI Malformed error in cypress
+                // we use this uncaught exception in this test to catch this and continue the rest of the test
+                cy.on('uncaught:exception', () => {
+                    done();
+                    return false;
                 });
 
-                it('should load the sign in gate', function () {
-                    visitArticleAndScrollToGateForLazyLoad();
+                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
+            });
 
-                    cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+            it('should not load the sign in gate if the user has already dismissed the gate', function () {
+                localStorage.setItem(
+                    'gu.prefs.sign-in-gate',
+                    '{"SignInGateMain-main-variant-1":"2020-07-22T08:25:05.567Z"}',
+                );
+
+                visitArticleAndScrollToGateForLazyLoad();
+
+                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
+            });
+
+            it('should not load the sign in gate if the article is not a valid section (membership)', function () {
+                visitArticleAndScrollToGateForLazyLoad({
+                    url:
+                        'https://www.theguardian.com/membership/2018/nov/15/support-guardian-readers-future-journalism',
                 });
 
-                it('should not load the sign in gate if the user has not read at least 3 article in a day', function () {
-                    setArticleCount(1);
+                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
+            });
 
-                    visitArticleAndScrollToGateForLazyLoad();
-
-                    cy.get('[data-cy=sign-in-gate-main]').should(
-                        'not.be.visible',
-                    );
-                });
-
-                it('should not load the sign in gate if the user is signed in', function () {
-                    // use GU_U cookie to determine if user is signed in
-                    cy.setCookie(
-                        'GU_U',
-                        'MCwCFHbDHWevL_GqgH0CcbeDWp4N9kR5AhQ2lD3zMjjbKJAgC7FUDtc18Ac8BA',
-                        { log: true },
-                    );
-
-                    visitArticleAndScrollToGateForLazyLoad();
-
-                    // when using GU_U cookie, there is an issue with the commercial.dcr.js bundle
-                    // causing a URI Malformed error in cypress
-                    // we use this uncaught exception in this test to catch this and continue the rest of the test
-                    cy.on('uncaught:exception', () => {
-                        done();
-                        return false;
-                    });
-
-                    cy.get('[data-cy=sign-in-gate-main]').should(
-                        'not.be.visible',
-                    );
-                });
-
-                it('should not load the sign in gate if the user has already dismissed the gate', function () {
-                    localStorage.setItem(
-                        'gu.prefs.sign-in-gate',
-                        '{"SignInGateMain-main-variant-1":"2020-07-22T08:25:05.567Z"}',
-                    );
-
-                    visitArticleAndScrollToGateForLazyLoad();
-
-                    cy.get('[data-cy=sign-in-gate-main]').should(
-                        'not.be.visible',
-                    );
-                });
-
-                it('should not load the sign in gate if the article is not a valid section (membership)', function () {
-                    visitArticleAndScrollToGateForLazyLoad({
-                        url:
-                            'https://www.theguardian.com/membership/2018/nov/15/support-guardian-readers-future-journalism',
-                    });
-
-                    cy.get('[data-cy=sign-in-gate-main]').should(
-                        'not.be.visible',
-                    );
-                });
-
-                it('should not load the sign in gate on a device with an ios9 user agent string', function () {
-                    // can't use visitArticleAndScrollToGateForLazyLoad for this method as overriding user agent
-                    cy.visit(
-                        'Article?url=https://www.theguardian.com/games/2018/aug/23/nier-automata-yoko-taro-interview',
-                        {
-                            onBeforeLoad: (win) => {
-                                Object.defineProperty(
-                                    win.navigator,
-                                    'userAgent',
-                                    {
-                                        value:
-                                            'Mozilla/5.0 (iPad; CPU OS 9_0 like Mac OS X) AppleWebKit/601.1.17 (KHTML, like Gecko) Version/8.0 Mobile/13A175 Safari/600.1.4',
-                                    },
-                                );
-                            },
+            it('should not load the sign in gate on a device with an ios9 user agent string', function () {
+                // can't use visitArticleAndScrollToGateForLazyLoad for this method as overriding user agent
+                cy.visit(
+                    'Article?url=https://www.theguardian.com/games/2018/aug/23/nier-automata-yoko-taro-interview',
+                    {
+                        onBeforeLoad: (win) => {
+                            Object.defineProperty(win.navigator, 'userAgent', {
+                                value:
+                                    'Mozilla/5.0 (iPad; CPU OS 9_0 like Mac OS X) AppleWebKit/601.1.17 (KHTML, like Gecko) Version/8.0 Mobile/13A175 Safari/600.1.4',
+                            });
                         },
-                    );
-                    scrollToGateForLazyLoading();
+                    },
+                );
+                scrollToGateForLazyLoading();
 
-                    cy.get('[data-cy=sign-in-gate-main]').should(
-                        'not.be.visible',
-                    );
-                });
+                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
+            });
 
-                it('should remove gate when the dismiss button is clicked', function () {
-                    visitArticleAndScrollToGateForLazyLoad();
+            it('should remove gate when the dismiss button is clicked', function () {
+                visitArticleAndScrollToGateForLazyLoad();
 
-                    cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
 
-                    cy.get('[data-cy=sign-in-gate-main_dismiss]').click();
+                cy.get('[data-cy=sign-in-gate-main_dismiss]').click();
 
-                    cy.get('[data-cy=sign-in-gate-main]').should(
-                        'not.be.visible',
-                    );
-                });
+                cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
+            });
 
-                it('register button should contain profile.theguardian.com href', function () {
-                    visitArticleAndScrollToGateForLazyLoad();
+            it('register button should contain profile.theguardian.com href', function () {
+                visitArticleAndScrollToGateForLazyLoad();
 
-                    cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
 
-                    cy.get('[data-cy=sign-in-gate-main_register]')
-                        .invoke('attr', 'href')
-                        .should('contains', 'profile.theguardian.com');
-                });
+                cy.get('[data-cy=sign-in-gate-main_register]')
+                    .invoke('attr', 'href')
+                    .should('contains', 'profile.theguardian.com');
+            });
 
-                it('sign in link should contain profile.theguardian.com href', function () {
-                    visitArticleAndScrollToGateForLazyLoad();
+            it('sign in link should contain profile.theguardian.com href', function () {
+                visitArticleAndScrollToGateForLazyLoad();
 
-                    cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
 
-                    cy.get('[data-cy=sign-in-gate-main_signin]')
-                        .invoke('attr', 'href')
-                        .should('contains', 'profile.theguardian.com');
-                });
+                cy.get('[data-cy=sign-in-gate-main_signin]')
+                    .invoke('attr', 'href')
+                    .should('contains', 'profile.theguardian.com');
+            });
 
-                it('should show cmp ui when privacy settings link is clicked', function () {
-                    visitArticleAndScrollToGateForLazyLoad();
+            it('should show cmp ui when privacy settings link is clicked', function () {
+                visitArticleAndScrollToGateForLazyLoad();
 
-                    cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+                cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
 
-                    cy.get('[data-cy=sign-in-gate-main_privacy]').click();
+                cy.get('[data-cy=sign-in-gate-main_privacy]').click();
 
-                    cy.contains('privacy settings');
-                });
+                cy.contains('privacy settings');
             });
         });
+    });
 
-        onlyRunIf(switchIsOn('abSignInGateDismissWindow'), () => {
-            describe('SignInGateDismissWindow - control', function () {
-                beforeEach(function () {
-                    setMvtCookie('876000');
-
-                    // set article count to be min number to view gate
-                    setArticleCount(3);
-                });
-
-                it('should load the sign in gate', function () {
-                    visitArticleAndScrollToGateForLazyLoad();
-
-                    cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
-                });
-
-                it('should not load the sign in gate if the user has not read at least 3 article in a day', function () {
-                    setArticleCount(1);
-
-                    visitArticleAndScrollToGateForLazyLoad();
-
-                    cy.get('[data-cy=sign-in-gate-main]').should(
-                        'not.be.visible',
-                    );
-                });
-
-                it('should not load the sign in gate if the user is signed in', function () {
-                    // use GU_U cookie to determine if user is signed in
-                    cy.setCookie(
-                        'GU_U',
-                        'MCwCFHbDHWevL_GqgH0CcbeDWp4N9kR5AhQ2lD3zMjjbKJAgC7FUDtc18Ac8BA',
-                        {
-                            log: true,
-                        },
-                    );
-
-                    visitArticleAndScrollToGateForLazyLoad();
-
-                    // when using GU_U cookie, there is an issue with the commercial.dcr.js bundle
-                    // causing a URI Malformed error in cypress
-                    // we use this uncaught exception in this test to catch this and continue the rest of the test
-                    cy.on('uncaught:exception', () => {
-                        done();
-                        return false;
-                    });
-
-                    cy.get('[data-cy=sign-in-gate-main]').should(
-                        'not.be.visible',
-                    );
-                });
-
-                it('should not load the sign in gate if the user has already dismissed the gate', function () {
-                    localStorage.setItem(
-                        'gu.prefs.sign-in-gate',
-                        '{"SignInGateDismissWindow-dismiss-window-control":"2020-07-22T08:25:05.567Z"}',
-                    );
-
-                    visitArticleAndScrollToGateForLazyLoad();
-
-                    cy.get('[data-cy=sign-in-gate-main]').should(
-                        'not.be.visible',
-                    );
-                });
-                it('should not load the sign in gate if the article is not a valid section (membership)', function () {
-                    visitArticleAndScrollToGateForLazyLoad({
-                        url:
-                            'https://www.theguardian.com/membership/2018/nov/15/support-guardian-readers-future-journalism',
-                    });
-
-                    cy.get('[data-cy=sign-in-gate-main]').should(
-                        'not.be.visible',
-                    );
-                });
-
-                it('should not load the sign in gate on a device with an ios9 user agent string', function () {
-                    // can't use visitArticleAndScrollToGateForLazyLoad for this method as overriding user agent
-                    cy.visit(
-                        'Article?url=https://www.theguardian.com/games/2018/aug/23/nier-automata-yoko-taro-interview',
-                        {
-                            onBeforeLoad: (win) => {
-                                Object.defineProperty(
-                                    win.navigator,
-                                    'userAgent',
-                                    {
-                                        value:
-                                            'Mozilla/5.0 (iPad; CPU OS 9_0 like Mac OS X) AppleWebKit/601.1.17 (KHTML, like Gecko) Version/8.0 Mobile/13A175 Safari/600.1.4',
-                                    },
-                                );
-                            },
-                        },
-                    );
-                    scrollToGateForLazyLoading();
-
-                    cy.get('[data-cy=sign-in-gate-main]').should(
-                        'not.be.visible',
-                    );
-                });
-
-                it('should remove gate when the dismiss button is clicked', function () {
-                    visitArticleAndScrollToGateForLazyLoad();
-
-                    cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
-
-                    cy.get('[data-cy=sign-in-gate-main_dismiss]').click();
-
-                    cy.get('[data-cy=sign-in-gate-main]').should(
-                        'not.be.visible',
-                    );
-                });
-
-                it('register button should contain profile.theguardian.com href', function () {
-                    visitArticleAndScrollToGateForLazyLoad();
-
-                    cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
-
-                    cy.get('[data-cy=sign-in-gate-main_register]')
-                        .invoke('attr', 'href')
-                        .should('contains', 'profile.theguardian.com');
-                });
-
-                it('sign in link should contain profile.theguardian.com href', function () {
-                    visitArticleAndScrollToGateForLazyLoad();
-
-                    cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
-
-                    cy.get('[data-cy=sign-in-gate-main_signin]')
-                        .invoke('attr', 'href')
-                        .should('contains', 'profile.theguardian.com');
-                });
-
-                it('should show cmp ui when privacy settings link is clicked', function () {
-                    visitArticleAndScrollToGateForLazyLoad();
-
-                    cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
-
-                    cy.get('[data-cy=sign-in-gate-main_privacy]').click();
-
-                    cy.contains('privacy settings');
-                });
-            });
-        });
-
-        onlyRunIf(switchIsOn('abSignInGateDismissWindow'), () => {
-            describe('SignInGateDismissWindow - variant 1 - article', function () {
-                beforeEach(function () {
-                    setMvtCookie('877000');
-
-                    // set article count to be min number to view gate
-                    setArticleCount(3);
-                });
-                it('should load the sign in gate', function () {
-                    visitArticleAndScrollToGateForLazyLoad();
-
-                    cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
-                });
-
-                it('should remove gate when the dismiss button is clicked', function () {
-                    visitArticleAndScrollToGateForLazyLoad();
-
-                    cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
-
-                    cy.get('[data-cy=sign-in-gate-main_dismiss]').click();
-
-                    cy.get('[data-cy=sign-in-gate-main]').should(
-                        'not.be.visible',
-                    );
-                });
-
-                it('should load the sign in gate even if the user has already dismissed the gate', function () {
-                    localStorage.setItem(
-                        'gu.prefs.sign-in-gate',
-                        '{"SignInGateDismissWindow-variant-1-article":"2020-07-22T08:25:05.567Z"}',
-                    );
-
-                    visitArticleAndScrollToGateForLazyLoad();
-
-                    cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
-                });
-
-                it('should reshow the sign in gate if the user has already dismissed the gate but navigates to a new article', function () {
-                    visitArticleAndScrollToGateForLazyLoad();
-
-                    cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
-
-                    cy.get('[data-cy=sign-in-gate-main_dismiss]').click();
-
-                    cy.get('[data-cy=sign-in-gate-main]').should(
-                        'not.be.visible',
-                    );
-
-                    visitArticleAndScrollToGateForLazyLoad();
-
-                    cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
-                });
-            });
-        });
-
-        onlyRunIf(switchIsOn('abSignInGateDismissWindow'), () => {
-            describe('SignInGateDismissWindow - variant 2 - day', function () {
-                beforeEach(function () {
-                    setMvtCookie('878000');
-
-                    // set article count to be min number to view gate
-                    setArticleCount(3);
-                });
-
-                it('should load the sign in gate', function () {
-                    visitArticleAndScrollToGateForLazyLoad();
-
-                    cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
-                });
-
-                it('should remove gate when the dismiss button is clicked', function () {
-                    visitArticleAndScrollToGateForLazyLoad();
-
-                    cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
-
-                    cy.get('[data-cy=sign-in-gate-main_dismiss]').click();
-
-                    cy.get('[data-cy=sign-in-gate-main]').should(
-                        'not.be.visible',
-                    );
-                });
-
-                it('should not load the sign in gate if the user has dismissed the gate in last 24hrs', function () {
-                    const lessThanADayAgo = new Date();
-                    lessThanADayAgo.setHours(lessThanADayAgo.getHours() - 16);
-                    localStorage.setItem(
-                        'gu.prefs.sign-in-gate',
-                        JSON.stringify({
-                            'SignInGateDismissWindow-dismiss-window-variant-2-day': lessThanADayAgo.toISOString(),
-                        }),
-                    );
-
-                    visitArticleAndScrollToGateForLazyLoad();
-
-                    cy.get('[data-cy=sign-in-gate-main]').should(
-                        'not.be.visible',
-                    );
-                });
-
-                it('should load the sign in gate if the user has dismissed the gate more than 24hrs ago', function () {
-                    const moreThanADayAgo = new Date();
-                    moreThanADayAgo.setHours(moreThanADayAgo.getHours() - 48);
-                    localStorage.setItem(
-                        'gu.prefs.sign-in-gate',
-                        JSON.stringify({
-                            'SignInGateDismissWindow-dismiss-window-variant-2-day': moreThanADayAgo.toISOString(),
-                        }),
-                    );
-
-                    visitArticleAndScrollToGateForLazyLoad();
-
-                    cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
-                });
-            });
-        });
-
+    describe('SignInGatePatientia', function () {
         onlyRunIf(switchIsOn('abSignInGatePatientia'), () => {
-            describe('SignInGatePatientia', function () {
-                beforeEach(function () {
-                    // sign in gate patientia runs from 999901-1000000 MVT IDs, so 999901 forces user into test variant
-                    setMvtCookie('999901');
+            beforeEach(function () {
+                // sign in gate patientia runs from 999901-1000000 MVT IDs, so 999901 forces user into test variant
+                setMvtCookie('999901');
 
-                    // set article count to be min number to view gate
-                    setArticleCount(3);
-                });
+                // set article count to be min number to view gate
+                setArticleCount(3);
+            });
 
-                it('should load the sign in gate', function () {
-                    visitArticleAndScrollToGateForLazyLoad();
+            it('should load the sign in gate', function () {
+                visitArticleAndScrollToGateForLazyLoad();
 
-                    cy.get('[data-cy=sign-in-gate-patientia]').should(
-                        'be.visible',
-                    );
-                });
+                cy.get('[data-cy=sign-in-gate-patientia]').should('be.visible');
+            });
 
-                it('should remove gate when the dismiss button is clicked', function () {
-                    visitArticleAndScrollToGateForLazyLoad();
+            it('should remove gate when the dismiss button is clicked', function () {
+                visitArticleAndScrollToGateForLazyLoad();
 
-                    cy.get('[data-cy=sign-in-gate-patientia]').should(
-                        'be.visible',
-                    );
+                cy.get('[data-cy=sign-in-gate-patientia]').should('be.visible');
 
-                    cy.get('[data-cy=sign-in-gate-patientia_dismiss]').click();
+                cy.get('[data-cy=sign-in-gate-patientia_dismiss]').click();
 
-                    cy.get('[data-cy=sign-in-gate-patientia]').should(
-                        'not.be.visible',
-                    );
-                });
+                cy.get('[data-cy=sign-in-gate-patientia]').should(
+                    'not.be.visible',
+                );
             });
         });
     });

--- a/cypress/lib/abSwitches.js
+++ b/cypress/lib/abSwitches.js
@@ -1,0 +1,11 @@
+let abSwitches;
+
+export const getAbSwitches = (x) => {
+    const url =
+        'https://www.theguardian.com/games/2018/aug/23/nier-automata-yoko-taro-interview';
+
+    cy.visit(`Article?url=${url}`).then((contentWindow) => {
+        abSwitches = contentWindow.guardian.config.switches;
+        Cypress.env('SWITCHES', abSwitches);
+    });
+};

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -16,6 +16,14 @@
 // Import commands.js using ES2015 syntax:
 import './commands';
 import 'cypress-plugin-tab';
+import { getAbSwitches } from '../lib/abSwitches';
+console.log('running Support');
+
+// eslint-disable-next-line mocha/no-top-level-hooks
+before(function () {
+    console.log('running Support Before');
+    getAbSwitches();
+});
 
 // Remove the consent iframe before the tests run
 // eslint-disable-next-line mocha/no-top-level-hooks

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
         "@babel/preset-react": "^7.10.1",
         "@babel/preset-typescript": "^7.10.1",
         "@babel/runtime": "^7.10.2",
+        "@cypress/skip-test": "^2.5.0",
         "@storybook/addon-actions": "^5.3.19",
         "@storybook/addon-links": "^5.2.5",
         "@storybook/addon-storysource": "^5.2.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2092,6 +2092,11 @@
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
 
+"@cypress/skip-test@^2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@cypress/skip-test/-/skip-test-2.5.0.tgz#ba3fc8c441a9dda5fa410e783006107ff3b9d050"
+  integrity sha512-OqyToxRLUG/EAfZa0w8sAooOW6tr8pYCBpo3SLsKycrV2RTj9Sy7rB+5U0MvES87kWCHtO10qMIESuw8RiEYyQ==
+
 "@cypress/xvfb@^1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@cypress/xvfb/-/xvfb-1.2.4.tgz#2daf42e8275b39f4aa53c14214e557bd14e7748a"


### PR DESCRIPTION
## Why?

AB test switches are defined in Frontend and required to be "ON" for Cypress E2E Sign In Gate Test to successfully run and pass. However, in practice it is useful to be able to switch an AB test on and off in Frontend PROD Admin UI without having to make any code changes to a different repo. 
 
In order not to break CI builds in DCR if someone switches off a Sign In Gate AB test in the Frontend Admin tool, we now run a setup test suite to load active switches from Frontend into a Cypress Environment Variable available to this spec only.

 With the help of a utility function `onlyRunIf` that wraps each AB test suite ("describe"), we can use this env var to check if a switch is ON to conditionally decide which AB test suites to run. .

For local development and CODE, you will still need to ensure the switches are ON to run your cypress tests. 
