### PR TITLE
Fix some AMP errors

### DIFF
--- a/src/amp/components/elements/VideoYoutubeBlockComponent.tsx
+++ b/src/amp/components/elements/VideoYoutubeBlockComponent.tsx
@@ -7,7 +7,7 @@ export const VideoYoutubeBlockComponent: React.FC<{
     pillar: Pillar;
 }> = ({ element, pillar }) => {
     const youtubeId = getIdFromUrl(
-        element.url,
+        element.originalUrl || element.url,
         '^[a-zA-Z0-9_-]{11}$', // Alpha numeric, underscores and hyphens, exactly 11 numbers long
         false,
         'v',

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -284,7 +284,7 @@ interface VideoFacebookBlockElement {
     url: string;
     height: number;
     width: number;
-    caption: string;
+    caption?: string;
     embedUrl?: string;
 }
 
@@ -303,6 +303,7 @@ interface VideoYoutubeBlockElement {
     _type: 'model.dotcomrendering.pageElements.VideoYoutubeBlockElement';
     embedUrl?: string;
     url: string;
+    originalUrl: string;
     height: number;
     width: number;
     caption?: string;

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -1945,7 +1945,6 @@
             },
             "required": [
                 "_type",
-                "caption",
                 "height",
                 "url",
                 "width"
@@ -2004,6 +2003,9 @@
                 "url": {
                     "type": "string"
                 },
+                "originalUrl": {
+                    "type": "string"
+                },
                 "height": {
                     "type": "number"
                 },
@@ -2023,6 +2025,7 @@
             "required": [
                 "_type",
                 "height",
+                "originalUrl",
                 "url",
                 "width"
             ]


### PR DESCRIPTION
* caption should be optional
* prefer original URL for youtube video ID (this is more likely to be in correct format) as get a runtime error sometimes atm

Nb. motivated by a steep rise in AMP 500s recently:

![Screenshot 2020-09-02 at 09 58 06](https://user-images.githubusercontent.com/858402/92015499-c9f61f80-ed48-11ea-8390-8b8eca8f0ee2.png)

I couldn't find an immediate cause that explains the shift around the 8th, but from Kibana, the main issue appears to be the Youtube one - caused by the URL format being different from expected - so possibly there was a tools change or Youtube change recently. Kibana doesn't go back far enough to verify unfortunately.

Some example problem cases are here:

https://docs.google.com/spreadsheets/d/1oSsGgZxdkkJVR0eOQ3RiJECLUYOOhBHMyRpfmc25sOE/edit?usp=sharing