### PR TITLE
Add Height and Width to Images

### DIFF
--- a/src/web/components/Picture.tsx
+++ b/src/web/components/Picture.tsx
@@ -22,7 +22,9 @@ export const Picture: React.FC<{
     sources: PictureSource[];
     alt: string;
     src: string;
-}> = ({ sources, alt, src }) => {
+    height: string;
+    width: string;
+}> = ({ sources, alt, src, height, width }) => {
     return (
         // https://stackoverflow.com/questions/10844205/html-5-strange-img-always-adds-3px-margin-at-bottom
         // why did we put `style="vertical-align: middle;"` inside the img tag
@@ -32,7 +34,7 @@ export const Picture: React.FC<{
                     .map(forSource)
                     .join(
                         '',
-                    )}<!--[if IE 9]></video><![endif]--><img style="vertical-align: middle;" itemprop="contentUrl" alt="${alt}" src="${src}" />`,
+                    )}<!--[if IE 9]></video><![endif]--><img style="vertical-align: middle;" itemprop="contentUrl" alt="${alt}" src="${src}" height="${height}" width="${width}" />`,
             }}
         />
     );

--- a/src/web/components/elements/ImageComponent.tsx
+++ b/src/web/components/elements/ImageComponent.tsx
@@ -292,6 +292,22 @@ export const ImageComponent = ({
     const isNotOpinion =
         designType !== 'Comment' && designType !== 'GuardianView';
 
+    // We get the first 'media' height and width. This doesn't match the actual image height and width but that's ok
+    // because the image sources and CSS deal with the sizing. What the height and width gives us is a true
+    // ratio to apply to the image in the page, so the browser's pre-parser can reserve the space.
+    //
+    // The default is the 5:3 standard that The Grid suggests, at our wide breakpoint width.
+    const imageWidth =
+        (element.media &&
+            element.media.allImages[0] &&
+            element.media.allImages[0].fields.width) ||
+        '620';
+    const imageHeight =
+        (element.media &&
+            element.media.allImages[0] &&
+            element.media.allImages[0].fields.height) ||
+        '372';
+
     if (isMainMedia && display === Display.Immersive && isNotOpinion) {
         return (
             <div
@@ -313,6 +329,8 @@ export const ImageComponent = ({
                     sources={sources}
                     alt={element.data.alt || ''}
                     src={getFallback(element.imageSources)}
+                    width={imageWidth}
+                    height={imageHeight}
                 />
                 {starRating && <PositionStarRating rating={starRating} />}
                 {title && (
@@ -329,6 +347,7 @@ export const ImageComponent = ({
                     position: relative;
 
                     img {
+                        height: 100%;
                         width: 100%;
                         object-fit: cover;
                     }
@@ -338,6 +357,8 @@ export const ImageComponent = ({
                     sources={sources}
                     alt={element.data.alt || ''}
                     src={getFallback(element.imageSources)}
+                    width={imageWidth}
+                    height={imageHeight}
                 />
                 {starRating && <PositionStarRating rating={starRating} />}
                 {title && (
@@ -354,6 +375,7 @@ export const ImageComponent = ({
                     position: relative;
 
                     img {
+                        height: 100%;
                         width: 100%;
                         object-fit: cover;
                     }
@@ -363,6 +385,8 @@ export const ImageComponent = ({
                     sources={sources}
                     alt={element.data.alt || ''}
                     src={getFallback(element.imageSources)}
+                    width={imageWidth}
+                    height={imageHeight}
                 />
                 {isMainMedia && (
                     // Below tablet, main media images show an info toggle at the bottom right of


### PR DESCRIPTION
## What does this change?

This adds a height and width to the image element, so the pre-parser in the browser can reserve space and prevent re-rendering on image load.

### Before

![2020-09-03 11 56 12](https://user-images.githubusercontent.com/638051/92107619-032c9f00-edde-11ea-9483-9b405ce9e540.gif)

![2020-09-03 11 55 27](https://user-images.githubusercontent.com/638051/92107629-06278f80-edde-11ea-8587-d899b57a3f3e.gif)


### After

![2020-09-03 11 55 05](https://user-images.githubusercontent.com/638051/92107651-0a53ad00-edde-11ea-9391-3fdf2f33b4c4.gif)

![2020-09-03 11 55 49](https://user-images.githubusercontent.com/638051/92107660-0d4e9d80-edde-11ea-9c88-1bff89155176.gif)

![2020-09-03 11 54 38](https://user-images.githubusercontent.com/638051/92107668-10498e00-edde-11ea-8c7f-639935806a0a.gif)

## Why?

Improves CLS and LCP times on DCR.
