### PR TITLE
Updating standfirst to correct li element styling

### DIFF
--- a/src/web/components/Standfirst.tsx
+++ b/src/web/components/Standfirst.tsx
@@ -3,7 +3,7 @@ import { css, cx } from 'emotion';
 import { neutral } from '@guardian/src-foundations/palette';
 import { space } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
-import { headline, textSans } from '@guardian/src-foundations/typography';
+import { headline } from '@guardian/src-foundations/typography';
 import { Display } from '@root/src/lib/display';
 
 type Props = {
@@ -14,7 +14,6 @@ type Props = {
 
 const nestedStyles = css`
     li {
-        ${textSans.medium()};
         margin-bottom: 6px;
         padding-left: 20px;
 
@@ -36,12 +35,6 @@ const nestedStyles = css`
 
     p {
         margin-bottom: 8px;
-    }
-
-    li {
-        ${headline.xxxsmall({
-            fontWeight: 'bold',
-        })};
     }
 
     strong {


### PR DESCRIPTION
## What does this change?
Updates the styling of the <li> item within a standfirst to use a lighter font style in order to be more aligned with frontend.

### Before
<img width="643" alt="Screen Shot 2020-09-03 at 14 32 12" src="https://user-images.githubusercontent.com/2051501/92121906-ba331580-edf2-11ea-8967-27e971c24978.png">

### After
<img width="643" alt="Screen Shot 2020-09-03 at 14 35 15" src="https://user-images.githubusercontent.com/2051501/92121940-c61ed780-edf2-11ea-86d1-e7b21adfb2fa.png">

## Why?
Parity
