### PR TITLE
Fix Yarn link bug with Typescript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ node_modules
 !.vscode/extensions.json
 !.vscode/settings.json
 !.vscode/dcr.code-snippets
+.metals/
 
 # System files
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -6,20 +6,21 @@ Frontend rendering framework for theguardian.com. It uses [React](https://reactj
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 <!-- Automatically created with yarn run createtoc and on push hook -->
 
-- [Where can I see Dotcom Rendering in Production?](#where-can-i-see-dotcom-rendering-in-production)
-- [Quick start](#quick-start)
-  - [Install Node.js](#install-nodejs)
-  - [Running instructions](#running-instructions)
-  - [Detailed Setup](#detailed-setup)
-  - [Technologies](#technologies)
-  - [Architecture Diagram](#architecture-diagram)
-  - [Concepts](#concepts)
-  - [Feedback](#feedback)
-- [Code Quality](#code-quality)
-- [IDE setup](#ide-setup)
-  - [Extensions](#extensions)
-  - [Auto fix on save](#auto-fix-on-save)
-- [Thanks](#thanks)
+- [Dotcom Rendering](#dotcom-rendering)
+  - [Where can I see Dotcom Rendering in Production?](#where-can-i-see-dotcom-rendering-in-production)
+  - [Quick start](#quick-start)
+    - [Install Node.js](#install-nodejs)
+    - [Running instructions](#running-instructions)
+    - [Detailed Setup](#detailed-setup)
+    - [Technologies](#technologies)
+    - [Architecture Diagram](#architecture-diagram)
+    - [Concepts](#concepts)
+    - [Feedback](#feedback)
+  - [Code Quality](#code-quality)
+  - [IDE setup](#ide-setup)
+    - [Extensions](#extensions)
+    - [Auto fix on save](#auto-fix-on-save)
+  - [Thanks](#thanks)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -125,6 +126,7 @@ $ make lint
 $ make stylelint
 $ make tsc
 $ make test
+$ make me breakfast
 ```
 
 If you get lint errors, you can attempt to automatically fix them with:

--- a/README.md
+++ b/README.md
@@ -126,7 +126,6 @@ $ make lint
 $ make stylelint
 $ make tsc
 $ make test
-$ make me breakfast
 ```
 
 If you get lint errors, you can attempt to automatically fix them with:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -44,6 +44,7 @@
         /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
         "paths": {
             /* Aliases should also be added to the webpack, babel and jest configurations */
+            "*": ["node_modules/@types/*", "*"], // Make sure that yarn linking doesn't confuse things https://github.com/microsoft/TypeScript/issues/11916#issuecomment-257130001
             "@root/*": ["./*"],
             "@frontend/*": ["./src/*"]
         },


### PR DESCRIPTION
## What does this change?

Typescript gets confused with `yarn link` because it follows the symlink, this adds this fix https://github.com/microsoft/TypeScript/issues/11916#issuecomment-257130001

### Before

![image](https://user-images.githubusercontent.com/638051/92122430-50ffd200-edf3-11ea-9c43-64e9ac390d1c.png)


### After

Type checks work.