### PR TITLE
Add native lazy loading to images

### DIFF
--- a/src/web/components/Picture.tsx
+++ b/src/web/components/Picture.tsx
@@ -34,7 +34,7 @@ export const Picture: React.FC<{
                     .map(forSource)
                     .join(
                         '',
-                    )}<!--[if IE 9]></video><![endif]--><img style="vertical-align: middle;" itemprop="contentUrl" alt="${alt}" src="${src}" height="${height}" width="${width}" />`,
+                    )}<!--[if IE 9]></video><![endif]--><img style="vertical-align: middle;" itemprop="contentUrl" alt="${alt}" src="${src}" height="${height}" width="${width}" loading="lazy" />`,
             }}
         />
     );


### PR DESCRIPTION
## What does this change?

Adds native lazy image loading to all article images.

https://web.dev/native-lazy-loading/

This has been running on fronts for a long while https://github.com/guardian/frontend/pull/21584

Happy to A/B test, but this feels like a safe just-do that should improve perf in general.

See before and after in these super clear gifs - you're looking for the third image on https://www.theguardian.com/film/2020/sep/03/tenet-dialogue-christopher-nolan-sound-technology not loading until scroll position is nearer.

### Before

![2020-09-03 15 00 49](https://user-images.githubusercontent.com/638051/92125296-cae58a80-edf6-11ea-8146-e2046b805b1f.gif)


### After

![2020-09-03 15 00 05](https://user-images.githubusercontent.com/638051/92125309-ce791180-edf6-11ea-906b-7bcf6ceae6a9.gif)

## Why?

Load the things we need when we need them and not before.
