### PR TITLE
Map block element support

### DIFF
--- a/src/amp/components/elements/MapBlockComponent.tsx
+++ b/src/amp/components/elements/MapBlockComponent.tsx
@@ -12,7 +12,7 @@ export const MapBlockComponent: React.SFC<{
     pillar: Pillar;
 }> = ({ element, pillar }) => {
     const attributes = {
-        src: `${element.url}`,
+        src: `${element.embedUrl}`,
         title: `${element.source}: ${element.title}`,
         layout: 'responsive',
         sandbox: 'allow-scripts allow-same-origin',

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -175,6 +175,7 @@ interface InteractiveBlockElement extends InteractiveAtomBlockElementBase {
 interface MapBlockElement {
     _type: 'model.dotcomrendering.pageElements.MapBlockElement';
     embedUrl: string;
+    originalUrl: string;
     source: string;
     title: string;
     height: number;

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -174,11 +174,12 @@ interface InteractiveBlockElement extends InteractiveAtomBlockElementBase {
 
 interface MapBlockElement {
     _type: 'model.dotcomrendering.pageElements.MapBlockElement';
-    url: string;
-    originalUrl: string;
+    embedUrl: string;
     source: string;
-    caption: string;
     title: string;
+    height: number;
+    width: number;
+    caption?: string;
 }
 
 interface MultiImageBlockElement {

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -1516,29 +1516,32 @@
                         "model.dotcomrendering.pageElements.MapBlockElement"
                     ]
                 },
-                "url": {
-                    "type": "string"
-                },
-                "originalUrl": {
+                "embedUrl": {
                     "type": "string"
                 },
                 "source": {
                     "type": "string"
                 },
-                "caption": {
+                "title": {
                     "type": "string"
                 },
-                "title": {
+                "height": {
+                    "type": "number"
+                },
+                "width": {
+                    "type": "number"
+                },
+                "caption": {
                     "type": "string"
                 }
             },
             "required": [
                 "_type",
-                "caption",
-                "originalUrl",
+                "embedUrl",
+                "height",
                 "source",
                 "title",
-                "url"
+                "width"
             ]
         },
         "MultiImageBlockElement": {

--- a/src/web/components/elements/MapEmbedBlockComponent.tsx
+++ b/src/web/components/elements/MapEmbedBlockComponent.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { MaintainAspectRatio } from '@frontend/web/components/MaintainAspectRatio';
+import { Caption } from '@root/src/web/components/Caption';
+import { Display } from '@root/src/lib/display';
+
+export const MapEmbedBlockComponent: React.FC<{
+    embedUrl?: string;
+    height: number;
+    width: number;
+    title?: string;
+    caption?: string;
+    pillar: Pillar;
+    display: Display;
+    designType: DesignType;
+    credit?: string;
+}> = ({
+    embedUrl,
+    title,
+    width,
+    height,
+    caption,
+    pillar,
+    display,
+    designType,
+    credit,
+}) => {
+    // 812 is the full height on an iphone X. This ensures that the embed doesn't display any larger than the available viewport
+    // Constrain iframe embeds with a width to their natural width
+    // rather than stretch them to the container using
+    // a max that would prevent portrait videos from being taller than an iphone X (baseline)
+    // More context: https://github.com/guardian/frontend/pull/17902
+    const maxHeight = 812;
+    const aspectRatio = width / height;
+    const maxWidth = maxHeight * aspectRatio;
+
+    const hasCaption = caption != null;
+
+    const embedContainer = css`
+        max-width: ${maxWidth}px;
+        width: 100%;
+        margin-bottom: ${hasCaption ? `0px` : `6px`};
+    `;
+
+    return (
+        <div className={embedContainer}>
+            <MaintainAspectRatio height={height} width={width}>
+                <iframe
+                    src={embedUrl}
+                    title={title}
+                    height={height}
+                    width={width}
+                    allowFullScreen={true}
+                />
+            </MaintainAspectRatio>
+            {hasCaption && (
+                <Caption
+                    captionText={caption}
+                    designType={designType}
+                    pillar={pillar}
+                    display={display}
+                    credit={credit}
+                />
+            )}
+        </div>
+    );
+};

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -11,6 +11,7 @@ import { EmbedBlockComponent } from '@root/src/web/components/elements/EmbedBloc
 import { HighlightBlockComponent } from '@root/src/web/components/elements/HighlightBlockComponent';
 import { ImageBlockComponent } from '@root/src/web/components/elements/ImageBlockComponent';
 import { InstagramBlockComponent } from '@root/src/web/components/elements/InstagramBlockComponent';
+import { MapEmbedBlockComponent } from '@root/src/web/components/elements/MapEmbedBlockComponent';
 import { MultiImageBlockComponent } from '@root/src/web/components/elements/MultiImageBlockComponent';
 import { PullQuoteBlockComponent } from '@root/src/web/components/elements/PullQuoteBlockComponent';
 import { SoundcloudBlockComponent } from '@root/src/web/components/elements/SoundcloudBlockComponent';
@@ -180,6 +181,20 @@ export const ArticleRenderer: React.FC<{
                             html={element.html}
                             js={element.js}
                             css={element.css}
+                        />
+                    );
+                case 'model.dotcomrendering.pageElements.MapBlockElement':
+                    return (
+                        <MapEmbedBlockComponent
+                            pillar={pillar}
+                            embedUrl={element.embedUrl}
+                            height={element.height}
+                            width={element.width}
+                            caption={element.caption}
+                            credit={element.source}
+                            title={element.title}
+                            display={display}
+                            designType={designType}
                         />
                     );
                 case 'model.dotcomrendering.pageElements.MultiImageBlockElement':
@@ -362,7 +377,6 @@ export const ArticleRenderer: React.FC<{
                 case 'model.dotcomrendering.pageElements.CommentBlockElement':
                 case 'model.dotcomrendering.pageElements.ContentAtomBlockElement':
                 case 'model.dotcomrendering.pageElements.GenericAtomBlockElement':
-                case 'model.dotcomrendering.pageElements.MapBlockElement':
                 case 'model.dotcomrendering.pageElements.VideoBlockElement':
                     return null;
             }


### PR DESCRIPTION
##  What does this change?
Adds support for rendering the MapBlockElement, keeping the aspect ratio and adding the caption. Depends on https://github.com/guardian/frontend/pull/22968

### Frontend
<img width="643" alt="Screen Shot 2020-09-03 at 17 47 52" src="https://user-images.githubusercontent.com/2051501/92143799-acd75480-ee0d-11ea-97d5-fb651798fcb2.png">

### DCR
<img width="643" alt="Screen Shot 2020-09-03 at 17 43 02" src="https://user-images.githubusercontent.com/2051501/92143628-73064e00-ee0d-11ea-9123-189bf609cb2d.png">

## Why?
Parity