### PR TITLE
Ability to force AB Switch state for Cypress Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,21 +6,20 @@ Frontend rendering framework for theguardian.com. It uses [React](https://reactj
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 <!-- Automatically created with yarn run createtoc and on push hook -->
 
-- [Dotcom Rendering](#dotcom-rendering)
-  - [Where can I see Dotcom Rendering in Production?](#where-can-i-see-dotcom-rendering-in-production)
-  - [Quick start](#quick-start)
-    - [Install Node.js](#install-nodejs)
-    - [Running instructions](#running-instructions)
-    - [Detailed Setup](#detailed-setup)
-    - [Technologies](#technologies)
-    - [Architecture Diagram](#architecture-diagram)
-    - [Concepts](#concepts)
-    - [Feedback](#feedback)
-  - [Code Quality](#code-quality)
-  - [IDE setup](#ide-setup)
-    - [Extensions](#extensions)
-    - [Auto fix on save](#auto-fix-on-save)
-  - [Thanks](#thanks)
+- [Where can I see Dotcom Rendering in Production?](#where-can-i-see-dotcom-rendering-in-production)
+- [Quick start](#quick-start)
+  - [Install Node.js](#install-nodejs)
+  - [Running instructions](#running-instructions)
+  - [Detailed Setup](#detailed-setup)
+  - [Technologies](#technologies)
+  - [Architecture Diagram](#architecture-diagram)
+  - [Concepts](#concepts)
+  - [Feedback](#feedback)
+- [Code Quality](#code-quality)
+- [IDE setup](#ide-setup)
+  - [Extensions](#extensions)
+  - [Auto fix on save](#auto-fix-on-save)
+- [Thanks](#thanks)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/src/web/components/HydrateApp.tsx
+++ b/src/web/components/HydrateApp.tsx
@@ -6,6 +6,7 @@ import { ABProvider } from '@guardian/ab-react';
 import { tests } from '@frontend/web/experiments/ab-tests';
 import { getCookie } from '@frontend/web/browser/cookie';
 import { getForcedParticipationsFromUrl } from '@frontend/web/lib/getAbUrlHash';
+import { getCypressSwitches } from '@frontend/web/experiments/cypress-switches';
 
 type Props = {
     CAPI: CAPIBrowserType;
@@ -31,12 +32,15 @@ export const HydrateApp = ({ CAPI, NAV }: Props) => {
 
     const windowHash = window && window.location && window.location.hash;
 
+    // forced switches when running within cypress
+    const cypressAbSwitches = getCypressSwitches();
+
     ReactDOM.render(
         <ABProvider
             arrayOfTestObjects={tests}
             abTestSwitches={{
-                ...{ abAbTestTest: true }, // Test switch, used for Cypress integration test
                 ...CAPI.config.switches,
+                ...cypressAbSwitches,
             }}
             pageIsSensitive={CAPI.config.isSensitive}
             mvtMaxValue={1000000}

--- a/src/web/components/HydrateApp.tsx
+++ b/src/web/components/HydrateApp.tsx
@@ -32,7 +32,8 @@ export const HydrateApp = ({ CAPI, NAV }: Props) => {
 
     const windowHash = window && window.location && window.location.hash;
 
-    // forced switches when running within cypress
+    // Get the forced switches to use for when running within cypress
+    // Is empty object if not in cypress
     const cypressAbSwitches = getCypressSwitches();
 
     ReactDOM.render(
@@ -40,7 +41,7 @@ export const HydrateApp = ({ CAPI, NAV }: Props) => {
             arrayOfTestObjects={tests}
             abTestSwitches={{
                 ...CAPI.config.switches,
-                ...cypressAbSwitches,
+                ...cypressAbSwitches, // by adding cypress switches below CAPI, we can override any production switch in Cypress
             }}
             pageIsSensitive={CAPI.config.isSensitive}
             mvtMaxValue={1000000}

--- a/src/web/components/SignInGate/README.md
+++ b/src/web/components/SignInGate/README.md
@@ -294,8 +294,8 @@ The disadvantage of this method is that it's a bit tricky to work out exactly wh
 <ABProvider
     arrayOfTestObjects={tests}
     abTestSwitches={{
-        ...{ abAbTestTest: true },
         ...CAPI.config.switches,
+        ...cypressAbSwitches,
     }}
     pageIsSensitive={CAPI.config.isSensitive}
     mvtMaxValue={1000000}
@@ -320,8 +320,8 @@ The advantages of using the forcedTestVariant:
 
 ```tsx
  abTestSwitches={{
-       ...{ abAbTestTest: true },
        ...CAPI.config.switches,
+       ...cypressAbSwitches,
        ...{ abSignInGateSwitchName: true }, // DO NOT COMMIT THIS!!
    }}
 ```
@@ -406,6 +406,21 @@ it('should load the sign in gate', () => {
 ```
 
 To run the cypress tests interactively, make sure the development server is running first, and then use `yarn cypress:open` to open the interactive cypress testing tool.
+
+Since the Cypress tests rely on a production article, it would normally get the AB switch state from there. In some cases this switch may not be on, or may not be defined yet, in turn meaning that the Cypress tests will fail.
+
+To decouple the switch state from production, we define the state of the switch in DCR that will be set only when running within Cypress. In `src/web/experiments/cypress-switches.ts` update the `cypressSwitches` object to add the switch and state for your new test.
+
+```ts
+...
+const cypressSwitches = {
+    abAbTestTest: true,
+    abSignInGatePatientia: true, // setting the Patientia test to always be true in Cypress regardless of production state
+};
+...
+```
+
+Now the AB test will be picked up even if the switch does not exist yet in Frontend, or the switch is set to Off in Frontend too.
 
 #### Unit Tests
 

--- a/src/web/experiments/cypress-switches.ts
+++ b/src/web/experiments/cypress-switches.ts
@@ -1,16 +1,25 @@
-// switches to force to on (or off) when running within cypress tests
+// Forced AB Test Switches for Cypress testing
 
-// forced switches here
+// AB test switches are defined in Frontend and required to be "ON" for Cypress E2E Tests to successfully run and pass.
+// However, it is useful to be able to switch an AB test on/off in Frontend Admin UI without breaking tests that rely
+// on those switches in another repo (DCR).
+
+// By adding the switches here, and the state we want them to be in when we run Cypress tests, we no longer have to
+// worry about the state of the switch in Frontend. In turn allowing tests to pass even if a switch has changed state
+// in Frontend, e.g. a switch has been set to "OFF".
+
+// Add switches to be a specific state in Cypress to this object
 const cypressSwitches = {
     abAbTestTest: true, // Test switch, used for Cypress integration test
     abSignInGateMainControl: true,
     abSignInGateMainVariant: true,
-    abSignInGatePatientia: false,
+    abSignInGatePatientia: true,
 };
 
+// Function to retrieve the switches if running in Cypress
 export const getCypressSwitches = () => {
-    // if running within cypress, return the forced switches
+    // If running within cypress, return the forced switches
     if (window.Cypress) return cypressSwitches;
-    // otherwise just return empty object
+    // Otherwise just return empty object
     return {};
 };

--- a/src/web/experiments/cypress-switches.ts
+++ b/src/web/experiments/cypress-switches.ts
@@ -1,0 +1,16 @@
+// switches to force to on (or off) when running within cypress tests
+
+// forced switches here
+const cypressSwitches = {
+    abAbTestTest: true, // Test switch, used for Cypress integration test
+    abSignInGateMainControl: true,
+    abSignInGateMainVariant: true,
+    abSignInGatePatientia: false,
+};
+
+export const getCypressSwitches = () => {
+    // if running within cypress, return the forced switches
+    if (window.Cypress) return cypressSwitches;
+    // otherwise just return empty object
+    return {};
+};

--- a/window.guardian.d.ts
+++ b/window.guardian.d.ts
@@ -1,5 +1,5 @@
 import { WindowGuardianConfig } from '@root/src/model/window-guardian';
-import {ReaderRevenueDevUtils} from "@root/src/web/lib/readerRevenueDevUtils";
+import { ReaderRevenueDevUtils } from '@root/src/web/lib/readerRevenueDevUtils';
 
 declare global {
     /* ~ Here, declare things that go in the global namespace, or augment
@@ -55,6 +55,7 @@ declare global {
          * This gives support across all 3 cases.
          */
         guardianPolyfilledImport: (url: string) => Promise<any>; // can't be nested beyond top level
+        Cypress: any; // for checking if running within cypress
     }
 }
 /* ~ this line is required as per TypeScript's global-modifying-module.d.ts instructions */


### PR DESCRIPTION
AB test switches are defined in Frontend and required to be "ON" for Cypress E2E Sign In Gate Test to successfully run and pass. However, in practice it is useful to be able to switch an AB test on and off in Frontend PROD Admin UI without having to make any code changes to a different repo.

In order not to break CI builds in DCR if someone switches off a Sign In Gate AB test in the Frontend Admin tool, we've added the ability to define a state that a switch should be in DCR, and will only run within a Cypress environment.

In #1877 @vlbee tried to do a similar thing by skipping tests if the switch was set to off in Frontend PROD, but this caused non-deterministic behaviour due to tests running asynchronously.

This presents a simpler solution, as we can set the state of the test switch in `cypressSwitches` which will only be picked up by Cypress, meaning that tests will still run regardless of the state in PROD.

@gtrufitt it would be useful to get your thoughts in this too?