### PR TITLE
A11y fixes

### DIFF
--- a/src/web/components/CommentCount.tsx
+++ b/src/web/components/CommentCount.tsx
@@ -69,12 +69,12 @@ export const CommentCount = ({ short, long, pillar, setIsExpanded }: Props) => {
     return (
         <div
             className={containerStyles(pillar)}
-            aria-label={`${short} Comments`}
             data-cy="comment-counts"
         >
             <a
                 href="#comments"
                 className={linkStyles}
+                aria-label={`${short} Comments`}
                 onClick={() => setIsExpanded(true)}
             >
                 <div className={iconContainerStyles}>

--- a/src/web/components/Nav/ExpandedMenu/Column.tsx
+++ b/src/web/components/Nav/ExpandedMenu/Column.tsx
@@ -212,8 +212,7 @@ export const Column = ({
                 id={columnInputId}
                 tabIndex={-1}
                 key="OpenExpandedMenuCheckbox"
-                role="menuitemcheckbox"
-                aria-checked="false"
+                aria-hidden="true"
             />
             <CollapseColumnButton
                 collapseColumnInputId={collapseColumnInputId}

--- a/src/web/components/Nav/Nav.tsx
+++ b/src/web/components/Nav/Nav.tsx
@@ -204,8 +204,7 @@ export const Nav = ({ display, pillar, nav, subscribeUrl, edition }: Props) => {
                     name="more"
                     tabIndex={-1}
                     key="OpenExpandedMenuCheckbox"
-                    role="menuitemcheckbox"
-                    aria-checked="false"
+                    aria-hidden="true"
                 />
                 <Pillars
                     display={display}


### PR DESCRIPTION
## What does this change?

This raises the lighthouse accessibility score from 89 to 94 by fixing

* [role]s are not contained by their required parent element
* Link does not have a discernible name

The commit messages have some pretty in depth notes. But at a high level, the fixes are to

 * "aria hide" checkboxes used for the [checkbox hack](https://css-tricks.com/the-checkbox-hack/) based implementation of the nav/expanded menu
 * Move aria-label from a parent div to the link element in CommentCount


Respectively

### Before

<img width="939" alt="Lighthouse_Report_Viewer" src="https://user-images.githubusercontent.com/1672034/92237686-b5806700-eeaf-11ea-8901-420e43afaee4.png">

### After

<img width="937" alt="Lighthouse_Report_Viewer" src="https://user-images.githubusercontent.com/1672034/92238212-9df5ae00-eeb0-11ea-98ea-5b403a9c6553.png">

## Why?

It'd be great to clear all the a11y issues (except the visuals one) and add a PR check to prevent any other issues from being introduced in future PRs!