### PR TITLE
Update footer label from beta -> modern

### DIFF
--- a/src/web/components/Footer.tsx
+++ b/src/web/components/Footer.tsx
@@ -241,7 +241,7 @@ export const Footer: React.FC<{
         </div>
         <div className={copyright}>
             © {year} Guardian News & Media Limited or its affiliated companies.
-            All rights reserved. (beta)
+            All rights reserved. (modern)
         </div>
     </footer>
 );


### PR DESCRIPTION
### What does this change?

Updates the Footer from `(beta)` to `(modern)` as part of the hearts and minds campaign to change perception of DCR as the primary article-serving platform for Dotcom.