### PR TITLE
Rename `master` to `main`

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ If you get lint errors, you can attempt to automatically fix them with:
 $ make fix
 ```
 
-See [the makefile](https://github.com/guardian/dotcom-rendering/blob/master/makefile) for the full list.
+See [the makefile](https://github.com/guardian/dotcom-rendering/blob/main/makefile) for the full list.
 
 [Read about testing tools and testing strategy](docs/testing.md).
 

--- a/docs/architecture/020-react-to-preact.md
+++ b/docs/architecture/020-react-to-preact.md
@@ -4,7 +4,7 @@
 
 We decided to make the jump from React to Preact. Main advantages was reducing the bundle size, with minimal changes to the architecture.
 
-Preact had been quite good at keeping up with React features, which was one of the main [precvious concerns.](https://github.com/guardian/dotcom-rendering/blob/master/docs/architecture/003-react.md)
+Preact had been quite good at keeping up with React features, which was one of the main [precvious concerns.](https://github.com/guardian/dotcom-rendering/blob/main/docs/architecture/003-react.md)
 
 Preact uses a lib called [`preact/compat`](https://preactjs.com/guide/v10/switching-to-preact) which allows us to not have a major refactoring to embrace React.
 

--- a/docs/contributing/detailed-setup-guide.md
+++ b/docs/contributing/detailed-setup-guide.md
@@ -32,7 +32,7 @@ The only thing you need to make sure you have installed before you get going is 
 We recommend [nvm](https://github.com/creationix/nvm) (especially combined with [this handy gist](https://gist.github.com/sndrs/5940e9e8a3f506b287233ed65365befb)). It is great at managing multiple versions of Node.js on one machine.
 
 If you prefer to [install Node.js manually](https://nodejs.org),
-check the [.nvmrc](https://github.com/guardian/dotcom-rendering/blob/master/.nvmrc) for the current required version.
+check the [.nvmrc](https://github.com/guardian/dotcom-rendering/blob/main/.nvmrc) for the current required version.
 
 That's it – everything else should be installed for you on demand.
 
@@ -68,9 +68,9 @@ http://localhost:3030/AMPArticle?url=http://localhost:9000/world/2013/jun/09/edw
 
 ### Note on rebasing vs merging
 
-The dotcom-rendering github account is set up to merge PRs into master instead of rebase. Merge commits are useful to quickly revert things when there is a major incident - whereas with rebase you might have to revert a whole load of commits.
+The dotcom-rendering github account is set up to merge PRs into main instead of rebase. Merge commits are useful to quickly revert things when there is a major incident - whereas with rebase you might have to revert a whole load of commits.
 
-However, if you are working on a feature branch and plan to make a PR, it's still recommended to rebase on `master` to avoid extranous merge commits in branches.
+However, if you are working on a feature branch and plan to make a PR, it's still recommended to rebase on `main` to avoid extranous merge commits in branches.
 
 ### Debugging tools
 

--- a/docs/contributing/where-should-my-code-live.md
+++ b/docs/contributing/where-should-my-code-live.md
@@ -28,7 +28,7 @@ In the first instance, consider adding the script as a low priority script. Thes
 
 An example is the [Google Analytics tracking script](https://developers.google.com/analytics/devguides/collection/analyticsjs/).
 
-They can be added to the `lowPriorityScripts` array in the [`src/web/document.tsx`](https://github.com/guardian/dotcom-rendering/blob/master/src/web/document.tsx) module.
+They can be added to the `lowPriorityScripts` array in the [`src/web/document.tsx`](https://github.com/guardian/dotcom-rendering/blob/main/src/web/document.tsx) module.
 
 ### High priority scripts
 
@@ -38,11 +38,11 @@ Examples include the [polyfill.io](https://polyfill.io) response and the main ap
 
 ⚠️ **High priority scripts have a considerable impact on site performance and should be added sparingly. Please get approval from at least 2 members of the dotcom platform team before adding a new script here.**
 
-They can be added to the `priorityScripts` array in the [`src/web/document.tsx`](https://github.com/guardian/dotcom-rendering/blob/master/src/web/document.tsx) module.
+They can be added to the `priorityScripts` array in the [`src/web/document.tsx`](https://github.com/guardian/dotcom-rendering/blob/main/src/web/document.tsx) module.
 
 ## Data extraction
 
-`dotcom-rendering` receives most of its data from CAPI, via the [`DotcomponentsDataModel`](https://github.com/guardian/frontend/blob/master/article/app/model/dotcomponents/DotcomponentsDataModel.scala) in `frontend`.
+`dotcom-rendering` receives most of its data from CAPI, via the [`DotcomponentsDataModel`](https://github.com/guardian/frontend/blob/main/article/app/model/dotcomponents/DotcomponentsDataModel.scala) in `frontend`.
 
 The data received from CAPI is probably not in an immediately useful form, and some data extraction or parsing logic is needed. When contemplating where to put this logic, consider the following axioms, in order of importance.
 

--- a/docs/development/ab-testing-in-dcr.md
+++ b/docs/development/ab-testing-in-dcr.md
@@ -6,11 +6,11 @@ The library docs above explain the integration and the API.
 
 ### Quick Start
 
-1. [Create a switch in Frontend](https://github.com/guardian/frontend/blob/master/common/app/conf/switches/ABTestSwitches.scala)
-2. Ensure that you [create an A/B test](https://github.com/guardian/frontend/tree/master/static/src/javascripts/projects/common/modules/experiments/tests) on _Frontend_.
-3. Add your test to [concurrent tests](https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/common/modules/experiments/ab-tests.js) on _Frontend_.
-4. Copy the JS file into DCR (and update to TS types) in [web/experiments/tests](https://github.com/guardian/dotcom-rendering/tree/master/src/web/experiments/tests)
-5. Add it to the test array in [src/web/experiments/ab-tests.ts](https://github.com/guardian/dotcom-rendering/blob/master/src/web/experiments/ab-tests.ts)
+1. [Create a switch in Frontend](https://github.com/guardian/frontend/blob/main/common/app/conf/switches/ABTestSwitches.scala)
+2. Ensure that you [create an A/B test](https://github.com/guardian/frontend/tree/main/static/src/javascripts/projects/common/modules/experiments/tests) on _Frontend_.
+3. Add your test to [concurrent tests](https://github.com/guardian/frontend/blob/main/static/src/javascripts/projects/common/modules/experiments/ab-tests.js) on _Frontend_.
+4. Copy the JS file into DCR (and update to TS types) in [web/experiments/tests](https://github.com/guardian/dotcom-rendering/tree/main/src/web/experiments/tests)
+5. Add it to the test array in [src/web/experiments/ab-tests.ts](https://github.com/guardian/dotcom-rendering/blob/main/src/web/experiments/ab-tests.ts)
 6. Use the [A/B test API](https://github.com/guardian/ab-testing#the-api)
 7. Force the A/B test (ignoring canRun of A/B test and variant) with the URL opt-in http://local...#ab-yourTest=yourVariant
 8. Set a GU_mvt_id or GU_mvt_id_local cookie with the MVT ID that matches the test Audience and Audience Offset ([Use this calculator](https://ab-tests.netlify.app/))

--- a/docs/principles/developer-experience.md
+++ b/docs/principles/developer-experience.md
@@ -32,7 +32,7 @@ Performance targets should be discoverable and highly visible. If they are not m
 the earliest opportunity.
 
 -   [Speedcurve dashboard](https://speedcurve.com/guardian/favorite/?d=30&db=23315&de=1&ds=1)
--   [Bundle size](https://github.com/guardian/dotcom-rendering/blob/master/docs/principles/lines-in-the-sand.md#our-javascript-bundle-size-will-not-exceed-120kb)
+-   [Bundle size](https://github.com/guardian/dotcom-rendering/blob/main/docs/principles/lines-in-the-sand.md#our-javascript-bundle-size-will-not-exceed-120kb)
 
 ## We only deliver the assets that the page needs
 

--- a/docs/principles/performance-budgets.md
+++ b/docs/principles/performance-budgets.md
@@ -20,7 +20,7 @@ Google's Data analysis suggests that ensuring the page is interactive within 5 s
 
 We aim to ensure our pages are consistently interactive within 5 seconds of the initial request.
 
-## Our critical JavaScript [bundle size](https://github.com/guardian/dotcom-rendering/blob/master/package.json#L13-L19) will not exceed 120KB
+## Our critical JavaScript [bundle size](https://github.com/guardian/dotcom-rendering/blob/main/package.json#L13-L19) will not exceed 120KB
 
 Alex Russell conducted analysis of real world JavaScript in 2017<sup>[[2]](#refs--alex-russell)</sup>. He concluded that to ensure a time to interactive of <= 5 seconds on first load, sites should serve between 130KB and 170KB of critical JavaScript. Since we don't have direct control over the size of all JavaScript, we will keep our critical JavaScript bundles below 120KB (minified and gzipped).
 

--- a/docs/seti.md
+++ b/docs/seti.md
@@ -43,6 +43,6 @@ Advice for SETI new starters on Dotcom
 
 * [Dotcom Alerts & Monitoring](https://docs.google.com/presentation/d/1YtpEM1myWSzZQpFIqokN48PqdsEuvJzYUkCnjU8ypG4/edit?usp=sharing) (with speakers notes!)
 * [The Google SRE Book](https://landing.google.com/sre/sre-book/toc/index.html)
-* [Dotcom Incident Response & Triage Docs](https://github.com/guardian/frontend/blob/master/docs/01-start-here/08-incidents.md)
+* [Dotcom Incident Response & Triage Docs](https://github.com/guardian/frontend/blob/main/docs/01-start-here/08-incidents.md)
 * [Dotcom Rendering Original Intoduction Tech Time](https://docs.google.com/presentation/d/1YBe3WxeoxmzR327nXZbSVIvr69OT0M6FOLFr3qQVctI/edit?usp=sharing) (with speakers notes!)
-* [Dotcom Rendering Architecture Docs](https://github.com/guardian/dotcom-rendering/tree/master/docs/architecture)
+* [Dotcom Rendering Architecture Docs](https://github.com/guardian/dotcom-rendering/tree/main/docs/architecture)

--- a/src/web/components/SignInGate/README.md
+++ b/src/web/components/SignInGate/README.md
@@ -2,7 +2,7 @@
 
 ## Quick Setup Guide
 
-1. Create AB test switch in [guardian/frontend](https://github.com/guardian/frontend/blob/master/common/app/conf/switches/ABTestSwitches.scala), [docs](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md#adding-a-switch)
+1. Create AB test switch in [guardian/frontend](https://github.com/guardian/frontend/blob/main/common/app/conf/switches/ABTestSwitches.scala), [docs](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md#adding-a-switch)
 2. Add test definition to `src/web/experiments/tests` folder, and import test in the `src/web/experiments/ab-tests.ts` file. Variant name in test definition must be unique.
 3. Import test definition in the `tests` array in the `SignInGateSelector.tsx`
 4. If the test needs a design, make it in the `gateDesigns` folder
@@ -50,7 +50,7 @@ There are a few steps to take to set up a Sign In Gate AB Test.
 
 #### AB Test Switch
 
-First a AB Test Switch needs to be set up in [guardian/frontend](https://github.com/guardian/frontend/blob/master/common/app/conf/switches/ABTestSwitches.scala). You can follow the instructions from [here](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md#adding-a-switch).
+First a AB Test Switch needs to be set up in [guardian/frontend](https://github.com/guardian/frontend/blob/main/common/app/conf/switches/ABTestSwitches.scala). You can follow the instructions from [here](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md#adding-a-switch).
 
 Example:
 
@@ -126,7 +126,7 @@ The most important properties are:
 
 Once you've made the test definition, you'll need to import it into the `tests` array in the `src/web/experiments/ab-tests.ts` file.
 
-The test definition should also be replicated in `frontend` too if the same sign in gate tests is required on both `DCR` and `frontend`. Use the existing documentation in [`frontend`](https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/common/modules/identity/sign-in-gate/README.md) to set up the tests there. Tests should be mirrored is as far as possible.
+The test definition should also be replicated in `frontend` too if the same sign in gate tests is required on both `DCR` and `frontend`. Use the existing documentation in [`frontend`](https://github.com/guardian/frontend/blob/main/static/src/javascripts/projects/common/modules/identity/sign-in-gate/README.md) to set up the tests there. Tests should be mirrored is as far as possible.
 
 ### Sign In Gate Design
 
@@ -326,7 +326,7 @@ The advantages of using the forcedTestVariant:
    }}
 ```
 
-The disadvantage of this is that you have to make sure that you **DO NOT** commit the `forcedTestVariant` or `abTestSwitches` change to master, and that if the `id` or variant id changes, you have to make sure to change it here too.
+The disadvantage of this is that you have to make sure that you **DO NOT** commit the `forcedTestVariant` or `abTestSwitches` change to main, and that if the `id` or variant id changes, you have to make sure to change it here too.
 
 #### Testing in CODE
 


### PR DESCRIPTION
This changes references in our documentation to `master` to reference `main` instead. I've also updated links to the frontend repository, to reflect its recent rename.