### PR TITLE
Add title to AudioAtomBlockElement type in DCR

### DIFF
--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -13,6 +13,7 @@ interface AudioAtomBlockElement {
     _type: 'model.dotcomrendering.pageElements.AudioAtomBlockElement';
     id: string;
     kicker: string;
+    title?: string;
     trackUrl: string;
     duration: number;
     coverUrl: string;


### PR DESCRIPTION
### What does this change?

Align the `AudioAtomBlockElement`'s type with that of the backend ( https://github.com/guardian/frontend/pull/22981 ). 

![Screenshot 2020-09-08 at 15 15 02](https://user-images.githubusercontent.com/6035518/92488356-5a6bae80-f1e6-11ea-8922-1a92d3ccaaa7.png)
