### PR TITLE
Lock accessibility score at 96

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -14,5 +14,5 @@ jobs:
               env:
                   LHCI_GITHUB_TOKEN: ${{ secrets.LHCI_GITHUB_TOKEN }}
               run: |
-                  npm install -g puppeteer-core@2.1.0 @lhci/cli@0.4.x
+                  npm install -g puppeteer-core@2.1.0 @lhci/cli@0.7.0
                   lhci autorun

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -19,7 +19,7 @@ module.exports = {
         "first-contentful-paint": ["warn", {"maxNumericValue": 1000}],
         "largest-contentful-paint": ["warn", {"maxNumericValue": 3000}],
         "interactive": ["warn", {"maxNumericValue": 3500}],
-        "cumulative-layout-shift": ["warn", {"maxNumericValue": 0.001}],
+        "cumulative-layout-shift": ["warn", {"maxNumericValue": 0.002}],
         'categories:accessibility': ['error', {minScore: 0.96}]
       }
     }

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -16,7 +16,7 @@ module.exports = {
     assert: {
       includePassedAssertions: true,
       assertions: {
-        "first-contentful-paint": ["warn", {"maxNumericValue": 1000}],
+        "first-contentful-paint": ["warn", {"maxNumericValue": 1500}],
         "largest-contentful-paint": ["warn", {"maxNumericValue": 3000}],
         "interactive": ["warn", {"maxNumericValue": 3500}],
         "cumulative-layout-shift": ["warn", {"maxNumericValue": 0.002}],

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -20,7 +20,7 @@ module.exports = {
         "largest-contentful-paint": ["warn", {"maxNumericValue": 3000}],
         "interactive": ["warn", {"maxNumericValue": 3500}],
         "cumulative-layout-shift": ["warn", {"maxNumericValue": 0.002}],
-        'categories:accessibility': ['error', {minScore: 0.96}]
+        'categories:accessibility': ['error', {minScore: 0.97}]
       }
     }
   },

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -20,6 +20,7 @@ module.exports = {
         "largest-contentful-paint": ["warn", {"maxNumericValue": 3000}],
         "interactive": ["warn", {"maxNumericValue": 3500}],
         "cumulative-layout-shift": ["warn", {"maxNumericValue": 0.001}],
+        'categories:accessibility': ['error', {minScore: 0.96}]
       }
     }
   },

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -14,7 +14,6 @@ module.exports = {
       target: 'temporary-public-storage',
     },
     assert: {
-      includePassedAssertions: true,
       assertions: {
         "first-contentful-paint": ["warn", {"maxNumericValue": 1500}],
         "largest-contentful-paint": ["warn", {"maxNumericValue": 3000}],

--- a/src/web/components/Hide.tsx
+++ b/src/web/components/Hide.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { css } from 'emotion';
 import { until, from, Breakpoint } from '@guardian/src-foundations/mq';
-import { props } from 'cypress/types/bluebird';
 
 interface Props {
 	children: React.ReactNode;

--- a/src/web/components/Hide.tsx
+++ b/src/web/components/Hide.tsx
@@ -1,14 +1,30 @@
 import React from 'react';
 import { css } from 'emotion';
 import { until, from, Breakpoint } from '@guardian/src-foundations/mq';
+import { props } from 'cypress/types/bluebird';
 
-type Props = {
+interface Props {
 	children: React.ReactNode;
 	when: 'above' | 'below';
 	breakpoint: Breakpoint;
-};
+}
 
-export const Hide = ({ children, when, breakpoint }: Props) => {
+interface PropsSpan extends Props {
+	el?: 'span';
+	key?: string;
+}
+interface PropsLi extends Props {
+	el: 'li';
+	key: string;
+}
+
+export const Hide = ({
+	children,
+	when,
+	breakpoint,
+	el,
+	key,
+}: PropsSpan | PropsLi) => {
 	let whenToHide;
 	if (when === 'below') {
 		whenToHide = css`
@@ -23,5 +39,11 @@ export const Hide = ({ children, when, breakpoint }: Props) => {
 			}
 		`;
 	}
-	return <span className={whenToHide}>{children}</span>;
+	return el === 'li' ? (
+		<li className={whenToHide} key={key}>
+			{children}
+		</li>
+	) : (
+		<span className={whenToHide}>{children}</span>
+	);
 };

--- a/src/web/components/Nav/ExpandedMenu/ReaderRevenueLinks.tsx
+++ b/src/web/components/Nav/ExpandedMenu/ReaderRevenueLinks.tsx
@@ -76,7 +76,7 @@ export const ReaderRevenueLinks: React.FC<{
 	];
 
 	return (
-		<ul className={hideDesktop}>
+		<ul className={hideDesktop} role="menu">
 			{links.map((link) => (
 				<li
 					key={link.title.toLowerCase()}

--- a/src/web/components/ShareIcons.tsx
+++ b/src/web/components/ShareIcons.tsx
@@ -163,8 +163,8 @@ export const ShareIcons = ({
 			)}
 
 			{displayIcons.includes('whatsApp') && (
-				<Hide when="above" breakpoint="phablet">
-					<li className={liStyles(size)} key="whatsApp">
+				<Hide when="above" breakpoint="phablet" el="li" key="whatsApp">
+					<span className={liStyles(size)}>
 						<a
 							href={`whatsapp://send?text="${encodeTitle(
 								webTitle,
@@ -178,13 +178,13 @@ export const ShareIcons = ({
 								<WhatsAppIcon />
 							</span>
 						</a>
-					</li>
+					</span>
 				</Hide>
 			)}
 
 			{displayIcons.includes('messenger') && (
-				<Hide when="above" breakpoint="phablet">
-					<li className={liStyles(size)} key="messenger">
+				<Hide when="above" breakpoint="phablet" el="li" key="messenger">
+					<span className={liStyles(size)}>
 						<a
 							href={`fb-messenger://share?link=${encodeUrl(
 								pageId,
@@ -198,7 +198,7 @@ export const ShareIcons = ({
 								<MessengerIcon />
 							</span>
 						</a>
-					</li>
+					</span>
 				</Hide>
 			)}
 		</ul>


### PR DESCRIPTION
## What does this change?

This will make the lighthouse action and lighthouse status check fail if the accessibility goes above or below 96.

When that happens, the result will be

### After

The action fails
<img width="659" alt="Lock_accessibility_score_at_96_by_jorgeazevedo_·_Pull_Request__3_·_jorgeazevedo_dotcom-rendering" src="https://user-images.githubusercontent.com/1672034/92488138-0f519b80-f1e6-11ea-8303-f29dc7aef669.png">

The status check
<img width="660" alt="Lock_accessibility_score_at_96_by_jorgeazevedo_·_Pull_Request__3_·_jorgeazevedo_dotcom-rendering" src="https://user-images.githubusercontent.com/1672034/92488162-19739a00-f1e6-11ea-8a80-9605a9d0b804.png">

Wish the error was more descriptive (like "This PR introduces one new accessibility issue")  but I don't think it's configurable or anything :-\

## Why?

This will hopefully prevent us from introducing accessibility issues on the article page (the ones lighthouse can detect, anyway).

If the score goes up, we still get a failure. The PR author will need to bump the accessibility score assertion value, and gets to brag about it in standup the next day.