### PR TITLE
Remove lazy loading from main media images

### DIFF
--- a/src/web/components/Picture.tsx
+++ b/src/web/components/Picture.tsx
@@ -24,7 +24,8 @@ export const Picture: React.FC<{
     src: string;
     height: string;
     width: string;
-}> = ({ sources, alt, src, height, width }) => {
+    isLazy?: boolean;
+}> = ({ sources, alt, src, height, width, isLazy = true }) => {
     return (
         // https://stackoverflow.com/questions/10844205/html-5-strange-img-always-adds-3px-margin-at-bottom
         // why did we put `style="vertical-align: middle;"` inside the img tag
@@ -34,7 +35,9 @@ export const Picture: React.FC<{
                     .map(forSource)
                     .join(
                         '',
-                    )}<!--[if IE 9]></video><![endif]--><img style="vertical-align: middle;" itemprop="contentUrl" alt="${alt}" src="${src}" height="${height}" width="${width}" loading="lazy" />`,
+                    )}<!--[if IE 9]></video><![endif]--><img style="vertical-align: middle;" itemprop="contentUrl" alt="${alt}" src="${src}" height="${height}" width="${width}" ${
+                    isLazy ? 'loading="lazy"' : ''
+                } />`,
             }}
         />
     );

--- a/src/web/components/elements/ImageComponent.tsx
+++ b/src/web/components/elements/ImageComponent.tsx
@@ -331,6 +331,7 @@ export const ImageComponent = ({
                     src={getFallback(element.imageSources)}
                     width={imageWidth}
                     height={imageHeight}
+                    isLazy={!isMainMedia}
                 />
                 {starRating && <PositionStarRating rating={starRating} />}
                 {title && (
@@ -359,6 +360,7 @@ export const ImageComponent = ({
                     src={getFallback(element.imageSources)}
                     width={imageWidth}
                     height={imageHeight}
+                    isLazy={!isMainMedia}
                 />
                 {starRating && <PositionStarRating rating={starRating} />}
                 {title && (
@@ -387,6 +389,7 @@ export const ImageComponent = ({
                     src={getFallback(element.imageSources)}
                     width={imageWidth}
                     height={imageHeight}
+                    isLazy={!isMainMedia}
                 />
                 {isMainMedia && (
                     // Below tablet, main media images show an info toggle at the bottom right of


### PR DESCRIPTION
## What does this change?

Makes main media non-lazy. This was a mistake https://web.dev/native-lazy-loading/#avoid-lazy-loading-images-that-are-in-the-first-visible-viewport

> images which are loaded lazily the browser currently needs to wait until it knows where the image is positioned on the page,