### PR TITLE
Update Atoms-rendering to 1.11.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "@emotion/core": "^10.0.28",
         "@guardian/ab-core": "^2.0.0",
         "@guardian/ab-react": "^2.0.1",
-        "@guardian/atoms-rendering": "^1.11.1",
+        "@guardian/atoms-rendering": "^1.11.2",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/consent-management-platform": "4.3.0",
         "@guardian/discussion-rendering": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "@emotion/core": "^10.0.28",
         "@guardian/ab-core": "^2.0.0",
         "@guardian/ab-react": "^2.0.1",
-        "@guardian/atoms-rendering": "^1.11.0",
+        "@guardian/atoms-rendering": "^1.11.1",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/consent-management-platform": "4.3.0",
         "@guardian/discussion-rendering": "^2.6.0",


### PR DESCRIPTION

## What does this change?
Actually bumps to atoms-rendering to 1.11.2, small change to chart atoms.
