### PR TITLE
Curated container test

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Frontend rendering framework for theguardian.com. It uses [React](https://reactj
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 <!-- Automatically created with yarn run createtoc and on push hook -->
 
+- [Moving to main as default branch](#moving-to-main-as-default-branch)
 - [Where can I see Dotcom Rendering in Production?](#where-can-i-see-dotcom-rendering-in-production)
 - [Quick start](#quick-start)
   - [Install Node.js](#install-nodejs)

--- a/index.d.ts
+++ b/index.d.ts
@@ -535,6 +535,7 @@ type OphanComponentName =
     | 'related-content'
     | 'more-media-in-section'
     | 'more-galleries'
+    | 'curated-content'
     | 'default-onwards'; // We should never see this in the analytics data!
 
 interface CommercialConfigType {

--- a/src/web/components/Onwards/HeadlinesContainer.tsx
+++ b/src/web/components/Onwards/HeadlinesContainer.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+
+type Props = {};
+
+export const HeadlinesContainer: React.FC<Props> = ({}: Props) => {
+    // need funky layout
+    return null;
+};

--- a/src/web/components/Onwards/OnwardsUpper.tsx
+++ b/src/web/components/Onwards/OnwardsUpper.tsx
@@ -158,15 +158,23 @@ export const OnwardsUpper = ({
         ophanComponentName = 'related-stories';
     }
 
-    if (!url) {
-        return null;
-    }
+    const headlinesDataUrl =
+        'http://localhost:9000/container/data/uk-alpha/news/regular-stories.json';
 
     return (
-        <OnwardsData
-            url={url}
-            limit={8}
-            ophanComponentName={ophanComponentName}
-        />
+        <div>
+            <OnwardsData
+                url={headlinesDataUrl}
+                limit={4}
+                ophanComponentName="curated-content"
+            />
+            {url && (
+                <OnwardsData
+                    url={url}
+                    limit={8}
+                    ophanComponentName={ophanComponentName}
+                />
+            )}
+        </div>
     );
 };

--- a/src/web/components/Onwards/OnwardsUpper.tsx
+++ b/src/web/components/Onwards/OnwardsUpper.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-
 import { joinUrl } from '@root/src/web/lib/joinUrl';
-
+import { useAB } from '@guardian/ab-react';
 import { OnwardsData } from './OnwardsData';
 
 // This list is a direct copy from https://github.com/guardian/frontend/blob/6da0b3d8bfd58e8e20f80fc738b070fb23ed154e/static/src/javascripts/projects/common/modules/onward/related.js#L27
@@ -158,16 +157,24 @@ export const OnwardsUpper = ({
         ophanComponentName = 'related-stories';
     }
 
+    const ABTestAPI = useAB();
     const headlinesDataUrl =
         'http://localhost:9000/container/data/uk-alpha/news/regular-stories.json';
 
+    const inCuratedContainerTest = ABTestAPI.isUserInVariant(
+        'CuratedContainerTest',
+        'variant',
+    );
+
     return (
         <div>
-            <OnwardsData
-                url={headlinesDataUrl}
-                limit={4}
-                ophanComponentName="curated-content"
-            />
+            {inCuratedContainerTest && (
+                <OnwardsData
+                    url={headlinesDataUrl}
+                    limit={4}
+                    ophanComponentName="curated-content"
+                />
+            )}
             {url && (
                 <OnwardsData
                     url={url}

--- a/src/web/experiments/ab-tests.ts
+++ b/src/web/experiments/ab-tests.ts
@@ -3,10 +3,12 @@ import { abTestTest } from '@frontend/web/experiments/tests/ab-test-test';
 import { signInGateMainVariant } from '@root/src/web/experiments/tests/sign-in-gate-main-variant';
 import { signInGateMainControl } from '@root/src/web/experiments/tests/sign-in-gate-main-control';
 import { signInGatePatientia } from '@frontend/web/experiments/tests/sign-in-gate-patientia';
+import { curatedContainerTest } from '@frontend/web/experiments/tests/curated-container-test';
 
 export const tests: ABTest[] = [
     abTestTest,
     signInGateMainVariant,
     signInGateMainControl,
     signInGatePatientia,
+    curatedContainerTest,
 ];

--- a/src/web/experiments/tests/curated-container-test.ts
+++ b/src/web/experiments/tests/curated-container-test.ts
@@ -1,0 +1,40 @@
+import { ABTest } from '@guardian/ab-core';
+
+export const curatedContainerTest: ABTest = {
+    id: 'CuratedContainerTest',
+    start: '2020-09-14',
+    expiry: '2020-11-02',
+    author: 'nicl',
+    description:
+        'Tests an additional "curated" onwards container below the article body',
+    audience: 0.0, // TODO will update once we are confident things are working
+    audienceOffset: 0,
+    successMeasure: 'CTR on article pages',
+    audienceCriteria: 'Everyone',
+    idealOutcome:
+        'A significant increase in CTR compared to when the additional container is not present',
+    showForSensitive: true,
+    canRun: () => true,
+    variants: [
+        {
+            id: 'control',
+            test: (): void => {},
+            impression: (impression) => {
+                impression();
+            },
+            success: (success) => {
+                success();
+            },
+        },
+        {
+            id: 'variant',
+            test: (): void => {},
+            impression: (impression) => {
+                impression();
+            },
+            success: (success) => {
+                success();
+            },
+        },
+    ],
+};

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -49,7 +49,6 @@ import {
 } from '@root/src/web/lib/layoutHelpers';
 import { Stuck, SendToBack } from '@root/src/web/layouts/lib/stickiness';
 import { Display } from '@root/src/lib/display';
-import { useAB } from '@guardian/ab-react';
 
 const MOSTVIEWED_STICKY_HEIGHT = 1059;
 
@@ -277,14 +276,7 @@ export const StandardLayout = ({
         (tag) => tag.type === 'Series' || tag.type === 'Blog',
     );
 
-    const ABTestAPI = useAB();
-    const inCuratedContainerTest = ABTestAPI.isUserInVariant(
-        'CuratedContainerTest',
-        'variant',
-    );
-
-    const showOnwardsLower =
-        inCuratedContainerTest || (seriesTag && CAPI.hasStoryPackage);
+    const showOnwardsLower = seriesTag && CAPI.hasStoryPackage;
 
     const showMatchStats = designType === 'MatchReport' && CAPI.matchUrl;
 

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -49,6 +49,7 @@ import {
 } from '@root/src/web/lib/layoutHelpers';
 import { Stuck, SendToBack } from '@root/src/web/layouts/lib/stickiness';
 import { Display } from '@root/src/lib/display';
+import { useAB } from '@guardian/ab-react';
 
 const MOSTVIEWED_STICKY_HEIGHT = 1059;
 
@@ -275,7 +276,15 @@ export const StandardLayout = ({
     const seriesTag = CAPI.tags.find(
         (tag) => tag.type === 'Series' || tag.type === 'Blog',
     );
-    const showOnwardsLower = true; // seriesTag && CAPI.hasStoryPackage;
+
+    const ABTestAPI = useAB();
+    const inCuratedContainerTest = ABTestAPI.isUserInVariant(
+        'CuratedContainerTest',
+        'variant',
+    );
+
+    const showOnwardsLower =
+        inCuratedContainerTest || (seriesTag && CAPI.hasStoryPackage);
 
     const showMatchStats = designType === 'MatchReport' && CAPI.matchUrl;
 

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -275,7 +275,7 @@ export const StandardLayout = ({
     const seriesTag = CAPI.tags.find(
         (tag) => tag.type === 'Series' || tag.type === 'Blog',
     );
-    const showOnwardsLower = seriesTag && CAPI.hasStoryPackage;
+    const showOnwardsLower = true; // seriesTag && CAPI.hasStoryPackage;
 
     const showMatchStats = designType === 'MatchReport' && CAPI.matchUrl;
 


### PR DESCRIPTION
## What does this change?

Introduce a basic curated container component. 

**Note, we still need to do some work in Frontend to return the current headlines component - currently it's including the 'Brexitu' container.** There are also issues here - for example, the `sss` in the first container item, which we'll need to consider.

### Before

Only this:

![Screenshot 2020-09-11 at 11 43 17](https://user-images.githubusercontent.com/858402/92914974-06e6a400-f424-11ea-86bd-05e64997478f.png)

### After

![Screenshot 2020-09-11 at 11 36 26](https://user-images.githubusercontent.com/858402/92914849-eae30280-f423-11ea-9c4e-cee0f27474fc.png)

## Why?

See the test description etc., but the basic hypothesis is that this additional curated container will prove valuable to users and increase CTR on article pages.
