### PR TITLE
Braze Banner Integration (Attempt 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Frontend rendering framework for theguardian.com. It uses [React](https://reactj
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 <!-- Automatically created with yarn run createtoc and on push hook -->
 
+- [Moving to main as default branch](#moving-to-main-as-default-branch)
 - [Where can I see Dotcom Rendering in Production?](#where-can-i-see-dotcom-rendering-in-production)
 - [Quick start](#quick-start)
   - [Install Node.js](#install-nodejs)

--- a/fixtures/CAPI/comment.ts
+++ b/fixtures/CAPI/comment.ts
@@ -2552,6 +2552,7 @@ export const comment: CAPIType = {
     config: {
         ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
         discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
+        idApiUrl: 'https://idapi.theguardian.com',
         sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
         sentryHost: 'app.getsentry.com/35463',
         dcrSentryDsn:

--- a/fixtures/CAPI/review/showcaseReview.ts
+++ b/fixtures/CAPI/review/showcaseReview.ts
@@ -2660,6 +2660,7 @@ export const showcaseReviewCAPI: CAPIType = {
     config: {
         ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
         discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
+        idApiUrl: 'https://idapi.theguardian.com',
         sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
         sentryHost: 'app.getsentry.com/35463',
         dcrSentryDsn:

--- a/fixtures/CAPI/review/standardReview.ts
+++ b/fixtures/CAPI/review/standardReview.ts
@@ -2337,6 +2337,7 @@ export const standardReviewCAPI: CAPIType = {
     config: {
         ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
         discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
+        idApiUrl: 'https://idapi.theguardian.com',
         sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
         sentryHost: 'app.getsentry.com/35463',
         dcrSentryDsn:

--- a/fixtures/CAPI/richLink.ts
+++ b/fixtures/CAPI/richLink.ts
@@ -2767,6 +2767,7 @@ export const richLink: CAPIType = {
     config: {
         ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
         discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
+        idApiUrl: 'https://idapi.theguardian.com',
         sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
         sentryHost: 'app.getsentry.com/35463',
         dcrSentryDsn:

--- a/fixtures/articles/AdvertisementFeature.ts
+++ b/fixtures/articles/AdvertisementFeature.ts
@@ -2506,6 +2506,7 @@ export const AdvertisementFeature: CAPIType = {
     config: {
         ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
         discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
+        idApiUrl: 'https://idapi.theguardian.com',
         sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
         sentryHost: 'app.getsentry.com/35463',
         dcrSentryDsn:

--- a/fixtures/articles/Analysis.ts
+++ b/fixtures/articles/Analysis.ts
@@ -2956,6 +2956,7 @@ export const Analysis: CAPIType = {
     config: {
         ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
         discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
+        idApiUrl: 'https://idapi.theguardian.com',
         sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
         sentryHost: 'app.getsentry.com/35463',
         dcrSentryDsn:

--- a/fixtures/articles/Article.ts
+++ b/fixtures/articles/Article.ts
@@ -3681,6 +3681,7 @@ export const Article: CAPIType = {
     config: {
         ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
         discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
+        idApiUrl: 'https://idapi.theguardian.com',
         sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
         sentryHost: 'app.getsentry.com/35463',
         dcrSentryDsn:

--- a/fixtures/articles/Comment.ts
+++ b/fixtures/articles/Comment.ts
@@ -3143,6 +3143,7 @@ export const Comment: CAPIType = {
     config: {
         ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
         discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
+        idApiUrl: 'https://idapi.theguardian.com',
         sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
         sentryHost: 'app.getsentry.com/35463',
         dcrSentryDsn:

--- a/fixtures/articles/Feature.ts
+++ b/fixtures/articles/Feature.ts
@@ -3389,6 +3389,7 @@ export const Feature: CAPIType = {
     config: {
         ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
         discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
+        idApiUrl: 'https://idapi.theguardian.com',
         sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
         sentryHost: 'app.getsentry.com/35463',
         dcrSentryDsn:

--- a/fixtures/articles/GuardianView.ts
+++ b/fixtures/articles/GuardianView.ts
@@ -2965,6 +2965,7 @@ export const GuardianView: CAPIType = {
     config: {
         ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
         discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
+        idApiUrl: 'https://idapi.theguardian.com',
         sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
         sentryHost: 'app.getsentry.com/35463',
         dcrSentryDsn:

--- a/fixtures/articles/Immersive.ts
+++ b/fixtures/articles/Immersive.ts
@@ -4784,6 +4784,7 @@ export const Immersive: CAPIType = {
     config: {
         ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
         discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
+        idApiUrl: 'https://idapi.theguardian.com',
         sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
         sentryHost: 'app.getsentry.com/35463',
         dcrSentryDsn:

--- a/fixtures/articles/Interview.ts
+++ b/fixtures/articles/Interview.ts
@@ -6377,6 +6377,7 @@ export const Interview: CAPIType = {
     config: {
         ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
         discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
+        idApiUrl: 'https://idapi.theguardian.com',
         sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
         sentryHost: 'app.getsentry.com/35463',
         dcrSentryDsn:

--- a/fixtures/articles/MatchReport.ts
+++ b/fixtures/articles/MatchReport.ts
@@ -2793,6 +2793,7 @@ export const MatchReport: CAPIType = {
     config: {
         ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
         discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
+        idApiUrl: 'https://idapi.theguardian.com',
         sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
         sentryHost: 'app.getsentry.com/35463',
         dcrSentryDsn:

--- a/fixtures/articles/PhotoEssay.ts
+++ b/fixtures/articles/PhotoEssay.ts
@@ -9295,6 +9295,7 @@ export const PhotoEssay: CAPIType = {
     config: {
         ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
         discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
+        idApiUrl: 'https://idapi.theguardian.com',
         sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
         sentryHost: 'app.getsentry.com/35463',
         dcrSentryDsn:

--- a/fixtures/articles/Quiz.ts
+++ b/fixtures/articles/Quiz.ts
@@ -3033,6 +3033,7 @@ export const Quiz: CAPIType = {
     config: {
         ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
         discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
+        idApiUrl: 'https://idapi.theguardian.com',
         sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
         sentryHost: 'app.getsentry.com/35463',
         dcrSentryDsn:

--- a/fixtures/articles/Recipe.ts
+++ b/fixtures/articles/Recipe.ts
@@ -5407,6 +5407,7 @@ export const Recipe: CAPIType = {
     config: {
         ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
         discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
+        idApiUrl: 'https://idapi.theguardian.com',
         sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
         sentryHost: 'app.getsentry.com/35463',
         dcrSentryDsn:

--- a/fixtures/articles/Review.ts
+++ b/fixtures/articles/Review.ts
@@ -2660,6 +2660,7 @@ export const Review: CAPIType = {
     config: {
         ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
         discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
+        idApiUrl: 'https://idapi.theguardian.com',
         sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
         sentryHost: 'app.getsentry.com/35463',
         dcrSentryDsn:

--- a/index.d.ts
+++ b/index.d.ts
@@ -315,6 +315,7 @@ type CAPIBrowserType = {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         sharedAdTargeting: { [key: string]: any };
         adUnit: string;
+        idApiUrl: string;
         discussionApiUrl: string;
         discussionD2Uid: string;
         discussionApiClientHeader: string;
@@ -585,6 +586,7 @@ interface ConfigType extends CommercialConfigType {
     keywordIds: string;
     showRelatedContent: boolean;
     shouldHideReaderRevenue?: boolean;
+    idApiUrl: string;
     discussionApiUrl: string;
     discussionD2Uid: string;
     discussionApiClientHeader: string;
@@ -592,6 +594,7 @@ interface ConfigType extends CommercialConfigType {
     references?: { [key: string]: string }[];
     host?: string;
     idUrl?: string;
+    brazeApiKey?: string;
 }
 
 interface GADataType {

--- a/package.json
+++ b/package.json
@@ -32,12 +32,14 @@
         "*": "lint"
     },
     "dependencies": {
+        "@braze/web-sdk-core": "^3.0.0",
         "@emotion/core": "^10.0.28",
         "@guardian/ab-core": "^2.0.0",
         "@guardian/ab-react": "^2.0.1",
         "@guardian/atoms-rendering": "^1.11.2",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/consent-management-platform": "4.3.0",
+        "@guardian/braze-components": "^0.0.5",
         "@guardian/discussion-rendering": "^2.6.0",
         "@guardian/shimport": "^1.0.2",
         "@guardian/src-button": "^1.5.0",

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -2432,6 +2432,9 @@
                 "shouldHideReaderRevenue": {
                     "type": "boolean"
                 },
+                "idApiUrl": {
+                    "type": "string"
+                },
                 "discussionApiUrl": {
                     "type": "string"
                 },
@@ -2496,6 +2499,7 @@
                 "contentType",
                 "dcrSentryDsn",
                 "dfpAccountId",
+                "idApiUrl",
                 "discussionApiClientHeader",
                 "discussionApiUrl",
                 "discussionD2Uid",

--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -142,6 +142,7 @@ export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
             discussionApiUrl: CAPI.config.discussionApiUrl,
             discussionD2Uid: CAPI.config.discussionD2Uid,
             discussionApiClientHeader: CAPI.config.discussionApiClientHeader,
+            idApiUrl: CAPI.config.idApiUrl,
 
             dcrSentryDsn: CAPI.config.dcrSentryDsn,
 

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -35,6 +35,7 @@ import { getCookie } from '@root/src/web/browser/cookie';
 import { getCountryCode } from '@frontend/web/lib/getCountryCode';
 import { getDiscussion } from '@root/src/web/lib/getDiscussion';
 import { getUser } from '@root/src/web/lib/getUser';
+import { getBrazeUuid } from '@root/src/web/lib/getBrazeUuid';
 import { getCommentContext } from '@root/src/web/lib/getCommentContext';
 import { FocusStyleManager } from '@guardian/src-foundations/utils';
 import { incrementAlreadyVisited } from '@root/src/web/lib/alreadyVisited';
@@ -134,7 +135,11 @@ const componentEventHandler = (
 
 export const App = ({ CAPI, NAV }: Props) => {
     const [isSignedIn, setIsSignedIn] = useState<boolean>();
+    const [isDigitalSubscriber, setIsDigitalSubscriber] = useState<boolean>();
     const [user, setUser] = useState<UserProfile>();
+    const [asyncBrazeUuid, setAsyncBrazeUuid] = useState<
+        Promise<string | null>
+    >();
     const [countryCode, setCountryCode] = useState<string>();
     // This is an async version of the countryCode state value defined above.
     // This can be used where you've got logic which depends on countryCode but
@@ -175,14 +180,21 @@ export const App = ({ CAPI, NAV }: Props) => {
     }, []);
 
     useEffect(() => {
+        setIsDigitalSubscriber(getCookie('gu_digital_subscriber') === 'true');
+    }, []);
+
+    useEffect(() => {
         const callGetUser = async () => {
             setUser(await getUser(CAPI.config.discussionApiUrl));
         };
-
+        const callGetBrazeUuid = async () => {
+            setAsyncBrazeUuid(getBrazeUuid(CAPI.config.idApiUrl));
+        };
         if (isSignedIn) {
             callGetUser();
+            callGetBrazeUuid();
         }
-    }, [isSignedIn, CAPI.config.discussionApiUrl]);
+    }, [isSignedIn, CAPI.config.discussionApiUrl, CAPI.config.idApiUrl]);
 
     useEffect(() => {
         const callFetch = () => {
@@ -642,6 +654,8 @@ export const App = ({ CAPI, NAV }: Props) => {
                     isSignedIn={isSignedIn}
                     asyncCountryCode={asyncCountryCode}
                     CAPI={CAPI}
+                    asyncBrazeUuid={asyncBrazeUuid}
+                    isDigitalSubscriber={isDigitalSubscriber}
                 />
             </Portal>
         </React.StrictMode>

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -187,14 +187,19 @@ export const App = ({ CAPI, NAV }: Props) => {
         const callGetUser = async () => {
             setUser(await getUser(CAPI.config.discussionApiUrl));
         };
-        const callGetBrazeUuid = async () => {
-            setAsyncBrazeUuid(getBrazeUuid(CAPI.config.idApiUrl));
-        };
+
         if (isSignedIn) {
             callGetUser();
-            callGetBrazeUuid();
         }
-    }, [isSignedIn, CAPI.config.discussionApiUrl, CAPI.config.idApiUrl]);
+    }, [isSignedIn, CAPI.config.discussionApiUrl]);
+
+    useEffect(() => {
+        if (isSignedIn) {
+            setAsyncBrazeUuid(getBrazeUuid(CAPI.config.idApiUrl));
+        } else {
+            setAsyncBrazeUuid(Promise.resolve(null));
+        }
+    }, [isSignedIn, CAPI.config.idApiUrl]);
 
     useEffect(() => {
         const callFetch = () => {

--- a/src/web/components/StickyBottomBanner/BrazeBanner.test.ts
+++ b/src/web/components/StickyBottomBanner/BrazeBanner.test.ts
@@ -1,0 +1,66 @@
+import { brazeVendorId, hasRequiredConsents } from './BrazeBanner';
+
+let mockOnConsentChangeResult: any;
+jest.mock('@guardian/consent-management-platform', () => ({
+    onConsentChange: (callback: any) => {
+        callback(mockOnConsentChangeResult);
+    },
+}));
+
+afterEach(() => {
+    mockOnConsentChangeResult = undefined;
+});
+
+describe('hasRequiredConsents', () => {
+    describe('when the user is covered by tcfv2 and consent is given', () => {
+        it('returns a promise which resolves with true', async () => {
+            mockOnConsentChangeResult = {
+                tcfv2: {
+                    vendorConsents: {
+                        [brazeVendorId]: true,
+                    },
+                },
+            };
+
+            await expect(hasRequiredConsents()).resolves.toBe(true);
+        });
+    });
+
+    describe('when the user is covered by tcfv2 and consent is not given', () => {
+        it('returns a promise which resolves with false', async () => {
+            mockOnConsentChangeResult = {
+                tcfv2: {
+                    vendorConsents: {
+                        [brazeVendorId]: false,
+                    },
+                },
+            };
+
+            await expect(hasRequiredConsents()).resolves.toBe(false);
+        });
+    });
+
+    describe('when the user is covered by ccpa and consent is given', () => {
+        it('returns a promise which resolves with true', async () => {
+            mockOnConsentChangeResult = {
+                ccpa: {
+                    doNotSell: false,
+                },
+            };
+
+            await expect(hasRequiredConsents()).resolves.toBe(true);
+        });
+    });
+
+    describe('when the user is covered by ccpa and consent is not given', () => {
+        it('returns a promise which resolves with false', async () => {
+            mockOnConsentChangeResult = {
+                ccpa: {
+                    doNotSell: true,
+                },
+            };
+
+            await expect(hasRequiredConsents()).resolves.toBe(false);
+        });
+    });
+});

--- a/src/web/components/StickyBottomBanner/BrazeBanner.tsx
+++ b/src/web/components/StickyBottomBanner/BrazeBanner.tsx
@@ -1,0 +1,134 @@
+import React, { useEffect, useState } from 'react';
+import * as emotion from 'emotion';
+import * as emotionCore from '@emotion/core';
+import * as emotionTheming from 'emotion-theming';
+import { onConsentChange } from '@guardian/consent-management-platform';
+import { getZIndex } from '@root/src/web/lib/getZIndex';
+import { Props as BrazeBannerProps } from '@guardian/braze-components';
+import { CanShowResult } from './bannerPicker';
+
+export const brazeVendorId = '5ed8c49c4b8ce4571c7ad801';
+
+type Props = {
+    meta: any;
+};
+
+const containerStyles = emotion.css`
+    position: fixed;
+    bottom: -1px;
+    width: 100%;
+    ${getZIndex('banner')}
+`;
+
+export const hasRequiredConsents = (): Promise<boolean> =>
+    new Promise((resolve) => {
+        onConsentChange(({ tcfv2, ccpa }) => {
+            const consentGivenUnderCcpa = ccpa && !ccpa.doNotSell;
+            const consentGivenUnderTcfv2 =
+                tcfv2 && tcfv2.vendorConsents[brazeVendorId];
+
+            resolve(!!(consentGivenUnderCcpa || consentGivenUnderTcfv2));
+        });
+    });
+
+export const canShow = async (
+    asyncBrazeUuid: Promise<null | string>,
+    isDigitalSubscriber: undefined | boolean,
+): Promise<CanShowResult> => {
+    const { brazeSwitch } = window.guardian.config.switches;
+    const apiKey = window.guardian.config.page.brazeApiKey;
+
+    if (!(brazeSwitch && apiKey)) {
+        return { result: false };
+    }
+
+    if (!isDigitalSubscriber) {
+        return { result: false };
+    }
+
+    const [brazeUuid, hasGivenConsent] = await Promise.all([
+        asyncBrazeUuid,
+        hasRequiredConsents(),
+    ]);
+
+    if (!(brazeUuid && hasGivenConsent)) {
+        return { result: false };
+    }
+
+    try {
+        const { default: appboy } = await import(
+            /* webpackChunkName: "braze-web-sdk-core" */ '@braze/web-sdk-core'
+        );
+
+        appboy.initialize(apiKey, {
+            noCookies: true,
+            baseUrl: 'https://sdk.fra-01.braze.eu/api/v3',
+            sessionTimeoutInSeconds: 1,
+            minimumIntervalBetweenTriggerActionsInSeconds: 0,
+        });
+
+        return new Promise((resolve) => {
+            appboy.subscribeToInAppMessage((message) => {
+                const meta = (message as any).extras;
+
+                if (meta) {
+                    resolve({ result: true, meta });
+                }
+                resolve({ result: false });
+            });
+
+            appboy.changeUser(brazeUuid);
+            appboy.openSession();
+        });
+    } catch {
+        return { result: false };
+    }
+};
+
+export const BrazeBanner = ({ meta }: Props) => {
+    const [ExampleComponent, setExampleComponent] = useState<
+        React.FC<BrazeBannerProps>
+    >();
+
+    useEffect(() => {
+        if (meta && meta['test-key']) {
+            // TODO: unify the way we handle sharing these deps (this is
+            // duplicated in SlotBodyEnd). Probably via the automat client
+            // library.
+            window.guardian.automat = {
+                react: React,
+                preact: React,
+                emotionCore,
+                emotionTheming,
+                emotion,
+            };
+
+            import(
+                /* webpackChunkName: "guardian-braze-components" */ '@guardian/braze-components'
+            )
+                .then((module) => {
+                    setExampleComponent(() => module.ExampleComponent);
+                })
+                .catch((error) =>
+                    window.guardian.modules.sentry.reportError(
+                        error,
+                        'braze-banner',
+                    ),
+                );
+        }
+    }, [meta]);
+
+    if (ExampleComponent && meta && meta['test-key']) {
+        return (
+            <div className={containerStyles}>
+                <ExampleComponent
+                    message={meta['test-key']}
+                    onButtonClick={() => {}}
+                />
+                ;
+            </div>
+        );
+    }
+
+    return <div />;
+};

--- a/src/web/lib/getBrazeUuid.ts
+++ b/src/web/lib/getBrazeUuid.ts
@@ -1,0 +1,22 @@
+import { joinUrl } from '@root/src/web/lib/joinUrl';
+
+export const getBrazeUuid = async (ajaxUrl: string): Promise<string> => {
+    const url = joinUrl([ajaxUrl, 'user/me']);
+    return fetch(url, {
+        credentials: 'include',
+    })
+        .then((response) => {
+            if (!response.ok) {
+                throw Error(
+                    response.statusText ||
+                        `getBrazeUuid | An api call returned HTTP status ${response.status}`,
+                );
+            }
+            return response;
+        })
+        .then((response) => response.json())
+        .then((json) => json.user.privateFields.brazeUuid)
+        .catch((error) => {
+            window.guardian.modules.sentry.reportError(error, 'getBrazeUuid');
+        });
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2322,10 +2322,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
   integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
 
-"@guardian/atoms-rendering@^1.11.0":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-1.11.0.tgz#973e29d88d4863fac6b108ef7d92ad16a55a8878"
-  integrity sha512-rKKRaSXPCII27wWG1APZCqDQL2q1CPj7w8269vyKlPydH6TPvPGupccePUBFgMX/kLBp0IRw+yFWKMgo12nhyA==
+"@guardian/atoms-rendering@^1.11.2":
+  version "1.11.2"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-1.11.2.tgz#da392c908848ef6ba8d4bc731da2a9c422f90612"
+  integrity sha512-xARDBnWZQx2hTGeJZLw7O3+KGy6UPyDaz5ll2FqItB/1bOZQjV3BV43UkjAIOP2iUrjncMk2/q0+mjqE7rSiTQ==
 
 "@guardian/automat-client@^0.2.16":
   version "0.2.16"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2038,6 +2038,11 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@braze/web-sdk-core@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@braze/web-sdk-core/-/web-sdk-core-3.0.0.tgz#32fd4a045e143dc28bb0a623ebea4abd01068042"
+  integrity sha512-hRiHFG3a1V9dj47K0quiU+2TnYabdexpwuqb4yqWYn5s1eiUA3S+XFs0YvKM0jmpSnW9ok5uiLJnddvlrGsR8g==
+
 "@chromaui/localtunnel@2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@chromaui/localtunnel/-/localtunnel-2.0.1.tgz#2d4cef4efa189a2a2f015d639e754956c54cacd1"
@@ -2327,6 +2332,14 @@
   resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.16.tgz#3ef47e7f49e633aea51c67f061d8d313a26fa9bc"
   integrity sha512-SgNU2bgiyQaXNfqanx4SDmxqAhXW6QBCTk4tRnCgV9Ht6noRl7UsDfx4I0u+M4H3TRnK4I/i2mmlJBtnuwhxEg==
 
+"@guardian/braze-components@^0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-0.0.5.tgz#abd9eaaf17feb59dc749b4b616cac80325115df0"
+  integrity sha512-jVO/TAmCKBtxb9yvAVguJ2edE+OLdcUPlk+VN2TsoVR6HqOqzlt1Mmo1WSautU1mO3km4LfIba9mUV49t9eBHw==
+  dependencies:
+    "@guardian/src-button" "^2.1.0"
+    "@guardian/src-foundations" "^2.1.0"
+
 "@guardian/consent-management-platform@4.3.0":
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-4.3.0.tgz#2a9f548db78a7c9017708ec6ba79ba258ae9adc1"
@@ -2369,6 +2382,13 @@
     "@guardian/src-helpers" "^1.5.0"
     "@guardian/src-icons" "^1.5.0"
 
+"@guardian/src-button@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/src-button/-/src-button-2.1.0.tgz#59e4bec31dce699debcb2c49c128251e00e96ecc"
+  integrity sha512-9k/HudQOVePp4kjBd/NgZTR46X+VRQ2flWkaewxu1v8wcnBMC4Sm4wYgqsj6Jo7qAf1q3r4kLV/nG8rnd7BETQ==
+  dependencies:
+    "@guardian/src-helpers" "^2.1.0"
+
 "@guardian/src-checkbox@^1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@guardian/src-checkbox/-/src-checkbox-1.5.0.tgz#d81e1759d3fddc8986b3748f5ef16a38ea0b47be"
@@ -2389,12 +2409,24 @@
   resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-1.5.0.tgz#457f6ff8238946b2b3ac763d78ef29b89f199f18"
   integrity sha512-/7WNDZvehlxXf9kFTJuZfNcNumfSdeuUoxFLCCKMLp1atdVL/WPlyYSVtw2mUhuGjeLufPRe28sc+mefzJAi1g==
 
+"@guardian/src-foundations@^2.1.0", "@guardian/src-foundations@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-2.2.0.tgz#24066902f964bfe4cb4b2056204e10b8787e3e97"
+  integrity sha512-wkXxF9O7xoYxZMxg6XQJWiZpnxG/Luff1BnQfvYJGHRgjZs7GMM7pZCueiO4GyB39qXxQH1Rsp1jlzdV+GKRLw==
+
 "@guardian/src-helpers@^1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@guardian/src-helpers/-/src-helpers-1.5.0.tgz#1c32a751609e797446236769b04eedb95d59ce24"
   integrity sha512-fGZ8nH251FuymaBWYtyP1eVjy3DhcnOjXyhGWZy+E4fJ+ZYO77JAnEGam+I8lJyHTpPJUOdSJ1uKOQ1m3xfgGA==
   dependencies:
     "@guardian/src-foundations" "^1.5.0"
+
+"@guardian/src-helpers@^2.1.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@guardian/src-helpers/-/src-helpers-2.2.0.tgz#7d24f612ac1db201e235e0482ad9185b7f230a9d"
+  integrity sha512-3tdF8eemIPhYZBBZFF+EFKo2ltfmZKC+JAB2aZajiRS6mVhsbpjkIU2XhvXFjkmtZRMKbT/K/xHWV1PDJLB5uA==
+  dependencies:
+    "@guardian/src-foundations" "^2.2.0"
 
 "@guardian/src-icons@^1.5.0":
   version "1.5.0"


### PR DESCRIPTION
## What does this change?

This PR reverts #1904 which itself reverted #1859. This re-adds the (initally turned off) Braze banner integration but fixes an issue which was preventing reader revenue banners from showing. See #1859 for details of that functionality. The second commit here (23cc963) is the interesting part with the fix.
