### PR TITLE
Outstream ad css fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Frontend rendering framework for theguardian.com. It uses [React](https://reactj
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 <!-- Automatically created with yarn run createtoc and on push hook -->
 
-- [Moving to main as default branch](#moving-to-main-as-default-branch)
 - [Where can I see Dotcom Rendering in Production?](#where-can-i-see-dotcom-rendering-in-production)
 - [Quick start](#quick-start)
   - [Install Node.js](#install-nodejs)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Frontend rendering framework for theguardian.com. It uses [React](https://reactj
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 <!-- Automatically created with yarn run createtoc and on push hook -->
 
+- [Moving to main as default branch](#moving-to-main-as-default-branch)
 - [Where can I see Dotcom Rendering in Production?](#where-can-i-see-dotcom-rendering-in-production)
 - [Quick start](#quick-start)
   - [Install Node.js](#install-nodejs)

--- a/src/web/components/ArticleContainer.tsx
+++ b/src/web/components/ArticleContainer.tsx
@@ -41,7 +41,7 @@ const articleAdStyles = css`
             margin-left: 20px;
         }
         ${from.desktop} {
-            width: auto;
+            width: 100%;
             float: right;
             margin: 0;
             margin-top: 4px;

--- a/src/web/components/ArticleContainer.tsx
+++ b/src/web/components/ArticleContainer.tsx
@@ -41,7 +41,7 @@ const articleAdStyles = css`
             margin-left: 20px;
         }
         ${from.desktop} {
-            width: 100%;
+            width: auto;
             float: right;
             margin: 0;
             margin-top: 4px;
@@ -62,6 +62,7 @@ const articleAdStyles = css`
     .ad-slot--outstream {
         ${from.tablet} {
             margin-left: 0;
+            width: 100%;
 
             .ad-slot__label {
                 margin-left: 35px;


### PR DESCRIPTION
## What does this change?
Fixes the stying of outsteam ads css to support a new ad patner called Connatix

### Before
<img width="1023" alt="Screenshot 2020-09-11 at 15 26 49" src="https://user-images.githubusercontent.com/51630004/92928580-f5af8e80-f447-11ea-9c0a-98eb8de505c3.png">


### After
<img width="1023" alt="Screenshot 2020-09-11 at 15 26 31" src="https://user-images.githubusercontent.com/51630004/92928594-fc3e0600-f447-11ea-8bdf-83cabba4b95a.png">

## Why?
Connatix ads will render OK
