### PR TITLE
Use async for low priority scripts

### DIFF
--- a/src/web/server/document.test.tsx
+++ b/src/web/server/document.test.tsx
@@ -107,3 +107,26 @@ test('Footer ophan data-attributes exist', () => {
         expect.stringContaining(`data-link-name="footer : primary : Opinion"`),
     );
 });
+
+test('Sample of script tags have the correct attributes', () => {
+    expect(result).toEqual(
+        expect.stringContaining(
+            `<script defer type="module" src="/assets/react.js"></script>`,
+        ),
+    );
+    expect(result).toEqual(
+        expect.stringContaining(
+            `<script defer nomodule src=\"/assets/react.js\"></script>`,
+        ),
+    );
+    expect(result).toEqual(
+        expect.stringContaining(
+            `<script async type="module" src="/assets/ophan.js"></script>`,
+        ),
+    );
+    expect(result).toEqual(
+        expect.stringContaining(
+            `<script async nomodule src=\"/assets/ophan.js\"></script>`,
+        ),
+    );
+});

--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -19,17 +19,18 @@ interface RenderToStringResult {
 
 const generateScriptTags = (
     scripts: Array<{ src: string; module?: boolean }>,
+    scriptAttrs: string = '',
 ) =>
     scripts.reduce((scriptTags, script) => {
         if (script.module) {
             scriptTags.push(
-                `<script defer module src="${getDist({
+                `<script ${scriptAttrs} module src="${getDist({
                     path: script.src,
                     legacy: false,
                 })}"></script>`,
             );
             scriptTags.push(
-                `<script defer nomodule src="${getDist({
+                `<script ${scriptAttrs} nomodule src="${getDist({
                     path: script.src,
                     legacy: true,
                 })}"></script>`,
@@ -90,6 +91,7 @@ export const document = ({ data }: Props) => {
             { src: 'dynamicImport.js', module: true },
             { src: 'react.js', module: true },
         ].filter(Boolean),
+        'defer',
     );
 
     /**
@@ -99,13 +101,16 @@ export const document = ({ data }: Props) => {
      * *before* the high priority scripts, although this is very
      * unlikely.
      */
-    const lowPriorityScriptTags = generateScriptTags([
-        { src: 'https://www.google-analytics.com/analytics.js' },
-        { src: 'ga.js', module: true },
-        { src: 'ophan.js', module: true },
-        { src: 'lotame.js', module: true },
-        { src: 'atomIframe.js', module: true },
-    ]);
+    const lowPriorityScriptTags = generateScriptTags(
+        [
+            { src: 'https://www.google-analytics.com/analytics.js' },
+            { src: 'ga.js', module: true },
+            { src: 'ophan.js', module: true },
+            { src: 'lotame.js', module: true },
+            { src: 'atomIframe.js', module: true },
+        ],
+        'async',
+    );
 
     /**
      * We escape windowGuardian here to prevent errors when the data

--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -24,7 +24,7 @@ const generateScriptTags = (
     scripts.reduce((scriptTags, script) => {
         if (script.module) {
             scriptTags.push(
-                `<script ${scriptAttrs} module src="${getDist({
+                `<script ${scriptAttrs} type="module" src="${getDist({
                     path: script.src,
                     legacy: false,
                 })}"></script>`,


### PR DESCRIPTION
## What does this change?

Following on from https://github.com/guardian/dotcom-rendering/pull/1851 - @jorgeazevedo noticed a bump in loading times of low-priority scripts:

<img width="500" alt="dotcom-rendering_CODE___Favorites___SpeedCurve" src="https://user-images.githubusercontent.com/638051/93076655-950a9680-f67f-11ea-8c8b-b3014e1a3ec4.png">

Following @nicl's [document](https://docs.google.com/document/d/1Nc1LmfXf9cobmtwCnrxXu-v3KojRCXqKp_youHs_X9Y/edit) we implemented low priority scripts with `async` rather than `defer`. 

This PR re-implements that behaviour.

It also uses `type=module` instead of `module` as even though we've not identified issues, the suggestion in most documentation is to use the type attribute with module value, and `nomodule` attribute alone.

### After

![Screen Shot 2020-09-14 at 11 38 13](https://user-images.githubusercontent.com/638051/93076989-1cf0a080-f680-11ea-99f7-50cc7612a7d4.png)
![Screen Shot 2020-09-14 at 11 38 01](https://user-images.githubusercontent.com/638051/93076996-1eba6400-f680-11ea-853f-777b32afa8d4.png)

