### PR TITLE
Always add the index to the root, even when the index is 0 (falsy)

### DIFF
--- a/src/web/components/Hydrate.tsx
+++ b/src/web/components/Hydrate.tsx
@@ -7,7 +7,7 @@ type Props = {
 };
 
 export const Hydrate = ({ root, index, children }: Props) => {
-    const rootWithIndex = index ? `${root}-${index}` : root;
+    const rootWithIndex = index===0 || index ? `${root}-${index}` : root;
     const element = document.getElementById(rootWithIndex);
     if (!element) return null;
     window.performance.mark(`${rootWithIndex}-hydrate-start`);


### PR DESCRIPTION
## What does this change?
Here we fix a bug where we don't identify and hydrate elements where their index is 0, since 0 evaluates to false and is not appended to the `root` to give the expected `rootWithIndex`.

### Before
This QuizAtom element with an index of 0 was given the wrong `rootWithIndex` (missing the 0), meaning the element was not hydrated:

![quiz-atom-not-hydrated](https://user-images.githubusercontent.com/9820960/93230510-a8952a80-f76f-11ea-8023-1893becb0f5e.png)

### After

With this change, the `rootWithIndex` was as expected, and the element was hydrated:

![quiz-atom-hydrated](https://user-images.githubusercontent.com/9820960/93230709-e09c6d80-f76f-11ea-9ab8-934acaf56597.png)