### PR TITLE
Add end-to-end banner tests

### DIFF
--- a/cypress/integration/e2e/article.bannerPicker.e2e.spec.js
+++ b/cypress/integration/e2e/article.bannerPicker.e2e.spec.js
@@ -1,0 +1,45 @@
+/* eslint-disable no-undef */
+/* eslint-disable func-names */
+
+describe('Banner Picker Integration', function () {
+    const visitArticle = (
+        url = 'https://www.theguardian.com/games/2018/aug/23/nier-automata-yoko-taro-interview',
+    ) => {
+        cy.visit(`Article?url=${url}`);
+    };
+
+    const cmpIframe = () => {
+        return cy
+            .get('iframe#sp_message_iframe_208529')
+            .its('0.contentDocument.body')
+            .should('not.be.empty')
+            .then(cy.wrap);
+    };
+
+    describe('When consent cookies are not set', function () {
+        it('shows the CMP', function () {
+            cy.clearCookie('consentUUID');
+            cy.clearCookie('euconsent-v2');
+
+            visitArticle();
+
+            cmpIframe().contains("It's your choice");
+        });
+    });
+
+    it('makes a single request to the banner service', function () {
+        visitArticle();
+
+        cy.window().then((win) => {
+            const fetchSpy = cy.spy(win, 'fetch');
+            fetchSpy
+                .withArgs(
+                    'https://contributions.guardianapis.com/banner',
+                    Cypress.sinon.match.any,
+                )
+                .as('readerRevenueBannerFetch');
+        });
+
+        cy.get('@readerRevenueBannerFetch').should('have.been.calledOnce');
+    });
+});


### PR DESCRIPTION
## What does this change?

Adds two very basic e2e banner tests:

* ensure that when consent cookies aren't set we show the CMP
* ensure that we make a single request to the reader revenue /banner endpoint

## Why?

Additional confidence in the banner picking logic.