### PR TITLE
Refactor getUser and getBrazeUuid to use callApi

### DIFF
--- a/src/web/lib/api.tsx
+++ b/src/web/lib/api.tsx
@@ -21,6 +21,7 @@ interface FetchOptions {
             | 'application/x-www-form-urlencoded';
     };
     body?: string;
+    credentials?: 'omit' | 'include' | 'same-origin';
 }
 
 function checkForErrors(response: any) {
@@ -33,7 +34,7 @@ function checkForErrors(response: any) {
     return response;
 }
 
-const callApi = (url: string, options?: FetchOptions) => {
+export const callApi = (url: string, options?: FetchOptions) => {
     return fetch(url, options)
         .then(checkForErrors)
         .then((response) => response.json());

--- a/src/web/lib/getBrazeUuid.ts
+++ b/src/web/lib/getBrazeUuid.ts
@@ -1,20 +1,11 @@
 import { joinUrl } from '@root/src/web/lib/joinUrl';
+import { callApi } from '@root/src/web/lib/api';
 
 export const getBrazeUuid = async (ajaxUrl: string): Promise<string> => {
     const url = joinUrl([ajaxUrl, 'user/me']);
-    return fetch(url, {
+    return callApi(url, {
         credentials: 'include',
     })
-        .then((response) => {
-            if (!response.ok) {
-                throw Error(
-                    response.statusText ||
-                        `getBrazeUuid | An api call returned HTTP status ${response.status}`,
-                );
-            }
-            return response;
-        })
-        .then((response) => response.json())
         .then((json) => json.user.privateFields.brazeUuid)
         .catch((error) => {
             window.guardian.modules.sentry.reportError(error, 'getBrazeUuid');

--- a/src/web/lib/getUser.ts
+++ b/src/web/lib/getUser.ts
@@ -1,20 +1,11 @@
 import { joinUrl } from '@root/src/web/lib/joinUrl';
+import { callApi } from '@root/src/web/lib/api';
 
 export const getUser = async (ajaxUrl: string): Promise<UserProfile> => {
     const url = joinUrl([ajaxUrl, 'profile/me']);
-    return fetch(url, {
+    return callApi(url, {
         credentials: 'include',
     })
-        .then((response) => {
-            if (!response.ok) {
-                throw Error(
-                    response.statusText ||
-                        `getUser | An api call returned HTTP status ${response.status}`,
-                );
-            }
-            return response;
-        })
-        .then((response) => response.json())
         .then((json) => json.userProfile)
         .catch((error) => {
             window.guardian.modules.sentry.reportError(error, 'get-user');


### PR DESCRIPTION
### What does this change?

Refactor `getUser` and `getBrazeUuid` to use `callApi` instead of using `fetch` directly.

### Why?

Using `callApi` has the benefit of being able to remove some boilerplate (error handling, json decoding) from the two call sites.
