### PR TITLE
Transpile all @guardian/ node_modules

### DIFF
--- a/scripts/webpack/browser.js
+++ b/scripts/webpack/browser.js
@@ -74,7 +74,7 @@ module.exports = ({ isLegacyJS }) => ({
         rules: [
             {
                 test: /(\.tsx)|(\.js)|(\.ts)|(\.mjs)$/,
-                exclude: /node_modules\/(?!@guardian).*/,
+                exclude: /node_modules\/(?!@guardian\/).*/,
                 use: [
                     {
                         loader: 'babel-loader',

--- a/scripts/webpack/browser.js
+++ b/scripts/webpack/browser.js
@@ -74,7 +74,7 @@ module.exports = ({ isLegacyJS }) => ({
         rules: [
             {
                 test: /(\.tsx)|(\.js)|(\.ts)|(\.mjs)$/,
-                exclude: /node_modules\/(?!(@guardian\/discussion-rendering)|(@guardian\/types)|(dynamic-import-polyfill))\/.*/,
+                exclude: /node_modules\/(?!@guardian).*/,
                 use: [
                     {
                         loader: 'babel-loader',


### PR DESCRIPTION
### What does this change?

As per discussion in the client-side infra meeting it was concluded that we should transpile all @guardian/ node_modules in platforms to allow ES2020 Transpilation for all @guardian modules.

https://docs.google.com/document/d/1Vi7m35w46F72z6n4fucsxm6i28xbmn2iMfPGM7zWGz8/edit#

> Define spec for building guardian libraries to
> - ES2020, optionally with TypeScript declaration files
> - Consumers have to include any @guardian libraries in node_modules in their transpilation toolchain

https://regex101.com/r/8JeBqE/1