### PR TITLE
Add dynamic import polyfill back to transpilation

### DIFF
--- a/scripts/webpack/browser.js
+++ b/scripts/webpack/browser.js
@@ -74,7 +74,7 @@ module.exports = ({ isLegacyJS }) => ({
         rules: [
             {
                 test: /(\.tsx)|(\.js)|(\.ts)|(\.mjs)$/,
-                exclude: /node_modules\/(?!@guardian\/).*/,
+                exclude: /node_modules\/(?!(@guardian\/)|(dynamic-import-polyfill)).*/,
                 use: [
                     {
                         loader: 'babel-loader',


### PR DESCRIPTION
## What does this change?

In my excitement of https://github.com/guardian/dotcom-rendering/pull/1919 I accidentally removed the `dynamic-import-polyfill` from transpilation. @tjmw spotted this, thanks!

Regex tested: https://regex101.com/r/8JeBqE/3