### PR TITLE
Remove old CMP

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "@guardian/ab-react": "^2.0.1",
         "@guardian/atoms-rendering": "^1.11.2",
         "@guardian/automat-client": "^0.2.16",
-        "@guardian/consent-management-platform": "5.0.0-0",
+        "@guardian/consent-management-platform": "5.0.0",
         "@guardian/braze-components": "^0.0.5",
         "@guardian/discussion-rendering": "^2.6.0",
         "@guardian/shimport": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "@guardian/ab-react": "^2.0.1",
         "@guardian/atoms-rendering": "^1.11.2",
         "@guardian/automat-client": "^0.2.16",
-        "@guardian/consent-management-platform": "4.3.0",
+        "@guardian/consent-management-platform": "5.0.0-0",
         "@guardian/braze-components": "^0.0.5",
         "@guardian/discussion-rendering": "^2.6.0",
         "@guardian/shimport": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2340,10 +2340,10 @@
     "@guardian/src-button" "^2.1.0"
     "@guardian/src-foundations" "^2.1.0"
 
-"@guardian/consent-management-platform@5.0.0-0":
-  version "5.0.0-0"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-5.0.0-0.tgz#d55282b95b1e624608096876ef25909457be2fe3"
-  integrity sha512-tKZDpZVu2eHgh+TDxB1+HwmICDEl5Ay/RWvgEyJnXD5DQAGhurKOxlWSiq16d/Fvycei3pRrpa8jwUQ0svVdNA==
+"@guardian/consent-management-platform@5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-5.0.0.tgz#1a0c1de69f2c0d6cafa51a224beaa2839b402bc4"
+  integrity sha512-UaWjeZQQktI/rOIoeQyQTkbyjiMPCeNVvCWKdYMiJpDcISxjRwi/rLWYQ7C9bsX7RzimbA6WgIBePBn0B1YfjQ==
 
 "@guardian/discussion-rendering@^2.6.0":
   version "2.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2340,12 +2340,10 @@
     "@guardian/src-button" "^2.1.0"
     "@guardian/src-foundations" "^2.1.0"
 
-"@guardian/consent-management-platform@4.3.0":
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-4.3.0.tgz#2a9f548db78a7c9017708ec6ba79ba258ae9adc1"
-  integrity sha512-hF8urPA3stLh5gT1Htq6eqvIWoBtikjoI4dXp9MpZ9iKwD2GQKOEFeQeOpmTUrnY0sA860ReLdiWyMUs627oJA==
-  dependencies:
-    "@guardian/old-cmp" "npm:@guardian/consent-management-platform@^3.4.10"
+"@guardian/consent-management-platform@5.0.0-0":
+  version "5.0.0-0"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-5.0.0-0.tgz#d55282b95b1e624608096876ef25909457be2fe3"
+  integrity sha512-tKZDpZVu2eHgh+TDxB1+HwmICDEl5Ay/RWvgEyJnXD5DQAGhurKOxlWSiq16d/Fvycei3pRrpa8jwUQ0svVdNA==
 
 "@guardian/discussion-rendering@^2.6.0":
   version "2.6.0"
@@ -2357,15 +2355,6 @@
     react-app-rewired "^2.1.6"
     react-focus-lock "^2.2.1"
     timeago.js "^4.0.2"
-
-"@guardian/old-cmp@npm:@guardian/consent-management-platform@^3.4.10":
-  version "3.4.10"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-3.4.10.tgz#604e71d27c6bfa4664c83c55578a8aa73ff09d82"
-  integrity sha512-P3dTf9EqYhpH7JQ+Bg9MNoIQ08U4yD5j+s5epO9mNTaIBiX1BeOF3RcI3KNj/dBxSggaut0rBdQ82GN54Bg4jA==
-  dependencies:
-    consent-string "1.5.2"
-    js-cookie "2.2.1"
-    whatwg-fetch "3.0.0"
 
 "@guardian/shimport@^1.0.2":
   version "1.0.2"
@@ -5785,11 +5774,6 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-base-64@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/base-64/-/base-64-0.1.0.tgz#780a99c84e7d600260361511c4877613bf24f6bb"
-  integrity sha1-eAqZyE59YAJgNhURxId2E78k9rs=
-
 base64-js@^1.0.2:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
@@ -7059,13 +7043,6 @@ confusing-browser-globals@^1.0.7:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.9.tgz#72bc13b483c0276801681871d4898516f8f54fdd"
   integrity sha512-KbS1Y0jMtyPgIxjO7ZzMAuUpAKMt1SzCL9fsrKsX6b0zJPTaT0SiSPmewwVZg9UAO83HVIlEhZF84LIjZ0lmAw==
-
-consent-string@1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/consent-string/-/consent-string-1.5.2.tgz#cd3615f406a1d7649ebc9722960b5e451cf6a685"
-  integrity sha512-xzfHnFzHQSupiamNY93UGn8FggPajHYExI45pzadhVpXVaj3ztnhnA7lYjKXl09pKRQKCT4hvjytt+2eoH7Jaw==
-  dependencies:
-    base-64 "^0.1.0"
 
 console-browserify@^1.1.0:
   version "1.1.0"
@@ -12334,11 +12311,6 @@ jpeg-js@0.1.2, jpeg-js@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.1.2.tgz#135b992c0575c985cfa0f494a3227ed238583ece"
   integrity sha1-E1uZLAV1yYXPoPSUoyJ+0jhYPs4=
-
-js-cookie@2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
-  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
 
 js-levenshtein@^1.1.3:
   version "1.1.6"
@@ -19538,7 +19510,7 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3, whatwg-encoding@^1.0.5:
   dependencies:
     iconv-lite "0.4.24"
 
-whatwg-fetch@3.0.0, whatwg-fetch@>=0.10.0:
+whatwg-fetch@>=0.10.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
   integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==


### PR DESCRIPTION
Use latest CMP that removes the old one entirely

sibling to https://github.com/guardian/frontend/pull/23008