### PR TITLE
Rich link text color

### DIFF
--- a/src/web/components/RichLink.tsx
+++ b/src/web/components/RichLink.tsx
@@ -121,6 +121,7 @@ const richLinkElements = css`
 
 const richLinkHeader = css`
     padding-bottom: 10px;
+    color: ${neutral[0]};
 `;
 
 const richLinkTitle = css`

--- a/src/web/components/RichLink.tsx
+++ b/src/web/components/RichLink.tsx
@@ -152,10 +152,11 @@ const readMoreTextStyle = css`
     font-size: 14px;
     ${from.wide} {
         ${headline.xxxsmall()}
+        line-height: 25px;
     }
     display: inline-block;
     height: 30px;
-    line-height: 26px;
+    line-height: 25px;
     padding-left: 4px;
     vertical-align: top;
     font-weight: 500;

--- a/src/web/components/RichLink.tsx
+++ b/src/web/components/RichLink.tsx
@@ -116,7 +116,10 @@ const richLinkLink = css`
 `;
 
 const richLinkElements = css`
-    padding: 4px 5px 5px 7px;
+    padding-top: 2px;
+    padding-right: 5px;
+    padding-left: 5px;
+    padding-bottom: 5px;
 `;
 
 const richLinkHeader = css`
@@ -281,7 +284,7 @@ export const RichLink = ({
             data-name={(isPlaceholder && 'placeholder') || ''}
         >
             <div className={cx(richLinkContainer, neutralBackground)}>
-                <a className={cx(richLinkLink)} href={url}>
+                <a className={richLinkLink} href={url}>
                     <div className={richLinkTopBorder(pillar)} />
                     {showImage && (
                         <div>


### PR DESCRIPTION
# What does this change? 
Set rich link text colours

### Before
<img width="251" alt="Screenshot 2020-09-18 at 13 00 21" src="https://user-images.githubusercontent.com/8831403/93595063-edf36b00-f9ae-11ea-94ff-ae161ab580d6.png">

### After
<img width="358" alt="Screenshot 2020-09-18 at 12 55 53" src="https://user-images.githubusercontent.com/8831403/93594734-5261fa80-f9ae-11ea-9a2e-5bda5dacf917.png">

## Why?
We should not have pallet colours applied to the text on rich links
