### PR TITLE
Rename bestFor to selectScrSetItemForWidth

### DIFF
--- a/src/web/components/elements/ImageComponent.tsx
+++ b/src/web/components/elements/ImageComponent.tsx
@@ -26,7 +26,7 @@ type Props = {
 
 const widths = [1020, 660, 480, 0];
 
-const bestFor = (
+const selectScrSetItemForWidth = (
     desiredWidth: number,
     inlineSrcSets: SrcSetItem[],
 ): SrcSetItem => {
@@ -51,7 +51,7 @@ const getSrcSetsForWeighting = (
             weighting.toLowerCase() === forWeighting.toLowerCase(),
     )[0].srcSet;
 
-const makeSource = (
+const makePictureSource = (
     hidpi: boolean,
     minWidth: number,
     srcSet: SrcSetItem,
@@ -76,8 +76,20 @@ const makeSources = (
     // Until that happens, here we're manually injecting (inadequate) <source> elements for
     // those images, albeit without the necessary query params for hidpi images :(
     widths.forEach((width) => {
-        sources.push(makeSource(true, width, bestFor(width, inlineSrcSets)));
-        sources.push(makeSource(false, width, bestFor(width, inlineSrcSets)));
+        sources.push(
+            makePictureSource(
+                true,
+                width,
+                selectScrSetItemForWidth(width, inlineSrcSets),
+            ),
+        );
+        sources.push(
+            makePictureSource(
+                false,
+                width,
+                selectScrSetItemForWidth(width, inlineSrcSets),
+            ),
+        );
     });
 
     return sources;
@@ -86,7 +98,7 @@ const makeSources = (
 const getFallback: (imageSources: ImageSource[]) => string = (imageSources) => {
     const inlineSrcSets = getSrcSetsForWeighting(imageSources, 'inline');
 
-    return bestFor(300, inlineSrcSets).src;
+    return selectScrSetItemForWidth(300, inlineSrcSets).src;
 };
 
 const starsWrapper = css`


### PR DESCRIPTION

## What does this change?

Refactoring: Rename `bestFor` to `selectScrSetItemForWidth` in ImageComponent
