### PR TITLE
Don’t show Braze banner on Glabs paid content pages

### DIFF
--- a/src/web/components/StickyBottomBanner/BrazeBanner.test.ts
+++ b/src/web/components/StickyBottomBanner/BrazeBanner.test.ts
@@ -1,4 +1,8 @@
-import { brazeVendorId, hasRequiredConsents } from './BrazeBanner';
+import {
+    brazeVendorId,
+    hasRequiredConsents,
+    canShowPreChecks,
+} from './BrazeBanner';
 
 let mockOnConsentChangeResult: any;
 jest.mock('@guardian/consent-management-platform', () => ({
@@ -61,6 +65,73 @@ describe('hasRequiredConsents', () => {
             };
 
             await expect(hasRequiredConsents()).resolves.toBe(false);
+        });
+    });
+});
+
+describe('canShowPreChecks', () => {
+    describe('when the switch is off', () => {
+        it('returns false', () => {
+            const result = canShowPreChecks({
+                brazeSwitch: false,
+                apiKey: 'abcde',
+                isDigitalSubscriber: true,
+                pageConfig: { isPaidContent: false },
+            });
+
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('when the api key is empty', () => {
+        it('returns false', () => {
+            const result = canShowPreChecks({
+                brazeSwitch: true,
+                apiKey: '',
+                isDigitalSubscriber: true,
+                pageConfig: { isPaidContent: false },
+            });
+
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('when not a digital subscriber', () => {
+        it('returns false', () => {
+            const result = canShowPreChecks({
+                brazeSwitch: true,
+                apiKey: 'abcde',
+                isDigitalSubscriber: false,
+                pageConfig: { isPaidContent: false },
+            });
+
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('when viewing paid content', () => {
+        it('returns false', () => {
+            const result = canShowPreChecks({
+                brazeSwitch: true,
+                apiKey: 'abcde',
+                isDigitalSubscriber: true,
+                pageConfig: { isPaidContent: true },
+            });
+
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('when all checks pass', () => {
+        it('returns true', () => {
+            const result = canShowPreChecks({
+                brazeSwitch: true,
+                apiKey: 'abcde',
+                isDigitalSubscriber: true,
+                pageConfig: { isPaidContent: false },
+            });
+
+            expect(result).toBe(true);
         });
     });
 });


### PR DESCRIPTION
## What does this change?

Prevents the Braze banner from showing on Glabs paid content pages. (DCR equivalent of guardian/frontend#23009).

### Before

In theory the Braze banner would show on Glabs paid content pages (not in practice since the feature isn't enabled yet).

### After

No Braze banner on Glabs paid content pages.

### Notes

This PR is based on #1910. Once that's been merged I'll rebase this PR on `main` and update the base branch.
