### PR TITLE
Carousel / onwards test

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,8 @@
     "eslint.enable": true,
     "editor.codeActionsOnSave": {
         "source.fixAll.eslint": true
+    },
+    "files.watcherExclude": {
+        "**/target": true
     }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -684,6 +684,7 @@ interface TrailType {
     shortUrl?: string;
     commentCount?: number;
     starRating?: number;
+    linkText?: string;
 }
 
 interface TrailTabType {

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -571,6 +571,7 @@ export const App = ({ CAPI, NAV }: Props) => {
                             keywordIds={CAPI.config.keywordIds}
                             contentType={CAPI.contentType}
                             tags={CAPI.tags}
+                            edition={CAPI.editionId}
                         />
                     </Suspense>
                 </Lazy>

--- a/src/web/components/Card/components/CardAge.tsx
+++ b/src/web/components/Card/components/CardAge.tsx
@@ -9,17 +9,14 @@ import ClockIcon from '@frontend/static/icons/clock.svg';
 import { makeRelativeDate } from '@root/src/web/lib/dateTime';
 import { decidePillarLight } from '@root/src/web/lib/decidePillarLight';
 
-const ageStyles = (designType?: DesignType) => css`
+const ageStyles = (designType: DesignType, pillar: Pillar) => css`
     ${textSans.xsmall()};
-    color: ${neutral[60]};
-
-    /* Provide side padding for positioning and also to keep spacing
-    between any sibings (like GuardianLines) */
-    padding-left: 5px;
-    padding-right: 5px;
+    color: ${designType === 'Live' ? decidePillarLight(pillar) : neutral[60]};
 
     svg {
-        fill: ${neutral[46]};
+        fill: ${designType === 'Live'
+            ? decidePillarLight(pillar)
+            : neutral[46]};
         margin-bottom: -1px;
         height: 11px;
         width: 11px;
@@ -90,7 +87,7 @@ export const CardAge = ({
     return (
         <span
             className={cx(
-                ageStyles(designType),
+                ageStyles(designType, pillar),
                 colourStyles(designType, pillar),
             )}
         >

--- a/src/web/components/Card/components/CardAge.tsx
+++ b/src/web/components/Card/components/CardAge.tsx
@@ -13,6 +13,11 @@ const ageStyles = (designType: DesignType, pillar: Pillar) => css`
     ${textSans.xsmall()};
     color: ${designType === 'Live' ? decidePillarLight(pillar) : neutral[60]};
 
+    /* Provide side padding for positioning and also to keep spacing
+    between any sibings (like GuardianLines) */
+    padding-left: 5px;
+    padding-right: 5px;
+
     svg {
         fill: ${designType === 'Live'
             ? decidePillarLight(pillar)

--- a/src/web/components/Card/components/CardFooter.tsx
+++ b/src/web/components/Card/components/CardFooter.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 import { Lines } from '@guardian/src-ed-lines';
+import { space } from '@guardian/src-foundations';
 
 type Props = {
     designType: DesignType;
@@ -14,6 +15,7 @@ const spaceBetween = css`
     display: flex;
     justify-content: space-between;
     align-items: center;
+    margin: 0 ${space[1]}px;
 `;
 
 const flexEnd = css`
@@ -26,6 +28,7 @@ const linesWrapperStyles = css`
     flex-grow: 1;
     /* Push the lines down to align with the bottom of the card */
     margin-top: 5px;
+    margin-left: 5px;
 `;
 
 export const CardFooter = ({

--- a/src/web/components/Card/components/CardFooter.tsx
+++ b/src/web/components/Card/components/CardFooter.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { css } from 'emotion';
 
 import { Lines } from '@guardian/src-ed-lines';
-import { space } from '@guardian/src-foundations';
 
 type Props = {
     designType: DesignType;
@@ -15,7 +14,6 @@ const spaceBetween = css`
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin: 0 ${space[1]}px;
 `;
 
 const flexEnd = css`
@@ -28,7 +26,6 @@ const linesWrapperStyles = css`
     flex-grow: 1;
     /* Push the lines down to align with the bottom of the card */
     margin-top: 5px;
-    margin-left: 5px;
 `;
 
 export const CardFooter = ({

--- a/src/web/components/Onwards/Carousel.stories.tsx
+++ b/src/web/components/Onwards/Carousel.stories.tsx
@@ -184,6 +184,12 @@ const trails: TrailType[] = [
     },
 ];
 
-export const Headlines = () => <Carousel heading="Headlines" trails={trails} />;
+export const Headlines = () => (
+    <Carousel
+        heading="Headlines"
+        trails={trails}
+        ophanComponentName="curated-content"
+    />
+);
 
 Headlines.story = 'Headlines carousel';

--- a/src/web/components/Onwards/Carousel.stories.tsx
+++ b/src/web/components/Onwards/Carousel.stories.tsx
@@ -1,0 +1,189 @@
+import React from 'react';
+
+import { Carousel } from './Carousel';
+
+export default {
+    component: Carousel,
+    title: 'Components/Carousel',
+};
+
+const trails: TrailType[] = [
+    {
+        url:
+            'https://www.theguardian.com/politics/live/2020/sep/15/uk-coronavirus-live-covid-19-second-wave-testing-capacity-government-brexit-politics-boris-johnson',
+        linkText:
+            'UK coronavirus live: Covid testing shortage will take weeks to resolve, says Matt Hancock',
+        showByline: false,
+        byline: 'Andrew Sparrow',
+        image:
+            'https://i.guim.co.uk/img/media/9e3148e304f3d6d6eeafadaf4b707eb4b6f4f64c/0_196_3500_2099/master/3500.jpg?width=300&quality=85&auto=format&fit=max&s=4c6370b54991b05550d1fa7b78f69829',
+        isLiveBlog: true,
+        pillar: 'news',
+        designType: 'Live',
+        webPublicationDate: '2020-09-15T13:46:52.000Z',
+        headline:
+            'UK coronavirus: testing shortage will take weeks to resolve, says Matt Hancock',
+        shortUrl: 'https://gu.com/p/ezyq3',
+    },
+    {
+        url:
+            'https://www.theguardian.com/society/2020/sep/15/ex-tory-mp-charlie-elphicke-jailed-for-two-years-for-sexual-assaults',
+        linkText:
+            'Ex-Tory MP Charlie Elphicke jailed for two years for sexual assaults',
+        showByline: false,
+        byline: 'Ben Quinn',
+        image:
+            'https://i.guim.co.uk/img/media/877e5e3f240c1958504827796249cd8a46caf0a1/0_116_1969_1181/master/1969.jpg?width=300&quality=85&auto=format&fit=max&s=444e206a147224a7e50e0eeb4780620c',
+        isLiveBlog: false,
+        pillar: 'news',
+        designType: 'Article',
+        webPublicationDate: '2020-09-15T11:44:46.000Z',
+        headline: 'Ex-Tory MP jailed for two years for sexual assaults',
+        shortUrl: 'https://gu.com/p/ezmac',
+        kickerText: 'Charlie Elphicke',
+    },
+    {
+        url:
+            'https://www.theguardian.com/politics/2020/sep/15/no-10-rejects-any-concessions-for-rebel-tories-on-brexit-bill',
+        linkText:
+            'No 10 rejects any concessions for rebel Tories on Brexit bill',
+        showByline: false,
+        byline: 'Jessica Elgot and Peter Walker',
+        image:
+            'https://i.guim.co.uk/img/media/f7c663fe69644c3ca5fd402fab40f3b5501064cc/0_99_4505_2703/master/4505.jpg?width=300&quality=85&auto=format&fit=max&s=fca4c60f52a8e1c686d48742d43e6887',
+        isLiveBlog: false,
+        pillar: 'news',
+        designType: 'Article',
+        webPublicationDate: '2020-09-15T13:24:45.000Z',
+        headline: 'No 10 rejects any concessions for rebel Tories on bill',
+        shortUrl: 'https://gu.com/p/ezn2d',
+        kickerText: 'Brexit',
+    },
+    {
+        url:
+            'https://www.theguardian.com/environment/2020/sep/15/every-global-target-to-stem-destruction-of-nature-by-2020-missed-un-report-aoe',
+        linkText:
+            'World fails to meet a single target to stop destruction of nature – UN report',
+        showByline: false,
+        byline: 'Patrick Greenfield',
+        image:
+            'https://i.guim.co.uk/img/media/b204a14ffd1911591e9aa0f2df6769798bbdd1c1/0_225_4000_2400/master/4000.jpg?width=300&quality=85&auto=format&fit=max&s=b7f695cc8b23cec50344273aa46503bf',
+        isLiveBlog: false,
+        pillar: 'news',
+        designType: 'Article',
+        webPublicationDate: '2020-09-15T13:15:36.000Z',
+        headline:
+            'World fails to meet a single target to stop destruction of nature – UN report',
+        shortUrl: 'https://gu.com/p/ezgye',
+        kickerText: 'Environment',
+    },
+    {
+        url:
+            'https://www.theguardian.com/world/2020/sep/15/alexei-navalny-poisoned-russian-opposition-leader-photo-hospital',
+        linkText:
+            "'Hi, this is Navalny': poisoned Russian opposition leader posts hospital photo",
+        showByline: false,
+        byline: 'Shaun Walker in Moscow',
+        image:
+            'https://i.guim.co.uk/img/media/f285ba35a26e663f9d5e2808558f644fa12765e1/0_136_960_576/master/960.jpg?width=300&quality=85&auto=format&fit=max&s=b33e6ce3806d5e7ddb26d4decbb824a5',
+        isLiveBlog: false,
+        pillar: 'news',
+        designType: 'Article',
+        webPublicationDate: '2020-09-15T10:41:04.000Z',
+        headline: 'Poisoned Russian opposition leader posts hospital photo',
+        shortUrl: 'https://gu.com/p/ezmtk',
+        kickerText: "'Hi, this is Navalny'",
+    },
+    {
+        url:
+            'https://www.theguardian.com/media/2020/sep/15/gary-lineker-takes-bbc-pay-cut-and-agrees-to-tweet-more-carefully',
+        linkText:
+            'Gary Lineker takes 25% BBC pay cut and agrees to tweet more carefully',
+        showByline: false,
+        byline: 'Jim Waterson Media editor',
+        image:
+            'https://i.guim.co.uk/img/media/3ec6d136faade765328e86db332665d19e011d1c/0_1268_3203_1922/master/3203.jpg?width=300&quality=85&auto=format&fit=max&s=b8ec99f56446dc12f76c6880d43b1202',
+        isLiveBlog: false,
+        pillar: 'news',
+        designType: 'Article',
+        webPublicationDate: '2020-09-15T11:00:32.000Z',
+        headline:
+            'Gary Lineker takes 25% pay cut and agrees to tweet more carefully',
+        shortUrl: 'https://gu.com/p/ezmcp',
+        kickerText: 'BBC',
+    },
+    {
+        url:
+            'https://www.theguardian.com/us-news/2020/sep/15/us-election-kim-darroch-donald-trump-joe-biden',
+        linkText:
+            '‘The US feels very volatile’: former ambassador warns of election violence',
+        showByline: false,
+        byline: 'Julian Borger in Washington',
+        image:
+            'https://i.guim.co.uk/img/media/cf291623610b4e9bd53adad56ea1752c5557ad21/0_26_5636_3382/master/5636.jpg?width=300&quality=85&auto=format&fit=max&s=444feb3e9cc898bda708438d05ea6941',
+        isLiveBlog: false,
+        pillar: 'news',
+        designType: 'Article',
+        webPublicationDate: '2020-09-15T09:30:22.000Z',
+        headline: 'Former ambassador warns of election violence',
+        shortUrl: 'https://gu.com/p/ezk38',
+        kickerText: '‘The US feels very volatile’',
+    },
+    {
+        url:
+            'https://www.theguardian.com/us-news/2020/sep/15/trump-iran-retaliate-1000-times-greater-force',
+        linkText:
+            "Trump threatens to retaliate to any Iran attack with '1,000 times greater' force",
+        showByline: false,
+        byline: 'Tom McCarthy',
+        image:
+            'https://i.guim.co.uk/img/media/c38b10a48e27c463ce16d058e02aafda4328e52f/0_20_2462_1478/master/2462.jpg?width=300&quality=85&auto=format&fit=max&s=63656ef63ad936d92d96316f13ce2715',
+        isLiveBlog: false,
+        pillar: 'news',
+        designType: 'Article',
+        webPublicationDate: '2020-09-15T13:04:57.000Z',
+        headline:
+            "Trump threatens to retaliate to any attack with '1,000 times greater' force",
+        shortUrl: 'https://gu.com/p/ezmpz',
+        kickerText: 'Iran',
+    },
+    {
+        url:
+            'https://www.theguardian.com/world/2020/sep/15/after-fire-greece-vows-to-empty-lesbos-of-all-refugees-by-easter',
+        linkText:
+            'Greece vows to empty Lesbos of all refugees by Easter after fire',
+        showByline: false,
+        byline: 'Helena Smith in Athens Philip Oltermann in Berlin',
+        image:
+            'https://i.guim.co.uk/img/media/8c0eff269da77ac303734e8717705d4b70f7d5e2/0_97_5472_3283/master/5472.jpg?width=300&quality=85&auto=format&fit=max&s=3b45f3f609dd7aee06eb1428a172bb8c',
+        isLiveBlog: false,
+        pillar: 'news',
+        designType: 'Article',
+        webPublicationDate: '2020-09-15T13:28:24.000Z',
+        headline:
+            'Government vows to empty Lesbos of all refugees by Easter after fire',
+        shortUrl: 'https://gu.com/p/ezm92',
+        kickerText: 'Greece',
+    },
+    {
+        url:
+            'https://www.theguardian.com/books/2020/sep/15/most-diverse-booker-prize-shortlist-is-also-almost-all-american-hilary-mantel',
+        linkText:
+            'Most diverse Booker prize shortlist ever as Hilary Mantel misses out',
+        showByline: false,
+        byline: 'Alison Flood',
+        image:
+            'https://i.guim.co.uk/img/media/f022aacc31e1e95a07f382206c9b8e5620214e0a/0_0_2560_1536/master/2560.jpg?width=300&quality=85&auto=format&fit=max&s=b4a6348eb191bf5d366ed6282f2ada70',
+        isLiveBlog: false,
+        pillar: 'culture',
+        designType: 'Article',
+        webPublicationDate: '2020-09-15T12:21:07.000Z',
+        headline: 'Most diverse shortlist ever as Hilary Mantel misses out',
+        shortUrl: 'https://gu.com/p/ezmt9',
+        kickerText: 'Booker prize 2020',
+    },
+];
+
+export const Headlines = () => <Carousel heading="Headlines" trails={trails} />;
+
+Headlines.story = 'Headlines carousel';

--- a/src/web/components/Onwards/Carousel.tsx
+++ b/src/web/components/Onwards/Carousel.tsx
@@ -112,7 +112,6 @@ const headlineWrapperStyle = css`
     width: 176px;
     background-color: ${palette.neutral[97]};
     min-height: 107px;
-    padding: ${space[1]}px;
 
     margin-top: -45px;
     flex-grow: 1;
@@ -131,7 +130,9 @@ const headlineWrapperFirstStyle = css`
 const headlineStyle = css`
     ${headline.xxxsmall()};
     color: ${palette.neutral[7]};
-    margin-bottom: ${space[1]}px;
+
+    display: block;
+    padding: ${space[1]}px;
 `;
 
 const headlineFirstStyle = css`

--- a/src/web/components/Onwards/Carousel.tsx
+++ b/src/web/components/Onwards/Carousel.tsx
@@ -9,9 +9,7 @@ import { from } from '@guardian/src-foundations/mq';
 import { palette, space } from '@guardian/src-foundations';
 import libDebounce from 'lodash/debounce';
 import { LeftColumn } from '@frontend/web/components/LeftColumn';
-import { Hide } from '@frontend/web/components/Hide';
 import { formatAttrString } from '@frontend/web/lib/formatAttrString';
-import { OnwardsTitle } from './OnwardsTitle';
 import { CardAge } from '../Card/components/CardAge';
 
 const navIconStyle = css`
@@ -27,10 +25,6 @@ const wrapperStyle = css`
     display: flex;
     justify-content: space-between;
     overflow: hidden;
-
-    ${from.desktop} {
-        overflow: hidden;
-    }
 `;
 
 const containerStyles = css`
@@ -76,7 +70,7 @@ const carouselStyle = css`
     position: relative; /* must set position for offset(Left) calculations of children to be relative to this box */
 
     overflow-x: scroll; /* Scrollbar is less intrusive visually on non-desktop devices typically */
-    ${from.desktop} {
+    ${from.tablet} {
         overflow: hidden;
     }
 
@@ -150,6 +144,7 @@ const headlineFirstStyle = css`
 
 const dotsStyle = css`
     margin-bottom: ${space[2]}px;
+    margin-left: 10px;
 `;
 
 const dotStyle = css`
@@ -183,12 +178,57 @@ const verticalLine = css`
 const navRowStyles = css`
     display: flex;
     justify-content: space-between;
-    align-items: flex-end;
+    align-items: center;
 
     ${from.tablet} {
+        padding-right: 10px;
+    }
+
+    ${from.leftCol} {
         margin-left: 10px;
     }
 `;
+
+const linkStyles = css`
+    text-decoration: none;
+    color: ${palette.text.anchorSecondary};
+
+    :hover {
+        text-decoration: underline;
+    }
+`;
+
+const headerStyles = css`
+    ${headline.xsmall({ fontWeight: 'bold' })};
+    color: ${palette.text.primary};
+    padding-bottom: 14px;
+    padding-top: 6px;
+    margin-left: 10px;
+
+    ${from.leftCol} {
+        margin-left: 0;
+    }
+`;
+
+const titleStyle = css`
+    color: ${palette.news.main};
+`;
+
+export const Title = ({ title, url }: { title: string; url?: string }) => (
+    <>
+        {url ? (
+            <a className={linkStyles} href={url}>
+                <h2 className={headerStyles}>
+                    More from <span className={titleStyle}>{title}</span>
+                </h2>
+            </a>
+        ) : (
+            <h2 className={headerStyles}>
+                More from <span className={titleStyle}>{title}</span>
+            </h2>
+        )}
+    </>
+);
 
 const interleave = <A,>(arr: A[], separator: A): A[] => {
     const separated = arr.map((elem) => [elem, separator]).flat();
@@ -229,7 +269,6 @@ const Card: React.FC<CardProps> = ({ trail, isFirst }: CardProps) => (
 
 export const Carousel: React.FC<OnwardsType> = ({
     heading,
-    description,
     trails,
     url,
     ophanComponentName,
@@ -322,35 +361,15 @@ export const Carousel: React.FC<OnwardsType> = ({
     return (
         <div className={wrapperStyle}>
             <LeftColumn showRightBorder={false} showPartialRightBorder={true}>
-                <OnwardsTitle
-                    title={heading}
-                    description={description}
-                    url={url}
-                />
+                <div />
             </LeftColumn>
             <div
                 className={containerStyles}
                 data-component={ophanComponentName}
                 data-link={formatAttrString(heading)}
             >
-                <Hide when="above" breakpoint="leftCol">
-                    <OnwardsTitle
-                        title={heading}
-                        description={description}
-                        url={url}
-                    />
-                </Hide>
-
                 <div className={navRowStyles}>
-                    <div className={dotsStyle}>
-                        {trails.map((value, i) => (
-                            <span
-                                className={
-                                    i === index ? dotActiveStyle : dotStyle
-                                }
-                            />
-                        ))}
-                    </div>
+                    <Title title={heading} url={url} />
 
                     <div className={navIconStyle}>
                         <button onClick={prev} className={buttonStyle}>
@@ -360,6 +379,14 @@ export const Carousel: React.FC<OnwardsType> = ({
                             <SvgChevronRightSingle />
                         </button>
                     </div>
+                </div>
+
+                <div className={dotsStyle}>
+                    {trails.map((value, i) => (
+                        <span
+                            className={i === index ? dotActiveStyle : dotStyle}
+                        />
+                    ))}
                 </div>
 
                 <div className={carouselStyle} ref={carouselRef}>

--- a/src/web/components/Onwards/Carousel.tsx
+++ b/src/web/components/Onwards/Carousel.tsx
@@ -1,0 +1,182 @@
+import React, { useRef } from 'react';
+import {
+    SvgChevronLeftSingle,
+    SvgChevronRightSingle,
+} from '@guardian/src-icons';
+import { css } from 'emotion';
+import { headline } from '@guardian/src-foundations/typography';
+import { neutral } from '@guardian/src-foundations/palette';
+import { until } from '@guardian/src-foundations/mq';
+import { palette, space } from '@guardian/src-foundations';
+import { CardAge } from '../Card/components/CardAge';
+
+type Props = {
+    heading: string;
+    trails: TrailType[];
+};
+
+const navIconStyle = css`
+    display: inline-block;
+
+    svg {
+        height: 24px;
+        fill: ${neutral};
+    }
+`;
+
+const headingStyle = css`
+    ${headline.xxsmall()};
+    ${until.desktop} {
+        ${headline.xxxsmall()};
+    }
+`;
+
+const carouselStyle = css`
+    width: 100%;
+    height: 227px;
+    display: flex;
+
+    scroll-snap-type: x mandatory;
+    scroll-behavior: smooth;
+    overflow-x: scroll;
+`;
+
+const cardWrapperStyle = css`
+    position: relative;
+    width: 258px;
+    flex-shrink: 0;
+    margin: 0 ${space[2]}px;
+
+    scroll-snap-align: start;
+`;
+
+// TODO image ratio is wrong from source. We could wrap in a div and use
+// absolute positioning to fix this?
+const cardImageStyle = css`
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 258px;
+    height: 181px;
+`;
+
+const headlineWrapperStyle = css`
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 176px;
+    background-color: ${palette.neutral[97]};
+    min-height: 103px;
+    padding: ${space[1]}px;
+`;
+
+const headlineStyle = css`
+    ${headline.xxxsmall()};
+    a {
+        text-decoration: none;
+    }
+`;
+
+const dotsStyle = css``;
+
+const dotStyle = css`
+    display: inline-block;
+    height: ${space[3]}px;
+    width: ${space[3]}px;
+    background-color: ${palette.neutral[93]};
+    border-radius: 50%;
+    margin-right: ${space[1]}px;
+`;
+
+const dotActiveStyle = css`
+    ${dotStyle};
+    background-color: ${palette.news[400]};
+`;
+
+export const Carousel: React.FC<Props> = ({ heading, trails }: Props) => {
+    const carouselRef = useRef<HTMLDivElement>(null);
+    const activeIndex = 1; // TODO update based on (debounced) scroll or next/prev
+
+    const getItems = (): HTMLElement[] => {
+        const { current } = carouselRef;
+        if (current === null) return [];
+
+        return Array.from(current.children) as HTMLElement[];
+    };
+
+    const prev = () => {
+        const { current } = carouselRef;
+        if (current === null) return;
+        const scrolled = current.scrollLeft || 0;
+
+        const offsets = getItems().map((el) => el.offsetLeft);
+        const nextOffset = offsets
+            .reverse()
+            .find((offset) => offset < scrolled);
+
+        if (nextOffset) {
+            current.scrollTo({ left: nextOffset });
+        }
+    };
+
+    const next = () => {
+        const { current } = carouselRef;
+        if (current === null) return;
+        const scrolled = current.scrollLeft || 0;
+
+        const offsets = getItems().map((el) => el.offsetLeft);
+        const nextOffset = offsets.find((offset) => offset > scrolled);
+
+        if (nextOffset) {
+            current.scrollTo({ left: nextOffset });
+        }
+    };
+
+    return (
+        <div>
+            <div>
+                <h3 className={headingStyle}>{heading}</h3>
+                <div className={navIconStyle}>
+                    <button onClick={prev}>
+                        <SvgChevronLeftSingle />
+                    </button>
+                    <button onClick={next}>
+                        <SvgChevronRightSingle />
+                    </button>
+                </div>
+                <div className={dotsStyle}>
+                    {trails.map((value, i) => (
+                        <span
+                            className={
+                                i === activeIndex ? dotActiveStyle : dotStyle
+                            }
+                        />
+                    ))}
+                </div>
+            </div>
+            <div className={carouselStyle} ref={carouselRef}>
+                {trails.map((trail) => (
+                    <div className={cardWrapperStyle}>
+                        <img
+                            className={cardImageStyle}
+                            src={trail.image}
+                            alt=""
+                            role="presentation"
+                        />
+                        <div className={headlineWrapperStyle}>
+                            <h4 className={headlineStyle}>
+                                <a href={trail.url}>{trail.headline}</a>
+                            </h4>
+                            <CardAge
+                                webPublicationDate={trail.webPublicationDate}
+                                showClock={true}
+                                pillar="news"
+                                designType="Article"
+                            />
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+};

--- a/src/web/components/Onwards/Carousel.tsx
+++ b/src/web/components/Onwards/Carousel.tsx
@@ -86,6 +86,10 @@ const cardWrapperStyle = css`
     margin: 0 ${space[2]}px;
 
     scroll-snap-align: start;
+
+    :hover {
+        filter: brightness(90%);
+    }
 `;
 
 const cardWrapperFirstStyle = css`
@@ -240,7 +244,10 @@ type CardProps = {
 };
 
 const Card: React.FC<CardProps> = ({ trail, isFirst }: CardProps) => (
-    <div className={isFirst ? cardWrapperFirstStyle : cardWrapperStyle}>
+    <a
+        href={trail.url}
+        className={isFirst ? cardWrapperFirstStyle : cardWrapperStyle}
+    >
         <img
             className={cardImageStyle}
             src={trail.image}
@@ -262,7 +269,7 @@ const Card: React.FC<CardProps> = ({ trail, isFirst }: CardProps) => (
                 designType={isFirst ? 'Live' : 'Article'}
             />
         </div>
-    </div>
+    </a>
 );
 
 export const Carousel: React.FC<OnwardsType> = ({

--- a/src/web/components/Onwards/Carousel.tsx
+++ b/src/web/components/Onwards/Carousel.tsx
@@ -104,8 +104,6 @@ const cardWrapperFirstStyle = css`
     margin-left: 0;
 `;
 
-// TODO image ratio is wrong from source. We could wrap in a div and use
-// absolute positioning to fix this?
 const cardImageStyle = css`
     width: 258px;
 `;
@@ -254,7 +252,7 @@ export const Carousel: React.FC<OnwardsType> = ({
     ophanComponentName,
 }: OnwardsType) => {
     const carouselRef = useRef<HTMLDivElement>(null);
-    const [index, setIndex] = useState(0); // TODO update based on (debounced) scroll or next/prev
+    const [index, setIndex] = useState(0);
 
     const notPresentation = (el: HTMLElement): boolean =>
         el.getAttribute('role') !== 'presentation';

--- a/src/web/components/Onwards/Carousel.tsx
+++ b/src/web/components/Onwards/Carousel.tsx
@@ -16,7 +16,7 @@ const navIconStyle = css`
     display: inline-block;
 
     svg {
-        height: 24px;
+        height: 32px;
         fill: ${palette.neutral[46]};
     }
 `;
@@ -144,7 +144,10 @@ const headlineFirstStyle = css`
 
 const dotsStyle = css`
     margin-bottom: ${space[2]}px;
-    margin-left: 10px;
+
+    ${from.tablet} {
+        margin-left: 10px;
+    }
 `;
 
 const dotStyle = css`
@@ -184,7 +187,7 @@ const navRowStyles = css`
         padding-right: 10px;
     }
 
-    ${from.leftCol} {
+    ${from.tablet} {
         margin-left: 10px;
     }
 `;
@@ -203,11 +206,6 @@ const headerStyles = css`
     color: ${palette.text.primary};
     padding-bottom: 14px;
     padding-top: 6px;
-    margin-left: 10px;
-
-    ${from.leftCol} {
-        margin-left: 0;
-    }
 `;
 
 const titleStyle = css`
@@ -219,12 +217,12 @@ export const Title = ({ title, url }: { title: string; url?: string }) => (
         {url ? (
             <a className={linkStyles} href={url}>
                 <h2 className={headerStyles}>
-                    More from <span className={titleStyle}>{title}</span>
+                    From <span className={titleStyle}>{title}</span>
                 </h2>
             </a>
         ) : (
             <h2 className={headerStyles}>
-                More from <span className={titleStyle}>{title}</span>
+                From <span className={titleStyle}>{title}</span>
             </h2>
         )}
     </>

--- a/src/web/components/Onwards/Carousel.tsx
+++ b/src/web/components/Onwards/Carousel.tsx
@@ -61,8 +61,9 @@ const containerStyles = css`
 `;
 
 const carouselStyle = css`
-    height: 227px;
+    min-height: 227px;
     display: flex;
+    align-items: stretch;
 
     scroll-snap-type: x mandatory;
     /* scroll-behavior: smooth; */
@@ -90,6 +91,12 @@ const cardWrapperStyle = css`
     :hover {
         filter: brightness(90%);
     }
+
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+
+    text-decoration: none;
 `;
 
 const cardWrapperFirstStyle = css`
@@ -100,21 +107,17 @@ const cardWrapperFirstStyle = css`
 // TODO image ratio is wrong from source. We could wrap in a div and use
 // absolute positioning to fix this?
 const cardImageStyle = css`
-    position: absolute;
-    top: 0;
-    left: 0;
     width: 258px;
-    height: 181px;
 `;
 
 const headlineWrapperStyle = css`
-    position: absolute;
-    bottom: 0;
-    left: 0;
     width: 176px;
     background-color: ${palette.neutral[97]};
     min-height: 107px;
     padding: ${space[1]}px;
+
+    margin-top: -45px;
+    flex-grow: 1;
 
     display: flex;
     flex-direction: column;
@@ -123,27 +126,19 @@ const headlineWrapperStyle = css`
 
 const headlineWrapperFirstStyle = css`
     ${headlineWrapperStyle};
-
     background-color: ${palette.news.dark};
     color: white;
 `;
 
 const headlineStyle = css`
     ${headline.xxxsmall()};
-    a {
-        text-decoration: none;
-        color: ${palette.neutral[7]};
-    }
-
+    color: ${palette.neutral[7]};
     margin-bottom: ${space[1]}px;
 `;
 
 const headlineFirstStyle = css`
     ${headlineStyle};
-
-    a {
-        color: ${palette.neutral[100]};
-    }
+    color: ${palette.neutral[100]};
 `;
 
 const dotsStyle = css`
@@ -196,15 +191,6 @@ const navRowStyles = css`
     }
 `;
 
-const linkStyles = css`
-    text-decoration: none;
-    color: ${palette.text.anchorSecondary};
-
-    :hover {
-        text-decoration: underline;
-    }
-`;
-
 const headerStyles = css`
     ${headline.xsmall({ fontWeight: 'bold' })};
     color: ${palette.text.primary};
@@ -216,20 +202,10 @@ const titleStyle = css`
     color: ${palette.news.main};
 `;
 
-export const Title = ({ title, url }: { title: string; url?: string }) => (
-    <>
-        {url ? (
-            <a className={linkStyles} href={url}>
-                <h2 className={headerStyles}>
-                    From <span className={titleStyle}>{title}</span>
-                </h2>
-            </a>
-        ) : (
-            <h2 className={headerStyles}>
-                From <span className={titleStyle}>{title}</span>
-            </h2>
-        )}
-    </>
+export const Title = ({ title }: { title: string; url?: string }) => (
+    <h2 className={headerStyles}>
+        From <span className={titleStyle}>{title}</span>
+    </h2>
 );
 
 const interleave = <A,>(arr: A[], separator: A): A[] => {
@@ -260,7 +236,7 @@ const Card: React.FC<CardProps> = ({ trail, isFirst }: CardProps) => (
             }
         >
             <h4 className={isFirst ? headlineFirstStyle : headlineStyle}>
-                <a href={trail.url}>{trail.headline}</a>
+                {trail.headline}
             </h4>
             <CardAge
                 webPublicationDate={trail.webPublicationDate}
@@ -275,7 +251,6 @@ const Card: React.FC<CardProps> = ({ trail, isFirst }: CardProps) => (
 export const Carousel: React.FC<OnwardsType> = ({
     heading,
     trails,
-    url,
     ophanComponentName,
 }: OnwardsType) => {
     const carouselRef = useRef<HTMLDivElement>(null);
@@ -374,7 +349,7 @@ export const Carousel: React.FC<OnwardsType> = ({
                 data-link={formatAttrString(heading)}
             >
                 <div className={navRowStyles}>
-                    <Title title={heading} url={url} />
+                    <Title title={heading} />
 
                     <div className={navIconStyle}>
                         <button onClick={prev} className={buttonStyle}>

--- a/src/web/components/Onwards/Carousel.tsx
+++ b/src/web/components/Onwards/Carousel.tsx
@@ -5,9 +5,8 @@ import {
 } from '@guardian/src-icons';
 import { css } from 'emotion';
 import { headline } from '@guardian/src-foundations/typography';
-import { neutral } from '@guardian/src-foundations/palette';
 import { until } from '@guardian/src-foundations/mq';
-import { palette, space } from '@guardian/src-foundations';
+import { palette, space, border } from '@guardian/src-foundations';
 import libDebounce from 'lodash/debounce';
 import { CardAge } from '../Card/components/CardAge';
 
@@ -21,19 +20,24 @@ const navIconStyle = css`
 
     svg {
         height: 24px;
-        fill: ${neutral};
+        fill: ${palette.neutral[46]};
     }
 `;
 
-const headerRowStyle = css`
+const headerOuterStyle = css`
+    border-top: 1px solid ${border.primary};
+    padding-top: ${space[2]}px;
+`;
+
+const headerInnerStyle = css`
     display: flex;
     justify-content: space-between;
 `;
 
 const headingStyle = css`
-    ${headline.xxsmall()};
+    ${headline.xxsmall({ fontWeight: 'bold' })};
     ${until.desktop} {
-        ${headline.xxxsmall()};
+        ${headline.xxxsmall({ fontWeight: 'bold' })};
     }
 `;
 
@@ -77,18 +81,42 @@ const headlineWrapperStyle = css`
     left: 0;
     width: 176px;
     background-color: ${palette.neutral[97]};
-    min-height: 103px;
+    min-height: 107px;
     padding: ${space[1]}px;
+
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+`;
+
+const headlineWrapperFirstStyle = css`
+    ${headlineWrapperStyle};
+
+    background-color: ${palette.news.dark};
+    color: white;
 `;
 
 const headlineStyle = css`
     ${headline.xxxsmall()};
     a {
         text-decoration: none;
+        color: ${palette.neutral[7]};
+    }
+
+    margin-bottom: ${space[1]}px;
+`;
+
+const headlineFirstStyle = css`
+    ${headlineStyle};
+
+    a {
+        color: ${palette.neutral[100]};
     }
 `;
 
-const dotsStyle = css``;
+const dotsStyle = css`
+    margin-bottom: ${space[2]}px;
+`;
 
 const dotStyle = css`
     display: inline-block;
@@ -101,12 +129,62 @@ const dotStyle = css`
 
 const dotActiveStyle = css`
     ${dotStyle};
-    background-color: ${palette.news[400]};
+    background-color: ${palette.news.main};
 `;
+
+const buttonStyle = css`
+    border: none;
+    background: none;
+    cursor: pointer;
+`;
+
+const verticalLine = css`
+    width: 1px;
+    background-color: ${palette.neutral[86]};
+    flex-shrink: 0;
+`;
+
+const interleave = <A,>(arr: A[], separator: A): A[] => {
+    return arr.map((elem) => [elem, separator]).flat();
+};
+
+type CardProps = {
+    trail: TrailType;
+    isFirst?: boolean;
+};
+
+const Card: React.FC<CardProps> = ({ trail, isFirst }: CardProps) => (
+    <div className={isFirst ? cardWrapperFirstStyle : cardWrapperStyle}>
+        <img
+            className={cardImageStyle}
+            src={trail.image}
+            alt=""
+            role="presentation"
+        />
+        <div
+            className={
+                isFirst ? headlineWrapperFirstStyle : headlineWrapperStyle
+            }
+        >
+            <h4 className={isFirst ? headlineFirstStyle : headlineStyle}>
+                <a href={trail.url}>{trail.headline}</a>
+            </h4>
+            <CardAge
+                webPublicationDate={trail.webPublicationDate}
+                showClock={true}
+                pillar="news"
+                designType={isFirst ? 'Live' : 'Article'}
+            />
+        </div>
+    </div>
+);
 
 export const Carousel: React.FC<Props> = ({ heading, trails }: Props) => {
     const carouselRef = useRef<HTMLDivElement>(null);
     const [index, setIndex] = useState(0); // TODO update based on (debounced) scroll or next/prev
+
+    const notPresentation = (el: HTMLElement): boolean =>
+        el.getAttribute('role') !== 'presentation';
 
     const getItems = (): HTMLElement[] => {
         const { current } = carouselRef;
@@ -120,7 +198,10 @@ export const Carousel: React.FC<Props> = ({ heading, trails }: Props) => {
         if (current === null) return 0;
         const scrolled = current.scrollLeft || 0;
 
-        const active = getItems().findIndex((el) => el.offsetLeft >= scrolled);
+        const active = getItems()
+            .filter(notPresentation)
+            .findIndex((el) => el.offsetLeft >= scrolled);
+
         return Math.max(0, active);
     };
 
@@ -133,7 +214,10 @@ export const Carousel: React.FC<Props> = ({ heading, trails }: Props) => {
         if (current === null) return;
         const scrolled = current.scrollLeft || 0;
 
-        const offsets = getItems().map((el) => el.offsetLeft);
+        const offsets = getItems()
+            .filter(notPresentation)
+            .map((el) => el.offsetLeft);
+
         const nextOffset = offsets
             .reverse()
             .find((offset) => offset < scrolled);
@@ -152,7 +236,10 @@ export const Carousel: React.FC<Props> = ({ heading, trails }: Props) => {
         if (current === null) return;
         const scrolled = current.scrollLeft || 0;
 
-        const offsets = getItems().map((el) => el.offsetLeft);
+        const offsets = getItems()
+            .filter(notPresentation)
+            .map((el) => el.offsetLeft);
+
         const nextOffset = offsets.find((offset) => offset > scrolled);
 
         if (nextOffset) {
@@ -171,50 +258,36 @@ export const Carousel: React.FC<Props> = ({ heading, trails }: Props) => {
         }
     });
 
+    const cards = trails.map((trail, i) => (
+        <Card trail={trail} isFirst={i === 0} />
+    ));
+
     return (
         <div>
-            <div className={headerRowStyle}>
-                <h3 className={headingStyle}>{heading}</h3>
-                <div className={navIconStyle}>
-                    <button onClick={prev}>
-                        <SvgChevronLeftSingle />
-                    </button>
-                    <button onClick={next}>
-                        <SvgChevronRightSingle />
-                    </button>
+            <div className={headerOuterStyle}>
+                <div className={headerInnerStyle}>
+                    <h3 className={headingStyle}>{heading}</h3>
+                    <div className={navIconStyle}>
+                        <button onClick={prev} className={buttonStyle}>
+                            <SvgChevronLeftSingle />
+                        </button>
+                        <button onClick={next} className={buttonStyle}>
+                            <SvgChevronRightSingle />
+                        </button>
+                    </div>
                 </div>
             </div>
+
             <div className={dotsStyle}>
                 {trails.map((value, i) => (
                     <span className={i === index ? dotActiveStyle : dotStyle} />
                 ))}
             </div>
             <div className={carouselStyle} ref={carouselRef}>
-                {trails.map((trail, i) => (
-                    <div
-                        className={
-                            i === 0 ? cardWrapperFirstStyle : cardWrapperStyle
-                        }
-                    >
-                        <img
-                            className={cardImageStyle}
-                            src={trail.image}
-                            alt=""
-                            role="presentation"
-                        />
-                        <div className={headlineWrapperStyle}>
-                            <h4 className={headlineStyle}>
-                                <a href={trail.url}>{trail.headline}</a>
-                            </h4>
-                            <CardAge
-                                webPublicationDate={trail.webPublicationDate}
-                                showClock={true}
-                                pillar="news"
-                                designType="Article"
-                            />
-                        </div>
-                    </div>
-                ))}
+                {interleave(
+                    cards,
+                    <div role="presentation" className={verticalLine} />,
+                )}
             </div>
         </div>
     );

--- a/src/web/components/Onwards/Onwards.stories.tsx
+++ b/src/web/components/Onwards/Onwards.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 
 import { Section } from '@frontend/web/components/Section';
@@ -23,77 +24,70 @@ export default {
 
 export const linkAndDescriptionStory = () => (
     <Section>
-        <OnwardsLayout onwardSections={[linkAndDescription]} />
+        <OnwardsLayout {...linkAndDescription} />
     </Section>
 );
 linkAndDescriptionStory.story = { name: 'With link and description' };
 
 export const withLongDescriptionStory = () => (
     <Section>
-        <OnwardsLayout onwardSections={[withLongDescription]} />
+        <OnwardsLayout {...withLongDescription} />
     </Section>
 );
 withLongDescriptionStory.story = { name: 'With long description' };
 
 export const oneTrailStory = () => (
     <Section>
-        <OnwardsLayout onwardSections={[oneTrail]} />
+        <OnwardsLayout {...oneTrail} />
     </Section>
 );
 oneTrailStory.story = { name: 'With one trail' };
 
 export const twoTrailStory = () => (
     <Section>
-        <OnwardsLayout onwardSections={[twoTrails]} />
+        <OnwardsLayout {...twoTrails} />
     </Section>
 );
 twoTrailStory.story = { name: 'With two trails' };
 
 export const threeTrailStory = () => (
     <Section>
-        <OnwardsLayout onwardSections={[threeTrails]} />
+        <OnwardsLayout {...threeTrails} />
     </Section>
 );
 threeTrailStory.story = { name: 'With three trails' };
 
 export const fourTrailStory = () => (
     <Section>
-        <OnwardsLayout onwardSections={[fourTrails]} />
+        <OnwardsLayout {...fourTrails} />
     </Section>
 );
 fourTrailStory.story = { name: 'With four trails' };
 
 export const exactlyFiveStory = () => (
     <Section>
-        <OnwardsLayout onwardSections={[fiveTrails]} />
+        <OnwardsLayout {...fiveTrails} />
     </Section>
 );
 exactlyFiveStory.story = { name: 'with five trails' };
 
 export const sixTrailStory = () => (
     <Section>
-        <OnwardsLayout onwardSections={[sixTrails]} />
+        <OnwardsLayout {...sixTrails} />
     </Section>
 );
 sixTrailStory.story = { name: 'With six trails' };
 
 export const sevenTrailStory = () => (
     <Section>
-        <OnwardsLayout onwardSections={[sevenTrails]} />
+        <OnwardsLayout {...sevenTrails} />
     </Section>
 );
 sevenTrailStory.story = { name: 'With seven trails' };
 
 export const eightTrailStory = () => (
     <Section>
-        <OnwardsLayout onwardSections={[eightTrails]} />
+        <OnwardsLayout {...eightTrails} />
     </Section>
 );
 eightTrailStory.story = { name: 'With eight trails' };
-
-export const twoSections = () => (
-    <Section>
-        <OnwardsLayout onwardSections={[threeTrails, eightTrails]} />
-    </Section>
-);
-twoSections.story = { name: 'with two sections' };

--- a/src/web/components/Onwards/Onwards.test.tsx
+++ b/src/web/components/Onwards/Onwards.test.tsx
@@ -19,7 +19,8 @@ describe('OnwardsLayout', () => {
         useApi.mockReturnValue(response);
 
         const { asFragment } = render(
-            <OnwardsLayout onwardSections={[linkAndDescription]} />,
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            <OnwardsLayout {...linkAndDescription} />,
         );
 
         // Renders data-component

--- a/src/web/components/Onwards/OnwardsContainer.tsx
+++ b/src/web/components/Onwards/OnwardsContainer.tsx
@@ -19,6 +19,7 @@ export const OnwardsContainer = ({
             display: flex;
             flex-grow: 1;
             flex-direction: column;
+            width: 100%;
 
             margin-top: 6px;
             ${from.leftCol} {

--- a/src/web/components/Onwards/OnwardsData.tsx
+++ b/src/web/components/Onwards/OnwardsData.tsx
@@ -1,13 +1,10 @@
-import React from 'react';
-
 import { useApi } from '@root/src/web/lib/api';
-
-import { OnwardsLayout } from './OnwardsLayout';
 
 type Props = {
     url: string;
     limit: number; // Limit the number of items shown (the api often returns more)
     ophanComponentName: OphanComponentName;
+    container: React.FC<OnwardsType>;
 };
 
 type OnwardsResponse = {
@@ -16,16 +13,20 @@ type OnwardsResponse = {
     displayname: string;
 };
 
-export const OnwardsData = ({ url, limit, ophanComponentName }: Props) => {
+export const OnwardsData = ({
+    url,
+    limit,
+    ophanComponentName,
+    container,
+}: Props) => {
     const { data } = useApi<OnwardsResponse>(url);
-    const onwardSections: OnwardsType[] = [];
     if (data && data.trails) {
-        onwardSections.push({
+        return container({
             heading: data.heading || data.displayname, // Sometimes the api returns heading as 'displayName'
             trails: limit ? data.trails.slice(0, limit) : data.trails,
             ophanComponentName,
         });
     }
 
-    return <OnwardsLayout onwardSections={onwardSections} />;
+    return null;
 };

--- a/src/web/components/Onwards/OnwardsData.tsx
+++ b/src/web/components/Onwards/OnwardsData.tsx
@@ -1,10 +1,11 @@
 import { useApi } from '@root/src/web/lib/api';
+import React from 'react';
 
 type Props = {
     url: string;
     limit: number; // Limit the number of items shown (the api often returns more)
     ophanComponentName: OphanComponentName;
-    container: React.FC<OnwardsType>;
+    Container: React.FC<OnwardsType>;
 };
 
 type OnwardsResponse = {
@@ -17,15 +18,17 @@ export const OnwardsData = ({
     url,
     limit,
     ophanComponentName,
-    container,
+    Container,
 }: Props) => {
     const { data } = useApi<OnwardsResponse>(url);
     if (data && data.trails) {
-        return container({
-            heading: data.heading || data.displayname, // Sometimes the api returns heading as 'displayName'
-            trails: limit ? data.trails.slice(0, limit) : data.trails,
-            ophanComponentName,
-        });
+        return (
+            <Container
+                heading={data.heading || data.displayname} // Sometimes the api returns heading as 'displayName'
+                trails={limit ? data.trails.slice(0, limit) : data.trails}
+                ophanComponentName={ophanComponentName}
+            />
+        );
     }
 
     return null;

--- a/src/web/components/Onwards/OnwardsLayout.tsx
+++ b/src/web/components/Onwards/OnwardsLayout.tsx
@@ -14,10 +14,6 @@ import { ExactlyFive } from './ExactlyFive';
 import { FourOrLess } from './FourOrLess';
 import { Spotlight } from './Spotlight';
 
-type Props = {
-    onwardSections: OnwardsType[];
-};
-
 const decideLayout = (trails: TrailType[]) => {
     switch (trails.length) {
         case 1:
@@ -36,8 +32,8 @@ const decideLayout = (trails: TrailType[]) => {
     }
 };
 
-export const OnwardsLayout = ({ onwardSections }: Props) => {
-    const sections = useComments(onwardSections);
+export const OnwardsLayout: React.FC<OnwardsType> = (data: OnwardsType) => {
+    const sections = useComments([data]);
 
     return (
         <>

--- a/src/web/components/Onwards/OnwardsLower.tsx
+++ b/src/web/components/Onwards/OnwardsLower.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { joinUrl } from '@root/src/web/lib/joinUrl';
 import { OnwardsData } from './OnwardsData';
+import { OnwardsLayout } from './OnwardsLayout';
 
 type Props = {
     ajaxUrl: string;
@@ -37,6 +38,7 @@ export const OnwardsLower = ({ ajaxUrl, hasStoryPackage, tags }: Props) => {
             url={url}
             limit={4}
             ophanComponentName={ophanComponentName}
+            container={OnwardsLayout}
         />
     );
 };

--- a/src/web/components/Onwards/OnwardsLower.tsx
+++ b/src/web/components/Onwards/OnwardsLower.tsx
@@ -38,7 +38,7 @@ export const OnwardsLower = ({ ajaxUrl, hasStoryPackage, tags }: Props) => {
             url={url}
             limit={4}
             ophanComponentName={ophanComponentName}
-            container={OnwardsLayout}
+            Container={OnwardsLayout}
         />
     );
 };

--- a/src/web/components/Onwards/OnwardsUpper.tsx
+++ b/src/web/components/Onwards/OnwardsUpper.tsx
@@ -70,6 +70,19 @@ const onwardsWrapper = css`
     width: 100%;
 `;
 
+const headlinesContainer = (edition: Edition): string => {
+    switch (edition) {
+        case 'UK':
+            return 'uk-alpha/news/regular-stories';
+        case 'US':
+            return 'c5cad9ee-584d-4e85-85cd-bf8ee481b026';
+        case 'AU':
+            return 'au-alpha/news/regular-stories';
+        case 'INT':
+            return '10f21d96-18f6-426f-821b-19df55dfb831';
+    }
+};
+
 type Props = {
     ajaxUrl: string;
     hasRelated: boolean;
@@ -81,6 +94,7 @@ type Props = {
     keywordIds: string | string[];
     contentType: string;
     tags: TagType[];
+    edition: Edition;
 };
 
 export const OnwardsUpper = ({
@@ -94,6 +108,7 @@ export const OnwardsUpper = ({
     keywordIds,
     contentType,
     tags,
+    edition,
 }: Props) => {
     const dontShowRelatedContent = !showRelatedContent || !hasRelated;
 
@@ -167,7 +182,8 @@ export const OnwardsUpper = ({
     const ABTestAPI = useAB();
     const headlinesDataUrl = joinUrl([
         ajaxUrl,
-        '/container/data/uk-alpha/news/regular-stories.json',
+        'container/data',
+        `${headlinesContainer(edition)}.json`,
     ]);
 
     const inCuratedContainerTest = ABTestAPI.isUserInVariant(
@@ -175,11 +191,11 @@ export const OnwardsUpper = ({
         'fixed',
     );
 
-    const inCuratedCarouselTest = true; // ABTestAPI.isUserInVariant(
-    /*         'CuratedContainerTest',
+    const inCuratedCarouselTest = ABTestAPI.isUserInVariant(
+        'CuratedContainerTest',
         'carousel',
     );
- */
+
     return (
         <div className={onwardsWrapper}>
             {inCuratedCarouselTest && (

--- a/src/web/components/Onwards/OnwardsUpper.tsx
+++ b/src/web/components/Onwards/OnwardsUpper.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { joinUrl } from '@root/src/web/lib/joinUrl';
 import { useAB } from '@guardian/ab-react';
+import { css } from 'emotion';
 import { OnwardsData } from './OnwardsData';
+import { Carousel } from './Carousel';
+import { OnwardsLayout } from './OnwardsLayout';
 
 // This list is a direct copy from https://github.com/guardian/frontend/blob/6da0b3d8bfd58e8e20f80fc738b070fb23ed154e/static/src/javascripts/projects/common/modules/onward/related.js#L27
 // If you change this list then you should also update ^
@@ -62,6 +65,10 @@ const firstPopularTag = (
     // filter for the first tag in the whitelist
     return isPaidContent ? pageTags[0] : firstTagInWhitelist;
 };
+
+const onwardsWrapper = css`
+    width: 100%;
+`;
 
 type Props = {
     ajaxUrl: string;
@@ -165,16 +172,30 @@ export const OnwardsUpper = ({
 
     const inCuratedContainerTest = ABTestAPI.isUserInVariant(
         'CuratedContainerTest',
-        'variant',
+        'fixed',
     );
 
+    const inCuratedCarouselTest = true; // ABTestAPI.isUserInVariant(
+    /*         'CuratedContainerTest',
+        'carousel',
+    );
+ */
     return (
-        <div>
+        <div className={onwardsWrapper}>
+            {inCuratedCarouselTest && (
+                <OnwardsData
+                    url={headlinesDataUrl}
+                    limit={10}
+                    ophanComponentName="curated-content"
+                    container={Carousel}
+                />
+            )}
             {inCuratedContainerTest && (
                 <OnwardsData
                     url={headlinesDataUrl}
                     limit={4}
                     ophanComponentName="curated-content"
+                    container={OnwardsLayout}
                 />
             )}
             {url && (
@@ -182,6 +203,7 @@ export const OnwardsUpper = ({
                     url={url}
                     limit={8}
                     ophanComponentName={ophanComponentName}
+                    container={OnwardsLayout}
                 />
             )}
         </div>

--- a/src/web/components/Onwards/OnwardsUpper.tsx
+++ b/src/web/components/Onwards/OnwardsUpper.tsx
@@ -203,7 +203,7 @@ export const OnwardsUpper = ({
                     url={headlinesDataUrl}
                     limit={10}
                     ophanComponentName="curated-content"
-                    container={Carousel}
+                    Container={Carousel}
                 />
             )}
             {inCuratedContainerTest && (
@@ -211,7 +211,7 @@ export const OnwardsUpper = ({
                     url={headlinesDataUrl}
                     limit={4}
                     ophanComponentName="curated-content"
-                    container={OnwardsLayout}
+                    Container={OnwardsLayout}
                 />
             )}
             {url && (
@@ -219,7 +219,7 @@ export const OnwardsUpper = ({
                     url={url}
                     limit={8}
                     ophanComponentName={ophanComponentName}
-                    container={OnwardsLayout}
+                    Container={OnwardsLayout}
                 />
             )}
         </div>

--- a/src/web/experiments/tests/curated-container-test.ts
+++ b/src/web/experiments/tests/curated-container-test.ts
@@ -27,7 +27,17 @@ export const curatedContainerTest: ABTest = {
             },
         },
         {
-            id: 'variant',
+            id: 'fixed',
+            test: (): void => {},
+            impression: (impression) => {
+                impression();
+            },
+            success: (success) => {
+                success();
+            },
+        },
+        {
+            id: 'carousel',
             test: (): void => {},
             impression: (impression) => {
                 impression();


### PR DESCRIPTION
Questions:

* do we want to add some scroll behaviour on non-mobile? I.e. show scrollbar, or translate vertical scroll to horizontal, or support drag+drop (these are doable but require more effort for the last in particular)
* do we want to make the nav arrows larger for the larger breakpoints?
* text vertical position - ideal is for first two lines to sit over image and then expand downwards after that. I'll try and add that with some CSS wizardry!

## What does this change?

Adds a Carousel component and updates the (not yet live) curated content test to include this as a C variant.

### Before

n/a

### After

![Kapture 2020-09-22 at 14 58 41](https://user-images.githubusercontent.com/858402/93893693-da653e80-fce5-11ea-960b-7f8d448aff0a.gif)
![Kapture 2020-09-22 at 15 00 56](https://user-images.githubusercontent.com/858402/93893710-ddf8c580-fce5-11ea-9a8a-cbe2d43b4714.gif)

## Why?

As part on our curated content test.