### PR TITLE
Fix match score widget to display at certain breakpoint

### DIFF
--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -73,7 +73,6 @@ const gridTemplateWidePreFurnished = css`
 
 const gridTemplateLeftCol = css`
     grid-template-areas:
-        'preFurniture  right-column'
         'title         right-column'
         'headline      right-column'
         'standfirst    right-column'
@@ -86,6 +85,7 @@ const gridTemplateLeftCol = css`
 
 const gridTemplateLeftColPreFurnished = css`
     grid-template-areas:
+        'preFurniture  right-column'
         'title         right-column'
         'headline      right-column'
         'standfirst    right-column'


### PR DESCRIPTION
##  What does this change?
Fixes an issue that was introduced as part of https://github.com/guardian/dotcom-rendering/pull/1913whereby the match score widget was not displaying correctly between two breakpoints.

### Before
<img width="876" alt="Screen Shot 2020-09-23 at 15 51 25" src="https://user-images.githubusercontent.com/2051501/94029455-bc1a4400-fdb4-11ea-83a2-c68f5cbeade7.png">

### After
<img width="876" alt="Screen Shot 2020-09-23 at 15 51 35" src="https://user-images.githubusercontent.com/2051501/94029466-bf153480-fdb4-11ea-804b-de61341cd267.png">

## Why?
https://trello.com/c/epxyq6NX/2062-football-score-widget-displaying-incorrectly-at-certain-breakpoint