### PR TITLE
Gtrufitt/bugfix opinion byline

### DIFF
--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -184,6 +184,7 @@ const avatarPositionStyles = css`
     overflow: hidden;
     margin-bottom: -29px;
     margin-top: -50px;
+    pointer-event: none;
 
     /*  Why target img element?
 

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -184,7 +184,7 @@ const avatarPositionStyles = css`
     overflow: hidden;
     margin-bottom: -29px;
     margin-top: -50px;
-    pointer-event: none;
+    pointer-events: none;
 
     /*  Why target img element?
 


### PR DESCRIPTION
### What does this change?

The Avatar is blocking clicks on the byline, this is a bugfix that adds `pointer-events: none` to prevent the avatar from blocking it. Pointer-events work in all our supported browsers.

### Before
When hovering, there's only a tiny part we can click:

![2020-09-24 12 08 40](https://user-images.githubusercontent.com/638051/94137741-d3157080-fe5e-11ea-8996-20c7ebefe486.gif)

### After

Can click link anywhere:

![2020-09-24 12 08 54](https://user-images.githubusercontent.com/638051/94137773-e1fc2300-fe5e-11ea-8003-480e377c624e.gif)
