### PR TITLE
bump cmp lib to 6.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "@guardian/ab-react": "^2.0.1",
         "@guardian/atoms-rendering": "^1.11.2",
         "@guardian/automat-client": "^0.2.16",
-        "@guardian/consent-management-platform": "6.0.0",
+        "@guardian/consent-management-platform": "6.1.0",
         "@guardian/braze-components": "0.0.11",
         "@guardian/discussion-rendering": "^2.6.0",
         "@guardian/shimport": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2281,10 +2281,10 @@
     "@guardian/src-icons" "^2.2.0"
     emotion-theming "^10.0.19"
 
-"@guardian/consent-management-platform@6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.0.0.tgz#81eea5a8a965f1d94b8271ba946a2e59697487ec"
-  integrity sha512-ruroeF+lEcNQlRwUljd/PgWXDjriqlPJp5V9C1511ss5ItawFIJANm5ubJKidlMMpANcalqPudQuDnpCweHd6w==
+"@guardian/consent-management-platform@6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.1.0.tgz#0de83ca15d37a60bd79f2e95046ca68d8cc5141d"
+  integrity sha512-EVRoGDSk78UK9+0ILHkkubWjLdBvNrvmObwNfbrYxXnfOtyszGuy+mfhtGtLAXUKf85w+7nXnY/hKRmz4MfyeQ==
 
 "@guardian/discussion-rendering@^2.6.0":
   version "2.6.0"


### PR DESCRIPTION
bump cmp lib to 6.1.0 which is the new release to support getting consent easier https://www.npmjs.com/package/@guardian/consent-management-platform#getconsentforvendor-consent