### PR TITLE
Bump @guardian/braze-components to 0.0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "@guardian/atoms-rendering": "^1.11.2",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/consent-management-platform": "6.0.0",
-        "@guardian/braze-components": "0.0.9",
+        "@guardian/braze-components": "0.0.10",
         "@guardian/discussion-rendering": "^2.6.0",
         "@guardian/shimport": "^1.0.2",
         "@guardian/src-button": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "@guardian/atoms-rendering": "^1.11.2",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/consent-management-platform": "6.0.0",
-        "@guardian/braze-components": "^0.0.7",
+        "@guardian/braze-components": "0.0.9",
         "@guardian/discussion-rendering": "^2.6.0",
         "@guardian/shimport": "^1.0.2",
         "@guardian/src-button": "^1.5.0",

--- a/src/web/components/StickyBottomBanner/BrazeBanner.tsx
+++ b/src/web/components/StickyBottomBanner/BrazeBanner.tsx
@@ -102,7 +102,7 @@ export const canShow = async (
 
         return new Promise((resolve) => {
             appboy.subscribeToInAppMessage((message: any) => {
-                const meta = message.extras;
+                const { extras } = message;
 
                 const buttonHandler = (buttonId: number) => {
                     const thisButton = new appboy.InAppMessageButton(
@@ -122,16 +122,16 @@ export const canShow = async (
                     appboy.logInAppMessageImpression(message);
                 };
 
-                if (meta) {
-                    const newMeta = {
-                        ...meta,
+                if (extras) {
+                    const meta = {
+                        dataFromBraze: extras,
                         logImpression,
                         buttonHandler,
                     };
-                    resolve({ result: true, meta: newMeta });
+                    resolve({ result: true, meta });
+                } else {
+                    resolve({ result: false });
                 }
-
-                resolve({ result: false });
             });
 
             appboy.changeUser(brazeUuid);
@@ -160,8 +160,8 @@ const BrazeBannerWithSatisfiedDependencies = ({
         <div className={containerStyles}>
             <BrazeComponent
                 onButtonClick={meta.buttonHandler}
-                header={meta.header}
-                body={meta.body}
+                componentName={meta.dataFromBraze.componentName}
+                brazeMessageProps={meta.dataFromBraze}
             />
         </div>
     );
@@ -189,7 +189,7 @@ export const BrazeBanner = ({ meta }: Props) => {
                 /* webpackChunkName: "guardian-braze-components" */ '@guardian/braze-components'
             )
                 .then((module) => {
-                    setBrazeComponent(() => module.DigitalSubscriberAppBanner);
+                    setBrazeComponent(() => module.BrazeMessage);
                 })
                 .catch((error) =>
                     window.guardian.modules.sentry.reportError(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2270,15 +2270,16 @@
   resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.16.tgz#3ef47e7f49e633aea51c67f061d8d313a26fa9bc"
   integrity sha512-SgNU2bgiyQaXNfqanx4SDmxqAhXW6QBCTk4tRnCgV9Ht6noRl7UsDfx4I0u+M4H3TRnK4I/i2mmlJBtnuwhxEg==
 
-"@guardian/braze-components@^0.0.7":
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-0.0.7.tgz#06d6301b13a4b5393bf71e61a1c8078525369fbf"
-  integrity sha512-ZlXQe5EuPnv+hsEJIEVAbHTSxqBx8yPd9JmCw8ndvYGE8z04H+ZTzTbK26PwpLWiYGSKBmdRvtRqy/qO5A2l6g==
+"@guardian/braze-components@0.0.9":
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-0.0.9.tgz#df4293febbfb04f155ea23aa7726c25971659db3"
+  integrity sha512-HNhKoTTjrNWFdMQEtGrZsfr/INeX4Y2mt03GzHnZ7DSXrDBBHVfQYhgn72ye50tMcdXMzzjIbMTJ1MCnLcL5XA==
   dependencies:
     "@guardian/src-button" "^2.1.0"
     "@guardian/src-foundations" "^2.1.0"
     "@guardian/src-grid" "^2.2.0"
     "@guardian/src-icons" "^2.2.0"
+    emotion-theming "^10.0.19"
 
 "@guardian/consent-management-platform@6.0.0":
   version "6.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2270,10 +2270,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.16.tgz#3ef47e7f49e633aea51c67f061d8d313a26fa9bc"
   integrity sha512-SgNU2bgiyQaXNfqanx4SDmxqAhXW6QBCTk4tRnCgV9Ht6noRl7UsDfx4I0u+M4H3TRnK4I/i2mmlJBtnuwhxEg==
 
-"@guardian/braze-components@0.0.9":
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-0.0.9.tgz#df4293febbfb04f155ea23aa7726c25971659db3"
-  integrity sha512-HNhKoTTjrNWFdMQEtGrZsfr/INeX4Y2mt03GzHnZ7DSXrDBBHVfQYhgn72ye50tMcdXMzzjIbMTJ1MCnLcL5XA==
+"@guardian/braze-components@0.0.10":
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-0.0.10.tgz#a5e49f06a2ec81ad7f3c4bf2f81ebe6b39ab1dee"
+  integrity sha512-1vwhZpg9wSY0oCGERcblz3QcOvtguUSSpexJdmwB4HoO+sDVcVXkNeaceDzRQdlnGO89JxpGiSOuIBzpssBJWg==
   dependencies:
     "@guardian/src-button" "^2.1.0"
     "@guardian/src-foundations" "^2.1.0"


### PR DESCRIPTION
## What does this change?

This PR bumps @guardian/braze-components to 0.0.10 which gives a few changes:

* We can now use the new `BrazeMessage` component which takes a `componentName` prop provided by Braze
* 0.0.10 is published as cjs and esm, which seems to fix a linting issue we were seeing before
* The buttons in the underlying banner component are now wired correctly

Here it is working locally:

<img width="1552" alt="Screenshot 2020-09-24 at 13 02 15" src="https://user-images.githubusercontent.com/379839/94142675-90579680-fe66-11ea-80a5-e96bc5839e5b.png">

This is the DCR equivalent of guardian/frontend#23021 and guardian/frontend#23028 rolled into one.