### PR TITLE
update footer padding on mobile

### DIFF
--- a/src/web/components/Footer.tsx
+++ b/src/web/components/Footer.tsx
@@ -17,7 +17,7 @@ import { BackToTop } from './BackToTop';
 
 // CSS vars
 const emailSignupSideMargins = 10;
-const footerItemContainerPadding = 19;
+const footerItemContainerPadding = 20;
 const emailSignupWidth =
     pillarWidth +
     firstPillarWidth -
@@ -158,9 +158,13 @@ const footerItemContainers = css`
     }
 
     width: 100%;
-    padding: 0 ${footerItemContainerPadding}px;
+    padding: 0 ${footerItemContainerPadding / 2}px;
     position: relative;
     border: ${footerBorders};
+
+    ${from.mobileLandscape} {
+        padding: 0 ${footerItemContainerPadding}px;
+    }
 `;
 
 const bttPosition = css`


### PR DESCRIPTION
<!-- YOU SHOULD KNOW: dotcom is running an experiment called PR Deployments. -->
<!-- As soon as you open this PR, a github action called PR Deployment will run your code in an isolated environment and make it accessible in a public URL that you can use for testing etc -->
<!-- Every time you push to this branch, you will get an annoying email alert from github telling you that the previous PR deployment has been canceled. -->
<!-- You do not need to wait for the PR deployment action to go green before you can merge -->


## What does this change?
Padding on mobile changed from 20px to 10px

### Before
![image](https://user-images.githubusercontent.com/20658471/94159243-37dec400-fe7b-11ea-8afc-2bab79595bd5.png)

### After
![image](https://user-images.githubusercontent.com/20658471/94159269-4200c280-fe7b-11ea-9bca-05a915c8952a.png)

## Why?
To align with the rest of the page and make consistent
