### PR TITLE
Showcase opinion v2

### DIFF
--- a/src/web/components/StickyAd.tsx
+++ b/src/web/components/StickyAd.tsx
@@ -6,12 +6,11 @@ import { namedAdSlotParameters } from '@root/src/model/advertisement';
 
 type Props = {
     name: AdSlotType;
-    height?: number;
+    height: number;
 };
-const adSlotWrapper = ({ height }: { height?: number }) => css`
+const adSlotWrapper = (height: number) => css`
     position: static;
-    min-height: 274px;
-    ${height ? `height: ${height}px;` : ''}
+    height: ${height}px;
 `;
 
 const stickyAdSlot = css`
@@ -20,7 +19,7 @@ const stickyAdSlot = css`
 `;
 
 export const StickyAd = ({ name, height }: Props) => (
-    <div className={adSlotWrapper({ height })}>
+    <div className={adSlotWrapper(height)}>
         <AdSlot asps={namedAdSlotParameters(name)} localStyles={stickyAdSlot} />
     </div>
 );

--- a/src/web/components/StickyAd.tsx
+++ b/src/web/components/StickyAd.tsx
@@ -6,11 +6,12 @@ import { namedAdSlotParameters } from '@root/src/model/advertisement';
 
 type Props = {
     name: AdSlotType;
-    height: number;
+    height?: number;
 };
-const adSlotWrapper = (height: number) => css`
+const adSlotWrapper = ({ height }: { height?: number }) => css`
     position: static;
-    height: ${height}px;
+    min-height: 274px;
+    ${height ? `height: ${height}px;` : ''}
 `;
 
 const stickyAdSlot = css`
@@ -19,7 +20,7 @@ const stickyAdSlot = css`
 `;
 
 export const StickyAd = ({ name, height }: Props) => (
-    <div className={adSlotWrapper(height)}>
+    <div className={adSlotWrapper({ height })}>
         <AdSlot asps={namedAdSlotParameters(name)} localStyles={stickyAdSlot} />
     </div>
 );

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -43,6 +43,8 @@ import { getCurrentPillar } from '@root/src/web/lib/layoutHelpers';
 import { Stuck, SendToBack } from '@root/src/web/layouts/lib/stickiness';
 import { Display } from '@root/src/lib/display';
 
+const MOSTVIEWED_STICKY_HEIGHT = 1059;
+
 const gridWide = css`
     grid-template-areas:
         'title      border  headline    right-column'
@@ -511,7 +513,10 @@ export const CommentLayout = ({
                     </GridItem>
                     <GridItem area="right-column">
                         <RightColumn>
-                            <StickyAd name="right" />
+                            <StickyAd
+                                name="right"
+                                height={MOSTVIEWED_STICKY_HEIGHT}
+                            />
                             {!isPaidContent ? <MostViewedRightIsland /> : <></>}
                         </RightColumn>
                     </GridItem>

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -43,12 +43,32 @@ import { getCurrentPillar } from '@root/src/web/lib/layoutHelpers';
 import { Stuck, SendToBack } from '@root/src/web/layouts/lib/stickiness';
 import { Display } from '@root/src/lib/display';
 
-const MOSTVIEWED_STICKY_HEIGHT = 1059;
+const gridWide = css`
+    grid-template-areas:
+        'title      border  headline    right-column'
+        'lines      border  headline    right-column'
+        'meta       border  standfirst  right-column'
+        'meta       border  media       right-column'
+        '.          border  body        right-column'
+        '.          border  .           right-column';
+`;
+
+const showcaseGridWide = css`
+    grid-template-areas:
+        'title      border  headline    headline'
+        'lines      border  headline    headline'
+        'meta       border  standfirst  standfirst'
+        'meta       border  media       media'
+        '.          border  body        right-column'
+        '.          border  .           right-column';
+`;
 
 const StandardGrid = ({
     children,
+    display,
 }: {
     children: JSX.Element | JSX.Element[];
+    display: Display;
 }) => (
     <div
         className={css`
@@ -78,13 +98,10 @@ const StandardGrid = ({
                         1px /* Vertical grey border */
                         1fr /* Main content */
                         300px; /* Right Column */
-                    grid-template-areas:
-                        'title      border  headline    right-column'
-                        'lines      border  headline    right-column'
-                        'meta       border  standfirst  right-column'
-                        'meta       border  media       right-column'
-                        '.          border  body        right-column'
-                        '.          border  .           right-column';
+
+                    ${display === Display.Showcase
+                        ? showcaseGridWide
+                        : gridWide}
                 }
 
                 ${until.wide} {
@@ -93,13 +110,10 @@ const StandardGrid = ({
                         1px /* Vertical grey border */
                         1fr /* Main content */
                         300px; /* Right Column */
-                    grid-template-areas:
-                        'title      border  headline    right-column'
-                        'lines      border  headline    right-column'
-                        'meta       border  standfirst  right-column'
-                        'meta       border  media       right-column'
-                        '.          border  body        right-column'
-                        '.          border  .           right-column';
+
+                    ${display === Display.Showcase
+                        ? showcaseGridWide
+                        : gridWide}
                 }
 
                 ${until.leftCol} {
@@ -170,7 +184,6 @@ const avatarPositionStyles = css`
     overflow: hidden;
     margin-bottom: -29px;
     margin-top: -50px;
-    pointer-events: none;
 
     /*  Why target img element?
 
@@ -223,6 +236,10 @@ const ageWarningMargins = css`
         margin-left: -10px;
         margin-top: 0;
     }
+`;
+
+const mainMediaWrapper = css`
+    position: relative;
 `;
 
 interface Props {
@@ -340,7 +357,7 @@ export const CommentLayout = ({
             </div>
 
             <Section showTopBorder={false} backgroundColour={opinion[800]}>
-                <StandardGrid>
+                <StandardGrid display={display}>
                     <GridItem area="title">
                         <ArticleTitle
                             display={display}
@@ -421,13 +438,25 @@ export const CommentLayout = ({
                         />
                     </GridItem>
                     <GridItem area="media">
-                        <div className={maxWidth}>
+                        <div
+                            className={
+                                display === Display.Showcase &&
+                                CAPI.pageType.hasShowcaseMainElement
+                                    ? mainMediaWrapper
+                                    : maxWidth
+                            }
+                        >
                             <MainMedia
                                 display={display}
                                 designType={designType}
                                 elements={CAPI.mainMediaElements}
                                 pillar={pillar}
                                 adTargeting={adTargeting}
+                                starRating={
+                                    designType === 'Review' && CAPI.starRating
+                                        ? CAPI.starRating
+                                        : undefined
+                                }
                             />
                         </div>
                     </GridItem>
@@ -482,10 +511,7 @@ export const CommentLayout = ({
                     </GridItem>
                     <GridItem area="right-column">
                         <RightColumn>
-                            <StickyAd
-                                name="right"
-                                height={MOSTVIEWED_STICKY_HEIGHT}
-                            />
+                            <StickyAd name="right" />
                             {!isPaidContent ? <MostViewedRightIsland /> : <></>}
                         </RightColumn>
                     </GridItem>

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -50,8 +50,6 @@ import {
 import { Stuck, SendToBack } from '@root/src/web/layouts/lib/stickiness';
 import { Display } from '@root/src/lib/display';
 
-const MOSTVIEWED_STICKY_HEIGHT = 1059;
-
 const gridTemplateWide = css`
     grid-template-areas:
         'title  border  headline     right-column'
@@ -75,6 +73,7 @@ const gridTemplateWidePreFurnished = css`
 
 const gridTemplateLeftCol = css`
     grid-template-areas:
+        'preFurniture  right-column'
         'title         right-column'
         'headline      right-column'
         'standfirst    right-column'
@@ -87,7 +86,6 @@ const gridTemplateLeftCol = css`
 
 const gridTemplateLeftColPreFurnished = css`
     grid-template-areas:
-        'preFurniture  right-column'
         'title         right-column'
         'headline      right-column'
         'standfirst    right-column'
@@ -543,10 +541,7 @@ export const StandardLayout = ({
                     </GridItem>
                     <GridItem area="right-column">
                         <RightColumn>
-                            <StickyAd
-                                name="right"
-                                height={MOSTVIEWED_STICKY_HEIGHT}
-                            />
+                            <StickyAd name="right" />
                             {!isPaidContent ? <MostViewedRightIsland /> : <></>}
                         </RightColumn>
                     </GridItem>

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -50,6 +50,8 @@ import {
 import { Stuck, SendToBack } from '@root/src/web/layouts/lib/stickiness';
 import { Display } from '@root/src/lib/display';
 
+const MOSTVIEWED_STICKY_HEIGHT = 1059;
+
 const gridTemplateWide = css`
     grid-template-areas:
         'title  border  headline     right-column'
@@ -541,7 +543,10 @@ export const StandardLayout = ({
                     </GridItem>
                     <GridItem area="right-column">
                         <RightColumn>
-                            <StickyAd name="right" />
+                            <StickyAd
+                                name="right"
+                                height={MOSTVIEWED_STICKY_HEIGHT}
+                            />
                             {!isPaidContent ? <MostViewedRightIsland /> : <></>}
                         </RightColumn>
                     </GridItem>


### PR DESCRIPTION
## What does this change?
Support Showcase weighting of main media images

# NOTE: 
there is currently a lot of spacing between showcase image and right column due to some complexities with knock-on effects with the sticky ad slot

<img width="388" alt="Screenshot 2020-09-28 at 15 19 19" src="https://user-images.githubusercontent.com/8831403/94444276-1264f980-019e-11eb-8d40-e97570d6a50f.png">


**example showcase**: https://www.theguardian.com/commentisfree/2020/aug/09/work-britain-industries-jobs-tory-manufacturing-investment

example non-showcase opinion: https://www.theguardian.com/commentisfree/2020/sep/14/covid-19-global-education-crisis-girls-impacted

### Before
<img width="996" alt="Screenshot 2020-09-14 at 17 36 39" src="https://user-images.githubusercontent.com/8831403/93113301-eda65780-f6b0-11ea-8e0a-e8b721c38725.png">

### After
<img width="1010" alt="Screenshot 2020-09-14 at 17 35 01" src="https://user-images.githubusercontent.com/8831403/93113314-f139de80-f6b0-11ea-8f57-1cc09af94c4d.png">

## Why?
Parity

## Note:
this does not apply if  `hasShowcaseMainElement` is false, to avoid having full width for showcase opinions (not sure this is the best approach) 