### PR TITLE
Use minimum that's a multiple of 3

### DIFF
--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -60,8 +60,8 @@ Mappings:
       Value: rendering
   StageMap:
     PROD:
-      MinCapacity: 6
-      MaxCapacity: 24
+      MinCapacity: 9
+      MaxCapacity: 36
     CODE:
       MinCapacity: 1
       MaxCapacity: 4

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -60,8 +60,8 @@ Mappings:
       Value: rendering
   StageMap:
     PROD:
-      MinCapacity: 8
-      MaxCapacity: 32
+      MinCapacity: 6
+      MaxCapacity: 24
     CODE:
       MinCapacity: 1
       MaxCapacity: 4


### PR DESCRIPTION
<!-- YOU SHOULD KNOW: dotcom is running an experiment called PR Deployments. -->
<!-- As soon as you open this PR, a github action called PR Deployment will run your code in an isolated environment and make it accessible in a public URL that you can use for testing etc -->
<!-- Every time you push to this branch, you will get an annoying email alert from github telling you that the previous PR deployment has been canceled. -->
<!-- You do not need to wait for the PR deployment action to go green before you can merge -->


## What does this change?
Changes our ASG min size to 9 from 8 so that we always have balance between the 3 AZs.

## Why?
There have been occasional issues when deploys happen very close together that we have attributed to automatic rebalancing done by AWS (that they have confirmed can't be controlled by us).


