### PR TITLE
Bumped braze-components npm module to 0.0.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "@guardian/atoms-rendering": "^1.11.2",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/consent-management-platform": "6.0.0",
-        "@guardian/braze-components": "0.0.10",
+        "@guardian/braze-components": "0.0.11",
         "@guardian/discussion-rendering": "^2.6.0",
         "@guardian/shimport": "^1.0.2",
         "@guardian/src-button": "^1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2270,10 +2270,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.16.tgz#3ef47e7f49e633aea51c67f061d8d313a26fa9bc"
   integrity sha512-SgNU2bgiyQaXNfqanx4SDmxqAhXW6QBCTk4tRnCgV9Ht6noRl7UsDfx4I0u+M4H3TRnK4I/i2mmlJBtnuwhxEg==
 
-"@guardian/braze-components@0.0.10":
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-0.0.10.tgz#a5e49f06a2ec81ad7f3c4bf2f81ebe6b39ab1dee"
-  integrity sha512-1vwhZpg9wSY0oCGERcblz3QcOvtguUSSpexJdmwB4HoO+sDVcVXkNeaceDzRQdlnGO89JxpGiSOuIBzpssBJWg==
+"@guardian/braze-components@0.0.11":
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-0.0.11.tgz#93bc757be9b273fb3d305e9f0321862696a7aee4"
+  integrity sha512-mkBliGKiqHN4jm3N/Jy+JVNfmZESvNT9lO4pwiMvjiy9TaN/yW9ZWRVelsXHw05qcqlQsuiRp/B85htxz3Tk+Q==
   dependencies:
     "@guardian/src-button" "^2.1.0"
     "@guardian/src-foundations" "^2.1.0"


### PR DESCRIPTION
<!-- YOU SHOULD KNOW: dotcom is running an experiment called PR Deployments. -->
<!-- As soon as you open this PR, a github action called PR Deployment will run your code in an isolated environment and make it accessible in a public URL that you can use for testing etc -->
<!-- Every time you push to this branch, you will get an annoying email alert from github telling you that the previous PR deployment has been canceled. -->
<!-- You do not need to wait for the PR deployment action to go green before you can merge -->


## What does this change?
This bumps the version of the braze-components npm module from 0.0.10 to 0.0.11. This brings css fixes for browsers like IE 11 and Edge (primarily for image sizing issues).

[Equivalent PR for frontend.](https://github.com/guardian/frontend/pull/23035)

## Before:
(On Edge 84)
<img width="1431" alt="Screenshot 2020-09-25 at 14 12 25" src="https://user-images.githubusercontent.com/379839/94271325-6327e880-ff39-11ea-81b9-07084cba67b6.png">
## After:
<img width="1431" alt="Screenshot 2020-09-25 at 14 13 11" src="https://user-images.githubusercontent.com/379839/94271410-82267a80-ff39-11ea-8216-78f00926a77f.png">

