### PR TITLE
Send VIEW event to Ophan for Braze banner

### DIFF
--- a/src/web/browser/ophan/ophan.ts
+++ b/src/web/browser/ophan/ophan.ts
@@ -54,7 +54,8 @@ export type OphanComponentType =
     | 'ACQUISITIONS_EDITORIAL_LINK'
     | 'ACQUISITIONS_SUBSCRIPTIONS_BANNER'
     | 'ACQUISITIONS_OTHER'
-    | 'SIGN_IN_GATE';
+    | 'SIGN_IN_GATE'
+    | 'RETENTION_ENGAGEMENT_BANNER';
 
 export type OphanComponent = {
     componentType: OphanComponentType;

--- a/src/web/components/StickyBottomBanner/BrazeBanner.tsx
+++ b/src/web/components/StickyBottomBanner/BrazeBanner.tsx
@@ -5,6 +5,7 @@ import * as emotionTheming from 'emotion-theming';
 import { onConsentChange } from '@guardian/consent-management-platform';
 import { getZIndex } from '@root/src/web/lib/getZIndex';
 import { Props as BrazeBannerProps } from '@guardian/braze-components';
+import { submitComponentEvent } from '@root/src/web/browser/ophan/ophan';
 import { CanShowResult } from './bannerPicker';
 
 export const brazeVendorId = '5ed8c49c4b8ce4571c7ad801';
@@ -152,7 +153,17 @@ const BrazeBannerWithSatisfiedDependencies = ({
     meta,
 }: InnerProps) => {
     useEffect(() => {
+        // Log the impression with Braze
         meta.logImpression();
+
+        // Log VIEW event with Ophan
+        submitComponentEvent({
+            component: {
+                componentType: 'RETENTION_ENGAGEMENT_BANNER',
+                id: meta.dataFromBraze.componentName,
+            },
+            action: 'VIEW',
+        });
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 


### PR DESCRIPTION
## What does this change?

Start sending Braze banner view events to Ophan.

## Why?

To get an accurate idea of how often we're showing the banner, which is useful feedback to understand how the campaign is performing (and whether it's configured correctly).