### PR TITLE
Hide trailing carousel dots on wider breakpoints

### DIFF
--- a/src/web/components/Onwards/Carousel/Carousel.tsx
+++ b/src/web/components/Onwards/Carousel/Carousel.tsx
@@ -161,17 +161,27 @@ const dotsStyle = css`
     }
 `;
 
-const dotStyle = css`
+const dotStyle = (index: number) => css`
     display: inline-block;
     height: ${space[3]}px;
     width: ${space[3]}px;
     background-color: ${palette.neutral[93]};
     border-radius: 50%;
     margin-right: ${space[1]}px;
+
+    /* This is a bit of a hack for the test, while we think of better UX here.
+    It's very fragile to things like carousel item count.*/
+    ${from.phablet} {
+        display: ${index >= 7 ? 'none' : 'auto'};
+    }
+
+    ${from.desktop} {
+        display: ${index >= 6 ? 'none' : 'auto'};
+    }
 `;
 
-const dotActiveStyle = css`
-    ${dotStyle};
+const dotActiveStyle = (index: number) => css`
+    ${dotStyle(index)};
     background-color: ${palette.news.main};
 `;
 
@@ -387,7 +397,9 @@ export const Carousel: React.FC<OnwardsType> = ({
                 <div className={dotsStyle}>
                     {trails.map((value, i) => (
                         <span
-                            className={i === index ? dotActiveStyle : dotStyle}
+                            className={
+                                i === index ? dotActiveStyle(i) : dotStyle(i)
+                            }
                         />
                     ))}
                 </div>


### PR DESCRIPTION
## What does this change?

Hide trailing dots on wider breakpoints.

### Before
(Even with scrolling to the end, the right two dots will never become active.)
![Screenshot 2020-09-28 at 11 31 13](https://user-images.githubusercontent.com/858402/94421880-24cf3b00-017e-11eb-940b-9c0ee63f334b.png)

### After

(Fewer dots, but all can be made active with scrolling.)
![Screenshot 2020-09-28 at 11 23 50](https://user-images.githubusercontent.com/858402/94421653-c7d38500-017d-11eb-91f6-7cbdff1ae4ae.png)

## Why?

The purpose here is to not show dots that will never be made active through scrolling - as 'active' is defined by whatever is at the midpoint of the container.

This 'solution' is quite fragile; we'll need to think of a better approach to the UX here in time.