### PR TITLE
Reduce carousel text overal to single line

### DIFF
--- a/src/web/components/Onwards/Carousel/Carousel.tsx
+++ b/src/web/components/Onwards/Carousel/Carousel.tsx
@@ -116,9 +116,9 @@ const headlineWrapperStyle = (designType: DesignType, pillar: Pillar) => css`
     width: 90%;
     min-height: 107px;
 
-    margin-top: -42px;
+    margin-top: -21px;
     ${from.desktop} {
-        margin-top: -48px;
+        margin-top: -23px;
     }
 
     flex-grow: 1;


### PR DESCRIPTION
(Previously we had two lines of text overap the image for each card.)

![Screenshot 2020-09-28 at 12 24 28](https://user-images.githubusercontent.com/858402/94426672-da51bc80-0185-11eb-81e5-a2a5bcd33d90.png)
![Screenshot 2020-09-28 at 12 24 46](https://user-images.githubusercontent.com/858402/94426676-daea5300-0185-11eb-92b9-348fa05573f1.png)
