### PR TITLE
Remove 'By' when the byline is empty

### DIFF
--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -408,11 +408,7 @@ export const App = ({ CAPI, NAV }: Props) => {
             ))}
             {CAPI.chartAtoms.map((chart) => (
                 <Hydrate root="chart-atom" index={chart.chartIndex}>
-                    <ChartAtom
-                        id={chart.id}
-                        url={chart.url}
-                        html={chart.html}
-                    />
+                    <ChartAtom id={chart.id} html={chart.html} />
                 </Hydrate>
             ))}
             {CAPI.qandaAtoms.map((qandaAtom) => (

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -408,7 +408,11 @@ export const App = ({ CAPI, NAV }: Props) => {
             ))}
             {CAPI.chartAtoms.map((chart) => (
                 <Hydrate root="chart-atom" index={chart.chartIndex}>
-                    <ChartAtom id={chart.id} html={chart.html} />
+                    <ChartAtom
+                        id={chart.id}
+                        html={chart.html}
+                        url={chart.url}
+                    />
                 </Hydrate>
             ))}
             {CAPI.qandaAtoms.map((qandaAtom) => (

--- a/src/web/components/ArticleHeadline.stories.tsx
+++ b/src/web/components/ArticleHeadline.stories.tsx
@@ -118,6 +118,43 @@ export const ShowcaseInterview = () => (
 );
 ShowcaseInterview.story = { name: 'Interview (with showcase)' };
 
+export const ShowcaseInterviewNobyline = () => (
+    <Section>
+        <Flex>
+            <LeftColumn>
+                <></>
+            </LeftColumn>
+            <ArticleContainer>
+                <div
+                    className={css`
+                        margin-bottom: -100px;
+                    `}
+                >
+                    <ArticleHeadline
+                        headlineString="This is an Interview headline. It has a black background, white text and overlays the image below it (as a sibling)"
+                        display={Display.Showcase}
+                        designType="Interview"
+                        pillar="culture"
+                        tags={[]}
+                        isShowcase={true}
+                        byline=""
+                    />
+                </div>
+                <MainMedia
+                    display={Display.Standard}
+                    designType="Article"
+                    hideCaption={true}
+                    elements={mainMediaElements}
+                    pillar="news"
+                />
+            </ArticleContainer>
+        </Flex>
+    </Section>
+);
+ShowcaseInterviewNobyline.story = {
+    name: 'Interview (with showcase and NO BYLINE)',
+};
+
 export const Interview = () => (
     <Section>
         <Flex>
@@ -150,6 +187,41 @@ export const Interview = () => (
     </Section>
 );
 Interview.story = { name: 'Interview (without showcase)' };
+
+export const InterviewNoByline = () => (
+    <Section>
+        <Flex>
+            <LeftColumn>
+                <></>
+            </LeftColumn>
+            <ArticleContainer>
+                <ArticleHeadline
+                    headlineString="This is an Interview headline. It has a black background, white text and overlays the image below it (as a sibling)"
+                    display={Display.Standard}
+                    designType="Interview"
+                    pillar="culture"
+                    tags={[]}
+                    byline=""
+                />
+                <Standfirst
+                    display={Display.Standard}
+                    designType="Interview"
+                    standfirst="This is the standfirst text. We include here to demonstrate spacing in this case where we have a Interview type article that does not have a showcase main media element"
+                />
+                <MainMedia
+                    display={Display.Standard}
+                    designType="Article"
+                    hideCaption={true}
+                    elements={mainMediaElements}
+                    pillar="news"
+                />
+            </ArticleContainer>
+        </Flex>
+    </Section>
+);
+InterviewNoByline.story = {
+    name: 'Interview (without showcase with NO BYLINE)',
+};
 
 export const Comment = () => (
     <Section>

--- a/src/web/components/HeadlineByline.stories.tsx
+++ b/src/web/components/HeadlineByline.stories.tsx
@@ -130,3 +130,16 @@ export const MultipleStory = () => {
     );
 };
 MultipleStory.story = { name: 'Immersive with multiple contributors' };
+
+export const noBylineStory = () => {
+    return (
+        <HeadlineByline
+            display={Display.Standard}
+            designType="Interview"
+            pillar="culture"
+            byline=""
+            tags={[]}
+        />
+    );
+};
+noBylineStory.story = { name: 'No byline' };

--- a/src/web/components/HeadlineByline.tsx
+++ b/src/web/components/HeadlineByline.tsx
@@ -123,14 +123,18 @@ export const HeadlineByline = ({
                 case 'Quiz':
                 case 'AdvertisementFeature':
                 default:
-                    return (
-                        <div className={immersiveStyles}>
-                            by{' '}
-                            <span className={immersiveLinkStyles(pillar)}>
-                                <BylineLink byline={byline} tags={tags} />
-                            </span>
-                        </div>
-                    );
+                    if (byline) {
+                        return (
+                            <div className={immersiveStyles}>
+                                by{' '}
+                                <span className={immersiveLinkStyles(pillar)}>
+                                    <BylineLink byline={byline} tags={tags} />
+                                </span>
+                            </div>
+                        );
+                    }
+
+                    return null;
             }
         }
         case Display.Showcase:

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -102,13 +102,7 @@ export const ArticleRenderer: React.FC<{
                         </div>
                     );
                 case 'model.dotcomrendering.pageElements.ChartAtomBlockElement':
-                    return (
-                        <ChartAtom
-                            url={element.url}
-                            id={element.id}
-                            html={element.html}
-                        />
-                    );
+                    return <ChartAtom id={element.id} html={element.html} />;
                 case 'model.dotcomrendering.pageElements.DocumentBlockElement':
                     return (
                         <DocumentBlockComponent

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -102,7 +102,13 @@ export const ArticleRenderer: React.FC<{
                         </div>
                     );
                 case 'model.dotcomrendering.pageElements.ChartAtomBlockElement':
-                    return <ChartAtom id={element.id} html={element.html} />;
+                    return (
+                        <ChartAtom
+                            id={element.id}
+                            html={element.html}
+                            url={element.url}
+                        />
+                    );
                 case 'model.dotcomrendering.pageElements.DocumentBlockElement':
                     return (
                         <DocumentBlockComponent


### PR DESCRIPTION
## What does this change?

If the byline is empty then 'by' will no longer appear on DCR.

### After
![Screenshot 2020-09-28 at 12 11 05](https://user-images.githubusercontent.com/35331926/94426673-da51bc80-0185-11eb-8bcf-19da5f20114b.png)
![Screenshot 2020-09-28 at 12 11 13](https://user-images.githubusercontent.com/35331926/94426686-dde54380-0185-11eb-88d4-293fa7469f3f.png)

![Screenshot 2020-09-28 at 12 25 24](https://user-images.githubusercontent.com/35331926/94426698-e2a9f780-0185-11eb-9272-b97a68412fb8.png)
![Screenshot 2020-09-28 at 12 25 28](https://user-images.githubusercontent.com/35331926/94426704-e50c5180-0185-11eb-8cc7-27e1fe1a99c6.png)

