### PR TITLE
Identity | Sign In Gate | Fire customevent to re-init commercial code when gate dismissed

### DIFF
--- a/src/web/components/SignInGate/SignInGateSelector.tsx
+++ b/src/web/components/SignInGate/SignInGateSelector.tsx
@@ -176,6 +176,17 @@ export const SignInGateSelector = ({
         });
     }, [ab]);
 
+    useEffect(() => {
+        // this hook will fire when the sign in gate is dismissed
+        // which will happen when the showGate state is set to false
+        // this only happens within the dismissGate method
+        if (showGate === false) {
+            document.dispatchEvent(
+                new CustomEvent('dcr:page:article:redisplayed'),
+            );
+        }
+    }, [showGate]);
+
     // check to see if the test is available on this render cycle
     // required by the ab test framework, as we have to wait for the above
     // useEffect hook to determine which test to run


### PR DESCRIPTION
## What does this change?
- Adds `useEffect` hook that fires once the sign in gate has been dismissed by the user (`showGate` set to `false`) that emits an `dcr:page:article:redisplayed` custom event to reinitialse the inline article body ads in case they failed to initalise before the gate had been dismissed

## Why?
- Inline article body ads may not have displayed previously due to a race condition as the ad initialisation competes with the sign in gate