### PR TITLE
Remove black overlay from immersive headlines

### DIFF
--- a/src/web/components/ImmersiveHeadline.tsx
+++ b/src/web/components/ImmersiveHeadline.tsx
@@ -147,16 +147,14 @@ export const ImmersiveHeadline = ({
                                 pillar={pillar}
                                 badge={badge}
                             />
-                            <div className="articleHeight" ref={articleHeight}>
-                                <ArticleHeadline
-                                    display={display}
-                                    headlineString={headline}
-                                    designType={designType}
-                                    pillar={pillar}
-                                    tags={tags}
-                                    byline={author.byline}
-                                />
-                            </div>
+                            <ArticleHeadline
+                                display={display}
+                                headlineString={headline}
+                                designType={designType}
+                                pillar={pillar}
+                                tags={tags}
+                                byline={author.byline}
+                            />
                         </PositionHeadline>
                     </Flex>
                 </div>

--- a/src/web/components/ImmersiveHeadline.tsx
+++ b/src/web/components/ImmersiveHeadline.tsx
@@ -51,21 +51,34 @@ const blackBlock = css`
         position: absolute;
         content: '';
         width: 0%;
-        ${from.phablet} {
+        ${from.tablet} {
+            width: 6%;
+            height: 114px;
+        }
+        /* These media queries are to avoid edge cases on long headlines */
+        @media screen and (max-width: 942px) and (min-width: 858px) {
+            width: 10%;
+            height: 114px;
+        }
+        @media screen and (max-width: 979px) and (min-width: 942px) {
+            width: 15%;
+        }
+        @media screen and (max-width: 1140px) and (min-width: 990px) {
+            height: 260px;
+            width: 15%;
+        }
+        @media screen and (max-width: 1300px) and (min-width: 1140px) {
+            height: 260px;
             width: 15%;
         }
         ${from.wide} {
             width: 20%;
+            height: 260px;
         }
         right: 0;
         bottom: 0;
         display: block;
         z-index: 1;
-
-        top: -68px;
-        ${from.leftCol} {
-            top: -64px;
-        }
     }
 `;
 
@@ -108,42 +121,46 @@ export const ImmersiveHeadline = ({
     pillar,
     captionText,
     badge,
-}: Props) => (
-    <div className={cx(postionRelative)}>
-        <div className={blackBlock}>
-            <div className={cx(center, padding)}>
-                <Flex>
-                    <LeftColumn showRightBorder={false}>
-                        <Caption
-                            display={display}
-                            designType={designType}
-                            captionText={captionText}
-                            pillar={pillar}
-                            shouldLimitWidth={true}
-                        />
-                    </LeftColumn>
-                    <PositionHeadline>
-                        <ArticleTitle
-                            display={display}
-                            designType={designType}
-                            tags={tags}
-                            sectionLabel={sectionLabel}
-                            sectionUrl={sectionUrl}
-                            guardianBaseURL={guardianBaseURL}
-                            pillar={pillar}
-                            badge={badge}
-                        />
-                        <ArticleHeadline
-                            display={display}
-                            headlineString={headline}
-                            designType={designType}
-                            pillar={pillar}
-                            tags={tags}
-                            byline={author.byline}
-                        />
-                    </PositionHeadline>
-                </Flex>
+}: Props) => {
+    return (
+        <div className={cx(postionRelative)}>
+            <div className={blackBlock}>
+                <div className={cx(center, padding)}>
+                    <Flex>
+                        <LeftColumn showRightBorder={false}>
+                            <Caption
+                                display={display}
+                                designType={designType}
+                                captionText={captionText}
+                                pillar={pillar}
+                                shouldLimitWidth={true}
+                            />
+                        </LeftColumn>
+                        <PositionHeadline>
+                            <ArticleTitle
+                                display={display}
+                                designType={designType}
+                                tags={tags}
+                                sectionLabel={sectionLabel}
+                                sectionUrl={sectionUrl}
+                                guardianBaseURL={guardianBaseURL}
+                                pillar={pillar}
+                                badge={badge}
+                            />
+                            <div className="articleHeight" ref={articleHeight}>
+                                <ArticleHeadline
+                                    display={display}
+                                    headlineString={headline}
+                                    designType={designType}
+                                    pillar={pillar}
+                                    tags={tags}
+                                    byline={author.byline}
+                                />
+                            </div>
+                        </PositionHeadline>
+                    </Flex>
+                </div>
             </div>
         </div>
-    </div>
-);
+    );
+};


### PR DESCRIPTION
## What does this change?
Based on this report:

"Hi team - not sure if this is one for you, but a report of strangeness on this article, specifically the display of its headline, on mobile safari and Firefox on an ipad (see screenshot below)

Article in question is here:  https://www.theguardian.com/society/2020/sep/27/housing-crisis-planning-converting-office-blocks-homes-catastrophe-jenrick

I don't have access to an iPad so haven't been able to replicate, but appreciate anyone taking a look."


This add additional break points for more granular control of the existing `::after` blank box css class and sets the correct height at each break point. 

### Before

![Screenshot 2020-09-29 at 14 33 20](https://user-images.githubusercontent.com/35331926/94567921-e01dcf80-0263-11eb-877e-9e3740c61996.png)

![Screenshot 2020-09-29 at 14 32 52](https://user-images.githubusercontent.com/35331926/94568015-ee6beb80-0263-11eb-8214-f223ffeac905.png)


### After
![Screenshot 2020-09-29 at 14 33 33](https://user-images.githubusercontent.com/35331926/94568263-2f640000-0264-11eb-9b1e-e4e4b9f0d783.png)

![Screenshot 2020-09-29 at 14 33 44](https://user-images.githubusercontent.com/35331926/94568255-2b37e280-0264-11eb-8272-12346b5b3b1c.png)

