### PR TITLE
Show signin gate 5 times after the first dismissal if user does not signin

### DIFF
--- a/cypress/integration/e2e/sign-in-gate.spec.js
+++ b/cypress/integration/e2e/sign-in-gate.spec.js
@@ -105,7 +105,7 @@ describe('Sign In Gate Tests', function () {
         it('should not load the sign in gate if the user has already dismissed the gate', function () {
             localStorage.setItem(
                 'gu.prefs.sign-in-gate',
-                '{"SignInGateMain-main-variant-1":"2020-07-22T08:25:05.567Z"}',
+                '{"SignInGateMain-main-variant-2":"2020-07-22T08:25:05.567Z"}',
             );
 
             visitArticleAndScrollToGateForLazyLoad();

--- a/cypress/integration/e2e/sign-in-gate.spec.js
+++ b/cypress/integration/e2e/sign-in-gate.spec.js
@@ -106,8 +106,10 @@ describe('Sign In Gate Tests', function () {
             localStorage.setItem(
                 'gu.prefs.sign-in-gate',
                 `{
-                    "SignInGateMain-main-variant-2": "2020-07-22T08:25:05.567Z",
-                    "gate-dismissed-count-SignInGateMain-main-variant-2": 6
+                    "value": {
+                        "SignInGateMain-main-variant-2": "2020-07-22T08:25:05.567Z",
+                        "gate-dismissed-count-SignInGateMain-main-variant-2": 6
+                    }
                 }`,
             );
 

--- a/cypress/integration/e2e/sign-in-gate.spec.js
+++ b/cypress/integration/e2e/sign-in-gate.spec.js
@@ -105,7 +105,10 @@ describe('Sign In Gate Tests', function () {
         it('should not load the sign in gate if the user has already dismissed the gate', function () {
             localStorage.setItem(
                 'gu.prefs.sign-in-gate',
-                '{"SignInGateMain-main-variant-2":"2020-07-22T08:25:05.567Z"}',
+                `{
+                    "SignInGateMain-main-variant-2": "2020-07-22T08:25:05.567Z",
+                    "gate-dismissed-count-SignInGateMain-main-variant-2": 6
+                }`,
             );
 
             visitArticleAndScrollToGateForLazyLoad();

--- a/src/web/components/SignInGate/SignInGateSelector.tsx
+++ b/src/web/components/SignInGate/SignInGateSelector.tsx
@@ -3,7 +3,7 @@ import { useAB } from '@guardian/ab-react';
 import { ABTest, Runnable } from '@guardian/ab-core';
 import { constructQuery } from '@root/src/lib/querystring';
 
-import { setUserDismissedGate } from '@frontend/web/components/SignInGate/dismissGate';
+import { incrementUserDismissedGateCount, setUserDismissedGate } from '@frontend/web/components/SignInGate/dismissGate';
 import {
     SignInGateComponent,
     CurrentABTest,
@@ -51,6 +51,7 @@ const dismissGate = (
 ) => {
     setShowGate(false);
     setUserDismissedGate(currentAbTestValue.variant, currentAbTestValue.name);
+    incrementUserDismissedGateCount(currentAbTestValue.variant, currentAbTestValue.name);
 
     // When the user closes the sign in gate, we scroll them back to the main content
     const articleBody = document.querySelector(
@@ -74,13 +75,13 @@ const tests: ReadonlyArray<ABTest> = [
 const testVariantToGateMapping: GateTestMap = {
     'patientia-control-1': gatePatientiaControl,
     'patientia-variant-1': gatePatientiaVariant,
-    'main-control-1': gateMainControl,
-    'main-variant-1': gateMainVariant,
+    'main-control-2': gateMainControl,
+    'main-variant-2': gateMainVariant,
 };
 
 const testIdToComponentId: { [key: string]: string } = {
-    SignInGateMainVariant: 'main_variant_1',
-    SignInGateMainControl: 'main_control_1',
+    SignInGateMainVariant: 'main_variant_2',
+    SignInGateMainControl: 'main_control_2',
     SignInGatePatientia: 'patientia_test',
 };
 

--- a/src/web/components/SignInGate/dismissGate.test.ts
+++ b/src/web/components/SignInGate/dismissGate.test.ts
@@ -16,7 +16,9 @@ describe('SignInGate - dismissGate methods', () => {
             localStorage.setItem(
                 'gu.prefs.sign-in-gate',
                 JSON.stringify({
-                    'SignInGateName-variant-name': new Date().toISOString(),
+                    value: {
+                        'SignInGateName-variant-name': new Date().toISOString(),
+                    }
                 }),
             );
 
@@ -41,7 +43,9 @@ describe('SignInGate - dismissGate methods', () => {
             localStorage.setItem(
                 'gu.prefs.sign-in-gate',
                 JSON.stringify({
-                    'SignInGateName-variant-other': new Date().toISOString(),
+                    value: {
+                        'SignInGateName-variant-other': new Date().toISOString(),
+                    }
                 }),
             );
 
@@ -57,7 +61,9 @@ describe('SignInGate - dismissGate methods', () => {
             localStorage.setItem(
                 'gu.prefs.sign-in-gate',
                 JSON.stringify({
-                    'SignInGateOther-variant-name': new Date().toISOString(),
+                    value: {
+                        'SignInGateOther-variant-name': new Date().toISOString(),
+                    }
                 }),
             );
 
@@ -75,7 +81,9 @@ describe('SignInGate - dismissGate methods', () => {
             localStorage.setItem(
                 'gu.prefs.sign-in-gate',
                 JSON.stringify({
-                    'SignInGateCurrent-variant-name': lessThanADayAgo.toISOString(),
+                    value: {
+                        'SignInGateCurrent-variant-name': lessThanADayAgo.toISOString(),
+                    }
                 }),
             );
             const output = hasUserDismissedGate(
@@ -93,7 +101,9 @@ describe('SignInGate - dismissGate methods', () => {
             localStorage.setItem(
                 'gu.prefs.sign-in-gate',
                 JSON.stringify({
-                    'SignInGateCurrent-variant-name': moreThanADayAgo.toISOString(),
+                    value: {
+                        'SignInGateCurrent-variant-name': moreThanADayAgo.toISOString(),
+                    }
                 }),
             );
 

--- a/src/web/components/SignInGate/dismissGate.test.ts
+++ b/src/web/components/SignInGate/dismissGate.test.ts
@@ -1,4 +1,10 @@
-import { hasUserDismissedGate, setUserDismissedGate, unsetUserDismissedGate } from './dismissGate';
+import {
+    hasUserDismissedGate,
+    hasUserDismissedGateMoreThanCount,
+    incrementUserDismissedGateCount,
+    setUserDismissedGate,
+    unsetUserDismissedGate
+} from './dismissGate';
 
 describe('SignInGate - dismissGate methods', () => {
     beforeEach(() => {
@@ -147,6 +153,28 @@ describe('SignInGate - dismissGate methods', () => {
             expect(output1).toBe(true);
             expect(output2).toBe(false);
 
+        });
+    });
+
+    describe('hasUserDismissedGateMoreThanCount and incrementUserDismissedGateCount', () => {
+        test('hasUserDismissedGateMoreThanCount depends on the counter incremented by incrementUserDismissedGateCount', () => {
+            expect(hasUserDismissedGateMoreThanCount('variant-1', 'test-1', 0)).toBe(false);
+
+            incrementUserDismissedGateCount('variant-1', 'test-1');
+            expect(hasUserDismissedGateMoreThanCount('variant-1', 'test-1', 0)).toBe(true);
+            expect(hasUserDismissedGateMoreThanCount('variant-1', 'test-1', 1)).toBe(false);
+
+            incrementUserDismissedGateCount('variant-1', 'test-1');
+            expect(hasUserDismissedGateMoreThanCount('variant-1', 'test-1', 1)).toBe(true);
+            expect(hasUserDismissedGateMoreThanCount('variant-1', 'test-1', 2)).toBe(false);
+
+            expect(hasUserDismissedGateMoreThanCount('variant-2', 'test-1', 0)).toBe(false);
+        });
+
+        test('incrementing does not affect other variants or tests', () => {
+            incrementUserDismissedGateCount('variant-1', 'test-1');
+            expect(hasUserDismissedGateMoreThanCount('variant-2', 'test-1', 0)).toBe(false);
+            expect(hasUserDismissedGateMoreThanCount('variant-1', 'test-2', 0)).toBe(false);
         });
     });
 });

--- a/src/web/components/SignInGate/dismissGate.ts
+++ b/src/web/components/SignInGate/dismissGate.ts
@@ -111,13 +111,13 @@ const retrieveDismissedCount = (
     }
 };
 
-// Test whether the user has dismissed the gate variant at least `count` times
-export const hasUserDismissedGateCount = (
+// Test whether the user has dismissed the gate variant more than `count` times
+export const hasUserDismissedGateMoreThanCount = (
     variant: string,
     name: string,
     count: number
 ): boolean => {
-    return retrieveDismissedCount(variant, name) >= count;
+    return retrieveDismissedCount(variant, name) > count;
 };
 
 // Increment the number of times a user has dismissed this gate variant

--- a/src/web/components/SignInGate/dismissGate.ts
+++ b/src/web/components/SignInGate/dismissGate.ts
@@ -14,10 +14,20 @@ const localStorageDismissedCountKey = (variant: string, name: string): string =>
 // Invalid json stored against `localStorageKey` should not break signin gate for a user forever
 const getSigninGatePrefsSafely = () => {
     try {
-        return JSON.parse(localStorage.getItem(localStorageKey) || '{}');
+        const prefs = JSON.parse(localStorage.getItem(localStorageKey) || '{}');
+
+        if (typeof prefs === 'object' && typeof prefs.value === 'object') {
+            return prefs.value;
+        }
+        return {};
+
     } catch (e) {
         return {};
     }
+};
+
+const setSigninGatePrefs = (prefs: any) => {
+    localStorage.setItem(localStorageKey, JSON.stringify({ value: prefs } ));
 };
 
 // set in user preferences that the user has dismissed the gate, set the value to the current ISO date string
@@ -35,7 +45,7 @@ export const setUserDismissedGate = (variant: string, name: string): void => {
     try {
         const prefs = getSigninGatePrefsSafely();
         prefs[localStorageDismissedDateKey(variant, name)] = new Date().toISOString();
-        localStorage.setItem(localStorageKey, JSON.stringify(prefs));
+        setSigninGatePrefs(prefs);
     } catch (error) {
         // Alas, sometimes localstorage isn't available
     }
@@ -45,7 +55,7 @@ export const unsetUserDismissedGate = (variant: string, name: string): void => {
     try {
         const prefs = getSigninGatePrefsSafely();
         delete prefs[localStorageDismissedDateKey(variant, name)]
-        localStorage.setItem(localStorageKey, JSON.stringify(prefs));
+        setSigninGatePrefs(prefs);
     } catch (error) {
         // Alas, sometimes localstorage isn't available
     }
@@ -128,7 +138,7 @@ export const incrementUserDismissedGateCount = (
     try {
         const prefs = getSigninGatePrefsSafely();
         prefs[localStorageDismissedCountKey(variant, name)] = retrieveDismissedCount(variant, name) + 1;
-        localStorage.setItem(localStorageKey, JSON.stringify(prefs));
+        setSigninGatePrefs(prefs);
     } catch (error) {
         // localstorage isn't available so show the gate
     }

--- a/src/web/components/SignInGate/gates/main-variant.tsx
+++ b/src/web/components/SignInGate/gates/main-variant.tsx
@@ -12,7 +12,7 @@ import {
     isIOS9,
 } from '@frontend/web/components/SignInGate/displayRule';
 import { initPerf } from '@root/src/web/browser/initPerf';
-import { hasUserDismissedGateCount } from '../dismissGate';
+import { hasUserDismissedGateMoreThanCount } from '../dismissGate';
 
 const SignInGateMain = React.lazy(() => {
     const { start, end } = initPerf('SignInGateMain');
@@ -31,7 +31,7 @@ const canShow = (
     currentTest: CurrentABTest,
 ): boolean =>
     !isSignedIn &&
-    !hasUserDismissedGateCount(currentTest.variant, currentTest.name, 5) &&
+    !hasUserDismissedGateMoreThanCount(currentTest.variant, currentTest.name, 5) &&
     isNPageOrHigherPageView(3) &&
     isValidContentType(CAPI) &&
     isValidSection(CAPI) &&

--- a/src/web/components/SignInGate/gates/main-variant.tsx
+++ b/src/web/components/SignInGate/gates/main-variant.tsx
@@ -12,7 +12,7 @@ import {
     isIOS9,
 } from '@frontend/web/components/SignInGate/displayRule';
 import { initPerf } from '@root/src/web/browser/initPerf';
-import { hasUserDismissedGate } from '../dismissGate';
+import { hasUserDismissedGateCount } from '../dismissGate';
 
 const SignInGateMain = React.lazy(() => {
     const { start, end } = initPerf('SignInGateMain');
@@ -31,7 +31,7 @@ const canShow = (
     currentTest: CurrentABTest,
 ): boolean =>
     !isSignedIn &&
-    !hasUserDismissedGate(currentTest.variant, currentTest.name) &&
+    !hasUserDismissedGateCount(currentTest.variant, currentTest.name, 5) &&
     isNPageOrHigherPageView(3) &&
     isValidContentType(CAPI) &&
     isValidSection(CAPI) &&

--- a/src/web/experiments/tests/sign-in-gate-main-control.ts
+++ b/src/web/experiments/tests/sign-in-gate-main-control.ts
@@ -6,7 +6,7 @@ export const signInGateMainControl: ABTest = {
     expiry: '2020-12-01',
     author: 'Mahesh Makani',
     description:
-        'Show sign in gate to 100% of users on 3rd article view of simple article templates, with higher priority over banners and epic. Control Audience.',
+        'Show sign in gate to 100% of users on 3rd article view of simple article templates, and show a further 5 times after the first dismissal, with higher priority over banners and epic. Control Audience.',
     audience: 0.09,
     audienceOffset: 0.9,
     successMeasure: 'N/A - User does not see gate, only to compare to variant.',

--- a/src/web/experiments/tests/sign-in-gate-main-control.ts
+++ b/src/web/experiments/tests/sign-in-gate-main-control.ts
@@ -19,7 +19,7 @@ export const signInGateMainControl: ABTest = {
     canRun: () => true,
     variants: [
         {
-            id: 'main-control-1',
+            id: 'main-control-2',
             test: (): void => { },
         },
     ],

--- a/src/web/experiments/tests/sign-in-gate-main-variant.ts
+++ b/src/web/experiments/tests/sign-in-gate-main-variant.ts
@@ -19,7 +19,7 @@ export const signInGateMainVariant: ABTest = {
     canRun: () => true,
     variants: [
         {
-            id: 'main-variant-1',
+            id: 'main-variant-2',
             test: (): void => { },
         },
     ],

--- a/src/web/experiments/tests/sign-in-gate-main-variant.ts
+++ b/src/web/experiments/tests/sign-in-gate-main-variant.ts
@@ -6,7 +6,7 @@ export const signInGateMainVariant: ABTest = {
     expiry: '2020-12-01',
     author: 'Mahesh Makani',
     description:
-        'Show sign in gate to 100% of users on 3rd article view of simple article templates, with higher priority over banners and epic. Main/Variant Audience.',
+        'Show sign in gate to 100% of users on 3rd article view of simple article templates, and show a further 5 times after the first dismissal, with higher priority over banners and epic. Main/Variant Audience.',
     audience: 0.9,
     audienceOffset: 0.0,
     successMeasure: 'Users sign in or create a Guardian account',


### PR DESCRIPTION
<!-- YOU SHOULD KNOW: dotcom is running an experiment called PR Deployments. -->
<!-- As soon as you open this PR, a github action called PR Deployment will run your code in an isolated environment and make it accessible in a public URL that you can use for testing etc -->
<!-- Every time you push to this branch, you will get an annoying email alert from github telling you that the previous PR deployment has been canceled. -->
<!-- You do not need to wait for the PR deployment action to go green before you can merge -->


## What does this change?

Show signin gate 5 times after the first dismissal if user does not signin or register.
See https://trello.com/c/Xp9mwQGy/2471-goal-update-dismiss-rules-to-display-the-sign-in-gate-on-every-eligible-article-after-dismissing-t

Equivalent PR for dotcom
https://github.com/guardian/frontend/pull/23058

### Before

Signin gate was dismissed once and did not come back

### After

Show signin gate 5 times after the first dismissal if user does not signin

## Why?

Increase number of users registering / signing in. Data shows that a large percentage of users signin after 5 gate viewings