### PR TITLE
Bump atoms-rendering version to 1.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "@emotion/core": "^10.0.28",
         "@guardian/ab-core": "^2.0.0",
         "@guardian/ab-react": "^2.0.1",
-        "@guardian/atoms-rendering": "^1.11.2",
+        "@guardian/atoms-rendering": "^1.12.0",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/consent-management-platform": "6.1.0",
         "@guardian/braze-components": "0.0.11",

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -408,11 +408,7 @@ export const App = ({ CAPI, NAV }: Props) => {
             ))}
             {CAPI.chartAtoms.map((chart) => (
                 <Hydrate root="chart-atom" index={chart.chartIndex}>
-                    <ChartAtom
-                        id={chart.id}
-                        html={chart.html}
-                        url={chart.url}
-                    />
+                    <ChartAtom id={chart.id} html={chart.html} />
                 </Hydrate>
             ))}
             {CAPI.qandaAtoms.map((qandaAtom) => (

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -102,13 +102,7 @@ export const ArticleRenderer: React.FC<{
                         </div>
                     );
                 case 'model.dotcomrendering.pageElements.ChartAtomBlockElement':
-                    return (
-                        <ChartAtom
-                            id={element.id}
-                            html={element.html}
-                            url={element.url}
-                        />
-                    );
+                    return <ChartAtom id={element.id} html={element.html} />;
                 case 'model.dotcomrendering.pageElements.DocumentBlockElement':
                     return (
                         <DocumentBlockComponent

--- a/yarn.lock
+++ b/yarn.lock
@@ -2260,10 +2260,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
   integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
 
-"@guardian/atoms-rendering@^1.11.2":
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-1.11.2.tgz#da392c908848ef6ba8d4bc731da2a9c422f90612"
-  integrity sha512-xARDBnWZQx2hTGeJZLw7O3+KGy6UPyDaz5ll2FqItB/1bOZQjV3BV43UkjAIOP2iUrjncMk2/q0+mjqE7rSiTQ==
+"@guardian/atoms-rendering@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-1.12.0.tgz#b8cefc171d80c19a180e0e78c6854eccc50a04b3"
+  integrity sha512-yL/o+3R44kz5HPLCrX8PTGUoCJDPdMwVKAvbFWS4ZgoQI1b04wFBdo5YJ5aSB9VRfV3E3EI8SAlyHFdhORPlig==
 
 "@guardian/automat-client@^0.2.16":
   version "0.2.16"


### PR DESCRIPTION
###What does this change?

Bump atoms-rendering version to 1.12.0

nb: The change in the ChartAtom interface came from here: https://github.com/guardian/atoms-rendering/pull/70