### PR TITLE
Open syndication link in separate process

### DIFF
--- a/src/web/components/SyndicationButton.tsx
+++ b/src/web/components/SyndicationButton.tsx
@@ -57,6 +57,7 @@ export const SyndicationButton: React.FC<{
                             webUrl,
                         )}&type=article&internalpagecode=${internalPageCode}`}
                         target="_blank"
+                        rel="noopener"
                         title="Reuse this content"
                     >
                         <span className={syndicationButton}>


### PR DESCRIPTION
# What does this change?
The general idea is to always set `rel="noopener"` or `rel="noreferrer"` when using `target="_blank"`

* `rel="noopener"` prevents the new page from being able to access the window.opener property and ensures it runs in a separate process.
* `rel="noreferrer"` has the same effect but also prevents the Referer header from being sent to the new page. See Link type "noreferrer".

I think  `rel="noopener"` works here as we don't need to hide the Referer header from the syndication website.

See https://web.dev/external-anchors-use-rel-noopener

## Why?


This was flagged by lighthouse as not conforming to best practices.

<img width="897" alt="Lighthouse_Report" src="https://user-images.githubusercontent.com/1672034/94838350-5a3d8800-040d-11eb-8cb6-7015e537077c.png">