### PR TITLE
Add isCountry display rule for sign in gate

### DIFF
--- a/src/web/components/SignInGate/displayRule.test.ts
+++ b/src/web/components/SignInGate/displayRule.test.ts
@@ -1,11 +1,13 @@
 import { incrementDailyArticleCount } from '@frontend/web/lib/dailyArticleCount';
 import { CAPI } from '@root/fixtures/CAPI/CAPI';
 import { makeGuardianBrowserCAPI } from '@root/src/model/window-guardian';
+import { setCountryCodeSynchronous } from '@root/src/web/lib/getCountryCode'
 import {
     isNPageOrHigherPageView,
     isIOS9,
     isValidContentType,
     isValidSection,
+    isCountry
 } from './displayRule';
 
 describe('SignInGate - displayRule methods', () => {
@@ -59,6 +61,24 @@ describe('SignInGate - displayRule methods', () => {
             const output = isNPageOrHigherPageView(5);
 
             expect(output).toBe(false);
+        });
+    });
+
+    describe('isCountry(\'countryCode\')', () => {
+        beforeEach(() => {
+            localStorage.clear();
+        });
+        test('geolocation is US', () => {
+            setCountryCodeSynchronous('US')
+            expect(isCountry('US')).toBe(true);
+        });
+
+        test('geolocation is not US', () => {
+            setCountryCodeSynchronous('GB')
+            expect(isCountry('US')).toBe(false);
+        });
+        test('geolocation is false if not set', () => {
+            expect(isCountry('US')).toBe(false);
         });
     });
 

--- a/src/web/components/SignInGate/displayRule.ts
+++ b/src/web/components/SignInGate/displayRule.ts
@@ -1,5 +1,6 @@
 // use the dailyArticleCount from the local storage to see how many articles the user has viewed in a day
 import { getDailyArticleCount } from '@frontend/web/lib/dailyArticleCount';
+import { getCountryCodeFromLocalStorage } from '@frontend/web/lib/getCountryCode';
 
 // in our case if this is the n-numbered article or higher the user has viewed then set the gate
 export const isNPageOrHigherPageView = (n: number = 2): boolean => {
@@ -10,6 +11,13 @@ export const isNPageOrHigherPageView = (n: number = 2): boolean => {
 
     return count >= n;
 };
+
+// use gu.location to determine is the browser is in the specified country
+// Note, use country codes specified in guardian/frontend/static/src/javascripts/lib/geolocation.js
+export const isCountry = (countryCode: string): boolean => {
+    const countryCodeFromStorage = getCountryCodeFromLocalStorage()
+    return countryCodeFromStorage === countryCode
+}
 
 // determine if the useragent is running iOS 9 (known to be buggy for sign in flow)
 export const isIOS9 = (): boolean => {

--- a/src/web/lib/getCountryCode.ts
+++ b/src/web/lib/getCountryCode.ts
@@ -33,6 +33,30 @@ export const setCountryCode = (countryCode: string): void => {
     });
 };
 
+export const setCountryCodeSynchronous = (countryCode: string): void => {
+    if (countryCode) {
+        localStorage.setItem(
+            COUNTRY_CODE_KEY,
+            JSON.stringify({
+                value: countryCode,
+                expires: new Date().getTime() + TEN_DAYS,
+            }),
+        );
+    }
+};
+
+export const getCountryCodeFromLocalStorage = (): string | null => {
+    let localCountryCode: LocalCountryCodeType | null;
+    try {
+        const item = localStorage.getItem(COUNTRY_CODE_KEY);
+        localCountryCode = item ? JSON.parse(item) : null;
+    } catch (error) {
+        localCountryCode = null;
+    }
+
+    return (localCountryCode && localCountryCode.value) || null
+};
+
 export const getCountryCode = async () => {
     // Read local storage to see if we already have a value
     let localCountryCode: LocalCountryCodeType | null;
@@ -51,7 +75,7 @@ export const getCountryCode = async () => {
                 if (!response.ok) {
                     throw Error(
                         response.statusText ||
-                            `getCountryCode | An api call returned HTTP status ${response.status}`,
+                        `getCountryCode | An api call returned HTTP status ${response.status}`,
                     );
                 }
                 return response;

--- a/src/web/lib/getCountryCode.ts
+++ b/src/web/lib/getCountryCode.ts
@@ -46,15 +46,13 @@ export const setCountryCodeSynchronous = (countryCode: string): void => {
 };
 
 export const getCountryCodeFromLocalStorage = (): string | null => {
-    let localCountryCode: LocalCountryCodeType | null;
     try {
         const item = localStorage.getItem(COUNTRY_CODE_KEY);
-        localCountryCode = item ? JSON.parse(item) : null;
+        const localCountryCode = item ? JSON.parse(item) : null;
+        return localCountryCode.value || null
     } catch (error) {
-        localCountryCode = null;
+        return null
     }
-
-    return (localCountryCode && localCountryCode.value) || null
 };
 
 export const getCountryCode = async () => {


### PR DESCRIPTION
# What does this change?

Adds a new sign in gate display rule `isCountry(countryCode)` based on the available local storage value of `gu.geolocation` which is set asynchronously on page load.  

## Why?

This display rule will be used on upcoming tests.
