### PR TITLE
Bump atoms-rendering to 1.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "@emotion/core": "^10.0.28",
         "@guardian/ab-core": "^2.0.0",
         "@guardian/ab-react": "^2.0.1",
-        "@guardian/atoms-rendering": "^1.12.0",
+        "@guardian/atoms-rendering": "^1.13.0",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/consent-management-platform": "6.1.0",
         "@guardian/braze-components": "0.0.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2260,10 +2260,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
   integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
 
-"@guardian/atoms-rendering@^1.12.0":
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-1.12.0.tgz#b8cefc171d80c19a180e0e78c6854eccc50a04b3"
-  integrity sha512-yL/o+3R44kz5HPLCrX8PTGUoCJDPdMwVKAvbFWS4ZgoQI1b04wFBdo5YJ5aSB9VRfV3E3EI8SAlyHFdhORPlig==
+"@guardian/atoms-rendering@^1.13.0":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-1.13.0.tgz#3b8bdb7a74db83a6ff5437af39fd58270b24748d"
+  integrity sha512-DNwlF7X4OkHeTiEEzhTaw1z9qCckTOEspxc4EegHfYw0KRnjuRR/+KFOc/Ckz7Bb1tg475XJzO7Kr0BHSIcMEg==
 
 "@guardian/automat-client@^0.2.16":
   version "0.2.16"


### PR DESCRIPTION
## What does this change?

Bump atoms-rendering to 1.13.0 (this bring a correction to the AudioAtom which wasn't working well on Safari).

<img width="1239" alt="Screenshot 2020-10-07 at 05 31 38" src="https://user-images.githubusercontent.com/6035518/95287766-b3b71400-085e-11eb-9d67-ae52807b3782.png">

