### PR TITLE
Tell Chromatic to ignore YouTube player

### DIFF
--- a/src/web/components/elements/YoutubeBlockComponent.tsx
+++ b/src/web/components/elements/YoutubeBlockComponent.tsx
@@ -41,7 +41,7 @@ export const YoutubeBlockComponent = ({
         (role === 'showcase' || role === 'supporting' || role === 'immersive');
 
     return (
-        <>
+        <div data-chromatic="ignore">
             <YoutubeAtom
                 format={asFormat(pillar, display, designType)}
                 videoMeta={element}
@@ -62,6 +62,6 @@ export const YoutubeBlockComponent = ({
                     shouldLimitWidth={shouldLimitWidth}
                 />
             )}
-        </>
+        </div>
     );
 };


### PR DESCRIPTION
## What does this change?

We get quite a lot of differences reported by Chromatic related to the YouTube player which in general aren't related to the change at hand. Reduce these false positives by [telling Chromatic to ignore](https://www.chromatic.com/docs/ignoring-elements#ignore-dom-elements) the YouTube player.