### PR TITLE
Identity - Add pageview sign in gate AB test 

### DIFF
--- a/cypress/integration/e2e/sign-in-gate.spec.js
+++ b/cypress/integration/e2e/sign-in-gate.spec.js
@@ -17,6 +17,19 @@ describe('Sign In Gate Tests', function () {
         );
     };
 
+    const setGeolocation = (n) => {
+        localStorage.setItem(
+            'gu.geolocation',
+            JSON.stringify({
+                value: n,
+            }),
+        );
+    };
+
+    const clearGeolocation = () => {
+        localStorage.removeItem('gu.geolocation');
+    };
+
     const setMvtCookie = (str) => {
         cy.setCookie('GU_mvt_id_local', str, {
             log: true,
@@ -209,6 +222,39 @@ describe('Sign In Gate Tests', function () {
             cy.get('[data-cy=sign-in-gate-patientia_dismiss]').click();
 
             cy.get('[data-cy=sign-in-gate-patientia]').should('not.be.visible');
+        });
+    });
+
+    describe('SignInGatePageview', function () {
+        beforeEach(function () {
+            setMvtCookie('790000');
+
+            // set article count to be min number to view gate
+            setArticleCount(3);
+        });
+
+        it('should load the sign in gate if there is no available geolocation in local storage', function () {
+            visitArticle();
+            clearGeolocation();
+            scrollToGateForLazyLoading();
+            cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+        });
+
+        it('should load the sign in gate for a non-US browser', function () {
+            visitArticle();
+            setGeolocation('GB');
+            scrollToGateForLazyLoading();
+
+            cy.get('[data-cy=sign-in-gate-main]').should('be.visible');
+            cy.get('[data-cy=sign-in-gate-main_dismiss]').click();
+            cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
+        });
+        it('should not load the sign in gate for a US browser', function () {
+            visitArticle();
+            setGeolocation('US');
+            scrollToGateForLazyLoading();
+
+            cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
         });
     });
 });

--- a/src/web/components/SignInGate/SignInGateSelector.tsx
+++ b/src/web/components/SignInGate/SignInGateSelector.tsx
@@ -3,7 +3,10 @@ import { useAB } from '@guardian/ab-react';
 import { ABTest, Runnable } from '@guardian/ab-core';
 import { constructQuery } from '@root/src/lib/querystring';
 
-import { incrementUserDismissedGateCount, setUserDismissedGate } from '@frontend/web/components/SignInGate/dismissGate';
+import {
+    incrementUserDismissedGateCount,
+    setUserDismissedGate,
+} from '@frontend/web/components/SignInGate/dismissGate';
 import {
     SignInGateComponent,
     CurrentABTest,
@@ -14,12 +17,17 @@ import { getCookie } from '@frontend/web/browser/cookie';
 import { signInGatePatientia } from '@frontend/web/experiments/tests/sign-in-gate-patientia';
 import { signInGateMainVariant } from '@root/src/web/experiments/tests/sign-in-gate-main-variant';
 import { signInGateMainControl } from '@root/src/web/experiments/tests/sign-in-gate-main-control';
+import { signInGatePageview } from '@root/src/web/experiments/tests/sign-in-gate-pageview';
 
 // Sign in Gate Types
 import { signInGateComponent as gateMainVariant } from '@root/src/web/components/SignInGate/gates/main-variant';
 import { signInGateComponent as gateMainControl } from '@root/src/web/components/SignInGate/gates/main-control';
 import { signInGateComponent as gatePatientiaControl } from '@root/src/web/components/SignInGate/gates/patientia-control';
 import { signInGateComponent as gatePatientiaVariant } from '@root/src/web/components/SignInGate/gates/patientia-variant';
+import { signInGateComponent as gatePageviewVariant1 } from '@root/src/web/components/SignInGate/gates/pageview-variant-1';
+import { signInGateComponent as gatePageviewVariant2 } from '@root/src/web/components/SignInGate/gates/pageview-variant-2';
+import { signInGateComponent as gatePageviewVariant3 } from '@root/src/web/components/SignInGate/gates/pageview-variant-3';
+import { signInGateComponent as gatePageviewVariant4 } from '@root/src/web/components/SignInGate/gates/pageview-variant-4';
 
 import {
     ComponentEventParams,
@@ -51,7 +59,10 @@ const dismissGate = (
 ) => {
     setShowGate(false);
     setUserDismissedGate(currentAbTestValue.variant, currentAbTestValue.name);
-    incrementUserDismissedGateCount(currentAbTestValue.variant, currentAbTestValue.name);
+    incrementUserDismissedGateCount(
+        currentAbTestValue.variant,
+        currentAbTestValue.name,
+    );
 
     // When the user closes the sign in gate, we scroll them back to the main content
     const articleBody = document.querySelector(
@@ -70,6 +81,7 @@ const tests: ReadonlyArray<ABTest> = [
     signInGatePatientia,
     signInGateMainVariant,
     signInGateMainControl,
+    signInGatePageview,
 ];
 
 const testVariantToGateMapping: GateTestMap = {
@@ -77,12 +89,17 @@ const testVariantToGateMapping: GateTestMap = {
     'patientia-variant-1': gatePatientiaVariant,
     'main-control-2': gateMainControl,
     'main-variant-2': gateMainVariant,
+    'pageview-variant-1': gatePageviewVariant1,
+    'pageview-variant-2': gatePageviewVariant2,
+    'pageview-variant-3': gatePageviewVariant3,
+    'pageview-variant-4': gatePageviewVariant4,
 };
 
 const testIdToComponentId: { [key: string]: string } = {
     SignInGateMainVariant: 'main_variant_2',
     SignInGateMainControl: 'main_control_2',
     SignInGatePatientia: 'patientia_test',
+    SignInGatePageview: 'pageview_test',
 };
 
 // function to generate the profile.theguardian.com url with tracking params

--- a/src/web/components/SignInGate/gates/pageview-variant-1.tsx
+++ b/src/web/components/SignInGate/gates/pageview-variant-1.tsx
@@ -1,0 +1,70 @@
+import React, { Suspense } from 'react';
+import { Lazy } from '@root/src/web/components/Lazy';
+
+import {
+    SignInGateComponent,
+    CurrentABTest,
+} from '@frontend/web/components/SignInGate/gateDesigns/types';
+import {
+    isNPageOrHigherPageView,
+    isValidContentType,
+    isValidSection,
+    isIOS9,
+    isCountry,
+} from '@frontend/web/components/SignInGate/displayRule';
+import { initPerf } from '@root/src/web/browser/initPerf';
+import { hasUserDismissedGateMoreThanCount } from '../dismissGate';
+
+const SignInGateMain = React.lazy(() => {
+    const { start, end } = initPerf('SignInGateMain');
+    start();
+    return import(
+        /* webpackChunkName: "SignInGateMain" */ '../gateDesigns/SignInGateMain'
+    ).then((module) => {
+        end();
+        return { default: module.SignInGateMain };
+    });
+});
+
+// 3rd page view & new dismiss rule (capped at 5)
+const canShow = (
+    CAPI: CAPIBrowserType,
+    isSignedIn: boolean,
+    currentTest: CurrentABTest,
+): boolean =>
+    !isSignedIn &&
+    !hasUserDismissedGateMoreThanCount(
+        currentTest.variant,
+        currentTest.name,
+        5,
+    ) &&
+    isNPageOrHigherPageView(3) &&
+    isValidContentType(CAPI) &&
+    isValidSection(CAPI) &&
+    !isIOS9() &&
+    !isCountry('US');
+
+export const signInGateComponent: SignInGateComponent = {
+    gate: ({
+        ophanComponentId,
+        dismissGate,
+        guUrl,
+        signInUrl,
+        abTest,
+        isComment,
+    }) => (
+        <Lazy margin={300}>
+            <Suspense fallback={<></>}>
+                <SignInGateMain
+                    ophanComponentId={ophanComponentId}
+                    dismissGate={dismissGate}
+                    guUrl={guUrl}
+                    signInUrl={signInUrl}
+                    abTest={abTest}
+                    isComment={isComment}
+                />
+            </Suspense>
+        </Lazy>
+    ),
+    canShow,
+};

--- a/src/web/components/SignInGate/gates/pageview-variant-2.tsx
+++ b/src/web/components/SignInGate/gates/pageview-variant-2.tsx
@@ -1,0 +1,70 @@
+import React, { Suspense } from 'react';
+import { Lazy } from '@root/src/web/components/Lazy';
+
+import {
+    SignInGateComponent,
+    CurrentABTest,
+} from '@frontend/web/components/SignInGate/gateDesigns/types';
+import {
+    isNPageOrHigherPageView,
+    isValidContentType,
+    isValidSection,
+    isIOS9,
+    isCountry,
+} from '@frontend/web/components/SignInGate/displayRule';
+import { initPerf } from '@root/src/web/browser/initPerf';
+import { hasUserDismissedGateMoreThanCount } from '../dismissGate';
+
+const SignInGateMain = React.lazy(() => {
+    const { start, end } = initPerf('SignInGateMain');
+    start();
+    return import(
+        /* webpackChunkName: "SignInGateMain" */ '../gateDesigns/SignInGateMain'
+    ).then((module) => {
+        end();
+        return { default: module.SignInGateMain };
+    });
+});
+
+// 2nd page view & new dismiss rule (capped at 5)
+const canShow = (
+    CAPI: CAPIBrowserType,
+    isSignedIn: boolean,
+    currentTest: CurrentABTest,
+): boolean =>
+    !isSignedIn &&
+    !hasUserDismissedGateMoreThanCount(
+        currentTest.variant,
+        currentTest.name,
+        5,
+    ) &&
+    isNPageOrHigherPageView(2) &&
+    isValidContentType(CAPI) &&
+    isValidSection(CAPI) &&
+    !isIOS9() &&
+    !isCountry('US');
+
+export const signInGateComponent: SignInGateComponent = {
+    gate: ({
+        ophanComponentId,
+        dismissGate,
+        guUrl,
+        signInUrl,
+        abTest,
+        isComment,
+    }) => (
+        <Lazy margin={300}>
+            <Suspense fallback={<></>}>
+                <SignInGateMain
+                    ophanComponentId={ophanComponentId}
+                    dismissGate={dismissGate}
+                    guUrl={guUrl}
+                    signInUrl={signInUrl}
+                    abTest={abTest}
+                    isComment={isComment}
+                />
+            </Suspense>
+        </Lazy>
+    ),
+    canShow,
+};

--- a/src/web/components/SignInGate/gates/pageview-variant-3.tsx
+++ b/src/web/components/SignInGate/gates/pageview-variant-3.tsx
@@ -1,0 +1,66 @@
+import React, { Suspense } from 'react';
+import { Lazy } from '@root/src/web/components/Lazy';
+
+import {
+    SignInGateComponent,
+    CurrentABTest,
+} from '@frontend/web/components/SignInGate/gateDesigns/types';
+import {
+    isNPageOrHigherPageView,
+    isValidContentType,
+    isValidSection,
+    isIOS9,
+    isCountry,
+} from '@frontend/web/components/SignInGate/displayRule';
+import { initPerf } from '@root/src/web/browser/initPerf';
+import { hasUserDismissedGate } from '../dismissGate';
+
+const SignInGateMain = React.lazy(() => {
+    const { start, end } = initPerf('SignInGateMain');
+    start();
+    return import(
+        /* webpackChunkName: "SignInGateMain" */ '../gateDesigns/SignInGateMain'
+    ).then((module) => {
+        end();
+        return { default: module.SignInGateMain };
+    });
+});
+
+// 3rd page view & old dismiss rule (never see gate again after first dismissal)
+const canShow = (
+    CAPI: CAPIBrowserType,
+    isSignedIn: boolean,
+    currentTest: CurrentABTest,
+): boolean =>
+    !isSignedIn &&
+    !hasUserDismissedGate(currentTest.variant, currentTest.name) &&
+    isNPageOrHigherPageView(3) &&
+    isValidContentType(CAPI) &&
+    isValidSection(CAPI) &&
+    !isIOS9() &&
+    !isCountry('US');
+
+export const signInGateComponent: SignInGateComponent = {
+    gate: ({
+        ophanComponentId,
+        dismissGate,
+        guUrl,
+        signInUrl,
+        abTest,
+        isComment,
+    }) => (
+        <Lazy margin={300}>
+            <Suspense fallback={<></>}>
+                <SignInGateMain
+                    ophanComponentId={ophanComponentId}
+                    dismissGate={dismissGate}
+                    guUrl={guUrl}
+                    signInUrl={signInUrl}
+                    abTest={abTest}
+                    isComment={isComment}
+                />
+            </Suspense>
+        </Lazy>
+    ),
+    canShow,
+};

--- a/src/web/components/SignInGate/gates/pageview-variant-4.tsx
+++ b/src/web/components/SignInGate/gates/pageview-variant-4.tsx
@@ -1,0 +1,66 @@
+import React, { Suspense } from 'react';
+import { Lazy } from '@root/src/web/components/Lazy';
+
+import {
+    SignInGateComponent,
+    CurrentABTest,
+} from '@frontend/web/components/SignInGate/gateDesigns/types';
+import {
+    isNPageOrHigherPageView,
+    isValidContentType,
+    isValidSection,
+    isIOS9,
+    isCountry,
+} from '@frontend/web/components/SignInGate/displayRule';
+import { initPerf } from '@root/src/web/browser/initPerf';
+import { hasUserDismissedGate } from '../dismissGate';
+
+const SignInGateMain = React.lazy(() => {
+    const { start, end } = initPerf('SignInGateMain');
+    start();
+    return import(
+        /* webpackChunkName: "SignInGateMain" */ '../gateDesigns/SignInGateMain'
+    ).then((module) => {
+        end();
+        return { default: module.SignInGateMain };
+    });
+});
+
+// 2nd page view & old dismiss rule (never see gate again after first dismissal)
+const canShow = (
+    CAPI: CAPIBrowserType,
+    isSignedIn: boolean,
+    currentTest: CurrentABTest,
+): boolean =>
+    !isSignedIn &&
+    !hasUserDismissedGate(currentTest.variant, currentTest.name) &&
+    isNPageOrHigherPageView(2) &&
+    isValidContentType(CAPI) &&
+    isValidSection(CAPI) &&
+    !isIOS9() &&
+    !isCountry('US');
+
+export const signInGateComponent: SignInGateComponent = {
+    gate: ({
+        ophanComponentId,
+        dismissGate,
+        guUrl,
+        signInUrl,
+        abTest,
+        isComment,
+    }) => (
+        <Lazy margin={300}>
+            <Suspense fallback={<></>}>
+                <SignInGateMain
+                    ophanComponentId={ophanComponentId}
+                    dismissGate={dismissGate}
+                    guUrl={guUrl}
+                    signInUrl={signInUrl}
+                    abTest={abTest}
+                    isComment={isComment}
+                />
+            </Suspense>
+        </Lazy>
+    ),
+    canShow,
+};

--- a/src/web/experiments/ab-tests.ts
+++ b/src/web/experiments/ab-tests.ts
@@ -3,6 +3,7 @@ import { abTestTest } from '@frontend/web/experiments/tests/ab-test-test';
 import { signInGateMainVariant } from '@root/src/web/experiments/tests/sign-in-gate-main-variant';
 import { signInGateMainControl } from '@root/src/web/experiments/tests/sign-in-gate-main-control';
 import { signInGatePatientia } from '@frontend/web/experiments/tests/sign-in-gate-patientia';
+import { signInGatePageview } from '@frontend/web/experiments/tests/sign-in-gate-pageview';
 import { curatedContainerTest } from '@frontend/web/experiments/tests/curated-container-test';
 
 export const tests: ABTest[] = [
@@ -10,5 +11,6 @@ export const tests: ABTest[] = [
     signInGateMainVariant,
     signInGateMainControl,
     signInGatePatientia,
+    signInGatePageview,
     curatedContainerTest,
 ];

--- a/src/web/experiments/cypress-switches.ts
+++ b/src/web/experiments/cypress-switches.ts
@@ -14,6 +14,7 @@ const cypressSwitches = {
     abSignInGateMainControl: true,
     abSignInGateMainVariant: true,
     abSignInGatePatientia: true,
+    abSignInGatePageview: true,
 };
 
 // Function to retrieve the switches if running in Cypress

--- a/src/web/experiments/tests/sign-in-gate-main-variant.ts
+++ b/src/web/experiments/tests/sign-in-gate-main-variant.ts
@@ -7,7 +7,7 @@ export const signInGateMainVariant: ABTest = {
     author: 'Mahesh Makani',
     description:
         'Show sign in gate to 100% of users on 3rd article view of simple article templates, and show a further 5 times after the first dismissal, with higher priority over banners and epic. Main/Variant Audience.',
-    audience: 0.9,
+    audience: 0.7710,
     audienceOffset: 0.0,
     successMeasure: 'Users sign in or create a Guardian account',
     audienceCriteria:

--- a/src/web/experiments/tests/sign-in-gate-pageview.ts
+++ b/src/web/experiments/tests/sign-in-gate-pageview.ts
@@ -1,0 +1,38 @@
+import { ABTest } from '@guardian/ab-core';
+
+export const signInGatePageview: ABTest = {
+    id: 'SignInGatePageview',
+    start: '2020-10-09',
+    expiry: '2020-12-01',
+    author: 'vlbee',
+    description:
+        'Compare showing the gate on the 2nd vs 3rd article view with new and old dimiss rule variants, on simple article templates, with higher priority over banners and epi, excluding the US',
+    audience: 0.1290,
+    audienceOffset: 0.7710,
+    successMeasure: 'Users sign in or create a Guardian account',
+    audienceCriteria:
+        '2nd or 3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss or reshown after 5 dismisses, not on help, info sections etc. Exclude US, iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',
+    dataLinkNames: 'SignInGatePageview',
+    idealOutcome:
+        'Moving to a second page view gate would lead to an estimated increase in the number of weekly sign ins of between +25% and +35%.',
+    showForSensitive: false,
+    canRun: () => true,
+    variants: [
+        {
+            id: 'pageview-variant-1', // 3rd page view & new dismiss rule (capped at 5)
+            test: (): void => { },
+        },
+        {
+            id: 'pageview-variant-2', // 2nd page view & new dismiss rule (capped at 5)
+            test: (): void => { },
+        },
+        {
+            id: 'pageview-variant-3', // 3rd page view & old dismiss rule (never see gate again after first dismissal)
+            test: (): void => { },
+        },
+        {
+            id: 'pageview-variant-4', // 2nd page view & new dismiss rule (never see gate again after first dismissal)
+            test: (): void => { },
+        },
+    ],
+};


### PR DESCRIPTION
## What does this change?

- Adds a new Sign In Gate AB test called SignInGatePageview  - compares showing the gate on the 2nd vs 3rd article view with new and old dismiss rule variants, on simple article templates, with higher priority over banners and epi, excluding the US.


FE PR is https://github.com/guardian/frontend/pull/23081

##### TODO
- [x] Cypress tests