### PR TITLE
Use placeholderUrl and set atom height based on comment in html

### DIFF
--- a/src/amp/components/Elements.tsx
+++ b/src/amp/components/Elements.tsx
@@ -95,7 +95,13 @@ export const Elements = (
             case 'model.dotcomrendering.pageElements.InstagramBlockElement':
                 return <InstagramBlockComponent key={i} element={element} />;
             case 'model.dotcomrendering.pageElements.InteractiveAtomBlockElement':
-                return <InteractiveAtomBlockComponent url={element.url} />;
+                return (
+                    <InteractiveAtomBlockComponent
+                        url={element.url}
+                        html={element.html}
+                        placeholderUrl={element.placeholderUrl}
+                    />
+                ); // element.placeholderUrl
             case 'model.dotcomrendering.pageElements.InteractiveBlockElement': // Plain Interactive Embeds
                 return <InteractiveAtomBlockComponent url={element.url} />;
             case 'model.dotcomrendering.pageElements.MapBlockElement':

--- a/src/amp/components/elements/InteractiveAtomBlockComponent.tsx
+++ b/src/amp/components/elements/InteractiveAtomBlockComponent.tsx
@@ -2,7 +2,9 @@ import React from 'react';
 import { css } from 'emotion';
 import { ShowMoreButton } from '@root/src/amp/components/ShowMoreButton';
 
-const styles = css`
+const styles = (height: number) => css`
+    height: ${height}px;
+    width: 100%;
     margin-top: 16px;
     margin-bottom: 12px;
 `;
@@ -16,20 +18,50 @@ const showMore = css`
     }
 `;
 
-export const InteractiveAtomBlockComponent: React.SFC<{ url: string }> = ({
-    url,
-}) => {
+// We look in the html field of the atom for a hint
+// for the height of the atom
+// We look for an html comment <!-- MobileHeight: 100 -->
+// and if we find it use that value for the CSS height of the atom
+// otherwise we use a default height
+const getHeight = (html?: string): number => {
+    const defaultInteractiveAtomHeight = 100;
+    if (html) {
+        const heightRegex = /<!-- MobileHeight: (.*) -->/;
+        const getHeightFromComment = heightRegex.exec(html);
+        if (
+            getHeightFromComment &&
+            typeof Number(getHeightFromComment[1]) === 'number'
+        ) {
+            return Number(getHeightFromComment[1]); // Returns [ '<!-- MobileHeight: 100 -->', '100', index: 4, input: 'test<!-- MobileHeight: 100 -->', groups: undefined ]
+        }
+    }
+
+    return defaultInteractiveAtomHeight;
+};
+
+export const InteractiveAtomBlockComponent: React.SFC<{
+    url: string;
+    html?: string;
+    placeholderUrl?: string;
+}> = ({ url, placeholderUrl, html }) => {
     return (
         <amp-iframe
-            class={styles}
+            class={styles(getHeight(html))}
             src={url}
             layout="responsive"
             sandbox="allow-scripts allow-same-origin allow-top-navigation-by-user-activation allow-popups"
             height="1"
-            width="8"
+            width="1"
             resizable=""
             data-cy="atom-embed-url"
         >
+            {placeholderUrl && (
+                <amp-img
+                    placeholder={true}
+                    layout="fill"
+                    src={placeholderUrl}
+                />
+            )}
             <div overflow="" className={showMore}>
                 <ShowMoreButton />
             </div>

--- a/src/amp/components/elements/InteractiveAtomBlockComponent.tsx
+++ b/src/amp/components/elements/InteractiveAtomBlockComponent.tsx
@@ -44,6 +44,15 @@ export const InteractiveAtomBlockComponent: React.SFC<{
     html?: string;
     placeholderUrl?: string;
 }> = ({ url, placeholderUrl, html }) => {
+    // On Dot Com, Interactive Atoms are sometimes used to modify the page
+    // around them. CSS, JS but no HTML can exist in an atom, and because we just
+    // add it to the page, it can modify the world around it.
+    // We can't do that on AMP, so if the html field of an interactive atom is an
+    // empty string then we just want to walk away from it.
+    if (html === '') {
+        return null;
+    }
+
     return (
         <amp-iframe
             class={styles(getHeight(html))}

--- a/src/amp/components/elements/InteractiveAtomBlockComponent.tsx
+++ b/src/amp/components/elements/InteractiveAtomBlockComponent.tsx
@@ -18,15 +18,37 @@ const showMore = css`
     }
 `;
 
-// We look in the html field of the atom for a hint
-// for the height of the atom
-// We look for an html comment <!-- MobileHeight: 100 -->
-// and if we find it use that value for the CSS height of the atom
-// otherwise we use a default height
+// We look in the html field of the atom for a hint for the height of the atom
+// We look for an html comment <!-- MobileHeight: 100 --> and if we find it use
+// that value for the CSS height of the atom otherwise we use a default height
+//
+// 150px default height is a fairly safe arbitrary number to avoid excessive
+// whitespace but give top-of-page atoms the chance to avoid resizing (or at
+// least show a good portion of the atom)
+
+const defaultInteractiveAtomHeight = 150;
+
+// Using the MobileHeight comment is ok (lets be very aware we're creating a
+// loosely-defined contract between interactive atoms and AMP here, that should
+// really be in CAPI)
+
+const heightRegex = /<!-- MobileHeight: (.*) -->/;
+
+//  The value of <!-- MobileHeight: value --> should be the height of an
+//  interactive atom at the widest mobile breakpoint to give a guesstimate to
+//  AMP for a reasonable height
+//
+// It should only be used on interactive atoms that are at the top of articles,
+// as it only matters when the bottom of the interactive atom is within the
+// viewport (otherwise AMP will auto-resize)
+//
+// Placeholder images must always exist for atoms that require using the
+// MobileHeight comment, otherwise the atom will not show on AMP
+//
+// Full page interactives should always have both
+
 const getHeight = (html?: string): number => {
-    const defaultInteractiveAtomHeight = 100;
     if (html) {
-        const heightRegex = /<!-- MobileHeight: (.*) -->/;
         const getHeightFromComment = heightRegex.exec(html);
         if (
             getHeightFromComment &&

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -3,6 +3,7 @@
 // -------------------------------------
 interface InteractiveAtomBlockElementBase {
     url: string;
+    placeholderUrl?: string;
     id?: string;
     html?: string;
     css?: string;

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -924,6 +924,9 @@
                 "url": {
                     "type": "string"
                 },
+                "placeholderUrl": {
+                    "type": "string"
+                },
                 "css": {
                     "type": "string"
                 },
@@ -1137,6 +1140,9 @@
                     ]
                 },
                 "url": {
+                    "type": "string"
+                },
+                "placeholderUrl": {
                     "type": "string"
                 },
                 "id": {
@@ -1473,6 +1479,9 @@
                 },
                 "url": {
                     "type": "string"
+                },
+                "placeholderUrl": {
+                    "type": "string"
                 }
             },
             "required": [
@@ -1492,6 +1501,9 @@
                     ]
                 },
                 "url": {
+                    "type": "string"
+                },
+                "placeholderUrl": {
                     "type": "string"
                 },
                 "id": {


### PR DESCRIPTION
## What does this change?

- Adds a default height of 150px to Interactive Atoms on AMP
- Creates a mechanism for adding a height hint for interactive atoms on AMP through the use of a comment within the `html` field of the interactive atom
- Uses the `placeholderUrl` of an atom as a an image placeholder for interactive atoms on AMP, ensuring that we can show atoms at the top of articles
- Does not render the interactive atom if the `html` prop is an empty string (as this is used for modifying pages on Dotcom, not possible on AMP)

## Why?

Allows the showing of interactive atoms in AMP that exist at the top of an article - which includes full page interactive articles.
