### PR TITLE
Fix broken CMP banner picker test

### DIFF
--- a/cypress/integration/e2e/article.bannerPicker.e2e.spec.js
+++ b/cypress/integration/e2e/article.bannerPicker.e2e.spec.js
@@ -10,7 +10,7 @@ describe('Banner Picker Integration', function () {
 
     const cmpIframe = () => {
         return cy
-            .get('iframe#sp_message_iframe_208529')
+            .get('iframe[id*="sp_message_iframe"]')
             .its('0.contentDocument.body')
             .should('not.be.empty')
             .then(cy.wrap);


### PR DESCRIPTION
## What does this change?

This makes the id matching for the CMP iframe fuzzier in the e2e test. I'm not sure what the final number is, but it's recently changed and has caused this test to fail.

### Before

Test: 🔴 

### After

Test: 💚 