### PR TITLE
Fix flip-flopping Cypress test

### DIFF
--- a/cypress/integration/e2e/article.e2e.spec.js
+++ b/cypress/integration/e2e/article.e2e.spec.js
@@ -2,15 +2,20 @@ import { getPolyfill } from '../../lib/polyfill';
 import { fetchPolyfill } from '../../lib/config';
 import { articles, AMPArticles } from '../../lib/articles.js';
 import { setupApiRoutes } from '../../lib/apiRoutes.js';
+import { setUrlFragment } from '../../lib/setUrlFragment.js';
 
 describe('E2E Page rendering', function () {
     before(getPolyfill);
     beforeEach(setupApiRoutes);
 
     describe('for WEB', function () {
-        it(`It should load the designType under the pillar`, function () {
-            articles.map((article, index) => {
-                const { url, designType, pillar } = article;
+        // eslint-disable-next-line mocha/no-setup-in-describe
+        articles.map((article, index) => {
+            it(`It should load the designType under the pillar (${article.url})`, function () {
+                const { url: articleUrl, designType, pillar } = article;
+                const url = setUrlFragment(articleUrl, {
+                    'ab-CuratedContainerTest': 'control',
+                });
                 cy.log(`designType: ${designType}, pillar: ${pillar}`);
                 cy.visit(`Article?url=${url}`, fetchPolyfill);
                 const roughLoadPositionOfMostView = 1400;

--- a/cypress/lib/setUrlFragment.js
+++ b/cypress/lib/setUrlFragment.js
@@ -1,0 +1,13 @@
+const setUrlFragment = (urlString, fragments) => {
+    const url = new URL(urlString);
+
+    const newFragments = Object.entries(fragments)
+        .map(([key, value]) => `${key}=${value}`)
+        .join('&');
+
+    url.hash = (url.hash ? `${url.hash}&` : '') + newFragments;
+
+    return url;
+};
+
+export { setUrlFragment };


### PR DESCRIPTION
## What does this change?

The `cypress/integration/e2e/article.e2e.spec.js` has been sporadically failing recently. Looking at the Team City history it looks likely that this started happening when the audience % for the curated container test was increased in #1963. It's not totally clear why that's caused the failure to sometimes happen (presumably when we fall into one of the variants, not the control). Forcing the control via the URL seems to get things behaving more consistently, so going with that as a fix for now.

I also slightly refactored the web e2e article tests so that each article gets its own `it` block, since it's easier to see where failures happened that way.