### PR TITLE
Replace immersive black block with headline width

### DIFF
--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -141,12 +141,6 @@ const invertedText = css`
     padding-right: ${space[1]}px;
 `;
 
-const maxWidth = css`
-    ${from.desktop} {
-        max-width: 620px;
-    }
-`;
-
 const invertedWrapper = css`
     /*
         Because we use box-shadow (to get clean and even background styles
@@ -215,7 +209,6 @@ export const ArticleHeadline = ({
                             <h1
                                 className={cx(
                                     jumboFont,
-                                    maxWidth,
                                     immersiveStyles,
                                     displayBlock,
                                 )}
@@ -231,7 +224,6 @@ export const ArticleHeadline = ({
                             <span
                                 className={cx(
                                     jumboFont,
-                                    maxWidth,
                                     invertedStyles,
                                     immersiveStyles,
                                     displayBlock,
@@ -289,9 +281,7 @@ export const ArticleHeadline = ({
                     return (
                         // Inverted headlines have a wrapper div for positioning
                         // and a black background (only for the text)
-                        <div
-                            className={cx(shiftSlightly, maxWidth, displayFlex)}
-                        >
+                        <div className={cx(shiftSlightly, displayFlex)}>
                             <HeadlineTag tagText="Interview" pillar={pillar} />
                             <h1
                                 className={cx(

--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -141,6 +141,12 @@ const invertedText = css`
     padding-right: ${space[1]}px;
 `;
 
+const maxWidth = css`
+    ${from.desktop} {
+        max-width: 620px;
+    }
+`;
+
 const invertedWrapper = css`
     /*
         Because we use box-shadow (to get clean and even background styles
@@ -209,6 +215,7 @@ export const ArticleHeadline = ({
                             <h1
                                 className={cx(
                                     jumboFont,
+                                    maxWidth,
                                     immersiveStyles,
                                     displayBlock,
                                 )}
@@ -224,6 +231,7 @@ export const ArticleHeadline = ({
                             <span
                                 className={cx(
                                     jumboFont,
+                                    maxWidth,
                                     invertedStyles,
                                     immersiveStyles,
                                     displayBlock,
@@ -281,7 +289,9 @@ export const ArticleHeadline = ({
                     return (
                         // Inverted headlines have a wrapper div for positioning
                         // and a black background (only for the text)
-                        <div className={cx(shiftSlightly, displayFlex)}>
+                        <div
+                            className={cx(shiftSlightly, maxWidth, displayFlex)}
+                        >
                             <HeadlineTag tagText="Interview" pillar={pillar} />
                             <h1
                                 className={cx(

--- a/src/web/components/ImmersiveHeadline.tsx
+++ b/src/web/components/ImmersiveHeadline.tsx
@@ -45,43 +45,6 @@ const center = css`
     }
 `;
 
-const blackBlock = css`
-    ::after {
-        background-color: black;
-        position: absolute;
-        content: '';
-        width: 0%;
-        ${from.tablet} {
-            width: 6%;
-            height: 114px;
-        }
-        /* These media queries are to avoid edge cases on long headlines */
-        @media screen and (max-width: 942px) and (min-width: 858px) {
-            width: 10%;
-            height: 114px;
-        }
-        @media screen and (max-width: 979px) and (min-width: 942px) {
-            width: 15%;
-        }
-        @media screen and (max-width: 1140px) and (min-width: 990px) {
-            height: 260px;
-            width: 15%;
-        }
-        @media screen and (max-width: 1300px) and (min-width: 1140px) {
-            height: 260px;
-            width: 15%;
-        }
-        ${from.wide} {
-            width: 20%;
-            height: 260px;
-        }
-        right: 0;
-        bottom: 0;
-        display: block;
-        z-index: 1;
-    }
-`;
-
 const padding = css`
     padding-left: 0px;
 
@@ -124,40 +87,38 @@ export const ImmersiveHeadline = ({
 }: Props) => {
     return (
         <div className={cx(postionRelative)}>
-            <div className={blackBlock}>
-                <div className={cx(center, padding)}>
-                    <Flex>
-                        <LeftColumn showRightBorder={false}>
-                            <Caption
-                                display={display}
-                                designType={designType}
-                                captionText={captionText}
-                                pillar={pillar}
-                                shouldLimitWidth={true}
-                            />
-                        </LeftColumn>
-                        <PositionHeadline>
-                            <ArticleTitle
-                                display={display}
-                                designType={designType}
-                                tags={tags}
-                                sectionLabel={sectionLabel}
-                                sectionUrl={sectionUrl}
-                                guardianBaseURL={guardianBaseURL}
-                                pillar={pillar}
-                                badge={badge}
-                            />
-                            <ArticleHeadline
-                                display={display}
-                                headlineString={headline}
-                                designType={designType}
-                                pillar={pillar}
-                                tags={tags}
-                                byline={author.byline}
-                            />
-                        </PositionHeadline>
-                    </Flex>
-                </div>
+            <div className={cx(center, padding)}>
+                <Flex>
+                    <LeftColumn showRightBorder={false}>
+                        <Caption
+                            display={display}
+                            designType={designType}
+                            captionText={captionText}
+                            pillar={pillar}
+                            shouldLimitWidth={true}
+                        />
+                    </LeftColumn>
+                    <PositionHeadline>
+                        <ArticleTitle
+                            display={display}
+                            designType={designType}
+                            tags={tags}
+                            sectionLabel={sectionLabel}
+                            sectionUrl={sectionUrl}
+                            guardianBaseURL={guardianBaseURL}
+                            pillar={pillar}
+                            badge={badge}
+                        />
+                        <ArticleHeadline
+                            display={display}
+                            headlineString={headline}
+                            designType={designType}
+                            pillar={pillar}
+                            tags={tags}
+                            byline={author.byline}
+                        />
+                    </PositionHeadline>
+                </Flex>
             </div>
         </div>
     );


### PR DESCRIPTION
#  What does this change?
Uses the headline to determine the width rather than block

## Why?
Instead of guessing the width and the height of the end block element to match the headline, we should use the headline to cover the entire width