### PR TITLE
Amp a9 bidding

### DIFF
--- a/src/amp/components/Ad.test.tsx
+++ b/src/amp/components/Ad.test.tsx
@@ -9,6 +9,7 @@ describe('AdComponent', () => {
     const commercialConfig = {
         usePrebid: true,
         usePermutive: true,
+        useAps: true,
     };
     const commercialProperties = {
         UK: { adTargeting: [] },

--- a/src/amp/components/Ad.tsx
+++ b/src/amp/components/Ad.tsx
@@ -133,7 +133,7 @@ const realTimeConfig = (
 
     // Amazon Publisher Services
     const aps: Aps = {
-        PUB_ID: 'xxxx',
+        PUB_ID: '59666047',
         PARAMS: {
             amp: '1',
         },

--- a/src/amp/components/Ad.tsx
+++ b/src/amp/components/Ad.tsx
@@ -70,6 +70,18 @@ const adRegionClasses = {
 
 type AdRegion = 'US' | 'AU' | 'ROW';
 
+interface Aps {
+    PUB_ID: string;
+    PARAMS: {
+        amp: string;
+        us_privacy?: string;
+    };
+}
+
+interface Vendors {
+    aps?: Aps;
+}
+
 const dfpAdUnitRoot = 'theguardian.com';
 
 const ampData = (section: string, contentType: string): string => {
@@ -97,6 +109,7 @@ const realTimeConfig = (
     adRegion: AdRegion,
     usePrebid: boolean,
     usePermutive: boolean,
+    useAps: boolean,
 ): any => {
     const placementID = getPlacementId(adRegion);
     const preBidServerPrefix = 'https://prebid.adnxs.com/pbs/v1/openrtb2/amp';
@@ -118,11 +131,26 @@ const realTimeConfig = (
         'purl=HREF',
     ].join('&');
 
+    // Amazon Publisher Services
+    const aps: Aps = {
+        PUB_ID: 'xxxx',
+        PARAMS: {
+            amp: '1',
+        },
+    };
+    if (adRegion === 'US') aps.PARAMS.us_privacy = '1---';
+
+    const vendors: Vendors = {};
+    if (useAps) vendors.aps = aps;
+
     const data = {
         urls: [
             usePrebid ? prebidURL : '',
             usePermutive ? permutiveURL : '',
         ].filter((url) => url),
+        vendors: {
+            aps: useAps ? aps : '',
+        },
     };
 
     return JSON.stringify(data);
@@ -131,6 +159,7 @@ const realTimeConfig = (
 interface CommercialConfig {
     usePrebid: boolean;
     usePermutive: boolean;
+    useAps: boolean;
 }
 
 const ampAdElem = (
@@ -157,6 +186,7 @@ const ampAdElem = (
                 adRegion,
                 config.usePrebid,
                 config.usePermutive,
+                config.useAps,
             )}
         />
     );

--- a/src/amp/components/WithAds.tsx
+++ b/src/amp/components/WithAds.tsx
@@ -26,6 +26,7 @@ export const WithAds: React.SFC<{
     const commercialConfig = {
         usePrebid: adInfo.switches.ampPrebid,
         usePermutive: adInfo.switches.permutive,
+        useAps: true, // TODO: add switch
     };
 
     const ad = (id: string): JSX.Element => (


### PR DESCRIPTION
<!-- YOU SHOULD KNOW: dotcom is running an experiment called PR Deployments. -->
<!-- As soon as you open this PR, a github action called PR Deployment will run your code in an isolated environment and make it accessible in a public URL that you can use for testing etc -->
<!-- Every time you push to this branch, you will get an annoying email alert from github telling you that the previous PR deployment has been canceled. -->
<!-- You do not need to wait for the PR deployment action to go green before you can merge -->


## What does this change?

Adds A9 bidding to AMP, with compliance to GDPR & CCPA frameworks.

## Comparison

| Before     | After     |
|------------|-----------|
| No A9      | A9 is being called: |
| N/A        | ![after]  |


[after]: https://user-images.githubusercontent.com/76776/95842616-a7d7c000-0d3e-11eb-8727-bc6d22b74af9.png


## Why?

There is a revenue uplift when adding A9 & Amazon publisher services bidding.
