### PR TITLE
Identity / Add AB test SignInGatePersonalisedAdCopy

### DIFF
--- a/cypress/integration/e2e/sign-in-gate.spec.js
+++ b/cypress/integration/e2e/sign-in-gate.spec.js
@@ -257,4 +257,38 @@ describe('Sign In Gate Tests', function () {
             cy.get('[data-cy=sign-in-gate-main]').should('not.be.visible');
         });
     });
+
+    describe('SignInGatePersonalisedAdCopy', function () {
+        beforeEach(function () {
+            // sign in gate patientia runs from 999901-1000000 MVT IDs, so 999901 forces user into test variant
+            setMvtCookie('700001');
+
+            // set article count to be min number to view gate
+            setArticleCount(3);
+        });
+
+        it('should load the sign in gate', function () {
+            visitArticleAndScrollToGateForLazyLoad();
+
+            cy.get(
+                '[data-cy=sign-in-gate-personalised-ad-copy-variant-2]',
+            ).should('be.visible');
+        });
+
+        it('should remove gate when the dismiss button is clicked', function () {
+            visitArticleAndScrollToGateForLazyLoad();
+
+            cy.get(
+                '[data-cy=sign-in-gate-personalised-ad-copy-variant-2]',
+            ).should('be.visible');
+
+            cy.get(
+                '[data-cy=sign-in-gate-personalised-ad-copy-variant-2_dismiss]',
+            ).click();
+
+            cy.get(
+                '[data-cy=sign-in-gate-personalised-ad-copy-variant-2]',
+            ).should('not.be.visible');
+        });
+    });
 });

--- a/src/web/components/SignInGate/SignInGate.stories.tsx
+++ b/src/web/components/SignInGate/SignInGate.stories.tsx
@@ -3,6 +3,7 @@ import { Section } from '@frontend/web/components/Section';
 import { SignInGateSelector } from './SignInGateSelector';
 import { SignInGateMain } from './gateDesigns/SignInGateMain';
 import { SignInGatePatientia } from './gateDesigns/SignInGatePatientia';
+import { SignInGatePersonalisedAdCopyVariant2 } from './gateDesigns/SignInGatePersonalisedAdCopyVariant2';
 
 export default {
     component: SignInGateSelector,
@@ -39,3 +40,17 @@ export const mainPatientia = () => {
     );
 };
 mainPatientia.story = { name: 'patientia_standalone' };
+
+export const mainPersonalisedAdCopy = () => {
+    return (
+        <Section>
+            <SignInGatePersonalisedAdCopyVariant2
+                guUrl="https://theguardian.com"
+                signInUrl="https://profile.theguardian.com/"
+                dismissGate={() => {}}
+                ophanComponentId="test"
+            />
+        </Section>
+    );
+};
+mainPersonalisedAdCopy.story = { name: 'personalised_ad_copy_standalone' };

--- a/src/web/components/SignInGate/SignInGateSelector.tsx
+++ b/src/web/components/SignInGate/SignInGateSelector.tsx
@@ -18,6 +18,7 @@ import { signInGatePatientia } from '@frontend/web/experiments/tests/sign-in-gat
 import { signInGateMainVariant } from '@root/src/web/experiments/tests/sign-in-gate-main-variant';
 import { signInGateMainControl } from '@root/src/web/experiments/tests/sign-in-gate-main-control';
 import { signInGatePageview } from '@root/src/web/experiments/tests/sign-in-gate-pageview';
+import { signInGatePersonalisedAdCopy } from '@root/src/web/experiments/tests/sign-in-gate-personalised-ad-copy';
 
 // Sign in Gate Types
 import { signInGateComponent as gateMainVariant } from '@root/src/web/components/SignInGate/gates/main-variant';
@@ -28,6 +29,8 @@ import { signInGateComponent as gatePageviewVariant1 } from '@root/src/web/compo
 import { signInGateComponent as gatePageviewVariant2 } from '@root/src/web/components/SignInGate/gates/pageview-variant-2';
 import { signInGateComponent as gatePageviewVariant3 } from '@root/src/web/components/SignInGate/gates/pageview-variant-3';
 import { signInGateComponent as gatePageviewVariant4 } from '@root/src/web/components/SignInGate/gates/pageview-variant-4';
+import { signInGateComponent as gatePersonalisedAdCopyVariant1 } from '@root/src/web/components/SignInGate/gates/personalised-ad-copy-variant-1';
+import { signInGateComponent as gatePersonalisedAdCopyVariant2 } from '@root/src/web/components/SignInGate/gates/personalised-ad-copy-variant-2';
 
 import {
     ComponentEventParams,
@@ -82,6 +85,7 @@ const tests: ReadonlyArray<ABTest> = [
     signInGateMainVariant,
     signInGateMainControl,
     signInGatePageview,
+    signInGatePersonalisedAdCopy,
 ];
 
 const testVariantToGateMapping: GateTestMap = {
@@ -93,6 +97,8 @@ const testVariantToGateMapping: GateTestMap = {
     'pageview-variant-2': gatePageviewVariant2,
     'pageview-variant-3': gatePageviewVariant3,
     'pageview-variant-4': gatePageviewVariant4,
+    'personalised-ad-copy-variant-1': gatePersonalisedAdCopyVariant1,
+    'personalised-ad-copy-variant-2': gatePersonalisedAdCopyVariant2,
 };
 
 const testIdToComponentId: { [key: string]: string } = {
@@ -100,6 +106,7 @@ const testIdToComponentId: { [key: string]: string } = {
     SignInGateMainControl: 'main_control_2',
     SignInGatePatientia: 'patientia_test',
     SignInGatePageview: 'pageview_test',
+    SignInGatePersonlisedAdCopy: 'personlised_ad_copy_test',
 };
 
 // function to generate the profile.theguardian.com url with tracking params

--- a/src/web/components/SignInGate/gateDesigns/SignInGatePersonalisedAdCopyVariant2.tsx
+++ b/src/web/components/SignInGate/gateDesigns/SignInGatePersonalisedAdCopyVariant2.tsx
@@ -1,0 +1,251 @@
+import React from 'react';
+import { css, cx } from 'emotion';
+
+import { headline, textSans } from '@guardian/src-foundations/typography';
+import { from } from '@guardian/src-foundations/mq';
+import { space, palette, opinion } from '@guardian/src-foundations';
+import { LinkButton } from '@guardian/src-button';
+import { Link } from '@guardian/src-link';
+import { cmp } from '@guardian/consent-management-platform';
+import { trackLink } from '@frontend/web/components/SignInGate/componentEventTracking';
+import { SignInGateProps } from './types';
+
+const signinGate = css`
+    max-width: 617px;
+
+    ${from.desktop} {
+        min-height: 600px;
+    }
+
+    /* This needs to be here because link styles are applied globally to the article body :/ */
+    a {
+        text-decoration: underline;
+        border-bottom: none;
+        color: ${palette.text.primary};
+
+        :hover {
+            border-bottom: none;
+        }
+    }
+`;
+
+const headingStyles = css`
+    ${headline.small({ fontWeight: 'bold' })};
+    border-top: 2px black solid;
+    padding-bottom: 42px;
+
+    ${from.phablet} {
+        padding-right: 160px;
+        ${headline.medium({ fontWeight: 'bold' })};
+    }
+`;
+
+const bodyBold = css`
+    ${textSans.medium({ fontWeight: 'bold' })}
+    border-top: 1px ${palette.line.primary} solid;
+    padding-bottom: 20px;
+    ${from.phablet} {
+        padding-right: 130px;
+    }
+`;
+
+const bodyText = css`
+    ${textSans.medium({ lineHeight: 'regular' })}
+    padding-bottom: ${space[6]}px;
+
+    ${from.phablet} {
+        padding-right: 160px;
+    }
+`;
+
+const signInHeader = css`
+    padding-bottom: 0;
+`;
+
+const actionButtons = css`
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    margin-bottom: 42px;
+
+    > a {
+        margin-right: ${space[9]}px !important;
+        text-decoration: none !important;
+    }
+`;
+
+const registerButton = css`
+    color: ${palette.text.ctaPrimary} !important;
+`;
+
+const laterButton = css`
+    color: ${palette.brand[400]} !important;
+`;
+
+const signInLink = css`
+    color: ${palette.text.anchorPrimary} !important;
+`;
+
+const faq = css`
+    padding-top: ${space[3]}px;
+    padding-bottom: 18px;
+    margin-top: ${space[5]}px;
+
+    & a {
+        color: ${palette.text.primary};
+        display: block;
+        margin-bottom: ${space[4]}px;
+    }
+
+    & a:hover {
+        color: ${palette.text.primary};
+    }
+`;
+
+const privacyLink = css`
+    text-decoration: underline;
+    border: 0;
+    background: transparent;
+    font-size: inherit;
+    padding: 0;
+    cursor: pointer;
+`;
+
+const firstParagraphOverlay = (isComment: boolean) => css`
+    margin-top: -250px;
+    width: 100%;
+    height: 250px;
+    position: absolute;
+
+    /* "transparent" only works here because == rgba(0,0,0,0) */
+    background-image: linear-gradient(
+        0deg,
+        ${isComment ? opinion[800] : palette.background.primary},
+        70%,
+        rgba(255, 255, 255, 0)
+    );
+`;
+
+// This css hides all the elements in the article after the #sign-in-gate
+// using the General sibling combinator https://developer.mozilla.org/en-US/docs/Web/CSS/General_sibling_combinator
+const hideElementsCss = `
+    #sign-in-gate ~ * {
+        display: none;
+    }
+    `;
+
+export const SignInGatePersonalisedAdCopyVariant2 = ({
+    signInUrl,
+    guUrl,
+    dismissGate,
+    abTest,
+    ophanComponentId,
+    isComment,
+}: SignInGateProps) => {
+    return (
+        <div
+            className={signinGate}
+            data-cy="sign-in-gate-personalised-ad-copy-variant-2"
+        >
+            <style>{hideElementsCss}</style>
+            <div className={firstParagraphOverlay(!!isComment)} />
+            <h1 className={headingStyles}>
+                Register for free and continue reading
+            </h1>
+            <p className={bodyBold}>
+                It’s important to say this is not a step towards a paywall
+            </p>
+            <p className={bodyText}>
+                Registering is a free and simple way to help us sustain our
+                independent Guardian journalism.
+            </p>
+            <p className={bodyText}>
+                When you register with us we are able to improve our news
+                experience for you and for others. You will always be able to
+                control your own&nbsp;
+                <button
+                    data-cy="sign-in-gate-personalised-ad-copy-variant-2_privacy"
+                    className={privacyLink}
+                    onClick={() => {
+                        cmp.showPrivacyManager();
+                        trackLink(ophanComponentId, 'privacy', abTest);
+                    }}
+                >
+                    privacy settings
+                </button>
+                . Thank you
+            </p>
+            <div className={actionButtons}>
+                <LinkButton
+                    data-cy="sign-in-gate-personalised-ad-copy-variant-2_register"
+                    className={registerButton}
+                    priority="primary"
+                    size="small"
+                    href={signInUrl}
+                    onClick={() => {
+                        trackLink(ophanComponentId, 'register-link', abTest);
+                    }}
+                >
+                    Register for free
+                </LinkButton>
+
+                <LinkButton
+                    data-cy="sign-in-gate-personalised-ad-copy-variant-2_dismiss"
+                    className={laterButton}
+                    priority="subdued"
+                    size="small"
+                    onClick={() => {
+                        dismissGate();
+                        trackLink(ophanComponentId, 'not-now', abTest);
+                    }}
+                >
+                    I’ll do it later
+                </LinkButton>
+            </div>
+
+            <p className={cx([bodyBold, signInHeader])}>
+                Have a subscription? Made a contribution? Already registered?
+            </p>
+
+            <Link
+                data-cy="sign-in-gate-personalised-ad-copy-variant-2_signin"
+                className={signInLink}
+                href={signInUrl}
+                onClick={() => {
+                    trackLink(ophanComponentId, 'sign-in-link', abTest);
+                }}
+            >
+                Sign In
+            </Link>
+
+            <div className={faq}>
+                <Link
+                    href={`${guUrl}/membership/2019/dec/20/signing-in-to-the-guardian`}
+                    onClick={() => {
+                        trackLink(ophanComponentId, 'how-link', abTest);
+                    }}
+                >
+                    Why register & how does it help?
+                </Link>
+
+                <Link
+                    href={`${guUrl}/info/2014/nov/03/why-your-data-matters-to-us-full-text`}
+                    onClick={() => {
+                        trackLink(ophanComponentId, 'why-link', abTest);
+                    }}
+                >
+                    How will my information & data be used?
+                </Link>
+
+                <Link
+                    href={`${guUrl}/help/identity-faq`}
+                    onClick={() => {
+                        trackLink(ophanComponentId, 'help-link', abTest);
+                    }}
+                >
+                    Get help with registering or signing in
+                </Link>
+            </div>
+        </div>
+    );
+};

--- a/src/web/components/SignInGate/gates/personalised-ad-copy-variant-1.tsx
+++ b/src/web/components/SignInGate/gates/personalised-ad-copy-variant-1.tsx
@@ -1,0 +1,63 @@
+import React, { Suspense } from 'react';
+import { Lazy } from '@root/src/web/components/Lazy';
+
+import {
+    SignInGateComponent,
+    CurrentABTest,
+} from '@frontend/web/components/SignInGate/gateDesigns/types';
+import {
+    isNPageOrHigherPageView,
+    isValidContentType,
+    isValidSection,
+    isIOS9,
+} from '@frontend/web/components/SignInGate/displayRule';
+import { initPerf } from '@root/src/web/browser/initPerf';
+import { hasUserDismissedGateMoreThanCount } from '../dismissGate';
+
+const SignInGateMain = React.lazy(() => {
+    const { start, end } = initPerf('SignInGateMain');
+    start();
+    return import(
+        /* webpackChunkName: "SignInGateMain" */ '../gateDesigns/SignInGateMain'
+    ).then((module) => {
+        end();
+        return { default: module.SignInGateMain };
+    });
+});
+
+const canShow = (
+    CAPI: CAPIBrowserType,
+    isSignedIn: boolean,
+    currentTest: CurrentABTest,
+): boolean =>
+    !isSignedIn &&
+    !hasUserDismissedGateMoreThanCount(currentTest.variant, currentTest.name, 5) &&
+    isNPageOrHigherPageView(3) &&
+    isValidContentType(CAPI) &&
+    isValidSection(CAPI) &&
+    !isIOS9();
+
+export const signInGateComponent: SignInGateComponent = {
+    gate: ({
+        ophanComponentId,
+        dismissGate,
+        guUrl,
+        signInUrl,
+        abTest,
+        isComment,
+    }) => (
+        <Lazy margin={300}>
+            <Suspense fallback={<></>}>
+                <SignInGateMain
+                    ophanComponentId={ophanComponentId}
+                    dismissGate={dismissGate}
+                    guUrl={guUrl}
+                    signInUrl={signInUrl}
+                    abTest={abTest}
+                    isComment={isComment}
+                />
+            </Suspense>
+        </Lazy>
+    ),
+    canShow,
+};

--- a/src/web/components/SignInGate/gates/personalised-ad-copy-variant-2.tsx
+++ b/src/web/components/SignInGate/gates/personalised-ad-copy-variant-2.tsx
@@ -1,0 +1,67 @@
+import React, { Suspense } from 'react';
+import { Lazy } from '@root/src/web/components/Lazy';
+
+import {
+    SignInGateComponent,
+    CurrentABTest,
+} from '@frontend/web/components/SignInGate/gateDesigns/types';
+import {
+    isNPageOrHigherPageView,
+    isValidContentType,
+    isValidSection,
+    isIOS9,
+} from '@frontend/web/components/SignInGate/displayRule';
+import { initPerf } from '@root/src/web/browser/initPerf';
+import { hasUserDismissedGateMoreThanCount } from '../dismissGate';
+
+const SignInGate = React.lazy(() => {
+    const { start, end } = initPerf('SignInGatePersonalisedAdCopyVariant2');
+    start();
+    return import(
+        /* webpackChunkName: "SignInGatePersonalisedAdCopyVariant2" */ '../gateDesigns/SignInGatePersonalisedAdCopyVariant2'
+    ).then((module) => {
+        end();
+        return { default: module.SignInGatePersonalisedAdCopyVariant2 };
+    });
+});
+
+const canShow = (
+    CAPI: CAPIBrowserType,
+    isSignedIn: boolean,
+    currentTest: CurrentABTest,
+): boolean =>
+    !isSignedIn &&
+    !hasUserDismissedGateMoreThanCount(
+        currentTest.variant,
+        currentTest.name,
+        5,
+    ) &&
+    isNPageOrHigherPageView(3) &&
+    isValidContentType(CAPI) &&
+    isValidSection(CAPI) &&
+    !isIOS9();
+
+export const signInGateComponent: SignInGateComponent = {
+    gate: ({
+        ophanComponentId,
+        dismissGate,
+        guUrl,
+        signInUrl,
+        abTest,
+        isComment,
+    }) => (
+        <Lazy margin={300}>
+            <Suspense fallback={<></>}>
+                <SignInGate
+                    ophanComponentId={ophanComponentId}
+                    dismissGate={dismissGate}
+                    guUrl={guUrl}
+                    signInUrl={signInUrl}
+                    abTest={abTest}
+                    isComment={isComment}
+                />
+            </Suspense>
+        </Lazy>
+    ),
+    canShow,
+};

--- a/src/web/experiments/ab-tests.ts
+++ b/src/web/experiments/ab-tests.ts
@@ -4,6 +4,7 @@ import { signInGateMainVariant } from '@root/src/web/experiments/tests/sign-in-g
 import { signInGateMainControl } from '@root/src/web/experiments/tests/sign-in-gate-main-control';
 import { signInGatePatientia } from '@frontend/web/experiments/tests/sign-in-gate-patientia';
 import { signInGatePageview } from '@frontend/web/experiments/tests/sign-in-gate-pageview';
+import { signInGatePersonalisedAdCopy } from '@frontend/web/experiments/tests/sign-in-gate-personalised-ad-copy'
 import { curatedContainerTest } from '@frontend/web/experiments/tests/curated-container-test';
 
 export const tests: ABTest[] = [
@@ -12,5 +13,6 @@ export const tests: ABTest[] = [
     signInGateMainControl,
     signInGatePatientia,
     signInGatePageview,
+    signInGatePersonalisedAdCopy,
     curatedContainerTest,
 ];

--- a/src/web/experiments/cypress-switches.ts
+++ b/src/web/experiments/cypress-switches.ts
@@ -15,6 +15,7 @@ const cypressSwitches = {
     abSignInGateMainVariant: true,
     abSignInGatePatientia: true,
     abSignInGatePageview: true,
+    abSignInGatePersonalisedAdCopy: true,
 };
 
 // Function to retrieve the switches if running in Cypress

--- a/src/web/experiments/tests/sign-in-gate-personalised-ad-copy.ts
+++ b/src/web/experiments/tests/sign-in-gate-personalised-ad-copy.ts
@@ -1,26 +1,32 @@
+
 import { ABTest } from '@guardian/ab-core';
 
-export const signInGateMainVariant: ABTest = {
-    id: 'SignInGateMainVariant',
-    start: '2020-05-20',
+export const signInGatePersonalisedAdCopy: ABTest = {
+    id: 'SignInGatePersonalisedAdCopy',
+    start: '2020-10-13',
     expiry: '2020-12-01',
-    author: 'Mahesh Makani',
+    author: 'vlbee',
     description:
-        'Show sign in gate to 100% of users on 3rd article view of simple article templates, and show a further 5 times after the first dismissal, with higher priority over banners and epic. Main/Variant Audience.',
-    audience: 0.671,
-    audienceOffset: 0.0,
+        'Show sign in gate with and without personalised adverstising copy to 100% of users on 3rd article view of simple article templates, with higher priority over banners and epic.',
+    audience: 0.1,
+    audienceOffset: 0.671,
     successMeasure: 'Users sign in or create a Guardian account',
     audienceCriteria:
         '3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',
-    dataLinkNames: 'SignInGateMain',
+    dataLinkNames: 'SignInGatePersonalisedAdCopy',
     idealOutcome:
         'Increase the number of users signed in whilst running at a reasonable scale',
     showForSensitive: false,
     canRun: () => true,
     variants: [
         {
-            id: 'main-variant-2',
+            id: 'personalised-ad-copy-variant-1', // with copy (main-variant)
+            test: (): void => { },
+        },
+        {
+            id: 'personalised-ad-copy-variant-2', // without copy
             test: (): void => { },
         },
     ],
 };
+


### PR DESCRIPTION
## What does this change?

Adds an AB test to compare sign in gate copy about 'personalised advertising'

- Frontend version - https://github.com/guardian/frontend/pull/23103


