### PR TITLE
Make banner container position fixed

### DIFF
--- a/src/web/layouts/lib/stickiness.tsx
+++ b/src/web/layouts/lib/stickiness.tsx
@@ -29,7 +29,7 @@ const headerWrapper = css`
 
 // The css overrides here are necessary because ad-takeovers can inject css that breaks the banner
 const bannerWrapper = css`
-    position: sticky !important;
+    position: fixed !important;
     bottom: 0;
     ${getZIndexImportant('banner')}
     


### PR DESCRIPTION
This fixes a bug in firefox on android.
The only disadvantage of using `fixed` over `sticky` is that the banner overlaps the footer at the bottom of the page.

The bug is caused by firefox's (new) search bar at the bottom of the screen. E.g. if I highlight a word (double tap) while the search bar is visible then it works correctly:
![android_1](https://user-images.githubusercontent.com/1513454/95994434-34aa7880-0e28-11eb-8843-366a9c46340c.png)


If I scroll down then firefox hides the search bar. If I try to highlight the same word then firefox selects the wrong part of the screen:
![android_2](https://user-images.githubusercontent.com/1513454/95994445-383dff80-0e28-11eb-84db-2967e86820d4.png)


This is particularly problematic for buttons, because if a user scrolls down a bit then wants to click the close button on the banner then they have to click above the button.