### PR TITLE
Add resize listener for newsletter embeds

### DIFF
--- a/scripts/webpack/browser.js
+++ b/scripts/webpack/browser.js
@@ -47,6 +47,7 @@ module.exports = ({ isLegacyJS }) => ({
         dynamicImport: scriptPath('dynamicImport'),
         atomIframe: scriptPath('atomIframe'),
         embedIframe: scriptPath('embedIframe'),
+        newsletterEmbedIframe: scriptPath('newsletterEmbedIframe'),
     },
     output: {
         filename: generateName(isLegacyJS),

--- a/src/web/browser/newsletterEmbedIframe/init.ts
+++ b/src/web/browser/newsletterEmbedIframe/init.ts
@@ -3,7 +3,7 @@ import { startup } from '@root/src/web/browser/startup';
 
 const init = (): Promise<void> => {
     const allIframes: HTMLIFrameElement[] = [].slice.call(
-        document.querySelectorAll('.element-embed > .email-sub__iframe'),
+        document.querySelectorAll('.email-sub__iframe'),
     );
     type newsletterHeightEvent = { source: { location: { href: string } } };
 

--- a/src/web/browser/newsletterEmbedIframe/init.ts
+++ b/src/web/browser/newsletterEmbedIframe/init.ts
@@ -1,0 +1,40 @@
+import '../webpackPublicPath';
+import { startup } from '@root/src/web/browser/startup';
+
+const init = (): Promise<void> => {
+    const allIframes: HTMLIFrameElement[] = [].slice.call(
+        document.querySelectorAll('.element-embed > .email-sub__iframe'),
+    );
+    type newsletterHeightEvent = { source: { location: { href: string } } };
+
+    window.addEventListener('message', (event) => {
+        const iframes: HTMLIFrameElement[] = allIframes.filter((i) => {
+            try {
+                return (
+                    i.src ===
+                    (event as newsletterHeightEvent).source.location.href
+                );
+            } catch (e) {
+                return false;
+            }
+        });
+        if (iframes.length !== 0) {
+            try {
+                const message = JSON.parse(event.data);
+                switch (message.type) {
+                    case 'set-height':
+                        iframes.forEach((iframe) => {
+                            iframe.height = message.value;
+                        });
+                        break;
+                    default:
+                }
+                // eslint-disable-next-line no-empty
+            } catch (e) {}
+        }
+    });
+
+    return Promise.resolve();
+};
+
+startup('newsletterEmbedIframe', null, init);

--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -109,6 +109,7 @@ export const document = ({ data }: Props) => {
             { src: 'lotame.js', module: true },
             { src: 'atomIframe.js', module: true },
             { src: 'embedIframe.js', module: true },
+            { src: 'newsletterEmbedIframe.js', module: true },
         ],
         'async',
     );


### PR DESCRIPTION
## What does this change?
This uses a similar approach to [`atomIframe/init.ts`](https://github.com/guardian/dotcom-rendering/blob/main/src/web/browser/atomIframe/init.ts), but relies on the iframe `src` instead of the `name`. This is necessary as we have to support legacy iframes that will have been created without a `name` field.

_Note: I haven't managed to get this to work locally as the iframe `src` and the `event.source.location.href` never match up when using the local Dotcom architecture. It might need CODE for testing._

<!-- YOU SHOULD KNOW: dotcom is running an experiment called PR Deployments. -->
<!-- As soon as you open this PR, a github action called PR Deployment will run your code in an isolated environment and make it accessible in a public URL that you can use for testing etc -->
<!-- Every time you push to this branch, you will get an annoying email alert from github telling you that the previous PR deployment has been canceled. -->
<!-- You do not need to wait for the PR deployment action to go green before you can merge -->
### Before
![image](https://user-images.githubusercontent.com/9122944/96018170-d17a0f80-0e42-11eb-96d0-0c407ae0c90a.png)

### After
![image](https://user-images.githubusercontent.com/9122944/96251007-aeb53b80-0fa7-11eb-9e9f-40f97365ef2e.png)

## Why?
The new designs require iframe resizing.