### PR TITLE
Braze banner 'canShow' timeout metrics to Ophan

### DIFF
--- a/src/web/browser/initPerf.ts
+++ b/src/web/browser/initPerf.ts
@@ -9,13 +9,13 @@ export const initPerf = (name: string) => {
         perf.mark(startKey);
     };
 
-    const end = (shouldLog: boolean = true): TimeTakenInMilliseconds => {
+    const end = (): TimeTakenInMilliseconds => {
         perf.mark(endKey);
         perf.measure(name, startKey, endKey);
-        if (shouldLog) {
-            // eslint-disable-next-line no-console
-            console.log(JSON.stringify(perf.getEntriesByName(name)));
-        }
+
+        // eslint-disable-next-line no-console
+        console.log(JSON.stringify(perf.getEntriesByName(name)));
+
         const measureEntries = perf.getEntriesByName(name, "measure");
         const timeTakenFloat = measureEntries[0].duration;
         const timeTakenInt = Math.round(timeTakenFloat);

--- a/src/web/browser/initPerf.ts
+++ b/src/web/browser/initPerf.ts
@@ -1,4 +1,6 @@
 export const initPerf = (name: string) => {
+    type TimeTakenInMilliseconds = number;
+
     const perf = window.performance;
     const startKey = `${name}-start`;
     const endKey = `${name}-end`;
@@ -6,11 +8,20 @@ export const initPerf = (name: string) => {
     const start = () => {
         perf.mark(startKey);
     };
-    const end = () => {
+
+    const end = (dontLog: boolean = false): TimeTakenInMilliseconds => {
         perf.mark(endKey);
         perf.measure(name, startKey, endKey);
-        // eslint-disable-next-line no-console
-        console.log(JSON.stringify(perf.getEntriesByName(name)));
+
+        if (!dontLog) {
+            // eslint-disable-next-line no-console
+            console.log(JSON.stringify(perf.getEntriesByName(name)));
+        }
+        const measureEntries = perf.getEntriesByName(name, "measure");
+        const timeTakenFloat = measureEntries[0].duration;
+        const timeTakenInt = Math.round(timeTakenFloat);
+
+        return timeTakenInt;
     };
 
     return {

--- a/src/web/browser/initPerf.ts
+++ b/src/web/browser/initPerf.ts
@@ -9,11 +9,10 @@ export const initPerf = (name: string) => {
         perf.mark(startKey);
     };
 
-    const end = (dontLog: boolean = false): TimeTakenInMilliseconds => {
+    const end = (shouldLog: boolean = true): TimeTakenInMilliseconds => {
         perf.mark(endKey);
         perf.measure(name, startKey, endKey);
-
-        if (!dontLog) {
+        if (shouldLog) {
             // eslint-disable-next-line no-console
             console.log(JSON.stringify(perf.getEntriesByName(name)));
         }

--- a/src/web/browser/startup.ts
+++ b/src/web/browser/startup.ts
@@ -4,7 +4,7 @@ export interface Reporter {
     report: (err: Error, tags: { [key: string]: string }) => void;
 }
 
-const measure = (name: string, task: () => Promise<any>): void => {
+const measure = (name: string, task: () => Promise<void>): void => {
     const { start, end } = initPerf(name);
 
     start();

--- a/src/web/browser/startup.ts
+++ b/src/web/browser/startup.ts
@@ -14,8 +14,12 @@ const measure = (name: string, task: () => Promise<any>): void => {
         // in Chrome 59 which is used by Cypress in headless mode so if you do it will
         // break the Cypress tests on CI
         // See: https://github.com/cypress-io/cypress/issues/2651#issuecomment-432698837
-        .then(end)
-        .catch(end);
+        .then(() => {
+            end()
+        })
+        .catch(()=> {
+            end()
+        });
 };
 
 export const startup = <A>(

--- a/src/web/browser/startup.ts
+++ b/src/web/browser/startup.ts
@@ -4,7 +4,7 @@ export interface Reporter {
     report: (err: Error, tags: { [key: string]: string }) => void;
 }
 
-const measure = (name: string, task: () => Promise<void>): void => {
+const measure = (name: string, task: () => Promise<any>): void => {
     const { start, end } = initPerf(name);
 
     start();

--- a/src/web/components/StickyBottomBanner/BrazeBanner.tsx
+++ b/src/web/components/StickyBottomBanner/BrazeBanner.tsx
@@ -155,8 +155,8 @@ export const canShow = async (
     asyncBrazeUuid: Promise<null | string>,
     isDigitalSubscriber: undefined | boolean,
 ): Promise<CanShowResult> => {
-    const canShowTiming = initPerf('braze-banner');
-    canShowTiming.start();
+    const timing = initPerf('braze-banner');
+    timing.start();
 
     const forcedBrazeMeta = getBrazeMetaFromQueryString();
     if (forcedBrazeMeta) {
@@ -192,7 +192,7 @@ export const canShow = async (
     try {
         const result = await getMessageFromBraze(apiKey as string, brazeUuid)
 
-        const timeTaken = canShowTiming.end(true);
+        const timeTaken = timing.end();
         record({
             component: 'braze-banner-timing',
             value: timeTaken,

--- a/src/web/components/StickyBottomBanner/BrazeBanner.tsx
+++ b/src/web/components/StickyBottomBanner/BrazeBanner.tsx
@@ -6,7 +6,9 @@ import { onConsentChange } from '@guardian/consent-management-platform';
 import { getZIndex } from '@root/src/web/lib/getZIndex';
 import { Props as BrazeBannerProps } from '@guardian/braze-components';
 import { submitComponentEvent } from '@root/src/web/browser/ophan/ophan';
+import { initPerf } from '@root/src/web/browser/initPerf';
 import { CanShowResult } from './bannerPicker';
+
 
 export const brazeVendorId = '5ed8c49c4b8ce4571c7ad801';
 
@@ -154,6 +156,9 @@ export const canShow = async (
     asyncBrazeUuid: Promise<null | string>,
     isDigitalSubscriber: undefined | boolean,
 ): Promise<CanShowResult> => {
+    const performanceLogging = initPerf('braze-banner');
+    performanceLogging.start();
+
     const forcedBrazeMeta = getBrazeMetaFromQueryString();
     if (forcedBrazeMeta) {
         return {
@@ -186,7 +191,10 @@ export const canShow = async (
     }
 
     try {
-        return getMessageFromBraze(apiKey as string, brazeUuid);
+        return getMessageFromBraze(apiKey as string, brazeUuid).then(result => {
+            performanceLogging.end();
+            return result;
+        });
     } catch (e) {
         return { result: false };
     }


### PR DESCRIPTION
<!-- YOU SHOULD KNOW: dotcom is running an experiment called PR Deployments. -->
<!-- As soon as you open this PR, a github action called PR Deployment will run your code in an isolated environment and make it accessible in a public URL that you can use for testing etc -->
<!-- Every time you push to this branch, you will get an annoying email alert from github telling you that the previous PR deployment has been canceled. -->
<!-- You do not need to wait for the PR deployment action to go green before you can merge -->


## What does this change?
Measures the time taken for the braze-banner eligibility logic to take place, and sends that data to Ophan, so that we can measure how long it tends to take, and crucially how often it exceeds the 2 second limit specified for this logic to take place.

The equivalent Frontend PR can be found [here](https://github.com/guardian/frontend/pull/23127).
