### PR TITLE
Identity | Fix article count issue

### DIFF
--- a/src/web/components/SignInGate/displayRule.ts
+++ b/src/web/components/SignInGate/displayRule.ts
@@ -1,11 +1,14 @@
 // use the dailyArticleCount from the local storage to see how many articles the user has viewed in a day
-import { getDailyArticleCount } from '@frontend/web/lib/dailyArticleCount';
+import {
+    DailyArticle,
+    getDailyArticleCount,
+} from '@frontend/web/lib/dailyArticleCount';
 import { getCountryCodeFromLocalStorage } from '@frontend/web/lib/getCountryCode';
 
 // in our case if this is the n-numbered article or higher the user has viewed then set the gate
 export const isNPageOrHigherPageView = (n: number = 2): boolean => {
     // get daily read article count array from local storage
-    const [dailyCount] = getDailyArticleCount();
+    const [dailyCount = {} as DailyArticle] = getDailyArticleCount();
 
     const { count = 0 } = dailyCount;
 
@@ -15,9 +18,9 @@ export const isNPageOrHigherPageView = (n: number = 2): boolean => {
 // use gu.location to determine is the browser is in the specified country
 // Note, use country codes specified in guardian/frontend/static/src/javascripts/lib/geolocation.js
 export const isCountry = (countryCode: string): boolean => {
-    const countryCodeFromStorage = getCountryCodeFromLocalStorage()
-    return countryCodeFromStorage === countryCode
-}
+    const countryCodeFromStorage = getCountryCodeFromLocalStorage();
+    return countryCodeFromStorage === countryCode;
+};
 
 // determine if the useragent is running iOS 9 (known to be buggy for sign in flow)
 export const isIOS9 = (): boolean => {

--- a/src/web/lib/dailyArticleCount.ts
+++ b/src/web/lib/dailyArticleCount.ts
@@ -1,4 +1,4 @@
-interface DailyArticle {
+export interface DailyArticle {
     day: number;
     count: number;
 }


### PR DESCRIPTION
## What does this change?
Fix issue where if a user hadn't consented to an article count then we'd get an unhandled error exception.
We add a defensive clause to the `DailyArticle` if it doesn't exist.