### PR TITLE
Add es2019 to polyfill.io

### DIFF
--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -74,7 +74,7 @@ export const document = ({ data }: Props) => {
     ];
 
     const polyfillIO =
-        'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,es2018,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,fetch,NodeList.prototype.forEach&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1';
+        'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,es2018,es2019,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,fetch,NodeList.prototype.forEach&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1';
 
     /**
      * The highest priority scripts.


### PR DESCRIPTION
# What does this change?

Missing 'flat' from our polyfill so error in IE11 for the Carousel which uses it.

Array.prototype.flat is a part of es2019

![image](https://user-images.githubusercontent.com/638051/96246711-f1bfe080-0fa0-11eb-9721-89decd6cad0f.png)
