### PR TITLE
Fix "unexpected console.log" warning from eslint

### DIFF
--- a/src/web/components/StickyBottomBanner/BrazeBanner.tsx
+++ b/src/web/components/StickyBottomBanner/BrazeBanner.tsx
@@ -131,7 +131,7 @@ const getBrazeMetaFromQueryString = (): Meta | null => {
                 };
             } catch (e) {
                 // Parsing failed. Log a message and fall through.
-                // eslint-disable-line no-console
+                // eslint-disable-next-line no-console
                 console.log(`There was an error with ${qsArg}: `, e.message);
             }
         }


### PR DESCRIPTION
##  What does this change?

Uses the magic comment to disable eslint warning on the next line instead of the current line.