### PR TITLE
Limit banner height and allow scroll

### DIFF
--- a/src/web/layouts/lib/stickiness.tsx
+++ b/src/web/layouts/lib/stickiness.tsx
@@ -32,6 +32,8 @@ const bannerWrapper = css`
     position: fixed !important;
     bottom: 0;
     ${getZIndexImportant('banner')}
+    max-height: 80vh;
+    overflow: auto;
     
     width: 100% !important;
     background: none !important;


### PR DESCRIPTION
We have had reports of the close button being out of view on our banners if the user has set a very high font size in their browser.
This is because the banner container is `position: fixed`.

We can ensure the button is not too high with `80vh`.
This doesn't work for the width, which still overflows on mobile if the font is too large. So we allow scrolling in this case.

Now scrollable and with a limited height:
<img width="1642" alt="Screen Shot 2020-10-20 at 08 05 42" src="https://user-images.githubusercontent.com/1513454/96552597-de1bbf00-12ab-11eb-8a92-857a168b1f0a.png">
<img width="386" alt="Screen Shot 2020-10-20 at 08 06 42" src="https://user-images.githubusercontent.com/1513454/96552611-e1af4600-12ab-11eb-9a47-1d4a322d9cf3.png">
