### PR TITLE
Fix signin gate component typo

### DIFF
--- a/src/web/components/SignInGate/SignInGateSelector.tsx
+++ b/src/web/components/SignInGate/SignInGateSelector.tsx
@@ -113,7 +113,7 @@ const testIdToComponentId: { [key: string]: string } = {
     SignInGatePatientia: 'patientia_test',
     SignInGatePageview: 'pageview_test',
     SignInGatePageviewUs: 'pageview_us_test',
-    SignInGatePersonlisedAdCopy: 'personlised_ad_copy_test',
+    SignInGatePersonalisedAdCopy: 'personalised_ad_copy_test',
 };
 
 // function to generate the profile.theguardian.com url with tracking params


### PR DESCRIPTION


<!-- YOU SHOULD KNOW: dotcom is running an experiment called PR Deployments. -->
<!-- As soon as you open this PR, a github action called PR Deployment will run your code in an isolated environment and make it accessible in a public URL that you can use for testing etc -->
<!-- Every time you push to this branch, you will get an annoying email alert from github telling you that the previous PR deployment has been canceled. -->
<!-- You do not need to wait for the PR deployment action to go green before you can merge -->


## What does this change?

Fix typo that will prevent component events being sent for the personalised ad copy signin gate experiment.

### Before

### After

## Why?

We want to track these component events to test how the gate performs.