### PR TITLE
Do not show epic and sign-in gate

### DIFF
--- a/src/web/components/SignInGate/gateDesigns/SignInGateMain.tsx
+++ b/src/web/components/SignInGate/gateDesigns/SignInGateMain.tsx
@@ -143,6 +143,10 @@ const hideElementsCss = `
     #sign-in-gate ~ * {
         display: none;
     }
+    
+    #slot-body-end {
+        display: none;
+    }
 `;
 
 export const SignInGateMain = ({

--- a/src/web/components/SignInGate/gateDesigns/SignInGatePatientia.tsx
+++ b/src/web/components/SignInGate/gateDesigns/SignInGatePatientia.tsx
@@ -127,6 +127,10 @@ const hideElementsCss = `
     #sign-in-gate ~ * {
         display: none;
     }
+    
+    #slot-body-end {
+        display: none;
+    }
 `;
 
 export const SignInGatePatientia = ({

--- a/src/web/components/SignInGate/gateDesigns/SignInGatePersonalisedAdCopyVariant2.tsx
+++ b/src/web/components/SignInGate/gateDesigns/SignInGatePersonalisedAdCopyVariant2.tsx
@@ -143,6 +143,10 @@ const hideElementsCss = `
     #sign-in-gate ~ * {
         display: none;
     }
+    
+    #slot-body-end {
+        display: none;
+    }
 `;
 
 export const SignInGatePersonalisedAdCopyVariant2 = ({


### PR DESCRIPTION
Currently the epic displays below the sign-in gate, even though the rest of the article is hidden:
![Screen Shot 2020-10-20 at 09 28 04](https://user-images.githubusercontent.com/1513454/96560751-99e1ec00-12b6-11eb-9ecf-3d2bd0cec09d.png)

With this change, we hide the epic as well:
![Screen Shot 2020-10-20 at 09 24 35](https://user-images.githubusercontent.com/1513454/96560776-a23a2700-12b6-11eb-96a5-7f3a8a2b07bc.png)
