### PR TITLE
Add story for Braze banner

### DIFF
--- a/src/web/components/StickyBottomBanner/BrazeBanner.stories.tsx
+++ b/src/web/components/StickyBottomBanner/BrazeBanner.stories.tsx
@@ -1,0 +1,68 @@
+import React, { ReactElement, useState, useEffect } from 'react';
+import * as emotion from 'emotion';
+import * as emotionCore from '@emotion/core';
+import * as emotionTheming from 'emotion-theming';
+
+import { Props as BrazeBannerProps } from '@guardian/braze-components';
+
+export default {
+    component: 'BrazeBanner',
+    title: 'Components/StickyBottomBanner/BrazeBanner',
+};
+
+export const DefaultStory = (): ReactElement => {
+    const [BrazeMessage, setBrazeMessage] = useState<
+        React.FC<BrazeBannerProps>
+    >();
+
+    useEffect(() => {
+        window.guardian = window.guardian || {};
+        window.guardian.automat = {
+            react: React,
+            preact: React,
+            emotionCore,
+            emotionTheming,
+            emotion,
+        };
+
+        import(
+            /* webpackChunkName: "guardian-braze-components" */ '@guardian/braze-components'
+        ).then((module) => {
+            setBrazeMessage(() => module.BrazeMessage);
+        });
+    }, []);
+
+    if (BrazeMessage) {
+        const header = 'A note to our digital subscribers';
+        const body =
+            'Hi John, did you know that as a Guardian digital subscriber you can enjoy an enhanced experience of our quality, independent journalism on all your devices, including The Guardian Live app.';
+        const componentName = 'DigitalSubscriberAppBanner';
+
+        return (
+            <BrazeMessage
+                componentName={componentName}
+                logButtonClickWithBraze={(internalButtonId) => {
+                    // eslint-disable-next-line no-console
+                    console.log(
+                        `Button with internal ID ${internalButtonId} clicked`,
+                    );
+                }}
+                submitComponentEvent={(componentEvent) => {
+                    // eslint-disable-next-line no-console
+                    console.log(
+                        'submitComponentEvent called with: ',
+                        componentEvent,
+                    );
+                }}
+                brazeMessageProps={{
+                    header,
+                    body,
+                }}
+            />
+        );
+    }
+
+    return <div>Loading...</div>;
+};
+
+DefaultStory.story = { name: 'Braze Banner' };


### PR DESCRIPTION
## What does this change?

@liywjl and I encountered a scenario where a visual change only cropped up when rendering the banner in the context of the DCR project (it was related to peer dependencies). We manually spotted the issue but we'd like to pick up visual regressions like that in a more automated way in future, so add a basic story here.

We have to lazily load @guardian/braze-components in the same way we do in prod because we have to configure the shared deps (via the window) _before_ the component is loaded.