### PR TITLE
Match ad slots breakpoint label values with frontend

### DIFF
--- a/src/model/advertisement.ts
+++ b/src/model/advertisement.ts
@@ -106,7 +106,7 @@ export const namedAdSlotParameters = (name: AdSlotType): AdSlotParameters => {
             name: 'right',
             adTypes: ['mpu-banner-ad', 'rendered'],
             sizeMapping: {
-                mobile: ['1,1|2,2|300,250|300,274|300,600|fluid'],
+                mobile: ['1,1|2,2|300,250|300,274|fluid'],
                 // Pascal: It's not totally obvious where this sequence should come from the frontend code,
                 // but it should be correct.
             },

--- a/src/model/advertisement.ts
+++ b/src/model/advertisement.ts
@@ -145,11 +145,9 @@ export const namedAdSlotParameters = (name: AdSlotType): AdSlotParameters => {
                             'outOfPage',
                             'empty',
                             'fabric',
-                            'outstreamMobile',
-                            'mpu',
                             'fluid',
+                            'leaderboard',
                         ]),
-                        '728,90', // This value comes from file mark: c66fae4e-1d29-467a-a081-caad7a90cacd
                     ].join('|'),
                 ],
                 desktop: ['1,1|2,2|728,90|940,230|900,250|970,250|88,71|fluid'], // Values from file mark: c66fae4e-1d29-467a-a081-caad7a90cacd
@@ -169,11 +167,23 @@ export const namedAdSlotParameters = (name: AdSlotType): AdSlotParameters => {
                     adSizeNamesToString([
                         'outOfPage',
                         'empty',
-                        'outstreamMobile',
                         'mpu',
                         'googleCard',
                         'fluid',
                     ]),
+                ],
+                tablet: [
+                    [
+                        adSizeNamesToString([
+                            'outOfPage',
+                            'empty',
+                            'mpu',
+                            'googleCard',
+                            'halfPage',
+                            'leaderboard',
+                            'fluid',
+                        ]),
+                    ].join('|'),
                 ],
                 phablet: [
                     adSizeNamesToString([
@@ -193,9 +203,7 @@ export const namedAdSlotParameters = (name: AdSlotType): AdSlotParameters => {
                         'empty',
                         'mpu',
                         'googleCard',
-                        'video',
-                        'outstreamDesktop',
-                        'outstreamGoogleDesktop',
+                        'halfPage',
                         'fluid',
                     ]),
                 ],


### PR DESCRIPTION
###   What does this change?
@gtrufitt  found some inconsistencies on ad slots `data` labels for each breakpoint. In particular `most-pop` on `tablet` had a `null` value.
This PR makes sure we get 100% parity between frontend and dcr on those values

### Before

(no `data-tablet` attribute present)

<img width="1151" alt="Screenshot 2020-10-21 at 17 56 12" src="https://user-images.githubusercontent.com/51630004/96737809-bec58480-13c6-11eb-8675-8a5c4e9410f5.png">


### After

<img width="1151" alt="Screenshot 2020-10-21 at 17 45 18" src="https://user-images.githubusercontent.com/51630004/96737317-3515b700-13c6-11eb-975c-3015c896ed3c.png">


## Why?
This will bring some more revenue on tablets on most-pop ad slots
