### PR TITLE
Stop sending switches.remoteSubscriptionsBanner in Reader Revenue banner service payload

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -321,7 +321,6 @@ type CAPIBrowserType = {
         discussionApiClientHeader: string;
         dcrSentryDsn: string;
         remoteBanner: boolean;
-        remoteSubscriptionsBanner: boolean;
         ausMoment2020Header: boolean;
         switches: CAPIType['config']['switches'];
         host?: string;

--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -128,8 +128,6 @@ export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
             enableSentryReporting: CAPI.config.switches.enableSentryReporting,
             enableDiscussionSwitch: CAPI.config.switches.enableDiscussionSwitch,
             remoteBanner: CAPI.config.switches.remoteBanner,
-            remoteSubscriptionsBanner:
-                CAPI.config.switches.remoteSubscriptionsBanner,
             ausMoment2020Header: CAPI.config.switches.ausMoment2020Header,
 
             // used by lib/ad-targeting.ts

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -79,7 +79,6 @@ const buildPayload = (props: BuildPayloadProps) => {
                 props.subscriptionBannerLastClosedAt,
             mvtId: Number(getCookie('GU_mvt_id')),
             countryCode: props.countryCode,
-            switches: props.switches,
             weeklyArticleHistory: getWeeklyArticleHistory(),
             hasOptedOutOfArticleCount: !props.hasConsentedToArticleCounts,
         },
@@ -111,7 +110,6 @@ export const canShow = async ({
     alreadyVisitedCount,
     engagementBannerLastClosedAt,
     subscriptionBannerLastClosedAt,
-    switches,
 }: CanShowProps): Promise<CanShowResult> => {
     if (!remoteBannerConfig) return Promise.resolve({ result: false });
 

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -47,7 +47,6 @@ type BaseProps = {
     alreadyVisitedCount: number;
     engagementBannerLastClosedAt?: string;
     subscriptionBannerLastClosedAt?: string;
-    switches: { [key: string]: boolean };
     weeklyArticleHistory?: WeeklyArticleHistory;
 };
 

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -134,7 +134,6 @@ export const canShow = async ({
         alreadyVisitedCount,
         engagementBannerLastClosedAt,
         subscriptionBannerLastClosedAt,
-        switches,
         hasConsentedToArticleCounts,
     });
     const forcedVariant = getForcedVariant('banner');

--- a/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -70,10 +70,6 @@ const buildReaderRevenueBannerConfig = (
                 subscriptionBannerLastClosedAt: getBannerLastClosedAt(
                     'subscriptionBannerLastClosedAt',
                 ),
-                switches: {
-                    remoteSubscriptionsBanner: !!CAPI.config
-                        .remoteSubscriptionsBanner,
-                },
             }),
         /* eslint-disable-next-line react/jsx-props-no-spreading */
         show: (meta: any) => () => <ReaderRevenueBanner {...meta} />,


### PR DESCRIPTION
### What does this change?

When we first started using the remote Reader Revenue Banner service we wanted to be able switch the Subscriptions Banners served from this service on/off via a switch in the Frontend admin tools. When the switch was ON we use the service, and when the switch was OFF we'd revert back to the old banners in frontend and not serve any subs banners from the service. The service has been running for a number of months now and this switch is no longer necessary.

This PR removes the switches object from the payload sent to the remote banner service, which was only introduced to the payload for the use case described above.

**DO NOT MERGE UNTIL THIS PR HAS BEEN MERGED:**  https://github.com/guardian/support-dotcom-components/pull/271