### PR TITLE
⚡ AMP PubData workaround

### DIFF
--- a/src/amp/components/AdConsent.tsx
+++ b/src/amp/components/AdConsent.tsx
@@ -3,6 +3,14 @@ import { JsonScript } from './JsonScript';
 
 const sourcepointDomain = 'sourcepoint.theguardian.com';
 
+// This reads the bwid cookie
+const browserId = `bwid=CLIENT_ID(bwid)`;
+
+// Matches ampViewId from https://ophan.theguardian.com/amp.json
+const pageViewId = `pageViewId=CLIENT_ID(_ga)-PAGE_VIEW_ID`;
+
+const pubData = `?${browserId}&${pageViewId}`;
+
 const clientConfig = {
     accountId: 1257,
     mmsDomain: `https://${sourcepointDomain}`,
@@ -77,7 +85,7 @@ export const AdConsent: React.FC<{}> = ({}) => {
                     o={{
                         consentRequired: 'remote',
                         consentInstanceId: 'sourcepoint',
-                        checkConsentHref: `https://${sourcepointDomain}/wrapper/tcfv2/v1/amp?pvid=RANDOM-CLIENT_ID(bwid)-PAGE_VIEW_ID`,
+                        checkConsentHref: `https://${sourcepointDomain}/wrapper/tcfv2/v1/amp${pubData}`,
                         promptUISrc: `https://${sourcepointDomain}/amp/index.html?authId=CLIENT_ID`,
                         clientConfig,
                         geoOverride: {

--- a/src/amp/components/AdConsent.tsx
+++ b/src/amp/components/AdConsent.tsx
@@ -3,13 +3,13 @@ import { JsonScript } from './JsonScript';
 
 const sourcepointDomain = 'sourcepoint.theguardian.com';
 
-// This reads the bwid cookie
-const browserId = `bwid=CLIENT_ID(bwid)`;
+const pubData = {
+    // Matches ampViewId from https://ophan.theguardian.com/amp.json
+    pageViewId: `pageViewId=PAGE_VIEW_ID_64`,
+    browserId: `bwid=CLIENT_ID(bwid)`,
+};
 
-// Matches ampViewId from https://ophan.theguardian.com/amp.json
-const pageViewId = `pageViewId=PAGE_VIEW_ID_64`;
-
-const pubData = [browserId, pageViewId].join('&');
+const queryParams = new URLSearchParams(pubData).toString();
 
 const clientConfig = {
     accountId: 1257,
@@ -85,7 +85,7 @@ export const AdConsent: React.FC<{}> = ({}) => {
                     o={{
                         consentRequired: 'remote',
                         consentInstanceId: 'sourcepoint',
-                        checkConsentHref: `https://${sourcepointDomain}/wrapper/tcfv2/v1/amp?${pubData}`,
+                        checkConsentHref: `https://${sourcepointDomain}/wrapper/tcfv2/v1/amp?${queryParams}`,
                         promptUISrc: `https://${sourcepointDomain}/amp/index.html?authId=CLIENT_ID`,
                         clientConfig,
                         geoOverride: {

--- a/src/amp/components/AdConsent.tsx
+++ b/src/amp/components/AdConsent.tsx
@@ -6,7 +6,7 @@ const sourcepointDomain = 'sourcepoint.theguardian.com';
 const pubData = {
     // Matches ampViewId from https://ophan.theguardian.com/amp.json
     pageViewId: 'PAGE_VIEW_ID_64',
-    browserId: 'CLIENT_ID(bwid)',
+    browserId: 'CLIENT_ID',
 };
 
 const queryParams = new URLSearchParams(pubData).toString();

--- a/src/amp/components/AdConsent.tsx
+++ b/src/amp/components/AdConsent.tsx
@@ -77,7 +77,7 @@ export const AdConsent: React.FC<{}> = ({}) => {
                     o={{
                         consentRequired: 'remote',
                         consentInstanceId: 'sourcepoint',
-                        checkConsentHref: `https://${sourcepointDomain}/wrapper/tcfv2/v1/amp`,
+                        checkConsentHref: `https://${sourcepointDomain}/wrapper/tcfv2/v1/amp?pvid=RANDOM-CLIENT_ID(bwid)-PAGE_VIEW_ID`,
                         promptUISrc: `https://${sourcepointDomain}/amp/index.html?authId=CLIENT_ID`,
                         clientConfig,
                         geoOverride: {

--- a/src/amp/components/AdConsent.tsx
+++ b/src/amp/components/AdConsent.tsx
@@ -7,9 +7,9 @@ const sourcepointDomain = 'sourcepoint.theguardian.com';
 const browserId = `bwid=CLIENT_ID(bwid)`;
 
 // Matches ampViewId from https://ophan.theguardian.com/amp.json
-const pageViewId = `pageViewId=CLIENT_ID(_ga)-PAGE_VIEW_ID`;
+const pageViewId = `pageViewId=PAGE_VIEW_ID_64`;
 
-const pubData = `?${browserId}&${pageViewId}`;
+const pubData = [browserId, pageViewId].join('&');
 
 const clientConfig = {
     accountId: 1257,
@@ -85,7 +85,7 @@ export const AdConsent: React.FC<{}> = ({}) => {
                     o={{
                         consentRequired: 'remote',
                         consentInstanceId: 'sourcepoint',
-                        checkConsentHref: `https://${sourcepointDomain}/wrapper/tcfv2/v1/amp${pubData}`,
+                        checkConsentHref: `https://${sourcepointDomain}/wrapper/tcfv2/v1/amp?${pubData}`,
                         promptUISrc: `https://${sourcepointDomain}/amp/index.html?authId=CLIENT_ID`,
                         clientConfig,
                         geoOverride: {

--- a/src/amp/components/AdConsent.tsx
+++ b/src/amp/components/AdConsent.tsx
@@ -5,8 +5,8 @@ const sourcepointDomain = 'sourcepoint.theguardian.com';
 
 const pubData = {
     // Matches ampViewId from https://ophan.theguardian.com/amp.json
-    pageViewId: `pageViewId=PAGE_VIEW_ID_64`,
-    browserId: `bwid=CLIENT_ID(bwid)`,
+    pageViewId: 'PAGE_VIEW_ID_64',
+    browserId: 'CLIENT_ID(bwid)',
 };
 
 const queryParams = new URLSearchParams(pubData).toString();


### PR DESCRIPTION
<!-- YOU SHOULD KNOW: dotcom is running an experiment called PR Deployments. -->
<!-- As soon as you open this PR, a github action called PR Deployment will run your code in an isolated environment and make it accessible in a public URL that you can use for testing etc -->
<!-- Every time you push to this branch, you will get an annoying email alert from github telling you that the previous PR deployment has been canceled. -->
<!-- You do not need to wait for the PR deployment action to go green before you can merge -->

 
## What does this change?

Adds the `pubData` elements (**Browser ID** and **Pageview ID**) through a query string to the Sourcepoint url.

### Example

```log
https://sourcepoint.theguardian.com/wrapper/tcfv2/v1/amp
?bwid=amp-tB-GkMTn02lJKdSfZqvHOw
&pageViewId=KxDi71iPcuCnlS4KRwHGOQ
&__amp_source_origin=https%3A%2F%2Famp.theguardian.test
```

![image](https://user-images.githubusercontent.com/76776/97594613-c1456100-19fa-11eb-9549-3d7f4a3a9ddf.png)


## Why?

We currently cannot join consent with pageviews.

cc. @janua 
