### PR TITLE
Delay re-fetching RR banner if closed

### DIFF
--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -10,8 +10,8 @@ import {
 import {
     shouldHideSupportMessaging,
     getArticleCountConsent,
-    noBannerUntilLater,
-    setNoBannerUntilLater,
+    withinLocalNoBannerCachePeriod,
+    setLocalNoBannerCachePeriod,
 } from '@root/src/web/lib/contributions';
 import { getCookie } from '@root/src/web/browser/cookie';
 import {
@@ -120,7 +120,7 @@ export const canShow = async ({
         return Promise.resolve({ result: false });
     }
 
-    if (engagementBannerLastClosedAt && subscriptionBannerLastClosedAt && noBannerUntilLater()) {
+    if (engagementBannerLastClosedAt && subscriptionBannerLastClosedAt && withinLocalNoBannerCachePeriod()) {
         // Both banners have been dismissed *and* we have recently been told not to display a banner
         return Promise.resolve({ result: false });
     }
@@ -156,7 +156,7 @@ export const canShow = async ({
             if (!json.data) {
                 if (engagementBannerLastClosedAt && subscriptionBannerLastClosedAt) {
                     // Both banners have been dismissed *and* we have been told not too display a banner - do not request banner for a while
-                    setNoBannerUntilLater();
+                    setLocalNoBannerCachePeriod();
                 }
                 return { result: false };
             }

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -11,7 +11,7 @@ import {
     shouldHideSupportMessaging,
     getArticleCountConsent,
     noBannerUntilLater,
-    setNoBannerUntilLaterKey,
+    setNoBannerUntilLater,
 } from '@root/src/web/lib/contributions';
 import { getCookie } from '@root/src/web/browser/cookie';
 import {
@@ -156,7 +156,7 @@ export const canShow = async ({
             if (!json.data) {
                 if (engagementBannerLastClosedAt && subscriptionBannerLastClosedAt) {
                     // Both banners have been dismissed *and* we have been told not too display a banner - do not request banner for a while
-                    setNoBannerUntilLaterKey();
+                    setNoBannerUntilLater();
                 }
                 return { result: false };
             }

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -121,7 +121,6 @@ export const canShow = async ({
     }
 
     if (engagementBannerLastClosedAt && subscriptionBannerLastClosedAt && withinLocalNoBannerCachePeriod()) {
-        // Both banners have been dismissed *and* we have recently been told not to display a banner
         return Promise.resolve({ result: false });
     }
 
@@ -155,7 +154,6 @@ export const canShow = async ({
         .then((json) => {
             if (!json.data) {
                 if (engagementBannerLastClosedAt && subscriptionBannerLastClosedAt) {
-                    // Both banners have been dismissed *and* we have been told not too display a banner - do not request banner for a while
                     setLocalNoBannerCachePeriod();
                 }
                 return { result: false };

--- a/src/web/lib/contributions.ts
+++ b/src/web/lib/contributions.ts
@@ -164,5 +164,6 @@ export const noBannerUntilLater = (): boolean => {
     return false;
 };
 
-export const setNoBannerUntilLaterKey = (): void =>
-    window.localStorage.setItem(NO_BANNER_UNTIL_LATER_KEY, `${Date.now() + (20*60000)}`);
+const twentyMins = 20*60000;
+export const setNoBannerUntilLater = (): void =>
+    window.localStorage.setItem(NO_BANNER_UNTIL_LATER_KEY, `${Date.now() + twentyMins}`);

--- a/src/web/lib/contributions.ts
+++ b/src/web/lib/contributions.ts
@@ -151,7 +151,7 @@ export const getArticleCountConsent = (): Promise<boolean> => {
     });
 };
 
-export const noBannerUntilLater = (): boolean => {
+export const withinLocalNoBannerCachePeriod = (): boolean => {
     const item = window.localStorage.getItem(NO_BANNER_UNTIL_LATER_KEY);
     if (item && !Number.isNaN(parseInt(item, 10))) {
         const noBanner = parseInt(item, 10) > Date.now();
@@ -165,5 +165,5 @@ export const noBannerUntilLater = (): boolean => {
 };
 
 const twentyMins = 20*60000;
-export const setNoBannerUntilLater = (): void =>
+export const setLocalNoBannerCachePeriod = (): void =>
     window.localStorage.setItem(NO_BANNER_UNTIL_LATER_KEY, `${Date.now() + twentyMins}`);

--- a/src/web/lib/contributions.ts
+++ b/src/web/lib/contributions.ts
@@ -18,6 +18,7 @@ export const SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE =
 //  Local storage keys
 const DAILY_ARTICLE_COUNT_KEY = 'gu.history.dailyArticleCount';
 const WEEKLY_ARTICLE_COUNT_KEY = 'gu.history.weeklyArticleCount';
+export const NO_BANNER_UNTIL_LATER_KEY = 'gu.noRRBannerUntilLater';   // Do not request RR banner until after this timestamp
 
 // Cookie set by the User Attributes API upon signing in.
 // Value computed server-side and looks at all of the user's active products,
@@ -149,3 +150,19 @@ export const getArticleCountConsent = (): Promise<boolean> => {
         });
     });
 };
+
+export const noBannerUntilLater = (): boolean => {
+    const item = window.localStorage.getItem(NO_BANNER_UNTIL_LATER_KEY);
+    if (item && !Number.isNaN(parseInt(item, 10))) {
+        const noBanner = parseInt(item, 10) > Date.now();
+        if (!noBanner) {
+            // Expired
+            window.localStorage.removeItem(NO_BANNER_UNTIL_LATER_KEY);
+        }
+        return noBanner;
+    }
+    return false;
+};
+
+export const setNoBannerUntilLaterKey = (): void =>
+    window.localStorage.setItem(NO_BANNER_UNTIL_LATER_KEY, `${Date.now() + (20*60000)}`);

--- a/src/web/lib/contributions.ts
+++ b/src/web/lib/contributions.ts
@@ -18,7 +18,7 @@ export const SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE =
 //  Local storage keys
 const DAILY_ARTICLE_COUNT_KEY = 'gu.history.dailyArticleCount';
 const WEEKLY_ARTICLE_COUNT_KEY = 'gu.history.weeklyArticleCount';
-export const NO_BANNER_UNTIL_LATER_KEY = 'gu.noRRBannerUntilLater';   // Do not request RR banner until after this timestamp
+export const NO_RR_BANNER_TIMESTAMP_KEY = 'gu.noRRBannerTimestamp';   // timestamp of when we were last told not to show a RR banner
 
 // Cookie set by the User Attributes API upon signing in.
 // Value computed server-side and looks at all of the user's active products,
@@ -151,19 +151,19 @@ export const getArticleCountConsent = (): Promise<boolean> => {
     });
 };
 
+const twentyMins = 20*60000;
 export const withinLocalNoBannerCachePeriod = (): boolean => {
-    const item = window.localStorage.getItem(NO_BANNER_UNTIL_LATER_KEY);
+    const item = window.localStorage.getItem(NO_RR_BANNER_TIMESTAMP_KEY);
     if (item && !Number.isNaN(parseInt(item, 10))) {
-        const noBanner = parseInt(item, 10) > Date.now();
-        if (!noBanner) {
+        const withinCachePeriod = (parseInt(item, 10) + twentyMins) > Date.now();
+        if (!withinCachePeriod) {
             // Expired
-            window.localStorage.removeItem(NO_BANNER_UNTIL_LATER_KEY);
+            window.localStorage.removeItem(NO_RR_BANNER_TIMESTAMP_KEY);
         }
-        return noBanner;
+        return withinCachePeriod;
     }
     return false;
 };
 
-const twentyMins = 20*60000;
 export const setLocalNoBannerCachePeriod = (): void =>
-    window.localStorage.setItem(NO_BANNER_UNTIL_LATER_KEY, `${Date.now() + twentyMins}`);
+    window.localStorage.setItem(NO_RR_BANNER_TIMESTAMP_KEY, `${Date.now()}`);


### PR DESCRIPTION
This is an optimisation to reduce the number of requests made by the client to support-dotcom-components.

Currently we make a request to find out if the user should see a RR banner even if the user has previously closed the banner.
This is because we need to check if the banner has been redeployed since the user last closed it.
(Note - there are actually 2 banner 'channels', each with its own 'last closed at' timestamp).
This means a lot of unnecessary requests because banners are redeployed very infrequently, and most page views should not see a banner.

E.g. in the last 24 hours:
- 25m requests were sent to /banner
- 19m of these returned no banner

The solution in this PR is to avoid making any banner requests for 20 minutes after a request returns no banner, if the user has closed the banner.
So, if the user has already closed the banner (both channels) and the response has no banner, we add a local storage item with a timestamp 20mins into the future.

This is a bit like caching the /banner response when it returns no banner, but it's a POST so that would not be reliable.

Edit:
We also discussed having the client fetch the banner deploy timestamps directly (via fastly).
This would certainly avoid even more requests to /banner, but at the cost of more complexity (we'd have to make that data public, and behind fastly).
We'll try this solution for now.