### PR TITLE
Extend Curated container test

### DIFF
--- a/src/web/experiments/tests/curated-container-test.ts
+++ b/src/web/experiments/tests/curated-container-test.ts
@@ -3,8 +3,8 @@ import { ABTest } from '@guardian/ab-core';
 export const curatedContainerTest: ABTest = {
     id: 'CuratedContainerTest',
     start: '2020-09-14',
-    expiry: '2020-11-02',
-    author: 'nicl',
+    expiry: '2020-11-10',
+    author: 'gtrufitt',
     description:
         'Tests an additional "curated" onwards container below the article body',
     audience: 0.5,


### PR DESCRIPTION
## What does this change?

Extends the curated container test while we wait for results.

https://github.com/guardian/frontend/pull/23179