### PR TITLE
Add Newsletter merch unit AB test

### DIFF
--- a/src/web/experiments/ab-tests.ts
+++ b/src/web/experiments/ab-tests.ts
@@ -3,7 +3,7 @@ import { abTestTest } from '@frontend/web/experiments/tests/ab-test-test';
 import { signInGateMainVariant } from '@root/src/web/experiments/tests/sign-in-gate-main-variant';
 import { signInGateMainControl } from '@root/src/web/experiments/tests/sign-in-gate-main-control';
 import { curatedContainerTest } from '@frontend/web/experiments/tests/curated-container-test';
-import { newsletterMerchUnit } from './tests/newsletter-merch-unit-test';
+import { newsletterMerchUnit } from '@frontend/web/experiments/tests/newsletter-merch-unit-test';
 
 export const tests: ABTest[] = [
     abTestTest,

--- a/src/web/experiments/ab-tests.ts
+++ b/src/web/experiments/ab-tests.ts
@@ -3,10 +3,12 @@ import { abTestTest } from '@frontend/web/experiments/tests/ab-test-test';
 import { signInGateMainVariant } from '@root/src/web/experiments/tests/sign-in-gate-main-variant';
 import { signInGateMainControl } from '@root/src/web/experiments/tests/sign-in-gate-main-control';
 import { curatedContainerTest } from '@frontend/web/experiments/tests/curated-container-test';
+import { newsletterMerchUnit } from './tests/newsletter-merch-unit-test';
 
 export const tests: ABTest[] = [
     abTestTest,
     signInGateMainVariant,
     signInGateMainControl,
     curatedContainerTest,
+    newsletterMerchUnit,
 ];

--- a/src/web/experiments/tests/newsletter-merch-unit-test.ts
+++ b/src/web/experiments/tests/newsletter-merch-unit-test.ts
@@ -7,7 +7,7 @@ export const newsletterMerchUnit: ABTest = {
     author: 'Josh Buckland',
     description:
         'Show a newsletter advert in the merchandising unit to 50% of users',
-    audience: 1,
+    audience: 0.5,
     audienceOffset: 0.0,
     successMeasure:
         'We see increased engagement from users shown the Newsletters ad unit',

--- a/src/web/experiments/tests/newsletter-merch-unit-test.ts
+++ b/src/web/experiments/tests/newsletter-merch-unit-test.ts
@@ -1,0 +1,26 @@
+import { ABTest } from '@guardian/ab-core';
+
+export const newsletterMerchUnit: ABTest = {
+    id: 'NewsletterMerchUnit',
+    start: '2020-11-02',
+    expiry: '2020-12-01',
+    author: 'Josh Buckland',
+    description:
+        'Show a newsletter advert in the merchandising unit to 50% of users',
+    audience: 1,
+    audienceOffset: 0.0,
+    successMeasure:
+        'We see increased engagement from users shown the Newsletters ad unit',
+    audienceCriteria: 'Website users only.',
+    dataLinkNames: 'n/a',
+    idealOutcome:
+        'Increase engagement for lighthouse segments 4 and 5 via newsletters',
+    showForSensitive: false,
+    canRun: () => true,
+    variants: [
+        {
+            id: 'variant',
+            test: (): void => {},
+        },
+    ],
+};


### PR DESCRIPTION
## What does this change?
DCR implementation of: https://github.com/guardian/frontend/pull/23187
In order to test the impact of a newsletters merch unit across
lighthouse segments we want to roll out a 50/50 AB test. The variant
will then be targeted with the newsletters merch unit.

<!-- YOU SHOULD KNOW: dotcom is running an experiment called PR Deployments. -->
<!-- As soon as you open this PR, a github action called PR Deployment will run your code in an isolated environment and make it accessible in a public URL that you can use for testing etc -->
<!-- Every time you push to this branch, you will get an annoying email alert from github telling you that the previous PR deployment has been canceled. -->
<!-- You do not need to wait for the PR deployment action to go green before you can merge -->

## Why?
Newsletter engagement OKR
