### PR TITLE
Global Ad slot css for ad imbed

### DIFF
--- a/src/web/components/ArticleBody.tsx
+++ b/src/web/components/ArticleBody.tsx
@@ -46,30 +46,6 @@ const bodyStyle = (display: Display) => css`
     }
 `;
 
-const imbedAdSlotStyles = css`
-    div > div.ad-slot--im {
-        float: left;
-        width: 130px;
-
-        ${from.mobileLandscape} {
-            width: 220px;
-        }
-
-        &:not(.ad-slot--rendered) {
-            width: 0;
-            height: 0;
-        }
-
-        &.ad-slot--rendered {
-            margin: 5px 10px 6px 0;
-            ${from.mobileLandscape} {
-                margin-bottom: 12px;
-                margin-right: 20px;
-            }
-        }
-    }
-`;
-
 const linkColour = pillarMap(
     (pillar) => css`
         a {
@@ -96,7 +72,6 @@ export const ArticleBody = ({
             className={cx(
                 bodyStyle(display),
                 linkColour[pillar],
-                imbedAdSlotStyles,
             )}
         >
             <ArticleRenderer

--- a/src/web/components/ArticleBody.tsx
+++ b/src/web/components/ArticleBody.tsx
@@ -3,7 +3,7 @@ import { css, cx } from 'emotion';
 
 import { border } from '@guardian/src-foundations/palette';
 import { headline } from '@guardian/src-foundations/typography';
-import { between } from '@guardian/src-foundations/mq';
+import { between, from } from '@guardian/src-foundations/mq';
 import { pillarMap, pillarPalette } from '@root/src/lib/pillars';
 import { ArticleRenderer } from '@root/src/web/lib/ArticleRenderer';
 import { Display } from '@root/src/lib/display';
@@ -46,6 +46,30 @@ const bodyStyle = (display: Display) => css`
     }
 `;
 
+const imbedAdSlotStyles = css`
+    div > div.ad-slot--im {
+        float: left;
+        width: 130px;
+
+        ${from.mobileLandscape} {
+            width: 220px;
+        }
+
+        &:not(.ad-slot--rendered) {
+            width: 0;
+            height: 0;
+        }
+
+        &.ad-slot--rendered {
+            margin: 5px 10px 6px 0;
+            ${from.mobileLandscape} {
+                margin-bottom: 12px;
+                margin-right: 20px;
+            }
+        }
+    }
+`;
+
 const linkColour = pillarMap(
     (pillar) => css`
         a {
@@ -68,7 +92,13 @@ export const ArticleBody = ({
     adTargeting,
 }: Props) => {
     return (
-        <div className={cx(bodyStyle(display), linkColour[pillar])}>
+        <div
+            className={cx(
+                bodyStyle(display),
+                linkColour[pillar],
+                imbedAdSlotStyles,
+            )}
+        >
             <ArticleRenderer
                 display={display}
                 elements={blocks[0] ? blocks[0].elements : []}

--- a/src/web/components/ArticleBody.tsx
+++ b/src/web/components/ArticleBody.tsx
@@ -3,7 +3,7 @@ import { css, cx } from 'emotion';
 
 import { border } from '@guardian/src-foundations/palette';
 import { headline } from '@guardian/src-foundations/typography';
-import { between, from } from '@guardian/src-foundations/mq';
+import { between } from '@guardian/src-foundations/mq';
 import { pillarMap, pillarPalette } from '@root/src/lib/pillars';
 import { ArticleRenderer } from '@root/src/web/lib/ArticleRenderer';
 import { Display } from '@root/src/lib/display';

--- a/src/web/components/ArticleContainer.tsx
+++ b/src/web/components/ArticleContainer.tsx
@@ -17,6 +17,8 @@ const articleContainer = css`
     z-index: 1;
 `;
 
+// styles from _adslot.scss in frontend
+// TODO: still a lot of styles to migrate from _adslot.scss
 const articleAdStyles = css`
     .ad-slot {
         width: 300px;
@@ -94,13 +96,48 @@ const articleAdStyles = css`
     ${labelStyles};
 `;
 
+// styles from _creatives.scss in frontend
+// TODO: still a lot of styles to migrate from _creatives.scss
+const articleCreativesStyles = css`
+    .creative__background-parent {
+        contain: size layout style;
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        z-index: -1;
+
+        /* This will clip the fixed-positioned child to the boundaries of its parent */
+        clip: rect(0, auto, auto, 0);
+
+        .creative__background {
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+
+            /* unable to find transition in frontend scss files, but it was being conditionally applied to DCR  */
+            transition: background 100ms ease
+        }
+
+        .creative__background--parallax {
+            position: absolute;
+        }
+
+        .creative__background--fixed {
+            position: fixed;
+        }
+    }
+`
+
 type Props = {
     children: JSXElements;
 };
 
 export const ArticleContainer = ({ children }: Props) => {
     return (
-        <main className={cx(articleContainer, articleAdStyles)}>
+        <main className={cx(articleContainer, articleAdStyles, articleCreativesStyles)}>
             {children}
         </main>
     );

--- a/src/web/components/ArticleContainer.tsx
+++ b/src/web/components/ArticleContainer.tsx
@@ -70,6 +70,27 @@ const articleAdStyles = css`
             }
         }
     }
+    .ad-slot--im {
+        float: left;
+        width: 130px;
+
+        ${from.mobileLandscape} {
+            width: 220px;
+        }
+
+        &:not(.ad-slot--rendered) {
+            width: 0;
+            height: 0;
+        }
+
+        &.ad-slot--rendered {
+            margin: 5px 10px 6px 0;
+            ${from.mobileLandscape} {
+                margin-bottom: 12px;
+                margin-right: 20px;
+            }
+        }
+    }
     ${labelStyles};
 `;
 


### PR DESCRIPTION
# What does this change?
Applies global CSS rules to inline Ad slots

## NOTE
We need https://github.com/guardian/frontend/pull/23204 to remove inline styles, but we should first merge this. To test this PR you will need to manually delete the styles attr from the div

### Example article
https://www.theguardian.com/us-news/2020/oct/29/lordstown-ohio-trump-gm-plant-election

### Before
![Screenshot 2020-10-30 at 10 06 30](https://user-images.githubusercontent.com/8831403/97885405-3a0c2c00-1d1f-11eb-8076-43c8b7ff3eb1.png)


### After
!!!! IF YOU REMOVE STYLES ATTR FROM DIV

![Screenshot 2020-11-02 at 15 53 00](https://user-images.githubusercontent.com/8831403/97888983-b3a61900-1d23-11eb-99f3-5f03330f672b.png)


## Why?
Some CSS styles are applied globally from frontend to the ads based on classNames