### PR TITLE
Double PROD ASG Min and Max for Election

### DIFF
--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -60,8 +60,8 @@ Mappings:
       Value: rendering
   StageMap:
     PROD:
-      MinCapacity: 9
-      MaxCapacity: 36
+      MinCapacity: 18
+      MaxCapacity: 72
     CODE:
       MinCapacity: 1
       MaxCapacity: 4


### PR DESCRIPTION
## What does this change?

As per https://github.com/guardian/platform/pull/1420 - here we double the (much smaller) DCR server min and max.

## Why?

Election traffic baseline is higher and spiky.