### PR TITLE
Youtube Atom overlay

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -329,6 +329,7 @@ type CAPIBrowserType = {
     timelineAtoms: TimelineBlockElement[];
     chartAtoms: ChartAtomBlockElement[];
     audioAtoms: AudioAtomBlockElement[];
+    youtubeBlockElement: YoutubeBlockElement[];
     youtubeMainMediaBlockElement: YoutubeBlockElement[];
 };
 
@@ -671,6 +672,7 @@ type IslandType =
     | 'timeline-atom'
     | 'sign-in-gate'
     | 'audio-atom'
+    | 'youtube-block'
     | 'youtube-block-main-media'
     | 'chart-atom';
 

--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -215,6 +215,11 @@ export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
             'model.dotcomrendering.pageElements.AudioAtomBlockElement',
             'audioIndex',
         ),
+        youtubeBlockElement: blockElementWithIndex(
+            CAPI.blocks,
+            'model.dotcomrendering.pageElements.YoutubeBlockElement',
+            'youtubeIndex',
+        ),
         youtubeMainMediaBlockElement: CAPI.mainMediaElements.reduce(
             (
                 acc: CAPIElement[],

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -425,6 +425,27 @@ export const App = ({ CAPI, NAV }: Props) => {
                     />
                 </Hydrate>
             ))}
+            {CAPI.youtubeBlockElement.map((youtubeBlock, index) => (
+                <Hydrate
+                    key={index}
+                    root="youtube-block"
+                    index={youtubeBlock.youtubeIndex}
+                >
+                    <YoutubeBlockComponent
+                        display={display}
+                        designType={CAPI.designType}
+                        element={youtubeBlock}
+                        pillar={pillar}
+                        hideCaption={false}
+                        // eslint-disable-next-line jsx-a11y/aria-role
+                        role="inline"
+                        adTargeting={adTargeting}
+                        isMainMedia={false}
+                        overlayImage={youtubeBlock.overrideImage}
+                        duration={youtubeBlock.duration}
+                    />
+                </Hydrate>
+            ))}
             {NAV.subNavSections && (
                 <Hydrate root="sub-nav-root">
                     <>

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -383,18 +383,22 @@ export const ArticleRenderer: React.FC<{
                     );
                 case 'model.dotcomrendering.pageElements.YoutubeBlockElement':
                     return (
-                        <YoutubeBlockComponent
-                            display={display}
-                            designType={designType}
-                            key={i}
-                            element={element}
-                            pillar={pillar}
-                            hideCaption={false}
-                            // eslint-disable-next-line jsx-a11y/aria-role
-                            role="inline"
-                            adTargeting={adTargeting}
-                            isMainMedia={false}
-                        />
+                        <div key={i} id={`youtube-block-${i}`}>
+                            <YoutubeBlockComponent
+                                display={display}
+                                designType={designType}
+                                key={i}
+                                element={element}
+                                pillar={pillar}
+                                hideCaption={false}
+                                // eslint-disable-next-line jsx-a11y/aria-role
+                                role="inline"
+                                adTargeting={adTargeting}
+                                isMainMedia={false}
+                                overlayImage={element.overrideImage}
+                                duration={element.duration}
+                            />
+                        </div>
                     );
                 case 'model.dotcomrendering.pageElements.TimelineBlockElement':
                     return (


### PR DESCRIPTION
<!-- YOU SHOULD KNOW: dotcom is running an experiment called PR Deployments. -->
<!-- As soon as you open this PR, a github action called PR Deployment will run your code in an isolated environment and make it accessible in a public URL that you can use for testing etc -->
<!-- Every time you push to this branch, you will get an annoying email alert from github telling you that the previous PR deployment has been canceled. -->
<!-- You do not need to wait for the PR deployment action to go green before you can merge -->


## What does this change?
Add support for overlay image on youtube atom ~embeds~

### Before/After
TODO: need to find example

## Why?
Overlay images can exist for embed youtube blocks, therefore we need to support it similar to how main media implements it