### PR TITLE
Byline clickability

### DIFF
--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -190,6 +190,7 @@ const avatarPositionStyles = css`
     overflow: hidden;
     margin-bottom: -29px;
     margin-top: -50px;
+    pointer-events: none;
 
     /*  Why target img element?
 


### PR DESCRIPTION
This PR fixes a problem where the author byline wasn't easy to click on on opinion pieces.

### Before
![before](https://user-images.githubusercontent.com/1336821/98046168-9b1c2880-1e21-11eb-9a2c-15a63c4fac88.gif)


### After
![after](https://user-images.githubusercontent.com/1336821/98046174-9e171900-1e21-11eb-9447-6acd02ea7731.gif)


## Why?
The div wrapping the avatar is pushed up to force the avatar to sit above the guardian lines but this same div was also invisibly overlaying the byline, stealing the hoveryness
