### PR TITLE
Youtube atom origin prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "@emotion/core": "^10.0.28",
         "@guardian/ab-core": "^2.0.0",
         "@guardian/ab-react": "^2.0.1",
-        "@guardian/atoms-rendering": "^2.0.5",
+        "@guardian/atoms-rendering": "^2.0.7",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/braze-components": "^0.0.13",
         "@guardian/consent-management-platform": "^6.6.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "@emotion/core": "^10.0.28",
         "@guardian/ab-core": "^2.0.0",
         "@guardian/ab-react": "^2.0.1",
-        "@guardian/atoms-rendering": "^2.0.7",
+        "@guardian/atoms-rendering": "^2.0.8",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/braze-components": "^0.0.13",
         "@guardian/consent-management-platform": "^6.6.0",

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -422,6 +422,7 @@ export const App = ({ CAPI, NAV }: Props) => {
                         isMainMedia={false}
                         overlayImage={youtubeBlock.overrideImage}
                         duration={youtubeBlock.duration}
+                        origin={CAPI.config.host}
                     />
                 </Hydrate>
             ))}
@@ -443,6 +444,7 @@ export const App = ({ CAPI, NAV }: Props) => {
                         isMainMedia={false}
                         overlayImage={youtubeBlock.overrideImage}
                         duration={youtubeBlock.duration}
+                        origin={CAPI.config.host}
                     />
                 </Hydrate>
             ))}

--- a/src/web/components/ArticleBody.tsx
+++ b/src/web/components/ArticleBody.tsx
@@ -14,6 +14,7 @@ type Props = {
     blocks: Block[];
     designType: DesignType;
     adTargeting: AdTargeting;
+    host?: string;
 };
 
 const pillarColours = pillarMap(
@@ -66,6 +67,7 @@ export const ArticleBody = ({
     blocks,
     designType,
     adTargeting,
+    host,
 }: Props) => {
     return (
         <div className={cx(bodyStyle(display), linkColour[pillar])}>
@@ -75,6 +77,7 @@ export const ArticleBody = ({
                 pillar={pillar}
                 designType={designType}
                 adTargeting={adTargeting}
+                host={host}
             />
         </div>
     );

--- a/src/web/components/elements/YoutubeBlockComponent.tsx
+++ b/src/web/components/elements/YoutubeBlockComponent.tsx
@@ -23,6 +23,7 @@ type Props = {
     width?: number;
     title?: string;
     duration?: number; // in seconds
+    origin?: string;
 };
 
 const expiredOverlayStyles = (overrideImage: string) => css`
@@ -73,6 +74,7 @@ export const YoutubeBlockComponent = ({
     width = 460,
     title = 'YouTube video player',
     duration,
+    origin,
 }: Props) => {
     const shouldLimitWidth =
         !isMainMedia &&
@@ -128,6 +130,7 @@ export const YoutubeBlockComponent = ({
                 width={width}
                 title={title}
                 duration={duration}
+                origin={origin}
             />
             {!hideCaption && (
                 <Caption

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -264,7 +264,7 @@ export const CommentLayout = ({
     pillar,
 }: Props) => {
     const {
-        config: { isPaidContent },
+        config: { isPaidContent, host },
     } = CAPI;
 
     const adTargeting: AdTargeting = buildAdTargeting(CAPI.config);
@@ -493,6 +493,7 @@ export const CommentLayout = ({
                                     display={display}
                                     designType={designType}
                                     adTargeting={adTargeting}
+                                    host={host}
                                 />
                                 {showBodyEndSlot && <div id="slot-body-end" />}
                                 <GuardianLines count={4} pillar={pillar} />

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -191,7 +191,7 @@ export const ImmersiveLayout = ({
     pillar,
 }: Props) => {
     const {
-        config: { isPaidContent },
+        config: { isPaidContent, host },
     } = CAPI;
 
     const adTargeting: AdTargeting = buildAdTargeting(CAPI.config);
@@ -411,6 +411,7 @@ export const ImmersiveLayout = ({
                                     blocks={CAPI.blocks}
                                     designType={designType}
                                     adTargeting={adTargeting}
+                                    host={host}
                                 />
                                 {showBodyEndSlot && <div id="slot-body-end" />}
                                 <GuardianLines count={4} pillar={pillar} />

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -246,7 +246,7 @@ export const ShowcaseLayout = ({
     pillar,
 }: Props) => {
     const {
-        config: { isPaidContent },
+        config: { isPaidContent, host },
     } = CAPI;
 
     const adTargeting: AdTargeting = buildAdTargeting(CAPI.config);
@@ -448,6 +448,7 @@ export const ShowcaseLayout = ({
                                     display={display}
                                     designType={designType}
                                     adTargeting={adTargeting}
+                                    host={host}
                                 />
                                 {showBodyEndSlot && <div id="slot-body-end" />}
                                 <GuardianLines count={4} pillar={pillar} />

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -47,7 +47,11 @@ import {
     decideLineEffect,
     getCurrentPillar,
 } from '@root/src/web/lib/layoutHelpers';
-import {Stuck, SendToBack, BannerWrapper} from '@root/src/web/layouts/lib/stickiness';
+import {
+    Stuck,
+    SendToBack,
+    BannerWrapper,
+} from '@root/src/web/layouts/lib/stickiness';
 import { Display } from '@root/src/lib/display';
 
 const MOSTVIEWED_STICKY_HEIGHT = 1059;
@@ -304,7 +308,7 @@ export const StandardLayout = ({
     pillar,
 }: Props) => {
     const {
-        config: { isPaidContent },
+        config: { isPaidContent, host },
     } = CAPI;
 
     const adTargeting: AdTargeting = buildAdTargeting(CAPI.config);
@@ -517,6 +521,7 @@ export const StandardLayout = ({
                                     display={display}
                                     designType={designType}
                                     adTargeting={adTargeting}
+                                    host={host}
                                 />
                                 {showMatchStats && <div id="match-stats" />}
 

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -54,7 +54,8 @@ export const ArticleRenderer: React.FC<{
     pillar: Pillar;
     designType: DesignType;
     adTargeting?: AdTargeting;
-}> = ({ display, elements, pillar, designType, adTargeting }) => {
+    host?: string;
+}> = ({ display, elements, pillar, designType, adTargeting, host }) => {
     // const cleanedElements = elements.map(element =>
     //     'html' in element ? { ...element, html: clean(element.html) } : element,
     // );
@@ -397,6 +398,7 @@ export const ArticleRenderer: React.FC<{
                                 isMainMedia={false}
                                 overlayImage={element.overrideImage}
                                 duration={element.duration}
+                                origin={host}
                             />
                         </div>
                     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2260,10 +2260,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
   integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
 
-"@guardian/atoms-rendering@^2.0.5":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-2.0.5.tgz#87b548f2a93e786402936b3ba45e21d703b9c9c9"
-  integrity sha512-LPKa9+m9RCC3BUF9vg6DkFq86VAg9xhujdtOerWLKT9EC/enVvrS5sx2V7ZzH5aOWYAIj57gjw7wpt6e9n+R8Q==
+"@guardian/atoms-rendering@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-2.0.7.tgz#28e18367706fce3912cd4e09235b1ac24b97c495"
+  integrity sha512-wSRfsfzddCgVC7rXookfvKU7jJe+769ZXQU79+6rMRih/AJ7qPnE2QNcqtfvLZLXZ/UfkKX0MTNuBHxq7iU8Bg==
 
 "@guardian/automat-client@^0.2.16":
   version "0.2.16"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2260,10 +2260,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
   integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
 
-"@guardian/atoms-rendering@^2.0.7":
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-2.0.7.tgz#28e18367706fce3912cd4e09235b1ac24b97c495"
-  integrity sha512-wSRfsfzddCgVC7rXookfvKU7jJe+769ZXQU79+6rMRih/AJ7qPnE2QNcqtfvLZLXZ/UfkKX0MTNuBHxq7iU8Bg==
+"@guardian/atoms-rendering@^2.0.8":
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-2.0.8.tgz#8707c6969177cff7b296a96d766868b1bbd9ac8c"
+  integrity sha512-TcKVIVODb7PIR6B3EnVeYdU23P46+kUwIoUzMvQVsqcC+ktq036mD57XX+8QScYRl1NpuenDCDwMcBMYyNHzzA==
 
 "@guardian/automat-client@^0.2.16":
   version "0.2.16"


### PR DESCRIPTION
## What does this change?
Support optional origin prop to be set in youtube iframe URL

## Why?
When origin is set, if the URL doesn't match then the video will be prevented from playing. As we have `host` passed down in the JSON, we should use that to set the origin