### PR TITLE
Add AU consent switch

### DIFF
--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -346,6 +346,7 @@ export const App = ({ CAPI, NAV }: Props) => {
             });
 
             if (
+                CAPI.config.switches.auConsent ||
                 window?.guardian?.config?.tests?.useAusCmpVariant === 'variant'
             ) {
                 cmp.init({
@@ -359,7 +360,11 @@ export const App = ({ CAPI, NAV }: Props) => {
                 });
             }
         }
-    }, [countryCode, CAPI.config.switches.consentManagement]);
+    }, [
+        countryCode,
+        CAPI.config.switches.consentManagement,
+        CAPI.config.switches.auConsent,
+    ]);
 
     const pillar = decidePillar(CAPI);
     const display: Display = decideDisplay(CAPI);


### PR DESCRIPTION
<!-- YOU SHOULD KNOW: dotcom is running an experiment called PR Deployments. -->
<!-- As soon as you open this PR, a github action called PR Deployment will run your code in an isolated environment and make it accessible in a public URL that you can use for testing etc -->
<!-- Every time you push to this branch, you will get an annoying email alert from github telling you that the previous PR deployment has been canceled. -->
<!-- You do not need to wait for the PR deployment action to go green before you can merge -->


## What does this change?

- adds a switch to turn on consent in AU

correlate of https://github.com/guardian/frontend/pull/23215
