### PR TITLE
Use acast enabled version of AudioAtom

### DIFF
--- a/fixtures/CAPI/CAPI.ts
+++ b/fixtures/CAPI/CAPI.ts
@@ -2792,6 +2792,7 @@ export const CAPI: CAPIType = modifyDCRJsonResponse({
             videojs: true,
             surveys: true,
             inizio: true,
+            acast: true,
         },
         hasYouTubeAtom: false,
         inBodyInternalLinkCount: 15,

--- a/fixtures/switches.ts
+++ b/fixtures/switches.ts
@@ -90,4 +90,5 @@ export const switches = {
     surveys: true,
     abCommercialAdVerification: false,
     inizio: true,
+    acast: true,
 };

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "@emotion/core": "^10.0.28",
         "@guardian/ab-core": "^2.0.0",
         "@guardian/ab-react": "^2.0.1",
-        "@guardian/atoms-rendering": "^2.0.8",
+        "@guardian/atoms-rendering": "^2.0.9",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/braze-components": "^0.0.13",
         "@guardian/consent-management-platform": "^6.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2260,10 +2260,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
   integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
 
-"@guardian/atoms-rendering@^2.0.8":
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-2.0.8.tgz#8707c6969177cff7b296a96d766868b1bbd9ac8c"
-  integrity sha512-TcKVIVODb7PIR6B3EnVeYdU23P46+kUwIoUzMvQVsqcC+ktq036mD57XX+8QScYRl1NpuenDCDwMcBMYyNHzzA==
+"@guardian/atoms-rendering@^2.0.9":
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-2.0.9.tgz#5e2ae5e5701314de4f3def000fe2cf8355eed086"
+  integrity sha512-viuUAFnS7d8/QQFlt7mSQJKHySg/87IXmJArJWF43k6qfDmRGGjwPiJdiGKXEHwR8KgyTMSDzk1pSJ1NfzATiQ==
 
 "@guardian/automat-client@^0.2.16":
   version "0.2.16"


### PR DESCRIPTION
### What
This PR adds `@guardian/atoms-rendering` at `v2.0.9` which encludes support for Acast via the `should UseAcast` prop.

We decide how to set the `shouldUseAcast` prop within a `useEffect` during hydration on the client (in `App.jsx`). The logic is:

```typescript
            if (
                aCastisEnabled &&
                consentGiven &&
                readerCanBeShownAds && // Eg. Not a subscriber
                contentIsNotSensitive
            ) {
                setShouldUseAcast(true);
            }
```

### Why make the decision about whether to display Acast ads here, and not in the atom itself?
Because:

1, it keeps the atom simple and
2, becuase different platforms might use different methods to decide if a user has consented to ads or not
