### PR TITLE
Revert "Double PROD ASG Min and Max for Election"

### DIFF
--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -60,8 +60,8 @@ Mappings:
       Value: rendering
   StageMap:
     PROD:
-      MinCapacity: 18
-      MaxCapacity: 72
+      MinCapacity: 9
+      MaxCapacity: 36
     CODE:
       MinCapacity: 1
       MaxCapacity: 4


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#2018