### PR TITLE
GuardianLines for GuardianView

### DIFF
--- a/src/web/components/Card/Card.stories.tsx
+++ b/src/web/components/Card/Card.stories.tsx
@@ -97,10 +97,10 @@ export const News = () => (
                                     {...{
                                         linkTo:
                                             '/society/2019/nov/14/witchcraft-and-black-magic-contribute-to-increase-in-child-abuse',
-                                        pillar: 'news',
-                                        designType: 'Article',
+                                        pillar: 'opinion',
+                                        designType: 'GuardianView',
                                         headlineText: headlines[3],
-                                        kickerText: kickers[2],
+                                        kickerText: 'Editorial',
                                         imageUrl: images[6],
                                         imagePosition: 'top',
                                         commentCount: 82224,

--- a/src/web/components/Card/components/CardFooter.tsx
+++ b/src/web/components/Card/components/CardFooter.tsx
@@ -34,7 +34,7 @@ export const CardFooter = ({
     mediaMeta,
     commentCount,
 }: Props) => {
-    if (designType === 'Comment') {
+    if (designType === 'Comment' || designType === 'GuardianView') {
         return (
             <footer className={spaceBetween}>
                 {age}


### PR DESCRIPTION
Editorial articles with the design type `GuardianView` should also show the GuardianLines at the bottom of the card foooter

### Before
![Screenshot 2020-11-10 at 10 04 49](https://user-images.githubusercontent.com/1336821/98659849-7b629400-233c-11eb-85dd-a38e36a9e5d1.jpg)



### After
![Screenshot 2020-11-10 at 10 04 07](https://user-images.githubusercontent.com/1336821/98659805-6d147800-233c-11eb-927e-79dd709c2b8a.jpg)
