### PR TITLE
Set Radio selection vertically for callout on condition

### DIFF
--- a/fixtures/calloutCampaign.ts
+++ b/fixtures/calloutCampaign.ts
@@ -119,3 +119,117 @@ export const calloutCampaign: CalloutBlockElement = {
         },
     ],
 };
+
+export const calloutCampaignOnlyTwoRadio: CalloutBlockElement = {
+    _type: 'model.dotcomrendering.pageElements.CalloutBlockElement',
+    id: '14d1b1bc-8983-43fb-8f2e-8ca08a711944',
+    calloutsUrl:
+        'https://callouts.code.dev-guardianapis.com/formstack-campaign/submit',
+    tagName: 'callout-early-coronavirus-events',
+    activeFrom: 1588118400000,
+    displayOnSensitive: false,
+    formId: 3860296,
+    title: 'Were you infected at this time?',
+    description:
+        '<p>If you attended one of these events and believe you may have been infected by coronavirus, we\'d like to hear from you. You can get in touch by filling in the form below, or by contacting us&nbsp;<a href="https://www.theguardian.com/info/2015/aug/12/whatsapp-sharing-stories-with-the-guardian">via WhatsApp</a>&nbsp;by&nbsp;<a href="https://api.whatsapp.com/send?phone=447867825056">clicking here&nbsp;</a>or adding the contact +44(0)7867825056. Only the Guardian can see your contributions and one of our journalists may contact you to discuss further. </p>',
+    formFields: [
+        {
+            textSize: 50,
+            name: 'which_event_did_you_attend_and_when',
+            hideLabel: false,
+            label: 'Which event did you attend and when?',
+            id: '91884886',
+            type: 'text',
+            required: true,
+        },
+        {
+            name: 'share_your_experiences_here',
+            description: 'Please include as much detail as possible',
+            hideLabel: false,
+            label: 'Share your experiences here',
+            id: '91884874',
+            type: 'textarea',
+            required: true,
+        },
+        {
+            name:
+                'you_can_upload_a_photo_here_if_you_think_it_will_add_to_your_story',
+            hideLabel: false,
+            label:
+                'You can upload a photo here if you think it will add to your story',
+            id: '91884877',
+            type: 'file',
+            required: false,
+        },
+        {
+            name: 'can_we_publish_your_response',
+            options: [
+                {
+                    label: 'Yes, entirely',
+                    value: 'Yes, entirely',
+                },
+                {
+                    label: 'Yes, but please keep me anonymous',
+                    value: 'Yes, but please keep me anonymous',
+                },
+            ],
+            hideLabel: false,
+            label: 'Can we publish your response?',
+            id: '91884878',
+            type: 'radio',
+            required: true,
+        },
+        {
+            name: 'can_we_publish_your_response',
+            options: [
+                {
+                    label: 'Yes, entirely',
+                    value: 'Yes, entirely',
+                },
+                {
+                    label: 'Yes, but please keep me anonymous',
+                    value: 'Yes, but please keep me anonymous',
+                },
+                {
+                    label: 'Yes, but please contact me first',
+                    value: 'Yes, but please contact me first',
+                },
+                {
+                    label: 'No, this is information only',
+                    value: 'No, this is information only',
+                },
+            ],
+            hideLabel: false,
+            label: 'Can we publish your response?',
+            id: '918848785',
+            type: 'checkbox',
+            required: true,
+        },
+        {
+            name: 'do_you_have_anything_else_to_add',
+            hideLabel: false,
+            label: 'Do you have anything else to add?',
+            id: '91884881',
+            type: 'select',
+            options: [
+                {
+                    label: 'Yes, entirely',
+                    value: 'Yes, entirely',
+                },
+                {
+                    label: 'Yes, but please keep me anonymous',
+                    value: 'Yes, but please keep me anonymous',
+                },
+                {
+                    label: 'Yes, but please contact me first',
+                    value: 'Yes, but please contact me first',
+                },
+                {
+                    label: 'No, this is information only',
+                    value: 'No, this is information only',
+                },
+            ],
+            required: false,
+        },
+    ],
+};

--- a/src/web/components/Callout/Form.stories.tsx
+++ b/src/web/components/Callout/Form.stories.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { css } from 'emotion';
 
-import { calloutCampaign } from '@root/fixtures/calloutCampaign';
+import {
+    calloutCampaign,
+    calloutCampaignOnlyTwoRadio,
+} from '@root/fixtures/calloutCampaign';
 import { Form } from './Form';
 
 export default {
@@ -22,6 +25,23 @@ export const Default = () => {
     );
 };
 Default.story = { name: 'default' };
+
+export const WithOnlyTwoRadio = () => {
+    return (
+        <div
+            className={css`
+                width: 630px;
+                padding: 15px;
+            `}
+        >
+            <Form
+                formFields={calloutCampaignOnlyTwoRadio.formFields}
+                onSubmit={() => {}}
+            />
+        </div>
+    );
+};
+WithOnlyTwoRadio.story = { name: 'with only two radio' };
 
 export const WithError = () => {
     return (

--- a/src/web/components/Callout/Form.tsx
+++ b/src/web/components/Callout/Form.tsx
@@ -171,10 +171,7 @@ export const Form = ({ onSubmit, formFields, error }: FormProps) => {
                 </Button>
                 <div
                     className={css`
-                        a {
-                            border: 0;
-                        }
-                        a:hover {
+                        a, a:hover  {
                             border: 0;
                         }
                     `}

--- a/src/web/components/Callout/RadioSelect.tsx
+++ b/src/web/components/Callout/RadioSelect.tsx
@@ -25,7 +25,7 @@ export const RadioSelect = ({
         `}
     >
         <FieldLabel formField={formField} />
-        <RadioGroup name={formField.name} orientation="horizontal">
+        <RadioGroup name={formField.name} orientation="vertical">
             {formField.options.map((option, index) => {
                 const isRadioChecked =
                     formField.id in formData &&

--- a/src/web/components/Callout/RadioSelect.tsx
+++ b/src/web/components/Callout/RadioSelect.tsx
@@ -25,7 +25,12 @@ export const RadioSelect = ({
         `}
     >
         <FieldLabel formField={formField} />
-        <RadioGroup name={formField.name} orientation="vertical">
+        <RadioGroup
+            name={formField.name}
+            orientation={
+                formField.options.length > 2 ? 'vertical' : 'horizontal'
+            }
+        >
             {formField.options.map((option, index) => {
                 const isRadioChecked =
                     formField.id in formData &&


### PR DESCRIPTION
<!-- YOU SHOULD KNOW: dotcom is running an experiment called PR Deployments. -->
<!-- As soon as you open this PR, a github action called PR Deployment will run your code in an isolated environment and make it accessible in a public URL that you can use for testing etc -->
<!-- Every time you push to this branch, you will get an annoying email alert from github telling you that the previous PR deployment has been canceled. -->
<!-- You do not need to wait for the PR deployment action to go green before you can merge -->


## What does this change?
Change the orientation of Radio buttons in Callout component depending on the number of radio inputs

### Before
![Screenshot 2020-11-11 at 12 40 18](https://user-images.githubusercontent.com/8831403/98812872-35c8c880-241b-11eb-9f43-98bc618af74c.png)

### After
2 Radio
![Screenshot 2020-11-11 at 13 24 20](https://user-images.githubusercontent.com/8831403/98816946-4f6d0e80-2421-11eb-9811-6a2b453336fa.png)

More than 2 Radio
![Screenshot 2020-11-11 at 12 39 51](https://user-images.githubusercontent.com/8831403/98812883-38c3b900-241b-11eb-8198-9f054498a535.png)

## Why?
As mentioned by @SiAdcock https://github.com/guardian/source/issues/580#issuecomment-718728816, it is recommended  to use horizontal radio buttons if there are only 2 answers.