### PR TITLE
Update ophan tracker js to 1.3.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
         "lodash.get": "^4.4.2",
         "log4js": "4.2.0",
         "minify-css-string": "^1.0.0",
-        "ophan-tracker-js": "^1.3.22",
+        "ophan-tracker-js": "^1.3.23",
         "pm2": "^4.3.0",
         "polished": "^1.9.2",
         "preact": "^10.3.1",


### PR DESCRIPTION
<!-- YOU SHOULD KNOW: dotcom is running an experiment called PR Deployments. -->
<!-- As soon as you open this PR, a github action called PR Deployment will run your code in an isolated environment and make it accessible in a public URL that you can use for testing etc -->
<!-- Every time you push to this branch, you will get an annoying email alert from github telling you that the previous PR deployment has been canceled. -->
<!-- You do not need to wait for the PR deployment action to go green before you can merge -->

## What does this change?

We may receive garbage in iframe message that will result in client side errors which we could safely ignore.
We currently have about [10k errors per day in Sentry with this problem](https://sentry.io/organizations/the-guardian/issues/1813121539/?project=35463&query=is%3Aunresolved) 

See https://github.com/guardian/ophan/pull/3964
