### PR TITLE
Added timings for the Braze SDK load and Braze 'appboy'-related calls

### DIFF
--- a/src/web/browser/initPerf.ts
+++ b/src/web/browser/initPerf.ts
@@ -23,8 +23,13 @@ export const initPerf = (name: string) => {
         return timeTakenInt;
     };
 
+    const clear = () => {
+        perf.clearMarks(startKey)
+    }
+
     return {
         start,
         end,
+        clear,
     };
 };

--- a/src/web/components/StickyBottomBanner/BrazeBanner.tsx
+++ b/src/web/components/StickyBottomBanner/BrazeBanner.tsx
@@ -140,8 +140,8 @@ const getMessageFromBraze = async (
             value: appboyTimeTaken,
         });
     }).catch(() => {
-        // eslint-disable-next-line no-console
         appboyTiming.clear();
+        // eslint-disable-next-line no-console
         console.log("Appboy Timing failed.");
     });
 

--- a/src/web/components/StickyBottomBanner/BrazeBanner.tsx
+++ b/src/web/components/StickyBottomBanner/BrazeBanner.tsx
@@ -141,6 +141,7 @@ const getMessageFromBraze = async (
         });
     }).catch(() => {
         // eslint-disable-next-line no-console
+        appboyTiming.clear();
         console.log("Appboy Timing failed.");
     });
 
@@ -232,6 +233,7 @@ export const canShow = async (
 
         return result;
     } catch (e) {
+        bannerTiming.clear();
         return { result: false };
     }
 };

--- a/src/web/components/StickyBottomBanner/BrazeBanner.tsx
+++ b/src/web/components/StickyBottomBanner/BrazeBanner.tsx
@@ -61,13 +61,25 @@ export const canShowPreChecks = ({
             !pageConfig.isPaidContent,
     );
 
+const appboyTiming = initPerf('braze-appboy');
+
 const getMessageFromBraze = async (
     apiKey: string,
     brazeUuid: string,
 ): Promise<CanShowResult> => {
+
+    const sdkLoadTiming = initPerf('braze-sdk-load');
+    sdkLoadTiming.start();
+
     const { default: appboy } = await import(
         /* webpackChunkName: "braze-web-sdk-core" */ '@braze/web-sdk-core'
     );
+
+    const sdkLoadTimeTaken = sdkLoadTiming.end();
+    record({
+        component: 'braze-sdk-load-timing',
+        value: sdkLoadTimeTaken,
+    });
 
     appboy.initialize(apiKey, {
         enableLogging: false,
@@ -78,6 +90,8 @@ const getMessageFromBraze = async (
     });
 
     return new Promise((resolve) => {
+
+        appboyTiming.start();
         appboy.subscribeToInAppMessage((message: any) => {
             const { extras } = message;
 
@@ -156,8 +170,8 @@ export const canShow = async (
     asyncBrazeUuid: Promise<null | string>,
     isDigitalSubscriber: undefined | boolean,
 ): Promise<CanShowResult> => {
-    const timing = initPerf('braze-banner');
-    timing.start();
+    const bannerTiming = initPerf('braze-banner');
+    bannerTiming.start();
 
     const forcedBrazeMeta = getBrazeMetaFromQueryString();
     if (forcedBrazeMeta) {
@@ -193,7 +207,13 @@ export const canShow = async (
     try {
         const result = await getMessageFromBraze(apiKey as string, brazeUuid)
 
-        const timeTaken = timing.end();
+        const appboyTimeTaken = appboyTiming.end()
+        record({
+            component: 'braze-appboy-timing',
+            value: appboyTimeTaken,
+        });
+
+        const timeTaken = bannerTiming.end();
         record({
             component: 'braze-banner-timing',
             value: timeTaken,


### PR DESCRIPTION
<!-- YOU SHOULD KNOW: dotcom is running an experiment called PR Deployments. -->
<!-- As soon as you open this PR, a github action called PR Deployment will run your code in an isolated environment and make it accessible in a public URL that you can use for testing etc -->
<!-- Every time you push to this branch, you will get an annoying email alert from github telling you that the previous PR deployment has been canceled. -->
<!-- You do not need to wait for the PR deployment action to go green before you can merge -->

Equivalent PR for Frontend [here](**url**).

## What does this change?
This adds additional timing measurements. We (TX) want to collect RUM data, which we will pull from Ophan in order to see which calls are taking up the most time. Currently our banner exceeds its time limit roughly 1 in 3 page views where it would otherwise be valid to show.

## Why?
We want to figure out what takes the most time, in order to identify where improvements are made. We are especially interested in Braze's API calls and SDK load time.
