### PR TITLE
Reporting the AB test from dotcom

### DIFF
--- a/src/web/experiments/ab-tests.ts
+++ b/src/web/experiments/ab-tests.ts
@@ -3,12 +3,13 @@ import { abTestTest } from '@frontend/web/experiments/tests/ab-test-test';
 import { signInGateMainVariant } from '@root/src/web/experiments/tests/sign-in-gate-main-variant';
 import { signInGateMainControl } from '@root/src/web/experiments/tests/sign-in-gate-main-control';
 import { curatedContainerTest } from '@frontend/web/experiments/tests/curated-container-test';
-import {newsletterMerchUnitLighthouse} from "@root/src/web/experiments/tests/newsletter-merch-unit-test";
+import {newsletterMerchUnitLighthouseControl, newsletterMerchUnitLighthouseVariants} from "@root/src/web/experiments/tests/newsletter-merch-unit-test";
 
 export const tests: ABTest[] = [
     abTestTest,
     signInGateMainVariant,
     signInGateMainControl,
     curatedContainerTest,
-    newsletterMerchUnitLighthouse,
+    newsletterMerchUnitLighthouseControl,
+    newsletterMerchUnitLighthouseVariants
 ];

--- a/src/web/experiments/ab-tests.ts
+++ b/src/web/experiments/ab-tests.ts
@@ -3,10 +3,12 @@ import { abTestTest } from '@frontend/web/experiments/tests/ab-test-test';
 import { signInGateMainVariant } from '@root/src/web/experiments/tests/sign-in-gate-main-variant';
 import { signInGateMainControl } from '@root/src/web/experiments/tests/sign-in-gate-main-control';
 import { curatedContainerTest } from '@frontend/web/experiments/tests/curated-container-test';
+import {newsletterMerchUnitLighthouse} from "@root/src/web/experiments/tests/newsletter-merch-unit-test";
 
 export const tests: ABTest[] = [
     abTestTest,
     signInGateMainVariant,
     signInGateMainControl,
     curatedContainerTest,
+    newsletterMerchUnitLighthouse,
 ];

--- a/src/web/experiments/tests/newsletter-merch-unit-test.ts
+++ b/src/web/experiments/tests/newsletter-merch-unit-test.ts
@@ -26,9 +26,10 @@ export const newsletterMerchUnitLighthouseVariants: ABTest = {
     start: '2020-11-11',
     expiry: '2020-12-01',
     author: 'Josh Buckland & Alex Dufournet',
-    description: 'Show a newsletter advert in the merchandising unit to 25% of users. ' +
-        'These two variants test value of showing newsletter merch units instead of reader revenue ones. ' +
-        'This test needs to run at the same time as NewsletterMerchUnitLighthouseControl',
+    description: 'Show a newsletter advert in the merchandising unit to 25% of users and reader revenue' +
+        'to another 25%. The remaining 50% are covered by NewsletterMerchUnitLighthouseControl ' +
+        'which needs to run at the same time. These two variants test the value of showing ' + 
+        'newsletter merch units instead of reader revenue ones. ',
     audience: 0.5,
     audienceOffset: 0.5,
     successMeasure: 'We see increased engagement from users shown the Newsletters ad unit',

--- a/src/web/experiments/tests/newsletter-merch-unit-test.ts
+++ b/src/web/experiments/tests/newsletter-merch-unit-test.ts
@@ -1,12 +1,12 @@
 import { ABTest } from '@guardian/ab-core';
 
-export const newsletterMerchUnitLighthouse: ABTest = {
-    id: 'NewsletterMerchUnitLighthouse',
+export const newsletterMerchUnitLighthouseControl: ABTest = {
+    id: 'NewsletterMerchUnitLighthouseControl',
     start: '2020-11-11',
     expiry: '2020-12-01',
     author: 'Josh Buckland & Alex Dufournet',
     description: 'Show a newsletter advert in the merchandising unit to 50% of users',
-    audience: 1.0,
+    audience: 0.5,
     audienceOffset: 0.0,
     successMeasure: 'We see increased engagement from users shown the Newsletters ad unit',
     audienceCriteria: 'Website users only.',
@@ -18,8 +18,29 @@ export const newsletterMerchUnitLighthouse: ABTest = {
             id: 'control',
             test: (): void => {},
         },
+    ],
+};
+
+export const newsletterMerchUnitLighthouseVariants: ABTest = {
+    id: 'NewsletterMerchUnitLighthouseVariants',
+    start: '2020-11-11',
+    expiry: '2020-12-01',
+    author: 'Josh Buckland & Alex Dufournet',
+    description: 'Show a newsletter advert in the merchandising unit to 50% of users',
+    audience: 0.5,
+    audienceOffset: 0.5,
+    successMeasure: 'We see increased engagement from users shown the Newsletters ad unit',
+    audienceCriteria: 'Website users only.',
+    idealOutcome: 'Investigate lighthouse segment engagement via newsletters',
+    showForSensitive: false,
+    canRun: () => true,
+    variants: [
         {
-            id: 'variant',
+            id: 'variant1',
+            test: (): void => {},
+        },
+        {
+            id: 'variant2',
             test: (): void => {},
         },
     ],

--- a/src/web/experiments/tests/newsletter-merch-unit-test.ts
+++ b/src/web/experiments/tests/newsletter-merch-unit-test.ts
@@ -5,7 +5,7 @@ export const newsletterMerchUnitLighthouseControl: ABTest = {
     start: '2020-11-11',
     expiry: '2020-12-01',
     author: 'Josh Buckland & Alex Dufournet',
-    description: 'Show any merch unit to 50% of users. This is the control for the NewsletterMerchUnitLighthouseVariants test.',
+    description: 'Show BAU merch unit to 50% of users. This is the control for the NewsletterMerchUnitLighthouseVariants test.',
     audience: 0.5,
     audienceOffset: 0.0,
     successMeasure: 'We see increased engagement from users shown the Newsletters ad unit',

--- a/src/web/experiments/tests/newsletter-merch-unit-test.ts
+++ b/src/web/experiments/tests/newsletter-merch-unit-test.ts
@@ -5,7 +5,7 @@ export const newsletterMerchUnitLighthouseControl: ABTest = {
     start: '2020-11-11',
     expiry: '2020-12-01',
     author: 'Josh Buckland & Alex Dufournet',
-    description: 'Show a newsletter advert in the merchandising unit to 50% of users',
+    description: 'Show any merch unit to 50% of users. This is the control for the NewsletterMerchUnitLighthouseVariants test.',
     audience: 0.5,
     audienceOffset: 0.0,
     successMeasure: 'We see increased engagement from users shown the Newsletters ad unit',
@@ -26,7 +26,9 @@ export const newsletterMerchUnitLighthouseVariants: ABTest = {
     start: '2020-11-11',
     expiry: '2020-12-01',
     author: 'Josh Buckland & Alex Dufournet',
-    description: 'Show a newsletter advert in the merchandising unit to 50% of users',
+    description: 'Show a newsletter advert in the merchandising unit to 25% of users. ' +
+        'These two variants test value of showing newsletter merch units instead of reader revenue ones. ' +
+        'This test needs to run at the same time as NewsletterMerchUnitLighthouseVariants',
     audience: 0.5,
     audienceOffset: 0.5,
     successMeasure: 'We see increased engagement from users shown the Newsletters ad unit',
@@ -36,11 +38,11 @@ export const newsletterMerchUnitLighthouseVariants: ABTest = {
     canRun: () => true,
     variants: [
         {
-            id: 'variant1',
+            id: 'newsletter',
             test: (): void => {},
         },
         {
-            id: 'variant2',
+            id: 'reader-revenue',
             test: (): void => {},
         },
     ],

--- a/src/web/experiments/tests/newsletter-merch-unit-test.ts
+++ b/src/web/experiments/tests/newsletter-merch-unit-test.ts
@@ -6,7 +6,7 @@ export const newsletterMerchUnitLighthouse: ABTest = {
     expiry: '2020-12-01',
     author: 'Josh Buckland & Alex Dufournet',
     description: 'Show a newsletter advert in the merchandising unit to 50% of users',
-    audience: 1.0, // 0.01%
+    audience: 1.0,
     audienceOffset: 0.0,
     successMeasure: 'We see increased engagement from users shown the Newsletters ad unit',
     audienceCriteria: 'Website users only.',
@@ -17,22 +17,10 @@ export const newsletterMerchUnitLighthouse: ABTest = {
         {
             id: 'control',
             test: (): void => {},
-            impression: (impression) => {
-                impression();
-            },
-            success: (success) => {
-                success();
-            },
         },
         {
             id: 'variant',
             test: (): void => {},
-            impression: (impression) => {
-                impression();
-            },
-            success: (success) => {
-                success();
-            },
         },
     ],
 };

--- a/src/web/experiments/tests/newsletter-merch-unit-test.ts
+++ b/src/web/experiments/tests/newsletter-merch-unit-test.ts
@@ -28,7 +28,7 @@ export const newsletterMerchUnitLighthouseVariants: ABTest = {
     author: 'Josh Buckland & Alex Dufournet',
     description: 'Show a newsletter advert in the merchandising unit to 25% of users. ' +
         'These two variants test value of showing newsletter merch units instead of reader revenue ones. ' +
-        'This test needs to run at the same time as NewsletterMerchUnitLighthouseVariants',
+        'This test needs to run at the same time as NewsletterMerchUnitLighthouseControl',
     audience: 0.5,
     audienceOffset: 0.5,
     successMeasure: 'We see increased engagement from users shown the Newsletters ad unit',

--- a/src/web/experiments/tests/newsletter-merch-unit-test.ts
+++ b/src/web/experiments/tests/newsletter-merch-unit-test.ts
@@ -1,0 +1,38 @@
+import { ABTest } from '@guardian/ab-core';
+
+export const newsletterMerchUnitLighthouse: ABTest = {
+    id: 'NewsletterMerchUnitLighthouse',
+    start: '2020-11-11',
+    expiry: '2020-12-01',
+    author: 'Josh Buckland & Alex Dufournet',
+    description: 'Show a newsletter advert in the merchandising unit to 50% of users',
+    audience: 1.0, // 0.01%
+    audienceOffset: 0.0,
+    successMeasure: 'We see increased engagement from users shown the Newsletters ad unit',
+    audienceCriteria: 'Website users only.',
+    idealOutcome: 'Investigate lighthouse segment engagement via newsletters',
+    showForSensitive: false,
+    canRun: () => true,
+    variants: [
+        {
+            id: 'control',
+            test: (): void => {},
+            impression: (impression) => {
+                impression();
+            },
+            success: (success) => {
+                success();
+            },
+        },
+        {
+            id: 'variant',
+            test: (): void => {},
+            impression: (impression) => {
+                impression();
+            },
+            success: (success) => {
+                success();
+            },
+        },
+    ],
+};


### PR DESCRIPTION
### What does this change?
See https://github.com/guardian/frontend/pull/23230

Adding the newsletter merch a/b test to match the dotcom implementation

Requires testing to confirm the opt-in and tracking

### Before
N/A
### After
N/A

## Why?
This A/B test should help us understand if there's value in using the merch space to promote our own newsletters

