### PR TITLE
Update dependabot to more regularly update @guardian deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,22 @@
 # Please see the documentation for all configuration options:
 # https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
+# We check @guardian NPM dependencies daily and the rest of the npm dependencies weekly.
+
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  # @guardian NPM packages
+  - package-ecosystem: "npm" 
+    directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 10
+    allow: "@guardian/*"
+    lables:
+      - "Guardian Dependency"
+  # General NPM Dependencies
+  - package-ecosystem: "npm" 
+    directory: "/" 
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## What does this change?

We want to prioritise `@guardian/` NPM dependency updates over the rest of NPM to ensure that we're keeping up to date with our internal packages.

This PR splits dependabot into @guardian and the rest of npm.

### Before

All npm, daily, 5 max open at once.

### After

- @guardian packages are checked daily, with a limit of 10 open at once.
- npm in general is checked weekly (reduced from daily), with a limit of 10 open at once.

(Note, this could leave us with 20 open dependabot PRs so we need to keep on top of them!)

## Why?

This should allow us to focus our dep bumps on internal packages, while allowing less of a flood of other npm deps every day - we can set aside time early in the week to check and merge through the non @guardian deps.
