### PR TITLE
Introduce MediaAtomBlockElement

### DIFF
--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -189,6 +189,11 @@ interface MapBlockElement {
     caption?: string;
 }
 
+interface MediaAtomBlockElement {
+    _type: 'model.dotcomrendering.pageElements.MediaAtomBlockElement';
+    id: string;
+}
+
 interface MultiImageBlockElement {
     _type: 'model.dotcomrendering.pageElements.MultiImageBlockElement';
     images: ImageBlockElement[];
@@ -356,6 +361,7 @@ type CAPIElement =
     | InteractiveAtomBlockElement
     | InteractiveBlockElement
     | MapBlockElement
+    | MediaAtomBlockElement
     | MultiImageBlockElement
     | ProfileAtomBlockElement
     | PullquoteBlockElement

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -84,6 +84,9 @@
                         "$ref": "#/definitions/MapBlockElement"
                     },
                     {
+                        "$ref": "#/definitions/MediaAtomBlockElement"
+                    },
+                    {
                         "$ref": "#/definitions/MultiImageBlockElement"
                     },
                     {
@@ -1571,6 +1574,24 @@
                 "width"
             ]
         },
+        "MediaAtomBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.MediaAtomBlockElement"
+                    ]
+                },
+                "id": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "_type",
+                "id"
+            ]
+        },
         "MultiImageBlockElement": {
             "type": "object",
             "properties": {
@@ -2182,6 +2203,9 @@
                             },
                             {
                                 "$ref": "#/definitions/MapBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/MediaAtomBlockElement"
                             },
                             {
                                 "$ref": "#/definitions/MultiImageBlockElement"

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -420,6 +420,7 @@ export const ArticleRenderer: React.FC<{
                 case 'model.dotcomrendering.pageElements.CodeBlockElement':
                 case 'model.dotcomrendering.pageElements.ContentAtomBlockElement':
                 case 'model.dotcomrendering.pageElements.GenericAtomBlockElement':
+                case 'model.dotcomrendering.pageElements.MediaAtomBlockElement':
                 case 'model.dotcomrendering.pageElements.VideoBlockElement':
                     return null;
             }


### PR DESCRIPTION

## What does this change?

Introduce the `MediaAtomBlockElement`. The type is currently simple (and has no visual effect) since this PR is just to allow the release of the backend type into the DCR data object. 