### PR TITLE
Remove split on guardian and non guardian dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,18 +7,9 @@
 
 version: 2
 updates:
-  # @guardian NPM packages
+  # NPM packages
   - package-ecosystem: "npm" 
     directory: "/"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 10
-    allow: "@guardian/*"
-    lables:
-      - "Guardian Dependency"
-  # General NPM Dependencies
-  - package-ecosystem: "npm" 
-    directory: "/" 
-    schedule:
-      interval: "weekly"
     open-pull-requests-limit: 10


### PR DESCRIPTION


## What does this change?

You can't have two targets of the same npm in dependabot, so setting back to just the one for all npm modules