### PR TITLE
Skip frontend test on CI only

### DIFF
--- a/cypress/integration/e2e/commercial.spec.js
+++ b/cypress/integration/e2e/commercial.spec.js
@@ -34,8 +34,6 @@ describe('Commercial E2E tests', function () {
 
     describe('Ad slot Parity between DCR and Frontend for a long read', function () {
         it(`It should check slots for a long article in DCR`, function () {
-            console.log(Cypress.env('TEAMCITY'));
-            cy.log(Cypress.env('TEAMCITY'));
             runLongReadTestFor(`Article?url=${longReadURL}`);
         });
 

--- a/cypress/integration/e2e/commercial.spec.js
+++ b/cypress/integration/e2e/commercial.spec.js
@@ -34,6 +34,7 @@ describe('Commercial E2E tests', function () {
 
     describe('Ad slot Parity between DCR and Frontend for a long read', function () {
         it(`It should check slots for a long article in DCR`, function () {
+            cy.log(process.env);
             runLongReadTestFor(`Article?url=${longReadURL}`);
         });
 
@@ -41,7 +42,6 @@ describe('Commercial E2E tests', function () {
         // eslint-disable-next-line mocha/no-setup-in-describe
         skipOn(Cypress.env('CI') === 'true', () => {
             it(`It should check slots for a long article in Frontend`, function () {
-                cy.log(process.env);
                 Cypress.config('baseUrl', '');
                 runLongReadTestFor(`${longReadURL}?dcr=false`);
             });

--- a/cypress/integration/e2e/commercial.spec.js
+++ b/cypress/integration/e2e/commercial.spec.js
@@ -34,13 +34,14 @@ describe('Commercial E2E tests', function () {
 
     describe('Ad slot Parity between DCR and Frontend for a long read', function () {
         it(`It should check slots for a long article in DCR`, function () {
-            cy.log(process.env);
+            console.log(Cypress.env('TEAMCITY'));
+            cy.log(Cypress.env('TEAMCITY'));
             runLongReadTestFor(`Article?url=${longReadURL}`);
         });
 
         // Skipping only on CI because, overriding the baseURL works fine locally but hangs on CI.
         // eslint-disable-next-line mocha/no-setup-in-describe
-        skipOn(Cypress.env('CI') === 'true', () => {
+        skipOn(Cypress.env('TEAMCITY') === 'true', () => {
             it(`It should check slots for a long article in Frontend`, function () {
                 Cypress.config('baseUrl', '');
                 runLongReadTestFor(`${longReadURL}?dcr=false`);

--- a/cypress/integration/e2e/commercial.spec.js
+++ b/cypress/integration/e2e/commercial.spec.js
@@ -1,6 +1,7 @@
 import { getPolyfill } from '../../lib/polyfill';
 import { fetchPolyfill } from '../../lib/config';
 import { disableCMP } from '../../lib/disableCMP';
+import { skipOn } from '@cypress/skip-test';
 
 describe('Commercial E2E tests', function () {
     before(getPolyfill);
@@ -36,12 +37,13 @@ describe('Commercial E2E tests', function () {
             runLongReadTestFor(`Article?url=${longReadURL}`);
         });
 
-        // Uncomment to check Locally.
-        // It seems overriding the baseURL works fine locally but hangs on CI.
-
-        // it(`It should check slots for a long article in Frontend`, function () {
-        //     Cypress.config('baseUrl', '');
-        //     runLongReadTestFor(`${longReadURL}?dcr=false`);
-        // });
+        // Skipping only on CI because, overriding the baseURL works fine locally but hangs on CI.
+        // eslint-disable-next-line mocha/no-setup-in-describe
+        skipOn(Cypress.env('CI') === 'true', () => {
+            it(`It should check slots for a long article in Frontend`, function () {
+                Cypress.config('baseUrl', '');
+                runLongReadTestFor(`${longReadURL}?dcr=false`);
+            });
+        });
     });
 });

--- a/cypress/integration/e2e/commercial.spec.js
+++ b/cypress/integration/e2e/commercial.spec.js
@@ -41,6 +41,7 @@ describe('Commercial E2E tests', function () {
         // eslint-disable-next-line mocha/no-setup-in-describe
         skipOn(Cypress.env('CI') === 'true', () => {
             it(`It should check slots for a long article in Frontend`, function () {
+                cy.log(process.env);
                 Cypress.config('baseUrl', '');
                 runLongReadTestFor(`${longReadURL}?dcr=false`);
             });

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -8,4 +8,7 @@
 // https://on.cypress.io/plugins-guide
 // ***********************************************************
 
-module.exports = (on, config) => {};
+module.exports = (on, config) => {
+    config.env = { ...config.env, ...process.env };
+    return config;
+};

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -10,6 +10,5 @@
 
 module.exports = (on, config) => {
     config.env = { ...config.env, ...process.env };
-    console.log(config.env);
     return config;
 };

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -10,5 +10,6 @@
 
 module.exports = (on, config) => {
     config.env = { ...config.env, ...process.env };
+    console.log(config.env);
     return config;
 };

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "dependencies": {
         "@braze/web-sdk-core": "^3.0.0",
         "@emotion/core": "^10.0.35",
+        "@cypress/skip-test": "^2.5.0",
         "@guardian/ab-core": "^2.0.0",
         "@guardian/ab-react": "^2.0.1",
         "@guardian/atoms-rendering": "^2.0.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2047,6 +2047,11 @@
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
 
+"@cypress/skip-test@^2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@cypress/skip-test/-/skip-test-2.5.0.tgz#ba3fc8c441a9dda5fa410e783006107ff3b9d050"
+  integrity sha512-OqyToxRLUG/EAfZa0w8sAooOW6tr8pYCBpo3SLsKycrV2RTj9Sy7rB+5U0MvES87kWCHtO10qMIESuw8RiEYyQ==
+
 "@cypress/xvfb@^1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@cypress/xvfb/-/xvfb-1.2.4.tgz#2daf42e8275b39f4aa53c14214e557bd14e7748a"


### PR DESCRIPTION
## What does this change?

Skipping the commercial frontend test only on CI as suggested by @mxdvl here: https://github.com/guardian/dotcom-rendering/pull/2030#discussion_r523009470

## Why?

I will allow running it locally and skip it on CI where it hangs
