### PR TITLE
AMP epic: use new data model

### DIFF
--- a/src/amp/components/Epic.tsx
+++ b/src/amp/components/Epic.tsx
@@ -148,10 +148,10 @@ export const Epic: React.FC<{ webURL: string }> = ({ webURL }) => {
                         <MoustacheSection name="ticker">
                             <Ticker
                                 percentage={moustacheVariable('percentage')}
-                                currentAmountFigure={moustacheVariable('currentAmountFigure')}
-                                currentAmountCaption={moustacheVariable('currentAmountCaption')}
-                                goalAmountFigure={moustacheVariable('goalAmountFigure')}
-                                goalAmountCaption={moustacheVariable('goalAmountCaption')}
+                                topLeft={moustacheVariable('topLeft')}
+                                bottomLeft={moustacheVariable('bottomLeft')}
+                                topRight={moustacheVariable('topRight')}
+                                bottomRight={moustacheVariable('bottomRight')}
                             />
                         </MoustacheSection>
 

--- a/src/amp/components/Ticker.tsx
+++ b/src/amp/components/Ticker.tsx
@@ -55,28 +55,28 @@ const amountCaptionStyle = css`
 
 export const Ticker: React.FC<{
     percentage: string,
-    currentAmountFigure: string,
-    currentAmountCaption: string,
-    goalAmountFigure: string,
-    goalAmountCaption: string,
+    topLeft: string,
+    bottomLeft: string,
+    topRight: string,
+    bottomRight: string,
 }> = ({
     percentage,
-    currentAmountFigure,
-    currentAmountCaption,
-    goalAmountFigure,
-    goalAmountCaption,
+    topLeft,
+    bottomLeft,
+    topRight,
+    bottomRight,
 }) => {
     return (
         <div>
             <div className={tickerWrapperStyle}>
                 <div className={tickerInfoStyle}>
                     <div className={leftStyle}>
-                        <p className={currentAmountStyle}>{currentAmountFigure}</p>
-                        <p className={amountCaptionStyle}>{currentAmountCaption}</p>
+                        <p className={currentAmountStyle}>{topLeft}</p>
+                        <p className={amountCaptionStyle}>{bottomLeft}</p>
                     </div>
                     <div className={rightStyle}>
-                        <p className={goalAmountStyle}>{goalAmountFigure}</p>
-                        <p className={amountCaptionStyle}>{goalAmountCaption}</p>
+                        <p className={goalAmountStyle}>{topRight}</p>
+                        <p className={amountCaptionStyle}>{bottomRight}</p>
                     </div>
                 </div>
                 <div className={tickerBackgroundStyle}>


### PR DESCRIPTION
The model on the backend changed here: https://github.com/guardian/support-dotcom-components/pull/289
This was part of the work to integrate it with the epic tool.
This PR updates the client to use that model.

![Screen Shot 2020-11-16 at 13 19 14](https://user-images.githubusercontent.com/1513454/99257559-1f51b100-280f-11eb-96b1-93291e7f7704.png)
