### PR TITLE
bump CMP to 6.7.1

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -11,6 +11,7 @@ module.exports = {
         ],
         '@babel/plugin-proposal-class-properties',
         '@babel/plugin-proposal-optional-chaining',
+        '@babel/plugin-proposal-nullish-coalescing-operator',
         [
             'module-resolver',
             {

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     },
     "dependencies": {
         "@braze/web-sdk-core": "^3.0.0",
-        "@emotion/core": "^10.0.35",
         "@cypress/skip-test": "^2.5.0",
+        "@emotion/core": "^10.0.35",
         "@guardian/ab-core": "^2.0.0",
         "@guardian/ab-react": "^2.0.1",
         "@guardian/atoms-rendering": "^2.0.9",
@@ -116,6 +116,7 @@
         "@babel/core": "^7.11.6",
         "@babel/helper-create-regexp-features-plugin": "^7.10.4",
         "@babel/plugin-proposal-class-properties": "^7.10.4",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.12.1",
         "@babel/plugin-proposal-object-rest-spread": "^7.11.0",
         "@babel/plugin-proposal-optional-chaining": "^7.11.0",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3",
@@ -254,7 +255,7 @@
         },
         "testResultsProcessor": "jest-teamcity-reporter",
         "transformIgnorePatterns": [
-            "/node_modules/(?!@guardian/).+\\.js$"
+            "/node_modules/(?!@guardian/)"
         ],
         "collectCoverageFrom": [
             "src/**/*.{ts,tsx}"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "@guardian/atoms-rendering": "^2.0.9",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/braze-components": "^0.0.14",
-        "@guardian/consent-management-platform": "^6.6.0",
+        "@guardian/consent-management-platform": "^6.7.1",
         "@guardian/discussion-rendering": "^3.1.2",
         "@guardian/shimport": "^1.0.2",
         "@guardian/src-button": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "@guardian/atoms-rendering": "^2.0.9",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/braze-components": "^0.0.14",
-        "@guardian/consent-management-platform": "^6.7.1",
+        "@guardian/consent-management-platform": "^6.7.2",
         "@guardian/discussion-rendering": "^3.1.2",
         "@guardian/shimport": "^1.0.2",
         "@guardian/src-button": "^2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2225,10 +2225,10 @@
     "@guardian/src-icons" "2.4.0"
     emotion-theming "^10.0.19"
 
-"@guardian/consent-management-platform@^6.7.1":
-  version "6.7.1"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.7.1.tgz#4a87fea4ff5d3d7e4f9200aead4bbef4f17796f9"
-  integrity sha512-sAYqwzYRzQu2pTmen+aU9GQWVvy/M2jXJibC4qA8yurt8levWqfD3b+LWXeaIh8sUkXKiYsifQYbQtuj8m9REA==
+"@guardian/consent-management-platform@^6.7.2":
+  version "6.7.2"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.7.2.tgz#4a6e2c7757bb014dc2adf4853db5e668f2798530"
+  integrity sha512-tAl+oohzjkRFqLkd5NcZKAp6v5hH0cKdwzX2LwLhQVgwVmtyPVdfr9UZZaIFK4xcHOOqXLQ+Jcy3oBAgOfs47w==
 
 "@guardian/discussion-rendering@^3.1.2":
   version "3.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -814,6 +814,14 @@
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.0"
 
+"@babel/plugin-proposal-nullish-coalescing-operator@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.12.1.tgz#3ed4fff31c015e7f3f1467f190dbe545cd7b046c"
+  integrity sha512-nZY0ESiaQDI1y96+jk6VxMOaL4LPo/QDHBqL+SF3/vl6dHkTwHlOI8L4ZwuRBHgakRBw5zsVylel7QPbbGuYgg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.0"
+
 "@babel/plugin-proposal-numeric-separator@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.10.4.tgz#ce1590ff0a65ad12970a609d78855e9a4c1aef06"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2228,10 +2228,10 @@
     "@guardian/src-icons" "2.4.0"
     emotion-theming "^10.0.19"
 
-"@guardian/consent-management-platform@^6.6.0":
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.6.0.tgz#e6328fdfba40bb423f8a63084b1096423041a564"
-  integrity sha512-QIEd65+sPN56VMekx5JinZZIFHq0ahfG1HGISfG9HRG6+31r1VNv8d6VXySszJXhY1ksCh4Rtn0BW3MmSq5NkQ==
+"@guardian/consent-management-platform@^6.7.1":
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.7.1.tgz#4a87fea4ff5d3d7e4f9200aead4bbef4f17796f9"
+  integrity sha512-sAYqwzYRzQu2pTmen+aU9GQWVvy/M2jXJibC4qA8yurt8levWqfD3b+LWXeaIh8sUkXKiYsifQYbQtuj8m9REA==
 
 "@guardian/discussion-rendering@^3.1.2":
   version "3.1.2"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

bumps CMP to 6.7.1

## Why?

to support Oz

correlate of https://github.com/guardian/frontend/pull/23253