### PR TITLE
Update browser.js webpack to use preset-env instead of preset-modules

### DIFF
--- a/scripts/webpack/browser.js
+++ b/scripts/webpack/browser.js
@@ -104,7 +104,15 @@ module.exports = ({ isLegacyJS }) => ({
                                               modules: false,
                                           },
                                       ]
-                                    : '@babel/preset-modules',
+                                    : [
+                                          '@babel/preset-env',
+                                          {
+                                              bugfixes: true,
+                                              targets: {
+                                                  esmodules: true,
+                                              },
+                                          },
+                                      ],
                             ],
                         },
                     },


### PR DESCRIPTION
## What does this change?

Updates `preset-modules` babel preset to `preset-env` as per the message at the top of https://github.com/babel/preset-modules. This allows us to use nullish coalescing which was failing in our version of `preset-modules`.

There does not seem to be a difference in bundle size which suggest the bundling is equal.

There are no issues with Cypress or UI differences.

Onward journeys, CMP etc seem to be loading as expected: https://5f8e08b183c3.ngrok.io/Article

--

Using preset-env settings for https://babeljs.io/docs/en/babel-preset-env#bugfixes and https://babeljs.io/docs/en/babel-preset-env#targetsesmodules - we have the direct equivalent of `preset-modules` (the behaviour of which was rolled into preset-env)