### PR TITLE
Use VideoAtom in DCR

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,11 +33,11 @@
     },
     "dependencies": {
         "@braze/web-sdk-core": "^3.0.0",
-        "@emotion/core": "^10.0.35",
         "@cypress/skip-test": "^2.5.0",
+        "@emotion/core": "^10.0.35",
         "@guardian/ab-core": "^2.0.0",
         "@guardian/ab-react": "^2.0.1",
-        "@guardian/atoms-rendering": "^2.0.9",
+        "@guardian/atoms-rendering": "^2.4.1",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/braze-components": "^0.0.14",
         "@guardian/consent-management-platform": "^6.6.0",

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -192,6 +192,13 @@ interface MapBlockElement {
 interface MediaAtomBlockElement {
     _type: 'model.dotcomrendering.pageElements.MediaAtomBlockElement';
     id: string;
+    assets: VideoAssets[];
+    posterImage?: {
+        url: string;
+        width: number;
+    }[];
+    title?: string;
+    duration?: number;
 }
 
 interface MultiImageBlockElement {

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -1585,10 +1585,41 @@
                 },
                 "id": {
                     "type": "string"
+                },
+                "assets": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/VideoAssets"
+                    }
+                },
+                "posterImage": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "url": {
+                                "type": "string"
+                            },
+                            "width": {
+                                "type": "number"
+                            }
+                        },
+                        "required": [
+                            "url",
+                            "width"
+                        ]
+                    }
+                },
+                "title": {
+                    "type": "string"
+                },
+                "duration": {
+                    "type": "number"
                 }
             },
             "required": [
                 "_type",
+                "assets",
                 "id"
             ]
         },

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -36,6 +36,7 @@ import {
     GuideAtom,
     ProfileAtom,
     TimelineAtom,
+    VideoAtom,
 } from '@guardian/atoms-rendering';
 import { Display } from '@root/src/lib/display';
 import { withSignInGateSlot } from '@root/src/web/lib/withSignInGateSlot';
@@ -416,11 +417,20 @@ export const ArticleRenderer: React.FC<{
                             />
                         </div>
                     );
+                case 'model.dotcomrendering.pageElements.MediaAtomBlockElement':
+                    return (
+                        <VideoAtom
+                            assets={element.assets}
+                            poster={
+                                element.posterImage &&
+                                element.posterImage[0].url
+                            }
+                        />
+                    );
                 case 'model.dotcomrendering.pageElements.AudioBlockElement':
                 case 'model.dotcomrendering.pageElements.CodeBlockElement':
                 case 'model.dotcomrendering.pageElements.ContentAtomBlockElement':
                 case 'model.dotcomrendering.pageElements.GenericAtomBlockElement':
-                case 'model.dotcomrendering.pageElements.MediaAtomBlockElement':
                 case 'model.dotcomrendering.pageElements.VideoBlockElement':
                     return null;
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2196,10 +2196,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
   integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
 
-"@guardian/atoms-rendering@^2.0.9":
-  version "2.0.9"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-2.0.9.tgz#5e2ae5e5701314de4f3def000fe2cf8355eed086"
-  integrity sha512-viuUAFnS7d8/QQFlt7mSQJKHySg/87IXmJArJWF43k6qfDmRGGjwPiJdiGKXEHwR8KgyTMSDzk1pSJ1NfzATiQ==
+"@guardian/atoms-rendering@^2.4.1":
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-2.4.1.tgz#357be3f0b21d80b5c6d5b879cdb150421a08b1e2"
+  integrity sha512-PMdJ8QmkYMIt8Vypr7QyZC5q8WQCT+Pazbs8vb9OZ7oOnNyMydyNGvGgxD8j0wCNFohtM/pCl6fm7W41p2EDOA==
 
 "@guardian/automat-client@^0.2.16":
   version "0.2.16"


### PR DESCRIPTION
With this PR, if DCR is sent:

```typescript
interface MediaAtomBlockElement {
    _type: 'model.dotcomrendering.pageElements.MediaAtomBlockElement';
    id: string;
    assets: VideoAssets[];
    posterImage?: {
        url: string;
        width: number;
    }[];
    title?: string;
    duration?: number;
}
```

then it will

```typescript
                case 'model.dotcomrendering.pageElements.MediaAtomBlockElement':
                    return (
                        <VideoAtom
                            assets={element.assets}
                            poster={
                                element.posterImage &&
                                element.posterImage[0].url
                            }
                        />
                    );
```

See: https://github.com/guardian/atoms-rendering/pull/109

