### PR TITLE
Use opinion pillar if designType is Comment

### DIFF
--- a/src/web/components/MostViewed/MostViewedFooter/SecondTierItem.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/SecondTierItem.tsx
@@ -97,6 +97,7 @@ export const SecondTierItem = ({
     } = trail;
 
     const avatarToShow = avatarUrl || image;
+    const pilarToUse = designType === 'Comment' ? 'opinion' : pillar;
 
     return (
         <div className={itemStyles(showRightBorder)}>
@@ -112,7 +113,7 @@ export const SecondTierItem = ({
                             <LinkHeadline
                                 designType={designType}
                                 headlineText={headlineText}
-                                pillar={pillar}
+                                pillar={pilarToUse}
                                 size="small"
                                 byline={showByline ? byline : undefined}
                             />
@@ -120,7 +121,7 @@ export const SecondTierItem = ({
                             <LinkHeadline
                                 designType={designType}
                                 headlineText={headlineText}
-                                pillar={pillar}
+                                pillar={pilarToUse}
                                 size="small"
                                 byline={showByline ? byline : undefined}
                             />
@@ -138,7 +139,7 @@ export const SecondTierItem = ({
                                     <Avatar
                                         imageSrc={avatarToShow}
                                         imageAlt=""
-                                        pillar={pillar}
+                                        pillar={pilarToUse}
                                     />
                                 </div>
                             </div>


### PR DESCRIPTION
We're using the wrong pillar for popular or frequently shared comment pieces, we should override the given pillar with `opinion` in these cases.

### Before
![Screenshot 2020-11-18 at 21 02 27](https://user-images.githubusercontent.com/1336821/99588952-3943ed00-29e3-11eb-9516-f29404522680.jpg)


### After
![Screenshot 2020-11-18 at 21 11 47](https://user-images.githubusercontent.com/1336821/99588963-3c3edd80-29e3-11eb-8a31-b11979d08df5.jpg)

