### PR TITLE
Aus bump cmp

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "@guardian/atoms-rendering": "^2.0.9",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/braze-components": "^0.0.14",
-        "@guardian/consent-management-platform": "^6.7.3",
+        "@guardian/consent-management-platform": "^6.7.4",
         "@guardian/discussion-rendering": "^3.1.2",
         "@guardian/shimport": "^1.0.2",
         "@guardian/src-button": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "@guardian/atoms-rendering": "^2.0.9",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/braze-components": "^0.0.14",
-        "@guardian/consent-management-platform": "^6.7.2",
+        "@guardian/consent-management-platform": "^6.7.3",
         "@guardian/discussion-rendering": "^3.1.2",
         "@guardian/shimport": "^1.0.2",
         "@guardian/src-button": "^2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2225,10 +2225,10 @@
     "@guardian/src-icons" "2.4.0"
     emotion-theming "^10.0.19"
 
-"@guardian/consent-management-platform@^6.7.3":
-  version "6.7.3"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.7.3.tgz#46a3f137430190bfaad192f82b6898d89bd4cc44"
-  integrity sha512-Vfb4zQrl0zDASVjeQ/6M+MkeRHCnVJhoN8dr99JKlU9rYG9Rk7WICJa3cpMk2vz7QBox8i6SaZlegjcleGsm2w==
+"@guardian/consent-management-platform@^6.7.4":
+  version "6.7.4"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.7.4.tgz#ae75775c40f8234a2e2774c126a688e9a98f5df4"
+  integrity sha512-f/XieB0dOyGYZDhP/UmyrHiyuehETt2L1GKqacsySFdcD/++fKe7LLcXbza4NE54MHyS0wbvd+Qh4avjG4IPLg==
 
 "@guardian/discussion-rendering@^3.1.2":
   version "3.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2225,10 +2225,10 @@
     "@guardian/src-icons" "2.4.0"
     emotion-theming "^10.0.19"
 
-"@guardian/consent-management-platform@^6.7.2":
-  version "6.7.2"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.7.2.tgz#4a6e2c7757bb014dc2adf4853db5e668f2798530"
-  integrity sha512-tAl+oohzjkRFqLkd5NcZKAp6v5hH0cKdwzX2LwLhQVgwVmtyPVdfr9UZZaIFK4xcHOOqXLQ+Jcy3oBAgOfs47w==
+"@guardian/consent-management-platform@^6.7.3":
+  version "6.7.3"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.7.3.tgz#46a3f137430190bfaad192f82b6898d89bd4cc44"
+  integrity sha512-Vfb4zQrl0zDASVjeQ/6M+MkeRHCnVJhoN8dr99JKlU9rYG9Rk7WICJa3cpMk2vz7QBox8i6SaZlegjcleGsm2w==
 
 "@guardian/discussion-rendering@^3.1.2":
   version "3.1.2"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Bump CMP to v6.7.4.

- Fixes `getConsentFor` errors for `aus-advertising`, which was removed.
- Fixes CORS `unsafe-eval` issues (seen on https://support.theguardian.com/)

## Why?

Keep in sync with `frontend`.
