### PR TITLE
Move Ophan to priority scripts

### DIFF
--- a/src/web/server/document.test.tsx
+++ b/src/web/server/document.test.tsx
@@ -121,12 +121,12 @@ test('Sample of script tags have the correct attributes', () => {
     );
     expect(result).toEqual(
         expect.stringContaining(
-            `<script async type="module" src="/assets/ophan.js"></script>`,
+            `<script defer type="module" src="/assets/ophan.js"></script>`,
         ),
     );
     expect(result).toEqual(
         expect.stringContaining(
-            `<script async nomodule src=\"/assets/ophan.js\"></script>`,
+            `<script defer nomodule src=\"/assets/ophan.js\"></script>`,
         ),
     );
 });

--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -86,6 +86,7 @@ export const document = ({ data }: Props) => {
     const priorityScriptTags = generateScriptTags(
         [
             { src: polyfillIO },
+            { src: 'ophan.js', module: true },
             CAPI.config && { src: CAPI.config.commercialBundleUrl },
             { src: 'sentry.js', module: true },
             { src: 'dynamicImport.js', module: true },
@@ -105,7 +106,6 @@ export const document = ({ data }: Props) => {
         [
             { src: 'https://www.google-analytics.com/analytics.js' },
             { src: 'ga.js', module: true },
-            { src: 'ophan.js', module: true },
             { src: 'lotame.js', module: true },
             { src: 'atomIframe.js', module: true },
             { src: 'embedIframe.js', module: true },


### PR DESCRIPTION
This moves Ophan to priority scripts to hopefully stop `undefined` errors on the sign in gate.
