### PR TITLE
Remove check for aus test/switch

### DIFF
--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -351,26 +351,12 @@ export const App = ({ CAPI, NAV }: Props) => {
                 }
             });
 
-            if (
-                CAPI.config.switches.auConsent ||
-                window?.guardian?.config?.tests?.useAusCmpVariant === 'variant'
-            ) {
-                cmp.init({
-                    country: countryCode,
-                    pubData,
-                });
-            } else {
-                cmp.init({
-                    isInUsa: countryCode === 'US',
-                    pubData,
-                });
-            }
+            cmp.init({
+                country: countryCode,
+                pubData,
+            });
         }
-    }, [
-        countryCode,
-        CAPI.config.switches.consentManagement,
-        CAPI.config.switches.auConsent,
-    ]);
+    }, [countryCode, CAPI.config.switches.consentManagement]);
 
     // *****************
     // *     ACast     *


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

removes the check for aus consent stuff 

## Why?

it's now live 

correlate to https://github.com/guardian/frontend/pull/23277