### PR TITLE
Curated container test iteration

### DIFF
--- a/cypress/integration/e2e/article.e2e.spec.js
+++ b/cypress/integration/e2e/article.e2e.spec.js
@@ -14,7 +14,7 @@ describe('E2E Page rendering', function () {
             it(`It should load the designType under the pillar (${article.url})`, function () {
                 const { url: articleUrl, designType, pillar } = article;
                 const url = setUrlFragment(articleUrl, {
-                    'ab-CuratedContainerTest': 'control',
+                    'ab-CuratedContainerTest2': 'control',
                 });
                 cy.log(`designType: ${designType}, pillar: ${pillar}`);
                 cy.visit(`Article?url=${url}`, fetchPolyfill);

--- a/fixtures/onwards.mocks.ts
+++ b/fixtures/onwards.mocks.ts
@@ -116,54 +116,63 @@ export const storyPackageTrails: OnwardsType = {
     heading: 'More on this story',
     trails,
     ophanComponentName: 'more-on-this-story',
+    pillar: 'news',
 };
 
 export const oneTrail: OnwardsType = {
     heading: 'More on this story',
     trails: trails.slice(0, 1),
     ophanComponentName: 'more-on-this-story',
+    pillar: 'news',
 };
 
 export const twoTrails: OnwardsType = {
     heading: 'More on this story',
     trails: trails.slice(0, 2),
     ophanComponentName: 'more-on-this-story',
+    pillar: 'news',
 };
 
 export const threeTrails: OnwardsType = {
     heading: 'More on this story',
     trails: trails.slice(0, 3),
     ophanComponentName: 'more-on-this-story',
+    pillar: 'news',
 };
 
 export const fourTrails: OnwardsType = {
     heading: 'More on this story',
     trails: trails.slice(0, 4),
     ophanComponentName: 'more-on-this-story',
+    pillar: 'news',
 };
 
 export const fiveTrails: OnwardsType = {
     heading: 'More on this story',
     trails: trails.slice(0, 5),
     ophanComponentName: 'more-on-this-story',
+    pillar: 'news',
 };
 
 export const sixTrails: OnwardsType = {
     heading: 'More on this story',
     trails: trails.slice(0, 6),
     ophanComponentName: 'more-on-this-story',
+    pillar: 'news',
 };
 
 export const sevenTrails: OnwardsType = {
     heading: 'More on this story',
     trails: trails.slice(0, 7),
     ophanComponentName: 'more-on-this-story',
+    pillar: 'news',
 };
 
 export const eightTrails: OnwardsType = {
     heading: 'More on this story',
     trails: trails.slice(0, 8),
     ophanComponentName: 'more-on-this-story',
+    pillar: 'news',
 };
 
 export const linkAndDescription: OnwardsType = {
@@ -173,6 +182,7 @@ export const linkAndDescription: OnwardsType = {
     heading: 'More on this story',
     trails: trails.slice(0, 8),
     ophanComponentName: 'more-on-this-story',
+    pillar: 'news',
 };
 
 export const withLongDescription: OnwardsType = {
@@ -181,4 +191,5 @@ export const withLongDescription: OnwardsType = {
     heading: 'More on this story',
     trails: trails.slice(0, 8),
     ophanComponentName: 'more-on-this-story',
+    pillar: 'news',
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -497,6 +497,7 @@ type OnwardsType = {
     description?: string;
     url?: string;
     ophanComponentName: OphanComponentName;
+    pillar: Pillar;
 };
 
 type OphanComponentName =

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -717,6 +717,7 @@ export const App = ({ CAPI, NAV }: Props) => {
                             contentType={CAPI.contentType}
                             tags={CAPI.tags}
                             edition={CAPI.editionId}
+                            pillar={pillar}
                         />
                     </Suspense>
                 </Lazy>
@@ -734,6 +735,7 @@ export const App = ({ CAPI, NAV }: Props) => {
                             ajaxUrl={CAPI.config.ajaxUrl}
                             hasStoryPackage={CAPI.hasStoryPackage}
                             tags={CAPI.tags}
+                            pillar={pillar}
                         />
                     </Suspense>
                 </Lazy>

--- a/src/web/components/Onwards/Carousel/Carousel.stories.tsx
+++ b/src/web/components/Onwards/Carousel/Carousel.stories.tsx
@@ -189,6 +189,7 @@ export const Headlines = () => (
         heading="Headlines"
         trails={trails}
         ophanComponentName="curated-content"
+        pillar='news'
     />
 );
 

--- a/src/web/components/Onwards/Carousel/Carousel.tsx
+++ b/src/web/components/Onwards/Carousel/Carousel.tsx
@@ -10,6 +10,7 @@ import { palette, space } from '@guardian/src-foundations';
 import libDebounce from 'lodash/debounce';
 import { LeftColumn } from '@frontend/web/components/LeftColumn';
 import { formatAttrString } from '@frontend/web/lib/formatAttrString';
+import { pillarPalette } from '@root/src/lib/pillars';
 import { CardAge } from '../../Card/components/CardAge';
 import { Kicker } from '../../Kicker';
 import { headlineBackgroundColour, headlineColour } from './cardColours';
@@ -180,9 +181,9 @@ const dotStyle = (index: number) => css`
     }
 `;
 
-const dotActiveStyle = (index: number) => css`
+const dotActiveStyle = (index: number, pillar: Pillar) => css`
     ${dotStyle(index)};
-    background-color: ${palette.news[400]};
+    background-color: ${pillarPalette[pillar].main};
 `;
 
 const buttonStyle = css`
@@ -220,13 +221,13 @@ const headerStyles = css`
     padding-top: 0;
 `;
 
-const titleStyle = css`
-    color: ${palette.news[400]};
+const titleStyle = (pillar: Pillar) => css`
+    color: ${pillarPalette[pillar].main};
 `;
 
-export const Title = ({ title }: { title: string; url?: string }) => (
+export const Title = ({ title, pillar }: { title: string; url?: string; pillar: Pillar }) => (
     <h2 className={headerStyles}>
-        From <span className={titleStyle}>{title}</span>
+        More from <span className={titleStyle(pillar)}>{title}</span>
     </h2>
 );
 
@@ -286,6 +287,7 @@ export const Carousel: React.FC<OnwardsType> = ({
     heading,
     trails,
     ophanComponentName,
+    pillar,
 }: OnwardsType) => {
     const carouselRef = useRef<HTMLDivElement>(null);
     const [index, setIndex] = useState(0);
@@ -386,7 +388,8 @@ export const Carousel: React.FC<OnwardsType> = ({
                 data-link={formatAttrString(heading)}
             >
                 <div className={navRowStyles}>
-                    <Title title={heading} />
+
+                    <Title title={heading} pillar={pillar} />
 
                     <div className={navIconStyle} data-link-name="nav-arrow">
                         <button onClick={prev} className={buttonStyle}>
@@ -402,7 +405,7 @@ export const Carousel: React.FC<OnwardsType> = ({
                     {trails.map((value, i) => (
                         <span
                             className={
-                                i === index ? dotActiveStyle(i) : dotStyle(i)
+                                i === index ? dotActiveStyle(i, pillar) : dotStyle(i)
                             }
                         />
                     ))}

--- a/src/web/components/Onwards/OnwardsData.tsx
+++ b/src/web/components/Onwards/OnwardsData.tsx
@@ -6,6 +6,7 @@ type Props = {
     limit: number; // Limit the number of items shown (the api often returns more)
     ophanComponentName: OphanComponentName;
     Container: React.FC<OnwardsType>;
+    pillar: Pillar;
 };
 
 type OnwardsResponse = {
@@ -20,6 +21,7 @@ export const OnwardsData = ({
     limit,
     ophanComponentName,
     Container,
+    pillar,
 }: Props) => {
     const { data } = useApi<OnwardsResponse>(url);
     if (data && data.trails) {
@@ -29,6 +31,7 @@ export const OnwardsData = ({
                 trails={limit ? data.trails.slice(0, limit) : data.trails}
                 description={data.description}
                 ophanComponentName={ophanComponentName}
+                pillar={pillar}
             />
         );
     }

--- a/src/web/components/Onwards/OnwardsLower.tsx
+++ b/src/web/components/Onwards/OnwardsLower.tsx
@@ -8,9 +8,10 @@ type Props = {
     ajaxUrl: string;
     hasStoryPackage: boolean;
     tags: TagType[];
+    pillar: Pillar;
 };
 
-export const OnwardsLower = ({ ajaxUrl, hasStoryPackage, tags }: Props) => {
+export const OnwardsLower = ({ ajaxUrl, hasStoryPackage, tags, pillar }: Props) => {
     // In this context, Blog tags are treated the same as Series tags
     const seriesTag = tags.find(
         (tag) => tag.type === 'Series' || tag.type === 'Blog',
@@ -39,6 +40,7 @@ export const OnwardsLower = ({ ajaxUrl, hasStoryPackage, tags }: Props) => {
             limit={4}
             ophanComponentName={ophanComponentName}
             Container={OnwardsLayout}
+            pillar={pillar}
         />
     );
 };

--- a/src/web/components/Onwards/OnwardsUpper.tsx
+++ b/src/web/components/Onwards/OnwardsUpper.tsx
@@ -84,6 +84,88 @@ const headlinesContainer = (edition: Edition): string => {
     }
 };
 
+const sportContainer = (edition: Edition): string => {
+    switch (edition) {
+        case 'UK':
+            return '754c-8e8c-fad9-a927';
+        case 'US':
+            return 'f6dd-d7b1-0e85-4650';
+        case 'AU':
+            return 'c45d-318f-896c-3a85';
+        case 'INT':
+            return 'd1ad8ec3-5ee2-4673-94c8-cc3f8d261e52';
+    }
+};
+
+const opinionContainer = (edition: Edition): string => {
+    switch (edition) {
+        case 'UK':
+            return '3ff78b30-52f5-4d30-ace8-c887113cbe0d';
+        case 'US':
+            return '98df412d-b0e7-4d9a-98c2-062642823e94';
+        case 'AU':
+            return 'au-alpha/contributors/feature-stories';
+        case 'INT':
+            return 'ee3386bb-9430-4a6d-8bca-b99d65790f3b';
+    }
+};
+
+const cultureContainer = (edition: Edition): string => {
+    switch (edition) {
+        case 'UK':
+            return 'ae511a89-ef38-4ec9-aab1-3a5ebc96d118';
+        case 'US':
+            return 'fb59c1f8-72a7-41d5-8365-a4d574809bed';
+        case 'AU':
+            return '22262088-4bce-4290-9810-cb50bbead8db';
+        case 'INT':
+            return 'c7154e22-7292-4d93-a14d-22fd4b6b693d';
+    }
+};
+
+const lifestyleContainer = (edition: Edition): string => {
+    switch (edition) {
+        case 'UK':
+            return 'uk-alpha/features/feature-stories';
+        case 'US':
+            return 'us-alpha/features/feature-stories';
+        case 'AU':
+            return '13636104-51ce-4264-bb6b-556c80227331';
+        case 'INT':
+            return '7b297ef5-a3f9-45e5-b915-b54951d7f6ec';
+    }
+};
+
+const getContainerDataUrl = (pillar:Pillar, edition: Edition, ajaxUrl: string)=>{
+    switch(pillar){
+        case 'sport': return joinUrl([
+            ajaxUrl,
+            'container/data',
+            `${sportContainer(edition)}.json`,]);
+        case 'news': return joinUrl([
+            ajaxUrl,
+            'container/data',
+            `${headlinesContainer(edition)}.json`,]);
+        case 'culture': return joinUrl([
+            ajaxUrl,
+            'container/data',
+            `${cultureContainer(edition)}.json`,]);
+        case 'lifestyle': return joinUrl([
+            ajaxUrl,
+            'container/data',
+            `${lifestyleContainer(edition)}.json`,]);
+        case 'opinion': return joinUrl([
+            ajaxUrl,
+            'container/data',
+            `${opinionContainer(edition)}.json`,]);
+        default: return joinUrl([
+            ajaxUrl,
+            'container/data',
+            `${headlinesContainer(edition)}.json`,]);
+    }
+};
+
+
 type Props = {
     ajaxUrl: string;
     hasRelated: boolean;
@@ -96,6 +178,7 @@ type Props = {
     contentType: string;
     tags: TagType[];
     edition: Edition;
+    pillar:Pillar;
 };
 
 export const OnwardsUpper = ({
@@ -110,6 +193,7 @@ export const OnwardsUpper = ({
     contentType,
     tags,
     edition,
+    pillar
 }: Props) => {
     const dontShowRelatedContent = !showRelatedContent || !hasRelated;
 
@@ -181,19 +265,16 @@ export const OnwardsUpper = ({
     }
 
     const ABTestAPI = useAB();
-    const headlinesDataUrl = joinUrl([
-        ajaxUrl,
-        'container/data',
-        `${headlinesContainer(edition)}.json`,
-    ]);
 
-    const inCuratedContainerTest = ABTestAPI.isUserInVariant(
-        'CuratedContainerTest',
+    const containerDataUrl = getContainerDataUrl(pillar, edition, ajaxUrl);
+
+    const inCuratedContainerTest2 = ABTestAPI.isUserInVariant(
+        'CuratedContainerTest2',
         'fixed',
     );
 
     const inCuratedCarouselTest = ABTestAPI.isUserInVariant(
-        'CuratedContainerTest',
+        'CuratedContainerTest2',
         'carousel',
     );
 
@@ -202,20 +283,22 @@ export const OnwardsUpper = ({
             {inCuratedCarouselTest && (
                 <Section showTopBorder={true}>
                     <OnwardsData
-                        url={headlinesDataUrl}
+                        url={containerDataUrl}
                         limit={8}
                         ophanComponentName="curated-content"
                         Container={Carousel}
+                        pillar={pillar}
                     />
                 </Section>
             )}
-            {inCuratedContainerTest && (
+            {inCuratedContainerTest2 && (
                 <Section showTopBorder={true}>
                     <OnwardsData
-                        url={headlinesDataUrl}
+                        url={containerDataUrl}
                         limit={8}
                         ophanComponentName="curated-content"
                         Container={OnwardsLayout}
+                        pillar={pillar}
                     />
                 </Section>
             )}
@@ -226,6 +309,7 @@ export const OnwardsUpper = ({
                         limit={8}
                         ophanComponentName={ophanComponentName}
                         Container={OnwardsLayout}
+                        pillar={pillar}
                     />
                 </Section>
             )}

--- a/src/web/experiments/ab-tests.ts
+++ b/src/web/experiments/ab-tests.ts
@@ -2,14 +2,14 @@ import { ABTest } from '@guardian/ab-core';
 import { abTestTest } from '@frontend/web/experiments/tests/ab-test-test';
 import { signInGateMainVariant } from '@root/src/web/experiments/tests/sign-in-gate-main-variant';
 import { signInGateMainControl } from '@root/src/web/experiments/tests/sign-in-gate-main-control';
-import { curatedContainerTest } from '@frontend/web/experiments/tests/curated-container-test';
+import { curatedContainerTest2 } from '@frontend/web/experiments/tests/curated-container-test';
 import {newsletterMerchUnitLighthouseControl, newsletterMerchUnitLighthouseVariants} from "@root/src/web/experiments/tests/newsletter-merch-unit-test";
 
 export const tests: ABTest[] = [
     abTestTest,
     signInGateMainVariant,
     signInGateMainControl,
-    curatedContainerTest,
+    curatedContainerTest2,
     newsletterMerchUnitLighthouseControl,
     newsletterMerchUnitLighthouseVariants
 ];

--- a/src/web/experiments/tests/curated-container-test.ts
+++ b/src/web/experiments/tests/curated-container-test.ts
@@ -1,12 +1,12 @@
 import { ABTest } from '@guardian/ab-core';
 
-export const curatedContainerTest: ABTest = {
-    id: 'CuratedContainerTest',
-    start: '2020-09-14',
-    expiry: '2020-11-10',
-    author: 'gtrufitt',
+export const curatedContainerTest2: ABTest = {
+    id: 'CuratedContainerTest2',
+    start: '2020-11-23',
+    expiry: '2020-12-10',
+    author: 'rcrphillips',
     description:
-        'Tests an additional "curated" onwards container below the article body',
+        'Tests an additional "curated" onwards container below the article body and extends it to utilise different containers based on the pillar of the article',
     audience: 0.5,
     audienceOffset: 0,
     successMeasure: 'CTR on article pages',

--- a/src/web/lib/useComments.test.tsx
+++ b/src/web/lib/useComments.test.tsx
@@ -63,6 +63,7 @@ describe('buildUrl', () => {
     it('builds the url as expected', () => {
         const sections: OnwardsType[] = [
             {
+                pillar: 'opinion',
                 heading: 'opinion',
                 trails: [
                     {
@@ -111,6 +112,7 @@ describe('buildUrl', () => {
     it('handles the legacy gu domain', () => {
         const sections: OnwardsType[] = [
             {
+                pillar: 'opinion',
                 heading: 'opinion',
                 trails: [
                     {

--- a/src/web/lib/useComments.ts
+++ b/src/web/lib/useComments.ts
@@ -46,6 +46,7 @@ const withComments = (
             url: section.url,
             trails: updateTrailsWithCounts(section.trails, counts),
             ophanComponentName: section.ophanComponentName,
+            pillar: 'opinion',
         };
     });
 };


### PR DESCRIPTION
## What does this change?
Following  on from the previous curated container test, this utilises the same test, but iterates on  it, by displaying a container more relevant to the pillar of the current article.
### Before
For example, on a sport article, users would see headlines from the homepage, with the news pillar styling

<img width="1289" alt="Screen Shot 2020-11-20 at 22 43 42" src="https://user-images.githubusercontent.com/2051501/99856930-05eb9480-2b82-11eb-8ee4-23436939efe0.png">

### After
Fixed style
<img width="1289" alt="Screen Shot 2020-11-20 at 22 40 23" src="https://user-images.githubusercontent.com/2051501/99856965-126fed00-2b82-11eb-978c-408eeb438f4f.png">
Carousel style
<img width="1289" alt="Screen Shot 2020-11-20 at 22 42 01" src="https://user-images.githubusercontent.com/2051501/99856976-169c0a80-2b82-11eb-9fa7-b040123e903b.png">

## Why?
We believe that by showing users a more relevant set of curated stories, we will increase their click through rate and session time