### PR TITLE
QuoteIcon Size

### DIFF
--- a/src/web/components/QuoteIcon.tsx
+++ b/src/web/components/QuoteIcon.tsx
@@ -22,8 +22,8 @@ const sizeStyles = (size: SmallHeadlineSize) => {
     const mediumSvg = css`
         margin-right: 4px;
         svg {
-            height: 21px;
-            width: 10px;
+            height: 20px;
+            width: 11px;
         }
     `;
     const largeSvg = css`

--- a/src/web/components/QuoteIcon.tsx
+++ b/src/web/components/QuoteIcon.tsx
@@ -22,8 +22,8 @@ const sizeStyles = (size: SmallHeadlineSize) => {
     const mediumSvg = css`
         margin-right: 4px;
         svg {
-            height: 20px;
-            width: 11px;
+            height: 21px;
+            width: 10px;
         }
     `;
     const largeSvg = css`

--- a/src/web/components/elements/BlockquoteBlockComponent.tsx
+++ b/src/web/components/elements/BlockquoteBlockComponent.tsx
@@ -73,7 +73,7 @@ export const BlockquoteBlockComponent: React.FC<Props> = ({
     if (quoted) {
         return (
             <BlockquoteRow>
-                <QuoteIcon colour={pillarPalette[pillar].main} size="large" />
+                <QuoteIcon colour={pillarPalette[pillar].main} size="medium" />
                 <RewrappedComponent
                     isUnwrapped={isUnwrapped}
                     html={unwrappedHtml}


### PR DESCRIPTION
This PR reduces the size of icon used in `BlockquoteBlockComponent` from `large` to `medium`.

### DCR Before
<img width="636" alt="Screenshot 2020-11-23 at 15 37 57" src="https://user-images.githubusercontent.com/1336821/99981968-e632b700-2da1-11eb-860b-4c3967f1aecf.png">

### Frontend
<img width="636" alt="Screenshot 2020-11-23 at 15 41 16" src="https://user-images.githubusercontent.com/1336821/99982355-593c2d80-2da2-11eb-829f-5f427f592fe8.png">


### DCR After
<img width="636" alt="Screenshot 2020-11-23 at 15 45 55" src="https://user-images.githubusercontent.com/1336821/99982938-221a4c00-2da3-11eb-9bd1-21b45d258ebf.png">



## Why?
To align the size of the icon with the size of the quote text.
