### PR TITLE
Disable lazy loading images in Chromatic

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -11,9 +11,11 @@ import { defaults } from './default-css';
 import 'reset-css';
 
 import { Lazy } from '@root/src/web/components/Lazy';
+import { Picture } from '@root/src/web/components/Picture';
 
 // Prevent components being lazy rendered when we're taking Chromatic snapshots
 Lazy.disabled = isChromatic();
+Picture.disableLazyLoading = isChromatic();
 
 // Add base css for the site
 // let css = `${getFontsCss()}${defaults}`;

--- a/src/web/components/Picture.tsx
+++ b/src/web/components/Picture.tsx
@@ -8,6 +8,15 @@ export interface PictureSource {
     hidpi: boolean;
 }
 
+type Props = {
+    sources: PictureSource[];
+    alt: string;
+    src: string;
+    height: string;
+    width: string;
+    isLazy?: boolean;
+}
+
 const mq: (source: PictureSource) => string = (source) =>
     source.hidpi
         ? `(min-width: ${source.minWidth}px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: ${source.minWidth}px) and (min-resolution: 120dpi)`
@@ -18,14 +27,7 @@ const forSource: (source: PictureSource) => string = (source) =>
         source.srcset
     }" />`;
 
-export const Picture: React.FC<{
-    sources: PictureSource[];
-    alt: string;
-    src: string;
-    height: string;
-    width: string;
-    isLazy?: boolean;
-}> = ({ sources, alt, src, height, width, isLazy = true }) => {
+export const Picture = ({ sources, alt, src, height, width, isLazy = true }: Props) => {
     return (
         // https://stackoverflow.com/questions/10844205/html-5-strange-img-always-adds-3px-margin-at-bottom
         // why did we put `style="vertical-align: middle;"` inside the img tag
@@ -36,9 +38,13 @@ export const Picture: React.FC<{
                     .join(
                         '',
                     )}<!--[if IE 9]></video><![endif]--><img style="vertical-align: middle;" itemprop="contentUrl" alt="${alt}" src="${src}" height="${height}" width="${width}" ${
-                    isLazy ? 'loading="lazy"' : ''
+                    isLazy && !Picture.disableLazyLoading ? 'loading="lazy"' : ''
                 } />`,
             }}
         />
     );
 };
+
+// We use disableLazyLoading to decide if we want to turn off lazy loading of images site wide. We use this
+// to prevent false negatives on Chromatic snapshots (see /.storybook/config)
+Picture.disableLazyLoading = false;


### PR DESCRIPTION
### What?
In the same way that we don't lazy render content at the bottom of the page for Chromatic snapshots, this PR prevents images being lazy loaded by the browser.

### Why?
Since making images lazy, Chromatic has been routinely throwing up false negatives where images are sometimes rendered at the bottom of page layouts and sometimes not.