### PR TITLE
Add back 300x600 size for right

### DIFF
--- a/src/model/advertisement.ts
+++ b/src/model/advertisement.ts
@@ -86,7 +86,7 @@ export const namedAdSlotParameters = (name: AdSlotType): AdSlotParameters => {
             name: 'right',
             adTypes: ['mpu-banner-ad', 'rendered'],
             sizeMapping: {
-                mobile: ['1,1|2,2|300,250|300,274|fluid'],
+                mobile: ['1,1|2,2|300,250|300,274|300,600|fluid'],
                 // mark: 01303e88-ef1f-462d-9b6e-242419435cec
             },
             showLabel: true,


### PR DESCRIPTION
## What does this change?
Adds back  300x600 size for desktop after it got removed in this PR: https://github.com/guardian/dotcom-rendering/pull/1995

While it was matching the frontend's behaviour for `mobile` breakpoint, I have now observed that dfp-right slot in frontend doesn't have a `data-desktop` attribute and uses some logic to add or remove the 300x600 depending on the space left, logic found here and puts them all in `data-mobile`:
https://github.com/guardian/frontend/blob/c50006380a443b474ea471eadd58fe13ffe297e5/static/src/javascripts/projects/commercial/modules/article-aside-adverts.js#L10

## Why?
Adding it back should make 300x600 eligible in desktop 

