### PR TITLE
Footer Styling

### DIFF
--- a/src/web/components/Footer.tsx
+++ b/src/web/components/Footer.tsx
@@ -146,7 +146,10 @@ const readerRevenueLinks = css`
 
 const copyright = css`
     ${textSans.xsmall()};
-    padding: 12px;
+    padding-left: 20px;
+    padding-right: 12px;
+    padding-top: 12px;
+    padding-bottom: 12px;
 
     ${until.tablet} {
         margin-top: 11px;

--- a/src/web/components/Footer.tsx
+++ b/src/web/components/Footer.tsx
@@ -75,6 +75,7 @@ const footerLink = css`
     text-decoration: none;
     padding-bottom: 12px;
     display: block;
+    line-height: 19px;
 
     :hover {
         text-decoration: underline;

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -599,6 +599,7 @@ export const CommentLayout = ({
                 padded={false}
                 backgroundColour={brandBackground.primary}
                 borderColour={brandBorder.primary}
+                showSideBorders={false}
             >
                 <Footer
                     pageFooter={CAPI.pageFooter}

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -526,6 +526,7 @@ export const ImmersiveLayout = ({
                 padded={false}
                 backgroundColour={brandBackground.primary}
                 borderColour={brandBorder.primary}
+                showSideBorders={false}
             >
                 <Footer
                     pageFooter={CAPI.pageFooter}

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -550,6 +550,7 @@ export const ShowcaseLayout = ({
                 padded={false}
                 backgroundColour={brandBackground.primary}
                 borderColour={brandBorder.primary}
+                showSideBorders={false}
             >
                 <Footer
                     pageFooter={CAPI.pageFooter}

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -628,6 +628,7 @@ export const StandardLayout = ({
                 padded={false}
                 backgroundColour={brandBackground.primary}
                 borderColour={brandBorder.primary}
+                showSideBorders={false}
             >
                 <Footer
                     pageFooter={CAPI.pageFooter}


### PR DESCRIPTION
## What does this change?
Makes a few small styling changes to the page footer

1. Removes double borders.
The grey side borders were being set both by the `Section` and also by the code inside the section. We have a prop `showSideBorders` that we can use in this situation to prevent this.

2. Line Height
On Frontend the footer is not so deep, mainly because the text has a different `line-height`. Here I copy over the value used in Frontend for parity

3. Vertical alignment
I've increased the left margin on the copyright text to bring it into alignment with the rest of the page.


### Before
![Screenshot 2020-11-25 at 13 36 08](https://user-images.githubusercontent.com/1336821/100234577-31280800-2f23-11eb-8659-536f676102b3.jpg)

### After
![Screenshot 2020-11-25 at 13 35 08](https://user-images.githubusercontent.com/1336821/100234595-36855280-2f23-11eb-8953-0fa8ce6ef7c5.jpg)

### What does this not do?
There's also a footer styling issue around the padding for the Sign Up and another issue with how the offter displays between the `desktop` and `leftCol` breakpoints. These are not covered in this PR but there's [a ticket here](https://trello.com/c/QGf838H4/2175-footer-responsive-design)
