### PR TITLE
Correct path of static assets

### DIFF
--- a/scripts/deploy/build-riffraff-bundle.js
+++ b/scripts/deploy/build-riffraff-bundle.js
@@ -37,7 +37,7 @@ const copyStatic = () => {
     log(' - copying static');
     return cpy(
         ['**/*'],
-        path.resolve(target, `${siteName}-static`, 'src/static', siteName),
+        path.resolve(target, `${siteName}-static`, 'static', siteName),
         {
             cwd: path.resolve(root, 'src/static'),
             parents: true,


### PR DESCRIPTION
I noticed that the last-modified time for the fonts in S3 is stuck on November 2019 (`PROD/frontend-static/static/frontend/fonts`).  
After a bit of investigation, I discovered that #900 changed the destination for static assets to PROD/frontend-static/**src**/static/frontend/fonts.  Since the [helpful directory layout diagram](https://github.com/guardian/dotcom-rendering/blob/4ccbfb15f86d1fcbe83a9d354f50faa36ba091aa/scripts/deploy/build-riffraff-bundle.js#L22) wasn't updated at the same time and DCR still references the old path,  I presume this was a mistake.

Fortunately these files are rarely actually changed so it hasn't caused a problem.  Hopefully we aren't reading from this incorrect path, and can delete these files.