### PR TITLE
Hoist decidePosition

### DIFF
--- a/src/lib/decidePosition.ts
+++ b/src/lib/decidePosition.ts
@@ -1,0 +1,102 @@
+import { css } from 'emotion';
+
+import { from, until } from '@guardian/src-foundations/mq';
+
+const roleCss = {
+    supporting: css`
+        ${from.tablet} {
+            position: relative;
+            float: left;
+            width: 300px;
+            margin-right: 20px;
+            line-height: 0;
+        }
+        ${from.leftCol} {
+            margin-left: -160px;
+        }
+        ${from.wide} {
+            width: 380px;
+            margin-left: -240px;
+        }
+    `,
+
+    immersive: css`
+        ${until.tablet} {
+            margin-left: -20px;
+            margin-right: -20px;
+        }
+        ${until.mobileLandscape} {
+            margin-left: -10px;
+            margin-right: -10px;
+        }
+        ${from.tablet} {
+            margin-left: -20px;
+            margin-right: -100px;
+        }
+        ${from.desktop} {
+            margin-left: -20px;
+            margin-right: -340px;
+        }
+        ${from.leftCol} {
+            margin-left: -160px;
+            margin-right: -320px;
+        }
+        ${from.wide} {
+            margin-left: -240px;
+            margin-right: -400px;
+        }
+    `,
+
+    showcase: css`
+        position: relative;
+        ${from.leftCol} {
+            margin-left: -160px;
+        }
+        ${from.wide} {
+            margin-left: -240px;
+        }
+    `,
+
+    thumbnail: css`
+        float: left;
+        clear: left;
+        width: 120px;
+        margin-right: 20px;
+        ${from.tablet} {
+            width: 140px;
+        }
+        ${from.wide} {
+            margin-left: -240px;
+        }
+        ${from.leftCol} {
+            position: relative;
+            margin-left: -160px;
+        }
+    `,
+
+    halfWidth: css`
+        width: 50%;
+        float: left;
+        clear: left;
+        margin-right: 16px;
+    `,
+};
+
+export const decidePosition = (role: RoleType) => {
+    switch (role) {
+        case 'inline':
+            return css``;
+        case 'supporting':
+            return roleCss.supporting;
+        case 'immersive':
+            return roleCss.immersive;
+        case 'showcase':
+            return roleCss.showcase;
+        case 'thumbnail':
+            return roleCss.thumbnail;
+        case 'halfWidth':
+            return roleCss.halfWidth;
+        default:
+            return css``;
+    }
+};

--- a/src/lib/decidePosition.ts
+++ b/src/lib/decidePosition.ts
@@ -10,6 +10,8 @@ const roleCss = {
             width: 300px;
             margin-right: 20px;
             line-height: 0;
+            margin-top: 6px;
+            margin-bottom: 12px;
         }
         ${from.leftCol} {
             margin-left: -160px;
@@ -21,6 +23,8 @@ const roleCss = {
     `,
 
     immersive: css`
+        margin-top: 12px;
+        margin-bottom: 12px;
         ${until.tablet} {
             margin-left: -20px;
             margin-right: -20px;
@@ -49,6 +53,8 @@ const roleCss = {
 
     showcase: css`
         position: relative;
+        margin-top: 12px;
+        margin-bottom: 12px;
         ${from.leftCol} {
             margin-left: -160px;
         }
@@ -62,6 +68,8 @@ const roleCss = {
         clear: left;
         width: 120px;
         margin-right: 20px;
+        margin-bottom: 0;
+        margin-top: 6px;
         ${from.tablet} {
             width: 140px;
         }
@@ -79,6 +87,8 @@ const roleCss = {
         float: left;
         clear: left;
         margin-right: 16px;
+        margin-top: 12px;
+        margin-bottom: 12px;
     `,
 };
 

--- a/src/lib/decidePosition.ts
+++ b/src/lib/decidePosition.ts
@@ -3,6 +3,11 @@ import { css } from 'emotion';
 import { from, until } from '@guardian/src-foundations/mq';
 
 const roleCss = {
+    inline: css`
+        margin-top: 12px;
+        margin-bottom: 12px;
+    `,
+
     supporting: css`
         ${from.tablet} {
             position: relative;
@@ -95,7 +100,7 @@ const roleCss = {
 export const decidePosition = (role: RoleType) => {
     switch (role) {
         case 'inline':
-            return css``;
+            return roleCss.inline;
         case 'supporting':
             return roleCss.supporting;
         case 'immersive':
@@ -107,6 +112,6 @@ export const decidePosition = (role: RoleType) => {
         case 'halfWidth':
             return roleCss.halfWidth;
         default:
-            return css``;
+            return roleCss.inline;
     }
 };

--- a/src/web/components/elements/ImageBlockComponent.tsx
+++ b/src/web/components/elements/ImageBlockComponent.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
-import { css, cx } from 'emotion';
 import { ImageComponent } from '@root/src/web/components/elements/ImageComponent';
 
-import { from } from '@guardian/src-foundations/mq';
 import { Display } from '@root/src/lib/display';
 import { decidePosition } from '@root/src/lib/decidePosition';
 
@@ -15,32 +13,6 @@ type Props = {
     title?: string;
 };
 
-const decideSpacing = (role: RoleType) => {
-    switch (role) {
-        case 'supporting':
-            return css`
-                ${from.tablet} {
-                    margin-top: 6px;
-                    margin-bottom: 12px;
-                }
-            `;
-        case 'thumbnail':
-            return css`
-                margin-bottom: 0;
-                margin-top: 6px;
-            `;
-        case 'halfWidth':
-        case 'immersive':
-        case 'showcase':
-        case 'inline':
-        default:
-            return css`
-                margin-top: 12px;
-                margin-bottom: 12px;
-            `;
-    }
-};
-
 export const ImageBlockComponent = ({
     display,
     designType,
@@ -51,7 +23,7 @@ export const ImageBlockComponent = ({
 }: Props) => {
     const { role } = element;
     return (
-        <div className={cx(decidePosition(role), decideSpacing(role))}>
+        <div className={decidePosition(role)}>
             <ImageComponent
                 display={display}
                 designType={designType}

--- a/src/web/components/elements/ImageBlockComponent.tsx
+++ b/src/web/components/elements/ImageBlockComponent.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { css } from 'emotion';
+import { css, cx } from 'emotion';
 import { ImageComponent } from '@root/src/web/components/elements/ImageComponent';
 
-import { from, until } from '@guardian/src-foundations/mq';
+import { from } from '@guardian/src-foundations/mq';
 import { Display } from '@root/src/lib/display';
+import { decidePosition } from '@root/src/lib/decidePosition';
 
 type Props = {
     display: Display;
@@ -14,119 +15,29 @@ type Props = {
     title?: string;
 };
 
-const imageCss = {
-    inline: css`
-        margin-top: 12px;
-        margin-bottom: 12px;
-    `,
-
-    supporting: css`
-        ${from.tablet} {
-            position: relative;
-            float: left;
-            width: 300px;
-            margin-top: 6px;
-            margin-bottom: 12px;
-            margin-right: 20px;
-            line-height: 0;
-        }
-        ${from.leftCol} {
-            margin-left: -160px;
-        }
-        ${from.wide} {
-            width: 380px;
-            margin-left: -240px;
-        }
-    `,
-
-    immersive: css`
-        margin-top: 12px;
-        margin-bottom: 12px;
-
-        ${until.tablet} {
-            margin-left: -20px;
-            margin-right: -20px;
-        }
-        ${until.mobileLandscape} {
-            margin-left: -10px;
-            margin-right: -10px;
-        }
-        ${from.tablet} {
-            margin-left: -20px;
-            margin-right: -100px;
-        }
-        ${from.desktop} {
-            margin-left: -20px;
-            margin-right: -340px;
-        }
-        ${from.leftCol} {
-            margin-left: -160px;
-            margin-right: -320px;
-        }
-        ${from.wide} {
-            margin-left: -240px;
-            margin-right: -400px;
-        }
-    `,
-
-    showcase: css`
-        position: relative;
-        margin-top: 12px;
-        margin-bottom: 12px;
-        ${from.leftCol} {
-            margin-bottom: 12px;
-            margin-left: -160px;
-        }
-        ${from.wide} {
-            margin-left: -240px;
-        }
-    `,
-
-    thumbnail: css`
-        float: left;
-        clear: left;
-        margin-bottom: 0;
-        width: 120px;
-        margin-right: 20px;
-        margin-top: 6px;
-        ${from.tablet} {
-            width: 140px;
-        }
-        ${from.wide} {
-            margin-left: -240px;
-        }
-        ${from.leftCol} {
-            position: relative;
-            margin-left: -160px;
-        }
-    `,
-
-    halfWidth: css`
-        margin-top: 12px;
-        margin-bottom: 12px;
-        width: 50%;
-        float: left;
-        clear: left;
-        margin-right: 16px;
-    `,
-};
-
-const decidePosition = (role: RoleType) => {
+const decideSpacing = (role: RoleType) => {
     switch (role) {
-        case 'inline':
-            return imageCss.inline;
         case 'supporting':
-            return imageCss.supporting;
-        case 'immersive':
-            return imageCss.immersive;
-        case 'showcase':
-            return imageCss.showcase;
+            return css`
+                ${from.tablet} {
+                    margin-top: 6px;
+                    margin-bottom: 12px;
+                }
+            `;
         case 'thumbnail':
-            return imageCss.thumbnail;
+            return css`
+                margin-bottom: 0;
+                margin-top: 6px;
+            `;
         case 'halfWidth':
-            return imageCss.halfWidth;
+        case 'immersive':
+        case 'showcase':
+        case 'inline':
         default:
-            return imageCss.inline;
+            return css`
+                margin-top: 12px;
+                margin-bottom: 12px;
+            `;
     }
 };
 
@@ -140,7 +51,7 @@ export const ImageBlockComponent = ({
 }: Props) => {
     const { role } = element;
     return (
-        <div className={decidePosition(role)}>
+        <div className={cx(decidePosition(role), decideSpacing(role))}>
             <ImageComponent
                 display={display}
                 designType={designType}


### PR DESCRIPTION
## What does this change?
Moves `decidePosition` up out of `ImageComponent` into `/src/libs`

## Why?
This is the function we use to position elements based on their `role`. Up until now we've only used this for images but there is a requirement to also position other types of elements in the same way.