### PR TITLE
Use auto-foft to load fonts

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
         "@types/sanitize-html": "^1.18.3",
         "@typescript-eslint/eslint-plugin-tslint": "^4.1.1",
         "ajv": "^6.10.1",
-        "auto-foft": "guardian/auto-foft#1232160",
+        "auto-foft": "guardian/auto-foft#0a6510c",
         "aws-sdk": "^2.791.0",
         "chalk": "^4.1.0",
         "columnify": "^1.5.4",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
         "@types/sanitize-html": "^1.18.3",
         "@typescript-eslint/eslint-plugin-tslint": "^4.1.1",
         "ajv": "^6.10.1",
-        "auto-foft": "guardian/auto-foft#2555005",
+        "auto-foft": "guardian/auto-foft#1232160",
         "aws-sdk": "^2.791.0",
         "chalk": "^4.1.0",
         "columnify": "^1.5.4",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
         "@types/sanitize-html": "^1.18.3",
         "@typescript-eslint/eslint-plugin-tslint": "^4.1.1",
         "ajv": "^6.10.1",
-        "auto-foft": "guardian/auto-foft#0a6510c",
+        "auto-foft": "guardian/auto-foft#29ad5a33",
         "aws-sdk": "^2.791.0",
         "chalk": "^4.1.0",
         "columnify": "^1.5.4",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
         "@types/sanitize-html": "^1.18.3",
         "@typescript-eslint/eslint-plugin-tslint": "^4.1.1",
         "ajv": "^6.10.1",
+        "auto-foft": "guardian/auto-foft#64c8dfa",
         "aws-sdk": "^2.791.0",
         "chalk": "^4.1.0",
         "columnify": "^1.5.4",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
         "@types/sanitize-html": "^1.18.3",
         "@typescript-eslint/eslint-plugin-tslint": "^4.1.1",
         "ajv": "^6.10.1",
-        "auto-foft": "guardian/auto-foft#64c8dfa",
+        "auto-foft": "guardian/auto-foft#2555005",
         "aws-sdk": "^2.791.0",
         "chalk": "^4.1.0",
         "columnify": "^1.5.4",

--- a/src/lib/auto-foft.js
+++ b/src/lib/auto-foft.js
@@ -1,0 +1,10 @@
+// @preval
+
+// note: this file is intended to imported using babel-plugin-preval
+// the easiest way is probably with the import-comment:
+// https://www.npmjs.com/package/babel-plugin-preval#import-comment
+
+const { readFileSync } = require('fs');
+
+// https://github.com/guardian/auto-foft
+module.exports = readFileSync(require.resolve('auto-foft'), 'utf-8');

--- a/src/lib/fonts-css.ts
+++ b/src/lib/fonts-css.ts
@@ -1,4 +1,5 @@
 import minifyCssString from 'minify-css-string';
+import { Display } from '@root/src/lib/display';
 import { getStatic } from './assets';
 
 type FontFamily =
@@ -16,7 +17,7 @@ interface FontDisplay {
     woff2: string;
     woff: string;
     ttf: string;
-    weight: number;
+    weight: string | number;
     style: FontStyle;
 }
 
@@ -267,6 +268,174 @@ const fontList: FontDisplay[] = [
         style: 'normal',
     },
 ];
+
+export const isCritical = ({
+    font,
+    designType,
+    display,
+}: {
+    font: FontDisplay;
+    designType: DesignType;
+    display: Display;
+}): boolean => {
+    switch (display) {
+        case Display.Immersive:
+            switch (designType) {
+                case 'Comment':
+                case 'GuardianView':
+                    switch (font.family) {
+                        case 'GuardianTextEgyptian':
+                        case 'Guardian Text Egyptian Web':
+                        case 'GuardianTextSans':
+                        case 'Guardian Text Sans Web':
+                            return (
+                                font.weight === '400' && font.style === 'normal'
+                            );
+                        case 'GH Guardian Headline':
+                        case 'Guardian Egyptian Web':
+                            return (
+                                (font.weight === '200' ||
+                                    font.weight === '300' ||
+                                    font.weight === '700') &&
+                                font.style === 'normal'
+                            );
+                        default:
+                            return false;
+                    }
+                case 'Review':
+                case 'Recipe':
+                case 'Feature':
+                case 'Analysis':
+                case 'Interview':
+                case 'Live':
+                case 'Media':
+                case 'PhotoEssay':
+                case 'Article':
+                case 'SpecialReport':
+                case 'MatchReport':
+                case 'GuardianLabs':
+                case 'Quiz':
+                case 'AdvertisementFeature':
+                case 'Immersive':
+                default:
+                    switch (font.family) {
+                        case 'GuardianTextEgyptian':
+                        case 'Guardian Text Egyptian Web':
+                        case 'GuardianTextSans':
+                        case 'Guardian Text Sans Web':
+                            return (
+                                font.weight === '400' && font.style === 'normal'
+                            );
+                        case 'GH Guardian Headline':
+                        case 'Guardian Egyptian Web':
+                            return (
+                                (font.weight === '300' ||
+                                    font.weight === '700') &&
+                                font.style === 'normal'
+                            );
+                        default:
+                            return false;
+                    }
+            }
+        case Display.Showcase:
+        case Display.Standard:
+        default: {
+            switch (designType) {
+                case 'Comment':
+                case 'GuardianView':
+                    switch (font.family) {
+                        case 'GuardianTextEgyptian':
+                        case 'Guardian Text Egyptian Web':
+                        case 'GuardianTextSans':
+                        case 'Guardian Text Sans Web':
+                            return (
+                                font.weight === '400' && font.style === 'normal'
+                            );
+                        case 'GH Guardian Headline':
+                        case 'Guardian Egyptian Web':
+                            return (
+                                font.weight === '300' &&
+                                (font.style === 'normal' ||
+                                    font.style === 'italic')
+                            );
+                        default:
+                            return false;
+                    }
+                case 'Review':
+                case 'Recipe':
+                case 'Feature':
+                    switch (font.family) {
+                        case 'GuardianTextEgyptian':
+                        case 'Guardian Text Egyptian Web':
+                        case 'GuardianTextSans':
+                        case 'Guardian Text Sans Web':
+                            return (
+                                font.weight === '400' && font.style === 'normal'
+                            );
+                        case 'GH Guardian Headline':
+                        case 'Guardian Egyptian Web':
+                            return (
+                                (font.weight === '300' ||
+                                    font.weight === '700') &&
+                                font.style === 'normal'
+                            );
+                        default:
+                            return false;
+                    }
+                case 'Interview':
+                    switch (font.family) {
+                        case 'GuardianTextEgyptian':
+                        case 'Guardian Text Egyptian Web':
+                        case 'GuardianTextSans':
+                        case 'Guardian Text Sans Web':
+                            return (
+                                font.weight === '400' && font.style === 'normal'
+                            );
+                        case 'GH Guardian Headline':
+                        case 'Guardian Egyptian Web':
+                            return (
+                                (font.weight === '700' &&
+                                    font.style === 'normal') ||
+                                (font.weight === '400' &&
+                                    font.style === 'italic')
+                            );
+                        default:
+                            return false;
+                    }
+                case 'Analysis':
+                case 'Live':
+                case 'Media':
+                case 'PhotoEssay':
+                case 'Article':
+                case 'SpecialReport':
+                case 'MatchReport':
+                case 'GuardianLabs':
+                case 'Quiz':
+                case 'AdvertisementFeature':
+                case 'Immersive':
+                default:
+                    switch (font.family) {
+                        case 'GuardianTextEgyptian':
+                        case 'Guardian Text Egyptian Web':
+                        case 'GuardianTextSans':
+                        case 'Guardian Text Sans Web':
+                            return (
+                                font.weight === '400' && font.style === 'normal'
+                            );
+                        case 'GH Guardian Headline':
+                        case 'Guardian Egyptian Web':
+                            return (
+                                (font.weight === '500' ||
+                                    font.weight === '700') &&
+                                font.style === 'normal'
+                            );
+                        default:
+                            return false;
+                    }
+            }
+        }
+    }
+};
 
 const template: (_: FontDisplay) => string = ({
     family,

--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -57,20 +57,13 @@ export const document = ({ data }: Props) => {
 
     /**
      * Preload the following woff2 font files
-     * TODO: Identify critical fonts to preload
+     * mark: PswXqO - keep these in sync with autoFoft rules
      */
     const fontFiles = [
-        // 'fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Light.woff2',
-        // 'fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-LightItalic.woff2',
         'fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.woff2',
-        'fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-MediumItalic.woff2',
         'fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.woff2',
         'fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff2',
-        // 'fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.woff2',
-        'fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.woff2',
         'fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.woff2',
-        // 'fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-RegularItalic.woff2',
-        'fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Bold.woff2',
     ];
 
     const polyfillIO =

--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -60,10 +60,10 @@ export const document = ({ data }: Props) => {
      * mark: PswXqO - keep these in sync with autoFoft rules
      */
     const fontFiles = [
-        'fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.woff2',
-        'fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.woff2',
         'fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff2',
         'fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.woff2',
+        'fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.woff2',
+        'fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.woff2',
     ];
 
     const polyfillIO =

--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -56,7 +56,7 @@ export const document = ({ data }: Props) => {
     );
 
     /**
-     * Preload the following woff2 font files
+     * Preload the critical woff2 font files
      * mark: PswXqO - keep these in sync with autoFoft rules
      */
     const fontFiles = [

--- a/src/web/server/htmlTemplate.ts
+++ b/src/web/server/htmlTemplate.ts
@@ -204,8 +204,9 @@ export const htmlTemplate = ({
                     <img src="https://sb.scorecardresearch.com/p?c1=2&c2=6035250&cv=2.0&cj=1&cs_ucfr=0&comscorekw=${keywords}" />
                 </noscript>
                 ${[...priorityScriptTags].join('\n')}
-                <style class="webfont" data-auto-foft-fonts>${getFontsCss()}</style>
+                <style data-auto-foft-fonts>${getFontsCss()}</style>
                 <script>
+                // mark: PswXqO - keep these in sync with preloads
                 window.autoFoft = {
                     isCritical: ({ family, style, weight }) => {
                         switch (family) {

--- a/src/web/server/htmlTemplate.ts
+++ b/src/web/server/htmlTemplate.ts
@@ -210,17 +210,13 @@ export const htmlTemplate = ({
                 window.autoFoft = {
                     isCritical: function (font) {
                         switch (font.family) {
-                            case 'GuardianTextEgyptian':
-                            case 'Guardian Text Egyptian Web':
-                            case 'GuardianTextSans':
-                            case 'Guardian Text Sans Web':
-                                return font.weight === 'normal' || font.weight === '400';
                             case 'GH Guardian Headline':
                             case 'Guardian Egyptian Web':
                                 return (font.weight === '500' || font.weight === '700') &&
                                     font.style === 'normal';
                             default:
-                                return false;
+                                return (font.weight === 'normal' || font.weight === '400') &&
+                                    font.style === 'normal';
                         }
                     }
                 }

--- a/src/web/server/htmlTemplate.ts
+++ b/src/web/server/htmlTemplate.ts
@@ -210,13 +210,17 @@ export const htmlTemplate = ({
                 window.autoFoft = {
                     isCritical: function (font) {
                         switch (font.family) {
+                            case 'GuardianTextEgyptian':
+                            case 'Guardian Text Egyptian Web':
+                            case 'GuardianTextSans':
+                            case 'Guardian Text Sans Web':
+                                return font.weight === 'normal' || font.weight === '400';
                             case 'GH Guardian Headline':
                             case 'Guardian Egyptian Web':
                                 return (font.weight === '500' || font.weight === '700') &&
                                     font.style === 'normal';
                             default:
-                                return (font.weight === 'normal' || font.weight === '400') &&
-                                    font.style === 'normal';
+                                return false;
                         }
                     }
                 }

--- a/src/web/server/htmlTemplate.ts
+++ b/src/web/server/htmlTemplate.ts
@@ -207,6 +207,12 @@ export const htmlTemplate = ({
                 <style data-auto-foft-fonts>${getFontsCss()}</style>
                 <script>
                 // mark: PswXqO - keep these in sync with preloads
+                // Using https://github.com/guardian/auto-foft
+                // and fonts from https://github.com/guardian/fonts
+                // We load the regular weight, non-italic versions of body
+                // fonts, and the bold and medium weights of headlines.
+                // The weightings are described in 
+ 				// https://theguardian.design/2a1e5182b/p/930d69-typography
                 window.autoFoft = {
                     isCritical: function (font) {
                         switch (font.family) {

--- a/src/web/server/htmlTemplate.ts
+++ b/src/web/server/htmlTemplate.ts
@@ -1,4 +1,5 @@
 import resetCSS from /* preval */ '@root/src/lib/reset-css';
+import autoFoft from /* preval */ '@root/src/lib/auto-foft';
 import { getFontsCss } from '@root/src/lib/fonts-css';
 import { getStatic, CDN } from '@root/src/lib/assets';
 import { brandBackground } from '@guardian/src-foundations/palette';
@@ -203,8 +204,32 @@ export const htmlTemplate = ({
                     <img src="https://sb.scorecardresearch.com/p?c1=2&c2=6035250&cv=2.0&cj=1&cs_ucfr=0&comscorekw=${keywords}" />
                 </noscript>
                 ${[...priorityScriptTags].join('\n')}
-                <style class="webfont">${getFontsCss()}${resetCSS}${css}</style>
-
+                <style class="webfont" data-auto-foft-fonts>${getFontsCss()}</style>
+                <script>
+                window.autoFoft = {
+                    defaultRules: [
+                        // mark: PswXqO - keep these in sync with preloads
+                        ({ family, weight, style }) =>
+                            (
+                                family === 'GuardianTextEgyptian' ||
+                                family === 'Guardian Text Egyptian Web' ||
+                                family === 'GuardianTextSans' ||
+                                family === 'Guardian Text Sans Web'
+                            ) &&
+                            weight === '400' &&
+                            style === 'normal',
+                        ({ family, weight, style }) =>
+                            (
+                                family === 'GH Guardian Headline' ||
+                                family === 'Guardian Egyptian Web'
+                            ) &&
+                            (weight === '500' || weight === '700') &&
+                            style === 'normal',
+                    ],
+                }
+                ${autoFoft}
+                </script>
+                <style>${resetCSS}${css}</style>
             </head>
 
             <body>

--- a/src/web/server/htmlTemplate.ts
+++ b/src/web/server/htmlTemplate.ts
@@ -208,17 +208,17 @@ export const htmlTemplate = ({
                 <script>
                 // mark: PswXqO - keep these in sync with preloads
                 window.autoFoft = {
-                    isCritical: ({ family, style, weight }) => {
-                        switch (family) {
+                    isCritical: function (font) {
+                        switch (font.family) {
                             case 'GuardianTextEgyptian':
                             case 'Guardian Text Egyptian Web':
                             case 'GuardianTextSans':
                             case 'Guardian Text Sans Web':
-                                return weight === 'normal' || weight === '400';
+                                return font.weight === 'normal' || font.weight === '400';
                             case 'GH Guardian Headline':
                             case 'Guardian Egyptian Web':
-                                return (weight === '500' || weight === '700') &&
-                                    style === 'normal';
+                                return (font.weight === '500' || font.weight === '700') &&
+                                    font.style === 'normal';
                             default:
                                 return false;
                         }

--- a/src/web/server/htmlTemplate.ts
+++ b/src/web/server/htmlTemplate.ts
@@ -207,25 +207,21 @@ export const htmlTemplate = ({
                 <style class="webfont" data-auto-foft-fonts>${getFontsCss()}</style>
                 <script>
                 window.autoFoft = {
-                    defaultRules: [
-                        // mark: PswXqO - keep these in sync with preloads
-                        ({ family, weight, style }) =>
-                            (
-                                family === 'GuardianTextEgyptian' ||
-                                family === 'Guardian Text Egyptian Web' ||
-                                family === 'GuardianTextSans' ||
-                                family === 'Guardian Text Sans Web'
-                            ) &&
-                            weight === '400' &&
-                            style === 'normal',
-                        ({ family, weight, style }) =>
-                            (
-                                family === 'GH Guardian Headline' ||
-                                family === 'Guardian Egyptian Web'
-                            ) &&
-                            (weight === '500' || weight === '700') &&
-                            style === 'normal',
-                    ],
+                    isCritical: ({ family, style, weight }) => {
+                        switch (family) {
+                            case 'GuardianTextEgyptian':
+                            case 'Guardian Text Egyptian Web':
+                            case 'GuardianTextSans':
+                            case 'Guardian Text Sans Web':
+                                return weight === 'normal' || weight === '400';
+                            case 'GH Guardian Headline':
+                            case 'Guardian Egyptian Web':
+                                return (weight === '500' || weight === '700') &&
+                                    style === 'normal';
+                            default:
+                                return false;
+                        }
+                    }
                 }
                 ${autoFoft}
                 </script>

--- a/src/web/server/htmlTemplate.ts
+++ b/src/web/server/htmlTemplate.ts
@@ -220,7 +220,8 @@ export const htmlTemplate = ({
                             case 'Guardian Text Egyptian Web':
                             case 'GuardianTextSans':
                             case 'Guardian Text Sans Web':
-                                return font.weight === 'normal' || font.weight === '400';
+                                return (font.weight === 'normal' || font.weight === '400') && 
+                                    font.style === 'normal';
                             case 'GH Guardian Headline':
                             case 'Guardian Egyptian Web':
                                 return (font.weight === '500' || font.weight === '700') &&

--- a/yarn.lock
+++ b/yarn.lock
@@ -5125,9 +5125,9 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-auto-foft@guardian/auto-foft#1232160:
+auto-foft@guardian/auto-foft#0a6510c:
   version "0.1.0"
-  resolved "https://codeload.github.com/guardian/auto-foft/tar.gz/1232160e70f01d7872333022a9dbabd22828e0a7"
+  resolved "https://codeload.github.com/guardian/auto-foft/tar.gz/0a6510cfb7c62e2e4660dcd510352f8cf264eb0a"
 
 autoprefixer@^9.5.1:
   version "9.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5125,9 +5125,9 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-auto-foft@guardian/auto-foft#2555005:
+auto-foft@guardian/auto-foft#1232160:
   version "0.1.0"
-  resolved "https://codeload.github.com/guardian/auto-foft/tar.gz/255500500e0487fdf6d0c68ad0e6f05fb4c0e38e"
+  resolved "https://codeload.github.com/guardian/auto-foft/tar.gz/1232160e70f01d7872333022a9dbabd22828e0a7"
 
 autoprefixer@^9.5.1:
   version "9.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5125,9 +5125,9 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-auto-foft@guardian/auto-foft#64c8dfa:
+auto-foft@guardian/auto-foft#2555005:
   version "0.1.0"
-  resolved "https://codeload.github.com/guardian/auto-foft/tar.gz/64c8dfadba5b252cdeed23cdbbb605bc23b42974"
+  resolved "https://codeload.github.com/guardian/auto-foft/tar.gz/255500500e0487fdf6d0c68ad0e6f05fb4c0e38e"
 
 autoprefixer@^9.5.1:
   version "9.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5125,6 +5125,10 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
+auto-foft@guardian/auto-foft#64c8dfa:
+  version "0.1.0"
+  resolved "https://codeload.github.com/guardian/auto-foft/tar.gz/64c8dfadba5b252cdeed23cdbbb605bc23b42974"
+
 autoprefixer@^9.5.1:
   version "9.6.1"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.6.1.tgz#51967a02d2d2300bb01866c1611ec8348d355a47"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5125,9 +5125,9 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-auto-foft@guardian/auto-foft#0a6510c:
+auto-foft@guardian/auto-foft#29ad5a33:
   version "0.1.0"
-  resolved "https://codeload.github.com/guardian/auto-foft/tar.gz/0a6510cfb7c62e2e4660dcd510352f8cf264eb0a"
+  resolved "https://codeload.github.com/guardian/auto-foft/tar.gz/29ad5a33aecf04dd7fc61d93af28825f8fb6760e"
 
 autoprefixer@^9.5.1:
   version "9.6.1"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

adds https://github.com/guardian/auto-foft to prioritise font loading and minimise reflows

## Why?

currently fonts are loaded on-demand by the browser and used as soon as they're ready. each new font triggers a reflow and requests are not prioritised

`auto-foft` allows you specify which of your fonts are critical, and which can wait. 

it renders immediately with fallbacks while it downloads the critical ones then applies them all in one go, falling back to faux styles for missing fonts. 

then it gets the rest and applies them all in one go too.

if the files are cached it happens as fast as the browser can manage (as with untouched CSS `@font-face`)

this means:

- initial bandwidth is used for the most important stuff first
- only 2 reflows on a cold cache

## frontend

if this gets a 👍 we can do the same for frontend and the coronavirus interactive widget, then we can start sharing font files better but still have control over how they load

attached to #2138