### PR TITLE
Position Embeds based on their role

### DIFF
--- a/fixtures/articles/AdvertisementFeature.ts
+++ b/fixtures/articles/AdvertisementFeature.ts
@@ -2326,6 +2326,7 @@ export const AdvertisementFeature: CAPIType = {
                     safe: false,
                     alt:
                         'Do you have a pressing question about electric cars? Submit it below for your chance to have your question answered by an EV expert...',
+                    role: 'supporting',
                     _type:
                         'model.dotcomrendering.pageElements.EmbedBlockElement',
                     html:

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -105,6 +105,7 @@ interface DocumentBlockElement {
 interface EmbedBlockElement {
     _type: 'model.dotcomrendering.pageElements.EmbedBlockElement';
     safe?: boolean;
+    role?: RoleType;
     alt?: string;
     html: string;
     isMandatory: boolean;

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -1100,6 +1100,9 @@
                 "safe": {
                     "type": "boolean"
                 },
+                "role": {
+                    "$ref": "#/definitions/RoleType"
+                },
                 "alt": {
                     "type": "string"
                 },
@@ -1115,6 +1118,17 @@
                 "html",
                 "isMandatory"
             ]
+        },
+        "RoleType": {
+            "enum": [
+                "halfWidth",
+                "immersive",
+                "inline",
+                "showcase",
+                "supporting",
+                "thumbnail"
+            ],
+            "type": "string"
         },
         "ExplainerAtomBlockElement": {
             "type": "object",
@@ -1430,17 +1444,6 @@
                 "src",
                 "width"
             ]
-        },
-        "RoleType": {
-            "enum": [
-                "halfWidth",
-                "immersive",
-                "inline",
-                "showcase",
-                "supporting",
-                "thumbnail"
-            ],
-            "type": "string"
         },
         "InstagramBlockElement": {
             "type": "object",

--- a/src/web/components/elements/EmbedBlockComponent.tsx
+++ b/src/web/components/elements/EmbedBlockComponent.tsx
@@ -21,7 +21,6 @@ const embedContainer = css`
         /* Some embeds can hijack the iframe and calculate an incorrect width, which pushes the body out */
         width: 100% !important;
     }
-    margin-bottom: 16px;
 `;
 
 export const EmbedBlockComponent = ({ html, alt }: Props) => {

--- a/src/web/components/elements/UnsafeEmbedBlockComponent.tsx
+++ b/src/web/components/elements/UnsafeEmbedBlockComponent.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import { css } from 'emotion';
 
-import { from } from '@guardian/src-foundations/mq';
-import { space } from '@guardian/src-foundations';
-
 type Props = {
     html: string;
     alt: string;
@@ -14,38 +11,17 @@ const fullWidthStyles = css`
     width: 100%;
 `;
 
-const unsafeEmbedWrapperStyles = css`
-    position: relative;
-    float: left;
-    width: 300px;
-    margin-top: ${space[1]}px;
-    margin-bottom: ${space[3]}px;
-    margin-right: ${space[5]}px;
-
-    &.img--landscape {
-        margin-right: ${space[5]}px;
-    }
-    ${from.leftCol} {
-        margin-left: -${space[9]}px;
-    }
-    ${from.wide} {
-        width: 380px;
-    }
-`;
-
 export const UnsafeEmbedBlockComponent = ({ html, alt, index }: Props) => (
-    <figure className={unsafeEmbedWrapperStyles}>
-        <iframe
-            className={`${fullWidthStyles} js-embed__iframe`}
-            title={alt}
-            // name is used to identify each unique iframe on the page to resize
-            // we therefore use the "unsafe-embed-" prefix followed by index to
-            // construct a unique ID
-            name={`unsafe-embed-${index}`}
-            data-cy="embed-block"
-            srcDoc={`${html}
+    <iframe
+        className={`${fullWidthStyles} js-embed__iframe`}
+        title={alt}
+        // name is used to identify each unique iframe on the page to resize
+        // we therefore use the "unsafe-embed-" prefix followed by index to
+        // construct a unique ID
+        name={`unsafe-embed-${index}`}
+        data-cy="embed-block"
+        srcDoc={`${html}
             <script src="https://interactive.guim.co.uk/libs/iframe-messenger/iframeMessenger.js"></script>
             <gu-script>iframeMessenger.enableAutoResize();</gu-script>`}
-        />
-    </figure>
+    />
 );

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -29,6 +29,8 @@ import { VimeoBlockComponent } from '@root/src/web/components/elements/VimeoBloc
 import { YoutubeEmbedBlockComponent } from '@root/src/web/components/elements/YoutubeEmbedBlockComponent';
 import { YoutubeBlockComponent } from '@root/src/web/components/elements/YoutubeBlockComponent';
 
+import { Figure } from '@root/src/web/components/Figure';
+
 import {
     AudioAtom,
     ChartAtom,
@@ -145,20 +147,24 @@ export const ArticleRenderer: React.FC<{
                 case 'model.dotcomrendering.pageElements.EmbedBlockElement':
                     if (!element.safe) {
                         return (
-                            <UnsafeEmbedBlockComponent
-                                key={i}
-                                html={element.html}
-                                alt={element.alt || ''}
-                                index={i}
-                            />
+                            <Figure role={element.role}>
+                                <UnsafeEmbedBlockComponent
+                                    key={i}
+                                    html={element.html}
+                                    alt={element.alt || ''}
+                                    index={i}
+                                />
+                            </Figure>
                         );
                     }
                     return (
-                        <EmbedBlockComponent
-                            key={i}
-                            html={element.html}
-                            alt={element.alt}
-                        />
+                        <Figure role={element.role}>
+                            <EmbedBlockComponent
+                                key={i}
+                                html={element.html}
+                                alt={element.alt}
+                            />
+                        </Figure>
                     );
                 case 'model.dotcomrendering.pageElements.ExplainerAtomBlockElement':
                     return (

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -5,11 +5,13 @@ import { BlockquoteBlockComponent } from '@root/src/web/components/elements/Bloc
 import { CalloutBlockComponent } from '@root/src/web/components/elements/CalloutBlockComponent';
 import { CaptionBlockComponent } from '@root/src/web/components/elements/CaptionBlockComponent';
 import { CommentBlockComponent } from '@root/src/web/components/elements/CommentBlockComponent';
+import { DefaultRichLink } from '@root/src/web/components/RichLink';
 import { DocumentBlockComponent } from '@root/src/web/components/elements/DocumentBlockComponent';
 import { DisclaimerBlockComponent } from '@root/src/web/components/elements/DisclaimerBlockComponent';
 import { DividerBlockComponent } from '@root/src/web/components/elements/DividerBlockComponent';
 import { EmbedBlockComponent } from '@root/src/web/components/elements/EmbedBlockComponent';
 import { UnsafeEmbedBlockComponent } from '@root/src/web/components/elements/UnsafeEmbedBlockComponent';
+import { GuVideoBlockComponent } from '@root/src/web/components/elements/GuVideoBlockComponent';
 import { HighlightBlockComponent } from '@root/src/web/components/elements/HighlightBlockComponent';
 import { ImageBlockComponent } from '@root/src/web/components/elements/ImageBlockComponent';
 import { InstagramBlockComponent } from '@root/src/web/components/elements/InstagramBlockComponent';
@@ -40,9 +42,7 @@ import {
 } from '@guardian/atoms-rendering';
 import { Display } from '@root/src/lib/display';
 import { withSignInGateSlot } from '@root/src/web/lib/withSignInGateSlot';
-import { GuVideoBlockComponent } from '@root/src/web/components/elements/GuVideoBlockComponent';
 import { toTypesPillar } from '@root/src/lib/format';
-import { DefaultRichLink } from '../components/RichLink';
 
 // This is required for spacefinder to work!
 const commercialPosition = css`


### PR DESCRIPTION
## What does this change?
Positions the `EmbedBlockComponent` and `UnsafeBlockComponent` based on the elements `role`. We use `Figure` to do this.

### A note on vertical margins
I've removed the `margin-bottom` css from the embed component. I'm planing on doing this each time we wrap a component in `Figure`. I think we should start to centralise to one location the place where we set the vertical spacing between elements on the page.

### Next Steps
We won't see non default (`role` = `inline`) behaviour until the `role` property is passed down from CAPI into the DCR model @shtukas ? Once we have the `role` property available on the model, assuming it is a mandatory field, then we should update our types to show `role` as required.

## Why?
Because embeds can have a role and we should respect this when deciding where to place them in an article.