### PR TITLE
Restrict where we support force-braze-message

### DIFF
--- a/src/web/components/StickyBottomBanner/BrazeBanner.tsx
+++ b/src/web/components/StickyBottomBanner/BrazeBanner.tsx
@@ -150,10 +150,24 @@ const getMessageFromBraze = async (
     return canShowPromise;
 };
 
+const FORCE_BRAZE_ALLOWLIST = [
+    'preview.gutools.co.uk',
+    'preview.code.dev-gutools.co.uk',
+    'localhost',
+    'm.thegulocal.com',
+];
+
 const getBrazeMetaFromQueryString = (): Meta | null => {
     if (URLSearchParams) {
-        const params = new URLSearchParams(window.location.search);
         const qsArg = 'force-braze-message';
+
+        if (!FORCE_BRAZE_ALLOWLIST.includes(window.location.hostname)) {
+            // eslint-disable-next-line no-console
+            console.log(`${qsArg} is not supported on this domain`);
+            return null;
+        }
+
+        const params = new URLSearchParams(window.location.search);
         const value = params.get(qsArg);
         if (value) {
             try {


### PR DESCRIPTION
Restrict the domains where we support the `force-braze-message` query string arg. Marketing can use this to force the Braze banner to appear. As we make the banner configuration more flexible it doesn't make sense to support this on the main website, so restrict to preview (and dev environments).

### Before

The `force-braze-message` query string arg can be used in all environments.

### After

The `force-braze-message` can only be used in preview and dev.