### PR TITLE
Cypress Intercept Improvements

### DIFF
--- a/cypress/integration/e2e/article.e2e.spec.js
+++ b/cypress/integration/e2e/article.e2e.spec.js
@@ -29,9 +29,9 @@ describe('E2E Page rendering', function () {
                         req.reply((res) => {
                             expect(res.body).to.have.property('heading');
                             expect(res.statusCode).to.be.equal(200);
-                            cy.contains('Most viewed');
                         });
                     });
+                    cy.contains('Most viewed');
                 }
 
                 cy.scrollTo('bottom', { duration: 500 });
@@ -51,9 +51,9 @@ describe('E2E Page rendering', function () {
                     cy.intercept('GET', '/embed/card/**', (req) => {
                         req.reply((res) => {
                             expect(res.statusCode).to.be.equal(200);
-                            cy.contains('Read more');
                         });
                     });
+                    cy.contains('Read more');
                 }
 
                 // We scroll again here because not all the content at the bottom of the page loads
@@ -65,9 +65,9 @@ describe('E2E Page rendering', function () {
                     req.reply((res) => {
                         expect(res.body).to.have.property('tabs');
                         expect(res.statusCode).to.be.equal(200);
-                        cy.contains('Most commented');
                     });
                 });
+                cy.contains('Most commented');
             });
         });
     });

--- a/cypress/integration/e2e/article.e2e.spec.js
+++ b/cypress/integration/e2e/article.e2e.spec.js
@@ -13,8 +13,8 @@ describe('E2E Page rendering', function () {
     describe('for WEB', function () {
         // eslint-disable-next-line mocha/no-setup-in-describe
         articles.map((article, index) => {
-            it(`It should load the designType under the pillar (${article.url})`, function () {
-                const { url: articleUrl, designType, pillar } = article;
+          const { url: articleUrl, designType, pillar } = article;
+            it(`It should load ${designType} articles under the pillar ${pillar} (${articleUrl})`, function () {
                 const url = setUrlFragment(articleUrl, {
                     'ab-CuratedContainerTest2': 'control',
                 });

--- a/cypress/integration/e2e/article.e2e.spec.js
+++ b/cypress/integration/e2e/article.e2e.spec.js
@@ -28,7 +28,7 @@ describe('E2E Page rendering', function () {
                     cy.intercept('GET', '**/most-read-geo**', (req) => {
                         req.reply((res) => {
                             expect(res.body).to.have.property('heading');
-                            expect(req.statusCode).to.be.equal(200);
+                            expect(res.statusCode).to.be.equal(200);
                             cy.contains('Most viewed');
                         })
                     });

--- a/cypress/integration/e2e/article.e2e.spec.js
+++ b/cypress/integration/e2e/article.e2e.spec.js
@@ -26,7 +26,7 @@ describe('E2E Page rendering', function () {
 
                 if (!article.hideMostViewed) {
                     cy.intercept('GET', '**/most-read-geo**', (req) => {
-                        expect(req.response.body).to.have.property(
+                        expect(req.body).to.have.property(
                             'heading',
                         );
                         expect(req.status).to.be.equal(200);
@@ -39,9 +39,9 @@ describe('E2E Page rendering', function () {
 
                 cy.intercept('POST', '/sharecount/**', (req) => {
                     expect(req.status).to.be.equal(200);
-                    expect(req.response.body).to.have.property('path');
-                    expect(req.response.body).to.have.property('refreshStatus');
-                    expect(req.response.body)
+                    expect(req.body).to.have.property('path');
+                    expect(req.body).to.have.property('refreshStatus');
+                    expect(req.body)
                         .to.have.property('share_count')
                         .that.is.a('number');
                 })
@@ -59,7 +59,7 @@ describe('E2E Page rendering', function () {
                 cy.scrollTo('bottom', { duration: 500 });
 
                 cy.intercept('GET', '/most-read/**', (req) => {
-                    expect(req.response.body).to.have.property('tabs');
+                    expect(req.body).to.have.property('tabs');
                     expect(req.status).to.be.equal(200);
                     cy.contains('Most commented');
                 });

--- a/cypress/integration/e2e/article.e2e.spec.js
+++ b/cypress/integration/e2e/article.e2e.spec.js
@@ -13,7 +13,7 @@ describe('E2E Page rendering', function () {
     describe('for WEB', function () {
         // eslint-disable-next-line mocha/no-setup-in-describe
         articles.map((article, index) => {
-          const { url: articleUrl, designType, pillar } = article;
+            const { url: articleUrl, designType, pillar } = article;
             it(`It should load ${designType} articles under the pillar ${pillar} (${articleUrl})`, function () {
                 const url = setUrlFragment(articleUrl, {
                     'ab-CuratedContainerTest2': 'control',
@@ -30,7 +30,7 @@ describe('E2E Page rendering', function () {
                             expect(res.body).to.have.property('heading');
                             expect(res.statusCode).to.be.equal(200);
                             cy.contains('Most viewed');
-                        })
+                        });
                     });
                 }
 
@@ -44,15 +44,15 @@ describe('E2E Page rendering', function () {
                         expect(res.body)
                             .to.have.property('share_count')
                             .that.is.a('number');
-                    })
-                })
+                    });
+                });
 
                 if (article.hasRichLinks) {
                     cy.intercept('GET', '/embed/card/**', (req) => {
                         req.reply((res) => {
                             expect(res.statusCode).to.be.equal(200);
                             cy.contains('Read more');
-                        })
+                        });
                     });
                 }
 
@@ -66,7 +66,7 @@ describe('E2E Page rendering', function () {
                         expect(res.body).to.have.property('tabs');
                         expect(res.statusCode).to.be.equal(200);
                         cy.contains('Most commented');
-                    })
+                    });
                 });
             });
         });

--- a/cypress/integration/e2e/article.e2e.spec.js
+++ b/cypress/integration/e2e/article.e2e.spec.js
@@ -26,30 +26,33 @@ describe('E2E Page rendering', function () {
 
                 if (!article.hideMostViewed) {
                     cy.intercept('GET', '**/most-read-geo**', (req) => {
-                        expect(req.body).to.have.property(
-                            'heading',
-                        );
-                        expect(req.status).to.be.equal(200);
-
-                        cy.contains('Most viewed');
+                        req.reply((res) => {
+                            expect(res.body).to.have.property('heading');
+                            expect(req.statusCode).to.be.equal(200);
+                            cy.contains('Most viewed');
+                        })
                     });
                 }
 
                 cy.scrollTo('bottom', { duration: 500 });
 
                 cy.intercept('POST', '/sharecount/**', (req) => {
-                    expect(req.status).to.be.equal(200);
-                    expect(req.body).to.have.property('path');
-                    expect(req.body).to.have.property('refreshStatus');
-                    expect(req.body)
-                        .to.have.property('share_count')
-                        .that.is.a('number');
+                    req.reply((res) => {
+                        expect(res.statusCode).to.be.equal(200);
+                        expect(res.body).to.have.property('path');
+                        expect(res.body).to.have.property('refreshStatus');
+                        expect(res.body)
+                            .to.have.property('share_count')
+                            .that.is.a('number');
+                    })
                 })
 
                 if (article.hasRichLinks) {
                     cy.intercept('GET', '/embed/card/**', (req) => {
-                        expect(req.status).to.be.equal(200);
-                        cy.contains('Read more');
+                        req.reply((res) => {
+                            expect(res.statusCode).to.be.equal(200);
+                            cy.contains('Read more');
+                        })
                     });
                 }
 
@@ -59,9 +62,11 @@ describe('E2E Page rendering', function () {
                 cy.scrollTo('bottom', { duration: 500 });
 
                 cy.intercept('GET', '/most-read/**', (req) => {
-                    expect(req.body).to.have.property('tabs');
-                    expect(req.status).to.be.equal(200);
-                    cy.contains('Most commented');
+                    req.reply((res) => {
+                        expect(res.body).to.have.property('tabs');
+                        expect(res.statusCode).to.be.equal(200);
+                        cy.contains('Most commented');
+                    })
                 });
             });
         });


### PR DESCRIPTION
### What does this change?
Replaces the use of `req.response.body` with `req.body` inside a `req.reply` callback. Looks like the upgrade to v6 the other day caused these checks to become a bit flakey and I noticed that the examples in the docs are using a newer structure to access the body so I've implemented that instead.

See: https://docs.cypress.io/api/commands/intercept.html#Intercepting-a-response
