### PR TITLE
Weird Dropcaps

### DIFF
--- a/src/web/components/elements/TextBlockComponent.stories.tsx
+++ b/src/web/components/elements/TextBlockComponent.stories.tsx
@@ -9,7 +9,7 @@ const html =
 const quotedHtml =
     '<p>“Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesquepharetra libero nec varius feugiat. Nulla commodo sagittis erat amalesuada. Ut iaculis interdum eros, et tristique ex. In veldignissim arcu. Nulla nisi urna, laoreet a aliquam at, viverra eueros. Proin imperdiet pellentesque turpis sed luctus. Donecdignissim lacus in risus fermentum maximus eu vel justo. Duis nontortor ac elit dapibus imperdiet ut at risus. Etiam pretium, odioeget accumsan venenatis, tortor mi aliquet nisl, vel ullamcorperneque nulla vel elit. Etiam porta mauris nec sagittis luctus.</p>';
 const shortHtml =
-    '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesquepharetra libero </p>';
+    'Since its arrival on Netflix last month, The Queen’s Gambit has attracted a staggering <a href="https://www.theguardian.com/tv-and-radio/2020/nov/26/the-queens-gambit-netflix-most-watched-series-hit-chess">62 million</a> viewers – making it the streaming service’s most-watched scripted limited series.';
 const differentWrapperTags =
     '<span><p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesquepharetra libero nec varius feugiat. Nulla commodo sagittis erat amalesuada. Ut iaculis interdum eros, et tristique ex. In veldignissim arcu. Nulla nisi urna, laoreet a aliquam at, viverra eueros. Proin imperdiet pellentesque turpis sed luctus. Donecdignissim lacus in risus fermentum maximus eu vel justo. Duis nontortor ac elit dapibus imperdiet ut at risus. Etiam pretium, odioeget accumsan venenatis, tortor mi aliquet nisl, vel ullamcorperneque nulla vel elit. Etiam porta mauris nec sagittis luctus.</p></span>';
 const aListHtml =
@@ -88,7 +88,7 @@ export const ShortText = () => {
         </div>
     );
 };
-ShortText.story = { name: 'with text less than 299 characters' };
+ShortText.story = { name: 'with text less than 200 characters' };
 
 export const NoTags = () => {
     return (

--- a/src/web/components/elements/TextBlockComponent.tsx
+++ b/src/web/components/elements/TextBlockComponent.tsx
@@ -25,8 +25,16 @@ const isLetter = (letter: string) => {
     return letter.toLowerCase() !== letter.toUpperCase();
 };
 
-const isLongEnough = (html: string) => {
-    return html.length > 199;
+const isLongEnough = (html: any) => {
+    // Only show a dropcap if the block of text is 200 characters or
+    // longer. But we first need to strip any markup from our html string so
+    // that we accurately measure the length that the reader will see. Eg. remove
+    // link tag html.
+    // https://stackoverflow.com/questions/822452/strip-html-from-text-javascript is
+    // a good discussion on how this can be done. Of the two approaches, regex and
+    // DOM, both have unikely failure scenarios but the impact for failure with DOM
+    // manipulation carries a potential security risk so we're using a regex.
+    return html.replace(/(<([^>]+)>)/gi, '').length > 199;
 };
 
 const decideDropCapLetter = (html: string) => {


### PR DESCRIPTION
## What does this change?
One of the rules for deciding when a dropcap appears is that the length of the text it proceeds should be greater than 200 characters. We had a bug where when we tried to decide the length of this text we ended up also counting any html markup characters as well, incorrectly returning a longer value than what the reader actually sees.

In [this article](https://www.theguardian.com/sport/2020/nov/29/chess-world-hails-queens-gambit-fuelled-boom) there is a link in the first paragraph which leads to two possible outcomes when counting length

### Before (with markup)
```
Since its arrival on Netflix last month, The Queen’s Gambit has attracted a staggering <a href="https://www.theguardian.com/tv-and-radio/2020/nov/26/the-queens-gambit-netflix-most-watched-series-hit-chess">62 million</a> viewers – making it the streaming service’s most-watched scripted limited series.
```

Length: `302` - Weird DropCap

### After
```
Since its arrival on Netflix last month, The Queen’s Gambit has attracted a staggering 62 million viewers – making it the streaming service’s most-watched scripted limited series.
```

Length: `179` - No DropCap


## Why?
![image](https://user-images.githubusercontent.com/1336821/100550177-09f96f80-3270-11eb-8fe6-1a84d77aef5e.png)

