### PR TITLE
Extend merch unit test by one week

### DIFF
--- a/src/web/experiments/tests/newsletter-merch-unit-test.ts
+++ b/src/web/experiments/tests/newsletter-merch-unit-test.ts
@@ -3,12 +3,14 @@ import { ABTest } from '@guardian/ab-core';
 export const newsletterMerchUnitLighthouseControl: ABTest = {
     id: 'NewsletterMerchUnitLighthouseControl',
     start: '2020-11-11',
-    expiry: '2020-12-01',
+    expiry: '2020-12-08',
     author: 'Josh Buckland & Alex Dufournet',
-    description: 'Show BAU merch unit to 50% of users. This is the control for the NewsletterMerchUnitLighthouseVariants test.',
+    description:
+        'Show BAU merch unit to 50% of users. This is the control for the NewsletterMerchUnitLighthouseVariants test.',
     audience: 0.5,
     audienceOffset: 0.0,
-    successMeasure: 'We see increased engagement from users shown the Newsletters ad unit',
+    successMeasure:
+        'We see increased engagement from users shown the Newsletters ad unit',
     audienceCriteria: 'Website users only.',
     idealOutcome: 'Investigate lighthouse segment engagement via newsletters',
     showForSensitive: false,
@@ -24,15 +26,17 @@ export const newsletterMerchUnitLighthouseControl: ABTest = {
 export const newsletterMerchUnitLighthouseVariants: ABTest = {
     id: 'NewsletterMerchUnitLighthouseVariants',
     start: '2020-11-11',
-    expiry: '2020-12-01',
+    expiry: '2020-12-08',
     author: 'Josh Buckland & Alex Dufournet',
-    description: 'Show a newsletter advert in the merchandising unit to 25% of users and reader revenue' +
+    description:
+        'Show a newsletter advert in the merchandising unit to 25% of users and reader revenue' +
         'to another 25%. The remaining 50% are covered by NewsletterMerchUnitLighthouseControl ' +
-        'which needs to run at the same time. These two variants test the value of showing ' + 
+        'which needs to run at the same time. These two variants test the value of showing ' +
         'newsletter merch units instead of reader revenue ones. ',
     audience: 0.5,
     audienceOffset: 0.5,
-    successMeasure: 'We see increased engagement from users shown the Newsletters ad unit',
+    successMeasure:
+        'We see increased engagement from users shown the Newsletters ad unit',
     audienceCriteria: 'Website users only.',
     idealOutcome: 'Investigate lighthouse segment engagement via newsletters',
     showForSensitive: false,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Extends merch unit test by one week to allow a grace period to determine significance. See https://github.com/guardian/frontend/pull/23320

