### PR TITLE
Identity | Sign in gate | Stop scroll on dismiss

### DIFF
--- a/src/web/components/SignInGate/SignInGateSelector.tsx
+++ b/src/web/components/SignInGate/SignInGateSelector.tsx
@@ -55,13 +55,6 @@ const dismissGate = (
         currentAbTestValue.variant,
         currentAbTestValue.name,
     );
-
-    // When the user closes the sign in gate, we scroll them back to the main content
-    const articleBody = document.querySelector(
-        '.article-body-commercial-selector',
-    );
-
-    articleBody?.scrollIntoView(true);
 };
 
 type GateTestMap = { [name: string]: SignInGateComponent };

--- a/src/web/experiments/tests/sign-in-gate-main-control.ts
+++ b/src/web/experiments/tests/sign-in-gate-main-control.ts
@@ -3,7 +3,7 @@ import { ABTest } from '@guardian/ab-core';
 export const signInGateMainControl: ABTest = {
     id: 'SignInGateMainControl',
     start: '2020-05-20',
-    expiry: '2020-12-01',
+    expiry: '2021-12-01',
     author: 'Mahesh Makani',
     description:
         'Show sign in gate to 100% of users on 3rd article view of simple article templates, and show a further 5 times after the first dismissal, with higher priority over banners and epic. Control Audience.',
@@ -20,7 +20,7 @@ export const signInGateMainControl: ABTest = {
     variants: [
         {
             id: 'main-control-3',
-            test: (): void => { },
+            test: (): void => {},
         },
     ],
 };

--- a/src/web/experiments/tests/sign-in-gate-main-variant.ts
+++ b/src/web/experiments/tests/sign-in-gate-main-variant.ts
@@ -3,7 +3,7 @@ import { ABTest } from '@guardian/ab-core';
 export const signInGateMainVariant: ABTest = {
     id: 'SignInGateMainVariant',
     start: '2020-05-20',
-    expiry: '2020-12-01',
+    expiry: '2021-12-01',
     author: 'Mahesh Makani',
     description:
         'Show sign in gate to 100% of users on 3rd article view of simple article templates, and show a further 5 times after the first dismissal, with higher priority over banners and epic. Main/Variant Audience.',
@@ -20,7 +20,7 @@ export const signInGateMainVariant: ABTest = {
     variants: [
         {
             id: 'main-variant-3',
-            test: (): void => { },
+            test: (): void => {},
         },
     ],
 };


### PR DESCRIPTION
## What does this change?
- Remove scrolling to the top of the article body on sign in gate dismiss
- Extend sign in gate test expiry

## Why?
 Cumulative Layout Shift Score of 0.43 (https://web.dev/cls/) - 'Good' total CLS is below 0.1, and because CrUX reports are used for Google search rankings now, this will have a big impact on our rankings.

We should allow the sign in gate just to expand from its current position, rather than shifting back to the top of the page.