### PR TITLE
Add missing google-analytics.com to prefetch list

### DIFF
--- a/src/web/server/htmlTemplate.ts
+++ b/src/web/server/htmlTemplate.ts
@@ -96,6 +96,7 @@ export const htmlTemplate = ({
         `https://phar.gu-web.net`,
         `https://static.theguardian.com`,
         `https://support.theguardian.com`,
+        `https://www.google-analytics.com`,
     ];
 
     const preconnectTags = staticPreconnectUrls.map(


### PR DESCRIPTION

## What does this change?

Add missing `google-analytics.com` to prefetch list. This brings DCR on par with the list of preconnect and prefetch URLs on frontend.