### PR TITLE
Add larger image preview for Google Discover

### DIFF
--- a/src/web/server/htmlTemplate.ts
+++ b/src/web/server/htmlTemplate.ts
@@ -68,10 +68,6 @@ export const htmlTemplate = ({
 
     const twitterMetaTags = generateMetaTags(twitterData, 'name');
 
-    // This tag enables pages to be featured in Google Discover as large previews
-    // See: https://developers.google.com/search/docs/advanced/mobile/google-discover?hl=en&visit_id=637424198370039526-3805703503&rd=1
-    const googleDiscoverMetaTag = '<meta name="robots" content="max-image-preview:large">';
-
     // Duplicated prefetch and preconnect tags from DCP:
     // Documented here: https://github.com/guardian/frontend/pull/12935
     // Preconnect should be used for the most crucial third party domains
@@ -139,7 +135,9 @@ export const htmlTemplate = ({
 
                 ${twitterMetaTags}
 
-                ${googleDiscoverMetaTag}
+                <!--  This tag enables pages to be featured in Google Discover as large previews
+                    See: https://developers.google.com/search/docs/advanced/mobile/google-discover?hl=en&visit_id=637424198370039526-3805703503&rd=1 -->
+                <meta name="robots" content="max-image-preview:large">
 
                 <script>
                     window.guardian = ${windowGuardian};

--- a/src/web/server/htmlTemplate.ts
+++ b/src/web/server/htmlTemplate.ts
@@ -68,6 +68,10 @@ export const htmlTemplate = ({
 
     const twitterMetaTags = generateMetaTags(twitterData, 'name');
 
+    // This tag enables pages to be featured in Google Discover as large previews
+    // See: https://developers.google.com/search/docs/advanced/mobile/google-discover?hl=en&visit_id=637424198370039526-3805703503&rd=1
+    const googleDiscoverMetaTag = '<meta name="robots" content="max-image-preview:large">';
+
     // Duplicated prefetch and preconnect tags from DCP:
     // Documented here: https://github.com/guardian/frontend/pull/12935
     // Preconnect should be used for the most crucial third party domains
@@ -134,6 +138,8 @@ export const htmlTemplate = ({
                 ${twitterSecAndPrivacyMetaTags}
 
                 ${twitterMetaTags}
+
+                ${googleDiscoverMetaTag}
 
                 <script>
                     window.guardian = ${windowGuardian};


### PR DESCRIPTION
## What does this change?

Adding this meta tag allows Google Discover to include larger article previews where the main image is >=1200px. 

[https://developers.google.com/search/docs/advanced/mobile/google-discover?hl=en&visit_id=637424198370039526-3805703503&rd=1](url)

This is already implemented on frontend so this essentially brings DCR to parity.