### PR TITLE
Use the pillar colour for the active 'dot' on the Carousel

### DIFF
--- a/src/web/components/Onwards/Carousel/Carousel.stories.tsx
+++ b/src/web/components/Onwards/Carousel/Carousel.stories.tsx
@@ -185,12 +185,21 @@ const trails: TrailType[] = [
 ];
 
 export const Headlines = () => (
-    <Carousel
-        heading="Headlines"
-        trails={trails}
-        ophanComponentName="curated-content"
-        pillar='news'
-    />
+    <>
+        <Carousel
+            heading="Headlines"
+            trails={trails}
+            ophanComponentName="curated-content"
+            pillar="news"
+        />
+
+        <Carousel
+            heading="Sport"
+            trails={trails}
+            ophanComponentName="curated-content"
+            pillar="sport"
+        />
+    </>
 );
 
 Headlines.story = 'Headlines carousel';

--- a/src/web/components/Onwards/Carousel/Carousel.tsx
+++ b/src/web/components/Onwards/Carousel/Carousel.tsx
@@ -184,12 +184,12 @@ const dotStyle = css`
     }
 `;
 
-const dotActiveStyle = css`
-    background-color: ${palette.news[400]};
+const dotActiveStyle = (pillar: Pillar) => css`
+    background-color: ${pillarPalette[pillar].dark};
 
     &:hover,
     &:focus {
-        background-color: ${palette.news[300]};
+        background-color: ${pillarPalette[pillar].main};
     }
 `;
 
@@ -465,7 +465,7 @@ export const Carousel: React.FC<OnwardsType> = ({
                             aria-hidden="true"
                             className={cx(
                                 dotStyle,
-                                i === index && dotActiveStyle,
+                                i === index && dotActiveStyle(pillar),
                                 adjustNumberOfDotsStyle(i, trails.length),
                             )}
                         />

--- a/src/web/components/Onwards/Carousel/Carousel.tsx
+++ b/src/web/components/Onwards/Carousel/Carousel.tsx
@@ -185,7 +185,7 @@ const dotStyle = css`
 `;
 
 const dotActiveStyle = (pillar: Pillar) => css`
-    background-color: ${pillarPalette[pillar].dark};
+    background-color: ${pillarPalette[pillar][400]};
 
     &:hover,
     &:focus {


### PR DESCRIPTION
## What does this change?
Brings in the pillar colour for active dot.

### Before
Always a news red active dot.

### After

![image](https://user-images.githubusercontent.com/638051/100775846-b6b42800-33fb-11eb-8ea3-70c1dfc47cc9.png)

## Why?
Isn't it just lovely?
