### PR TITLE
window.performance is undefined

### DIFF
--- a/src/web/browser/initPerf.ts
+++ b/src/web/browser/initPerf.ts
@@ -1,9 +1,19 @@
-export const initPerf = (name: string) => {
+export const initPerf = (
+    name: string,
+): { start: () => void; end: () => number; clear: () => void } => {
     type TimeTakenInMilliseconds = number;
 
     const perf = window.performance;
     const startKey = `${name}-start`;
     const endKey = `${name}-end`;
+
+    if (!perf)
+        // Return noops if window.performance does not exist
+        return {
+            start: () => {},
+            end: () => 0,
+            clear: () => {},
+        };
 
     const start = () => {
         perf.mark(startKey);
@@ -16,7 +26,7 @@ export const initPerf = (name: string) => {
         // eslint-disable-next-line no-console
         console.log(JSON.stringify(perf.getEntriesByName(name)));
 
-        const measureEntries = perf.getEntriesByName(name, "measure");
+        const measureEntries = perf.getEntriesByName(name, 'measure');
         const timeTakenFloat = measureEntries[0].duration;
         const timeTakenInt = Math.round(timeTakenFloat);
 
@@ -24,8 +34,8 @@ export const initPerf = (name: string) => {
     };
 
     const clear = () => {
-        perf.clearMarks(startKey)
-    }
+        perf.clearMarks(startKey);
+    };
 
     return {
         start,

--- a/src/web/components/Hydrate.tsx
+++ b/src/web/components/Hydrate.tsx
@@ -7,13 +7,13 @@ type Props = {
 };
 
 export const Hydrate = ({ root, index, children }: Props) => {
-    const rootWithIndex = index===0 || index ? `${root}-${index}` : root;
+    const rootWithIndex = index === 0 || index ? `${root}-${index}` : root;
     const element = document.getElementById(rootWithIndex);
     if (!element) return null;
-    window.performance.mark(`${rootWithIndex}-hydrate-start`);
+    window.performance?.mark(`${rootWithIndex}-hydrate-start`);
     ReactDOM.hydrate(children, element);
-    window.performance.mark(`${rootWithIndex}-hydrate-end`);
-    window.performance.measure(
+    window.performance?.mark(`${rootWithIndex}-hydrate-end`);
+    window.performance?.measure(
         `${rootWithIndex}-hydrate`,
         `${rootWithIndex}-hydrate-start`,
         `${rootWithIndex}-hydrate-end`,

--- a/src/web/components/Portal.tsx
+++ b/src/web/components/Portal.tsx
@@ -10,7 +10,7 @@ export const Portal = ({ root, children, richLinkIndex }: Props) => {
     const rootId = richLinkIndex ? `${root}-${richLinkIndex}` : root;
     const element = document.getElementById(rootId);
     if (!element) return null;
-    window.performance.mark(`${rootId}-portal-start`);
+    window.performance?.mark(`${rootId}-portal-start`);
     // First remove any placeholder. Why? Because we sometimes server side render Placeholders in
     // the root divs where the Portal is being inserted so the page is rendered with the placeholder
     // showing (to reduce jank). But ReactDOM.createPortal won't replace content so we need to
@@ -21,8 +21,8 @@ export const Portal = ({ root, children, richLinkIndex }: Props) => {
     if (placeholderElement) placeholderElement.remove();
 
     const result = ReactDOM.createPortal(children, element);
-    window.performance.mark(`${rootId}-portal-end`);
-    window.performance.measure(
+    window.performance?.mark(`${rootId}-portal-end`);
+    window.performance?.measure(
         `${rootId}-portal`,
         `${rootId}-portal-start`,
         `${rootId}-portal-end`,


### PR DESCRIPTION
## What does this change?
On older browsers `window.performance` can be undefined causing errors so here we use typescript optional chainging to stop attempts to access `mark()` if `performance` isn't there.

![image](https://user-images.githubusercontent.com/1336821/100856398-494bda00-3483-11eb-97f4-264ee7905075.png)

### Why
Adding a guard should prevent javascript from throwing
