### PR TITLE
Carousel - re-applying pillar styling for active dot

### DIFF
--- a/src/web/components/Onwards/Carousel/Carousel.tsx
+++ b/src/web/components/Onwards/Carousel/Carousel.tsx
@@ -184,12 +184,11 @@ const dotStyle = css`
     }
 `;
 
-const dotActiveStyle = css`
-    background-color: ${palette.news[400]};
-
+const dotActiveStyle = (index: number, pillar: Pillar) => css`
+    background-color: ${pillarPalette[pillar].main};
     &:hover,
     &:focus {
-        background-color: ${palette.news[300]};
+        background-color: ${pillarPalette[pillar][300]};
     }
 `;
 
@@ -465,7 +464,7 @@ export const Carousel: React.FC<OnwardsType> = ({
                             aria-hidden="true"
                             className={cx(
                                 dotStyle,
-                                i === index && dotActiveStyle,
+                                i === index && dotActiveStyle(index, pillar),
                                 adjustNumberOfDotsStyle(i, trails.length),
                             )}
                         />


### PR DESCRIPTION
## What does this change?
As part of https://github.com/guardian/dotcom-rendering/pull/2126,  the dot pillar styling got removed.
### Before
<img width="295" alt="Screen Shot 2020-12-02 at 12 09 34" src="https://user-images.githubusercontent.com/2051501/100872257-70150b00-3499-11eb-8b10-6cf270893b4b.png">

### After
<img width="295" alt="Screen Shot 2020-12-02 at 12 09 01" src="https://user-images.githubusercontent.com/2051501/100872267-74412880-3499-11eb-84a9-da6003310d5b.png">

