### PR TITLE
Add AMP Validation Github Action

### DIFF
--- a/.github/workflows/amp-validation.yml
+++ b/.github/workflows/amp-validation.yml
@@ -1,0 +1,24 @@
+name: AMP Validation
+on: push
+
+jobs:
+    amp_validation:
+        name: AMP Validation
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v1
+
+            - name: Use Node.js 10.15.3
+              uses: actions/setup-node@v1
+              with:
+                  node-version: '10.15.3'
+
+            # Cache npm dependencies using https://github.com/bahmutov/npm-install
+            - uses: bahmutov/npm-install@v1
+
+            - name: Install
+              run: yarn
+
+            - name: Validate AMP
+              run: make ampValidation

--- a/makefile
+++ b/makefile
@@ -68,6 +68,10 @@ cypress: clear clean-dist install
 	$(call log, "starting frontend DEV server for Cypress")
 	@NODE_ENV=development start-server-and-test 'node scripts/frontend/dev-server' 3030 'cypress run --spec "cypress/integration/**/*"'
 
+ampValidation: clean-dist install
+	$(call log, "starting frontend DEV server for AMP Validation")
+	@NODE_ENV=development start-server-and-test 'node scripts/frontend/dev-server' 3030 'node scripts/test/amp-validation.js'
+
 # quality #########################################
 
 tsc: clean-dist install

--- a/scripts/test/amp-validation.js
+++ b/scripts/test/amp-validation.js
@@ -1,0 +1,37 @@
+const amphtmlValidator = require('amphtml-validator');
+const http = require('http');
+
+amphtmlValidator.getInstance().then((validator) => {
+    [
+        'https://www.theguardian.com/politics/2020/dec/02/brexit-uk-has-lowered-demands-on-fish-catches-says-eu',
+        'https://www.theguardian.com/uk-news/2020/dec/02/man-57-is-arrested-on-suspicion-of-attempted-in-burnley-ms',
+        'https://www.theguardian.com/business/2020/dec/02/minister-asks-watchdog-to-examine-conduct-of-arcadia-group-bosses',
+        'https://www.theguardian.com/artanddesign/2020/dec/02/muhammad-ali-cleveland-williams-neil-leifers-best-photograph',
+        'https://www.theguardian.com/football/live/2020/dec/02/sevilla-v-chelsea-champions-league-live',
+        'https://www.theguardian.com/commentisfree/2020/dec/02/cautious-christmas-covid',
+    ].map((url) => {
+        http.get(`http://localhost:3030/ampArticle?url=${url}`, (res) => {
+            let data = '';
+            res.on('data', function (chunk) {
+                data += chunk;
+            });
+            res.on('end', function () {
+                const result = validator.validateString(data);
+                console.log(url);
+                (result.status === 'PASS'
+                    ? console.log
+                    : console.error)(result.status);
+                for (let ii = 0; ii < result.errors.length; ii++) {
+                    const error = result.errors[ii];
+                    let msg = `line ${error.line}, col ${error.col}: ${error.message}`;
+                    if (error.specUrl !== null) {
+                        msg += ` (see ${error.specUrl})`;
+                    }
+                    (error.severity === 'ERROR' ? console.error : console.warn)(
+                        msg,
+                    );
+                }
+            });
+        });
+    });
+});

--- a/scripts/test/amp-validation.js
+++ b/scripts/test/amp-validation.js
@@ -1,37 +1,44 @@
 const amphtmlValidator = require('amphtml-validator');
 const http = require('http');
 
+const domain = 'http://localhost:3030';
+
+console.log(`Testing AMP validation on ${domain}`);
 amphtmlValidator.getInstance().then((validator) => {
     [
-        'https://www.theguardian.com/politics/2020/dec/02/brexit-uk-has-lowered-demands-on-fish-catches-says-eu',
-        'https://www.theguardian.com/uk-news/2020/dec/02/man-57-is-arrested-on-suspicion-of-attempted-in-burnley-ms',
-        'https://www.theguardian.com/business/2020/dec/02/minister-asks-watchdog-to-examine-conduct-of-arcadia-group-bosses',
-        'https://www.theguardian.com/artanddesign/2020/dec/02/muhammad-ali-cleveland-williams-neil-leifers-best-photograph',
-        'https://www.theguardian.com/football/live/2020/dec/02/sevilla-v-chelsea-champions-league-live',
-        'https://www.theguardian.com/commentisfree/2020/dec/02/cautious-christmas-covid',
+        'politics/2020/dec/02/brexit-uk-has-lowered-demands-on-fish-catches-says-eu',
+        'uk-news/2020/dec/02/man-57-is-arrested-on-suspicion-of-attempted-in-burnley-ms',
+        'business/2020/dec/02/minister-asks-watchdog-to-examine-conduct-of-arcadia-group-bosses',
+        'artanddesign/2020/dec/02/muhammad-ali-cleveland-williams-neil-leifers-best-photograph',
+        'football/live/2020/dec/02/sevilla-v-chelsea-champions-league-live',
+        'commentisfree/2020/dec/02/cautious-christmas-covid',
     ].map((url) => {
-        http.get(`http://localhost:3030/ampArticle?url=${url}`, (res) => {
-            let data = '';
-            res.on('data', function (chunk) {
-                data += chunk;
-            });
-            res.on('end', function () {
-                const result = validator.validateString(data);
-                console.log(url);
-                (result.status === 'PASS'
-                    ? console.log
-                    : console.error)(result.status);
-                for (let ii = 0; ii < result.errors.length; ii++) {
-                    const error = result.errors[ii];
-                    let msg = `line ${error.line}, col ${error.col}: ${error.message}`;
-                    if (error.specUrl !== null) {
-                        msg += ` (see ${error.specUrl})`;
+        // COPIED DIRECTLY FROM https://www.npmjs.com/package/amphtml-validator
+        http.get(
+            `${domain}/AmpArticle?url=https://www.theguardian.com/${url}`,
+            (res) => {
+                let data = '';
+                res.on('data', function (chunk) {
+                    data += chunk;
+                });
+                res.on('end', function () {
+                    const result = validator.validateString(data);
+                    console.log(url);
+                    (result.status === 'PASS'
+                        ? console.log
+                        : console.error)(result.status);
+                    for (let ii = 0; ii < result.errors.length; ii++) {
+                        const error = result.errors[ii];
+                        let msg = `line ${error.line}, col ${error.col}: ${error.message}`;
+                        if (error.specUrl !== null) {
+                            msg += ` (see ${error.specUrl})`;
+                        }
+                        (error.severity === 'ERROR'
+                            ? console.error
+                            : console.warn)(msg);
                     }
-                    (error.severity === 'ERROR' ? console.error : console.warn)(
-                        msg,
-                    );
-                }
-            });
-        });
+                });
+            },
+        );
     });
 });


### PR DESCRIPTION
## What does this change?

Adds a simple test for AMP validation against the PR's changes.

## Why?

Protects us at PR time against catastrophic AMP annihilation. 
