### PR TITLE
Add documentation of contracts and a new Viewer article body selector contract

### DIFF
--- a/docs/contracts/000-contracts.md
+++ b/docs/contracts/000-contracts.md
@@ -1,0 +1,15 @@
+# Contracts of Dotcom Rendering
+
+## Context
+
+Dotcom is not a self-isolated platform. We have a number of use cases which require integration with other systems (e.g. composer viewer), or running code we don't directly control (e.g. interactives, and to a lesser extent advertising). Even code we do control directly may live outside this codebase, and a loose contract could be the preferred way to integrate with DCR.
+
+This directory is designed to document these contracts that we need to maintain, but are easily missed or forgotten about. That is, it is not meant to document strong contracts that are already well defined in the code (e.g. shared types with a direct library dependency). It is intended to document loose contracts such as a stable identifier on an element that is used by another system, or a message format when communicating with an iframe.
+
+## Format
+
+### What is the contract?
+
+### Where is it relied upon?
+
+### Why is it required?

--- a/docs/contracts/001-commercial-selectors.md
+++ b/docs/contracts/001-commercial-selectors.md
@@ -1,0 +1,13 @@
+# Commercial selectors
+
+## What is the contract?
+
+We place the `article-body-commercial-selector` class on the container element of the article body. (TODO: are there others?)
+
+## Where is it relied upon?
+
+It is relied upon in the commercial DCR bundle from frontend.
+
+## Why is it required?
+
+For dynamic placement of adverts in the article body.

--- a/docs/contracts/002-viewer-body-selector.md
+++ b/docs/contracts/002-viewer-body-selector.md
@@ -1,0 +1,13 @@
+# Viewer Body Selector
+
+## What is the contract?
+
+We place the `article-body-viewer-selector` class on the container element for the article body.
+
+## Where is it relied upon?
+
+[Here](https://github.com/guardian/editorial-viewer/blob/714862c72d8070e18715f01b04a64f2fd2500ff2/public/javascript/components/viewer.js#L252) is where the viewer from composer selects links from the article body of preview articles.
+
+## Why is it required?
+
+Special behaviour is added to links in viewer to control whether or not the link opens in a new tab or within the iframe.

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -446,7 +446,7 @@ export const ArticleRenderer: React.FC<{
 
     return (
         <div
-            className={`article-body-commercial-selector ${commercialPosition}`}
+            className={`article-body-commercial-selector ${commercialPosition} article-body-viewer-selector`}
         >
             {/* Insert the placeholder for the sign in gate on the 2nd article element */}
             {withSignInGateSlot(output)}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds an additional selector to the article body so that the viewer in composer can select this element.  I've also added some documentation for contracts because I feel these are very important to document for loose contracts such as this.

## Why?
Allows viewer to continue treating external links in preview articles specially. We could add this functionality in DCR directly, but it turned out to be quite complicated for a requirement of another system.