### PR TITLE
SubNav is 14px when under tablet and 16px when over

### DIFF
--- a/src/web/components/SubNav/SubNav.tsx
+++ b/src/web/components/SubNav/SubNav.tsx
@@ -49,7 +49,12 @@ const collapsedStyles = css`
 `;
 
 const fontStyle = css`
-    ${textSans.medium()};
+    ${textSans.small()};
+    font-size: 14px;
+    ${from.tablet} {
+        ${textSans.medium()};
+        font-size: 16px;
+    }
     font-weight: 500;
     color: ${neutral[7]};
     padding: 0 5px;


### PR DESCRIPTION
## What does this change?
Adjusts the font sizes used in the SubNav above and below `tablet`.

### Why aren't we using Source?
Because Source does not provide a 14px or a 16px `textSans` font.

### Before
![2020-12-04 11 09 36](https://user-images.githubusercontent.com/1336821/101157010-5c94ac00-3621-11eb-9f4e-2d5b2553b1a2.gif)

### After
![2020-12-04 11 10 23](https://user-images.githubusercontent.com/1336821/101157032-68806e00-3621-11eb-8d42-a0004bdea635.gif)

## Why?
For design parity