### PR TITLE
EOY header test

### DIFF
--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -172,6 +172,8 @@ export const App = ({ CAPI, NAV }: Props) => {
 
     const hasCommentsHash = hasCommentsHashInUrl();
 
+    const pageViewId = window.guardian?.config?.ophan?.pageViewId;
+
     // *******************************
     // ** Setup AB Test Tracking *****
     // *******************************
@@ -332,7 +334,7 @@ export const App = ({ CAPI, NAV }: Props) => {
         if (CAPI.config.switches.consentManagement && countryCode) {
             const pubData = {
                 browserId: getCookie('bwid') || undefined,
-                pageViewId: window.guardian?.config?.ophan?.pageViewId,
+                pageViewId,
             };
             injectPrivacySettingsLink(); // manually updates the footer DOM because it's not hydrated
 
@@ -433,6 +435,7 @@ export const App = ({ CAPI, NAV }: Props) => {
                     edition={CAPI.editionId}
                     dataLinkNamePrefix="nav2 : "
                     inHeader={true}
+                    pageViewId={pageViewId}
                 />
             </Portal>
             <Hydrate root="links-root">
@@ -784,6 +787,7 @@ export const App = ({ CAPI, NAV }: Props) => {
                         edition={CAPI.editionId}
                         dataLinkNamePrefix="footer : "
                         inHeader={false}
+                        pageViewId={pageViewId}
                     />
                 </Lazy>
             </Portal>

--- a/src/web/components/ReaderRevenueLinks.stories.tsx
+++ b/src/web/components/ReaderRevenueLinks.stories.tsx
@@ -2,12 +2,27 @@ import React from 'react';
 import { css } from 'emotion';
 
 import { brandBackground } from '@guardian/src-foundations/palette';
+import { ABProvider } from '@guardian/ab-react';
 
 import { ReaderRevenueLinks } from './ReaderRevenueLinks';
 
 export default {
     component: ReaderRevenueLinks,
     title: 'Components/ReaderRevenueLinks',
+};
+
+const AbProvider: React.FC = ({ children }) => {
+    return (
+        <ABProvider
+            mvtMaxValue={1000000}
+            mvtId={1234}
+            pageIsSensitive={false}
+            abTestSwitches={{}}
+            arrayOfTestObjects={[]}
+        >
+            {children}
+        </ABProvider>
+    );
 };
 
 const revenueUrls = {
@@ -26,7 +41,9 @@ const Container = ({ children }: { children: JSXElements }) => (
             background-color: ${brandBackground.primary};
         `}
     >
-        {children}
+        <AbProvider>
+            {children}
+        </AbProvider>
     </div>
 );
 
@@ -38,6 +55,7 @@ export const Header = () => {
                 urls={revenueUrls}
                 dataLinkNamePrefix=""
                 inHeader={true}
+                pageViewId="1234"
             />
         </Container>
     );
@@ -58,6 +76,7 @@ export const HeaderMobile = () => {
                 urls={revenueUrls}
                 dataLinkNamePrefix=""
                 inHeader={true}
+                pageViewId="1234"
             />
         </Container>
     );
@@ -78,6 +97,7 @@ export const Footer = () => {
                 urls={revenueUrls}
                 dataLinkNamePrefix=""
                 inHeader={false}
+                pageViewId="1234"
             />
         </Container>
     );
@@ -98,6 +118,7 @@ export const FooterMobile = () => {
                 urls={revenueUrls}
                 dataLinkNamePrefix=""
                 inHeader={false}
+                pageViewId="1234"
             />
         </Container>
     );

--- a/src/web/components/ReaderRevenueLinks.test.tsx
+++ b/src/web/components/ReaderRevenueLinks.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, wait } from '@testing-library/react';
 import { shouldHideSupportMessaging as shouldHideSupportMessaging_ } from '@root/src/web/lib/contributions';
+import { ABProvider } from '@guardian/ab-react';
 import { ReaderRevenueLinks } from './ReaderRevenueLinks';
 
 const shouldHideSupportMessaging: any = shouldHideSupportMessaging_;
@@ -8,6 +9,20 @@ const shouldHideSupportMessaging: any = shouldHideSupportMessaging_;
 jest.mock('@root/src/web/lib/contributions', () => ({
     shouldHideSupportMessaging: jest.fn(() => true),
 }));
+
+const AbProvider: React.FC = ({ children }) => {
+    return (
+        <ABProvider
+            mvtMaxValue={1000000}
+            mvtId={1234}
+            pageIsSensitive={false}
+            abTestSwitches={{}}
+            arrayOfTestObjects={[]}
+        >
+            {children}
+        </ABProvider>
+    );
+};
 
 describe('ReaderRevenueLinks', () => {
     const urls = {
@@ -21,12 +36,15 @@ describe('ReaderRevenueLinks', () => {
         shouldHideSupportMessaging.mockReturnValue(true);
 
         const { container } = render(
-            <ReaderRevenueLinks
-                urls={urls}
-                edition={edition}
-                dataLinkNamePrefix="nav2 : "
-                inHeader={true}
-            />,
+            <AbProvider>
+                <ReaderRevenueLinks
+                    urls={urls}
+                    edition={edition}
+                    dataLinkNamePrefix="nav2 : "
+                    inHeader={true}
+                    pageViewId="1234"
+                />
+            </AbProvider>,
         );
 
         // expect nothing to be rendered
@@ -37,12 +55,15 @@ describe('ReaderRevenueLinks', () => {
         shouldHideSupportMessaging.mockReturnValue(false);
 
         const { container } = render(
-            <ReaderRevenueLinks
-                urls={urls}
-                edition={edition}
-                dataLinkNamePrefix="nav2 : "
-                inHeader={true}
-            />,
+            <AbProvider>
+                <ReaderRevenueLinks
+                    urls={urls}
+                    edition={edition}
+                    dataLinkNamePrefix="nav2 : "
+                    inHeader={true}
+                    pageViewId="1234"
+                />,
+            </AbProvider>,
         );
 
         // expect links to be rendered

--- a/src/web/components/ReaderRevenueLinks.tsx
+++ b/src/web/components/ReaderRevenueLinks.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { css, cx } from 'emotion';
 
 import ArrowRightIcon from '@frontend/static/icons/arrow-right.svg';
@@ -9,10 +9,15 @@ import {
 } from '@guardian/src-foundations/palette';
 import { textSans, headline } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
-import { LinkButton , buttonBrand } from '@guardian/src-button';
 
 import { shouldHideSupportMessaging } from '@root/src/web/lib/contributions';
-import {ThemeProvider} from "@root/node_modules/emotion-theming";
+import { useAB } from '@guardian/ab-react';
+import {addTrackingCodesToUrl} from "@root/src/web/lib/acquisitions";
+import {
+    GlobalEoyHeaderTestName,
+    GlobalEoyHeaderTestVariant
+} from "@root/src/web/experiments/tests/global-eoy-header-test";
+import {sendOphanComponentEvent} from "@root/src/web/browser/ophan/ophan";
 
 type Props = {
     edition: Edition;
@@ -23,6 +28,7 @@ type Props = {
     };
     dataLinkNamePrefix: string;
     inHeader: boolean;
+    pageViewId: string;
 };
 
 const paddingStyles = css`
@@ -114,41 +120,77 @@ const subMessageStyles = css`
     margin: 5px 0;
 `;
 
+const month = new Date().getMonth() + 1;    // js date month begins at 0
+
 export const ReaderRevenueLinks: React.FC<Props> = ({
     edition,
     urls,
     dataLinkNamePrefix,
     inHeader,
+    pageViewId,
 }) => {
-    const showAusMomentHeader = edition === 'AU';
+    const ABTestAPI = useAB();
+
+    const getTestVariant = (): GlobalEoyHeaderTestVariant => {
+        if (inHeader && edition !== 'US') {
+            if (ABTestAPI.isUserInVariant(
+                GlobalEoyHeaderTestName,
+                'control',
+            )) {
+                return 'control';
+            }
+            if (ABTestAPI.isUserInVariant(
+                GlobalEoyHeaderTestName,
+                'variant',
+            )) {
+                return 'variant';
+            }
+        }
+        return 'notintest'
+    };
+
+    const variantName: GlobalEoyHeaderTestVariant = getTestVariant();
+
+    useEffect(() => {
+        if (variantName !== 'notintest') {
+            sendOphanComponentEvent('VIEW', {
+                abTestName: GlobalEoyHeaderTestName,
+                abTestVariant: variantName,
+                campaignCode: 'header_support',
+                componentType: 'ACQUISITIONS_HEADER',
+            });
+        }
+    }, [variantName]);
+
+    const getHeading = (): string | JSX.Element => {
+        if (variantName === 'variant') return month === 12 ? `Support us this December` : 'Support us for 2021';
+        return <span>Support The&nbsp;Guardian</span>;
+    };
+
+    const subheading = variantName === 'variant' ?
+        'Power vital, open, independent journalism' :
+        'Available for everyone, funded by readers';
+
+    const getUrl = (rrType: 'contribute' | 'subscribe'): string => {
+        if (variantName !== 'notintest') {
+            return addTrackingCodesToUrl({
+                base: `https://support.theguardian.com/${rrType}`,
+                componentType: 'ACQUISITIONS_HEADER',
+                componentId: 'header_support',
+                campaignCode: 'header_support',
+                abTest: {
+                    name: GlobalEoyHeaderTestName,
+                    variant: variantName,
+                },
+                pageViewId,
+                referrerUrl: window.location.origin + window.location.pathname,
+            });
+        }
+        // Use the normal url
+        return urls[rrType];
+    };
 
     if (shouldHideSupportMessaging()) {
-        if (showAusMomentHeader) {
-            return (
-                <div className={cx(inHeader && paddingStyles)}>
-                    <div
-                        className={cx({
-                            [hiddenUntilTablet]: inHeader,
-                        })}
-                    >
-                        <div className={messageStyles}>Thank you</div>
-
-                        <div className={subMessageStyles}>
-                            <ThemeProvider theme={buttonBrand}>
-                                <LinkButton
-                                    priority="secondary"
-                                    showIcon={true}
-                                    size="small"
-                                    href="https://support.theguardian.com/aus-2020-map?INTCMP=Aus_moment_2020_frontend_header"
-                                >
-                                    Hear from other supporters
-                                </LinkButton>
-                            </ThemeProvider>
-                        </div>
-                    </div>
-                </div>
-            );
-        }
         return null;
     }
     return (
@@ -158,20 +200,20 @@ export const ReaderRevenueLinks: React.FC<Props> = ({
                     [hiddenUntilTablet]: inHeader,
                 })}
             >
-                <div className={messageStyles}>Support The&nbsp;Guardian</div>
+                <div className={messageStyles}>{getHeading()}</div>
                 <div className={subMessageStyles}>
-                    <div> Available for everyone, funded by readers</div>
+                    <div> {subheading} </div>
                 </div>
                 <a
                     className={linkStyles}
-                    href={urls.contribute}
+                    href={getUrl('contribute')}
                     data-link-name={`${dataLinkNamePrefix}contribute-cta`}
                 >
                     Contribute <ArrowRightIcon />
                 </a>
                 <a
                     className={linkStyles}
-                    href={urls.subscribe}
+                    href={getUrl('subscribe')}
                     data-link-name={`${dataLinkNamePrefix}subscribe-cta`}
                 >
                     Subscribe <ArrowRightIcon />
@@ -187,7 +229,7 @@ export const ReaderRevenueLinks: React.FC<Props> = ({
                 {edition === 'UK' ? (
                     <a
                         className={linkStyles}
-                        href={urls.subscribe}
+                        href={getUrl('subscribe')}
                         data-link-name={`${dataLinkNamePrefix}contribute-cta`}
                     >
                         Subscribe <ArrowRightIcon />
@@ -195,7 +237,7 @@ export const ReaderRevenueLinks: React.FC<Props> = ({
                 ) : (
                     <a
                         className={linkStyles}
-                        href={urls.contribute}
+                        href={getUrl('contribute')}
                         data-link-name={`${dataLinkNamePrefix}support-cta`}
                     >
                         Contribute <ArrowRightIcon />

--- a/src/web/experiments/ab-tests.ts
+++ b/src/web/experiments/ab-tests.ts
@@ -4,6 +4,7 @@ import { signInGateMainVariant } from '@root/src/web/experiments/tests/sign-in-g
 import { signInGateMainControl } from '@root/src/web/experiments/tests/sign-in-gate-main-control';
 import { curatedContainerTest2 } from '@frontend/web/experiments/tests/curated-container-test';
 import {newsletterMerchUnitLighthouseControl, newsletterMerchUnitLighthouseVariants} from "@root/src/web/experiments/tests/newsletter-merch-unit-test";
+import {globalEoyHeaderTest} from "@root/src/web/experiments/tests/global-eoy-header-test";
 
 export const tests: ABTest[] = [
     abTestTest,
@@ -11,5 +12,6 @@ export const tests: ABTest[] = [
     signInGateMainControl,
     curatedContainerTest2,
     newsletterMerchUnitLighthouseControl,
-    newsletterMerchUnitLighthouseVariants
+    newsletterMerchUnitLighthouseVariants,
+    globalEoyHeaderTest
 ];

--- a/src/web/experiments/tests/global-eoy-header-test.ts
+++ b/src/web/experiments/tests/global-eoy-header-test.ts
@@ -1,0 +1,31 @@
+import { ABTest } from '@guardian/ab-core';
+
+export const GlobalEoyHeaderTestName = 'GlobalEoyHeaderTest';
+export type GlobalEoyHeaderTestVariant = 'control' | 'variant' | 'notintest';
+
+const month = new Date().getMonth() + 1;    // js date month begins at 0
+
+export const globalEoyHeaderTest: ABTest = {
+    id: GlobalEoyHeaderTestName,
+    start: '2020-12-02',
+    expiry: '2021-02-01',
+    author: 'Tom Forbes',
+    description: 'Test reader revenue message in header',
+    audience: 1.0,
+    audienceOffset: 0,
+    successMeasure: 'AV',
+    idealOutcome: 'AV',
+    showForSensitive: false,
+    audienceCriteria: 'All',
+    canRun: () => month === 12 || month === 1,
+    variants: [
+        {
+            id: 'control',
+            test: (): void => {},
+        },
+        {
+            id: 'variant',
+            test: (): void => {},
+        },
+    ],
+};

--- a/src/web/lib/acquisitions.test.ts
+++ b/src/web/lib/acquisitions.test.ts
@@ -1,0 +1,22 @@
+import {addTrackingCodesToUrl} from "@root/src/web/lib/acquisitions";
+
+describe('acquisitions', () => {
+    it('should addTrackingCodesToUrl', () => {
+        const result = addTrackingCodesToUrl({
+            base: `https://support.theguardian.com/contribute`,
+            componentType: 'ACQUISITIONS_HEADER',
+            componentId: 'header_support',
+            campaignCode: 'header_support',
+            abTest: {
+                name: 'testName',
+                variant: 'variantName'
+            },
+            pageViewId: 'abcdefg',
+            referrerUrl: 'https://theguardian.com/uk'
+        });
+
+        expect(result).toEqual(
+            'https://support.theguardian.com/contribute?REFPVID=abcdefg&INTCMP=header_support&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentId%22%3A%22header_support%22%2C%22componentType%22%3A%22ACQUISITIONS_HEADER%22%2C%22campaignCode%22%3A%22header_support%22%2C%22abTest%22%3A%7B%22name%22%3A%22testName%22%2C%22variant%22%3A%22variantName%22%7D%2C%22referrerPageviewId%22%3A%22abcdefg%22%2C%22referrerUrl%22%3A%22https%3A%2F%2Ftheguardian.com%2Fuk%22%7D'
+        );
+    });
+});

--- a/src/web/lib/acquisitions.ts
+++ b/src/web/lib/acquisitions.ts
@@ -1,0 +1,49 @@
+import {OphanComponentType} from "@root/src/web/browser/ophan/ophan";
+import {constructQuery} from "@root/src/lib/querystring";
+
+type AcquisitionLinkParams = {
+    base: string,
+    componentType: OphanComponentType,
+    componentId: string,
+    campaignCode?: string,
+    abTest?: { name: string, variant: string },
+    pageViewId: string,
+    referrerUrl: string,
+};
+
+// Adds acquisition tracking codes if it is a support url
+export const addTrackingCodesToUrl = ({
+    base,
+    componentType,
+    componentId,
+    campaignCode,
+    abTest,
+    pageViewId,
+    referrerUrl
+}: AcquisitionLinkParams): string => {
+    const isSupportUrl = base.search(/(support.theguardian.com)(\/[a-z]*)?\/(contribute|subscribe)/) >= 0;
+
+    if (isSupportUrl) {
+        const acquisitionData = {
+            source: 'GUARDIAN_WEB',
+            componentId,
+            componentType,
+            campaignCode,
+            abTest,
+            referrerPageviewId: pageViewId,
+            referrerUrl,
+        };
+
+        const params = {
+            REFPVID: pageViewId,
+            INTCMP: campaignCode,
+            acquisitionData: JSON.stringify(acquisitionData),
+        };
+
+        return `${base}${base.includes('?') ? '&' : '?'}${constructQuery(
+            params
+        )}`;
+    }
+
+    return base;
+};


### PR DESCRIPTION
A/B test different copy in the header cta bar.
frontend PR: https://github.com/guardian/frontend/pull/23340

Also removed an old AU-only feature in the header cta bar.

### Control
![Screen Shot 2020-12-04 at 15 27 07](https://user-images.githubusercontent.com/1513454/101181836-426cc500-3645-11eb-86af-95670460d61d.png)

### Variant
![Screen Shot 2020-12-04 at 15 27 26](https://user-images.githubusercontent.com/1513454/101181849-4567b580-3645-11eb-965a-9126695fa00d.png)

### Variant in January
![Screen Shot 2020-12-04 at 15 29 17](https://user-images.githubusercontent.com/1513454/101182042-81027f80-3645-11eb-9719-5fd188e50e29.png)
