### PR TITLE
Extra options for ContainerLayout 

### DIFF
--- a/src/web/components/ContainerLayout.stories.tsx
+++ b/src/web/components/ContainerLayout.stories.tsx
@@ -75,6 +75,23 @@ export const BordersStory = () => {
 };
 BordersStory.story = { name: 'with all borders' };
 
+export const LeftContentStory = () => {
+    return (
+        <ContainerLayout
+            title="Borders"
+            showTopBorder={true}
+            sideBorders={true}
+            centralBorder="full"
+            leftContent={<Grey heightInPixels={200} />}
+        >
+            <Grey />
+        </ContainerLayout>
+    );
+};
+LeftContentStory.story = {
+    name: 'with an element passed into the left column',
+};
+
 export const BackgroundStory = () => {
     return (
         <ContainerLayout
@@ -122,6 +139,41 @@ export const SidesStory = () => {
     );
 };
 SidesStory.story = { name: 'with a full border divider' };
+
+export const MarginsStory = () => {
+    return (
+        <>
+            <ContainerLayout
+                title="No Vertical Margins"
+                sideBorders={true}
+                showTopBorder={true}
+                centralBorder="full"
+                verticalMargins={false}
+            >
+                <Grey />
+            </ContainerLayout>
+            <ContainerLayout
+                title="No Vertical Margins"
+                sideBorders={true}
+                showTopBorder={true}
+                centralBorder="full"
+                verticalMargins={false}
+            >
+                <Grey />
+            </ContainerLayout>
+            <ContainerLayout
+                title="No Vertical Margins"
+                sideBorders={true}
+                showTopBorder={true}
+                centralBorder="full"
+                verticalMargins={false}
+            >
+                <Grey />
+            </ContainerLayout>
+        </>
+    );
+};
+MarginsStory.story = { name: 'with no vertical margins' };
 
 export const MultipleStory = () => {
     return (

--- a/src/web/components/ContainerLayout.tsx
+++ b/src/web/components/ContainerLayout.tsx
@@ -21,6 +21,7 @@ type Props = {
     showTopBorder?: boolean;
     padSides?: boolean;
     padContent?: boolean;
+    verticalMargins?: boolean;
     backgroundColour?: string;
     borderColour?: string;
     children?: React.ReactNode;
@@ -29,15 +30,20 @@ type Props = {
 const Container = ({
     children,
     padded,
+    verticalMargins,
 }: {
     children: React.ReactNode;
     padded: boolean;
+    verticalMargins: boolean;
 }) => {
     const containerStyles = css`
         display: flex;
         flex-grow: 1;
         flex-direction: column;
         width: 100%;
+    `;
+
+    const margins = css`
         margin-top: ${space[2]}px;
         /*
            Keep spacing at the bottom of the container consistent at 36px, regardless of
@@ -57,7 +63,15 @@ const Container = ({
         }
     `;
     return (
-        <div className={cx(containerStyles, padded && padding)}>{children}</div>
+        <div
+            className={cx(
+                containerStyles,
+                padded && padding,
+                verticalMargins && margins,
+            )}
+        >
+            {children}
+        </div>
     );
 };
 
@@ -72,6 +86,7 @@ export const ContainerLayout = ({
     showTopBorder = false,
     padSides = true,
     padContent = true,
+    verticalMargins = true,
     borderColour,
     backgroundColour,
     children,
@@ -97,7 +112,7 @@ export const ContainerLayout = ({
                     url={url}
                 />
             </LeftColumn>
-            <Container padded={padContent}>
+            <Container padded={padContent} verticalMargins={verticalMargins}>
                 <Hide when="above" breakpoint="leftCol">
                     <ContainerTitle
                         title={title}

--- a/src/web/components/ContainerLayout.tsx
+++ b/src/web/components/ContainerLayout.tsx
@@ -24,6 +24,7 @@ type Props = {
     verticalMargins?: boolean;
     backgroundColour?: string;
     borderColour?: string;
+    leftContent?: JSXElements;
     children?: React.ReactNode;
 };
 
@@ -90,6 +91,7 @@ export const ContainerLayout = ({
     borderColour,
     backgroundColour,
     children,
+    leftContent,
 }: Props) => (
     <Section
         sectionId={sectionId}
@@ -105,12 +107,15 @@ export const ContainerLayout = ({
                 borderColour={borderColour}
                 showPartialRightBorder={centralBorder === 'partial'}
             >
-                <ContainerTitle
-                    title={title}
-                    fontColour={fontColour}
-                    description={description}
-                    url={url}
-                />
+                <>
+                    <ContainerTitle
+                        title={title}
+                        fontColour={fontColour}
+                        description={description}
+                        url={url}
+                    />
+                    {leftContent}
+                </>
             </LeftColumn>
             <Container padded={padContent} verticalMargins={verticalMargins}>
                 <Hide when="above" breakpoint="leftCol">

--- a/src/web/components/ContainerTitle.tsx
+++ b/src/web/components/ContainerTitle.tsx
@@ -58,20 +58,23 @@ export const ContainerTitle = ({
     fontColour?: string;
     description?: string;
     url?: string;
-}) => (
-    <>
-        {url ? (
-            <a className={linkStyles} href={url}>
+}) => {
+    if (!title) return null;
+    return (
+        <>
+            {url ? (
+                <a className={linkStyles} href={url}>
+                    <h2 className={headerStyles(fontColour)}>{title}</h2>
+                </a>
+            ) : (
                 <h2 className={headerStyles(fontColour)}>{title}</h2>
-            </a>
-        ) : (
-            <h2 className={headerStyles(fontColour)}>{title}</h2>
-        )}
-        {description && (
-            <p
-                className={descriptionStyles(fontColour)}
-                dangerouslySetInnerHTML={{ __html: description }}
-            />
-        )}
-    </>
-);
+            )}
+            {description && (
+                <p
+                    className={descriptionStyles(fontColour)}
+                    dangerouslySetInnerHTML={{ __html: description }}
+                />
+            )}
+        </>
+    );
+};


### PR DESCRIPTION
## What does this change?
Adds two new props foer `ContainerLayout`

1. `verticalMargins?: boolean`
This makes the margin spacing set above and below the container optional

### Why add this?
For general flexibility bit specifically, this will be useful when refactoring the immersive headline, allowing us to layout strips of content like Headline and Headline Title that want the classic layout but live above each other. The alternative is to put such content into one container but in the case of immersive headlines we need the flexibility of keeping them separate.

2. `leftContent?: boolean`
Allows react elements to be passed through to be inserted in the left column

### Why add this?
There are numerous examples of the left column container images, links or other special content that we need to support. We also need the ability to insert the Caption for the immersive layout
