### PR TITLE
The Portrait Immersive Main Media Width Problem

### DIFF
--- a/src/web/components/Img.tsx
+++ b/src/web/components/Img.tsx
@@ -48,6 +48,17 @@ const buildSourcesString = (srcSets: SrcSetItem[]): string => {
     return srcSets.map((srcSet) => `${srcSet.src} ${srcSet.width}w`).join(',');
 };
 
+/**
+ *       mobile: 320
+ *       mobileMedium: 375
+ *       mobileLandscape: 480
+ *       phablet: 660
+ *       tablet: 740
+ *       desktop: 980
+ *       leftCol: 1140
+ *       wide: 1300
+ */
+
 const buildSizesString = (role: RoleType, isMainMedia: boolean): string => {
     switch (role) {
         case 'inline':
@@ -57,8 +68,25 @@ const buildSizesString = (role: RoleType, isMainMedia: boolean): string => {
         case 'thumbnail':
             return '140px';
         case 'immersive':
+            // Immersive MainMedia elements fill the height of the viewport, meaning
+            // on mobile devices even though the viewport width is small, we'll need
+            // a larger image to maintain quality. Deciding which width image to ask
+            // for is difficult because aspect ratios and orientations between
+            // different devices varies so the values given below are best estimates
+            // based on the most popular configurations
+
+            // Immersive body images stretch the full viewport width below wide,
+            // but do not stretch beyond 1300px after that.
             return isMainMedia
-                ? '100vw'
+                ? `
+                    (min-width: ${breakpoints.leftCol}px) 1600px,
+                    (min-width: ${breakpoints.desktop}px) 1900px,
+                    (min-width: ${breakpoints.tablet}px) 1900px,
+                    (min-width: ${breakpoints.phablet}px) 1600px,
+                    (min-width: ${breakpoints.mobileLandscape}px) 1300px,
+                    (min-width: ${breakpoints.mobileMedium}px) 900px,
+                    1300px
+                `
                 : `(min-width: ${breakpoints.wide}px) 1300px, 100vw`;
         case 'supporting':
             return `(min-width: ${breakpoints.wide}px) 380px, 300px`;

--- a/src/web/components/Img.tsx
+++ b/src/web/components/Img.tsx
@@ -78,15 +78,7 @@ const buildSizesString = (role: RoleType, isMainMedia: boolean): string => {
             // Immersive body images stretch the full viewport width below wide,
             // but do not stretch beyond 1300px after that.
             return isMainMedia
-                ? `
-                    (min-width: ${breakpoints.leftCol}px) 1600px,
-                    (min-width: ${breakpoints.desktop}px) 1900px,
-                    (min-width: ${breakpoints.tablet}px) 1900px,
-                    (min-width: ${breakpoints.phablet}px) 1600px,
-                    (min-width: ${breakpoints.mobileLandscape}px) 1300px,
-                    (min-width: ${breakpoints.mobileMedium}px) 900px,
-                    1300px
-                `
+                ? `(orientation: portrait) 167vh, 100vw`
                 : `(min-width: ${breakpoints.wide}px) 1300px, 100vw`;
         case 'supporting':
             return `(min-width: ${breakpoints.wide}px) 380px, 300px`;

--- a/src/web/components/Img.tsx
+++ b/src/web/components/Img.tsx
@@ -74,6 +74,9 @@ const buildSizesString = (role: RoleType, isMainMedia: boolean): string => {
             // for is difficult because aspect ratios and orientations between
             // different devices varies so the values given below are best estimates
             // based on the most popular configurations
+            //
+            // The value of 167vh relates to a 5:3 image which is equal to 167 (viewport height)  : 100 (viewport width).
+            //
 
             // Immersive body images stretch the full viewport width below wide,
             // but do not stretch beyond 1300px after that.

--- a/src/web/components/Img.tsx
+++ b/src/web/components/Img.tsx
@@ -70,13 +70,10 @@ const buildSizesString = (role: RoleType, isMainMedia: boolean): string => {
         case 'immersive':
             // Immersive MainMedia elements fill the height of the viewport, meaning
             // on mobile devices even though the viewport width is small, we'll need
-            // a larger image to maintain quality. Deciding which width image to ask
-            // for is difficult because aspect ratios and orientations between
-            // different devices varies so the values given below are best estimates
-            // based on the most popular configurations
-            //
-            // The value of 167vh relates to a 5:3 image which is equal to 167 (viewport height)  : 100 (viewport width).
-            //
+            // a larger image to maintain quality. To solve this problem we're using
+            // the viewport height (vh) to calculate width. The value of 167vh
+            // relates to an assumed image ratio of 5:3 which is equal to
+            // 167 (viewport height)  : 100 (viewport width).
 
             // Immersive body images stretch the full viewport width below wide,
             // but do not stretch beyond 1300px after that.

--- a/src/web/components/elements/ImageBlockComponent.stories.tsx
+++ b/src/web/components/elements/ImageBlockComponent.stories.tsx
@@ -15,7 +15,7 @@ export default {
     component: ImageBlockComponent,
     title: 'Components/ImageBlockComponent',
     parameters: {
-        chromatic: { diffThreshold: 0.2 },
+        chromatic: { diffThreshold: 0.4 },
     },
 };
 

--- a/src/web/components/elements/ImageBlockComponent.stories.tsx
+++ b/src/web/components/elements/ImageBlockComponent.stories.tsx
@@ -14,6 +14,9 @@ import { image } from './ImageBlockComponent.mocks';
 export default {
     component: ImageBlockComponent,
     title: 'Components/ImageBlockComponent',
+    parameters: {
+        chromatic: { diffThreshold: 0.2 },
+    },
 };
 
 const Container = ({ children }: { children: JSX.Element | JSX.Element[] }) => (


### PR DESCRIPTION
## What does this change?
This is a proposal for discussion around a problem where immersive main media images are being chosen by the browser poorly on portrait devices. This happens because we size the main media content based on 100vh but for portrait aspect ratios this results in us loading much smaller images than we need.

Before                                |  After
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/1336821/101352213-b4355080-3889-11eb-88be-b4a7d94250db.jpg)  |  ![](https://user-images.githubusercontent.com/1336821/101352217-b5667d80-3889-11eb-8a69-70860244a433.jpg)


## What was done in Frontend?
This problem has already been raised, discussed and solved 5 years ago, see:

https://github.com/guardian/frontend/pull/12811
and then
https://github.com/guardian/frontend/pull/12847

That work resulted in this excellent code:

```scala
@immersivePortraitSource(largestImage: model.ImageAsset, hidpi: Boolean = false) = {
    <source media="@if(hidpi) {
        (orientation: portrait) and (-webkit-min-device-pixel-ratio: 1.25), (orientation: portrait) and (min-resolution: 120dpi)
    } else {
        (orientation: portrait)
    }"

    sizes="@{100 * largestImage.ratioDouble}vh"
    @* This adds 15 src options to the srcset from 500 to the largest image width incrementing by 250px *@
    srcset="@{(500 to largestImage.width by 250)
        .toList
        .map(width => ImgSrc.srcsetForProfile(views.support.ImageProfile(width = Some(width)), picture, hidpi).asSrcSetString)
        .mkString(", ")}" />
}
```

where `ratioDouble` is

```scala
lazy val ratioDouble: Double = width.toDouble / height
```


## Why are we not doing the same thing?
We must ensure that this work is not lost when transitioning to `image-rendering` but before we adopt the IR picture tag approach, this PR  applies a simpler method via the `img` tag.

So instead of using an `imageRatio` based on an images `height` and `width` to calculate the correct width to set in `sizes` this PR is simply using the viewport height and an assumed image ration of 5:3 to decide what width to ask for.

## Shouldn't we be more explicit?
There's [a case](https://twitter.com/tabatkins/status/1265642071920017418) for being [more chill](https://twitter.com/tabatkins/status/1265642071920017418). The argument goes along the lines of: it's [hard to get this right](https://css-tricks.com/a-guide-to-the-responsive-images-syntax-in-html/) and when you aim for absolute perfection it's very easy to make mistakes because the logic is complex. Keeping it chill makes it easy to see what's going on.

Of course, we can do better and we should. Even small perf gains at scale are worth the extra complexity. But a staged approach to getting there, starting off simple, might be nice?
