### PR TITLE
Support Embeds in MainMedia

### DIFF
--- a/src/web/components/MainMedia.tsx
+++ b/src/web/components/MainMedia.tsx
@@ -5,6 +5,7 @@ import { until } from '@guardian/src-foundations/mq';
 
 import { ImageComponent } from '@root/src/web/components/elements/ImageComponent';
 import { YoutubeBlockComponent } from '@root/src/web/components/elements/YoutubeBlockComponent';
+import { EmbedBlockComponent } from '@root/src/web/components/elements/EmbedBlockComponent';
 import { Display } from '@root/src/lib/display';
 
 const mainMedia = css`
@@ -82,6 +83,10 @@ function renderElement(
                         duration={element.duration}
                     />
                 </div>
+            );
+        case 'model.dotcomrendering.pageElements.EmbedBlockElement':
+            return (
+                <EmbedBlockComponent html={element.html} alt={element.alt} />
             );
         default:
             // eslint-disable-next-line no-console


### PR DESCRIPTION
## What does this change?
Adds support for [articles](https://www.theguardian.com/us-news/2019/nov/21/wildfire-prescribed-burns-california-native-americans) that have embed components as their Main Media. The [particular example](https://www.theguardian.com/us-news/2019/nov/21/wildfire-prescribed-burns-california-native-americans) given needs a css update to remove a `postion: fixed;` property before scrolling will work as expected on DCR.

In addition, the blue background on the Nav menu should be restored by s separate PR. (Or not, it kind of looks cool @HarryFischer ?)



![2020-12-07 15 06 55](https://user-images.githubusercontent.com/1336821/101367272-e2bd2680-389d-11eb-8b4f-f8f51de48cc5.gif)
