### PR TITLE
Thank you header for supporters

### DIFF
--- a/src/web/components/ReaderRevenueLinks.test.tsx
+++ b/src/web/components/ReaderRevenueLinks.test.tsx
@@ -32,14 +32,14 @@ describe('ReaderRevenueLinks', () => {
     };
     const edition: Edition = 'UK';
 
-    it('should not render if shouldHideSupportMessaging() returns true', async () => {
+    it('should not render if shouldHideSupportMessaging() returns true and edition is US', async () => {
         shouldHideSupportMessaging.mockReturnValue(true);
 
         const { container } = render(
             <AbProvider>
                 <ReaderRevenueLinks
                     urls={urls}
-                    edition={edition}
+                    edition="US"
                     dataLinkNamePrefix="nav2 : "
                     inHeader={true}
                     pageViewId="1234"

--- a/src/web/components/ReaderRevenueLinks.tsx
+++ b/src/web/components/ReaderRevenueLinks.tsx
@@ -191,6 +191,23 @@ export const ReaderRevenueLinks: React.FC<Props> = ({
     };
 
     if (shouldHideSupportMessaging()) {
+        if (edition !== 'US') {
+            return (
+                <div className={cx(inHeader && paddingStyles)}>
+                    <div
+                        className={cx({
+                            [hiddenUntilTablet]: inHeader,
+                        })}
+                    >
+                        <div className={messageStyles}> Thank you for your support </div>
+                        <div className={subMessageStyles}>
+                            <div> You've powered our journalism </div>
+                            <div> through a historic year </div>
+                        </div>
+                    </div>
+                </div>
+            )
+        }
         return null;
     }
     return (

--- a/src/web/components/ReaderRevenueLinks.tsx
+++ b/src/web/components/ReaderRevenueLinks.tsx
@@ -201,7 +201,7 @@ export const ReaderRevenueLinks: React.FC<Props> = ({
                     >
                         <div className={messageStyles}> Thank you for your support </div>
                         <div className={subMessageStyles}>
-                            <div> You've powered our journalism </div>
+                            <div> You’ve powered our journalism </div>
                             <div> through a historic year </div>
                         </div>
                     </div>

--- a/src/web/components/ReaderRevenueLinks.tsx
+++ b/src/web/components/ReaderRevenueLinks.tsx
@@ -191,7 +191,8 @@ export const ReaderRevenueLinks: React.FC<Props> = ({
     };
 
     if (shouldHideSupportMessaging()) {
-        if (edition !== 'US') {
+        // Use the same switch as the A/B test to decide whether to display thankyou message
+        if (variantName !== 'notintest') {
             return (
                 <div className={cx(inHeader && paddingStyles)}>
                     <div


### PR DESCRIPTION
Adds a message for supporters to the header (excluding US edition).

![Screen Shot 2020-12-09 at 07 28 55](https://user-images.githubusercontent.com/1513454/101598818-a3ebb580-39f0-11eb-81d1-fe7cedbc7daa.png)
![Screen Shot 2020-12-09 at 07 29 09](https://user-images.githubusercontent.com/1513454/101598824-a4844c00-39f0-11eb-8d8f-758836cde57f.png)
![Screen Shot 2020-12-09 at 07 29 23](https://user-images.githubusercontent.com/1513454/101598825-a4844c00-39f0-11eb-9b29-e88726b30a10.png)
