### PR TITLE
Use picture tag instead of img

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -12,11 +12,11 @@ import { defaults } from './default-css';
 import 'reset-css';
 
 import { Lazy } from '@root/src/web/components/Lazy';
-import { Img } from '@root/src/web/components/Img';
+import { Picture } from '@root/src/web/components/Picture';
 
 // Prevent components being lazy rendered when we're taking Chromatic snapshots
 Lazy.disabled = isChromatic();
-Img.disableLazyLoading = isChromatic();
+Picture.disableLazyLoading = isChromatic();
 
 // Add base css for the site
 let css = `${getFontsCss()}${defaults}`;

--- a/src/web/components/Picture.tsx
+++ b/src/web/components/Picture.tsx
@@ -48,12 +48,13 @@ const getFallback = (
     role: RoleType,
     resolution: ResolutionType,
     imageSources: ImageSource[],
-): string => {
+): string | undefined => {
     const sourcesForRole: SrcSetItem[] = getSourcesForRole(imageSources, role);
     const sourcesForResolution: SrcSetItem[] = getSourcesForResolution(
         sourcesForRole,
         resolution,
     );
+    if (sourcesForResolution.length === 0) return undefined;
     // The assumption here is readers on devices that do not support srcset are likely to be on poor
     // network connections so we're going to fallback to a small image
     return getClosestSetForWidth(300, sourcesForResolution).src;

--- a/src/web/components/Picture.tsx
+++ b/src/web/components/Picture.tsx
@@ -96,7 +96,7 @@ const getSizes = (role: RoleType, isMainMedia: boolean): string => {
     }
 };
 
-export const Img = ({
+export const Picture = ({
     imageSources,
     role,
     alt,
@@ -125,7 +125,9 @@ export const Img = ({
                 src={fallbackSrc}
                 height={height}
                 width={width}
-                loading={isLazy && !Img.disableLazyLoading ? 'lazy' : undefined}
+                loading={
+                    isLazy && !Picture.disableLazyLoading ? 'lazy' : undefined
+                }
                 // https://stackoverflow.com/questions/10844205/html-5-strange-img-always-adds-3px-margin-at-bottom
                 // why did we add the css `vertical-align: middle;` to the img tag
                 className={css`
@@ -138,4 +140,4 @@ export const Img = ({
 
 // We use disableLazyLoading to decide if we want to turn off lazy loading of images site wide. We use this
 // to prevent false negatives on Chromatic snapshots (see /.storybook/config)
-Img.disableLazyLoading = false;
+Picture.disableLazyLoading = false;

--- a/src/web/components/elements/ImageComponent.tsx
+++ b/src/web/components/elements/ImageComponent.tsx
@@ -6,7 +6,7 @@ import { headline } from '@guardian/src-foundations/typography';
 import { pillarPalette } from '@root/src/lib/pillars';
 import { brandAltBackground, neutral } from '@guardian/src-foundations/palette';
 
-import { Img } from '@root/src/web/components/Img';
+import { Picture } from 'src/web/components/Picture';
 import { Caption } from '@root/src/web/components/Caption';
 import { Hide } from '@root/src/web/components/Hide';
 import { StarRating } from '@root/src/web/components/StarRating/StarRating';
@@ -256,7 +256,7 @@ export const ImageComponent = ({
                     }
                 `}
             >
-                <Img
+                <Picture
                     role={role}
                     imageSources={element.imageSources}
                     alt={element.data.alt || ''}
@@ -286,7 +286,7 @@ export const ImageComponent = ({
                     }
                 `}
             >
-                <Img
+                <Picture
                     role={role}
                     imageSources={element.imageSources}
                     alt={element.data.alt || ''}
@@ -316,7 +316,7 @@ export const ImageComponent = ({
                     }
                 `}
             >
-                <Img
+                <Picture
                     role={role}
                     imageSources={element.imageSources}
                     alt={element.data.alt || ''}

--- a/src/web/components/elements/ImageComponent.tsx
+++ b/src/web/components/elements/ImageComponent.tsx
@@ -6,7 +6,7 @@ import { headline } from '@guardian/src-foundations/typography';
 import { pillarPalette } from '@root/src/lib/pillars';
 import { brandAltBackground, neutral } from '@guardian/src-foundations/palette';
 
-import { Picture } from 'src/web/components/Picture';
+import { Picture } from '@root/src/web/components/Picture';
 import { Caption } from '@root/src/web/components/Caption';
 import { Hide } from '@root/src/web/components/Hide';
 import { StarRating } from '@root/src/web/components/StarRating/StarRating';


### PR DESCRIPTION
## What?
This PR is part of the ongoing work to improve how images are rendered in DCR. Here we replace the `img` tag with a `picture` tag using multiple sources.

## Why?
In the [previous PR](https://github.com/guardian/dotcom-rendering/pull/2067) in this series we added a function to define a `sizes` array specific to DCR and applied that to an `img` tag. This was successful in improving the image chosen in many cases but we were still left with 2 issues:

1. The [Wealthy Guy problem](https://github.com/guardian/frontend/pull/11400). Mobile devices with small screens but high dpr values can end up being served excessively large files, wasting bandwidth.

2. The [DPR1/2 quality 45/85 thing](https://blog.imgix.com/2016/03/30/dpr-quality). We want to be able to specify a different set of images to use above a certain resolution. This is because we've found that for high resolution screens, by using `dpr=2&quality=45` together we can [reduce the file size](https://github.com/guardian/frontend/pull/12079#issuecomment-188754193) without noticeably impacting quality.

By reintroducing a `picture` tag we can now address point 2. We do this by having two sources under the `picture` tag, one for high dpi devices which uses the source sets that have the `dpr=2&quality=45` structure, and the other for the rest, using `quality=80`.

## What is different to Frontend?
One thing where this approach diverges from that used in Frontend is here we only set two `source` tags, one for hidpi images and one for the rest. But [in Frontend](https://github.com/guardian/frontend/blob/126dfcbc1aa961650b7f7ff41ee50a12782bb62e/common/app/views/fragments/image.scala.html#L47) two source tags are set for _each breakpoint_, like this:

```scala
    @widths.breakpoints.map { breakpointWidth =>
        <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (min-resolution: 120dpi)"
        sizes="@breakpointWidth.width"
        srcset="@SrcSet.asSrcSetString(ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath = None, maybeImageMedia = Some(picture), hidpi = true))" />
        <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px)"
        sizes="@breakpointWidth.width"
        srcset="@SrcSet.asSrcSetString(ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath = None, maybeImageMedia = Some(picture)))" />
    }
```

I'm curious what others think here (@JamieB-gu @gtrufitt ?) but my feeling is that we don't want to be so explicit in directing the browser. Frontend is dealing with absolutes, each `sizes` and `srcset` attribute on each `source` tag only ever contains one value, so the browser never has a choice. In this PR we are going from one set of sources (used by the `img` tag) to two, split by resolution. But for the rest we are still letting the browser make it's own choice. We give it hints in the form of an array of `sizes` but it is still free to make a different choice if it thinks it should. Reasons why browsers might decide to pick a different image than what might be expected include:

- It already has a larger version in its cache
- it thinks the network conditions are too poor to justify downloading a larger image so it degrades the image in favour of speed

These choices are not made by all browsers (perhaps even none of them) but they are part of the spec and we should offer browsers the chance to make them or others to improve the experience for the reader

## Does it work?
This code was manually tested for all image roles, at all breakpoints and on both DPR2 and DPR1 devices 👍 

## What next?
The end goal for images in DCR is to use [Image Rendering ](https://github.com/guardian/image-rendering). Once we have a stable approach working locally for DCR we can decide how best to hoist this code up and what contract we want to use.

More investigation and testing is needed to quantify and decide an approach for the Wealthy Guy problem. I'm keen to make sure we learn from and respect the [previous work](https://github.com/guardian/frontend/pull/11400) in this area
