### PR TITLE
Fix some HTML validation errors

### DIFF
--- a/src/web/components/Footer.tsx
+++ b/src/web/components/Footer.tsx
@@ -52,6 +52,8 @@ const pillarWrap = css`
 const emailSignup = css`
     padding-top: 12px;
     min-height: 150px;
+    overflow: hidden;
+    border: 0;
 
     ${from.desktop} {
         margin: 0 ${emailSignupSideMargins}px;
@@ -233,13 +235,11 @@ export const Footer: React.FC<{
             <iframe
                 title="Guardian Email Sign-up Form"
                 src="https://www.theguardian.com/email/form/footer/today-uk"
-                scrolling="no"
                 id="footer__email-form"
                 className={emailSignup}
                 data-form-success-desc="We will send you our picks of the most important headlines tomorrow morning."
                 data-node-uid="2"
                 height="100"
-                frameBorder="0"
             />
 
             <FooterLinks pageFooter={pageFooter} />

--- a/src/web/components/Footer.tsx
+++ b/src/web/components/Footer.tsx
@@ -234,12 +234,11 @@ export const Footer: React.FC<{
                 title="Guardian Email Sign-up Form"
                 src="https://www.theguardian.com/email/form/footer/today-uk"
                 scrolling="no"
-                seamless={true}
                 id="footer__email-form"
                 className={emailSignup}
                 data-form-success-desc="We will send you our picks of the most important headlines tomorrow morning."
                 data-node-uid="2"
-                height="100px"
+                height="100"
                 frameBorder="0"
             />
 

--- a/src/web/components/GuardianLines.tsx
+++ b/src/web/components/GuardianLines.tsx
@@ -7,7 +7,7 @@ import { remSpace } from '@guardian/src-foundations';
 import { neutralBorder } from '@root/src/lib/pillars';
 
 const linesCssOverwrite = (pillar: Pillar) => css`
-    div > {
+    div > * {
         background-image: repeating-linear-gradient(
             to bottom,
             ${neutralBorder(pillar)},

--- a/src/web/components/SyndicationButton.tsx
+++ b/src/web/components/SyndicationButton.tsx
@@ -45,7 +45,6 @@ export const SyndicationButton: React.FC<{
         text-overflow: ellipsis;
 
         padding: 0 0.5rem;
-        margin-right: 8;
     `;
     return (
         <div className={submetaSyndication}>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
I ran a DCR article through an HTML validator yesterday for an unrelated reason and there were quite a few errors that cropped up. This PR resolves a few of them (the one's that seemed easy to fix).

### Before
Before

### After
Same as before but with more valid HTML

## Why?
While most browsers will handle small validation errors seamlessly, it doesn't hurt to be closer to valid HTML.
