### PR TITLE
Use 100vh for height of immersive image

### DIFF
--- a/src/web/components/MainMedia.tsx
+++ b/src/web/components/MainMedia.tsx
@@ -48,6 +48,8 @@ const immersiveWrapper = css`
     */
     flex-grow: 1;
     ${getZIndex('mainMedia')}
+    /* Prevent the immersive image 100vh from spilling into main content */
+    overflow: hidden;
 `;
 
 function renderElement(

--- a/src/web/components/elements/ImageComponent.tsx
+++ b/src/web/components/elements/ImageComponent.tsx
@@ -248,7 +248,7 @@ export const ImageComponent = ({
                     /* These styles depend on the containing layout component wrapping the main media
                     with a div set to 100vh. This is the case for ImmersiveLayout which should
                     always be used if display === 'immersive' */
-                    height: 100%;
+                    height: 100vh;
                     width: 100%;
 
                     img {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Add 100vh to immersive main media to fix Safari bug.

### Before
![2020-12-11 14 46 28](https://user-images.githubusercontent.com/638051/101917168-d697d880-3bbf-11eb-99a3-65a4c55615bf.gif)

### After
![2020-12-11 14 46 06](https://user-images.githubusercontent.com/638051/101917149-d13a8e00-3bbf-11eb-9040-54e0ea0fe4d5.gif)

## Overflow hidden

Avoid spilling out into the main content. Before and after shows identical styling.

### Before 

![Screen Shot 2020-12-11 at 14 47 15](https://user-images.githubusercontent.com/638051/101917299-fc24e200-3bbf-11eb-89e1-9fdd0f5401ac.png)

### AFter

![Screen Shot 2020-12-11 at 14 47 27](https://user-images.githubusercontent.com/638051/101917336-0810a400-3bc0-11eb-8767-b23a3ba94818.png)
