### PR TITLE
Wrapped Series Tag

### DIFF
--- a/src/web/components/ArticleTitle.stories.tsx
+++ b/src/web/components/ArticleTitle.stories.tsx
@@ -142,7 +142,8 @@ export const ImmersiveSeriesTag = () => {
                 tags={[
                     {
                         id: '',
-                        title: 'Series title',
+                        title:
+                            'Series title with the addition of some more text to see how this wraps',
                         type: 'Series',
                     },
                 ]}

--- a/src/web/components/ArticleTitle.tsx
+++ b/src/web/components/ArticleTitle.tsx
@@ -46,15 +46,15 @@ const marginTop = css`
 `;
 
 const immersiveMargins = css`
-    margin-bottom: 5px;
     /*
         Make sure we vertically align the title font with the body font
     */
     ${from.tablet} {
-        margin-left: 10px;
+        margin-left: 16px;
     }
     ${from.leftCol} {
-        margin-left: 19px;
+        margin-bottom: 5px;
+        margin-left: 25px;
     }
 `;
 

--- a/src/web/components/ArticleTitle.tsx
+++ b/src/web/components/ArticleTitle.tsx
@@ -46,6 +46,8 @@ const marginTop = css`
 `;
 
 const immersiveMargins = css`
+    max-width: 400px;
+    margin-bottom: 4px;
     /*
         Make sure we vertically align the title font with the body font
     */
@@ -53,7 +55,6 @@ const immersiveMargins = css`
         margin-left: 16px;
     }
     ${from.leftCol} {
-        margin-bottom: 5px;
         margin-left: 25px;
     }
 `;

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -75,8 +75,14 @@ const invertedStyle = (pillar: Pillar) => css`
     white-space: pre-wrap;
     box-shadow: -6px 0 0 ${pillarPalette[pillar].main};
     box-decoration-break: clone;
-    line-height: 26px;
+    line-height: 28px;
+    ${from.leftCol} {
+        line-height: 28px;
+    }
 
+    padding-right: ${space[3]}px;
+    padding-top: ${space[1]}px;
+    padding-bottom: ${space[3]}px;
     padding-left: ${space[3]}px;
     ${from.mobileLandscape} {
         padding-left: ${space[5]}px;
@@ -84,10 +90,6 @@ const invertedStyle = (pillar: Pillar) => css`
     ${from.tablet} {
         padding-left: ${space[1]}px;
     }
-
-    padding-right: ${space[3]}px;
-    padding-top: ${space[1]}px;
-    padding-bottom: ${space[1]}px;
 `;
 
 const whiteFont = css`

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -71,12 +71,18 @@ const invertedStyle = (pillar: Pillar) => css`
     color: ${neutral[100]};
     background-color: ${pillarPalette[pillar].main};
 
+    /* Handle text wrapping onto a new line */
+    white-space: pre-wrap;
+    box-shadow: -6px 0 0 ${pillarPalette[pillar].main};
+    box-decoration-break: clone;
+    line-height: 26px;
+
     padding-left: ${space[3]}px;
     ${from.mobileLandscape} {
         padding-left: ${space[5]}px;
     }
     ${from.tablet} {
-        padding-left: ${space[3]}px;
+        padding-left: ${space[1]}px;
     }
 
     padding-right: ${space[3]}px;


### PR DESCRIPTION
## What does this change?
Fixes a styling glitch seen when longer series tags were wrapping on smaller screens

### Before
![Screenshot 2020-12-11 at 15 24 07](https://user-images.githubusercontent.com/1336821/101921487-fb427f00-3bc4-11eb-8e01-c364eaf2ade4.jpg)

### After

![Screenshot 2020-12-11 at 15 25 37](https://user-images.githubusercontent.com/1336821/101921658-262cd300-3bc5-11eb-9ad1-801b5c3725e5.jpg)


