### PR TITLE
Add data link name for standfirst

### DIFF
--- a/src/web/components/Standfirst.tsx
+++ b/src/web/components/Standfirst.tsx
@@ -140,7 +140,7 @@ export const Standfirst = ({ display, designType, standfirst }: Props) => (
                         tagName, // Just return anchors as is
                         attribs: {
                             ...attribs, // Merge into the existing attributes
-                            'data-link-name': 'in body link', // Add the data-link-name for Ophan to anchors
+                            'data-link-name': 'in standfirst link', // Add the data-link-name for Ophan to anchors
                         },
                     }),
                 },

--- a/src/web/components/Standfirst.tsx
+++ b/src/web/components/Standfirst.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { css, cx } from 'emotion';
+
 import { neutral } from '@guardian/src-foundations/palette';
 import { space } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { headline } from '@guardian/src-foundations/typography';
 import { Display } from '@root/src/lib/display';
+import { sanitise } from '@frontend/lib/sanitise-html';
 
 type Props = {
     display: Display;
@@ -125,18 +127,24 @@ const standfirstStyles = (designType: DesignType, display: Display) => {
     }
 };
 
-export const Standfirst = ({ display, designType, standfirst }: Props) => {
-    const standfirstHTMLWithDataLinkName = standfirst
-        .split('<a ')
-        .join('<a data-link-name="in standfirst link" ');
-
-    return (
-        <div
-            className={cx(nestedStyles, standfirstStyles(designType, display))}
-            // eslint-disable-next-line react/no-danger
-            dangerouslySetInnerHTML={{
-                __html: standfirstHTMLWithDataLinkName,
-            }}
-        />
-    );
-};
+export const Standfirst = ({ display, designType, standfirst }: Props) => (
+    <div
+        className={cx(nestedStyles, standfirstStyles(designType, display))}
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{
+            __html: sanitise(standfirst, {
+                allowedTags: false, // Leave tags from CAPI alone
+                allowedAttributes: false, // Leave attributes from CAPI alone
+                transformTags: {
+                    a: (tagName: string, attribs: { [key: string]: any }) => ({
+                        tagName, // Just return anchors as is
+                        attribs: {
+                            ...attribs, // Merge into the existing attributes
+                            'data-link-name': 'in body link', // Add the data-link-name for Ophan to anchors
+                        },
+                    }),
+                },
+            }),
+        }}
+    />
+);

--- a/src/web/components/Standfirst.tsx
+++ b/src/web/components/Standfirst.tsx
@@ -126,12 +126,16 @@ const standfirstStyles = (designType: DesignType, display: Display) => {
 };
 
 export const Standfirst = ({ display, designType, standfirst }: Props) => {
+    const standfirstHTMLWithDataLinkName = standfirst
+        .split('<a ')
+        .join('<a data-link-name="in standfirst link" ');
+
     return (
         <div
             className={cx(nestedStyles, standfirstStyles(designType, display))}
             // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{
-                __html: standfirst,
+                __html: standfirstHTMLWithDataLinkName,
             }}
         />
     );


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Add `data-link-name="in standfirst link"` to standfirst links

## Why?
Parity with frontend