### PR TITLE
Platform support for new Braze banner campaign

### DIFF
--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -141,7 +141,10 @@ const componentEventHandler = (
 
 export const App = ({ CAPI, NAV }: Props) => {
     const [isSignedIn, setIsSignedIn] = useState<boolean>();
-    const [isDigitalSubscriber, setIsDigitalSubscriber] = useState<boolean>();
+    const [
+        shouldHideSupportMessaging,
+        setShouldHideSupportMessaging,
+    ] = useState<boolean>();
     const [user, setUser] = useState<UserProfile>();
     const [asyncBrazeUuid, setAsyncBrazeUuid] = useState<
         Promise<string | null>
@@ -190,7 +193,9 @@ export const App = ({ CAPI, NAV }: Props) => {
     }, []);
 
     useEffect(() => {
-        setIsDigitalSubscriber(getCookie('gu_digital_subscriber') === 'true');
+        setShouldHideSupportMessaging(
+            getCookie('gu_hide_support_messaging') === 'true',
+        );
     }, []);
 
     useEffect(() => {
@@ -797,7 +802,7 @@ export const App = ({ CAPI, NAV }: Props) => {
                     asyncCountryCode={asyncCountryCode}
                     CAPI={CAPI}
                     asyncBrazeUuid={asyncBrazeUuid}
-                    isDigitalSubscriber={isDigitalSubscriber}
+                    shouldHideSupportMessaging={shouldHideSupportMessaging}
                 />
             </Portal>
         </React.StrictMode>

--- a/src/web/components/StickyBottomBanner/BrazeBanner.test.ts
+++ b/src/web/components/StickyBottomBanner/BrazeBanner.test.ts
@@ -98,7 +98,7 @@ describe('canShowPreChecks', () => {
             const result = canShowPreChecks({
                 brazeSwitch: false,
                 apiKey: 'abcde',
-                isDigitalSubscriber: true,
+                shouldHideSupportMessaging: true,
                 pageConfig: { isPaidContent: false },
             });
 
@@ -111,7 +111,7 @@ describe('canShowPreChecks', () => {
             const result = canShowPreChecks({
                 brazeSwitch: true,
                 apiKey: '',
-                isDigitalSubscriber: true,
+                shouldHideSupportMessaging: true,
                 pageConfig: { isPaidContent: false },
             });
 
@@ -119,12 +119,12 @@ describe('canShowPreChecks', () => {
         });
     });
 
-    describe('when not a digital subscriber', () => {
+    describe('when not a supporter', () => {
         it('returns false', () => {
             const result = canShowPreChecks({
                 brazeSwitch: true,
                 apiKey: 'abcde',
-                isDigitalSubscriber: false,
+                shouldHideSupportMessaging: false,
                 pageConfig: { isPaidContent: false },
             });
 
@@ -137,7 +137,7 @@ describe('canShowPreChecks', () => {
             const result = canShowPreChecks({
                 brazeSwitch: true,
                 apiKey: 'abcde',
-                isDigitalSubscriber: true,
+                shouldHideSupportMessaging: true,
                 pageConfig: { isPaidContent: true },
             });
 
@@ -150,7 +150,7 @@ describe('canShowPreChecks', () => {
             const result = canShowPreChecks({
                 brazeSwitch: true,
                 apiKey: 'abcde',
-                isDigitalSubscriber: true,
+                shouldHideSupportMessaging: true,
                 pageConfig: { isPaidContent: false },
             });
 

--- a/src/web/components/StickyBottomBanner/BrazeBanner.tsx
+++ b/src/web/components/StickyBottomBanner/BrazeBanner.tsx
@@ -161,15 +161,15 @@ const getBrazeMetaFromQueryString = (): Meta | null => {
     if (URLSearchParams) {
         const qsArg = 'force-braze-message';
 
-        if (!FORCE_BRAZE_ALLOWLIST.includes(window.location.hostname)) {
-            // eslint-disable-next-line no-console
-            console.log(`${qsArg} is not supported on this domain`);
-            return null;
-        }
-
         const params = new URLSearchParams(window.location.search);
         const value = params.get(qsArg);
         if (value) {
+            if (!FORCE_BRAZE_ALLOWLIST.includes(window.location.hostname)) {
+                // eslint-disable-next-line no-console
+                console.log(`${qsArg} is not supported on this domain`);
+                return null;
+            }
+
             try {
                 const dataFromBraze = JSON.parse(value);
 

--- a/src/web/components/StickyBottomBanner/BrazeBanner.tsx
+++ b/src/web/components/StickyBottomBanner/BrazeBanner.tsx
@@ -48,22 +48,26 @@ export const hasRequiredConsents = (): Promise<boolean> =>
 type PreCheckArgs = {
     brazeSwitch: boolean;
     apiKey?: string;
-    isDigitalSubscriber?: boolean;
+    shouldHideSupportMessaging?: boolean;
     pageConfig: { [key: string]: any };
 };
 
 export const canShowPreChecks = ({
     brazeSwitch,
     apiKey,
-    isDigitalSubscriber,
+    shouldHideSupportMessaging,
     pageConfig,
-}: PreCheckArgs) =>
-    Boolean(
-        brazeSwitch &&
-            apiKey &&
-            isDigitalSubscriber &&
-            !pageConfig.isPaidContent,
+}: PreCheckArgs) => {
+    // Currently all active web canvases in Braze target existing supporters,
+    // subscribers or otherwise those with a Guardian product. We can use the
+    // value of `shouldHideSupportMessaging` to identify these users, limiting
+    // the number of requests we need to initialise Braze on the page:
+    const userIsGuSupporter = shouldHideSupportMessaging;
+
+    return Boolean(
+        brazeSwitch && apiKey && userIsGuSupporter && !pageConfig.isPaidContent,
     );
+};
 
 const getMessageFromBraze = async (
     apiKey: string,
@@ -94,7 +98,9 @@ const getMessageFromBraze = async (
     });
 
     const canShowPromise: Promise<CanShowResult> = new Promise((resolve) => {
-        appboy.subscribeToInAppMessage((message: any) => {
+        let subscriptionId: string | undefined;
+
+        const callback = (message: any) => {
             const { extras } = message;
 
             const logButtonClickWithBraze = (internalButtonId: number) => {
@@ -126,7 +132,16 @@ const getMessageFromBraze = async (
             } else {
                 resolve({ result: false });
             }
-        });
+
+            // Unsubscribe
+            if (subscriptionId) {
+                appboy.removeSubscription(subscriptionId);
+            }
+        };
+
+        // Keep hold of the subscription ID so that we can unsubscribe in the
+        // callback, ensuring that the callback is only invoked once per page
+        subscriptionId = appboy.subscribeToInAppMessage(callback);
 
         appboy.changeUser(brazeUuid);
         appboy.openSession();
@@ -192,7 +207,7 @@ const getBrazeMetaFromQueryString = (): Meta | null => {
 // We can show a Braze banner if:
 // - The Braze switch is on
 // - We have a Braze API key
-// - The user is a digital subscriber
+// - The user should have support messaging hidden, implying they are a contributor or subscriber
 // - We're not on a Glabs paid content page
 // - We've got a Braze UUID from the API, given a user's ID Creds
 // - The user has given Consent via CCPA or TCFV2
@@ -202,7 +217,7 @@ const getBrazeMetaFromQueryString = (): Meta | null => {
 // - The force-braze-message query string arg is passed
 export const canShow = async (
     asyncBrazeUuid: Promise<null | string>,
-    isDigitalSubscriber: undefined | boolean,
+    shouldHideSupportMessaging: undefined | boolean,
 ): Promise<CanShowResult> => {
     const bannerTiming = initPerf('braze-banner');
     bannerTiming.start();
@@ -222,7 +237,7 @@ export const canShow = async (
         !canShowPreChecks({
             brazeSwitch,
             apiKey,
-            isDigitalSubscriber,
+            shouldHideSupportMessaging,
             pageConfig: window.guardian.config.page,
         })
     ) {

--- a/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -13,7 +13,7 @@ type Props = {
     asyncCountryCode?: Promise<string>;
     CAPI: CAPIBrowserType;
     asyncBrazeUuid?: Promise<null | string>;
-    isDigitalSubscriber?: boolean;
+    shouldHideSupportMessaging?: boolean;
 };
 
 type FulfilledProps = {
@@ -21,7 +21,7 @@ type FulfilledProps = {
     asyncCountryCode: Promise<string>;
     CAPI: CAPIBrowserType;
     asyncBrazeUuid: Promise<null | string>;
-    isDigitalSubscriber: boolean;
+    shouldHideSupportMessaging: boolean;
 };
 
 const getBannerLastClosedAt = (key: string): string | undefined => {
@@ -79,10 +79,11 @@ const buildReaderRevenueBannerConfig = (
 
 const buildBrazeBanner = (
     asyncBrazeUuid: Promise<null | string>,
-    isDigitalSubscriber: undefined | boolean,
+    shouldHideSupportMessaging: undefined | boolean,
 ): Banner => ({
     id: 'braze-banner',
-    canShow: () => canShowBrazeBanner(asyncBrazeUuid, isDigitalSubscriber),
+    canShow: () =>
+        canShowBrazeBanner(asyncBrazeUuid, shouldHideSupportMessaging),
     show: (meta: any) => () => <BrazeBanner meta={meta} />,
     timeoutMillis: DEFAULT_BANNER_TIMEOUT_MILLIS,
 });
@@ -92,7 +93,7 @@ const StickyBottomBannerWithFullfilledDependencies = ({
     asyncCountryCode,
     CAPI,
     asyncBrazeUuid,
-    isDigitalSubscriber,
+    shouldHideSupportMessaging,
 }: FulfilledProps) => {
     const [SelectedBanner, setSelectedBanner] = useState<React.FC | null>(null);
 
@@ -105,7 +106,7 @@ const StickyBottomBannerWithFullfilledDependencies = ({
         );
         const brazeBanner = buildBrazeBanner(
             asyncBrazeUuid,
-            isDigitalSubscriber,
+            shouldHideSupportMessaging,
         );
         const bannerConfig: BannerConfig = [CMP, readerRevenue, brazeBanner];
 
@@ -130,13 +131,13 @@ export const StickyBottomBanner = ({
     asyncCountryCode,
     CAPI,
     asyncBrazeUuid,
-    isDigitalSubscriber,
+    shouldHideSupportMessaging,
 }: Props) => {
     if (
         isSignedIn === undefined ||
         asyncCountryCode === undefined ||
         asyncBrazeUuid === undefined ||
-        isDigitalSubscriber === undefined
+        shouldHideSupportMessaging === undefined
     ) {
         return null;
     }
@@ -146,7 +147,7 @@ export const StickyBottomBanner = ({
             isSignedIn={isSignedIn}
             asyncCountryCode={asyncCountryCode}
             asyncBrazeUuid={asyncBrazeUuid}
-            isDigitalSubscriber={isDigitalSubscriber}
+            shouldHideSupportMessaging={shouldHideSupportMessaging}
             CAPI={CAPI}
         />
     );


### PR DESCRIPTION
## What does this change?

This PR includes a few changes to the platform code around showing Braze banners, to support a new campaign which will run alongside the existing one.

In particular:

* Because users might now be eligible for > 1 message from Braze we now unsubscribe from in-app message events after we receive an event. This is so that we don't have multiple messages delivered from Braze in the same page request (we wouldn't actually _show_ > 1 message because we wrap the callback logic up in a promise which can only ever resolve once).

* Update the pre-check to look at the `gu_hide_support_messaging` cookie instead of `gu_digital_subscriber`. The new campaign has a wider audience, though we'd still like to restrict the number of readers we load the Braze SDK for. Broadening to users who _shouldn't_ see support messaging (which means they have a product, or otherwise subscribed/contributed).

Also includes a bonus fix to move the `force-braze-message` host check further down so we only ever run it if the query string arg was specified (right now we're console.log-ing that the current host isn't valid on every page view).
