### PR TITLE
Improve print layout

### DIFF
--- a/src/static/css/print.css
+++ b/src/static/css/print.css
@@ -1,0 +1,4 @@
+[data-print-layout='hide'] {
+    display: none !important;
+    color: #000000;
+}

--- a/src/web/components/AdSlot.tsx
+++ b/src/web/components/AdSlot.tsx
@@ -150,6 +150,7 @@ export const AdSlotCore: React.FC<{
     const sizeMappings = makeInternalSizeMappings(sizeMapping);
     return (
         <div
+            data-print-layout='hide'
             id={`dfp-ad--${optId || name}`}
             className={`${makeClassNames(
                 name,
@@ -171,9 +172,9 @@ export const AdSlot: React.FC<{
     localStyles?: string;
 }> = ({ asps, localStyles }) => {
     // eslint-disable-next-line react/jsx-props-no-spreading
-    return <AdSlotCore {...asps} localStyles={localStyles} />;
+    return <AdSlotCore data-print-layout='hide' {...asps} localStyles={localStyles} />;
 };
 
 export const MobileStickyContainer: React.FC<{}> = ({}) => {
-    return <div className={`mobilesticky-container ${mobileStickyAdStyles}`} />;
+    return <div data-print-layout='hide' className={`mobilesticky-container ${mobileStickyAdStyles}`} />;
 };

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -435,7 +435,7 @@ export const App = ({ CAPI, NAV }: Props) => {
                     edition={CAPI.editionId}
                     dataLinkNamePrefix="nav2 : "
                     inHeader={true}
-                    pageViewId={pageViewId}
+                    // pageViewId={pageViewId}
                 />
             </Portal>
             <Hydrate root="links-root">
@@ -787,7 +787,7 @@ export const App = ({ CAPI, NAV }: Props) => {
                         edition={CAPI.editionId}
                         dataLinkNamePrefix="footer : "
                         inHeader={false}
-                        pageViewId={pageViewId}
+                        // pageViewId={pageViewId}
                     />
                 </Lazy>
             </Portal>

--- a/src/web/components/ArticleContainer.tsx
+++ b/src/web/components/ArticleContainer.tsx
@@ -25,11 +25,17 @@ const articleAdStyles = css`
         min-height: 274px;
         text-align: center;
         position: relative;
+        @media print{
+            display: none !important;
+        }
     }
     .ad-slot--mostpop {
         ${from.desktop} {
             margin: 0;
             width: auto;
+            @media print{
+            display: none !important;
+        }
         }
     }
     .ad-slot--inline {
@@ -39,6 +45,9 @@ const articleAdStyles = css`
             float: right;
             margin-top: 4px;
             margin-left: 20px;
+            @media print{
+            display: none !important;
+        }
         }
         ${from.desktop} {
             width: auto;
@@ -46,6 +55,9 @@ const articleAdStyles = css`
             margin: 0;
             margin-top: 4px;
             margin-left: 20px;
+            @media print{
+            display: none !important;
+        }
         }
     }
     .ad-slot--offset-right {
@@ -53,10 +65,19 @@ const articleAdStyles = css`
             float: right;
             width: auto;
             margin-right: -318px;
+            @media print{
+            display: none !important;
+        }
         }
 
         ${from.wide} {
             margin-right: -398px;
+            @media print{
+            display: none !important;
+        }
+        }
+        @media print{
+            display: none !important;
         }
     }
     .ad-slot--outstream {
@@ -67,7 +88,13 @@ const articleAdStyles = css`
             .ad-slot__label {
                 margin-left: 35px;
                 margin-right: 35px;
+                @media print{
+            display: none !important;
+        }
             }
+        }
+        @media print{
+            display: none !important;
         }
     }
     ${labelStyles};

--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -303,7 +303,7 @@ export const ArticleMeta = ({
     const showAvatar =
         onlyOneContributor && shouldShowAvatar(designType, display);
     return (
-        <div className={metaContainer({ display, designType })}>
+        <div data-print-layout='hide' className={metaContainer({ display, designType })}>
             <div className={cx(meta)}>
                 {branding && <Branding branding={branding} pillar={pillar} />}
                 <RowBelowLeftCol>
@@ -333,7 +333,7 @@ export const ArticleMeta = ({
                         </div>
                     </>
                 </RowBelowLeftCol>
-                <div className={metaFlex}>
+                <div data-print-layout='hide' className={metaFlex}>
                     <div className={metaExtras}>
                         <SharingIcons
                             sharingUrls={sharingUrls}

--- a/src/web/components/Footer.tsx
+++ b/src/web/components/Footer.tsx
@@ -221,7 +221,7 @@ export const Footer: React.FC<{
     pillar: Pillar;
     pageFooter: FooterType;
 }> = ({ pillars, pillar, pageFooter }) => (
-    <footer className={footer} data-link-name="footer" data-component="footer">
+    <footer data-print-layout='hide' className={footer} data-link-name="footer" data-component="footer">
         <div className={pillarWrap}>
             <Pillars
                 display={Display.Standard}

--- a/src/web/components/HeaderAdSlot.tsx
+++ b/src/web/components/HeaderAdSlot.tsx
@@ -35,7 +35,7 @@ export const HeaderAdSlot: React.FC<{
     isAdFreeUser: boolean;
     shouldHideAds: boolean;
 }> = ({ isAdFreeUser, shouldHideAds }) => (
-    <div className={headerWrapper}>
+    <div data-print-layout='hide' className={headerWrapper}>
         <Hide when="below" breakpoint="tablet">
             <div
                 className={cx({
@@ -44,6 +44,7 @@ export const HeaderAdSlot: React.FC<{
                 })}
             >
                 <AdSlot
+                    data-print-layout='hide'
                     asps={namedAdSlotParameters('top-above-nav')}
                     localStyles={adSlotAboveNav}
                 />

--- a/src/web/components/Links.tsx
+++ b/src/web/components/Links.tsx
@@ -160,7 +160,7 @@ export const Links = ({ userId }: Props) => {
         },
     ];
     return (
-        <div className={linksStyles}>
+        <div data-print-layout='hide' className={linksStyles}>
             <div className={seperatorStyles} />
             <a
                 href="https://jobs.theguardian.com/?INTCMP=jobs_uk_web_newheader"
@@ -169,10 +169,10 @@ export const Links = ({ userId }: Props) => {
             >
                 Search jobs
             </a>
-            <div className={seperatorHideStyles} />
+            <div data-print-layout='hide' className={seperatorHideStyles} />
 
             {userId ? (
-                <div className={linkStyles}>
+                <div data-print-layout='hide' className={linkStyles}>
                     <ProfileIcon />
                     <Dropdown
                         label="My account"
@@ -183,6 +183,7 @@ export const Links = ({ userId }: Props) => {
                 </div>
             ) : (
                 <a
+                    data-print-layout='hide'
                     className={linkStyles}
                     href={`https://profile.theguardian.com/signin?INTCMP=DOTCOM_NEWHEADER_SIGNIN&ABCMP=ab-sign-in&${createAuthenticationEventParams('guardian_signin_header')}`}
                     data-link-name="nav2 : topbar : signin"
@@ -192,6 +193,7 @@ export const Links = ({ userId }: Props) => {
             )}
 
             <Search
+                data-print-layout='hide'
                 className={cx(linkTablet({ showAtTablet: false }), linkStyles)}
                 href="https://www.google.co.uk/advanced_search?q=site:www.theguardian.com"
                 dataLinkName="nav2 : search"

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.tsx
@@ -113,7 +113,7 @@ export const MostViewedFooter = ({ sectionName, pillar, ajaxUrl }: Props) => {
 
 
     return (
-        <div className={`content-footer ${cx(adSlotUnspecifiedWidth)}`}>
+        <div data-print-layout='hide' className={`content-footer ${cx(adSlotUnspecifiedWidth)}`}>
             <div
                 className={cx(stackBelow('leftCol'), mostPopularAdStyle)}
                 data-link-name="most-popular"

--- a/src/web/components/ReaderRevenueLinks.stories.tsx
+++ b/src/web/components/ReaderRevenueLinks.stories.tsx
@@ -55,7 +55,7 @@ export const Header = () => {
                 urls={revenueUrls}
                 dataLinkNamePrefix=""
                 inHeader={true}
-                pageViewId="1234"
+                // pageViewId="1234"
             />
         </Container>
     );
@@ -76,7 +76,7 @@ export const HeaderMobile = () => {
                 urls={revenueUrls}
                 dataLinkNamePrefix=""
                 inHeader={true}
-                pageViewId="1234"
+                // pageViewId="1234"
             />
         </Container>
     );
@@ -97,7 +97,7 @@ export const Footer = () => {
                 urls={revenueUrls}
                 dataLinkNamePrefix=""
                 inHeader={false}
-                pageViewId="1234"
+                // pageViewId="1234"
             />
         </Container>
     );
@@ -118,7 +118,7 @@ export const FooterMobile = () => {
                 urls={revenueUrls}
                 dataLinkNamePrefix=""
                 inHeader={false}
-                pageViewId="1234"
+                // pageViewId="1234"
             />
         </Container>
     );

--- a/src/web/components/ReaderRevenueLinks.test.tsx
+++ b/src/web/components/ReaderRevenueLinks.test.tsx
@@ -42,7 +42,7 @@ describe('ReaderRevenueLinks', () => {
                     edition="US"
                     dataLinkNamePrefix="nav2 : "
                     inHeader={true}
-                    pageViewId="1234"
+                    // pageViewId="1234"
                 />
             </AbProvider>,
         );
@@ -61,7 +61,7 @@ describe('ReaderRevenueLinks', () => {
                     edition={edition}
                     dataLinkNamePrefix="nav2 : "
                     inHeader={true}
-                    pageViewId="1234"
+                    // pageViewId="1234"
                 />,
             </AbProvider>,
         );

--- a/src/web/components/RichLink.tsx
+++ b/src/web/components/RichLink.tsx
@@ -84,6 +84,7 @@ const neutralBackground = css`
     }
 `;
 
+
 const richLinkPillarColour: (pillar: Pillar) => colour = (pillar) => {
     if (pillar) {
         return pillarPalette[pillar].main;
@@ -279,6 +280,7 @@ export const RichLink = ({
 
     return (
         <div
+            data-print-layout='hide'
             data-link-name={`rich-link-${richLinkIndex} | ${richLinkIndex}`}
             data-component="rich-link"
             className={pillarBackground(pillar)}

--- a/src/web/components/Standfirst.tsx
+++ b/src/web/components/Standfirst.tsx
@@ -128,6 +128,7 @@ const standfirstStyles = (designType: DesignType, display: Display) => {
 export const Standfirst = ({ display, designType, standfirst }: Props) => {
     return (
         <div
+            data-print-layout='hide'
             className={cx(nestedStyles, standfirstStyles(designType, display))}
             // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{

--- a/src/web/components/SubMeta.tsx
+++ b/src/web/components/SubMeta.tsx
@@ -62,7 +62,7 @@ export const SubMeta = ({
     const hasSubMetaKeywordLinks = subMetaKeywordLinks.length > 0;
     const sharingUrls = getSharingUrls(pageId, webTitle);
     return (
-        <div className={bottomPadding}>
+        <div data-print-layout='hide' className={bottomPadding}>
             {badge && (
                 <div className={badgeWrapper}>
                     <Badge

--- a/src/web/components/SubNav/SubNav.tsx
+++ b/src/web/components/SubNav/SubNav.tsx
@@ -168,6 +168,7 @@ export const SubNav = ({ subNavSections, pillar, currentNavLink }: Props) => {
 
     return (
         <div
+            data-print-layout='hide'
             className={cx(
                 { [wrapperCollapsed]: collapseWrapper },
                 spaceBetween,
@@ -175,6 +176,7 @@ export const SubNav = ({ subNavSections, pillar, currentNavLink }: Props) => {
             data-cy="sub-nav"
         >
             <ul
+                data-print-layout='hide'
                 ref={ulRef}
                 className={cx({
                     [collapsedStyles]: !expandSubNav,

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -292,6 +292,7 @@ const ageWarningMargins = css`
     }
 `;
 
+
 interface Props {
     CAPI: CAPIType;
     NAV: NavType;
@@ -352,6 +353,7 @@ export const StandardLayout = ({
                 </Stuck>
                 <SendToBack>
                     <Section
+                        data-print-layout='hide'
                         showTopBorder={false}
                         showSideBorders={false}
                         padded={false}
@@ -361,6 +363,7 @@ export const StandardLayout = ({
                     </Section>
 
                     <Section
+                        data-print-layout='hide'
                         showSideBorders={true}
                         borderColour={brandLine.primary}
                         showTopBorder={false}
@@ -368,6 +371,7 @@ export const StandardLayout = ({
                         backgroundColour={brandBackground.primary}
                     >
                         <Nav
+                            data-print-layout='hide'
                             pillar={getCurrentPillar(CAPI)}
                             nav={NAV}
                             display={display}
@@ -380,11 +384,13 @@ export const StandardLayout = ({
 
                     {NAV.subNavSections && (
                         <Section
+                            data-print-layout='hide'
                             backgroundColour={background.primary}
                             padded={false}
                             sectionId="sub-nav-root"
                         >
                             <SubNav
+                                data-print-layout='hide'
                                 subNavSections={NAV.subNavSections}
                                 currentNavLink={NAV.currentNavLink}
                                 pillar={pillar}
@@ -393,16 +399,17 @@ export const StandardLayout = ({
                     )}
 
                     <Section
+                        data-print-layout='hide'
                         backgroundColour={background.primary}
                         padded={false}
                         showTopBorder={false}
                     >
-                        <GuardianLines count={4} pillar={pillar} />
+                        <GuardianLines data-print-layout='hide' count={4} pillar={pillar} />
                     </Section>
                 </SendToBack>
             </div>
 
-            <Section showTopBorder={false}>
+            <Section data-print-layout='hide' showTopBorder={false}>
                 <StandardGrid designType={designType} CAPI={CAPI}>
                     <GridItem area="title">
                         <ArticleTitle
@@ -480,7 +487,7 @@ export const StandardLayout = ({
                             />
                         </div>
                     </GridItem>
-                    <GridItem area="lines">
+                    <GridItem data-print-layout='hide' area="lines">
                         <div className={maxWidth}>
                             <div className={stretchLines}>
                                 <GuardianLines
@@ -526,7 +533,7 @@ export const StandardLayout = ({
                                 {showMatchStats && <div id="match-stats" />}
 
                                 {showBodyEndSlot && <div id="slot-body-end" />}
-                                <GuardianLines count={4} pillar={pillar} />
+                                <GuardianLines data-print-layout='hide' count={4} pillar={pillar} />
                                 <SubMeta
                                     pillar={pillar}
                                     subMetaKeywordLinks={
@@ -559,24 +566,25 @@ export const StandardLayout = ({
             </Section>
 
             <Section
+                data-print-layout='hide'
                 padded={false}
                 showTopBorder={false}
                 showSideBorders={false}
                 backgroundColour={neutral[93]}
             >
-                <AdSlot asps={namedAdSlotParameters('merchandising-high')} />
+                <AdSlot data-print-layout='hide' asps={namedAdSlotParameters('merchandising-high')} />
             </Section>
 
             {!isPaidContent && (
                 <>
                     {/* Onwards (when signed OUT) */}
-                    <div id="onwards-upper-whensignedout" />
+                    <div data-print-layout='hide' id="onwards-upper-whensignedout" />
                     {showOnwardsLower && (
-                        <Section sectionId="onwards-lower-whensignedout" />
+                        <Section data-print-layout='hide' sectionId="onwards-lower-whensignedout" />
                     )}
 
                     {showComments && (
-                        <Section sectionId="comments">
+                        <Section sectionId="comments" data-print-layout='hide'>
                             <CommentsLayout
                                 pillar={pillar}
                                 baseUrl={CAPI.config.discussionApiUrl}
@@ -597,34 +605,37 @@ export const StandardLayout = ({
                     {/* Onwards (when signed IN) */}
                     <div id="onwards-upper-whensignedin" />
                     {showOnwardsLower && (
-                        <Section sectionId="onwards-lower-whensignedin" />
+                        <Section data-print-layout='hide' sectionId="onwards-lower-whensignedin" />
                     )}
 
-                    <Section sectionId="most-viewed-footer" />
+                    <Section data-print-layout='hide' sectionId="most-viewed-footer" />
                 </>
             )}
 
             <Section
+                data-print-layout='hide'
                 padded={false}
                 showTopBorder={false}
                 showSideBorders={false}
                 backgroundColour={neutral[93]}
             >
-                <AdSlot asps={namedAdSlotParameters('merchandising')} />
+                <AdSlot data-print-layout='hide' asps={namedAdSlotParameters('merchandising')} />
             </Section>
 
             {NAV.subNavSections && (
-                <Section padded={false} sectionId="sub-nav-root">
+                <Section data-print-layout='hide' padded={false} sectionId="sub-nav-root">
                     <SubNav
+                        qdata-print-layout='hide'
                         subNavSections={NAV.subNavSections}
                         currentNavLink={NAV.currentNavLink}
                         pillar={pillar}
                     />
-                    <GuardianLines count={4} pillar={pillar} />
+                    <GuardianLines data-print-layout='hide' count={4} pillar={pillar} />
                 </Section>
             )}
 
             <Section
+                data-print-layout='hide'
                 padded={false}
                 backgroundColour={brandBackground.primary}
                 borderColour={brandBorder.primary}
@@ -637,8 +648,8 @@ export const StandardLayout = ({
                 />
             </Section>
 
-            <BannerWrapper />
-            <MobileStickyContainer />
+            <BannerWrapper data-print-layout='hide' />
+            <MobileStickyContainer data-print-layout='hide' />
         </>
     );
 };

--- a/src/web/layouts/lib/stickiness.tsx
+++ b/src/web/layouts/lib/stickiness.tsx
@@ -34,20 +34,20 @@ const bannerWrapper = css`
     ${getZIndexImportant('banner')}
     max-height: 80vh;
     overflow: auto;
-    
+
     width: 100% !important;
     background: none !important;
     top: auto !important;
 `;
 
 export const Stuck = ({ children }: Props) => (
-    <div className={stickyAdWrapper}>{children}</div>
+    <div data-print-layout='hide' className={stickyAdWrapper}>{children}</div>
 );
 
 export const SendToBack = ({ children }: Props) => (
-    <div className={headerWrapper}>{children}</div>
+    <div data-print-layout='hide' className={headerWrapper}>{children}</div>
 );
 
 export const BannerWrapper = ({ children }: Props) => (
-    <div id="bottom-banner" className={bannerWrapper}>{children}</div>
+    <div data-print-layout='hide' id="bottom-banner" className={bannerWrapper}>{children}</div>
 );

--- a/src/web/server/htmlTemplate.ts
+++ b/src/web/server/htmlTemplate.ts
@@ -211,6 +211,7 @@ export const htmlTemplate = ({
                 ${[...priorityScriptTags].join('\n')}
                 <style class="webfont">${getFontsCss()}${resetCSS}${css}</style>
 
+                <link rel="stylesheet" media=print href="${CDN}static/frontend/css/print.css">
             </head>
 
             <body>


### PR DESCRIPTION
### If you want to hide an element from printing add this attribute `data-print-layout='hide'`

### Before
Print layout looked janky, it should be a buit better now, still bits to fix. **The huge reader revenue changes were not mine and must have been pulled in from a main merge.** 



<img width="573" alt="Screenshot 2020-12-14 at 09 43 21" src="https://user-images.githubusercontent.com/35331926/102065746-dcc0cb80-3df0-11eb-8f55-a138dda01962.png">

### After

<img width="573" alt="Screenshot 2020-12-14 at 09 37 11" src="https://user-images.githubusercontent.com/35331926/102065819-f235f580-3df0-11eb-8ef0-6b2e4f2fc807.png">

