### PR TITLE
Fix for encoding comscore keywords

### DIFF
--- a/src/web/server/htmlTemplate.ts
+++ b/src/web/server/htmlTemplate.ts
@@ -206,7 +206,7 @@ export const htmlTemplate = ({
                 </script>
 
                 <noscript>
-                    <img src="https://sb.scorecardresearch.com/p?c1=2&c2=6035250&cv=2.0&cj=1&cs_ucfr=0&comscorekw=${keywords}" />
+                    <img src="https://sb.scorecardresearch.com/p?c1=2&c2=6035250&cv=2.0&cj=1&cs_ucfr=0&comscorekw=${encodeURIComponent(keywords).replace(/%20/g, '+')}" />
                 </noscript>
                 ${[...priorityScriptTags].join('\n')}
                 <style class="webfont">${getFontsCss()}${resetCSS}${css}</style>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
DCR didn't correctly encode keywords for comscore keywords the same way that frontend did.
Keywords are passed as part of the src of an `img` tag (in a `<noscript>` tag) and the spaces in the `src` field meant the page didn't validate.

This change replicates the encoding from frontend (which includes `+` instead of spaces)

### Before DCR
![before](https://user-images.githubusercontent.com/768467/101944859-4e2c2e80-3be5-11eb-8b13-6e4cd314d0df.png)

### After DCR
![after](https://user-images.githubusercontent.com/768467/101944875-54220f80-3be5-11eb-8f63-090e8cdbf68b.png)

### Frontend (DCP) for comparison:
![DCP](https://user-images.githubusercontent.com/768467/101944933-656b1c00-3be5-11eb-90b1-61f4c236e6a9.png)

## Why?
Spaces in the `img` src aren't valid.