### PR TITLE
Improve Print Layout

### DIFF
--- a/src/amp/components/topMeta/Standfirst.tsx
+++ b/src/amp/components/topMeta/Standfirst.tsx
@@ -42,6 +42,7 @@ export const Standfirst: React.SFC<{
 }> = ({ text, pillar }) => {
     return (
         <div
+            data-print-layout='hide'
             className={composeLabsCSS(
                 pillar,
                 cx(standfirstCss(pillar)),

--- a/src/static/css/print.css
+++ b/src/static/css/print.css
@@ -1,0 +1,4 @@
+[data-print-layout='hide'] {
+    display: none !important;
+    color: #000000;
+}

--- a/src/web/components/ArticleContainer.tsx
+++ b/src/web/components/ArticleContainer.tsx
@@ -25,6 +25,9 @@ const articleAdStyles = css`
         min-height: 274px;
         text-align: center;
         position: relative;
+        @media print{
+            display: none !important;
+        }
     }
     .ad-slot--mostpop {
         ${from.desktop} {

--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -333,7 +333,7 @@ export const ArticleMeta = ({
                         </div>
                     </>
                 </RowBelowLeftCol>
-                <div className={metaFlex}>
+                <div data-print-layout='hide' className={metaFlex}>
                     <div className={metaExtras}>
                         <SharingIcons
                             sharingUrls={sharingUrls}

--- a/src/web/components/Footer.tsx
+++ b/src/web/components/Footer.tsx
@@ -221,7 +221,7 @@ export const Footer: React.FC<{
     pillar: Pillar;
     pageFooter: FooterType;
 }> = ({ pillars, pillar, pageFooter }) => (
-    <footer className={footer} data-link-name="footer" data-component="footer">
+    <footer data-print-layout='hide' className={footer} data-link-name="footer" data-component="footer">
         <div className={pillarWrap}>
             <Pillars
                 display={Display.Standard}

--- a/src/web/components/Links.tsx
+++ b/src/web/components/Links.tsx
@@ -160,7 +160,7 @@ export const Links = ({ userId }: Props) => {
         },
     ];
     return (
-        <div className={linksStyles}>
+        <div data-print-layout='hide' className={linksStyles}>
             <div className={seperatorStyles} />
             <a
                 href="https://jobs.theguardian.com/?INTCMP=jobs_uk_web_newheader"

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.tsx
@@ -113,7 +113,7 @@ export const MostViewedFooter = ({ sectionName, pillar, ajaxUrl }: Props) => {
 
 
     return (
-        <div className={`content-footer ${cx(adSlotUnspecifiedWidth)}`}>
+        <div data-print-layout='hide' className={`content-footer ${cx(adSlotUnspecifiedWidth)}`}>
             <div
                 className={cx(stackBelow('leftCol'), mostPopularAdStyle)}
                 data-link-name="most-popular"

--- a/src/web/components/RichLink.tsx
+++ b/src/web/components/RichLink.tsx
@@ -285,7 +285,7 @@ export const RichLink = ({
             className={pillarBackground(pillar)}
             data-name={(isPlaceholder && 'placeholder') || ''}
         >
-            <div data-print-layout='hide' className={cx(richLinkContainer, neutralBackground)}>
+            <div className={cx(richLinkContainer, neutralBackground)}>
                 <a className={richLinkLink} href={url}>
                     <div className={richLinkTopBorder(pillar)} />
                     {showImage && (

--- a/src/web/components/RichLink.tsx
+++ b/src/web/components/RichLink.tsx
@@ -279,12 +279,13 @@ export const RichLink = ({
 
     return (
         <div
+            data-print-layout='hide'
             data-link-name={`rich-link-${richLinkIndex} | ${richLinkIndex}`}
             data-component="rich-link"
             className={pillarBackground(pillar)}
             data-name={(isPlaceholder && 'placeholder') || ''}
         >
-            <div className={cx(richLinkContainer, neutralBackground)}>
+            <div data-print-layout='hide' className={cx(richLinkContainer, neutralBackground)}>
                 <a className={richLinkLink} href={url}>
                     <div className={richLinkTopBorder(pillar)} />
                     {showImage && (

--- a/src/web/components/Standfirst.tsx
+++ b/src/web/components/Standfirst.tsx
@@ -128,6 +128,7 @@ const standfirstStyles = (designType: DesignType, display: Display) => {
 export const Standfirst = ({ display, designType, standfirst }: Props) => {
     return (
         <div
+            data-print-layout='hide'
             className={cx(nestedStyles, standfirstStyles(designType, display))}
             // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{

--- a/src/web/components/SubMeta.tsx
+++ b/src/web/components/SubMeta.tsx
@@ -62,7 +62,7 @@ export const SubMeta = ({
     const hasSubMetaKeywordLinks = subMetaKeywordLinks.length > 0;
     const sharingUrls = getSharingUrls(pageId, webTitle);
     return (
-        <div className={bottomPadding}>
+        <div data-print-layout='hide' className={bottomPadding}>
             {badge && (
                 <div className={badgeWrapper}>
                     <Badge

--- a/src/web/components/SubNav/SubNav.tsx
+++ b/src/web/components/SubNav/SubNav.tsx
@@ -176,7 +176,6 @@ export const SubNav = ({ subNavSections, pillar, currentNavLink }: Props) => {
             data-cy="sub-nav"
         >
             <ul
-                data-print-layout='hide'
                 ref={ulRef}
                 className={cx({
                     [collapsedStyles]: !expandSubNav,
@@ -214,7 +213,6 @@ export const SubNav = ({ subNavSections, pillar, currentNavLink }: Props) => {
             </ul>
             {showMore && (
                 <button
-                    data-print-layout='hide'
                     onClick={() => setIsExpanded(!isExpanded)}
                     className={showMoreStyle}
                 >

--- a/src/web/components/SubNav/SubNav.tsx
+++ b/src/web/components/SubNav/SubNav.tsx
@@ -168,6 +168,7 @@ export const SubNav = ({ subNavSections, pillar, currentNavLink }: Props) => {
 
     return (
         <div
+            data-print-layout='hide'
             className={cx(
                 { [wrapperCollapsed]: collapseWrapper },
                 spaceBetween,
@@ -175,6 +176,7 @@ export const SubNav = ({ subNavSections, pillar, currentNavLink }: Props) => {
             data-cy="sub-nav"
         >
             <ul
+                data-print-layout='hide'
                 ref={ulRef}
                 className={cx({
                     [collapsedStyles]: !expandSubNav,
@@ -212,6 +214,7 @@ export const SubNav = ({ subNavSections, pillar, currentNavLink }: Props) => {
             </ul>
             {showMore && (
                 <button
+                    data-print-layout='hide'
                     onClick={() => setIsExpanded(!isExpanded)}
                     className={showMoreStyle}
                 >

--- a/src/web/components/elements/CalloutBlockComponent.tsx
+++ b/src/web/components/elements/CalloutBlockComponent.tsx
@@ -266,7 +266,10 @@ export const CalloutBlockComponent = ({
 
     if (submissionSuccess) {
         return (
-            <figure className={wrapperStyles}>
+            <figure
+                data-print-layout='hide'
+                className={wrapperStyles}
+            >
                 <details
                     className={cx(calloutDetailsStyles, backgroundColorStyle)}
                     aria-hidden={true}
@@ -292,7 +295,10 @@ export const CalloutBlockComponent = ({
     }
 
     return (
-        <figure className={wrapperStyles}>
+        <figure
+            data-print-layout='hide'
+            className={wrapperStyles}
+        >
             <details
                 className={cx(calloutDetailsStyles, {
                     [backgroundColorStyle]: isExpanded,

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -340,14 +340,12 @@ export const StandardLayout = ({
 
                 <Stuck>
                     <Section
-                        data-print-layout='hide'
                         showTopBorder={false}
                         showSideBorders={false}
                         padded={false}
                         shouldCenter={false}
                     >
                         <HeaderAdSlot
-                            data-print-layout='hide'
                             isAdFreeUser={CAPI.isAdFreeUser}
                             shouldHideAds={CAPI.shouldHideAds}
                         />
@@ -355,7 +353,6 @@ export const StandardLayout = ({
                 </Stuck>
                 <SendToBack>
                     <Section
-                        data-print-layout='hide'
                         showTopBorder={false}
                         showSideBorders={false}
                         padded={false}
@@ -365,7 +362,6 @@ export const StandardLayout = ({
                     </Section>
 
                     <Section
-                        data-print-layout='hide'
                         showSideBorders={true}
                         borderColour={brandLine.primary}
                         showTopBorder={false}
@@ -373,7 +369,6 @@ export const StandardLayout = ({
                         backgroundColour={brandBackground.primary}
                     >
                         <Nav
-                            data-print-layout='hide'
                             pillar={getCurrentPillar(CAPI)}
                             nav={NAV}
                             display={display}
@@ -386,13 +381,11 @@ export const StandardLayout = ({
 
                     {NAV.subNavSections && (
                         <Section
-                            data-print-layout='hide'
                             backgroundColour={background.primary}
                             padded={false}
                             sectionId="sub-nav-root"
                         >
                             <SubNav
-                                data-print-layout='hide'
                                 subNavSections={NAV.subNavSections}
                                 currentNavLink={NAV.currentNavLink}
                                 pillar={pillar}
@@ -401,12 +394,11 @@ export const StandardLayout = ({
                     )}
 
                     <Section
-                        data-print-layout='hide'
                         backgroundColour={background.primary}
                         padded={false}
                         showTopBorder={false}
                     >
-                        <GuardianLines data-print-layout='hide' count={4} pillar={pillar} />
+                        <GuardianLines count={4} pillar={pillar} />
                     </Section>
                 </SendToBack>
             </div>

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -566,7 +566,7 @@ export const StandardLayout = ({
                 showSideBorders={false}
                 backgroundColour={neutral[93]}
             >
-                <AdSlot data-print-layout='hide' asps={namedAdSlotParameters('merchandising-high')} />
+                <AdSlot asps={namedAdSlotParameters('merchandising-high')} />
             </Section>
 
             {!isPaidContent && (

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -336,15 +336,18 @@ export const StandardLayout = ({
     const { branding } = CAPI.commercialProperties[CAPI.editionId];
     return (
         <>
-            <div>
+            <div data-print-layout='hide'>
+
                 <Stuck>
                     <Section
+                        data-print-layout='hide'
                         showTopBorder={false}
                         showSideBorders={false}
                         padded={false}
                         shouldCenter={false}
                     >
                         <HeaderAdSlot
+                            data-print-layout='hide'
                             isAdFreeUser={CAPI.isAdFreeUser}
                             shouldHideAds={CAPI.shouldHideAds}
                         />
@@ -352,6 +355,7 @@ export const StandardLayout = ({
                 </Stuck>
                 <SendToBack>
                     <Section
+                        data-print-layout='hide'
                         showTopBorder={false}
                         showSideBorders={false}
                         padded={false}
@@ -361,6 +365,7 @@ export const StandardLayout = ({
                     </Section>
 
                     <Section
+                        data-print-layout='hide'
                         showSideBorders={true}
                         borderColour={brandLine.primary}
                         showTopBorder={false}
@@ -368,6 +373,7 @@ export const StandardLayout = ({
                         backgroundColour={brandBackground.primary}
                     >
                         <Nav
+                            data-print-layout='hide'
                             pillar={getCurrentPillar(CAPI)}
                             nav={NAV}
                             display={display}
@@ -380,11 +386,13 @@ export const StandardLayout = ({
 
                     {NAV.subNavSections && (
                         <Section
+                            data-print-layout='hide'
                             backgroundColour={background.primary}
                             padded={false}
                             sectionId="sub-nav-root"
                         >
                             <SubNav
+                                data-print-layout='hide'
                                 subNavSections={NAV.subNavSections}
                                 currentNavLink={NAV.currentNavLink}
                                 pillar={pillar}
@@ -393,16 +401,17 @@ export const StandardLayout = ({
                     )}
 
                     <Section
+                        data-print-layout='hide'
                         backgroundColour={background.primary}
                         padded={false}
                         showTopBorder={false}
                     >
-                        <GuardianLines count={4} pillar={pillar} />
+                        <GuardianLines data-print-layout='hide' count={4} pillar={pillar} />
                     </Section>
                 </SendToBack>
             </div>
 
-            <Section showTopBorder={false}>
+            <Section data-print-layout='hide' showTopBorder={false}>
                 <StandardGrid designType={designType} CAPI={CAPI}>
                     <GridItem area="title">
                         <ArticleTitle
@@ -480,7 +489,7 @@ export const StandardLayout = ({
                             />
                         </div>
                     </GridItem>
-                    <GridItem area="lines">
+                    <GridItem data-print-layout='hide' area="lines">
                         <div className={maxWidth}>
                             <div className={stretchLines}>
                                 <GuardianLines
@@ -494,7 +503,7 @@ export const StandardLayout = ({
                             </div>
                         </div>
                     </GridItem>
-                    <GridItem area="meta">
+                    <GridItem data-print-layout='hide' area="meta">
                         <div className={maxWidth}>
                             <ArticleMeta
                                 branding={branding}
@@ -526,7 +535,7 @@ export const StandardLayout = ({
                                 {showMatchStats && <div id="match-stats" />}
 
                                 {showBodyEndSlot && <div id="slot-body-end" />}
-                                <GuardianLines count={4} pillar={pillar} />
+                                <GuardianLines data-print-layout='hide' count={4} pillar={pillar} />
                                 <SubMeta
                                     pillar={pillar}
                                     subMetaKeywordLinks={
@@ -559,24 +568,25 @@ export const StandardLayout = ({
             </Section>
 
             <Section
+                data-print-layout='hide'
                 padded={false}
                 showTopBorder={false}
                 showSideBorders={false}
                 backgroundColour={neutral[93]}
             >
-                <AdSlot asps={namedAdSlotParameters('merchandising-high')} />
+                <AdSlot data-print-layout='hide' asps={namedAdSlotParameters('merchandising-high')} />
             </Section>
 
             {!isPaidContent && (
                 <>
                     {/* Onwards (when signed OUT) */}
-                    <div id="onwards-upper-whensignedout" />
+                    <div data-print-layout='hide' id="onwards-upper-whensignedout" />
                     {showOnwardsLower && (
-                        <Section sectionId="onwards-lower-whensignedout" />
+                        <Section data-print-layout='hide' sectionId="onwards-lower-whensignedout" />
                     )}
 
                     {showComments && (
-                        <Section sectionId="comments">
+                        <Section data-print-layout='hide' sectionId="comments">
                             <CommentsLayout
                                 pillar={pillar}
                                 baseUrl={CAPI.config.discussionApiUrl}
@@ -595,26 +605,27 @@ export const StandardLayout = ({
                     )}
 
                     {/* Onwards (when signed IN) */}
-                    <div id="onwards-upper-whensignedin" />
+                    <div data-print-layout='hide' id="onwards-upper-whensignedin" />
                     {showOnwardsLower && (
-                        <Section sectionId="onwards-lower-whensignedin" />
+                        <Section data-print-layout='hide' sectionId="onwards-lower-whensignedin" />
                     )}
 
-                    <Section sectionId="most-viewed-footer" />
+                    <Section data-print-layout='hide' sectionId="most-viewed-footer" />
                 </>
             )}
 
             <Section
+                data-print-layout='hide'
                 padded={false}
                 showTopBorder={false}
                 showSideBorders={false}
                 backgroundColour={neutral[93]}
             >
-                <AdSlot asps={namedAdSlotParameters('merchandising')} />
+                <AdSlot data-print-layout='hide' asps={namedAdSlotParameters('merchandising')} />
             </Section>
 
             {NAV.subNavSections && (
-                <Section padded={false} sectionId="sub-nav-root">
+                <Section data-print-layout='hide' padded={false} sectionId="sub-nav-root">
                     <SubNav
                         subNavSections={NAV.subNavSections}
                         currentNavLink={NAV.currentNavLink}
@@ -625,6 +636,7 @@ export const StandardLayout = ({
             )}
 
             <Section
+                data-print-layout='hide'
                 padded={false}
                 backgroundColour={brandBackground.primary}
                 borderColour={brandBorder.primary}
@@ -637,8 +649,8 @@ export const StandardLayout = ({
                 />
             </Section>
 
-            <BannerWrapper />
-            <MobileStickyContainer />
+            <BannerWrapper data-print-layout='hide' />
+            <MobileStickyContainer data-print-layout='hide' />
         </>
     );
 };

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -566,7 +566,7 @@ export const StandardLayout = ({
                 showSideBorders={false}
                 backgroundColour={neutral[93]}
             >
-                <AdSlot asps={namedAdSlotParameters('merchandising-high')} />
+                <AdSlot data-print-layout='hide' asps={namedAdSlotParameters('merchandising-high')} />
             </Section>
 
             {!isPaidContent && (

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -481,7 +481,7 @@ export const StandardLayout = ({
                             />
                         </div>
                     </GridItem>
-                    <GridItem data-print-layout='hide' area="lines">
+                    <GridItem area="lines">
                         <div className={maxWidth}>
                             <div className={stretchLines}>
                                 <GuardianLines
@@ -495,7 +495,7 @@ export const StandardLayout = ({
                             </div>
                         </div>
                     </GridItem>
-                    <GridItem data-print-layout='hide' area="meta">
+                    <GridItem area="meta">
                         <div className={maxWidth}>
                             <ArticleMeta
                                 branding={branding}
@@ -613,7 +613,7 @@ export const StandardLayout = ({
                 showSideBorders={false}
                 backgroundColour={neutral[93]}
             >
-                <AdSlot data-print-layout='hide' asps={namedAdSlotParameters('merchandising')} />
+                <AdSlot asps={namedAdSlotParameters('merchandising')} />
             </Section>
 
             {NAV.subNavSections && (

--- a/src/web/layouts/lib/stickiness.tsx
+++ b/src/web/layouts/lib/stickiness.tsx
@@ -34,7 +34,7 @@ const bannerWrapper = css`
     ${getZIndexImportant('banner')}
     max-height: 80vh;
     overflow: auto;
-    
+
     width: 100% !important;
     background: none !important;
     top: auto !important;

--- a/src/web/server/htmlTemplate.ts
+++ b/src/web/server/htmlTemplate.ts
@@ -211,6 +211,7 @@ export const htmlTemplate = ({
                 ${[...priorityScriptTags].join('\n')}
                 <style class="webfont">${getFontsCss()}${resetCSS}${css}</style>
 
+                <link rel="stylesheet" media="print" href="${CDN}static/frontend/css/print.css">
             </head>
 
             <body>


### PR DESCRIPTION
## What does this change?
This makes the print layout a little more acceptable by removing certain page elements. (There is potentially more to do but this is a start). There are still edge cases, like atoms-rendering but this is a start.

### Before
<img width="573" alt="Screenshot 2020-12-14 at 11 30 30" src="https://user-images.githubusercontent.com/35331926/102076650-ee5d9f80-3dff-11eb-9f22-becb6987cde9.png">


### After
<img width="573" alt="Screenshot 2020-12-14 at 11 30 11" src="https://user-images.githubusercontent.com/35331926/102076676-fb7a8e80-3dff-11eb-844a-fb15b5aface3.png">


