### PR TITLE
Remove credentials from form submit

### DIFF
--- a/src/web/components/elements/CalloutBlockComponent.tsx
+++ b/src/web/components/elements/CalloutBlockComponent.tsx
@@ -151,7 +151,6 @@ export const CalloutBlockComponent = ({
             headers: {
                 'Content-Type': 'application/x-www-form-urlencoded',
             },
-            credentials: 'include',
         })
             .then((resp) => {
                 if (resp.status === 201) {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Remove credentials from being passed down on form submit

## Why?
Prevents submission because of CORS