### PR TITLE
Added stretchRight prop

### DIFF
--- a/src/web/components/ContainerLayout.stories.tsx
+++ b/src/web/components/ContainerLayout.stories.tsx
@@ -110,6 +110,24 @@ export const BackgroundStory = () => {
 };
 BackgroundStory.story = { name: 'with a blue background' };
 
+export const StretchRightStory = () => {
+    return (
+        <ContainerLayout
+            title="Stretched Right"
+            description="About this content"
+            showTopBorder={true}
+            sideBorders={true}
+            centralBorder="full"
+            stretchRight={true}
+        >
+            <Grey />
+        </ContainerLayout>
+    );
+};
+StretchRightStory.story = {
+    name: 'with content stretched to the right (no margin)',
+};
+
 export const PartialStory = () => {
     return (
         <ContainerLayout

--- a/src/web/components/ContainerLayout.tsx
+++ b/src/web/components/ContainerLayout.tsx
@@ -26,16 +26,19 @@ type Props = {
     borderColour?: string;
     leftContent?: JSXElements;
     children?: React.ReactNode;
+    stretchRight?: boolean;
 };
 
 const Container = ({
     children,
     padded,
     verticalMargins,
+    stretchRight,
 }: {
     children: React.ReactNode;
     padded: boolean;
     verticalMargins: boolean;
+    stretchRight: boolean;
 }) => {
     const containerStyles = css`
         display: flex;
@@ -51,6 +54,9 @@ const Container = ({
            breakpoint, based on chat with Harry Fisher
         */
         margin-bottom: ${space[9]}px;
+    `;
+
+    const rightMargin = css`
         ${from.wide} {
             margin-right: 68px;
         }
@@ -69,6 +75,7 @@ const Container = ({
                 containerStyles,
                 padded && padding,
                 verticalMargins && margins,
+                !stretchRight && rightMargin,
             )}
         >
             {children}
@@ -92,6 +99,7 @@ export const ContainerLayout = ({
     backgroundColour,
     children,
     leftContent,
+    stretchRight = false,
 }: Props) => (
     <Section
         sectionId={sectionId}
@@ -117,7 +125,11 @@ export const ContainerLayout = ({
                     {leftContent}
                 </>
             </LeftColumn>
-            <Container padded={padContent} verticalMargins={verticalMargins}>
+            <Container
+                padded={padContent}
+                verticalMargins={verticalMargins}
+                stretchRight={stretchRight}
+            >
                 <Hide when="above" breakpoint="leftCol">
                     <ContainerTitle
                         title={title}


### PR DESCRIPTION
## What does this change?
Adds a `stretchRight?: boolean` prop to `ContainerLayout`

![2020-12-15 09 33 05](https://user-images.githubusercontent.com/1336821/102197111-a058a280-3eb8-11eb-867d-5d115755ccb8.gif)


## Why?
Because we sometimes want to fille this space and align vertically with other content above and below. Both Most Popular and Comments will (should?) do this when there is no advert showing
