### PR TITLE
RightColumn padding

### DIFF
--- a/src/web/components/RightColumn.tsx
+++ b/src/web/components/RightColumn.tsx
@@ -26,16 +26,10 @@ const hideBelowDesktop = css`
     }
 `;
 
-const padding = css`
-    padding-top: 6px;
-`;
-
 type Props = {
     children: JSXElements;
 };
 
 export const RightColumn = ({ children }: Props) => {
-    return (
-        <section className={cx(hideBelowDesktop, padding)}>{children}</section>
-    );
+    return <section className={cx(hideBelowDesktop)}>{children}</section>;
 };

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -518,13 +518,23 @@ export const CommentLayout = ({
                         </ArticleContainer>
                     </GridItem>
                     <GridItem area="right-column">
-                        <RightColumn>
-                            <StickyAd
-                                name="right"
-                                height={MOSTVIEWED_STICKY_HEIGHT}
-                            />
-                            {!isPaidContent ? <MostViewedRightIsland /> : <></>}
-                        </RightColumn>
+                        <div
+                            className={css`
+                                padding-top: 6px;
+                            `}
+                        >
+                            <RightColumn>
+                                <StickyAd
+                                    name="right"
+                                    height={MOSTVIEWED_STICKY_HEIGHT}
+                                />
+                                {!isPaidContent ? (
+                                    <MostViewedRightIsland />
+                                ) : (
+                                    <></>
+                                )}
+                            </RightColumn>
+                        </div>
                     </GridItem>
                 </StandardGrid>
             </Section>

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -521,6 +521,7 @@ export const CommentLayout = ({
                         <div
                             className={css`
                                 padding-top: 6px;
+                                height: 100%;
                             `}
                         >
                             <RightColumn>

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -524,23 +524,29 @@ export const ImmersiveLayout = ({
                         </ArticleContainer>
                     </GridItem>
                     <GridItem area="right-column">
-                        <RightColumn>
-                            <>
-                                {mainMedia && (
-                                    <div
-                                        className={css`
-                                            margin-top: ${space[4]}px;
-                                        `}
-                                    >
-                                        <AdSlot
-                                            asps={namedAdSlotParameters(
-                                                'right',
-                                            )}
-                                        />
-                                    </div>
-                                )}
-                            </>
-                        </RightColumn>
+                        <div
+                            className={css`
+                                padding-top: 6px;
+                            `}
+                        >
+                            <RightColumn>
+                                <>
+                                    {mainMedia && (
+                                        <div
+                                            className={css`
+                                                margin-top: ${space[4]}px;
+                                            `}
+                                        >
+                                            <AdSlot
+                                                asps={namedAdSlotParameters(
+                                                    'right',
+                                                )}
+                                            />
+                                        </div>
+                                    )}
+                                </>
+                            </RightColumn>
+                        </div>
                     </GridItem>
                 </ImmersiveGrid>
             </Section>

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -527,6 +527,7 @@ export const ImmersiveLayout = ({
                         <div
                             className={css`
                                 padding-top: 6px;
+                                height: 100%;
                             `}
                         >
                             <RightColumn>

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -472,10 +472,20 @@ export const ShowcaseLayout = ({
                         </ArticleContainer>
                     </GridItem>
                     <GridItem area="right-column">
-                        <RightColumn>
-                            <AdSlot asps={namedAdSlotParameters('right')} />
-                            {!isPaidContent ? <MostViewedRightIsland /> : <></>}
-                        </RightColumn>
+                        <div
+                            className={css`
+                                padding-top: 6px;
+                            `}
+                        >
+                            <RightColumn>
+                                <AdSlot asps={namedAdSlotParameters('right')} />
+                                {!isPaidContent ? (
+                                    <MostViewedRightIsland />
+                                ) : (
+                                    <></>
+                                )}
+                            </RightColumn>
+                        </div>
                     </GridItem>
                 </ShowcaseGrid>
             </Section>

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -475,6 +475,7 @@ export const ShowcaseLayout = ({
                         <div
                             className={css`
                                 padding-top: 6px;
+                                height: 100%;
                             `}
                         >
                             <RightColumn>

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -336,8 +336,7 @@ export const StandardLayout = ({
     const { branding } = CAPI.commercialProperties[CAPI.editionId];
     return (
         <>
-            <div data-print-layout='hide'>
-
+            <div data-print-layout="hide">
                 <Stuck>
                     <Section
                         showTopBorder={false}
@@ -403,7 +402,7 @@ export const StandardLayout = ({
                 </SendToBack>
             </div>
 
-            <Section data-print-layout='hide' showTopBorder={false}>
+            <Section data-print-layout="hide" showTopBorder={false}>
                 <StandardGrid designType={designType} CAPI={CAPI}>
                     <GridItem area="title">
                         <ArticleTitle
@@ -527,7 +526,11 @@ export const StandardLayout = ({
                                 {showMatchStats && <div id="match-stats" />}
 
                                 {showBodyEndSlot && <div id="slot-body-end" />}
-                                <GuardianLines data-print-layout='hide' count={4} pillar={pillar} />
+                                <GuardianLines
+                                    data-print-layout="hide"
+                                    count={4}
+                                    pillar={pillar}
+                                />
                                 <SubMeta
                                     pillar={pillar}
                                     subMetaKeywordLinks={
@@ -548,37 +551,56 @@ export const StandardLayout = ({
                         </ArticleContainer>
                     </GridItem>
                     <GridItem area="right-column">
-                        <RightColumn>
-                            <StickyAd
-                                name="right"
-                                height={MOSTVIEWED_STICKY_HEIGHT}
-                            />
-                            {!isPaidContent ? <MostViewedRightIsland /> : <></>}
-                        </RightColumn>
+                        <div
+                            className={css`
+                                padding-top: 6px;
+                            `}
+                        >
+                            <RightColumn>
+                                <StickyAd
+                                    name="right"
+                                    height={MOSTVIEWED_STICKY_HEIGHT}
+                                />
+                                {!isPaidContent ? (
+                                    <MostViewedRightIsland />
+                                ) : (
+                                    <></>
+                                )}
+                            </RightColumn>
+                        </div>
                     </GridItem>
                 </StandardGrid>
             </Section>
 
             <Section
-                data-print-layout='hide'
+                data-print-layout="hide"
                 padded={false}
                 showTopBorder={false}
                 showSideBorders={false}
                 backgroundColour={neutral[93]}
             >
-                <AdSlot data-print-layout='hide' asps={namedAdSlotParameters('merchandising-high')} />
+                <AdSlot
+                    data-print-layout="hide"
+                    asps={namedAdSlotParameters('merchandising-high')}
+                />
             </Section>
 
             {!isPaidContent && (
                 <>
                     {/* Onwards (when signed OUT) */}
-                    <div data-print-layout='hide' id="onwards-upper-whensignedout" />
+                    <div
+                        data-print-layout="hide"
+                        id="onwards-upper-whensignedout"
+                    />
                     {showOnwardsLower && (
-                        <Section data-print-layout='hide' sectionId="onwards-lower-whensignedout" />
+                        <Section
+                            data-print-layout="hide"
+                            sectionId="onwards-lower-whensignedout"
+                        />
                     )}
 
                     {showComments && (
-                        <Section data-print-layout='hide' sectionId="comments">
+                        <Section data-print-layout="hide" sectionId="comments">
                             <CommentsLayout
                                 pillar={pillar}
                                 baseUrl={CAPI.config.discussionApiUrl}
@@ -597,17 +619,26 @@ export const StandardLayout = ({
                     )}
 
                     {/* Onwards (when signed IN) */}
-                    <div data-print-layout='hide' id="onwards-upper-whensignedin" />
+                    <div
+                        data-print-layout="hide"
+                        id="onwards-upper-whensignedin"
+                    />
                     {showOnwardsLower && (
-                        <Section data-print-layout='hide' sectionId="onwards-lower-whensignedin" />
+                        <Section
+                            data-print-layout="hide"
+                            sectionId="onwards-lower-whensignedin"
+                        />
                     )}
 
-                    <Section data-print-layout='hide' sectionId="most-viewed-footer" />
+                    <Section
+                        data-print-layout="hide"
+                        sectionId="most-viewed-footer"
+                    />
                 </>
             )}
 
             <Section
-                data-print-layout='hide'
+                data-print-layout="hide"
                 padded={false}
                 showTopBorder={false}
                 showSideBorders={false}
@@ -617,7 +648,11 @@ export const StandardLayout = ({
             </Section>
 
             {NAV.subNavSections && (
-                <Section data-print-layout='hide' padded={false} sectionId="sub-nav-root">
+                <Section
+                    data-print-layout="hide"
+                    padded={false}
+                    sectionId="sub-nav-root"
+                >
                     <SubNav
                         subNavSections={NAV.subNavSections}
                         currentNavLink={NAV.currentNavLink}
@@ -628,7 +663,7 @@ export const StandardLayout = ({
             )}
 
             <Section
-                data-print-layout='hide'
+                data-print-layout="hide"
                 padded={false}
                 backgroundColour={brandBackground.primary}
                 borderColour={brandBorder.primary}
@@ -641,8 +676,8 @@ export const StandardLayout = ({
                 />
             </Section>
 
-            <BannerWrapper data-print-layout='hide' />
-            <MobileStickyContainer data-print-layout='hide' />
+            <BannerWrapper data-print-layout="hide" />
+            <MobileStickyContainer data-print-layout="hide" />
         </>
     );
 };

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -554,6 +554,7 @@ export const StandardLayout = ({
                         <div
                             className={css`
                                 padding-top: 6px;
+                                height: 100%;
                             `}
                         >
                             <RightColumn>


### PR DESCRIPTION
## What does this change?
Hoists the 6px padding that lives above the RightColumn out into the layouts so it's set in context

## Why?
So we can use `RightColumn` without it being padding