### PR TITLE
Small AdSlot Refactor

### DIFF
--- a/src/web/components/AdSlot.tsx
+++ b/src/web/components/AdSlot.tsx
@@ -118,7 +118,7 @@ export const makeClassNames = (
     return baseClassNames.concat(adTypeClassNames, optClassNames).join(' ');
 };
 
-export const AdSlotCore: React.FC<{
+const AdSlotCore: React.FC<{
     name: AdSlotType;
     adTypes: string[];
     sizeMapping: AdSlotInputSizeMappings;

--- a/src/web/components/AdSlot.tsx
+++ b/src/web/components/AdSlot.tsx
@@ -5,7 +5,7 @@ import { border, neutral, text } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 
-const adSlotStyles = css`
+const positionRelative = css`
     position: relative;
 `;
 
@@ -157,7 +157,7 @@ const AdSlotCore: React.FC<{
                 name,
                 adTypes,
                 optClassNames || [],
-            )} ${localStyles} ${labelStyles} ${adSlotStyles}`}
+            )} ${positionRelative} ${localStyles} ${labelStyles}`}
             data-link-name={`ad slot ${name}`}
             data-name={name}
             // {...getOptionalProps()}

--- a/src/web/components/AdSlot.tsx
+++ b/src/web/components/AdSlot.tsx
@@ -8,6 +8,7 @@ import { from } from '@guardian/src-foundations/mq';
 const adSlotStyles = css`
     position: relative;
 `;
+
 export const labelStyles = css`
     .ad-slot__label,
     .ad-slot__scroll {
@@ -32,6 +33,7 @@ export const labelStyles = css`
         width: 100%;
     }
 `;
+
 const mobileStickyAdStyles = css`
     position: fixed;
     bottom: 0;


### PR DESCRIPTION
## What?
Makes a few small refactors to `AdSlot`

1. Removed an unused export
2. Spacing
3. Renamed `adSlotStyles` to `postitionRelative` (because this is what it does)
4. Moved `positionRelative` further up so that it can be overridden by `localStyles`

## Why?
I hit an issue where local styles of `position: sticky;` were being lost because they were being overridden.