### PR TITLE
Bump @guardian/braze-components to 0.0.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "@guardian/ab-react": "^2.0.1",
         "@guardian/atoms-rendering": "^2.4.1",
         "@guardian/automat-client": "^0.2.16",
-        "@guardian/braze-components": "^0.0.14",
+        "@guardian/braze-components": "^0.0.15",
         "@guardian/consent-management-platform": "^6.7.4",
         "@guardian/discussion-rendering": "^3.1.2",
         "@guardian/shimport": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2097,10 +2097,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.16.tgz#3ef47e7f49e633aea51c67f061d8d313a26fa9bc"
   integrity sha512-SgNU2bgiyQaXNfqanx4SDmxqAhXW6QBCTk4tRnCgV9Ht6noRl7UsDfx4I0u+M4H3TRnK4I/i2mmlJBtnuwhxEg==
 
-"@guardian/braze-components@^0.0.14":
-  version "0.0.14"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-0.0.14.tgz#da0edde0b1758a713019b1bdc7d643fdb9dcaab8"
-  integrity sha512-kdaEU6tAx5Rcq6jw2lxyNunXMLtrpyiX1dgZuGjDTvZM1RTJOEOI/36+/U9agB9oXpHmZ2y4mst5rvsa42uaqg==
+"@guardian/braze-components@^0.0.15":
+  version "0.0.15"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-0.0.15.tgz#60de1a5886d6ffd191fa3b2fd7de9f25c610a712"
+  integrity sha512-AClH4hKyRr2aD6Z5O9wFZ/6sazSjKREgjXR8aINCVqEc2vEACb0nHfBwBvE8pyNeBj+P9mipTSxVtXxB3Jl5ag==
   dependencies:
     "@guardian/src-button" "2.4.0"
     "@guardian/src-foundations" "2.4.0"


### PR DESCRIPTION
Bumps the version of @guardian/braze-components. This mostly includes some changes to dev tooling to support upcoming features and some refactoring of the components. There shouldn't be any user facing changes. Underlying changes can be seen [here](https://github.com/guardian/braze-components/compare/v0.0.14...v0.0.15).