### PR TITLE
Reduce container padding

### DIFF
--- a/src/web/components/ContainerLayout.tsx
+++ b/src/web/components/ContainerLayout.tsx
@@ -64,11 +64,8 @@ const Container = ({
 
     const padding = css`
         padding: 0 10px;
-
-        ${from.mobileLandscape} {
-            padding: 0 20px;
-        }
     `;
+
     return (
         <div
             className={cx(


### PR DESCRIPTION
## What does this change?
Reduces the side padding used for content inside `ContainerLayout`

## Why?
In every case where we've used this component to date the padding has been turned off because, I suspect, it is too large. Looking at articles, I only ever see 10px of padding to the sides, not 20px.