### PR TITLE
Stop monitoring performance in Portal

### DIFF
--- a/src/web/components/Portal.tsx
+++ b/src/web/components/Portal.tsx
@@ -1,7 +1,5 @@
 import ReactDOM from 'react-dom';
 
-import { initPerf } from '@root/src/web/browser/initPerf';
-
 type Props = {
     root: IslandType;
     children: React.ReactNode;
@@ -15,10 +13,8 @@ type Props = {
 // https://github.com/preactjs/preact/blob/df748d106fb78fbd46d14563b4712f921ccf0300/compat/src/portals.js
 export const Portal = ({ root, children, richLinkIndex }: Props) => {
     const rootId = richLinkIndex ? `${root}-${richLinkIndex}` : root;
-    const { start, end } = initPerf(`${rootId}-portal`);
     const element = document.getElementById(rootId);
     if (!element) return null;
-    start();
     // First remove any placeholder. Why? Because we sometimes server side render Placeholders in
     // the root divs where the Portal is being inserted so the page is rendered with the placeholder
     // showing (to reduce jank). But ReactDOM.createPortal won't replace content so we need to
@@ -28,6 +24,5 @@ export const Portal = ({ root, children, richLinkIndex }: Props) => {
     );
     if (placeholderElement) placeholderElement.remove();
     const result = ReactDOM.createPortal(children, element);
-    end();
     return result;
 };

--- a/src/web/components/Portal.tsx
+++ b/src/web/components/Portal.tsx
@@ -1,16 +1,24 @@
 import ReactDOM from 'react-dom';
 
+import { initPerf } from '@root/src/web/browser/initPerf';
+
 type Props = {
     root: IslandType;
     children: React.ReactNode;
     richLinkIndex?: number;
 };
 
+// See the preact portal code for details on how this feature works
+// In particular, we can see that portals can safely be recreated and
+// that will not cause the child component being passed in to be mounted
+// again. Instead it is simply rerendered
+// https://github.com/preactjs/preact/blob/df748d106fb78fbd46d14563b4712f921ccf0300/compat/src/portals.js
 export const Portal = ({ root, children, richLinkIndex }: Props) => {
     const rootId = richLinkIndex ? `${root}-${richLinkIndex}` : root;
+    const { start, end } = initPerf(`${rootId}-portal`);
     const element = document.getElementById(rootId);
     if (!element) return null;
-    window.performance?.mark(`${rootId}-portal-start`);
+    start();
     // First remove any placeholder. Why? Because we sometimes server side render Placeholders in
     // the root divs where the Portal is being inserted so the page is rendered with the placeholder
     // showing (to reduce jank). But ReactDOM.createPortal won't replace content so we need to
@@ -19,13 +27,7 @@ export const Portal = ({ root, children, richLinkIndex }: Props) => {
         '[data-name="placeholder"]',
     );
     if (placeholderElement) placeholderElement.remove();
-
     const result = ReactDOM.createPortal(children, element);
-    window.performance?.mark(`${rootId}-portal-end`);
-    window.performance?.measure(
-        `${rootId}-portal`,
-        `${rootId}-portal-start`,
-        `${rootId}-portal-end`,
-    );
+    end();
     return result;
 };


### PR DESCRIPTION
## What does this change?
Removes calls out to the `window.performance` api from `Portal.tsx`

## Why?
Because
1) This is in effect, a render, something we're not tracking in `perf`
2) I'm not entirely certain that we're even capture the time the render takes (we could just be logging how long it takes to make the request)
3) Portal can and does rerun, which triggers multiple perf measurements
4) We use Portal a lot and too many perf logs is confusing and undesireable
