### PR TITLE
Refactor RightColumn

### DIFF
--- a/src/web/components/RightColumn.tsx
+++ b/src/web/components/RightColumn.tsx
@@ -15,14 +15,6 @@ const hideBelowDesktop = css`
         flex-basis: 300px;
         flex-grow: 0;
         flex-shrink: 0;
-        margin-left: 20px;
-        margin-right: -20px;
-    }
-
-    ${from.leftCol} {
-        /* above 1140 */
-        margin-left: 0px;
-        margin-right: 0px;
     }
 `;
 

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -522,6 +522,16 @@ export const CommentLayout = ({
                             className={css`
                                 padding-top: 6px;
                                 height: 100%;
+                                ${from.desktop} {
+                                    /* above 980 */
+                                    margin-left: 20px;
+                                    margin-right: -20px;
+                                }
+                                ${from.leftCol} {
+                                    /* above 1140 */
+                                    margin-left: 0px;
+                                    margin-right: 0px;
+                                }
                             `}
                         >
                             <RightColumn>

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -528,6 +528,16 @@ export const ImmersiveLayout = ({
                             className={css`
                                 padding-top: 6px;
                                 height: 100%;
+                                ${from.desktop} {
+                                    /* above 980 */
+                                    margin-left: 20px;
+                                    margin-right: -20px;
+                                }
+                                ${from.leftCol} {
+                                    /* above 1140 */
+                                    margin-left: 0px;
+                                    margin-right: 0px;
+                                }
                             `}
                         >
                             <RightColumn>

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -476,6 +476,16 @@ export const ShowcaseLayout = ({
                             className={css`
                                 padding-top: 6px;
                                 height: 100%;
+                                ${from.desktop} {
+                                    /* above 980 */
+                                    margin-left: 20px;
+                                    margin-right: -20px;
+                                }
+                                ${from.leftCol} {
+                                    /* above 1140 */
+                                    margin-left: 0px;
+                                    margin-right: 0px;
+                                }
                             `}
                         >
                             <RightColumn>

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -555,6 +555,16 @@ export const StandardLayout = ({
                             className={css`
                                 padding-top: 6px;
                                 height: 100%;
+                                ${from.desktop} {
+                                    /* above 980 */
+                                    margin-left: 20px;
+                                    margin-right: -20px;
+                                }
+                                ${from.leftCol} {
+                                    /* above 1140 */
+                                    margin-left: 0px;
+                                    margin-right: 0px;
+                                }
                             `}
                         >
                             <RightColumn>


### PR DESCRIPTION
## What does this change?
Moves some margin css, that is specific to the context of the `RightColumn` being used in a grid, out of the component and into a context wrapper

## Why?
So we don't get these margins when using `RightColumn` in other contexts