### PR TITLE
Fix hidden focus issue for accessiblity on callout

### DIFF
--- a/src/web/components/elements/CalloutBlockComponent.tsx
+++ b/src/web/components/elements/CalloutBlockComponent.tsx
@@ -282,7 +282,6 @@ export const CalloutBlockComponent = ({
                     className={cx(calloutDetailsStyles, backgroundColorStyle)}
                     aria-hidden={true}
                     open={isExpanded}
-                    // tabIndex={-1}
                 >
                     <summary className={summeryStyles}>
                         <div className={summeryContentWrapper}>

--- a/src/web/components/elements/CalloutBlockComponent.tsx
+++ b/src/web/components/elements/CalloutBlockComponent.tsx
@@ -45,6 +45,15 @@ const summeryStyles = css`
     /* 176da211-05aa-4280-859b-1e3157b3f19e */
     pointer-events: none;
 
+    /*
+        why hide visibility?
+        because we want to prevent the user for tabbing to the summery HTML element
+        without using tabIndex={-1} which would disable focus on all child DOM elements
+
+        NOTE: requires "visibility: visible;" on child elements to display and enable focus
+    */
+    visibility: hidden;
+
     a {
         /* but we do want to allow click on links */
         pointer-events: all;
@@ -52,6 +61,7 @@ const summeryStyles = css`
 `;
 
 const summeryContentWrapper = css`
+    visibility: visible;
     min-height: 70px;
     display: flex;
     flex-direction: row;
@@ -93,6 +103,8 @@ const buttonWrapperStyles = css`
     position: absolute;
     cursor: pointer;
     margin-top: -5px;
+
+    visibility: visible;
 
     /* We need to ensure our pointer-events are turned back on on the button */
     /* 176da211-05aa-4280-859b-1e3157b3f19e */
@@ -270,6 +282,7 @@ export const CalloutBlockComponent = ({
                     className={cx(calloutDetailsStyles, backgroundColorStyle)}
                     aria-hidden={true}
                     open={isExpanded}
+                    // tabIndex={-1}
                 >
                     <summary className={summeryStyles}>
                         <div className={summeryContentWrapper}>
@@ -335,6 +348,7 @@ export const CalloutBlockComponent = ({
                                 icon={<PlusIcon />}
                                 onClick={() => setIsExpanded(true)}
                                 custom-guardian="callout-form-open-button"
+                                tabIndex={0}
                             >
                                 Tell us
                             </Button>
@@ -356,8 +370,6 @@ export const CalloutBlockComponent = ({
                             icon={<MinusIcon />}
                             onClick={() => setIsExpanded(false)}
                             custom-guardian="callout-form-close-button"
-                            // TODO: use ref once forwardRef is implemented @guardian/src-button
-                            // ref={lastElement}
                         >
                             Hide
                         </Button>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
When tabbing thought the article, we would focus on `summery` HTML element, however we do not display any visual clues. 

Normally we would use the `tabIndex={-1}` to prevent the element from being tabbable, however that would propagate to all child element (which we do not want). 

A work around was to use `visibility: hidden;` on the `summery` element and then `visibility: visible;` on all child elements.

## Why?
`summery` HTML elements have thier own state outside of the React DOM. We want the user only to be able to open and close `summery` using the buttons, in order to display the correct styling. Therefore preventing the user from tabbing `summery` would avoid us being out of sync with state

## example article
https://www.theguardian.com/politics/2020/may/05/boris-johnson-boasted-of-shaking-hands-on-day-sage-warned-not-to