### PR TITLE
Hide summary children when details not open on callout

### DIFF
--- a/src/web/components/elements/CalloutBlockComponent.tsx
+++ b/src/web/components/elements/CalloutBlockComponent.tsx
@@ -20,6 +20,11 @@ const calloutDetailsStyles = css`
     border-bottom: 1px ${neutral[86]} solid;
     position: relative;
     padding-bottom: 10px;
+
+    /* IE does not support summary HTML elements, so we need to hide children ourself */
+    :not([open]) > *:not(summary) {
+        display: none;
+    }
 `;
 
 const backgroundColorStyle = css`


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Hides call child elements for `details` HTML elements if `details` is not open

### Before
![Screenshot 2020-12-15 at 17 56 16](https://user-images.githubusercontent.com/8831403/102253112-d9b40100-3efe-11eb-8b33-d2d60d8f11a9.png)


### After
![Screenshot 2020-12-15 at 17 55 37](https://user-images.githubusercontent.com/8831403/102253043-c5700400-3efe-11eb-9f3b-592ebc58b3ed.png)


## Why?
IE doesn't support `details`/`summary` https://caniuse.com/?search=summary 
Therefore we need some CSS logic to make sure the child DOM Nodes are hidden correctly