### PR TITLE
Nest AudioAtom a level down from App to avoid App rerenders

### DIFF
--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -431,7 +431,9 @@ export const App = ({ CAPI, NAV }: Props) => {
                         kicker={audioAtom.kicker}
                         title={audioAtom.title}
                         pillar={pillar}
-                        CAPI={CAPI}
+                        contentIsNotSensitive={!CAPI.config.isSensitive}
+                        aCastisEnabled={CAPI.config.switches.acast}
+                        readerCanBeShownAds={!CAPI.isAdFreeUser}
                     />
                 </Hydrate>
             ))}

--- a/src/web/components/AudioAtomWrapper.tsx
+++ b/src/web/components/AudioAtomWrapper.tsx
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from 'react';
+import { AudioAtom } from '@guardian/atoms-rendering';
+import { toTypesPillar } from '@root/src/lib/format';
+import {
+    onConsentChange,
+    getConsentFor,
+} from '@guardian/consent-management-platform';
+
+type Props = {
+    id: string;
+    trackUrl: string;
+    kicker: string;
+    title?: string | undefined;
+    pillar: Pillar;
+    CAPI: CAPIBrowserType;
+};
+
+export const AudioAtomWrapper = ({
+    id,
+    trackUrl,
+    kicker,
+    title,
+    pillar,
+    CAPI,
+}: Props) => {
+    // *****************
+    // *     ACast     *
+    // *****************
+    const [shouldUseAcast, setShouldUseAcast] = useState<boolean>(false);
+    useEffect(() => {
+        onConsentChange((state: any) => {
+            // Should we use ad enabled audio? If so, then set the shouldUseAcast
+            // state to true, triggering a rerender of AudioAtom using a new track url
+            // (one with adverts)
+            const consentGiven = getConsentFor('acast', state);
+            const aCastisEnabled = CAPI.config.switches.acast;
+            const readerCanBeShownAds = !CAPI.isAdFreeUser;
+            const contentIsNotSensitive = !CAPI.config.isSensitive;
+            if (
+                aCastisEnabled &&
+                consentGiven &&
+                readerCanBeShownAds && // Eg. Not a subscriber
+                contentIsNotSensitive
+            ) {
+                setShouldUseAcast(true);
+            }
+        });
+    }, [
+        CAPI.config.isSensitive,
+        CAPI.config.switches.acast,
+        CAPI.isAdFreeUser,
+    ]);
+
+    return (
+        <AudioAtom
+            id={id}
+            trackUrl={trackUrl}
+            kicker={kicker}
+            title={title}
+            pillar={toTypesPillar(pillar)}
+            shouldUseAcast={shouldUseAcast}
+        />
+    );
+};

--- a/src/web/components/AudioAtomWrapper.tsx
+++ b/src/web/components/AudioAtomWrapper.tsx
@@ -12,7 +12,9 @@ type Props = {
     kicker: string;
     title?: string | undefined;
     pillar: Pillar;
-    CAPI: CAPIBrowserType;
+    contentIsNotSensitive: boolean;
+    aCastisEnabled: boolean;
+    readerCanBeShownAds: boolean;
 };
 
 export const AudioAtomWrapper = ({
@@ -21,7 +23,9 @@ export const AudioAtomWrapper = ({
     kicker,
     title,
     pillar,
-    CAPI,
+    contentIsNotSensitive,
+    aCastisEnabled,
+    readerCanBeShownAds,
 }: Props) => {
     // *****************
     // *     ACast     *
@@ -33,9 +37,6 @@ export const AudioAtomWrapper = ({
             // state to true, triggering a rerender of AudioAtom using a new track url
             // (one with adverts)
             const consentGiven = getConsentFor('acast', state);
-            const aCastisEnabled = CAPI.config.switches.acast;
-            const readerCanBeShownAds = !CAPI.isAdFreeUser;
-            const contentIsNotSensitive = !CAPI.config.isSensitive;
             if (
                 aCastisEnabled &&
                 consentGiven &&
@@ -45,11 +46,7 @@ export const AudioAtomWrapper = ({
                 setShouldUseAcast(true);
             }
         });
-    }, [
-        CAPI.config.isSensitive,
-        CAPI.config.switches.acast,
-        CAPI.isAdFreeUser,
-    ]);
+    }, [contentIsNotSensitive, aCastisEnabled, readerCanBeShownAds]);
 
     return (
         <AudioAtom


### PR DESCRIPTION
## What does this change?

Updating state in App.tsx is an anti-pattern within DCR, as it causes a re-hyrdation of the hydrate components within App. 

Therefore we need to push our state for `shouldUseAcast` a level lower in order to only re-render the audio atom.
