### PR TITLE
Use diffThreshold to reduce false negatives

### DIFF
--- a/src/web/components/elements/MultiImageBlockComponent.stories.tsx
+++ b/src/web/components/elements/MultiImageBlockComponent.stories.tsx
@@ -11,6 +11,7 @@ const threeImages = fourImages.slice(0, 3);
 export default {
     component: MultiImageBlockComponent,
     title: 'Components/MultiImageBlockComponent',
+    chromatic: { diffThreshold: 0.4 },
 };
 
 export const SingleImage = () => {
@@ -38,7 +39,6 @@ export const SingleImageWithCaption = () => {
 };
 SingleImageWithCaption.story = {
     name: 'single image with caption',
-    chromatic: { disable: true },
 };
 
 export const SideBySide = () => {
@@ -52,7 +52,6 @@ export const SideBySide = () => {
 };
 SideBySide.story = {
     name: 'side by side',
-    chromatic: { disable: true },
 };
 
 export const SideBySideWithCaption = () => {


### PR DESCRIPTION
## What does this change?
I'd disabled Chromatic on some stories to try to prevent some false negatives but we're still seeing them on similar stories in the same file so this PR enables them again and reduces the `diffThreshold` for the whole file