### PR TITLE
Align terms text in callout

### DIFF
--- a/src/web/components/Callout/Form.tsx
+++ b/src/web/components/Callout/Form.tsx
@@ -171,9 +171,11 @@ export const Form = ({ onSubmit, formFields, error }: FormProps) => {
                 </Button>
                 <div
                     className={css`
-                        a, a:hover  {
+                        a,
+                        a:hover {
                             border: 0;
                         }
+                        text-align: right;
                     `}
                 >
                     <Link


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Align text for terms and conditions on callout

### Before
<img width="357" alt="Screenshot 2020-12-16 at 11 57 18" src="https://user-images.githubusercontent.com/8831403/102345817-dddf2d80-3f95-11eb-9709-3c55dbae1413.png">

### After
<img width="355" alt="Screenshot 2020-12-16 at 11 25 45" src="https://user-images.githubusercontent.com/8831403/102345723-b720f700-3f95-11eb-9362-7a0199e8bf5d.png">

## Why?
Looks nicer