### PR TITLE
A star flag can mean a stand alone divider

### DIFF
--- a/src/model/add-dividers.test.ts
+++ b/src/model/add-dividers.test.ts
@@ -1,15 +1,15 @@
-import { addDropCaps } from './add-dropcaps';
+import { addDividers } from './add-dividers';
 import { bodyJSON } from './exampleBodyJSON';
 
 const example = JSON.parse(bodyJSON);
 
 describe('Drop Caps', () => {
     it('creates an identical but new object when no changes are needed', () => {
-        expect(addDropCaps(example)).not.toBe(example); // We created a new object
-        expect(addDropCaps(example)).toEqual(example); // The new object is what we expect
+        expect(addDividers(example)).not.toBe(example); // We created a new object
+        expect(addDividers(example)).toEqual(example); // The new object is what we expect
     });
 
-    it('sets the drop cap flag correctly', () => {
+    it('sets the divider flag correctly', () => {
         const input = {
             ...example,
             blocks: [
@@ -60,10 +60,10 @@ describe('Drop Caps', () => {
             ],
         };
 
-        expect(addDropCaps(input)).toEqual(expectedOutput);
+        expect(addDividers(input)).toEqual(expectedOutput);
     });
 
-    it('handles multiple drop cap flags', () => {
+    it('handles multiple divider flags', () => {
         const input = {
             ...example,
             blocks: [
@@ -134,10 +134,10 @@ describe('Drop Caps', () => {
             ],
         };
 
-        expect(addDropCaps(input)).toEqual(expectedOutput);
+        expect(addDividers(input)).toEqual(expectedOutput);
     });
 
-    it('handles drop cap flags being put before elements that are not text', () => {
+    it('handles divider flags being put before elements that are not text', () => {
         const input = {
             ...example,
             blocks: [
@@ -172,6 +172,10 @@ describe('Drop Caps', () => {
                     elements: [
                         {
                             _type:
+                                'model.dotcomrendering.pageElements.DividerBlockElement',
+                        },
+                        {
+                            _type:
                                 'model.dotcomrendering.pageElements.InstagramBlockElement',
                             html: '',
                             url: '',
@@ -187,10 +191,10 @@ describe('Drop Caps', () => {
             ],
         };
 
-        expect(addDropCaps(input)).toEqual(expectedOutput);
+        expect(addDividers(input)).toEqual(expectedOutput);
     });
 
-    it('handles multiple drop cap flags in sequence', () => {
+    it('handles multiple divider flags in sequence', () => {
         const input = {
             ...example,
             blocks: [
@@ -247,6 +251,14 @@ describe('Drop Caps', () => {
                         },
                         {
                             _type:
+                                'model.dotcomrendering.pageElements.DividerBlockElement',
+                        },
+                        {
+                            _type:
+                                'model.dotcomrendering.pageElements.DividerBlockElement',
+                        },
+                        {
+                            _type:
                                 'model.dotcomrendering.pageElements.TextBlockElement',
                             dropCap: true,
                             html: '<p>I should become a drop cap.</p>',
@@ -261,6 +273,6 @@ describe('Drop Caps', () => {
             ],
         };
 
-        expect(addDropCaps(input)).toEqual(expectedOutput);
+        expect(addDividers(input)).toEqual(expectedOutput);
     });
 });

--- a/src/model/add-dividers.test.ts
+++ b/src/model/add-dividers.test.ts
@@ -3,7 +3,7 @@ import { bodyJSON } from './exampleBodyJSON';
 
 const example = JSON.parse(bodyJSON);
 
-describe('Drop Caps', () => {
+describe('Dividers and Drop Caps', () => {
     it('creates an identical but new object when no changes are needed', () => {
         expect(addDividers(example)).not.toBe(example); // We created a new object
         expect(addDividers(example)).toEqual(example); // The new object is what we expect

--- a/src/model/add-dividers.ts
+++ b/src/model/add-dividers.ts
@@ -1,7 +1,7 @@
 import { JSDOM } from 'jsdom';
 
-const isDropCapFlag = (element: CAPIElement): boolean => {
-    // A drop cap flag: <h2><strong>* * *</strong></h2>
+const isDividerFlag = (element: CAPIElement): boolean => {
+    // A star flag: <h2><strong>* * *</strong></h2>
     if (
         element._type !==
         'model.dotcomrendering.pageElements.SubheadingBlockElement'
@@ -23,37 +23,35 @@ const prevElementWasDropCapFlag = (
     elements: CAPIElement[],
     i: number,
 ): boolean => {
-    return isSubheading(elements[i - 1]) && isDropCapFlag(elements[i - 1]);
+    return isSubheading(elements[i - 1]) && isDividerFlag(elements[i - 1]);
 };
 
-const checkForDropCaps = (elements: CAPIElement[]): CAPIElement[] => {
-    // checkForDropCaps loops the array of article elements looking for drop cap flags and
-    // enhancing the data accordingly. In short, if a h2 tag is equal to * * * then the
-    // text element immediately aftwards should have dropCap set to true
+const checkForDividers = (elements: CAPIElement[]): CAPIElement[] => {
+    // checkForDividers loops the array of article elements looking for star flags and
+    // enhancing the data accordingly. In short, if a h2 tag is equal to * * * then we
+    // insert a divider and any the text element immediately aftwards should have dropCap
+    // set to true
     const enhanced: CAPIElement[] = [];
     elements.forEach((element, i) => {
         switch (element._type) {
             case 'model.dotcomrendering.pageElements.SubheadingBlockElement':
-                if (!isDropCapFlag(element)) {
+                if (isDividerFlag(element)) {
+                    enhanced.push({
+                        _type:
+                            'model.dotcomrendering.pageElements.DividerBlockElement',
+                    });
+                } else {
                     enhanced.push(element);
                 }
-                // Otherwise, if it was a drop cap we delete it by not passing it
-                // through
                 break;
             case 'model.dotcomrendering.pageElements.TextBlockElement':
                 // Always pass first element through
                 if (i === 0) enhanced.push(element);
                 else if (prevElementWasDropCapFlag(elements, i))
-                    enhanced.push(
-                        {
-                            _type:
-                                'model.dotcomrendering.pageElements.DividerBlockElement',
-                        },
-                        {
-                            ...element,
-                            dropCap: true,
-                        },
-                    );
+                    enhanced.push({
+                        ...element,
+                        dropCap: true,
+                    });
                 else enhanced.push(element);
                 break;
             default:
@@ -63,11 +61,11 @@ const checkForDropCaps = (elements: CAPIElement[]): CAPIElement[] => {
     return enhanced;
 };
 
-export const addDropCaps = (data: CAPIType): CAPIType => {
+export const addDividers = (data: CAPIType): CAPIType => {
     const enhancedBlocks = data.blocks.map((block: Block) => {
         return {
             ...block,
-            elements: checkForDropCaps(block.elements),
+            elements: checkForDividers(block.elements),
         };
     });
 

--- a/src/web/server/render.ts
+++ b/src/web/server/render.ts
@@ -3,7 +3,7 @@ import { extract as extractNAV } from '@root/src/model/extract-nav';
 
 import { document } from '@root/src/web/server/document';
 import { validateAsCAPIType } from '@root/src/model/validate';
-import { addDropCaps } from '@root/src/model/add-dropcaps';
+import { addDividers } from 'src/model/add-dividers';
 import { setIsDev } from '@root/src/model/set-is-dev';
 import { enhancePhotoEssay } from '@root/src/model/enhance-photoessay';
 import { enhanceBlockquotes } from '@root/src/model/enhance-blockquotes';
@@ -17,8 +17,8 @@ class CAPIEnhancer {
         this.capi = capi;
     }
 
-    addDropCaps() {
-        this.capi = addDropCaps(this.capi);
+    addDividers() {
+        this.capi = addDividers(this.capi);
         return this;
     }
 
@@ -47,7 +47,7 @@ export const render = ({ body }: express.Request, res: express.Response) => {
     try {
         const CAPI = new CAPIEnhancer(body)
             .validateAsCAPIType()
-            .addDropCaps()
+            .addDividers()
             .enhanceBlockquotes()
             .enhancePhotoEssay().capi;
 

--- a/src/web/server/render.ts
+++ b/src/web/server/render.ts
@@ -3,7 +3,7 @@ import { extract as extractNAV } from '@root/src/model/extract-nav';
 
 import { document } from '@root/src/web/server/document';
 import { validateAsCAPIType } from '@root/src/model/validate';
-import { addDividers } from 'src/model/add-dividers';
+import { addDividers } from '@root/src/model/add-dividers';
 import { setIsDev } from '@root/src/model/set-is-dev';
 import { enhancePhotoEssay } from '@root/src/model/enhance-photoessay';
 import { enhanceBlockquotes } from '@root/src/model/enhance-blockquotes';


### PR DESCRIPTION
## What does this change?
Adds support for stand alone dividers in the page based on `* * *`

### Before
We only inserted a divider if the subsequent element was a text element (which we make a drop cap)

### After
We now allow a `* * *` flag to exist by itself and insert a divider, regardless of whether the subsequent element is text or not
