### PR TITLE
[CMP] add platform to pubData

### DIFF
--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -261,6 +261,7 @@ export const App = ({ CAPI, NAV }: Props) => {
         // handled in here.
         if (CAPI.config.switches.consentManagement && countryCode) {
             const pubData = {
+                platform: 'next-gen',
                 browserId: getCookie('bwid') || undefined,
                 pageViewId,
             };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Add `platform` to `pubData`, so we can pinpoint which consent signals are missing a `pageView`.

## Why?

More self-sufficient data.