### PR TITLE
Don't stick right ad for Immersives or Showcase Display types

### DIFF
--- a/src/web/components/AdSlot.tsx
+++ b/src/web/components/AdSlot.tsx
@@ -143,10 +143,6 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
                                 'ad-slot--mpu-banner-ad',
                                 'ad-slot--rendered',
                                 'js-sticky-mpu',
-                                css`
-                                    position: sticky;
-                                    top: 0;
-                                `,
                                 labelStyles,
                             )}
                             data-link-name="ad slot right"


### PR DESCRIPTION
## What does this change?
Fixes a bug introduced in #2258 which caused the `position: sticky` css to be applied to the `right` slot on Showcase and Immersive articles. 

### Before
![2020-12-17 23 51 15](https://user-images.githubusercontent.com/1336821/102557372-e5502500-40c2-11eb-9692-0e4a75b92ee9.gif)



### After

![2020-12-17 23 52 49](https://user-images.githubusercontent.com/1336821/102557409-0284f380-40c3-11eb-8378-cd09fe394741.gif)

