### PR TITLE
Bumped @guardian/braze-components to version 0.0.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "@guardian/ab-react": "^2.0.1",
         "@guardian/atoms-rendering": "^2.4.1",
         "@guardian/automat-client": "^0.2.16",
-        "@guardian/braze-components": "^0.0.15",
+        "@guardian/braze-components": "^0.0.16",
         "@guardian/consent-management-platform": "^6.7.4",
         "@guardian/discussion-rendering": "^3.1.2",
         "@guardian/shimport": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2097,15 +2097,15 @@
   resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.16.tgz#3ef47e7f49e633aea51c67f061d8d313a26fa9bc"
   integrity sha512-SgNU2bgiyQaXNfqanx4SDmxqAhXW6QBCTk4tRnCgV9Ht6noRl7UsDfx4I0u+M4H3TRnK4I/i2mmlJBtnuwhxEg==
 
-"@guardian/braze-components@^0.0.15":
-  version "0.0.15"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-0.0.15.tgz#60de1a5886d6ffd191fa3b2fd7de9f25c610a712"
-  integrity sha512-AClH4hKyRr2aD6Z5O9wFZ/6sazSjKREgjXR8aINCVqEc2vEACb0nHfBwBvE8pyNeBj+P9mipTSxVtXxB3Jl5ag==
+"@guardian/braze-components@^0.0.16":
+  version "0.0.16"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-0.0.16.tgz#e827afb4ee06b599ee1b14069763cd26d6c3b560"
+  integrity sha512-GA6OWg48iUS83O/316uynHm4xvYzEp8efwRjfqLTfr0gTtcgsiUb/eebh94RgFiDQM5cylpmEeDzsWXGkE7N+w==
   dependencies:
-    "@guardian/src-button" "2.4.0"
-    "@guardian/src-foundations" "2.4.0"
-    "@guardian/src-grid" "2.4.0"
-    "@guardian/src-icons" "2.4.0"
+    "@guardian/src-button" "2.7.1"
+    "@guardian/src-foundations" "2.7.1"
+    "@guardian/src-grid" "2.7.1"
+    "@guardian/src-icons" "2.7.1"
     emotion-theming "^10.0.19"
 
 "@guardian/consent-management-platform@^6.7.4":
@@ -2131,14 +2131,7 @@
   dependencies:
     tslib "^2.0.0"
 
-"@guardian/src-button@2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@guardian/src-button/-/src-button-2.4.0.tgz#44c7300fea0c78e09ea67deae67fed56aea3b820"
-  integrity sha512-HqtrfsYlp+Cld9fH3IPO29KSfjCDTYF8Xs06LLqyEJq28Ti8nXZ457GmF9mYYV6AOPDhWDZUFjPbvSpGAKNIqw==
-  dependencies:
-    "@guardian/src-helpers" "^2.4.0"
-
-"@guardian/src-button@^2.7.1":
+"@guardian/src-button@2.7.1", "@guardian/src-button@^2.7.1":
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/@guardian/src-button/-/src-button-2.7.1.tgz#088eb57732c10516eb111692c68813713176f08f"
   integrity sha512-LMj7NBEugdx69SwlYR3n91vjG8QXL42W0JXMVAHYja1/8eM7TwFlO8H11oPxBfqWdpniqj5q7KYtfHTJmSnVrw==
@@ -2161,29 +2154,17 @@
   dependencies:
     "@guardian/src-helpers" "^2.7.1"
 
-"@guardian/src-foundations@2.4.0", "@guardian/src-foundations@^2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-2.4.0.tgz#e87d935881b5554e35c00a5b054ced948ac1b5c7"
-  integrity sha512-yShUGqULr7joOxWW+sUq9uziXC9WfIv/S05Tmi8QxevYpkgrSyLK0jSUY3S2ZRg+SfXSyX1g30qvOI+NuhSKfA==
-
-"@guardian/src-foundations@^2.7.1":
+"@guardian/src-foundations@2.7.1", "@guardian/src-foundations@^2.7.1":
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-2.7.1.tgz#d245a5ebedd520bf3be1b10ff7c5a0b5962a0a03"
   integrity sha512-U0XVJWugB6vXoORZPcfvnISAhwaIM5/Pz5uGj628+OcqF3vwm0dBUt1UTesVqOsG7tVUQvGG/n96wXWjGwmVmQ==
 
-"@guardian/src-grid@2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@guardian/src-grid/-/src-grid-2.4.0.tgz#a7fb0a6660c7960cf70f75436736c2feb744db1a"
-  integrity sha512-m9s29VtQk/MSKi1WldcnctuxS/xVkPjWcIOiumYRHk14Hn50XkymIzp99qvwZ7ytLlzLPWRX89oI3tCU6MzM4w==
+"@guardian/src-grid@2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@guardian/src-grid/-/src-grid-2.7.1.tgz#e6c524259bcb9edb3d219f29fd04ad96e4d0f655"
+  integrity sha512-lG/0OYi5IF/KUtp4DfuX4GsoeVHFSDGETaabZypkN14uNp4zf4xgpFNLIFkYOcPKtrLzvFLlrf+xgnF0k/cPaA==
   dependencies:
-    "@guardian/src-helpers" "^2.4.0"
-
-"@guardian/src-helpers@^2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@guardian/src-helpers/-/src-helpers-2.4.0.tgz#b21bd49554fef5826bdf3663dc08927e8a0ad9f6"
-  integrity sha512-/x96RAKoH6DTox024mipSdZA7zJJmLRKPn8KMwKx1t+W+Cy9W3tsh/Jdw8YYVkeRdURjCtvTBG374Mr6fyqVyA==
-  dependencies:
-    "@guardian/src-foundations" "^2.4.0"
+    "@guardian/src-helpers" "^2.7.1"
 
 "@guardian/src-helpers@^2.7.1":
   version "2.7.1"
@@ -2192,12 +2173,7 @@
   dependencies:
     "@guardian/src-foundations" "^2.7.1"
 
-"@guardian/src-icons@2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@guardian/src-icons/-/src-icons-2.4.0.tgz#6560e1e0f486da8aac58b7f9da802bcf93178b89"
-  integrity sha512-un/QwSgtBpcAti3sVOo9vtTWlnWlQ8yGsw75oF2zpzyu542ZMb0AEOZnrmZ7zc/df2M6cFoUIFkQYs/alX+HVA==
-
-"@guardian/src-icons@^2.7.1":
+"@guardian/src-icons@2.7.1", "@guardian/src-icons@^2.7.1":
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/@guardian/src-icons/-/src-icons-2.7.1.tgz#600ba5a16fd3857657360632caac1b2f38740829"
   integrity sha512-gQ7XrH3R++kZOXSK4e5ajRrUxNMgzQH7LiQ4HSYH51mJceh3YWtsc4934O5sCpJjJjhFiWGYubbg4BG14smUPg==


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

This PR bumps braze-components to 0.0.16 in order to support Marketing’s new SpecialEditionBanner.

The accompanying Frontend PR is available [here](https://github.com/guardian/frontend/pull/23409).

