### PR TITLE
Add monkey patch for performance method that aren't avaliable

### DIFF
--- a/src/web/browser/initPerf.ts
+++ b/src/web/browser/initPerf.ts
@@ -7,13 +7,14 @@ export const initPerf = (
     const startKey = `${name}-start`;
     const endKey = `${name}-end`;
 
-    if (!perf)
+    if (!perf) {
         // Return noops if window.performance does not exist
         return {
             start: () => {},
             end: () => 0,
             clear: () => {},
         };
+    }
 
     const start = () => {
         perf.mark(startKey);
@@ -27,7 +28,8 @@ export const initPerf = (
         console.log(JSON.stringify(perf.getEntriesByName(name)));
 
         const measureEntries = perf.getEntriesByName(name, 'measure');
-        const timeTakenFloat = measureEntries[0].duration;
+        const timeTakenFloat =
+            (measureEntries && measureEntries[0]?.duration) || 0;
         const timeTakenInt = Math.round(timeTakenFloat);
 
         return timeTakenInt;

--- a/src/web/browser/initPerf.ts
+++ b/src/web/browser/initPerf.ts
@@ -29,7 +29,10 @@ export const initPerf = (
 
         const measureEntries = perf.getEntriesByName(name, 'measure');
         const timeTakenFloat =
-            (measureEntries && measureEntries[0]?.duration) || 0;
+            (measureEntries &&
+                measureEntries[0] &&
+                measureEntries[0].duration) ||
+            0;
         const timeTakenInt = Math.round(timeTakenFloat);
 
         return timeTakenInt;

--- a/src/web/server/htmlTemplate.ts
+++ b/src/web/server/htmlTemplate.ts
@@ -156,7 +156,7 @@ export const htmlTemplate = ({
 
                 <script>
                     // Noop monkey patch perf.mark and perf.measure if not supported
-                    if(window.performance.mark === undefined) {
+                    if(window.performance !== undefined && window.performance.mark === undefined) {
                         window.performance.mark = function(){};
                         window.performance.measure = function(){};
                     }

--- a/src/web/server/htmlTemplate.ts
+++ b/src/web/server/htmlTemplate.ts
@@ -155,6 +155,14 @@ export const htmlTemplate = ({
                 </script>
 
                 <script>
+                    // Noop monkey patch perf.mark and perf.measure if not supported
+                    if(window.performance.mark === undefined) {
+                        window.performance.mark = function(){};
+                        window.performance.measure = function(){};
+                    }
+                </script>
+
+                <script>
                     // this is a global that's called at the bottom of the pf.io response,
                     // once the polyfills have run. This may be useful for debugging.
                     // mainly to support browsers that don't support async=false or defer


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Monkey patches the `performance.mark` and `performance.measure` methods in browsers where it is unsupported.

```
  // Noop monkey patch perf.mark and perf.measure if not supported
if(window.performance.mark === undefined) {
    window.performance.mark = function(){};
    window.performance.measure = function(){};
}
```

### Before

Application fails miserably

![image](https://user-images.githubusercontent.com/638051/102625498-7ebc1d00-413d-11eb-9f06-ba1d1092be2f.png)


### After

Application runs

![image](https://user-images.githubusercontent.com/638051/102625424-63511200-413d-11eb-8b80-91098c51db99.png)



