### PR TITLE
useOnce

### DIFF
--- a/src/web/lib/useOnce.ts
+++ b/src/web/lib/useOnce.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Ensures that the given task is only run once and only after all items in waitFor are defined
+ * @param {Function} task - The task to execute once
+ * @param {Array} waitFor - An array of variables that must be defined before the task is executed
+ * */
+export const useOnce = (task: Function, waitFor: unknown[]) => {
+    const [alreadyRun, setAlreadyRun] = useState(false);
+    const isReady = (dependencies: unknown[]) => {
+        return dependencies.every((dep) => dep !== undefined);
+    };
+    useEffect(() => {
+        if (!alreadyRun && isReady(waitFor)) {
+            task();
+            setAlreadyRun(true);
+        }
+    }, [alreadyRun, waitFor, task]);
+};


### PR DESCRIPTION
## What?
Add the custom hook `useOnce`. This function takes `task: Function` as the function to run once, and an array of dependecies to wait for before executing `waitFor: unknown[]`. The end result is:

- `task` is only run once
- Execution only happens after all dependencies are defined
- Execution happens after the first render (because we use `useEffect`)

## How is this different to useEffect?
This function *will not* rerun `task` if any of the given dependencies (`waitFor` array) changes. If you need your code to dynamically respond like this then do not use `useOnce` but ,in that case, do not put it in `App`.

## Why?
This codifies and abstracts a pattern that is used to prevent multiples renders.

We already have in several places in the code guards such as `if (!theThingWeDependOn) return null;`. These guards are important for code that is not idempptent but also as a performance improvement. Conceptially, this can be seen as similar to how `shouldComponentUpdate` used to work.

In addition, we want to use this abstraction in `App.tsx` so that we explicitly make it clear to developers editing this file that their code will not rerun if any of their dependencies change. This behaviour is desired in `App` and is the *key difference*. to how `useEffect` works. This difference is important to understand.
