### PR TITLE
Bump @guardian/discussion-rendering to 3.3.0

### DIFF
--- a/cypress/integration/e2e/discussion.spec.js
+++ b/cypress/integration/e2e/discussion.spec.js
@@ -18,7 +18,7 @@ describe('Discussion', function () {
     it('should scroll the page to the comments section and expand it when the comment count link is clicked', function () {
         cy.visit(`/Article?url=${articleUrl}`);
         cy.get('[data-cy=comment-counts]').click();
-        cy.contains('Displaying comments');
+        cy.contains('Displaying threads');
     });
 
     it('should show a count of the comments', function () {
@@ -31,7 +31,7 @@ describe('Discussion', function () {
     //     const roughLoadPositionOfComments = 4000;
     //     cy.scrollTo(0, roughLoadPositionOfComments, { duration: 500 });
     //     cy.contains('View more comments').click();
-    //     cy.contains('Displaying comments');
+    //     cy.contains('Displaying threads');
     // });
 
     it('should automatically expand and scroll to a comment if the reader loads a permalink', function () {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "@guardian/automat-client": "^0.2.16",
         "@guardian/braze-components": "^0.0.16",
         "@guardian/consent-management-platform": "^6.7.4",
-        "@guardian/discussion-rendering": "^3.1.2",
+        "@guardian/discussion-rendering": "^3.3.0",
         "@guardian/shimport": "^1.0.2",
         "@guardian/src-button": "^2.7.1",
         "@guardian/src-checkbox": "^2.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2113,10 +2113,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.7.4.tgz#ae75775c40f8234a2e2774c126a688e9a98f5df4"
   integrity sha512-f/XieB0dOyGYZDhP/UmyrHiyuehETt2L1GKqacsySFdcD/++fKe7LLcXbza4NE54MHyS0wbvd+Qh4avjG4IPLg==
 
-"@guardian/discussion-rendering@^3.1.2":
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-3.1.2.tgz#c8da0ec815820e6bd9a7adc319fe2ef07441c12c"
-  integrity sha512-NvxOCUuX55LGp1AHBmxfIHT4+0h2rdTeGx4jYGp6ReCndXSZ0ucJ77FYzz1hryST0wZAWE3o/tZdnbOoZ15F7w==
+"@guardian/discussion-rendering@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-3.3.0.tgz#5f9c5d9ed5a275b7bba2b60b6ec865819ea7241e"
+  integrity sha512-xajsYRlMAHqjEWtVfyXbWd3KNHqDqrVlez3GBiZgrU1ag3L4TzoQW3WliAo35oZLjn1j6Pt4/G4n57x3DqAidQ==
   dependencies:
     babel-plugin-emotion "^10.0.33"
     customize-cra "^1.0.0"
@@ -9241,15 +9241,17 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-focus-lock@^0.6.7:
-  version "0.6.8"
-  resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.6.8.tgz#61985fadfa92f02f2ee1d90bc738efaf7f3c9f46"
-  integrity sha512-vkHTluRCoq9FcsrldC0ulQHiyBYgVJB2CX53I8r0nTC6KnEij7Of0jpBspjt3/CuNb6fyoj3aOh9J2HgQUM0og==
-
 focus-lock@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.7.0.tgz#b2bfb0ca7beacc8710a1ff74275fe0dc60a1d88a"
   integrity sha512-LI7v2mH02R55SekHYdv9pRHR9RajVNyIJ2N5IEkWbg7FT5ZmJ9Hw4mWxHeEUcd+dJo0QmzztHvDvWcc7prVFsw==
+
+focus-lock@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.8.1.tgz#bb36968abf77a2063fa173cb6c47b12ac8599d33"
+  integrity sha512-/LFZOIo82WDsyyv7h7oc0MJF9ACOvDRdx9rWPZ2pgMfNWu/z8hQDBtOchuB/0BVLmuFOZjV02YwUVzNsWx/EzA==
+  dependencies:
+    tslib "^1.9.3"
 
 follow-redirects@1.5.10:
   version "1.5.10"
@@ -15211,9 +15213,9 @@ rdf-canonize@^1.0.2:
     semver "^5.6.0"
 
 react-app-rewired@^2.1.6:
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/react-app-rewired/-/react-app-rewired-2.1.6.tgz#33ee3076a7f34d6a7c94e649cac67e7c8c580de8"
-  integrity sha512-06flj0kK5tf/RN4naRv/sn6j3sQd7rsURoRLKLpffXDzJeNiAaTNic+0I8Basojy5WDwREkTqrMLewSAjcb13w==
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/react-app-rewired/-/react-app-rewired-2.1.8.tgz#e192f93b98daf96889418d33d3e86cf863812b56"
+  integrity sha512-wjXPdKPLscA7mn0I1de1NHrbfWdXz4S1ladaGgHVKdn1hTgKK5N6EdGIJM0KrS6bKnJBj7WuqJroDTsPKKr66Q==
   dependencies:
     semver "^5.6.0"
 
@@ -15338,12 +15340,12 @@ react-focus-lock@^2.1.0:
     use-sidecar "^1.0.1"
 
 react-focus-lock@^2.2.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.3.1.tgz#9d5d85899773609c7eefa4fc54fff6a0f5f2fc47"
-  integrity sha512-j15cWLPzH0gOmRrUg01C09Peu8qbcdVqr6Bjyfxj80cNZmH+idk/bNBYEDSmkAtwkXI+xEYWSmHYqtaQhZ8iUQ==
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.5.0.tgz#12e3a3940e897c26e2c2a0408cd25ea3c99b3709"
+  integrity sha512-XLxj6uTXgz0US8TmqNU2jMfnXwZG0mH2r/afQqvPEaX6nyEll5LHVcEXk2XDUQ34RVeLPkO/xK5x6c/qiuSq/A==
   dependencies:
     "@babel/runtime" "^7.0.0"
-    focus-lock "^0.6.7"
+    focus-lock "^0.8.1"
     prop-types "^15.6.2"
     react-clientside-effect "^1.2.2"
     use-callback-ref "^1.2.1"


### PR DESCRIPTION
## What does this change?
Bumps `@guardian/discussion-rendering` to https://github.com/guardian/discussion-rendering/releases/tag/v3.3.0
