### PR TITLE
⚡ AMP add platform to pubData

### DIFF
--- a/src/amp/components/AdConsent.tsx
+++ b/src/amp/components/AdConsent.tsx
@@ -7,6 +7,7 @@ const pubData = {
     // Matches ampViewId from https://ophan.theguardian.com/amp.json
     pageViewId: 'PAGE_VIEW_ID_64',
     browserId: 'CLIENT_ID',
+    platform: 'amp',
 };
 
 const queryParams = new URLSearchParams(pubData).toString();


### PR DESCRIPTION
## What does this change?

Adds `platform` to the `pubData` sent to Sourcepoint.

## Why?

Helps data to be more self-sufficient when processed from SP.

Follow up to #2005, and linked to #2263 for the web platform.

