### PR TITLE
Callout file error fix

### DIFF
--- a/src/web/components/Callout/FileUpload.tsx
+++ b/src/web/components/Callout/FileUpload.tsx
@@ -3,6 +3,7 @@ import { css } from 'emotion';
 
 import { textSans } from '@guardian/src-foundations/typography';
 import { text } from '@guardian/src-foundations/palette';
+import { space } from '@guardian/src-foundations';
 
 import { stringifyFileBase64 } from '../../lib/stringifyFileBase64';
 import { FieldLabel } from './FieldLabel';
@@ -13,9 +14,9 @@ const fileUploadInputStyles = css`
 `;
 
 const errorMessagesStyles = css`
-    padding-bottom: 10px;
+    padding-top: ${space[2]}px;
     color: ${text.error};
-    ${textSans.medium({ fontWeight: 'bold' })};
+    ${textSans.small({ fontWeight: 'bold' })};
 `;
 
 type Props = {
@@ -28,8 +29,8 @@ export const FileUpload = ({ formField, formData, setFormData }: Props) => {
     const [error, setError] = useState('');
     const onSelectFile = async (event: React.ChangeEvent<HTMLInputElement>) => {
         if (event.target.files && event.target.files[0]) {
+            setError('');
             try {
-                setError('');
                 const stringifiedFile = await stringifyFileBase64(
                     event.target.files[0],
                 );
@@ -38,7 +39,9 @@ export const FileUpload = ({ formField, formData, setFormData }: Props) => {
                     [formField.id]: stringifiedFile,
                 });
             } catch (e) {
-                setError(e);
+                setError(
+                    'Sorry there was a problem with the file you uploaded above. Check the size and type. We only accept images, pdfs and .doc or .docx files',
+                );
             }
         }
     };

--- a/src/web/lib/stringifyFileBase64.ts
+++ b/src/web/lib/stringifyFileBase64.ts
@@ -10,16 +10,11 @@ export const stringifyFileBase64 = (file: File) =>
                     reader.result.toString().split(';base64,')[1];
                 // remove data:*/*;base64, from the start of the base64 string
 
-                reject(
-                    Error(
-                        'Sorry there was a problem with the file you uploaded above. Check the size and type. We only accept images, pdfs and .doc or .docx files',
-                    ),
-                );
                 if (fileAsBase64) {
                     resolve(fileAsBase64);
                 } else {
                     reject(
-                        Error(
+                        new Error(
                             'Sorry there was a problem with the file you uploaded above. Check the size and type. We only accept images, pdfs and .doc or .docx files',
                         ),
                     );
@@ -29,7 +24,7 @@ export const stringifyFileBase64 = (file: File) =>
         );
         reader.addEventListener('error', () => {
             reject(
-                Error(
+                new Error(
                     'Sorry there was a problem with the file you uploaded above. Check the size and type. We only accept images, pdfs and .doc or .docx files',
                 ),
             );


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Stop error from throwing on callout file change

## Why?
On file change, we would always throw an error. This was added for debugging reasons and forgotten about. It prevented the file from being sent to the server