### PR TITLE
Include epic in AMP validation test

### DIFF
--- a/src/amp/server/document.test.tsx
+++ b/src/amp/server/document.test.tsx
@@ -59,11 +59,12 @@ test('produces valid AMP doc', async () => {
     const body = (
         <Article
             nav={nav}
-            articleData={CAPI}
+            articleData={{ ...CAPI, shouldHideReaderRevenue: false }}
             config={config}
             analytics={analytics}
         />
     );
+
     const result = v.validateString(
         document({
             body,


### PR DESCRIPTION
By setting `shouldHideReaderRevenue` to true we include the contributions epic in the body.