### PR TITLE
Update atoms rendering v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "@emotion/core": "^10.0.35",
         "@guardian/ab-core": "^2.0.0",
         "@guardian/ab-react": "^2.0.1",
-        "@guardian/atoms-rendering": "^4.2.0",
+        "@guardian/atoms-rendering": "^5.0.0",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/braze-components": "^0.0.16",
         "@guardian/consent-management-platform": "^6.7.4",

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -342,7 +342,10 @@ interface YoutubeBlockElement {
     id?: string;
     channelId?: string;
     duration?: number;
-    posterSrc?: string;
+    posterImage?: {
+        url: string;
+        width: number;
+    }[];
     expired: boolean;
     overrideImage?: string;
     altText?: string;

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -2160,8 +2160,23 @@
                 "duration": {
                     "type": "number"
                 },
-                "posterSrc": {
-                    "type": "string"
+                "posterImage": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "url": {
+                                "type": "string"
+                            },
+                            "width": {
+                                "type": "number"
+                            }
+                        },
+                        "required": [
+                            "url",
+                            "width"
+                        ]
+                    }
                 },
                 "expired": {
                     "type": "boolean"

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -337,6 +337,7 @@ export const App = ({ CAPI, NAV }: Props) => {
                         adTargeting={adTargeting}
                         isMainMedia={false}
                         overlayImage={youtubeBlock.overrideImage}
+                        posterImage={youtubeBlock.posterImage}
                         duration={youtubeBlock.duration}
                         origin={CAPI.config.host}
                     />
@@ -359,6 +360,7 @@ export const App = ({ CAPI, NAV }: Props) => {
                         adTargeting={adTargeting}
                         isMainMedia={false}
                         overlayImage={youtubeBlock.overrideImage}
+                        posterImage={youtubeBlock.posterImage}
                         duration={youtubeBlock.duration}
                         origin={CAPI.config.host}
                     />

--- a/src/web/components/MainMedia.tsx
+++ b/src/web/components/MainMedia.tsx
@@ -92,6 +92,7 @@ function renderElement(
                         adTargeting={adTargeting}
                         isMainMedia={true}
                         overlayImage={element.overrideImage}
+                        posterImage={element.posterImage}
                         duration={element.duration}
                     />
                 </div>

--- a/src/web/components/elements/YoutubeBlockComponent.tsx
+++ b/src/web/components/elements/YoutubeBlockComponent.tsx
@@ -19,6 +19,10 @@ type Props = {
     role: RoleType;
     hideCaption?: boolean;
     overlayImage?: string;
+    posterImage?: {
+        url: string;
+        width: number;
+    }[];
     adTargeting?: AdTargeting;
     isMainMedia?: boolean;
     height?: number;
@@ -69,6 +73,7 @@ export const YoutubeBlockComponent = ({
     pillar,
     hideCaption,
     overlayImage,
+    posterImage,
     role,
     adTargeting,
     isMainMedia,
@@ -150,12 +155,32 @@ export const YoutubeBlockComponent = ({
                 videoMeta={element}
                 overlayImage={
                     overlayImage
-                        ? {
-                              src: overlayImage,
-                              alt: element.altText || element.mediaTitle,
-                          }
+                        ? [
+                              {
+                                  srcSet: [
+                                      {
+                                          src: overlayImage,
+                                          width: 500, // we do not have width for overlayImage so set a random number
+                                      },
+                                  ],
+                              },
+                          ]
                         : undefined
                 }
+                posterImage={
+                    posterImage
+                        ? [
+                              {
+                                  srcSet: posterImage.map((img) => ({
+                                      src: img.url,
+                                      width: img.width,
+                                  })),
+                              },
+                          ]
+                        : undefined
+                }
+                role={role}
+                alt={element.altText || element.mediaTitle}
                 adTargeting={adTargeting}
                 height={height}
                 width={width}

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -406,6 +406,7 @@ export const ArticleRenderer: React.FC<{
                                 adTargeting={adTargeting}
                                 isMainMedia={false}
                                 overlayImage={element.overrideImage}
+                                posterImage={element.posterImage}
                                 duration={element.duration}
                                 origin={host}
                             />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2087,10 +2087,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
   integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
 
-"@guardian/atoms-rendering@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-4.2.0.tgz#d5346da84db0b56a632d43e38a7a347139ca93a8"
-  integrity sha512-NMA5+p3GL8h8ADveJmhCk0DD0Wm+wESECLSmsEumD1neHeDgz8vB8DSFuKOMC1BUuddAb3nX8SPGzZLg3w2xmQ==
+"@guardian/atoms-rendering@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-5.0.0.tgz#b3d1c971c8ab0cc9201e4aca7f0b89b39c1e6ebe"
+  integrity sha512-jV2hT4LyoAvnjWQ+61vYXb2lfoVKeXjf3d+1bSxL0SEEEkWwTB3PGGK7fVQ9aVF+NLFwc6uR8Qcn83yr8nk66Q==
 
 "@guardian/automat-client@^0.2.16":
   version "0.2.16"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Updates Atoms Rendering to [v5](https://github.com/guardian/atoms-rendering/releases/tag/v5.0.0)

- Support `posterImage` prop for youtube atom
- Use new `overlayImage` prop data structure for youtube atom
- Remove figure from being defined in Atoms and lift wrapper to DCR
