### PR TITLE
Remove SpecialReport type

### DIFF
--- a/docs/patterns/switch-on-display-design.md
+++ b/docs/patterns/switch-on-display-design.md
@@ -23,7 +23,6 @@ const shouldShowAvatar = (designType: DesignType, display: Display) => {
                 case 'PhotoEssay':
                 case 'Analysis':
                 case 'Article':
-                case 'SpecialReport':
                 case 'MatchReport':
                 case 'GuardianView':
                 case 'GuardianLabs':

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,7 +18,6 @@ type DesignType =
     | 'Comment'
     | 'Feature'
     | 'Live'
-    | 'SpecialReport'
     | 'Recipe'
     | 'MatchReport'
     | 'Interview'
@@ -256,7 +255,7 @@ interface CAPIType {
     config: ConfigType;
     // The CAPI object sent from frontend can have designType Immersive. We force this to be Article
     // in decideDesignType but need to allow the type here before then
-    designType: DesignType | "Immersive";
+    designType: DesignType | "Immersive" | "SpecialReport";
     showBottomSocialButtons: boolean;
     shouldHideReaderRevenue: boolean;
 
@@ -289,7 +288,7 @@ interface CAPIType {
 type CAPIBrowserType = {
     // The CAPI object sent from frontend can have designType Immersive. We force this to be Article
     // in decideDesignType but need to allow the type here before then
-    designType: DesignType | "Immersive";
+    designType: DesignType | "Immersive" | "SpecialReport";
     pillar: Pillar;
     config: ConfigTypeBrowser;
     richLinks: RichLinkBlockElement[];

--- a/src/amp/components/Epic.tsx
+++ b/src/amp/components/Epic.tsx
@@ -186,43 +186,67 @@ const buildUrl = (
 };
 
 export const Epic: React.FC<{ webURL: string }> = ({ webURL }) => {
-    const epicUrl = process.env.NODE_ENV === 'production'
-        ? 'https://contributions.guardianapis.com/amp/epic'
-        : 'https://contributions.code.dev-guardianapis.com/amp/epic';
+    const epicUrl =
+        process.env.NODE_ENV === 'production'
+            ? 'https://contributions.guardianapis.com/amp/epic'
+            : 'https://contributions.code.dev-guardianapis.com/amp/epic';
 
     return (
         <amp-list
-            layout='fixed-height'
+            layout="fixed-height"
             // This means that if the user refreshes at the end of the article while the epic is in view then the epic
             // will not display. This is such an edge case that we can live with it, and in general it will fill the
             // space.
-            height='1px'
+            height="1px"
             src={epicUrl}
-            credentials='include'
+            credentials="include"
         >
             <MoustacheTemplate>
                 <div className={epicStyle}>
-
-                    <MoustacheSection name='ticker'>
+                    <MoustacheSection name="ticker">
                         <div className={tickerWrapperStyle}>
                             <div className={tickerInfoStyle}>
                                 <div className={leftStyle}>
-                                    <p className={topLeftStyle}>{moustacheVariable('topLeft')}</p>
-                                    <p className={labelStyle}>{moustacheVariable('bottomLeft')}</p>
+                                    <p className={topLeftStyle}>
+                                        {moustacheVariable('topLeft')}
+                                    </p>
+                                    <p className={labelStyle}>
+                                        {moustacheVariable('bottomLeft')}
+                                    </p>
                                 </div>
                                 <div className={rightStyle}>
-                                    <p className={topRightStyle}>{moustacheVariable('topRight')}</p>
-                                    <p className={labelStyle}>{moustacheVariable('bottomRight')}</p>
+                                    <p className={topRightStyle}>
+                                        {moustacheVariable('topRight')}
+                                    </p>
+                                    <p className={labelStyle}>
+                                        {moustacheVariable('bottomRight')}
+                                    </p>
                                 </div>
                             </div>
 
                             <div>
                                 <div className={tickerBackgroundStyle}>
-                                    <MoustacheSection name='goalExceededMarkerPercentage'>
-                                        <div id='goal-exceeded-marker' className={goalExceededMarkerStyle} style={{left: `${moustacheVariable('goalExceededMarkerPercentage')}%`}} />
+                                    <MoustacheSection name="goalExceededMarkerPercentage">
+                                        <div
+                                            id="goal-exceeded-marker"
+                                            className={goalExceededMarkerStyle}
+                                            style={{
+                                                left: `${moustacheVariable(
+                                                    'goalExceededMarkerPercentage',
+                                                )}%`,
+                                            }}
+                                        />
                                     </MoustacheSection>
 
-                                    <div id='ticker-progress' className={tickerProgressStyle} style={{ width: `${moustacheVariable('percentage')}%` }} />
+                                    <div
+                                        id="ticker-progress"
+                                        className={tickerProgressStyle}
+                                        style={{
+                                            width: `${moustacheVariable(
+                                                'percentage',
+                                            )}%`,
+                                        }}
+                                    />
                                 </div>
                             </div>
                         </div>

--- a/src/amp/types/ArticleModel.tsx
+++ b/src/amp/types/ArticleModel.tsx
@@ -29,5 +29,5 @@ export interface ArticleModel {
     commercialProperties: CommercialProperties;
     isImmersive: boolean;
     starRating?: number;
-    designType: DesignType | 'Immersive';
+    designType: DesignType | 'Immersive' | 'SpecialReport';
 }

--- a/src/lib/designTypes.ts
+++ b/src/lib/designTypes.ts
@@ -6,7 +6,6 @@ export const designTypes: DesignType[] = [
     'Comment',
     'Feature',
     'Live',
-    'SpecialReport',
     'Recipe',
     'MatchReport',
     'Interview',

--- a/src/web/components/ArticleHeadline.stories.tsx
+++ b/src/web/components/ArticleHeadline.stories.tsx
@@ -516,9 +516,9 @@ export const SpecialReport = () => (
             </LeftColumn>
             <ArticleContainer>
                 <ArticleHeadline
-                    headlineString="This is the headline you see when design type is SpecialReport"
+                    headlineString="This is the headline you see when pillar is SpecialReport"
                     display={Display.Standard}
-                    designType="SpecialReport"
+                    designType="Article"
                     pillar="news"
                     tags={[]}
                 />

--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -231,7 +231,6 @@ export const ArticleHeadline = ({
                 case 'Media':
                 case 'PhotoEssay':
                 case 'Article':
-                case 'SpecialReport':
                 case 'MatchReport':
                 case 'GuardianLabs':
                 case 'Quiz':
@@ -352,7 +351,6 @@ export const ArticleHeadline = ({
                 case 'Media':
                 case 'PhotoEssay':
                 case 'Article':
-                case 'SpecialReport':
                 case 'MatchReport':
                 case 'GuardianLabs':
                 case 'Quiz':

--- a/src/web/components/ArticleHeadlinePadding.tsx
+++ b/src/web/components/ArticleHeadlinePadding.tsx
@@ -20,7 +20,6 @@ const determinPadding = (designType: DesignType) => {
         case 'Media':
         case 'PhotoEssay':
         case 'Live':
-        case 'SpecialReport':
         case 'Recipe':
         case 'MatchReport':
         case 'GuardianView':

--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -137,7 +137,6 @@ const metaContainer = ({
                 case 'Media':
                 case 'Analysis':
                 case 'Article':
-                case 'SpecialReport':
                 case 'MatchReport':
                 case 'GuardianView':
                 case 'GuardianLabs':
@@ -187,7 +186,6 @@ const shouldShowAvatar = (designType: DesignType, display: Display) => {
                 case 'PhotoEssay':
                 case 'Analysis':
                 case 'Article':
-                case 'SpecialReport':
                 case 'MatchReport':
                 case 'GuardianView':
                 case 'GuardianLabs':
@@ -219,7 +217,6 @@ const shouldShowContributor = (designType: DesignType, display: Display) => {
                 case 'Interview':
                 case 'Analysis':
                 case 'Article':
-                case 'SpecialReport':
                 case 'Recipe':
                 case 'MatchReport':
                 case 'GuardianLabs':

--- a/src/web/components/Byline.tsx
+++ b/src/web/components/Byline.tsx
@@ -52,7 +52,6 @@ const colourStyles = (designType: DesignType, pillar: Pillar) => {
         case 'PhotoEssay':
         case 'Review':
         case 'Live':
-        case 'SpecialReport':
         case 'Recipe':
         case 'MatchReport':
         case 'GuardianView':

--- a/src/web/components/Caption.tsx
+++ b/src/web/components/Caption.tsx
@@ -180,7 +180,6 @@ export const Caption = ({
         case 'Article':
         case 'Media':
         case 'Live':
-        case 'SpecialReport':
         case 'Recipe':
         case 'MatchReport':
         case 'GuardianView':

--- a/src/web/components/Card/components/CardAge.tsx
+++ b/src/web/components/Card/components/CardAge.tsx
@@ -49,7 +49,6 @@ const colourStyles = (designType: DesignType, pillar: Pillar) => {
         case 'Analysis':
         case 'Article':
         case 'Review':
-        case 'SpecialReport':
         case 'Recipe':
         case 'MatchReport':
         case 'GuardianView':

--- a/src/web/components/Card/components/CardLink.tsx
+++ b/src/web/components/Card/components/CardLink.tsx
@@ -71,7 +71,6 @@ const linkStyles = (designType: DesignType, pillar: Pillar) => {
         case 'Article':
         case 'Review':
         case 'PhotoEssay':
-        case 'SpecialReport':
         case 'Recipe':
         case 'MatchReport':
         case 'GuardianLabs':

--- a/src/web/components/CardCommentCount.tsx
+++ b/src/web/components/CardCommentCount.tsx
@@ -78,7 +78,6 @@ const colourStyles = (designType: DesignType, pillar: Pillar) => {
         case 'Analysis':
         case 'Article':
         case 'Review':
-        case 'SpecialReport':
         case 'Recipe':
         case 'MatchReport':
         case 'GuardianView':

--- a/src/web/components/CardHeadline.tsx
+++ b/src/web/components/CardHeadline.tsx
@@ -82,7 +82,6 @@ const headlineStyles = (designType: DesignType, pillar: Pillar) => {
         case 'PhotoEssay':
         case 'Article':
         case 'Review':
-        case 'SpecialReport':
         case 'Recipe':
         case 'MatchReport':
         case 'GuardianView':

--- a/src/web/components/DropCap.tsx
+++ b/src/web/components/DropCap.tsx
@@ -44,7 +44,6 @@ const outerStyles = (pillar: Pillar, designType: DesignType) => {
         case 'Media':
         case 'Review':
         case 'Live':
-        case 'SpecialReport':
         case 'Recipe':
         case 'MatchReport':
         case 'GuardianLabs':
@@ -83,7 +82,6 @@ const innerStyles = (designType: DesignType) => {
         case 'PhotoEssay':
         case 'Review':
         case 'Live':
-        case 'SpecialReport':
         case 'Recipe':
         case 'MatchReport':
         case 'GuardianLabs':

--- a/src/web/components/HeadlineByline.tsx
+++ b/src/web/components/HeadlineByline.tsx
@@ -115,7 +115,6 @@ export const HeadlineByline = ({
                 case 'PhotoEssay':
                 case 'Review':
                 case 'Live':
-                case 'SpecialReport':
                 case 'Recipe':
                 case 'MatchReport':
                 case 'GuardianLabs':
@@ -170,7 +169,6 @@ export const HeadlineByline = ({
                 case 'PhotoEssay':
                 case 'Review':
                 case 'Live':
-                case 'SpecialReport':
                 case 'Recipe':
                 case 'MatchReport':
                 case 'GuardianLabs':

--- a/src/web/components/Kicker.tsx
+++ b/src/web/components/Kicker.tsx
@@ -42,7 +42,6 @@ const decideColour = (
         case 'Analysis':
         case 'Article':
         case 'Review':
-        case 'SpecialReport':
         case 'Recipe':
         case 'MatchReport':
         case 'GuardianView':

--- a/src/web/components/Onwards/Carousel/cardColours.tsx
+++ b/src/web/components/Onwards/Carousel/cardColours.tsx
@@ -23,7 +23,6 @@ export const headlineBackgroundColour = (
         case 'Article':
         case 'Review':
         case 'PhotoEssay':
-        case 'SpecialReport':
         case 'Recipe':
         case 'MatchReport':
         case 'GuardianLabs':
@@ -55,7 +54,6 @@ export const headlineColour = (designType: DesignType, pillar: Pillar) => {
         case 'PhotoEssay':
         case 'Article':
         case 'Review':
-        case 'SpecialReport':
         case 'Recipe':
         case 'MatchReport':
         case 'GuardianView':

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -197,7 +197,6 @@ export const SeriesSectionLink = ({
                 case 'PhotoEssay':
                 case 'Analysis':
                 case 'Article':
-                case 'SpecialReport':
                 case 'Recipe':
                 case 'MatchReport':
                 case 'GuardianLabs':
@@ -240,7 +239,6 @@ export const SeriesSectionLink = ({
                 case 'PhotoEssay':
                 case 'Analysis':
                 case 'Article':
-                case 'SpecialReport':
                 case 'Recipe':
                 case 'MatchReport':
                 case 'GuardianLabs':

--- a/src/web/components/Standfirst.stories.tsx
+++ b/src/web/components/Standfirst.stories.tsx
@@ -171,7 +171,7 @@ export const SpecialReport = () => {
         <Section>
             <Standfirst
                 display={Display.Standard}
-                designType="SpecialReport"
+                designType="Article"
                 standfirst="This is how SpecialReport standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
             />
         </Section>

--- a/src/web/components/Standfirst.tsx
+++ b/src/web/components/Standfirst.tsx
@@ -61,7 +61,6 @@ const standfirstStyles = (designType: DesignType, display: Display) => {
                 case 'Recipe':
                 case 'Review':
                 case 'Media':
-                case 'SpecialReport':
                 case 'MatchReport':
                 case 'AdvertisementFeature':
                 case 'GuardianLabs':
@@ -103,7 +102,6 @@ const standfirstStyles = (designType: DesignType, display: Display) => {
                     `;
                 case 'Media':
                 case 'PhotoEssay':
-                case 'SpecialReport':
                 case 'MatchReport':
                 case 'AdvertisementFeature':
                 case 'GuardianLabs':

--- a/src/web/components/elements/PullQuoteBlockComponent.tsx
+++ b/src/web/components/elements/PullQuoteBlockComponent.tsx
@@ -213,7 +213,6 @@ export const PullQuoteBlockComponent: React.FC<{
         case 'Recipe':
         case 'Review':
         case 'Media':
-        case 'SpecialReport':
         case 'MatchReport':
         case 'AdvertisementFeature':
         case 'GuardianLabs':

--- a/src/web/components/elements/TextBlockComponent.tsx
+++ b/src/web/components/elements/TextBlockComponent.tsx
@@ -80,7 +80,6 @@ const shouldShowDropCap = ({
         case 'Article':
         case 'Media':
         case 'Live':
-        case 'SpecialReport':
         case 'MatchReport':
         case 'GuardianView':
         case 'GuardianLabs':

--- a/src/web/layouts/DecideLayout.tsx
+++ b/src/web/layouts/DecideLayout.tsx
@@ -41,7 +41,6 @@ export const DecideLayout = ({ CAPI, NAV }: Props) => {
                 case 'PhotoEssay':
                 case 'Analysis':
                 case 'Article':
-                case 'SpecialReport':
                 case 'Recipe':
                 case 'MatchReport':
                 case 'GuardianLabs':
@@ -80,7 +79,6 @@ export const DecideLayout = ({ CAPI, NAV }: Props) => {
                 case 'PhotoEssay':
                 case 'Analysis':
                 case 'Article':
-                case 'SpecialReport':
                 case 'Recipe':
                 case 'MatchReport':
                 case 'GuardianLabs':
@@ -120,7 +118,6 @@ export const DecideLayout = ({ CAPI, NAV }: Props) => {
                 case 'PhotoEssay':
                 case 'Analysis':
                 case 'Article':
-                case 'SpecialReport':
                 case 'Recipe':
                 case 'MatchReport':
                 case 'GuardianLabs':

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -198,7 +198,6 @@ const PositionHeadline = ({
         case 'PhotoEssay':
         case 'Review':
         case 'Live':
-        case 'SpecialReport':
         case 'Recipe':
         case 'MatchReport':
         case 'GuardianView':

--- a/src/web/lib/decideDesignType.ts
+++ b/src/web/lib/decideDesignType.ts
@@ -4,5 +4,6 @@ export const decideDesignType = (
     CAPI: CAPIType | CAPIBrowserType | ArticleModel,
 ): DesignType => {
     if (CAPI.designType === 'Immersive') return 'Article';
+    if (CAPI.designType === 'SpecialReport') return 'Article';
     return CAPI.designType;
 };

--- a/src/web/lib/layoutHelpers.ts
+++ b/src/web/lib/layoutHelpers.ts
@@ -19,7 +19,6 @@ export const decideLineEffect = (
         case 'PhotoEssay':
         case 'Analysis':
         case 'Article':
-        case 'SpecialReport':
         case 'MatchReport':
         case 'GuardianLabs':
         case 'Quiz':


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Here we remove the `SpecialReport` design type from DCR

## Why?
Instead of having `SpecialReport` as a design type we want to use [Special](https://github.com/guardian/types/blob/main/src/format.ts#L11) as a pillar value from @guardian/types

We're not _using_ `SpecialReport` anywhere in DCR specifically so this initial preparation PR (ahead of importing `Special`) is made as a convenience to better break up this work.