### PR TITLE
Update atoms rendering v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "@emotion/core": "^10.0.35",
         "@guardian/ab-core": "^2.0.0",
         "@guardian/ab-react": "^2.0.1",
-        "@guardian/atoms-rendering": "^5.0.0",
+        "@guardian/atoms-rendering": "^6.0.0",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/braze-components": "^0.0.16",
         "@guardian/consent-management-platform": "^6.7.4",

--- a/src/amp/components/Epic.tsx
+++ b/src/amp/components/Epic.tsx
@@ -186,43 +186,67 @@ const buildUrl = (
 };
 
 export const Epic: React.FC<{ webURL: string }> = ({ webURL }) => {
-    const epicUrl = process.env.NODE_ENV === 'production'
-        ? 'https://contributions.guardianapis.com/amp/epic'
-        : 'https://contributions.code.dev-guardianapis.com/amp/epic';
+    const epicUrl =
+        process.env.NODE_ENV === 'production'
+            ? 'https://contributions.guardianapis.com/amp/epic'
+            : 'https://contributions.code.dev-guardianapis.com/amp/epic';
 
     return (
         <amp-list
-            layout='fixed-height'
+            layout="fixed-height"
             // This means that if the user refreshes at the end of the article while the epic is in view then the epic
             // will not display. This is such an edge case that we can live with it, and in general it will fill the
             // space.
-            height='1px'
+            height="1px"
             src={epicUrl}
-            credentials='include'
+            credentials="include"
         >
             <MoustacheTemplate>
                 <div className={epicStyle}>
-
-                    <MoustacheSection name='ticker'>
+                    <MoustacheSection name="ticker">
                         <div className={tickerWrapperStyle}>
                             <div className={tickerInfoStyle}>
                                 <div className={leftStyle}>
-                                    <p className={topLeftStyle}>{moustacheVariable('topLeft')}</p>
-                                    <p className={labelStyle}>{moustacheVariable('bottomLeft')}</p>
+                                    <p className={topLeftStyle}>
+                                        {moustacheVariable('topLeft')}
+                                    </p>
+                                    <p className={labelStyle}>
+                                        {moustacheVariable('bottomLeft')}
+                                    </p>
                                 </div>
                                 <div className={rightStyle}>
-                                    <p className={topRightStyle}>{moustacheVariable('topRight')}</p>
-                                    <p className={labelStyle}>{moustacheVariable('bottomRight')}</p>
+                                    <p className={topRightStyle}>
+                                        {moustacheVariable('topRight')}
+                                    </p>
+                                    <p className={labelStyle}>
+                                        {moustacheVariable('bottomRight')}
+                                    </p>
                                 </div>
                             </div>
 
                             <div>
                                 <div className={tickerBackgroundStyle}>
-                                    <MoustacheSection name='goalExceededMarkerPercentage'>
-                                        <div id='goal-exceeded-marker' className={goalExceededMarkerStyle} style={{left: `${moustacheVariable('goalExceededMarkerPercentage')}%`}} />
+                                    <MoustacheSection name="goalExceededMarkerPercentage">
+                                        <div
+                                            id="goal-exceeded-marker"
+                                            className={goalExceededMarkerStyle}
+                                            style={{
+                                                left: `${moustacheVariable(
+                                                    'goalExceededMarkerPercentage',
+                                                )}%`,
+                                            }}
+                                        />
                                     </MoustacheSection>
 
-                                    <div id='ticker-progress' className={tickerProgressStyle} style={{ width: `${moustacheVariable('percentage')}%` }} />
+                                    <div
+                                        id="ticker-progress"
+                                        className={tickerProgressStyle}
+                                        style={{
+                                            width: `${moustacheVariable(
+                                                'percentage',
+                                            )}%`,
+                                        }}
+                                    />
                                 </div>
                             </div>
                         </div>

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -336,8 +336,8 @@ interface YoutubeBlockElement {
     _type: 'model.dotcomrendering.pageElements.YoutubeBlockElement';
     assetId: string;
     mediaTitle: string;
-    id?: string;
-    channelId?: string;
+    id: string;
+    channelId: string;
     duration?: number;
     posterImage?: {
         url: string;

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -2160,7 +2160,9 @@
             "required": [
                 "_type",
                 "assetId",
+                "channelId",
                 "expired",
+                "id",
                 "mediaTitle"
             ]
         },

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -331,14 +331,17 @@ export const App = ({ CAPI, NAV }: Props) => {
                     <YoutubeBlockComponent
                         display={display}
                         designType={designType}
-                        element={youtubeBlock}
                         pillar={pillar}
                         hideCaption={false}
                         // eslint-disable-next-line jsx-a11y/aria-role
                         role="inline"
                         adTargeting={adTargeting}
                         isMainMedia={false}
-                        overlayImage={youtubeBlock.overrideImage}
+                        id={youtubeBlock.id}
+                        assetId={youtubeBlock.assetId}
+                        channelId={youtubeBlock.channelId}
+                        expired={youtubeBlock.expired}
+                        overrideImage={youtubeBlock.overrideImage}
                         posterImage={youtubeBlock.posterImage}
                         duration={youtubeBlock.duration}
                         origin={CAPI.config.host}
@@ -354,14 +357,17 @@ export const App = ({ CAPI, NAV }: Props) => {
                     <YoutubeBlockComponent
                         display={display}
                         designType={designType}
-                        element={youtubeBlock}
                         pillar={pillar}
                         hideCaption={false}
                         // eslint-disable-next-line jsx-a11y/aria-role
                         role="inline"
                         adTargeting={adTargeting}
                         isMainMedia={false}
-                        overlayImage={youtubeBlock.overrideImage}
+                        id={youtubeBlock.id}
+                        assetId={youtubeBlock.assetId}
+                        channelId={youtubeBlock.channelId}
+                        expired={youtubeBlock.expired}
+                        overrideImage={youtubeBlock.overrideImage}
                         posterImage={youtubeBlock.posterImage}
                         duration={youtubeBlock.duration}
                         origin={CAPI.config.host}

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -344,6 +344,8 @@ export const App = ({ CAPI, NAV }: Props) => {
                         overrideImage={youtubeBlock.overrideImage}
                         posterImage={youtubeBlock.posterImage}
                         duration={youtubeBlock.duration}
+                        mediaTitle={youtubeBlock.mediaTitle}
+                        altText={youtubeBlock.altText}
                         origin={CAPI.config.host}
                     />
                 </Hydrate>
@@ -370,6 +372,8 @@ export const App = ({ CAPI, NAV }: Props) => {
                         overrideImage={youtubeBlock.overrideImage}
                         posterImage={youtubeBlock.posterImage}
                         duration={youtubeBlock.duration}
+                        mediaTitle={youtubeBlock.mediaTitle}
+                        altText={youtubeBlock.altText}
                         origin={CAPI.config.host}
                     />
                 </Hydrate>

--- a/src/web/components/MainMedia.tsx
+++ b/src/web/components/MainMedia.tsx
@@ -84,14 +84,17 @@ function renderElement(
                         display={display}
                         designType={designType}
                         key={i}
-                        element={element}
                         pillar={pillar}
                         hideCaption={hideCaption}
                         // eslint-disable-next-line jsx-a11y/aria-role
                         role="inline"
                         adTargeting={adTargeting}
                         isMainMedia={true}
-                        overlayImage={element.overrideImage}
+                        id={element.id}
+                        assetId={element.assetId}
+                        channelId={element.channelId}
+                        expired={element.expired}
+                        overrideImage={element.overrideImage}
                         posterImage={element.posterImage}
                         duration={element.duration}
                     />

--- a/src/web/components/elements/YoutubeBlockComponent.stories.tsx
+++ b/src/web/components/elements/YoutubeBlockComponent.stories.tsx
@@ -14,9 +14,6 @@ export default {
     title: 'Components/YoutubeBlockComponent',
 };
 
-const overrideImage =
-    'https://i.guim.co.uk/img/media/49565a29c6586fe6b748926e0be96c5e9c90473c/0_0_4981_2989/500.jpg?quality=85&auto=format&fit=max&s=17c70ec70002ea34886fd6c2605cd81e';
-
 const Container = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
     <Section showTopBorder={false}>
         <Flex>
@@ -38,7 +35,7 @@ const Container = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
     </Section>
 );
 
-export const noOverlay = () => {
+export const Default = () => {
     return (
         <Container>
             <p>
@@ -50,17 +47,11 @@ export const noOverlay = () => {
             <YoutubeBlockComponent
                 display={Display.Standard}
                 designType="Article"
-                element={{
-                    mediaTitle:
-                        "Prince Harry and Meghan's 'bombshell' plans explained – video",
-                    assetId: 'd2Q5bXvEgMg',
-                    _type:
-                        'model.dotcomrendering.pageElements.YoutubeBlockElement',
-                    id: 'c2b8a51c-cb3d-41e7-bb79-1d9a091d0c28',
-                    channelId: 'UCIRYBXDze5krPDzAEOxFGVA',
-                    expired: false,
-                    overrideImage,
-                }}
+                assetId="d2Q5bXvEgMg"
+                mediaTitle="Prince Harry and Meghan's 'bombshell' plans explained – video"
+                id="c2b8a51c-cb3d-41e7-bb79-1d9a091d0c28"
+                channelId="UCIRYBXDze5krPDzAEOxFGVA"
+                expired={false}
                 pillar="news"
                 // eslint-disable-next-line jsx-a11y/aria-role
                 role="inline"
@@ -74,7 +65,7 @@ export const noOverlay = () => {
         </Container>
     );
 };
-noOverlay.story = { name: 'with no overlay' };
+Default.story = { name: 'default' };
 
 export const Vertical = () => {
     return (
@@ -88,17 +79,11 @@ export const Vertical = () => {
             <YoutubeBlockComponent
                 display={Display.Standard}
                 designType="Article"
-                element={{
-                    mediaTitle:
-                        "Prince Harry and Meghan's 'bombshell' plans explained – video",
-                    assetId: 'd2Q5bXvEgMg',
-                    _type:
-                        'model.dotcomrendering.pageElements.YoutubeBlockElement',
-                    id: 'c2b8a51c-cb3d-41e7-bb79-1d9a091d0c28',
-                    channelId: 'UCIRYBXDze5krPDzAEOxFGVA',
-                    expired: false,
-                    overrideImage,
-                }}
+                assetId="d2Q5bXvEgMg"
+                mediaTitle="Prince Harry and Meghan's 'bombshell' plans explained – video"
+                id="c2b8a51c-cb3d-41e7-bb79-1d9a091d0c28"
+                channelId="UCIRYBXDze5krPDzAEOxFGVA"
+                expired={false}
                 pillar="news"
                 // eslint-disable-next-line jsx-a11y/aria-role
                 role="inline"
@@ -128,17 +113,12 @@ export const Expired = () => {
             <YoutubeBlockComponent
                 display={Display.Standard}
                 designType="Article"
-                element={{
-                    mediaTitle:
-                        "Prince Harry and Meghan's 'bombshell' plans explained – video",
-                    assetId: 'd2Q5bXvEgMg',
-                    _type:
-                        'model.dotcomrendering.pageElements.YoutubeBlockElement',
-                    id: 'c2b8a51c-cb3d-41e7-bb79-1d9a091d0c28',
-                    channelId: 'UCIRYBXDze5krPDzAEOxFGVA',
-                    expired: true,
-                    overrideImage,
-                }}
+                assetId="d2Q5bXvEgMg"
+                mediaTitle="Prince Harry and Meghan's 'bombshell' plans explained – video"
+                id="c2b8a51c-cb3d-41e7-bb79-1d9a091d0c28"
+                channelId="UCIRYBXDze5krPDzAEOxFGVA"
+                expired={true}
+                overrideImage="https://i.guim.co.uk/img/media/49565a29c6586fe6b748926e0be96c5e9c90473c/0_0_4981_2989/500.jpg?quality=85&auto=format&fit=max&s=17c70ec70002ea34886fd6c2605cd81e"
                 pillar="news"
                 // eslint-disable-next-line jsx-a11y/aria-role
                 role="inline"
@@ -155,3 +135,164 @@ export const Expired = () => {
     );
 };
 Expired.story = { name: 'expired video' };
+
+export const WithOverlayImage = () => {
+    return (
+        <Container>
+            <p>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+                eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+                enim ad minim veniam, quis nostrud exercitation ullamco laboris
+                nisi ut aliquip ex ea commodo consequat.{' '}
+            </p>
+            <YoutubeBlockComponent
+                display={Display.Standard}
+                designType="Article"
+                assetId="d2Q5bXvEgMg"
+                mediaTitle="Prince Harry and Meghan's 'bombshell' plans explained – video"
+                id="c2b8a51c-cb3d-41e7-bb79-1d9a091d0c28"
+                channelId="UCIRYBXDze5krPDzAEOxFGVA"
+                expired={false}
+                duration={333}
+                overrideImage="https://i.guim.co.uk/img/media/49565a29c6586fe6b748926e0be96c5e9c90473c/0_0_4981_2989/500.jpg?quality=85&auto=format&fit=max&s=17c70ec70002ea34886fd6c2605cd81e"
+                pillar="news"
+                // eslint-disable-next-line jsx-a11y/aria-role
+                role="inline"
+                height={259}
+                width={460}
+            />
+            <p>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+                eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+                enim ad minim veniam, quis nostrud exercitation ullamco laboris
+                nisi ut aliquip ex ea commodo consequat.{' '}
+            </p>
+        </Container>
+    );
+};
+WithOverlayImage.story = { name: 'with overlay image' };
+
+export const WithPosterImage = () => {
+    return (
+        <Container>
+            <p>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+                eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+                enim ad minim veniam, quis nostrud exercitation ullamco laboris
+                nisi ut aliquip ex ea commodo consequat.{' '}
+            </p>
+            <YoutubeBlockComponent
+                display={Display.Standard}
+                designType="Article"
+                assetId="d2Q5bXvEgMg"
+                mediaTitle="Prince Harry and Meghan's 'bombshell' plans explained – video"
+                id="c2b8a51c-cb3d-41e7-bb79-1d9a091d0c28"
+                channelId="UCIRYBXDze5krPDzAEOxFGVA"
+                expired={false}
+                pillar="news"
+                duration={333}
+                posterImage={[
+                    {
+                        url:
+                            'https://media.guim.co.uk/45c34a4312b228773b1bdec415b4253667b21ae3/0_0_4255_2394/2000.jpg',
+                        width: 2000,
+                    },
+                    {
+                        url:
+                            'https://media.guim.co.uk/45c34a4312b228773b1bdec415b4253667b21ae3/0_0_4255_2394/1000.jpg',
+                        width: 1000,
+                    },
+                    {
+                        url:
+                            'https://media.guim.co.uk/45c34a4312b228773b1bdec415b4253667b21ae3/0_0_4255_2394/500.jpg',
+                        width: 500,
+                    },
+                    {
+                        url:
+                            'https://media.guim.co.uk/45c34a4312b228773b1bdec415b4253667b21ae3/0_0_4255_2394/140.jpg',
+                        width: 140,
+                    },
+                    {
+                        url:
+                            'https://media.guim.co.uk/45c34a4312b228773b1bdec415b4253667b21ae3/0_0_4255_2394/4255.jpg',
+                        width: 4255,
+                    },
+                ]}
+                // eslint-disable-next-line jsx-a11y/aria-role
+                role="inline"
+                height={259}
+                width={460}
+            />
+            <p>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+                eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+                enim ad minim veniam, quis nostrud exercitation ullamco laboris
+                nisi ut aliquip ex ea commodo consequat.{' '}
+            </p>
+        </Container>
+    );
+};
+WithPosterImage.story = { name: 'with poster image' };
+
+export const WithPosterAndOverlayImage = () => {
+    return (
+        <Container>
+            <p>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+                eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+                enim ad minim veniam, quis nostrud exercitation ullamco laboris
+                nisi ut aliquip ex ea commodo consequat.{' '}
+            </p>
+            <YoutubeBlockComponent
+                display={Display.Standard}
+                designType="Article"
+                assetId="d2Q5bXvEgMg"
+                mediaTitle="Prince Harry and Meghan's 'bombshell' plans explained – video"
+                id="c2b8a51c-cb3d-41e7-bb79-1d9a091d0c28"
+                channelId="UCIRYBXDze5krPDzAEOxFGVA"
+                expired={false}
+                overrideImage="https://i.guim.co.uk/img/media/49565a29c6586fe6b748926e0be96c5e9c90473c/0_0_4981_2989/500.jpg?quality=85&auto=format&fit=max&s=17c70ec70002ea34886fd6c2605cd81e"
+                pillar="news"
+                duration={333}
+                posterImage={[
+                    {
+                        url:
+                            'https://media.guim.co.uk/45c34a4312b228773b1bdec415b4253667b21ae3/0_0_4255_2394/2000.jpg',
+                        width: 2000,
+                    },
+                    {
+                        url:
+                            'https://media.guim.co.uk/45c34a4312b228773b1bdec415b4253667b21ae3/0_0_4255_2394/1000.jpg',
+                        width: 1000,
+                    },
+                    {
+                        url:
+                            'https://media.guim.co.uk/45c34a4312b228773b1bdec415b4253667b21ae3/0_0_4255_2394/500.jpg',
+                        width: 500,
+                    },
+                    {
+                        url:
+                            'https://media.guim.co.uk/45c34a4312b228773b1bdec415b4253667b21ae3/0_0_4255_2394/140.jpg',
+                        width: 140,
+                    },
+                    {
+                        url:
+                            'https://media.guim.co.uk/45c34a4312b228773b1bdec415b4253667b21ae3/0_0_4255_2394/4255.jpg',
+                        width: 4255,
+                    },
+                ]}
+                // eslint-disable-next-line jsx-a11y/aria-role
+                role="inline"
+                height={259}
+                width={460}
+            />
+            <p>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+                eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+                enim ad minim veniam, quis nostrud exercitation ullamco laboris
+                nisi ut aliquip ex ea commodo consequat.{' '}
+            </p>
+        </Container>
+    );
+};
+WithPosterAndOverlayImage.story = { name: 'with poster and overlay image' };

--- a/src/web/components/elements/YoutubeBlockComponent.tsx
+++ b/src/web/components/elements/YoutubeBlockComponent.tsx
@@ -32,7 +32,6 @@ type Props = {
     isMainMedia?: boolean;
     height?: number;
     width?: number;
-    title?: string;
     duration?: number; // in seconds
     origin?: string;
 };
@@ -88,7 +87,6 @@ export const YoutubeBlockComponent = ({
     isMainMedia,
     height = 259,
     width = 460,
-    title,
     duration,
     origin,
 }: Props) => {
@@ -188,11 +186,11 @@ export const YoutubeBlockComponent = ({
                         : undefined
                 }
                 role={role}
-                alt={altText || mediaTitle || title || ''}
+                alt={altText || mediaTitle || ''}
                 adTargeting={adTargeting}
                 height={height}
                 width={width}
-                title={title}
+                title={mediaTitle}
                 duration={duration}
                 origin={origin}
                 eventEmitters={[ophanTracking, gaTracking]}

--- a/src/web/components/elements/YoutubeBlockComponent.tsx
+++ b/src/web/components/elements/YoutubeBlockComponent.tsx
@@ -12,13 +12,18 @@ import { Caption } from '@root/src/web/components/Caption';
 import { Display } from '@guardian/types/Format';
 
 type Props = {
+    id: string;
+    mediaTitle?: string;
+    altText?: string;
     display: Display;
     designType: DesignType;
-    element: YoutubeBlockElement;
+    assetId: string;
+    channelId: string;
+    expired: boolean;
     pillar: Pillar;
     role: RoleType;
     hideCaption?: boolean;
-    overlayImage?: string;
+    overrideImage?: string;
     posterImage?: {
         url: string;
         width: number;
@@ -67,19 +72,23 @@ const expiredSVGWrapperStyles = css`
 `;
 
 export const YoutubeBlockComponent = ({
+    id,
+    assetId,
+    mediaTitle,
+    altText,
     display,
     designType,
-    element,
     pillar,
     hideCaption,
-    overlayImage,
+    overrideImage,
     posterImage,
+    expired,
     role,
     adTargeting,
     isMainMedia,
     height = 259,
     width = 460,
-    title = 'YouTube video player',
+    title,
     duration,
     origin,
 }: Props) => {
@@ -87,7 +96,7 @@ export const YoutubeBlockComponent = ({
         !isMainMedia &&
         (role === 'showcase' || role === 'supporting' || role === 'immersive');
 
-    if (element.expired) {
+    if (expired) {
         return (
             <figure
                 className={css`
@@ -97,8 +106,7 @@ export const YoutubeBlockComponent = ({
             >
                 <div
                     className={
-                        element.overrideImage &&
-                        expiredOverlayStyles(element.overrideImage)
+                        overrideImage && expiredOverlayStyles(overrideImage)
                     }
                 >
                     <div className={expiredTextWrapperStyles}>
@@ -122,7 +130,7 @@ export const YoutubeBlockComponent = ({
                     <Caption
                         display={display}
                         designType={designType}
-                        captionText={element.mediaTitle || ''}
+                        captionText={mediaTitle || ''}
                         pillar={pillar}
                         displayCredit={false}
                         shouldLimitWidth={shouldLimitWidth}
@@ -133,33 +141,33 @@ export const YoutubeBlockComponent = ({
     }
 
     const ophanTracking = (trackingEvent: string) => {
-        if (!element.id) return;
+        if (!id) return;
         record({
             video: {
-                id: `gu-video-youtube-${element.id}`,
+                id: `gu-video-youtube-${id}`,
                 eventType: `video:content:${trackingEvent}`,
             },
         });
     };
     const gaTracking = (trackingEvent: string) => {
-        if (!element.id) return;
+        if (!id) return;
         trackVideoInteraction({
             trackingEvent,
-            elementId: element.id,
+            elementId: id,
         });
     };
 
     return (
         <div data-chromatic="ignore">
             <YoutubeAtom
-                videoMeta={element}
-                overlayImage={
-                    overlayImage
+                assetId={assetId}
+                overrideImage={
+                    overrideImage
                         ? [
                               {
                                   srcSet: [
                                       {
-                                          src: overlayImage,
+                                          src: overrideImage,
                                           width: 500, // we do not have width for overlayImage so set a random number
                                       },
                                   ],
@@ -180,7 +188,7 @@ export const YoutubeBlockComponent = ({
                         : undefined
                 }
                 role={role}
-                alt={element.altText || element.mediaTitle}
+                alt={altText || mediaTitle || title || ''}
                 adTargeting={adTargeting}
                 height={height}
                 width={width}
@@ -193,7 +201,7 @@ export const YoutubeBlockComponent = ({
                 <Caption
                     display={display}
                     designType={designType}
-                    captionText={element.mediaTitle || ''}
+                    captionText={mediaTitle || ''}
                     pillar={pillar}
                     displayCredit={false}
                     shouldLimitWidth={shouldLimitWidth}

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -411,6 +411,8 @@ export const ArticleRenderer: React.FC<{
                                 overrideImage={element.overrideImage}
                                 posterImage={element.posterImage}
                                 duration={element.duration}
+                                mediaTitle={element.mediaTitle}
+                                altText={element.altText}
                                 origin={host}
                             />
                         </div>

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -398,14 +398,17 @@ export const ArticleRenderer: React.FC<{
                                 display={display}
                                 designType={designType}
                                 key={i}
-                                element={element}
                                 pillar={pillar}
                                 hideCaption={false}
                                 // eslint-disable-next-line jsx-a11y/aria-role
                                 role="inline"
                                 adTargeting={adTargeting}
                                 isMainMedia={false}
-                                overlayImage={element.overrideImage}
+                                id={element.id}
+                                assetId={element.assetId}
+                                channelId={element.channelId}
+                                expired={element.expired}
+                                overrideImage={element.overrideImage}
                                 posterImage={element.posterImage}
                                 duration={element.duration}
                                 origin={host}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2087,10 +2087,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
   integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
 
-"@guardian/atoms-rendering@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-5.0.0.tgz#b3d1c971c8ab0cc9201e4aca7f0b89b39c1e6ebe"
-  integrity sha512-jV2hT4LyoAvnjWQ+61vYXb2lfoVKeXjf3d+1bSxL0SEEEkWwTB3PGGK7fVQ9aVF+NLFwc6uR8Qcn83yr8nk66Q==
+"@guardian/atoms-rendering@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-6.0.0.tgz#e0066f37ccfb84131737cead54fb10fb624a4053"
+  integrity sha512-OTMmarddZQlIKamjtAd8qPO407bIoNWyyHxc/7rLbkR/LjK+vmzeGZrKhrzYE1nqsrMMNnIzi2mvKN1opjXfQQ==
 
 "@guardian/automat-client@^0.2.16":
   version "0.2.16"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
- Updates atoms rendering to v6
- Changes the props for the youtube atom
- Add storybook for each youtube atom case

## Why?
- Stay up to date with atoms rendering
- The props for youtube atom are not nested anymore, instead they are flatterned to be more explicit
- Update contains some fixes for quiz atom and audio atom accesibility