### PR TITLE
fix for comment slot sizing not matching DCP

### DIFF
--- a/src/web/components/AdSlot.tsx
+++ b/src/web/components/AdSlot.tsx
@@ -231,6 +231,7 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
                         data-mobile={[
                             `${Size.outOfPage}`,
                             `${Size.empty}`,
+                            `${Size.halfPage}`,
                             `${Size.outstreamMobile}`,
                             `${Size.mpu}`,
                             `${Size.googleCard}`,
@@ -245,6 +246,8 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
                             `${Size.outstreamDesktop}`,
                             `${Size.outstreamGoogleDesktop}`,
                             `${Size.fluid}`,
+                            `${Size.halfPage}`,
+                            `${Size.skyscraper}`,
                         ].join('|')}
                         data-phablet={[
                             `${Size.outOfPage}`,

--- a/src/web/components/AdSlot.tsx
+++ b/src/web/components/AdSlot.tsx
@@ -231,22 +231,27 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
                         data-mobile={[
                             `${Size.outOfPage}`,
                             `${Size.empty}`,
-                            `${Size.halfPage}`,
+                            `${Size.outstreamMobile}`,
+                            `${Size.mpu}`,
+                            `${Size.googleCard}`,
                             `${Size.fluid}`,
                         ].join('|')}
                         data-desktop={[
                             `${Size.outOfPage}`,
                             `${Size.empty}`,
+                            `${Size.mpu}`,
+                            `${Size.googleCard}`,
                             `${Size.video}`,
                             `${Size.outstreamDesktop}`,
                             `${Size.outstreamGoogleDesktop}`,
                             `${Size.fluid}`,
-                            `${Size.halfPage}`,
-                            `${Size.skyscraper}`,
                         ].join('|')}
                         data-phablet={[
                             `${Size.outOfPage}`,
                             `${Size.empty}`,
+                            `${Size.outstreamMobile}`,
+                            `${Size.mpu}`,
+                            `${Size.googleCard}`,
                             `${Size.outstreamDesktop}`,
                             `${Size.outstreamGoogleDesktop}`,
                             `${Size.fluid}`,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Matches the ad sizes supported by the DCR ad-slot to the sizes supported by the DCP ad-slot.

### Before
On DCR:

```
document.getElementById('dfp-ad--comments').getAttribute('data-desktop')
"1,1|2,2|620,1|620,350|550,310|fluid|300,600|160,600"
```

### After
Now matches DCP:

```
document.getElementById('dfp-ad--comments').getAttribute('data-desktop')
"1,1|2,2|300,250|300,274|620,1|620,350|550,310|fluid|300,600|160,600"
```
## Why?
DCR and DCP should always have been the same