### PR TITLE
Share in new tabs

### DIFF
--- a/src/web/components/ShareIcons.tsx
+++ b/src/web/components/ShareIcons.tsx
@@ -137,7 +137,12 @@ export const SharingIcons: React.FC<{
                         })}
                         key={`${id}Share`}
                     >
-                        <a href={url} role="button" aria-label={userMessage}>
+                        <a
+                            href={url}
+                            role="button"
+                            aria-label={userMessage}
+                            target="_blank"
+                        >
                             <span
                                 className={cx(
                                     shareIcon(pillarPalette[pillar].main),


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds `target="_blank"` to sharing links

## Why?
Because this is how Frontend works and feels like the right flow for the best UX.

Also because we've had reports that clicking these links in Preview causes errors when Preview tries to open the external pages directly:


![Screenshot 2020-12-31 at 16 05 21](https://user-images.githubusercontent.com/1336821/103417288-049a8800-4b82-11eb-8b5b-7e8671871778.jpg)