### PR TITLE
Pillar > CAPIPillar

### DIFF
--- a/cypress/integration/e2e/article.interactivity.spec.js
+++ b/cypress/integration/e2e/article.interactivity.spec.js
@@ -65,7 +65,7 @@ describe('Interactivity', function () {
         });
     });
 
-    describe('Navigating the Pillar menu', function () {
+    describe('Navigating the pillar menu', function () {
         it('should expand and close the desktop pillar menu when More is clicked', function () {
             cy.visit(`/Article?url=${articleUrl}`);
             cy.get('[data-cy=nav-show-more-button]').click();

--- a/fixtures/ga.ts
+++ b/fixtures/ga.ts
@@ -1,4 +1,4 @@
-const pillar: Pillar = 'lifestyle';
+const pillar: CAPIPillar = 'lifestyle';
 const edition: Edition = 'UK';
 export const ga = {
     pillar,

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,11 +3,11 @@
 // ------------------------- //
 
 // Pillars are used for styling
-// RealPillars have Pillar palette colours
+// RealPillars have pillar palette colours
 // FakePillars allow us to make modifications to style based on rules outside of the pillar of an article
 type RealPillars = 'news' | 'opinion' | 'sport' | 'culture' | 'lifestyle';
 type FakePillars = 'labs';
-type Pillar = RealPillars | FakePillars;
+type CAPIPillar = RealPillars | FakePillars;
 
 // https://github.com/guardian/content-api-scala-client/blob/master/client/src/main/scala/com.gu.contentapi.client/utils/DesignType.scala
 type DesignType =
@@ -95,12 +95,12 @@ interface LinkType extends SimpleLinkType {
     longTitle: string;
     children?: LinkType[];
     mobileOnly?: boolean;
-    pillar?: Pillar;
+    pillar?: CAPIPillar;
     more?: boolean;
 }
 
 interface PillarType extends LinkType {
-    pillar: Pillar;
+    pillar: CAPIPillar;
 }
 
 interface MoreType extends LinkType {
@@ -239,7 +239,7 @@ interface CAPIType {
     pageId: string;
     version: number; // TODO: check who uses?
     tags: TagType[];
-    pillar: Pillar;
+    pillar: CAPIPillar;
     isImmersive: boolean;
     sectionLabel: string;
     sectionUrl: string;
@@ -289,7 +289,7 @@ type CAPIBrowserType = {
     // The CAPI object sent from frontend can have designType Immersive. We force this to be Article
     // in decideDesignType but need to allow the type here before then
     designType: DesignType | "Immersive" | "SpecialReport";
-    pillar: Pillar;
+    pillar: CAPIPillar;
     config: ConfigTypeBrowser;
     richLinks: RichLinkBlockElement[];
     editionId: Edition;
@@ -348,7 +348,7 @@ interface BadgeType {
 interface KickerType {
     text: string;
     designType: DesignType;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     showPulsingDot?: boolean;
     showSlash?: boolean;
     inCard?: boolean; // True when headline is showing inside a card (used to handle coloured backgrounds)
@@ -369,7 +369,7 @@ type LineEffectType = 'squiggly' | 'dotted' | 'straight';
 
 interface CardType {
     linkTo: string;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     designType: DesignType;
     headlineText: string;
     headlineSize?: SmallHeadlineSize;
@@ -406,7 +406,7 @@ type HeadlineLink = {
 interface LinkHeadlineType {
     designType: DesignType;
     headlineText: string; // The text shown
-    pillar: Pillar; // Used to colour the headline (dark) and the kicker (main)
+    pillar: CAPIPillar; // Used to colour the headline (dark) and the kicker (main)
     showUnderline?: boolean; // Some headlines have text-decoration underlined when hovered
     kickerText?: string;
     showPulsingDot?: boolean;
@@ -420,7 +420,7 @@ interface LinkHeadlineType {
 interface CardHeadlineType {
     headlineText: string; // The text shown
     designType: DesignType; // Used to decide when to add type specific styles
-    pillar: Pillar; // Used to colour the headline (dark) and the kicker (main)
+    pillar: CAPIPillar; // Used to colour the headline (dark) and the kicker (main)
     kickerText?: string;
     showPulsingDot?: boolean;
     showSlash?: boolean;
@@ -494,7 +494,7 @@ type OnwardsType = {
     description?: string;
     url?: string;
     ophanComponentName: OphanComponentName;
-    pillar: Pillar;
+    pillar: CAPIPillar;
 };
 
 type OphanComponentName =
@@ -601,7 +601,7 @@ interface ConfigTypeBrowser {
 }
 
 interface GADataType {
-    pillar: Pillar;
+    pillar: CAPIPillar;
     webTitle: string;
     section: string;
     contentType: string;
@@ -677,7 +677,7 @@ type IslandType =
 
 interface TrailType {
     designType: DesignType;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     url: string;
     headline: string;
     isLiveBlog: boolean;

--- a/src/amp/components/Blocks.tsx
+++ b/src/amp/components/Blocks.tsx
@@ -8,7 +8,7 @@ import { blockLink } from '@root/src/amp/lib/block-link';
 import { findBlockAdSlots } from '@root/src/amp/lib/find-adslots';
 import { WithAds } from '@root/src/amp/components/WithAds';
 
-const blockStyle = (pillar: Pillar) => css`
+const blockStyle = (pillar: CAPIPillar) => css`
     padding: 6px 10px 12px;
     background-color: ${palette.neutral[100]};
     border-top: 1px solid ${pillarPalette[pillar].dark};
@@ -39,7 +39,7 @@ const clearBoth = css`
 // that out and have an Ad element type we match against
 export const Blocks: React.SFC<{
     blocks: Block[];
-    pillar: Pillar;
+    pillar: CAPIPillar;
     edition: Edition;
     section?: string;
     contentType: string;

--- a/src/amp/components/BodyArticle.tsx
+++ b/src/amp/components/BodyArticle.tsx
@@ -16,7 +16,7 @@ import { getSharingUrls } from '@root/src/lib/sharing-urls';
 import { buildAdTargeting } from '@root/src/lib/ad-targeting';
 import { Epic } from '@root/src/amp/components/Epic';
 
-const bulletStyle = (pillar: Pillar) => css`
+const bulletStyle = (pillar: CAPIPillar) => css`
     .bullet {
         color: transparent;
         font-size: 1px;
@@ -34,7 +34,7 @@ const bulletStyle = (pillar: Pillar) => css`
     }
 `;
 
-const body = (pillar: Pillar, designType: DesignType) => {
+const body = (pillar: CAPIPillar, designType: DesignType) => {
     const defaultStyles: DesignTypesObj = designTypeDefault(
         palette.neutral[100],
     );
@@ -63,7 +63,7 @@ const adStyle = css`
 `;
 
 export const Body: React.FC<{
-    pillar: Pillar;
+    pillar: CAPIPillar;
     designType: DesignType;
     data: ArticleModel;
     config: ConfigType;

--- a/src/amp/components/BodyLiveblog.tsx
+++ b/src/amp/components/BodyLiveblog.tsx
@@ -69,7 +69,7 @@ const updateButtonStyle = css`
 // updates happening. This happens because we don't include new styles on block
 // updates, but only on initial page load.
 export const Body: React.FC<{
-    pillar: Pillar;
+    pillar: CAPIPillar;
     data: ArticleModel;
     config: ConfigType;
 }> = ({ pillar, data, config }) => {

--- a/src/amp/components/Caption.tsx
+++ b/src/amp/components/Caption.tsx
@@ -23,7 +23,7 @@ const captionPadding = css`
 
 export const Caption: React.FC<{
     captionText?: string;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     padCaption?: boolean;
     credit?: string;
     displayCredit?: boolean;

--- a/src/amp/components/Elements.tsx
+++ b/src/amp/components/Elements.tsx
@@ -27,7 +27,7 @@ import { clean } from '@root/src/model/clean';
 
 export const Elements = (
     elements: CAPIElement[],
-    pillar: Pillar,
+    pillar: CAPIPillar,
     isImmersive: boolean,
     adTargeting?: AdTargeting,
 ): JSX.Element[] => {

--- a/src/amp/components/Expandable.tsx
+++ b/src/amp/components/Expandable.tsx
@@ -8,7 +8,7 @@ import { palette } from '@guardian/src-foundations';
 import { body, textSans, headline } from '@guardian/src-foundations/typography';
 import { TextStyle } from '@root/src/amp/components/elements/TextBlockComponent';
 
-const wrapper = (pillar: Pillar) => css`
+const wrapper = (pillar: CAPIPillar) => css`
     background: ${palette.neutral[93]};
     position: relative;
     padding: 0 5px 6px;
@@ -69,7 +69,7 @@ const creditStyle = css`
     margin: 12px 0;
 `;
 
-const pillarColour = (pillar: Pillar) => css`
+const pillarColour = (pillar: CAPIPillar) => css`
     color: ${pillarPalette[pillar].main};
 `;
 
@@ -118,7 +118,7 @@ export const Expandable: React.FC<{
     img?: string;
     html: string;
     credit?: string;
-    pillar: Pillar;
+    pillar: CAPIPillar;
 }> = ({ id, type, title, img, html, credit, pillar }) => (
     <aside className={wrapper(pillar)}>
         <div className={headers}>

--- a/src/amp/components/Header.tsx
+++ b/src/amp/components/Header.tsx
@@ -65,7 +65,7 @@ const pillarListItemStyle = css`
     }
 `;
 
-const pillarLinkStyle = (pillar: Pillar) => css`
+const pillarLinkStyle = (pillar: CAPIPillar) => css`
     text-decoration: none;
     cursor: pointer;
     display: block;

--- a/src/amp/components/MainMedia.tsx
+++ b/src/amp/components/MainMedia.tsx
@@ -126,7 +126,7 @@ const expanded = css`
 
 const asComponent = (
     element: CAPIElement,
-    pillar: Pillar,
+    pillar: CAPIPillar,
     adTargeting?: any,
 ): JSX.Element | null => {
     switch (element._type) {
@@ -147,7 +147,7 @@ const asComponent = (
 
 export const MainMedia: React.FC<{
     element: CAPIElement;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     adTargeting?: any;
 }> = ({ element, pillar, adTargeting }) => {
     return (

--- a/src/amp/components/ShareIcons.tsx
+++ b/src/amp/components/ShareIcons.tsx
@@ -23,7 +23,7 @@ const shareIconsListItem = css`
     min-width: 32px;
 `;
 
-const shareIcon = (pillar: Pillar) => css`
+const shareIcon = (pillar: CAPIPillar) => css`
     border: 1px solid ${neutralBorder(pillar)};
     white-space: nowrap;
     overflow: hidden;
@@ -72,7 +72,7 @@ export const ShareIcons: React.FC<{
         };
     };
     displayIcons: SharePlatform[];
-    pillar: Pillar;
+    pillar: CAPIPillar;
     className?: string;
 }> = ({ sharingUrls, displayIcons, pillar, className }) => {
     const icons: { [K in SharePlatform]?: React.ComponentType } = {

--- a/src/amp/components/SubMeta.tsx
+++ b/src/amp/components/SubMeta.tsx
@@ -8,7 +8,7 @@ import { textSans, body } from '@guardian/src-foundations/typography';
 import { ShareIcons } from '@root/src/amp/components/ShareIcons';
 import CommentIcon from '@frontend/static/icons/comment.svg';
 
-const guardianLines = (pillar: Pillar) => css`
+const guardianLines = (pillar: CAPIPillar) => css`
     background-image: repeating-linear-gradient(
         to bottom,
         ${neutralBorder(pillar)},
@@ -23,7 +23,7 @@ const guardianLines = (pillar: Pillar) => css`
     margin-top: 12px;
 `;
 
-const linkStyle = (pillar: Pillar) => css`
+const linkStyle = (pillar: CAPIPillar) => css`
     position: relative;
     padding-left: 5px;
     padding-right: 6px;
@@ -49,7 +49,7 @@ const itemStyle = css`
     }
 `;
 
-const keywordListStyle = (pillar: Pillar) => css`
+const keywordListStyle = (pillar: CAPIPillar) => css`
     display: block;
     margin-left: -6px;
     padding-top: 6px;
@@ -58,7 +58,7 @@ const keywordListStyle = (pillar: Pillar) => css`
     margin-bottom: 6px;
 `;
 
-const sectionLinkStyle = (pillar: Pillar) => css`
+const sectionLinkStyle = (pillar: CAPIPillar) => css`
     position: relative;
     padding-left: 5px;
     padding-right: 6px;
@@ -111,7 +111,7 @@ const shareIcons = css`
 `;
 
 export const SubMeta: React.FC<{
-    pillar: Pillar;
+    pillar: CAPIPillar;
     sections: SimpleLinkType[];
     keywords: SimpleLinkType[];
     sharingURLs: {

--- a/src/amp/components/elements/DisclaimerBlockComponent.tsx
+++ b/src/amp/components/elements/DisclaimerBlockComponent.tsx
@@ -3,7 +3,7 @@ import { css } from 'emotion';
 import { pillarPalette } from '@root/src/lib/pillars';
 import { textSans } from '@guardian/src-foundations/typography';
 
-const style = (pillar: Pillar) => css`
+const style = (pillar: CAPIPillar) => css`
     ${textSans.small()};
 
     a {
@@ -13,7 +13,7 @@ const style = (pillar: Pillar) => css`
 
 export const DisclaimerBlockComponent: React.FC<{
     html: string;
-    pillar: Pillar;
+    pillar: CAPIPillar;
 }> = ({ html, pillar }) => (
     <span
         className={style(pillar)}

--- a/src/amp/components/elements/GuVideoBlockComponent.tsx
+++ b/src/amp/components/elements/GuVideoBlockComponent.tsx
@@ -3,7 +3,7 @@ import { Caption } from '@root/src/amp/components/Caption';
 
 export const GuVideoBlockComponent: React.FC<{
     element: GuVideoBlockElement;
-    pillar: Pillar;
+    pillar: CAPIPillar;
 }> = ({ element, pillar }) => {
     return (
         <Caption captionText={element.caption} pillar={pillar}>

--- a/src/amp/components/elements/ImageBlockComponent.tsx
+++ b/src/amp/components/elements/ImageBlockComponent.tsx
@@ -20,7 +20,7 @@ const captionStyle = css`
 
 export const ImageBlockComponent: React.FC<{
     element: ImageBlockElement;
-    pillar: Pillar;
+    pillar: CAPIPillar;
 }> = ({ element, pillar }) => {
     const containerWidth = 600;
     const image: SrcSetItem = bestFitImage(

--- a/src/amp/components/elements/MapBlockComponent.tsx
+++ b/src/amp/components/elements/MapBlockComponent.tsx
@@ -9,7 +9,7 @@ const noCaptionStyle = css`
 
 export const MapBlockComponent: React.SFC<{
     element: MapBlockElement;
-    pillar: Pillar;
+    pillar: CAPIPillar;
 }> = ({ element, pillar }) => {
     const attributes = {
         src: `${element.embedUrl}`,

--- a/src/amp/components/elements/PullquoteBlockComponent.tsx
+++ b/src/amp/components/elements/PullquoteBlockComponent.tsx
@@ -5,7 +5,7 @@ import { pillarPalette } from '@root/src/lib/pillars';
 import { palette } from '@guardian/src-foundations';
 import { body } from '@guardian/src-foundations/typography';
 
-const styles = (pillar: Pillar) => css`
+const styles = (pillar: CAPIPillar) => css`
     background-color: ${palette.neutral[97]};
     padding: 0.375rem 0.625rem 0.75rem;
     margin-bottom: 0.75rem;
@@ -20,7 +20,7 @@ const styles = (pillar: Pillar) => css`
 
 export const PullquoteBlockComponent: React.FC<{
     html: string;
-    pillar: Pillar;
+    pillar: CAPIPillar;
 }> = ({ html, pillar }) => (
     <aside className={styles(pillar)}>
         <Quote />{' '}

--- a/src/amp/components/elements/RichLinkBlockComponent.tsx
+++ b/src/amp/components/elements/RichLinkBlockComponent.tsx
@@ -17,7 +17,7 @@ const richLinkContainer = css`
     margin-right: 20px;
 `;
 
-const pillarColour = (pillar: Pillar) => css`
+const pillarColour = (pillar: CAPIPillar) => css`
     color: ${pillarPalette[pillar].dark};
 `;
 
@@ -41,7 +41,7 @@ const richLink = css`
 
 export const RichLinkBlockComponent: React.FC<{
     element: RichLinkBlockElement;
-    pillar: Pillar;
+    pillar: CAPIPillar;
 }> = ({ element, pillar }) => (
     <aside className={richLinkContainer}>
         <a className={cx(richLink, pillarColour(pillar))} href={element.url}>

--- a/src/amp/components/elements/SubheadingBlockComponent.tsx
+++ b/src/amp/components/elements/SubheadingBlockComponent.tsx
@@ -5,7 +5,7 @@ import { headline, textSans } from '@guardian/src-foundations/typography';
 import { pillarPalette } from '@root/src/lib/pillars';
 import { composeLabsCSS } from '@root/src/amp/lib/compose-labs-css';
 
-const style = (pillar: Pillar) => css`
+const style = (pillar: CAPIPillar) => css`
     h2 {
         margin-top: 24px;
         margin-bottom: 10px;
@@ -41,7 +41,7 @@ const subHeadingStyleLabs = css`
 
 export const SubheadingBlockComponent: React.FC<{
     html: string;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     isImmersive: boolean;
 }> = ({ html, pillar, isImmersive }) => (
     <span

--- a/src/amp/components/elements/TextBlockComponent.tsx
+++ b/src/amp/components/elements/TextBlockComponent.tsx
@@ -31,7 +31,7 @@ export const ListStyle = (iconColour: string) => css`
     }
 `;
 
-export const LinkStyle = (pillar: Pillar) => css`
+export const LinkStyle = (pillar: CAPIPillar) => css`
     a {
         color: ${pillarPalette[pillar].dark};
         text-decoration: none;
@@ -42,7 +42,7 @@ export const LinkStyle = (pillar: Pillar) => css`
     }
 `;
 
-export const TextStyle = (pillar: Pillar) => css`
+export const TextStyle = (pillar: CAPIPillar) => css`
     strong {
         font-weight: 700;
     }
@@ -74,7 +74,7 @@ const textStyleLabs = css`
 
 export const TextBlockComponent: React.FC<{
     html: string;
-    pillar: Pillar;
+    pillar: CAPIPillar;
 }> = ({ html, pillar }) => (
     <span
         className={composeLabsCSS(pillar, TextStyle(pillar), textStyleLabs)}

--- a/src/amp/components/elements/TimelineBlockComponent.tsx
+++ b/src/amp/components/elements/TimelineBlockComponent.tsx
@@ -70,7 +70,7 @@ export const TimelineBlockComponent: React.FC<{
     title: string;
     description?: string;
     events: TimelineEvent[];
-    pillar: Pillar;
+    pillar: CAPIPillar;
 }> = ({ id, title, description, events, pillar }) => (
     <Expandable
         id={id}

--- a/src/amp/components/elements/TwitterBlockComponent.tsx
+++ b/src/amp/components/elements/TwitterBlockComponent.tsx
@@ -16,7 +16,7 @@ const makeFallback = (html: string): string | null => {
 
 export const TwitterBlockComponent: React.FC<{
     element: TweetBlockElement;
-    pillar: Pillar;
+    pillar: CAPIPillar;
 }> = ({ element, pillar }) => {
     const fallbackHTML = makeFallback(element.html);
 

--- a/src/amp/components/elements/VideoFacebookBlockComponent.tsx
+++ b/src/amp/components/elements/VideoFacebookBlockComponent.tsx
@@ -3,7 +3,7 @@ import { Caption } from '@root/src/amp/components/Caption';
 
 export const VideoFacebookBlockComponent: React.FC<{
     element: VideoFacebookBlockElement;
-    pillar: Pillar;
+    pillar: CAPIPillar;
 }> = ({ element, pillar }) => {
     return (
         <Caption captionText={element.caption} pillar={pillar}>

--- a/src/amp/components/elements/VideoVimeoBlockComponent.tsx
+++ b/src/amp/components/elements/VideoVimeoBlockComponent.tsx
@@ -4,7 +4,7 @@ import { Caption } from '@root/src/amp/components/Caption';
 
 export const VideoVimeoBlockComponent: React.FC<{
     element: VideoVimeoBlockElement;
-    pillar: Pillar;
+    pillar: CAPIPillar;
 }> = ({ element, pillar }) => {
     const vimeoId = getIdFromUrl(element.url, '(\\d+)($|\\/)', true);
 

--- a/src/amp/components/elements/VideoYoutubeBlockComponent.tsx
+++ b/src/amp/components/elements/VideoYoutubeBlockComponent.tsx
@@ -4,7 +4,7 @@ import { Caption } from '@root/src/amp/components/Caption';
 
 export const VideoYoutubeBlockComponent: React.FC<{
     element: VideoYoutubeBlockElement;
-    pillar: Pillar;
+    pillar: CAPIPillar;
 }> = ({ element, pillar }) => {
     const youtubeId = getIdFromUrl(
         element.originalUrl || element.url,

--- a/src/amp/components/elements/YoutubeBlockComponent.tsx
+++ b/src/amp/components/elements/YoutubeBlockComponent.tsx
@@ -27,7 +27,7 @@ const buildEmbedConfig = (adTargeting: AdTargeting): EmbedConfig => {
 
 export const YoutubeBlockComponent: React.FC<{
     element: YoutubeBlockElement;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     adTargeting?: AdTargeting;
 }> = ({ element, pillar, adTargeting }) => {
     // https://www.ampproject.org/docs/reference/components/amp-youtube

--- a/src/amp/components/topMeta/Branding.tsx
+++ b/src/amp/components/topMeta/Branding.tsx
@@ -3,7 +3,7 @@ import { LinkStyle } from '@root/src/amp/components/elements/TextBlockComponent'
 import { textSans } from '@guardian/src-foundations/typography';
 import { css } from 'emotion';
 
-const brandingStyle = (pillar: Pillar) => css`
+const brandingStyle = (pillar: CAPIPillar) => css`
     padding: 10px 0;
     ${LinkStyle(pillar)}
 
@@ -24,7 +24,7 @@ const brandingLogoStyle = css`
 
 export const Branding: React.FC<{
     branding: Branding;
-    pillar: Pillar;
+    pillar: CAPIPillar;
 }> = ({ branding, pillar }) => {
     const { logo, sponsorName } = branding;
 

--- a/src/amp/components/topMeta/Byline.tsx
+++ b/src/amp/components/topMeta/Byline.tsx
@@ -4,7 +4,7 @@ import { bylineTokens } from '@root/src/amp/lib/byline-tokens';
 export const Byline: React.FC<{
     byline?: string;
     tags: TagType[];
-    pillar: Pillar;
+    pillar: CAPIPillar;
     guardianBaseURL: string;
     className?: string;
 }> = ({ byline, tags, guardianBaseURL, className }) => {

--- a/src/amp/components/topMeta/SeriesLink.tsx
+++ b/src/amp/components/topMeta/SeriesLink.tsx
@@ -3,7 +3,7 @@ import { headline } from '@guardian/src-foundations/typography';
 import { css } from 'emotion';
 import { pillarPalette } from '@root/src/lib/pillars';
 
-const seriesStyle = (pillar: Pillar) => css`
+const seriesStyle = (pillar: CAPIPillar) => css`
     color: ${pillarPalette[pillar].main};
     ${headline.xxxsmall()};
     font-weight: 900;
@@ -19,7 +19,7 @@ export const SeriesLink: React.SFC<{
     fallbackToSection: boolean;
     sectionLabel?: string; // required for fallback only
     sectionUrl?: string; // required for fallback only
-    pillar: Pillar;
+    pillar: CAPIPillar;
 }> = ({
     baseURL,
     tags,

--- a/src/amp/components/topMeta/Standfirst.tsx
+++ b/src/amp/components/topMeta/Standfirst.tsx
@@ -9,7 +9,7 @@ import {
     LinkStyle,
 } from '@root/src/amp/components/elements/TextBlockComponent';
 
-const standfirstCss = (pillar: Pillar) => css`
+const standfirstCss = (pillar: CAPIPillar) => css`
     ${headline.xxxsmall()};
     font-weight: 100;
     color: ${palette.neutral[7]};
@@ -38,7 +38,7 @@ const labsStyle = css`
 
 export const Standfirst: React.SFC<{
     text: string;
-    pillar: Pillar;
+    pillar: CAPIPillar;
 }> = ({ text, pillar }) => {
     return (
         <div

--- a/src/amp/components/topMeta/TopMeta.tsx
+++ b/src/amp/components/topMeta/TopMeta.tsx
@@ -8,7 +8,7 @@ import { designTypeDefault } from '@root/src/lib/designTypes';
 export const TopMeta: React.SFC<{
     data: ArticleModel;
     designType: DesignType;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     adTargeting?: AdTargeting;
 }> = ({ data, designType, pillar, adTargeting }) => {
     // Note, liveblogs have a separate top meta - see TopMetaLiveblog

--- a/src/amp/components/topMeta/TopMetaExtras.tsx
+++ b/src/amp/components/topMeta/TopMetaExtras.tsx
@@ -32,7 +32,7 @@ const metaExtras = css`
     margin-bottom: 6px;
 `;
 
-const borders = (pillar: Pillar) => css`
+const borders = (pillar: CAPIPillar) => css`
     border-top: 1px solid ${neutralBorder(pillar)};
     border-bottom: 1px solid ${neutralBorder(pillar)};
     display: flex;
@@ -70,7 +70,7 @@ const WebPublicationDate: React.FC<{
 
 const AgeWarning: React.FC<{
     warning?: string;
-    pillar: Pillar;
+    pillar: CAPIPillar;
 }> = ({ warning, pillar }) => {
     if (!warning) {
         return null;
@@ -105,7 +105,7 @@ const TwitterHandle: React.FC<{
 
 export const TopMetaExtras: React.FC<{
     sharingUrls: SharingURLs;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     webPublicationDate: string;
     ageWarning?: string;
     twitterHandle?: string;

--- a/src/amp/components/topMeta/TopMetaLiveblog.tsx
+++ b/src/amp/components/topMeta/TopMetaLiveblog.tsx
@@ -12,7 +12,7 @@ import { ListStyle } from '@root/src/amp/components/elements/TextBlockComponent'
 import { getSharingUrls } from '@root/src/lib/sharing-urls';
 import { getAgeWarning } from '@root/src/lib/age-warning';
 
-const headerStyle = (pillar: Pillar) => css`
+const headerStyle = (pillar: CAPIPillar) => css`
     ${headline.small()};
     font-weight: 500;
     padding: 3px 10px 24px;
@@ -20,7 +20,7 @@ const headerStyle = (pillar: Pillar) => css`
     background-color: ${pillarPalette[pillar].main};
 `;
 
-const bylineStyle = (pillar: Pillar) => css`
+const bylineStyle = (pillar: CAPIPillar) => css`
     ${headline.xxxsmall()};
     color: ${pillarPalette[pillar].main};
     padding-top: 3px;
@@ -35,7 +35,7 @@ const bylineStyle = (pillar: Pillar) => css`
     }
 `;
 
-const standfirstStyle = (pillar: Pillar) => css`
+const standfirstStyle = (pillar: CAPIPillar) => css`
     ${headline.xxxsmall()};
     color: ${palette.neutral[100]};
     background-color: ${pillarPalette[pillar].dark};
@@ -63,7 +63,7 @@ const fullWidth = css`
 const Headline: React.FC<{
     headlineText: string;
     standfirst: string;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     starRating?: number;
 }> = ({ headlineText, pillar, standfirst }) => {
     return (

--- a/src/amp/components/topMeta/TopMetaNews.tsx
+++ b/src/amp/components/topMeta/TopMetaNews.tsx
@@ -22,7 +22,7 @@ const headerStyle = css`
     padding-top: 3px;
     color: ${palette.neutral[7]};
 `;
-const bylineStyle = (pillar: Pillar) => css`
+const bylineStyle = (pillar: CAPIPillar) => css`
     ${headline.xxxsmall()};
     color: ${pillarPalette[pillar].main};
     padding-bottom: 8px;

--- a/src/amp/components/topMeta/TopMetaOpinion.tsx
+++ b/src/amp/components/topMeta/TopMetaOpinion.tsx
@@ -20,7 +20,7 @@ const headerStyle = css`
     color: ${palette.neutral[7]};
 `;
 
-const bylineStyle = (pillar: Pillar) => css`
+const bylineStyle = (pillar: CAPIPillar) => css`
     ${headline.small()};
     color: ${pillarPalette[pillar].main};
     font-style: italic;
@@ -63,7 +63,7 @@ const bottomPadding = css`
 
 const BylineMeta: React.SFC<{
     articleData: ArticleModel;
-    pillar: Pillar;
+    pillar: CAPIPillar;
 }> = ({ articleData, pillar }) => {
     const contributorTag = articleData.tags.find(
         (t) => t.type === 'Contributor',
@@ -102,7 +102,7 @@ const BylineMeta: React.SFC<{
 
 export const TopMetaOpinion: React.FC<{
     articleData: ArticleModel;
-    pillar: Pillar;
+    pillar: CAPIPillar;
 }> = ({ articleData, pillar }) => {
     const { branding } = articleData.commercialProperties[
         articleData.editionId

--- a/src/amp/lib/compose-labs-css.ts
+++ b/src/amp/lib/compose-labs-css.ts
@@ -1,7 +1,7 @@
 import { cx } from 'emotion';
 
 export const composeLabsCSS = (
-    pillar: Pillar,
+    pillar: CAPIPillar,
     baseCSS: string,
     labsCSS: string,
 ): string => (pillar === 'labs' ? cx(baseCSS, labsCSS) : baseCSS);

--- a/src/amp/pages/Article.tsx
+++ b/src/amp/pages/Article.tsx
@@ -22,7 +22,7 @@ const backgroundColour = css`
 
 const Body: React.SFC<{
     data: ArticleModel;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     designType: DesignType;
     config: ConfigType;
 }> = ({ data, designType, config, pillar }) => {

--- a/src/amp/types/ArticleModel.tsx
+++ b/src/amp/types/ArticleModel.tsx
@@ -10,7 +10,7 @@ export interface ArticleModel {
     webPublicationDate: string;
     webPublicationDateDisplay: string;
     pageId: string;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     sectionLabel?: string;
     sectionUrl?: string;
     sectionName?: string;

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,6 +1,6 @@
 import { Pillar as TypesPillar } from '@guardian/types/Format';
 
-export const toTypesPillar = (p: Pillar): TypesPillar => {
+export const toTypesPillar = (p: CAPIPillar): TypesPillar => {
     switch (p) {
         case 'news':
             return TypesPillar.News;

--- a/src/lib/pillars.ts
+++ b/src/lib/pillars.ts
@@ -45,7 +45,7 @@ interface PillarColours {
     800: colour;
 }
 
-export const pillarNames: Pillar[] = [
+export const pillarNames: CAPIPillar[] = [
     'news',
     'opinion',
     'sport',
@@ -67,7 +67,7 @@ export const augmentedLabs: PillarColours = {
     800: '#65a897', // dark teal
 };
 
-export const pillarPalette: Record<Pillar, PillarColours> = {
+export const pillarPalette: Record<CAPIPillar, PillarColours> = {
     news,
     opinion,
     sport,
@@ -80,9 +80,9 @@ export const pillarPalette: Record<Pillar, PillarColours> = {
 This takes a function, f, and applies it to all pillars.
 It returns an object with each pillar as the keys and f('pillar') as the value
 */
-export const pillarMap: <T>(f: (name: Pillar) => T) => { [K in Pillar]: T } = (
-    f,
-) => ({
+export const pillarMap: <T>(
+    f: (name: CAPIPillar) => T,
+) => { [K in CAPIPillar]: T } = (f) => ({
     news: f('news'),
     opinion: f('opinion'),
     sport: f('sport'),
@@ -94,10 +94,13 @@ export const pillarMap: <T>(f: (name: Pillar) => T) => { [K in Pillar]: T } = (
 Further notes on this function:
     - It maps by hand because it's easy to lose track of types when you use Object.assign()
     - Where the function parameter f returns type T, pillarMap will return an object with
-      a key for each Pillar and values of type T.
+      a key for each pillar and values of type T.
  */
 
-export const getPillar = (pillar: Pillar, designType: DesignType): Pillar => {
+export const getPillar = (
+    pillar: CAPIPillar,
+    designType: DesignType,
+): CAPIPillar => {
     if (designType === 'Comment' && pillar === 'news') {
         return 'opinion';
     }
@@ -105,7 +108,7 @@ export const getPillar = (pillar: Pillar, designType: DesignType): Pillar => {
     return pillar;
 };
 
-export const neutralBorder = (pillar: Pillar): colour => {
+export const neutralBorder = (pillar: CAPIPillar): colour => {
     switch (pillar) {
         case 'labs':
             return border.primary; // 'dark' theme

--- a/src/model/find-pillar.ts
+++ b/src/model/find-pillar.ts
@@ -3,7 +3,7 @@ import { pillarNames } from '@root/src/lib/pillars';
 export const findPillar: (
     name: string,
     tags?: TagType[],
-) => Pillar | undefined = (name, tags?) => {
+) => CAPIPillar | undefined = (name, tags?) => {
     // Flag paid content for Labs pillar (for styling purposes)
     const isPaidContent = (tag: any) =>
         tag.type === 'Tone' && tag.id === 'tone/advertisement-features';

--- a/src/web/components/ArticleBody.tsx
+++ b/src/web/components/ArticleBody.tsx
@@ -9,7 +9,7 @@ import { ArticleRenderer } from '@root/src/web/lib/ArticleRenderer';
 import { Display } from '@guardian/types/Format';
 
 type Props = {
-    pillar: Pillar;
+    pillar: CAPIPillar;
     display: Display;
     blocks: Block[];
     designType: DesignType;

--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -15,7 +15,7 @@ type Props = {
     headlineString: string;
     display: Display;
     designType: DesignType; // Decides headline appearance
-    pillar: Pillar; // Decides headline colour when relevant
+    pillar: CAPIPillar; // Decides headline colour when relevant
     byline?: string;
     tags: TagType[];
     isShowcase?: boolean; // Used for Interviews to change headline position

--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -15,7 +15,7 @@ import { Dateline } from './Dateline';
 type Props = {
     display: Display;
     designType: DesignType;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     pageId: string;
     webTitle: string;
     author: AuthorType;

--- a/src/web/components/ArticleStandfirst.tsx
+++ b/src/web/components/ArticleStandfirst.tsx
@@ -25,7 +25,7 @@ const standfirstLinks = pillarMap(
 type Props = {
     display: Display;
     designType: DesignType;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     standfirst: string; // Can be html
 };
 

--- a/src/web/components/ArticleTitle.tsx
+++ b/src/web/components/ArticleTitle.tsx
@@ -13,7 +13,7 @@ type Props = {
     sectionLabel: string;
     sectionUrl: string;
     guardianBaseURL: string;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     badge?: BadgeType;
 };
 

--- a/src/web/components/AudioAtomWrapper.tsx
+++ b/src/web/components/AudioAtomWrapper.tsx
@@ -11,7 +11,7 @@ type Props = {
     trackUrl: string;
     kicker: string;
     title?: string | undefined;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     contentIsNotSensitive: boolean;
     aCastisEnabled: boolean;
     readerCanBeShownAds: boolean;

--- a/src/web/components/Avatar.tsx
+++ b/src/web/components/Avatar.tsx
@@ -9,7 +9,7 @@ const contributorImage = css`
     width: 100%;
 `;
 
-const pillarBackground = (pillar: Pillar = 'opinion') =>
+const pillarBackground = (pillar: CAPIPillar = 'opinion') =>
     css`
         background-color: ${pillar === 'opinion'
             ? pillarPalette[pillar].main
@@ -19,7 +19,7 @@ const pillarBackground = (pillar: Pillar = 'opinion') =>
 export const Avatar: React.FC<{
     imageSrc: string;
     imageAlt: string;
-    pillar: Pillar;
+    pillar: CAPIPillar;
 }> = ({ imageSrc, imageAlt, pillar }) => {
     return (
         <img

--- a/src/web/components/Branding.tsx
+++ b/src/web/components/Branding.tsx
@@ -27,7 +27,7 @@ const brandingLogoStyle = css`
     }
 `;
 
-const brandingAboutLink = (pillar: Pillar) => css`
+const brandingAboutLink = (pillar: CAPIPillar) => css`
     color: ${pillarPalette[pillar].main};
     ${textSans.xsmall()}
     display: block;
@@ -39,7 +39,7 @@ const brandingAboutLink = (pillar: Pillar) => css`
 
 export const Branding: React.FC<{
     branding: Branding;
-    pillar: Pillar;
+    pillar: CAPIPillar;
 }> = ({ branding, pillar }) => {
     if (!branding) return null;
     return (

--- a/src/web/components/Byline.tsx
+++ b/src/web/components/Byline.tsx
@@ -8,7 +8,7 @@ import { pillarPalette } from '@frontend/lib/pillars';
 type Props = {
     text: string;
     designType: DesignType;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     size: SmallHeadlineSize;
 };
 
@@ -41,7 +41,7 @@ const bylineStyles = (size: SmallHeadlineSize) => {
     }
 };
 
-const colourStyles = (designType: DesignType, pillar: Pillar) => {
+const colourStyles = (designType: DesignType, pillar: CAPIPillar) => {
     switch (designType) {
         case 'Comment':
         case 'Analysis':

--- a/src/web/components/Caption.stories.tsx
+++ b/src/web/components/Caption.stories.tsx
@@ -13,7 +13,7 @@ export default {
     display: Display;
     designType: DesignType;
     captionText?: string;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     padCaption?: boolean;
     credit?: string;
     displayCredit?: boolean;

--- a/src/web/components/Caption.tsx
+++ b/src/web/components/Caption.tsx
@@ -13,7 +13,7 @@ type Props = {
     display: Display;
     designType: DesignType;
     captionText?: string;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     padCaption?: boolean;
     credit?: string;
     displayCredit?: boolean;
@@ -105,12 +105,12 @@ const hideIconBelowLeftCol = css`
     }
 `;
 
-const iconStyle = (pillar: Pillar) => css`
+const iconStyle = (pillar: CAPIPillar) => css`
     fill: ${pillarPalette[pillar].main};
     padding-right: 3px;
 `;
 
-const captionLink = (pillar: Pillar) => css`
+const captionLink = (pillar: CAPIPillar) => css`
     a {
         color: ${pillarPalette[pillar].main};
         text-decoration: none;

--- a/src/web/components/Card/components/CardAge.tsx
+++ b/src/web/components/Card/components/CardAge.tsx
@@ -9,7 +9,7 @@ import ClockIcon from '@frontend/static/icons/clock.svg';
 import { makeRelativeDate } from '@root/src/web/lib/dateTime';
 import { decidePillarLight } from '@root/src/web/lib/decidePillarLight';
 
-const ageStyles = (designType: DesignType, pillar: Pillar) => css`
+const ageStyles = (designType: DesignType, pillar: CAPIPillar) => css`
     ${textSans.xsmall()};
     color: ${designType === 'Live' ? decidePillarLight(pillar) : neutral[60]};
 
@@ -35,7 +35,7 @@ const ageStyles = (designType: DesignType, pillar: Pillar) => css`
     }
 `;
 
-const colourStyles = (designType: DesignType, pillar: Pillar) => {
+const colourStyles = (designType: DesignType, pillar: CAPIPillar) => {
     switch (designType) {
         case 'Live':
             return css`
@@ -65,7 +65,7 @@ const colourStyles = (designType: DesignType, pillar: Pillar) => {
 
 type Props = {
     designType: DesignType;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     webPublicationDate: string;
     showClock?: boolean;
 };

--- a/src/web/components/Card/components/CardLink.tsx
+++ b/src/web/components/Card/components/CardLink.tsx
@@ -3,7 +3,7 @@ import { css } from 'emotion';
 import { neutral, opinion } from '@guardian/src-foundations/palette';
 import { pillarPalette } from '@frontend/lib/pillars';
 
-const linkStyles = (designType: DesignType, pillar: Pillar) => {
+const linkStyles = (designType: DesignType, pillar: CAPIPillar) => {
     const baseLinkStyles = css`
         display: flex;
         /* a tag specific styles */
@@ -95,7 +95,7 @@ type Props = {
     children: JSXElements;
     linkTo: string;
     designType: DesignType;
-    pillar: Pillar;
+    pillar: CAPIPillar;
 };
 
 export const CardLink = ({ children, linkTo, designType, pillar }: Props) => (

--- a/src/web/components/CardCommentCount.tsx
+++ b/src/web/components/CardCommentCount.tsx
@@ -11,7 +11,7 @@ import { pillarPalette } from '@frontend/lib/pillars';
 
 type Props = {
     designType: DesignType;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     short: string;
     long: string;
 };
@@ -49,7 +49,7 @@ const shortStyles = css`
     }
 `;
 
-const mediaStyles = (pillar: Pillar) => css`
+const mediaStyles = (pillar: CAPIPillar) => css`
     /* Below we force the colour to be bright if the pillar is news (because it looks better) */
     color: ${pillar === 'news'
         ? pillarPalette[pillar].bright
@@ -62,7 +62,7 @@ const mediaStyles = (pillar: Pillar) => css`
     }
 `;
 
-const colourStyles = (designType: DesignType, pillar: Pillar) => {
+const colourStyles = (designType: DesignType, pillar: CAPIPillar) => {
     switch (designType) {
         case 'Live':
             return css`

--- a/src/web/components/CardHeadline.tsx
+++ b/src/web/components/CardHeadline.tsx
@@ -70,7 +70,7 @@ const colourStyles = (colour: string) => css`
     color: ${colour};
 `;
 
-const headlineStyles = (designType: DesignType, pillar: Pillar) => {
+const headlineStyles = (designType: DesignType, pillar: CAPIPillar) => {
     switch (designType) {
         case 'Feature':
         case 'Interview':

--- a/src/web/components/CommentCount.tsx
+++ b/src/web/components/CommentCount.tsx
@@ -9,13 +9,13 @@ import { formatCount } from '@root/src/web/lib/formatCount';
 import CommentIcon from '@frontend/static/icons/comment.svg';
 
 type Props = {
-    pillar: Pillar;
+    pillar: CAPIPillar;
     isCommentable: boolean;
     commentCount: number;
     setIsExpanded: Function;
 };
 
-const containerStyles = (pillar: Pillar) => css`
+const containerStyles = (pillar: CAPIPillar) => css`
     display: flex;
     align-self: flex-end;
     flex-direction: column;
@@ -36,7 +36,7 @@ const iconContainerStyles = css`
     }
 `;
 
-const iconStyles = (pillar: Pillar) => css`
+const iconStyles = (pillar: CAPIPillar) => css`
     fill: ${pillarPalette[pillar].main};
 `;
 

--- a/src/web/components/Contributor.tsx
+++ b/src/web/components/Contributor.tsx
@@ -30,7 +30,7 @@ const twitterHandle = css`
     }
 `;
 
-const bylineStyle = (pillar: Pillar) => css`
+const bylineStyle = (pillar: CAPIPillar) => css`
     ${headline.xxxsmall()};
     color: ${pillarPalette[pillar].main};
     padding-bottom: 8px;
@@ -51,7 +51,7 @@ export const Contributor: React.FC<{
     designType: DesignType;
     author: AuthorType;
     tags: TagType[];
-    pillar: Pillar;
+    pillar: CAPIPillar;
 }> = ({ designType, author, tags, pillar }) => {
     if (!author.byline) {
         return null;

--- a/src/web/components/Discussion.tsx
+++ b/src/web/components/Discussion.tsx
@@ -22,7 +22,7 @@ type Props = {
     discussionApiUrl: string;
     shortUrlId: string;
     isCommentable: boolean;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     discussionD2Uid: string;
     discussionApiClientHeader: string;
     enableDiscussionSwitch: boolean;

--- a/src/web/components/DropCap.tsx
+++ b/src/web/components/DropCap.tsx
@@ -7,11 +7,11 @@ import { pillarPalette } from '@frontend/lib/pillars';
 
 type Props = {
     letter: string;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     designType: DesignType;
 };
 
-const outerStyles = (pillar: Pillar, designType: DesignType) => {
+const outerStyles = (pillar: CAPIPillar, designType: DesignType) => {
     const baseStyles = css`
         ${headline.large({
             fontWeight: 'light',

--- a/src/web/components/Footer.tsx
+++ b/src/web/components/Footer.tsx
@@ -218,7 +218,7 @@ const year = new Date().getFullYear();
 
 export const Footer: React.FC<{
     pillars: PillarType[];
-    pillar: Pillar;
+    pillar: CAPIPillar;
     pageFooter: FooterType;
 }> = ({ pillars, pillar, pageFooter }) => (
     <footer

--- a/src/web/components/GuardianLines.tsx
+++ b/src/web/components/GuardianLines.tsx
@@ -6,7 +6,7 @@ import { remSpace } from '@guardian/src-foundations';
 
 import { neutralBorder } from '@root/src/lib/pillars';
 
-const linesCssOverwrite = (pillar: Pillar) => css`
+const linesCssOverwrite = (pillar: CAPIPillar) => css`
     div > * {
         background-image: repeating-linear-gradient(
             to bottom,
@@ -23,7 +23,7 @@ export const GuardianLines = ({
     count,
     effect,
 }: {
-    pillar: Pillar;
+    pillar: CAPIPillar;
     count: 4 | 8 | undefined;
     effect?: 'straight' | 'squiggly' | 'dotted';
 }) => (

--- a/src/web/components/HeadlineByline.tsx
+++ b/src/web/components/HeadlineByline.tsx
@@ -36,7 +36,7 @@ const yellowBoxStyles = css`
     }
 `;
 
-const opinionStyles = (pillar: Pillar) => css`
+const opinionStyles = (pillar: CAPIPillar) => css`
     ${headline.medium({
         fontWeight: 'light',
     })}
@@ -64,7 +64,7 @@ const immersiveStyles = css`
     margin-bottom: ${space[6]}px;
 `;
 
-const immersiveLinkStyles = (pillar: Pillar) => css`
+const immersiveLinkStyles = (pillar: CAPIPillar) => css`
     a {
         color: ${pillarPalette[pillar].main};
         border-bottom: 1px solid ${pillarPalette[pillar].main};
@@ -85,7 +85,7 @@ const authorBylineWithImage = css`
 type Props = {
     display: Display;
     designType: DesignType;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     byline: string;
     tags: TagType[];
 };

--- a/src/web/components/HeadlineTag.tsx
+++ b/src/web/components/HeadlineTag.tsx
@@ -9,7 +9,7 @@ const headlineTagWrapper = css`
     margin-top: 6px;
 `;
 
-const headlineTagStyles = (pillar: Pillar) => css`
+const headlineTagStyles = (pillar: CAPIPillar) => css`
     background-color: ${pillarPalette[pillar].dark};
     color: ${brandText.primary};
     ${headline.xxsmall({ fontWeight: 'bold', lineHeight: 'loose' })}
@@ -21,7 +21,7 @@ const headlineTagStyles = (pillar: Pillar) => css`
 
 type Props = {
     tagText: string;
-    pillar: Pillar;
+    pillar: CAPIPillar;
 };
 
 export const HeadlineTag = ({ tagText, pillar }: Props) => (

--- a/src/web/components/Kicker.tsx
+++ b/src/web/components/Kicker.tsx
@@ -22,7 +22,7 @@ const slashStyles = css`
 
 const decideColour = (
     designType: DesignType,
-    pillar: Pillar,
+    pillar: CAPIPillar,
     inCard?: boolean,
 ) => {
     switch (designType) {

--- a/src/web/components/MainMedia.tsx
+++ b/src/web/components/MainMedia.tsx
@@ -56,7 +56,7 @@ function renderElement(
     display: Display,
     designType: DesignType,
     element: CAPIElement,
-    pillar: Pillar,
+    pillar: CAPIPillar,
     i: number,
     hideCaption?: boolean,
     adTargeting?: AdTargeting,
@@ -117,7 +117,7 @@ export const MainMedia: React.FC<{
     display: Display;
     designType: DesignType;
     elements: CAPIElement[];
-    pillar: Pillar;
+    pillar: CAPIPillar;
     hideCaption?: boolean;
     adTargeting?: AdTargeting;
     starRating?: number;

--- a/src/web/components/MediaMeta.tsx
+++ b/src/web/components/MediaMeta.tsx
@@ -10,11 +10,11 @@ import Video from '@frontend/static/icons/video.svg';
 
 type Props = {
     mediaType: MediaType;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     mediaDuration?: number;
 };
 
-const iconWrapperStyles = (mediaType: MediaType, pillar: Pillar) => css`
+const iconWrapperStyles = (mediaType: MediaType, pillar: CAPIPillar) => css`
     width: 24px;
     height: 23px;
     /* Below we force the colour to be bright if the pillar is news (because it looks better) */
@@ -35,7 +35,7 @@ const iconWrapperStyles = (mediaType: MediaType, pillar: Pillar) => css`
     }
 `;
 
-const durationStyles = (pillar: Pillar) => css`
+const durationStyles = (pillar: CAPIPillar) => css`
     /* Below we force the colour to be bright if the pillar is news (because it looks better) */
     color: ${pillar === 'news'
         ? pillarPalette[pillar].bright
@@ -89,7 +89,7 @@ const MediaIcon = ({
     pillar,
 }: {
     mediaType: MediaType;
-    pillar: Pillar;
+    pillar: CAPIPillar;
 }) => (
     <span className={iconWrapperStyles(mediaType, pillar)}>
         <Icon mediaType={mediaType} />
@@ -101,7 +101,7 @@ const MediaDuration = ({
     pillar,
 }: {
     mediaDuration: number;
-    pillar: Pillar;
+    pillar: CAPIPillar;
 }) => (
     <p className={durationStyles(pillar)}>{secondsToDuration(mediaDuration)}</p>
 );

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.tsx
@@ -93,7 +93,7 @@ const mostPopularAdStyle = css`
 
 interface Props {
     sectionName?: string;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     ajaxUrl: string;
     display: Display;
 }

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterData.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterData.tsx
@@ -12,7 +12,7 @@ import { SecondTierItem } from './SecondTierItem';
 
 type Props = {
     sectionName?: string;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     ajaxUrl: string;
 };
 

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterGrid.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterGrid.tsx
@@ -42,7 +42,7 @@ const firstTab = css`
     border-right: ${thinGreySolid};
 `;
 
-const selectedListTab = (pillar: Pillar) => css`
+const selectedListTab = (pillar: CAPIPillar) => css`
     /* TODO: Using a pseudo selector here could be faster? */
     box-shadow: inset 0px 4px 0px 0px ${pillar && pillarPalette[pillar].dark};
     transition: box-shadow 0.3s ease-in-out;
@@ -96,7 +96,7 @@ const gridContainer = css`
 type Props = {
     data: TrailTabType[];
     sectionName?: string;
-    pillar: Pillar;
+    pillar: CAPIPillar;
 };
 
 export const MostViewedFooterGrid = ({ data, sectionName, pillar }: Props) => {

--- a/src/web/components/MostViewed/MostViewedRight/MostViewedRight.tsx
+++ b/src/web/components/MostViewed/MostViewedRight/MostViewedRight.tsx
@@ -18,7 +18,7 @@ const headingStyles = css`
 `;
 
 interface Props {
-    pillar: Pillar;
+    pillar: CAPIPillar;
     limitItems?: number;
 }
 

--- a/src/web/components/MostViewed/MostViewedRight/MostViewedRightWrapper.tsx
+++ b/src/web/components/MostViewed/MostViewedRight/MostViewedRightWrapper.tsx
@@ -4,7 +4,7 @@ import { css } from 'emotion';
 import { MostViewedRight } from './MostViewedRight';
 
 type Props = {
-    pillar: Pillar;
+    pillar: CAPIPillar;
     limitItems?: number;
 };
 

--- a/src/web/components/Nav/Nav.test.tsx
+++ b/src/web/components/Nav/Nav.test.tsx
@@ -4,7 +4,7 @@ import { Display } from '@guardian/types/Format';
 import { Nav } from './Nav';
 import { nav } from './Nav.mock';
 
-// type Pillar = "news" | "opinion" | "sport" | "culture" | "lifestyle" | "labs"
+// type CAPIPillar = "news" | "opinion" | "sport" | "culture" | "lifestyle" | "labs"
 
 describe('Nav', () => {
     it('should display pillar titles', () => {

--- a/src/web/components/Nav/Nav.tsx
+++ b/src/web/components/Nav/Nav.tsx
@@ -19,7 +19,7 @@ import { navInputCheckboxId, showMoreButtonId, veggieBurgerId } from './config';
 import { ExpandedMenu } from './ExpandedMenu/ExpandedMenu';
 
 type Props = {
-    pillar: Pillar;
+    pillar: CAPIPillar;
     nav: NavType;
     display: Display;
     subscribeUrl: string;

--- a/src/web/components/Onwards/Carousel/Carousel.tsx
+++ b/src/web/components/Onwards/Carousel/Carousel.tsx
@@ -117,7 +117,10 @@ const cardImageStyle = css`
     width: 258px;
 `;
 
-const headlineWrapperStyle = (designType: DesignType, pillar: Pillar) => css`
+const headlineWrapperStyle = (
+    designType: DesignType,
+    pillar: CAPIPillar,
+) => css`
     width: 90%;
     min-height: 107px;
 
@@ -141,7 +144,7 @@ const headlineWrapperStyle = (designType: DesignType, pillar: Pillar) => css`
     color: white;
 `;
  */
-const headlineStyle = (designType: DesignType, pillar: Pillar) => css`
+const headlineStyle = (designType: DesignType, pillar: CAPIPillar) => css`
     ${headline.xxxsmall()};
     ${from.desktop} {
         ${headline.xxsmall()};
@@ -184,7 +187,7 @@ const dotStyle = css`
     }
 `;
 
-const dotActiveStyle = (pillar: Pillar) => css`
+const dotActiveStyle = (pillar: CAPIPillar) => css`
     background-color: ${pillarPalette[pillar][400]};
 
     &:hover,
@@ -248,7 +251,7 @@ const headerStyles = css`
     padding-top: 0;
 `;
 
-const titleStyle = (pillar: Pillar) => css`
+const titleStyle = (pillar: CAPIPillar) => css`
     color: ${pillarPalette[pillar].main};
 `;
 
@@ -258,7 +261,7 @@ export const Title = ({
 }: {
     title: string;
     url?: string;
-    pillar: Pillar;
+    pillar: CAPIPillar;
 }) => (
     <h2 className={headerStyles}>
         More from <span className={titleStyle(pillar)}>{title}</span>

--- a/src/web/components/Onwards/Carousel/cardColours.tsx
+++ b/src/web/components/Onwards/Carousel/cardColours.tsx
@@ -4,7 +4,7 @@ import { pillarPalette } from '@frontend/lib/pillars';
 
 export const headlineBackgroundColour = (
     designType: DesignType,
-    pillar: Pillar,
+    pillar: CAPIPillar,
 ) => {
     switch (designType) {
         case 'GuardianView':
@@ -42,7 +42,7 @@ const colourStyles = (colour: string) => css`
     color: ${colour};
 `;
 
-export const headlineColour = (designType: DesignType, pillar: Pillar) => {
+export const headlineColour = (designType: DesignType, pillar: CAPIPillar) => {
     switch (designType) {
         case 'Feature':
         case 'Interview':

--- a/src/web/components/Onwards/OnwardsData.tsx
+++ b/src/web/components/Onwards/OnwardsData.tsx
@@ -6,7 +6,7 @@ type Props = {
     limit: number; // Limit the number of items shown (the api often returns more)
     ophanComponentName: OphanComponentName;
     Container: React.FC<OnwardsType>;
-    pillar: Pillar;
+    pillar: CAPIPillar;
 };
 
 type OnwardsResponse = {

--- a/src/web/components/Onwards/OnwardsLower.tsx
+++ b/src/web/components/Onwards/OnwardsLower.tsx
@@ -8,7 +8,7 @@ type Props = {
     ajaxUrl: string;
     hasStoryPackage: boolean;
     tags: TagType[];
-    pillar: Pillar;
+    pillar: CAPIPillar;
 };
 
 export const OnwardsLower = ({

--- a/src/web/components/Onwards/OnwardsUpper.tsx
+++ b/src/web/components/Onwards/OnwardsUpper.tsx
@@ -137,7 +137,7 @@ const lifestyleContainer = (edition: Edition): string => {
 };
 
 const getContainerDataUrl = (
-    pillar: Pillar,
+    pillar: CAPIPillar,
     edition: Edition,
     ajaxUrl: string,
 ) => {
@@ -193,7 +193,7 @@ type Props = {
     contentType: string;
     tags: TagType[];
     edition: Edition;
-    pillar: Pillar;
+    pillar: CAPIPillar;
 };
 
 export const OnwardsUpper = ({

--- a/src/web/components/Pillars.tsx
+++ b/src/web/components/Pillars.tsx
@@ -227,7 +227,7 @@ export const Pillars: React.FC<{
     display: Display;
     isTopNav?: boolean;
     pillars: PillarType[];
-    pillar: Pillar;
+    pillar: CAPIPillar;
     showLastPillarDivider?: boolean;
     dataLinkName: string;
 }> = ({

--- a/src/web/components/RichLink.tsx
+++ b/src/web/components/RichLink.tsx
@@ -42,7 +42,7 @@ interface Props {
     contentType: ContentType;
     url: string;
     starRating?: number;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     tags: TagType[];
     sponsorName: string;
     contributorImage?: string;
@@ -84,26 +84,26 @@ const neutralBackground = css`
     }
 `;
 
-const richLinkPillarColour: (pillar: Pillar) => colour = (pillar) => {
+const richLinkPillarColour: (pillar: CAPIPillar) => colour = (pillar) => {
     if (pillar) {
         return pillarPalette[pillar].main;
     }
     return pillarPalette.news[400];
 };
 
-const pillarBackground: (pillar: Pillar) => colour = (pillar) => {
+const pillarBackground: (pillar: CAPIPillar) => colour = (pillar) => {
     return css`
         background-color: ${richLinkPillarColour(pillar)};
     `;
 };
 
-const textColour: (pillar: Pillar) => colour = (pillar) => {
+const textColour: (pillar: CAPIPillar) => colour = (pillar) => {
     return css`
         color: ${richLinkPillarColour(pillar)};
     `;
 };
 
-const richLinkTopBorder: (pillar: Pillar) => colour = (pillar) => {
+const richLinkTopBorder: (pillar: CAPIPillar) => colour = (pillar) => {
     return css`
         border-top: 1px;
         border-top-style: solid;
@@ -139,7 +139,7 @@ const richLinkTitle = css`
     }
 `;
 
-const richLinkReadMore: (pillar: Pillar) => colour = (pillar) => {
+const richLinkReadMore: (pillar: CAPIPillar) => colour = (pillar) => {
     return css`
         fill: ${richLinkPillarColour(pillar)};
         color: ${richLinkPillarColour(pillar)};

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -16,7 +16,7 @@ type Props = {
     sectionLabel: string;
     sectionUrl: string;
     guardianBaseURL: string;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     badge?: BadgeType;
     isSpecial?: boolean;
 };
@@ -62,7 +62,7 @@ const primaryStyle = css`
     padding-right: ${space[2]}px;
 `;
 
-const invertedStyle = (pillar: Pillar) => css`
+const invertedStyle = (pillar: CAPIPillar) => css`
     font-weight: 700;
     ${headline.xxxsmall({ fontWeight: 'bold' })};
     ${from.leftCol} {

--- a/src/web/components/ShareIcons.tsx
+++ b/src/web/components/ShareIcons.tsx
@@ -87,7 +87,7 @@ export const SharingIcons: React.FC<{
         };
     };
     displayIcons: SharePlatform[];
-    pillar: Pillar;
+    pillar: CAPIPillar;
     className?: string;
 }> = ({ sharingUrls, displayIcons, pillar, className }) => {
     const icons: { [K in SharePlatform]?: React.ComponentType } = {

--- a/src/web/components/SignedInAs.tsx
+++ b/src/web/components/SignedInAs.tsx
@@ -10,7 +10,7 @@ import { createAuthenticationEventParams } from '@root/src/lib/identity-componen
 
 type Props = {
     commentCount: number;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     enableDiscussionSwitch: boolean;
     user?: UserProfile;
     isClosedForComments?: boolean;
@@ -61,7 +61,7 @@ const usernameStyles = css`
     color: ${text.primary};
 `;
 
-const linkStyles = (pillar: Pillar) => css`
+const linkStyles = (pillar: CAPIPillar) => css`
     color: ${pillarPalette[pillar].dark};
     text-decoration: none;
     border-bottom: 1px solid ${border.secondary};

--- a/src/web/components/SubMeta.tsx
+++ b/src/web/components/SubMeta.tsx
@@ -38,7 +38,7 @@ const bottomPadding = css`
 `;
 
 type Props = {
-    pillar: Pillar;
+    pillar: CAPIPillar;
     subMetaSectionLinks: SimpleLinkType[];
     subMetaKeywordLinks: SimpleLinkType[];
     pageId: string;

--- a/src/web/components/SubMetaLinksList.test.tsx
+++ b/src/web/components/SubMetaLinksList.test.tsx
@@ -13,7 +13,7 @@ describe('SubMetaLinksList', () => {
             title: 'Test 2',
         },
     ];
-    const pillar: Pillar = 'news';
+    const pillar: CAPIPillar = 'news';
 
     it('It should render correct amount of links', () => {
         const { container, getByText } = render(

--- a/src/web/components/SubMetaLinksList.tsx
+++ b/src/web/components/SubMetaLinksList.tsx
@@ -68,7 +68,7 @@ const hideSlash = css`
 export const SubMetaLinksList: React.FC<{
     links: SimpleLinkType[];
     isSectionLinkList: boolean;
-    pillar: Pillar;
+    pillar: CAPIPillar;
 }> = ({ links, isSectionLinkList, pillar }) => (
     <ul
         className={cx(subMetaLinksList, [

--- a/src/web/components/SubNav/SubNav.tsx
+++ b/src/web/components/SubNav/SubNav.tsx
@@ -8,7 +8,7 @@ import { pillarPalette, pillarMap } from '@root/src/lib/pillars';
 
 type Props = {
     subNavSections: SubNavType;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     currentNavLink: string;
 };
 

--- a/src/web/components/elements/BlockquoteBlockComponent.tsx
+++ b/src/web/components/elements/BlockquoteBlockComponent.tsx
@@ -10,7 +10,7 @@ import { QuoteIcon } from '@root/src/web/components/QuoteIcon';
 
 type Props = {
     html: string;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     quoted?: boolean;
 };
 

--- a/src/web/components/elements/CalloutBlockComponent.tsx
+++ b/src/web/components/elements/CalloutBlockComponent.tsx
@@ -72,7 +72,7 @@ const summeryContentWrapper = css`
     flex-direction: row;
 `;
 
-const speechBubbleStyles = (pillar: Pillar) => css`
+const speechBubbleStyles = (pillar: CAPIPillar) => css`
     ${textSans.medium({ fontWeight: 'bold' })}
     color: ${neutral[100]};
     background-color: ${palette[pillar][400]};
@@ -128,7 +128,7 @@ export const CalloutBlockComponent = ({
     pillar,
 }: {
     callout: CalloutBlockElement;
-    pillar: Pillar;
+    pillar: CAPIPillar;
 }) => {
     let expandFormButtonRef: HTMLButtonElement | null = null;
     let firstFieldElementRef: HTMLElement | null = null;

--- a/src/web/components/elements/CaptionBlockComponent.stories.tsx
+++ b/src/web/components/elements/CaptionBlockComponent.stories.tsx
@@ -19,7 +19,7 @@ export default {
         display: Display;
         designType: DesignType;
         captionText?: string;
-        pillar: Pillar;
+        pillar: CAPIPillar;
         padCaption?: boolean;
         credit?: string;
         displayCredit?: boolean;

--- a/src/web/components/elements/CaptionBlockComponent.tsx
+++ b/src/web/components/elements/CaptionBlockComponent.tsx
@@ -7,7 +7,7 @@ type Props = {
     display: Display;
     designType: DesignType;
     captionText?: string;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     padCaption?: boolean;
     credit?: string;
     displayCredit?: boolean;

--- a/src/web/components/elements/DisclaimerBlockComponent.tsx
+++ b/src/web/components/elements/DisclaimerBlockComponent.tsx
@@ -3,7 +3,7 @@ import { body } from '@guardian/src-foundations/typography';
 import { pillarPalette } from '@root/src/lib/pillars';
 import { css } from 'emotion';
 
-const style = (pillar: Pillar) => css`
+const style = (pillar: CAPIPillar) => css`
     ${body.small()};
 
     a {
@@ -19,7 +19,7 @@ const style = (pillar: Pillar) => css`
 
 export const DisclaimerBlockComponent: React.FC<{
     html: string;
-    pillar: Pillar;
+    pillar: CAPIPillar;
 }> = ({ html, pillar }) => (
     <footer
         className={style(pillar)}

--- a/src/web/components/elements/GuVideoBlockComponent.tsx
+++ b/src/web/components/elements/GuVideoBlockComponent.tsx
@@ -7,7 +7,7 @@ import { Display } from '@guardian/types/Format';
 
 export const GuVideoBlockComponent: React.FC<{
     html: string;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     designType: DesignType;
     display: Display;
     credit: string;

--- a/src/web/components/elements/ImageBlockComponent.stories.tsx
+++ b/src/web/components/elements/ImageBlockComponent.stories.tsx
@@ -48,7 +48,7 @@ const Container = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
     display: Display;
     designType: DesignType;
     element: ImageBlockElement;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     hideCaption?: boolean;
 };
  */

--- a/src/web/components/elements/ImageBlockComponent.tsx
+++ b/src/web/components/elements/ImageBlockComponent.tsx
@@ -7,7 +7,7 @@ type Props = {
     display: Display;
     designType: DesignType;
     element: ImageBlockElement;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     hideCaption?: boolean;
     title?: string;
 };

--- a/src/web/components/elements/ImageComponent.tsx
+++ b/src/web/components/elements/ImageComponent.tsx
@@ -17,7 +17,7 @@ type Props = {
     designType: DesignType;
     element: ImageBlockElement;
     role: RoleType;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     hideCaption?: boolean;
     isMainMedia?: boolean;
     starRating?: number;
@@ -101,7 +101,7 @@ const moreTitlePadding = css`
     }
 `;
 
-const titleWrapper = (pillar: Pillar) => css`
+const titleWrapper = (pillar: CAPIPillar) => css`
     position: absolute;
     bottom: 0;
     width: 100%;
@@ -137,7 +137,7 @@ const titleWrapper = (pillar: Pillar) => css`
 const ImageTitle: React.FC<{
     title: string;
     role: RoleType;
-    pillar: Pillar;
+    pillar: CAPIPillar;
 }> = ({ title, role, pillar }) => {
     switch (role) {
         case 'inline':

--- a/src/web/components/elements/MapEmbedBlockComponent.tsx
+++ b/src/web/components/elements/MapEmbedBlockComponent.tsx
@@ -11,7 +11,7 @@ export const MapEmbedBlockComponent: React.FC<{
     width: number;
     title?: string;
     caption?: string;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     display: Display;
     designType: DesignType;
     credit?: string;

--- a/src/web/components/elements/MultiImageBlockComponent.tsx
+++ b/src/web/components/elements/MultiImageBlockComponent.tsx
@@ -13,7 +13,7 @@ type Props = {
     designType: DesignType;
     images: ImageBlockElement[];
     caption?: string;
-    pillar: Pillar;
+    pillar: CAPIPillar;
 };
 
 const ieFallback = css`

--- a/src/web/components/elements/PullQuoteBlockComponent.tsx
+++ b/src/web/components/elements/PullQuoteBlockComponent.tsx
@@ -119,7 +119,7 @@ function decideFont(role: string) {
 
 export const PullQuoteBlockComponent: React.FC<{
     html: string;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     designType: DesignType;
     role: string;
     attribution?: string;

--- a/src/web/components/elements/RichLinkComponent.tsx
+++ b/src/web/components/elements/RichLinkComponent.tsx
@@ -26,7 +26,7 @@ interface RichLinkType {
     contentType: ContentType;
     url: string;
     starRating?: number;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     tags: TagType[];
     sponsorName: string;
     contributorImage?: string;
@@ -42,7 +42,7 @@ const buildUrl: (element: RichLinkBlockElement, ajaxUrl: string) => string = (
 
 export const RichLinkComponent: React.FC<{
     element: RichLinkBlockElement;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     ajaxEndpoint: string;
     richLinkIndex: number;
 }> = ({ element, ajaxEndpoint, richLinkIndex }) => {

--- a/src/web/components/elements/SpotifyBlockComponent.tsx
+++ b/src/web/components/elements/SpotifyBlockComponent.tsx
@@ -8,7 +8,7 @@ export const SpotifyBlockComponent: React.FC<{
     height?: number;
     width?: number;
     title?: string;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     caption?: string;
     display: Display;
     designType: DesignType;

--- a/src/web/components/elements/TextBlockComponent.tsx
+++ b/src/web/components/elements/TextBlockComponent.tsx
@@ -14,7 +14,7 @@ import { Display } from '@guardian/types/Format';
 
 type Props = {
     html: string;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     designType: DesignType;
     display: Display;
     isFirstParagraph: boolean;

--- a/src/web/components/elements/VideoFacebookBlockComponent.tsx
+++ b/src/web/components/elements/VideoFacebookBlockComponent.tsx
@@ -6,7 +6,7 @@ import { MaintainAspectRatio } from '@frontend/web/components/MaintainAspectRati
 import { Display } from '@guardian/types/Format';
 
 export const VideoFacebookBlockComponent: React.FC<{
-    pillar: Pillar;
+    pillar: CAPIPillar;
     embedUrl?: string;
     height: number;
     width: number;

--- a/src/web/components/elements/VimeoBlockComponent.tsx
+++ b/src/web/components/elements/VimeoBlockComponent.tsx
@@ -16,7 +16,7 @@ const responsiveAspectRatio = (height: number, width: number) => css`
     }
 `;
 export const VimeoBlockComponent: React.FC<{
-    pillar: Pillar;
+    pillar: CAPIPillar;
     embedUrl?: string;
     height: number;
     width: number;

--- a/src/web/components/elements/YoutubeBlockComponent.tsx
+++ b/src/web/components/elements/YoutubeBlockComponent.tsx
@@ -20,7 +20,7 @@ type Props = {
     assetId: string;
     channelId: string;
     expired: boolean;
-    pillar: Pillar;
+    pillar: CAPIPillar;
     role: RoleType;
     hideCaption?: boolean;
     overrideImage?: string;

--- a/src/web/components/elements/YoutubeEmbedBlockComponent.tsx
+++ b/src/web/components/elements/YoutubeEmbedBlockComponent.tsx
@@ -6,7 +6,7 @@ import { MaintainAspectRatio } from '@frontend/web/components/MaintainAspectRati
 import { Display } from '@guardian/types/Format';
 
 export const YoutubeEmbedBlockComponent: React.FC<{
-    pillar: Pillar;
+    pillar: CAPIPillar;
     embedUrl?: string;
     height: number;
     width: number;

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -250,7 +250,7 @@ interface Props {
     NAV: NavType;
     display: Display;
     designType: DesignType;
-    pillar: Pillar;
+    pillar: CAPIPillar;
 }
 
 export const CommentLayout = ({

--- a/src/web/layouts/DecideLayout.tsx
+++ b/src/web/layouts/DecideLayout.tsx
@@ -16,7 +16,7 @@ type Props = {
 
 export const DecideLayout = ({ CAPI, NAV }: Props) => {
     const display: Display = decideDisplay(CAPI);
-    const pillar: Pillar = decidePillar(CAPI);
+    const pillar: CAPIPillar = decidePillar(CAPI);
     const designType: DesignType = decideDesignType(CAPI);
 
     switch (display) {

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -166,7 +166,7 @@ interface Props {
     NAV: NavType;
     display: Display;
     designType: DesignType;
-    pillar: Pillar;
+    pillar: CAPIPillar;
 }
 
 const decideCaption = (mainMedia: ImageBlockElement): string => {

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -232,7 +232,7 @@ interface Props {
     NAV: NavType;
     display: Display;
     designType: DesignType;
-    pillar: Pillar;
+    pillar: CAPIPillar;
 }
 
 export const ShowcaseLayout = ({

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -293,7 +293,7 @@ interface Props {
     NAV: NavType;
     display: Display;
     designType: DesignType;
-    pillar: Pillar;
+    pillar: CAPIPillar;
 }
 
 export const StandardLayout = ({

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -55,7 +55,7 @@ const commercialPosition = css`
 export const ArticleRenderer: React.FC<{
     display: Display;
     elements: CAPIElement[];
-    pillar: Pillar;
+    pillar: CAPIPillar;
     designType: DesignType;
     adTargeting?: AdTargeting;
     host?: string;

--- a/src/web/lib/decidePillar.ts
+++ b/src/web/lib/decidePillar.ts
@@ -1,4 +1,4 @@
-export const decidePillar = (CAPI: CAPIType | CAPIBrowserType): Pillar => {
+export const decidePillar = (CAPI: CAPIType | CAPIBrowserType): CAPIPillar => {
     // We override the pillar to be opinion on Comment news pieces
     if (CAPI.designType === 'Comment' && CAPI.pillar === 'news')
         return 'opinion';

--- a/src/web/lib/decidePillarLight.ts
+++ b/src/web/lib/decidePillarLight.ts
@@ -1,6 +1,6 @@
 import { pillarPalette } from '@frontend/lib/pillars';
 
-export const decidePillarLight = (pillar: Pillar) => {
+export const decidePillarLight = (pillar: CAPIPillar) => {
     // TODO: This function is a tempoary workaround while we wait for source foundation to be updated with
     // these colours
     switch (pillar) {

--- a/src/web/lib/layoutHelpers.ts
+++ b/src/web/lib/layoutHelpers.ts
@@ -1,6 +1,6 @@
 export const decideLineEffect = (
     designType: DesignType,
-    pillar: Pillar,
+    pillar: CAPIPillar,
 ): LineEffectType => {
     if (pillar === 'sport') {
         return 'dotted';
@@ -35,7 +35,7 @@ export const decideLineCount = (designType?: DesignType): 8 | 4 => {
     return 4;
 };
 
-export const getCurrentPillar = (CAPI: CAPIType): Pillar => {
+export const getCurrentPillar = (CAPI: CAPIType): CAPIPillar => {
     return (
         (CAPI.nav.currentPillar &&
             CAPI.nav.currentPillar.title.toLowerCase()) ||


### PR DESCRIPTION
## What?
Renames the type `Pillar` to `CAPIPillar`

**From hereon, `Pillar` refers to the a const enum version and CAPIPillar represents strings.**

## Why?
We are already importing the const enum version of `Pillar` in the codebase and plan to move everything over to this soon. But because we have two version of Pillar it creates the possibility for auto import errors and also is just generally confusing.

The concept of a string pillar type won't go away. CAPI us unlikely to move over to the types lib version so by explicitly defining this string version as `CAPIPillar` it's a lot clearer what the intentions are.
 