### PR TITLE
EOY header test: new variant

### DIFF
--- a/src/web/components/ReaderRevenueLinks.tsx
+++ b/src/web/components/ReaderRevenueLinks.tsx
@@ -141,6 +141,11 @@ export const ReaderRevenueLinks: React.FC<Props> = ({
 			if (ABTestAPI.isUserInVariant(GlobalEoyHeaderTestName, 'variant')) {
 				return 'variant';
 			}
+			if (
+				ABTestAPI.isUserInVariant(GlobalEoyHeaderTestName, 'variant2')
+			) {
+				return 'variant2';
+			}
 		}
 		return 'notintest';
 	};
@@ -159,7 +164,7 @@ export const ReaderRevenueLinks: React.FC<Props> = ({
 	}, [variantName]);
 
 	const getHeading = (): string | JSX.Element => {
-		if (variantName === 'variant')
+		if (variantName === 'variant' || variantName === 'variant2')
 			return month === 12
 				? `Support us this December`
 				: 'Support us in 2021';

--- a/src/web/experiments/tests/global-eoy-header-test.ts
+++ b/src/web/experiments/tests/global-eoy-header-test.ts
@@ -1,7 +1,11 @@
 import { ABTest } from '@guardian/ab-core';
 
 export const GlobalEoyHeaderTestName = 'GlobalEoyHeaderTest';
-export type GlobalEoyHeaderTestVariant = 'control' | 'variant' | 'notintest';
+export type GlobalEoyHeaderTestVariant =
+	| 'control'
+	| 'variant'
+	| 'variant2'
+	| 'notintest';
 
 const month = new Date().getMonth() + 1; // js date month begins at 0
 
@@ -24,7 +28,11 @@ export const globalEoyHeaderTest: ABTest = {
 			test: (): void => {},
 		},
 		{
-			id: 'variant',
+			id: 'variant', // different heading + subheading
+			test: (): void => {},
+		},
+		{
+			id: 'variant2', // different heading only
 			test: (): void => {},
 		},
 	],


### PR DESCRIPTION
We've been testing a variant with different heading + subheading.
Now we want another variant with different heading but the same subheading as the control.

The variant names here aren't great, but changing the original variant name will mess up the analysis at this point.

<img width="330" alt="Screen Shot 2021-01-04 at 11 40 45" src="https://user-images.githubusercontent.com/1513454/103532190-b4be0880-4e82-11eb-9933-a0bd7e24c085.png">
