### PR TITLE
Added CAPITrailType

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -696,6 +696,10 @@ interface TrailType {
     linkText?: string;
 }
 
+interface CAPITrailType extends TrailType {
+    pillar: CAPIPillar;
+}
+
 interface TrailTabType {
     heading: string;
     trails: TrailType[];

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -605,6 +605,7 @@ export const App = ({ CAPI, NAV }: Props) => {
 							tags={CAPI.tags}
 							edition={CAPI.editionId}
 							pillar={pillar}
+							designType={designType}
 						/>
 					</Suspense>
 				</Lazy>
@@ -623,6 +624,7 @@ export const App = ({ CAPI, NAV }: Props) => {
 							hasStoryPackage={CAPI.hasStoryPackage}
 							tags={CAPI.tags}
 							pillar={pillar}
+							designType={designType}
 						/>
 					</Suspense>
 				</Lazy>

--- a/src/web/components/Onwards/OnwardsData.tsx
+++ b/src/web/components/Onwards/OnwardsData.tsx
@@ -1,12 +1,15 @@
 import { useApi } from '@root/src/web/lib/api';
 import React from 'react';
 
+import { decidePillar } from '@root/src/web/lib/decidePillar';
+
 type Props = {
 	url: string;
 	limit: number; // Limit the number of items shown (the api often returns more)
 	ophanComponentName: OphanComponentName;
 	Container: React.FC<OnwardsType>;
 	pillar: CAPIPillar;
+	designType: DesignType;
 };
 
 type OnwardsResponse = {
@@ -22,13 +25,25 @@ export const OnwardsData = ({
 	ophanComponentName,
 	Container,
 	pillar,
+	designType,
 }: Props) => {
 	const { data } = useApi<OnwardsResponse>(url);
+
+	const buildTrails = (
+		trails: CAPITrailType[],
+		trailLimit: number,
+	): TrailType[] => {
+		return trails.slice(0, trailLimit).map((trail) => ({
+			...trail,
+			pillar: decidePillar({ pillar: trail.pillar, design: designType }),
+		}));
+	};
+
 	if (data && data.trails) {
 		return (
 			<Container
 				heading={data.heading || data.displayname} // Sometimes the api returns heading as 'displayName'
-				trails={limit ? data.trails.slice(0, limit) : data.trails}
+				trails={buildTrails(data.trails, limit)}
 				description={data.description}
 				ophanComponentName={ophanComponentName}
 				pillar={pillar}

--- a/src/web/components/Onwards/OnwardsLower.tsx
+++ b/src/web/components/Onwards/OnwardsLower.tsx
@@ -9,6 +9,7 @@ type Props = {
 	hasStoryPackage: boolean;
 	tags: TagType[];
 	pillar: CAPIPillar;
+	designType: DesignType;
 };
 
 export const OnwardsLower = ({
@@ -16,6 +17,7 @@ export const OnwardsLower = ({
 	hasStoryPackage,
 	tags,
 	pillar,
+	designType,
 }: Props) => {
 	// In this context, Blog tags are treated the same as Series tags
 	const seriesTag = tags.find(
@@ -46,6 +48,7 @@ export const OnwardsLower = ({
 			ophanComponentName={ophanComponentName}
 			Container={OnwardsLayout}
 			pillar={pillar}
+			designType={designType}
 		/>
 	);
 };

--- a/src/web/components/Onwards/OnwardsUpper.tsx
+++ b/src/web/components/Onwards/OnwardsUpper.tsx
@@ -194,6 +194,7 @@ type Props = {
 	tags: TagType[];
 	edition: Edition;
 	pillar: CAPIPillar;
+	designType: DesignType;
 };
 
 export const OnwardsUpper = ({
@@ -209,6 +210,7 @@ export const OnwardsUpper = ({
 	tags,
 	edition,
 	pillar,
+	designType,
 }: Props) => {
 	const dontShowRelatedContent = !showRelatedContent || !hasRelated;
 
@@ -303,6 +305,7 @@ export const OnwardsUpper = ({
 						ophanComponentName="curated-content"
 						Container={Carousel}
 						pillar={pillar}
+						designType={designType}
 					/>
 				</Section>
 			)}
@@ -314,6 +317,7 @@ export const OnwardsUpper = ({
 						ophanComponentName="curated-content"
 						Container={OnwardsLayout}
 						pillar={pillar}
+						designType={designType}
 					/>
 				</Section>
 			)}
@@ -325,6 +329,7 @@ export const OnwardsUpper = ({
 						ophanComponentName={ophanComponentName}
 						Container={OnwardsLayout}
 						pillar={pillar}
+						designType={designType}
 					/>
 				</Section>
 			)}


### PR DESCRIPTION
## What?
Adds a new `CAPITrailType` type so that we can have different types of trail data, data from CAPI and data that we pass into the stack (as `TrailType`).

To facilitate this data transformation, we add the `buildTrails` function

## Why?
This allows for the enhancement of the results we get back from api calls. Specifically, we are now able to transform `pillar` into a const enum.