### PR TITLE
Peachy

### DIFF
--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -562,7 +562,10 @@ export const CommentLayout = ({
 					)}
 
 					{showComments && (
-						<Section sectionId="comments">
+						<Section
+							sectionId="comments"
+							backgroundColour={opinion[800]}
+						>
 							<Discussion
 								discussionApiUrl={CAPI.config.discussionApiUrl}
 								shortUrlId={CAPI.config.shortUrlId}
@@ -587,7 +590,10 @@ export const CommentLayout = ({
 						<Section sectionId="onwards-lower-whensignedin" />
 					)}
 
-					<Section sectionId="most-viewed-footer" />
+					<Section
+						sectionId="most-viewed-footer"
+						backgroundColour={opinion[800]}
+					/>
 				</>
 			)}
 
@@ -601,7 +607,11 @@ export const CommentLayout = ({
 			</Section>
 
 			{NAV.subNavSections && (
-				<Section padded={false} sectionId="sub-nav-root">
+				<Section
+					padded={false}
+					sectionId="sub-nav-root"
+					backgroundColour={opinion[800]}
+				>
 					<SubNav
 						subNavSections={NAV.subNavSections}
 						currentNavLink={NAV.currentNavLink}


### PR DESCRIPTION
## What?
Here we propose extending the comment background colour to more of the page.

![Screenshot 2021-01-04 at 15 33 41](https://user-images.githubusercontent.com/1336821/103551445-40935d00-4ea2-11eb-86c9-44532abafdd6.jpg)


## Why?
Because why not? This type of change is easy in DCR and has zero cost in terms of css complexity.

There's an argument that the background implies some kind of 'opinion' quality to the content and so we should limit it purely to the comment piece itself, and that applying it to below the fold content like Most Popular changes it. But we already change the background colour of Most Viewed (in the right column) and in fact the context of Most Popular _does_ change for opinion pieces.

My feeling is that it is desirable to have a consistent background colour and that sudden switches on the same page are jarring.

Another reason to move towards more consistency is to help with future work like new layout designs or for dark mode. If we already start to think about page level colours this will help a lot with these things.

## Why not Onwards?
The cards in onwards use their background colour to distinguish their borders so using the same colour for the container background will wash out this distinction. If we did want to fully set the entire page background then we could perhaps use a special border colour for comment cards to prevent this wash out?