### PR TITLE
Remove GuardianLabs

### DIFF
--- a/docs/patterns/switch-on-display-design.md
+++ b/docs/patterns/switch-on-display-design.md
@@ -25,7 +25,6 @@ const shouldShowAvatar = (designType: DesignType, display: Display) => {
                 case 'Article':
                 case 'MatchReport':
                 case 'GuardianView':
-                case 'GuardianLabs':
                 case 'Quiz':
                 case 'AdvertisementFeature':
                 case 'Comment':

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,7 +22,6 @@ type DesignType =
     | 'MatchReport'
     | 'Interview'
     | 'GuardianView'
-    | 'GuardianLabs'
     | 'Quiz'
     | 'AdvertisementFeature'
     | 'PhotoEssay';
@@ -255,7 +254,7 @@ interface CAPIType {
     config: ConfigType;
     // The CAPI object sent from frontend can have designType Immersive. We force this to be Article
     // in decideDesignType but need to allow the type here before then
-    designType: DesignType | "Immersive" | "SpecialReport";
+    designType: DesignType | "Immersive" | "SpecialReport" | "GuardianLabs";
     showBottomSocialButtons: boolean;
     shouldHideReaderRevenue: boolean;
 
@@ -288,7 +287,7 @@ interface CAPIType {
 type CAPIBrowserType = {
     // The CAPI object sent from frontend can have designType Immersive. We force this to be Article
     // in decideDesignType but need to allow the type here before then
-    designType: DesignType | "Immersive" | "SpecialReport";
+    designType: DesignType | "Immersive" | "SpecialReport" | "GuardianLabs";
     pillar: CAPIPillar;
     config: ConfigTypeBrowser;
     richLinks: RichLinkBlockElement[];

--- a/src/amp/types/ArticleModel.tsx
+++ b/src/amp/types/ArticleModel.tsx
@@ -29,5 +29,5 @@ export interface ArticleModel {
 	commercialProperties: CommercialProperties;
 	isImmersive: boolean;
 	starRating?: number;
-	designType: DesignType | 'Immersive' | 'SpecialReport';
+	designType: DesignType | 'Immersive' | 'SpecialReport' | 'GuardianLabs';
 }

--- a/src/lib/designTypes.ts
+++ b/src/lib/designTypes.ts
@@ -10,7 +10,6 @@ export const designTypes: DesignType[] = [
 	'MatchReport',
 	'Interview',
 	'GuardianView',
-	'GuardianLabs',
 	'Quiz',
 	'AdvertisementFeature',
 	'PhotoEssay',

--- a/src/web/components/ArticleHeadline.stories.tsx
+++ b/src/web/components/ArticleHeadline.stories.tsx
@@ -363,26 +363,6 @@ export const Quiz = () => (
 );
 Quiz.story = { name: 'Quiz' };
 
-export const GuardianLabs = () => (
-	<Section>
-		<Flex>
-			<LeftColumn>
-				<></>
-			</LeftColumn>
-			<ArticleContainer>
-				<ArticleHeadline
-					headlineString="This is the headline you see when design type is GuardianLabs"
-					display={Display.Standard}
-					designType="GuardianLabs"
-					pillar="news"
-					tags={[]}
-				/>
-			</ArticleContainer>
-		</Flex>
-	</Section>
-);
-GuardianLabs.story = { name: 'GuardianLabs' };
-
 export const Recipe = () => (
 	<Section>
 		<Flex>

--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -232,7 +232,6 @@ export const ArticleHeadline = ({
 				case 'PhotoEssay':
 				case 'Article':
 				case 'MatchReport':
-				case 'GuardianLabs':
 				case 'Quiz':
 				case 'AdvertisementFeature':
 				default:
@@ -352,7 +351,6 @@ export const ArticleHeadline = ({
 				case 'PhotoEssay':
 				case 'Article':
 				case 'MatchReport':
-				case 'GuardianLabs':
 				case 'Quiz':
 				case 'AdvertisementFeature':
 				default:

--- a/src/web/components/ArticleHeadlinePadding.tsx
+++ b/src/web/components/ArticleHeadlinePadding.tsx
@@ -23,7 +23,6 @@ const determinPadding = (designType: DesignType) => {
 		case 'Recipe':
 		case 'MatchReport':
 		case 'GuardianView':
-		case 'GuardianLabs':
 		case 'Quiz':
 		case 'AdvertisementFeature':
 		case 'Feature':

--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -139,7 +139,6 @@ const metaContainer = ({
 				case 'Article':
 				case 'MatchReport':
 				case 'GuardianView':
-				case 'GuardianLabs':
 				case 'Quiz':
 				case 'AdvertisementFeature':
 				case 'Comment':
@@ -188,7 +187,6 @@ const shouldShowAvatar = (designType: DesignType, display: Display) => {
 				case 'Article':
 				case 'MatchReport':
 				case 'GuardianView':
-				case 'GuardianLabs':
 				case 'Quiz':
 				case 'AdvertisementFeature':
 				case 'Comment':
@@ -219,7 +217,6 @@ const shouldShowContributor = (designType: DesignType, display: Display) => {
 				case 'Article':
 				case 'Recipe':
 				case 'MatchReport':
-				case 'GuardianLabs':
 				case 'Quiz':
 				case 'AdvertisementFeature':
 				default:

--- a/src/web/components/Byline.tsx
+++ b/src/web/components/Byline.tsx
@@ -55,7 +55,6 @@ const colourStyles = (designType: DesignType, pillar: CAPIPillar) => {
 		case 'Recipe':
 		case 'MatchReport':
 		case 'GuardianView':
-		case 'GuardianLabs':
 		case 'Quiz':
 		case 'AdvertisementFeature':
 		default:

--- a/src/web/components/Caption.tsx
+++ b/src/web/components/Caption.tsx
@@ -183,7 +183,6 @@ export const Caption = ({
 		case 'Recipe':
 		case 'MatchReport':
 		case 'GuardianView':
-		case 'GuardianLabs':
 		case 'Quiz':
 		case 'AdvertisementFeature':
 		case 'Feature':

--- a/src/web/components/Card/components/CardAge.tsx
+++ b/src/web/components/Card/components/CardAge.tsx
@@ -52,7 +52,6 @@ const colourStyles = (designType: DesignType, pillar: CAPIPillar) => {
 		case 'Recipe':
 		case 'MatchReport':
 		case 'GuardianView':
-		case 'GuardianLabs':
 		case 'Quiz':
 		case 'AdvertisementFeature':
 		case 'Comment':

--- a/src/web/components/Card/components/CardLink.tsx
+++ b/src/web/components/Card/components/CardLink.tsx
@@ -73,7 +73,6 @@ const linkStyles = (designType: DesignType, pillar: CAPIPillar) => {
 		case 'PhotoEssay':
 		case 'Recipe':
 		case 'MatchReport':
-		case 'GuardianLabs':
 		case 'Quiz':
 		case 'AdvertisementFeature':
 		case 'Feature':

--- a/src/web/components/CardCommentCount.tsx
+++ b/src/web/components/CardCommentCount.tsx
@@ -81,7 +81,6 @@ const colourStyles = (designType: DesignType, pillar: CAPIPillar) => {
 		case 'Recipe':
 		case 'MatchReport':
 		case 'GuardianView':
-		case 'GuardianLabs':
 		case 'Quiz':
 		case 'AdvertisementFeature':
 		case 'Comment':

--- a/src/web/components/CardHeadline.tsx
+++ b/src/web/components/CardHeadline.tsx
@@ -85,7 +85,6 @@ const headlineStyles = (designType: DesignType, pillar: CAPIPillar) => {
 		case 'Recipe':
 		case 'MatchReport':
 		case 'GuardianView':
-		case 'GuardianLabs':
 		case 'Quiz':
 		case 'AdvertisementFeature':
 		case 'Comment':

--- a/src/web/components/DropCap.tsx
+++ b/src/web/components/DropCap.tsx
@@ -46,7 +46,6 @@ const outerStyles = (pillar: CAPIPillar, designType: DesignType) => {
 		case 'Live':
 		case 'Recipe':
 		case 'MatchReport':
-		case 'GuardianLabs':
 		case 'Quiz':
 		case 'AdvertisementFeature':
 		default:
@@ -84,7 +83,6 @@ const innerStyles = (designType: DesignType) => {
 		case 'Live':
 		case 'Recipe':
 		case 'MatchReport':
-		case 'GuardianLabs':
 		case 'Quiz':
 		case 'AdvertisementFeature':
 		default:

--- a/src/web/components/HeadlineByline.tsx
+++ b/src/web/components/HeadlineByline.tsx
@@ -117,7 +117,6 @@ export const HeadlineByline = ({
 				case 'Live':
 				case 'Recipe':
 				case 'MatchReport':
-				case 'GuardianLabs':
 				case 'Quiz':
 				case 'AdvertisementFeature':
 				default:
@@ -171,7 +170,6 @@ export const HeadlineByline = ({
 				case 'Live':
 				case 'Recipe':
 				case 'MatchReport':
-				case 'GuardianLabs':
 				case 'Quiz':
 				case 'AdvertisementFeature':
 				default:

--- a/src/web/components/Kicker.tsx
+++ b/src/web/components/Kicker.tsx
@@ -45,7 +45,6 @@ const decideColour = (
 		case 'Recipe':
 		case 'MatchReport':
 		case 'GuardianView':
-		case 'GuardianLabs':
 		case 'Quiz':
 		case 'AdvertisementFeature':
 		case 'Comment':

--- a/src/web/components/Onwards/Carousel/cardColours.tsx
+++ b/src/web/components/Onwards/Carousel/cardColours.tsx
@@ -25,7 +25,6 @@ export const headlineBackgroundColour = (
 		case 'PhotoEssay':
 		case 'Recipe':
 		case 'MatchReport':
-		case 'GuardianLabs':
 		case 'Quiz':
 		case 'AdvertisementFeature':
 		case 'Feature':
@@ -57,7 +56,6 @@ export const headlineColour = (designType: DesignType, pillar: CAPIPillar) => {
 		case 'Recipe':
 		case 'MatchReport':
 		case 'GuardianView':
-		case 'GuardianLabs':
 		case 'Quiz':
 		case 'AdvertisementFeature':
 		case 'Comment':

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -199,7 +199,6 @@ export const SeriesSectionLink = ({
 				case 'Article':
 				case 'Recipe':
 				case 'MatchReport':
-				case 'GuardianLabs':
 				case 'Quiz':
 				case 'AdvertisementFeature':
 				default: {
@@ -241,7 +240,6 @@ export const SeriesSectionLink = ({
 				case 'Article':
 				case 'Recipe':
 				case 'MatchReport':
-				case 'GuardianLabs':
 				case 'Quiz':
 				case 'AdvertisementFeature':
 				default: {

--- a/src/web/components/Standfirst.stories.tsx
+++ b/src/web/components/Standfirst.stories.tsx
@@ -192,19 +192,6 @@ export const GuardianView = () => {
 };
 GuardianView.story = { name: 'GuardianView' };
 
-export const GuardianLabs = () => {
-	return (
-		<Section>
-			<Standfirst
-				display={Display.Standard}
-				designType="GuardianLabs"
-				standfirst="This is how GuardianLabs standfirst text looks. Aut explicabo officia delectus omnis repellendus voluptas"
-			/>
-		</Section>
-	);
-};
-GuardianLabs.story = { name: 'GuardianLabs' };
-
 export const AdvertisementFeature = () => {
 	return (
 		<Section>

--- a/src/web/components/Standfirst.tsx
+++ b/src/web/components/Standfirst.tsx
@@ -63,7 +63,6 @@ const standfirstStyles = (designType: DesignType, display: Display) => {
 				case 'Media':
 				case 'MatchReport':
 				case 'AdvertisementFeature':
-				case 'GuardianLabs':
 				case 'Quiz':
 				case 'Article':
 				case 'Live':
@@ -104,7 +103,6 @@ const standfirstStyles = (designType: DesignType, display: Display) => {
 				case 'PhotoEssay':
 				case 'MatchReport':
 				case 'AdvertisementFeature':
-				case 'GuardianLabs':
 				case 'Quiz':
 				case 'Article':
 				case 'Live':

--- a/src/web/components/elements/PullQuoteBlockComponent.tsx
+++ b/src/web/components/elements/PullQuoteBlockComponent.tsx
@@ -215,7 +215,6 @@ export const PullQuoteBlockComponent: React.FC<{
 		case 'Media':
 		case 'MatchReport':
 		case 'AdvertisementFeature':
-		case 'GuardianLabs':
 		case 'Quiz':
 		case 'Article':
 		case 'Live':

--- a/src/web/components/elements/TextBlockComponent.tsx
+++ b/src/web/components/elements/TextBlockComponent.tsx
@@ -82,7 +82,6 @@ const shouldShowDropCap = ({
 		case 'Live':
 		case 'MatchReport':
 		case 'GuardianView':
-		case 'GuardianLabs':
 		case 'Quiz':
 		case 'AdvertisementFeature':
 		case 'Analysis':

--- a/src/web/layouts/DecideLayout.tsx
+++ b/src/web/layouts/DecideLayout.tsx
@@ -46,7 +46,6 @@ export const DecideLayout = ({ CAPI, NAV }: Props) => {
 				case 'Article':
 				case 'Recipe':
 				case 'MatchReport':
-				case 'GuardianLabs':
 				case 'Quiz':
 				case 'AdvertisementFeature':
 					return (
@@ -84,7 +83,6 @@ export const DecideLayout = ({ CAPI, NAV }: Props) => {
 				case 'Article':
 				case 'Recipe':
 				case 'MatchReport':
-				case 'GuardianLabs':
 				case 'Quiz':
 				case 'AdvertisementFeature':
 					return (
@@ -123,7 +121,6 @@ export const DecideLayout = ({ CAPI, NAV }: Props) => {
 				case 'Article':
 				case 'Recipe':
 				case 'MatchReport':
-				case 'GuardianLabs':
 				case 'Quiz':
 				case 'AdvertisementFeature':
 					return (

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -201,7 +201,6 @@ const PositionHeadline = ({
 		case 'Recipe':
 		case 'MatchReport':
 		case 'GuardianView':
-		case 'GuardianLabs':
 		case 'Quiz':
 		case 'AdvertisementFeature':
 		case 'Feature':

--- a/src/web/lib/decideDesignType.ts
+++ b/src/web/lib/decideDesignType.ts
@@ -5,5 +5,6 @@ export const decideDesignType = (
 ): DesignType => {
 	if (CAPI.designType === 'Immersive') return 'Article';
 	if (CAPI.designType === 'SpecialReport') return 'Article';
+	if (CAPI.designType === 'GuardianLabs') return 'AdvertisementFeature';
 	return CAPI.designType;
 };

--- a/src/web/lib/layoutHelpers.ts
+++ b/src/web/lib/layoutHelpers.ts
@@ -20,7 +20,6 @@ export const decideLineEffect = (
 		case 'Analysis':
 		case 'Article':
 		case 'MatchReport':
-		case 'GuardianLabs':
 		case 'Quiz':
 		case 'AdvertisementFeature':
 		default:


### PR DESCRIPTION
## What?
Removes the `GuardianLabs` designType.

If Frontend _does_ send us an article with this design type we now replace it with `AdvertisementFeature`

## Why?
It isn't used. [Searching the Frontend codebase](https://github.com/guardian/frontend/search?q=GuardianLabs&unscoped_q=GuardianLabs) only provides one reference, the one where it is passed into DCR.

We don't branch anywhere with it in DCR and paid content is already represented using `AdvertisementFeature`