### PR TITLE
pillarToTypesEnum

### DIFF
--- a/src/lib/pillarToTypesEnum.ts
+++ b/src/lib/pillarToTypesEnum.ts
@@ -1,0 +1,18 @@
+import { Pillar } from '@guardian/types/Format';
+
+export const pillarToTypesEnum = (pillar: CAPIPillar): Pillar => {
+	switch (pillar) {
+		case 'news':
+			return Pillar.News;
+		case 'opinion':
+			return Pillar.Opinion;
+		case 'culture':
+			return Pillar.Culture;
+		case 'sport':
+			return Pillar.Sport;
+		case 'lifestyle':
+			return Pillar.Lifestyle;
+		case 'labs':
+			return Pillar.News; // TODO: Remove this when we remove the labs pillar
+	}
+};


### PR DESCRIPTION
## What?
Adds the `pillarToTypesEnum` function. Takes a `CAPIPillar` and returns the equivalent `Pillar` from @guardian/types

```typescript
const pillarToTypesEnum = (pillar: CAPIPillar): Pillar ...
```

## Why?
This function will allow us to consume libs that use the `Pillar` type, such as recent versions of @guardian/atoms-rendering and @guardian/discussion-rendering. Like this we are not dependant on DCR fully supporting a const enum pillar to use new features from these libs.