### PR TITLE
Fix byline interview bug

### DIFF
--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -171,11 +171,11 @@ const immersiveWrapper = css`
 	${from.leftCol} {
 		margin-left: 25px;
 	}
-	/* 
+	/*
         We need this grow to ensure the headline fills the main content column
     */
 	flex-grow: 1;
-	/* 
+	/*
         This z-index is what ensures the headline text shows above the pseudo black
         box that extends the black background to the right
     */

--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -159,6 +159,7 @@ const metaContainer = ({
 	}
 };
 
+
 const getBylineImageUrl = (tags: TagType[]) => {
 	const contributorTag = tags.find((tag) => tag.type === 'Contributor');
 	return contributorTag && contributorTag.bylineImageUrl;

--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -159,7 +159,6 @@ const metaContainer = ({
 	}
 };
 
-
 const getBylineImageUrl = (tags: TagType[]) => {
 	const contributorTag = tags.find((tag) => tag.type === 'Contributor');
 	return contributorTag && contributorTag.bylineImageUrl;

--- a/src/web/components/HeadlineByline.tsx
+++ b/src/web/components/HeadlineByline.tsx
@@ -10,7 +10,7 @@ import { Display } from '@guardian/types/Format';
 
 const wrapperStyles = css`
 	margin-left: 6px;
-	margin-top: 5px;
+	margin-top: 4px;
 	/* Without z-index here the byline appears behind the main image for showcase views */
 	z-index: 1;
 `;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
There was an extra px margin above the byline on interview template

### Before
![Screenshot 2021-01-05 at 10 44 28](https://user-images.githubusercontent.com/20658471/103637198-0332dc00-4f43-11eb-9ea9-dc2c6bde9fb0.png)

### After
![Screenshot 2021-01-05 at 10 45 23](https://user-images.githubusercontent.com/20658471/103637284-28bfe580-4f43-11eb-9cae-31334fbc067d.png)

## Why?
