### PR TITLE
Upgrade atoms-rendering to v7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "@emotion/core": "^10.0.35",
         "@guardian/ab-core": "^2.0.0",
         "@guardian/ab-react": "^2.0.1",
-        "@guardian/atoms-rendering": "^6.0.0",
+        "@guardian/atoms-rendering": "^7.1.0",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/braze-components": "^0.0.16",
         "@guardian/consent-management-platform": "^6.7.4",

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -42,6 +42,7 @@ import { initPerf } from '@root/src/web/browser/initPerf';
 import { getCookie } from '@root/src/web/browser/cookie';
 import { getCountryCode } from '@frontend/web/lib/getCountryCode';
 import { getUser } from '@root/src/web/lib/getUser';
+import { toTypesPillar } from '@root/src/lib/format';
 import { FocusStyleManager } from '@guardian/src-foundations/utils';
 import { incrementAlreadyVisited } from '@root/src/web/lib/alreadyVisited';
 import { incrementDailyArticleCount } from '@frontend/web/lib/dailyArticleCount';
@@ -448,7 +449,7 @@ export const App = ({ CAPI, NAV }: Props) => {
 						html={qandaAtom.html}
 						image={qandaAtom.img}
 						credit={qandaAtom.credit}
-						pillar={pillar}
+						pillar={toTypesPillar(pillar)}
 						likeHandler={componentEventHandler(
 							'QANDA_ATOM',
 							qandaAtom.id,
@@ -475,7 +476,7 @@ export const App = ({ CAPI, NAV }: Props) => {
 						html={guideAtom.html}
 						image={guideAtom.img}
 						credit={guideAtom.credit}
-						pillar={pillar}
+						pillar={toTypesPillar(pillar)}
 						likeHandler={componentEventHandler(
 							'GUIDE_ATOM',
 							guideAtom.id,
@@ -505,7 +506,7 @@ export const App = ({ CAPI, NAV }: Props) => {
 						html={profileAtom.html}
 						image={profileAtom.img}
 						credit={profileAtom.credit}
-						pillar={pillar}
+						pillar={toTypesPillar(pillar)}
 						likeHandler={componentEventHandler(
 							'PROFILE_ATOM',
 							profileAtom.id,
@@ -534,7 +535,7 @@ export const App = ({ CAPI, NAV }: Props) => {
 						title={timelineAtom.title}
 						events={timelineAtom.events}
 						description={timelineAtom.description}
-						pillar={pillar}
+						pillar={toTypesPillar(pillar)}
 						likeHandler={componentEventHandler(
 							'TIMELINE_ATOM',
 							timelineAtom.id,

--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -197,7 +197,7 @@ export const ArticleRenderer: React.FC<{
 								html={element.html}
 								image={element.img}
 								credit={element.credit}
-								pillar={pillar}
+								pillar={toTypesPillar(pillar)}
 								likeHandler={() => {}}
 								dislikeHandler={() => {}}
 								expandCallback={() => {}}
@@ -291,7 +291,7 @@ export const ArticleRenderer: React.FC<{
 								html={element.html}
 								image={element.img}
 								credit={element.credit}
-								pillar={pillar}
+								pillar={toTypesPillar(pillar)}
 								likeHandler={() => {}}
 								dislikeHandler={() => {}}
 								expandCallback={() => {}}
@@ -318,7 +318,7 @@ export const ArticleRenderer: React.FC<{
 								html={element.html}
 								image={element.img}
 								credit={element.credit}
-								pillar={pillar}
+								pillar={toTypesPillar(pillar)}
 								likeHandler={() => {}}
 								dislikeHandler={() => {}}
 								expandCallback={() => {}}
@@ -472,7 +472,7 @@ export const ArticleRenderer: React.FC<{
 							<TimelineAtom
 								id={element.id}
 								title={element.title}
-								pillar={pillar}
+								pillar={toTypesPillar(pillar)}
 								events={element.events}
 								likeHandler={() => {}}
 								dislikeHandler={() => {}}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2087,10 +2087,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
   integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
 
-"@guardian/atoms-rendering@^6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-6.0.0.tgz#e0066f37ccfb84131737cead54fb10fb624a4053"
-  integrity sha512-OTMmarddZQlIKamjtAd8qPO407bIoNWyyHxc/7rLbkR/LjK+vmzeGZrKhrzYE1nqsrMMNnIzi2mvKN1opjXfQQ==
+"@guardian/atoms-rendering@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-7.1.0.tgz#a7307c6bb93036f7de1f85a7ef03785443289151"
+  integrity sha512-bGbKE+QiZi08Xtivr3kuCe+NsOG0/7YKiSlM6ogvYedjLMtUIZbE6Dm+oi/7ybCJrip1sxbBUKjEvqmHIdi1ow==
 
 "@guardian/automat-client@^0.2.16":
   version "0.2.16"


### PR DESCRIPTION
## What?
Bump @guardian/atoms-rendering to v7

As par to this upgrade we convert the `pillar` value from a string to a const enum

## Why?
To enable the latest features