### PR TITLE
Refactor decideDesignType

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,6 @@ type RealPillars = 'news' | 'opinion' | 'sport' | 'culture' | 'lifestyle';
 type FakePillars = 'labs';
 type CAPIPillar = RealPillars | FakePillars;
 
-// https://github.com/guardian/content-api-scala-client/blob/master/client/src/main/scala/com.gu.contentapi.client/utils/DesignType.scala
 type DesignType =
     | 'Article'
     | 'Media'
@@ -25,6 +24,10 @@ type DesignType =
     | 'Quiz'
     | 'AdvertisementFeature'
     | 'PhotoEssay';
+
+// CAPIDesign is what CAPI might give us but we only want to use a subset of these (DesignType)
+// https://github.com/guardian/content-api-scala-client/blob/master/client/src/main/scala/com.gu.contentapi.client/utils/DesignType.scala
+type CAPIDesign = DesignType | "Immersive" | "SpecialReport" | "GuardianLabs";
 
 // This is an object that allows you Type defaults of the designTypes.
 // The return type looks like: { Feature: any, Live: any, ...}
@@ -254,7 +257,7 @@ interface CAPIType {
     config: ConfigType;
     // The CAPI object sent from frontend can have designType Immersive. We force this to be Article
     // in decideDesignType but need to allow the type here before then
-    designType: DesignType | "Immersive" | "SpecialReport" | "GuardianLabs";
+    designType: CAPIDesign;
     showBottomSocialButtons: boolean;
     shouldHideReaderRevenue: boolean;
 
@@ -287,7 +290,7 @@ interface CAPIType {
 type CAPIBrowserType = {
     // The CAPI object sent from frontend can have designType Immersive. We force this to be Article
     // in decideDesignType but need to allow the type here before then
-    designType: DesignType | "Immersive" | "SpecialReport" | "GuardianLabs";
+    designType: CAPIDesign;
     pillar: CAPIPillar;
     config: ConfigTypeBrowser;
     richLinks: RichLinkBlockElement[];

--- a/src/amp/pages/Article.tsx
+++ b/src/amp/pages/Article.tsx
@@ -50,7 +50,7 @@ export const Article: React.FC<{
 	config: ConfigType;
 	analytics: AnalyticsModel;
 }> = ({ nav, articleData, config, analytics }) => {
-	const designType = decideDesignType(articleData);
+	const designType = decideDesignType(articleData.designType);
 	const pillar = decidePillar({
 		pillar: articleData.pillar,
 		design: designType,

--- a/src/amp/types/ArticleModel.tsx
+++ b/src/amp/types/ArticleModel.tsx
@@ -29,5 +29,5 @@ export interface ArticleModel {
 	commercialProperties: CommercialProperties;
 	isImmersive: boolean;
 	starRating?: number;
-	designType: DesignType | 'Immersive' | 'SpecialReport' | 'GuardianLabs';
+	designType: CAPIDesign;
 }

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -283,7 +283,7 @@ export const App = ({ CAPI, NAV }: Props) => {
 	}, []);
 
 	const display: Display = decideDisplay(CAPI);
-	const designType: DesignType = decideDesignType(CAPI);
+	const designType: DesignType = decideDesignType(CAPI.designType);
 	const pillar = decidePillar({
 		pillar: CAPI.pillar,
 		design: designType,

--- a/src/web/layouts/DecideLayout.tsx
+++ b/src/web/layouts/DecideLayout.tsx
@@ -16,7 +16,7 @@ type Props = {
 
 export const DecideLayout = ({ CAPI, NAV }: Props) => {
 	const display: Display = decideDisplay(CAPI);
-	const designType: DesignType = decideDesignType(CAPI);
+	const designType: DesignType = decideDesignType(CAPI.designType);
 	const pillar: CAPIPillar = decidePillar({
 		pillar: CAPI.pillar,
 		design: designType,

--- a/src/web/lib/decideDesignType.ts
+++ b/src/web/lib/decideDesignType.ts
@@ -1,10 +1,8 @@
-import { ArticleModel } from '@root/src/amp/types/ArticleModel';
-
 export const decideDesignType = (
-	CAPI: CAPIType | CAPIBrowserType | ArticleModel,
+	designType: DesignType | 'Immersive' | 'SpecialReport' | 'GuardianLabs',
 ): DesignType => {
-	if (CAPI.designType === 'Immersive') return 'Article';
-	if (CAPI.designType === 'SpecialReport') return 'Article';
-	if (CAPI.designType === 'GuardianLabs') return 'AdvertisementFeature';
-	return CAPI.designType;
+	if (designType === 'Immersive') return 'Article';
+	if (designType === 'SpecialReport') return 'Article';
+	if (designType === 'GuardianLabs') return 'AdvertisementFeature';
+	return designType;
 };

--- a/src/web/lib/decideDesignType.ts
+++ b/src/web/lib/decideDesignType.ts
@@ -1,6 +1,4 @@
-export const decideDesignType = (
-	designType: DesignType | 'Immersive' | 'SpecialReport' | 'GuardianLabs',
-): DesignType => {
+export const decideDesignType = (designType: CAPIDesign): DesignType => {
 	if (designType === 'Immersive') return 'Article';
 	if (designType === 'SpecialReport') return 'Article';
 	if (designType === 'GuardianLabs') return 'AdvertisementFeature';


### PR DESCRIPTION
## What?
Refactor decideDesignType to accept a single prop rather than the whole CAPI object. I also refactored the input type to be declared as `CAPIDesign` instead of the (growing) union which was repeated a lot

## Why?
This makes it easier to use this function as we don't need to have a union type for multiple data objects
