### PR TITLE
reportError for the 99%

### DIFF
--- a/src/web/browser/sentryLoader/init.ts
+++ b/src/web/browser/sentryLoader/init.ts
@@ -11,7 +11,15 @@ const init = async (): Promise<void> => {
 	// Sentry 99% of the time. So instead we just do some basic math here
 	// and use that to prevent the Sentry script from ever loading.
 	const randomCentile = Math.floor(Math.random() * 100) + 1; // A number between 1 - 100
-	if (randomCentile <= 99) return; // 99% of the time we do nothing here
+	if (randomCentile <= 99) {
+		// 99% of the time we don't want to remotely log errors with Sentry and so
+		// we just console them out
+		window.guardian.modules.sentry.reportError = (error) => {
+			// eslint-disable-next-line no-console
+			console.error(error);
+		};
+		return; // Don't initialise Sentry
+	}
 	// The other 1% of the time (randomCentile === 100) we continue
 	try {
 		// Downloading and initiliasing Sentry is asynchronous so we need a way


### PR DESCRIPTION
## What?
Defines the `reportError` function that should be used when Sentry is not initialised on the client (99% of the time)

## Why?
This wasn't being setup before so any code trying to call it threw an error