### PR TITLE
Ensure local SDK data is wiped on logout

### DIFF
--- a/src/web/components/StickyBottomBanner/BrazeBanner.test.ts
+++ b/src/web/components/StickyBottomBanner/BrazeBanner.test.ts
@@ -93,37 +93,9 @@ describe('hasRequiredConsents', () => {
 });
 
 describe('canShowPreChecks', () => {
-	describe('when the switch is off', () => {
-		it('returns false', () => {
-			const result = canShowPreChecks({
-				brazeSwitch: false,
-				apiKey: 'abcde',
-				shouldHideSupportMessaging: true,
-				pageConfig: { isPaidContent: false },
-			});
-
-			expect(result).toBe(false);
-		});
-	});
-
-	describe('when the api key is empty', () => {
-		it('returns false', () => {
-			const result = canShowPreChecks({
-				brazeSwitch: true,
-				apiKey: '',
-				shouldHideSupportMessaging: true,
-				pageConfig: { isPaidContent: false },
-			});
-
-			expect(result).toBe(false);
-		});
-	});
-
 	describe('when not a supporter', () => {
 		it('returns false', () => {
 			const result = canShowPreChecks({
-				brazeSwitch: true,
-				apiKey: 'abcde',
 				shouldHideSupportMessaging: false,
 				pageConfig: { isPaidContent: false },
 			});
@@ -135,8 +107,6 @@ describe('canShowPreChecks', () => {
 	describe('when viewing paid content', () => {
 		it('returns false', () => {
 			const result = canShowPreChecks({
-				brazeSwitch: true,
-				apiKey: 'abcde',
 				shouldHideSupportMessaging: true,
 				pageConfig: { isPaidContent: true },
 			});
@@ -148,8 +118,6 @@ describe('canShowPreChecks', () => {
 	describe('when all checks pass', () => {
 		it('returns true', () => {
 			const result = canShowPreChecks({
-				brazeSwitch: true,
-				apiKey: 'abcde',
 				shouldHideSupportMessaging: true,
 				pageConfig: { isPaidContent: false },
 			});

--- a/src/web/lib/hasCurrentBrazeUser.test.ts
+++ b/src/web/lib/hasCurrentBrazeUser.test.ts
@@ -1,0 +1,32 @@
+import {
+	clearHasCurrentBrazeUser,
+	hasCurrentBrazeUser,
+	setHasCurrentBrazeUser,
+} from './hasCurrentBrazeUser';
+
+beforeEach(() => clearHasCurrentBrazeUser);
+
+describe('hasCurrentBrazeUser', () => {
+	it('hasCurrentBrazeUser returns false when not set', () => {
+		const got = hasCurrentBrazeUser();
+
+		expect(got).toEqual(false);
+	});
+
+	it('hasCurrentBrazeUser returns true when set', () => {
+		setHasCurrentBrazeUser();
+
+		const got = hasCurrentBrazeUser();
+
+		expect(got).toEqual(true);
+	});
+
+	it('clearHasCurrentBrazeUser unsets the value', () => {
+		setHasCurrentBrazeUser();
+		clearHasCurrentBrazeUser();
+
+		const got = hasCurrentBrazeUser();
+
+		expect(got).toEqual(false);
+	});
+});

--- a/src/web/lib/hasCurrentBrazeUser.ts
+++ b/src/web/lib/hasCurrentBrazeUser.ts
@@ -1,0 +1,19 @@
+const KEY = 'gu.brazeUserSet';
+
+const hasCurrentBrazeUser = (): boolean => {
+	return localStorage.getItem(KEY) === 'true';
+};
+
+const setHasCurrentBrazeUser = (): void => {
+	localStorage.setItem(KEY, 'true');
+};
+
+const clearHasCurrentBrazeUser = (): void => {
+	localStorage.removeItem(KEY);
+};
+
+export {
+	hasCurrentBrazeUser,
+	setHasCurrentBrazeUser,
+	clearHasCurrentBrazeUser,
+};


### PR DESCRIPTION
## What does this change?

Ensures that any local SDK data is wiped when a user logs out.

If we’ve recorded in localStorage that there was a braze user, but we haven’t got a brazeUuid, then we treat that as meaning that the user has logged out.
