### PR TITLE
Get identity and mma base URL from config

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -565,6 +565,7 @@ interface ConfigType extends CommercialConfigType {
     references?: { [key: string]: string }[];
     host?: string;
     idUrl?: string;
+    mmaUrl?: string;
     brazeApiKey?: string;
 }
 
@@ -600,6 +601,7 @@ interface ConfigTypeBrowser {
     switches: CAPIType['config']['switches'];
     host?: string;
     idUrl?: string;
+    mmaUrl?: string;
 }
 
 interface GADataType {

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -317,6 +317,8 @@ export const App = ({ CAPI, NAV }: Props) => {
 				<Links
 					giftingURL={CAPI.nav.readerRevenueLinks.header.gifting}
 					userId={user ? user.userId : undefined}
+					idUrl={CAPI.config.idUrl}
+					mmaUrl={CAPI.config.mmaUrl}
 				/>
 			</HydrateOnce>
 			<HydrateOnce root="edition-root">

--- a/src/web/components/Header.tsx
+++ b/src/web/components/Header.tsx
@@ -15,9 +15,11 @@ const headerStyles = css`
 
 type Props = {
 	edition: Edition;
+	idUrl?: string;
+	mmaUrl?: string;
 };
 
-export const Header = ({ edition }: Props) => (
+export const Header = ({ edition, idUrl, mmaUrl }: Props) => (
 	<header className={headerStyles}>
 		<Hide when="below" breakpoint="desktop">
 			<div id="edition-root">
@@ -30,7 +32,7 @@ export const Header = ({ edition }: Props) => (
 		<Logo />
 		<div id="reader-revenue-links-header" />
 		<div id="links-root">
-			<Links giftingURL="" />
+			<Links giftingURL="" idUrl={idUrl} mmaUrl={mmaUrl} />
 		</div>
 	</header>
 );

--- a/src/web/components/Links.tsx
+++ b/src/web/components/Links.tsx
@@ -18,6 +18,8 @@ import { createAuthenticationEventParams } from '@root/src/lib/identity-componen
 type Props = {
 	giftingURL: string;
 	userId?: string;
+	idUrl?: string;
+	mmaUrl?: string;
 };
 
 const linkStyles = css`
@@ -124,7 +126,12 @@ const linksStyles = css`
 	${getZIndex('headerLinks')}
 `;
 
-export const Links = ({ userId, giftingURL }: Props) => {
+export const Links = ({
+	userId,
+	giftingURL,
+	idUrl: idUrlFromConfig,
+	mmaUrl: mmaUrlFromConfig,
+}: Props) => {
 	const [showGiftingLink, setShowGiftingLink] = useState<boolean>();
 
 	// show gifting if support messaging isn't shown
@@ -132,39 +139,43 @@ export const Links = ({ userId, giftingURL }: Props) => {
 		setShowGiftingLink(getCookie('gu_hide_support_messaging') === 'true');
 	}, []);
 
+	// Fall back on prod URLs just in case these aren't set for any reason
+	const idUrl = idUrlFromConfig || 'https://profile.theguardian.com';
+	const mmaUrl = mmaUrlFromConfig || 'https://manage.theguardian.com';
+
 	const identityLinks: DropdownLinkType[] = [
 		{
-			url: `https://manage.theguardian.com/`,
+			url: `${mmaUrl}/`,
 			title: 'Account overview',
 			dataLinkName: 'nav2 : topbar : account overview',
 		},
 		{
-			url: `https://manage.theguardian.com/public-settings`,
+			url: `${mmaUrl}/public-settings`,
 			title: 'Profile',
 			dataLinkName: 'nav2 : topbar : edit profile',
 		},
 		{
-			url: `https://manage.theguardian.com/email-prefs`,
+			url: `${mmaUrl}/email-prefs`,
 			title: 'Emails & marketing',
 			dataLinkName: 'nav2 : topbar : email prefs',
 		},
 		{
-			url: `https://manage.theguardian.com/account-settings`,
+			url: `${mmaUrl}/account-settings`,
 			title: 'Settings',
 			dataLinkName: 'nav2 : topbar : settings',
 		},
 		{
-			url: `https://manage.theguardian.com/help`,
+			url: `${mmaUrl}/help`,
 			title: 'Help',
 			dataLinkName: 'nav2 : topbar : help',
 		},
 		{
-			url: `https://profile.theguardian.com/user/id/${userId}`,
+			url: `${idUrl}/user/id/${userId}`,
 			title: 'Comments & replies',
 			dataLinkName: 'nav2 : topbar : comment activity',
 		},
 		{
-			url: `https://profile.theguardian.com/signout`,
+			url: `${idUrl}/signout`,
 			title: 'Sign out',
 			dataLinkName: 'nav2 : topbar : sign out',
 		},
@@ -211,7 +222,7 @@ export const Links = ({ userId, giftingURL }: Props) => {
 			) : (
 				<a
 					className={linkStyles}
-					href={`https://profile.theguardian.com/signin?INTCMP=DOTCOM_NEWHEADER_SIGNIN&ABCMP=ab-sign-in&${createAuthenticationEventParams(
+					href={`${idUrl}/signin?INTCMP=DOTCOM_NEWHEADER_SIGNIN&ABCMP=ab-sign-in&${createAuthenticationEventParams(
 						'guardian_signin_header',
 					)}`}
 					data-link-name="nav2 : topbar : signin"

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -315,7 +315,11 @@ export const CommentLayout = ({
 						padded={false}
 						backgroundColour={brandBackground.primary}
 					>
-						<Header edition={CAPI.editionId} />
+						<Header
+							edition={CAPI.editionId}
+							idUrl={CAPI.config.idUrl}
+							mmaUrl={CAPI.config.mmaUrl}
+						/>
 					</Section>
 
 					<Section

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -289,7 +289,11 @@ export const ShowcaseLayout = ({
 						padded={false}
 						backgroundColour={brandBackground.primary}
 					>
-						<Header edition={CAPI.editionId} />
+						<Header
+							edition={CAPI.editionId}
+							idUrl={CAPI.config.idUrl}
+							mmaUrl={CAPI.config.mmaUrl}
+						/>
 					</Section>
 
 					<Section

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -354,7 +354,11 @@ export const StandardLayout = ({
 						padded={false}
 						backgroundColour={brandBackground.primary}
 					>
-						<Header edition={CAPI.editionId} />
+						<Header
+							edition={CAPI.editionId}
+							idUrl={CAPI.config.idUrl}
+							mmaUrl={CAPI.config.mmaUrl}
+						/>
 					</Section>
 
 					<Section


### PR DESCRIPTION
Previously these URLs were always hardcoded to prod. This made it hard, for example, to sign in/out on DCR in the CODE environment, because the identity URL used was profile.theguardian.com which is a different domain to CODE.

Now the URLs are pulled from config, so should reflect the current environment.