### PR TITLE
Remove labs pillar

### DIFF
--- a/src/amp/components/Blocks.tsx
+++ b/src/amp/components/Blocks.tsx
@@ -40,6 +40,7 @@ const clearBoth = css`
 export const Blocks: React.SFC<{
 	blocks: Block[];
 	pillar: CAPIPillar;
+	designType: DesignType;
 	edition: Edition;
 	section?: string;
 	contentType: string;
@@ -50,6 +51,7 @@ export const Blocks: React.SFC<{
 }> = ({
 	blocks,
 	pillar,
+	designType,
 	edition,
 	section,
 	contentType,
@@ -76,7 +78,7 @@ export const Blocks: React.SFC<{
 					</a>
 				)}
 				{block.title && <h2>{block.title}</h2>}
-				{Elements(block.elements, pillar, false)}
+				{Elements(block.elements, pillar, designType, false)}
 				{/* Some elements float (e.g. rich links) */}
 				<div className={clearBoth} />{' '}
 				{block.blockLastUpdatedDisplay && (

--- a/src/amp/components/BodyArticle.tsx
+++ b/src/amp/components/BodyArticle.tsx
@@ -73,6 +73,7 @@ export const Body: React.FC<{
 	const elementsWithoutAds = Elements(
 		capiElements,
 		pillar,
+		designType,
 		data.isImmersive,
 		adTargeting,
 	);

--- a/src/amp/components/BodyLiveblog.tsx
+++ b/src/amp/components/BodyLiveblog.tsx
@@ -70,9 +70,10 @@ const updateButtonStyle = css`
 // updates, but only on initial page load.
 export const Body: React.FC<{
 	pillar: CAPIPillar;
+	designType: DesignType;
 	data: ArticleModel;
 	config: ConfigType;
-}> = ({ pillar, data, config }) => {
+}> = ({ pillar, designType, data, config }) => {
 	const url = `${data.guardianBaseURL}/${data.pageId}`;
 	const isFirstPage = data.pagination
 		? data.pagination.currentPage === 1
@@ -100,6 +101,7 @@ export const Body: React.FC<{
 				<div items="">
 					<Blocks
 						pillar={pillar}
+						designType={designType}
 						blocks={data.blocks}
 						// stuff for ads
 						edition={data.editionId}

--- a/src/amp/components/Elements.tsx
+++ b/src/amp/components/Elements.tsx
@@ -28,6 +28,7 @@ import { clean } from '@root/src/model/clean';
 export const Elements = (
 	elements: CAPIElement[],
 	pillar: CAPIPillar,
+	designType: DesignType,
 	isImmersive: boolean,
 	adTargeting?: AdTargeting,
 ): JSX.Element[] => {
@@ -44,6 +45,7 @@ export const Elements = (
 						key={i}
 						html={element.html}
 						pillar={pillar}
+						designType={designType}
 					/>
 				);
 			case 'model.dotcomrendering.pageElements.ChartAtomBlockElement':
@@ -160,6 +162,7 @@ export const Elements = (
 						key={i}
 						html={element.html}
 						pillar={pillar}
+						designType={designType}
 						isImmersive={isImmersive}
 					/>
 				);
@@ -169,6 +172,7 @@ export const Elements = (
 						key={i}
 						html={element.html}
 						pillar={pillar}
+						designType={designType}
 					/>
 				);
 			case 'model.dotcomrendering.pageElements.TimelineBlockElement':

--- a/src/amp/components/elements/SubheadingBlockComponent.tsx
+++ b/src/amp/components/elements/SubheadingBlockComponent.tsx
@@ -42,11 +42,12 @@ const subHeadingStyleLabs = css`
 export const SubheadingBlockComponent: React.FC<{
 	html: string;
 	pillar: CAPIPillar;
+	designType: DesignType;
 	isImmersive: boolean;
-}> = ({ html, pillar, isImmersive }) => (
+}> = ({ html, pillar, designType, isImmersive }) => (
 	<span
 		className={composeLabsCSS(
-			pillar,
+			designType,
 			cx(style(pillar), { [immersiveBodyStyle]: isImmersive }),
 			subHeadingStyleLabs,
 		)}

--- a/src/amp/components/elements/TextBlockComponent.tsx
+++ b/src/amp/components/elements/TextBlockComponent.tsx
@@ -75,9 +75,10 @@ const textStyleLabs = css`
 export const TextBlockComponent: React.FC<{
 	html: string;
 	pillar: CAPIPillar;
-}> = ({ html, pillar }) => (
+	designType: DesignType;
+}> = ({ html, pillar, designType }) => (
 	<span
-		className={composeLabsCSS(pillar, TextStyle(pillar), textStyleLabs)}
+		className={composeLabsCSS(designType, TextStyle(pillar), textStyleLabs)}
 		dangerouslySetInnerHTML={{
 			__html: sanitise(html),
 		}}

--- a/src/amp/components/topMeta/Standfirst.tsx
+++ b/src/amp/components/topMeta/Standfirst.tsx
@@ -39,12 +39,13 @@ const labsStyle = css`
 export const Standfirst: React.SFC<{
 	text: string;
 	pillar: CAPIPillar;
-}> = ({ text, pillar }) => {
+	designType: DesignType;
+}> = ({ text, pillar, designType }) => {
 	return (
 		<div
 			data-print-layout="hide"
 			className={composeLabsCSS(
-				pillar,
+				designType,
 				cx(standfirstCss(pillar)),
 				labsStyle,
 			)}

--- a/src/amp/components/topMeta/TopMeta.tsx
+++ b/src/amp/components/topMeta/TopMeta.tsx
@@ -17,15 +17,26 @@ export const TopMeta: React.SFC<{
 			articleData={data}
 			adTargeting={adTargeting}
 			pillar={pillar}
+			designType={designType}
 		/>,
 	);
 
 	// Extend defaultTopMeta with custom topMeta for some designTypes
 	const designTypeTopMeta: DesignTypesObj = {
 		...defaultTopMeta,
-		Comment: <TopMetaOpinion articleData={data} pillar={pillar} />,
+		Comment: (
+			<TopMetaOpinion
+				articleData={data}
+				pillar={pillar}
+				designType={designType}
+			/>
+		),
 		AdvertisementFeature: (
-			<TopMetaPaidContent articleData={data} pillar={pillar} />
+			<TopMetaPaidContent
+				articleData={data}
+				pillar={pillar}
+				designType={designType}
+			/>
 		),
 	};
 

--- a/src/amp/components/topMeta/TopMetaNews.tsx
+++ b/src/amp/components/topMeta/TopMetaNews.tsx
@@ -61,7 +61,8 @@ export const TopMetaNews: React.FC<{
 	articleData: ArticleModel;
 	adTargeting?: AdTargeting;
 	pillar: CAPIPillar;
-}> = ({ articleData, adTargeting, pillar }) => {
+	designType: DesignType;
+}> = ({ articleData, adTargeting, pillar, designType }) => {
 	const { branding } = articleData.commercialProperties[
 		articleData.editionId
 	];
@@ -93,7 +94,11 @@ export const TopMetaNews: React.FC<{
 				starRating={articleData.starRating}
 			/>
 
-			<Standfirst text={articleData.standfirst} pillar={pillar} />
+			<Standfirst
+				text={articleData.standfirst}
+				pillar={pillar}
+				designType={designType}
+			/>
 
 			{branding && <Branding branding={branding} pillar={pillar} />}
 

--- a/src/amp/components/topMeta/TopMetaOpinion.tsx
+++ b/src/amp/components/topMeta/TopMetaOpinion.tsx
@@ -103,7 +103,8 @@ const BylineMeta: React.SFC<{
 export const TopMetaOpinion: React.FC<{
 	articleData: ArticleModel;
 	pillar: CAPIPillar;
-}> = ({ articleData, pillar }) => {
+	designType: DesignType;
+}> = ({ articleData, pillar, designType }) => {
 	const { branding } = articleData.commercialProperties[
 		articleData.editionId
 	];
@@ -127,7 +128,11 @@ export const TopMetaOpinion: React.FC<{
 
 			<BylineMeta articleData={articleData} pillar={pillar} />
 
-			<Standfirst text={articleData.standfirst} pillar={pillar} />
+			<Standfirst
+				text={articleData.standfirst}
+				pillar={pillar}
+				designType={designType}
+			/>
 
 			<TopMetaExtras
 				sharingUrls={getSharingUrls(

--- a/src/amp/components/topMeta/TopMetaPaidContent.tsx
+++ b/src/amp/components/topMeta/TopMetaPaidContent.tsx
@@ -83,7 +83,8 @@ const Headline: React.FC<{
 export const TopMetaPaidContent: React.FC<{
 	articleData: ArticleModel;
 	pillar: CAPIPillar;
-}> = ({ articleData, pillar }) => {
+	designType: DesignType;
+}> = ({ articleData, pillar, designType }) => {
 	const { branding } = articleData.commercialProperties[
 		articleData.editionId
 	];
@@ -100,7 +101,11 @@ export const TopMetaPaidContent: React.FC<{
 
 			{!!branding && <PaidForByLogo branding={branding} />}
 
-			<Standfirst text={articleData.standfirst} pillar={pillar} />
+			<Standfirst
+				text={articleData.standfirst}
+				pillar={pillar}
+				designType={designType}
+			/>
 
 			<Byline
 				byline={articleData.author.byline}

--- a/src/amp/lib/compose-labs-css.ts
+++ b/src/amp/lib/compose-labs-css.ts
@@ -1,7 +1,8 @@
 import { cx } from 'emotion';
 
 export const composeLabsCSS = (
-	pillar: CAPIPillar,
+	designType: DesignType,
 	baseCSS: string,
 	labsCSS: string,
-): string => (pillar === 'labs' ? cx(baseCSS, labsCSS) : baseCSS);
+): string =>
+	designType === 'AdvertisementFeature' ? cx(baseCSS, labsCSS) : baseCSS;

--- a/src/amp/pages/Article.tsx
+++ b/src/amp/pages/Article.tsx
@@ -31,7 +31,14 @@ const Body: React.SFC<{
 		data.tags.find((tag) => tag.id === 'tone/minutebyminute') !== undefined;
 
 	if (isLiveBlog) {
-		return <BodyLiveblog pillar={pillar} data={data} config={config} />;
+		return (
+			<BodyLiveblog
+				pillar={pillar}
+				designType={designType}
+				data={data}
+				config={config}
+			/>
+		);
 	}
 
 	return (

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,19 +1,19 @@
-import { Pillar as TypesPillar } from '@guardian/types/Format';
+import { Pillar } from '@guardian/types/Format';
 
-export const toTypesPillar = (p: CAPIPillar): TypesPillar => {
+export const toTypesPillar = (p: CAPIPillar): Pillar => {
 	switch (p) {
 		case 'news':
-			return TypesPillar.News;
+			return Pillar.News;
 		case 'opinion':
-			return TypesPillar.Opinion;
+			return Pillar.Opinion;
 		case 'sport':
-			return TypesPillar.Sport;
+			return Pillar.Sport;
 		case 'culture':
-			return TypesPillar.Culture;
+			return Pillar.Culture;
 		case 'lifestyle':
-			return TypesPillar.Lifestyle;
-		case 'labs': // unsupported
+			return Pillar.Lifestyle;
+		case 'labs':
 		default:
-			return TypesPillar.News;
+			return Pillar.News;
 	}
 };

--- a/src/lib/pillars.ts
+++ b/src/lib/pillars.ts
@@ -51,7 +51,6 @@ export const pillarNames: CAPIPillar[] = [
 	'sport',
 	'culture',
 	'lifestyle',
-	'labs',
 ];
 
 export const augmentedLabs: PillarColours = {

--- a/src/model/find-pillar.test.ts
+++ b/src/model/find-pillar.test.ts
@@ -1,7 +1,7 @@
 import { findPillar } from './find-pillar';
 
 jest.mock('@frontend/lib/pillars', () => ({
-	pillarNames: ['news', 'opinion', 'sport', 'culture', 'lifestyle', 'labs'],
+	pillarNames: ['news', 'opinion', 'sport', 'culture', 'lifestyle'],
 }));
 
 describe('findPillar', () => {
@@ -14,23 +14,6 @@ describe('findPillar', () => {
 	});
 
 	it('returns "culture" if "arts"', () => {
-		expect(findPillar('Arts', [])).toBe('culture');
-	});
-
-	it('returns "labs" if paid content tagging exists', () => {
-		const tags = [
-			{
-				id: 'money/ticket-prices',
-				type: 'Keyword',
-				title: 'Ticket prices',
-			},
-			{
-				id: 'tone/advertisement-features',
-				type: 'Tone',
-				title: 'Consumer affairs',
-			},
-		];
-
-		expect(findPillar('Arts', tags)).toBe('labs');
+		expect(findPillar('Arts')).toBe('culture');
 	});
 });

--- a/src/model/find-pillar.ts
+++ b/src/model/find-pillar.ts
@@ -1,22 +1,16 @@
 import { pillarNames } from '@root/src/lib/pillars';
 
-export const findPillar: (
-	name: string,
-	tags?: TagType[],
-) => CAPIPillar | undefined = (name, tags?) => {
-	// Flag paid content for Labs pillar (for styling purposes)
-	const isPaidContent = (tag: any) =>
-		tag.type === 'Tone' && tag.id === 'tone/advertisement-features';
-
-	if (tags && tags.some(isPaidContent)) {
-		return 'labs';
-	}
-
+export const findPillar: (name: string) => CAPIPillar | undefined = (name) => {
 	const pillar: string = name.toLowerCase();
 	// The pillar name is "arts" in CAPI, but "culture" everywhere else,
 	// therefore we perform this substitution here.
 	if (pillar === 'arts') {
 		return 'culture';
+	}
+	// This is unlikely to happen but adding this guard here as we no longer
+	// support the labs pillar
+	if (pillar === 'labs') {
+		return 'lifestyle';
 	}
 	return pillarNames.find((_) => _ === pillar);
 };

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -246,26 +246,7 @@
             "$ref": "#/definitions/ConfigType"
         },
         "designType": {
-            "enum": [
-                "AdvertisementFeature",
-                "Analysis",
-                "Article",
-                "Comment",
-                "Feature",
-                "GuardianLabs",
-                "GuardianView",
-                "Immersive",
-                "Interview",
-                "Live",
-                "MatchReport",
-                "Media",
-                "PhotoEssay",
-                "Quiz",
-                "Recipe",
-                "Review",
-                "SpecialReport"
-            ],
-            "type": "string"
+            "$ref": "#/definitions/CAPIDesign"
         },
         "showBottomSocialButtons": {
             "type": "boolean"
@@ -2704,6 +2685,28 @@
                 "switches",
                 "videoDuration"
             ]
+        },
+        "CAPIDesign": {
+            "enum": [
+                "AdvertisementFeature",
+                "Analysis",
+                "Article",
+                "Comment",
+                "Feature",
+                "GuardianLabs",
+                "GuardianView",
+                "Immersive",
+                "Interview",
+                "Live",
+                "MatchReport",
+                "Media",
+                "PhotoEssay",
+                "Quiz",
+                "Recipe",
+                "Review",
+                "SpecialReport"
+            ],
+            "type": "string"
         },
         "CommercialProperties": {
             "type": "object",

--- a/src/web/components/HeadlineTag.stories.tsx
+++ b/src/web/components/HeadlineTag.stories.tsx
@@ -27,7 +27,7 @@ export const wrappedTagNameStory = () => {
 		>
 			<HeadlineTag
 				tagText="Very long tag name with enough text to wrap to a second line"
-				pillar="labs"
+				pillar="news"
 			/>
 		</div>
 	);

--- a/src/web/components/RichLink.stories.tsx
+++ b/src/web/components/RichLink.stories.tsx
@@ -180,7 +180,7 @@ export const Gallery = () => {
 						headlineText="Rich link headline"
 						contentType="gallery"
 						url=""
-						pillar="labs"
+						pillar="news"
 						tags={[]}
 						sponsorName=""
 						contributorImage={someContributor}

--- a/src/web/components/SignedInAs.stories.tsx
+++ b/src/web/components/SignedInAs.stories.tsx
@@ -70,7 +70,7 @@ Banned.story = { name: 'when banned' };
 export const NoDisplayName = () => {
 	return (
 		<SignedInAs
-			pillar="labs"
+			pillar="news"
 			enableDiscussionSwitch={true}
 			commentCount={32}
 			user={{

--- a/src/web/lib/decidePillar.ts
+++ b/src/web/lib/decidePillar.ts
@@ -7,5 +7,6 @@ export const decidePillar = ({
 }): CAPIPillar => {
 	// We override the pillar to be opinion on Comment news pieces
 	if (design === 'Comment' && pillar === 'news') return 'opinion';
+	if (pillar === 'labs') return 'lifestyle';
 	return pillar;
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Removes support for the `labs` pillar in favour of using the `AdvertisementFeature` design type

## Why?
Because we only want to have one method to represent paid for content

## Why Not?
Because now we can't ever have paid for content that uses a different design type and the other pillar options won't apply here (you won't ever have paid for `culture` articles I assume)