### PR TITLE
Fix Corona Cypress Test

### DIFF
--- a/cypress/integration/e2e/article.elements.spec.js
+++ b/cypress/integration/e2e/article.elements.spec.js
@@ -32,7 +32,7 @@ describe('Elements', function () {
 
             getAmpIframeBody('amp-iframe[data-cy="atom-embed-url"] > iframe', {
                 timeout: 30000,
-            }).contains('from PHE');
+            }).contains('Daily cases');
         });
 
         it('should render the counted interactive embed', function () {


### PR DESCRIPTION
## What?
Changes the assertion text for our corona cypress test from ‘from PHE’ to ‘Daily cases’

## Why?
The copy [shown at the bottom](https://www.theguardian.com/world/2020/apr/24/new-mother-dies-of-coronavirus-six-days-after-giving-birth) of the corona embed recently changed causing one of our Cypress tests to fail, breaking the build on `main`
