### PR TITLE
Atoms-Bump & Youtube Overlay Pillar fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "@emotion/core": "^10.0.35",
         "@guardian/ab-core": "^2.0.0",
         "@guardian/ab-react": "^2.0.1",
-        "@guardian/atoms-rendering": "^7.1.0",
+        "@guardian/atoms-rendering": "^7.1.2",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/braze-components": "^0.0.17",
         "@guardian/consent-management-platform": "^6.7.4",

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -42,7 +42,7 @@ import { initPerf } from '@root/src/web/browser/initPerf';
 import { getCookie } from '@root/src/web/browser/cookie';
 import { getCountryCode } from '@frontend/web/lib/getCountryCode';
 import { getUser } from '@root/src/web/lib/getUser';
-import { toTypesPillar } from '@root/src/lib/format';
+
 import { FocusStyleManager } from '@guardian/src-foundations/utils';
 import { incrementAlreadyVisited } from '@root/src/web/lib/alreadyVisited';
 import { incrementDailyArticleCount } from '@frontend/web/lib/dailyArticleCount';

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -35,6 +35,7 @@ import { Placeholder } from '@root/src/web/components/Placeholder';
 
 import { decidePillar } from '@root/src/web/lib/decidePillar';
 import { decideDisplay } from '@root/src/web/lib/decideDisplay';
+import { toTypesPillar } from '@root/src/lib/format';
 import { decideDesignType } from '@root/src/web/lib/decideDesignType';
 import { loadScript } from '@root/src/web/lib/loadScript';
 import { useOnce } from '@root/src/web/lib/useOnce';

--- a/src/web/components/elements/YoutubeBlockComponent.tsx
+++ b/src/web/components/elements/YoutubeBlockComponent.tsx
@@ -8,6 +8,8 @@ import { YoutubeAtom } from '@guardian/atoms-rendering';
 import { trackVideoInteraction } from '@root/src/web/browser/ga/ga';
 import { record } from '@root/src/web/browser/ophan/ophan';
 
+import { toTypesPillar } from '@root/src/lib/format';
+
 import { Caption } from '@root/src/web/components/Caption';
 import { Display } from '@guardian/types/Format';
 
@@ -194,6 +196,7 @@ export const YoutubeBlockComponent = ({
 				duration={duration}
 				origin={origin}
 				eventEmitters={[ophanTracking, gaTracking]}
+				pillar={toTypesPillar(pillar)}
 			/>
 			{!hideCaption && (
 				<Caption

--- a/yarn.lock
+++ b/yarn.lock
@@ -2087,10 +2087,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
   integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
 
-"@guardian/atoms-rendering@^7.1.0":
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-7.1.0.tgz#a7307c6bb93036f7de1f85a7ef03785443289151"
-  integrity sha512-bGbKE+QiZi08Xtivr3kuCe+NsOG0/7YKiSlM6ogvYedjLMtUIZbE6Dm+oi/7ybCJrip1sxbBUKjEvqmHIdi1ow==
+"@guardian/atoms-rendering@^7.1.2":
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-7.1.2.tgz#f12be337ced4a7623b225c0011cb926495dedd2c"
+  integrity sha512-gumf6VEtpu2OJGviyJUnatXe5IMykwevjdHWvQ1yrssug4Tnun2OlMdNFZIZ96FjOIuerXIPzZ4UVzY1jl2OGQ==
 
 "@guardian/automat-client@^0.2.16":
   version "0.2.16"


### PR DESCRIPTION
## What does this change?
- Updates atoms-rendering to 7.1.2
- Also uses the new pillar enum to decide on the correct colour of the play and duration overlay

![Screenshot 2021-01-07 at 14 29 17](https://user-images.githubusercontent.com/35331926/103910192-729ffb80-50fc-11eb-946b-5574f4a7fa45.png)
![Screenshot 2021-01-07 at 14 29 23](https://user-images.githubusercontent.com/35331926/103910201-75025580-50fc-11eb-9f02-b5c5d10f71e9.png)



