### PR TITLE
Update atoms rendering v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "@emotion/core": "^10.0.35",
         "@guardian/ab-core": "^2.0.0",
         "@guardian/ab-react": "^2.0.1",
-        "@guardian/atoms-rendering": "^7.1.2",
+        "@guardian/atoms-rendering": "^8.0.0",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/braze-components": "^0.0.17",
         "@guardian/consent-management-platform": "^6.7.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2087,10 +2087,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
   integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
 
-"@guardian/atoms-rendering@^7.1.2":
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-7.1.2.tgz#f12be337ced4a7623b225c0011cb926495dedd2c"
-  integrity sha512-gumf6VEtpu2OJGviyJUnatXe5IMykwevjdHWvQ1yrssug4Tnun2OlMdNFZIZ96FjOIuerXIPzZ4UVzY1jl2OGQ==
+"@guardian/atoms-rendering@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-8.0.0.tgz#387336a8ec7cb7dcd404876f5cd4081658f4962e"
+  integrity sha512-MdppqWF9djQu4U1LeYktP7T1FV+1Ijt+IQEDL1moq8WXbUAEaujQJBs4jj2/J2uHlghcBg2YRaVBZH2OePRfvA==
 
 "@guardian/automat-client@^0.2.16":
   version "0.2.16"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Update atoms rendering to v8. Notable updates include:

- Knowledge quiz submit button per question
- Replace Youtube overlay colours with decide palette

## Why?
Keep things up to date + unblock Quiz PR