### PR TITLE
Re-render header links to account for different server/client DOM structure

### DIFF
--- a/src/web/components/Links.tsx
+++ b/src/web/components/Links.tsx
@@ -14,6 +14,7 @@ import ProfileIcon from '@frontend/static/icons/profile.svg';
 import GiftingIcon from '@frontend/static/icons/gifting.svg';
 import { getZIndex } from '@frontend/web/lib/getZIndex';
 import { createAuthenticationEventParams } from '@root/src/lib/identity-component-event';
+import { useOnce } from '@frontend/web/lib/useOnce';
 
 type Props = {
 	giftingURL: string;
@@ -91,10 +92,10 @@ const Search = ({
 	href,
 	dataLinkName,
 }: {
-	href: string;
-	className?: string;
+    className?: string;
+    children: JSXElements;
+    href: string;
 	dataLinkName: string;
-	children: JSXElements;
 }) => (
 	<a href={href} className={className} data-link-name={dataLinkName}>
 		{children}
@@ -133,11 +134,18 @@ export const Links = ({
 	mmaUrl: mmaUrlFromConfig,
 }: Props) => {
 	const [showGiftingLink, setShowGiftingLink] = useState<boolean>();
+    const [userIsDefined, setUserIsDefined] = useState<boolean>();
 
 	// show gifting if support messaging isn't shown
 	useEffect(() => {
 		setShowGiftingLink(getCookie('gu_hide_support_messaging') === 'true');
-	}, []);
+    }, []);
+
+    // we intentionally re-render here because we know the DOM structure could be different
+    // from the server rendered version. This forces a full validation
+    useOnce(() => {
+        setUserIsDefined(!!userId)
+    }, [userId]);
 
 	// Fall back on prod URLs just in case these aren't set for any reason
 	const idUrl = idUrlFromConfig || 'https://profile.theguardian.com';
@@ -209,7 +217,7 @@ export const Links = ({
 			</a>
 			<div className={seperatorHideStyles} />
 
-			{userId ? (
+			{userIsDefined ? (
 				<div className={linkStyles}>
 					<ProfileIcon />
 					<Dropdown

--- a/src/web/components/Links.tsx
+++ b/src/web/components/Links.tsx
@@ -92,9 +92,9 @@ const Search = ({
 	href,
 	dataLinkName,
 }: {
-    className?: string;
-    children: JSXElements;
-    href: string;
+	className?: string;
+	children: JSXElements;
+	href: string;
 	dataLinkName: string;
 }) => (
 	<a href={href} className={className} data-link-name={dataLinkName}>
@@ -134,18 +134,18 @@ export const Links = ({
 	mmaUrl: mmaUrlFromConfig,
 }: Props) => {
 	const [showGiftingLink, setShowGiftingLink] = useState<boolean>();
-    const [userIsDefined, setUserIsDefined] = useState<boolean>();
+	const [userIsDefined, setUserIsDefined] = useState<boolean>();
 
 	// show gifting if support messaging isn't shown
 	useEffect(() => {
 		setShowGiftingLink(getCookie('gu_hide_support_messaging') === 'true');
-    }, []);
+	}, []);
 
-    // we intentionally re-render here because we know the DOM structure could be different
-    // from the server rendered version. This forces a full validation
-    useOnce(() => {
-        setUserIsDefined(!!userId)
-    }, [userId]);
+	// we intentionally re-render here because we know the DOM structure could be different
+	// from the server rendered version. This forces a full validation
+	useOnce(() => {
+		setUserIsDefined(!!userId);
+	}, [userId]);
 
 	// Fall back on prod URLs just in case these aren't set for any reason
 	const idUrl = idUrlFromConfig || 'https://profile.theguardian.com';


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
We are currently server rendering a different DOM structure for header links when someone is signed in, because we don't know that on the server. The problem with this is that (p)react now (as of react 16) expects server/client DOM structure to be largely the same - it will only do basic validation and updates to text content of nodes for performance reasons (vast majority of use cases client and server should be the same, so why do full validation all the time).

More reading here: https://github.com/facebook/react/issues/10591. The react docs also warn about this.

Due to the differences we have in our particular case, we end up with a sign in link with the text "Search" 😱 when someone is signed in!

The solution here is to re-render (once) the links by adding another hook in the `Links` component. I think that pretty much lines up with the suggested approach in the linked issue(s), but there are probably other ways we could get around it by bringing the DOM structure a little closer at the slightly increased risk of it breaking again in the future.

### Before
![image](https://user-images.githubusercontent.com/8754692/103919530-07f4bd00-5108-11eb-8a2c-d8d589d8ed67.png)


### After
![image](https://user-images.githubusercontent.com/8754692/103919184-ab919d80-5107-11eb-88d1-dfda3e161c86.png)


## Why?
Brings back search to DCR header!