### PR TITLE
Set max-width of Flex component child to 100%

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "@guardian/automat-client": "^0.2.16",
         "@guardian/braze-components": "^0.0.17",
         "@guardian/consent-management-platform": "^6.7.4",
-        "@guardian/discussion-rendering": "^4.4.0",
+        "@guardian/discussion-rendering": "^4.5.0",
         "@guardian/shimport": "^1.0.2",
         "@guardian/src-button": "^2.7.1",
         "@guardian/src-checkbox": "^2.7.1",

--- a/src/web/components/Discussion.tsx
+++ b/src/web/components/Discussion.tsx
@@ -173,6 +173,7 @@ export const Discussion = ({
 							${from.leftCol} {
 								padding-left: 10px;
 							}
+							max-width: 100%;
 						`}
 					>
 						<Hide when="above" breakpoint="leftCol">

--- a/yarn.lock
+++ b/yarn.lock
@@ -2113,10 +2113,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.7.4.tgz#ae75775c40f8234a2e2774c126a688e9a98f5df4"
   integrity sha512-f/XieB0dOyGYZDhP/UmyrHiyuehETt2L1GKqacsySFdcD/++fKe7LLcXbza4NE54MHyS0wbvd+Qh4avjG4IPLg==
 
-"@guardian/discussion-rendering@^4.4.0":
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-4.4.0.tgz#577acb55edd2680134894d60e6d669de10c791ea"
-  integrity sha512-n9DJHXz+WjT4A5l/SWhdPnzTihOf6imNTgU0Y6vwsFD1F4MiE02pjWR9TiaygQBbiZxYpR+d/fYd/9KFCmwgpA==
+"@guardian/discussion-rendering@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-4.5.0.tgz#eb489b1d1551e73c2bf1c5b0b54bfa39b10789d8"
+  integrity sha512-I1qbvb5JHkq/18k73P57zECLHBe5yI5L7VsX/Yqb7CT2ZFt2mG7rGjy04zjbd+5hLqcpeRQNs0KFMveoazM8uQ==
   dependencies:
     babel-plugin-emotion "^10.0.33"
     customize-cra "^1.0.0"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Sets the `max-width` of the first child in the `Flex` component to be `100%`. This stops horizontal scroll due to long usernames expanding the screen width when done in conjunction with https://github.com/guardian/discussion-rendering/pull/383

Will need to have the version of discussion-rendering with the accompanying bug fix released and then the version bumped in here

### Before
![image](https://user-images.githubusercontent.com/9122944/103928760-35dffe80-5114-11eb-9387-01e422222baa.png)

### After
![image](https://user-images.githubusercontent.com/9122944/103928695-1ea11100-5114-11eb-8344-7028507c4cf9.png)

## Why?
Poor UX