### PR TITLE
How we type children

### DIFF
--- a/.vscode/dcr.code-snippets
+++ b/.vscode/dcr.code-snippets
@@ -26,7 +26,7 @@
             "import React from 'react';",
             "",
             "type Props = {",
-            "  children: JSX.Element | JSX.Element[];",
+            "  children: React.ReactNode;",
             "}",
             "",
             "export const $TM_FILENAME_BASE = ({ children }: Props) => ($1",

--- a/index.d.ts
+++ b/index.d.ts
@@ -646,8 +646,6 @@ interface Props {
     data: DCRServerDocumentData; // Do not fall to the tempation to rename 'data' into something else
 }
 
-type JSXElements = JSX.Element | JSX.Element[];
-
 type IslandType =
     | 'reader-revenue-links-header'
     | 'sub-nav-root'

--- a/src/amp/components/Elements.tsx
+++ b/src/amp/components/Elements.tsx
@@ -30,7 +30,7 @@ export const Elements = (
 	pillar: CAPIPillar,
 	isImmersive: boolean,
 	adTargeting?: AdTargeting,
-): JSX.Element[] => {
+) => {
 	const cleanedElements = elements.map((element) =>
 		'html' in element ? { ...element, html: clean(element.html) } : element,
 	);

--- a/src/amp/components/MainMedia.tsx
+++ b/src/amp/components/MainMedia.tsx
@@ -63,7 +63,7 @@ const labelStyle = css`
 	}
 `;
 
-const mainImage = (element: ImageBlockElement): JSX.Element | null => {
+const mainImage = (element: ImageBlockElement) => {
 	const containerWidth = 600;
 	const image: SrcSetItem = bestFitImage(
 		element.imageSources,
@@ -128,7 +128,7 @@ const asComponent = (
 	element: CAPIElement,
 	pillar: CAPIPillar,
 	adTargeting?: any,
-): JSX.Element | null => {
+) => {
 	switch (element._type) {
 		case 'model.dotcomrendering.pageElements.ImageBlockElement':
 			return mainImage(element);

--- a/src/web/components/ArticleContainer.tsx
+++ b/src/web/components/ArticleContainer.tsx
@@ -77,7 +77,7 @@ const articleAdStyles = css`
 `;
 
 type Props = {
-	children: JSXElements;
+	children: React.ReactNode;
 };
 
 export const ArticleContainer = ({ children }: Props) => {

--- a/src/web/components/ArticleMeta.stories.tsx
+++ b/src/web/components/ArticleMeta.stories.tsx
@@ -4,7 +4,7 @@ import { css } from 'emotion';
 import { Display } from '@guardian/types/Format';
 import { ArticleMeta } from './ArticleMeta';
 
-const Container = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
+const Container = ({ children }: { children: React.ReactNode }) => (
 	<div
 		className={css`
 			width: 220px;

--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -226,11 +226,7 @@ const shouldShowContributor = (designType: DesignType, display: Display) => {
 	}
 };
 
-const AvatarContainer = ({
-	children,
-}: {
-	children: JSX.Element | JSX.Element[];
-}) => (
+const AvatarContainer = ({ children }: { children: React.ReactNode }) => (
 	<div
 		className={css`
 			width: 140px;
@@ -254,11 +250,7 @@ const AvatarContainer = ({
 	</div>
 );
 
-const RowBelowLeftCol = ({
-	children,
-}: {
-	children: JSX.Element | JSX.Element[];
-}) => (
+const RowBelowLeftCol = ({ children }: { children: React.ReactNode }) => (
 	<div
 		className={css`
 			display: flex;

--- a/src/web/components/ArticleTitle.stories.tsx
+++ b/src/web/components/ArticleTitle.stories.tsx
@@ -4,7 +4,7 @@ import { css } from 'emotion';
 import { Display } from '@guardian/types/Format';
 import { ArticleTitle } from './ArticleTitle';
 
-const Container = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
+const Container = ({ children }: { children: React.ReactNode }) => (
 	<div
 		className={css`
 			width: 620px;

--- a/src/web/components/Card/components/AvatarContainer.tsx
+++ b/src/web/components/Card/components/AvatarContainer.tsx
@@ -4,7 +4,7 @@ import { css } from 'emotion';
 import { from, until } from '@guardian/src-foundations/mq';
 
 type Props = {
-	children: JSXElements;
+	children: React.ReactNode;
 };
 
 const containerStyles = css`

--- a/src/web/components/Card/components/CardLayout.tsx
+++ b/src/web/components/Card/components/CardLayout.tsx
@@ -4,7 +4,7 @@ import { css } from 'emotion';
 import { until } from '@guardian/src-foundations/mq';
 
 type Props = {
-	children: JSXElements;
+	children: React.ReactNode;
 	imagePosition?: ImagePositionType;
 };
 

--- a/src/web/components/Card/components/CardLink.tsx
+++ b/src/web/components/Card/components/CardLink.tsx
@@ -91,7 +91,7 @@ const linkStyles = (designType: DesignType, pillar: CAPIPillar) => {
 };
 
 type Props = {
-	children: JSXElements;
+	children: React.ReactNode;
 	linkTo: string;
 	designType: DesignType;
 	pillar: CAPIPillar;

--- a/src/web/components/Card/components/ContentWrapper.tsx
+++ b/src/web/components/Card/components/ContentWrapper.tsx
@@ -23,7 +23,7 @@ const coverageStyles = (percentage?: string) => {
 };
 
 type Props = {
-	children: JSXElements;
+	children: React.ReactNode;
 	percentage?: CardPercentageType;
 };
 

--- a/src/web/components/Card/components/HeadlineWrapper.tsx
+++ b/src/web/components/Card/components/HeadlineWrapper.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 type Props = {
-	children: JSXElements;
+	children: React.ReactNode;
 };
 
 export const HeadlineWrapper = ({ children }: Props) => (

--- a/src/web/components/Card/components/ImageWrapper.tsx
+++ b/src/web/components/Card/components/ImageWrapper.tsx
@@ -4,7 +4,7 @@ import { css } from 'emotion';
 import { until } from '@guardian/src-foundations/mq';
 
 type Props = {
-	children: JSXElements;
+	children: React.ReactNode;
 	percentage?: CardPercentageType;
 };
 

--- a/src/web/components/Card/components/LI.tsx
+++ b/src/web/components/Card/components/LI.tsx
@@ -49,7 +49,7 @@ const decideSize = (percentage?: CardPercentageType, stretch?: boolean) => {
 };
 
 type Props = {
-	children: JSXElements;
+	children: React.ReactNode;
 	percentage?: CardPercentageType; // Used to give a particular LI more or less weight / space
 	stretch?: boolean; // When true, the card stretches based on content
 	showDivider?: boolean; // If this LI wraps a card in a row this should be true

--- a/src/web/components/Card/components/TopBar.tsx
+++ b/src/web/components/Card/components/TopBar.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 type Props = {
-	children: JSXElements;
+	children: React.ReactNode;
 	topBarColour: string;
 };
 

--- a/src/web/components/Card/components/UL.tsx
+++ b/src/web/components/Card/components/UL.tsx
@@ -20,7 +20,7 @@ const marginBottomStyles = css`
 `;
 
 type Props = {
-	children: JSXElements;
+	children: React.ReactNode;
 	direction?: 'row' | 'column'; // Passed to flex-direction
 	showDivider?: boolean; // If this UL is a column and not the left most column
 	bottomMargin?: boolean; // If this UL is a row, add spacing below

--- a/src/web/components/CardCommentCount.stories.tsx
+++ b/src/web/components/CardCommentCount.stories.tsx
@@ -8,7 +8,7 @@ export default {
 	title: 'Components/CardCommentCount',
 };
 
-const Container = ({ children }: { children: JSXElements }) => (
+const Container = ({ children }: { children: React.ReactNode }) => (
 	<div
 		className={css`
 			margin: 40px;

--- a/src/web/components/ContainerLayout.tsx
+++ b/src/web/components/ContainerLayout.tsx
@@ -24,7 +24,7 @@ type Props = {
 	verticalMargins?: boolean;
 	backgroundColour?: string;
 	borderColour?: string;
-	leftContent?: JSXElements;
+	leftContent?: React.ReactNode;
 	children?: React.ReactNode;
 	stretchRight?: boolean;
 };

--- a/src/web/components/Counts.stories.tsx
+++ b/src/web/components/Counts.stories.tsx
@@ -13,7 +13,7 @@ export default {
 	title: 'Components/Counts',
 };
 
-const Container = ({ children }: { children: JSXElements }) => (
+const Container = ({ children }: { children: React.ReactNode }) => (
 	<div
 		className={css`
 			margin: 40px;

--- a/src/web/components/Distribution.stories.tsx
+++ b/src/web/components/Distribution.stories.tsx
@@ -8,7 +8,7 @@ export default {
 	title: 'Components/Distribution',
 };
 
-const Container = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
+const Container = ({ children }: { children: React.ReactNode }) => (
 	<div
 		className={css`
 			width: 300px;

--- a/src/web/components/Distribution.tsx
+++ b/src/web/components/Distribution.tsx
@@ -16,7 +16,7 @@ type Section = {
 	color: string;
 };
 
-const Row = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
+const Row = ({ children }: { children: React.ReactNode }) => (
 	<div
 		className={css`
 			display: flex;

--- a/src/web/components/Donut.stories.tsx
+++ b/src/web/components/Donut.stories.tsx
@@ -52,7 +52,7 @@ const threeSections = [
 	},
 ];
 
-const Container = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
+const Container = ({ children }: { children: React.ReactNode }) => (
 	<div
 		className={css`
 			width: 620px;

--- a/src/web/components/Dropcap.stories.tsx
+++ b/src/web/components/Dropcap.stories.tsx
@@ -10,7 +10,7 @@ export default {
 	title: 'Components/DropCap',
 };
 
-const Container = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
+const Container = ({ children }: { children: React.ReactNode }) => (
 	<div
 		className={css`
 			width: 620px;

--- a/src/web/components/Dropdown.stories.tsx
+++ b/src/web/components/Dropdown.stories.tsx
@@ -5,7 +5,7 @@ import { brandBackground } from '@guardian/src-foundations/palette';
 
 import { Dropdown } from '@frontend/web/components/Dropdown';
 
-const Header = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
+const Header = ({ children }: { children: React.ReactNode }) => (
 	<div
 		className={css`
 			height: 300px;
@@ -17,7 +17,7 @@ const Header = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
 	</div>
 );
 
-const Nav = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
+const Nav = ({ children }: { children: React.ReactNode }) => (
 	<div
 		className={css`
 			height: 20px;

--- a/src/web/components/Figure.tsx
+++ b/src/web/components/Figure.tsx
@@ -6,7 +6,7 @@ import { space } from '@guardian/src-foundations';
 
 type Props = {
 	role?: RoleType;
-	children: JSXElements;
+	children: React.ReactNode;
 	id?: string;
 };
 

--- a/src/web/components/Figure.tsx
+++ b/src/web/components/Figure.tsx
@@ -125,11 +125,7 @@ const decidePosition = (role: RoleType) => {
 	}
 };
 
-export const Figure = ({
-	role = 'inline',
-	children,
-	id,
-}: Props): JSX.Element => {
+export const Figure = ({ role = 'inline', children, id }: Props) => {
 	return (
 		<figure id={id} className={decidePosition(role)}>
 			{children}

--- a/src/web/components/Flex.tsx
+++ b/src/web/components/Flex.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 type Props = {
-	children: JSXElements;
+	children: React.ReactNode;
 	direction?: 'row' | 'column';
 	justify?: 'space-between' | 'flex-start'; // Extend as required
 };

--- a/src/web/components/GoalAttempts.stories.tsx
+++ b/src/web/components/GoalAttempts.stories.tsx
@@ -8,7 +8,7 @@ export default {
 	title: 'Components/GoalAttempts',
 };
 
-const Container = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
+const Container = ({ children }: { children: React.ReactNode }) => (
 	<div
 		className={css`
 			width: 340px;

--- a/src/web/components/GoalAttempts.tsx
+++ b/src/web/components/GoalAttempts.tsx
@@ -22,7 +22,7 @@ const svgBackground = encodeURIComponent(
 	'<svg xmlns="http://www.w3.org/2000/svg" width="3" height="3" viewBox="0 0 3 3"><circle fill="rgba(255, 255, 255, 0.3)" cx="1.5" cy="1.5" r="1"/></svg>',
 );
 
-const Row = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
+const Row = ({ children }: { children: React.ReactNode }) => (
 	<div
 		className={css`
 			display: flex;

--- a/src/web/components/GridItem.tsx
+++ b/src/web/components/GridItem.tsx
@@ -3,7 +3,7 @@ import { css } from 'emotion';
 import { getZIndex } from '@frontend/web/lib/getZIndex';
 
 type Props = {
-	children: JSX.Element | JSX.Element[];
+	children: React.ReactNode;
 	area: string;
 };
 

--- a/src/web/components/Hide.tsx
+++ b/src/web/components/Hide.tsx
@@ -3,7 +3,7 @@ import { css } from 'emotion';
 import { until, from, Breakpoint } from '@guardian/src-foundations/mq';
 
 type Props = {
-	children: JSXElements;
+	children: React.ReactNode;
 	when: 'above' | 'below';
 	breakpoint: Breakpoint;
 };

--- a/src/web/components/HydrateOnce.tsx
+++ b/src/web/components/HydrateOnce.tsx
@@ -5,7 +5,7 @@ import { initPerf } from '@root/src/web/browser/initPerf';
 
 type Props = {
 	root: IslandType;
-	children: JSX.Element;
+	children: React.ReactNode;
 	index?: number;
 	waitFor?: unknown[];
 };

--- a/src/web/components/HydrateOnce.tsx
+++ b/src/web/components/HydrateOnce.tsx
@@ -5,7 +5,7 @@ import { initPerf } from '@root/src/web/browser/initPerf';
 
 type Props = {
 	root: IslandType;
-	children: React.ReactNode;
+	children: JSX.Element;
 	index?: number;
 	waitFor?: unknown[];
 };

--- a/src/web/components/Lazy.tsx
+++ b/src/web/components/Lazy.tsx
@@ -4,7 +4,7 @@ import { css } from 'emotion';
 import { useHasBeenSeen } from '@root/src/web/lib/useHasBeenSeen';
 
 type Props = {
-	children: JSX.Element;
+	children: React.ReactNode;
 	margin: number;
 };
 

--- a/src/web/components/Lazy.tsx
+++ b/src/web/components/Lazy.tsx
@@ -4,7 +4,7 @@ import { css } from 'emotion';
 import { useHasBeenSeen } from '@root/src/web/lib/useHasBeenSeen';
 
 type Props = {
-	children: React.ReactNode;
+	children: JSX.Element;
 	margin: number;
 };
 

--- a/src/web/components/LeftColumn.tsx
+++ b/src/web/components/LeftColumn.tsx
@@ -47,7 +47,7 @@ const rightBorder = (colour: string) => css`
 `;
 
 type Props = {
-	children: JSXElements;
+	children: React.ReactNode;
 	showRightBorder?: boolean;
 	showPartialRightBorder?: boolean;
 	borderColour?: string;

--- a/src/web/components/Lineup.stories.tsx
+++ b/src/web/components/Lineup.stories.tsx
@@ -3,7 +3,7 @@ import { css } from 'emotion';
 
 import { Lineup } from './Lineup';
 
-const Container = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
+const Container = ({ children }: { children: React.ReactNode }) => (
 	<div
 		className={css`
 			width: 340px;

--- a/src/web/components/Links.tsx
+++ b/src/web/components/Links.tsx
@@ -94,7 +94,7 @@ const Search = ({
 	href: string;
 	className?: string;
 	dataLinkName: string;
-	children: JSXElements;
+	children: React.ReactNode;
 }) => (
 	<a href={href} className={className} data-link-name={dataLinkName}>
 		{children}

--- a/src/web/components/MatchStats.tsx
+++ b/src/web/components/MatchStats.tsx
@@ -21,7 +21,7 @@ type Props = {
 
 const BACKGROUND_COLOUR = '#d9edf6';
 
-const StatsGrid = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
+const StatsGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
 		className={css`
 			/* IE Fallback */

--- a/src/web/components/Onwards/OnwardsContainer.tsx
+++ b/src/web/components/Onwards/OnwardsContainer.tsx
@@ -4,7 +4,7 @@ import { css } from 'emotion';
 import { from } from '@guardian/src-foundations/mq';
 
 type Props = {
-	children: JSX.Element | JSX.Element[];
+	children: React.ReactNode;
 	dataComponentName: string;
 	dataLinkName: string;
 };

--- a/src/web/components/ReaderRevenueLinks.stories.tsx
+++ b/src/web/components/ReaderRevenueLinks.stories.tsx
@@ -31,7 +31,7 @@ const revenueUrls = {
 	contribute: '',
 };
 
-const Container = ({ children }: { children: JSXElements }) => (
+const Container = ({ children }: { children: React.ReactNode }) => (
 	<div
 		className={css`
 			margin: 40px;

--- a/src/web/components/RightColumn.tsx
+++ b/src/web/components/RightColumn.tsx
@@ -19,7 +19,7 @@ const hideBelowDesktop = css`
 `;
 
 type Props = {
-	children: JSXElements;
+	children: React.ReactNode;
 };
 
 export const RightColumn = ({ children }: Props) => {

--- a/src/web/components/elements/CaptionBlockComponent.stories.tsx
+++ b/src/web/components/elements/CaptionBlockComponent.stories.tsx
@@ -28,7 +28,7 @@ export default {
     };
  */
 
-const Container = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
+const Container = ({ children }: { children: React.ReactNode }) => (
 	<Section showTopBorder={false}>
 		<Flex>
 			<LeftColumn>

--- a/src/web/components/elements/DocumentBlockComponent.stories.tsx
+++ b/src/web/components/elements/DocumentBlockComponent.stories.tsx
@@ -8,7 +8,7 @@ export default {
 	title: 'Components/DocumentBlockComponent',
 };
 
-const Container = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
+const Container = ({ children }: { children: React.ReactNode }) => (
 	<div
 		className={css`
 			max-width: 620px;

--- a/src/web/components/elements/ImageBlockComponent.stories.tsx
+++ b/src/web/components/elements/ImageBlockComponent.stories.tsx
@@ -21,7 +21,7 @@ export default {
 	},
 };
 
-const Container = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
+const Container = ({ children }: { children: React.ReactNode }) => (
 	<Section showTopBorder={false}>
 		<Flex>
 			<LeftColumn>

--- a/src/web/components/elements/ImageComponent.tsx
+++ b/src/web/components/elements/ImageComponent.tsx
@@ -159,7 +159,7 @@ const ImageTitle: React.FC<{
 	}
 };
 
-const Row = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
+const Row = ({ children }: { children: React.ReactNode }) => (
 	<div
 		className={css`
 			display: flex;

--- a/src/web/components/elements/MultiImageBlockComponent.tsx
+++ b/src/web/components/elements/MultiImageBlockComponent.tsx
@@ -30,11 +30,7 @@ const ieFallback = css`
 	}
 `;
 
-const SideBySideGrid = ({
-	children,
-}: {
-	children: JSX.Element | JSX.Element[];
-}) => (
+const SideBySideGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
 		className={css`
 			${ieFallback}
@@ -54,11 +50,7 @@ const SideBySideGrid = ({
 	</div>
 );
 
-const OneAboveTwoGrid = ({
-	children,
-}: {
-	children: JSX.Element | JSX.Element[];
-}) => (
+const OneAboveTwoGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
 		className={css`
 			${ieFallback}
@@ -80,11 +72,7 @@ const OneAboveTwoGrid = ({
 	</div>
 );
 
-const GridOfFour = ({
-	children,
-}: {
-	children: JSX.Element | JSX.Element[];
-}) => (
+const GridOfFour = ({ children }: { children: React.ReactNode }) => (
 	<div
 		className={css`
 			${ieFallback}

--- a/src/web/components/elements/PullQuoteBlockComponent.stories.tsx
+++ b/src/web/components/elements/PullQuoteBlockComponent.stories.tsx
@@ -13,7 +13,7 @@ export default {
 	title: 'Components/PullQuoteBlockComponent',
 };
 
-const Container = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
+const Container = ({ children }: { children: React.ReactNode }) => (
 	<Section showTopBorder={false}>
 		<Flex>
 			<LeftColumn>

--- a/src/web/components/elements/RewrappedComponent.tsx
+++ b/src/web/components/elements/RewrappedComponent.tsx
@@ -20,7 +20,7 @@ export const RewrappedComponent = ({
 	html: string;
 	elCss?: string;
 	tagName: string;
-}): JSX.Element => {
+}) => {
 	const element = isUnwrapped ? tagName : 'span';
 
 	// If we implement a span, we want to apply the CSS to the inner element

--- a/src/web/components/elements/VideoFacebookBlockComponent.stories.tsx
+++ b/src/web/components/elements/VideoFacebookBlockComponent.stories.tsx
@@ -9,7 +9,7 @@ export default {
 	title: 'Components/VideoFacebookComponent',
 };
 
-const Container = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
+const Container = ({ children }: { children: React.ReactNode }) => (
 	<div
 		className={css`
 			max-width: 620px;

--- a/src/web/components/elements/VimeoBlockComponent.stories.tsx
+++ b/src/web/components/elements/VimeoBlockComponent.stories.tsx
@@ -9,7 +9,7 @@ export default {
 	title: 'Components/VimeoComponent',
 };
 
-const Container = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
+const Container = ({ children }: { children: React.ReactNode }) => (
 	<div
 		className={css`
 			max-width: 620px;

--- a/src/web/components/elements/YoutubeBlockComponent.stories.tsx
+++ b/src/web/components/elements/YoutubeBlockComponent.stories.tsx
@@ -14,7 +14,7 @@ export default {
 	title: 'Components/YoutubeBlockComponent',
 };
 
-const Container = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
+const Container = ({ children }: { children: React.ReactNode }) => (
 	<Section showTopBorder={false}>
 		<Flex>
 			<LeftColumn>

--- a/src/web/components/elements/YoutubeEmbedBlockComponent.stories.tsx
+++ b/src/web/components/elements/YoutubeEmbedBlockComponent.stories.tsx
@@ -9,7 +9,7 @@ export default {
 	title: 'Components/YoutubeEmbedComponent',
 };
 
-const Container = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
+const Container = ({ children }: { children: React.ReactNode }) => (
 	<div
 		className={css`
 			max-width: 620px;

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -69,7 +69,7 @@ const StandardGrid = ({
 	children,
 	display,
 }: {
-	children: JSX.Element | JSX.Element[];
+	children: React.ReactNode;
 	display: Display;
 }) => (
 	<div

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -45,11 +45,7 @@ import {
 import { Display } from '@guardian/types/Format';
 import { BannerWrapper } from '@root/src/web/layouts/lib/stickiness';
 
-const ImmersiveGrid = ({
-	children,
-}: {
-	children: JSX.Element | JSX.Element[];
-}) => (
+const ImmersiveGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
 		className={css`
 			/* IE Fallback */

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -48,11 +48,7 @@ import {
 } from '@root/src/web/layouts/lib/stickiness';
 import { Display } from '@guardian/types/Format';
 
-const ShowcaseGrid = ({
-	children,
-}: {
-	children: JSX.Element | JSX.Element[];
-}) => (
+const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
 		className={css`
 			/* IE Fallback */
@@ -178,7 +174,7 @@ const PositionHeadline = ({
 	children,
 }: {
 	designType: DesignType;
-	children: JSX.Element | JSX.Element[];
+	children: React.ReactNode;
 }) => {
 	switch (designType) {
 		case 'Interview':

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -220,7 +220,7 @@ const StandardGrid = ({
 	designType,
 	CAPI,
 }: {
-	children: JSX.Element | JSX.Element[];
+	children: React.ReactNode;
 	designType: DesignType;
 	CAPI: CAPIType;
 }) => (

--- a/src/web/lib/withSignInGateSlot.tsx
+++ b/src/web/lib/withSignInGateSlot.tsx
@@ -7,7 +7,7 @@ const SignInGateSlot = <p id="sign-in-gate" />;
 
 export const withSignInGateSlot = (
 	articleElements: (JSX.Element | null | undefined)[],
-): (JSX.Element | null | undefined)[] => {
+) => {
 	return articleElements.map((element, i) => {
 		return (
 			<>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
1. Replaces `JSX.Element || JSX.Element[]` (won't accept functions) with `React.ReactNode` (everything) as the type to use for children

2. Removed `JSX.Element` as a return type, preferring typescript to infer these

## Why?
This reduces the chance of unwanted ts errors when refactoring code