### PR TITLE
Atom base type has optiona url prop

### DIFF
--- a/src/amp/components/Elements.tsx
+++ b/src/amp/components/Elements.tsx
@@ -47,7 +47,9 @@ export const Elements = (
 					/>
 				);
 			case 'model.dotcomrendering.pageElements.ChartAtomBlockElement':
-				return <InteractiveAtomBlockComponent url={element.url} />;
+				return (
+					<InteractiveAtomBlockComponent url={element.url || ''} />
+				);
 			case 'model.dotcomrendering.pageElements.CommentBlockElement':
 				return <CommentBlockComponent key={i} element={element} />;
 			case 'model.dotcomrendering.pageElements.ContentAtomBlockElement':
@@ -63,7 +65,9 @@ export const Elements = (
 			case 'model.dotcomrendering.pageElements.EmbedBlockElement':
 				return <EmbedBlockComponent key={i} element={element} />;
 			case 'model.dotcomrendering.pageElements.GenericAtomBlockElement':
-				return <InteractiveAtomBlockComponent url={element.url} />;
+				return (
+					<InteractiveAtomBlockComponent url={element.url || ''} />
+				);
 			case 'model.dotcomrendering.pageElements.GuideAtomBlockElement':
 				return (
 					<Expandable
@@ -97,13 +101,15 @@ export const Elements = (
 			case 'model.dotcomrendering.pageElements.InteractiveAtomBlockElement':
 				return (
 					<InteractiveAtomBlockComponent
-						url={element.url}
+						url={element.url || ''}
 						html={element.html}
 						placeholderUrl={element.placeholderUrl}
 					/>
 				); // element.placeholderUrl
 			case 'model.dotcomrendering.pageElements.InteractiveBlockElement': // Plain Interactive Embeds
-				return <InteractiveAtomBlockComponent url={element.url} />;
+				return (
+					<InteractiveAtomBlockComponent url={element.url || ''} />
+				);
 			case 'model.dotcomrendering.pageElements.MapBlockElement':
 				return (
 					<MapBlockComponent

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -2,7 +2,7 @@
 // Elements
 // -------------------------------------
 interface InteractiveAtomBlockElementBase {
-	url: string;
+	url?: string;
 	placeholderUrl?: string;
 	id?: string;
 	html?: string;

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -916,8 +916,7 @@
             "required": [
                 "_type",
                 "html",
-                "id",
-                "url"
+                "id"
             ]
         },
         "CodeBlockElement": {
@@ -1171,8 +1170,7 @@
                 }
             },
             "required": [
-                "_type",
-                "url"
+                "_type"
             ]
         },
         "GuideAtomBlockElement": {
@@ -1500,8 +1498,7 @@
             "required": [
                 "_type",
                 "id",
-                "js",
-                "url"
+                "js"
             ]
         },
         "InteractiveBlockElement": {
@@ -1533,8 +1530,7 @@
                 }
             },
             "required": [
-                "_type",
-                "url"
+                "_type"
             ]
         },
         "MapBlockElement": {


### PR DESCRIPTION
## What does this change?
Changes URL key in `InteractiveAtomBlockElementBase` from being mandatory to being optional.

## Why?
Quiz atoms do not return a URL