### PR TITLE
Remove Pillar from endpoint

### DIFF
--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterData.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterData.tsx
@@ -73,7 +73,7 @@ export const MostViewedFooterData = ({
 	const { data, error } = useApi<
 		MostViewedFooterPayloadType | TrailTabType[]
 	>(url);
-
+	console.log(url);
 	if (error) {
 		window.guardian.modules.sentry.reportError(error, 'most-viewed-footer');
 		return null;

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterData.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterData.tsx
@@ -51,7 +51,7 @@ function buildSectionUrl(
 }
 
 function buildDeeplyReadUrl(ajaxUrl: string) {
-	return joinUrl([ajaxUrl, 'most-read-deeply-read', `.json`]);
+	return joinUrl([ajaxUrl, 'most-read-deeply-read.json']);
 }
 
 export const MostViewedFooterData = ({

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterData.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterData.tsx
@@ -73,7 +73,7 @@ export const MostViewedFooterData = ({
 	const { data, error } = useApi<
 		MostViewedFooterPayloadType | TrailTabType[]
 	>(url);
-	console.log(url);
+
 	if (error) {
 		window.guardian.modules.sentry.reportError(error, 'most-viewed-footer');
 		return null;

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterData.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterData.tsx
@@ -50,8 +50,8 @@ function buildSectionUrl(
 	return joinUrl([ajaxUrl, `${endpoint}?dcr=true`]);
 }
 
-function buildDeeplyReadUrl(ajaxUrl: string, pillar: CAPIPillar) {
-	return joinUrl([ajaxUrl, 'most-read-deeply-read', `${pillar}.json?dcr`]);
+function buildDeeplyReadUrl(ajaxUrl: string) {
+	return joinUrl([ajaxUrl, 'most-read-deeply-read', `.json`]);
 }
 
 export const MostViewedFooterData = ({
@@ -68,7 +68,7 @@ export const MostViewedFooterData = ({
 	);
 
 	const url = inDeeplyReadTestVariant
-		? buildDeeplyReadUrl(ajaxUrl, pillar)
+		? buildDeeplyReadUrl(ajaxUrl)
 		: buildSectionUrl(ajaxUrl, pillar, sectionName);
 	const { data, error } = useApi<
 		MostViewedFooterPayloadType | TrailTabType[]


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Removes the pillar from the deeply read api endpoint call.

