### PR TITLE
Add ophan tracking calls to the blocked hosts for Cypress

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -4,5 +4,6 @@
     "baseUrl": "http://localhost:3030/",
     "video": false,
     "chromeWebSecurity": false,
+    "blockHosts": "*ophan.theguardian.com",
     "retries": 2
 }


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Blocks calls out to Ophan from inside Cypress tests. 

### Screenshot
![image](https://user-images.githubusercontent.com/9122944/104186650-9fab2180-540e-11eb-91fc-9386e1ba450f.png)
**Shows a blocked Ophan tracking call and the header from cypress (`x-cypress-matched-blocked-host`)  to indicate that it was blocked for that reason**

## Why?
Causes data quality issues as it throws off the number of positive/negative clicks for atoms.
