### PR TITLE
Add origin to youtube atom embed

### DIFF
--- a/src/web/lib/ArticleRenderer.tsx
+++ b/src/web/lib/ArticleRenderer.tsx
@@ -61,7 +61,7 @@ export const ArticleRenderer: React.FC<{
 	designType: DesignType;
 	adTargeting?: AdTargeting;
 	host?: string;
-}> = ({ display, elements, pillar, designType, adTargeting }) => {
+}> = ({ display, elements, pillar, designType, adTargeting, host }) => {
 	// const cleanedElements = elements.map(element =>
 	//     'html' in element ? { ...element, html: clean(element.html) } : element,
 	// );
@@ -484,6 +484,7 @@ export const ArticleRenderer: React.FC<{
 								duration={element.duration}
 								mediaTitle={element.mediaTitle}
 								altText={element.altText}
+								origin={host}
 							/>
 						</Figure>
 					);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Add origin to youtube atom for videos within the article

## Why?
Only added them to main media in https://github.com/guardian/dotcom-rendering/pull/2344 need to add them to embed youtube atoms
