### PR TITLE
Show full navigation menu on top of top-above-nav slot

### DIFF
--- a/src/web/components/Nav/ExpandedMenu/ExpandedMenu.tsx
+++ b/src/web/components/Nav/ExpandedMenu/ExpandedMenu.tsx
@@ -86,7 +86,7 @@ const mainMenuStyles = css`
 		margin-right: 70px;
 	}
 	${from.tablet} {
-		margin-right: 100px;
+		margin-right: 53px;
 	}
 `;
 

--- a/src/web/lib/getZIndex.test.tsx
+++ b/src/web/lib/getZIndex.test.tsx
@@ -1,9 +1,9 @@
 import { getZIndex } from './getZIndex';
 
 describe('getZIndex', () => {
-    it('gets the correct zindex for group and sibling', () => {
+	it('gets the correct zindex for group and sibling', () => {
 		expect(getZIndex('headerWrapper')).toBe('z-index: 9;');
-        expect(getZIndex('stickyAdWrapper')).toBe('z-index: 8;');
+		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 8;');
 		expect(getZIndex('headerLinks')).toBe('z-index: 7;');
 		expect(getZIndex('TheGuardian')).toBe('z-index: 6;');
 		expect(getZIndex('articleHeadline')).toBe('z-index: 5;');

--- a/src/web/lib/getZIndex.test.tsx
+++ b/src/web/lib/getZIndex.test.tsx
@@ -1,9 +1,9 @@
 import { getZIndex } from './getZIndex';
 
 describe('getZIndex', () => {
-	it('gets the correct zindex for group and sibling', () => {
-		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 9;');
-		expect(getZIndex('headerWrapper')).toBe('z-index: 8;');
+    it('gets the correct zindex for group and sibling', () => {
+		expect(getZIndex('headerWrapper')).toBe('z-index: 9;');
+        expect(getZIndex('stickyAdWrapper')).toBe('z-index: 8;');
 		expect(getZIndex('headerLinks')).toBe('z-index: 7;');
 		expect(getZIndex('TheGuardian')).toBe('z-index: 6;');
 		expect(getZIndex('articleHeadline')).toBe('z-index: 5;');

--- a/src/web/lib/getZIndex.tsx
+++ b/src/web/lib/getZIndex.tsx
@@ -27,8 +27,8 @@ const indices = [
 	'banner',
 
 	// Header
-	'stickyAdWrapper',
-	'headerWrapper',
+    'headerWrapper',
+    'stickyAdWrapper',
 
 	// Header links (should be above The Guardian svg)
 	'headerLinks',

--- a/src/web/lib/getZIndex.tsx
+++ b/src/web/lib/getZIndex.tsx
@@ -27,8 +27,8 @@ const indices = [
 	'banner',
 
 	// Header
-    'headerWrapper',
-    'stickyAdWrapper',
+	'headerWrapper',
+	'stickyAdWrapper',
 
 	// Header links (should be above The Guardian svg)
 	'headerLinks',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

On tablets the navigation menu was hidden behind top-above-nav ad slot. Changes top above nav z-index so that the navigation menu appears on top of it.
Also reducing right margin to make the menu larger and meet the burger button as in DCP

### Before

![Screenshot 2021-01-11 at 15 14 49](https://user-images.githubusercontent.com/51630004/104220833-c0906880-5448-11eb-9134-f1b0a764239a.png)


### After

<img width="415" alt="Screenshot 2021-01-11 at 20 39 03" src="https://user-images.githubusercontent.com/51630004/104224228-5e863200-544d-11eb-963c-9b31a0643ccb.png">

### DCP for reference:

**Note to dotcom team: Another card might be needed to give the same menu overlay as in DCP** 


<img width="415" alt="Screenshot 2021-01-11 at 20 39 12" src="https://user-images.githubusercontent.com/51630004/104224851-34813f80-544e-11eb-8315-3c5ba496d1ac.png">



## Why?
Will give full visibility of navigation menu on tablets
