### PR TITLE
Remove secondary capital letters from deeply read tab

### DIFF
--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterGrid.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterGrid.tsx
@@ -4,6 +4,7 @@ import { neutral, border } from '@guardian/src-foundations/palette';
 import { headline } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
 import { visuallyHidden } from '@guardian/src-foundations/accessibility';
+import { useAB } from '@guardian/ab-react';
 
 import { pillarPalette } from '@frontend/lib/pillars';
 import { MostViewedFooterItem } from './MostViewedFooterItem';
@@ -32,6 +33,16 @@ const listTab = css`
 	line-height: 1.1;
 	background-color: transparent;
 	text-transform: capitalize;
+	padding: 0 0 0;
+	margin-bottom: 16px;
+	width: 240px;
+	height: 28px;
+`;
+
+const listTabVariant = css`
+	font-weight: 700;
+	line-height: 1.1;
+	background-color: transparent;
 	padding: 0 0 0;
 	margin-bottom: 16px;
 	width: 240px;
@@ -101,19 +112,28 @@ type Props = {
 
 export const MostViewedFooterGrid = ({ data, sectionName, pillar }: Props) => {
 	const [selectedTabIndex, setSelectedTabIndex] = useState<number>(0);
-
+	const ABTestAPI = useAB();
+	const inDeeplyReadTestVariant = ABTestAPI.isUserInVariant(
+		'DeeplyReadTest',
+		'variant',
+	);
 	return (
 		<div>
 			{Array.isArray(data) && data.length > 1 && (
 				<ul className={tabsContainer} role="tablist">
 					{data.map((tab: TrailTabType, i: number) => (
 						<li
-							className={cx(listTab, {
-								[selectedListTab(pillar)]:
-									i === selectedTabIndex,
-								[unselectedListTab]: i !== selectedTabIndex,
-								[firstTab]: i === 0,
-							})}
+							className={cx(
+								inDeeplyReadTestVariant
+									? listTabVariant
+									: listTab,
+								{
+									[selectedListTab(pillar)]:
+										i === selectedTabIndex,
+									[unselectedListTab]: i !== selectedTabIndex,
+									[firstTab]: i === 0,
+								},
+							)}
 							role="tab"
 							aria-selected={i === selectedTabIndex}
 							aria-controls={`tabs-popular-${i}`}
@@ -133,10 +153,15 @@ export const MostViewedFooterGrid = ({ data, sectionName, pillar }: Props) => {
 								>
 									Most viewed{' '}
 								</span>
+
 								<span
-									className={css`
-										text-transform: capitalize;
-									`}
+									className={
+										!inDeeplyReadTestVariant
+											? css`
+													text-transform: capitalize;
+											  `
+											: ''
+									}
 									// "Across The Guardian" has a non-breaking space entity between "The" and "Guardian"
 									dangerouslySetInnerHTML={{
 										__html: tab.heading,

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterGrid.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterGrid.tsx
@@ -99,6 +99,7 @@ type Props = {
 	pillar: CAPIPillar;
 };
 
+// To avoid having to handle multiple ways of reducing the capitalisation styling
 const TabHeading = ({ heading }: { heading: string }) => {
 	switch (heading.toLowerCase()) {
 		case 'deeply read':

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterGrid.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterGrid.tsx
@@ -4,7 +4,6 @@ import { neutral, border } from '@guardian/src-foundations/palette';
 import { headline } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
 import { visuallyHidden } from '@guardian/src-foundations/accessibility';
-import { useAB } from '@guardian/ab-react';
 
 import { pillarPalette } from '@frontend/lib/pillars';
 import { MostViewedFooterItem } from './MostViewedFooterItem';
@@ -33,16 +32,6 @@ const listTab = css`
 	line-height: 1.1;
 	background-color: transparent;
 	text-transform: capitalize;
-	padding: 0 0 0;
-	margin-bottom: 16px;
-	width: 240px;
-	height: 28px;
-`;
-
-const listTabVariant = css`
-	font-weight: 700;
-	line-height: 1.1;
-	background-color: transparent;
 	padding: 0 0 0;
 	margin-bottom: 16px;
 	width: 240px;
@@ -110,30 +99,41 @@ type Props = {
 	pillar: CAPIPillar;
 };
 
+const TabHeading = ({ heading }: { heading: string }) => {
+	switch (heading.toLowerCase()) {
+		case 'deeply read':
+			return <span>Deeply read</span>;
+		case 'most popular':
+			return <span>Most popular</span>;
+		default:
+			return (
+				<span
+					className={css`
+						text-transform: capitalize;
+					`}
+					// "Across The Guardian" has a non-breaking space entity between "The" and "Guardian - Eg. "Across The&nbsp;Guardian"
+					dangerouslySetInnerHTML={{
+						__html: heading,
+					}}
+				/>
+			);
+	}
+};
+
 export const MostViewedFooterGrid = ({ data, sectionName, pillar }: Props) => {
 	const [selectedTabIndex, setSelectedTabIndex] = useState<number>(0);
-	const ABTestAPI = useAB();
-	const inDeeplyReadTestVariant = ABTestAPI.isUserInVariant(
-		'DeeplyReadTest',
-		'variant',
-	);
 	return (
 		<div>
 			{Array.isArray(data) && data.length > 1 && (
 				<ul className={tabsContainer} role="tablist">
 					{data.map((tab: TrailTabType, i: number) => (
 						<li
-							className={cx(
-								inDeeplyReadTestVariant
-									? listTabVariant
-									: listTab,
-								{
-									[selectedListTab(pillar)]:
-										i === selectedTabIndex,
-									[unselectedListTab]: i !== selectedTabIndex,
-									[firstTab]: i === 0,
-								},
-							)}
+							className={cx(listTab, {
+								[selectedListTab(pillar)]:
+									i === selectedTabIndex,
+								[unselectedListTab]: i !== selectedTabIndex,
+								[firstTab]: i === 0,
+							})}
 							role="tab"
 							aria-selected={i === selectedTabIndex}
 							aria-controls={`tabs-popular-${i}`}
@@ -154,19 +154,7 @@ export const MostViewedFooterGrid = ({ data, sectionName, pillar }: Props) => {
 									Most viewed{' '}
 								</span>
 
-								<span
-									className={
-										!inDeeplyReadTestVariant
-											? css`
-													text-transform: capitalize;
-											  `
-											: ''
-									}
-									// "Across The Guardian" has a non-breaking space entity between "The" and "Guardian"
-									dangerouslySetInnerHTML={{
-										__html: tab.heading,
-									}}
-								/>
+								<TabHeading heading={tab.heading} />
 							</button>
 						</li>
 					))}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Changes the capitalisation of the second word of the tab to fit in with design standards (note, it is formatted properly in frontend but DCR is capitalising erroneously). 


### Before
<img width="666" alt="Screenshot 2021-01-12 at 16 08 30" src="https://user-images.githubusercontent.com/35331926/104340380-89759200-54f0-11eb-9f55-fa29b5a5f38f.png">

### After
<img width="666" alt="Screenshot 2021-01-12 at 16 09 40" src="https://user-images.githubusercontent.com/35331926/104340442-998d7180-54f0-11eb-9011-ddfa7cf45bd0.png">

## Why?
Design
