### PR TITLE
No more bow waves

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,6 +1,7 @@
 import isChromatic from 'chromatic/isChromatic';
 
 import fetchMock from 'fetch-mock';
+import MockDate from 'mockdate';
 import { configure, addParameters } from '@storybook/react';
 
 import { sharecount } from '@root/fixtures/article';
@@ -17,6 +18,9 @@ import { Picture } from '@root/src/web/components/Picture';
 // Prevent components being lazy rendered when we're taking Chromatic snapshots
 Lazy.disabled = isChromatic();
 Picture.disableLazyLoading = isChromatic();
+
+// Fix the date to prevent false negatives with age warnings
+MockDate.set('Sun Jan 10 2021 12:00:00 GMT+0000 (Greenwich Mean Time)');
 
 // Add base css for the site
 let css = `${getFontsCss()}${defaults}`;

--- a/src/web/components/elements/MultiImageBlockComponent.mocks.tsx
+++ b/src/web/components/elements/MultiImageBlockComponent.mocks.tsx
@@ -2,12 +2,11 @@ export const fourImages: ImageBlockElement[] = [
 	{
 		role: 'halfWidth',
 		data: {
-			copyright: '© Tommy Trenchard / Greenpeace',
 			alt:
-				'Greenpeace’s ship Arctic Sunrise hits a wave during rough weather in the South Atlantic.',
+				'26 March – Residents in Manchester, England, taking part in the Clap For Our Carers campaign, people across the UK applauding NHS workers from the doorsteps, balconies or windows of their homes, in order to say thank you for all of their hard work dealing with the Covid-19 coronavirus pandemic.',
 			caption:
-				'Greenpeace’s ship Arctic Sunrise hits a wave during rough weather in the South Atlantic.',
-			credit: 'Photograph: Tommy Trenchard/Greenpeace',
+				'26 March – Residents in Manchester, England, taking part in the Clap For Our Carers campaign, people across the UK applauding NHS workers from the doorsteps, balconies or windows of their homes, in order to say thank you for all of their hard work dealing with the Covid-19 coronavirus pandemic',
+			credit: 'Photograph: Christopher Thomond/The Guardian',
 		},
 		imageSources: [
 			{
@@ -15,32 +14,32 @@ export const fourImages: ImageBlockElement[] = [
 				srcSet: [
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=f70dd057eabb09a74239f51650641c4a',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=620&quality=85&auto=format&fit=max&s=5de6219bf5481aa944b2c1f942c80d9c',
 						width: 620,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=d492338bc4d1b857a33a7d6998e58d55',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=072b43354e1349c796554a48581ab83b',
 						width: 1240,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=9ffe0420cf6b7a25d9fcf83066e49537',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=605&quality=85&auto=format&fit=max&s=e06469504b6d411b39241345c3c7a9dc',
 						width: 605,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=c867fb62ad1a7a0e51483037f5081fc2',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=81230eac2c49812b15332359c8da6d21',
 						width: 1210,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=6f4393bb49787a9f09014f0d73f35e53',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=445&quality=85&auto=format&fit=max&s=5dbe29aaa2422f808b5b68dea00482e6',
 						width: 445,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=3c545ae4299d83a325aa5935ebfbce11',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=154054f06c074827cd0d1fd6f94da7fc',
 						width: 890,
 					},
 				],
@@ -50,22 +49,22 @@ export const fourImages: ImageBlockElement[] = [
 				srcSet: [
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=140&quality=85&auto=format&fit=max&s=17a69e8ac10312b57ee185e7b5c12b06',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=140&quality=85&auto=format&fit=max&s=7677c6fe07e7f6cc023be2dd7e515a36',
 						width: 140,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=d81dd269cfa7c30e61beeaa746868972',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=05f1c7c1c9f3848857101a9f335f886e',
 						width: 280,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=120&quality=85&auto=format&fit=max&s=bc634c596641d789f5f48dd55c8177ae',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=120&quality=85&auto=format&fit=max&s=132a0f55edca73f79a0369e36628f242',
 						width: 120,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=33fed56e309ce3dc48241b9e511811aa',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=492dd440ce1180c1497b4b6a351cf2dd',
 						width: 240,
 					},
 				],
@@ -75,52 +74,52 @@ export const fourImages: ImageBlockElement[] = [
 				srcSet: [
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=380&quality=85&auto=format&fit=max&s=783257361864e3d3a0f24dadd43ba2c8',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=380&quality=85&auto=format&fit=max&s=621ddfa8bac6d9986bbf08dd4b006855',
 						width: 380,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=92ff97fd43ab1f8c8b0e70833028718e',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=ecc019633a166b0cf89a68d2c2d02349',
 						width: 760,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=300&quality=85&auto=format&fit=max&s=3e52dbd6bcc1b013003e6c1995b7bb91',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=300&quality=85&auto=format&fit=max&s=15abaa1a8f2c29e6ea1f1c905a1050d9',
 						width: 300,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=850629dd089c10958c9b8e82c1e39c9f',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=93093436bdae80a9e0d48fe7bb4ea37b',
 						width: 600,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=f70dd057eabb09a74239f51650641c4a',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=620&quality=85&auto=format&fit=max&s=5de6219bf5481aa944b2c1f942c80d9c',
 						width: 620,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=d492338bc4d1b857a33a7d6998e58d55',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=072b43354e1349c796554a48581ab83b',
 						width: 1240,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=9ffe0420cf6b7a25d9fcf83066e49537',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=605&quality=85&auto=format&fit=max&s=e06469504b6d411b39241345c3c7a9dc',
 						width: 605,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=c867fb62ad1a7a0e51483037f5081fc2',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=81230eac2c49812b15332359c8da6d21',
 						width: 1210,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=6f4393bb49787a9f09014f0d73f35e53',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=445&quality=85&auto=format&fit=max&s=5dbe29aaa2422f808b5b68dea00482e6',
 						width: 445,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=3c545ae4299d83a325aa5935ebfbce11',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=154054f06c074827cd0d1fd6f94da7fc',
 						width: 890,
 					},
 				],
@@ -130,72 +129,72 @@ export const fourImages: ImageBlockElement[] = [
 				srcSet: [
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=1020&quality=85&auto=format&fit=max&s=624a76f3dc9a7695e138c67610633b45',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=1020&quality=85&auto=format&fit=max&s=c98ec8b30d96c83601cd1c4506fe7823',
 						width: 1020,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=1020&quality=45&auto=format&fit=max&dpr=2&s=f85de213c16f04387749d64c9afacd5a',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=1020&quality=45&auto=format&fit=max&dpr=2&s=0e02187e84a7cfddfdd965bf528184ef',
 						width: 2040,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=940&quality=85&auto=format&fit=max&s=05ed80bb6e20fa018504bb702e75218d',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=940&quality=85&auto=format&fit=max&s=fa57e9613b4e8b5ae30214c20fe22b3b',
 						width: 940,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=940&quality=45&auto=format&fit=max&dpr=2&s=9dc3d27211b8be5f92defb9b912e6c81',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=940&quality=45&auto=format&fit=max&dpr=2&s=afed801ed4498e992ba35e2d57fc2fc2',
 						width: 1880,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=d8bcdf73ed74f16258ecdb92400ef2c0',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=700&quality=85&auto=format&fit=max&s=b69cc2b2413fe073d279ce492203d76c',
 						width: 700,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=fde8b72a040ceefcbb5ed6399a259b76',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=b3f21aa12f9f1a96df5f99f497013d0a',
 						width: 1400,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=d8bcdf73ed74f16258ecdb92400ef2c0',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=700&quality=85&auto=format&fit=max&s=b69cc2b2413fe073d279ce492203d76c',
 						width: 700,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=fde8b72a040ceefcbb5ed6399a259b76',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=b3f21aa12f9f1a96df5f99f497013d0a',
 						width: 1400,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=660&quality=85&auto=format&fit=max&s=0879bc44ac2be63a38ced704a0604514',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=660&quality=85&auto=format&fit=max&s=3e5b27701222fa6e5aa5929031ba9cf8',
 						width: 660,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=660&quality=45&auto=format&fit=max&dpr=2&s=2090ed6fb990e98d1f87ca526353942b',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=660&quality=45&auto=format&fit=max&dpr=2&s=46ddcdd9f52cb42c99d844ab8e6af504',
 						width: 1320,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=fdea12cbfc6379ce2ea9c8ca6e7d2c1b',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=645&quality=85&auto=format&fit=max&s=17fe61af6955d8e4cf743d1cd418cb20',
 						width: 645,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=482fd54191d45fe1fe775f1296b094b6',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=3a4a5b698ab4871d00605a3b52d22434',
 						width: 1290,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=afb1030bad54d5114b7b8c3a83fb546a',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=465&quality=85&auto=format&fit=max&s=972054aad7638dad619462d64167bce7',
 						width: 465,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=f4a89c4a74f00e29b2777b8a0c24a542',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=7fed10c96260c752137ebd46cac292f4',
 						width: 930,
 					},
 				],
@@ -205,32 +204,32 @@ export const fourImages: ImageBlockElement[] = [
 				srcSet: [
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=f70dd057eabb09a74239f51650641c4a',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=620&quality=85&auto=format&fit=max&s=5de6219bf5481aa944b2c1f942c80d9c',
 						width: 620,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=d492338bc4d1b857a33a7d6998e58d55',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=072b43354e1349c796554a48581ab83b',
 						width: 1240,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=9ffe0420cf6b7a25d9fcf83066e49537',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=605&quality=85&auto=format&fit=max&s=e06469504b6d411b39241345c3c7a9dc',
 						width: 605,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=c867fb62ad1a7a0e51483037f5081fc2',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=81230eac2c49812b15332359c8da6d21',
 						width: 1210,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=6f4393bb49787a9f09014f0d73f35e53',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=445&quality=85&auto=format&fit=max&s=5dbe29aaa2422f808b5b68dea00482e6',
 						width: 445,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=3c545ae4299d83a325aa5935ebfbce11',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=154054f06c074827cd0d1fd6f94da7fc',
 						width: 890,
 					},
 				],
@@ -240,72 +239,72 @@ export const fourImages: ImageBlockElement[] = [
 				srcSet: [
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=1300&quality=85&auto=format&fit=max&s=58e079130c99df397eefb44cd631e5fd',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=1300&quality=85&auto=format&fit=max&s=6eb752e9db345e9ee27b6becb5847181',
 						width: 1300,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=1300&quality=45&auto=format&fit=max&dpr=2&s=13eadd8a324cd00b82ed99e653637c64',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=1300&quality=45&auto=format&fit=max&dpr=2&s=4a0b1263ca8554c4e22671fd1a75ac64',
 						width: 2600,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=1140&quality=85&auto=format&fit=max&s=634a10dc8c7eac24404f019342f32386',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=1140&quality=85&auto=format&fit=max&s=074c422e5e8a6817b1dc86b67a0b4899',
 						width: 1140,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=1140&quality=45&auto=format&fit=max&dpr=2&s=f6cfb13dfaaaba727ac380d48506e004',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=1140&quality=45&auto=format&fit=max&dpr=2&s=d5a1286da45d465eb70fbf86e9882c15',
 						width: 2280,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=1125&quality=85&auto=format&fit=max&s=117d630bad3656bcb8644b79a51713eb',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=1125&quality=85&auto=format&fit=max&s=d0276b901cad246a3cb859c2c07d14e9',
 						width: 1125,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=1125&quality=45&auto=format&fit=max&dpr=2&s=29a1a3e8a5b4932f2437cd608fc68b00',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=1125&quality=45&auto=format&fit=max&dpr=2&s=a949f4de3e8f9ef7f202c13e216ffb32',
 						width: 2250,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=965&quality=85&auto=format&fit=max&s=ab81ffc4bb069288d0d031fee9f91dab',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=965&quality=85&auto=format&fit=max&s=60d7982d45e30a6a669937335032741b',
 						width: 965,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=965&quality=45&auto=format&fit=max&dpr=2&s=1e8031c855c745ef928b3355f831b126',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=965&quality=45&auto=format&fit=max&dpr=2&s=b17059413da6699784395faafd819f0e',
 						width: 1930,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=725&quality=85&auto=format&fit=max&s=c11e7a2e1b27f1da9efe176edfccd2b5',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=725&quality=85&auto=format&fit=max&s=1e3b746f390a2c8a565e3328ab1af3e7',
 						width: 725,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=725&quality=45&auto=format&fit=max&dpr=2&s=e2630fb3eaab5df471b4577a08dbffeb',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=725&quality=45&auto=format&fit=max&dpr=2&s=571055b016d39cf98cd9b4af0b2d9e4c',
 						width: 1450,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=fdea12cbfc6379ce2ea9c8ca6e7d2c1b',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=645&quality=85&auto=format&fit=max&s=17fe61af6955d8e4cf743d1cd418cb20',
 						width: 645,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=482fd54191d45fe1fe775f1296b094b6',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=3a4a5b698ab4871d00605a3b52d22434',
 						width: 1290,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=afb1030bad54d5114b7b8c3a83fb546a',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=465&quality=85&auto=format&fit=max&s=972054aad7638dad619462d64167bce7',
 						width: 465,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=f4a89c4a74f00e29b2777b8a0c24a542',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=7fed10c96260c752137ebd46cac292f4',
 						width: 930,
 					},
 				],
@@ -317,36 +316,36 @@ export const fourImages: ImageBlockElement[] = [
 				{
 					index: 0,
 					fields: {
-						height: '1667',
-						width: '2500',
+						height: '4480',
+						width: '6720',
 					},
 					mediaType: 'Image',
 					mimeType: 'image/jpeg',
 					url:
-						'https://media.guim.co.uk/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/2500.jpg',
+						'https://media.guim.co.uk/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/6720.jpg',
 				},
 				{
 					index: 1,
 					fields: {
 						isMaster: 'true',
-						height: '1667',
-						width: '2500',
+						height: '4480',
+						width: '6720',
 					},
 					mediaType: 'Image',
 					mimeType: 'image/jpeg',
 					url:
-						'https://media.guim.co.uk/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/master/2500.jpg',
+						'https://media.guim.co.uk/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg',
 				},
 				{
 					index: 2,
 					fields: {
-						height: '1334',
+						height: '1333',
 						width: '2000',
 					},
 					mediaType: 'Image',
 					mimeType: 'image/jpeg',
 					url:
-						'https://media.guim.co.uk/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/2000.jpg',
+						'https://media.guim.co.uk/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/2000.jpg',
 				},
 				{
 					index: 3,
@@ -357,7 +356,7 @@ export const fourImages: ImageBlockElement[] = [
 					mediaType: 'Image',
 					mimeType: 'image/jpeg',
 					url:
-						'https://media.guim.co.uk/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/1000.jpg',
+						'https://media.guim.co.uk/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/1000.jpg',
 				},
 				{
 					index: 4,
@@ -368,7 +367,7 @@ export const fourImages: ImageBlockElement[] = [
 					mediaType: 'Image',
 					mimeType: 'image/jpeg',
 					url:
-						'https://media.guim.co.uk/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/500.jpg',
+						'https://media.guim.co.uk/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/500.jpg',
 				},
 				{
 					index: 5,
@@ -379,21 +378,20 @@ export const fourImages: ImageBlockElement[] = [
 					mediaType: 'Image',
 					mimeType: 'image/jpeg',
 					url:
-						'https://media.guim.co.uk/71c5615514219be74f56eeeb6ea3deddc794e1ec/0_0_2500_1667/140.jpg',
+						'https://media.guim.co.uk/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/140.jpg',
 				},
 			],
 		},
-		displayCredit: true,
+		displayCredit: false,
 	},
 	{
 		role: 'halfWidth',
 		data: {
-			copyright: '© Tommy Trenchard / Greenpeace',
 			alt:
-				'A vessel is seen on the radar of the Arctic Sunrise in the mid-Atlantic ocean.',
+				'26 March – Residents in Manchester, England, taking part in the Clap For Our Carers campaign, people across the UK applauding NHS workers from the doorsteps, balconies or windows of their homes, in order to say thank you for all of their hard work dealing with the Covid-19 coronavirus pandemic.',
 			caption:
-				'A vessel is seen on the radar of the Arctic Sunrise in the mid-Atlantic ocean.',
-			credit: 'Photograph: Tommy Trenchard/Greenpeace',
+				'26 March – Residents in Manchester, England, taking part in the Clap For Our Carers campaign, people across the UK applauding NHS workers from the doorsteps, balconies or windows of their homes, in order to say thank you for all of their hard work dealing with the Covid-19 coronavirus pandemic',
+			credit: 'Photograph: Christopher Thomond/The Guardian',
 		},
 		imageSources: [
 			{
@@ -401,32 +399,32 @@ export const fourImages: ImageBlockElement[] = [
 				srcSet: [
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=1a1f41e93103d8f80ed96f1877cce8dd',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=620&quality=85&auto=format&fit=max&s=5de6219bf5481aa944b2c1f942c80d9c',
 						width: 620,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=dd1a14ee43f584cfb502c871f78dcf3d',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=072b43354e1349c796554a48581ab83b',
 						width: 1240,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=b39f8587f6de6b4882a266402b1de4fb',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=605&quality=85&auto=format&fit=max&s=e06469504b6d411b39241345c3c7a9dc',
 						width: 605,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=5085ead125476d718c3b99ee8313fb3a',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=81230eac2c49812b15332359c8da6d21',
 						width: 1210,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=30b4094e41b17742d7d07b4d1942628d',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=445&quality=85&auto=format&fit=max&s=5dbe29aaa2422f808b5b68dea00482e6',
 						width: 445,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=f5fa0b0a01a2ec6ffa214d1d979dcb36',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=154054f06c074827cd0d1fd6f94da7fc',
 						width: 890,
 					},
 				],
@@ -436,22 +434,22 @@ export const fourImages: ImageBlockElement[] = [
 				srcSet: [
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=140&quality=85&auto=format&fit=max&s=333a3a3814133344842bd07cf1e485f8',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=140&quality=85&auto=format&fit=max&s=7677c6fe07e7f6cc023be2dd7e515a36',
 						width: 140,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=1f60425205116b265ab692893a4da2bc',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=05f1c7c1c9f3848857101a9f335f886e',
 						width: 280,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=120&quality=85&auto=format&fit=max&s=d4101e6e70f05ea73fc3956ab9d57633',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=120&quality=85&auto=format&fit=max&s=132a0f55edca73f79a0369e36628f242',
 						width: 120,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=7b5db9389171ea20d54214ee34483f99',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=492dd440ce1180c1497b4b6a351cf2dd',
 						width: 240,
 					},
 				],
@@ -461,52 +459,52 @@ export const fourImages: ImageBlockElement[] = [
 				srcSet: [
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=380&quality=85&auto=format&fit=max&s=1464287ceb0e09ea17729a89d973e42b',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=380&quality=85&auto=format&fit=max&s=621ddfa8bac6d9986bbf08dd4b006855',
 						width: 380,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=d3eed1a4664033931edd676ededb9a3a',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=ecc019633a166b0cf89a68d2c2d02349',
 						width: 760,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=300&quality=85&auto=format&fit=max&s=4368ad1138f4f2cb441c2e90319f4d42',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=300&quality=85&auto=format&fit=max&s=15abaa1a8f2c29e6ea1f1c905a1050d9',
 						width: 300,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=284b97a79d5485f99224a0f4d4ec6cf2',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=93093436bdae80a9e0d48fe7bb4ea37b',
 						width: 600,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=1a1f41e93103d8f80ed96f1877cce8dd',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=620&quality=85&auto=format&fit=max&s=5de6219bf5481aa944b2c1f942c80d9c',
 						width: 620,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=dd1a14ee43f584cfb502c871f78dcf3d',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=072b43354e1349c796554a48581ab83b',
 						width: 1240,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=b39f8587f6de6b4882a266402b1de4fb',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=605&quality=85&auto=format&fit=max&s=e06469504b6d411b39241345c3c7a9dc',
 						width: 605,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=5085ead125476d718c3b99ee8313fb3a',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=81230eac2c49812b15332359c8da6d21',
 						width: 1210,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=30b4094e41b17742d7d07b4d1942628d',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=445&quality=85&auto=format&fit=max&s=5dbe29aaa2422f808b5b68dea00482e6',
 						width: 445,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=f5fa0b0a01a2ec6ffa214d1d979dcb36',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=154054f06c074827cd0d1fd6f94da7fc',
 						width: 890,
 					},
 				],
@@ -516,72 +514,72 @@ export const fourImages: ImageBlockElement[] = [
 				srcSet: [
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=1020&quality=85&auto=format&fit=max&s=a46a52f554db0e2e76170611240ce230',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=1020&quality=85&auto=format&fit=max&s=c98ec8b30d96c83601cd1c4506fe7823',
 						width: 1020,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=1020&quality=45&auto=format&fit=max&dpr=2&s=be848e3f9a6a4d104e590bc9bdc04d5d',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=1020&quality=45&auto=format&fit=max&dpr=2&s=0e02187e84a7cfddfdd965bf528184ef',
 						width: 2040,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=940&quality=85&auto=format&fit=max&s=e7abe49fa4d52320be12e03e2a6afb06',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=940&quality=85&auto=format&fit=max&s=fa57e9613b4e8b5ae30214c20fe22b3b',
 						width: 940,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=940&quality=45&auto=format&fit=max&dpr=2&s=8bd0c605e5bdc1af557a768500864187',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=940&quality=45&auto=format&fit=max&dpr=2&s=afed801ed4498e992ba35e2d57fc2fc2',
 						width: 1880,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=3a452c9a5c3d2b313ae33506cf44961e',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=700&quality=85&auto=format&fit=max&s=b69cc2b2413fe073d279ce492203d76c',
 						width: 700,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=69a79d5f3ee45439ab224208620433c9',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=b3f21aa12f9f1a96df5f99f497013d0a',
 						width: 1400,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=3a452c9a5c3d2b313ae33506cf44961e',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=700&quality=85&auto=format&fit=max&s=b69cc2b2413fe073d279ce492203d76c',
 						width: 700,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=69a79d5f3ee45439ab224208620433c9',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=b3f21aa12f9f1a96df5f99f497013d0a',
 						width: 1400,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=660&quality=85&auto=format&fit=max&s=c035d9a260e7607443983cf093a732ad',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=660&quality=85&auto=format&fit=max&s=3e5b27701222fa6e5aa5929031ba9cf8',
 						width: 660,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=660&quality=45&auto=format&fit=max&dpr=2&s=f8e81ab0fa3af51301556780dc925a6b',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=660&quality=45&auto=format&fit=max&dpr=2&s=46ddcdd9f52cb42c99d844ab8e6af504',
 						width: 1320,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=f45d48bbb50e99b69db54da172d693de',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=645&quality=85&auto=format&fit=max&s=17fe61af6955d8e4cf743d1cd418cb20',
 						width: 645,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=d1aecf02f0884aa6b462da3e292ae08c',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=3a4a5b698ab4871d00605a3b52d22434',
 						width: 1290,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=20976fe36bdd6c7c994467081cc9854a',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=465&quality=85&auto=format&fit=max&s=972054aad7638dad619462d64167bce7',
 						width: 465,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=f327ef15b32559eba8f849c0a4984eeb',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=7fed10c96260c752137ebd46cac292f4',
 						width: 930,
 					},
 				],
@@ -591,32 +589,32 @@ export const fourImages: ImageBlockElement[] = [
 				srcSet: [
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=1a1f41e93103d8f80ed96f1877cce8dd',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=620&quality=85&auto=format&fit=max&s=5de6219bf5481aa944b2c1f942c80d9c',
 						width: 620,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=dd1a14ee43f584cfb502c871f78dcf3d',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=072b43354e1349c796554a48581ab83b',
 						width: 1240,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=b39f8587f6de6b4882a266402b1de4fb',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=605&quality=85&auto=format&fit=max&s=e06469504b6d411b39241345c3c7a9dc',
 						width: 605,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=5085ead125476d718c3b99ee8313fb3a',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=81230eac2c49812b15332359c8da6d21',
 						width: 1210,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=30b4094e41b17742d7d07b4d1942628d',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=445&quality=85&auto=format&fit=max&s=5dbe29aaa2422f808b5b68dea00482e6',
 						width: 445,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=f5fa0b0a01a2ec6ffa214d1d979dcb36',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=154054f06c074827cd0d1fd6f94da7fc',
 						width: 890,
 					},
 				],
@@ -626,72 +624,72 @@ export const fourImages: ImageBlockElement[] = [
 				srcSet: [
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=1300&quality=85&auto=format&fit=max&s=e908ee2e8a1fb639ba7795933b6b7166',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=1300&quality=85&auto=format&fit=max&s=6eb752e9db345e9ee27b6becb5847181',
 						width: 1300,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=1300&quality=45&auto=format&fit=max&dpr=2&s=955ff64ffa266c77ee04a75142c445f2',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=1300&quality=45&auto=format&fit=max&dpr=2&s=4a0b1263ca8554c4e22671fd1a75ac64',
 						width: 2600,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=1140&quality=85&auto=format&fit=max&s=dbf50cddd4b86f8da4d280b7907c378e',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=1140&quality=85&auto=format&fit=max&s=074c422e5e8a6817b1dc86b67a0b4899',
 						width: 1140,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=1140&quality=45&auto=format&fit=max&dpr=2&s=5bebfcbd7f07943acf283b6157e8eb0f',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=1140&quality=45&auto=format&fit=max&dpr=2&s=d5a1286da45d465eb70fbf86e9882c15',
 						width: 2280,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=1125&quality=85&auto=format&fit=max&s=e523903e7e8ad2e51b053433eb2e4c43',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=1125&quality=85&auto=format&fit=max&s=d0276b901cad246a3cb859c2c07d14e9',
 						width: 1125,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=1125&quality=45&auto=format&fit=max&dpr=2&s=0bfd26e45abb4232fb0a5f5bad03f1a8',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=1125&quality=45&auto=format&fit=max&dpr=2&s=a949f4de3e8f9ef7f202c13e216ffb32',
 						width: 2250,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=965&quality=85&auto=format&fit=max&s=1007564a1513aef7346e3719c088dcbd',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=965&quality=85&auto=format&fit=max&s=60d7982d45e30a6a669937335032741b',
 						width: 965,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=965&quality=45&auto=format&fit=max&dpr=2&s=9c5d6595d96009b575cae135077df95b',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=965&quality=45&auto=format&fit=max&dpr=2&s=b17059413da6699784395faafd819f0e',
 						width: 1930,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=725&quality=85&auto=format&fit=max&s=b9e6445791d64e48014a24c4b5fbe4d8',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=725&quality=85&auto=format&fit=max&s=1e3b746f390a2c8a565e3328ab1af3e7',
 						width: 725,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=725&quality=45&auto=format&fit=max&dpr=2&s=dbd6d4625d12373074b7ee71735195a9',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=725&quality=45&auto=format&fit=max&dpr=2&s=571055b016d39cf98cd9b4af0b2d9e4c',
 						width: 1450,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=f45d48bbb50e99b69db54da172d693de',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=645&quality=85&auto=format&fit=max&s=17fe61af6955d8e4cf743d1cd418cb20',
 						width: 645,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=d1aecf02f0884aa6b462da3e292ae08c',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=3a4a5b698ab4871d00605a3b52d22434',
 						width: 1290,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=20976fe36bdd6c7c994467081cc9854a',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=465&quality=85&auto=format&fit=max&s=972054aad7638dad619462d64167bce7',
 						width: 465,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=f327ef15b32559eba8f849c0a4984eeb',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=7fed10c96260c752137ebd46cac292f4',
 						width: 930,
 					},
 				],
@@ -703,36 +701,36 @@ export const fourImages: ImageBlockElement[] = [
 				{
 					index: 0,
 					fields: {
-						height: '1667',
-						width: '2500',
+						height: '4480',
+						width: '6720',
 					},
 					mediaType: 'Image',
 					mimeType: 'image/jpeg',
 					url:
-						'https://media.guim.co.uk/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/2500.jpg',
+						'https://media.guim.co.uk/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/6720.jpg',
 				},
 				{
 					index: 1,
 					fields: {
 						isMaster: 'true',
-						height: '1667',
-						width: '2500',
+						height: '4480',
+						width: '6720',
 					},
 					mediaType: 'Image',
 					mimeType: 'image/jpeg',
 					url:
-						'https://media.guim.co.uk/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/master/2500.jpg',
+						'https://media.guim.co.uk/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg',
 				},
 				{
 					index: 2,
 					fields: {
-						height: '1334',
+						height: '1333',
 						width: '2000',
 					},
 					mediaType: 'Image',
 					mimeType: 'image/jpeg',
 					url:
-						'https://media.guim.co.uk/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/2000.jpg',
+						'https://media.guim.co.uk/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/2000.jpg',
 				},
 				{
 					index: 3,
@@ -743,7 +741,7 @@ export const fourImages: ImageBlockElement[] = [
 					mediaType: 'Image',
 					mimeType: 'image/jpeg',
 					url:
-						'https://media.guim.co.uk/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/1000.jpg',
+						'https://media.guim.co.uk/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/1000.jpg',
 				},
 				{
 					index: 4,
@@ -754,7 +752,7 @@ export const fourImages: ImageBlockElement[] = [
 					mediaType: 'Image',
 					mimeType: 'image/jpeg',
 					url:
-						'https://media.guim.co.uk/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/500.jpg',
+						'https://media.guim.co.uk/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/500.jpg',
 				},
 				{
 					index: 5,
@@ -765,21 +763,20 @@ export const fourImages: ImageBlockElement[] = [
 					mediaType: 'Image',
 					mimeType: 'image/jpeg',
 					url:
-						'https://media.guim.co.uk/8cfd6e1035a40a1056998c77a39909801bda7f26/0_0_2500_1667/140.jpg',
+						'https://media.guim.co.uk/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/140.jpg',
 				},
 			],
 		},
-		displayCredit: true,
+		displayCredit: false,
 	},
 	{
 		role: 'halfWidth',
 		data: {
-			copyright: '© Tommy Trenchard / Greenpeace',
 			alt:
-				'Second mate Helena De Carlos Watts and investigator Sophie Cooke watch the radar screen as the Arctic Sunrise approaches a vessel in the southern Atlantic Ocean.',
+				'26 March – Residents in Manchester, England, taking part in the Clap For Our Carers campaign, people across the UK applauding NHS workers from the doorsteps, balconies or windows of their homes, in order to say thank you for all of their hard work dealing with the Covid-19 coronavirus pandemic.',
 			caption:
-				'Second mate Helena De Carlos Watts and investigator Sophie Cooke watch the radar screen as the Arctic Sunrise approaches a vessel in the southern Atlantic Ocean.',
-			credit: 'Photograph: Tommy Trenchard/Greenpeace',
+				'26 March – Residents in Manchester, England, taking part in the Clap For Our Carers campaign, people across the UK applauding NHS workers from the doorsteps, balconies or windows of their homes, in order to say thank you for all of their hard work dealing with the Covid-19 coronavirus pandemic',
+			credit: 'Photograph: Christopher Thomond/The Guardian',
 		},
 		imageSources: [
 			{
@@ -787,32 +784,32 @@ export const fourImages: ImageBlockElement[] = [
 				srcSet: [
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=48e15d5d34cdf2677030c6349c4a6bf2',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=620&quality=85&auto=format&fit=max&s=5de6219bf5481aa944b2c1f942c80d9c',
 						width: 620,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=a95ecd11817238d37fd9bbbd5b8ee70e',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=072b43354e1349c796554a48581ab83b',
 						width: 1240,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=40432b37fa1c7e4907d202078a496d15',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=605&quality=85&auto=format&fit=max&s=e06469504b6d411b39241345c3c7a9dc',
 						width: 605,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=07cb72515ee014a5f6951cca0d71b631',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=81230eac2c49812b15332359c8da6d21',
 						width: 1210,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=3d194971fbccd3692587cc844457254b',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=445&quality=85&auto=format&fit=max&s=5dbe29aaa2422f808b5b68dea00482e6',
 						width: 445,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=bba08a4952a4b24f4c85b702dea4b534',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=154054f06c074827cd0d1fd6f94da7fc',
 						width: 890,
 					},
 				],
@@ -822,22 +819,22 @@ export const fourImages: ImageBlockElement[] = [
 				srcSet: [
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=140&quality=85&auto=format&fit=max&s=05ce8b8c9f83ba188b134aa1621d429a',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=140&quality=85&auto=format&fit=max&s=7677c6fe07e7f6cc023be2dd7e515a36',
 						width: 140,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=f81cccbcca62f07659a3730083de645a',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=05f1c7c1c9f3848857101a9f335f886e',
 						width: 280,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=120&quality=85&auto=format&fit=max&s=d9db4a6aeea90aca485904e70ddaccd4',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=120&quality=85&auto=format&fit=max&s=132a0f55edca73f79a0369e36628f242',
 						width: 120,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=fb974d50ad8c90d1bb07c7b3ab4a6cd8',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=492dd440ce1180c1497b4b6a351cf2dd',
 						width: 240,
 					},
 				],
@@ -847,52 +844,52 @@ export const fourImages: ImageBlockElement[] = [
 				srcSet: [
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=380&quality=85&auto=format&fit=max&s=87392954749c1fe40f9acfd7f5bce39b',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=380&quality=85&auto=format&fit=max&s=621ddfa8bac6d9986bbf08dd4b006855',
 						width: 380,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=bcfad42ee8e729f5a29790d14c0a8c9b',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=ecc019633a166b0cf89a68d2c2d02349',
 						width: 760,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=300&quality=85&auto=format&fit=max&s=0ee9331eac61a413ffaa7014015145e3',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=300&quality=85&auto=format&fit=max&s=15abaa1a8f2c29e6ea1f1c905a1050d9',
 						width: 300,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=ad0f597c419a9c869736af91f9f15acf',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=93093436bdae80a9e0d48fe7bb4ea37b',
 						width: 600,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=48e15d5d34cdf2677030c6349c4a6bf2',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=620&quality=85&auto=format&fit=max&s=5de6219bf5481aa944b2c1f942c80d9c',
 						width: 620,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=a95ecd11817238d37fd9bbbd5b8ee70e',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=072b43354e1349c796554a48581ab83b',
 						width: 1240,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=40432b37fa1c7e4907d202078a496d15',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=605&quality=85&auto=format&fit=max&s=e06469504b6d411b39241345c3c7a9dc',
 						width: 605,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=07cb72515ee014a5f6951cca0d71b631',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=81230eac2c49812b15332359c8da6d21',
 						width: 1210,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=3d194971fbccd3692587cc844457254b',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=445&quality=85&auto=format&fit=max&s=5dbe29aaa2422f808b5b68dea00482e6',
 						width: 445,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=bba08a4952a4b24f4c85b702dea4b534',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=154054f06c074827cd0d1fd6f94da7fc',
 						width: 890,
 					},
 				],
@@ -902,72 +899,72 @@ export const fourImages: ImageBlockElement[] = [
 				srcSet: [
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=1020&quality=85&auto=format&fit=max&s=f760a24db7ea1d2228fd5689398ac2d7',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=1020&quality=85&auto=format&fit=max&s=c98ec8b30d96c83601cd1c4506fe7823',
 						width: 1020,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=1020&quality=45&auto=format&fit=max&dpr=2&s=687689ef25b440a287139ec262f35e7b',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=1020&quality=45&auto=format&fit=max&dpr=2&s=0e02187e84a7cfddfdd965bf528184ef',
 						width: 2040,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=940&quality=85&auto=format&fit=max&s=c67ce0ccfdca1eef3794cc61fbf1d9f3',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=940&quality=85&auto=format&fit=max&s=fa57e9613b4e8b5ae30214c20fe22b3b',
 						width: 940,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=940&quality=45&auto=format&fit=max&dpr=2&s=5482c2e538e9653b1e1dfd66e97a3fe7',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=940&quality=45&auto=format&fit=max&dpr=2&s=afed801ed4498e992ba35e2d57fc2fc2',
 						width: 1880,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=68ebcc2dd6e13568cba4d7a7feffeed8',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=700&quality=85&auto=format&fit=max&s=b69cc2b2413fe073d279ce492203d76c',
 						width: 700,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=e760a5833fe9b557dc45171177145a7a',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=b3f21aa12f9f1a96df5f99f497013d0a',
 						width: 1400,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=68ebcc2dd6e13568cba4d7a7feffeed8',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=700&quality=85&auto=format&fit=max&s=b69cc2b2413fe073d279ce492203d76c',
 						width: 700,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=e760a5833fe9b557dc45171177145a7a',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=b3f21aa12f9f1a96df5f99f497013d0a',
 						width: 1400,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=660&quality=85&auto=format&fit=max&s=f49608389e051e6d3713bc6d3503b7fa',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=660&quality=85&auto=format&fit=max&s=3e5b27701222fa6e5aa5929031ba9cf8',
 						width: 660,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=660&quality=45&auto=format&fit=max&dpr=2&s=93cffd5d0a75f5885174bd38d4273f1b',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=660&quality=45&auto=format&fit=max&dpr=2&s=46ddcdd9f52cb42c99d844ab8e6af504',
 						width: 1320,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=95e38b41456988787c76bb9401c20835',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=645&quality=85&auto=format&fit=max&s=17fe61af6955d8e4cf743d1cd418cb20',
 						width: 645,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=3cae4fb30b88aa1ddc6b1883e2fa5632',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=3a4a5b698ab4871d00605a3b52d22434',
 						width: 1290,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=dedb7743d844de1e8560486fd1235619',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=465&quality=85&auto=format&fit=max&s=972054aad7638dad619462d64167bce7',
 						width: 465,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=cd444a4e8ca8c9a2bd85db2aa1ed77a7',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=7fed10c96260c752137ebd46cac292f4',
 						width: 930,
 					},
 				],
@@ -977,32 +974,32 @@ export const fourImages: ImageBlockElement[] = [
 				srcSet: [
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=48e15d5d34cdf2677030c6349c4a6bf2',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=620&quality=85&auto=format&fit=max&s=5de6219bf5481aa944b2c1f942c80d9c',
 						width: 620,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=a95ecd11817238d37fd9bbbd5b8ee70e',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=072b43354e1349c796554a48581ab83b',
 						width: 1240,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=40432b37fa1c7e4907d202078a496d15',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=605&quality=85&auto=format&fit=max&s=e06469504b6d411b39241345c3c7a9dc',
 						width: 605,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=07cb72515ee014a5f6951cca0d71b631',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=81230eac2c49812b15332359c8da6d21',
 						width: 1210,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=3d194971fbccd3692587cc844457254b',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=445&quality=85&auto=format&fit=max&s=5dbe29aaa2422f808b5b68dea00482e6',
 						width: 445,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=bba08a4952a4b24f4c85b702dea4b534',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=154054f06c074827cd0d1fd6f94da7fc',
 						width: 890,
 					},
 				],
@@ -1012,72 +1009,72 @@ export const fourImages: ImageBlockElement[] = [
 				srcSet: [
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=1300&quality=85&auto=format&fit=max&s=21d5fae46f9bec0fa7ee923ef8360bae',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=1300&quality=85&auto=format&fit=max&s=6eb752e9db345e9ee27b6becb5847181',
 						width: 1300,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=1300&quality=45&auto=format&fit=max&dpr=2&s=bdd034c39d5d22967ac44669ff040258',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=1300&quality=45&auto=format&fit=max&dpr=2&s=4a0b1263ca8554c4e22671fd1a75ac64',
 						width: 2600,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=1140&quality=85&auto=format&fit=max&s=dec643b163956f46820536b113ca1282',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=1140&quality=85&auto=format&fit=max&s=074c422e5e8a6817b1dc86b67a0b4899',
 						width: 1140,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=1140&quality=45&auto=format&fit=max&dpr=2&s=98ed6ad0ac33f01fc10537e16da529cd',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=1140&quality=45&auto=format&fit=max&dpr=2&s=d5a1286da45d465eb70fbf86e9882c15',
 						width: 2280,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=1125&quality=85&auto=format&fit=max&s=7020ae5b3786c579ec1edc7731309fae',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=1125&quality=85&auto=format&fit=max&s=d0276b901cad246a3cb859c2c07d14e9',
 						width: 1125,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=1125&quality=45&auto=format&fit=max&dpr=2&s=0f8c96c0b74f48eccc8e57e16338a13b',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=1125&quality=45&auto=format&fit=max&dpr=2&s=a949f4de3e8f9ef7f202c13e216ffb32',
 						width: 2250,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=965&quality=85&auto=format&fit=max&s=651d525cf91cebecebbbbdb596474763',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=965&quality=85&auto=format&fit=max&s=60d7982d45e30a6a669937335032741b',
 						width: 965,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=965&quality=45&auto=format&fit=max&dpr=2&s=90278c37c184a4d7414aa593b561a1af',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=965&quality=45&auto=format&fit=max&dpr=2&s=b17059413da6699784395faafd819f0e',
 						width: 1930,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=725&quality=85&auto=format&fit=max&s=fde24e4cf698ba9ad43245c58cd35ef1',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=725&quality=85&auto=format&fit=max&s=1e3b746f390a2c8a565e3328ab1af3e7',
 						width: 725,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=725&quality=45&auto=format&fit=max&dpr=2&s=3b8175e5793268a255ce7b9bec807668',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=725&quality=45&auto=format&fit=max&dpr=2&s=571055b016d39cf98cd9b4af0b2d9e4c',
 						width: 1450,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=95e38b41456988787c76bb9401c20835',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=645&quality=85&auto=format&fit=max&s=17fe61af6955d8e4cf743d1cd418cb20',
 						width: 645,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=3cae4fb30b88aa1ddc6b1883e2fa5632',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=3a4a5b698ab4871d00605a3b52d22434',
 						width: 1290,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=dedb7743d844de1e8560486fd1235619',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=465&quality=85&auto=format&fit=max&s=972054aad7638dad619462d64167bce7',
 						width: 465,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=cd444a4e8ca8c9a2bd85db2aa1ed77a7',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=7fed10c96260c752137ebd46cac292f4',
 						width: 930,
 					},
 				],
@@ -1089,36 +1086,36 @@ export const fourImages: ImageBlockElement[] = [
 				{
 					index: 0,
 					fields: {
-						height: '1667',
-						width: '2500',
+						height: '4480',
+						width: '6720',
 					},
 					mediaType: 'Image',
 					mimeType: 'image/jpeg',
 					url:
-						'https://media.guim.co.uk/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/2500.jpg',
+						'https://media.guim.co.uk/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/6720.jpg',
 				},
 				{
 					index: 1,
 					fields: {
 						isMaster: 'true',
-						height: '1667',
-						width: '2500',
+						height: '4480',
+						width: '6720',
 					},
 					mediaType: 'Image',
 					mimeType: 'image/jpeg',
 					url:
-						'https://media.guim.co.uk/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/master/2500.jpg',
+						'https://media.guim.co.uk/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg',
 				},
 				{
 					index: 2,
 					fields: {
-						height: '1334',
+						height: '1333',
 						width: '2000',
 					},
 					mediaType: 'Image',
 					mimeType: 'image/jpeg',
 					url:
-						'https://media.guim.co.uk/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/2000.jpg',
+						'https://media.guim.co.uk/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/2000.jpg',
 				},
 				{
 					index: 3,
@@ -1129,7 +1126,7 @@ export const fourImages: ImageBlockElement[] = [
 					mediaType: 'Image',
 					mimeType: 'image/jpeg',
 					url:
-						'https://media.guim.co.uk/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/1000.jpg',
+						'https://media.guim.co.uk/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/1000.jpg',
 				},
 				{
 					index: 4,
@@ -1140,7 +1137,7 @@ export const fourImages: ImageBlockElement[] = [
 					mediaType: 'Image',
 					mimeType: 'image/jpeg',
 					url:
-						'https://media.guim.co.uk/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/500.jpg',
+						'https://media.guim.co.uk/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/500.jpg',
 				},
 				{
 					index: 5,
@@ -1151,21 +1148,20 @@ export const fourImages: ImageBlockElement[] = [
 					mediaType: 'Image',
 					mimeType: 'image/jpeg',
 					url:
-						'https://media.guim.co.uk/8d27ad6d9b593bc31fa0c24bb69bf0890baa9f81/0_0_2500_1667/140.jpg',
+						'https://media.guim.co.uk/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/140.jpg',
 				},
 			],
 		},
-		displayCredit: true,
+		displayCredit: false,
 	},
 	{
 		role: 'halfWidth',
 		data: {
-			copyright: '© Tommy Trenchard / Greenpeace',
 			alt:
-				'A Greenpeace inflatable boat observes as frozen tuna are transferred from one ship to another in the middle of the Atlantic Ocean.',
+				'26 March – Residents in Manchester, England, taking part in the Clap For Our Carers campaign, people across the UK applauding NHS workers from the doorsteps, balconies or windows of their homes, in order to say thank you for all of their hard work dealing with the Covid-19 coronavirus pandemic.',
 			caption:
-				'A Greenpeace inflatable boat observes as frozen tuna are transferred from one ship to another in the middle of the Atlantic Ocean.',
-			credit: 'Photograph: Tommy Trenchard/Greenpeace',
+				'26 March – Residents in Manchester, England, taking part in the Clap For Our Carers campaign, people across the UK applauding NHS workers from the doorsteps, balconies or windows of their homes, in order to say thank you for all of their hard work dealing with the Covid-19 coronavirus pandemic',
+			credit: 'Photograph: Christopher Thomond/The Guardian',
 		},
 		imageSources: [
 			{
@@ -1173,32 +1169,32 @@ export const fourImages: ImageBlockElement[] = [
 				srcSet: [
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=5f0aad213210796efce5bc6e4b36f59b',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=620&quality=85&auto=format&fit=max&s=5de6219bf5481aa944b2c1f942c80d9c',
 						width: 620,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=e8deb95a117dfeb50e2589ba8a52659c',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=072b43354e1349c796554a48581ab83b',
 						width: 1240,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=8da200c890a10261a96778219bafbbf7',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=605&quality=85&auto=format&fit=max&s=e06469504b6d411b39241345c3c7a9dc',
 						width: 605,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=7cdad992b7f86597b5962968fe064d7a',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=81230eac2c49812b15332359c8da6d21',
 						width: 1210,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=517b6cf595a28030747904afc06ca99c',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=445&quality=85&auto=format&fit=max&s=5dbe29aaa2422f808b5b68dea00482e6',
 						width: 445,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=cd91e3355d3b9535f03c49de18c042e9',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=154054f06c074827cd0d1fd6f94da7fc',
 						width: 890,
 					},
 				],
@@ -1208,22 +1204,22 @@ export const fourImages: ImageBlockElement[] = [
 				srcSet: [
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=140&quality=85&auto=format&fit=max&s=46f2811868440560a977d6864d49910e',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=140&quality=85&auto=format&fit=max&s=7677c6fe07e7f6cc023be2dd7e515a36',
 						width: 140,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=2a44939d4251a73f838c78e55f682c93',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=05f1c7c1c9f3848857101a9f335f886e',
 						width: 280,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=120&quality=85&auto=format&fit=max&s=ef2feb81c3f887f850dc08c57add7a7b',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=120&quality=85&auto=format&fit=max&s=132a0f55edca73f79a0369e36628f242',
 						width: 120,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=b347c73fa5602c1316d3cd8de2401713',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=492dd440ce1180c1497b4b6a351cf2dd',
 						width: 240,
 					},
 				],
@@ -1233,52 +1229,52 @@ export const fourImages: ImageBlockElement[] = [
 				srcSet: [
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=380&quality=85&auto=format&fit=max&s=be2cefb415a0326466aa09d9a70e95f4',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=380&quality=85&auto=format&fit=max&s=621ddfa8bac6d9986bbf08dd4b006855',
 						width: 380,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=32442832dd714139c8b6af3c3d263684',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=ecc019633a166b0cf89a68d2c2d02349',
 						width: 760,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=300&quality=85&auto=format&fit=max&s=1482e95ab52e1a8a2943c22815bf53e4',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=300&quality=85&auto=format&fit=max&s=15abaa1a8f2c29e6ea1f1c905a1050d9',
 						width: 300,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=e364ab01ad53bf52d38f8964dcd7e43f',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=93093436bdae80a9e0d48fe7bb4ea37b',
 						width: 600,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=5f0aad213210796efce5bc6e4b36f59b',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=620&quality=85&auto=format&fit=max&s=5de6219bf5481aa944b2c1f942c80d9c',
 						width: 620,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=e8deb95a117dfeb50e2589ba8a52659c',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=072b43354e1349c796554a48581ab83b',
 						width: 1240,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=8da200c890a10261a96778219bafbbf7',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=605&quality=85&auto=format&fit=max&s=e06469504b6d411b39241345c3c7a9dc',
 						width: 605,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=7cdad992b7f86597b5962968fe064d7a',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=81230eac2c49812b15332359c8da6d21',
 						width: 1210,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=517b6cf595a28030747904afc06ca99c',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=445&quality=85&auto=format&fit=max&s=5dbe29aaa2422f808b5b68dea00482e6',
 						width: 445,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=cd91e3355d3b9535f03c49de18c042e9',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=154054f06c074827cd0d1fd6f94da7fc',
 						width: 890,
 					},
 				],
@@ -1288,72 +1284,72 @@ export const fourImages: ImageBlockElement[] = [
 				srcSet: [
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=1020&quality=85&auto=format&fit=max&s=773503c05c0d2d2a5289d5135eab3bf9',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=1020&quality=85&auto=format&fit=max&s=c98ec8b30d96c83601cd1c4506fe7823',
 						width: 1020,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=1020&quality=45&auto=format&fit=max&dpr=2&s=99f61fb65f3db7331a9accd7dcaef487',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=1020&quality=45&auto=format&fit=max&dpr=2&s=0e02187e84a7cfddfdd965bf528184ef',
 						width: 2040,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=940&quality=85&auto=format&fit=max&s=fc5c19b9d108d6640e027993afa24af1',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=940&quality=85&auto=format&fit=max&s=fa57e9613b4e8b5ae30214c20fe22b3b',
 						width: 940,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=940&quality=45&auto=format&fit=max&dpr=2&s=4bd7f37b18f0912c852861476fc52ba5',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=940&quality=45&auto=format&fit=max&dpr=2&s=afed801ed4498e992ba35e2d57fc2fc2',
 						width: 1880,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=5076e3e1d235ee37c5d8f2817d03ac23',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=700&quality=85&auto=format&fit=max&s=b69cc2b2413fe073d279ce492203d76c',
 						width: 700,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=1c53bc70bb0b4f0a7c438ee616ebe810',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=b3f21aa12f9f1a96df5f99f497013d0a',
 						width: 1400,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=700&quality=85&auto=format&fit=max&s=5076e3e1d235ee37c5d8f2817d03ac23',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=700&quality=85&auto=format&fit=max&s=b69cc2b2413fe073d279ce492203d76c',
 						width: 700,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=1c53bc70bb0b4f0a7c438ee616ebe810',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=b3f21aa12f9f1a96df5f99f497013d0a',
 						width: 1400,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=660&quality=85&auto=format&fit=max&s=d19f425eeacd2bfceeae01dee61fe01d',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=660&quality=85&auto=format&fit=max&s=3e5b27701222fa6e5aa5929031ba9cf8',
 						width: 660,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=660&quality=45&auto=format&fit=max&dpr=2&s=2860e067ff5bd111b0fb3bdf7f53633b',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=660&quality=45&auto=format&fit=max&dpr=2&s=46ddcdd9f52cb42c99d844ab8e6af504',
 						width: 1320,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=427e2816ab973fe59c9a87dc9144caf6',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=645&quality=85&auto=format&fit=max&s=17fe61af6955d8e4cf743d1cd418cb20',
 						width: 645,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=c65bbe1a99f10e53f66ef07a4fdf5c4a',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=3a4a5b698ab4871d00605a3b52d22434',
 						width: 1290,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=b705d2cefa6d0b9bb435523649374f3d',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=465&quality=85&auto=format&fit=max&s=972054aad7638dad619462d64167bce7',
 						width: 465,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=a08d573f5068f467d77c4628aa31e863',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=7fed10c96260c752137ebd46cac292f4',
 						width: 930,
 					},
 				],
@@ -1363,32 +1359,32 @@ export const fourImages: ImageBlockElement[] = [
 				srcSet: [
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=620&quality=85&auto=format&fit=max&s=5f0aad213210796efce5bc6e4b36f59b',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=620&quality=85&auto=format&fit=max&s=5de6219bf5481aa944b2c1f942c80d9c',
 						width: 620,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=e8deb95a117dfeb50e2589ba8a52659c',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=072b43354e1349c796554a48581ab83b',
 						width: 1240,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=605&quality=85&auto=format&fit=max&s=8da200c890a10261a96778219bafbbf7',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=605&quality=85&auto=format&fit=max&s=e06469504b6d411b39241345c3c7a9dc',
 						width: 605,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=7cdad992b7f86597b5962968fe064d7a',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=81230eac2c49812b15332359c8da6d21',
 						width: 1210,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=445&quality=85&auto=format&fit=max&s=517b6cf595a28030747904afc06ca99c',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=445&quality=85&auto=format&fit=max&s=5dbe29aaa2422f808b5b68dea00482e6',
 						width: 445,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=cd91e3355d3b9535f03c49de18c042e9',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=154054f06c074827cd0d1fd6f94da7fc',
 						width: 890,
 					},
 				],
@@ -1398,72 +1394,72 @@ export const fourImages: ImageBlockElement[] = [
 				srcSet: [
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=1300&quality=85&auto=format&fit=max&s=b184a2b9e93b4083aa7a6fed6eec45c2',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=1300&quality=85&auto=format&fit=max&s=6eb752e9db345e9ee27b6becb5847181',
 						width: 1300,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=1300&quality=45&auto=format&fit=max&dpr=2&s=fd2a2d24f60db471a2580c85207c0f77',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=1300&quality=45&auto=format&fit=max&dpr=2&s=4a0b1263ca8554c4e22671fd1a75ac64',
 						width: 2600,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=1140&quality=85&auto=format&fit=max&s=8cfe0ddf82131868395e69ce26f1af5f',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=1140&quality=85&auto=format&fit=max&s=074c422e5e8a6817b1dc86b67a0b4899',
 						width: 1140,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=1140&quality=45&auto=format&fit=max&dpr=2&s=7b8fa4d6d96248046e24f47796d347db',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=1140&quality=45&auto=format&fit=max&dpr=2&s=d5a1286da45d465eb70fbf86e9882c15',
 						width: 2280,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=1125&quality=85&auto=format&fit=max&s=7090db5a62dcac6f9d03479f88513f73',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=1125&quality=85&auto=format&fit=max&s=d0276b901cad246a3cb859c2c07d14e9',
 						width: 1125,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=1125&quality=45&auto=format&fit=max&dpr=2&s=51a09168635bbb6994527ec403a4da49',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=1125&quality=45&auto=format&fit=max&dpr=2&s=a949f4de3e8f9ef7f202c13e216ffb32',
 						width: 2250,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=965&quality=85&auto=format&fit=max&s=029e623ff8dd7413cd197efb537acc71',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=965&quality=85&auto=format&fit=max&s=60d7982d45e30a6a669937335032741b',
 						width: 965,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=965&quality=45&auto=format&fit=max&dpr=2&s=9cefb63048efd535ef87d07d4849f4ac',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=965&quality=45&auto=format&fit=max&dpr=2&s=b17059413da6699784395faafd819f0e',
 						width: 1930,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=725&quality=85&auto=format&fit=max&s=83b5f0e48e1cd7a9e2aea238c2aa4b13',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=725&quality=85&auto=format&fit=max&s=1e3b746f390a2c8a565e3328ab1af3e7',
 						width: 725,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=725&quality=45&auto=format&fit=max&dpr=2&s=f88f9cf18582298fdfdc5859b2edc23d',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=725&quality=45&auto=format&fit=max&dpr=2&s=571055b016d39cf98cd9b4af0b2d9e4c',
 						width: 1450,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=645&quality=85&auto=format&fit=max&s=427e2816ab973fe59c9a87dc9144caf6',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=645&quality=85&auto=format&fit=max&s=17fe61af6955d8e4cf743d1cd418cb20',
 						width: 645,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=c65bbe1a99f10e53f66ef07a4fdf5c4a',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=3a4a5b698ab4871d00605a3b52d22434',
 						width: 1290,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=465&quality=85&auto=format&fit=max&s=b705d2cefa6d0b9bb435523649374f3d',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=465&quality=85&auto=format&fit=max&s=972054aad7638dad619462d64167bce7',
 						width: 465,
 					},
 					{
 						src:
-							'https://i.guim.co.uk/img/media/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=a08d573f5068f467d77c4628aa31e863',
+							'https://i.guim.co.uk/img/media/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=7fed10c96260c752137ebd46cac292f4',
 						width: 930,
 					},
 				],
@@ -1475,36 +1471,36 @@ export const fourImages: ImageBlockElement[] = [
 				{
 					index: 0,
 					fields: {
-						height: '1667',
-						width: '2500',
+						height: '4480',
+						width: '6720',
 					},
 					mediaType: 'Image',
 					mimeType: 'image/jpeg',
 					url:
-						'https://media.guim.co.uk/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/2500.jpg',
+						'https://media.guim.co.uk/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/6720.jpg',
 				},
 				{
 					index: 1,
 					fields: {
 						isMaster: 'true',
-						height: '1667',
-						width: '2500',
+						height: '4480',
+						width: '6720',
 					},
 					mediaType: 'Image',
 					mimeType: 'image/jpeg',
 					url:
-						'https://media.guim.co.uk/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/master/2500.jpg',
+						'https://media.guim.co.uk/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/master/6720.jpg',
 				},
 				{
 					index: 2,
 					fields: {
-						height: '1334',
+						height: '1333',
 						width: '2000',
 					},
 					mediaType: 'Image',
 					mimeType: 'image/jpeg',
 					url:
-						'https://media.guim.co.uk/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/2000.jpg',
+						'https://media.guim.co.uk/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/2000.jpg',
 				},
 				{
 					index: 3,
@@ -1515,7 +1511,7 @@ export const fourImages: ImageBlockElement[] = [
 					mediaType: 'Image',
 					mimeType: 'image/jpeg',
 					url:
-						'https://media.guim.co.uk/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/1000.jpg',
+						'https://media.guim.co.uk/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/1000.jpg',
 				},
 				{
 					index: 4,
@@ -1526,7 +1522,7 @@ export const fourImages: ImageBlockElement[] = [
 					mediaType: 'Image',
 					mimeType: 'image/jpeg',
 					url:
-						'https://media.guim.co.uk/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/500.jpg',
+						'https://media.guim.co.uk/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/500.jpg',
 				},
 				{
 					index: 5,
@@ -1537,10 +1533,10 @@ export const fourImages: ImageBlockElement[] = [
 					mediaType: 'Image',
 					mimeType: 'image/jpeg',
 					url:
-						'https://media.guim.co.uk/6202b6f627a815c59069e0690f78ef177718ae5b/0_0_2500_1667/140.jpg',
+						'https://media.guim.co.uk/56b42eef576bc04c820da710459acd91082bb37b/0_0_6720_4480/140.jpg',
 				},
 			],
 		},
-		displayCredit: true,
+		displayCredit: false,
 	},
 ];

--- a/src/web/components/elements/MultiImageBlockComponent.stories.tsx
+++ b/src/web/components/elements/MultiImageBlockComponent.stories.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { ContainerLayout } from '@root/src/web/components/ContainerLayout';
+
 import { MultiImageBlockComponent } from './MultiImageBlockComponent';
 
 import { fourImages } from './MultiImageBlockComponent.mocks';
@@ -16,11 +18,13 @@ export default {
 
 export const SingleImage = () => {
 	return (
-		<MultiImageBlockComponent
-			designType="Article"
-			pillar="news"
-			images={oneImage}
-		/>
+		<ContainerLayout>
+			<MultiImageBlockComponent
+				designType="Article"
+				pillar="news"
+				images={oneImage}
+			/>
+		</ContainerLayout>
 	);
 };
 SingleImage.story = {
@@ -29,12 +33,14 @@ SingleImage.story = {
 
 export const SingleImageWithCaption = () => {
 	return (
-		<MultiImageBlockComponent
-			designType="Article"
-			pillar="news"
-			images={oneImage}
-			caption="This is the caption for a single image"
-		/>
+		<ContainerLayout>
+			<MultiImageBlockComponent
+				designType="Article"
+				pillar="news"
+				images={oneImage}
+				caption="This is the caption for a single image"
+			/>
+		</ContainerLayout>
 	);
 };
 SingleImageWithCaption.story = {
@@ -43,11 +49,13 @@ SingleImageWithCaption.story = {
 
 export const SideBySide = () => {
 	return (
-		<MultiImageBlockComponent
-			designType="Article"
-			pillar="news"
-			images={twoImages}
-		/>
+		<ContainerLayout>
+			<MultiImageBlockComponent
+				designType="Article"
+				pillar="news"
+				images={twoImages}
+			/>
+		</ContainerLayout>
 	);
 };
 SideBySide.story = {
@@ -56,12 +64,14 @@ SideBySide.story = {
 
 export const SideBySideWithCaption = () => {
 	return (
-		<MultiImageBlockComponent
-			designType="Article"
-			pillar="news"
-			images={twoImages}
-			caption="This is the caption for side by side"
-		/>
+		<ContainerLayout>
+			<MultiImageBlockComponent
+				designType="Article"
+				pillar="news"
+				images={twoImages}
+				caption="This is the caption for side by side"
+			/>
+		</ContainerLayout>
 	);
 };
 SideBySideWithCaption.story = {
@@ -70,11 +80,13 @@ SideBySideWithCaption.story = {
 
 export const OneAboveTwo = () => {
 	return (
-		<MultiImageBlockComponent
-			designType="Article"
-			pillar="news"
-			images={threeImages}
-		/>
+		<ContainerLayout>
+			<MultiImageBlockComponent
+				designType="Article"
+				pillar="news"
+				images={threeImages}
+			/>
+		</ContainerLayout>
 	);
 };
 OneAboveTwo.story = {
@@ -83,12 +95,14 @@ OneAboveTwo.story = {
 
 export const OneAboveTwoWithCaption = () => {
 	return (
-		<MultiImageBlockComponent
-			designType="Article"
-			pillar="news"
-			images={threeImages}
-			caption="This is the caption for one above two"
-		/>
+		<ContainerLayout>
+			<MultiImageBlockComponent
+				designType="Article"
+				pillar="news"
+				images={threeImages}
+				caption="This is the caption for one above two"
+			/>
+		</ContainerLayout>
 	);
 };
 OneAboveTwoWithCaption.story = {
@@ -97,11 +111,13 @@ OneAboveTwoWithCaption.story = {
 
 export const GridOfFour = () => {
 	return (
-		<MultiImageBlockComponent
-			designType="Article"
-			pillar="news"
-			images={fourImages}
-		/>
+		<ContainerLayout>
+			<MultiImageBlockComponent
+				designType="Article"
+				pillar="news"
+				images={fourImages}
+			/>
+		</ContainerLayout>
 	);
 };
 GridOfFour.story = {
@@ -110,12 +126,14 @@ GridOfFour.story = {
 
 export const GridOfFourWithCaption = () => {
 	return (
-		<MultiImageBlockComponent
-			designType="Article"
-			pillar="news"
-			images={fourImages}
-			caption="This is the caption for grid of four"
-		/>
+		<ContainerLayout>
+			<MultiImageBlockComponent
+				designType="Article"
+				pillar="news"
+				images={fourImages}
+				caption="This is the caption for grid of four"
+			/>
+		</ContainerLayout>
 	);
 };
 GridOfFourWithCaption.story = {

--- a/src/web/components/elements/YoutubeEmbedBlockComponent.stories.tsx
+++ b/src/web/components/elements/YoutubeEmbedBlockComponent.stories.tsx
@@ -7,6 +7,11 @@ import { YoutubeEmbedBlockComponent } from './YoutubeEmbedBlockComponent';
 export default {
 	component: YoutubeEmbedBlockComponent,
 	title: 'Components/YoutubeEmbedComponent',
+	parameters: {
+		chromatic: {
+			disabled: true,
+		},
+	},
 };
 
 const Container = ({ children }: { children: React.ReactNode }) => (


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Tries to calm the false negatives we've been seeing in the visual diffs recently around a particular image of a Greenpeace ship crashing through a big wave which Chromatic really seems to object to

Also:
- Wraps the `MultiImageBlockElement` stories in a `ContainerLayout` for better presentation
- Disables diffs on that Madonna video that kept being flagged because the YouTube logo intermittantly got shown
- Fixes time to last sunday in perpetuity so that we don't get diffs on age warnings each month (nor on the copyright notice each year)

## Why?
Teampeace
