### PR TITLE
Change Deeply Read Tabs to Grey

### DIFF
--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterGrid.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterGrid.tsx
@@ -43,14 +43,14 @@ const firstTab = css`
 	border-right: ${thinGreySolid};
 `;
 
-const selectedListTab = (pillar: CAPIPillar) => css`
+const selectedListTabStyles = (pillar: CAPIPillar) => css`
 	/* TODO: Using a pseudo selector here could be faster? */
 	box-shadow: inset 0px 4px 0px 0px ${pillar && pillarPalette[pillar].dark};
 	transition: box-shadow 0.3s ease-in-out;
 `;
 
 // Used for the deeply read test
-const selectedDeeplyListTab = css`
+const selectedDeeplyListTabStyles = css`
 	box-shadow: inset 0px 4px 0px 0px ${neutral[46]};
 	transition: box-shadow 0.3s ease-in-out;
 `;
@@ -143,8 +143,8 @@ export const MostViewedFooterGrid = ({ data, sectionName, pillar }: Props) => {
 						<li
 							className={cx(listTab, {
 								[inDeeplyReadTestVariant
-									? selectedDeeplyListTab
-									: selectedListTab(pillar)]:
+									? selectedDeeplyListTabStyles
+									: selectedListTabStyles(pillar)]:
 									i === selectedTabIndex,
 								[unselectedListTab]: i !== selectedTabIndex,
 								[firstTab]: i === 0,

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterGrid.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterGrid.tsx
@@ -43,7 +43,7 @@ const firstTab = css`
 	border-right: ${thinGreySolid};
 `;
 
-const selectedListTab = (pillar?: CAPIPillar) => css`
+const selectedListTab = (pillar: CAPIPillar) => css`
 	/* TODO: Using a pseudo selector here could be faster? */
 	box-shadow: inset 0px 4px 0px 0px ${pillar && pillarPalette[pillar].dark};
 	transition: box-shadow 0.3s ease-in-out;

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterGrid.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterGrid.tsx
@@ -4,6 +4,7 @@ import { neutral, border } from '@guardian/src-foundations/palette';
 import { headline } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
 import { visuallyHidden } from '@guardian/src-foundations/accessibility';
+import { useAB } from '@guardian/ab-react';
 
 import { pillarPalette } from '@frontend/lib/pillars';
 import { MostViewedFooterItem } from './MostViewedFooterItem';
@@ -42,9 +43,15 @@ const firstTab = css`
 	border-right: ${thinGreySolid};
 `;
 
-const selectedListTab = (pillar: CAPIPillar) => css`
+const selectedListTab = (pillar?: CAPIPillar) => css`
 	/* TODO: Using a pseudo selector here could be faster? */
 	box-shadow: inset 0px 4px 0px 0px ${pillar && pillarPalette[pillar].dark};
+	transition: box-shadow 0.3s ease-in-out;
+`;
+
+// Used for the deeply read test
+const selectedDeeplyListTab = css`
+	box-shadow: inset 0px 4px 0px 0px ${neutral[46]};
 	transition: box-shadow 0.3s ease-in-out;
 `;
 
@@ -123,6 +130,11 @@ const TabHeading = ({ heading }: { heading: string }) => {
 
 export const MostViewedFooterGrid = ({ data, sectionName, pillar }: Props) => {
 	const [selectedTabIndex, setSelectedTabIndex] = useState<number>(0);
+	const ABTestAPI = useAB();
+	const inDeeplyReadTestVariant = ABTestAPI.isUserInVariant(
+		'DeeplyReadTest',
+		'variant',
+	);
 	return (
 		<div>
 			{Array.isArray(data) && data.length > 1 && (
@@ -130,7 +142,9 @@ export const MostViewedFooterGrid = ({ data, sectionName, pillar }: Props) => {
 					{data.map((tab: TrailTabType, i: number) => (
 						<li
 							className={cx(listTab, {
-								[selectedListTab(pillar)]:
+								[inDeeplyReadTestVariant
+									? selectedDeeplyListTab
+									: selectedListTab(pillar)]:
 									i === selectedTabIndex,
 								[unselectedListTab]: i !== selectedTabIndex,
 								[firstTab]: i === 0,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Based on design feedback for the Deeply Read test the pillar colour will now be ignored and a standard colour will be used on all pages.

### Before
<img width="820" alt="Screenshot 2021-01-13 at 10 08 08" src="https://user-images.githubusercontent.com/35331926/104438677-2a635c00-5588-11eb-8394-b73771f372c6.png">

### After
<img width="820" alt="Screenshot 2021-01-13 at 10 09 02" src="https://user-images.githubusercontent.com/35331926/104438660-22a3b780-5588-11eb-80f5-4b632c89d1db.png">

## Why?
Design Request