### PR TITLE
Revert "Show full navigation menu on top of top-above-nav slot"

### DIFF
--- a/src/web/components/Nav/ExpandedMenu/ExpandedMenu.tsx
+++ b/src/web/components/Nav/ExpandedMenu/ExpandedMenu.tsx
@@ -86,7 +86,7 @@ const mainMenuStyles = css`
 		margin-right: 70px;
 	}
 	${from.tablet} {
-		margin-right: 53px;
+		margin-right: 100px;
 	}
 `;
 

--- a/src/web/lib/getZIndex.test.tsx
+++ b/src/web/lib/getZIndex.test.tsx
@@ -2,8 +2,8 @@ import { getZIndex } from './getZIndex';
 
 describe('getZIndex', () => {
 	it('gets the correct zindex for group and sibling', () => {
-		expect(getZIndex('headerWrapper')).toBe('z-index: 9;');
-		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 8;');
+		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 9;');
+		expect(getZIndex('headerWrapper')).toBe('z-index: 8;');
 		expect(getZIndex('headerLinks')).toBe('z-index: 7;');
 		expect(getZIndex('TheGuardian')).toBe('z-index: 6;');
 		expect(getZIndex('articleHeadline')).toBe('z-index: 5;');

--- a/src/web/lib/getZIndex.tsx
+++ b/src/web/lib/getZIndex.tsx
@@ -27,8 +27,8 @@ const indices = [
 	'banner',
 
 	// Header
-	'headerWrapper',
 	'stickyAdWrapper',
+	'headerWrapper',
 
 	// Header links (should be above The Guardian svg)
 	'headerLinks',


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#2352

This has cause issue on scrolling the top-above-nav hides behind the navbar 