### PR TITLE
Support YoutubeEmbedBlockComponent in main media

### DIFF
--- a/src/web/components/MainMedia.tsx
+++ b/src/web/components/MainMedia.tsx
@@ -55,7 +55,6 @@ const immersiveWrapper = css`
 `;
 
 const youtubeWrapperStyles = css`
-	margin-top: 12px;
 	margin-bottom: 12px;
 `;
 

--- a/src/web/components/MainMedia.tsx
+++ b/src/web/components/MainMedia.tsx
@@ -8,7 +8,6 @@ import { ImageComponent } from '@root/src/web/components/elements/ImageComponent
 import { YoutubeBlockComponent } from '@root/src/web/components/elements/YoutubeBlockComponent';
 import { YoutubeEmbedBlockComponent } from '@root/src/web/components/elements/YoutubeEmbedBlockComponent';
 import { EmbedBlockComponent } from '@root/src/web/components/elements/EmbedBlockComponent';
-import { Figure } from '@root/src/web/components/Figure';
 
 import { getZIndex } from '@frontend/web/lib/getZIndex';
 
@@ -83,7 +82,7 @@ function renderElement(
 			);
 		case 'model.dotcomrendering.pageElements.YoutubeBlockElement':
 			return (
-				<div
+				<figure
 					key={i}
 					id={`youtube-block-main-media-${i}`}
 					data-cy="main-media-youtube-atom"
@@ -107,11 +106,11 @@ function renderElement(
 						duration={element.duration}
 						origin={host}
 					/>
-				</div>
+				</figure>
 			);
 		case 'model.dotcomrendering.pageElements.VideoYoutubeBlockElement':
 			return (
-				<Figure role={element.role}>
+				<figure>
 					<YoutubeEmbedBlockComponent
 						pillar={pillar}
 						embedUrl={element.embedUrl}
@@ -123,7 +122,7 @@ function renderElement(
 						display={display}
 						designType={designType}
 					/>
-				</Figure>
+				</figure>
 			);
 		case 'model.dotcomrendering.pageElements.EmbedBlockElement':
 			return (

--- a/src/web/components/MainMedia.tsx
+++ b/src/web/components/MainMedia.tsx
@@ -2,11 +2,14 @@ import React from 'react';
 import { css, cx } from 'emotion';
 
 import { until } from '@guardian/src-foundations/mq';
+import { Display } from '@guardian/types/Format';
 
 import { ImageComponent } from '@root/src/web/components/elements/ImageComponent';
 import { YoutubeBlockComponent } from '@root/src/web/components/elements/YoutubeBlockComponent';
+import { YoutubeEmbedBlockComponent } from '@root/src/web/components/elements/YoutubeEmbedBlockComponent';
 import { EmbedBlockComponent } from '@root/src/web/components/elements/EmbedBlockComponent';
-import { Display } from '@guardian/types/Format';
+import { Figure } from '@root/src/web/components/Figure';
+
 import { getZIndex } from '@frontend/web/lib/getZIndex';
 
 const mainMedia = css`
@@ -105,6 +108,22 @@ function renderElement(
 						origin={host}
 					/>
 				</div>
+			);
+		case 'model.dotcomrendering.pageElements.VideoYoutubeBlockElement':
+			return (
+				<Figure role={element.role}>
+					<YoutubeEmbedBlockComponent
+						pillar={pillar}
+						embedUrl={element.embedUrl}
+						height={element.height}
+						width={element.width}
+						caption={element.caption}
+						credit={element.credit}
+						title={element.title}
+						display={display}
+						designType={designType}
+					/>
+				</Figure>
 			);
 		case 'model.dotcomrendering.pageElements.EmbedBlockElement':
 			return (

--- a/src/web/components/MainMedia.tsx
+++ b/src/web/components/MainMedia.tsx
@@ -54,6 +54,11 @@ const immersiveWrapper = css`
     overflow: hidden;
 `;
 
+const youtubeWrapperStyles = css`
+	margin-top: 12px;
+	margin-bottom: 12px;
+`;
+
 function renderElement(
 	display: Display,
 	designType: DesignType,
@@ -86,6 +91,7 @@ function renderElement(
 					key={i}
 					id={`youtube-block-main-media-${i}`}
 					data-cy="main-media-youtube-atom"
+					className={youtubeWrapperStyles}
 				>
 					<YoutubeBlockComponent
 						display={display}
@@ -110,7 +116,7 @@ function renderElement(
 			);
 		case 'model.dotcomrendering.pageElements.VideoYoutubeBlockElement':
 			return (
-				<figure>
+				<figure className={youtubeWrapperStyles}>
 					<YoutubeEmbedBlockComponent
 						pillar={pillar}
 						embedUrl={element.embedUrl}

--- a/src/web/components/MainMedia.tsx
+++ b/src/web/components/MainMedia.tsx
@@ -54,10 +54,6 @@ const immersiveWrapper = css`
     overflow: hidden;
 `;
 
-const youtubeWrapperStyles = css`
-	margin-bottom: 12px;
-`;
-
 function renderElement(
 	display: Display,
 	designType: DesignType,
@@ -86,11 +82,10 @@ function renderElement(
 			);
 		case 'model.dotcomrendering.pageElements.YoutubeBlockElement':
 			return (
-				<figure
+				<div
 					key={i}
 					id={`youtube-block-main-media-${i}`}
 					data-cy="main-media-youtube-atom"
-					className={youtubeWrapperStyles}
 				>
 					<YoutubeBlockComponent
 						display={display}
@@ -111,23 +106,21 @@ function renderElement(
 						duration={element.duration}
 						origin={host}
 					/>
-				</figure>
+				</div>
 			);
 		case 'model.dotcomrendering.pageElements.VideoYoutubeBlockElement':
 			return (
-				<figure className={youtubeWrapperStyles}>
-					<YoutubeEmbedBlockComponent
-						pillar={pillar}
-						embedUrl={element.embedUrl}
-						height={element.height}
-						width={element.width}
-						caption={element.caption}
-						credit={element.credit}
-						title={element.title}
-						display={display}
-						designType={designType}
-					/>
-				</figure>
+				<YoutubeEmbedBlockComponent
+					pillar={pillar}
+					embedUrl={element.embedUrl}
+					height={element.height}
+					width={element.width}
+					caption={element.caption}
+					credit={element.credit}
+					title={element.title}
+					display={display}
+					designType={designType}
+				/>
 			);
 		case 'model.dotcomrendering.pageElements.EmbedBlockElement':
 			return (


### PR DESCRIPTION
## What does this change?
Adds support for `YoutubeEmbedBlockComponent` as main media

## Article used
https://www.theguardian.com/film/2021/jan/13/netflix-new-films-movie-promo-video-disney-streaming-wars

### Before
<img width="892" alt="Screenshot 2021-01-14 at 11 42 39" src="https://user-images.githubusercontent.com/8831403/104586642-a4b1e000-565d-11eb-91a5-750d8b1101a1.png">

### After
<img width="883" alt="Screenshot 2021-01-14 at 11 42 01" src="https://user-images.githubusercontent.com/8831403/104586630-a085c280-565d-11eb-80df-86c5a5e46983.png">

## Why?
frontend parity