### PR TITLE
 Support guvideo as main media

### DIFF
--- a/src/web/components/MainMedia.tsx
+++ b/src/web/components/MainMedia.tsx
@@ -7,6 +7,7 @@ import { Display } from '@guardian/types/Format';
 import { ImageComponent } from '@root/src/web/components/elements/ImageComponent';
 import { YoutubeBlockComponent } from '@root/src/web/components/elements/YoutubeBlockComponent';
 import { YoutubeEmbedBlockComponent } from '@root/src/web/components/elements/YoutubeEmbedBlockComponent';
+import { GuVideoBlockComponent } from '@root/src/web/components/elements/GuVideoBlockComponent';
 import { EmbedBlockComponent } from '@root/src/web/components/elements/EmbedBlockComponent';
 
 import { getZIndex } from '@frontend/web/lib/getZIndex';
@@ -121,7 +122,18 @@ function renderElement(
 					display={display}
 					designType={designType}
 				/>
-			);
+            );
+        case 'model.dotcomrendering.pageElements.GuVideoBlockElement':
+            return (
+	<GuVideoBlockComponent
+		html={element.html}
+		pillar={pillar}
+		designType={designType}
+		display={display}
+		credit={element.source}
+		caption={element.caption}
+	/>
+            );
 		case 'model.dotcomrendering.pageElements.EmbedBlockElement':
 			return (
 				<EmbedBlockComponent html={element.html} alt={element.alt} />

--- a/src/web/components/MainMedia.tsx
+++ b/src/web/components/MainMedia.tsx
@@ -122,18 +122,18 @@ function renderElement(
 					display={display}
 					designType={designType}
 				/>
-            );
-        case 'model.dotcomrendering.pageElements.GuVideoBlockElement':
-            return (
-	<GuVideoBlockComponent
-		html={element.html}
-		pillar={pillar}
-		designType={designType}
-		display={display}
-		credit={element.source}
-		caption={element.caption}
-	/>
-            );
+			);
+		case 'model.dotcomrendering.pageElements.GuVideoBlockElement':
+			return (
+				<GuVideoBlockComponent
+					html={element.html}
+					pillar={pillar}
+					designType={designType}
+					display={display}
+					credit={element.source}
+					caption={element.caption}
+				/>
+			);
 		case 'model.dotcomrendering.pageElements.EmbedBlockElement':
 			return (
 				<EmbedBlockComponent html={element.html} alt={element.alt} />


### PR DESCRIPTION
## What does this change?
Enables support for articles such as this - https://www.theguardian.com/world/2015/nov/07/fisherman-lost-at-sea-436-days-book-extract where an old school guardian video is the main media.

<img width="674" alt="Screen Shot 2021-01-15 at 10 15 29" src="https://user-images.githubusercontent.com/2051501/104719420-54ea1c00-5724-11eb-831c-f49687ef0e38.png">


### Why?
Pushing up that could render number, one article at a time.....

