### PR TITLE
Bumped Typescript version to 4.1.3 and fixed emerging bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -219,7 +219,7 @@
         "tslint-plugin-prettier": "^2.3.0",
         "tslint-react": "^4.0.0",
         "tslint-react-a11y": "^1.1.0",
-        "typescript": "^3.9.7",
+        "typescript": "^4.1.3",
         "typescript-json-schema": "^0.43.0",
         "webpack": "^4.44.2",
         "webpack-assets-manifest": "^3.1.1",

--- a/src/web/lib/loadScript.ts
+++ b/src/web/lib/loadScript.ts
@@ -4,7 +4,7 @@
 export const loadScript = (
 	src: string,
 	props?: Omit<Partial<HTMLScriptElement>, 'src' | 'onload' | 'onerror'>,
-): Promise<Event | undefined> =>
+): Promise<Event | void> =>
 	new Promise((resolve, reject) => {
 		// creating this before the check below allows us to compare the resolved `src` values
 		const script = document.createElement('script');

--- a/yarn.lock
+++ b/yarn.lock
@@ -18148,10 +18148,15 @@ typescript-json-schema@^0.43.0:
     typescript "~4.0.2"
     yargs "^15.4.1"
 
-typescript@^3.8.3, typescript@^3.9.3, typescript@^3.9.7:
+typescript@^3.8.3, typescript@^3.9.3:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+
+typescript@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
+  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
 
 typescript@~4.0.2:
   version "4.0.5"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Bumped Typescript in anticipation of the inclusion of `@guardian/libs` which was causing some type issues when used with Typescript 3.9.7.

Also fixed a bug related to `loadScript.ts` - where the Promise output needed to include a `void` type.

### Before
Typescript at version 4.1.3.

### After
Typescript at version 3.9.7.

## Why?
To allow the integration of `@guardian/libs`