### PR TITLE
Add breadcrumps to sentry

### DIFF
--- a/src/web/browser/sentryLoader/sentry.ts
+++ b/src/web/browser/sentryLoader/sentry.ts
@@ -38,6 +38,7 @@ Sentry.init({
 	dsn: dcrSentryDsn,
 	environment: window.guardian.config.stage || 'DEV',
 	integrations: [new CaptureConsole({ levels: ['error'] })],
+    maxBreadcrumbs: 50,
 	// sampleRate: // We use Math.random in init.ts to sample errors
 	beforeSend(event) {
 		// Skip sending events in certain situations

--- a/src/web/browser/sentryLoader/sentry.ts
+++ b/src/web/browser/sentryLoader/sentry.ts
@@ -38,7 +38,7 @@ Sentry.init({
 	dsn: dcrSentryDsn,
 	environment: window.guardian.config.stage || 'DEV',
 	integrations: [new CaptureConsole({ levels: ['error'] })],
-    maxBreadcrumbs: 50,
+	maxBreadcrumbs: 50,
 	// sampleRate: // We use Math.random in init.ts to sample errors
 	beforeSend(event) {
 		// Skip sending events in certain situations


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds [max-breadcrumbs](https://docs.sentry.io/platforms/node/configuration/options/#max-breadcrumbs) configuration to Sentry so that it can display the console logs 

I'm expecting  to  show the Breadcrumbs panel following this change, as it happens in frontend sentry configuration

<img width="840" alt="Screenshot 2021-01-15 at 17 05 12" src="https://user-images.githubusercontent.com/51630004/104743084-f50b6980-5753-11eb-865b-4e59df8add98.png">

