### PR TITLE
Refactor dependency handling for the Braze SDK

### DIFF
--- a/src/web/lib/braze/checkBrazeDependencies.test.ts
+++ b/src/web/lib/braze/checkBrazeDependencies.test.ts
@@ -1,0 +1,318 @@
+import { checkBrazeDependencies } from './checkBrazeDependencies';
+
+let mockBrazeUuid: string | null;
+jest.mock('@root/src/web/lib/getBrazeUuid', () => ({
+	getBrazeUuid: () => {
+		return Promise.resolve(mockBrazeUuid);
+	},
+}));
+
+let mockConsentsPromise: Promise<boolean>;
+jest.mock('./hasRequiredConsents', () => ({
+	hasRequiredConsents: () => {
+		return mockConsentsPromise;
+	},
+}));
+
+let mockHideSupportMessaging: boolean;
+jest.mock('./hideSupportMessaging', () => ({
+	hideSupportMessaging: () => {
+		return mockHideSupportMessaging;
+	},
+}));
+
+describe('checkBrazeDependecies', () => {
+	let windowSpy: jest.SpyInstance<any>;
+
+	beforeEach(() => {
+		windowSpy = jest.spyOn(window, 'window', 'get');
+	});
+
+	afterEach(() => {
+		windowSpy.mockRestore();
+
+		// Wait for any unsettled promises to complete at the end of each test. Once
+		// we encounter a failure in our list of checks we don't need to wait on
+		// subsequent operations to complete which is why there might be unsettled
+		// promises.
+		const flushPromises = new Promise(setImmediate);
+		return flushPromises;
+	});
+
+	const setWindow = (windowData: { [key: string]: any }) =>
+		windowSpy.mockImplementation(() => windowData);
+
+	it('succeeds if all dependencies are fulfilled', async () => {
+		setWindow({
+			guardian: {
+				config: {
+					switches: {
+						brazeSwitch: true,
+					},
+					page: {
+						brazeApiKey: 'fake-api-key',
+						isPaidContent: false,
+					},
+				},
+			},
+		});
+		mockBrazeUuid = 'fake-uuid';
+		mockConsentsPromise = Promise.resolve(true);
+		mockHideSupportMessaging = true;
+
+		const isSignedIn = true;
+		const idApiUrl = 'https://idapi.example.com';
+		const got = await checkBrazeDependencies(isSignedIn, idApiUrl);
+
+		expect(got.isSuccessful).toEqual(true);
+		expect(got.data).toEqual({
+			brazeSwitch: true,
+			apiKey: 'fake-api-key',
+			consent: true,
+			isNotPaidContent: true,
+			brazeUuid: 'fake-uuid',
+			userIsGuSupporter: true,
+		});
+	});
+
+	it('fails if the switch is disabled', async () => {
+		setWindow({
+			guardian: {
+				config: {
+					switches: {
+						brazeSwitch: false,
+					},
+					page: {
+						brazeApiKey: 'fake-api-key',
+						isPaidContent: false,
+					},
+				},
+			},
+		});
+		mockBrazeUuid = 'fake-uuid';
+		mockConsentsPromise = Promise.resolve(true);
+		mockHideSupportMessaging = true;
+
+		const isSignedIn = true;
+		const idApiUrl = 'https://idapi.example.com';
+		const got = await checkBrazeDependencies(isSignedIn, idApiUrl);
+
+		expect(got.isSuccessful).toEqual(false);
+		expect(got.data).toEqual({});
+		// Condition to keep TypeScript happy
+		if (!got.isSuccessful) {
+			expect(got.failure.field).toEqual('brazeSwitch');
+			expect(got.failure.data).toEqual(false);
+		}
+	});
+
+	it('fails if the api key is not set', async () => {
+		setWindow({
+			guardian: {
+				config: {
+					switches: {
+						brazeSwitch: true,
+					},
+					page: {
+						brazeApiKey: null,
+						isPaidContent: false,
+					},
+				},
+			},
+		});
+		mockBrazeUuid = 'fake-uuid';
+		mockConsentsPromise = Promise.resolve(true);
+		mockHideSupportMessaging = true;
+
+		const isSignedIn = true;
+		const idApiUrl = 'https://idapi.example.com';
+		const got = await checkBrazeDependencies(isSignedIn, idApiUrl);
+
+		expect(got.isSuccessful).toEqual(false);
+		expect(got.data).toEqual({
+			brazeSwitch: true,
+		});
+		// Condition to keep TypeScript happy
+		if (!got.isSuccessful) {
+			expect(got.failure.field).toEqual('apiKey');
+			expect(got.failure.data).toEqual(null);
+		}
+	});
+
+	it('fails if the brazeUuid is not available', async () => {
+		setWindow({
+			guardian: {
+				config: {
+					switches: {
+						brazeSwitch: true,
+					},
+					page: {
+						brazeApiKey: 'fake-api-key',
+						isPaidContent: false,
+					},
+				},
+			},
+		});
+		mockBrazeUuid = null;
+		mockConsentsPromise = Promise.resolve(true);
+		mockHideSupportMessaging = true;
+
+		const isSignedIn = true;
+		const idApiUrl = 'https://idapi.example.com';
+		const got = await checkBrazeDependencies(isSignedIn, idApiUrl);
+
+		expect(got.isSuccessful).toEqual(false);
+		expect(got.data).toEqual({
+			brazeSwitch: true,
+			apiKey: 'fake-api-key',
+		});
+		// Condition to keep TypeScript happy
+		if (!got.isSuccessful) {
+			expect(got.failure.field).toEqual('brazeUuid');
+			expect(got.failure.data).toEqual(null);
+		}
+	});
+
+	it('fails if the required consents are not given', async () => {
+		setWindow({
+			guardian: {
+				config: {
+					switches: {
+						brazeSwitch: true,
+					},
+					page: {
+						brazeApiKey: 'fake-api-key',
+						isPaidContent: false,
+					},
+				},
+			},
+		});
+		mockBrazeUuid = 'fake-uuid';
+		mockConsentsPromise = Promise.resolve(false);
+		mockHideSupportMessaging = true;
+
+		const isSignedIn = true;
+		const idApiUrl = 'https://idapi.example.com';
+		const got = await checkBrazeDependencies(isSignedIn, idApiUrl);
+
+		expect(got.isSuccessful).toEqual(false);
+		expect(got.data).toEqual({
+			brazeSwitch: true,
+			brazeUuid: 'fake-uuid',
+			apiKey: 'fake-api-key',
+		});
+		// Condition to keep TypeScript happy
+		if (!got.isSuccessful) {
+			expect(got.failure.field).toEqual('consent');
+			expect(got.failure.data).toEqual(false);
+		}
+	});
+
+	it('fails if support messaging is not hidden', async () => {
+		setWindow({
+			guardian: {
+				config: {
+					switches: {
+						brazeSwitch: true,
+					},
+					page: {
+						brazeApiKey: 'fake-api-key',
+						isPaidContent: false,
+					},
+				},
+			},
+		});
+		mockBrazeUuid = 'fake-uuid';
+		mockConsentsPromise = Promise.resolve(true);
+		mockHideSupportMessaging = false;
+
+		const isSignedIn = true;
+		const idApiUrl = 'https://idapi.example.com';
+		const got = await checkBrazeDependencies(isSignedIn, idApiUrl);
+
+		expect(got.isSuccessful).toEqual(false);
+		expect(got.data).toEqual({
+			brazeSwitch: true,
+			apiKey: 'fake-api-key',
+			consent: true,
+			brazeUuid: 'fake-uuid',
+		});
+		// Condition to keep TypeScript happy
+		if (!got.isSuccessful) {
+			expect(got.failure.field).toEqual('userIsGuSupporter');
+			expect(got.failure.data).toEqual(false);
+		}
+	});
+
+	it('fails if the page is a paid content page', async () => {
+		setWindow({
+			guardian: {
+				config: {
+					switches: {
+						brazeSwitch: true,
+					},
+					page: {
+						brazeApiKey: 'fake-api-key',
+						isPaidContent: true,
+					},
+				},
+			},
+		});
+		mockBrazeUuid = 'fake-uuid';
+		mockConsentsPromise = Promise.resolve(true);
+		mockHideSupportMessaging = true;
+
+		const isSignedIn = true;
+		const idApiUrl = 'https://idapi.example.com';
+		const got = await checkBrazeDependencies(isSignedIn, idApiUrl);
+
+		expect(got.isSuccessful).toEqual(false);
+		expect(got.data).toEqual({
+			brazeSwitch: true,
+			apiKey: 'fake-api-key',
+			consent: true,
+			brazeUuid: 'fake-uuid',
+			userIsGuSupporter: true,
+		});
+		// Condition to keep TypeScript happy
+		if (!got.isSuccessful) {
+			expect(got.failure.field).toEqual('isNotPaidContent');
+			expect(got.failure.data).toEqual(false);
+		}
+	});
+
+	it('fails if any underlying async operation fails', async () => {
+		setWindow({
+			guardian: {
+				config: {
+					switches: {
+						brazeSwitch: true,
+					},
+					page: {
+						brazeApiKey: 'fake-api-key',
+						isPaidContent: false,
+					},
+				},
+			},
+		});
+		mockBrazeUuid = 'fake-uuid';
+		mockConsentsPromise = Promise.reject(new Error('something went wrong'));
+		mockHideSupportMessaging = true;
+
+		const isSignedIn = true;
+		const idApiUrl = 'https://idapi.example.com';
+		const got = await checkBrazeDependencies(isSignedIn, idApiUrl);
+
+		expect(got.isSuccessful).toEqual(false);
+		expect(got.data).toEqual({
+			brazeSwitch: true,
+			brazeUuid: 'fake-uuid',
+			apiKey: 'fake-api-key',
+		});
+		// Condition to keep TypeScript happy
+		if (!got.isSuccessful) {
+			expect(got.failure.field).toEqual('consent');
+			expect(got.failure.data).toEqual('something went wrong');
+		}
+	});
+});

--- a/src/web/lib/braze/checkBrazeDependencies.ts
+++ b/src/web/lib/braze/checkBrazeDependencies.ts
@@ -1,0 +1,104 @@
+import { getBrazeUuid } from '@root/src/web/lib/getBrazeUuid';
+import { hasRequiredConsents } from './hasRequiredConsents';
+import { hideSupportMessaging } from './hideSupportMessaging';
+
+type SuccessResult = {
+	isSuccessful: true;
+	data: ResultData;
+};
+
+type FailureResult = {
+	isSuccessful: false;
+	failure: {
+		field: string;
+		data: any;
+	};
+	data: ResultData;
+};
+
+type DependenciesResult = SuccessResult | FailureResult;
+
+type ResultData = { [key: string]: string | boolean };
+
+type DependencyResult = {
+	name: string;
+	value: Promise<string | boolean | null | undefined>;
+};
+const buildFailureResponse = (name: string, value: any, data: ResultData) => ({
+	isSuccessful: false,
+	failure: {
+		field: name,
+		data: value,
+	},
+	data,
+});
+
+const buildDependencies = (
+	isSignedIn: boolean,
+	idApiUrl: string,
+): DependencyResult[] => {
+	return [
+		{
+			name: 'brazeSwitch',
+			value: Promise.resolve(window.guardian.config.switches.brazeSwitch),
+		},
+		{
+			name: 'apiKey',
+			value: Promise.resolve(window.guardian.config.page.brazeApiKey),
+		},
+		{
+			name: 'brazeUuid',
+			value: isSignedIn ? getBrazeUuid(idApiUrl) : Promise.resolve(null),
+		},
+		{
+			name: 'consent',
+			value: hasRequiredConsents(),
+		},
+		{
+			name: 'userIsGuSupporter',
+			value: Promise.resolve(hideSupportMessaging()),
+		},
+		{
+			name: 'isNotPaidContent',
+			value: Promise.resolve(!window.guardian.config.page.isPaidContent),
+		},
+	];
+};
+
+const checkBrazeDependencies = async (
+	isSignedIn: boolean,
+	idApiUrl: string,
+): Promise<DependenciesResult> => {
+	const dependencies = buildDependencies(isSignedIn, idApiUrl);
+
+	const data: ResultData = {};
+
+	// I think we could possibly clean this up a bit when we can use
+	// Promise.allSettled reliably (it's not available in our current Node
+	// version and polyfill.io doesn't have a polyfill yet).
+	for (const { name, value } of dependencies) {
+		try {
+			// eslint-disable-next-line no-await-in-loop
+			const result = await value;
+
+			if (result) {
+				data[name] = result;
+			} else {
+				return buildFailureResponse(name, result, data);
+			}
+		} catch (e) {
+			return buildFailureResponse(
+				name,
+				e && e.message ? e.message : e,
+				data,
+			);
+		}
+	}
+
+	return {
+		isSuccessful: true,
+		data,
+	};
+};
+
+export { checkBrazeDependencies };

--- a/src/web/lib/braze/hasRequiredConsents.test.ts
+++ b/src/web/lib/braze/hasRequiredConsents.test.ts
@@ -1,4 +1,4 @@
-import { hasRequiredConsents, canShowPreChecks } from './BrazeBanner';
+import { hasRequiredConsents } from './hasRequiredConsents';
 
 const brazeVendorId = '5ed8c49c4b8ce4571c7ad801';
 
@@ -88,41 +88,6 @@ describe('hasRequiredConsents', () => {
 			};
 
 			await expect(hasRequiredConsents()).resolves.toBe(false);
-		});
-	});
-});
-
-describe('canShowPreChecks', () => {
-	describe('when not a supporter', () => {
-		it('returns false', () => {
-			const result = canShowPreChecks({
-				shouldHideSupportMessaging: false,
-				pageConfig: { isPaidContent: false },
-			});
-
-			expect(result).toBe(false);
-		});
-	});
-
-	describe('when viewing paid content', () => {
-		it('returns false', () => {
-			const result = canShowPreChecks({
-				shouldHideSupportMessaging: true,
-				pageConfig: { isPaidContent: true },
-			});
-
-			expect(result).toBe(false);
-		});
-	});
-
-	describe('when all checks pass', () => {
-		it('returns true', () => {
-			const result = canShowPreChecks({
-				shouldHideSupportMessaging: true,
-				pageConfig: { isPaidContent: false },
-			});
-
-			expect(result).toBe(true);
 		});
 	});
 });

--- a/src/web/lib/braze/hasRequiredConsents.ts
+++ b/src/web/lib/braze/hasRequiredConsents.ts
@@ -1,0 +1,17 @@
+import {
+	getConsentFor,
+	onConsentChange,
+} from '@guardian/consent-management-platform';
+
+const hasRequiredConsents = (): Promise<boolean> =>
+	new Promise((resolve, reject) => {
+		onConsentChange((state) => {
+			try {
+				resolve(getConsentFor('braze', state));
+			} catch (e) {
+				reject(e);
+			}
+		});
+	});
+
+export { hasRequiredConsents };

--- a/src/web/lib/braze/hideSupportMessaging.ts
+++ b/src/web/lib/braze/hideSupportMessaging.ts
@@ -1,0 +1,7 @@
+import { getCookie } from '@root/src/web/browser/cookie';
+import { HIDE_SUPPORT_MESSAGING_COOKIE } from '@root/src/web/lib/contributions';
+
+const hideSupportMessaging = () =>
+	getCookie(HIDE_SUPPORT_MESSAGING_COOKIE) === 'true';
+
+export { hideSupportMessaging };


### PR DESCRIPTION
## What does this change?

Refactors the way dependencies for loading the Braze web SDK are handled. By dependencies we mean the information we need and the conditions which need to be true before we can load the SDK. Currently these are:

* That the switch is on
* The API key is set
* The relevant consents have been given
* That the page isn't paid (GLabs) content
* That the user is signed in and we have their uuid
* That the user _is_ a Gu supporter

### Before

Dependency checks were all intermingled with other code in `BrazeBanner`.

### After

Dependency checks have been extracted out to `checkBrazeDependencies.ts` and are configured in a way that we think makes them much clearer. We're using the new (generic) `dependecyChecker` which we've added in this PR, which takes an array of async dependencies/conditions and processes them until one fails. Note that this is a slight change from the original code where we would make each check in turn in serial, now we're kicking them all off "concurrently" (in quotes because JS is single threaded. Some of the work _may_ be parallelisable, for example the request to idapi) and processing the results serially, until we come across a check which fails.

## Why?

* It's hopefully clearer to a new/returning reader of the code what the dependencies actually are.
* It's easier to write tests around the dependencies.
* We'd like to extract more Braze related code out to its own NPM package, which could be shared across DCR and frontend. Modularising the existing code is a first step along that path.
* It's much easier to have functionality like common logging for when dependencies aren't all met which is really useful when developing.