### PR TITLE
Increase Deeply Read test audience to 25%

### DIFF
--- a/src/web/experiments/tests/deeply-read-test.ts
+++ b/src/web/experiments/tests/deeply-read-test.ts
@@ -7,7 +7,7 @@ export const deeplyReadTest: ABTest = {
 	author: 'nitro-marky',
 	description:
 		'Tests an onward hypothesis by replacing the second tab in the Most Popular container with deeply read items.',
-	audience: 0.01,
+	audience: 0.25,
 	audienceOffset: 0,
 	successMeasure: 'Increased CTR on article pages',
 	audienceCriteria: 'Everyone',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Increase the audience percentage of the deeply read test to 25%. It was originally going to be higher but given the extra traffic DCR gets it should be enough to reach significance quickly enough.
