### PR TITLE
Add overflow-wrap: break-word to textBlockCompoment paraStyles

### DIFF
--- a/src/web/components/elements/TextBlockComponent.tsx
+++ b/src/web/components/elements/TextBlockComponent.tsx
@@ -137,6 +137,7 @@ export const TextBlockComponent: React.FC<Props> = ({
 	const paraStyles = css`
 		margin-bottom: 16px;
 		${body.medium()};
+        line-break: anywhere;
 
 		ul {
 			margin-bottom: 12px;

--- a/src/web/components/elements/TextBlockComponent.tsx
+++ b/src/web/components/elements/TextBlockComponent.tsx
@@ -137,7 +137,7 @@ export const TextBlockComponent: React.FC<Props> = ({
 	const paraStyles = css`
 		margin-bottom: 16px;
 		${body.medium()};
-        line-break: anywhere;
+		overflow-wrap: anywhere;
 
 		ul {
 			margin-bottom: 12px;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds `overflow-wrap: anywhere` to `textBlockComponent` to allow the line to break and not flow out of the browser window on small screens.
| Before | After |
| --- | ----------- |
| ![image](https://user-images.githubusercontent.com/638051/105058544-3ced0200-5a6e-11eb-8cd4-2acc4f22efe3.png)  |![image](https://user-images.githubusercontent.com/638051/105061645-a6224480-5a71-11eb-91a6-5306eb7f3496.png)|


## Why?
To break long lines.