### PR TITLE
Add clear: left; to supporting content

### DIFF
--- a/src/web/components/Figure.tsx
+++ b/src/web/components/Figure.tsx
@@ -17,6 +17,7 @@ const roleCss = {
 	`,
 
 	supporting: css`
+		clear: left;
 		margin-top: ${space[3]}px;
 		margin-bottom: ${space[3]}px;
 		${from.tablet} {


### PR DESCRIPTION
## What does this change?

Clears supporting content on the left to prevent getting caught on floated content above. This matches the 'thumbnail' role which already has `clear: left`.

| Before | After |
| --- | ----------- |
|![Screen Shot 2021-01-20 at 11 08 29](https://user-images.githubusercontent.com/638051/105167110-33b47180-5b10-11eb-83e8-a976ff5abd35.png) |![Screen Shot 2021-01-20 at 11 08 16](https://user-images.githubusercontent.com/638051/105167136-3d3dd980-5b10-11eb-94b5-871024a8445f.png)|


## Why?
