### PR TITLE
Bump cmp lib tp 6.11.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "@guardian/atoms-rendering": "^9.1.0",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/braze-components": "^0.0.19",
-        "@guardian/consent-management-platform": "^6.11.1",
+        "@guardian/consent-management-platform": "^6.11.2",
         "@guardian/discussion-rendering": "^5.0.0",
         "@guardian/shimport": "^1.0.2",
         "@guardian/src-button": "^2.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2110,10 +2110,10 @@
     "@guardian/src-icons" "2.7.1"
     emotion-theming "^10.0.19"
 
-"@guardian/consent-management-platform@^6.11.1":
-  version "6.11.1"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.11.1.tgz#087a95665e53e23ad5a25c07238590c1c74ba453"
-  integrity sha512-GJpjZ2fv+tg5CODhoaBVqFoh6oABqpQb4HR1Dju7ogz8zcsvBUEnATGkH0U47sq0tuzo95h1XnWXcjwb/Z2OpQ==
+"@guardian/consent-management-platform@^6.11.2":
+  version "6.11.2"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.11.2.tgz#668d0f911aff5c3bc42cb54c606b07640d18f0b8"
+  integrity sha512-tX+lZZFgn9PP8RUj14MnsYa7ikBAyTWfQJPNls4o2Q5c+o0uRVYHnlgifvspj0k1m05rFEmYjnmj7rxwpnH2Xw==
 
 "@guardian/discussion-rendering@^5.0.0":
   version "5.0.0"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Bumps CMP lib to 6.11.2

## Why?
New version throws an error when no tcfdata found to be picked up by sentry
