### PR TITLE
Increase expiry length on Deeply test

### DIFF
--- a/src/web/experiments/tests/deeply-read-test.ts
+++ b/src/web/experiments/tests/deeply-read-test.ts
@@ -3,7 +3,7 @@ import { ABTest } from '@guardian/ab-core';
 export const deeplyReadTest: ABTest = {
 	id: 'DeeplyReadTest',
 	start: '2021-01-05',
-	expiry: '2021-01-25',
+	expiry: '2021-01-29',
 	author: 'nitro-marky',
 	description:
 		'Tests an onward hypothesis by replacing the second tab in the Most Popular container with deeply read items.',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Increase Deeply Read test to the 29th.
