### PR TITLE
Identity | Sign in gate | Fix whitespace fade on sign in gate design test variant 3

### DIFF
--- a/src/web/components/SignInGate/gateDesigns/design-opt-test/SignInGateDesignOptVar3.tsx
+++ b/src/web/components/SignInGate/gateDesigns/design-opt-test/SignInGateDesignOptVar3.tsx
@@ -24,6 +24,7 @@ import {
 
 const firstParagraphOverlay = (isComment: boolean) => css`
 	${sharedFirstParagraphOverlay(isComment)}
+	margin-top: -100px;
 	height: 100px;
 `;
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Due to the change in whitespace for this test, the fade would mess up on certain articles. This corrects this by setting the correct margin to match the new whitespace height.

### Before
![chrome_RAJACPr0mJ](https://user-images.githubusercontent.com/13315440/105366463-48b80000-5bf7-11eb-97a0-3f2c9d6bb48f.png)

### After
![chrome_ia2ztpAT7a](https://user-images.githubusercontent.com/13315440/105366482-4ce41d80-5bf7-11eb-9104-abae076213e5.png)

