### PR TITLE
Adds Ipsos MORI tag to AMP

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -571,6 +571,7 @@ interface ConfigType extends CommercialConfigType {
     idUrl?: string;
     mmaUrl?: string;
     brazeApiKey?: string;
+    ipsosTag?: string;
 }
 
 interface ConfigTypeBrowser {

--- a/src/amp/components/Analytics.test.tsx
+++ b/src/amp/components/Analytics.test.tsx
@@ -19,7 +19,8 @@ describe('AnalyticsComponent', () => {
 			payload: {
 				'properties.content.title': 'article title',
 			},
-		},
+        },
+        ipsosSectionName: 'section',
 	};
 
 	beforeEach(() => {

--- a/src/amp/components/Analytics.test.tsx
+++ b/src/amp/components/Analytics.test.tsx
@@ -19,8 +19,8 @@ describe('AnalyticsComponent', () => {
 			payload: {
 				'properties.content.title': 'article title',
 			},
-        },
-        ipsosSectionName: 'section',
+		},
+		ipsosSectionName: 'section',
 	};
 
 	beforeEach(() => {

--- a/src/amp/components/Analytics.tsx
+++ b/src/amp/components/Analytics.tsx
@@ -16,8 +16,8 @@ export interface AnalyticsModel {
 		namespace: string;
 		apiKey: string;
 		payload: PermutivePayload;
-    };
-    ipsosSectionName: string;
+	};
+	ipsosSectionName: string;
 }
 
 export const Analytics: React.FC<{
@@ -34,8 +34,8 @@ export const Analytics: React.FC<{
 		beacon,
 		neilsenAPIID,
 		domain,
-        permutive,
-        ipsosSectionName,
+		permutive,
+		ipsosSectionName,
 	},
 }) => {
 	const scripts: string[] = [
@@ -102,7 +102,7 @@ export const Analytics: React.FC<{
                 }
             </script>
         </amp-analytics>`,
-        `<amp-analytics data-block-on-consent config="https://uk-script.dotmetrics.net/AmpConfig.json?dom=www.theguardian.com&tag=${ipsosSectionName}">
+		`<amp-analytics data-block-on-consent config="https://uk-script.dotmetrics.net/AmpConfig.json?dom=www.theguardian.com&tag=${ipsosSectionName}">
             <script type="application/json">
                 {
                     "enabled": "$EQUALS(\${ampGeo(ISOCountry)}, gb)"

--- a/src/amp/components/Analytics.tsx
+++ b/src/amp/components/Analytics.tsx
@@ -102,7 +102,13 @@ export const Analytics: React.FC<{
                 }
             </script>
         </amp-analytics>`,
-        `<amp-analytics data-block-on-consent config="https://uk-script.dotmetrics.net/AmpConfig.json&dom=${domain}&tag=${ipsosSectionName}"></amp-analytics>`,
+        `<amp-analytics data-block-on-consent config="https://uk-script.dotmetrics.net/AmpConfig.json?dom=www.theguardian.com&tag=${ipsosSectionName}">
+            <script type="application/json">
+                {
+                    "enabled": "$EQUALS(\${ampGeo(ISOCountry)}, gb)"
+                }
+            </script>
+        </amp-analytics>`,
 	];
 
 	// Trial implementation of MoDI tracker tag. For now only to appear on the business section on AMP

--- a/src/amp/components/Analytics.tsx
+++ b/src/amp/components/Analytics.tsx
@@ -16,7 +16,8 @@ export interface AnalyticsModel {
 		namespace: string;
 		apiKey: string;
 		payload: PermutivePayload;
-	};
+    };
+    ipsosSectionName: string;
 }
 
 export const Analytics: React.FC<{
@@ -33,7 +34,8 @@ export const Analytics: React.FC<{
 		beacon,
 		neilsenAPIID,
 		domain,
-		permutive,
+        permutive,
+        ipsosSectionName,
 	},
 }) => {
 	const scripts: string[] = [
@@ -100,6 +102,7 @@ export const Analytics: React.FC<{
                 }
             </script>
         </amp-analytics>`,
+        `<amp-analytics data-block-on-consent config="https://uk-script.dotmetrics.net/AmpConfig.json&dom=${domain}&tag=${ipsosSectionName}"></amp-analytics>`,
 	];
 
 	// Trial implementation of MoDI tracker tag. For now only to appear on the business section on AMP

--- a/src/amp/server/document.test.tsx
+++ b/src/amp/server/document.test.tsx
@@ -53,7 +53,8 @@ test('produces valid AMP doc', async () => {
 			payload: {
 				'properties.content.title': 'article title',
 			},
-		},
+        },
+        ipsosSectionName: "section",
 	};
 
 	const body = (

--- a/src/amp/server/document.test.tsx
+++ b/src/amp/server/document.test.tsx
@@ -53,8 +53,8 @@ test('produces valid AMP doc', async () => {
 			payload: {
 				'properties.content.title': 'article title',
 			},
-        },
-        ipsosSectionName: "section",
+		},
+		ipsosSectionName: 'section',
 	};
 
 	const body = (

--- a/src/amp/server/render.tsx
+++ b/src/amp/server/render.tsx
@@ -41,7 +41,8 @@ export const render = ({ body }: express.Request, res: express.Response) => {
 				namespace: 'guardian',
 				apiKey: '359ba275-5edd-4756-84f8-21a24369ce0b',
 				payload: generatePermutivePayload(config),
-			},
+            },
+            ipsosSectionName: config.ipsosTag || 'guardian',
 		};
 
 		const metadata = {

--- a/src/amp/server/render.tsx
+++ b/src/amp/server/render.tsx
@@ -41,8 +41,8 @@ export const render = ({ body }: express.Request, res: express.Response) => {
 				namespace: 'guardian',
 				apiKey: '359ba275-5edd-4756-84f8-21a24369ce0b',
 				payload: generatePermutivePayload(config),
-            },
-            ipsosSectionName: config.ipsosTag || 'guardian',
+			},
+			ipsosSectionName: config.ipsosTag || 'guardian',
 		};
 
 		const metadata = {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds Ipsos MORI analytics (i.e. dotmetrics) to AMP. We have followed their simple instructions except for 2 differences:

1. We are hardcoding `www.theguardian.com` instead of using `AMPDOC_HOST` to populate the `dom` URL parameter. I believe this will be needed because dotmetrics has been configured to understand our domain as www.theguardian.com and will not return a config for amp.theguardian.com. It shouldn't affect the tracking requests anyway.
2. I've added a geolocation restriction so the tracking is only fired in the UK.

One thing that is difficult to know is whether this will work correctly in production before release. Dotmetrics do domain matching and so it's impossible to test until served from theguardian.com. Presumably they've worked this out so that it'll work either direct to amp.theguardian.com or through the google cache, but I haven't been able to verify yet.

### Before
No Ipsos MORI analytics

### After (In the UK only)
![image](https://user-images.githubusercontent.com/8754692/105370298-5b343880-5bfb-11eb-9f16-b29268cfa09d.png)

## Why?
See #1961 for more details.
