### PR TITLE
Set up large image variant styles

### DIFF
--- a/src/web/components/Card/components/CardAge.tsx
+++ b/src/web/components/Card/components/CardAge.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css, cx } from 'emotion';
+import { css } from 'emotion';
 
 import { neutral } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
@@ -7,11 +7,10 @@ import { textSans } from '@guardian/src-foundations/typography';
 import ClockIcon from '@frontend/static/icons/clock.svg';
 
 import { makeRelativeDate } from '@root/src/web/lib/dateTime';
-import { decidePillarLight } from '@root/src/web/lib/decidePillarLight';
 
-const ageStyles = (designType: DesignType, pillar: CAPIPillar) => css`
+const ageStyles = (designType: DesignType) => css`
 	${textSans.xsmall()};
-	color: ${designType === 'Live' ? decidePillarLight(pillar) : neutral[60]};
+	color: ${neutral[100]};
 
 	/* Provide side padding for positioning and also to keep spacing
     between any sibings (like GuardianLines) */
@@ -19,9 +18,7 @@ const ageStyles = (designType: DesignType, pillar: CAPIPillar) => css`
 	padding-right: 5px;
 
 	svg {
-		fill: ${designType === 'Live'
-			? decidePillarLight(pillar)
-			: neutral[46]};
+		fill: ${neutral[100]};
 		margin-bottom: -1px;
 		height: 11px;
 		width: 11px;
@@ -35,33 +32,6 @@ const ageStyles = (designType: DesignType, pillar: CAPIPillar) => css`
 	}
 `;
 
-const colourStyles = (designType: DesignType, pillar: CAPIPillar) => {
-	switch (designType) {
-		case 'Live':
-			return css`
-				/* stylelint-disable-next-line color-no-hex */
-				color: ${decidePillarLight(pillar)};
-			`;
-		case 'Feature':
-		case 'Interview':
-		case 'Media':
-		case 'PhotoEssay':
-		case 'Analysis':
-		case 'Article':
-		case 'Review':
-		case 'Recipe':
-		case 'MatchReport':
-		case 'GuardianView':
-		case 'Quiz':
-		case 'AdvertisementFeature':
-		case 'Comment':
-		default:
-			return css`
-				color: ${neutral[60]};
-			`;
-	}
-};
-
 type Props = {
 	designType: DesignType;
 	pillar: CAPIPillar;
@@ -71,7 +41,6 @@ type Props = {
 
 export const CardAge = ({
 	designType,
-	pillar,
 	webPublicationDate,
 	showClock,
 }: Props) => {
@@ -87,12 +56,7 @@ export const CardAge = ({
 	}
 
 	return (
-		<span
-			className={cx(
-				ageStyles(designType, pillar),
-				colourStyles(designType, pillar),
-			)}
-		>
+		<span className={ageStyles(designType)}>
 			{showClock && <ClockIcon />}
 			<time dateTime={webPublicationDate}>{displayString}</time>
 		</span>

--- a/src/web/components/Card/components/CardAge.tsx
+++ b/src/web/components/Card/components/CardAge.tsx
@@ -7,16 +7,20 @@ import { textSans } from '@guardian/src-foundations/typography';
 import ClockIcon from '@frontend/static/icons/clock.svg';
 
 import { makeRelativeDate } from '@root/src/web/lib/dateTime';
+import { space } from '@guardian/src-foundations';
 
 const ageStyles = (designType: DesignType) => css`
 	${textSans.xsmall()};
 	color: ${neutral[100]};
+	min-width: 25%;
+	align-self: flex-end;
+	text-align: end;
 
 	/* Provide side padding for positioning and also to keep spacing
     between any sibings (like GuardianLines) */
-	padding-left: 5px;
-	padding-right: 5px;
-
+	padding-left: ${space[1]}px;
+	padding-right: ${space[1]}px;
+	line-height: 1.25;
 	svg {
 		fill: ${neutral[100]};
 		margin-bottom: -1px;
@@ -30,6 +34,14 @@ const ageStyles = (designType: DesignType) => css`
 			fontWeight: designType === `Media` ? `bold` : `regular`,
 		})};
 	}
+`;
+
+const ageTextStyles = css`
+	background-color: rgba(0, 0, 0, 0.75);
+	white-space: pre-wrap;
+	box-shadow: -${space[1]}px 0 0 rgba(0, 0, 0, 0.75);
+	/* Box decoration is required to push the box shadow out on Firefox */
+	box-decoration-break: clone;
 `;
 
 type Props = {
@@ -57,8 +69,10 @@ export const CardAge = ({
 
 	return (
 		<span className={ageStyles(designType)}>
-			{showClock && <ClockIcon />}
-			<time dateTime={webPublicationDate}>{displayString}</time>
+			<span className={ageTextStyles}>
+				{showClock && <ClockIcon />}
+				<time dateTime={webPublicationDate}>{displayString}</time>
+			</span>
 		</span>
 	);
 };

--- a/src/web/components/Onwards/Carousel/Carousel.tsx
+++ b/src/web/components/Onwards/Carousel/Carousel.tsx
@@ -11,9 +11,7 @@ import libDebounce from 'lodash/debounce';
 import { LeftColumn } from '@frontend/web/components/LeftColumn';
 import { formatAttrString } from '@frontend/web/lib/formatAttrString';
 import { pillarPalette } from '@root/src/lib/pillars';
-import { CardAge } from '../../Card/components/CardAge';
-import { Kicker } from '../../Kicker';
-import { headlineBackgroundColour, headlineColour } from './cardColours';
+import { CarouselCard } from './CarouselCard';
 
 const navIconStyle = css`
 	display: inline-block;
@@ -85,75 +83,6 @@ const carouselStyle = css`
 	${from.tablet} {
 		margin-left: 10px;
 	}
-`;
-
-const cardWrapperStyle = css`
-	position: relative;
-	width: 258px;
-	flex-shrink: 0;
-	margin: 0 ${space[2]}px;
-
-	scroll-snap-align: start;
-
-	:hover {
-		filter: brightness(90%);
-	}
-
-	display: flex;
-	flex-direction: column;
-	align-items: stretch;
-
-	text-decoration: none;
-
-	color: inherit;
-`;
-
-const cardWrapperFirstStyle = css`
-	${cardWrapperStyle};
-	margin-left: 0;
-`;
-
-const cardImageStyle = css`
-	width: 258px;
-`;
-
-const headlineWrapperStyle = (
-	designType: DesignType,
-	pillar: CAPIPillar,
-) => css`
-	width: 90%;
-	min-height: 107px;
-
-	margin-top: -21px;
-	${from.desktop} {
-		margin-top: -23px;
-	}
-
-	flex-grow: 1;
-
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
-
-	${headlineBackgroundColour(designType, pillar)}
-`;
-
-/* const headlineWrapperFirstStyle = css`
-    ${headlineWrapperStyle};
-    background-color: ${palette.news.dark};
-    color: white;
-`;
- */
-const headlineStyle = (designType: DesignType, pillar: CAPIPillar) => css`
-	${headline.xxxsmall()};
-	${from.desktop} {
-		${headline.xxsmall()};
-	}
-
-	${headlineColour(designType, pillar)};
-
-	display: block;
-	padding: ${space[1]}px;
 `;
 
 /* const headlineFirstStyle = css`
@@ -274,52 +203,6 @@ const interleave = <A,>(arr: A[], separator: A): A[] => {
 	return separated;
 };
 
-type CardProps = {
-	trail: TrailType;
-	isFirst?: boolean;
-};
-
-const Card: React.FC<CardProps> = ({ trail, isFirst }: CardProps) => {
-	const kickerText = trail.designType === 'Live' ? 'Live' : trail.kickerText;
-
-	return (
-		<a
-			href={trail.url}
-			className={isFirst ? cardWrapperFirstStyle : cardWrapperStyle}
-			data-link-name="article"
-		>
-			<img
-				className={cardImageStyle}
-				src={trail.image}
-				alt=""
-				role="presentation"
-			/>
-			<div
-				className={headlineWrapperStyle(trail.designType, trail.pillar)}
-			>
-				<h4 className={headlineStyle(trail.designType, trail.pillar)}>
-					{kickerText && (
-						<Kicker
-							text={kickerText}
-							designType={trail.designType}
-							pillar={trail.pillar}
-							showPulsingDot={trail.isLiveBlog}
-							inCard={true}
-						/>
-					)}
-					{trail.headline}
-				</h4>
-				<CardAge
-					webPublicationDate={trail.webPublicationDate}
-					showClock={true}
-					pillar={trail.pillar}
-					designType={trail.designType}
-				/>
-			</div>
-		</a>
-	);
-};
-
 export const Carousel: React.FC<OnwardsType> = ({
 	heading,
 	trails,
@@ -421,7 +304,7 @@ export const Carousel: React.FC<OnwardsType> = ({
 	});
 
 	const cards = trails.map((trail, i) => (
-		<Card trail={trail} isFirst={i === 0} />
+		<CarouselCard trail={trail} isFirst={i === 0} />
 	));
 
 	return (

--- a/src/web/components/Onwards/Carousel/CarouselCard.tsx
+++ b/src/web/components/Onwards/Carousel/CarouselCard.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { css, cx } from 'emotion';
+import { headline } from '@guardian/src-foundations/typography';
+import { from } from '@guardian/src-foundations/mq';
+import { space } from '@guardian/src-foundations';
+import { pillarPalette } from '@root/src/lib/pillars';
+import { neutral } from '@guardian/src-foundations/palette';
+import { CardAge } from '../../Card/components/CardAge';
+import { Kicker } from '../../Kicker';
+
+const cardWrapperStyle = (pillar: CAPIPillar) => css`
+	position: relative;
+	width: 258px;
+	flex-shrink: 0;
+	margin: 0 ${space[2]}px;
+	border-top: 4px solid ${pillarPalette[pillar].main};
+
+	scroll-snap-align: start;
+
+	:hover {
+		filter: brightness(90%);
+	}
+
+	display: flex;
+	flex-direction: column;
+	align-items: stretch;
+	justify-content: flex-end;
+
+	text-decoration: none;
+
+	color: inherit;
+`;
+
+const cardBackgroundImageStyle = (imageUrl: string | undefined) => css`
+	background: transparent url(${imageUrl}) no-repeat center / cover;
+`;
+
+const cardWrapperFirstStyle = css`
+	margin-left: 0;
+`;
+
+// const cardImageStyle = css`
+// 	width: 258px;
+// `;
+
+const headlineWrapperStyle = css`
+	width: 100%;
+	/* min-height: 107px; */
+	max-height: fit-content;
+
+	margin-top: -21px;
+	${from.desktop} {
+		margin-top: -23px;
+	}
+
+	flex-grow: 0;
+
+	display: flex;
+	flex-direction: column;
+	justify-content: flex-end;
+	background-color: rgba(0, 0, 0, 0.75);
+
+	/* {headlineBackgroundColour(designType, pillar)} */
+`;
+
+const headlineStyle = css`
+	${headline.xxxsmall()};
+
+	color: ${neutral[100]};
+
+	display: inline;
+	padding: ${space[1]}px;
+`;
+
+type CardProps = {
+	trail: TrailType;
+	isFirst?: boolean;
+};
+
+export const CarouselCard: React.FC<CardProps> = ({
+	trail,
+	isFirst,
+}: CardProps) => {
+	const kickerText = trail.designType === 'Live' ? 'Live' : trail.kickerText;
+
+	return (
+		<a
+			href={trail.url}
+			className={cx(
+				isFirst
+					? cx(cardWrapperStyle(trail.pillar), cardWrapperFirstStyle)
+					: cardWrapperStyle(trail.pillar),
+				cardBackgroundImageStyle(trail.image),
+			)}
+			data-link-name="article"
+		>
+			{/* <img
+				className={cardImageStyle}
+				src={trail.image}
+				alt=""
+				role="presentation"
+			/> */}
+			<div className={headlineWrapperStyle}>
+				<h4 className={headlineStyle}>
+					{kickerText && (
+						<Kicker
+							text={kickerText}
+							designType={trail.designType}
+							pillar={trail.pillar}
+							showPulsingDot={trail.isLiveBlog}
+							inCard={true}
+						/>
+					)}
+					{trail.headline}
+				</h4>
+				<CardAge
+					webPublicationDate={trail.webPublicationDate}
+					showClock={true}
+					pillar={trail.pillar}
+					designType={trail.designType}
+				/>
+			</div>
+		</a>
+	);
+};

--- a/src/web/components/Onwards/Carousel/CarouselCard.tsx
+++ b/src/web/components/Onwards/Carousel/CarouselCard.tsx
@@ -29,6 +29,7 @@ const cardWrapperStyle = (pillar: CAPIPillar) => css`
 	text-decoration: none;
 
 	color: inherit;
+	margin-bottom: -4px;
 `;
 
 const cardBackgroundImageStyle = (imageUrl: string | undefined) => css`
@@ -56,10 +57,10 @@ const headlineWrapperStyle = css`
 	flex-grow: 0;
 
 	display: flex;
-	flex-direction: column;
-	justify-content: flex-end;
-	background-color: rgba(0, 0, 0, 0.75);
-
+	flex-direction: row;
+	align-content: flex-end;
+	margin-left: ${space[1]}px;
+	margin-bottom: ${space[1]}px;
 	/* {headlineBackgroundColour(designType, pillar)} */
 `;
 
@@ -69,7 +70,17 @@ const headlineStyle = css`
 	color: ${neutral[100]};
 
 	display: inline;
-	padding: ${space[1]}px;
+
+	max-width: 75%;
+`;
+
+const headlineTextStyle = css`
+	background-color: rgba(0, 0, 0, 0.75);
+	box-shadow: -${space[1]}px 0 0 rgba(0, 0, 0, 0.75);
+	/* Box decoration is required to push the box shadow out on Firefox */
+	box-decoration-break: clone;
+	line-height: 1.25;
+	white-space: pre-wrap;
 `;
 
 type CardProps = {
@@ -102,16 +113,18 @@ export const CarouselCard: React.FC<CardProps> = ({
 			/> */}
 			<div className={headlineWrapperStyle}>
 				<h4 className={headlineStyle}>
-					{kickerText && (
-						<Kicker
-							text={kickerText}
-							designType={trail.designType}
-							pillar={trail.pillar}
-							showPulsingDot={trail.isLiveBlog}
-							inCard={true}
-						/>
-					)}
-					{trail.headline}
+					<span className={headlineTextStyle}>
+						{kickerText && (
+							<Kicker
+								text={kickerText}
+								designType={trail.designType}
+								pillar={trail.pillar}
+								showPulsingDot={trail.isLiveBlog}
+								inCard={true}
+							/>
+						)}
+						{trail.headline}
+					</span>
 				</h4>
 				<CardAge
 					webPublicationDate={trail.webPublicationDate}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Applies the styling for the "large image variant" in the upcoming curated content carousel test.

For design example, see [relevant Figma link](https://www.figma.com/file/j7Y1d0wXpnmoCW3j0u1dF4/DotCom---Onward-Journeys-OKR?node-id=1066%3A19998)

### Before

### After

![image](https://user-images.githubusercontent.com/9122944/105487815-9b052980-5ca8-11eb-951f-36ca56bc7e1e.png)


## Why?
