### PR TITLE
Fix typo on Chromatic config

### DIFF
--- a/src/web/components/elements/YoutubeEmbedBlockComponent.stories.tsx
+++ b/src/web/components/elements/YoutubeEmbedBlockComponent.stories.tsx
@@ -9,7 +9,7 @@ export default {
 	title: 'Components/YoutubeEmbedComponent',
 	parameters: {
 		chromatic: {
-			disabled: true,
+			disable: true,
 		},
 	},
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Replaces `disabled` with `disable`

## Why?
Because it's `disable` and, for context, we don't want to keep seeing this:

<img width="1549" alt="Screenshot 2021-01-22 at 14 31 43" src="https://user-images.githubusercontent.com/1336821/105503581-ae22f400-5cbe-11eb-9aba-05fd976ef900.png">

