### PR TITLE
⚡ AMP update pubData

### DIFF
--- a/src/amp/components/AdConsent.tsx
+++ b/src/amp/components/AdConsent.tsx
@@ -4,9 +4,11 @@ import { JsonScript } from './JsonScript';
 const sourcepointDomain = 'sourcepoint.theguardian.com';
 
 const pubData = {
+	authId: 'CLIENT_ID',
+	client_id: 'CLIENT_ID',
 	// Matches ampViewId from https://ophan.theguardian.com/amp.json
-	pageViewId: 'PAGE_VIEW_ID_64',
-	browserId: 'CLIENT_ID',
+	page_view_id: 'PAGE_VIEW_ID',
+	page_view_id_64: 'PAGE_VIEW_ID_64',
 	platform: 'amp',
 };
 
@@ -86,8 +88,8 @@ export const AdConsent: React.FC<{}> = ({}) => {
 					o={{
 						consentRequired: 'remote',
 						consentInstanceId: 'sourcepoint',
-						checkConsentHref: `https://${sourcepointDomain}/wrapper/tcfv2/v1/amp?${queryParams}`,
-						promptUISrc: `https://${sourcepointDomain}/amp/index.html?authId=CLIENT_ID`,
+						checkConsentHref: `https://${sourcepointDomain}/wrapper/tcfv2/v1/amp`,
+						promptUISrc: `https://${sourcepointDomain}/amp/index.html?${queryParams}`,
 						clientConfig,
 						geoOverride: {
 							tcfv2: {


### PR DESCRIPTION
## What does this change?

Send `pubData` as query parameters to `promptUISrc` instead of `checkConsentHref`.

Follow-up on the initial implementation in #2005.

## Why?

Sourcepoint have confirmed that they implemented the processing of `pubData` on AMP and provided some more information on how it should be formatted.

> to have the google amp expanded variables added directly to pubData, please add the following query parameters in the ‘promptUISrc’ field
> 
> ```
> ?authId=CLIENT_ID&client_id=CLIENT_ID&page_view_id=PAGE_VIEW_ID&page_view_id_64=PAGE_VIEW_ID_6
>```
>
> e.g
>
> ```
> "promptUISrc": "https://sp-cdn.sp-demo.com/amp/index.html?authId=CLIENT_ID&client_id=CLIENT_ID&page_view_id=PAGE_VIEW_ID&page_view_id_64=PAGE_VIEW_ID_64"
>```
>
> in the action data you receive from us, it should be something like:
>
> ```
>"pubData":{"clientId":"amp-9c2O3YdU56CCrprfQMjp-A","pageviewId":"4814","pageviewId64":"T0tMfC1HxahUpgoyh9p1Jw"}
>```