### PR TITLE
Only mock the date when building for Chromatic

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -19,8 +19,10 @@ import { Picture } from '@root/src/web/components/Picture';
 Lazy.disabled = isChromatic();
 Picture.disableLazyLoading = isChromatic();
 
-// Fix the date to prevent false negatives with age warnings
-MockDate.set('Sun Jan 10 2021 12:00:00 GMT+0000 (Greenwich Mean Time)');
+if (isChromatic()) {
+    // Fix the date to prevent false negatives
+    MockDate.set('Sun Jan 10 2021 12:00:00 GMT+0000 (Greenwich Mean Time)');
+}
 
 // Add base css for the site
 let css = `${getFontsCss()}${defaults}`;


### PR DESCRIPTION
## What?
Wraps the call to MockDate in a check to see if we're building the stories for Chromatic and only executes the mock in this context.

## Why?
The reason we want to mock the date is to prevent false negatives in Chromatic. But doing so has started to cause issues when running Storybook locally where we're using code that is dependant on time advancing. Because `MockDate` freezes time, functions like `setTimeout` or `setInterval` won't work as expected.
