### PR TITLE
Fewer Cases

### DIFF
--- a/docs/patterns/switch-on-display-design.md
+++ b/docs/patterns/switch-on-display-design.md
@@ -18,15 +18,6 @@ const shouldShowAvatar = (design: Design, display: Display) => {
                 case Design.Recipe:
                 case Design.Interview:
                     return true;
-                case Design.Live:
-                case Design.Media:
-                case Design.PhotoEssay:
-                case Design.Analysis:
-                case Design.Article:
-                case Design.MatchReport:
-                case Design.GuardianView:
-                case Design.Quiz:
-                case Design.Comment:
                 default:
                     return false;
             }

--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -225,17 +225,6 @@ export const ArticleHeadline = ({
 							)}
 						</>
 					);
-				case Design.Review:
-				case Design.Recipe:
-				case Design.Feature:
-				case Design.Analysis:
-				case Design.Interview:
-				case Design.Live:
-				case Design.Media:
-				case Design.PhotoEssay:
-				case Design.Article:
-				case Design.MatchReport:
-				case Design.Quiz:
 				default:
 					if (noMainMedia) {
 						return (
@@ -349,12 +338,6 @@ export const ArticleHeadline = ({
 							)}
 						</div>
 					);
-				case Design.Live:
-				case Design.Media:
-				case Design.PhotoEssay:
-				case Design.Article:
-				case Design.MatchReport:
-				case Design.Quiz:
 				default:
 					return (
 						<h1 className={standardFont}>

--- a/src/web/components/ArticleHeadlinePadding.tsx
+++ b/src/web/components/ArticleHeadlinePadding.tsx
@@ -17,22 +17,11 @@ const standardPadding = css`
 
 const determinePadding = (design: Design) => {
 	switch (design) {
-		case Design.Article:
-		case Design.Media:
-		case Design.PhotoEssay:
-		case Design.Live:
-		case Design.Recipe:
-		case Design.MatchReport:
-		case Design.GuardianView:
-		case Design.Quiz:
-		case Design.Feature:
-		case Design.Comment:
-		case Design.Analysis:
-			return standardPadding;
-
 		case Design.Review:
 		case Design.Interview:
 			return null;
+		default:
+			return standardPadding;
 	}
 };
 

--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -129,18 +129,6 @@ const metaContainer = ({
 							margin-left: 40px;
 						}
 					`;
-				case Design.Feature:
-				case Design.Review:
-				case Design.Recipe:
-				case Design.Interview:
-				case Design.Live:
-				case Design.Media:
-				case Design.Analysis:
-				case Design.Article:
-				case Design.MatchReport:
-				case Design.GuardianView:
-				case Design.Quiz:
-				case Design.Comment:
 				default:
 					return css`
 						${until.phablet} {
@@ -179,15 +167,6 @@ const shouldShowAvatar = (design: Design, display: Display) => {
 				case Design.Recipe:
 				case Design.Interview:
 					return true;
-				case Design.Live:
-				case Design.Media:
-				case Design.PhotoEssay:
-				case Design.Analysis:
-				case Design.Article:
-				case Design.MatchReport:
-				case Design.GuardianView:
-				case Design.Quiz:
-				case Design.Comment:
 				default:
 					return false;
 			}
@@ -205,17 +184,6 @@ const shouldShowContributor = (design: Design, display: Display) => {
 				case Design.Comment:
 				case Design.GuardianView:
 					return false;
-				case Design.Feature:
-				case Design.Review:
-				case Design.Live:
-				case Design.Media:
-				case Design.PhotoEssay:
-				case Design.Interview:
-				case Design.Analysis:
-				case Design.Article:
-				case Design.Recipe:
-				case Design.MatchReport:
-				case Design.Quiz:
 				default:
 					return true;
 			}

--- a/src/web/components/Byline.tsx
+++ b/src/web/components/Byline.tsx
@@ -44,19 +44,6 @@ const bylineStyles = (size: SmallHeadlineSize) => {
 
 const colourStyles = (design: Design, pillar: Theme) => {
 	switch (design) {
-		case Design.Comment:
-		case Design.Analysis:
-		case Design.Feature:
-		case Design.Interview:
-		case Design.Article:
-		case Design.Media:
-		case Design.PhotoEssay:
-		case Design.Review:
-		case Design.Live:
-		case Design.Recipe:
-		case Design.MatchReport:
-		case Design.GuardianView:
-		case Design.Quiz:
 		default:
 			return css`
 				color: ${pillarPalette[pillar].main};

--- a/src/web/components/Caption.tsx
+++ b/src/web/components/Caption.tsx
@@ -177,18 +177,6 @@ export const Caption = ({
 					{credit && displayCredit && ` ${credit}`}
 				</figcaption>
 			);
-		case Design.Article:
-		case Design.Media:
-		case Design.Live:
-		case Design.Recipe:
-		case Design.MatchReport:
-		case Design.GuardianView:
-		case Design.Quiz:
-		case Design.Feature:
-		case Design.Comment:
-		case Design.Analysis:
-		case Design.Review:
-		case Design.Interview:
 		default:
 			return (
 				<figcaption

--- a/src/web/components/Card/components/CardAge.tsx
+++ b/src/web/components/Card/components/CardAge.tsx
@@ -43,18 +43,6 @@ const colourStyles = (design: Design, pillar: Theme) => {
 				/* stylelint-disable-next-line color-no-hex */
 				color: ${decidePillarLight(pillar)};
 			`;
-		case Design.Feature:
-		case Design.Interview:
-		case Design.Media:
-		case Design.PhotoEssay:
-		case Design.Analysis:
-		case Design.Article:
-		case Design.Review:
-		case Design.Recipe:
-		case Design.MatchReport:
-		case Design.GuardianView:
-		case Design.Quiz:
-		case Design.Comment:
 		default:
 			return css`
 				color: ${neutral[60]};

--- a/src/web/components/Card/components/CardLink.tsx
+++ b/src/web/components/Card/components/CardLink.tsx
@@ -70,15 +70,6 @@ const linkStyles = (design: Design, pillar: Theme) => {
 					filter: brightness(90%);
 				}
 			`;
-		case Design.Article:
-		case Design.Review:
-		case Design.PhotoEssay:
-		case Design.Recipe:
-		case Design.MatchReport:
-		case Design.Quiz:
-		case Design.Feature:
-		case Design.Analysis:
-		case Design.Interview:
 		default:
 			return css`
 				${baseLinkStyles}

--- a/src/web/components/CardCommentCount.tsx
+++ b/src/web/components/CardCommentCount.tsx
@@ -72,18 +72,6 @@ const colourStyles = (design: Design, pillar: Theme) => {
 					fill: ${decidePillarLight(pillar)};
 				}
 			`;
-		case Design.Feature:
-		case Design.Interview:
-		case Design.Media:
-		case Design.PhotoEssay:
-		case Design.Analysis:
-		case Design.Article:
-		case Design.Review:
-		case Design.Recipe:
-		case Design.MatchReport:
-		case Design.GuardianView:
-		case Design.Quiz:
-		case Design.Comment:
 		default:
 			return css`
 				color: ${neutral[60]};

--- a/src/web/components/CardHeadline.tsx
+++ b/src/web/components/CardHeadline.tsx
@@ -79,16 +79,8 @@ const headlineStyles = (design: Design, pillar: Theme) => {
 		case Design.Media:
 		case Design.Live:
 			return colourStyles(neutral[97]);
-		case Design.Analysis:
-		case Design.PhotoEssay:
-		case Design.Article:
-		case Design.Review:
-		case Design.Recipe:
-		case Design.MatchReport:
-		case Design.GuardianView:
-		case Design.Quiz:
-		case Design.Comment:
 		default:
+			return undefined;
 	}
 };
 

--- a/src/web/components/DropCap.tsx
+++ b/src/web/components/DropCap.tsx
@@ -39,17 +39,6 @@ const outerStyles = (pillar: Theme, design: Design) => {
 					? opinion[400]
 					: pillarPalette[pillar].dark};
 			`;
-		case Design.PhotoEssay:
-		case Design.Analysis:
-		case Design.Feature:
-		case Design.Interview:
-		case Design.Article:
-		case Design.Media:
-		case Design.Review:
-		case Design.Live:
-		case Design.Recipe:
-		case Design.MatchReport:
-		case Design.Quiz:
 		default:
 			return css`
 				${baseStyles};
@@ -75,17 +64,6 @@ const innerStyles = (design: Design) => {
 				${baseStyles};
 				font-weight: 200;
 			`;
-		case Design.Analysis:
-		case Design.Feature:
-		case Design.Interview:
-		case Design.Article:
-		case Design.Media:
-		case Design.PhotoEssay:
-		case Design.Review:
-		case Design.Live:
-		case Design.Recipe:
-		case Design.MatchReport:
-		case Design.Quiz:
 		default:
 			return css`
 				${baseStyles};

--- a/src/web/components/HeadlineByline.tsx
+++ b/src/web/components/HeadlineByline.tsx
@@ -107,17 +107,6 @@ export const HeadlineByline = ({
 							<BylineLink byline={byline} tags={tags} />
 						</div>
 					);
-				case Design.Interview:
-				case Design.Analysis:
-				case Design.Feature:
-				case Design.Article:
-				case Design.Media:
-				case Design.PhotoEssay:
-				case Design.Review:
-				case Design.Live:
-				case Design.Recipe:
-				case Design.MatchReport:
-				case Design.Quiz:
 				default:
 					if (byline) {
 						return (
@@ -159,17 +148,6 @@ export const HeadlineByline = ({
 							<BylineLink byline={byline} tags={tags} />
 						</div>
 					);
-
-				case Design.Analysis:
-				case Design.Feature:
-				case Design.Article:
-				case Design.Media:
-				case Design.PhotoEssay:
-				case Design.Review:
-				case Design.Live:
-				case Design.Recipe:
-				case Design.MatchReport:
-				case Design.Quiz:
 				default:
 					return null;
 			}

--- a/src/web/components/Kicker.tsx
+++ b/src/web/components/Kicker.tsx
@@ -33,17 +33,6 @@ const decideColour = (design: Design, pillar: Theme, inCard?: boolean) => {
 			return inCard && pillar === Pillar.News
 				? pillarPalette[pillar].bright
 				: pillarPalette[pillar].main;
-		case Design.Feature:
-		case Design.PhotoEssay:
-		case Design.Interview:
-		case Design.Analysis:
-		case Design.Article:
-		case Design.Review:
-		case Design.Recipe:
-		case Design.MatchReport:
-		case Design.GuardianView:
-		case Design.Quiz:
-		case Design.Comment:
 		default:
 			return pillarPalette[pillar].main;
 	}

--- a/src/web/components/Onwards/Carousel/cardColours.tsx
+++ b/src/web/components/Onwards/Carousel/cardColours.tsx
@@ -18,15 +18,6 @@ export const headlineBackgroundColour = (design: Design, pillar: Theme) => {
 			return css`
 				background-color: ${pillarPalette[pillar].dark};
 			`;
-		case Design.Article:
-		case Design.Review:
-		case Design.PhotoEssay:
-		case Design.Recipe:
-		case Design.MatchReport:
-		case Design.Quiz:
-		case Design.Feature:
-		case Design.Analysis:
-		case Design.Interview:
 		default:
 			return css`
 				background-color: ${neutral[97]};
@@ -46,15 +37,7 @@ export const headlineColour = (design: Design, pillar: Theme) => {
 		case Design.Media:
 		case Design.Live:
 			return colourStyles(neutral[97]);
-		case Design.Analysis:
-		case Design.PhotoEssay:
-		case Design.Article:
-		case Design.Review:
-		case Design.Recipe:
-		case Design.MatchReport:
-		case Design.GuardianView:
-		case Design.Quiz:
-		case Design.Comment:
 		default:
+			return undefined;
 	}
 };

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -189,17 +189,6 @@ export const SeriesSectionLink = ({
 						</div>
 					);
 				}
-				case Design.Feature:
-				case Design.Review:
-				case Design.Interview:
-				case Design.Live:
-				case Design.Media:
-				case Design.PhotoEssay:
-				case Design.Analysis:
-				case Design.Article:
-				case Design.Recipe:
-				case Design.MatchReport:
-				case Design.Quiz:
 				default: {
 					if (hasSeriesTag) {
 						if (!tag) return null; // Just to keep ts happy
@@ -226,80 +215,63 @@ export const SeriesSectionLink = ({
 		case Display.Showcase:
 		case Display.Standard:
 		default: {
-			switch (design) {
-				case Design.Comment:
-				case Design.GuardianView:
-				case Design.Feature:
-				case Design.Review:
-				case Design.Interview:
-				case Design.Live:
-				case Design.Media:
-				case Design.PhotoEssay:
-				case Design.Analysis:
-				case Design.Article:
-				case Design.Recipe:
-				case Design.MatchReport:
-				case Design.Quiz:
-				default: {
-					if (tag) {
-						// We have a tag, we're not immersive, show both series and section titles
-						return (
-							// Sometimes the tags/titles are shown inline, sometimes stacked
-							<div className={cx(!badge && rowBelowLeftCol)}>
-								<a
-									href={`${guardianBaseURL}/${tag.id}`}
-									className={cx(
-										sectionLabelLink,
-										design === Design.MatchReport
-											? blackText
-											: pillarColours[pillar],
-										primaryStyle,
-										isSpecial && yellowBackground,
-									)}
-									data-component="series"
-									data-link-name="article series"
-								>
-									<span>{tag.title}</span>
-								</a>
-
-								<Hide when="below" breakpoint="tablet">
-									<a
-										href={`${guardianBaseURL}/${sectionUrl}`}
-										className={cx(
-											sectionLabelLink,
-											design === Design.MatchReport
-												? blackText
-												: pillarColours[pillar],
-											secondaryStyle,
-										)}
-										data-component="section"
-										data-link-name="article section"
-									>
-										<span>{sectionLabel}</span>
-									</a>
-								</Hide>
-							</div>
-						);
-					}
-					// There's no tag so fallback to section title
-					return (
+			if (tag) {
+				// We have a tag, we're not immersive, show both series and section titles
+				return (
+					// Sometimes the tags/titles are shown inline, sometimes stacked
+					<div className={cx(!badge && rowBelowLeftCol)}>
 						<a
-							href={`${guardianBaseURL}/${sectionUrl}`}
+							href={`${guardianBaseURL}/${tag.id}`}
 							className={cx(
 								sectionLabelLink,
 								design === Design.MatchReport
 									? blackText
 									: pillarColours[pillar],
 								primaryStyle,
+								isSpecial && yellowBackground,
 							)}
-							data-component="section"
-							data-link-name="article section"
+							data-component="series"
+							data-link-name="article series"
 						>
-							<span>{sectionLabel}</span>
+							<span>{tag.title}</span>
 						</a>
-					);
-				}
+
+						<Hide when="below" breakpoint="tablet">
+							<a
+								href={`${guardianBaseURL}/${sectionUrl}`}
+								className={cx(
+									sectionLabelLink,
+									design === Design.MatchReport
+										? blackText
+										: pillarColours[pillar],
+									secondaryStyle,
+								)}
+								data-component="section"
+								data-link-name="article section"
+							>
+								<span>{sectionLabel}</span>
+							</a>
+						</Hide>
+					</div>
+				);
 			}
+			// There's no tag so fallback to section title
+			return (
+				<a
+					href={`${guardianBaseURL}/${sectionUrl}`}
+					className={cx(
+						sectionLabelLink,
+						design === Design.MatchReport
+							? blackText
+							: pillarColours[pillar],
+						primaryStyle,
+					)}
+					data-component="section"
+					data-link-name="article section"
+				>
+					<span>{sectionLabel}</span>
+				</a>
+			);
 		}
 	}
 };

--- a/src/web/components/Standfirst.tsx
+++ b/src/web/components/Standfirst.tsx
@@ -55,18 +55,6 @@ const standfirstStyles = (design: Design, display: Display) => {
 						margin-bottom: ${space[3]}px;
 						line-height: 22px;
 					`;
-				case Design.Comment:
-				case Design.GuardianView:
-				case Design.Feature:
-				case Design.Recipe:
-				case Design.Review:
-				case Design.Media:
-				case Design.MatchReport:
-				case Design.Quiz:
-				case Design.Article:
-				case Design.Live:
-				case Design.Analysis:
-				case Design.Interview:
 				default:
 					return css`
 						${headline.xsmall({
@@ -98,14 +86,6 @@ const standfirstStyles = (design: Design, display: Display) => {
 						})};
 						margin-bottom: ${space[3]}px;
 					`;
-				case Design.Media:
-				case Design.PhotoEssay:
-				case Design.MatchReport:
-				case Design.Quiz:
-				case Design.Article:
-				case Design.Live:
-				case Design.Analysis:
-				case Design.Interview:
 				default:
 					return css`
 						${headline.xxxsmall({

--- a/src/web/components/elements/PullQuoteBlockComponent.tsx
+++ b/src/web/components/elements/PullQuoteBlockComponent.tsx
@@ -212,16 +212,6 @@ export const PullQuoteBlockComponent: React.FC<{
 					</footer>
 				</aside>
 			);
-		case Design.Feature:
-		case Design.Recipe:
-		case Design.Review:
-		case Design.Media:
-		case Design.MatchReport:
-		case Design.Quiz:
-		case Design.Article:
-		case Design.Live:
-		case Design.Analysis:
-		case Design.Interview:
 		default:
 			return (
 				<aside

--- a/src/web/components/elements/TextBlockComponent.tsx
+++ b/src/web/components/elements/TextBlockComponent.tsx
@@ -77,13 +77,7 @@ const shouldShowDropCap = ({
 		case Design.PhotoEssay:
 		case Design.Recipe:
 			return true;
-		case Design.Article:
-		case Design.Media:
-		case Design.Live:
-		case Design.MatchReport:
-		case Design.GuardianView:
-		case Design.Quiz:
-		case Design.Analysis:
+		default:
 			return false;
 	}
 };

--- a/src/web/layouts/DecideLayout.tsx
+++ b/src/web/layouts/DecideLayout.tsx
@@ -36,17 +36,6 @@ export const DecideLayout = ({ CAPI, NAV }: Props) => {
 							pillar={pillar}
 						/>
 					);
-				case Design.Feature:
-				case Design.Review:
-				case Design.Interview:
-				case Design.Live:
-				case Design.Media:
-				case Design.PhotoEssay:
-				case Design.Analysis:
-				case Design.Article:
-				case Design.Recipe:
-				case Design.MatchReport:
-				case Design.Quiz:
 				default:
 					return (
 						<ImmersiveLayout
@@ -72,17 +61,6 @@ export const DecideLayout = ({ CAPI, NAV }: Props) => {
 							pillar={pillar}
 						/>
 					);
-				case Design.Feature:
-				case Design.Review:
-				case Design.Interview:
-				case Design.Live:
-				case Design.Media:
-				case Design.PhotoEssay:
-				case Design.Analysis:
-				case Design.Article:
-				case Design.Recipe:
-				case Design.MatchReport:
-				case Design.Quiz:
 				default:
 					return (
 						<ShowcaseLayout
@@ -109,17 +87,6 @@ export const DecideLayout = ({ CAPI, NAV }: Props) => {
 							pillar={pillar}
 						/>
 					);
-				case Design.Feature:
-				case Design.Review:
-				case Design.Interview:
-				case Design.Live:
-				case Design.Media:
-				case Design.PhotoEssay:
-				case Design.Analysis:
-				case Design.Article:
-				case Design.Recipe:
-				case Design.MatchReport:
-				case Design.Quiz:
 				default:
 					return (
 						<StandardLayout

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -189,18 +189,6 @@ const PositionHeadline = ({
 					<div className={maxWidth}>{children}</div>
 				</div>
 			);
-		case Design.Article:
-		case Design.Media:
-		case Design.PhotoEssay:
-		case Design.Review:
-		case Design.Live:
-		case Design.Recipe:
-		case Design.MatchReport:
-		case Design.GuardianView:
-		case Design.Quiz:
-		case Design.Feature:
-		case Design.Comment:
-		case Design.Analysis:
 		default:
 			return <div className={maxWidth}>{children}</div>;
 	}

--- a/src/web/lib/layoutHelpers.ts
+++ b/src/web/lib/layoutHelpers.ts
@@ -13,17 +13,6 @@ export const decideLineEffect = (
 		case Design.Feature:
 		case Design.Recipe:
 			return 'squiggly';
-		case Design.Comment:
-		case Design.GuardianView:
-		case Design.Review:
-		case Design.Interview:
-		case Design.Live:
-		case Design.Media:
-		case Design.PhotoEssay:
-		case Design.Analysis:
-		case Design.Article:
-		case Design.MatchReport:
-		case Design.Quiz:
 		default:
 			return 'straight';
 	}


### PR DESCRIPTION
## What?
Replaces the pattern where we were explicitly declaring all possible `Design` types when switching on that type with a pattern where we only declare the cases that we actually switch on.

## Why?
Because by doing this we make it easier to add or remove `Design` types in future and also because this ensures that we always include a `default` case