### PR TITLE
Update atoms rendering 10.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "@emotion/core": "^10.0.35",
         "@guardian/ab-core": "^2.0.0",
         "@guardian/ab-react": "^2.0.1",
-        "@guardian/atoms-rendering": "^10.0.1",
+        "@guardian/atoms-rendering": "^10.0.2",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/braze-components": "^0.0.19",
         "@guardian/consent-management-platform": "^6.11.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2087,10 +2087,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
   integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
 
-"@guardian/atoms-rendering@^10.0.1":
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-10.0.1.tgz#3b10cb1610ddf9597ebedd948071969348924788"
-  integrity sha512-KwWzxLvzyk6VD42caKyJh3yek8xmGL9tUA0Dyn6O/YKcZT+WuSTWtJh/Oz5vopv4JlFtpMTAm561F06kL7t91Q==
+"@guardian/atoms-rendering@^10.0.2":
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-10.0.2.tgz#1cedc3745fb5b03d35ab8c63bf313c2286ae79b9"
+  integrity sha512-abD4XIFNJ220qkxnmqo2zVQ+1OUXl1Tjw93beVvowkcYlSpmfr3HSJIq+gxXxg2uwDfbZFaXUy3yCNlFUqBvCQ==
   dependencies:
     youtube-player "^5.5.2"
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Upate Atoms rendering to fix youtube full screen support

### Before
<img width="146" alt="Screenshot 2021-01-25 at 11 10 48" src="https://user-images.githubusercontent.com/8831403/105703439-23800600-5f05-11eb-955a-a5080d302898.png">

### After
<img width="152" alt="Screenshot 2021-01-25 at 11 10 43" src="https://user-images.githubusercontent.com/8831403/105703451-27138d00-5f05-11eb-9b2e-d4026ad1a972.png">


## Why?
Fix issue of no full screen support
