### PR TITLE
ClickToView Designs

### DIFF
--- a/src/web/components/ClickToView.tsx
+++ b/src/web/components/ClickToView.tsx
@@ -122,16 +122,17 @@ export const ClickToView = ({ children, width, height, onAccept }: Props) => {
 					<Inner>
 						<Top>
 							<Headline width={width}>
-								The colourful beak is very large
+								Allow content provided by a third party?
 							</Headline>
 							<Body width={width}>
-								Quaerat quaerat ex nihil autem consequatur.
-								Velit rerum at ad dignissimos aut excepturi
-								ratione excepturi. Quaerat ipsam natus totam et
-								aut distinctio eaque voluptatem.
+								This article includes content hosted on
+								other.com. We ask for your permission before
+								anything is loaded, as the provider may be using
+								cookies and other technologies. To view this
+								content, click &apos;Allow&apos;.
 								<Link href="https://theguardian.com">
 									{' '}
-									Quaerat ipsam
+									Learn more
 								</Link>
 							</Body>
 						</Top>
@@ -143,7 +144,7 @@ export const ClickToView = ({ children, width, height, onAccept }: Props) => {
 								iconSide="left"
 								onClick={() => handleClick()}
 							>
-								Click to view
+								Allow
 							</Button>
 						</Bottom>
 					</Inner>

--- a/src/web/components/ClickToView.tsx
+++ b/src/web/components/ClickToView.tsx
@@ -31,6 +31,7 @@ const Container = ({
 		className={css`
 			width: ${width}px;
 			height: ${height}px;
+			background: ${background.secondary};
 		`}
 	>
 		{children}
@@ -40,7 +41,7 @@ const Container = ({
 const Outer = ({ children }: { children: React.ReactNode }) => (
 	<div
 		className={css`
-			background: ${background.primary};
+			background: ${background.secondary};
 			border: 1px solid ${border.primary};
 			height: 100%;
 		`}

--- a/src/web/components/ClickToView.tsx
+++ b/src/web/components/ClickToView.tsx
@@ -125,11 +125,16 @@ export const ClickToView = ({ children, width, height, onAccept }: Props) => {
 								Allow content provided by a third party?
 							</Headline>
 							<Body width={width}>
-								This article includes content hosted on
-								other.com. We ask for your permission before
-								anything is loaded, as the provider may be using
-								cookies and other technologies. To view this
-								content, click &apos;Allow&apos;.
+								<p>
+									This article includes content hosted on
+									other.com. We ask for your permission before
+									anything is loaded, as the provider may be
+									using cookies and other technologies.
+								</p>
+								<p>
+									To view this content, click
+									&apos;Allow&apos;.
+								</p>
 								<Link href="https://theguardian.com">
 									{' '}
 									Learn more

--- a/src/web/components/ClickToView.tsx
+++ b/src/web/components/ClickToView.tsx
@@ -131,8 +131,8 @@ export const ClickToView = ({ children, width, height, onAccept }: Props) => {
 									using cookies and other technologies.
 								</p>
 								<p>
-									To view this content, click
-									&apos;Allow&apos;.
+									To view this content, click &apos;Allow and
+									continue&apos;.
 								</p>
 							</Body>
 						</Top>
@@ -144,7 +144,7 @@ export const ClickToView = ({ children, width, height, onAccept }: Props) => {
 								iconSide="left"
 								onClick={() => handleClick()}
 							>
-								Allow
+								Allow and continue
 							</Button>
 						</Bottom>
 					</Inner>

--- a/src/web/components/ClickToView.tsx
+++ b/src/web/components/ClickToView.tsx
@@ -5,7 +5,6 @@ import { css } from 'emotion';
 import { border, background } from '@guardian/src-foundations/palette';
 import { headline, textSans } from '@guardian/src-foundations/typography';
 import { Button } from '@guardian/src-button';
-import { Link } from '@guardian/src-link';
 import { SvgCheckmark } from '@guardian/src-icons';
 import { space } from '@guardian/src-foundations';
 
@@ -135,10 +134,6 @@ export const ClickToView = ({ children, width, height, onAccept }: Props) => {
 									To view this content, click
 									&apos;Allow&apos;.
 								</p>
-								<Link href="https://theguardian.com">
-									{' '}
-									Learn more
-								</Link>
 							</Body>
 						</Top>
 						<Bottom>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Brings the `ClickToView` component inline with the designs by updating the copy and adding a grey background

### Before
<img width="406" alt="Screenshot 2021-01-26 at 11 00 23" src="https://user-images.githubusercontent.com/1336821/105836833-b6807500-5fc5-11eb-9c85-57c89deec470.png">


### After
<img width="406" alt="Screenshot 2021-01-26 at 11 15 49" src="https://user-images.githubusercontent.com/1336821/105838356-e7fa4000-5fc7-11eb-8bb5-81b35bdae70b.png">



