### PR TITLE
Add Firefox to Cypress

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -42,3 +42,20 @@ jobs:
                   quiet: true
                   browser: firefox
 									spec: cypress/integration/parallel-${{ matrix.group }}/*.js
+
+    cypress-edge:
+        name: Edge
+        runs-on: windows-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v1
+            - name: Cypress run
+              uses: cypress-io/github-action@v2
+              env:
+                NODE_ENV: development
+              with:
+                  start: node scripts/frontend/dev-server
+                  wait-on: 'http://localhost:3030'
+                  wait-on-timeout: 180
+                  quiet: true
+                  browser: edge

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -26,7 +26,7 @@ jobs:
         name: Cypress - Firefox
         runs-on: ubuntu-16.04
         container:
-          image: cypress/browsers:node12.16.1-chrome80-ff73
+          image: cypress/browsers:node14.15.0-chrome86-ff82
           options: --user 1001
         steps:
             - name: Checkout

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -43,19 +43,3 @@ jobs:
                   browser: firefox
 									spec: cypress/integration/parallel-${{ matrix.group }}/*.js
 
-    cypress-edge:
-        name: Edge
-        runs-on: windows-latest
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v1
-            - name: Cypress run
-              uses: cypress-io/github-action@v2
-              env:
-                NODE_ENV: development
-              with:
-                  start: node scripts/frontend/dev-server
-                  wait-on: 'http://localhost:3030'
-                  wait-on-timeout: 180
-                  quiet: true
-                  browser: edge

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -22,7 +22,7 @@ jobs:
                   quiet: true
                   browser: chrome
                   spec: cypress/integration/parallel-${{ matrix.group }}/*.js
-      cypress-firefox:
+    cypress-firefox:
         name: Cypress - Firefox
         runs-on: ubuntu-16.04
         container:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -2,7 +2,7 @@ name: cypress
 on: [push]
 jobs:
     cypress-chrome:
-        name: Cypress - Chrome
+        name: Chrome
         runs-on: ubuntu-16.04
         strategy:
           fail-fast: false
@@ -23,7 +23,7 @@ jobs:
                   browser: chrome
                   spec: cypress/integration/parallel-${{ matrix.group }}/*.js
     cypress-firefox:
-        name: Cypress - Firefox
+        name: Firefox
         runs-on: ubuntu-16.04
         container:
           image: cypress/browsers:node14.15.0-chrome86-ff82

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,8 +1,8 @@
 name: cypress
 on: [push]
 jobs:
-    cypress:
-        name: Cypress
+    cypress-chrome:
+        name: Cypress - Chrome
         runs-on: ubuntu-16.04
         strategy:
           fail-fast: false
@@ -22,3 +22,23 @@ jobs:
                   quiet: true
                   browser: chrome
                   spec: cypress/integration/parallel-${{ matrix.group }}/*.js
+      cypress-firefox:
+        name: Cypress - Firefox
+        runs-on: ubuntu-16.04
+        container:
+          image: cypress/browsers:node12.16.1-chrome80-ff73
+          options: --user 1001
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v1
+            - name: Cypress run
+              uses: cypress-io/github-action@v2
+              env:
+                NODE_ENV: development
+              with:
+                  start: node scripts/frontend/dev-server
+                  wait-on: 'http://localhost:3030'
+                  wait-on-timeout: 180
+                  quiet: true
+                  browser: firefox
+									spec: cypress/integration/parallel-${{ matrix.group }}/*.js

--- a/cypress/integration/parallel-2/article.elements.spec.js
+++ b/cypress/integration/parallel-2/article.elements.spec.js
@@ -7,7 +7,7 @@ describe('Elements', function () {
 		setLocalBaseUrl();
 	});
 
-	describe('AMP', function () {
+	describe('AMP', { browser: 'chrome' }, function () {
 		// Based on examples from this blog post about working with iframes in Cypress
 		// https://www.cypress.io/blog/2020/02/12/working-with-iframes-in-cypress/
 		const getAmpIframeBody = (iframeSelector) => {
@@ -109,7 +109,7 @@ describe('Elements', function () {
 		// 	getIframeBody().contains('View More on Instagram');
 		// });
 
-		it('should render the embed', function () {
+		it('should render the embed', { browser: 'chrome' }, function () {
 			const getIframeBody = () => {
 				return cy
 					.get('div[data-cy="embed-block"] > div > iframe')
@@ -160,20 +160,24 @@ describe('Elements', function () {
 			getIframeBody().contains('Switching parties');
 		});
 
-		it('should render the soundcloud embed', function () {
-			const getIframeBody = () => {
-				return cy
-					.get('div[data-cy="soundcloud-embed"] > iframe')
-					.its('0.contentDocument.body')
-					.should('not.be.empty')
-					.then(cy.wrap);
-			};
-			cy.visit(
-				'Article?url=https://www.theguardian.com/music/2020/jan/31/elon-musk-edm-artist-first-track-dont-doubt-ur-vibe',
-			);
+		it(
+			'should render the soundcloud embed',
+			{ browser: 'chrome' },
+			function () {
+				const getIframeBody = () => {
+					return cy
+						.get('div[data-cy="soundcloud-embed"] > iframe')
+						.its('0.contentDocument.body')
+						.should('not.be.empty')
+						.then(cy.wrap);
+				};
+				cy.visit(
+					'Article?url=https://www.theguardian.com/music/2020/jan/31/elon-musk-edm-artist-first-track-dont-doubt-ur-vibe',
+				);
 
-			getIframeBody().contains('Cookie policy');
-		});
+				getIframeBody().contains('Cookie policy');
+			},
+		);
 
 		it('should render the football embed', function () {
 			const getBody = () => {

--- a/cypress/integration/parallel-3/article.interactivity.spec.js
+++ b/cypress/integration/parallel-3/article.interactivity.spec.js
@@ -107,33 +107,47 @@ describe('Interactivity', function () {
 				cy.focused().should('have.attr', 'data-cy', 'veggie-burger');
 			});
 
-			it('should transfer focus to the sub nav when tabbing from the veggie burger without opening the menu', function () {
-				cy.viewport('iphone-x');
-				cy.visit(`/Article?url=${articleUrl}`);
-				cy.get('[data-cy=veggie-burger]').focus().tab();
-				cy.get('[data-cy=sub-nav] a').first().should('have.focus');
-			});
+			it(
+				'should transfer focus to the sub nav when tabbing from the veggie burger without opening the menu',
+				{ browser: '!firefox' },
+				function () {
+					cy.viewport('iphone-x');
+					cy.visit(`/Article?url=${articleUrl}`);
+					cy.get('[data-cy=veggie-burger]').focus().tab();
+					cy.get('[data-cy=sub-nav] a').first().should('have.focus');
+				},
+			);
 
-			it('should immediately focus on the News menu item when the menu first opens', function () {
-				cy.viewport('iphone-x');
-				cy.visit(`/Article?url=${articleUrl}`);
-				cy.get('[data-cy=veggie-burger]').click();
-				cy.get('[data-cy=column-collapse-News]').should('have.focus');
-			});
+			it(
+				'should immediately focus on the News menu item when the menu first opens',
+				{ browser: '!firefox' },
+				function () {
+					cy.viewport('iphone-x');
+					cy.visit(`/Article?url=${articleUrl}`);
+					cy.get('[data-cy=veggie-burger]').click();
+					cy.get('[data-cy=column-collapse-News]').should(
+						'have.focus',
+					);
+				},
+			);
 
-			it('should transfer focus to sub menu items when tabbing from section header', function () {
-				cy.viewport('iphone-x');
-				cy.visit(`/Article?url=${articleUrl}`);
-				cy.get('[data-cy=veggie-burger]').click();
-				cy.focused().type('{enter}').tab();
-				// get the first column (news column)
-				cy.get('[data-cy="nav-menu-columns"] li')
-					.first()
-					.within(() => {
-						// get the first element in that column
-						cy.get('ul > li > a').first().should('have.focus');
-					});
-			});
+			it(
+				'should transfer focus to sub menu items when tabbing from section header',
+				{ browser: '!firefox' },
+				function () {
+					cy.viewport('iphone-x');
+					cy.visit(`/Article?url=${articleUrl}`);
+					cy.get('[data-cy=veggie-burger]').click();
+					cy.focused().type('{enter}').tab();
+					// get the first column (news column)
+					cy.get('[data-cy="nav-menu-columns"] li')
+						.first()
+						.within(() => {
+							// get the first element in that column
+							cy.get('ul > li > a').first().should('have.focus');
+						});
+				},
+			);
 
 			it('should let reader traverse section titles using keyboard', function () {
 				cy.viewport('iphone-x');


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Allows cross browser testing in Cypress by [adding Firefox][gh-action documentation] to the Github action.

We might want to consider [parallelising the code][parallel cypress] in future to speed this up if we expect to be running many tests like this.


### Development issues
- [x] **Firefox**: Errors for soundcloud embeds. Could be related to `chromeSecurityWarning`
- [x] **Firefox**: Tabbing through page doesn't work. Could be due to Firefox support for tabbing and the way Cypress triggers this. See https://github.com/cypress-io/cypress/issues/299
- [ ] **Firefox**: Errors for feedback message in `atom.interactivity.spec.js`. Related to a bug in Timeline where we can't parse the date as a string in Firefox if the day is missing. See [atoms-rendering TimelineAtom][]. Should be passing Unix date through from Frontend



## Why?
Catch errors that are browser specific.

[gh-action documentation]: https://github.com/cypress-io/github-action#firefox
[parallel cypress]: https://docs.cypress.io/guides/guides/parallelization.html#Turning-on-parallelization
[atoms-rendering TimelineAtom]: https://github.com/guardian/atoms-rendering/blob/16b72b5e82101f30771aa823668fff632143ffa0/src/TimelineAtom.tsx#L71-L74