### PR TITLE
Fix Timeline bug in firefox

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -2,7 +2,7 @@ name: cypress
 on: [push]
 jobs:
     cypress-chrome:
-        name: Chrome
+        name: Cypress - Chrome
         runs-on: ubuntu-16.04
         strategy:
           fail-fast: false
@@ -22,11 +22,11 @@ jobs:
                   quiet: true
                   browser: chrome
                   spec: cypress/integration/parallel-${{ matrix.group }}/*.js
-    cypress-firefox:
-        name: Firefox
+      cypress-firefox:
+        name: Cypress - Firefox
         runs-on: ubuntu-16.04
         container:
-          image: cypress/browsers:node14.15.0-chrome86-ff82
+          image: cypress/browsers:node12.16.1-chrome80-ff73
           options: --user 1001
         steps:
             - name: Checkout

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -42,21 +42,3 @@ jobs:
                   quiet: true
                   browser: firefox
 									spec: cypress/integration/parallel-${{ matrix.group }}/*.js
-
-
-    cypress-edge:
-        name: Edge
-        runs-on: windows-latest
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v1
-            - name: Cypress run
-              uses: cypress-io/github-action@v2
-              env:
-                NODE_ENV: development
-              with:
-                  start: node scripts/frontend/dev-server
-                  wait-on: 'http://localhost:3030'
-                  wait-on-timeout: 180
-                  quiet: true
-                  browser: edge

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -43,3 +43,20 @@ jobs:
                   browser: firefox
 									spec: cypress/integration/parallel-${{ matrix.group }}/*.js
 
+
+    cypress-edge:
+        name: Edge
+        runs-on: windows-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v1
+            - name: Cypress run
+              uses: cypress-io/github-action@v2
+              env:
+                NODE_ENV: development
+              with:
+                  start: node scripts/frontend/dev-server
+                  wait-on: 'http://localhost:3030'
+                  wait-on-timeout: 180
+                  quiet: true
+                  browser: edge

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "@emotion/core": "^10.0.35",
         "@guardian/ab-core": "^2.0.0",
         "@guardian/ab-react": "^2.0.1",
-        "@guardian/atoms-rendering": "^11.0.0",
+        "@guardian/atoms-rendering": "^11.0.1",
         "@guardian/automat-client": "^0.2.17",
         "@guardian/braze-components": "^1.0.1",
         "@guardian/consent-management-platform": "^6.11.3",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "@emotion/core": "^10.0.35",
         "@guardian/ab-core": "^2.0.0",
         "@guardian/ab-react": "^2.0.1",
-        "@guardian/atoms-rendering": "^10.0.2",
+        "@guardian/atoms-rendering": "^11.0.0",
         "@guardian/automat-client": "^0.2.17",
         "@guardian/braze-components": "^1.0.1",
         "@guardian/consent-management-platform": "^6.11.3",

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -632,8 +632,10 @@ interface VideoAssets {
 interface TimelineEvent {
 	title: string;
 	date: string;
+	unixDate: number;
 	body?: string;
 	toDate?: string;
+	toUnixDate?: number;
 }
 
 interface Switches {

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -2366,16 +2366,23 @@
                 "date": {
                     "type": "string"
                 },
+                "unixDate": {
+                    "type": "number"
+                },
                 "body": {
                     "type": "string"
                 },
                 "toDate": {
                     "type": "string"
+                },
+                "toUnixDate": {
+                    "type": "number"
                 }
             },
             "required": [
                 "date",
-                "title"
+                "title",
+                "unixDate"
             ]
         },
         "TweetBlockElement": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2301,10 +2301,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
   integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
 
-"@guardian/atoms-rendering@^10.0.2":
-  version "10.0.2"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-10.0.2.tgz#1cedc3745fb5b03d35ab8c63bf313c2286ae79b9"
-  integrity sha512-abD4XIFNJ220qkxnmqo2zVQ+1OUXl1Tjw93beVvowkcYlSpmfr3HSJIq+gxXxg2uwDfbZFaXUy3yCNlFUqBvCQ==
+"@guardian/atoms-rendering@^11.0.0":
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-11.0.0.tgz#f7e37f7ee1beb123659ff23a45529e7674290c2a"
+  integrity sha512-cav5+vGM7VXlcV/xMqn8XXw0EedQHDwV9c/kxxImXDH29OXrM4+v7NpaypMUeZ2UA5HUufILCgS5Le3HVCFlJg==
   dependencies:
     youtube-player "^5.5.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2301,10 +2301,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
   integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
 
-"@guardian/atoms-rendering@^11.0.0":
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-11.0.0.tgz#f7e37f7ee1beb123659ff23a45529e7674290c2a"
-  integrity sha512-cav5+vGM7VXlcV/xMqn8XXw0EedQHDwV9c/kxxImXDH29OXrM4+v7NpaypMUeZ2UA5HUufILCgS5Le3HVCFlJg==
+"@guardian/atoms-rendering@^11.0.1":
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/@guardian/atoms-rendering/-/atoms-rendering-11.0.1.tgz#7133b1b89c1a19d729e5fb836d50a8a44cdeb7e0"
+  integrity sha512-4lpUC3J+BHChkhsWTJiwR0J+0tq1YKn2AEZQTWdbHVLhXjzGyzuNqBTs3BWAV9+JxUahdxhWH6g3+/x+BbK9IA==
   dependencies:
     youtube-player "^5.5.2"
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Updates DCR to use unix time in Timeline Atoms

See also: 
- https://github.com/guardian/frontend/pull/23504
- https://github.com/guardian/atoms-rendering/pull/197

## Why?
Fix bug on Firefox. See https://github.com/guardian/atoms-rendering/pull/197