### PR TITLE
ArticleTitle uses palette

### DIFF
--- a/src/web/components/ArticleTitle.stories.tsx
+++ b/src/web/components/ArticleTitle.stories.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import { css } from 'emotion';
 
 import { Display, Design, Pillar } from '@guardian/types';
+
+import { decidePalette } from '../lib/decidePalette';
+
 import { ArticleTitle } from './ArticleTitle';
 
 const Container = ({ children }: { children: React.ReactNode }) => (
@@ -59,9 +62,16 @@ export const defaultStory = () => {
 			<ArticleTitle
 				// eslint-disable-next-line react/jsx-props-no-spreading
 				{...brexitCAPI}
-				display={Display.Standard}
-				pillar={Pillar.Sport}
-				design={Design.Article}
+				format={{
+					display: Display.Standard,
+					theme: Pillar.Sport,
+					design: Design.Article,
+				}}
+				palette={decidePalette({
+					display: Display.Standard,
+					theme: Pillar.Sport,
+					design: Design.Article,
+				})}
 			/>
 		</Container>
 	);
@@ -74,9 +84,16 @@ export const beyondTheBlade = () => {
 			<ArticleTitle
 				// eslint-disable-next-line react/jsx-props-no-spreading
 				{...beyondTheBladeCAPI}
-				display={Display.Standard}
-				pillar={Pillar.News}
-				design={Design.Article}
+				format={{
+					display: Display.Standard,
+					theme: Pillar.News,
+					design: Design.Article,
+				}}
+				palette={decidePalette({
+					display: Display.Standard,
+					theme: Pillar.News,
+					design: Design.Article,
+				})}
 			/>
 		</Container>
 	);
@@ -94,9 +111,16 @@ export const immersiveComment = () => {
 			<ArticleTitle
 				// eslint-disable-next-line react/jsx-props-no-spreading
 				{...brexitCAPI}
-				display={Display.Immersive}
-				pillar={Pillar.Sport}
-				design={Design.Comment}
+				format={{
+					display: Display.Immersive,
+					theme: Pillar.Sport,
+					design: Design.Comment,
+				}}
+				palette={decidePalette({
+					display: Display.Immersive,
+					theme: Pillar.Sport,
+					design: Design.Comment,
+				})}
 			/>
 		</div>
 	);
@@ -114,9 +138,16 @@ export const immersiveCommentTag = () => {
 			<ArticleTitle
 				// eslint-disable-next-line react/jsx-props-no-spreading
 				{...CAPI}
-				display={Display.Immersive}
-				pillar={Pillar.Sport}
-				design={Design.Comment}
+				format={{
+					display: Display.Immersive,
+					theme: Pillar.Sport,
+					design: Design.Comment,
+				}}
+				palette={decidePalette({
+					display: Display.Immersive,
+					theme: Pillar.Sport,
+					design: Design.Comment,
+				})}
 				tags={[
 					{
 						id: '',
@@ -136,9 +167,16 @@ export const ImmersiveSeriesTag = () => {
 			<ArticleTitle
 				// eslint-disable-next-line react/jsx-props-no-spreading
 				{...CAPI}
-				display={Display.Immersive}
-				pillar={Pillar.Sport}
-				design={Design.Review}
+				format={{
+					display: Display.Immersive,
+					theme: Pillar.Sport,
+					design: Design.Review,
+				}}
+				palette={decidePalette({
+					display: Display.Immersive,
+					theme: Pillar.Sport,
+					design: Design.Review,
+				})}
 				tags={[
 					{
 						id: '',
@@ -159,9 +197,16 @@ export const ArticleBlogTag = () => {
 			<ArticleTitle
 				// eslint-disable-next-line react/jsx-props-no-spreading
 				{...CAPI}
-				display={Display.Standard}
-				pillar={Pillar.Sport}
-				design={Design.Article}
+				format={{
+					display: Display.Standard,
+					theme: Pillar.Sport,
+					design: Design.Article,
+				}}
+				palette={decidePalette({
+					display: Display.Standard,
+					theme: Pillar.Sport,
+					design: Design.Article,
+				})}
 				tags={[
 					{
 						id: '',
@@ -181,9 +226,16 @@ export const ArticleOpinionTag = () => {
 			<ArticleTitle
 				// eslint-disable-next-line react/jsx-props-no-spreading
 				{...CAPI}
-				display={Display.Standard}
-				pillar={Pillar.Sport}
-				design={Design.Article}
+				format={{
+					display: Display.Standard,
+					theme: Pillar.Sport,
+					design: Design.Article,
+				}}
+				palette={decidePalette({
+					display: Display.Standard,
+					theme: Pillar.Sport,
+					design: Design.Article,
+				})}
 				tags={[
 					{
 						id: '',
@@ -203,9 +255,16 @@ export const ArticleSeriesTag = () => {
 			<ArticleTitle
 				// eslint-disable-next-line react/jsx-props-no-spreading
 				{...CAPI}
-				display={Display.Standard}
-				pillar={Pillar.Sport}
-				design={Design.Article}
+				format={{
+					display: Display.Standard,
+					theme: Pillar.Sport,
+					design: Design.Article,
+				}}
+				palette={decidePalette({
+					display: Display.Standard,
+					theme: Pillar.Sport,
+					design: Design.Article,
+				})}
 				tags={[
 					{
 						id: '',
@@ -225,9 +284,16 @@ export const ArticleNoTags = () => {
 			<ArticleTitle
 				// eslint-disable-next-line react/jsx-props-no-spreading
 				{...CAPI}
-				display={Display.Standard}
-				pillar={Pillar.Culture}
-				design={Design.Article}
+				format={{
+					display: Display.Standard,
+					theme: Pillar.Culture,
+					design: Design.Article,
+				}}
+				palette={decidePalette({
+					display: Display.Standard,
+					theme: Pillar.Culture,
+					design: Design.Article,
+				})}
 			/>
 		</Container>
 	);

--- a/src/web/components/ArticleTitle.tsx
+++ b/src/web/components/ArticleTitle.tsx
@@ -7,13 +7,12 @@ import { Display, Design } from '@guardian/types';
 import { SeriesSectionLink } from './SeriesSectionLink';
 
 type Props = {
-	display: Display;
-	design: Design;
+	format: Format;
+	palette: Palette;
 	tags: TagType[];
 	sectionLabel: string;
 	sectionUrl: string;
 	guardianBaseURL: string;
-	pillar: Theme;
 	badge?: BadgeType;
 };
 
@@ -60,17 +59,16 @@ const immersiveMargins = css`
 `;
 
 export const ArticleTitle = ({
-	display,
-	design,
+	format,
+	palette,
 	tags,
 	sectionLabel,
 	sectionUrl,
 	guardianBaseURL,
-	pillar,
 	badge,
 }: Props) => (
 	<div className={cx(sectionStyles, badge && badgeContainer)}>
-		{badge && display !== Display.Immersive && (
+		{badge && format.display !== Display.Immersive && (
 			<div className={titleBadgeWrapper}>
 				<Badge imageUrl={badge.imageUrl} seriesTag={badge.seriesTag} />
 			</div>
@@ -78,19 +76,18 @@ export const ArticleTitle = ({
 		<div
 			className={cx(
 				badge && marginTop,
-				display === Display.Immersive &&
-					design !== Design.PrintShop &&
+				format.display === Display.Immersive &&
+					format.design !== Design.PrintShop &&
 					immersiveMargins,
 			)}
 		>
 			<SeriesSectionLink
-				display={display}
-				design={design}
+				format={format}
+				palette={palette}
 				tags={tags}
 				sectionLabel={sectionLabel}
 				sectionUrl={sectionUrl}
 				guardianBaseURL={guardianBaseURL}
-				pillar={pillar}
 				badge={badge}
 			/>
 		</div>

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -1,24 +1,21 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 
-import { pillarMap, pillarPalette } from '@root/src/lib/pillars';
 import { headline } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
-import { space, neutral, brandAltBackground } from '@guardian/src-foundations';
+import { space } from '@guardian/src-foundations';
 
 import { Hide } from '@frontend/web/components/Hide';
 import { Display, Design } from '@guardian/types';
 
 type Props = {
-	display: Display;
-	design: Design;
+	format: Format;
+	palette: Palette;
 	tags: TagType[];
 	sectionLabel: string;
 	sectionUrl: string;
 	guardianBaseURL: string;
-	pillar: Theme;
 	badge?: BadgeType;
-	isSpecial?: boolean;
 };
 
 const sectionLabelLink = css`
@@ -40,18 +37,6 @@ const marginBottom = css`
 	margin-bottom: 5px;
 `;
 
-const yellowBackground = css`
-	background-color: ${brandAltBackground.primary};
-	padding-left: 2px;
-`;
-
-const pillarColours = pillarMap(
-	(pillar) =>
-		css`
-			color: ${pillarPalette[pillar].main};
-		`,
-);
-
 const primaryStyle = css`
 	font-weight: 700;
 	${headline.xxxsmall({ fontWeight: 'bold' })};
@@ -62,18 +47,15 @@ const primaryStyle = css`
 	padding-right: ${space[2]}px;
 `;
 
-const invertedStyle = (pillar: Theme) => css`
+const invertedStyle = css`
 	font-weight: 700;
 	${headline.xxxsmall({ fontWeight: 'bold' })};
 	${from.leftCol} {
 		${headline.xxsmall({ fontWeight: 'bold' })};
 	}
-	color: ${neutral[100]};
-	background-color: ${pillarPalette[pillar].main};
 
 	/* Handle text wrapping onto a new line */
 	white-space: pre-wrap;
-	box-shadow: -6px 0 0 ${pillarPalette[pillar].main};
 	box-decoration-break: clone;
 	line-height: 28px;
 	${from.leftCol} {
@@ -92,17 +74,12 @@ const invertedStyle = (pillar: Theme) => css`
 	}
 `;
 
-const whiteFont = css`
+const fontStyles = css`
 	font-weight: 700;
 	${headline.xxxsmall({ fontWeight: 'bold' })};
 	${from.leftCol} {
 		${headline.xxsmall({ fontWeight: 'bold' })};
 	}
-	color: ${neutral[100]};
-`;
-
-const blackText = css`
-	color: ${neutral[0]};
 `;
 
 const secondaryStyle = css`
@@ -111,15 +88,13 @@ const secondaryStyle = css`
 `;
 
 export const SeriesSectionLink = ({
-	display,
-	design,
+	format,
+	palette,
 	tags,
 	sectionLabel,
 	sectionUrl,
 	guardianBaseURL,
-	pillar,
 	badge,
-	isSpecial,
 }: Props) => {
 	// If we have a tag, use it to show 2 section titles
 	const tag = tags.find(
@@ -131,9 +106,9 @@ export const SeriesSectionLink = ({
 
 	const hasSeriesTag = tag && tag.type === 'Series';
 
-	switch (display) {
+	switch (format.display) {
 		case Display.Immersive: {
-			switch (design) {
+			switch (format.design) {
 				case Design.Comment:
 				case Design.GuardianView: {
 					if (tag) {
@@ -146,7 +121,12 @@ export const SeriesSectionLink = ({
 									className={cx(
 										sectionLabelLink,
 										primaryStyle,
-										whiteFont,
+										fontStyles,
+										css`
+											color: ${palette.text.seriesTitle};
+											background-color: ${palette
+												.background.seriesTitle};
+										`,
 									)}
 									data-component="series"
 									data-link-name="article series"
@@ -160,7 +140,13 @@ export const SeriesSectionLink = ({
 										className={cx(
 											sectionLabelLink,
 											secondaryStyle,
-											whiteFont,
+											fontStyles,
+											css`
+												color: ${palette.text
+													.sectionTitle};
+												background-color: ${palette
+													.background.sectionTitle};
+											`,
 										)}
 										data-component="section"
 										data-link-name="article section"
@@ -179,7 +165,12 @@ export const SeriesSectionLink = ({
 								className={cx(
 									sectionLabelLink,
 									primaryStyle,
-									whiteFont,
+									fontStyles,
+									css`
+										color: ${palette.text.sectionTitle};
+										background-color: ${palette.background
+											.sectionTitle};
+									`,
 								)}
 								data-component="section"
 								data-link-name="article section"
@@ -197,8 +188,14 @@ export const SeriesSectionLink = ({
 								href={`${guardianBaseURL}/${tag.id}`}
 								className={cx(
 									sectionLabelLink,
-									pillarColours[pillar],
-									invertedStyle(pillar),
+									css`
+										color: ${palette.text.seriesTitle};
+										background-color: ${palette.background
+											.seriesTitle};
+										box-shadow: -6px 0 0
+											${palette.background.seriesTitle};
+									`,
+									invertedStyle,
 								)}
 								data-component="series"
 								data-link-name="article series"
@@ -224,11 +221,12 @@ export const SeriesSectionLink = ({
 							href={`${guardianBaseURL}/${tag.id}`}
 							className={cx(
 								sectionLabelLink,
-								design === Design.MatchReport
-									? blackText
-									: pillarColours[pillar],
+								css`
+									color: ${palette.text.seriesTitle};
+									background-color: ${palette.background
+										.seriesTitle};
+								`,
 								primaryStyle,
-								isSpecial && yellowBackground,
 							)}
 							data-component="series"
 							data-link-name="article series"
@@ -241,9 +239,11 @@ export const SeriesSectionLink = ({
 								href={`${guardianBaseURL}/${sectionUrl}`}
 								className={cx(
 									sectionLabelLink,
-									design === Design.MatchReport
-										? blackText
-										: pillarColours[pillar],
+									css`
+										color: ${palette.text.sectionTitle};
+										background-color: ${palette.background
+											.sectionTitle};
+									`,
 									secondaryStyle,
 								)}
 								data-component="section"
@@ -261,9 +261,11 @@ export const SeriesSectionLink = ({
 					href={`${guardianBaseURL}/${sectionUrl}`}
 					className={cx(
 						sectionLabelLink,
-						design === Design.MatchReport
-							? blackText
-							: pillarColours[pillar],
+						css`
+							color: ${palette.text.sectionTitle};
+							background-color: ${palette.background
+								.sectionTitle};
+						`,
 						primaryStyle,
 					)}
 					data-component="section"

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -364,13 +364,12 @@ export const CommentLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				<StandardGrid display={format.display}>
 					<GridItem area="title">
 						<ArticleTitle
-							display={format.display}
-							design={format.design}
+							format={format}
+							palette={palette}
 							tags={CAPI.tags}
 							sectionLabel={CAPI.sectionLabel}
 							sectionUrl={CAPI.sectionUrl}
 							guardianBaseURL={CAPI.guardianBaseURL}
-							pillar={format.theme}
 							badge={CAPI.badge}
 						/>
 					</GridItem>

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -343,13 +343,12 @@ export const ImmersiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 							leftContent={<LeftColCaption />}
 						>
 							<ArticleTitle
-								display={format.display}
-								design={format.design}
+								format={format}
+								palette={palette}
 								tags={CAPI.tags}
 								sectionLabel={CAPI.sectionLabel}
 								sectionUrl={CAPI.sectionUrl}
 								guardianBaseURL={CAPI.guardianBaseURL}
-								pillar={format.theme}
 								badge={CAPI.badge}
 							/>
 						</ContainerLayout>
@@ -407,13 +406,12 @@ export const ImmersiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 									`}
 								>
 									<ArticleTitle
-										display={format.display}
-										design={format.design}
+										format={format}
+										palette={palette}
 										tags={CAPI.tags}
 										sectionLabel={CAPI.sectionLabel}
 										sectionUrl={CAPI.sectionUrl}
 										guardianBaseURL={CAPI.guardianBaseURL}
-										pillar={format.theme}
 										badge={CAPI.badge}
 									/>
 								</div>

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -321,13 +321,12 @@ export const ShowcaseLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				<ShowcaseGrid>
 					<GridItem area="title">
 						<ArticleTitle
-							display={format.display}
-							design={format.design}
+							format={format}
+							palette={palette}
 							tags={CAPI.tags}
 							sectionLabel={CAPI.sectionLabel}
 							sectionUrl={CAPI.sectionUrl}
 							guardianBaseURL={CAPI.guardianBaseURL}
-							pillar={format.theme}
 							badge={CAPI.badge}
 						/>
 					</GridItem>

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -404,13 +404,12 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				<StandardGrid design={format.design} CAPI={CAPI}>
 					<GridItem area="title">
 						<ArticleTitle
-							display={format.display}
-							design={format.design}
+							format={format}
+							palette={palette}
 							tags={CAPI.tags}
 							sectionLabel={CAPI.sectionLabel}
 							sectionUrl={CAPI.sectionUrl}
 							guardianBaseURL={CAPI.guardianBaseURL}
-							pillar={format.theme}
 							badge={CAPI.badge}
 						/>
 					</GridItem>

--- a/src/web/lib/decidePalette.ts
+++ b/src/web/lib/decidePalette.ts
@@ -4,14 +4,17 @@ import { neutral, text } from '@guardian/src-foundations';
 
 import { pillarPalette } from '@root/src/lib/pillars';
 
+const WHITE = neutral[100];
+const BLACK = text.primary;
+
 const textHeadline = (format: Format): string => {
 	switch (format.display) {
 		case Display.Immersive:
 			switch (format.design) {
 				case Design.PrintShop:
-					return text.primary;
+					return BLACK;
 				default:
-					return neutral[100];
+					return WHITE;
 			}
 		case Display.Showcase:
 		case Display.Standard: {
@@ -21,20 +24,58 @@ const textHeadline = (format: Format): string => {
 				case Design.Feature:
 					return pillarPalette[format.theme].dark;
 				case Design.Interview:
-					return neutral[100];
+					return WHITE;
 				default:
-					return text.primary;
+					return BLACK;
 			}
 		}
 		default:
-			return text.primary;
+			return BLACK;
 	}
 };
+
+const textSeriesTitle = (format: Format): string => {
+	switch (format.display) {
+		case Display.Immersive:
+			return WHITE;
+		case Display.Showcase:
+		case Display.Standard:
+			switch (format.design) {
+				case Design.MatchReport:
+					return BLACK;
+				default:
+					return WHITE;
+			}
+		default:
+			return pillarPalette[format.theme].main;
+	}
+};
+
+const textSectionTitle = textSeriesTitle;
+
+const backgroundSeriesTitle = (format: Format): string => {
+	switch (format.display) {
+		case Display.Immersive:
+			return pillarPalette[format.theme].main;
+		case Display.Showcase:
+		case Display.Standard:
+		default:
+			return 'transparent';
+	}
+};
+
+const backgroundSectionTitle = backgroundSeriesTitle;
 
 export const decidePalette = (format: Format) => {
 	return {
 		text: {
 			headline: textHeadline(format),
+			seriesTitle: textSeriesTitle(format),
+			sectionTitle: textSectionTitle(format),
+		},
+		background: {
+			seriesTitle: backgroundSeriesTitle(format),
+			sectionTitle: backgroundSectionTitle(format),
 		},
 	};
 };

--- a/src/web/lib/decidePalette.ts
+++ b/src/web/lib/decidePalette.ts
@@ -44,10 +44,10 @@ const textSeriesTitle = (format: Format): string => {
 				case Design.MatchReport:
 					return BLACK;
 				default:
-					return WHITE;
+					return pillarPalette[format.theme].main;
 			}
 		default:
-			return pillarPalette[format.theme].main;
+			return BLACK;
 	}
 };
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Replaces local definition of colours with the `palette` object

## Why?
To make the code more scalable and easier to maintain.

## Why do I see these visual diffs?
By doing this work we fix some incorrect settings for things like Immersive Comment pieces. We don't have any of these so the bug was never surfaced by by simplifying the logic we fixed it by accident!