### PR TITLE
Add titlebar colouring

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,5 +16,9 @@
     },
     "files.watcherExclude": {
         "**/target": true
+    },
+    "workbench.colorCustomizations": {
+        "titleBar.activeBackground": "#648FFF",
+        "titleBar.activeForeground": "#000000"
     }
 }


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds colouring to the VS Code titlebar to aid in distinguishing between projects. Colour palette based on https://davidmathlogic.com/colorblind/#%23648FFF-%23785EF0-%23DC267F-%23FE6100-%23FFB000
### After
![image](https://user-images.githubusercontent.com/9122944/106137882-47408780-6163-11eb-8217-05b46b2352fa.png)

## Why?
Make it easier to switch VS Code windows when working across projects.