### PR TITLE
Change Onward Description link colour and add story

### DIFF
--- a/fixtures/onwards.mocks.ts
+++ b/fixtures/onwards.mocks.ts
@@ -217,7 +217,7 @@ export const withLongDescription: OnwardsType = {
 	pillar: Pillar.News,
 };
 
-export const withLongDescriptionAndLink: OnwardsType = {
+export const withLink: OnwardsType = {
 	description:
 		'<p>The long-running series in which readers answer other readers’ questions on subjects ranging from trivial flights of fancy to profound scientific and philosophical concepts</p><p><em>Please send new questions to </em><strong><a href="mailto://nq@theguardian.com">nq@theguardian.com</a></strong>.</p>',
 	heading: 'More on this story',

--- a/fixtures/onwards.mocks.ts
+++ b/fixtures/onwards.mocks.ts
@@ -216,3 +216,12 @@ export const withLongDescription: OnwardsType = {
 	ophanComponentName: 'more-on-this-story',
 	pillar: Pillar.News,
 };
+
+export const withLongDescriptionAndLink: OnwardsType = {
+	description:
+		'<p>The long-running series in which readers answer other readers’ questions on subjects ranging from trivial flights of fancy to profound scientific and philosophical concepts</p><p><em>Please send new questions to </em><strong><a href="mailto://nq@theguardian.com">nq@theguardian.com</a></strong>.</p>',
+	heading: 'More on this story',
+	trails: trails.slice(0, 8),
+	ophanComponentName: 'more-on-this-story',
+	pillar: Pillar.News,
+};

--- a/src/web/components/ContainerTitle.tsx
+++ b/src/web/components/ContainerTitle.tsx
@@ -38,7 +38,10 @@ const descriptionStyles = (fontColour?: string) => css`
 		/* Handle paragraphs in the description */
 		margin-bottom: ${space[3]}px;
 	}
-
+	a {
+		color: ${text.primary};
+		text-decoration: none;
+	}
 	${between.tablet.and.leftCol} {
 		margin-left: 10px;
 	}

--- a/src/web/components/Onwards/Onwards.stories.tsx
+++ b/src/web/components/Onwards/Onwards.stories.tsx
@@ -6,7 +6,7 @@ import { Section } from '@frontend/web/components/Section';
 import {
 	linkAndDescription,
 	withLongDescription,
-	withLongDescriptionAndLink,
+	withLink,
 	oneTrail,
 	twoTrails,
 	threeTrails,
@@ -37,12 +37,12 @@ export const withLongDescriptionStory = () => (
 );
 withLongDescriptionStory.story = { name: 'With long description' };
 
-export const withLongDescriptionAndLinkStory = () => (
+export const withLinkStory = () => (
 	<Section>
-		<OnwardsLayout {...withLongDescriptionAndLink} />
+		<OnwardsLayout {...withLink} />
 	</Section>
 );
-withLongDescriptionAndLinkStory.story = { name: 'With link' };
+withLinkStory.story = { name: 'With link' };
 
 export const oneTrailStory = () => (
 	<Section>

--- a/src/web/components/Onwards/Onwards.stories.tsx
+++ b/src/web/components/Onwards/Onwards.stories.tsx
@@ -6,6 +6,7 @@ import { Section } from '@frontend/web/components/Section';
 import {
 	linkAndDescription,
 	withLongDescription,
+	withLongDescriptionAndLink,
 	oneTrail,
 	twoTrails,
 	threeTrails,
@@ -35,6 +36,13 @@ export const withLongDescriptionStory = () => (
 	</Section>
 );
 withLongDescriptionStory.story = { name: 'With long description' };
+
+export const withLongDescriptionAndLinkStory = () => (
+	<Section>
+		<OnwardsLayout {...withLongDescriptionAndLink} />
+	</Section>
+);
+withLongDescriptionAndLinkStory.story = { name: 'With link' };
 
 export const oneTrailStory = () => (
 	<Section>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Changes the link colour in the onwards description from blue to text.primary. It also removes text decoration. 

A story has also been added for confirmation.

### Before

![Screenshot 2021-01-29 at 14 04 33](https://user-images.githubusercontent.com/35331926/106284325-0025c580-623b-11eb-96cd-b7116e57de3d.png)

### After

<img width="244" alt="Screenshot 2021-01-29 at 13 58 20" src="https://user-images.githubusercontent.com/35331926/106284340-05831000-623b-11eb-816f-ecbde70af53f.png">

## Why?
Parity