### PR TITLE
Refactor ShareIcons

### DIFF
--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -9,7 +9,7 @@ import { Counts } from '@root/src/web/components/Counts';
 import { Branding } from '@root/src/web/components/Branding';
 import { Display, Design } from '@guardian/types';
 import type { Format } from '@guardian/types';
-import { SharingIcons } from './ShareIcons';
+import { ShareIcons } from './ShareIcons';
 import { Dateline } from './Dateline';
 
 type Props = {
@@ -274,7 +274,7 @@ export const ArticleMeta = ({
 				</RowBelowLeftCol>
 				<div data-print-layout="hide" className={metaFlex}>
 					<div className={metaExtras}>
-						<SharingIcons
+						<ShareIcons
 							pageId={pageId}
 							webTitle={webTitle}
 							pillar={format.theme}

--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -6,7 +6,6 @@ import { Contributor } from '@root/src/web/components/Contributor';
 import { Avatar } from '@root/src/web/components/Avatar';
 import { Counts } from '@root/src/web/components/Counts';
 
-import { getSharingUrls } from '@root/src/lib/sharing-urls';
 import { Branding } from '@root/src/web/components/Branding';
 import { Display, Design } from '@guardian/types';
 import type { Format } from '@guardian/types';
@@ -233,7 +232,6 @@ export const ArticleMeta = ({
 	primaryDateline,
 	secondaryDateline,
 }: Props) => {
-	const sharingUrls = getSharingUrls(pageId, webTitle);
 	const bylineImageUrl = getBylineImageUrl(tags);
 	const authorName = getAuthorName(tags);
 
@@ -277,7 +275,8 @@ export const ArticleMeta = ({
 				<div data-print-layout="hide" className={metaFlex}>
 					<div className={metaExtras}>
 						<SharingIcons
-							sharingUrls={sharingUrls}
+							pageId={pageId}
+							webTitle={webTitle}
 							pillar={format.theme}
 							displayIcons={['facebook', 'twitter', 'email']}
 						/>

--- a/src/web/components/ShareIcons.stories.tsx
+++ b/src/web/components/ShareIcons.stories.tsx
@@ -1,0 +1,29 @@
+import { Pillar } from '@guardian/types';
+import React from 'react';
+
+import { ShareIcons } from './ShareIcons';
+
+export default {
+	component: ShareIcons,
+	title: 'Components/ShareIcons',
+};
+
+export const All = () => {
+	return (
+		<ShareIcons
+			pageId=""
+			webTitle=""
+			displayIcons={[
+				'facebook',
+				'email',
+				'linkedIn',
+				'messenger',
+				'pinterest',
+				'twitter',
+				'whatsApp',
+			]}
+			pillar={Pillar.News}
+		/>
+	);
+};
+All.story = { name: 'All' };

--- a/src/web/components/ShareIcons.tsx
+++ b/src/web/components/ShareIcons.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css, cx } from 'emotion';
+import { css } from 'emotion';
 
 import { border } from '@guardian/src-foundations/palette';
 import { from } from '@guardian/src-foundations/mq';
@@ -17,7 +17,7 @@ import MessengerIcon from '@frontend/static/icons/messenger.svg';
 
 import { Hide } from './Hide';
 
-const shareIconList = css`
+const ulStyles = css`
 	float: left;
 	${from.wide} {
 		flex: auto;
@@ -70,10 +70,9 @@ export const ShareIcons: React.FC<{
 	webTitle: string;
 	displayIcons: SharePlatform[];
 	pillar: Theme;
-	className?: string;
-}> = ({ pageId, webTitle, displayIcons, pillar, className }) => {
+}> = ({ pageId, webTitle, displayIcons, pillar }) => {
 	return (
-		<ul className={cx(shareIconList, [className])}>
+		<ul className={ulStyles}>
 			{displayIcons.includes('facebook') && (
 				<li className={liStyles} key="facebook">
 					<a

--- a/src/web/components/ShareIcons.tsx
+++ b/src/web/components/ShareIcons.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
 import { css, cx } from 'emotion';
+
+import { border } from '@guardian/src-foundations/palette';
+import { from } from '@guardian/src-foundations/mq';
+
+import { pillarMap, pillarPalette } from '@root/src/lib/pillars';
+import { getSharingUrls } from '@frontend/lib/sharing-urls';
+
 import TwitterIconPadded from '@frontend/static/icons/twitter-padded.svg';
 import FacebookIcon from '@frontend/static/icons/facebook.svg';
 import EmailIcon from '@frontend/static/icons/email.svg';
@@ -7,9 +14,6 @@ import LinkedInIcon from '@frontend/static/icons/linked-in.svg';
 import PinterestIcon from '@frontend/static/icons/pinterest.svg';
 import WhatsAppIcon from '@frontend/static/icons/whatsapp.svg';
 import MessengerIcon from '@frontend/static/icons/messenger.svg';
-import { border } from '@guardian/src-foundations/palette';
-import { from } from '@guardian/src-foundations/mq';
-import { pillarMap, pillarPalette } from '@root/src/lib/pillars';
 
 const pillarFill = pillarMap(
 	(pillar) =>
@@ -80,16 +84,13 @@ interface ShareListItemType {
 }
 
 export const SharingIcons: React.FC<{
-	sharingUrls: {
-		[K in SharePlatform]?: {
-			url: string;
-			userMessage: string;
-		};
-	};
+	pageId: string;
+	webTitle: string;
 	displayIcons: SharePlatform[];
 	pillar: Theme;
 	className?: string;
-}> = ({ sharingUrls, displayIcons, pillar, className }) => {
+}> = ({ pageId, webTitle, displayIcons, pillar, className }) => {
+	const sharingUrls = getSharingUrls(pageId, webTitle);
 	const icons: { [K in SharePlatform]?: React.ComponentType } = {
 		facebook: FacebookIcon,
 		twitter: TwitterIconPadded,

--- a/src/web/components/ShareIcons.tsx
+++ b/src/web/components/ShareIcons.tsx
@@ -3,9 +3,9 @@ import { css, cx } from 'emotion';
 
 import { border } from '@guardian/src-foundations/palette';
 import { from } from '@guardian/src-foundations/mq';
+import type { Theme } from '@guardian/types';
 
-import { pillarMap, pillarPalette } from '@root/src/lib/pillars';
-import { getSharingUrls } from '@frontend/lib/sharing-urls';
+import { pillarPalette } from '@root/src/lib/pillars';
 
 import TwitterIconPadded from '@frontend/static/icons/twitter-padded.svg';
 import FacebookIcon from '@frontend/static/icons/facebook.svg';
@@ -15,12 +15,7 @@ import PinterestIcon from '@frontend/static/icons/pinterest.svg';
 import WhatsAppIcon from '@frontend/static/icons/whatsapp.svg';
 import MessengerIcon from '@frontend/static/icons/messenger.svg';
 
-const pillarFill = pillarMap(
-	(pillar) =>
-		css`
-			fill: ${pillarPalette[pillar].main};
-		`,
-);
+import { Hide } from './Hide';
 
 const shareIconList = css`
 	float: left;
@@ -29,14 +24,14 @@ const shareIconList = css`
 	}
 `;
 
-const shareIconsListItem = css`
+const liStyles = css`
 	padding: 0 3px 6px 0;
 	float: left;
 	min-width: 32px;
 	cursor: pointer;
 `;
 
-const shareIcon = (colour: string) => css`
+const iconStyles = (pillar: Theme) => css`
 	border: 1px solid ${border.secondary};
 	white-space: nowrap;
 	overflow: hidden;
@@ -50,6 +45,7 @@ const shareIcon = (colour: string) => css`
 	vertical-align: middle;
 	position: relative;
 	box-sizing: content-box;
+	fill: ${pillarPalette[pillar].main};
 
 	svg {
 		height: 88%;
@@ -63,25 +59,11 @@ const shareIcon = (colour: string) => css`
 	}
 
 	:hover {
-		background-color: ${colour};
-		border-color: ${colour};
+		background-color: ${pillarPalette[pillar].main};
+		border-color: ${pillarPalette[pillar].main};
 		fill: white;
 	}
 `;
-
-const mobileOnlyShareIconsListItem = css`
-	${from.phablet} {
-		display: none;
-	}
-`;
-
-interface ShareListItemType {
-	id: SharePlatform;
-	Icon: React.ComponentType;
-	url: string;
-	userMessage: string;
-	mobileOnly: boolean;
-}
 
 export const ShareIcons: React.FC<{
 	pageId: string;
@@ -90,72 +72,119 @@ export const ShareIcons: React.FC<{
 	pillar: Theme;
 	className?: string;
 }> = ({ pageId, webTitle, displayIcons, pillar, className }) => {
-	const sharingUrls = getSharingUrls(pageId, webTitle);
-	const icons: { [K in SharePlatform]?: React.ComponentType } = {
-		facebook: FacebookIcon,
-		twitter: TwitterIconPadded,
-		email: EmailIcon,
-		linkedIn: LinkedInIcon,
-		pinterest: PinterestIcon,
-		whatsApp: WhatsAppIcon,
-		messenger: MessengerIcon,
-	};
-
-	const mobileOnlyIcons: SharePlatform[] = ['whatsApp', 'messenger'];
-
-	const shareList = displayIcons.reduce((list: ShareListItemType[], id) => {
-		const icon = icons[id];
-		const sharingUrl = sharingUrls[id];
-
-		if (icon && sharingUrl) {
-			const listItem: ShareListItemType = {
-				id,
-				Icon: icon,
-				mobileOnly: mobileOnlyIcons.includes(id),
-				...sharingUrl,
-			};
-			list.push(listItem);
-		}
-
-		return list;
-	}, []);
-
 	return (
 		<ul className={cx(shareIconList, [className])}>
-			{shareList.map((shareListItem) => {
-				const {
-					Icon,
-					id,
-					url,
-					userMessage,
-					mobileOnly,
-				} = shareListItem;
-
-				return (
-					<li
-						className={cx(shareIconsListItem, {
-							[mobileOnlyShareIconsListItem]: mobileOnly,
-						})}
-						key={`${id}Share`}
+			{displayIcons.includes('facebook') && (
+				<li className={liStyles} key="facebook">
+					<a
+						href={`https://www.facebook.com/dialog/share?app_id=202314643182694&href=https://www.theguardian.com/${pageId}&CMP=share_btn_fb`}
+						role="button"
+						aria-label="Share on Facebook"
+						target="_blank"
 					>
+						<span className={iconStyles(pillar)}>
+							<FacebookIcon />
+						</span>
+					</a>
+				</li>
+			)}
+
+			{displayIcons.includes('pinterest') && (
+				<li className={liStyles} key="pinterest">
+					<a
+						href={`http://www.pinterest.com/pin/find/?url=https://www.theguardian.com/${pageId}`}
+						role="button"
+						aria-label="Share on Pinterest"
+						target="_blank"
+					>
+						<span className={iconStyles(pillar)}>
+							<PinterestIcon />
+						</span>
+					</a>
+				</li>
+			)}
+
+			{displayIcons.includes('twitter') && (
+				<li className={liStyles} key="twitter">
+					<a
+						href={`https://twitter.com/intent/tweet?text=${webTitle.replace(
+							/Leave.EU/gi,
+							'Leave. EU',
+						)}&url=https://www.theguardian.com/&CMP=share_btn_tw`}
+						role="button"
+						aria-label="Share on Twitter"
+						target="_blank"
+					>
+						<span className={iconStyles(pillar)}>
+							<TwitterIconPadded />
+						</span>
+					</a>
+				</li>
+			)}
+
+			{displayIcons.includes('whatsApp') && (
+				<Hide when="above" breakpoint="phablet">
+					<li className={liStyles} key="whatsApp">
 						<a
-							href={url}
+							href={`whatsapp://send?text="${webTitle}" https://www.theguardian.com/${pageId}&CMP=share_btn_wa`}
 							role="button"
-							aria-label={userMessage}
+							aria-label="Share on WhatsApp"
 							target="_blank"
 						>
-							<span
-								className={cx(
-									shareIcon(pillarPalette[pillar].main),
-									pillarFill[pillar],
-								)}
-							>
-								<Icon />
+							<span className={iconStyles(pillar)}>
+								<WhatsAppIcon />
 							</span>
 						</a>
 					</li>
-				);
-			})}
+				</Hide>
+			)}
+
+			{displayIcons.includes('email') && (
+				<li className={liStyles} key="email">
+					<a
+						href={`mailto:?subject=${webTitle}&body=https://www.theguardian.com/${pageId}&CMP=share_btn_link`}
+						role="button"
+						aria-label="Share via Email"
+						target="_blank"
+					>
+						<span className={iconStyles(pillar)}>
+							<EmailIcon />
+						</span>
+					</a>
+				</li>
+			)}
+
+			{displayIcons.includes('linkedIn') && (
+				<li className={liStyles} key="linkedIn">
+					<a
+						href={`http://www.linkedin.com/shareArticle?title=${webTitle}&mini=true&url=https://www.theguardian.com/${pageId}`}
+						role="button"
+						aria-label="Share on LinkedIn"
+						target="_blank"
+					>
+						<span className={iconStyles(pillar)}>
+							<LinkedInIcon />
+						</span>
+					</a>
+				</li>
+			)}
+
+			{displayIcons.includes('messenger') && (
+				<Hide when="above" breakpoint="phablet">
+					<li className={liStyles} key="messenger">
+						<a
+							href={`fb-messenger://share?link=https://www.theguardian.com/${pageId}&app_id=180444840287&CMP=share_btn_me`}
+							role="button"
+							aria-label="Share on Messanger>"
+							target="_blank"
+						>
+							<span className={iconStyles(pillar)}>
+								<MessengerIcon />
+							</span>
+						</a>
+					</li>
+				</Hide>
+			)}
 		</ul>
 	);
 };

--- a/src/web/components/ShareIcons.tsx
+++ b/src/web/components/ShareIcons.tsx
@@ -83,7 +83,7 @@ interface ShareListItemType {
 	mobileOnly: boolean;
 }
 
-export const SharingIcons: React.FC<{
+export const ShareIcons: React.FC<{
 	pageId: string;
 	webTitle: string;
 	displayIcons: SharePlatform[];

--- a/src/web/components/ShareIcons.tsx
+++ b/src/web/components/ShareIcons.tsx
@@ -88,21 +88,6 @@ export const ShareIcons: React.FC<{
 				</li>
 			)}
 
-			{displayIcons.includes('pinterest') && (
-				<li className={liStyles} key="pinterest">
-					<a
-						href={`http://www.pinterest.com/pin/find/?url=https://www.theguardian.com/${pageId}`}
-						role="button"
-						aria-label="Share on Pinterest"
-						target="_blank"
-					>
-						<span className={iconStyles(pillar)}>
-							<PinterestIcon />
-						</span>
-					</a>
-				</li>
-			)}
-
 			{displayIcons.includes('twitter') && (
 				<li className={liStyles} key="twitter">
 					<a
@@ -119,23 +104,6 @@ export const ShareIcons: React.FC<{
 						</span>
 					</a>
 				</li>
-			)}
-
-			{displayIcons.includes('whatsApp') && (
-				<Hide when="above" breakpoint="phablet">
-					<li className={liStyles} key="whatsApp">
-						<a
-							href={`whatsapp://send?text="${webTitle}" https://www.theguardian.com/${pageId}&CMP=share_btn_wa`}
-							role="button"
-							aria-label="Share on WhatsApp"
-							target="_blank"
-						>
-							<span className={iconStyles(pillar)}>
-								<WhatsAppIcon />
-							</span>
-						</a>
-					</li>
-				</Hide>
 			)}
 
 			{displayIcons.includes('email') && (
@@ -166,6 +134,38 @@ export const ShareIcons: React.FC<{
 						</span>
 					</a>
 				</li>
+			)}
+
+			{displayIcons.includes('pinterest') && (
+				<li className={liStyles} key="pinterest">
+					<a
+						href={`http://www.pinterest.com/pin/find/?url=https://www.theguardian.com/${pageId}`}
+						role="button"
+						aria-label="Share on Pinterest"
+						target="_blank"
+					>
+						<span className={iconStyles(pillar)}>
+							<PinterestIcon />
+						</span>
+					</a>
+				</li>
+			)}
+
+			{displayIcons.includes('whatsApp') && (
+				<Hide when="above" breakpoint="phablet">
+					<li className={liStyles} key="whatsApp">
+						<a
+							href={`whatsapp://send?text="${webTitle}" https://www.theguardian.com/${pageId}&CMP=share_btn_wa`}
+							role="button"
+							aria-label="Share on WhatsApp"
+							target="_blank"
+						>
+							<span className={iconStyles(pillar)}>
+								<WhatsAppIcon />
+							</span>
+						</a>
+					</li>
+				</Hide>
 			)}
 
 			{displayIcons.includes('messenger') && (

--- a/src/web/components/SubMeta.tsx
+++ b/src/web/components/SubMeta.tsx
@@ -4,7 +4,7 @@ import { css } from 'emotion';
 import { textSans } from '@guardian/src-foundations/typography';
 import { neutral } from '@guardian/src-foundations/palette';
 
-import { SharingIcons } from '@frontend/web/components/ShareIcons';
+import { ShareIcons } from '@frontend/web/components/ShareIcons';
 import { SubMetaLinksList } from '@frontend/web/components/SubMetaLinksList';
 import { SyndicationButton } from '@frontend/web/components/SyndicationButton';
 import { Badge } from '@frontend/web/components/Badge';
@@ -87,7 +87,7 @@ export const SubMeta = ({
 				/>
 			)}
 			{showBottomSocialButtons && (
-				<SharingIcons
+				<ShareIcons
 					className={subMetaSharingIcons}
 					pageId={pageId}
 					webTitle={webTitle}

--- a/src/web/components/SubMeta.tsx
+++ b/src/web/components/SubMeta.tsx
@@ -16,14 +16,6 @@ const subMetaLabel = css`
 	color: ${neutral[60]};
 `;
 
-const subMetaSharingIcons = css`
-	:after {
-		content: '';
-		display: block;
-		clear: left;
-	}
-`;
-
 const badgeWrapper = css`
 	float: right;
 	margin-top: 6px;
@@ -88,7 +80,6 @@ export const SubMeta = ({
 			)}
 			{showBottomSocialButtons && (
 				<ShareIcons
-					className={subMetaSharingIcons}
 					pageId={pageId}
 					webTitle={webTitle}
 					pillar={pillar}

--- a/src/web/components/SubMeta.tsx
+++ b/src/web/components/SubMeta.tsx
@@ -8,7 +8,6 @@ import { SharingIcons } from '@frontend/web/components/ShareIcons';
 import { SubMetaLinksList } from '@frontend/web/components/SubMetaLinksList';
 import { SyndicationButton } from '@frontend/web/components/SyndicationButton';
 import { Badge } from '@frontend/web/components/Badge';
-import { getSharingUrls } from '@frontend/lib/sharing-urls';
 import { until } from '@guardian/src-foundations/mq';
 
 const subMetaLabel = css`
@@ -60,7 +59,6 @@ export const SubMeta = ({
 }: Props) => {
 	const hasSubMetaSectionLinks = subMetaSectionLinks.length > 0;
 	const hasSubMetaKeywordLinks = subMetaKeywordLinks.length > 0;
-	const sharingUrls = getSharingUrls(pageId, webTitle);
 	return (
 		<div data-print-layout="hide" className={bottomPadding}>
 			{badge && (
@@ -91,7 +89,8 @@ export const SubMeta = ({
 			{showBottomSocialButtons && (
 				<SharingIcons
 					className={subMetaSharingIcons}
-					sharingUrls={sharingUrls}
+					pageId={pageId}
+					webTitle={webTitle}
 					pillar={pillar}
 					displayIcons={[
 						'facebook',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Moves logic out of abstracted functions using loops / reduce into a more explicit pattern where we just inline the html we need to render the share icons.

## Why?
There's nothing wrong with loops but more explicit code is easier to maintain and move around and some of the work we've been doing on atoms-rendering and special reports highlighted that a simpler style here might be more suited to our use case

### What happened to clear left?
The icons in the sub meta were using this css but it doesn't appear to have any effect and passing class names is problematic (because they are unknowns) so I've removed the `className` prop and the use of this css

```typescript
const subMetaSharingIcons = css`
	:after {
		content: '';
		display: block;
		clear: left;
	}
`;
```
