### PR TITLE
Special Icons

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -59,7 +59,8 @@ type Palette = {
 	},
 	fill: {
 		commentCount: Colour;
-	}
+		shareIcon: Colour;
+	},
 };
 
 type Edition = 'UK' | 'US' | 'INT' | 'AU';

--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -279,7 +279,7 @@ export const ArticleMeta = ({
 						<ShareIcons
 							pageId={pageId}
 							webTitle={webTitle}
-							pillar={format.theme}
+							palette={palette}
 							displayIcons={['facebook', 'twitter', 'email']}
 						/>
 					</div>

--- a/src/web/components/ShareIcons.stories.tsx
+++ b/src/web/components/ShareIcons.stories.tsx
@@ -1,5 +1,8 @@
-import { Pillar } from '@guardian/types';
 import React from 'react';
+
+import { Design, Display, Pillar } from '@guardian/types';
+
+import { decidePalette } from '../lib/decidePalette';
 
 import { ShareIcons } from './ShareIcons';
 
@@ -22,7 +25,11 @@ export const All = () => {
 				'twitter',
 				'whatsApp',
 			]}
-			pillar={Pillar.News}
+			palette={decidePalette({
+				theme: Pillar.News,
+				design: Design.Article,
+				display: Display.Standard,
+			})}
 		/>
 	);
 };

--- a/src/web/components/ShareIcons.tsx
+++ b/src/web/components/ShareIcons.tsx
@@ -3,9 +3,6 @@ import { css } from 'emotion';
 
 import { border } from '@guardian/src-foundations/palette';
 import { from } from '@guardian/src-foundations/mq';
-import type { Theme } from '@guardian/types';
-
-import { pillarPalette } from '@root/src/lib/pillars';
 
 import TwitterIconPadded from '@frontend/static/icons/twitter-padded.svg';
 import FacebookIcon from '@frontend/static/icons/facebook.svg';
@@ -31,7 +28,7 @@ const liStyles = css`
 	cursor: pointer;
 `;
 
-const iconStyles = (pillar: Theme) => css`
+const iconStyles = (palette: Palette) => css`
 	border: 1px solid ${border.secondary};
 	white-space: nowrap;
 	overflow: hidden;
@@ -45,7 +42,7 @@ const iconStyles = (pillar: Theme) => css`
 	vertical-align: middle;
 	position: relative;
 	box-sizing: content-box;
-	fill: ${pillarPalette[pillar].main};
+	fill: ${palette.fill.shareIcon};
 
 	svg {
 		height: 88%;
@@ -59,8 +56,8 @@ const iconStyles = (pillar: Theme) => css`
 	}
 
 	:hover {
-		background-color: ${pillarPalette[pillar].main};
-		border-color: ${pillarPalette[pillar].main};
+		background-color: ${palette.fill.shareIcon};
+		border-color: ${palette.fill.shareIcon};
 		fill: white;
 	}
 `;
@@ -69,8 +66,8 @@ export const ShareIcons: React.FC<{
 	pageId: string;
 	webTitle: string;
 	displayIcons: SharePlatform[];
-	pillar: Theme;
-}> = ({ pageId, webTitle, displayIcons, pillar }) => {
+	palette: Palette;
+}> = ({ pageId, webTitle, displayIcons, palette }) => {
 	return (
 		<ul className={ulStyles}>
 			{displayIcons.includes('facebook') && (
@@ -81,7 +78,7 @@ export const ShareIcons: React.FC<{
 						aria-label="Share on Facebook"
 						target="_blank"
 					>
-						<span className={iconStyles(pillar)}>
+						<span className={iconStyles(palette)}>
 							<FacebookIcon />
 						</span>
 					</a>
@@ -99,7 +96,7 @@ export const ShareIcons: React.FC<{
 						aria-label="Share on Twitter"
 						target="_blank"
 					>
-						<span className={iconStyles(pillar)}>
+						<span className={iconStyles(palette)}>
 							<TwitterIconPadded />
 						</span>
 					</a>
@@ -114,7 +111,7 @@ export const ShareIcons: React.FC<{
 						aria-label="Share via Email"
 						target="_blank"
 					>
-						<span className={iconStyles(pillar)}>
+						<span className={iconStyles(palette)}>
 							<EmailIcon />
 						</span>
 					</a>
@@ -129,7 +126,7 @@ export const ShareIcons: React.FC<{
 						aria-label="Share on LinkedIn"
 						target="_blank"
 					>
-						<span className={iconStyles(pillar)}>
+						<span className={iconStyles(palette)}>
 							<LinkedInIcon />
 						</span>
 					</a>
@@ -144,7 +141,7 @@ export const ShareIcons: React.FC<{
 						aria-label="Share on Pinterest"
 						target="_blank"
 					>
-						<span className={iconStyles(pillar)}>
+						<span className={iconStyles(palette)}>
 							<PinterestIcon />
 						</span>
 					</a>
@@ -160,7 +157,7 @@ export const ShareIcons: React.FC<{
 							aria-label="Share on WhatsApp"
 							target="_blank"
 						>
-							<span className={iconStyles(pillar)}>
+							<span className={iconStyles(palette)}>
 								<WhatsAppIcon />
 							</span>
 						</a>
@@ -177,7 +174,7 @@ export const ShareIcons: React.FC<{
 							aria-label="Share on Messanger>"
 							target="_blank"
 						>
-							<span className={iconStyles(pillar)}>
+							<span className={iconStyles(palette)}>
 								<MessengerIcon />
 							</span>
 						</a>

--- a/src/web/components/SubMeta.tsx
+++ b/src/web/components/SubMeta.tsx
@@ -30,6 +30,7 @@ const bottomPadding = css`
 
 type Props = {
 	pillar: Theme;
+	palette: Palette;
 	subMetaSectionLinks: SimpleLinkType[];
 	subMetaKeywordLinks: SimpleLinkType[];
 	pageId: string;
@@ -41,6 +42,7 @@ type Props = {
 
 export const SubMeta = ({
 	pillar,
+	palette,
 	subMetaKeywordLinks,
 	subMetaSectionLinks,
 	pageId,
@@ -82,7 +84,7 @@ export const SubMeta = ({
 				<ShareIcons
 					pageId={pageId}
 					webTitle={webTitle}
-					pillar={pillar}
+					palette={palette}
 					displayIcons={[
 						'facebook',
 						'twitter',

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -503,6 +503,7 @@ export const CommentLayout = ({ CAPI, NAV, format, palette }: Props) => {
 								/>
 								<SubMeta
 									pillar={format.theme}
+									palette={palette}
 									subMetaKeywordLinks={
 										CAPI.subMetaKeywordLinks
 									}

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -513,6 +513,7 @@ export const ImmersiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 								/>
 								<SubMeta
 									pillar={format.theme}
+									palette={palette}
 									subMetaKeywordLinks={
 										CAPI.subMetaKeywordLinks
 									}

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -436,6 +436,7 @@ export const ShowcaseLayout = ({ CAPI, NAV, format, palette }: Props) => {
 								/>
 								<SubMeta
 									pillar={format.theme}
+									palette={palette}
 									subMetaKeywordLinks={
 										CAPI.subMetaKeywordLinks
 									}

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -534,6 +534,7 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 								/>
 								<SubMeta
 									pillar={format.theme}
+									palette={palette}
 									subMetaKeywordLinks={
 										CAPI.subMetaKeywordLinks
 									}

--- a/src/web/lib/decidePalette.ts
+++ b/src/web/lib/decidePalette.ts
@@ -131,6 +131,11 @@ const fillCommentCount = (format: Format): string => {
 	return pillarPalette[format.theme].main;
 };
 
+const fillShareIcon = (format: Format): string => {
+	if (format.theme === Special.SpecialReport) return specialReport[300];
+	return pillarPalette[format.theme].main;
+};
+
 export const decidePalette = (format: Format): Palette => {
 	return {
 		text: {
@@ -148,6 +153,7 @@ export const decidePalette = (format: Format): Palette => {
 		},
 		fill: {
 			commentCount: fillCommentCount(format),
+			shareIcon: fillShareIcon(format),
 		},
 	};
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
We now use palette for colouring share icons, which means we support icons with special report styling

### Before
![Screenshot 2021-02-01 at 15 42 08](https://user-images.githubusercontent.com/1336821/106481162-0f5b7c00-64a4-11eb-9cdf-c9f4420403fa.jpg)

### After
![Screenshot 2021-02-01 at 15 26 19](https://user-images.githubusercontent.com/1336821/106481073-f652cb00-64a3-11eb-91a7-a9ce7cee9718.jpg)
