### PR TITLE
Refactor pillarPalette to support specialReport

### DIFF
--- a/src/amp/components/topMeta/PaidForBand.tsx
+++ b/src/amp/components/topMeta/PaidForBand.tsx
@@ -6,33 +6,8 @@ import { textSans } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 import LabsLogo from '@frontend/static/logos/the-guardian-labs.svg';
 import ArrowRightIcon from '@frontend/static/icons/arrow-right.svg';
-import { labs } from '@guardian/src-foundations/palette';
-
-type PillarColours = {
-	dark: string;
-	main: string;
-	bright: string;
-	pastel: string;
-	faded: string;
-	300: string;
-	400: string;
-	500: string;
-	600: string;
-	800: string;
-};
-
-const augmentedLabs: PillarColours = {
-	dark: labs[300],
-	main: labs[400],
-	bright: '#69d1ca', // bright teal
-	pastel: '', // TODO
-	faded: '#65a897', // dark teal
-	300: labs[300],
-	400: labs[400],
-	500: '#69d1ca', // bright teal
-	600: '', // TODO
-	800: '#65a897', // dark teal
-};
+import { pillarPalette } from '@root/src/lib/pillars';
+import { Special } from '@guardian/types';
 
 const headerStyle = css`
 	display: flex;
@@ -41,7 +16,7 @@ const headerStyle = css`
 	margin: 0 -10px;
 	padding: 0 10px;
 	height: 58px;
-	background-color: ${augmentedLabs.bright};
+	background-color: ${pillarPalette[Special.Labs].bright};
 
 	${from.mobileLandscape} {
 		padding: 0 20px;
@@ -71,8 +46,8 @@ const aboutButtonStyle = css`
 	margin-left: 10px;
 	padding: 10px;
 	border: 0;
-	border-left: solid 1px ${augmentedLabs.faded};
-	border-right: solid 1px ${augmentedLabs.faded};
+	border-left: solid 1px ${pillarPalette[Special.Labs].faded};
+	border-right: solid 1px ${pillarPalette[Special.Labs].faded};
 	background: transparent;
 	color: inherit;
 	cursor: pointer;
@@ -111,7 +86,7 @@ const logoStyle = css`
 
 const aStyle = css`
 	display: inline-block;
-	color: ${augmentedLabs.bright};
+	color: ${pillarPalette[Special.Labs].bright};
 	text-decoration: none;
 	margin-top: 10px;
 	&:hover {
@@ -120,7 +95,7 @@ const aStyle = css`
 `;
 
 const iconStyle = css`
-	fill: ${augmentedLabs.bright};
+	fill: ${pillarPalette[Special.Labs].bright};
 	margin: 0 0;
 	padding-right: 3px;
 	vertical-align: middle;

--- a/src/amp/components/topMeta/PaidForBand.tsx
+++ b/src/amp/components/topMeta/PaidForBand.tsx
@@ -6,7 +6,33 @@ import { textSans } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 import LabsLogo from '@frontend/static/logos/the-guardian-labs.svg';
 import ArrowRightIcon from '@frontend/static/icons/arrow-right.svg';
-import { augmentedLabs } from '@root/src/lib/pillars';
+import { labs } from '@guardian/src-foundations/palette';
+
+type PillarColours = {
+	dark: string;
+	main: string;
+	bright: string;
+	pastel: string;
+	faded: string;
+	300: string;
+	400: string;
+	500: string;
+	600: string;
+	800: string;
+};
+
+const augmentedLabs: PillarColours = {
+	dark: labs[300],
+	main: labs[400],
+	bright: '#69d1ca', // bright teal
+	pastel: '', // TODO
+	faded: '#65a897', // dark teal
+	300: labs[300],
+	400: labs[400],
+	500: '#69d1ca', // bright teal
+	600: '', // TODO
+	800: '#65a897', // dark teal
+};
 
 const headerStyle = css`
 	display: flex;

--- a/src/lib/pillars.ts
+++ b/src/lib/pillars.ts
@@ -23,6 +23,41 @@ export const pillarNames: Theme[] = [
 	Special.Labs,
 ];
 
+type PillarPalette = {
+	dark: colour;
+	main: colour;
+	bright: colour;
+	pastel: colour;
+	faded: colour;
+	300: colour;
+	400: colour;
+	500: colour;
+	600: colour;
+	800: colour;
+};
+
+type SpecialPalette = {
+	dark: colour;
+	main: colour;
+	bright: colour;
+	faded: colour;
+	300: colour;
+	400: colour;
+	500: colour;
+	800: colour;
+};
+
+type LabsPalette = {
+	dark: colour;
+	main: colour;
+	bright: colour;
+	faded: colour;
+	300: colour;
+	400: colour;
+	500: colour;
+	800: colour;
+};
+
 // pillarPalette exposes a convenience object for deciding colour
 //
 // Usage:
@@ -31,18 +66,7 @@ export const pillarNames: Theme[] = [
 // `pillarPalette[Pillar.Opinion].dark`
 export const pillarPalette: Record<
 	Theme,
-	{
-		dark: colour;
-		main: colour;
-		bright: colour;
-		pastel: colour;
-		faded: colour;
-		300: colour;
-		400: colour;
-		500: colour;
-		600: colour;
-		800: colour;
-	}
+	PillarPalette | SpecialPalette | LabsPalette
 > = {
 	[Pillar.News]: {
 		dark: news[300],
@@ -108,24 +132,20 @@ export const pillarPalette: Record<
 		dark: labs[300],
 		main: labs[400],
 		bright: '#69d1ca', // bright teal
-		pastel: '', // TODO
 		faded: '#65a897', // dark teal
 		300: labs[300],
 		400: labs[400],
 		500: '#69d1ca', // bright teal
-		600: '', // TODO
 		800: '#65a897', // dark teal
 	},
 	[Special.SpecialReport]: {
 		dark: specialReport[300],
 		main: specialReport[400],
 		bright: specialReport[500],
-		pastel: '', // TODO
 		faded: specialReport[800],
 		300: specialReport[300],
 		400: specialReport[400],
 		500: specialReport[500],
-		600: '', // TODO
 		800: specialReport[800],
 	},
 };

--- a/src/lib/pillars.ts
+++ b/src/lib/pillars.ts
@@ -23,7 +23,7 @@ export const pillarNames: Theme[] = [
 	Special.Labs,
 ];
 
-// pillarPalette exposes a convinience object for deciding colour based on pillar
+// pillarPalette exposes a convenience object for deciding colour
 //
 // Usage:
 // `pillarPalette[Pillar.Opinion][300]`

--- a/src/lib/pillars.ts
+++ b/src/lib/pillars.ts
@@ -2,51 +2,17 @@ import { Special, Pillar } from '@guardian/types';
 import type { Theme } from '@guardian/types';
 
 import {
-	news as _news,
-	opinion as _opinion,
-	sport as _sport,
-	culture as _culture,
-	lifestyle as _lifestyle,
+	news,
+	opinion,
+	sport,
+	culture,
+	lifestyle,
+	specialReport,
 	labs,
 	border,
 } from '@guardian/src-foundations/palette';
 
 type colour = string;
-
-const [news, opinion, sport, culture, lifestyle] = [
-	_news,
-	_opinion,
-	_sport,
-	_culture,
-	_lifestyle,
-].map((p) => ({
-	// maps legacy colour names to new names in Source
-	dark: p[300],
-	main: p[400],
-	bright: p[500],
-	pastel: p[600],
-	faded: p[800],
-
-	// continue to expose the new names too!
-	300: p[300],
-	400: p[400],
-	500: p[500],
-	600: p[600],
-	800: p[800],
-}));
-
-interface PillarColours {
-	dark: colour;
-	main: colour;
-	bright: colour;
-	pastel: colour;
-	faded: colour;
-	300: colour;
-	400: colour;
-	500: colour;
-	600: colour;
-	800: colour;
-}
 
 export const pillarNames: Theme[] = [
 	Pillar.News,
@@ -57,27 +23,111 @@ export const pillarNames: Theme[] = [
 	Special.Labs,
 ];
 
-export const augmentedLabs: PillarColours = {
-	dark: labs[300],
-	main: labs[400],
-	bright: '#69d1ca', // bright teal
-	pastel: '', // TODO
-	faded: '#65a897', // dark teal
-	300: labs[300],
-	400: labs[400],
-	500: '#69d1ca', // bright teal
-	600: '', // TODO
-	800: '#65a897', // dark teal
-};
-
-export const pillarPalette: Record<Theme, PillarColours> = {
-	[Pillar.News]: news,
-	[Pillar.Opinion]: opinion,
-	[Pillar.Sport]: sport,
-	[Pillar.Culture]: culture,
-	[Pillar.Lifestyle]: lifestyle,
-	[Special.Labs]: augmentedLabs,
-	[Special.SpecialReport]: news,
+// pillarPalette exposes a convinience object for deciding colour based on pillar
+//
+// Usage:
+// `pillarPalette[Pillar.Opinion][300]`
+// or
+// `pillarPalette[Pillar.Opinion].dark`
+export const pillarPalette: Record<
+	Theme,
+	{
+		dark: colour;
+		main: colour;
+		bright: colour;
+		pastel: colour;
+		faded: colour;
+		300: colour;
+		400: colour;
+		500: colour;
+		600: colour;
+		800: colour;
+	}
+> = {
+	[Pillar.News]: {
+		dark: news[300],
+		main: news[400],
+		bright: news[500],
+		pastel: news[600],
+		faded: news[800],
+		300: news[300],
+		400: news[400],
+		500: news[500],
+		600: news[600],
+		800: news[800],
+	},
+	[Pillar.Opinion]: {
+		dark: opinion[300],
+		main: opinion[400],
+		bright: opinion[500],
+		pastel: opinion[600],
+		faded: opinion[800],
+		300: opinion[300],
+		400: opinion[400],
+		500: opinion[500],
+		600: opinion[600],
+		800: opinion[800],
+	},
+	[Pillar.Sport]: {
+		dark: sport[300],
+		main: sport[400],
+		bright: sport[500],
+		pastel: sport[600],
+		faded: sport[800],
+		300: sport[300],
+		400: sport[400],
+		500: sport[500],
+		600: sport[600],
+		800: sport[800],
+	},
+	[Pillar.Culture]: {
+		dark: culture[300],
+		main: culture[400],
+		bright: culture[500],
+		pastel: culture[600],
+		faded: culture[800],
+		300: culture[300],
+		400: culture[400],
+		500: culture[500],
+		600: culture[600],
+		800: culture[800],
+	},
+	[Pillar.Lifestyle]: {
+		dark: lifestyle[300],
+		main: lifestyle[400],
+		bright: lifestyle[500],
+		pastel: lifestyle[600],
+		faded: lifestyle[800],
+		300: lifestyle[300],
+		400: lifestyle[400],
+		500: lifestyle[500],
+		600: lifestyle[600],
+		800: lifestyle[800],
+	},
+	[Special.Labs]: {
+		dark: labs[300],
+		main: labs[400],
+		bright: '#69d1ca', // bright teal
+		pastel: '', // TODO
+		faded: '#65a897', // dark teal
+		300: labs[300],
+		400: labs[400],
+		500: '#69d1ca', // bright teal
+		600: '', // TODO
+		800: '#65a897', // dark teal
+	},
+	[Special.SpecialReport]: {
+		dark: specialReport[300],
+		main: specialReport[400],
+		bright: specialReport[500],
+		pastel: '', // TODO
+		faded: specialReport[800],
+		300: specialReport[300],
+		400: specialReport[400],
+		500: specialReport[500],
+		600: '', // TODO
+		800: specialReport[800],
+	},
 };
 
 /*


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Makes `pillarPalette` a little more explicit and verbose by inlining and repeating some code

## Why?
Although this creates a larger, more repetitive piece of code, I hope that this newer pattern will be a lot easier to maintain and edit. The was already an attempt to make the original abstraction handle `labs` colours, which are different, and then, when trying to add support for `specialReport` I got stuck because the Source repo does no expose a value for the `600` key on this particular palette.

Handling this edge case inside the abstraction was confusing, with typescript making overrides difficult. Instead, by moving the abstraction back inline I was able to handle special reports being different.