### PR TITLE
Use an 'immersive' card style for Carousel test

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -405,7 +405,7 @@ interface KickerType {
 	inCard?: boolean; // True when headline is showing inside a card (used to handle coloured backgrounds)
 }
 
-type ImagePositionType = 'left' | 'top' | 'right' | 'full';
+type ImagePositionType = 'left' | 'top' | 'right';
 
 type SmallHeadlineSize = 'tiny' | 'small' | 'medium' | 'large';
 
@@ -447,7 +447,7 @@ interface CardType {
     minWidthInPixels?: number;
 }
 
-type ImageSizeType = 'small' | 'medium' | 'large' | 'jumbo' | 'immersive';
+type ImageSizeType = 'small' | 'medium' | 'large' | 'jumbo';
 type CardPercentageType = '25%' | '33%' | '50%' | '67%' | '75%' | '100%';
 
 type HeadlineLink = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -481,7 +481,7 @@ interface CardHeadlineType {
 	size?: SmallHeadlineSize;
 	byline?: string;
     showByline?: boolean;
-    isFullCardImage?: boolean; // Used for arousel AB test
+    isFullCardImage?: boolean; // Used for carousel AB test
 }
 
 type UserBadge = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -405,7 +405,7 @@ interface KickerType {
 	inCard?: boolean; // True when headline is showing inside a card (used to handle coloured backgrounds)
 }
 
-type ImagePositionType = 'left' | 'top' | 'right';
+type ImagePositionType = 'left' | 'top' | 'right' | 'full';
 
 type SmallHeadlineSize = 'tiny' | 'small' | 'medium' | 'large';
 
@@ -431,6 +431,7 @@ interface CardType {
     imageUrl?: string;
     imagePosition?: ImagePositionType;
     imageSize?: ImageSizeType; // Size is ignored when position = 'top' because in that case the image flows based on width
+    isFullCardImage?: boolean // For use in Carousel until we decide a `Display.Immersive` convention
     standfirst?: string;
     avatar?: AvatarType;
     showClock?: boolean;
@@ -446,7 +447,7 @@ interface CardType {
     minWidthInPixels?: number;
 }
 
-type ImageSizeType = 'small' | 'medium' | 'large' | 'jumbo';
+type ImageSizeType = 'small' | 'medium' | 'large' | 'jumbo' | 'immersive';
 type CardPercentageType = '25%' | '33%' | '50%' | '67%' | '75%' | '100%';
 
 type HeadlineLink = {
@@ -479,7 +480,8 @@ interface CardHeadlineType {
 	showQuotes?: boolean; // Even with design !== Comment, a piece can be opinion
 	size?: SmallHeadlineSize;
 	byline?: string;
-	showByline?: boolean;
+    showByline?: boolean;
+    isFullCardImage?: boolean; // Used for arousel AB test
 }
 
 type UserBadge = {
@@ -546,7 +548,8 @@ type OnwardsType = {
 	description?: string;
 	url?: string;
 	ophanComponentName: OphanComponentName;
-	pillar: Theme;
+    pillar: Theme;
+    isFullCardImage?: boolean
 };
 
 type OphanComponentName =

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -33,14 +33,12 @@ type CoveragesType = {
 		medium: CardPercentageType;
 		large: CardPercentageType;
 		jumbo: CardPercentageType;
-		immersive: CardPercentageType;
 	};
 	content: {
 		small: CardPercentageType;
 		medium: CardPercentageType;
 		large: CardPercentageType;
 		jumbo: CardPercentageType;
-		immersive: CardPercentageType;
 	};
 };
 
@@ -53,14 +51,12 @@ const coverages: CoveragesType = {
 		medium: '50%',
 		large: '67%',
 		jumbo: '75%',
-		immersive: '100%',
 	},
 	content: {
 		small: '75%',
 		medium: '50%',
 		large: '33%',
 		jumbo: '25%',
-		immersive: '25%',
 	},
 };
 

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'emotion';
+import { css, cx } from 'emotion';
 
 import { Design, Pillar } from '@guardian/types';
 import { brandAltBackground } from '@guardian/src-foundations/palette';
@@ -33,12 +33,14 @@ type CoveragesType = {
 		medium: CardPercentageType;
 		large: CardPercentageType;
 		jumbo: CardPercentageType;
+		immersive: CardPercentageType;
 	};
 	content: {
 		small: CardPercentageType;
 		medium: CardPercentageType;
 		large: CardPercentageType;
 		jumbo: CardPercentageType;
+		immersive: CardPercentageType;
 	};
 };
 
@@ -51,12 +53,14 @@ const coverages: CoveragesType = {
 		medium: '50%',
 		large: '67%',
 		jumbo: '75%',
+		immersive: '100%',
 	},
 	content: {
 		small: '75%',
 		medium: '50%',
 		large: '33%',
 		jumbo: '25%',
+		immersive: '25%',
 	},
 };
 
@@ -82,6 +86,12 @@ const StarRatingComponent: React.FC<{ rating: number }> = ({ rating }) => (
 	</>
 );
 
+const fullCardImageAgeStyles = css`
+	min-width: 25%;
+	align-self: flex-end;
+	text-align: end;
+`;
+
 export const Card = ({
 	linkTo,
 	format,
@@ -94,6 +104,7 @@ export const Card = ({
 	imageUrl,
 	imagePosition,
 	imageSize,
+	isFullCardImage,
 	standfirst,
 	avatar,
 	showClock,
@@ -139,6 +150,7 @@ export const Card = ({
 							<ImageWrapper
 								percentage={imageCoverage}
 								alwaysVertical={alwaysVertical}
+								isFullCardImage={isFullCardImage}
 							>
 								<img
 									src={imageUrl}
@@ -154,9 +166,14 @@ export const Card = ({
 								</>
 							</ImageWrapper>
 						)}
-						<ContentWrapper percentage={contentCoverage}>
+						<ContentWrapper
+							percentage={contentCoverage}
+							isFullCardImage={isFullCardImage}
+						>
 							<Flex>
-								<HeadlineWrapper>
+								<HeadlineWrapper
+									isFullCardImage={isFullCardImage}
+								>
 									<CardHeadline
 										headlineText={headlineText}
 										design={format.design}
@@ -178,6 +195,7 @@ export const Card = ({
 										}
 										byline={byline}
 										showByline={showByline}
+										isFullCardImage={isFullCardImage}
 									/>
 								</HeadlineWrapper>
 								<>
@@ -196,7 +214,11 @@ export const Card = ({
 									)}
 								</>
 							</Flex>
-							<div>
+							<div
+								className={cx(
+									isFullCardImage && fullCardImageAgeStyles,
+								)}
+							>
 								{standfirst && (
 									<StandfirstWrapper>
 										{standfirst}
@@ -224,9 +246,13 @@ export const Card = ({
 													webPublicationDate
 												}
 												showClock={showClock}
+												isFullCardImage={
+													isFullCardImage
+												}
 											/>
 										) : undefined
 									}
+									isFullCardImage={isFullCardImage}
 									mediaMeta={
 										format.design === Design.Media &&
 										mediaType ? (

--- a/src/web/components/Card/components/CardAge.tsx
+++ b/src/web/components/Card/components/CardAge.tsx
@@ -9,32 +9,47 @@ import ClockIcon from '@frontend/static/icons/clock.svg';
 
 import { makeRelativeDate } from '@root/src/web/lib/dateTime';
 import { decidePillarLight } from '@root/src/web/lib/decidePillarLight';
+import { space } from '@guardian/src-foundations';
+import { until } from '@guardian/src-foundations/mq';
 
-const ageStyles = (design: Design, pillar: Theme) => css`
-	${textSans.xsmall()};
-	color: ${design === Design.Live ? decidePillarLight(pillar) : neutral[60]};
+const ageStyles = (
+	design: Design,
+	pillar: Theme,
+	isFullCardImage?: boolean,
+) => {
+	// This is annoying but can't apply SVG color otherwise
+	const smallImageSvgColor =
+		design === Design.Live ? decidePillarLight(pillar) : neutral[46];
 
-	/* Provide side padding for positioning and also to keep spacing
-    between any sibings (like GuardianLines) */
-	padding-left: 5px;
-	padding-right: 5px;
-
-	svg {
-		fill: ${design === Design.Live
+	return css`
+		${textSans.xsmall()};
+		color: ${design === Design.Live
 			? decidePillarLight(pillar)
-			: neutral[46]};
-		margin-bottom: -1px;
-		height: 11px;
-		width: 11px;
-		margin-right: 2px;
-	}
+			: neutral[60]};
 
-	> time {
-		${textSans.xsmall({
-			fontWeight: design === Design.Media ? `bold` : `regular`,
-		})};
-	}
-`;
+		/* Provide side padding for positioning and also to keep spacing
+    between any sibings (like GuardianLines) */
+		padding-left: 5px;
+		padding-right: 5px;
+		${until.tablet} {
+			line-height: 1.25;
+		}
+
+		svg {
+			fill: ${isFullCardImage ? neutral[100] : smallImageSvgColor};
+			margin-bottom: -1px;
+			height: 11px;
+			width: 11px;
+			margin-right: 2px;
+		}
+
+		> time {
+			${textSans.xsmall({
+				fontWeight: design === Design.Media ? `bold` : `regular`,
+			})};
+		}
+	`;
+};
 
 const colourStyles = (design: Design, pillar: Theme) => {
 	switch (design) {
@@ -50,11 +65,24 @@ const colourStyles = (design: Design, pillar: Theme) => {
 	}
 };
 
+const fullCardImageTextStyles = css`
+	color: ${neutral[100]};
+	background-color: rgba(0, 0, 0, 0.75);
+	box-shadow: -${space[1]}px 0 0 rgba(0, 0, 0, 0.75);
+	/* Box decoration is required to push the box shadow out on Firefox */
+	box-decoration-break: clone;
+	line-height: 1;
+	white-space: pre-wrap;
+	padding-left: ${space[1]}px;
+	padding-right: ${space[1]}px;
+`;
+
 type Props = {
 	design: Design;
 	pillar: Theme;
 	webPublicationDate: string;
 	showClock?: boolean;
+	isFullCardImage?: boolean;
 };
 
 export const CardAge = ({
@@ -62,6 +90,7 @@ export const CardAge = ({
 	pillar,
 	webPublicationDate,
 	showClock,
+	isFullCardImage,
 }: Props) => {
 	const displayString = makeRelativeDate(
 		new Date(webPublicationDate).getTime(),
@@ -77,12 +106,14 @@ export const CardAge = ({
 	return (
 		<span
 			className={cx(
-				ageStyles(design, pillar),
+				ageStyles(design, pillar, isFullCardImage),
 				colourStyles(design, pillar),
 			)}
 		>
-			{showClock && <ClockIcon />}
-			<time dateTime={webPublicationDate}>{displayString}</time>
+			<span className={cx(isFullCardImage && fullCardImageTextStyles)}>
+				{showClock && <ClockIcon />}
+				<time dateTime={webPublicationDate}>{displayString}</time>
+			</span>
 		</span>
 	);
 };

--- a/src/web/components/Card/components/CardAge.tsx
+++ b/src/web/components/Card/components/CardAge.tsx
@@ -21,11 +21,14 @@ const ageStyles = (
 	const smallImageSvgColor =
 		design === Design.Live ? decidePillarLight(pillar) : neutral[46];
 
+	const svgColor = isFullCardImage ? neutral[100] : smallImageSvgColor;
+
+	const smallImageTextColor =
+		design === Design.Live ? decidePillarLight(pillar) : neutral[60];
+
 	return css`
 		${textSans.xsmall()};
-		color: ${design === Design.Live
-			? decidePillarLight(pillar)
-			: neutral[60]};
+		color: ${smallImageTextColor};
 
 		/* Provide side padding for positioning and also to keep spacing
     between any sibings (like GuardianLines) */
@@ -36,7 +39,7 @@ const ageStyles = (
 		}
 
 		svg {
-			fill: ${isFullCardImage ? neutral[100] : smallImageSvgColor};
+			fill: ${svgColor};
 			margin-bottom: -1px;
 			height: 11px;
 			width: 11px;

--- a/src/web/components/Card/components/CardFooter.tsx
+++ b/src/web/components/Card/components/CardFooter.tsx
@@ -9,12 +9,21 @@ type Props = {
 	age?: JSX.Element;
 	mediaMeta?: JSX.Element;
 	commentCount?: JSX.Element;
+	isFullCardImage?: boolean;
 };
 
 const spaceBetween = css`
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
+`;
+
+const fullCardImageAge = css`
+	display: flex;
+	justify-content: flex-end;
+	flex-direction: column;
+	margin-bottom: -2px;
+	margin-right: -1px;
 `;
 
 const flexEnd = css`
@@ -29,7 +38,13 @@ const linesWrapperStyles = css`
 	margin-top: 5px;
 `;
 
-export const CardFooter = ({ design, age, mediaMeta, commentCount }: Props) => {
+export const CardFooter = ({
+	design,
+	age,
+	mediaMeta,
+	commentCount,
+	isFullCardImage,
+}: Props) => {
 	if (design === Design.Comment || design === Design.GuardianView) {
 		return (
 			<footer className={spaceBetween}>
@@ -54,7 +69,9 @@ export const CardFooter = ({ design, age, mediaMeta, commentCount }: Props) => {
 
 	if (age) {
 		return (
-			<footer className={spaceBetween}>
+			<footer
+				className={isFullCardImage ? fullCardImageAge : spaceBetween}
+			>
 				{age}
 				{commentCount}
 			</footer>

--- a/src/web/components/Card/components/CardFooter.tsx
+++ b/src/web/components/Card/components/CardFooter.tsx
@@ -18,7 +18,7 @@ const spaceBetween = css`
 	align-items: center;
 `;
 
-const fullCardImageAge = css`
+const fullCardImageLayout = css`
 	display: flex;
 	justify-content: flex-end;
 	flex-direction: column;
@@ -70,7 +70,7 @@ export const CardFooter = ({
 	if (age) {
 		return (
 			<footer
-				className={isFullCardImage ? fullCardImageAge : spaceBetween}
+				className={isFullCardImage ? fullCardImageLayout : spaceBetween}
 			>
 				{age}
 				{commentCount}

--- a/src/web/components/Card/components/CardLayout.tsx
+++ b/src/web/components/Card/components/CardLayout.tsx
@@ -18,8 +18,6 @@ const decideDirection = (imagePosition?: ImagePositionType) => {
 			return 'row';
 		case 'right':
 			return 'row-reverse';
-		case 'full':
-			return 'column';
 		// If there's no image (so no imagePosition) default to top down
 		default:
 			return 'column';

--- a/src/web/components/Card/components/CardLayout.tsx
+++ b/src/web/components/Card/components/CardLayout.tsx
@@ -18,6 +18,8 @@ const decideDirection = (imagePosition?: ImagePositionType) => {
 			return 'row';
 		case 'right':
 			return 'row-reverse';
+		case 'full':
+			return 'column';
 		// If there's no image (so no imagePosition) default to top down
 		default:
 			return 'column';

--- a/src/web/components/Card/components/ContentWrapper.tsx
+++ b/src/web/components/Card/components/ContentWrapper.tsx
@@ -1,12 +1,29 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 
-import { until } from '@guardian/src-foundations/mq';
+import { from, until } from '@guardian/src-foundations/mq';
+import { space } from '@guardian/src-foundations';
 
 const sizingStyles = css`
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
+`;
+
+const fullCardImageStyles = css`
+	flex-direction: row;
+	flex-grow: 0;
+	width: 100%;
+	position: absolute;
+	bottom: 0;
+	align-content: flex-end;
+	margin-left: ${space[1]}px;
+	margin-bottom: 0px;
+	max-height: fit-content;
+	margin-top: -21px;
+	${from.desktop} {
+		margin-top: -23px;
+	}
 `;
 
 const coverageStyles = (percentage?: string) => {
@@ -24,11 +41,22 @@ const coverageStyles = (percentage?: string) => {
 
 type Props = {
 	children: React.ReactNode;
+	isFullCardImage?: boolean;
 	percentage?: CardPercentageType;
 };
 
-export const ContentWrapper = ({ children, percentage }: Props) => (
-	<div className={cx(sizingStyles, coverageStyles(percentage))}>
+export const ContentWrapper = ({
+	children,
+	percentage,
+	isFullCardImage,
+}: Props) => (
+	<div
+		className={cx(
+			sizingStyles,
+			coverageStyles(percentage),
+			isFullCardImage && fullCardImageStyles,
+		)}
+	>
 		{children}
 	</div>
 );

--- a/src/web/components/Card/components/HeadlineWrapper.tsx
+++ b/src/web/components/Card/components/HeadlineWrapper.tsx
@@ -3,13 +3,14 @@ import { css } from 'emotion';
 
 type Props = {
 	children: React.ReactNode;
+	isFullCardImage?: boolean;
 };
 
-export const HeadlineWrapper = ({ children }: Props) => (
+export const HeadlineWrapper = ({ children, isFullCardImage }: Props) => (
 	<div
 		className={css`
-			padding-bottom: 8px;
-			padding-left: 5px;
+			padding-bottom: ${isFullCardImage ? 0 : 8}px;
+			padding-left: ${isFullCardImage ? 0 : 5}px;
 			padding-right: 5px;
 		`}
 	>

--- a/src/web/components/Card/components/ImageWrapper.tsx
+++ b/src/web/components/Card/components/ImageWrapper.tsx
@@ -54,7 +54,6 @@ export const ImageWrapper = ({
 
 					img {
 						width: 100%;
-						height: 100%;
 						display: block;
 						object-fit: ${isFullCardImage && 'cover'};
 					}

--- a/src/web/components/Card/components/ImageWrapper.tsx
+++ b/src/web/components/Card/components/ImageWrapper.tsx
@@ -1,42 +1,65 @@
 import React from 'react';
-import { css } from 'emotion';
+import { css, cx } from 'emotion';
 
-import { until } from '@guardian/src-foundations/mq';
+import { from, until } from '@guardian/src-foundations/mq';
 
 type Props = {
 	children: React.ReactNode;
 	alwaysVertical?: boolean;
 	percentage?: CardPercentageType;
+	isFullCardImage?: boolean;
 };
+
+const cardHeight = css`
+	${from.tablet} {
+		height: 274px;
+		width: 459px;
+	}
+
+	${until.tablet} {
+		height: 203px;
+		width: 340px;
+	}
+
+	${until.phablet} {
+		height: 171px;
+		width: 286px;
+	}
+`;
 
 export const ImageWrapper = ({
 	children,
 	percentage,
 	alwaysVertical,
+	isFullCardImage,
 }: Props) => {
 	return (
 		<div
-			className={css`
-				/* position relative is required here to bound the image overlay */
-				position: relative;
-
-				flex-basis: ${percentage && percentage};
-				${!alwaysVertical && until.tablet} {
-					/* Below tablet, we fix the size of the image and add a margin
+			className={cx(
+				isFullCardImage && cardHeight,
+				css`
+					/* position relative is required here to bound the image overlay */
+					position: relative;
+					flex-basis: ${percentage && percentage};
+					${!alwaysVertical && until.tablet} {
+						/* Below tablet, we fix the size of the image and add a margin
                        around it. The corresponding content flex grows to fill the space */
-					margin-left: 6px;
-					width: 119px;
-					flex-shrink: 0;
-					margin-top: 6px;
-					margin-bottom: 6px;
-					flex-basis: unset;
-				}
+						margin-left: 6px;
+						width: 119px;
+						flex-shrink: 0;
+						margin-top: 6px;
+						margin-bottom: 6px;
+						flex-basis: unset;
+					}
 
-				img {
-					width: 100%;
-					display: block;
-				}
-			`}
+					img {
+						width: 100%;
+						height: 100%;
+						display: block;
+						object-fit: ${isFullCardImage && 'cover'};
+					}
+				`,
+			)}
 		>
 			<>
 				{children}

--- a/src/web/components/Card/components/LI.tsx
+++ b/src/web/components/Card/components/LI.tsx
@@ -12,8 +12,13 @@ const liStyles = css`
 	display: flex;
 `;
 
-const sidePaddingStyles = css`
+const sidePaddingStyles = (padSidesOnMobile: boolean) => css`
 	/* Set spacing on the li element */
+	${padSidesOnMobile && until.tablet} {
+		padding-left: 10px;
+		padding-right: 10px;
+	}
+
 	${from.tablet} {
 		padding-left: 10px;
 		padding-right: 10px;
@@ -59,6 +64,7 @@ type Props = {
 	stretch?: boolean; // When true, the card stretches based on content
 	showDivider?: boolean; // If this LI wraps a card in a row this should be true
 	padSides?: boolean; // If this LI directly wraps a card this should be true
+	padSidesOnMobile?: boolean; // Should be true if spacing between cards is desired on mobile devices
 	bottomMargin?: boolean; // True when wrapping a card in a column and not the last item
 	showTopMarginWhenStacked?: boolean;
 	snapAlignStart?: boolean; // True when snapping card when scrolling e.g. in carousel
@@ -70,6 +76,7 @@ export const LI = ({
 	stretch,
 	showDivider,
 	padSides = false,
+	padSidesOnMobile = false,
 	bottomMargin,
 	showTopMarginWhenStacked,
 	snapAlignStart = false,
@@ -83,7 +90,7 @@ export const LI = ({
 				liStyles,
 				sizeStyles,
 				showDivider && verticalDivider,
-				padSides && sidePaddingStyles,
+				padSides && sidePaddingStyles(padSidesOnMobile),
 				bottomMargin && marginBottomStyles,
 				showTopMarginWhenStacked && marginTopStyles,
 				snapAlignStart && snapAlignStartStyles,

--- a/src/web/components/CardHeadline.tsx
+++ b/src/web/components/CardHeadline.tsx
@@ -10,6 +10,7 @@ import { QuoteIcon } from '@root/src/web/components/QuoteIcon';
 import { Kicker } from '@root/src/web/components/Kicker';
 import { Byline } from '@root/src/web/components/Byline';
 import { pillarPalette } from '@frontend/lib/pillars';
+import { space } from '@guardian/src-foundations';
 
 const fontStyles = (size: SmallHeadlineSize) => {
 	switch (size) {
@@ -84,6 +85,17 @@ const headlineStyles = (design: Design, pillar: Theme) => {
 	}
 };
 
+const fullCardImageTextStyles = css`
+	${headline.xxxsmall()};
+	color: ${neutral[100]};
+	background-color: rgba(0, 0, 0, 0.75);
+	box-shadow: -${space[1]}px 0 0 rgba(0, 0, 0, 0.75);
+	/* Box decoration is required to push the box shadow out on Firefox */
+	box-decoration-break: clone;
+	line-height: 1.25;
+	white-space: pre-wrap;
+`;
+
 export const CardHeadline = ({
 	headlineText,
 	design,
@@ -95,30 +107,40 @@ export const CardHeadline = ({
 	size = 'medium',
 	byline,
 	showByline,
+	isFullCardImage,
 }: CardHeadlineType) => (
 	<>
 		<h4
 			className={cx(
 				fontStyles(size),
 				design === Design.Analysis && underlinedStyles(size),
+				isFullCardImage &&
+					css`
+						line-height: 1; /* Reset line height in full image carousel */
+					`,
 			)}
 		>
-			{kickerText && (
-				<Kicker
-					text={kickerText}
-					design={design}
-					pillar={pillar}
-					showPulsingDot={showPulsingDot}
-					showSlash={showSlash}
-					inCard={true}
-				/>
-			)}
-			{showQuotes && (
-				<QuoteIcon colour={pillarPalette[pillar].main} size={size} />
-			)}
+			<span className={cx(isFullCardImage && fullCardImageTextStyles)}>
+				{kickerText && (
+					<Kicker
+						text={kickerText}
+						design={design}
+						pillar={pillar}
+						showPulsingDot={showPulsingDot}
+						showSlash={showSlash}
+						inCard={true}
+					/>
+				)}
+				{showQuotes && (
+					<QuoteIcon
+						colour={pillarPalette[pillar].main}
+						size={size}
+					/>
+				)}
 
-			<span className={headlineStyles(design, pillar)}>
-				{headlineText}
+				<span className={headlineStyles(design, pillar)}>
+					{headlineText}
+				</span>
 			</span>
 		</h4>
 		{byline && showByline && (

--- a/src/web/components/Onwards/Carousel/Carousel.stories.tsx
+++ b/src/web/components/Onwards/Carousel/Carousel.stories.tsx
@@ -2,11 +2,21 @@ import React from 'react';
 
 import { Design, Pillar } from '@guardian/types';
 
+import { breakpoints } from '@guardian/src-foundations/mq';
 import { Carousel } from './Carousel';
 
 export default {
 	component: Carousel,
 	title: 'Components/Carousel',
+	parameters: {
+		chromatic: {
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.tablet,
+				breakpoints.desktop,
+			],
+		},
+	},
 };
 
 const trails: TrailType[] = [
@@ -205,3 +215,25 @@ export const Headlines = () => (
 );
 
 Headlines.story = 'Headlines carousel';
+
+export const Immersive = () => (
+	<>
+		<Carousel
+			heading="Headlines"
+			trails={trails}
+			ophanComponentName="curated-content"
+			pillar={Pillar.News}
+			isFullCardImage={true}
+		/>
+
+		<Carousel
+			heading="Sport"
+			trails={trails}
+			ophanComponentName="curated-content"
+			pillar={Pillar.Sport}
+			isFullCardImage={true}
+		/>
+	</>
+);
+
+Immersive.story = 'Immersive carousel';

--- a/src/web/components/Onwards/Carousel/Carousel.tsx
+++ b/src/web/components/Onwards/Carousel/Carousel.tsx
@@ -65,8 +65,8 @@ const containerStyles = css`
 	}
 `;
 
-const carouselStyle = css`
-	min-height: 227px;
+const carouselStyle = (isFullCardImage?: boolean) => css`
+	min-height: ${!isFullCardImage && '227px'};
 	position: relative; /* must set position for offset(Left) calculations of children to be relative to this box */
 
 	display: flex;
@@ -192,11 +192,13 @@ type CarouselCardProps = {
 	isFirst: boolean;
 	pillar: Theme;
 	design: Design;
+	display?: Display;
 	linkTo: string;
 	headlineText: string;
 	webPublicationDate: string;
 	kickerText?: string;
 	imageUrl?: string;
+	isFullCardImage?: boolean;
 };
 
 export const CarouselCard: React.FC<CarouselCardProps> = ({
@@ -208,8 +210,15 @@ export const CarouselCard: React.FC<CarouselCardProps> = ({
 	webPublicationDate,
 	kickerText,
 	isFirst,
+	isFullCardImage,
 }: CarouselCardProps) => (
-	<LI stretch={true} percentage="100%" showDivider={!isFirst} padSides={true}>
+	<LI
+		stretch={true}
+		percentage="100%"
+		showDivider={!isFirst}
+		padSides={true}
+		padSidesOnMobile={true}
+	>
 		<Card
 			linkTo={linkTo}
 			format={{
@@ -224,6 +233,7 @@ export const CarouselCard: React.FC<CarouselCardProps> = ({
 			showClock={true}
 			alwaysVertical={true}
 			minWidthInPixels={258}
+			isFullCardImage={isFullCardImage}
 		/>
 	</LI>
 );
@@ -233,6 +243,7 @@ export const Carousel: React.FC<OnwardsType> = ({
 	trails,
 	ophanComponentName,
 	pillar,
+	isFullCardImage,
 }: OnwardsType) => {
 	const carouselRef = useRef<HTMLUListElement>(null);
 	const [index, setIndex] = useState(0);
@@ -379,7 +390,10 @@ export const Carousel: React.FC<OnwardsType> = ({
 					))}
 				</div>
 
-				<ul className={carouselStyle} ref={carouselRef}>
+				<ul
+					className={carouselStyle(isFullCardImage)}
+					ref={carouselRef}
+				>
 					{trails.map((trail, i) => {
 						const {
 							pillar: cardPillar,
@@ -401,6 +415,7 @@ export const Carousel: React.FC<OnwardsType> = ({
 								webPublicationDate={webPublicationDate}
 								imageUrl={imageUrl}
 								kickerText={kickerText}
+								isFullCardImage={isFullCardImage}
 							/>
 						);
 					})}


### PR DESCRIPTION
This adds a `isFullCardImage` prop that is used to create an 'immersive'
card component for use in the Carousel AB test.

This will definitely need refactoring  at a future date to make this
much easier to read and handle, but for an AB test this _should_
consolidate all of the design changes required into a single commit that
can be reverted if not needed. If this gets taken into production, we
will probably want to update this as part of the work to rationalise
card designs.

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

### Before
![image](https://user-images.githubusercontent.com/9122944/106497006-7170ad00-64b5-11eb-9456-f35fe6a3c6ee.png)

### After
![image](https://user-images.githubusercontent.com/9122944/106497038-7c2b4200-64b5-11eb-9dfd-081c617b3fdd.png)


## Why?
Required for Carousel AB test
