### PR TITLE
Track subnav more and add basic tracking doc

### DIFF
--- a/docs/development/track-user-behaviour.md
+++ b/docs/development/track-user-behaviour.md
@@ -1,0 +1,26 @@
+# Track user behaviour
+
+*Note, the key library here - `tracker-js` is not well-documented at the time of
+writing, but the hope is that this will improve soon.*
+
+## Track clicks:
+
+* add a data-link-name attribute to your component and the `ophan-tracking.js`
+  script will automatically send click data to Ophan.
+
+The code that does this is
+[here](https://github.com/guardian/ophan/blob/75b86abcce07369c8998521399327d436246c016/tracker-js/assets/coffee/ophan/click-path-capture.coffee)
+if you're interested in seeing the nitty gritty.
+
+## Track anything else
+
+Have a look at
+[tracker-js](https://github.com/guardian/ophan/tree/master/tracker-js/assets/coffee/ophan)
+as there are a few existing helpers which you can use. For example, the
+`data-component` attribute can be used to track attention time.
+
+Unfortunately, this library is not properly documented (yet) so it may be
+easiest to ask around to find out what is available.
+
+If `tracker-js` doesn't do what you need, you can fire your own Ophan events
+using the helpers in `ophan.ts`.

--- a/src/web/components/SubNav/SubNav.tsx
+++ b/src/web/components/SubNav/SubNav.tsx
@@ -163,7 +163,7 @@ export const SubNav = ({ subNavSections, format, currentNavLink }: Props) => {
 		} else {
 			setShowMore(false);
 		}
-	}, [ulRef]);
+	}, []);
 
 	const collapseWrapper = !showMore || !isExpanded;
 	const expandSubNav = !showMore || isExpanded;
@@ -176,6 +176,7 @@ export const SubNav = ({ subNavSections, format, currentNavLink }: Props) => {
 				spaceBetween,
 			)}
 			data-cy="sub-nav"
+			data-component="sub-nav"
 		>
 			<ul
 				ref={ulRef}

--- a/src/web/components/SubNav/SubNav.tsx
+++ b/src/web/components/SubNav/SubNav.tsx
@@ -163,7 +163,7 @@ export const SubNav = ({ subNavSections, format, currentNavLink }: Props) => {
 		} else {
 			setShowMore(false);
 		}
-	}, [ulRef, setShowMore]);
+	}, [ulRef]);
 
 	const collapseWrapper = !showMore || !isExpanded;
 	const expandSubNav = !showMore || isExpanded;
@@ -220,6 +220,7 @@ export const SubNav = ({ subNavSections, format, currentNavLink }: Props) => {
 				<button
 					onClick={() => setIsExpanded(!isExpanded)}
 					className={showMoreStyle}
+					data-link-name="nav2 : subnav-toggle"
 				>
 					{isExpanded ? 'Less' : 'More'}
 				</button>


### PR DESCRIPTION
### Before

No DCR tracking of the subnav 'More' toggle.

Also adds some basic docs on tracking. The real solution here though is to document `tracker-js`.

### After

![Screenshot 2021-02-02 at 16 12 58](https://user-images.githubusercontent.com/858402/106629162-76476680-6572-11eb-92c9-8f622f0c6143.png)

## Why?

We want to understand how many users click this on DCR.
