### PR TITLE
Sticky nav 2 (JS version with backscroll behaviour)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -698,7 +698,7 @@ interface DCRBrowserDocumentData {
 	page: string;
 	site: string;
 	CAPI: CAPIBrowserType;
-	NAV: SubNavBrowserType;
+	NAV: NavType;
 	GA: GADataType;
 	linkedData: object;
 }
@@ -708,7 +708,8 @@ interface Props {
 }
 
 type IslandType =
-	| 'reader-revenue-links-header'
+    | 'reader-revenue-links-header'
+    | 'fixed-nav-root'
 	| 'sub-nav-root'
 	| 'edition-root'
 	| 'most-viewed-right'

--- a/src/amp/server/document.test.tsx
+++ b/src/amp/server/document.test.tsx
@@ -2,7 +2,7 @@ import validator from 'amphtml-validator';
 import React from 'react';
 import { CAPI } from '@root/fixtures/CAPI/CAPI';
 import { Article } from '@root/src/amp/pages/Article';
-import { extract as extractNAV } from '@root/src/model/extract-nav';
+import { extractNAV } from '@root/src/model/extract-nav';
 import { AnalyticsModel } from '@root/src/amp/components/Analytics';
 import { document } from './document';
 

--- a/src/amp/server/render.tsx
+++ b/src/amp/server/render.tsx
@@ -3,7 +3,7 @@ import express from 'express';
 import { document } from '@root/src/amp/server/document';
 import { Article } from '@root/src/amp/pages/Article';
 import { extractScripts } from '@root/src/amp/lib/scripts';
-import { extract as extractNAV } from '@root/src/model/extract-nav';
+import { extractNAV } from '@root/src/model/extract-nav';
 import { AnalyticsModel } from '@root/src/amp/components/Analytics';
 import { validateAsCAPIType as validateV2 } from '@root/src/model/validate';
 import { findBySubsection } from '@root/src/model/article-sections';

--- a/src/model/extract-nav.ts
+++ b/src/model/extract-nav.ts
@@ -75,7 +75,7 @@ const buildRRLinkModel = (data: {}): ReaderRevenuePositions => ({
 	ampFooter: buildRRLinkCategories(data, 'ampFooter'),
 });
 
-export const extract = (data: {}): NavType => {
+export const extractNAV = (data: {}): NavType => {
 	let pillars = getArray<any>(data, 'pillars');
 
 	pillars = pillars.map((link) => getLink(link, { isPillar: true }));

--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -280,10 +280,7 @@ export const makeWindowGuardian = (
 			cssIDs,
 			data: {
 				...dcrDocumentData,
-				NAV: {
-					subNavSections: dcrDocumentData.NAV.subNavSections,
-					currentNavLink: dcrDocumentData.NAV.currentNavLink,
-				},
+				NAV: dcrDocumentData.NAV,
 				CAPI: makeGuardianBrowserCAPI(dcrDocumentData.CAPI),
 			},
 		},

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -62,6 +62,7 @@ import {
 	OphanComponentEvent,
 } from '../browser/ophan/ophan';
 import { trackPerformance } from '../browser/ga/ga';
+import { FixedNav } from './FixedNav';
 import { decidePalette } from '../lib/decidePalette';
 
 // *******************************
@@ -455,6 +456,16 @@ export const App = ({ CAPI, NAV }: Props) => {
 					</>
 				</HydrateOnce>
 			))}
+
+			<HydrateOnce root="fixed-nav-root">
+				<FixedNav
+					CAPI={CAPI}
+					NAV={NAV}
+					format={format}
+					palette={decidePalette(format)}
+				/>
+			</HydrateOnce>
+
 			{NAV.subNavSections && (
 				<HydrateOnce root="sub-nav-root">
 					<>

--- a/src/web/components/FixedNav.tsx
+++ b/src/web/components/FixedNav.tsx
@@ -98,7 +98,7 @@ export const FixedNav: React.FC<Props> = ({
 					<SubNav
 						subNavSections={NAV.subNavSections}
 						currentNavLink={NAV.currentNavLink}
-						format={format}
+						palette={palette}
 					/>
 				</Section>
 			)}
@@ -134,7 +134,7 @@ export const FixedNav: React.FC<Props> = ({
 							<SubNav
 								subNavSections={NAV.subNavSections}
 								currentNavLink={NAV.currentNavLink}
-								format={format}
+								palette={palette}
 							/>
 						</Section>
 					)}

--- a/src/web/components/FixedNav.tsx
+++ b/src/web/components/FixedNav.tsx
@@ -1,0 +1,143 @@
+import React, { useEffect, useState } from 'react';
+import { css } from 'emotion';
+
+import { Section } from '@root/src/web/components/Section';
+import { SubNav } from '@root/src/web/components/SubNav/SubNav';
+import { Nav } from '@root/src/web/components/Nav/Nav';
+import { brandBackground, brandLine } from '@guardian/src-foundations/palette';
+import { Pillar } from '@guardian/types';
+import { neutralBorder } from '@root/src/lib/pillars';
+import libDebounce from 'lodash.debounce';
+
+interface Props {
+	CAPI: CAPIBrowserType;
+	NAV: NavType;
+	format: Format;
+	palette: Palette;
+}
+
+const fixed = (pillar: Pillar) => css`
+	width: 100%;
+	position: fixed;
+	top: 0;
+	z-index: 9000;
+	background-color: white;
+	box-shadow: 0 0 transparent, 0 0 transparent,
+		1px 3px 6px ${neutralBorder(pillar)};
+`;
+
+// FixedNav will stay fixed to the top of the screen as the user scrolls down
+// until disappearing after a certain threshold of scrolling. It will also show,
+// even if outside this range, if the user is scrolling up.
+export const FixedNav: React.FC<Props> = ({
+	CAPI,
+	NAV,
+	format,
+	palette,
+}: Props) => {
+	const initialState = { shouldFix: false, scrollY: 0 };
+	const [state, setState] = useState(initialState);
+
+	const pillar = Pillar.News; // TODO use 'getCurrentPillar' but expects full CAPI type :(
+
+	useEffect(() => {
+		const handle = () => {
+			setState((oldState) => {
+				const rangeStart = 300; // TODO derive from nav value, but difficult as ads can shift layout.
+				const rangeEnd = 600;
+				const newY = window.scrollY;
+				const goingBack = newY < oldState.scrollY;
+				const inStickyRange = newY > rangeStart && newY < rangeEnd;
+				const beforeRange = newY < rangeStart;
+
+				return {
+					shouldFix: inStickyRange || (goingBack && !beforeRange),
+					scrollY: newY,
+				};
+			});
+		};
+
+		window.addEventListener('scroll', libDebounce(handle, 20), {
+			passive: true,
+		});
+
+		return () => {
+			console.log('removing event listener...');
+			window.removeEventListener('scroll', handle);
+		};
+	}, []);
+
+	return (
+		<>
+			<Section
+				showSideBorders={true}
+				borderColour={brandLine.primary}
+				showTopBorder={false}
+				padded={false}
+				backgroundColour={brandBackground.primary}
+			>
+				<Nav
+					nav={NAV}
+					format={{
+						...format,
+						theme: Pillar.News,
+					}}
+					subscribeUrl={CAPI.nav.readerRevenueLinks.header.subscribe}
+					edition={CAPI.editionId}
+				/>
+			</Section>
+
+			{NAV.subNavSections && (
+				<Section
+					backgroundColour={palette.background.article}
+					padded={false}
+					sectionId="sub-nav-root"
+				>
+					<SubNav
+						subNavSections={NAV.subNavSections}
+						currentNavLink={NAV.currentNavLink}
+						format={format}
+					/>
+				</Section>
+			)}
+
+			{state.shouldFix && (
+				<div className={fixed(pillar)}>
+					<Section
+						showSideBorders={true}
+						borderColour={brandLine.primary}
+						showTopBorder={false}
+						padded={false}
+						backgroundColour={brandBackground.primary}
+					>
+						<Nav
+							nav={NAV}
+							format={{
+								...format,
+								theme: Pillar.News,
+							}}
+							subscribeUrl={
+								CAPI.nav.readerRevenueLinks.header.subscribe
+							}
+							edition={CAPI.editionId}
+						/>
+					</Section>
+
+					{NAV.subNavSections && (
+						<Section
+							backgroundColour={palette.background.article}
+							padded={false}
+							sectionId="sub-nav-root"
+						>
+							<SubNav
+								subNavSections={NAV.subNavSections}
+								currentNavLink={NAV.currentNavLink}
+								format={format}
+							/>
+						</Section>
+					)}
+				</div>
+			)}
+		</>
+	);
+};

--- a/src/web/components/FixedNav.tsx
+++ b/src/web/components/FixedNav.tsx
@@ -8,6 +8,8 @@ import { brandBackground, brandLine } from '@guardian/src-foundations/palette';
 import { Pillar } from '@guardian/types';
 import { neutralBorder } from '@root/src/lib/pillars';
 import libDebounce from 'lodash.debounce';
+import { decideTheme } from '@root/src/web/lib/decideTheme';
+import { decideDesign } from '@root/src/web/lib/decideDesign';
 
 interface Props {
 	CAPI: CAPIBrowserType;
@@ -16,7 +18,7 @@ interface Props {
 	palette: Palette;
 }
 
-const fixed = (pillar: Pillar) => css`
+const fixed = (pillar: Theme) => css`
 	width: 100%;
 	position: fixed;
 	top: 0;
@@ -38,7 +40,10 @@ export const FixedNav: React.FC<Props> = ({
 	const initialState = { shouldFix: false, scrollY: 0 };
 	const [state, setState] = useState(initialState);
 
-	const pillar = Pillar.News; // TODO use 'getCurrentPillar' but expects full CAPI type :(
+	const pillar = decideTheme({
+		pillar: CAPI.pillar,
+		design: decideDesign(CAPI.designType, CAPI.tags),
+	});
 
 	useEffect(() => {
 		const handle = () => {

--- a/src/web/components/FixedNav.tsx
+++ b/src/web/components/FixedNav.tsx
@@ -26,9 +26,9 @@ const fixed = (pillar: Pillar) => css`
 		1px 3px 6px ${neutralBorder(pillar)};
 `;
 
-// FixedNav will stay fixed to the top of the screen as the user scrolls down
-// until disappearing after a certain threshold of scrolling. It will also show,
-// even if outside this range, if the user is scrolling up.
+// FixedNav reappears fixed to top of viewport if below initial buffer and user
+// is scrolling back. Idea is that scrolling back up may indicate intent to
+// reach nav.
 export const FixedNav: React.FC<Props> = ({
 	CAPI,
 	NAV,
@@ -43,15 +43,13 @@ export const FixedNav: React.FC<Props> = ({
 	useEffect(() => {
 		const handle = () => {
 			setState((oldState) => {
-				const rangeStart = 300; // TODO derive from nav value, but difficult as ads can shift layout.
-				const rangeEnd = 600;
+				const buffer = 300;
 				const newY = window.scrollY;
 				const goingBack = newY < oldState.scrollY;
-				const inStickyRange = newY > rangeStart && newY < rangeEnd;
-				const beforeRange = newY < rangeStart;
+				const beforeRange = newY < buffer;
 
 				return {
-					shouldFix: inStickyRange || (goingBack && !beforeRange),
+					shouldFix: goingBack && !beforeRange,
 					scrollY: newY,
 				};
 			});
@@ -62,7 +60,6 @@ export const FixedNav: React.FC<Props> = ({
 		});
 
 		return () => {
-			console.log('removing event listener...');
 			window.removeEventListener('scroll', handle);
 		};
 	}, []);

--- a/src/web/experiments/tests/sticky-nav-test.ts
+++ b/src/web/experiments/tests/sticky-nav-test.ts
@@ -1,0 +1,32 @@
+import { ABTest } from '@guardian/ab-core';
+
+export const stickyNavTest: ABTest = {
+	id: 'stickyNavTest',
+	start: '2021-02-08',
+	expiry: '2021-05-03',
+	author: 'nlong',
+	description: 'Tests sticky nav behaviour.',
+	audience: 0.1,
+	audienceOffset: 0,
+	successMeasure:
+		'Increased CTR on sticky variant, more visits to fronts, increase in number of pillars visited per user.',
+	audienceCriteria: 'Everyone',
+	idealOutcome:
+		'Significant increase in the metrics mentioned, consistent with hypothesis that sticky nav improves pillar understanding and engagement.',
+	showForSensitive: true,
+	canRun: () => true,
+	variants: [
+		{
+			id: 'control',
+			test: (): void => {},
+		},
+		{
+			id: 'sticky-nav-simple',
+			test: (): void => {},
+		},
+		{
+			id: 'sticky-nav-fancy',
+			test: (): void => {},
+		},
+	],
+};

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -45,6 +45,8 @@ import {
 	SendToBack,
 	BannerWrapper,
 } from '@root/src/web/layouts/lib/stickiness';
+import { makeGuardianBrowserCAPI } from '@root/src/model/window-guardian';
+import { FixedNav } from '@root/src/web/components/FixedNav';
 
 const gridWide = css`
 	grid-template-areas:
@@ -336,19 +338,14 @@ export const CommentLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						/>
 					</Section>
 
-					{NAV.subNavSections && (
-						<Section
-							backgroundColour={palette.background.article}
-							padded={false}
-							sectionId="sub-nav-root"
-						>
-							<SubNav
-								subNavSections={NAV.subNavSections}
-								currentNavLink={NAV.currentNavLink}
-								palette={palette}
-							/>
-						</Section>
-					)}
+					<div id="fixed-nav-root">
+						<FixedNav
+							CAPI={makeGuardianBrowserCAPI(CAPI)}
+							NAV={NAV}
+							format={format}
+							palette={palette}
+						/>
+					</div>
 
 					<Section
 						backgroundColour={palette.background.article}
@@ -619,7 +616,7 @@ export const CommentLayout = ({ CAPI, NAV, format, palette }: Props) => {
 					<SubNav
 						subNavSections={NAV.subNavSections}
 						currentNavLink={NAV.currentNavLink}
-						palette={palette}
+						format={format}
 					/>
 					<GuardianLines count={4} pillar={format.theme} />
 				</Section>

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -5,7 +5,6 @@ import {
 	neutral,
 	brandBorder,
 	brandBackground,
-	brandLine,
 } from '@guardian/src-foundations/palette';
 import { from, until } from '@guardian/src-foundations/mq';
 import { Display, Design } from '@guardian/types';
@@ -28,7 +27,6 @@ import { Header } from '@root/src/web/components/Header';
 import { Footer } from '@root/src/web/components/Footer';
 import { SubNav } from '@root/src/web/components/SubNav/SubNav';
 import { Section } from '@root/src/web/components/Section';
-import { Nav } from '@root/src/web/components/Nav/Nav';
 import { HeaderAdSlot } from '@root/src/web/components/HeaderAdSlot';
 import { MobileStickyContainer, AdSlot } from '@root/src/web/components/AdSlot';
 import { Border } from '@root/src/web/components/Border';
@@ -39,7 +37,6 @@ import { Discussion } from '@frontend/web/components/Discussion';
 import { buildAdTargeting } from '@root/src/lib/ad-targeting';
 import { parse } from '@frontend/lib/slot-machine-flags';
 import { getAgeWarning } from '@root/src/lib/age-warning';
-import { getCurrentPillar } from '@root/src/web/lib/layoutHelpers';
 import {
 	Stuck,
 	SendToBack,
@@ -315,26 +312,6 @@ export const CommentLayout = ({ CAPI, NAV, format, palette }: Props) => {
 							edition={CAPI.editionId}
 							idUrl={CAPI.config.idUrl}
 							mmaUrl={CAPI.config.mmaUrl}
-						/>
-					</Section>
-
-					<Section
-						showSideBorders={true}
-						borderColour={brandLine.primary}
-						showTopBorder={false}
-						padded={false}
-						backgroundColour={brandBackground.primary}
-					>
-						<Nav
-							nav={NAV}
-							format={{
-								...format,
-								theme: getCurrentPillar(CAPI),
-							}}
-							subscribeUrl={
-								CAPI.nav.readerRevenueLinks.header.subscribe
-							}
-							edition={CAPI.editionId}
 						/>
 					</Section>
 
@@ -616,7 +593,7 @@ export const CommentLayout = ({ CAPI, NAV, format, palette }: Props) => {
 					<SubNav
 						subNavSections={NAV.subNavSections}
 						currentNavLink={NAV.currentNavLink}
-						format={format}
+						palette={palette}
 					/>
 					<GuardianLines count={4} pillar={format.theme} />
 				</Section>

--- a/src/web/layouts/Immersive.stories.tsx
+++ b/src/web/layouts/Immersive.stories.tsx
@@ -16,12 +16,11 @@ import { Comment } from '@root/fixtures/articles/Comment';
 import { MatchReport } from '@root/fixtures/articles/MatchReport';
 import { PrintShop } from '@root/fixtures/articles/PrintShop';
 
-import { NAV } from '@root/fixtures/NAV';
-
 import { HydrateApp } from '@root/src/web/components/HydrateApp';
 import { embedIframe } from '@root/src/web/browser/embedIframe/embedIframe';
 import { mockRESTCalls } from '@root/src/web/lib/mockRESTCalls';
 
+import { extractNAV } from '@root/src/model/extract-nav';
 import { DecideLayout } from './DecideLayout';
 
 mockRESTCalls();
@@ -48,11 +47,13 @@ const convertToImmersive = (CAPI: CAPIType) => {
 // the client. We need a separate component so that we can make use of useEffect to ensure
 // the hydrate step only runs once the dom has been rendered.
 const HydratedLayout = ({ ServerCAPI }: { ServerCAPI: CAPIType }) => {
+	const NAV = extractNAV(ServerCAPI.nav);
+
 	useEffect(() => {
 		const CAPI = makeGuardianBrowserCAPI(ServerCAPI);
 		HydrateApp({ CAPI, NAV });
 		embedIframe();
-	}, [ServerCAPI]);
+	}, [ServerCAPI, NAV]);
 	return <DecideLayout CAPI={ServerCAPI} NAV={NAV} />;
 };
 

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -22,7 +22,6 @@ import { ArticleTitle } from '@root/src/web/components/ArticleTitle';
 import { ArticleHeadline } from '@root/src/web/components/ArticleHeadline';
 import { ArticleStandfirst } from '@root/src/web/components/ArticleStandfirst';
 import { Footer } from '@root/src/web/components/Footer';
-import { SubNav } from '@root/src/web/components/SubNav/SubNav';
 import { Section } from '@root/src/web/components/Section';
 import { Nav } from '@root/src/web/components/Nav/Nav';
 import { MobileStickyContainer, AdSlot } from '@root/src/web/components/AdSlot';
@@ -44,6 +43,8 @@ import {
 	getCurrentPillar,
 } from '@root/src/web/lib/layoutHelpers';
 import { BannerWrapper } from '@root/src/web/layouts/lib/stickiness';
+import { makeGuardianBrowserCAPI } from '@root/src/model/window-guardian';
+import { FixedNav } from '@root/src/web/components/FixedNav';
 
 const ImmersiveGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -627,16 +628,14 @@ export const ImmersiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				<AdSlot position="merchandising" display={format.display} />
 			</Section>
 
-			{NAV.subNavSections && (
-				<Section padded={false} sectionId="sub-nav-root">
-					<SubNav
-						subNavSections={NAV.subNavSections}
-						currentNavLink={NAV.currentNavLink}
-						palette={palette}
-					/>
-					<GuardianLines count={4} pillar={format.theme} />
-				</Section>
-			)}
+			<div id="fixed-nav-root">
+				<FixedNav
+					CAPI={makeGuardianBrowserCAPI(CAPI)}
+					NAV={NAV}
+					format={format}
+					palette={palette}
+				/>
+			</div>
 
 			<Section
 				padded={false}

--- a/src/web/layouts/Showcase.stories.tsx
+++ b/src/web/layouts/Showcase.stories.tsx
@@ -13,12 +13,11 @@ import { Recipe } from '@root/fixtures/articles/Recipe';
 import { Comment } from '@root/fixtures/articles/Comment';
 import { MatchReport } from '@root/fixtures/articles/MatchReport';
 
-import { NAV } from '@root/fixtures/NAV';
-
 import { HydrateApp } from '@root/src/web/components/HydrateApp';
 import { embedIframe } from '@root/src/web/browser/embedIframe/embedIframe';
 import { mockRESTCalls } from '@root/src/web/lib/mockRESTCalls';
 
+import { extractNAV } from '@root/src/model/extract-nav';
 import { DecideLayout } from './DecideLayout';
 
 mockRESTCalls();
@@ -45,11 +44,13 @@ const convertToShowcase = (CAPI: CAPIType) => {
 // the client. We need a separate component so that we can make use of useEffect to ensure
 // the hydrate step only runs once the dom has been rendered.
 const HydratedLayout = ({ ServerCAPI }: { ServerCAPI: CAPIType }) => {
+	const NAV = extractNAV(ServerCAPI.nav);
+
 	useEffect(() => {
 		const CAPI = makeGuardianBrowserCAPI(ServerCAPI);
 		HydrateApp({ CAPI, NAV });
 		embedIframe();
-	}, [ServerCAPI]);
+	}, [ServerCAPI, NAV]);
 	return <DecideLayout CAPI={ServerCAPI} NAV={NAV} />;
 };
 

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -4,7 +4,6 @@ import { css } from 'emotion';
 import {
 	neutral,
 	brandBackground,
-	brandLine,
 	brandBorder,
 } from '@guardian/src-foundations/palette';
 import { from, until } from '@guardian/src-foundations/mq';
@@ -26,7 +25,6 @@ import { Header } from '@root/src/web/components/Header';
 import { Footer } from '@root/src/web/components/Footer';
 import { SubNav } from '@root/src/web/components/SubNav/SubNav';
 import { Section } from '@root/src/web/components/Section';
-import { Nav } from '@root/src/web/components/Nav/Nav';
 import { HeaderAdSlot } from '@root/src/web/components/HeaderAdSlot';
 import { MobileStickyContainer, AdSlot } from '@root/src/web/components/AdSlot';
 import { Border } from '@root/src/web/components/Border';
@@ -40,7 +38,6 @@ import { getAgeWarning } from '@root/src/lib/age-warning';
 import {
 	decideLineCount,
 	decideLineEffect,
-	getCurrentPillar,
 } from '@root/src/web/lib/layoutHelpers';
 import {
 	Stuck,
@@ -271,26 +268,6 @@ export const ShowcaseLayout = ({ CAPI, NAV, format, palette }: Props) => {
 							edition={CAPI.editionId}
 							idUrl={CAPI.config.idUrl}
 							mmaUrl={CAPI.config.mmaUrl}
-						/>
-					</Section>
-
-					<Section
-						showSideBorders={true}
-						borderColour={brandLine.primary}
-						showTopBorder={false}
-						padded={false}
-						backgroundColour={brandBackground.primary}
-					>
-						<Nav
-							nav={NAV}
-							format={{
-								...format,
-								theme: getCurrentPillar(CAPI),
-							}}
-							subscribeUrl={
-								CAPI.nav.readerRevenueLinks.header.subscribe
-							}
-							edition={CAPI.editionId}
 						/>
 					</Section>
 
@@ -549,7 +526,7 @@ export const ShowcaseLayout = ({ CAPI, NAV, format, palette }: Props) => {
 					<SubNav
 						subNavSections={NAV.subNavSections}
 						currentNavLink={NAV.currentNavLink}
-						format={format}
+						palette={palette}
 					/>
 					<GuardianLines count={4} pillar={format.theme} />
 				</Section>

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -47,6 +47,8 @@ import {
 	SendToBack,
 	BannerWrapper,
 } from '@root/src/web/layouts/lib/stickiness';
+import { makeGuardianBrowserCAPI } from '@root/src/model/window-guardian';
+import { FixedNav } from '@root/src/web/components/FixedNav';
 
 const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -292,19 +294,14 @@ export const ShowcaseLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						/>
 					</Section>
 
-					{NAV.subNavSections && (
-						<Section
-							backgroundColour={palette.background.article}
-							padded={false}
-							sectionId="sub-nav-root"
-						>
-							<SubNav
-								subNavSections={NAV.subNavSections}
-								currentNavLink={NAV.currentNavLink}
-								palette={palette}
-							/>
-						</Section>
-					)}
+					<div id="fixed-nav-root">
+						<FixedNav
+							CAPI={makeGuardianBrowserCAPI(CAPI)}
+							NAV={NAV}
+							format={format}
+							palette={palette}
+						/>
+					</div>
 
 					<Section
 						backgroundColour={palette.background.article}
@@ -552,7 +549,7 @@ export const ShowcaseLayout = ({ CAPI, NAV, format, palette }: Props) => {
 					<SubNav
 						subNavSections={NAV.subNavSections}
 						currentNavLink={NAV.currentNavLink}
-						palette={palette}
+						format={format}
 					/>
 					<GuardianLines count={4} pillar={format.theme} />
 				</Section>

--- a/src/web/layouts/Standard.stories.tsx
+++ b/src/web/layouts/Standard.stories.tsx
@@ -14,12 +14,11 @@ import { Recipe } from '@root/fixtures/articles/Recipe';
 import { Comment } from '@root/fixtures/articles/Comment';
 import { MatchReport } from '@root/fixtures/articles/MatchReport';
 
-import { NAV } from '@root/fixtures/NAV';
-
 import { HydrateApp } from '@root/src/web/components/HydrateApp';
 import { embedIframe } from '@root/src/web/browser/embedIframe/embedIframe';
 import { mockRESTCalls } from '@root/src/web/lib/mockRESTCalls';
 
+import { extractNAV } from '@root/src/model/extract-nav';
 import { DecideLayout } from './DecideLayout';
 
 mockRESTCalls();
@@ -46,11 +45,13 @@ const convertToStandard = (CAPI: CAPIType) => {
 // the client. We need a separate component so that we can make use of useEffect to ensure
 // the hydrate step only runs once the dom has been rendered.
 const HydratedLayout = ({ ServerCAPI }: { ServerCAPI: CAPIType }) => {
+	const NAV = extractNAV(ServerCAPI.nav);
+
 	useEffect(() => {
 		const CAPI = makeGuardianBrowserCAPI(ServerCAPI);
 		HydrateApp({ CAPI, NAV });
 		embedIframe();
-	}, [ServerCAPI]);
+	}, [ServerCAPI, NAV]);
 	return <DecideLayout CAPI={ServerCAPI} NAV={NAV} />;
 };
 

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -49,7 +49,7 @@ import {
 	BannerWrapper,
 } from '@root/src/web/layouts/lib/stickiness';
 import { FixedNav } from '@root/src/web/components/FixedNav';
-import { makeGuardianBrowserCAPI } from 'src/model/window-guardian';
+import { makeGuardianBrowserCAPI } from '@root/src/model/window-guardian';
 
 const gridTemplateWide = css`
 	grid-template-areas:

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -5,7 +5,6 @@ import {
 	neutral,
 	brandAltBackground,
 	brandBackground,
-	brandLine,
 	brandBorder,
 } from '@guardian/src-foundations/palette';
 import { from, until } from '@guardian/src-foundations/mq';
@@ -29,7 +28,6 @@ import { Header } from '@root/src/web/components/Header';
 import { Footer } from '@root/src/web/components/Footer';
 import { SubNav } from '@root/src/web/components/SubNav/SubNav';
 import { Section } from '@root/src/web/components/Section';
-import { Nav } from '@root/src/web/components/Nav/Nav';
 import { HeaderAdSlot } from '@root/src/web/components/HeaderAdSlot';
 import { MobileStickyContainer, AdSlot } from '@root/src/web/components/AdSlot';
 import { Border } from '@root/src/web/components/Border';
@@ -44,13 +42,14 @@ import { getAgeWarning } from '@root/src/lib/age-warning';
 import {
 	decideLineCount,
 	decideLineEffect,
-	getCurrentPillar,
 } from '@root/src/web/lib/layoutHelpers';
 import {
 	Stuck,
 	SendToBack,
 	BannerWrapper,
 } from '@root/src/web/layouts/lib/stickiness';
+import { FixedNav } from '@root/src/web/components/FixedNav';
+import { makeGuardianBrowserCAPI } from 'src/model/window-guardian';
 
 const gridTemplateWide = css`
 	grid-template-areas:
@@ -355,39 +354,14 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						/>
 					</Section>
 
-					<Section
-						showSideBorders={true}
-						borderColour={brandLine.primary}
-						showTopBorder={false}
-						padded={false}
-						backgroundColour={brandBackground.primary}
-					>
-						<Nav
-							nav={NAV}
-							format={{
-								...format,
-								theme: getCurrentPillar(CAPI),
-							}}
-							subscribeUrl={
-								CAPI.nav.readerRevenueLinks.header.subscribe
-							}
-							edition={CAPI.editionId}
+					<div id="fixed-nav-root">
+						<FixedNav
+							CAPI={makeGuardianBrowserCAPI(CAPI)}
+							NAV={NAV}
+							format={format}
+							palette={palette}
 						/>
-					</Section>
-
-					{NAV.subNavSections && (
-						<Section
-							backgroundColour={palette.background.article}
-							padded={false}
-							sectionId="sub-nav-root"
-						>
-							<SubNav
-								subNavSections={NAV.subNavSections}
-								currentNavLink={NAV.currentNavLink}
-								palette={palette}
-							/>
-						</Section>
-					)}
+					</div>
 
 					<Section
 						backgroundColour={palette.background.article}

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -646,7 +646,7 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 					<SubNav
 						subNavSections={NAV.subNavSections}
 						currentNavLink={NAV.currentNavLink}
-						palette={palette}
+						format={format}
 					/>
 					<GuardianLines count={4} pillar={format.theme} />
 				</Section>

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -646,7 +646,7 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 					<SubNav
 						subNavSections={NAV.subNavSections}
 						currentNavLink={NAV.currentNavLink}
-						format={format}
+						palette={palette}
 					/>
 					<GuardianLines count={4} pillar={format.theme} />
 				</Section>

--- a/src/web/server/render.ts
+++ b/src/web/server/render.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { extract as extractNAV } from '@root/src/model/extract-nav';
+import { extractNAV } from '@root/src/model/extract-nav';
 
 import { document } from '@root/src/web/server/document';
 import { validateAsCAPIType } from '@root/src/model/validate';


### PR DESCRIPTION
WIP - still to add test harness code.

### Before

(No sticky nav behaviour on scroll.)

### After

![Kapture 2021-02-03 at 10 34 25](https://user-images.githubusercontent.com/858402/106734917-7fd0dd00-660b-11eb-859a-990dc6b0e417.gif)

## Why?

Increase engagement through nav visibility. Idea is that backwards scroll shows intent to access nav and/or journey to another piece of content.

## Tech questions

*Update:* on the increased size of `window.guardian` I've measured this, and on a standard article (https://www.theguardian.com/world/2020/feb/10/irish-general-election-everything-you-need-to-know) we see:

    before: 46kb
    after: 67kb

which is quite a big difference. However, it doesn't change the lighthouse score (81 when I ran it locally for both).

* is the increase in data on client justified (we have to send entire nav now)?
* is the user-benefit enough to justify extra complexity compared to basic CSS version?
* more generally, noticed that our client-side and server-side models often differ and this causes difficulties when writing code that must work with both (typically you have to use the client-side models and then adapt, but a lot of our utility functions rely on the server-side models). 