### PR TITLE
Special SubNav Palette

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -64,6 +64,9 @@ type Palette = {
 		shareIcon: Colour;
 		captionTriangle: Colour;
 	},
+	border: {
+		subNav: Colour;
+	}
 };
 
 type Edition = 'UK' | 'US' | 'INT' | 'AU';

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -461,7 +461,7 @@ export const App = ({ CAPI, NAV }: Props) => {
 						<SubNav
 							subNavSections={NAV.subNavSections}
 							currentNavLink={NAV.currentNavLink}
-							format={format}
+							palette={palette}
 						/>
 					</>
 				</HydrateOnce>

--- a/src/web/components/SubNav/SubNav.tsx
+++ b/src/web/components/SubNav/SubNav.tsx
@@ -112,7 +112,7 @@ const parentLinkStyle = css`
 	font-weight: 700;
 `;
 
-const listItemStyles = css`
+const listItemStyles = (palette: Palette) => css`
 	:after {
 		content: '';
 		display: inline-block;
@@ -123,17 +123,11 @@ const listItemStyles = css`
 		border-left: 10px solid ${neutral[7]};
 		margin-top: 12px;
 		margin-left: 2px;
+		border-left-color: ${palette.border.subNav};
 
 		${from.tablet} {
 			margin-top: 16px;
 		}
-	}
-`;
-
-// I'm not sure what the palette.neutral is for this should always receive a pillar by types.
-const leftColBorder = (palette: Palette) => css`
-	:after {
-		border-left-color: ${palette.border.subNav};
 	}
 `;
 
@@ -183,7 +177,7 @@ export const SubNav = ({ subNavSections, palette, currentNavLink }: Props) => {
 				{subNavSections.parent && (
 					<li
 						key={subNavSections.parent.url}
-						className={cx(listItemStyles, leftColBorder(palette))}
+						className={listItemStyles(palette)}
 					>
 						<a
 							className={parentLinkStyle}

--- a/src/web/components/SubNav/SubNav.tsx
+++ b/src/web/components/SubNav/SubNav.tsx
@@ -4,13 +4,10 @@ import { css, cx } from 'emotion';
 import { text, news, neutral } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
-import type { Format } from '@guardian/types';
-
-import { pillarPalette, pillarMap } from '@root/src/lib/pillars';
 
 type Props = {
 	subNavSections: SubNavType;
-	format: Format;
+	palette: Palette;
 	currentNavLink: string;
 };
 
@@ -134,18 +131,16 @@ const listItemStyles = css`
 `;
 
 // I'm not sure what the palette.neutral is for this should always receive a pillar by types.
-const leftColBorder = pillarMap(
-	(pillar) => css`
-		:after {
-			border-left-color: ${pillarPalette[pillar].main};
-		}
-	`,
-);
+const leftColBorder = (palette: Palette) => css`
+	:after {
+		border-left-color: ${palette.border.subNav};
+	}
+`;
 
 const trimLeadingSlash = (url: string): string =>
 	url.substr(0, 1) === '/' ? url.slice(1) : url;
 
-export const SubNav = ({ subNavSections, format, currentNavLink }: Props) => {
+export const SubNav = ({ subNavSections, palette, currentNavLink }: Props) => {
 	const [showMore, setShowMore] = useState(false);
 	const [isExpanded, setIsExpanded] = useState(false);
 	const ulRef = useRef<HTMLUListElement>(null);
@@ -188,10 +183,7 @@ export const SubNav = ({ subNavSections, format, currentNavLink }: Props) => {
 				{subNavSections.parent && (
 					<li
 						key={subNavSections.parent.url}
-						className={cx(
-							listItemStyles,
-							leftColBorder[format.theme],
-						)}
+						className={cx(listItemStyles, leftColBorder(palette))}
 					>
 						<a
 							className={parentLinkStyle}

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -345,7 +345,7 @@ export const CommentLayout = ({ CAPI, NAV, format, palette }: Props) => {
 							<SubNav
 								subNavSections={NAV.subNavSections}
 								currentNavLink={NAV.currentNavLink}
-								format={format}
+								palette={palette}
 							/>
 						</Section>
 					)}
@@ -619,7 +619,7 @@ export const CommentLayout = ({ CAPI, NAV, format, palette }: Props) => {
 					<SubNav
 						subNavSections={NAV.subNavSections}
 						currentNavLink={NAV.currentNavLink}
-						format={format}
+						palette={palette}
 					/>
 					<GuardianLines count={4} pillar={format.theme} />
 				</Section>

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -632,7 +632,7 @@ export const ImmersiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 					<SubNav
 						subNavSections={NAV.subNavSections}
 						currentNavLink={NAV.currentNavLink}
-						format={format}
+						palette={palette}
 					/>
 					<GuardianLines count={4} pillar={format.theme} />
 				</Section>

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -301,7 +301,7 @@ export const ShowcaseLayout = ({ CAPI, NAV, format, palette }: Props) => {
 							<SubNav
 								subNavSections={NAV.subNavSections}
 								currentNavLink={NAV.currentNavLink}
-								format={format}
+								palette={palette}
 							/>
 						</Section>
 					)}
@@ -552,7 +552,7 @@ export const ShowcaseLayout = ({ CAPI, NAV, format, palette }: Props) => {
 					<SubNav
 						subNavSections={NAV.subNavSections}
 						currentNavLink={NAV.currentNavLink}
-						format={format}
+						palette={palette}
 					/>
 					<GuardianLines count={4} pillar={format.theme} />
 				</Section>

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -384,7 +384,7 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 							<SubNav
 								subNavSections={NAV.subNavSections}
 								currentNavLink={NAV.currentNavLink}
-								format={format}
+								palette={palette}
 							/>
 						</Section>
 					)}
@@ -672,7 +672,7 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 					<SubNav
 						subNavSections={NAV.subNavSections}
 						currentNavLink={NAV.currentNavLink}
-						format={format}
+						palette={palette}
 					/>
 					<GuardianLines count={4} pillar={format.theme} />
 				</Section>

--- a/src/web/lib/decidePalette.ts
+++ b/src/web/lib/decidePalette.ts
@@ -151,6 +151,10 @@ const fillCaptionTriangle = (format: Format): string => {
 	return pillarPalette[format.theme].main;
 };
 
+const borderSubNav = (format: Format): string => {
+	return pillarPalette[format.theme].main;
+};
+
 export const decidePalette = (format: Format): Palette => {
 	return {
 		text: {
@@ -172,6 +176,9 @@ export const decidePalette = (format: Format): Palette => {
 			commentCount: fillCommentCount(format),
 			shareIcon: fillShareIcon(format),
 			captionTriangle: fillCaptionTriangle(format),
+		},
+		border: {
+			subNav: borderSubNav(format),
 		},
 	};
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds the `palette` pattern to `SubNav`

## Why?
To continue the [editorial palette](https://docs.google.com/document/d/1nkntFJUunqrwNYszTrc2RBfyYUd1bEAeQh76yVFOLjo/edit#) work and, nominally, to support special reports although in this case the support is already there because we're using `pillarPalette` via `format` and we don't do anything different so specials other than use their `main` colour
