### PR TITLE
Darker Special Caption

### DIFF
--- a/src/web/components/Caption.tsx
+++ b/src/web/components/Caption.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 
-import { text } from '@guardian/src-foundations/palette';
 import { from, until } from '@guardian/src-foundations/mq';
 import { textSans } from '@guardian/src-foundations/typography';
 import { space } from '@guardian/src-foundations';
@@ -20,12 +19,12 @@ type Props = {
 	isOverlayed?: boolean;
 };
 
-const captionStyle = css`
+const captionStyle = (palette: Palette) => css`
 	${textSans.xsmall()};
 	padding-top: 6px;
 	${textSans.xsmall()};
 	word-wrap: break-word;
-	color: ${text.supporting};
+	color: ${palette.text.caption};
 `;
 
 const bottomMargin = css`
@@ -178,7 +177,7 @@ export const Caption = ({
 			return (
 				<figcaption
 					className={cx(
-						captionStyle,
+						captionStyle(palette),
 						shouldLimitWidth && limitedWidth,
 						!isOverlayed && bottomMargin,
 						isOverlayed && overlayedStyles,

--- a/src/web/lib/decidePalette.ts
+++ b/src/web/lib/decidePalette.ts
@@ -88,7 +88,7 @@ const textCaption = (format: Format): string => {
 	if (format.theme === Special.SpecialReport) return specialReport[100];
 	switch (format.design) {
 		case Design.PhotoEssay:
-			return pillarPalette[format.theme].main;
+			return pillarPalette[format.theme].dark;
 		default:
 			return text.supporting;
 	}

--- a/src/web/lib/decidePalette.ts
+++ b/src/web/lib/decidePalette.ts
@@ -86,7 +86,12 @@ const textTwitterHandle = (format: Format): string => {
 
 const textCaption = (format: Format): string => {
 	if (format.theme === Special.SpecialReport) return specialReport[100];
-	return pillarPalette[format.theme].dark;
+	switch (format.design) {
+		case Design.PhotoEssay:
+			return pillarPalette[format.theme].main;
+		default:
+			return text.supporting;
+	}
 };
 
 const textCaptionLink = (format: Format): string => {


### PR DESCRIPTION
## What?
Fixes an issue where we weren't always using `palette` for the caption text which consequentially ensures the text for special reports is darker

## Before
![Screenshot 2021-02-03 at 11 30 47](https://user-images.githubusercontent.com/1336821/106741190-47cd9800-6613-11eb-81fd-738637a4c82e.jpg)


## After
![Screenshot 2021-02-03 at 11 28 02](https://user-images.githubusercontent.com/1336821/106741151-3be1d600-6613-11eb-9bb9-a70142945154.jpg)

