### PR TITLE
Special Links

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -57,6 +57,7 @@ type Palette = {
 		subMetaLink: Colour;
 		syndicationButton: Colour;
 		articleLink: Colour;
+		articleLinkHover: Colour;
 	},
 	background: {
 		article: Colour;

--- a/index.d.ts
+++ b/index.d.ts
@@ -56,6 +56,7 @@ type Palette = {
 		subMetaLabel: Colour;
 		subMetaLink: Colour;
 		syndicationButton: Colour;
+		articleLink: Colour;
 	},
 	background: {
 		article: Colour;
@@ -71,6 +72,8 @@ type Palette = {
 	border: {
 		syndicationButton: Colour;
 		subNav: Colour;
+		articleLink: Colour;
+		articleLinkHover: Colour;
 	}
 };
 

--- a/src/web/components/ArticleBody.tsx
+++ b/src/web/components/ArticleBody.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 
-import { border } from '@guardian/src-foundations/palette';
 import { headline } from '@guardian/src-foundations/typography';
 import { between } from '@guardian/src-foundations/mq';
-import { pillarMap, pillarPalette } from '@root/src/lib/pillars';
 import { ArticleRenderer } from '@root/src/web/lib/ArticleRenderer';
-import { Display, Pillar } from '@guardian/types';
+import { Display } from '@guardian/types';
 import type { Format } from '@guardian/types';
 
 type Props = {
@@ -16,15 +14,6 @@ type Props = {
 	adTargeting: AdTargeting;
 	host?: string;
 };
-
-const pillarColours = pillarMap(
-	(pillar) =>
-		css`
-			color: ${pillar === Pillar.Opinion || pillar === Pillar.Culture
-				? pillarPalette[pillar].dark
-				: pillarPalette[pillar].main};
-		`,
-);
 
 const bodyStyle = (display: Display) => css`
 	${between.tablet.and.desktop} {
@@ -47,19 +36,17 @@ const bodyStyle = (display: Display) => css`
 	}
 `;
 
-const linkColour = pillarMap(
-	(pillar) => css`
-		a {
-			text-decoration: none;
-			border-bottom: 1px solid ${border.secondary};
-			${pillarColours[pillar]};
+const linkColour = (palette: Palette) => css`
+	a {
+		text-decoration: none;
+		border-bottom: 1px solid ${palette.border.articleLink};
+		color: ${palette.text.articleLink};
 
-			:hover {
-				border-bottom: 1px solid ${pillarPalette[pillar].main};
-			}
+		:hover {
+			border-bottom: 1px solid ${palette.border.articleLinkHover};
 		}
-	`,
-);
+	}
+`;
 
 export const ArticleBody = ({
 	format,
@@ -69,9 +56,7 @@ export const ArticleBody = ({
 	host,
 }: Props) => {
 	return (
-		<div
-			className={cx(bodyStyle(format.display), linkColour[format.theme])}
-		>
+		<div className={cx(bodyStyle(format.display), linkColour(palette))}>
 			<ArticleRenderer
 				format={format}
 				palette={palette}

--- a/src/web/components/ArticleBody.tsx
+++ b/src/web/components/ArticleBody.tsx
@@ -43,6 +43,7 @@ const linkColour = (palette: Palette) => css`
 		color: ${palette.text.articleLink};
 
 		:hover {
+			color: ${palette.text.articleLinkHover};
 			border-bottom: 1px solid ${palette.border.articleLinkHover};
 		}
 	}

--- a/src/web/lib/decidePalette.ts
+++ b/src/web/lib/decidePalette.ts
@@ -121,6 +121,17 @@ const textSyndicationButton = (format: Format): string => {
 };
 
 const textArticleLink = (format: Format): string => {
+	if (format.theme === Special.SpecialReport) return specialReport[400];
+	switch (format.theme) {
+		case Pillar.Opinion:
+		case Pillar.Culture:
+			return pillarPalette[format.theme].dark;
+		default:
+			return pillarPalette[format.theme].main;
+	}
+};
+
+const textArticleLinkHover = (format: Format): string => {
 	if (format.theme === Special.SpecialReport) return specialReport[100];
 	switch (format.theme) {
 		case Pillar.Opinion:
@@ -197,7 +208,7 @@ const borderSubNav = (format: Format): string => {
 };
 
 const borderArticleLink = (format: Format): string => {
-	if (format.theme === Special.SpecialReport) return border.secondary;
+	if (format.theme === Special.SpecialReport) return specialReport[400];
 	return border.secondary;
 };
 
@@ -221,6 +232,7 @@ export const decidePalette = (format: Format): Palette => {
 			subMetaLink: textSubMetaLink(format),
 			syndicationButton: textSyndicationButton(format),
 			articleLink: textArticleLink(format),
+			articleLinkHover: textArticleLinkHover(format),
 		},
 		background: {
 			article: backgroundArticle(format),

--- a/src/web/lib/decidePalette.ts
+++ b/src/web/lib/decidePalette.ts
@@ -120,6 +120,17 @@ const textSyndicationButton = (format: Format): string => {
 	return text.supporting;
 };
 
+const textArticleLink = (format: Format): string => {
+	if (format.theme === Special.SpecialReport) return specialReport[100];
+	switch (format.theme) {
+		case Pillar.Opinion:
+		case Pillar.Culture:
+			return pillarPalette[format.theme].dark;
+		default:
+			return pillarPalette[format.theme].main;
+	}
+};
+
 const backgroundArticle = (format: Format): string => {
 	// Order matters. We want comment special report pieces to have the opinion background
 	if (format.design === Design.Comment) return opinion[800];
@@ -185,6 +196,16 @@ const borderSubNav = (format: Format): string => {
 	return pillarPalette[format.theme].main;
 };
 
+const borderArticleLink = (format: Format): string => {
+	if (format.theme === Special.SpecialReport) return border.secondary;
+	return border.secondary;
+};
+
+const borderArticleLinkHover = (format: Format): string => {
+	if (format.theme === Special.SpecialReport) return specialReport[100];
+	return pillarPalette[format.theme].main;
+};
+
 export const decidePalette = (format: Format): Palette => {
 	return {
 		text: {
@@ -199,6 +220,7 @@ export const decidePalette = (format: Format): Palette => {
 			subMetaLabel: textSubMetaLabel(format),
 			subMetaLink: textSubMetaLink(format),
 			syndicationButton: textSyndicationButton(format),
+			articleLink: textArticleLink(format),
 		},
 		background: {
 			article: backgroundArticle(format),
@@ -214,6 +236,8 @@ export const decidePalette = (format: Format): Palette => {
 		border: {
 			syndicationButton: borderSyndicationButton(),
 			subNav: borderSubNav(format),
+			articleLink: borderArticleLink(format),
+			articleLinkHover: borderArticleLinkHover(format),
 		},
 	};
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Uses the `palette`  pattern to decide colours for in bodt article links

## Special Reports
The links for these have been restyled to give more contrast and improve accessibility

### Before
![2021-02-03 15 25 29](https://user-images.githubusercontent.com/1336821/106768699-174a2600-6634-11eb-9200-7a26576e2129.gif)

### After
![2021-02-03 16 32 30](https://user-images.githubusercontent.com/1336821/106778061-7bbdb300-663d-11eb-8d4d-556dcf670240.gif)


