### PR TITLE
Added Higher order timer function

### DIFF
--- a/src/web/components/StickyBottomBanner/BrazeBanner.tsx
+++ b/src/web/components/StickyBottomBanner/BrazeBanner.tsx
@@ -104,10 +104,10 @@ const getMessageFromBraze = async (
 			return outcome;
 		})
 		.catch(() => {
-			appboyTiming.clear();
-			// eslint-disable-next-line no-console
-			console.log('Appboy Timing failed.');
 			return { result: false };
+		})
+		.finally(() => {
+			appboyTiming.clear();
 		});
 };
 

--- a/src/web/lib/braze/BrazeMessages.ts
+++ b/src/web/lib/braze/BrazeMessages.ts
@@ -12,7 +12,6 @@ interface Message {
 }
 
 class BrazeMessages {
-	// emitter: Emitter;
 	appboy: Appboy;
 
 	constructor(appboy: Appboy) {

--- a/src/web/lib/timer.ts
+++ b/src/web/lib/timer.ts
@@ -1,0 +1,66 @@
+// A higher order timer for measuring sections of an overall timeline
+
+const perf = window.performance;
+
+export class Timer {
+	handleMeasurement: (measureName: string, measurement: number) => any;
+
+	namePrefix: string;
+
+	constructor(
+		namePrefix: string,
+		handleMeasurement: (measureName: string, measurement: number) => any,
+	) {
+		this.handleMeasurement = handleMeasurement;
+		this.namePrefix = namePrefix;
+	}
+
+	private marks: Array<string> = [];
+
+	private createMark(newMark: string) {
+		perf.mark(newMark);
+		this.marks.push(newMark);
+	}
+
+	start() {
+		this.createMark(this.namePrefix);
+	}
+
+	// Measures time taken since previous mark and passes it to handleMeasurement()
+	pip(nameSuffix: string) {
+		const { length } = this.marks;
+		if (length === 0) {
+			// The start() method has not been run first
+			return;
+		}
+
+		const startMark = this.marks[length - 1];
+		const endMark = `${this.namePrefix}-${length - 1}-${nameSuffix}`;
+		// 'length - 1' used here to help sequence measurements in receiving platform
+
+		this.createMark(endMark);
+		perf.measure(endMark, startMark, endMark);
+		const measurement = perf.getEntriesByName(endMark, 'measure');
+
+		this.handleMeasurement(endMark, measurement[0].duration);
+	}
+
+	clear() {
+		// Remove all marks and measures created
+		perf.clearMarks(this.namePrefix);
+		this.marks.forEach((markName) => {
+			perf.clearMarks(markName);
+			perf.clearMeasures(markName);
+		});
+	}
+}
+
+// e.g.
+// const createLogTimer = (name: string) =>
+// 	new Timer(name, (measureName, measurement) =>
+// 		console.log(measureName, measurement),
+// 	);
+
+// const logTimer = createLogTimer('myTimer');
+
+// logTimer.start();

--- a/src/web/lib/timerOphan.ts
+++ b/src/web/lib/timerOphan.ts
@@ -1,0 +1,10 @@
+import { record } from '@root/src/web/browser/ophan/ophan';
+import { Timer } from './timer';
+
+export const createOphanTimer = (name: string) =>
+	new Timer(name, (measureName, measurement) => {
+		record({
+			component: measureName,
+			value: measurement,
+		});
+	});


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds a higher order `Timer` class, which can be used to process real user monitoring (RUM) data. The class is agnostic to how the measurements are used - this is specified in a callback passed to the class, for example logging it to the console or sending data to Ophan.

The `Timer` can be used to measure a continuous timeline of program execution, and is initialised with a name prefix and a callback function to be used on measurements. First, the `start()` method is run, then `pip(name: string)` is run each time the developer wants to measure a section of the program and process the data in the manner specified by the callback.

### Before

Braze RUM data is collected using `initPerf` and sent to Ophan with each measurement.

### After

Braze RUM data is collected and set to Ophan using an instance of `Timer`.


## Why?

We had tried to use `initPerf` to generate RUM data for the Braze web integration. However, it was opinionated on how to process user data (logging it to the console) and was geared towards making single measurements - consequently we had to write a lot of code and repeat ourselves in the consuming functions in order to use it for our purpose. We also didn't want to log to the console for other users.

We needed a utility which made a series of measurements, constituting a bigger overall timeline for our program execution, the output of which could be used to monitor the overall flow of the program and help us measure which parts of our program were taking the most time to execute (e.g. calls to Identity or Braze's methods themselves).

Given our experience with 