### PR TITLE
Explicitly type CAPIType.nav

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -132,24 +132,12 @@ interface Branding {
 	};
 }
 
-interface CAPILinkType extends SimpleLinkType {
-	longTitle: string;
-	children?: LinkType[];
-	mobileOnly?: boolean;
-	pillar?: CAPIPillar;
-	more?: boolean;
-}
-
 interface LinkType extends SimpleLinkType {
 	longTitle: string;
 	children?: LinkType[];
 	mobileOnly?: boolean;
 	pillar?: Pillar;
 	more?: boolean;
-}
-
-interface CAPIPillarType extends CAPILinkType {
-	pillar: CAPIPillar;
 }
 
 interface PillarType extends LinkType {
@@ -193,10 +181,6 @@ interface BaseNavType {
 
 interface NavType extends BaseNavType {
 	pillars: PillarType[];
-}
-
-interface CAPINavType extends BaseNavType {
-	pillars: CAPIPillarType[];
 }
 
 interface SubNavBrowserType {
@@ -275,6 +259,37 @@ type PageTypeType = {
 	isSensitive: boolean;
 };
 
+// Data types for the API request bodies from clients. The 'CAPI' prefix
+// convention doesn't really make sense anymore (it is not the CAPI model,
+// though closely related) but is not worth changing now.
+
+interface CAPILinkType {
+    url: string;
+	title: string;
+    longTitle: string;
+    iconName: string;
+	children?: CAPILinkType[];
+	mobileOnly?: boolean;
+	pillar?: CAPIPillar;
+    more?: boolean;
+    classList?: string[];
+}
+
+interface CAPINavType {
+    currentUrl: string;
+    pillars: CAPILinkType[];
+	otherLinks: CAPILinkType[];
+	brandExtensions: CAPILinkType[];
+    currentNavLink?: CAPILinkType;
+    currentParent?: CAPILinkType;
+    currentPillar?: CAPILinkType;
+	subNavSections?: {
+        parent?: CAPILinkType;
+        links: CAPILinkType[];
+    };
+	readerRevenueLinks: ReaderRevenuePositions;
+}
+
 // WARNING: run `gen-schema` task if changing this to update the associated JSON
 // schema definition.
 interface CAPIType {
@@ -332,8 +347,7 @@ interface CAPIType {
 	trailText: string;
 	badge?: BadgeType;
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	nav: any; // as not extracting directly into NavType here for now (nav stuff is getting moved out)
+	nav: CAPINavType; // TODO move this out as most code uses a different internal NAV model.
 
 	pageFooter: FooterType;
 
@@ -345,6 +359,9 @@ interface CAPIType {
 	matchUrl?: string;
 	isSpecialReport: boolean;
 }
+
+// Browser data models. Note the CAPI prefix here means something different to
+// the models above.
 
 type CAPIBrowserType = {
 	// The CAPI object sent from frontend can have designType Immersive. We force this to be Article
@@ -706,10 +723,6 @@ interface DCRBrowserDocumentData {
 	NAV: SubNavBrowserType;
 	GA: GADataType;
 	linkedData: object;
-}
-
-interface Props {
-	data: DCRServerDocumentData; // Do not fall to the tempation to rename 'data' into something else
 }
 
 type IslandType =

--- a/index.d.ts
+++ b/index.d.ts
@@ -259,18 +259,19 @@ type PageTypeType = {
 	isSensitive: boolean;
 };
 
-// Data types for the API request bodies from clients. The 'CAPI' prefix
-// convention doesn't really make sense anymore (it is not the CAPI model,
-// though closely related) but is not worth changing now.
+// Data types for the API request bodies from clients that require
+// transformation before internal use. If we use the data as-is, we avoid the
+// CAPI prefix. Note also, the 'CAPI' prefix naming convention is a bit
+// misleading - the model is *not* the same as the Content API content models.
 
 interface CAPILinkType {
     url: string;
-	title: string;
+    title: string;
     longTitle: string;
     iconName: string;
-	children?: CAPILinkType[];
-	mobileOnly?: boolean;
-	pillar?: CAPIPillar;
+    children?: CAPILinkType[];
+    mobileOnly?: boolean;
+    pillar?: CAPIPillar;
     more?: boolean;
     classList?: string[];
 }
@@ -278,16 +279,16 @@ interface CAPILinkType {
 interface CAPINavType {
     currentUrl: string;
     pillars: CAPILinkType[];
-	otherLinks: CAPILinkType[];
-	brandExtensions: CAPILinkType[];
+    otherLinks: CAPILinkType[];
+    brandExtensions: CAPILinkType[];
     currentNavLink?: CAPILinkType;
     currentParent?: CAPILinkType;
     currentPillar?: CAPILinkType;
-	subNavSections?: {
+    subNavSections?: {
         parent?: CAPILinkType;
         links: CAPILinkType[];
     };
-	readerRevenueLinks: ReaderRevenuePositions;
+    readerRevenueLinks: ReaderRevenuePositions;
 }
 
 // WARNING: run `gen-schema` task if changing this to update the associated JSON

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -290,7 +290,9 @@
         "badge": {
             "$ref": "#/definitions/BadgeType"
         },
-        "nav": {},
+        "nav": {
+            "$ref": "#/definitions/CAPINavType"
+        },
         "pageFooter": {
             "$ref": "#/definitions/FooterType"
         },
@@ -3006,6 +3008,162 @@
             "required": [
                 "imageUrl",
                 "seriesTag"
+            ]
+        },
+        "CAPINavType": {
+            "type": "object",
+            "properties": {
+                "currentUrl": {
+                    "type": "string"
+                },
+                "pillars": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/CAPILinkType"
+                    }
+                },
+                "otherLinks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/CAPILinkType"
+                    }
+                },
+                "brandExtensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/CAPILinkType"
+                    }
+                },
+                "currentNavLink": {
+                    "$ref": "#/definitions/CAPILinkType"
+                },
+                "currentParent": {
+                    "$ref": "#/definitions/CAPILinkType"
+                },
+                "currentPillar": {
+                    "$ref": "#/definitions/CAPILinkType"
+                },
+                "subNavSections": {
+                    "type": "object",
+                    "properties": {
+                        "parent": {
+                            "$ref": "#/definitions/CAPILinkType"
+                        },
+                        "links": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CAPILinkType"
+                            }
+                        }
+                    },
+                    "required": [
+                        "links"
+                    ]
+                },
+                "readerRevenueLinks": {
+                    "$ref": "#/definitions/ReaderRevenuePositions"
+                }
+            },
+            "required": [
+                "brandExtensions",
+                "currentUrl",
+                "otherLinks",
+                "pillars",
+                "readerRevenueLinks"
+            ]
+        },
+        "CAPILinkType": {
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "longTitle": {
+                    "type": "string"
+                },
+                "iconName": {
+                    "type": "string"
+                },
+                "children": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/CAPILinkType"
+                    }
+                },
+                "mobileOnly": {
+                    "type": "boolean"
+                },
+                "pillar": {
+                    "$ref": "#/definitions/CAPIPillar"
+                },
+                "more": {
+                    "type": "boolean"
+                },
+                "classList": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "iconName",
+                "longTitle",
+                "title",
+                "url"
+            ]
+        },
+        "ReaderRevenuePositions": {
+            "type": "object",
+            "properties": {
+                "header": {
+                    "$ref": "#/definitions/ReaderRevenueCategories"
+                },
+                "footer": {
+                    "$ref": "#/definitions/ReaderRevenueCategories"
+                },
+                "sideMenu": {
+                    "$ref": "#/definitions/ReaderRevenueCategories"
+                },
+                "ampHeader": {
+                    "$ref": "#/definitions/ReaderRevenueCategories"
+                },
+                "ampFooter": {
+                    "$ref": "#/definitions/ReaderRevenueCategories"
+                }
+            },
+            "required": [
+                "ampFooter",
+                "ampHeader",
+                "footer",
+                "header",
+                "sideMenu"
+            ]
+        },
+        "ReaderRevenueCategories": {
+            "type": "object",
+            "properties": {
+                "contribute": {
+                    "type": "string"
+                },
+                "subscribe": {
+                    "type": "string"
+                },
+                "support": {
+                    "type": "string"
+                },
+                "gifting": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "contribute",
+                "gifting",
+                "subscribe",
+                "support"
             ]
         },
         "FooterType": {

--- a/src/web/lib/layoutHelpers.ts
+++ b/src/web/lib/layoutHelpers.ts
@@ -28,7 +28,7 @@ export const decideLineCount = (design?: Design): 8 | 4 => {
 export const getCurrentPillar = (CAPI: CAPIType): Theme => {
 	const currentPillar =
 		(CAPI.nav.currentPillar &&
-			CAPI.nav.currentPillar.title.toLowerCase()) ||
+			(CAPI.nav.currentPillar.title.toLowerCase() as CAPIPillar)) ||
 		CAPI.pillar;
 	return decideTheme({ pillar: currentPillar });
 };

--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -41,6 +41,10 @@ const generateScriptTags = (
 		return scriptTags;
 	}, [] as string[]);
 
+interface Props {
+	data: DCRServerDocumentData;
+}
+
 export const document = ({ data }: Props) => {
 	const { CAPI, NAV, linkedData } = data;
 	const title = `${CAPI.headline} | ${CAPI.sectionLabel} | The Guardian`;


### PR DESCRIPTION
This provides extra type safety around fixtures and request body handling. (I hit some issues around typing recently when working on sticky nav that would have been easier to debug with this.)

Note, as we validate request data, it's possible we'll see production errors from this if our model doesn't match data sent. This should show up in logs as `Unable to validate request body for url...` so we can monitor for these on deploy and revert if necessary.

