### PR TITLE
Consistent SVG star icon sizing ★★★☆☆

### DIFF
--- a/src/static/icons/star.svg
+++ b/src/static/icons/star.svg
@@ -1,3 +1,8 @@
 <svg width="14" height="13" viewBox="0 0 14 13">
-    <path d="M0 5.2L3.7 8l-1.4 4.6.5.4 3.7-2.8 3.7 2.8.5-.4L9.3 8 13 5.2l-.2-.6H8.2L6.8 0h-.6L4.8 4.6H.2l-.2.6z"></path>
+    <path id="star" clip-path="url(#clip)" stroke-width="2"
+        d="M0 5.2L3.7 8l-1.4 4.6.5.4 3.7-2.8 3.7 2.8.5-.4L9.3 8 13 5.2l-.2-.6H8.2L6.8 0h-.6L4.8 4.6H.2l-.2.6z">
+    </path>
+    <clipPath id="clip">
+        <use xlink:href="#star" stroke="none" />
+    </clipPath>
 </svg>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Makes the stroke of the star icons `inside` rather than `centred` for visual consistency.

By using the filled shape as a `clip-path` to the stroke-shape, and doubling the stroke width, we achieve the same visual result as if the stroke was inside the shape.

![image](https://user-images.githubusercontent.com/76776/106813052-7f9e0500-663e-11eb-968e-dd9c10677dba.png)

<details>
    <summary>Example SVG code</summary>

```xml
<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="600" height="200"
	viewBox="-2 -2 60 20">
	<path id="star" paint-order="stroke"
		d="M0 5.2L3.7 8l-1.4 4.6.5.4 3.7-2.8 3.7 2.8.5-.4L9.3 8 13 5.2l-.2-.6H8.2L6.8 0h-.6L4.8 4.6H.2l-.2.6z">
	</path>
	<clipPath id="clip">
		<use xlink:href="#star" stroke="none" />
	</clipPath>

	<use xlink:href="#star" fill="rgba(255,100,0,0.5)" />
	<use x="15" xlink:href="#star" stroke="black" stroke-width="1" fill="rgba(255,100,0,0.5)" />
	<use x="30" xlink:href="#star" stroke="black" stroke-width="2" fill="rgba(255,100,0,0.5)" />
	<use x="45" xlink:href="#star" stroke="black" stroke-width="2" fill="rgba(255,100,0,0.5)" clip-path="url(#clip)" />

	<g text-anchor="middle" font-size="2px" font-family="sans-serif">
		<text y="16" x="7">baseline</text>
		<text y="16" x="7" dx="15">centred 1px</text>
		<text y="16" x="7" dx="30">centred 2px</text>
		<text y="16" x="7" dx="45">2px clipped</text>
	</g>
</svg>
```

</details>

## Screenshot

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/106797722-fe894280-662a-11eb-851d-08329fda52b2.png
[after]: https://user-images.githubusercontent.com/76776/106797762-0b0d9b00-662b-11eb-9199-27cb32c3181c.png

## Why?

It looks weird that empty stars are bigger than filled ones.
