### PR TITLE
Moving prefurniture to the correct const to fix football scores

### DIFF
--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -75,7 +75,6 @@ const gridTemplateWidePreFurnished = css`
 
 const gridTemplateLeftCol = css`
 	grid-template-areas:
-		'preFurniture  right-column'
 		'title         right-column'
 		'headline      right-column'
 		'standfirst    right-column'
@@ -88,6 +87,7 @@ const gridTemplateLeftCol = css`
 
 const gridTemplateLeftColPreFurnished = css`
 	grid-template-areas:
+		'preFurniture  right-column'
 		'title         right-column'
 		'headline      right-column'
 		'standfirst    right-column'


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds the prefurniture to the correct gird template area in order to fix an issue where the football scores were not appearing correctly.

### Before
<img width="702" alt="Screen Shot 2021-02-04 at 09 25 53" src="https://user-images.githubusercontent.com/2051501/106872567-5aa3a380-66cb-11eb-8ffc-c99029a0025f.png">

### After
<img width="701" alt="Screen Shot 2021-02-04 at 09 26 25" src="https://user-images.githubusercontent.com/2051501/106872591-6000ee00-66cb-11eb-882c-c836d39d178a.png">

## Why?
https://trello.com/c/PZABsweM/2415-football-scores-on-thinner-breakpoints-the-scores-go-to-the-bottom-and-appear-off-the-side-of-the-screen