### PR TITLE
Add spacing and border to both sets of links

### DIFF
--- a/src/web/components/SubMeta.tsx
+++ b/src/web/components/SubMeta.tsx
@@ -32,7 +32,7 @@ const listStyleNone = css`
 	list-style: none;
 `;
 
-const keywordListStyles = css`
+const listWrapper = css`
 	padding-bottom: 12px;
 	margin-bottom: 6px;
 	border-bottom: 1px solid ${border.secondary};
@@ -124,45 +124,57 @@ export const SubMeta = ({
 				</div>
 			)}
 			{(hasSectionLinks || hasKeywordLinks) && (
-				<span className={labelStyles(palette)}>Topics</span>
-			)}
-			{hasSectionLinks && (
-				<ul className={listStyleNone}>
-					{subMetaSectionLinks.map((link, i) => (
-						<li
-							className={cx(
-								listItemStyles(palette),
-								sectionStyles,
-								i === subMetaSectionLinks.length - 1 &&
-									hideSlash,
-							)}
-							key={link.url}
-						>
-							<a className={linkStyles(palette)} href={link.url}>
-								{link.title}
-							</a>
-						</li>
-					))}
-				</ul>
-			)}
-			{hasKeywordLinks && (
-				<ul className={cx(listStyleNone, keywordListStyles)}>
-					{subMetaKeywordLinks.map((link, i) => (
-						<li
-							className={cx(
-								listItemStyles(palette),
-								keywordStyles,
-								i === subMetaKeywordLinks.length - 1 &&
-									hideSlash,
-							)}
-							key={link.url}
-						>
-							<a className={linkStyles(palette)} href={link.url}>
-								{link.title}
-							</a>
-						</li>
-					))}
-				</ul>
+				<>
+					<span className={labelStyles(palette)}>Topics</span>
+					<div className={listWrapper}>
+						{hasSectionLinks && (
+							<ul className={listStyleNone}>
+								{subMetaSectionLinks.map((link, i) => (
+									<li
+										className={cx(
+											listItemStyles(palette),
+											sectionStyles,
+											i ===
+												subMetaSectionLinks.length -
+													1 && hideSlash,
+										)}
+										key={link.url}
+									>
+										<a
+											className={linkStyles(palette)}
+											href={link.url}
+										>
+											{link.title}
+										</a>
+									</li>
+								))}
+							</ul>
+						)}
+						{hasKeywordLinks && (
+							<ul className={listStyleNone}>
+								{subMetaKeywordLinks.map((link, i) => (
+									<li
+										className={cx(
+											listItemStyles(palette),
+											keywordStyles,
+											i ===
+												subMetaKeywordLinks.length -
+													1 && hideSlash,
+										)}
+										key={link.url}
+									>
+										<a
+											className={linkStyles(palette)}
+											href={link.url}
+										>
+											{link.title}
+										</a>
+									</li>
+								))}
+							</ul>
+						)}
+					</div>
+				</>
 			)}
 			{showBottomSocialButtons && (
 				<div


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Moves the css for padding and a bottom border away from the keyword links and adds it to a wrapper around both the section _and_ keyword links.

### Before
![Screenshot 2021-02-04 at 09 48 38](https://user-images.githubusercontent.com/1336821/106875080-2c739300-66ce-11eb-9387-4cf32d4c1743.jpg)

### After
![Screenshot 2021-02-04 at 09 48 11](https://user-images.githubusercontent.com/1336821/106875022-2087d100-66ce-11eb-9852-87fc124f342d.jpg)


## Why?
Because if we only apply this css to the bottom of the keyword links then we miss it entirely if there are none of them