### PR TITLE
Remove pillarToUse

### DIFF
--- a/src/web/components/Card/Card.stories.tsx
+++ b/src/web/components/Card/Card.stories.tsx
@@ -388,7 +388,7 @@ export const InDepth = () => (
 									'/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai',
 								format: {
 									display: Display.Standard,
-									theme: Pillar.News,
+									theme: Pillar.Opinion,
 									design: Design.Comment,
 								},
 								headlineText: headlines[7],

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 
-import { Design, Pillar } from '@guardian/types';
+import { Design } from '@guardian/types';
 import { brandAltBackground } from '@guardian/src-foundations/palette';
 
 import { StarRating } from '@root/src/web/components/StarRating/StarRating';
@@ -128,14 +128,9 @@ export const Card = ({
 	const showCommentCount = commentCount || commentCount === 0;
 	const { long: longCount, short: shortCount } = formatCount(commentCount);
 
-	const pillarToUse =
-		format.design === Design.Comment && format.theme === Pillar.News
-			? Pillar.Opinion
-			: format.theme;
-
 	return (
-		<CardLink linkTo={linkTo} design={format.design} pillar={pillarToUse}>
-			<TopBar topBarColour={pillarPalette[pillarToUse].main}>
+		<CardLink linkTo={linkTo} design={format.design} pillar={format.theme}>
+			<TopBar topBarColour={pillarPalette[format.theme].main}>
 				<CardLayout
 					imagePosition={imagePosition}
 					alwaysVertical={alwaysVertical}
@@ -173,7 +168,7 @@ export const Card = ({
 									<CardHeadline
 										headlineText={headlineText}
 										design={format.design}
-										pillar={pillarToUse}
+										pillar={format.theme}
 										size={headlineSize}
 										showQuotes={showQuotes}
 										kickerText={
@@ -237,7 +232,7 @@ export const Card = ({
 										webPublicationDate ? (
 											<CardAge
 												design={format.design}
-												pillar={pillarToUse}
+												pillar={format.theme}
 												webPublicationDate={
 													webPublicationDate
 												}
@@ -253,7 +248,7 @@ export const Card = ({
 										format.design === Design.Media &&
 										mediaType ? (
 											<MediaMeta
-												pillar={pillarToUse}
+												pillar={format.theme}
 												mediaType={mediaType}
 												mediaDuration={mediaDuration}
 											/>
@@ -265,7 +260,7 @@ export const Card = ({
 										shortCount ? (
 											<CardCommentCount
 												design={format.design}
-												pillar={pillarToUse}
+												pillar={format.theme}
 												long={longCount}
 												short={shortCount}
 											/>

--- a/src/web/components/MostViewed/MostViewedFooter/SecondTierItem.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/SecondTierItem.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 
-import { Design, Pillar, Display } from '@guardian/types';
+import { Display } from '@guardian/types';
 import type { Format } from '@guardian/types';
 import { border, neutral, text } from '@guardian/src-foundations/palette';
 import { headline } from '@guardian/src-foundations/typography';
@@ -100,11 +100,10 @@ export const SecondTierItem = ({
 	} = trail;
 
 	const avatarToShow = avatarUrl || image;
-	const pillarToUse = design === Design.Comment ? Pillar.Opinion : pillar;
-	const formatToUse: Format = {
+	const format: Format = {
 		design,
 		display: Display.Standard,
-		theme: pillarToUse,
+		theme: pillar,
 	};
 
 	return (
@@ -121,7 +120,7 @@ export const SecondTierItem = ({
 							<LinkHeadline
 								design={design}
 								headlineText={headlineText}
-								pillar={formatToUse.theme}
+								pillar={format.theme}
 								size="small"
 								byline={showByline ? byline : undefined}
 							/>
@@ -129,7 +128,7 @@ export const SecondTierItem = ({
 							<LinkHeadline
 								design={design}
 								headlineText={headlineText}
-								pillar={formatToUse.theme}
+								pillar={format.theme}
 								size="small"
 								byline={showByline ? byline : undefined}
 							/>
@@ -147,7 +146,7 @@ export const SecondTierItem = ({
 									<Avatar
 										imageSrc={avatarToShow}
 										imageAlt=""
-										palette={decidePalette(formatToUse)}
+										palette={decidePalette(format)}
 									/>
 								</div>
 							</div>


### PR DESCRIPTION
## What?
Deletes the `pillarToUse` override logic

## Why?
Because we do the same thing inside `decideTheme` so these checks are no longer needed