### PR TITLE
Removed prop spreading pattern in Card stories

### DIFF
--- a/src/web/components/Card/Card.stories.tsx
+++ b/src/web/components/Card/Card.stories.tsx
@@ -34,22 +34,19 @@ export const News = () => (
 				<UL direction="row" bottomMargin={true}>
 					<LI percentage="75%" showDivider={false} padSides={true}>
 						<Card
-							{...{
-								linkTo:
-									'/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai',
-								format: {
-									display: Display.Standard,
-									theme: Pillar.News,
-									design: Design.Article,
-								},
-								headlineText: headlines[0],
-								headlineSize: 'large',
-								kickerText: kickers[4],
-								imageUrl: images[0],
-								imagePosition: 'right',
-								imageSize: 'large',
-								standfirst: standfirsts[0],
+							linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+							format={{
+								display: Display.Standard,
+								theme: Pillar.News,
+								design: Design.Article,
 							}}
+							headlineText={headlines[0]}
+							headlineSize="large"
+							kickerText={kickers[4]}
+							imageUrl={images[0]}
+							imagePosition="right"
+							imageSize="large"
+							standfirst={standfirsts[0]}
 						/>
 					</LI>
 					<LI
@@ -59,41 +56,35 @@ export const News = () => (
 						padSides={true}
 					>
 						<Card
-							{...{
-								linkTo:
-									'/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai',
-								format: {
-									display: Display.Standard,
-									theme: Pillar.News,
-									design: Design.Article,
-								},
-								headlineText: headlines[1],
-								headlineSize: 'large',
-								kickerText: kickers[0],
-								imageUrl: images[5],
-								imagePosition: 'top',
-								standfirst: standfirsts[0],
+							linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+							format={{
+								display: Display.Standard,
+								theme: Pillar.News,
+								design: Design.Article,
 							}}
+							headlineText={headlines[1]}
+							headlineSize="large"
+							kickerText={kickers[0]}
+							imageUrl={images[5]}
+							imagePosition="top"
+							standfirst={standfirsts[0]}
 						/>
 					</LI>
 				</UL>
 				<UL direction="row">
 					<LI percentage="50%" padSides={true}>
 						<Card
-							{...{
-								linkTo:
-									'/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai',
-								format: {
-									display: Display.Standard,
-									theme: Pillar.Culture,
-									design: Design.Article,
-								},
-								headlineText: headlines[2],
-								kickerText: kickers[1],
-								imageUrl: images[3],
-								imagePosition: 'top',
-								standfirst: standfirsts[0],
+							linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+							format={{
+								display: Display.Standard,
+								theme: Pillar.Culture,
+								design: Design.Article,
 							}}
+							headlineText={headlines[2]}
+							kickerText={kickers[1]}
+							imageUrl={images[3]}
+							imagePosition="top"
+							standfirst={standfirsts[0]}
 						/>
 					</LI>
 					<LI
@@ -105,51 +96,42 @@ export const News = () => (
 						<UL direction="column">
 							<LI bottomMargin={true} stretch={true}>
 								<Card
-									{...{
-										linkTo:
-											'/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai',
-										format: {
-											display: Display.Standard,
-											theme: Pillar.Opinion,
-											design: Design.GuardianView,
-										},
-										headlineText: headlines[3],
-										kickerText: 'Editorial',
-										imageUrl: images[6],
-										imagePosition: 'top',
-										commentCount: 82224,
+									linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+									format={{
+										display: Display.Standard,
+										theme: Pillar.Opinion,
+										design: Design.GuardianView,
 									}}
+									headlineText={headlines[3]}
+									kickerText="Editorial"
+									imageUrl={images[6]}
+									imagePosition="top"
+									commentCount={82224}
 								/>
 							</LI>
 							<LI bottomMargin={true} stretch={true}>
 								<Card
-									{...{
-										linkTo:
-											'/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai',
-										format: {
-											display: Display.Standard,
-											theme: Pillar.News,
-											design: Design.Article,
-										},
-										headlineText: headlines[4],
-										headlineSize: 'small',
+									linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+									format={{
+										display: Display.Standard,
+										theme: Pillar.News,
+										design: Design.Article,
 									}}
+									headlineText={headlines[4]}
+									headlineSize="small"
 								/>
 							</LI>
 							<LI bottomMargin={false} stretch={true}>
 								<Card
-									{...{
-										linkTo:
-											'/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai',
-										format: {
-											display: Display.Standard,
-											theme: Pillar.News,
-											design: Design.Article,
-										},
-										headlineText: headlines[5],
-										headlineSize: 'small',
-										kickerText: kickers[3],
+									linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+									format={{
+										display: Display.Standard,
+										theme: Pillar.News,
+										design: Design.Article,
 									}}
+									headlineText={headlines[5]}
+									headlineSize="small"
+									kickerText={kickers[3]}
 								/>
 							</LI>
 						</UL>
@@ -163,100 +145,82 @@ export const News = () => (
 						<UL direction="column">
 							<LI bottomMargin={true} stretch={true}>
 								<Card
-									{...{
-										linkTo:
-											'/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai',
-										format: {
-											display: Display.Standard,
-											theme: Pillar.Sport,
-											design: Design.Article,
-										},
-										headlineText: headlines[6],
-										headlineSize: 'small',
-										kickerText: kickers[3],
-										commentCount: 26,
+									linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+									format={{
+										display: Display.Standard,
+										theme: Pillar.Sport,
+										design: Design.Article,
 									}}
+									headlineText={headlines[6]}
+									headlineSize="small"
+									kickerText={kickers[3]}
+									commentCount={26}
 								/>
 							</LI>
 							<LI bottomMargin={true} stretch={true}>
 								<Card
-									{...{
-										linkTo:
-											'/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai',
-										format: {
-											display: Display.Standard,
-											theme: Pillar.News,
-											design: Design.Article,
-										},
-										headlineText: headlines[7],
-										headlineSize: 'small',
-										kickerText: kickers[1],
+									linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+									format={{
+										display: Display.Standard,
+										theme: Pillar.News,
+										design: Design.Article,
 									}}
+									headlineText={headlines[7]}
+									headlineSize="small"
+									kickerText={kickers[1]}
 								/>
 							</LI>
 							<LI bottomMargin={true} stretch={true}>
 								<Card
-									{...{
-										linkTo:
-											'/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai',
-										format: {
-											display: Display.Standard,
-											theme: Pillar.News,
-											design: Design.Article,
-										},
-										headlineText: headlines[8],
-										headlineSize: 'small',
-										kickerText: kickers[0],
+									linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+									format={{
+										display: Display.Standard,
+										theme: Pillar.News,
+										design: Design.Article,
 									}}
+									headlineText={headlines[8]}
+									headlineSize="small"
+									kickerText={kickers[0]}
 								/>
 							</LI>
 							<LI bottomMargin={true} stretch={true}>
 								<Card
-									{...{
-										linkTo:
-											'/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai',
-										format: {
-											display: Display.Standard,
-											theme: Pillar.News,
-											design: Design.Article,
-										},
-										headlineText: headlines[9],
-										headlineSize: 'small',
-										kickerText: kickers[2],
+									linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+									format={{
+										display: Display.Standard,
+										theme: Pillar.News,
+										design: Design.Article,
 									}}
+									headlineText={headlines[9]}
+									headlineSize="small"
+									kickerText={kickers[2]}
 								/>
 							</LI>
 							<LI bottomMargin={true} stretch={true}>
 								<Card
-									{...{
-										linkTo:
-											'/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai',
-										format: {
-											display: Display.Standard,
-											theme: Pillar.Lifestyle,
-											design: Design.Article,
-										},
-										headlineText: headlines[10],
-										headlineSize: 'small',
-										kickerText: kickers[0],
+									linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+									format={{
+										display: Display.Standard,
+										theme: Pillar.Lifestyle,
+										design: Design.Article,
 									}}
+									headlineText={headlines[10]}
+									headlineSize="small"
+									kickerText={kickers[0]}
 								/>
 							</LI>
 							<LI bottomMargin={false} stretch={true}>
 								<Card
-									{...{
-										linkTo:
-											'/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai',
-										format: {
-											display: Display.Standard,
-											theme: Pillar.News,
-											design: Design.Article,
-										},
-										headlineText: headlines[11],
-										headlineSize: 'small',
-										kickerText: kickers[3],
-										commentCount: 44,
+									linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+									format={{
+										display: Display.Standard,
+										theme: Pillar.News,
+										design: Design.Article,
 									}}
+									headlineText={headlines[11]}
+									headlineSize="small"
+									kickerText={kickers[3]}
+									commentCount={44}
 								/>
 							</LI>
 						</UL>
@@ -280,98 +244,83 @@ export const InDepth = () => (
 						<UL direction="column">
 							<LI bottomMargin={true} stretch={true}>
 								<Card
-									{...{
-										linkTo:
-											'/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai',
-										format: {
-											display: Display.Standard,
-											theme: Pillar.Sport,
-											design: Design.Article,
-										},
-										headlineText: headlines[6],
-										headlineSize: 'medium',
-										kickerText: kickers[4],
-										imageUrl: images[5],
-										imagePosition: 'left',
-										imageSize: 'small',
+									linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+									format={{
+										display: Display.Standard,
+										theme: Pillar.Sport,
+										design: Design.Article,
 									}}
+									headlineText={headlines[6]}
+									headlineSize="medium"
+									kickerText={kickers[4]}
+									imageUrl={images[5]}
+									imagePosition="left"
+									imageSize="small"
 								/>
 							</LI>
 							<LI bottomMargin={true} stretch={true}>
 								<Card
-									{...{
-										linkTo:
-											'/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai',
-										format: {
-											display: Display.Standard,
-											theme: Pillar.Sport,
-											design: Design.Article,
-										},
-										headlineText: headlines[6],
-										headlineSize: 'small',
-										kickerText: kickers[3],
-										imageUrl: images[6],
-										imagePosition: 'left',
-										imageSize: 'small',
-										commentCount: 864,
+									linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+									format={{
+										display: Display.Standard,
+										theme: Pillar.Sport,
+										design: Design.Article,
 									}}
+									headlineText={headlines[6]}
+									headlineSize="small"
+									kickerText={kickers[3]}
+									imageUrl={images[6]}
+									imagePosition="left"
+									imageSize="small"
+									commentCount={864}
 								/>
 							</LI>
 							<LI bottomMargin={true} stretch={true}>
 								<Card
-									{...{
-										linkTo:
-											'/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai',
-										format: {
-											display: Display.Standard,
-											theme: Pillar.Sport,
-											design: Design.Article,
-										},
-										headlineText: headlines[6],
-										headlineSize: 'small',
-										kickerText: kickers[2],
-										imageUrl: images[3],
-										imagePosition: 'left',
-										imageSize: 'small',
+									linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+									format={{
+										display: Display.Standard,
+										theme: Pillar.Sport,
+										design: Design.Article,
 									}}
+									headlineText={headlines[6]}
+									headlineSize="small"
+									kickerText={kickers[2]}
+									imageUrl={images[3]}
+									imagePosition="left"
+									imageSize="small"
 								/>
 							</LI>
 							<LI bottomMargin={true} stretch={true}>
 								<Card
-									{...{
-										linkTo:
-											'/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai',
-										format: {
-											display: Display.Standard,
-											theme: Pillar.Sport,
-											design: Design.Article,
-										},
-										headlineText: headlines[2],
-										headlineSize: 'small',
-										kickerText: kickers[1],
-										imageUrl: images[2],
-										imagePosition: 'left',
-										imageSize: 'small',
+									linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+									format={{
+										display: Display.Standard,
+										theme: Pillar.Sport,
+										design: Design.Article,
 									}}
+									headlineText={headlines[2]}
+									headlineSize="small"
+									kickerText={kickers[1]}
+									imageUrl={images[2]}
+									imagePosition="left"
+									imageSize="small"
 								/>
 							</LI>
 							<LI bottomMargin={false} stretch={true}>
 								<Card
-									{...{
-										linkTo:
-											'/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai',
-										format: {
-											display: Display.Standard,
-											theme: Pillar.Sport,
-											design: Design.Article,
-										},
-										headlineText: headlines[7],
-										headlineSize: 'small',
-										kickerText: kickers[0],
-										imageUrl: images[1],
-										imagePosition: 'left',
-										imageSize: 'small',
+									linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+									format={{
+										display: Display.Standard,
+										theme: Pillar.Sport,
+										design: Design.Article,
 									}}
+									headlineText={headlines[7]}
+									headlineSize="small"
+									kickerText={kickers[0]}
+									imageUrl={images[1]}
+									imagePosition="left"
+									imageSize="small"
 								/>
 							</LI>
 						</UL>
@@ -383,22 +332,19 @@ export const InDepth = () => (
 						padSides={true}
 					>
 						<Card
-							{...{
-								linkTo:
-									'/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai',
-								format: {
-									display: Display.Standard,
-									theme: Pillar.News,
-									design: Design.Comment,
-								},
-								headlineText: headlines[7],
-								headlineSize: 'large',
-								kickerText: kickers[0],
-								imageUrl: images[0],
-								imagePosition: 'top',
-								webPublicationDate: '2019-11-11T09:45:30.000Z',
-								commentCount: 3694,
+							linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+							format={{
+								display: Display.Standard,
+								theme: Pillar.News,
+								design: Design.Comment,
 							}}
+							headlineText={headlines[7]}
+							headlineSize="large"
+							kickerText={kickers[0]}
+							imageUrl={images[0]}
+							imagePosition="top"
+							webPublicationDate="2019-11-11T09:45:30.000Z"
+							commentCount={3694}
 						/>
 					</LI>
 				</UL>
@@ -418,21 +364,18 @@ export const Related = () => (
 				<UL direction="row" bottomMargin={true}>
 					<LI padSides={true}>
 						<Card
-							{...{
-								linkTo:
-									'/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai',
-								format: {
-									display: Display.Standard,
-									theme: Pillar.Sport,
-									design: Design.Article,
-								},
-								headlineText: headlines[7],
-								headlineSize: 'medium',
-								kickerText: kickers[3],
-								webPublicationDate: '2019-11-11T09:45:30.000Z',
-								imageUrl: images[5],
-								imagePosition: 'top',
+							linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+							format={{
+								display: Display.Standard,
+								theme: Pillar.Sport,
+								design: Design.Article,
 							}}
+							headlineText={headlines[7]}
+							headlineSize="medium"
+							kickerText={kickers[3]}
+							webPublicationDate="2019-11-11T09:45:30.000Z"
+							imageUrl={images[5]}
+							imagePosition="top"
 						/>
 					</LI>
 					<LI
@@ -441,22 +384,19 @@ export const Related = () => (
 						showTopMarginWhenStacked={true}
 					>
 						<Card
-							{...{
-								linkTo:
-									'/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai',
-								format: {
-									display: Display.Standard,
-									theme: Pillar.Sport,
-									design: Design.Live,
-								},
-								headlineText: headlines[8],
-								headlineSize: 'medium',
-								kickerText: kickers[0],
-								webPublicationDate: '2019-11-11T09:45:30.000Z',
-								imageUrl: images[6],
-								imagePosition: 'top',
-								commentCount: 222864,
+							linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+							format={{
+								display: Display.Standard,
+								theme: Pillar.Sport,
+								design: Design.Live,
 							}}
+							headlineText={headlines[8]}
+							headlineSize="medium"
+							kickerText={kickers[0]}
+							webPublicationDate="2019-11-11T09:45:30.000Z"
+							imageUrl={images[6]}
+							imagePosition="top"
+							commentCount={222864}
 						/>
 					</LI>
 					<LI
@@ -465,40 +405,34 @@ export const Related = () => (
 						showTopMarginWhenStacked={true}
 					>
 						<Card
-							{...{
-								linkTo:
-									'/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai',
-								format: {
-									display: Display.Standard,
-									theme: Pillar.Sport,
-									design: Design.Comment,
-								},
-								headlineText: headlines[8],
-								headlineSize: 'medium',
-								kickerText: kickers[1],
-								webPublicationDate: '2019-11-11T09:45:30.000Z',
-								imageUrl: images[4],
-								imagePosition: 'top',
+							linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+							format={{
+								display: Display.Standard,
+								theme: Pillar.Sport,
+								design: Design.Comment,
 							}}
+							headlineText={headlines[8]}
+							headlineSize="medium"
+							kickerText={kickers[1]}
+							webPublicationDate="2019-11-11T09:45:30.000Z"
+							imageUrl={images[4]}
+							imagePosition="top"
 						/>
 					</LI>
 				</UL>
 				<UL direction="row">
 					<LI padSides={true}>
 						<Card
-							{...{
-								linkTo:
-									'/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai',
-								format: {
-									display: Display.Standard,
-									theme: Pillar.News,
-									design: Design.Article,
-								},
-								headlineText: headlines[9],
-								headlineSize: 'small',
-								kickerText: kickers[0],
-								webPublicationDate: '2019-11-11T09:45:30.000Z',
+							linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+							format={{
+								display: Display.Standard,
+								theme: Pillar.News,
+								design: Design.Article,
 							}}
+							headlineText={headlines[9]}
+							headlineSize="small"
+							kickerText={kickers[0]}
+							webPublicationDate="2019-11-11T09:45:30.000Z"
 						/>
 					</LI>
 					<LI
@@ -507,19 +441,16 @@ export const Related = () => (
 						showTopMarginWhenStacked={true}
 					>
 						<Card
-							{...{
-								linkTo:
-									'/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai',
-								format: {
-									display: Display.Standard,
-									theme: Pillar.Sport,
-									design: Design.Article,
-								},
-								headlineText: headlines[10],
-								headlineSize: 'small',
-								kickerText: kickers[2],
-								webPublicationDate: '2019-11-11T09:45:30.000Z',
+							linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+							format={{
+								display: Display.Standard,
+								theme: Pillar.Sport,
+								design: Design.Article,
 							}}
+							headlineText={headlines[10]}
+							headlineSize="small"
+							kickerText={kickers[2]}
+							webPublicationDate="2019-11-11T09:45:30.000Z"
 						/>
 					</LI>
 					<LI
@@ -528,19 +459,16 @@ export const Related = () => (
 						showTopMarginWhenStacked={true}
 					>
 						<Card
-							{...{
-								linkTo:
-									'/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai',
-								format: {
-									display: Display.Standard,
-									theme: Pillar.Culture,
-									design: Design.Interview,
-								},
-								headlineText: headlines[1],
-								headlineSize: 'small',
-								kickerText: kickers[1],
-								webPublicationDate: '2019-11-11T09:45:30.000Z',
+							linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+							format={{
+								display: Display.Standard,
+								theme: Pillar.Culture,
+								design: Design.Interview,
 							}}
+							headlineText={headlines[1]}
+							headlineSize="small"
+							kickerText={kickers[1]}
+							webPublicationDate="2019-11-11T09:45:30.000Z"
 						/>
 					</LI>
 					<LI
@@ -549,19 +477,16 @@ export const Related = () => (
 						showTopMarginWhenStacked={true}
 					>
 						<Card
-							{...{
-								linkTo:
-									'/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai',
-								format: {
-									display: Display.Standard,
-									theme: Pillar.Lifestyle,
-									design: Design.Feature,
-								},
-								headlineText: headlines[3],
-								headlineSize: 'small',
-								kickerText: kickers[0],
-								webPublicationDate: '2019-11-11T09:45:30.000Z',
+							linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+							format={{
+								display: Display.Standard,
+								theme: Pillar.Lifestyle,
+								design: Design.Feature,
 							}}
+							headlineText={headlines[3]}
+							headlineSize="small"
+							kickerText={kickers[0]}
+							webPublicationDate="2019-11-11T09:45:30.000Z"
 						/>
 					</LI>
 				</UL>
@@ -579,22 +504,19 @@ export const Spotlight = () => (
 			</LeftColumn>
 			<ArticleContainer>
 				<Card
-					{...{
-						linkTo:
-							'/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai',
-						format: {
-							display: Display.Standard,
-							theme: Pillar.Sport,
-							design: Design.Feature,
-						},
-						headlineText: headlines[11],
-						headlineSize: 'large',
-						kickerText: kickers[1],
-						webPublicationDate: '2019-11-11T09:45:30.000Z',
-						imageUrl: images[0],
-						imagePosition: 'right',
-						imageSize: 'jumbo',
+					linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+					format={{
+						display: Display.Standard,
+						theme: Pillar.Sport,
+						design: Design.Feature,
 					}}
+					headlineText={headlines[11]}
+					headlineSize="large"
+					kickerText={kickers[1]}
+					webPublicationDate="2019-11-11T09:45:30.000Z"
+					imageUrl={images[0]}
+					imagePosition="right"
+					imageSize="jumbo"
 				/>
 			</ArticleContainer>
 		</Flex>
@@ -612,27 +534,24 @@ export const Quad = () => (
 				<UL direction="row">
 					<LI padSides={true}>
 						<Card
-							{...{
-								linkTo:
-									'/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai',
-								format: {
-									display: Display.Standard,
-									theme: Pillar.Opinion,
-									design: Design.Comment,
-								},
-								headlineText: headlines[11],
-								headlineSize: 'medium',
-								showQuotes: true,
-								byline: 'George Monbiot',
-								kickerText: kickers[3],
-								webPublicationDate: '2019-11-11T09:45:30.000Z',
-								avatar: {
-									src:
-										'https://i.guim.co.uk/img/uploads/2017/10/06/George-Monbiot,-L.png?width=173&quality=85&auto=format&fit=max&s=be5b0d3f3aa55682e4930057fc3929a3',
-									alt: 'Avatar alt text',
-								},
-								showClock: true,
+							linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+							format={{
+								display: Display.Standard,
+								theme: Pillar.Opinion,
+								design: Design.Comment,
 							}}
+							headlineText={headlines[11]}
+							headlineSize="medium"
+							showQuotes={true}
+							byline="George Monbiot"
+							kickerText={kickers[3]}
+							webPublicationDate="2019-11-11T09:45:30.000Z"
+							avatar={{
+								src:
+									'https://i.guim.co.uk/img/uploads/2017/10/06/George-Monbiot,-L.png?width=173&quality=85&auto=format&fit=max&s=be5b0d3f3aa55682e4930057fc3929a3',
+								alt: 'Avatar alt text',
+							}}
+							showClock={true}
 						/>
 					</LI>
 					<LI
@@ -641,22 +560,19 @@ export const Quad = () => (
 						showTopMarginWhenStacked={true}
 					>
 						<Card
-							{...{
-								linkTo:
-									'/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai',
-								format: {
-									display: Display.Standard,
-									theme: Pillar.Opinion,
-									design: Design.Article,
-								},
-								headlineText: headlines[11],
-								headlineSize: 'medium',
-								webPublicationDate: '2019-11-11T09:45:30.000Z',
-								imageUrl: images[0],
-								imagePosition: 'top',
-								showClock: true,
-								commentCount: 30989,
+							linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+							format={{
+								display: Display.Standard,
+								theme: Pillar.Opinion,
+								design: Design.Article,
 							}}
+							headlineText={headlines[11]}
+							headlineSize="medium"
+							webPublicationDate="2019-11-11T09:45:30.000Z"
+							imageUrl={images[0]}
+							imagePosition="top"
+							showClock={true}
+							commentCount={30989}
 						/>
 					</LI>
 					<LI
@@ -665,23 +581,20 @@ export const Quad = () => (
 						showTopMarginWhenStacked={true}
 					>
 						<Card
-							{...{
-								linkTo:
-									'/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai',
-								format: {
-									display: Display.Standard,
-									theme: Pillar.News,
-									design: Design.Article,
-								},
-								headlineText: headlines[11],
-								headlineSize: 'medium',
-								kickerText: kickers[0],
-								webPublicationDate: '2019-11-11T09:45:30.000Z',
-								imageUrl: images[0],
-								imagePosition: 'top',
-								showClock: true,
-								commentCount: 0,
+							linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+							format={{
+								display: Display.Standard,
+								theme: Pillar.News,
+								design: Design.Article,
 							}}
+							headlineText={headlines[11]}
+							headlineSize="medium"
+							kickerText={kickers[0]}
+							webPublicationDate="2019-11-11T09:45:30.000Z"
+							imageUrl={images[0]}
+							imagePosition="top"
+							showClock={true}
+							commentCount={0}
 						/>
 					</LI>
 					<LI
@@ -690,22 +603,19 @@ export const Quad = () => (
 						showTopMarginWhenStacked={true}
 					>
 						<Card
-							{...{
-								linkTo:
-									'/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai',
-								format: {
-									display: Display.Standard,
-									theme: Pillar.News,
-									design: Design.Article,
-								},
-								headlineText: headlines[11],
-								headlineSize: 'medium',
-								kickerText: kickers[2],
-								webPublicationDate: '2019-11-11T09:45:30.000Z',
-								imageUrl: images[0],
-								imagePosition: 'top',
-								showClock: true,
+							linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+							format={{
+								display: Display.Standard,
+								theme: Pillar.News,
+								design: Design.Article,
 							}}
+							headlineText={headlines[11]}
+							headlineSize="medium"
+							kickerText={kickers[2]}
+							webPublicationDate="2019-11-11T09:45:30.000Z"
+							imageUrl={images[0]}
+							imagePosition="top"
+							showClock={true}
 						/>
 					</LI>
 				</UL>
@@ -729,23 +639,20 @@ export const Media = () => (
 						showTopMarginWhenStacked={true}
 					>
 						<Card
-							{...{
-								linkTo:
-									'/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai',
-								format: {
-									display: Display.Standard,
-									theme: Pillar.Culture,
-									design: Design.Media,
-								},
-								headlineText: headlines[11],
-								headlineSize: 'medium',
-								webPublicationDate: '2019-11-11T09:45:30.000Z',
-								imageUrl: images[0],
-								imagePosition: 'top',
-								showClock: true,
-								mediaType: 'Gallery',
-								commentCount: 0,
+							linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+							format={{
+								display: Display.Standard,
+								theme: Pillar.Culture,
+								design: Design.Media,
 							}}
+							headlineText={headlines[11]}
+							headlineSize="medium"
+							webPublicationDate="2019-11-11T09:45:30.000Z"
+							imageUrl={images[0]}
+							imagePosition="top"
+							showClock={true}
+							mediaType="Gallery"
+							commentCount={0}
 						/>
 					</LI>
 					<LI
@@ -754,24 +661,21 @@ export const Media = () => (
 						showTopMarginWhenStacked={true}
 					>
 						<Card
-							{...{
-								linkTo:
-									'/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai',
-								format: {
-									display: Display.Standard,
-									theme: Pillar.News,
-									design: Design.Media,
-								},
-								headlineText: headlines[11],
-								headlineSize: 'medium',
-								kickerText: kickers[0],
-								imageUrl: images[0],
-								imagePosition: 'top',
-								showClock: true,
-								mediaType: 'Audio',
-								mediaDuration: 35999,
-								commentCount: 864,
+							linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+							format={{
+								display: Display.Standard,
+								theme: Pillar.News,
+								design: Design.Media,
 							}}
+							headlineText={headlines[11]}
+							headlineSize="medium"
+							kickerText={kickers[0]}
+							imageUrl={images[0]}
+							imagePosition="top"
+							showClock={true}
+							mediaType="Audio"
+							mediaDuration={35999}
+							commentCount={864}
 						/>
 					</LI>
 					<LI
@@ -780,24 +684,21 @@ export const Media = () => (
 						showTopMarginWhenStacked={true}
 					>
 						<Card
-							{...{
-								linkTo:
-									'/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai',
-								format: {
-									display: Display.Standard,
-									theme: Pillar.Sport,
-									design: Design.Media,
-								},
-								headlineText: headlines[11],
-								headlineSize: 'medium',
-								kickerText: kickers[1],
-								webPublicationDate: '2019-11-11T09:45:30.000Z',
-								imageUrl: images[0],
-								imagePosition: 'top',
-								showClock: true,
-								mediaType: 'Video',
-								mediaDuration: 59,
+							linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+							format={{
+								display: Display.Standard,
+								theme: Pillar.Sport,
+								design: Design.Media,
 							}}
+							headlineText={headlines[11]}
+							headlineSize="medium"
+							kickerText={kickers[1]}
+							webPublicationDate="2019-11-11T09:45:30.000Z"
+							imageUrl={images[0]}
+							imagePosition="top"
+							showClock={true}
+							mediaType="Video"
+							mediaDuration={59}
 						/>
 					</LI>
 				</UL>

--- a/src/web/components/Onwards/ExactlyFive.tsx
+++ b/src/web/components/Onwards/ExactlyFive.tsx
@@ -16,29 +16,27 @@ export const ExactlyFive = ({ content }: Props) => (
 		<UL direction="row" bottomMargin={true}>
 			<LI padSides={true} percentage="33%">
 				<Card
-					{...{
-						linkTo: content[0].url,
-						format: {
-							display: Display.Standard,
-							design: content[0].design,
-							theme: content[0].pillar,
-						},
-						headlineText: content[0].headline,
-						headlineSize: 'medium',
-						byline: content[0].byline,
-						showByline: content[0].showByline,
-						showQuotes: content[0].design === Design.Comment,
-						webPublicationDate: content[0].webPublicationDate,
-						kickerText: content[0].kickerText,
-						showPulsingDot: content[0].isLiveBlog,
-						showSlash: true,
-						showClock: false,
-						imageUrl: content[0].image,
-						mediaType: content[0].mediaType,
-						mediaDuration: content[0].mediaDuration,
-						commentCount: content[0].commentCount,
-						starRating: content[0].starRating,
+					linkTo={content[0].url}
+					format={{
+						display: Display.Standard,
+						design: content[0].design,
+						theme: content[0].pillar,
 					}}
+					headlineText={content[0].headline}
+					headlineSize="medium"
+					byline={content[0].byline}
+					showByline={content[0].showByline}
+					showQuotes={content[0].design === Design.Comment}
+					webPublicationDate={content[0].webPublicationDate}
+					kickerText={content[0].kickerText}
+					showPulsingDot={content[0].isLiveBlog}
+					showSlash={true}
+					showClock={false}
+					imageUrl={content[0].image}
+					mediaType={content[0].mediaType}
+					mediaDuration={content[0].mediaDuration}
+					commentCount={content[0].commentCount}
+					starRating={content[0].starRating}
 				/>
 			</LI>
 			<LI
@@ -48,29 +46,27 @@ export const ExactlyFive = ({ content }: Props) => (
 				percentage="33%"
 			>
 				<Card
-					{...{
-						linkTo: content[1].url,
-						format: {
-							display: Display.Standard,
-							design: content[1].design,
-							theme: content[1].pillar,
-						},
-						headlineText: content[1].headline,
-						headlineSize: 'medium',
-						byline: content[1].byline,
-						showByline: content[1].showByline,
-						showQuotes: content[1].design === Design.Comment,
-						webPublicationDate: content[1].webPublicationDate,
-						kickerText: content[1].kickerText,
-						showPulsingDot: content[1].isLiveBlog,
-						showSlash: true,
-						showClock: false,
-						imageUrl: content[1].image,
-						mediaType: content[1].mediaType,
-						mediaDuration: content[1].mediaDuration,
-						commentCount: content[1].commentCount,
-						starRating: content[1].starRating,
+					linkTo={content[1].url}
+					format={{
+						display: Display.Standard,
+						design: content[1].design,
+						theme: content[1].pillar,
 					}}
+					headlineText={content[1].headline}
+					headlineSize="medium"
+					byline={content[1].byline}
+					showByline={content[1].showByline}
+					showQuotes={content[1].design === Design.Comment}
+					webPublicationDate={content[1].webPublicationDate}
+					kickerText={content[1].kickerText}
+					showPulsingDot={content[1].isLiveBlog}
+					showSlash={true}
+					showClock={false}
+					imageUrl={content[1].image}
+					mediaType={content[1].mediaType}
+					mediaDuration={content[1].mediaDuration}
+					commentCount={content[1].commentCount}
+					starRating={content[1].starRating}
 				/>
 			</LI>
 			<LI
@@ -82,86 +78,74 @@ export const ExactlyFive = ({ content }: Props) => (
 				<UL direction="column">
 					<LI bottomMargin={true} stretch={true}>
 						<Card
-							{...{
-								linkTo: content[2].url,
-								format: {
-									display: Display.Standard,
-									design: content[2].design,
-									theme: content[2].pillar,
-								},
-								headlineText: content[2].headline,
-								headlineSize: 'medium',
-								byline: content[2].byline,
-								showByline: content[2].showByline,
-								showQuotes:
-									content[2].design === Design.Comment,
-								webPublicationDate:
-									content[2].webPublicationDate,
-								kickerText: content[2].kickerText,
-								showPulsingDot: content[2].isLiveBlog,
-								showSlash: true,
-								showClock: false,
-								mediaType: content[2].mediaType,
-								mediaDuration: content[2].mediaDuration,
-								commentCount: content[2].commentCount,
-								starRating: content[2].starRating,
+							linkTo={content[2].url}
+							format={{
+								display: Display.Standard,
+								design: content[2].design,
+								theme: content[2].pillar,
 							}}
+							headlineText={content[2].headline}
+							headlineSize="medium"
+							byline={content[2].byline}
+							showByline={content[2].showByline}
+							showQuotes={content[2].design === Design.Comment}
+							webPublicationDate={content[2].webPublicationDate}
+							kickerText={content[2].kickerText}
+							showPulsingDot={content[2].isLiveBlog}
+							showSlash={true}
+							showClock={false}
+							mediaType={content[2].mediaType}
+							mediaDuration={content[2].mediaDuration}
+							commentCount={content[2].commentCount}
+							starRating={content[2].starRating}
 						/>
 					</LI>
 					<LI bottomMargin={true} stretch={true}>
 						<Card
-							{...{
-								linkTo: content[3].url,
-								format: {
-									display: Display.Standard,
-									design: content[3].design,
-									theme: content[3].pillar,
-								},
-								headlineText: content[3].headline,
-								headlineSize: 'medium',
-								byline: content[3].byline,
-								showByline: content[3].showByline,
-								showQuotes:
-									content[3].design === Design.Comment,
-								webPublicationDate:
-									content[3].webPublicationDate,
-								kickerText: content[3].kickerText,
-								showPulsingDot: content[3].isLiveBlog,
-								showSlash: true,
-								showClock: false,
-								mediaType: content[3].mediaType,
-								mediaDuration: content[3].mediaDuration,
-								commentCount: content[3].commentCount,
-								starRating: content[3].starRating,
+							linkTo={content[3].url}
+							format={{
+								display: Display.Standard,
+								design: content[3].design,
+								theme: content[3].pillar,
 							}}
+							headlineText={content[3].headline}
+							headlineSize="medium"
+							byline={content[3].byline}
+							showByline={content[3].showByline}
+							showQuotes={content[3].design === Design.Comment}
+							webPublicationDate={content[3].webPublicationDate}
+							kickerText={content[3].kickerText}
+							showPulsingDot={content[3].isLiveBlog}
+							showSlash={true}
+							showClock={false}
+							mediaType={content[3].mediaType}
+							mediaDuration={content[3].mediaDuration}
+							commentCount={content[3].commentCount}
+							starRating={content[3].starRating}
 						/>
 					</LI>
 					<LI bottomMargin={false} stretch={true}>
 						<Card
-							{...{
-								linkTo: content[4].url,
-								format: {
-									display: Display.Standard,
-									design: content[4].design,
-									theme: content[4].pillar,
-								},
-								headlineText: content[4].headline,
-								headlineSize: 'medium',
-								byline: content[4].byline,
-								showByline: content[4].showByline,
-								showQuotes:
-									content[4].design === Design.Comment,
-								webPublicationDate:
-									content[4].webPublicationDate,
-								kickerText: content[4].kickerText,
-								showPulsingDot: content[4].isLiveBlog,
-								showSlash: true,
-								showClock: false,
-								mediaType: content[4].mediaType,
-								mediaDuration: content[4].mediaDuration,
-								commentCount: content[4].commentCount,
-								starRating: content[4].starRating,
+							linkTo={content[4].url}
+							format={{
+								display: Display.Standard,
+								design: content[4].design,
+								theme: content[4].pillar,
 							}}
+							headlineText={content[4].headline}
+							headlineSize="medium"
+							byline={content[4].byline}
+							showByline={content[4].showByline}
+							showQuotes={content[4].design === Design.Comment}
+							webPublicationDate={content[4].webPublicationDate}
+							kickerText={content[4].kickerText}
+							showPulsingDot={content[4].isLiveBlog}
+							showSlash={true}
+							showClock={false}
+							mediaType={content[4].mediaType}
+							mediaDuration={content[4].mediaDuration}
+							commentCount={content[4].commentCount}
+							starRating={content[4].starRating}
 						/>
 					</LI>
 				</UL>

--- a/src/web/components/Onwards/FourOrLess.tsx
+++ b/src/web/components/Onwards/FourOrLess.tsx
@@ -39,29 +39,27 @@ export const FourOrLess = ({ content }: Props) => {
 						percentage={percentage}
 					>
 						<Card
-							{...{
-								linkTo: trail.url,
-								format: {
-									display: Display.Standard,
-									design: trail.design,
-									theme: trail.pillar,
-								},
-								headlineText: trail.headline,
-								headlineSize: 'medium',
-								byline: trail.byline,
-								showByline: trail.showByline,
-								showQuotes: trail.design === Design.Comment,
-								webPublicationDate: trail.webPublicationDate,
-								kickerText: trail.kickerText,
-								showPulsingDot: trail.isLiveBlog,
-								showSlash: true,
-								showClock: false,
-								imageUrl: trail.image,
-								mediaType: trail.mediaType,
-								mediaDuration: trail.mediaDuration,
-								commentCount: trail.commentCount,
-								starRating: trail.starRating,
+							linkTo={trail.url}
+							format={{
+								display: Display.Standard,
+								design: trail.design,
+								theme: trail.pillar,
 							}}
+							headlineText={trail.headline}
+							headlineSize="medium"
+							byline={trail.byline}
+							showByline={trail.showByline}
+							showQuotes={trail.design === Design.Comment}
+							webPublicationDate={trail.webPublicationDate}
+							kickerText={trail.kickerText}
+							showPulsingDot={trail.isLiveBlog}
+							showSlash={true}
+							showClock={false}
+							imageUrl={trail.image}
+							mediaType={trail.mediaType}
+							mediaDuration={trail.mediaDuration}
+							commentCount={trail.commentCount}
+							starRating={trail.starRating}
 						/>
 					</LI>
 				))}

--- a/src/web/components/Onwards/MoreThanFive.tsx
+++ b/src/web/components/Onwards/MoreThanFive.tsx
@@ -33,29 +33,27 @@ export const MoreThanFive = ({ content }: Props) => {
 			<UL direction="row" bottomMargin={true}>
 				<LI padSides={true} percentage="25%">
 					<Card
-						{...{
-							linkTo: content[0].url,
-							format: {
-								display: Display.Standard,
-								design: content[0].design,
-								theme: content[0].pillar,
-							},
-							headlineText: content[0].headline,
-							headlineSize: 'medium',
-							byline: content[0].byline,
-							showByline: content[0].showByline,
-							showQuotes: content[0].design === Design.Comment,
-							webPublicationDate: content[0].webPublicationDate,
-							kickerText: content[0].kickerText,
-							showPulsingDot: content[0].isLiveBlog,
-							showSlash: true,
-							showClock: false,
-							imageUrl: content[0].image,
-							mediaType: content[0].mediaType,
-							mediaDuration: content[0].mediaDuration,
-							commentCount: content[0].commentCount,
-							starRating: content[0].starRating,
+						linkTo={content[0].url}
+						format={{
+							display: Display.Standard,
+							design: content[0].design,
+							theme: content[0].pillar,
 						}}
+						headlineText={content[0].headline}
+						headlineSize="medium"
+						byline={content[0].byline}
+						showByline={content[0].showByline}
+						showQuotes={content[0].design === Design.Comment}
+						webPublicationDate={content[0].webPublicationDate}
+						kickerText={content[0].kickerText}
+						showPulsingDot={content[0].isLiveBlog}
+						showSlash={true}
+						showClock={false}
+						imageUrl={content[0].image}
+						mediaType={content[0].mediaType}
+						mediaDuration={content[0].mediaDuration}
+						commentCount={content[0].commentCount}
+						starRating={content[0].starRating}
 					/>
 				</LI>
 				<LI
@@ -65,29 +63,27 @@ export const MoreThanFive = ({ content }: Props) => {
 					percentage="25%"
 				>
 					<Card
-						{...{
-							linkTo: content[1].url,
-							format: {
-								display: Display.Standard,
-								design: content[1].design,
-								theme: content[1].pillar,
-							},
-							headlineText: content[1].headline,
-							headlineSize: 'medium',
-							byline: content[1].byline,
-							showByline: content[1].showByline,
-							showQuotes: content[1].design === Design.Comment,
-							webPublicationDate: content[1].webPublicationDate,
-							kickerText: content[1].kickerText,
-							showPulsingDot: content[1].isLiveBlog,
-							showSlash: true,
-							showClock: false,
-							imageUrl: content[1].image,
-							mediaType: content[1].mediaType,
-							mediaDuration: content[1].mediaDuration,
-							commentCount: content[1].commentCount,
-							starRating: content[1].starRating,
+						linkTo={content[1].url}
+						format={{
+							display: Display.Standard,
+							design: content[1].design,
+							theme: content[1].pillar,
 						}}
+						headlineText={content[1].headline}
+						headlineSize="medium"
+						byline={content[1].byline}
+						showByline={content[1].showByline}
+						showQuotes={content[1].design === Design.Comment}
+						webPublicationDate={content[1].webPublicationDate}
+						kickerText={content[1].kickerText}
+						showPulsingDot={content[1].isLiveBlog}
+						showSlash={true}
+						showClock={false}
+						imageUrl={content[1].image}
+						mediaType={content[1].mediaType}
+						mediaDuration={content[1].mediaDuration}
+						commentCount={content[1].commentCount}
+						starRating={content[1].starRating}
 					/>
 				</LI>
 				<LI
@@ -97,29 +93,27 @@ export const MoreThanFive = ({ content }: Props) => {
 					percentage="25%"
 				>
 					<Card
-						{...{
-							linkTo: content[2].url,
-							format: {
-								display: Display.Standard,
-								design: content[2].design,
-								theme: content[2].pillar,
-							},
-							headlineText: content[2].headline,
-							headlineSize: 'medium',
-							byline: content[2].byline,
-							showByline: content[2].showByline,
-							showQuotes: content[2].design === Design.Comment,
-							webPublicationDate: content[2].webPublicationDate,
-							kickerText: content[2].kickerText,
-							showPulsingDot: content[2].isLiveBlog,
-							showSlash: true,
-							showClock: false,
-							imageUrl: content[2].image,
-							mediaType: content[2].mediaType,
-							mediaDuration: content[2].mediaDuration,
-							commentCount: content[2].commentCount,
-							starRating: content[2].starRating,
+						linkTo={content[2].url}
+						format={{
+							display: Display.Standard,
+							design: content[2].design,
+							theme: content[2].pillar,
 						}}
+						headlineText={content[2].headline}
+						headlineSize="medium"
+						byline={content[2].byline}
+						showByline={content[2].showByline}
+						showQuotes={content[2].design === Design.Comment}
+						webPublicationDate={content[2].webPublicationDate}
+						kickerText={content[2].kickerText}
+						showPulsingDot={content[2].isLiveBlog}
+						showSlash={true}
+						showClock={false}
+						imageUrl={content[2].image}
+						mediaType={content[2].mediaType}
+						mediaDuration={content[2].mediaDuration}
+						commentCount={content[2].commentCount}
+						starRating={content[2].starRating}
 					/>
 				</LI>
 				<LI
@@ -129,29 +123,27 @@ export const MoreThanFive = ({ content }: Props) => {
 					percentage="25%"
 				>
 					<Card
-						{...{
-							linkTo: content[3].url,
-							format: {
-								display: Display.Standard,
-								design: content[3].design,
-								theme: content[3].pillar,
-							},
-							headlineText: content[3].headline,
-							headlineSize: 'medium',
-							byline: content[3].byline,
-							showByline: content[3].showByline,
-							showQuotes: content[3].design === Design.Comment,
-							webPublicationDate: content[3].webPublicationDate,
-							kickerText: content[3].kickerText,
-							showPulsingDot: content[3].isLiveBlog,
-							showSlash: true,
-							showClock: false,
-							imageUrl: content[3].image,
-							mediaType: content[3].mediaType,
-							mediaDuration: content[3].mediaDuration,
-							commentCount: content[3].commentCount,
-							starRating: content[3].starRating,
+						linkTo={content[3].url}
+						format={{
+							display: Display.Standard,
+							design: content[3].design,
+							theme: content[3].pillar,
 						}}
+						headlineText={content[3].headline}
+						headlineSize="medium"
+						byline={content[3].byline}
+						showByline={content[3].showByline}
+						showQuotes={content[3].design === Design.Comment}
+						webPublicationDate={content[3].webPublicationDate}
+						kickerText={content[3].kickerText}
+						showPulsingDot={content[3].isLiveBlog}
+						showSlash={true}
+						showClock={false}
+						imageUrl={content[3].image}
+						mediaType={content[3].mediaType}
+						mediaDuration={content[3].mediaDuration}
+						commentCount={content[3].commentCount}
+						starRating={content[3].starRating}
 					/>
 				</LI>
 			</UL>
@@ -164,28 +156,26 @@ export const MoreThanFive = ({ content }: Props) => {
 						percentage={secondRowPercentage}
 					>
 						<Card
-							{...{
-								linkTo: trail.url,
-								format: {
-									display: Display.Standard,
-									design: trail.design,
-									theme: trail.pillar,
-								},
-								headlineText: trail.headline,
-								headlineSize: 'small',
-								byline: trail.byline,
-								showByline: trail.showByline,
-								showQuotes: trail.design === Design.Comment,
-								webPublicationDate: trail.webPublicationDate,
-								kickerText: trail.kickerText,
-								showPulsingDot: trail.isLiveBlog,
-								showSlash: true,
-								showClock: false,
-								mediaType: trail.mediaType,
-								mediaDuration: trail.mediaDuration,
-								commentCount: trail.commentCount,
-								starRating: trail.starRating,
+							linkTo={trail.url}
+							format={{
+								display: Display.Standard,
+								design: trail.design,
+								theme: trail.pillar,
 							}}
+							headlineText={trail.headline}
+							headlineSize="small"
+							byline={trail.byline}
+							showByline={trail.showByline}
+							showQuotes={trail.design === Design.Comment}
+							webPublicationDate={trail.webPublicationDate}
+							kickerText={trail.kickerText}
+							showPulsingDot={trail.isLiveBlog}
+							showSlash={true}
+							showClock={false}
+							mediaType={trail.mediaType}
+							mediaDuration={trail.mediaDuration}
+							commentCount={trail.commentCount}
+							starRating={trail.starRating}
 						/>
 					</LI>
 				))}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Removes the use of prop spreading in the `Card` stories

### Before
```typescript
					<Card
						{...{
							linkTo: content[3].url,
							format: {
								display: Display.Standard,
								design: content[3].design,
								theme: content[3].pillar,
							},
							headlineText: content[3].headline,
							headlineSize: 'medium',
							mediaType: content[3].mediaType,
							mediaDuration: content[3].mediaDuration,
							commentCount: content[3].commentCount,
							starRating: content[3].starRating,
						}}
					/>
```

### After
```typescript
					<Card
						linkTo={content[3].url}
						format={{
							display: Display.Standard,
							design: content[3].design,
							theme: content[3].pillar,
						}}
						headlineText={content[3].headline}
						headlineSize="medium"
						mediaType={content[3].mediaType}
						mediaDuration={content[3].mediaDuration}
						commentCount={content[3].commentCount}
						starRating={content[3].starRating}
					/>
```

## Why?
This improve code readability and ensure we get the most benefit from Reacts features. Our stories are also as much a tool for testing as a recomendatino for how a component should be used and we want to encourage best practice.
