### PR TITLE
decideTrail

### DIFF
--- a/fixtures/onwards.mocks.ts
+++ b/fixtures/onwards.mocks.ts
@@ -1,4 +1,4 @@
-import { Pillar } from '@guardian/types';
+import { Display, Pillar } from '@guardian/types';
 
 import { decideDesign } from '@root/src/web/lib/decideDesign';
 import { decideTheme } from '@root/src/web/lib/decideTheme';
@@ -118,6 +118,7 @@ const CAPITrails: CAPITrailType[] = [
 ];
 
 const trails: TrailType[] = CAPITrails.map((thisTrail) => {
+	const display = Display.Standard;
 	const design = decideDesign(thisTrail.designType, []);
 	const pillar = decideTheme({ pillar: thisTrail.pillar, design });
 	return {
@@ -130,6 +131,7 @@ const trails: TrailType[] = CAPITrails.map((thisTrail) => {
 		webPublicationDate: thisTrail.webPublicationDate,
 		mediaType: thisTrail.mediaType,
 		mediaDuration: thisTrail.mediaDuration,
+		display,
 		pillar,
 		design,
 	};

--- a/fixtures/onwards.mocks.ts
+++ b/fixtures/onwards.mocks.ts
@@ -120,7 +120,7 @@ const CAPITrails: CAPITrailType[] = [
 const trails: TrailType[] = CAPITrails.map((thisTrail) => {
 	const display = Display.Standard;
 	const design = decideDesign(thisTrail.designType, []);
-	const pillar = decideTheme({ pillar: thisTrail.pillar, design });
+	const theme = decideTheme({ pillar: thisTrail.pillar, design });
 	return {
 		url: thisTrail.url,
 		headline: thisTrail.headline,
@@ -131,9 +131,11 @@ const trails: TrailType[] = CAPITrails.map((thisTrail) => {
 		webPublicationDate: thisTrail.webPublicationDate,
 		mediaType: thisTrail.mediaType,
 		mediaDuration: thisTrail.mediaDuration,
-		display,
-		pillar,
-		design,
+		format: {
+			display,
+			theme,
+			design,
+		},
 	};
 });
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -30,6 +30,7 @@ type CAPIDesign =
 	| 'SpecialReport'
 	| 'GuardianLabs';
 
+type Display = import('@guardian/types').Display;
 type Design = import('@guardian/types').Design;
 type Theme = import('@guardian/types').Theme;
 type Format = import('@guardian/types').Format;
@@ -806,6 +807,7 @@ interface BaseTrailType {
     linkText?: string;
 }
 interface TrailType extends BaseTrailType {
+    display: Display;
 	design: Design;
 	pillar: Theme;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -807,9 +807,7 @@ interface BaseTrailType {
     linkText?: string;
 }
 interface TrailType extends BaseTrailType {
-    display: Display;
-	design: Design;
-	pillar: Theme;
+    format: Format;
 }
 
 interface CAPITrailType extends BaseTrailType {

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterData.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterData.tsx
@@ -7,8 +7,7 @@ import { useAB } from '@guardian/ab-react';
 
 import { useApi } from '@root/src/web/lib/api';
 import { joinUrl } from '@root/src/lib/joinUrl';
-import { decideTheme } from '@root/src/web/lib/decideTheme';
-import { decideDesign } from '@root/src/web/lib/decideDesign';
+import { decideTrail } from '@root/src/web/lib/decideTrail';
 
 import { MostViewedFooterGrid } from './MostViewedFooterGrid';
 import { SecondTierItem } from './SecondTierItem';
@@ -51,20 +50,10 @@ function buildDeeplyReadUrl(ajaxUrl: string) {
 	return joinUrl([ajaxUrl, 'most-read-deeply-read.json']);
 }
 
-function transformTrail(trail: CAPITrailType): TrailType {
-	const design = decideDesign(trail.designType, []);
-	// Converts the CAPI string pillar into an enum
-	return {
-		...trail,
-		pillar: decideTheme({ pillar: trail.pillar, design }),
-		design,
-	};
-}
-
 function transformTabs(tabs: CAPITrailTabType[]): TrailTabType[] {
 	return tabs.map((tab) => ({
 		...tab,
-		trails: tab.trails.map((trail) => transformTrail(trail)),
+		trails: tab.trails.map((trail) => decideTrail(trail)),
 	}));
 }
 
@@ -108,7 +97,7 @@ export const MostViewedFooterData = ({
 				<div className={cx(stackBelow('tablet'), secondTierStyles)}>
 					{'mostCommented' in data && (
 						<SecondTierItem
-							trail={transformTrail(data.mostCommented)}
+							trail={decideTrail(data.mostCommented)}
 							title="Most commented"
 							dataLinkName="comment | group-0 | card-@1" // To match Frontend
 							showRightBorder={true}
@@ -116,7 +105,7 @@ export const MostViewedFooterData = ({
 					)}
 					{'mostShared' in data && (
 						<SecondTierItem
-							trail={transformTrail(data.mostShared)}
+							trail={decideTrail(data.mostShared)}
 							dataLinkName="news | group-0 | card-@1" // To match Frontend
 							title="Most shared"
 						/>

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterItem.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterItem.tsx
@@ -77,22 +77,22 @@ export const MostViewedFooterItem = ({ trail, position }: Props) => (
 			<div className={headlineHeader}>
 				{trail.isLiveBlog ? (
 					<LinkHeadline
-						design={trail.design}
+						design={trail.format.design}
 						headlineText={trail.headline}
-						pillar={trail.pillar}
+						pillar={trail.format.theme}
 						size="small"
 						kickerText="Live"
 						showSlash={true}
 						showPulsingDot={true}
-						showQuotes={trail.design === Design.Comment}
+						showQuotes={trail.format.design === Design.Comment}
 					/>
 				) : (
 					<LinkHeadline
-						design={trail.design}
+						design={trail.format.design}
 						headlineText={trail.headline}
-						pillar={trail.pillar}
+						pillar={trail.format.theme}
 						size="small"
-						showQuotes={trail.design === Design.Comment}
+						showQuotes={trail.format.design === Design.Comment}
 					/>
 				)}
 			</div>

--- a/src/web/components/MostViewed/MostViewedFooter/SecondTierItem.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/SecondTierItem.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { css } from 'emotion';
 
-import type { Format } from '@guardian/types';
 import { border, neutral, text } from '@guardian/src-foundations/palette';
 import { headline } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
@@ -90,21 +89,14 @@ export const SecondTierItem = ({
 		isLiveBlog,
 		avatarUrl,
 		image,
-		display,
-		design,
+		format,
 		byline,
 		showByline,
-		pillar,
 		ageWarning,
 		headline: headlineText,
 	} = trail;
 
 	const avatarToShow = avatarUrl || image;
-	const format: Format = {
-		design,
-		display,
-		theme: pillar,
-	};
 
 	return (
 		<div className={itemStyles(showRightBorder)}>
@@ -118,7 +110,7 @@ export const SecondTierItem = ({
 						<div className={titleStyles}>{title}</div>
 						{isLiveBlog ? (
 							<LinkHeadline
-								design={design}
+								design={format.design}
 								headlineText={headlineText}
 								pillar={format.theme}
 								size="small"
@@ -126,7 +118,7 @@ export const SecondTierItem = ({
 							/>
 						) : (
 							<LinkHeadline
-								design={design}
+								design={format.design}
 								headlineText={headlineText}
 								pillar={format.theme}
 								size="small"

--- a/src/web/components/MostViewed/MostViewedFooter/SecondTierItem.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/SecondTierItem.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { css } from 'emotion';
 
-import { Display } from '@guardian/types';
 import type { Format } from '@guardian/types';
 import { border, neutral, text } from '@guardian/src-foundations/palette';
 import { headline } from '@guardian/src-foundations/typography';
@@ -91,6 +90,7 @@ export const SecondTierItem = ({
 		isLiveBlog,
 		avatarUrl,
 		image,
+		display,
 		design,
 		byline,
 		showByline,
@@ -102,7 +102,7 @@ export const SecondTierItem = ({
 	const avatarToShow = avatarUrl || image;
 	const format: Format = {
 		design,
-		display: Display.Standard,
+		display,
 		theme: pillar,
 	};
 

--- a/src/web/components/MostViewed/MostViewedRight/MostViewedRight.tsx
+++ b/src/web/components/MostViewed/MostViewedRight/MostViewedRight.tsx
@@ -4,8 +4,7 @@ import { css } from 'emotion';
 import { headline } from '@guardian/src-foundations/typography';
 
 import { useApi } from '@root/src/web/lib/api';
-import { decideTheme } from '@root/src/web/lib/decideTheme';
-import { decideDesign } from '@root/src/web/lib/decideDesign';
+import { decideTrail } from '@root/src/web/lib/decideTrail';
 import { GuardianLines } from '@root/src/web/components/GuardianLines';
 
 import { MostViewedRightItem } from './MostViewedRightItem';
@@ -25,16 +24,6 @@ interface Props {
 	limitItems?: number;
 }
 
-function transformTrail(trail: CAPITrailType): TrailType {
-	const design = decideDesign(trail.designType, []);
-	return {
-		...trail,
-		// Converts the CAPI string pillar into an enum
-		pillar: decideTheme({ pillar: trail.pillar, design }),
-		design,
-	};
-}
-
 export const MostViewedRight = ({ pillar, limitItems = 5 }: Props) => {
 	const endpointUrl: string =
 		'https://api.nextgen.guardianapps.co.uk/most-read-geo.json?dcr=true';
@@ -46,26 +35,22 @@ export const MostViewedRight = ({ pillar, limitItems = 5 }: Props) => {
 	}
 
 	if (data) {
+		const trails: TrailType[] = data.trails
+			.map(decideTrail)
+			.slice(0, limitItems);
 		// Look I don't know why data-component is geo-most-popular either, but it is, ok? Ok.
 		return (
 			<div className={wrapperStyles} data-component="geo-most-popular">
 				<GuardianLines count={4} pillar={pillar} />
 				<h3 className={headingStyles}>Most viewed</h3>
 				<ul data-link-name="Right hand most popular geo GB">
-					{(data.trails || [])
-						.slice(0, limitItems)
-						.map(
-							(
-								trail: CAPITrailType,
-								mostViewedItemIndex: number,
-							) => (
-								<MostViewedRightItem
-									key={trail.url}
-									trail={transformTrail(trail)}
-									mostViewedItemIndex={mostViewedItemIndex}
-								/>
-							),
-						)}
+					{(trails || []).map((trail, index) => (
+						<MostViewedRightItem
+							key={trail.url}
+							trail={trail}
+							mostViewedItemIndex={index}
+						/>
+					))}
 				</ul>
 			</div>
 		);

--- a/src/web/components/MostViewed/MostViewedRight/MostViewedRight.tsx
+++ b/src/web/components/MostViewed/MostViewedRight/MostViewedRight.tsx
@@ -44,7 +44,7 @@ export const MostViewedRight = ({ pillar, limitItems = 5 }: Props) => {
 				<GuardianLines count={4} pillar={pillar} />
 				<h3 className={headingStyles}>Most viewed</h3>
 				<ul data-link-name="Right hand most popular geo GB">
-					{(trails || []).map((trail, index) => (
+					{trails.map((trail, index) => (
 						<MostViewedRightItem
 							key={trail.url}
 							trail={trail}

--- a/src/web/components/MostViewed/MostViewedRight/MostViewedRightItem.tsx
+++ b/src/web/components/MostViewed/MostViewedRight/MostViewedRightItem.tsx
@@ -7,7 +7,6 @@ import { AgeWarning } from '@root/src/web/components/AgeWarning';
 import { Avatar } from '@root/src/web/components/Avatar';
 import { LinkHeadline } from '@root/src/web/components/LinkHeadline';
 import { useHover } from '@root/src/web/lib/useHover';
-import { Display } from '@guardian/types';
 import { decidePalette } from '@root/src/web/lib/decidePalette';
 
 const listItemStyles = css`
@@ -81,7 +80,7 @@ export const MostViewedRightItem = ({ trail, mostViewedItemIndex }: Props) => {
 								imageSrc={trail.image}
 								imageAlt=""
 								palette={decidePalette({
-									display: Display.Standard,
+									display: trail.display,
 									design: trail.design,
 									theme: trail.pillar,
 								})}

--- a/src/web/components/MostViewed/MostViewedRight/MostViewedRightItem.tsx
+++ b/src/web/components/MostViewed/MostViewedRight/MostViewedRightItem.tsx
@@ -79,20 +79,16 @@ export const MostViewedRightItem = ({ trail, mostViewedItemIndex }: Props) => {
 							<Avatar
 								imageSrc={trail.image}
 								imageAlt=""
-								palette={decidePalette({
-									display: trail.display,
-									design: trail.design,
-									theme: trail.pillar,
-								})}
+								palette={decidePalette(trail.format)}
 							/>
 						</div>
 					)}
 					<div className={headlineWrapperStyles}>
 						{trail.isLiveBlog ? (
 							<LinkHeadline
-								design={trail.design}
+								design={trail.format.design}
 								headlineText={trail.headline}
-								pillar={trail.pillar}
+								pillar={trail.format.theme}
 								size="small"
 								showUnderline={isHovered}
 								link={linkProps}
@@ -104,9 +100,9 @@ export const MostViewedRightItem = ({ trail, mostViewedItemIndex }: Props) => {
 							/>
 						) : (
 							<LinkHeadline
-								design={trail.design}
+								design={trail.format.design}
 								headlineText={trail.headline}
-								pillar={trail.pillar}
+								pillar={trail.format.theme}
 								size="small"
 								showUnderline={isHovered}
 								link={linkProps}

--- a/src/web/components/Onwards/Carousel/Carousel.stories.tsx
+++ b/src/web/components/Onwards/Carousel/Carousel.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Design, Pillar } from '@guardian/types';
+import { Design, Display, Pillar } from '@guardian/types';
 
 import { breakpoints } from '@guardian/src-foundations/mq';
 import { Carousel } from './Carousel';
@@ -30,6 +30,7 @@ const trails: TrailType[] = [
 		image:
 			'https://i.guim.co.uk/img/media/9e3148e304f3d6d6eeafadaf4b707eb4b6f4f64c/0_196_3500_2099/master/3500.jpg?width=300&quality=85&auto=format&fit=max&s=4c6370b54991b05550d1fa7b78f69829',
 		isLiveBlog: true,
+		display: Display.Standard,
 		pillar: Pillar.News,
 		design: Design.Live,
 		webPublicationDate: '2020-09-15T13:46:52.000Z',
@@ -47,6 +48,7 @@ const trails: TrailType[] = [
 		image:
 			'https://i.guim.co.uk/img/media/877e5e3f240c1958504827796249cd8a46caf0a1/0_116_1969_1181/master/1969.jpg?width=300&quality=85&auto=format&fit=max&s=444e206a147224a7e50e0eeb4780620c',
 		isLiveBlog: false,
+		display: Display.Standard,
 		pillar: Pillar.News,
 		design: Design.Article,
 		webPublicationDate: '2020-09-15T11:44:46.000Z',
@@ -64,6 +66,7 @@ const trails: TrailType[] = [
 		image:
 			'https://i.guim.co.uk/img/media/f7c663fe69644c3ca5fd402fab40f3b5501064cc/0_99_4505_2703/master/4505.jpg?width=300&quality=85&auto=format&fit=max&s=fca4c60f52a8e1c686d48742d43e6887',
 		isLiveBlog: false,
+		display: Display.Standard,
 		pillar: Pillar.News,
 		design: Design.Article,
 		webPublicationDate: '2020-09-15T13:24:45.000Z',
@@ -81,6 +84,7 @@ const trails: TrailType[] = [
 		image:
 			'https://i.guim.co.uk/img/media/b204a14ffd1911591e9aa0f2df6769798bbdd1c1/0_225_4000_2400/master/4000.jpg?width=300&quality=85&auto=format&fit=max&s=b7f695cc8b23cec50344273aa46503bf',
 		isLiveBlog: false,
+		display: Display.Standard,
 		pillar: Pillar.News,
 		design: Design.Article,
 		webPublicationDate: '2020-09-15T13:15:36.000Z',
@@ -99,6 +103,7 @@ const trails: TrailType[] = [
 		image:
 			'https://i.guim.co.uk/img/media/f285ba35a26e663f9d5e2808558f644fa12765e1/0_136_960_576/master/960.jpg?width=300&quality=85&auto=format&fit=max&s=b33e6ce3806d5e7ddb26d4decbb824a5',
 		isLiveBlog: false,
+		display: Display.Standard,
 		pillar: Pillar.News,
 		design: Design.Article,
 		webPublicationDate: '2020-09-15T10:41:04.000Z',
@@ -116,6 +121,7 @@ const trails: TrailType[] = [
 		image:
 			'https://i.guim.co.uk/img/media/3ec6d136faade765328e86db332665d19e011d1c/0_1268_3203_1922/master/3203.jpg?width=300&quality=85&auto=format&fit=max&s=b8ec99f56446dc12f76c6880d43b1202',
 		isLiveBlog: false,
+		display: Display.Standard,
 		pillar: Pillar.News,
 		design: Design.Article,
 		webPublicationDate: '2020-09-15T11:00:32.000Z',
@@ -134,6 +140,7 @@ const trails: TrailType[] = [
 		image:
 			'https://i.guim.co.uk/img/media/cf291623610b4e9bd53adad56ea1752c5557ad21/0_26_5636_3382/master/5636.jpg?width=300&quality=85&auto=format&fit=max&s=444feb3e9cc898bda708438d05ea6941',
 		isLiveBlog: false,
+		display: Display.Standard,
 		pillar: Pillar.News,
 		design: Design.Article,
 		webPublicationDate: '2020-09-15T09:30:22.000Z',
@@ -151,6 +158,7 @@ const trails: TrailType[] = [
 		image:
 			'https://i.guim.co.uk/img/media/c38b10a48e27c463ce16d058e02aafda4328e52f/0_20_2462_1478/master/2462.jpg?width=300&quality=85&auto=format&fit=max&s=63656ef63ad936d92d96316f13ce2715',
 		isLiveBlog: false,
+		display: Display.Standard,
 		pillar: Pillar.News,
 		design: Design.Article,
 		webPublicationDate: '2020-09-15T13:04:57.000Z',
@@ -169,6 +177,7 @@ const trails: TrailType[] = [
 		image:
 			'https://i.guim.co.uk/img/media/8c0eff269da77ac303734e8717705d4b70f7d5e2/0_97_5472_3283/master/5472.jpg?width=300&quality=85&auto=format&fit=max&s=3b45f3f609dd7aee06eb1428a172bb8c',
 		isLiveBlog: false,
+		display: Display.Standard,
 		pillar: Pillar.News,
 		design: Design.Article,
 		webPublicationDate: '2020-09-15T13:28:24.000Z',
@@ -187,6 +196,7 @@ const trails: TrailType[] = [
 		image:
 			'https://i.guim.co.uk/img/media/f022aacc31e1e95a07f382206c9b8e5620214e0a/0_0_2560_1536/master/2560.jpg?width=300&quality=85&auto=format&fit=max&s=b4a6348eb191bf5d366ed6282f2ada70',
 		isLiveBlog: false,
+		display: Display.Standard,
 		pillar: Pillar.Culture,
 		design: Design.Article,
 		webPublicationDate: '2020-09-15T12:21:07.000Z',

--- a/src/web/components/Onwards/Carousel/Carousel.stories.tsx
+++ b/src/web/components/Onwards/Carousel/Carousel.stories.tsx
@@ -30,9 +30,11 @@ const trails: TrailType[] = [
 		image:
 			'https://i.guim.co.uk/img/media/9e3148e304f3d6d6eeafadaf4b707eb4b6f4f64c/0_196_3500_2099/master/3500.jpg?width=300&quality=85&auto=format&fit=max&s=4c6370b54991b05550d1fa7b78f69829',
 		isLiveBlog: true,
-		display: Display.Standard,
-		pillar: Pillar.News,
-		design: Design.Live,
+		format: {
+			display: Display.Standard,
+			theme: Pillar.News,
+			design: Design.Live,
+		},
 		webPublicationDate: '2020-09-15T13:46:52.000Z',
 		headline:
 			'UK coronavirus: testing shortage will take weeks to resolve, says Matt Hancock',
@@ -48,9 +50,11 @@ const trails: TrailType[] = [
 		image:
 			'https://i.guim.co.uk/img/media/877e5e3f240c1958504827796249cd8a46caf0a1/0_116_1969_1181/master/1969.jpg?width=300&quality=85&auto=format&fit=max&s=444e206a147224a7e50e0eeb4780620c',
 		isLiveBlog: false,
-		display: Display.Standard,
-		pillar: Pillar.News,
-		design: Design.Article,
+		format: {
+			display: Display.Standard,
+			theme: Pillar.News,
+			design: Design.Article,
+		},
 		webPublicationDate: '2020-09-15T11:44:46.000Z',
 		headline: 'Ex-Tory MP jailed for two years for sexual assaults',
 		shortUrl: 'https://theguardian.com/p/ezmac',
@@ -66,9 +70,11 @@ const trails: TrailType[] = [
 		image:
 			'https://i.guim.co.uk/img/media/f7c663fe69644c3ca5fd402fab40f3b5501064cc/0_99_4505_2703/master/4505.jpg?width=300&quality=85&auto=format&fit=max&s=fca4c60f52a8e1c686d48742d43e6887',
 		isLiveBlog: false,
-		display: Display.Standard,
-		pillar: Pillar.News,
-		design: Design.Article,
+		format: {
+			display: Display.Standard,
+			theme: Pillar.News,
+			design: Design.Article,
+		},
 		webPublicationDate: '2020-09-15T13:24:45.000Z',
 		headline: 'No 10 rejects any concessions for rebel Tories on bill',
 		shortUrl: 'https://theguardian.com/p/ezn2d',
@@ -84,9 +90,11 @@ const trails: TrailType[] = [
 		image:
 			'https://i.guim.co.uk/img/media/b204a14ffd1911591e9aa0f2df6769798bbdd1c1/0_225_4000_2400/master/4000.jpg?width=300&quality=85&auto=format&fit=max&s=b7f695cc8b23cec50344273aa46503bf',
 		isLiveBlog: false,
-		display: Display.Standard,
-		pillar: Pillar.News,
-		design: Design.Article,
+		format: {
+			display: Display.Standard,
+			theme: Pillar.News,
+			design: Design.Article,
+		},
 		webPublicationDate: '2020-09-15T13:15:36.000Z',
 		headline:
 			'World fails to meet a single target to stop destruction of nature – UN report',
@@ -103,9 +111,11 @@ const trails: TrailType[] = [
 		image:
 			'https://i.guim.co.uk/img/media/f285ba35a26e663f9d5e2808558f644fa12765e1/0_136_960_576/master/960.jpg?width=300&quality=85&auto=format&fit=max&s=b33e6ce3806d5e7ddb26d4decbb824a5',
 		isLiveBlog: false,
-		display: Display.Standard,
-		pillar: Pillar.News,
-		design: Design.Article,
+		format: {
+			display: Display.Standard,
+			theme: Pillar.News,
+			design: Design.Article,
+		},
 		webPublicationDate: '2020-09-15T10:41:04.000Z',
 		headline: 'Poisoned Russian opposition leader posts hospital photo',
 		shortUrl: 'https://theguardian.com/p/ezmtk',
@@ -121,9 +131,11 @@ const trails: TrailType[] = [
 		image:
 			'https://i.guim.co.uk/img/media/3ec6d136faade765328e86db332665d19e011d1c/0_1268_3203_1922/master/3203.jpg?width=300&quality=85&auto=format&fit=max&s=b8ec99f56446dc12f76c6880d43b1202',
 		isLiveBlog: false,
-		display: Display.Standard,
-		pillar: Pillar.News,
-		design: Design.Article,
+		format: {
+			display: Display.Standard,
+			theme: Pillar.News,
+			design: Design.Article,
+		},
 		webPublicationDate: '2020-09-15T11:00:32.000Z',
 		headline:
 			'Gary Lineker takes 25% pay cut and agrees to tweet more carefully',
@@ -140,9 +152,11 @@ const trails: TrailType[] = [
 		image:
 			'https://i.guim.co.uk/img/media/cf291623610b4e9bd53adad56ea1752c5557ad21/0_26_5636_3382/master/5636.jpg?width=300&quality=85&auto=format&fit=max&s=444feb3e9cc898bda708438d05ea6941',
 		isLiveBlog: false,
-		display: Display.Standard,
-		pillar: Pillar.News,
-		design: Design.Article,
+		format: {
+			display: Display.Standard,
+			theme: Pillar.News,
+			design: Design.Article,
+		},
 		webPublicationDate: '2020-09-15T09:30:22.000Z',
 		headline: 'Former ambassador warns of election violence',
 		shortUrl: 'https://theguardian.com/p/ezk38',
@@ -158,9 +172,11 @@ const trails: TrailType[] = [
 		image:
 			'https://i.guim.co.uk/img/media/c38b10a48e27c463ce16d058e02aafda4328e52f/0_20_2462_1478/master/2462.jpg?width=300&quality=85&auto=format&fit=max&s=63656ef63ad936d92d96316f13ce2715',
 		isLiveBlog: false,
-		display: Display.Standard,
-		pillar: Pillar.News,
-		design: Design.Article,
+		format: {
+			display: Display.Standard,
+			theme: Pillar.News,
+			design: Design.Article,
+		},
 		webPublicationDate: '2020-09-15T13:04:57.000Z',
 		headline:
 			"Trump threatens to retaliate to any attack with '1,000 times greater' force",
@@ -177,9 +193,11 @@ const trails: TrailType[] = [
 		image:
 			'https://i.guim.co.uk/img/media/8c0eff269da77ac303734e8717705d4b70f7d5e2/0_97_5472_3283/master/5472.jpg?width=300&quality=85&auto=format&fit=max&s=3b45f3f609dd7aee06eb1428a172bb8c',
 		isLiveBlog: false,
-		display: Display.Standard,
-		pillar: Pillar.News,
-		design: Design.Article,
+		format: {
+			display: Display.Standard,
+			theme: Pillar.News,
+			design: Design.Article,
+		},
 		webPublicationDate: '2020-09-15T13:28:24.000Z',
 		headline:
 			'Government vows to empty Lesbos of all refugees by Easter after fire',
@@ -196,9 +214,11 @@ const trails: TrailType[] = [
 		image:
 			'https://i.guim.co.uk/img/media/f022aacc31e1e95a07f382206c9b8e5620214e0a/0_0_2560_1536/master/2560.jpg?width=300&quality=85&auto=format&fit=max&s=b4a6348eb191bf5d366ed6282f2ada70',
 		isLiveBlog: false,
-		display: Display.Standard,
-		pillar: Pillar.Culture,
-		design: Design.Article,
+		format: {
+			display: Display.Standard,
+			theme: Pillar.Culture,
+			design: Design.Article,
+		},
 		webPublicationDate: '2020-09-15T12:21:07.000Z',
 		headline: 'Most diverse shortlist ever as Hilary Mantel misses out',
 		shortUrl: 'https://theguardian.com/p/ezmt9',

--- a/src/web/components/Onwards/Carousel/Carousel.tsx
+++ b/src/web/components/Onwards/Carousel/Carousel.tsx
@@ -175,7 +175,7 @@ const titleStyle = (pillar: Theme) => css`
 	color: ${pillarPalette[pillar].main};
 `;
 
-export const Title = ({
+const Title = ({
 	title,
 	pillar,
 }: {
@@ -186,57 +186,6 @@ export const Title = ({
 	<h2 className={headerStyles}>
 		More from <span className={titleStyle(pillar)}>{title}</span>
 	</h2>
-);
-
-type CarouselCardProps = {
-	isFirst: boolean;
-	pillar: Theme;
-	design: Design;
-	display: Display;
-	linkTo: string;
-	headlineText: string;
-	webPublicationDate: string;
-	kickerText?: string;
-	imageUrl?: string;
-	isFullCardImage?: boolean;
-};
-
-const CarouselCard: React.FC<CarouselCardProps> = ({
-	pillar,
-	display,
-	design,
-	linkTo,
-	imageUrl,
-	headlineText,
-	webPublicationDate,
-	kickerText,
-	isFirst,
-	isFullCardImage,
-}: CarouselCardProps) => (
-	<LI
-		stretch={true}
-		percentage="100%"
-		showDivider={!isFirst}
-		padSides={true}
-		padSidesOnMobile={true}
-	>
-		<Card
-			linkTo={linkTo}
-			format={{
-				display,
-				design,
-				theme: pillar,
-			}}
-			headlineText={headlineText}
-			webPublicationDate={webPublicationDate}
-			kickerText={kickerText || ''}
-			imageUrl={imageUrl || ''}
-			showClock={true}
-			alwaysVertical={true}
-			minWidthInPixels={258}
-			isFullCardImage={isFullCardImage}
-		/>
-	</LI>
 );
 
 export const Carousel: React.FC<OnwardsType> = ({
@@ -395,33 +344,28 @@ export const Carousel: React.FC<OnwardsType> = ({
 					className={carouselStyle(isFullCardImage)}
 					ref={carouselRef}
 				>
-					{trails.map((trail, i) => {
-						const {
-							pillar: cardPillar,
-							design,
-							display,
-							url: linkTo,
-							headline: headlineText,
-							webPublicationDate,
-							image: imageUrl,
-							kickerText,
-						} = trail;
-						return (
-							<CarouselCard
-								key={trail.url + i}
-								isFirst={i === 0}
-								pillar={cardPillar}
-								display={display}
-								design={design}
-								linkTo={linkTo}
-								headlineText={headlineText}
-								webPublicationDate={webPublicationDate}
-								imageUrl={imageUrl}
-								kickerText={kickerText}
+					{trails.map((trail, i) => (
+						<LI
+							stretch={true}
+							percentage="100%"
+							showDivider={i !== 0}
+							padSides={true}
+							padSidesOnMobile={true}
+						>
+							<Card
+								linkTo={trail.url}
+								format={trail.format}
+								headlineText={trail.headline}
+								webPublicationDate={trail.webPublicationDate}
+								kickerText={trail.kickerText || ''}
+								imageUrl={trail.image || ''}
+								showClock={true}
+								alwaysVertical={true}
+								minWidthInPixels={258}
 								isFullCardImage={isFullCardImage}
 							/>
-						);
-					})}
+						</LI>
+					))}
 				</ul>
 			</div>
 		</div>

--- a/src/web/components/Onwards/Carousel/Carousel.tsx
+++ b/src/web/components/Onwards/Carousel/Carousel.tsx
@@ -9,7 +9,6 @@ import {
 import { headline } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 import { palette, space } from '@guardian/src-foundations';
-import { Display } from '@guardian/types';
 
 import { LeftColumn } from '@frontend/web/components/LeftColumn';
 import { formatAttrString } from '@frontend/web/lib/formatAttrString';

--- a/src/web/components/Onwards/Carousel/Carousel.tsx
+++ b/src/web/components/Onwards/Carousel/Carousel.tsx
@@ -192,7 +192,7 @@ type CarouselCardProps = {
 	isFirst: boolean;
 	pillar: Theme;
 	design: Design;
-	display?: Display;
+	display: Display;
 	linkTo: string;
 	headlineText: string;
 	webPublicationDate: string;
@@ -201,8 +201,9 @@ type CarouselCardProps = {
 	isFullCardImage?: boolean;
 };
 
-export const CarouselCard: React.FC<CarouselCardProps> = ({
+const CarouselCard: React.FC<CarouselCardProps> = ({
 	pillar,
+	display,
 	design,
 	linkTo,
 	imageUrl,
@@ -222,7 +223,7 @@ export const CarouselCard: React.FC<CarouselCardProps> = ({
 		<Card
 			linkTo={linkTo}
 			format={{
-				display: Display.Standard,
+				display,
 				design,
 				theme: pillar,
 			}}
@@ -398,6 +399,7 @@ export const Carousel: React.FC<OnwardsType> = ({
 						const {
 							pillar: cardPillar,
 							design,
+							display,
 							url: linkTo,
 							headline: headlineText,
 							webPublicationDate,
@@ -409,6 +411,7 @@ export const Carousel: React.FC<OnwardsType> = ({
 								key={trail.url + i}
 								isFirst={i === 0}
 								pillar={cardPillar}
+								display={display}
 								design={design}
 								linkTo={linkTo}
 								headlineText={headlineText}

--- a/src/web/components/Onwards/Carousel/Carousel.tsx
+++ b/src/web/components/Onwards/Carousel/Carousel.tsx
@@ -374,7 +374,7 @@ export const Carousel: React.FC<OnwardsType> = ({
 				</div>
 
 				<div className={dotsStyle}>
-					{trails.map((value, i) => (
+					{trails.map((_, i) => (
 						<span
 							onClick={() => goToIndex(i)}
 							// This button is not particularly useful for keyboard users as the stories

--- a/src/web/components/Onwards/ExactlyFive.tsx
+++ b/src/web/components/Onwards/ExactlyFive.tsx
@@ -17,16 +17,12 @@ export const ExactlyFive = ({ content }: Props) => (
 			<LI padSides={true} percentage="33%">
 				<Card
 					linkTo={content[0].url}
-					format={{
-						display: content[0].display,
-						design: content[0].design,
-						theme: content[0].pillar,
-					}}
+					format={content[0].format}
 					headlineText={content[0].headline}
 					headlineSize="medium"
 					byline={content[0].byline}
 					showByline={content[0].showByline}
-					showQuotes={content[0].design === Design.Comment}
+					showQuotes={content[0].format.design === Design.Comment}
 					webPublicationDate={content[0].webPublicationDate}
 					kickerText={content[0].kickerText}
 					showPulsingDot={content[0].isLiveBlog}
@@ -47,16 +43,12 @@ export const ExactlyFive = ({ content }: Props) => (
 			>
 				<Card
 					linkTo={content[1].url}
-					format={{
-						display: content[1].display,
-						design: content[1].design,
-						theme: content[1].pillar,
-					}}
+					format={content[1].format}
 					headlineText={content[1].headline}
 					headlineSize="medium"
 					byline={content[1].byline}
 					showByline={content[1].showByline}
-					showQuotes={content[1].design === Design.Comment}
+					showQuotes={content[1].format.design === Design.Comment}
 					webPublicationDate={content[1].webPublicationDate}
 					kickerText={content[1].kickerText}
 					showPulsingDot={content[1].isLiveBlog}
@@ -79,16 +71,14 @@ export const ExactlyFive = ({ content }: Props) => (
 					<LI bottomMargin={true} stretch={true}>
 						<Card
 							linkTo={content[2].url}
-							format={{
-								display: content[2].display,
-								design: content[2].design,
-								theme: content[2].pillar,
-							}}
+							format={content[2].format}
 							headlineText={content[2].headline}
 							headlineSize="medium"
 							byline={content[2].byline}
 							showByline={content[2].showByline}
-							showQuotes={content[2].design === Design.Comment}
+							showQuotes={
+								content[2].format.design === Design.Comment
+							}
 							webPublicationDate={content[2].webPublicationDate}
 							kickerText={content[2].kickerText}
 							showPulsingDot={content[2].isLiveBlog}
@@ -103,16 +93,14 @@ export const ExactlyFive = ({ content }: Props) => (
 					<LI bottomMargin={true} stretch={true}>
 						<Card
 							linkTo={content[3].url}
-							format={{
-								display: content[3].display,
-								design: content[3].design,
-								theme: content[3].pillar,
-							}}
+							format={content[3].format}
 							headlineText={content[3].headline}
 							headlineSize="medium"
 							byline={content[3].byline}
 							showByline={content[3].showByline}
-							showQuotes={content[3].design === Design.Comment}
+							showQuotes={
+								content[3].format.design === Design.Comment
+							}
 							webPublicationDate={content[3].webPublicationDate}
 							kickerText={content[3].kickerText}
 							showPulsingDot={content[3].isLiveBlog}
@@ -127,16 +115,14 @@ export const ExactlyFive = ({ content }: Props) => (
 					<LI bottomMargin={false} stretch={true}>
 						<Card
 							linkTo={content[4].url}
-							format={{
-								display: content[4].display,
-								design: content[4].design,
-								theme: content[4].pillar,
-							}}
+							format={content[4].format}
 							headlineText={content[4].headline}
 							headlineSize="medium"
 							byline={content[4].byline}
 							showByline={content[4].showByline}
-							showQuotes={content[4].design === Design.Comment}
+							showQuotes={
+								content[4].format.design === Design.Comment
+							}
 							webPublicationDate={content[4].webPublicationDate}
 							kickerText={content[4].kickerText}
 							showPulsingDot={content[4].isLiveBlog}

--- a/src/web/components/Onwards/ExactlyFive.tsx
+++ b/src/web/components/Onwards/ExactlyFive.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 
-import { Design, Display } from '@guardian/types';
+import { Design } from '@guardian/types';
 
 import { Card } from '@frontend/web/components/Card/Card';
 import { UL } from '@frontend/web/components/Card/components/UL';
@@ -18,7 +18,7 @@ export const ExactlyFive = ({ content }: Props) => (
 				<Card
 					linkTo={content[0].url}
 					format={{
-						display: Display.Standard,
+						display: content[0].display,
 						design: content[0].design,
 						theme: content[0].pillar,
 					}}
@@ -48,7 +48,7 @@ export const ExactlyFive = ({ content }: Props) => (
 				<Card
 					linkTo={content[1].url}
 					format={{
-						display: Display.Standard,
+						display: content[1].display,
 						design: content[1].design,
 						theme: content[1].pillar,
 					}}
@@ -80,7 +80,7 @@ export const ExactlyFive = ({ content }: Props) => (
 						<Card
 							linkTo={content[2].url}
 							format={{
-								display: Display.Standard,
+								display: content[2].display,
 								design: content[2].design,
 								theme: content[2].pillar,
 							}}
@@ -104,7 +104,7 @@ export const ExactlyFive = ({ content }: Props) => (
 						<Card
 							linkTo={content[3].url}
 							format={{
-								display: Display.Standard,
+								display: content[3].display,
 								design: content[3].design,
 								theme: content[3].pillar,
 							}}
@@ -128,7 +128,7 @@ export const ExactlyFive = ({ content }: Props) => (
 						<Card
 							linkTo={content[4].url}
 							format={{
-								display: Display.Standard,
+								display: content[4].display,
 								design: content[4].design,
 								theme: content[4].pillar,
 							}}

--- a/src/web/components/Onwards/FourOrLess.tsx
+++ b/src/web/components/Onwards/FourOrLess.tsx
@@ -40,16 +40,12 @@ export const FourOrLess = ({ content }: Props) => {
 					>
 						<Card
 							linkTo={trail.url}
-							format={{
-								display: trail.display,
-								design: trail.design,
-								theme: trail.pillar,
-							}}
+							format={trail.format}
 							headlineText={trail.headline}
 							headlineSize="medium"
 							byline={trail.byline}
 							showByline={trail.showByline}
-							showQuotes={trail.design === Design.Comment}
+							showQuotes={trail.format.design === Design.Comment}
 							webPublicationDate={trail.webPublicationDate}
 							kickerText={trail.kickerText}
 							showPulsingDot={trail.isLiveBlog}

--- a/src/web/components/Onwards/FourOrLess.tsx
+++ b/src/web/components/Onwards/FourOrLess.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 
-import { Design, Display } from '@guardian/types';
+import { Design } from '@guardian/types';
 
 import { Card } from '@frontend/web/components/Card/Card';
 import { UL } from '@frontend/web/components/Card/components/UL';
@@ -41,7 +41,7 @@ export const FourOrLess = ({ content }: Props) => {
 						<Card
 							linkTo={trail.url}
 							format={{
-								display: Display.Standard,
+								display: trail.display,
 								design: trail.design,
 								theme: trail.pillar,
 							}}

--- a/src/web/components/Onwards/MoreThanFive.tsx
+++ b/src/web/components/Onwards/MoreThanFive.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 
-import { Design, Display } from '@guardian/types';
+import { Design } from '@guardian/types';
 
 import { Card } from '@frontend/web/components/Card/Card';
 import { UL } from '@frontend/web/components/Card/components/UL';
@@ -35,7 +35,7 @@ export const MoreThanFive = ({ content }: Props) => {
 					<Card
 						linkTo={content[0].url}
 						format={{
-							display: Display.Standard,
+							display: content[0].display,
 							design: content[0].design,
 							theme: content[0].pillar,
 						}}
@@ -65,7 +65,7 @@ export const MoreThanFive = ({ content }: Props) => {
 					<Card
 						linkTo={content[1].url}
 						format={{
-							display: Display.Standard,
+							display: content[1].display,
 							design: content[1].design,
 							theme: content[1].pillar,
 						}}
@@ -95,7 +95,7 @@ export const MoreThanFive = ({ content }: Props) => {
 					<Card
 						linkTo={content[2].url}
 						format={{
-							display: Display.Standard,
+							display: content[2].display,
 							design: content[2].design,
 							theme: content[2].pillar,
 						}}
@@ -125,7 +125,7 @@ export const MoreThanFive = ({ content }: Props) => {
 					<Card
 						linkTo={content[3].url}
 						format={{
-							display: Display.Standard,
+							display: content[3].display,
 							design: content[3].design,
 							theme: content[3].pillar,
 						}}
@@ -158,7 +158,7 @@ export const MoreThanFive = ({ content }: Props) => {
 						<Card
 							linkTo={trail.url}
 							format={{
-								display: Display.Standard,
+								display: trail.display,
 								design: trail.design,
 								theme: trail.pillar,
 							}}

--- a/src/web/components/Onwards/MoreThanFive.tsx
+++ b/src/web/components/Onwards/MoreThanFive.tsx
@@ -34,16 +34,12 @@ export const MoreThanFive = ({ content }: Props) => {
 				<LI padSides={true} percentage="25%">
 					<Card
 						linkTo={content[0].url}
-						format={{
-							display: content[0].display,
-							design: content[0].design,
-							theme: content[0].pillar,
-						}}
+						format={content[0].format}
 						headlineText={content[0].headline}
 						headlineSize="medium"
 						byline={content[0].byline}
 						showByline={content[0].showByline}
-						showQuotes={content[0].design === Design.Comment}
+						showQuotes={content[0].format.design === Design.Comment}
 						webPublicationDate={content[0].webPublicationDate}
 						kickerText={content[0].kickerText}
 						showPulsingDot={content[0].isLiveBlog}
@@ -64,16 +60,12 @@ export const MoreThanFive = ({ content }: Props) => {
 				>
 					<Card
 						linkTo={content[1].url}
-						format={{
-							display: content[1].display,
-							design: content[1].design,
-							theme: content[1].pillar,
-						}}
+						format={content[1].format}
 						headlineText={content[1].headline}
 						headlineSize="medium"
 						byline={content[1].byline}
 						showByline={content[1].showByline}
-						showQuotes={content[1].design === Design.Comment}
+						showQuotes={content[1].format.design === Design.Comment}
 						webPublicationDate={content[1].webPublicationDate}
 						kickerText={content[1].kickerText}
 						showPulsingDot={content[1].isLiveBlog}
@@ -94,16 +86,12 @@ export const MoreThanFive = ({ content }: Props) => {
 				>
 					<Card
 						linkTo={content[2].url}
-						format={{
-							display: content[2].display,
-							design: content[2].design,
-							theme: content[2].pillar,
-						}}
+						format={content[2].format}
 						headlineText={content[2].headline}
 						headlineSize="medium"
 						byline={content[2].byline}
 						showByline={content[2].showByline}
-						showQuotes={content[2].design === Design.Comment}
+						showQuotes={content[2].format.design === Design.Comment}
 						webPublicationDate={content[2].webPublicationDate}
 						kickerText={content[2].kickerText}
 						showPulsingDot={content[2].isLiveBlog}
@@ -124,16 +112,12 @@ export const MoreThanFive = ({ content }: Props) => {
 				>
 					<Card
 						linkTo={content[3].url}
-						format={{
-							display: content[3].display,
-							design: content[3].design,
-							theme: content[3].pillar,
-						}}
+						format={content[3].format}
 						headlineText={content[3].headline}
 						headlineSize="medium"
 						byline={content[3].byline}
 						showByline={content[3].showByline}
-						showQuotes={content[3].design === Design.Comment}
+						showQuotes={content[3].format.design === Design.Comment}
 						webPublicationDate={content[3].webPublicationDate}
 						kickerText={content[3].kickerText}
 						showPulsingDot={content[3].isLiveBlog}
@@ -157,16 +141,12 @@ export const MoreThanFive = ({ content }: Props) => {
 					>
 						<Card
 							linkTo={trail.url}
-							format={{
-								display: trail.display,
-								design: trail.design,
-								theme: trail.pillar,
-							}}
+							format={trail.format}
 							headlineText={trail.headline}
 							headlineSize="small"
 							byline={trail.byline}
 							showByline={trail.showByline}
-							showQuotes={trail.design === Design.Comment}
+							showQuotes={trail.format.design === Design.Comment}
 							webPublicationDate={trail.webPublicationDate}
 							kickerText={trail.kickerText}
 							showPulsingDot={trail.isLiveBlog}

--- a/src/web/components/Onwards/OnwardsData.tsx
+++ b/src/web/components/Onwards/OnwardsData.tsx
@@ -1,8 +1,7 @@
 import { useApi } from '@root/src/web/lib/api';
 import React from 'react';
 
-import { decideTheme } from '@root/src/web/lib/decideTheme';
-import { decideDesign } from '@root/src/web/lib/decideDesign';
+import { decideTrail } from '@root/src/web/lib/decideTrail';
 
 type Props = {
 	url: string;
@@ -32,14 +31,7 @@ export const OnwardsData = ({
 		trails: CAPITrailType[],
 		trailLimit: number,
 	): TrailType[] => {
-		return trails.slice(0, trailLimit).map((trail) => {
-			const design = decideDesign(trail.designType, []);
-			return {
-				...trail,
-				pillar: decideTheme({ pillar: trail.pillar, design }),
-				design,
-			};
-		});
+		return trails.slice(0, trailLimit).map(decideTrail);
 	};
 
 	if (data && data.trails) {

--- a/src/web/components/Onwards/Spotlight.tsx
+++ b/src/web/components/Onwards/Spotlight.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 
-import { Design, Display } from '@guardian/types';
+import { Design } from '@guardian/types';
 
 import { Card } from '@frontend/web/components/Card/Card';
 
@@ -13,7 +13,7 @@ export const Spotlight = ({ content }: Props) => (
 	<Card
 		linkTo={content[0].url}
 		format={{
-			display: Display.Standard,
+			display: content[0].display,
 			design: content[0].design,
 			theme: content[0].pillar,
 		}}

--- a/src/web/components/Onwards/Spotlight.tsx
+++ b/src/web/components/Onwards/Spotlight.tsx
@@ -12,16 +12,12 @@ type Props = {
 export const Spotlight = ({ content }: Props) => (
 	<Card
 		linkTo={content[0].url}
-		format={{
-			display: content[0].display,
-			design: content[0].design,
-			theme: content[0].pillar,
-		}}
+		format={content[0].format}
 		headlineText={content[0].headline}
 		headlineSize="large"
 		byline={content[0].byline}
 		showByline={content[0].showByline}
-		showQuotes={content[0].design === Design.Comment}
+		showQuotes={content[0].format.design === Design.Comment}
 		webPublicationDate={content[0].webPublicationDate}
 		kickerText={content[0].kickerText}
 		showPulsingDot={content[0].isLiveBlog}

--- a/src/web/lib/decideTrail.ts
+++ b/src/web/lib/decideTrail.ts
@@ -1,0 +1,12 @@
+import { decideDesign } from '@root/src/web/lib/decideDesign';
+import { decideTheme } from '@root/src/web/lib/decideTheme';
+
+export const decideTrail = (trail: CAPITrailType): TrailType => {
+	// We don't have tags here so we send an empty array
+	const design = decideDesign(trail.designType, []);
+	return {
+		...trail,
+		pillar: decideTheme({ pillar: trail.pillar, design }),
+		design,
+	};
+};

--- a/src/web/lib/decideTrail.ts
+++ b/src/web/lib/decideTrail.ts
@@ -7,9 +7,11 @@ export const decideTrail = (trail: CAPITrailType): TrailType => {
 	const design = decideDesign(trail.designType, []);
 	return {
 		...trail,
-		// We don't have enough data from CAPI to know what display should be
-		display: Display.Standard,
-		pillar: decideTheme({ pillar: trail.pillar, design }),
-		design,
+		format: {
+			// We don't have enough data from CAPI to know what display should be
+			display: Display.Standard,
+			theme: decideTheme({ pillar: trail.pillar, design }),
+			design,
+		},
 	};
 };

--- a/src/web/lib/decideTrail.ts
+++ b/src/web/lib/decideTrail.ts
@@ -1,3 +1,4 @@
+import { Display } from '@guardian/types';
 import { decideDesign } from '@root/src/web/lib/decideDesign';
 import { decideTheme } from '@root/src/web/lib/decideTheme';
 
@@ -6,6 +7,8 @@ export const decideTrail = (trail: CAPITrailType): TrailType => {
 	const design = decideDesign(trail.designType, []);
 	return {
 		...trail,
+		// We don't have enough data from CAPI to know what display should be
+		display: Display.Standard,
 		pillar: decideTheme({ pillar: trail.pillar, design }),
 		design,
 	};

--- a/src/web/lib/useComments.test.tsx
+++ b/src/web/lib/useComments.test.tsx
@@ -78,9 +78,11 @@ describe('buildUrl', () => {
 						image:
 							'https://i.guim.co.uk/img/media/8ffbd3dc5aedfd502ca5ddd5f91f82c767cd28ea/0_0_3442_2065/master/3442.jpg?width=300&quality=85&auto=format&fit=max&s=52292233df8e95c6308e01f4222e25b3',
 						isLiveBlog: false,
-						display: Display.Standard,
-						pillar: Pillar.Opinion,
-						design: Design.Comment,
+						format: {
+							display: Display.Standard,
+							theme: Pillar.Opinion,
+							design: Design.Comment,
+						},
 						webPublicationDate: '2020-11-03T11:00:02.000Z',
 						headline:
 							"There's no point railing against Farage. You have to present an alternative",
@@ -96,9 +98,11 @@ describe('buildUrl', () => {
 						image:
 							'https://i.guim.co.uk/img/media/5dfdcb80828f014e04054ab626750cc112e92364/0_129_5065_3039/master/5065.jpg?width=300&quality=85&auto=format&fit=max&s=c108e8f88f55b627161b8f1827c93698',
 						isLiveBlog: false,
-						display: Display.Standard,
-						pillar: Pillar.Opinion,
-						design: Design.Comment,
+						format: {
+							display: Display.Standard,
+							theme: Pillar.Opinion,
+							design: Design.Comment,
+						},
 						webPublicationDate: '2020-11-03T10:26:01.000Z',
 						headline:
 							"This election isn't about the next four years. It's about the next four millennia",
@@ -130,9 +134,11 @@ describe('buildUrl', () => {
 						image:
 							'https://i.guim.co.uk/img/media/637243d90e93683dd13234ff543ab9b93da3d8d0/0_161_3926_2355/master/3926.jpg?width=300&quality=85&auto=format&fit=max&s=4f1ca464b3b4e7c498acd29d548ecae0',
 						isLiveBlog: false,
-						display: Display.Standard,
-						pillar: Pillar.Opinion,
-						design: Design.Comment,
+						format: {
+							display: Display.Standard,
+							theme: Pillar.Opinion,
+							design: Design.Comment,
+						},
 						webPublicationDate: '2020-11-03T15:33:04.000Z',
 						headline:
 							'The EHRC report shows how difficult building real anti-racist politics will be',
@@ -148,9 +154,11 @@ describe('buildUrl', () => {
 						image:
 							'https://i.guim.co.uk/img/media/1f18d9b3ee4a6d38ff5a5544651f6cc382fdf480/0_203_5184_3110/master/5184.jpg?width=300&quality=85&auto=format&fit=max&s=ebc79b062b7f7f72582f8480a548eacb',
 						isLiveBlog: false,
-						display: Display.Standard,
-						pillar: Pillar.Opinion,
-						design: Design.Comment,
+						format: {
+							display: Display.Standard,
+							theme: Pillar.Opinion,
+							design: Design.Comment,
+						},
 						webPublicationDate: '2020-11-03T13:50:06.000Z',
 						headline:
 							"Macron wants to fix France's social ills – but he won't do it by 'reforming' Islam",

--- a/src/web/lib/useComments.test.tsx
+++ b/src/web/lib/useComments.test.tsx
@@ -1,4 +1,4 @@
-import { Design, Pillar } from '@guardian/types';
+import { Design, Display, Pillar } from '@guardian/types';
 
 import { findCount, buildUrl } from './useComments';
 
@@ -78,6 +78,7 @@ describe('buildUrl', () => {
 						image:
 							'https://i.guim.co.uk/img/media/8ffbd3dc5aedfd502ca5ddd5f91f82c767cd28ea/0_0_3442_2065/master/3442.jpg?width=300&quality=85&auto=format&fit=max&s=52292233df8e95c6308e01f4222e25b3',
 						isLiveBlog: false,
+						display: Display.Standard,
 						pillar: Pillar.Opinion,
 						design: Design.Comment,
 						webPublicationDate: '2020-11-03T11:00:02.000Z',
@@ -95,6 +96,7 @@ describe('buildUrl', () => {
 						image:
 							'https://i.guim.co.uk/img/media/5dfdcb80828f014e04054ab626750cc112e92364/0_129_5065_3039/master/5065.jpg?width=300&quality=85&auto=format&fit=max&s=c108e8f88f55b627161b8f1827c93698',
 						isLiveBlog: false,
+						display: Display.Standard,
 						pillar: Pillar.Opinion,
 						design: Design.Comment,
 						webPublicationDate: '2020-11-03T10:26:01.000Z',
@@ -128,6 +130,7 @@ describe('buildUrl', () => {
 						image:
 							'https://i.guim.co.uk/img/media/637243d90e93683dd13234ff543ab9b93da3d8d0/0_161_3926_2355/master/3926.jpg?width=300&quality=85&auto=format&fit=max&s=4f1ca464b3b4e7c498acd29d548ecae0',
 						isLiveBlog: false,
+						display: Display.Standard,
 						pillar: Pillar.Opinion,
 						design: Design.Comment,
 						webPublicationDate: '2020-11-03T15:33:04.000Z',
@@ -145,6 +148,7 @@ describe('buildUrl', () => {
 						image:
 							'https://i.guim.co.uk/img/media/1f18d9b3ee4a6d38ff5a5544651f6cc382fdf480/0_203_5184_3110/master/5184.jpg?width=300&quality=85&auto=format&fit=max&s=ebc79b062b7f7f72582f8480a548eacb',
 						isLiveBlog: false,
+						display: Display.Standard,
 						pillar: Pillar.Opinion,
 						design: Design.Comment,
 						webPublicationDate: '2020-11-03T13:50:06.000Z',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Hoists the logic to transform the `CAPITrailType` into `TrailType` up into a shared decide function called `decideTrail`. This now lives with the other decide family of functions, all serving to transform the old school CAPI data into the new and cool enums used to define `Format`

```typescript
export const decideTrail = (trail: CAPITrailType): TrailType => {
	// We don't have tags here so we send an empty array
	const design = decideDesign(trail.designType, []);
	return {
		...trail,
		format: {
			// We don't have enough data from CAPI to know what display should be
			display: Display.Standard,
			theme: decideTheme({ pillar: trail.pillar, design }),
			design,
		},
	};
};
```

### Hardcoding display
We currently need to hardcode `display` because card data from CAPI has no information that lets us decide this. We were doing this before but in multiple places, this PR centralises this hardcoded decision, making it easier to fix in the future.

### `format`
Once we had, `display`, `design` and `pillar` as props for `Card` and friends, it was logical to upgrade `TrailType` to use `format`.

