### PR TITLE
Use beige for editorials as well

### DIFF
--- a/fixtures/articles/GuardianView.ts
+++ b/fixtures/articles/GuardianView.ts
@@ -1,131 +1,240 @@
 import { switches } from '../switches';
 
 export const GuardianView: CAPIType = {
-	contributionsServiceUrl: 'https://contributions.guardianapis.com',
 	shouldHideReaderRevenue: false,
 	slotMachineFlags: '',
 	isAdFreeUser: false,
 	main:
-		'<figure class="element element-image" data-media-id="5eb2c12bdd2734356d482a711bc125019b6c8395"> <img src="https://media.guim.co.uk/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/1000.jpg" alt="Donald Trump holds up a newspaper that displays the headline \'Acquitted\'" width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">‘Doubtless Mr Trump will lose the popular vote again. But the electoral system is appallingly skewed, and becoming more so.’ </span> <span class="element-image__credit">Photograph: Nicholas Kamm/AFP via Getty Images</span> </figcaption> </figure>',
+		'<figure class="element element-image" data-media-id="c8200f3ea53cda44927b11af11e8fc731afc3f34"> <img src="https://media.guim.co.uk/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/1000.jpg" alt="‘Ministers have said further border measures are required, but cannot say when they will be applied.’ A man waiting at the Heathrow international arrivals hall on 29 January." width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">‘Ministers have said further border measures are required, but cannot say when they will be applied.’</span> <span class="element-image__credit">Photograph: May James/ZUMA Wire/REX/Shutterstock</span> </figcaption> </figure>',
 	subMetaSectionLinks: [
-		{ url: '/us-news/trump-impeachment', title: 'Trump impeachment' },
-		{ url: '/commentisfree/commentisfree', title: 'Opinion' },
+		{
+			url: '/world/coronavirus-outbreak',
+			title: 'Coronavirus',
+		},
+		{
+			url: '/commentisfree/commentisfree',
+			title: 'Opinion',
+		},
 	],
 	commercialProperties: {
 		UK: {
 			adTargeting: [
-				{ name: 'edition', value: 'uk' },
-				{ name: 'tn', value: ['editorials', 'comment'] },
 				{
-					name: 'k',
-					value: [
-						'republicans',
-						'us-politics',
-						'trump-impeachment',
-						'mittromney',
-						'us-news',
-						'democrats',
-						'donaldtrump',
-					],
+					name: 'edition',
+					value: 'uk',
 				},
-				{ name: 'su', value: ['0'] },
-				{ name: 'ct', value: 'article' },
-				{ name: 'bl', value: ['commentisfree'] },
-				{ name: 'p', value: 'ng' },
-				{ name: 'sh', value: 'https://theguardian.com/p/d8bv8' },
 				{
 					name: 'url',
 					value:
-						'/commentisfree/2020/feb/06/the-guardian-view-on-trumps-acquittal-over-to-the-voters',
+						'/commentisfree/2021/feb/03/the-guardian-view-on-quarantine-an-old-method-and-a-vital-one',
 				},
-				{ name: 'co', value: ['editorial'] },
+				{
+					name: 'tn',
+					value: ['editorials', 'comment'],
+				},
+				{
+					name: 'k',
+					value: [
+						'health',
+						'politics',
+						'conservatives',
+						'uk/uk',
+						'boris-johnson',
+						'vaccines',
+						'society',
+						'infectiousdiseases',
+						'coronavirus-outbreak',
+					],
+				},
+				{
+					name: 'sh',
+					value: 'https://gu.com/p/gaj9m',
+				},
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'bl',
+					value: ['commentisfree'],
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'co',
+					value: ['editorial'],
+				},
 			],
 		},
 		US: {
 			adTargeting: [
-				{ name: 'tn', value: ['editorials', 'comment'] },
-				{
-					name: 'k',
-					value: [
-						'republicans',
-						'us-politics',
-						'trump-impeachment',
-						'mittromney',
-						'us-news',
-						'democrats',
-						'donaldtrump',
-					],
-				},
-				{ name: 'su', value: ['0'] },
-				{ name: 'ct', value: 'article' },
-				{ name: 'bl', value: ['commentisfree'] },
-				{ name: 'p', value: 'ng' },
-				{ name: 'edition', value: 'us' },
-				{ name: 'sh', value: 'https://theguardian.com/p/d8bv8' },
 				{
 					name: 'url',
 					value:
-						'/commentisfree/2020/feb/06/the-guardian-view-on-trumps-acquittal-over-to-the-voters',
+						'/commentisfree/2021/feb/03/the-guardian-view-on-quarantine-an-old-method-and-a-vital-one',
 				},
-				{ name: 'co', value: ['editorial'] },
+				{
+					name: 'tn',
+					value: ['editorials', 'comment'],
+				},
+				{
+					name: 'k',
+					value: [
+						'health',
+						'politics',
+						'conservatives',
+						'uk/uk',
+						'boris-johnson',
+						'vaccines',
+						'society',
+						'infectiousdiseases',
+						'coronavirus-outbreak',
+					],
+				},
+				{
+					name: 'sh',
+					value: 'https://gu.com/p/gaj9m',
+				},
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'bl',
+					value: ['commentisfree'],
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'edition',
+					value: 'us',
+				},
+				{
+					name: 'co',
+					value: ['editorial'],
+				},
 			],
 		},
 		AU: {
 			adTargeting: [
-				{ name: 'tn', value: ['editorials', 'comment'] },
-				{
-					name: 'k',
-					value: [
-						'republicans',
-						'us-politics',
-						'trump-impeachment',
-						'mittromney',
-						'us-news',
-						'democrats',
-						'donaldtrump',
-					],
-				},
-				{ name: 'su', value: ['0'] },
-				{ name: 'ct', value: 'article' },
-				{ name: 'bl', value: ['commentisfree'] },
-				{ name: 'p', value: 'ng' },
-				{ name: 'sh', value: 'https://theguardian.com/p/d8bv8' },
 				{
 					name: 'url',
 					value:
-						'/commentisfree/2020/feb/06/the-guardian-view-on-trumps-acquittal-over-to-the-voters',
+						'/commentisfree/2021/feb/03/the-guardian-view-on-quarantine-an-old-method-and-a-vital-one',
 				},
-				{ name: 'co', value: ['editorial'] },
-				{ name: 'edition', value: 'au' },
+				{
+					name: 'tn',
+					value: ['editorials', 'comment'],
+				},
+				{
+					name: 'k',
+					value: [
+						'health',
+						'politics',
+						'conservatives',
+						'uk/uk',
+						'boris-johnson',
+						'vaccines',
+						'society',
+						'infectiousdiseases',
+						'coronavirus-outbreak',
+					],
+				},
+				{
+					name: 'sh',
+					value: 'https://gu.com/p/gaj9m',
+				},
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'bl',
+					value: ['commentisfree'],
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'co',
+					value: ['editorial'],
+				},
+				{
+					name: 'edition',
+					value: 'au',
+				},
 			],
 		},
 		INT: {
 			adTargeting: [
-				{ name: 'tn', value: ['editorials', 'comment'] },
-				{
-					name: 'k',
-					value: [
-						'republicans',
-						'us-politics',
-						'trump-impeachment',
-						'mittromney',
-						'us-news',
-						'democrats',
-						'donaldtrump',
-					],
-				},
-				{ name: 'edition', value: 'int' },
-				{ name: 'su', value: ['0'] },
-				{ name: 'ct', value: 'article' },
-				{ name: 'bl', value: ['commentisfree'] },
-				{ name: 'p', value: 'ng' },
-				{ name: 'sh', value: 'https://theguardian.com/p/d8bv8' },
 				{
 					name: 'url',
 					value:
-						'/commentisfree/2020/feb/06/the-guardian-view-on-trumps-acquittal-over-to-the-voters',
+						'/commentisfree/2021/feb/03/the-guardian-view-on-quarantine-an-old-method-and-a-vital-one',
 				},
-				{ name: 'co', value: ['editorial'] },
+				{
+					name: 'tn',
+					value: ['editorials', 'comment'],
+				},
+				{
+					name: 'k',
+					value: [
+						'health',
+						'politics',
+						'conservatives',
+						'uk/uk',
+						'boris-johnson',
+						'vaccines',
+						'society',
+						'infectiousdiseases',
+						'coronavirus-outbreak',
+					],
+				},
+				{
+					name: 'sh',
+					value: 'https://gu.com/p/gaj9m',
+				},
+				{
+					name: 'edition',
+					value: 'int',
+				},
+				{
+					name: 'su',
+					value: ['0'],
+				},
+				{
+					name: 'ct',
+					value: 'article',
+				},
+				{
+					name: 'bl',
+					value: ['commentisfree'],
+				},
+				{
+					name: 'p',
+					value: 'ng',
+				},
+				{
+					name: 'co',
+					value: ['editorial'],
+				},
 			],
 		},
 	},
@@ -243,6 +352,13 @@ export const GuardianView: CAPIType = {
 					dataLinkName: 'uk: footer : twitter',
 					extraClasses: '',
 				},
+				{
+					text: 'Newsletters',
+					url:
+						'/email-newsletters?INTCMP=DOTCOM_FOOTER_NEWSLETTER_UK',
+					dataLinkName: 'uk : footer : newsletters',
+					extraClasses: '',
+				},
 			],
 			[
 				{
@@ -271,12 +387,6 @@ export const GuardianView: CAPIType = {
 					dataLinkName: 'uk : footer : patrons',
 					extraClasses: '',
 				},
-				{
-					text: 'Discount Codes',
-					url: 'https://discountcode.theguardian.com/',
-					dataLinkName: 'uk: footer : discount code',
-					extraClasses: 'js-discount-code-link',
-				},
 			],
 		],
 	},
@@ -285,18 +395,18 @@ export const GuardianView: CAPIType = {
 		'twitter:app:name:googleplay': 'The Guardian',
 		'twitter:app:name:ipad': 'The Guardian',
 		'twitter:image':
-			'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctb3BpbmlvbnMucG5n&s=61bcfad75e4b5d668ac7ec6fa3af4352',
+			'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctb3BpbmlvbnMucG5n&s=9fc1862f6fbfa3747354c59cbfb5dad0',
 		'twitter:site': '@guardian',
 		'twitter:app:url:ipad':
-			'gnmguardian://commentisfree/2020/feb/06/the-guardian-view-on-trumps-acquittal-over-to-the-voters?contenttype=Article&source=twitter',
+			'gnmguardian://commentisfree/2021/feb/03/the-guardian-view-on-quarantine-an-old-method-and-a-vital-one?contenttype=Article&source=twitter',
 		'twitter:card': 'summary_large_image',
 		'twitter:app:name:iphone': 'The Guardian',
 		'twitter:app:id:ipad': '409128287',
 		'twitter:app:id:googleplay': 'com.guardian',
 		'twitter:app:url:googleplay':
-			'guardian://www.theguardian.com/commentisfree/2020/feb/06/the-guardian-view-on-trumps-acquittal-over-to-the-voters',
+			'guardian://www.theguardian.com/commentisfree/2021/feb/03/the-guardian-view-on-quarantine-an-old-method-and-a-vital-one',
 		'twitter:app:url:iphone':
-			'gnmguardian://commentisfree/2020/feb/06/the-guardian-view-on-trumps-acquittal-over-to-the-voters?contenttype=Article&source=twitter',
+			'gnmguardian://commentisfree/2021/feb/03/the-guardian-view-on-quarantine-an-old-method-and-a-vital-one?contenttype=Article&source=twitter',
 	},
 	beaconURL: '//phar.gu-web.net',
 	sectionName: 'commentisfree',
@@ -312,22 +422,45 @@ export const GuardianView: CAPIType = {
 		isSensitive: false,
 	},
 	hasStoryPackage: false,
+	contributionsServiceUrl: 'https://contributions.guardianapis.com',
 	publication: 'The Guardian',
 	trailText:
-		'<strong>Editorial:</strong> It was already evident that Republicans would not hold the president accountable. Now it is up to Democrats, and the electorate',
+		'<strong>Editorial:</strong> Controlling cross-border transmission of Covid cases is far from easy, but the government appears scarcely to have even tried',
 	subMetaKeywordLinks: [
-		{ url: '/us-news/donaldtrump', title: 'Donald Trump' },
-		{ url: '/us-news/republicans', title: 'Republicans' },
-		{ url: '/us-news/democrats', title: 'Democrats' },
-		{ url: '/us-news/mittromney', title: 'Mitt Romney' },
-		{ url: '/us-news/us-politics', title: 'US politics' },
-		{ url: '/tone/editorials', title: 'editorials' },
+		{
+			url: '/politics/health',
+			title: 'Health policy',
+		},
+		{
+			url: '/society/vaccines',
+			title: 'Vaccines and immunisation',
+		},
+		{
+			url: '/politics/boris-johnson',
+			title: 'Boris Johnson',
+		},
+		{
+			url: '/politics/conservatives',
+			title: 'Conservatives',
+		},
+		{
+			url: '/science/infectiousdiseases',
+			title: 'Infectious diseases',
+		},
+		{
+			url: '/society/health',
+			title: 'Health',
+		},
+		{
+			url: '/tone/editorials',
+			title: 'editorials',
+		},
 	],
-	headline: 'The Guardian view on Trump’s acquittal: over to the voters',
 	contentType: 'Article',
-	guardianBaseURL: 'https://www.theguardian.com',
+	headline:
+		'The Guardian view on quarantine: an old method and a vital one   ',
 	nav: {
-		currentUrl: '/us-news/us-politics',
+		currentUrl: '/commentisfree',
 		pillars: [
 			{
 				title: 'News',
@@ -512,14 +645,6 @@ export const GuardianView: CAPIType = {
 								classList: [],
 							},
 							{
-								title: 'Cities',
-								url: '/cities',
-								longTitle: '',
-								iconName: '',
-								children: [],
-								classList: [],
-							},
-							{
 								title: 'Global development',
 								url: '/global-development',
 								longTitle: '',
@@ -626,7 +751,23 @@ export const GuardianView: CAPIType = {
 								children: [],
 								classList: [],
 							},
+							{
+								title: 'Retail',
+								url: '/business/retail',
+								longTitle: '',
+								iconName: '',
+								children: [],
+								classList: [],
+							},
 						],
+						classList: [],
+					},
+					{
+						title: 'Coronavirus',
+						url: '/world/coronavirus-outbreak',
+						longTitle: 'Coronavirus',
+						iconName: '',
+						children: [],
 						classList: [],
 					},
 					{
@@ -803,14 +944,6 @@ export const GuardianView: CAPIType = {
 					{
 						title: 'Global development',
 						url: '/global-development',
-						longTitle: '',
-						iconName: '',
-						children: [],
-						classList: [],
-					},
-					{
-						title: 'Cities',
-						url: '/cities',
 						longTitle: '',
 						iconName: '',
 						children: [],
@@ -1396,6 +1529,14 @@ export const GuardianView: CAPIType = {
 						children: [],
 						classList: [],
 					},
+					{
+						title: 'Observer Food Monthly',
+						url: '/theobserver/foodmonthly',
+						longTitle: '',
+						iconName: '',
+						children: [],
+						classList: [],
+					},
 				],
 				classList: [],
 			},
@@ -1403,14 +1544,6 @@ export const GuardianView: CAPIType = {
 				title: 'Guardian Weekly',
 				url:
 					'https://www.theguardian.com/weekly?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_UK',
-				longTitle: '',
-				iconName: '',
-				children: [],
-				classList: [],
-			},
-			{
-				title: 'Professional networks',
-				url: '/guardian-professional',
 				longTitle: '',
 				iconName: '',
 				children: [],
@@ -1525,6 +1658,15 @@ export const GuardianView: CAPIType = {
 				classList: [],
 			},
 			{
+				title: 'Hire with Guardian Jobs',
+				url:
+					'https://recruiters.theguardian.com/?utm_source=gdnwb&utm_medium=navbar&utm_campaign=Guardian_Navbar_Recruiters&CMP_TU=trdmkt&CMP_BUNIT=jobs',
+				longTitle: '',
+				iconName: '',
+				children: [],
+				classList: [],
+			},
+			{
 				title: 'Holidays',
 				url:
 					'https://holidays.theguardian.com?INTCMP=holidays_uk_web_newheader',
@@ -1575,291 +1717,104 @@ export const GuardianView: CAPIType = {
 				classList: [],
 			},
 			{
-				title: 'Discount Codes',
-				url: 'https://discountcode.theguardian.com',
+				title: 'Guardian Puzzles app',
+				url: 'https://puzzles.theguardian.com/download',
 				longTitle: '',
 				iconName: '',
 				children: [],
-				classList: ['js-discount-code-link'],
+				classList: [],
 			},
 		],
 		currentNavLink: {
-			title: 'US Politics',
-			url: '/us-news/us-politics',
-			longTitle: 'US politics',
-			iconName: '',
-			children: [],
-			classList: [],
-		},
-		currentParent: {
-			title: 'News',
-			url: '/',
-			longTitle: 'Headlines',
+			title: 'Opinion',
+			url: '/commentisfree',
+			longTitle: 'Opinion home',
 			iconName: 'home',
 			children: [
 				{
-					title: 'US',
-					url: '/us-news',
-					longTitle: 'US news',
-					iconName: '',
-					children: [],
-					classList: [],
-				},
-				{
-					title: 'Elections 2020',
-					url: '/us-news/us-elections-2020',
-					longTitle: 'Elections 2020',
-					iconName: '',
-					children: [],
-					classList: [],
-				},
-				{
-					title: 'World',
-					url: '/world',
-					longTitle: 'World news',
-					iconName: '',
-					children: [
-						{
-							title: 'Europe',
-							url: '/world/europe-news',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'US',
-							url: '/us-news',
-							longTitle: 'US news',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Americas',
-							url: '/world/americas',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Asia',
-							url: '/world/asia',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Australia',
-							url: '/australia-news',
-							longTitle: 'Australia news',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Middle East',
-							url: '/world/middleeast',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Africa',
-							url: '/world/africa',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Inequality',
-							url: '/inequality',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Cities',
-							url: '/cities',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Global development',
-							url: '/global-development',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-					],
-					classList: [],
-				},
-				{
-					title: 'Environment',
-					url: '/environment',
-					longTitle: '',
-					iconName: '',
-					children: [
-						{
-							title: 'Climate change',
-							url: '/environment/climate-change',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Wildlife',
-							url: '/environment/wildlife',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Energy',
-							url: '/environment/energy',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Pollution',
-							url: '/environment/pollution',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-					],
-					classList: [],
-				},
-				{
-					title: 'Soccer',
-					url: '/football',
-					longTitle: '',
-					iconName: '',
-					children: [
-						{
-							title: 'Live scores',
-							url: '/football/live',
-							longTitle: 'football/live',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Tables',
-							url: '/football/tables',
-							longTitle: 'football/tables',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Fixtures',
-							url: '/football/fixtures',
-							longTitle: 'football/fixtures',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Results',
-							url: '/football/results',
-							longTitle: 'football/results',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Competitions',
-							url: '/football/competitions',
-							longTitle: 'football/competitions',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Clubs',
-							url: '/football/teams',
-							longTitle: 'football/teams',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-					],
-					classList: [],
-				},
-				{
-					title: 'US Politics',
-					url: '/us-news/us-politics',
-					longTitle: 'US politics',
-					iconName: '',
-					children: [],
-					classList: [],
-				},
-				{
-					title: 'Business',
-					url: '/business',
-					longTitle: '',
-					iconName: '',
-					children: [
-						{
-							title: 'Economics',
-							url: '/business/economics',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Sustainable business',
-							url: '/us/sustainable-business',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Diversity & equality in business',
-							url: '/business/diversity-and-equality',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Small business',
-							url: '/business/us-small-business',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-					],
-					classList: [],
-				},
-				{
-					title: 'Tech',
-					url: '/technology',
+					title: 'The Guardian view',
+					url: '/profile/editorial',
 					longTitle: '',
 					iconName: '',
 					children: [],
 					classList: [],
 				},
 				{
-					title: 'Science',
-					url: '/science',
+					title: 'Columnists',
+					url: '/index/contributors',
+					longTitle: '',
+					iconName: '',
+					children: [],
+					classList: [],
+				},
+				{
+					title: 'Cartoons',
+					url: '/cartoons/archive',
+					longTitle: '',
+					iconName: '',
+					children: [],
+					classList: [],
+				},
+				{
+					title: 'Opinion videos',
+					url: '/type/video+tone/comment',
+					longTitle: '',
+					iconName: '',
+					children: [],
+					classList: [],
+				},
+				{
+					title: 'Letters',
+					url: '/tone/letters',
+					longTitle: '',
+					iconName: '',
+					children: [],
+					classList: [],
+				},
+			],
+			classList: [],
+		},
+		currentParent: {
+			title: 'Opinion',
+			url: '/commentisfree',
+			longTitle: 'Opinion home',
+			iconName: 'home',
+			children: [
+				{
+					title: 'The Guardian view',
+					url: '/profile/editorial',
+					longTitle: '',
+					iconName: '',
+					children: [],
+					classList: [],
+				},
+				{
+					title: 'Columnists',
+					url: '/index/contributors',
+					longTitle: '',
+					iconName: '',
+					children: [],
+					classList: [],
+				},
+				{
+					title: 'Cartoons',
+					url: '/cartoons/archive',
+					longTitle: '',
+					iconName: '',
+					children: [],
+					classList: [],
+				},
+				{
+					title: 'Opinion videos',
+					url: '/type/video+tone/comment',
+					longTitle: '',
+					iconName: '',
+					children: [],
+					classList: [],
+				},
+				{
+					title: 'Letters',
+					url: '/tone/letters',
 					longTitle: '',
 					iconName: '',
 					children: [],
@@ -1869,274 +1824,46 @@ export const GuardianView: CAPIType = {
 			classList: [],
 		},
 		currentPillar: {
-			title: 'News',
-			url: '/',
-			longTitle: 'Headlines',
+			title: 'Opinion',
+			url: '/commentisfree',
+			longTitle: 'Opinion home',
 			iconName: 'home',
 			children: [
 				{
-					title: 'US',
-					url: '/us-news',
-					longTitle: 'US news',
-					iconName: '',
-					children: [],
-					classList: [],
-				},
-				{
-					title: 'Elections 2020',
-					url: '/us-news/us-elections-2020',
-					longTitle: 'Elections 2020',
-					iconName: '',
-					children: [],
-					classList: [],
-				},
-				{
-					title: 'World',
-					url: '/world',
-					longTitle: 'World news',
-					iconName: '',
-					children: [
-						{
-							title: 'Europe',
-							url: '/world/europe-news',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'US',
-							url: '/us-news',
-							longTitle: 'US news',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Americas',
-							url: '/world/americas',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Asia',
-							url: '/world/asia',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Australia',
-							url: '/australia-news',
-							longTitle: 'Australia news',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Middle East',
-							url: '/world/middleeast',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Africa',
-							url: '/world/africa',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Inequality',
-							url: '/inequality',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Cities',
-							url: '/cities',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Global development',
-							url: '/global-development',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-					],
-					classList: [],
-				},
-				{
-					title: 'Environment',
-					url: '/environment',
-					longTitle: '',
-					iconName: '',
-					children: [
-						{
-							title: 'Climate change',
-							url: '/environment/climate-change',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Wildlife',
-							url: '/environment/wildlife',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Energy',
-							url: '/environment/energy',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Pollution',
-							url: '/environment/pollution',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-					],
-					classList: [],
-				},
-				{
-					title: 'Soccer',
-					url: '/football',
-					longTitle: '',
-					iconName: '',
-					children: [
-						{
-							title: 'Live scores',
-							url: '/football/live',
-							longTitle: 'football/live',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Tables',
-							url: '/football/tables',
-							longTitle: 'football/tables',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Fixtures',
-							url: '/football/fixtures',
-							longTitle: 'football/fixtures',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Results',
-							url: '/football/results',
-							longTitle: 'football/results',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Competitions',
-							url: '/football/competitions',
-							longTitle: 'football/competitions',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Clubs',
-							url: '/football/teams',
-							longTitle: 'football/teams',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-					],
-					classList: [],
-				},
-				{
-					title: 'US Politics',
-					url: '/us-news/us-politics',
-					longTitle: 'US politics',
-					iconName: '',
-					children: [],
-					classList: [],
-				},
-				{
-					title: 'Business',
-					url: '/business',
-					longTitle: '',
-					iconName: '',
-					children: [
-						{
-							title: 'Economics',
-							url: '/business/economics',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Sustainable business',
-							url: '/us/sustainable-business',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Diversity & equality in business',
-							url: '/business/diversity-and-equality',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Small business',
-							url: '/business/us-small-business',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-					],
-					classList: [],
-				},
-				{
-					title: 'Tech',
-					url: '/technology',
+					title: 'The Guardian view',
+					url: '/profile/editorial',
 					longTitle: '',
 					iconName: '',
 					children: [],
 					classList: [],
 				},
 				{
-					title: 'Science',
-					url: '/science',
+					title: 'Columnists',
+					url: '/index/contributors',
+					longTitle: '',
+					iconName: '',
+					children: [],
+					classList: [],
+				},
+				{
+					title: 'Cartoons',
+					url: '/cartoons/archive',
+					longTitle: '',
+					iconName: '',
+					children: [],
+					classList: [],
+				},
+				{
+					title: 'Opinion videos',
+					url: '/type/video+tone/comment',
+					longTitle: '',
+					iconName: '',
+					children: [],
+					classList: [],
+				},
+				{
+					title: 'Letters',
+					url: '/tone/letters',
 					longTitle: '',
 					iconName: '',
 					children: [],
@@ -2148,268 +1875,40 @@ export const GuardianView: CAPIType = {
 		subNavSections: {
 			links: [
 				{
-					title: 'US',
-					url: '/us-news',
-					longTitle: 'US news',
-					iconName: '',
-					children: [],
-					classList: [],
-				},
-				{
-					title: 'Elections 2020',
-					url: '/us-news/us-elections-2020',
-					longTitle: 'Elections 2020',
-					iconName: '',
-					children: [],
-					classList: [],
-				},
-				{
-					title: 'World',
-					url: '/world',
-					longTitle: 'World news',
-					iconName: '',
-					children: [
-						{
-							title: 'Europe',
-							url: '/world/europe-news',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'US',
-							url: '/us-news',
-							longTitle: 'US news',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Americas',
-							url: '/world/americas',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Asia',
-							url: '/world/asia',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Australia',
-							url: '/australia-news',
-							longTitle: 'Australia news',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Middle East',
-							url: '/world/middleeast',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Africa',
-							url: '/world/africa',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Inequality',
-							url: '/inequality',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Cities',
-							url: '/cities',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Global development',
-							url: '/global-development',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-					],
-					classList: [],
-				},
-				{
-					title: 'Environment',
-					url: '/environment',
-					longTitle: '',
-					iconName: '',
-					children: [
-						{
-							title: 'Climate change',
-							url: '/environment/climate-change',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Wildlife',
-							url: '/environment/wildlife',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Energy',
-							url: '/environment/energy',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Pollution',
-							url: '/environment/pollution',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-					],
-					classList: [],
-				},
-				{
-					title: 'Soccer',
-					url: '/football',
-					longTitle: '',
-					iconName: '',
-					children: [
-						{
-							title: 'Live scores',
-							url: '/football/live',
-							longTitle: 'football/live',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Tables',
-							url: '/football/tables',
-							longTitle: 'football/tables',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Fixtures',
-							url: '/football/fixtures',
-							longTitle: 'football/fixtures',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Results',
-							url: '/football/results',
-							longTitle: 'football/results',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Competitions',
-							url: '/football/competitions',
-							longTitle: 'football/competitions',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Clubs',
-							url: '/football/teams',
-							longTitle: 'football/teams',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-					],
-					classList: [],
-				},
-				{
-					title: 'US Politics',
-					url: '/us-news/us-politics',
-					longTitle: 'US politics',
-					iconName: '',
-					children: [],
-					classList: [],
-				},
-				{
-					title: 'Business',
-					url: '/business',
-					longTitle: '',
-					iconName: '',
-					children: [
-						{
-							title: 'Economics',
-							url: '/business/economics',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Sustainable business',
-							url: '/us/sustainable-business',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Diversity & equality in business',
-							url: '/business/diversity-and-equality',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-						{
-							title: 'Small business',
-							url: '/business/us-small-business',
-							longTitle: '',
-							iconName: '',
-							children: [],
-							classList: [],
-						},
-					],
-					classList: [],
-				},
-				{
-					title: 'Tech',
-					url: '/technology',
+					title: 'The Guardian view',
+					url: '/profile/editorial',
 					longTitle: '',
 					iconName: '',
 					children: [],
 					classList: [],
 				},
 				{
-					title: 'Science',
-					url: '/science',
+					title: 'Columnists',
+					url: '/index/contributors',
+					longTitle: '',
+					iconName: '',
+					children: [],
+					classList: [],
+				},
+				{
+					title: 'Cartoons',
+					url: '/cartoons/archive',
+					longTitle: '',
+					iconName: '',
+					children: [],
+					classList: [],
+				},
+				{
+					title: 'Opinion videos',
+					url: '/type/video+tone/comment',
+					longTitle: '',
+					iconName: '',
+					children: [],
+					classList: [],
+				},
+				{
+					title: 'Letters',
+					url: '/tone/letters',
 					longTitle: '',
 					iconName: '',
 					children: [],
@@ -2420,66 +1919,66 @@ export const GuardianView: CAPIType = {
 		readerRevenueLinks: {
 			header: {
 				contribute:
-					'https://support.theguardian.com/contribute?INTCMP=header_support_contribute&acquisitionData=%7B"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_HEADER","componentId":"header_support_contribute"%7D',
+					'https://support.theguardian.com/contribute?INTCMP=header_support_contribute&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support_contribute%22,%22source%22:%22GUARDIAN_WEB%22%7D',
 				subscribe:
-					'https://support.theguardian.com/subscribe?INTCMP=header_support_subscribe&acquisitionData=%7B"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_HEADER","componentId":"header_support_subscribe"%7D',
+					'https://support.theguardian.com/subscribe?INTCMP=header_support_subscribe&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support_subscribe%22,%22source%22:%22GUARDIAN_WEB%22%7D',
 				support:
-					'https://support.theguardian.com?INTCMP=header_support&acquisitionData=%7B"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_HEADER","componentId":"header_support"%7D',
+					'https://support.theguardian.com?INTCMP=header_support&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support%22,%22source%22:%22GUARDIAN_WEB%22%7D',
 				gifting:
-					'https://support.theguardian.com/subscribe?INTCMP=header_support_gifting&acquisitionData=%7B"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_HEADER","componentId":"header_support_gifting"%7D',
+					'https://support.theguardian.com/subscribe?INTCMP=header_support_gifting&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support_gifting%22,%22source%22:%22GUARDIAN_WEB%22%7D',
 			},
 			footer: {
 				contribute:
-					'https://support.theguardian.com/contribute?INTCMP=footer_support_contribute&acquisitionData=%7B"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_FOOTER","componentId":"footer_support_contribute"%7D',
+					'https://support.theguardian.com/contribute?INTCMP=footer_support_contribute&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22footer_support_contribute%22,%22source%22:%22GUARDIAN_WEB%22%7D',
 				subscribe:
-					'https://support.theguardian.com/subscribe?INTCMP=footer_support_subscribe&acquisitionData=%7B"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_FOOTER","componentId":"footer_support_subscribe"%7D',
+					'https://support.theguardian.com/subscribe?INTCMP=footer_support_subscribe&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22footer_support_subscribe%22,%22source%22:%22GUARDIAN_WEB%22%7D',
 				support:
-					'https://support.theguardian.com?INTCMP=footer_support&acquisitionData=%7B"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_FOOTER","componentId":"footer_support"%7D',
+					'https://support.theguardian.com?INTCMP=footer_support&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22footer_support%22,%22source%22:%22GUARDIAN_WEB%22%7D',
 				gifting:
-					'https://support.theguardian.com/subscribe?INTCMP=footer_support_gifting&acquisitionData=%7B"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_FOOTER","componentId":"footer_support_gifting"%7D',
+					'https://support.theguardian.com/subscribe?INTCMP=footer_support_gifting&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22footer_support_gifting%22,%22source%22:%22GUARDIAN_WEB%22%7D',
 			},
 			sideMenu: {
 				contribute:
-					'https://support.theguardian.com/contribute?INTCMP=side_menu_support_contribute&acquisitionData=%7B"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_HEADER","componentId":"side_menu_support_contribute"%7D',
+					'https://support.theguardian.com/contribute?INTCMP=side_menu_support_contribute&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22side_menu_support_contribute%22,%22source%22:%22GUARDIAN_WEB%22%7D',
 				subscribe:
-					'https://support.theguardian.com/subscribe?INTCMP=side_menu_support_subscribe&acquisitionData=%7B"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_HEADER","componentId":"side_menu_support_subscribe"%7D',
+					'https://support.theguardian.com/subscribe?INTCMP=side_menu_support_subscribe&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22side_menu_support_subscribe%22,%22source%22:%22GUARDIAN_WEB%22%7D',
 				support:
-					'https://support.theguardian.com?INTCMP=side_menu_support&acquisitionData=%7B"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_HEADER","componentId":"side_menu_support"%7D',
+					'https://support.theguardian.com?INTCMP=side_menu_support&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22side_menu_support%22,%22source%22:%22GUARDIAN_WEB%22%7D',
 				gifting:
-					'https://support.theguardian.com/subscribe?INTCMP=side_menu_support_gifting&acquisitionData=%7B"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_HEADER","componentId":"side_menu_support_gifting"%7D',
+					'https://support.theguardian.com/subscribe?INTCMP=side_menu_support_gifting&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22side_menu_support_gifting%22,%22source%22:%22GUARDIAN_WEB%22%7D',
 			},
 			ampHeader: {
 				contribute:
-					'https://support.theguardian.com/contribute?INTCMP=header_support_contribute&acquisitionData=%7B"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_HEADER","componentId":"header_support_contribute"%7D',
+					'https://support.theguardian.com/contribute?INTCMP=header_support_contribute&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support_contribute%22,%22source%22:%22GUARDIAN_WEB%22%7D',
 				subscribe:
-					'https://support.theguardian.com/subscribe?INTCMP=header_support_subscribe&acquisitionData=%7B"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_HEADER","componentId":"header_support_subscribe"%7D',
+					'https://support.theguardian.com/subscribe?INTCMP=header_support_subscribe&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support_subscribe%22,%22source%22:%22GUARDIAN_WEB%22%7D',
 				support:
-					'https://support.theguardian.com?INTCMP=amp_header_support&acquisitionData=%7B"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_HEADER","componentId":"amp_header_support"%7D',
+					'https://support.theguardian.com?INTCMP=amp_header_support&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22amp_header_support%22,%22source%22:%22GUARDIAN_WEB%22%7D',
 				gifting:
-					'https://support.theguardian.com/subscribe?INTCMP=header_support_subscribe&acquisitionData=%7B"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_HEADER","componentId":"header_support_gifting"%7D',
+					'https://support.theguardian.com/subscribe?INTCMP=header_support_gifting&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support_gifting%22,%22source%22:%22GUARDIAN_WEB%22%7D',
 			},
 			ampFooter: {
 				contribute:
-					'https://support.theguardian.com/contribute?INTCMP=amp_footer_support_contribute&acquisitionData=%7B"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_FOOTER","componentId":"amp_footer_support_contribute"%7D',
+					'https://support.theguardian.com/contribute?INTCMP=amp_footer_support_contribute&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22amp_footer_support_contribute%22,%22source%22:%22GUARDIAN_WEB%22%7D',
 				subscribe:
-					'https://support.theguardian.com/subscribe?INTCMP=amp_footer_support_subscribe&acquisitionData=%7B"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_FOOTER","componentId":"amp_footer_support_subscribe"%7D',
+					'https://support.theguardian.com/subscribe?INTCMP=amp_footer_support_subscribe&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22amp_footer_support_subscribe%22,%22source%22:%22GUARDIAN_WEB%22%7D',
 				support:
-					'https://support.theguardian.com?INTCMP=footer_support&acquisitionData=%7B"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_FOOTER","componentId":"footer_support"%7D',
+					'https://support.theguardian.com?INTCMP=footer_support&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22footer_support%22,%22source%22:%22GUARDIAN_WEB%22%7D',
 				gifting:
-					'https://support.theguardian.com/subscribe?INTCMP=amp_footer_support_gifting&acquisitionData=%7B"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_FOOTER","componentId":"amp_footer_support_gifting"%7D',
+					'https://support.theguardian.com/subscribe?INTCMP=amp_footer_support_gifting&acquisitionData=%7B%22componentType%22:%22ACQUISITIONS_FOOTER%22,%22componentId%22:%22amp_footer_support_gifting%22,%22source%22:%22GUARDIAN_WEB%22%7D',
 			},
 		},
 	},
+	guardianBaseURL: 'https://www.theguardian.com',
 	mainMediaElements: [
 		{
 			role: 'inline',
 			data: {
-				copyright: 'AFP or licensors',
 				alt:
-					"Donald Trump holds up a newspaper that displays the headline 'Acquitted'",
+					'‘Ministers have said further border measures are required, but cannot say when they will be applied.’ A man waiting at the Heathrow international arrivals hall on 29 January.',
 				caption:
-					'‘Doubtless Mr Trump will lose the popular vote again. But the electoral system is appallingly skewed, and becoming more so.’ ',
-				credit: 'Photograph: Nicholas Kamm/AFP via Getty Images',
+					'‘Ministers have said further border measures are required, but cannot say when they will be applied.’',
+				credit: 'Photograph: May James/ZUMA Wire/REX/Shutterstock',
 			},
 			imageSources: [
 				{
@@ -2487,33 +1986,33 @@ export const GuardianView: CAPIType = {
 					srcSet: [
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=9e73940f239e0eab503ff3d05bbbd743',
-							width: 1240,
-						},
-						{
-							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=ab02d6b285927e5fd31a765a1f796cd1',
-							width: 1210,
-						},
-						{
-							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=e099a546ad711027a3068630aebd6bfd',
-							width: 890,
-						},
-						{
-							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=620&quality=85&auto=format&fit=max&s=16a60292c79a1964f0db3080628657c1',
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=620&quality=85&auto=format&fit=max&s=65e9a737e8d3a5e62766be63f200ffdc',
 							width: 620,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=605&quality=85&auto=format&fit=max&s=f35008b4814d9b8a7aae3ce351570a90',
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=a8ba524f3af26898e5bca2895ec6e29d',
+							width: 1240,
+						},
+						{
+							src:
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=605&quality=85&auto=format&fit=max&s=4274db44c63aa85739510dfcac178413',
 							width: 605,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=445&quality=85&auto=format&fit=max&s=430949cd4fc27ee20a666feb5bc33c49',
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=d2b6a863bf723ec26aa4958f1fc07693',
+							width: 1210,
+						},
+						{
+							src:
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=445&quality=85&auto=format&fit=max&s=b2e36ca6c7e0f65a9ef49bcc284a8f46',
 							width: 445,
+						},
+						{
+							src:
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=ad0731ec258bbf02c0fb25135942e6b2',
+							width: 890,
 						},
 					],
 				},
@@ -2522,22 +2021,22 @@ export const GuardianView: CAPIType = {
 					srcSet: [
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=140&quality=85&auto=format&fit=max&s=f8be6b267d23a1960ff4a9b5336f4cab',
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=140&quality=85&auto=format&fit=max&s=df1f0f80da2e008f55dcb719c5b64ae6',
 							width: 140,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=7e9354f3ced2144362231f9d0ff0b27a',
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=fa35f2e7edfd2a38f8602ff6b8ccb74b',
 							width: 280,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=120&quality=85&auto=format&fit=max&s=e31defbbf6ec4cfcc03061b0aadb5450',
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=120&quality=85&auto=format&fit=max&s=ccd00556d1c5bfc364a45233c280e2a7',
 							width: 120,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=d19c1d42c58e147eeba77c671988aad6',
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=88d49838164e64407f85a773dc746411',
 							width: 240,
 						},
 					],
@@ -2547,52 +2046,52 @@ export const GuardianView: CAPIType = {
 					srcSet: [
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=380&quality=85&auto=format&fit=max&s=b8c6e2691a082f0ac89c3c8537b9cef7',
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=380&quality=85&auto=format&fit=max&s=e71c7ed5ecc18120fa8773c826f50bd0',
 							width: 380,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=f90c217932806fb70c985367b42cf704',
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=fad9d345b3c671c9d3950c0ab5e9034b',
 							width: 760,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=300&quality=85&auto=format&fit=max&s=b84ae5bca307ea256925a51eb0116fba',
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=300&quality=85&auto=format&fit=max&s=b294b19570bb2856d32231ba66285449',
 							width: 300,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=92df8969c89033d2dce0331cfbc44299',
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=844e08da6df3711c5c3eb24928d94728',
 							width: 600,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=620&quality=85&auto=format&fit=max&s=16a60292c79a1964f0db3080628657c1',
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=620&quality=85&auto=format&fit=max&s=65e9a737e8d3a5e62766be63f200ffdc',
 							width: 620,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=9e73940f239e0eab503ff3d05bbbd743',
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=a8ba524f3af26898e5bca2895ec6e29d',
 							width: 1240,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=605&quality=85&auto=format&fit=max&s=f35008b4814d9b8a7aae3ce351570a90',
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=605&quality=85&auto=format&fit=max&s=4274db44c63aa85739510dfcac178413',
 							width: 605,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=ab02d6b285927e5fd31a765a1f796cd1',
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=d2b6a863bf723ec26aa4958f1fc07693',
 							width: 1210,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=445&quality=85&auto=format&fit=max&s=430949cd4fc27ee20a666feb5bc33c49',
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=445&quality=85&auto=format&fit=max&s=b2e36ca6c7e0f65a9ef49bcc284a8f46',
 							width: 445,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=e099a546ad711027a3068630aebd6bfd',
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=ad0731ec258bbf02c0fb25135942e6b2',
 							width: 890,
 						},
 					],
@@ -2602,53 +2101,73 @@ export const GuardianView: CAPIType = {
 					srcSet: [
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=860&quality=85&auto=format&fit=max&s=75a06781ae6253b65d711732324b3f03',
-							width: 860,
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=1020&quality=85&auto=format&fit=max&s=be1e5720158f6d4d61cb4f38277d4782',
+							width: 1020,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=860&quality=45&auto=format&fit=max&dpr=2&s=30bb46e7684fbad53452522a6314a79c',
-							width: 1720,
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=1020&quality=45&auto=format&fit=max&dpr=2&s=1dfb6c64fbd8a16ab516fec4cc549f5d',
+							width: 2040,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=780&quality=85&auto=format&fit=max&s=5a91840a3830438b0ebe8957951d5b11',
-							width: 780,
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=940&quality=85&auto=format&fit=max&s=6776a806cfaefb9824e3c64ec11a1de4',
+							width: 940,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=780&quality=45&auto=format&fit=max&dpr=2&s=a574599bf071e360fd4d31e4e0e7777a',
-							width: 1560,
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=940&quality=45&auto=format&fit=max&dpr=2&s=c3a074edda4b27e72f5772d4b74b844d',
+							width: 1880,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=620&quality=85&auto=format&fit=max&s=16a60292c79a1964f0db3080628657c1',
-							width: 620,
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=700&quality=85&auto=format&fit=max&s=f3e85030d0bd7b6ebe41958c540f92a1',
+							width: 700,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=9e73940f239e0eab503ff3d05bbbd743',
-							width: 1240,
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=cb1815c5d400a2d4c6ce53c257f32a52',
+							width: 1400,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=605&quality=85&auto=format&fit=max&s=f35008b4814d9b8a7aae3ce351570a90',
-							width: 605,
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=700&quality=85&auto=format&fit=max&s=f3e85030d0bd7b6ebe41958c540f92a1',
+							width: 700,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=ab02d6b285927e5fd31a765a1f796cd1',
-							width: 1210,
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=cb1815c5d400a2d4c6ce53c257f32a52',
+							width: 1400,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=445&quality=85&auto=format&fit=max&s=430949cd4fc27ee20a666feb5bc33c49',
-							width: 445,
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=660&quality=85&auto=format&fit=max&s=7c0319274ca2269971949422ad5b792f',
+							width: 660,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=e099a546ad711027a3068630aebd6bfd',
-							width: 890,
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=660&quality=45&auto=format&fit=max&dpr=2&s=cdcbd6e25a6ad27769f64b94d6b3041a',
+							width: 1320,
+						},
+						{
+							src:
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=645&quality=85&auto=format&fit=max&s=dbce27296d3001413277f72b260369c3',
+							width: 645,
+						},
+						{
+							src:
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=9095b7ef57d1bd6918b75d9757aeea6f',
+							width: 1290,
+						},
+						{
+							src:
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=465&quality=85&auto=format&fit=max&s=cebb53a5122ee05421188edfd0e4df61',
+							width: 465,
+						},
+						{
+							src:
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=8a07f0b470e352aa20e8f6c4b3745ef4',
+							width: 930,
 						},
 					],
 				},
@@ -2657,32 +2176,32 @@ export const GuardianView: CAPIType = {
 					srcSet: [
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=620&quality=85&auto=format&fit=max&s=16a60292c79a1964f0db3080628657c1',
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=620&quality=85&auto=format&fit=max&s=65e9a737e8d3a5e62766be63f200ffdc',
 							width: 620,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=9e73940f239e0eab503ff3d05bbbd743',
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=a8ba524f3af26898e5bca2895ec6e29d',
 							width: 1240,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=605&quality=85&auto=format&fit=max&s=f35008b4814d9b8a7aae3ce351570a90',
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=605&quality=85&auto=format&fit=max&s=4274db44c63aa85739510dfcac178413',
 							width: 605,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=ab02d6b285927e5fd31a765a1f796cd1',
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=d2b6a863bf723ec26aa4958f1fc07693',
 							width: 1210,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=445&quality=85&auto=format&fit=max&s=430949cd4fc27ee20a666feb5bc33c49',
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=445&quality=85&auto=format&fit=max&s=b2e36ca6c7e0f65a9ef49bcc284a8f46',
 							width: 445,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=e099a546ad711027a3068630aebd6bfd',
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=ad0731ec258bbf02c0fb25135942e6b2',
 							width: 890,
 						},
 					],
@@ -2692,33 +2211,73 @@ export const GuardianView: CAPIType = {
 					srcSet: [
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=620&quality=85&auto=format&fit=max&s=16a60292c79a1964f0db3080628657c1',
-							width: 620,
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=1300&quality=85&auto=format&fit=max&s=5671d8e875fa661be54c91a44d91f0b4',
+							width: 1300,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=9e73940f239e0eab503ff3d05bbbd743',
-							width: 1240,
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=1300&quality=45&auto=format&fit=max&dpr=2&s=28f0acfc3a27ec5048c8850d9cb292c9',
+							width: 2600,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=605&quality=85&auto=format&fit=max&s=f35008b4814d9b8a7aae3ce351570a90',
-							width: 605,
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=1140&quality=85&auto=format&fit=max&s=d2b0b7dbd62b7bc61e1980b6138f2b0a',
+							width: 1140,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=ab02d6b285927e5fd31a765a1f796cd1',
-							width: 1210,
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=1140&quality=45&auto=format&fit=max&dpr=2&s=2f6dd56a0e654b7ffc5ddb7206386ca8',
+							width: 2280,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=445&quality=85&auto=format&fit=max&s=430949cd4fc27ee20a666feb5bc33c49',
-							width: 445,
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=1125&quality=85&auto=format&fit=max&s=48d2b1a8faaad907faa3135c23992764',
+							width: 1125,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=e099a546ad711027a3068630aebd6bfd',
-							width: 890,
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=1125&quality=45&auto=format&fit=max&dpr=2&s=3281838687f8b0a5b0389e4899c52b16',
+							width: 2250,
+						},
+						{
+							src:
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=965&quality=85&auto=format&fit=max&s=9a8412b45aff53607515fbed23b3f920',
+							width: 965,
+						},
+						{
+							src:
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=965&quality=45&auto=format&fit=max&dpr=2&s=c3438be50fadcc216e63987d53bce318',
+							width: 1930,
+						},
+						{
+							src:
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=725&quality=85&auto=format&fit=max&s=b3574c3679cd804ad95d3c6e5de467c7',
+							width: 725,
+						},
+						{
+							src:
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=725&quality=45&auto=format&fit=max&dpr=2&s=bbfff86aca3d0ae3ceaa4bf601cddfc9',
+							width: 1450,
+						},
+						{
+							src:
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=645&quality=85&auto=format&fit=max&s=dbce27296d3001413277f72b260369c3',
+							width: 645,
+						},
+						{
+							src:
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=9095b7ef57d1bd6918b75d9757aeea6f',
+							width: 1290,
+						},
+						{
+							src:
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=465&quality=85&auto=format&fit=max&s=cebb53a5122ee05421188edfd0e4df61',
+							width: 465,
+						},
+						{
+							src:
+								'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=8a07f0b470e352aa20e8f6c4b3745ef4',
+							width: 930,
 						},
 					],
 				},
@@ -2728,133 +2287,134 @@ export const GuardianView: CAPIType = {
 				allImages: [
 					{
 						index: 0,
-						fields: { height: '1200', width: '2000' },
+						fields: {
+							height: '1200',
+							width: '2000',
+						},
 						mediaType: 'Image',
 						mimeType: 'image/jpeg',
 						url:
-							'https://media.guim.co.uk/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/2000.jpg',
+							'https://media.guim.co.uk/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/2000.jpg',
 					},
 					{
 						index: 1,
-						fields: { height: '600', width: '1000' },
+						fields: {
+							height: '600',
+							width: '1000',
+						},
 						mediaType: 'Image',
 						mimeType: 'image/jpeg',
 						url:
-							'https://media.guim.co.uk/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/1000.jpg',
+							'https://media.guim.co.uk/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/1000.jpg',
 					},
 					{
 						index: 2,
-						fields: { height: '300', width: '500' },
+						fields: {
+							height: '300',
+							width: '500',
+						},
 						mediaType: 'Image',
 						mimeType: 'image/jpeg',
 						url:
-							'https://media.guim.co.uk/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/500.jpg',
+							'https://media.guim.co.uk/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/500.jpg',
 					},
 					{
 						index: 3,
-						fields: { height: '84', width: '140' },
+						fields: {
+							height: '84',
+							width: '140',
+						},
 						mediaType: 'Image',
 						mimeType: 'image/jpeg',
 						url:
-							'https://media.guim.co.uk/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/140.jpg',
+							'https://media.guim.co.uk/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/140.jpg',
 					},
 					{
 						index: 4,
-						fields: { height: '3421', width: '5700' },
+						fields: {
+							height: '3193',
+							width: '5322',
+						},
 						mediaType: 'Image',
 						mimeType: 'image/jpeg',
 						url:
-							'https://media.guim.co.uk/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/5700.jpg',
+							'https://media.guim.co.uk/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/5322.jpg',
 					},
 					{
 						index: 5,
 						fields: {
 							isMaster: 'true',
-							height: '3421',
-							width: '5700',
+							height: '3193',
+							width: '5322',
 						},
 						mediaType: 'Image',
 						mimeType: 'image/jpeg',
 						url:
-							'https://media.guim.co.uk/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg',
+							'https://media.guim.co.uk/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg',
 					},
 				],
 			},
 			displayCredit: true,
 		},
 	],
-	webPublicationDate: '2020-02-06T18:49:00.000Z',
+	webPublicationDate: '2021-02-03T18:54:37.000Z',
+	author: {
+		byline: 'Editorial',
+	},
+	designType: 'GuardianView',
 	blocks: [
 		{
-			id: '0d97498a-fa10-4340-98b3-3400150bb9fd',
+			id: '5e74ae948f088d75755971e4',
 			elements: [
 				{
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
 					html:
-						'<p>Not all battles are fought in the belief that they will be won. Some are fought in the belief that conceding in advance would be even worse. Democrats knew Donald Trump was unlikely to be convicted by a Republican Senate when they launched impeachment proceedings; that he would erroneously claim, as he has done, <a href="https://www.theguardian.com/us-news/2020/feb/05/donald-trump-acquitted-senate-impeachment-trial" title="">“full exoneration”</a>; and that he would use the case to fire up his base. He may feel he is indestructible, as his lie-packed State of the Union address and Thursday’s buoyant, bizarre, rambling speech <a href="https://www.theguardian.com/us-news/live/2020/feb/06/donald-trump-speech-impeachment-verdict-romney-buttigieg-sanders-biden-live-latest-news" title="">about the “evil” process</a> suggests. He looks forward to November as the first impeached president to run for re-election.</p>',
+						'<p>The greatest advances in the battle against the coronavirus have been made by modern science, but before there were vaccines, countries had to rely on older techniques: stopping people mingling; preventing new cases of the disease arriving from overseas. Britain’s record with lockdowns is not great (late to implement, premature in lifting), but with quarantine at the border there is barely even a record to defend. For much of last year there was a notional obligation on travellers from various countries to self-isolate on arrival in the UK, but with a shifting roster of places that qualified for “safe” travel corridors.</p>',
 				},
 				{
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
 					html:
-						'<p>Yet a refusal to impeach him would itself have damaged the country’s constitutional protections; and a president who knew he would never face impeachment would likely be as emboldened <a href="https://www.theguardian.com/us-news/2020/feb/05/groans-walkouts-trump-state-of-the-union-sketch" title="">as the one who has faced it down</a>. The vote to acquit was not a vindication of the president’s conduct, any more than the farce of the Senate trial – in which jurors who had sworn to be impartial refused to even hear witnesses – amounted to justice in action. It was an indictment of the Republican party.</p>',
+						'<p>There were many categories of exemption. The regulations were unclear and poorly implemented. <a href="https://www.theguardian.com/world/commentisfree/2021/jan/28/uk-covid-travel-quarantine-hotel" title="">Efforts at enforcement have been patchy</a>. Essentially, self-isolation has been self-policed. Only towards the end of last year, as it became clear that mutant strains of the virus were spreading – and that Britain’s approach was persistently failing – did the government start focusing on <a href="https://www.theguardian.com/world/2021/jan/27/how-quarantine-rules-work-and-what-uk-government-is-planning" title="">quarantine as part of the anti-virus arsenal</a>. More travellers are now required to show proof of a negative Covid test and there are tighter restrictions on arrivals from certain “hotspot” countries. That approach is still flawed. People, and the virus they might carry, do not always travel straight from the heart of an outbreak to the UK. Mutations are dispersed along multiple paths.</p>',
 				},
 				{
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
 					html:
-						'<p>With the honourable exception of Mitt Romney, already experiencing the inevitable retaliation, pusillanimous Republican senators bowed to power. Those who voiced reservations before voting for acquittal merely underlined their complicity. Mr Trump has captured the party that resisted him in 2016, not only because they believe he can deliver their ideological agenda, “owning liberals” and guaranteeing a conservative supreme court, but also from <a href="https://twitter.com/TimAlberta/status/1223084826493931520" title="">fear</a>. They know Mr Trump to be both an election winner, and a man of infinite <a href="https://www.theguardian.pe.ca/news/world/head-on-a-pike-republican-senators-object-after-schiff-cites-impeachment-threat-402779/" title="">vindictiveness</a> who will exact retribution, including by unseating those who cross him.</p>',
+						'<p>Ministers have said further border measures are required, but cannot say when they will be applied. The new regime is expected to involve diverting large numbers of arrivals to government-approved hotels for up to 10 days, with an option of getting out sooner with a negative test. The Department for Transport and the Treasury <a href="https://www.theguardian.com/world/2021/feb/03/grant-shapps-resists-blanket-border-controls-to-stem-covid-in-britain" title="">have been squeamish</a> about the cost of such a regime. Passengers would get a bill, but the whole system would still be expensive and inflict another wound on an already injured aviation sector.</p>',
 				},
 				{
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
 					html:
-						'<p>That threat points to the fact that the issue is not only the political elite, but also the electors who have chosen to embrace or at least endure the president’s grotesqueries, whatever the evidence presented to them. His approval rating, though still poor, has not seen seismic shifts over the process. If anything, he appears to be <a href="https://www.washingtonpost.com/politics/2020/02/06/has-trumps-approval-rating-really-shot-up-49-percent-probably-not/" title="">near his highest level of approval</a> since entering office, though some suggest the figures may be misleading. While Democrats may continue to pursue him over Ukraine, <a href="https://www.theguardian.com/us-news/2020/feb/06/after-trump-acquittal-impeachment-new-revelations-continue-trickle-in" title="">seeking testimony in the House</a> from John Bolton and others (and Republicans may retaliate with questions about Joe and Hunter Biden), it seems unlikely to change the game. There is ample evidence of the US president urging a foreign power to interfere with American democracy – and ample evidence that a shocking number of voters either don’t believe it or don’t care.</p>',
+						'<p>But, as has been demonstrated many times in the pandemic, resisting tighter restrictions to avoid an immediate financial burden is a false economy. Delay allows the disease to spread. The onerous measures are still required and have to be in place for longer. That remains true even as the vaccination programme is rolled out. Not enough is yet known about vaccine resilience in the face of recently discovered coronavirus variants, let alone any future mutations. <a href="https://www.theguardian.com/world/2021/jan/22/covid-vaccines-what-are-the-implications-of-new-variants-of-virus" title="">The risk is not negligible.</a></p>',
 				},
 				{
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
 					html:
-						'<p>Tuesday’s Iowa caucuses should have offered the Democrats a chance to establish a new and compelling narrative. They backfired spectacularly. The chaos is <a href="https://www.theguardian.com/us-news/2020/feb/06/pete-buttigieg-bernie-sanders-nearly-tied-iowa-caucuses" title="">still not fully resolved</a>, with fresh allegations of inaccurate results surfacing. It has presented an image of division, rancour and incompetence: if the party can’t manage its own small-scale internal affairs, why entrust it with the affairs of state? There is a long way to go until November, and Iowa will probably end up as a footnote. But more concerning than the tallying of votes is the turnout, which <a href="https://www.politico.com/news/2020/02/04/iowa-caucus-low-turnout-110674" title="">appears to be closer</a> to the muted enthusiasm of 2016 than the surge that propelled Barack Obama to the front of the pack in 2008 and created a sense of dynamism – or, indeed, the national surge that brought renewed hope for Democrats in the midterms two years ago.</p>',
+						'<p>Countries with the strongest records against disease have applied the full range of containment measures quickly and thoroughly, including efficient testing, contact tracing, and a presumption that all new arrivals face quarantine (with some flexibility for humanitarian exceptions, naturally). That principle should be the basis for the UK’s regime. A speedy vaccination roll-out has given Boris Johnson <a href="https://www.theguardian.com/society/2021/jan/31/daily-record-as-600000-people-in-the-uk-receive-covid-jabs-on-saturday" title="">cause to celebrate</a> his government’s accomplishments relative to other countries. Ministerial relief at having something to cheer is palpable, but it must not lead to neglect of other fronts in the battle or feed the culture of impatience and denial that causes many Conservative MPs to demand unwarranted easing of restrictions.</p>',
 				},
 				{
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
 					html:
-						'<p>Doubtless Mr Trump will lose the popular vote again. But the electoral system is <a href="https://www.theguardian.com/us-news/series/the-fight-to-vote" title="">appallingly skewed</a>, and becoming even more so. Only a cohesive opposition has any hope of winning. And while Democrats turn inwards, with some even debating whether to back a nominee other than their preferred candidate, Republicans are ruthlessly united.</p>',
-				},
-				{
-					_type:
-						'model.dotcomrendering.pageElements.TextBlockElement',
-					html:
-						'<p>“I had always thought that our institutions would forever protect us against individual transgressors,” <a href="https://www.washingtonpost.com/opinions/2020/02/06/marie-yovanovitch-ukraine-ambassador-american-institutions-need-us/" title="">wrote</a> Marie Yovanovitch, the former ambassador to Ukraine, this week, speaking not only to fellow public servants, but to citizens as a whole. “It turns out that our institutions need us as much as we need them.”</p>',
-				},
-				{
-					_type:
-						'model.dotcomrendering.pageElements.TextBlockElement',
-					html:
-						'<p>The Republican party flunked its test long ago. The Democratic party risks failing its own. But ordinary voters must now make their choice too.</p>',
+						'<p>No one should belittle the social, economic and psychological cost of anti-Covid restrictions. Quarantine, like lockdown, is a harsh instrument to be used only as an emergency resort. But we are now a year into such an emergency. The government’s haphazard approach, justified by a pursuit of short-term economic relief, has only prolonged the ordeal. The vaccine programme illuminates a way out. It would be a tragic squandering of that success if overreliance on new technology were to breed complacency regarding older but no less vital methods of protecting the public.</p>',
 				},
 			],
-			blockCreatedOn: 1581012008000,
-			blockCreatedOnDisplay: '18:00 GMT',
-			blockLastUpdated: 1581016799000,
-			blockLastUpdatedDisplay: '19:19 GMT',
-			blockFirstPublished: 1581012008000,
-			blockFirstPublishedDisplay: '18:00 GMT',
-			primaryDateLine: 'Wed 19 Aug 2020 06.02 BST',
-			secondaryDateLine: 'Wed 19 Aug 2020 11.52 BST',
+			blockCreatedOnDisplay: '11.52 GMT',
+			blockLastUpdatedDisplay: '18.43 GMT',
+			primaryDateLine: 'Wed 3 Feb 2021 18.54 GMT',
+			secondaryDateLine: 'Last modified on Thu 4 Feb 2021 05.22 GMT',
 		},
 	],
-	author: { byline: 'Editorial' },
-	designType: 'GuardianView',
 	linkedData: [
 		{
 			'@type': 'NewsArticle',
 			'@context': 'https://schema.org',
 			'@id':
-				'https://amp.theguardian.com/commentisfree/2020/feb/06/the-guardian-view-on-trumps-acquittal-over-to-the-voters',
+				'https://amp.theguardian.com/commentisfree/2021/feb/03/the-guardian-view-on-quarantine-an-old-method-and-a-vital-one',
 			publisher: {
 				'@type': 'Organization',
 				'@context': 'https://schema.org',
@@ -2881,10 +2441,10 @@ export const GuardianView: CAPIType = {
 				productID: 'theguardian.com:basic',
 			},
 			image: [
-				'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctb3BpbmlvbnMucG5n&enable=upscale&s=bd9d87088c2f786e9cde0ed4a9c71dc6',
-				'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=1200&height=1200&quality=85&auto=format&fit=crop&s=d902d7ca8fc34afb3f5df3b32f64f6ba',
-				'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=1200&height=900&quality=85&auto=format&fit=crop&s=1b641e534f888291375f03e72d655b1a',
-				'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=1200&quality=85&auto=format&fit=max&s=dac22ddb43ba1df13c395443b153181e',
+				'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctb3BpbmlvbnMucG5n&enable=upscale&s=95a9c39af947732f73b8af9318d3b983',
+				'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=1200&height=1200&quality=85&auto=format&fit=crop&s=aefabb0b00e0f22e6369e0e289b1d699',
+				'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=1200&height=900&quality=85&auto=format&fit=crop&s=7826af58a1f33eca97d979efbeb2fd0e',
+				'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=1200&quality=85&auto=format&fit=max&s=0701f8ecfdb34e888d932a0c334c886e',
 			],
 			author: [
 				{
@@ -2893,85 +2453,149 @@ export const GuardianView: CAPIType = {
 					sameAs: 'https://www.theguardian.com/profile/editorial',
 				},
 			],
-			datePublished: '2020-02-06T18:49:00.000Z',
+			datePublished: '2021-02-03T18:54:37.000Z',
 			headline:
-				'The Guardian view on Trump’s acquittal: over to the voters',
-			dateModified: '2020-02-06T19:30:01.000Z',
+				'The Guardian view on quarantine: an old method and a vital one   ',
+			dateModified: '2021-02-04T05:22:07.000Z',
 			mainEntityOfPage:
-				'https://www.theguardian.com/commentisfree/2020/feb/06/the-guardian-view-on-trumps-acquittal-over-to-the-voters',
+				'https://www.theguardian.com/commentisfree/2021/feb/03/the-guardian-view-on-quarantine-an-old-method-and-a-vital-one',
 		},
 		{
 			'@type': 'WebPage',
 			'@context': 'https://schema.org',
 			'@id':
-				'https://www.theguardian.com/commentisfree/2020/feb/06/the-guardian-view-on-trumps-acquittal-over-to-the-voters',
+				'https://www.theguardian.com/commentisfree/2021/feb/03/the-guardian-view-on-quarantine-an-old-method-and-a-vital-one',
 			potentialAction: {
 				'@type': 'ViewAction',
 				target:
-					'android-app://com.guardian/https/www.theguardian.com/commentisfree/2020/feb/06/the-guardian-view-on-trumps-acquittal-over-to-the-voters',
+					'android-app://com.guardian/https/www.theguardian.com/commentisfree/2021/feb/03/the-guardian-view-on-quarantine-an-old-method-and-a-vital-one',
 			},
 		},
 	],
-	webPublicationDateDisplay: 'Thu 6 Feb 2020 18.49 GMT',
 	editionId: 'UK',
+	webPublicationDateDisplay: 'Wed 3 Feb 2021 18.54 GMT',
 	shouldHideAds: false,
 	standfirst:
-		'It was already evident that Republicans would not hold the president accountable. Now it is up to Democrats, and the electorate',
-	webTitle:
-		'The Guardian view on Trump’s acquittal: over to the voters | Editorial',
+		'<p>Controlling cross-border transmission of Covid cases is far from easy, but the government appears scarcely to have even tried</p>',
 	openGraphData: {
 		'og:url':
-			'http://www.theguardian.com/commentisfree/2020/feb/06/the-guardian-view-on-trumps-acquittal-over-to-the-voters',
+			'http://www.theguardian.com/commentisfree/2021/feb/03/the-guardian-view-on-quarantine-an-old-method-and-a-vital-one',
 		'article:author': 'https://www.theguardian.com/profile/editorial',
 		'og:image:height': '720',
 		'og:description':
-			'Editorial: It was already evident that Republicans would not hold the president accountable. Now it is up to Democrats, and the electorate',
+			'Editorial: Controlling cross-border transmission of Covid cases is far from easy, but the government appears scarcely to have even tried',
 		'og:image:width': '1200',
 		'og:image':
-			'https://i.guim.co.uk/img/media/5eb2c12bdd2734356d482a711bc125019b6c8395/0_345_5700_3421/master/5700.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctb3BpbmlvbnMucG5n&enable=upscale&s=bd9d87088c2f786e9cde0ed4a9c71dc6',
+			'https://i.guim.co.uk/img/media/c8200f3ea53cda44927b11af11e8fc731afc3f34/0_0_5322_3193/master/5322.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctb3BpbmlvbnMucG5n&enable=upscale&s=95a9c39af947732f73b8af9318d3b983',
 		'al:ios:url':
-			'gnmguardian://commentisfree/2020/feb/06/the-guardian-view-on-trumps-acquittal-over-to-the-voters?contenttype=Article&source=applinks',
+			'gnmguardian://commentisfree/2021/feb/03/the-guardian-view-on-quarantine-an-old-method-and-a-vital-one?contenttype=Article&source=applinks',
 		'article:publisher': 'https://www.facebook.com/theguardian',
 		'og:type': 'article',
 		'al:ios:app_store_id': '409128287',
 		'article:section': 'Opinion',
-		'article:published_time': '2020-02-06T18:49:00.000Z',
+		'article:published_time': '2021-02-03T18:54:37.000Z',
 		'og:title':
-			'The Guardian view on Trump’s acquittal: over to the voters | Editorial',
+			'The Guardian view on quarantine: an old method and a vital one | Editorial',
 		'fb:app_id': '180444840287',
 		'article:tag':
-			'Trump impeachment,Donald Trump,Republicans,Democrats,Mitt Romney,US news,US politics',
+			'Coronavirus,Health policy,Vaccines and immunisation,UK news,Boris Johnson,Politics,Conservatives,Infectious diseases,Health,Society',
 		'al:ios:app_name': 'The Guardian',
 		'og:site_name': 'the Guardian',
-		'article:modified_time': '2020-02-06T19:30:01.000Z',
+		'article:modified_time': '2021-02-04T05:22:07.000Z',
 	},
-	sectionUrl: 'us-news/trump-impeachment',
+	webTitle:
+		'The Guardian view on quarantine: an old method and a vital one | Editorial',
+	isSpecialReport: false,
+	sectionUrl: 'world/coronavirus-outbreak',
 	pageId:
-		'commentisfree/2020/feb/06/the-guardian-view-on-trumps-acquittal-over-to-the-voters',
+		'commentisfree/2021/feb/03/the-guardian-view-on-quarantine-an-old-method-and-a-vital-one',
 	version: 3,
 	tags: [
-		{ id: 'commentisfree/commentisfree', type: 'Blog', title: 'Opinion' },
 		{
-			id: 'us-news/trump-impeachment',
-			type: 'Keyword',
-			title: 'Trump impeachment',
+			id: 'commentisfree/commentisfree',
+			type: 'Blog',
+			title: 'Opinion',
 		},
-		{ id: 'us-news/donaldtrump', type: 'Keyword', title: 'Donald Trump' },
-		{ id: 'us-news/republicans', type: 'Keyword', title: 'Republicans' },
-		{ id: 'us-news/democrats', type: 'Keyword', title: 'Democrats' },
-		{ id: 'us-news/mittromney', type: 'Keyword', title: 'Mitt Romney' },
-		{ id: 'us-news/us-news', type: 'Keyword', title: 'US news' },
-		{ id: 'us-news/us-politics', type: 'Keyword', title: 'US politics' },
-		{ id: 'tone/editorials', type: 'Tone', title: 'Editorials' },
-		{ id: 'tone/comment', type: 'Tone', title: 'Comment' },
-		{ id: 'type/article', type: 'Type', title: 'Article' },
-		{ id: 'profile/editorial', type: 'Contributor', title: 'Editorial' },
+		{
+			id: 'world/coronavirus-outbreak',
+			type: 'Keyword',
+			title: 'Coronavirus',
+		},
+		{
+			id: 'politics/health',
+			type: 'Keyword',
+			title: 'Health policy',
+		},
+		{
+			id: 'society/vaccines',
+			type: 'Keyword',
+			title: 'Vaccines and immunisation',
+		},
+		{
+			id: 'uk/uk',
+			type: 'Keyword',
+			title: 'UK news',
+		},
+		{
+			id: 'politics/boris-johnson',
+			type: 'Keyword',
+			title: 'Boris Johnson',
+		},
+		{
+			id: 'politics/politics',
+			type: 'Keyword',
+			title: 'Politics',
+		},
+		{
+			id: 'politics/conservatives',
+			type: 'Keyword',
+			title: 'Conservatives',
+		},
+		{
+			id: 'science/infectiousdiseases',
+			type: 'Keyword',
+			title: 'Infectious diseases',
+		},
+		{
+			id: 'society/health',
+			type: 'Keyword',
+			title: 'Health',
+		},
+		{
+			id: 'society/society',
+			type: 'Keyword',
+			title: 'Society',
+		},
+		{
+			id: 'type/article',
+			type: 'Type',
+			title: 'Article',
+		},
+		{
+			id: 'tone/editorials',
+			type: 'Tone',
+			title: 'Editorials',
+		},
+		{
+			id: 'tone/comment',
+			type: 'Tone',
+			title: 'Comment',
+		},
+		{
+			id: 'profile/editorial',
+			type: 'Contributor',
+			title: 'Editorial',
+		},
 		{
 			id: 'publication/theguardian',
 			type: 'Publication',
 			title: 'The Guardian',
 		},
-		{ id: 'theguardian/journal', type: 'NewspaperBook', title: 'Journal' },
+		{
+			id: 'theguardian/journal',
+			type: 'NewspaperBook',
+			title: 'Journal',
+		},
 		{
 			id: 'theguardian/journal/opinion',
 			type: 'NewspaperBookSection',
@@ -2984,9 +2608,9 @@ export const GuardianView: CAPIType = {
 		},
 	],
 	pillar: 'opinion',
-	isCommentable: false,
+	isCommentable: true,
 	webURL:
-		'https://www.theguardian.com/commentisfree/2020/feb/06/the-guardian-view-on-trumps-acquittal-over-to-the-voters',
+		'https://www.theguardian.com/commentisfree/2021/feb/03/the-guardian-view-on-quarantine-an-old-method-and-a-vital-one',
 	keyEvents: [],
 	showBottomSocialButtons: true,
 	isImmersive: false,
@@ -3035,6 +2659,5 @@ export const GuardianView: CAPIType = {
 			'https://assets.guim.co.uk/data/vendor/a994b749adae30cd58f0e84c8fa28013/amp-iframe.html',
 		isPhotoEssay: false,
 	},
-	sectionLabel: 'Trump impeachment',
-	isSpecialReport: false,
+	sectionLabel: 'Coronavirus',
 };

--- a/src/web/lib/decidePalette.ts
+++ b/src/web/lib/decidePalette.ts
@@ -144,9 +144,18 @@ const textArticleLinkHover = (format: Format): string => {
 
 const backgroundArticle = (format: Format): string => {
 	// Order matters. We want comment special report pieces to have the opinion background
-	if (format.design === Design.Comment) return opinion[800];
-	if (format.theme === Special.SpecialReport) return specialReport[800];
-	return 'transparent';
+	if (
+		format.design !== Design.Comment &&
+		format.theme === Special.SpecialReport
+	)
+		return specialReport[800];
+	switch (format.design) {
+		case Design.Comment:
+		case Design.GuardianView:
+			return opinion[800];
+		default:
+			return 'transparent';
+	}
 };
 
 const backgroundSeriesTitle = (format: Format): string => {

--- a/src/web/lib/decidePalette.ts
+++ b/src/web/lib/decidePalette.ts
@@ -144,18 +144,10 @@ const textArticleLinkHover = (format: Format): string => {
 
 const backgroundArticle = (format: Format): string => {
 	// Order matters. We want comment special report pieces to have the opinion background
-	if (
-		format.design !== Design.Comment &&
-		format.theme === Special.SpecialReport
-	)
-		return specialReport[800];
-	switch (format.design) {
-		case Design.Comment:
-		case Design.GuardianView:
-			return opinion[800];
-		default:
-			return 'transparent';
-	}
+	if (format.design === Design.Comment) return opinion[800];
+	if (format.design === Design.GuardianView) return opinion[800];
+	if (format.theme === Special.SpecialReport) return specialReport[800]; // Note, check theme rather than design here
+	return 'transparent';
 };
 
 const backgroundSeriesTitle = (format: Format): string => {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Fixes an issue where the background colour for editorials was being set as white, not beige

### Before
![Screenshot 2021-02-05 at 09 10 22](https://user-images.githubusercontent.com/1336821/107013232-00b9e100-6792-11eb-89db-1b75897a12c9.jpg)


### After
![Screenshot 2021-02-05 at 09 10 42](https://user-images.githubusercontent.com/1336821/107013257-0a434900-6792-11eb-913a-3c476a96289e.jpg)

## Why?
In response to an issue raised to cp

## Why didn't we capture this in our stories?
We do snapshot GuardianView articles so we _should_ have caught this but the quality of that fixture data isn't great which meant we were not rendering a proper representation of an editorial article. To fix this, I've updated that fixtures data in this PR but I also added https://trello.com/c/NYD6Pzjm/2435-make-updating-article-fixtures-easier so that we prevent similar problems with other articles and ensure we have up to date data moving forwards