### PR TITLE
Html is an Option in pullquote

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         "@types/lodash.debounce": "^4.0.6",
         "@types/lodash.escape": "^4.0.6",
         "@types/node-fetch": "^2.5.8",
-        "@types/sanitize-html": "^1.18.3",
+        "@types/sanitize-html": "^1.27.1",
         "@typescript-eslint/eslint-plugin-tslint": "^4.13.0",
         "ajv": "^6.12.6",
         "aws-sdk": "^2.804.0",

--- a/src/amp/components/elements/PullquoteBlockComponent.tsx
+++ b/src/amp/components/elements/PullquoteBlockComponent.tsx
@@ -19,15 +19,21 @@ const styles = (pillar: Theme) => css`
 `;
 
 export const PullquoteBlockComponent: React.FC<{
-	html: string;
+	html?: string;
 	pillar: Theme;
-}> = ({ html, pillar }) => (
-	<aside className={styles(pillar)}>
-		<Quote />{' '}
-		<span
-			dangerouslySetInnerHTML={{
-				__html: html,
-			}}
-		/>
-	</aside>
-);
+}> = ({ html, pillar }) => {
+	if (html) {
+		return (
+			<aside className={styles(pillar)}>
+				<Quote />{' '}
+				<span
+					dangerouslySetInnerHTML={{
+						__html: html,
+					}}
+				/>
+			</aside>
+		);
+	} else {
+		return null;
+	}
+};

--- a/src/amp/components/elements/PullquoteBlockComponent.tsx
+++ b/src/amp/components/elements/PullquoteBlockComponent.tsx
@@ -22,18 +22,15 @@ export const PullquoteBlockComponent: React.FC<{
 	html?: string;
 	pillar: Theme;
 }> = ({ html, pillar }) => {
-	if (html) {
-		return (
-			<aside className={styles(pillar)}>
-				<Quote />{' '}
-				<span
-					dangerouslySetInnerHTML={{
-						__html: html,
-					}}
-				/>
-			</aside>
-		);
-	} else {
-		return null;
-	}
+	if (!html) return <></>;
+	return (
+		<aside className={styles(pillar)}>
+			<Quote />{' '}
+			<span
+				dangerouslySetInnerHTML={{
+					__html: html,
+				}}
+			/>
+		</aside>
+	);
 };

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -244,7 +244,7 @@ interface ProfileAtomBlockElement {
 
 interface PullquoteBlockElement {
 	_type: 'model.dotcomrendering.pageElements.PullquoteBlockElement';
-	html: string;
+	html?: string;
 	role: string;
 	attribution?: string;
 }

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -1837,7 +1837,6 @@
             },
             "required": [
                 "_type",
-                "html",
                 "role"
             ]
         },

--- a/src/web/components/elements/PullQuoteBlockComponent.tsx
+++ b/src/web/components/elements/PullQuoteBlockComponent.tsx
@@ -121,12 +121,13 @@ function decideFont(role: string) {
 }
 
 export const PullQuoteBlockComponent: React.FC<{
-	html: string;
+	html?: string;
 	pillar: Theme;
 	design: Design;
 	role: string;
 	attribution?: string;
 }> = ({ html, pillar, design, attribution, role }) => {
+	if (!html) return <></>;
 	switch (design) {
 		case Design.GuardianView:
 		case Design.Comment:

--- a/yarn.lock
+++ b/yarn.lock
@@ -4036,24 +4036,12 @@
   dependencies:
     "@types/node" "*"
 
-"@types/domhandler@*":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@types/domhandler/-/domhandler-2.4.1.tgz#7b3b347f7762180fbcb1ece1ce3dd0ebbb8c64cf"
-  integrity sha512-cfBw6q6tT5sa1gSPFSRKzF/xxYrrmeiut7E0TxNBObiLSBTuFEHibcfEe3waQPEDbqBsq+ql/TOniw65EyDFMA==
-
 "@types/dompurify@^2.0.4":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@types/dompurify/-/dompurify-2.0.4.tgz#25fce15f1f4b1bc0df0ad957040cf226416ac2d7"
   integrity sha512-y6K7NyXTQvjr8hJNsAFAD8yshCsIJ0d+OYEFzULuIqWyWOKL2hRru1I+rorI5U0K4SLAROTNuSUFXPDTu278YA==
   dependencies:
     "@types/trusted-types" "*"
-
-"@types/domutils@*":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@types/domutils/-/domutils-1.7.2.tgz#89422e579c165994ad5c09ce90325da596cc105d"
-  integrity sha512-Nnwy1Ztwq42SSNSZSh9EXBJGrOZPR+PQ2sRT4VZy8hnsFXfCil7YlKO2hd2360HyrtFz2qwnKQ13ENrgXNxJbw==
-  dependencies:
-    "@types/domhandler" "*"
 
 "@types/eslint-scope@^3.7.0":
   version "3.7.0"
@@ -4166,15 +4154,6 @@
     "@types/clean-css" "*"
     "@types/relateurl" "*"
     "@types/uglify-js" "*"
-
-"@types/htmlparser2@*":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@types/htmlparser2/-/htmlparser2-3.10.1.tgz#1e65ba81401d53f425c1e2ba5a3d05c90ab742c7"
-  integrity sha512-fCxmHS4ryCUCfV9+CJZY1UjkbR+6Al/EQdX5Jh03qBj9gdlPG5q+7uNoDgE/ZNXb3XNWSAQgqKIWnbRCbOyyWA==
-  dependencies:
-    "@types/domhandler" "*"
-    "@types/domutils" "*"
-    "@types/node" "*"
 
 "@types/is-function@^1.0.0":
   version "1.0.0"
@@ -4451,12 +4430,12 @@
   resolved "https://registry.yarnpkg.com/@types/relateurl/-/relateurl-0.2.28.tgz#6bda7db8653fa62643f5ee69e9f69c11a392e3a6"
   integrity sha1-a9p9uGU/piZD9e5p6facEaOS46Y=
 
-"@types/sanitize-html@^1.18.3":
-  version "1.20.1"
-  resolved "https://registry.yarnpkg.com/@types/sanitize-html/-/sanitize-html-1.20.1.tgz#6a64f98ca1589df2ed85ac725f53097a03b12981"
-  integrity sha512-WGFp6QuYUGaPl+WUfU4VYMYPx6buO9hfKkdeHCazjUzr0LlnrCKBjfKXiU+ra/JasDDALmtSGmOCtOT1iduQtQ==
+"@types/sanitize-html@^1.27.1":
+  version "1.27.1"
+  resolved "https://registry.yarnpkg.com/@types/sanitize-html/-/sanitize-html-1.27.1.tgz#1fc4b67edd6296eeb366960d13cd01f5d6bffdcd"
+  integrity sha512-TW5gfZYplKQYO8003WrxaDgwyJsEG74920S+Ei7zB9mbUFgm7l2NvFAumXzxL+1fOwM2I9A+G/1rgiEebQOxcQ==
   dependencies:
-    "@types/htmlparser2" "*"
+    htmlparser2 "^4.1.0"
 
 "@types/serve-static@*":
   version "1.13.2"
@@ -8292,6 +8271,13 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
+domhandler@^3.0.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-3.3.0.tgz#6db7ea46e4617eb15cf875df68b2b8524ce0037a"
+  integrity sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==
+  dependencies:
+    domelementtype "^2.0.1"
+
 domhandler@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.0.0.tgz#01ea7821de996d85f69029e81fa873c21833098e"
@@ -8320,7 +8306,7 @@ domutils@^1.5.1, domutils@^1.7.0:
     dom-serializer "0"
     domelementtype "1"
 
-domutils@^2.4.4:
+domutils@^2.0.0, domutils@^2.4.4:
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.4.4.tgz#282739c4b150d022d34699797369aad8d19bbbd3"
   integrity sha512-jBC0vOsECI4OMdD0GC9mGn7NXPLb+Qt6KW1YDQzeQYRUFKmNG8lh7mO5HiELfr+lLQE7loDVI4QcAxV80HS+RA==
@@ -10612,6 +10598,16 @@ htmlparser2@^3.10.0, htmlparser2@^3.3.0:
     entities "^1.1.1"
     inherits "^2.0.1"
     readable-stream "^3.1.1"
+
+htmlparser2@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-4.1.0.tgz#9a4ef161f2e4625ebf7dfbe6c0a2f52d18a59e78"
+  integrity sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^3.0.0"
+    domutils "^2.0.0"
+    entities "^2.0.0"
 
 htmlparser2@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
## What does this change?

As per https://www.theguardian.com/world/2020/sep/20/the-qanon-conspiracy?dcr=false there is a pullquote as the first element in CAPI with no `html` field. This is an Option(html) type in Frontend, so needs handling in DCR.

### Before

Pages with this element throw 500

### After

Pages with this element do not throw 500


