### PR TITLE
ChannelId is an Option in Frontend for YoutubeComponent

### DIFF
--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -370,7 +370,7 @@ interface YoutubeBlockElement {
 	assetId: string;
 	mediaTitle: string;
 	id: string;
-	channelId: string;
+	channelId?: string;
 	duration?: number;
 	posterImage?: {
 		url: string;

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -2332,7 +2332,6 @@
             "required": [
                 "_type",
                 "assetId",
-                "channelId",
                 "expired",
                 "id",
                 "mediaTitle"

--- a/src/web/components/elements/YoutubeBlockComponent.tsx
+++ b/src/web/components/elements/YoutubeBlockComponent.tsx
@@ -17,7 +17,7 @@ type Props = {
 	mediaTitle?: string;
 	altText?: string;
 	assetId: string;
-	channelId: string;
+	channelId?: string;
 	expired: boolean;
 	format: Format;
 	palette: Palette;


### PR DESCRIPTION
Matches Option from frontend with optional field in Typescript types. The optional-ness is already handled in the code with an if statement.

https://github.com/guardian/frontend/blob/92bcd986acbb192552f6e8500863c87ba0da5471/common/app/model/dotcomrendering/pageElements/PageElement.scala#L692<

Fixes pages like https://www.theguardian.com/uk-news/2020/aug/21/school-reopening-in-scotland-covid-19-five-lessons-for-the-rest-of-the-uk
