### PR TITLE
Inline sharecount mock

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -4,7 +4,6 @@ import fetchMock from 'fetch-mock';
 import MockDate from 'mockdate';
 import { configure, addParameters } from '@storybook/react';
 
-import { sharecount } from '@root/fixtures/article';
 import { commentCount } from '@root/fixtures/commentCounts';
 import { getFontsCss } from '@root/src/lib/fonts-css';
 
@@ -104,7 +103,12 @@ fetchMock
         'begin:https://api.nextgen.guardianapps.co.uk/sharecount/',
         {
             status: 200,
-            body: sharecount,
+            body: {
+                path:
+                    'money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+                share_count: 273,
+                refreshStatus: true,
+            },
         },
         {
             overwriteRoutes: false,

--- a/fixtures/article.ts
+++ b/fixtures/article.ts
@@ -2924,10 +2924,3 @@ export const data = {
 	},
 	version: 2,
 };
-
-export const sharecount = {
-	path:
-		'money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
-	share_count: 273,
-	refreshStatus: true,
-};

--- a/src/web/components/Counts.stories.tsx
+++ b/src/web/components/Counts.stories.tsx
@@ -4,7 +4,6 @@ import fetchMock from 'fetch-mock';
 
 import { Pillar, Design, Display } from '@guardian/types';
 
-import { sharecount } from '@root/fixtures/article';
 import { decidePalette } from '../lib/decidePalette';
 
 import { Counts } from './Counts';
@@ -79,7 +78,12 @@ export const ShareOnly = () => {
 			'begin:https://api.nextgen.guardianapps.co.uk/sharecount/',
 			{
 				status: 200,
-				body: sharecount,
+				body: {
+					path:
+						'money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+					share_count: 273,
+					refreshStatus: true,
+				},
 			},
 			{ overwriteRoutes: false },
 		);

--- a/src/web/lib/mockRESTCalls.ts
+++ b/src/web/lib/mockRESTCalls.ts
@@ -3,7 +3,6 @@ import fetchMock from 'fetch-mock';
 import { richLinkCard } from '@root/fixtures/card';
 import { mockTab1, responseWithTwoTabs } from '@root/fixtures/mostViewed';
 import { series } from '@root/fixtures/series';
-import { sharecount } from '@root/fixtures/article';
 import { commentCount } from '@root/fixtures/commentCounts';
 import { discussion } from '@root/fixtures/discussion';
 import { storypackage } from '@root/fixtures/storypackage';
@@ -71,7 +70,12 @@ export const mockRESTCalls = () =>
 			/.*api.nextgen.guardianapps.co.uk\/sharecount.*/,
 			{
 				status: 200,
-				body: sharecount,
+				body: {
+					path:
+						'money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+					share_count: 273,
+					refreshStatus: true,
+				},
 			},
 			{ overwriteRoutes: false },
 		)


### PR DESCRIPTION
## What?
Removes the `sharecount` export from the `article.ts` file and inlines it

## Why?
Because it didn't make sense to export this data from that file and because it's so small, and becuase it's already inlined in other places, rather than create a new export I inlined it.
