### PR TITLE
Missing types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -216,6 +216,12 @@ interface Block {
 	blockFirstPublishedDisplay?: string;
 	primaryDateLine: string;
 	secondaryDateLine: string;
+	createdOn?: number;
+	createdOnDisplay?: string;
+	lastUpdated?: number;
+	lastUpdatedDisplay?: string;
+	firstPublished?: number;
+	firstPublishedDisplay?: string;
 }
 
 interface Pagination {

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -123,6 +123,9 @@ interface EmbedBlockElement {
 	alt?: string;
 	html: string;
 	isMandatory: boolean;
+	isThirdPartyTracking?: boolean;
+	source?: string;
+	sourceDomain?: string;
 }
 
 interface ExplainerAtomBlockElement {
@@ -247,6 +250,7 @@ interface PullquoteBlockElement {
 	html?: string;
 	role: string;
 	attribution?: string;
+	isThirdPartyTracking?: boolean;
 }
 
 interface QABlockElement {
@@ -363,6 +367,9 @@ interface VideoYoutubeBlockElement {
 	credit?: string;
 	title?: string;
 	role?: RoleType;
+	isThirdPartyTracking?: boolean;
+	source?: string;
+	sourceDomain?: string;
 }
 
 interface YoutubeBlockElement {

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -1221,6 +1221,15 @@
                 },
                 "isMandatory": {
                     "type": "boolean"
+                },
+                "isThirdPartyTracking": {
+                    "type": "boolean"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "sourceDomain": {
+                    "type": "string"
                 }
             },
             "required": [
@@ -1833,6 +1842,9 @@
                 },
                 "attribution": {
                     "type": "string"
+                },
+                "isThirdPartyTracking": {
+                    "type": "boolean"
                 }
             },
             "required": [
@@ -2260,6 +2272,15 @@
                 },
                 "role": {
                     "$ref": "#/definitions/RoleType"
+                },
+                "isThirdPartyTracking": {
+                    "type": "boolean"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "sourceDomain": {
+                    "type": "string"
                 }
             },
             "required": [
@@ -2501,6 +2522,24 @@
                     "type": "string"
                 },
                 "secondaryDateLine": {
+                    "type": "string"
+                },
+                "createdOn": {
+                    "type": "number"
+                },
+                "createdOnDisplay": {
+                    "type": "string"
+                },
+                "lastUpdated": {
+                    "type": "number"
+                },
+                "lastUpdatedDisplay": {
+                    "type": "string"
+                },
+                "firstPublished": {
+                    "type": "number"
+                },
+                "firstPublishedDisplay": {
                     "type": "string"
                 }
             },


### PR DESCRIPTION
## What?
Adds some missing types to `CAPIType` as well as to some element types

## Why?
Because the latest data being sent from CAPI includes this data but we're not typing it causing errors when we try to update our fixtures.