### PR TITLE
Correct BylineLink

### DIFF
--- a/src/web/components/BylineLink.tsx
+++ b/src/web/components/BylineLink.tsx
@@ -5,15 +5,17 @@ type Props = {
 	tags: TagType[];
 };
 
+const getContributorTags = (tags: TagType[]): TagType[] => {
+	return tags.filter((t) => t.type === 'Contributor');
+};
+
 // This crazy function aims to split bylines such as
 // 'Harry Potter in Hogwarts' to ['Harry Potter', 'in Hogwarts']
 // Or
 // 'Jane Doe and John Smith` to ['Jane Doe', ' and ', 'John Smith']
 // It does this so we can have separate links to both contributors
 const bylineAsTokens = (byline: string, tags: TagType[]): string[] => {
-	const contributorTags = tags
-		.filter((t) => t.type === 'Contributor')
-		.map((c) => c.title);
+	const contributorTags = getContributorTags(tags).map((c) => c.title);
 	// The contributor tag title should exist inside the byline for this regex to work
 	const regex = new RegExp(`(${contributorTags.join('|')})`);
 
@@ -22,7 +24,9 @@ const bylineAsTokens = (byline: string, tags: TagType[]): string[] => {
 
 export const BylineLink = ({ byline, tags }: Props) => {
 	const renderedTokens = bylineAsTokens(byline, tags).map((token, i) => {
-		const associatedTags = tags.filter((t) => t.title === token);
+		const associatedTags = getContributorTags(tags).filter(
+			(t) => t.title === token,
+		);
 		if (associatedTags.length > 0) {
 			return (
 				<ContributorLink

--- a/src/web/components/BylineLink.tsx
+++ b/src/web/components/BylineLink.tsx
@@ -15,9 +15,9 @@ const getContributorTags = (tags: TagType[]): TagType[] => {
 // 'Jane Doe and John Smith` to ['Jane Doe', ' and ', 'John Smith']
 // It does this so we can have separate links to both contributors
 const bylineAsTokens = (byline: string, tags: TagType[]): string[] => {
-	const contributorTags = getContributorTags(tags).map((c) => c.title);
+	const titles = getContributorTags(tags).map((c) => c.title);
 	// The contributor tag title should exist inside the byline for this regex to work
-	const regex = new RegExp(`(${contributorTags.join('|')})`);
+	const regex = new RegExp(`(${titles.join('|')})`);
 
 	return byline.split(regex);
 };


### PR DESCRIPTION
Correct a bug in BylineLink. We now pick up the correct associated tags. This prevent bylines to point to tags pages when they should point to contributor pages.

Before:

<img width="507" alt="Screenshot 2021-02-08 at 12 42 41" src="https://user-images.githubusercontent.com/6035518/107221229-40d7c880-6a0b-11eb-8417-53f8da161c13.png">


After:

<img width="441" alt="Screenshot 2021-02-08 at 12 43 11" src="https://user-images.githubusercontent.com/6035518/107221240-46cda980-6a0b-11eb-92b7-1feb850bb211.png">


