### PR TITLE
Eslint camelcase pascalcase fix

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -53,7 +53,6 @@ module.exports = {
         'react/jsx-boolean-value': [2, 'always'],
         'import/prefer-default-export': 'off',
         // TODO: remove
-        '@typescript-eslint/camelcase': 'off',
         '@typescript-eslint/explicit-module-boundary-types': 'off',
         '@typescript-eslint/no-unsafe-member-access': 'off',
         '@typescript-eslint/no-unsafe-call': 'off',

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
         "emotion-theming": "^10.0.27",
         "eslint-config-airbnb": "^18.0.1",
         "eslint-config-airbnb-base": "^14.2.1",
-        "eslint-config-airbnb-typescript": "^6.3.0",
+        "eslint-config-airbnb-typescript": "^12.3.1",
         "eslint-config-prettier": "^6.15.0",
         "eslint-import-resolver-babel-module": "^5.1.2",
         "eslint-plugin-cypress": "^2.11.2",

--- a/src/lib/pillars.ts
+++ b/src/lib/pillars.ts
@@ -12,7 +12,7 @@ import {
 	border,
 } from '@guardian/src-foundations/palette';
 
-type colour = string;
+type ColourType = string;
 
 export const pillarNames: Theme[] = [
 	Pillar.News,
@@ -24,41 +24,41 @@ export const pillarNames: Theme[] = [
 ];
 
 type PillarPalette = {
-	dark: colour;
-	main: colour;
-	bright: colour;
-	pastel: colour;
-	faded: colour;
-	300: colour;
-	400: colour;
-	500: colour;
-	600: colour;
-	800: colour;
+	dark: ColourType;
+	main: ColourType;
+	bright: ColourType;
+	pastel: ColourType;
+	faded: ColourType;
+	300: ColourType;
+	400: ColourType;
+	500: ColourType;
+	600: ColourType;
+	800: ColourType;
 };
 
 type SpecialPalette = {
-	dark: colour;
-	main: colour;
-	bright: colour;
-	faded: colour;
-	300: colour;
-	400: colour;
-	500: colour;
-	800: colour;
+	dark: ColourType;
+	main: ColourType;
+	bright: ColourType;
+	faded: ColourType;
+	300: ColourType;
+	400: ColourType;
+	500: ColourType;
+	800: ColourType;
 };
 
 type LabsPalette = {
-	dark: colour;
-	main: colour;
-	bright: colour;
-	faded: colour;
-	300: colour;
-	400: colour;
-	500: colour;
-	800: colour;
+	dark: ColourType;
+	main: ColourType;
+	bright: ColourType;
+	faded: ColourType;
+	300: ColourType;
+	400: ColourType;
+	500: ColourType;
+	800: ColourType;
 };
 
-// pillarPalette exposes a convenience object for deciding colour
+// pillarPalette exposes a convenience object for deciding ColourType
 //
 // Usage:
 // `pillarPalette[Pillar.Opinion][300]`
@@ -172,7 +172,7 @@ Further notes on this function:
       a key for each pillar and values of type T.
  */
 
-export const neutralBorder = (pillar: Theme): colour => {
+export const neutralBorder = (pillar: Theme): ColourType => {
 	switch (pillar) {
 		case Special.Labs:
 			return border.primary; // 'dark' theme

--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -1,8 +1,8 @@
-type stage = 'DEV' | 'CODE' | 'PROD';
+type StageType = 'DEV' | 'CODE' | 'PROD';
 
 export interface WindowGuardianConfig {
 	isDotcomRendering: boolean;
-	stage: stage;
+	stage: StageType;
 	frontendAssetsFullURL: string;
 	page: {
 		dcrCouldRender: boolean;

--- a/src/web/browser/ga/ga.ts
+++ b/src/web/browser/ga/ga.ts
@@ -45,13 +45,14 @@ export const init = (): void => {
 	});
 };
 
-type coreVitalsArgs = {
+type CoreVitalsArgsType = {
 	name: string;
 	delta: number;
 	id: string;
 };
+
 // https://www.npmjs.com/package/web-vitals#using-analyticsjs
-const sendCoreVital = ({ name, delta, id }: coreVitalsArgs): void => {
+const sendCoreVital = ({ name, delta, id }: CoreVitalsArgsType): void => {
 	const { ga } = window;
 
 	if (!ga) {

--- a/src/web/browser/newsletterEmbedIframe/init.ts
+++ b/src/web/browser/newsletterEmbedIframe/init.ts
@@ -1,18 +1,19 @@
 import '../webpackPublicPath';
 import { startup } from '@root/src/web/browser/startup';
 
+type NewsletterHeightEventType = { source: { location: { href: string } } };
+
 const init = (): Promise<void> => {
 	const allIframes: HTMLIFrameElement[] = [].slice.call(
 		document.querySelectorAll('.email-sub__iframe'),
 	);
-	type newsletterHeightEvent = { source: { location: { href: string } } };
 
 	window.addEventListener('message', (event) => {
 		const iframes: HTMLIFrameElement[] = allIframes.filter((i) => {
 			try {
 				return (
 					i.src ===
-					(event as newsletterHeightEvent).source.location.href
+					(event as NewsletterHeightEventType).source.location.href
 				);
 			} catch (e) {
 				return false;

--- a/src/web/browser/updateIframeHeight.tsx
+++ b/src/web/browser/updateIframeHeight.tsx
@@ -1,13 +1,14 @@
+type HeightEventType = { source: { name: string } };
+
 export const updateIframeHeight = (queryString: string): Promise<void> => {
 	const iframes: HTMLIFrameElement[] = [].slice.call(
 		document.querySelectorAll(queryString),
 	);
-	type heightEvent = { source: { name: string } };
 
 	window.addEventListener('message', (event) => {
 		const iframe: HTMLIFrameElement | undefined = iframes.find((i) => {
 			try {
-				return i.name === (event as heightEvent).source.name;
+				return i.name === (event as HeightEventType).source.name;
 			} catch (e) {
 				return false;
 			}

--- a/src/web/components/Callout/Form.tsx
+++ b/src/web/components/Callout/Form.tsx
@@ -38,12 +38,12 @@ const formFieldWrapperStyles = css`
 	flex-direction: column;
 `;
 
-type formData = { [key in string]: any };
+type FormDataType = { [key in string]: any };
 
 type FormFieldProp = {
 	formField: CampaignFieldType;
-	formData: formData;
-	setFormData: React.Dispatch<React.SetStateAction<formData>>;
+	formData: FormDataType;
+	setFormData: React.Dispatch<React.SetStateAction<FormDataType>>;
 };
 
 const FormField = ({ formField, formData, setFormData }: FormFieldProp) => {
@@ -110,7 +110,7 @@ const FormField = ({ formField, formData, setFormData }: FormFieldProp) => {
 };
 
 type FormProps = {
-	onSubmit: (formData: formData) => void;
+	onSubmit: (formData: FormDataType) => void;
 	formFields: CampaignFieldType[];
 	error?: string;
 };

--- a/src/web/components/Callout/RadioSelect.tsx
+++ b/src/web/components/Callout/RadioSelect.tsx
@@ -4,7 +4,7 @@ import { css } from 'emotion';
 import { RadioGroup, Radio } from '@guardian/src-radio';
 import { FieldLabel } from './FieldLabel';
 
-type fieldProp = {
+type FieldProp = {
 	formField: CampaignFieldRadio;
 	formData: { [key in string]: any };
 	setFormData: React.Dispatch<React.SetStateAction<{ [x: string]: any }>>;
@@ -14,7 +14,7 @@ export const RadioSelect = ({
 	formField,
 	formData,
 	setFormData,
-}: fieldProp) => (
+}: FieldProp) => (
 	// work around to enforce `display: flex;` to `RadioGroup`'s fieldset tag
 	// https://github.com/guardian/source/issues/580
 	<div

--- a/src/web/components/RichLink.tsx
+++ b/src/web/components/RichLink.tsx
@@ -35,7 +35,7 @@ type CardStyle =
 	| 'external'
 	| 'news';
 
-type colour = string;
+type ColourType = string;
 
 interface Props {
 	richLinkIndex: number;
@@ -87,26 +87,26 @@ const neutralBackground = css`
 	}
 `;
 
-const richLinkPillarColour: (format: Format) => colour = (format) => {
+const richLinkPillarColour: (format: Format) => ColourType = (format) => {
 	if (format) {
 		return pillarPalette[format.theme].main;
 	}
 	return pillarPalette[Pillar.News][400];
 };
 
-const pillarBackground: (format: Format) => colour = (format) => {
+const pillarBackground: (format: Format) => ColourType = (format) => {
 	return css`
 		background-color: ${richLinkPillarColour(format)};
 	`;
 };
 
-const textColour: (format: Format) => colour = (format) => {
+const textColour: (format: Format) => ColourType = (format) => {
 	return css`
 		color: ${richLinkPillarColour(format)};
 	`;
 };
 
-const richLinkTopBorder: (format: Format) => colour = (format) => {
+const richLinkTopBorder: (format: Format) => ColourType = (format) => {
 	return css`
 		border-top: 1px;
 		border-top-style: solid;
@@ -142,7 +142,7 @@ const richLinkTitle = css`
 	}
 `;
 
-const richLinkReadMore: (format: Format) => colour = (format) => {
+const richLinkReadMore: (format: Format) => ColourType = (format) => {
 	return css`
 		fill: ${richLinkPillarColour(format)};
 		color: ${richLinkPillarColour(format)};

--- a/src/web/components/elements/CalloutBlockComponent.tsx
+++ b/src/web/components/elements/CalloutBlockComponent.tsx
@@ -124,7 +124,7 @@ const buttonWrapperStyles = css`
 // after it was opened
 let hasFormBeenOpened = true;
 
-type formData = { [key in string]: any };
+type FormDataType = { [key in string]: any };
 
 export const CalloutBlockComponent = ({
 	callout,
@@ -143,7 +143,7 @@ export const CalloutBlockComponent = ({
 
 	const { title, description, formFields } = callout;
 
-	const onSubmit = async (formData: formData) => {
+	const onSubmit = async (formData: FormDataType) => {
 		// Reset error for new submission attempt
 		setError('');
 

--- a/src/web/lib/formatAttrString.ts
+++ b/src/web/lib/formatAttrString.ts
@@ -1,11 +1,11 @@
-type strInOutFunc = (str: string) => string;
+type StrInOutFuncType = (str: string) => string;
 
-const removeAlphaNumeric: strInOutFunc = (str) =>
+const removeAlphaNumeric: StrInOutFuncType = (str) =>
 	str.replace(new RegExp('[^0-9a-z ]', 'gi'), ';'); // We set it to semicolon so we can remove it at the end
-const lowercase: strInOutFunc = (str) => str.toLowerCase();
-const replaceSpacesWithHyphens: strInOutFunc = (str) =>
+const lowercase: StrInOutFuncType = (str) => str.toLowerCase();
+const replaceSpacesWithHyphens: StrInOutFuncType = (str) =>
 	str.replace(new RegExp(' ', 'g'), '-'); // Replace the space
-const removeTempChars: strInOutFunc = (str) =>
+const removeTempChars: StrInOutFuncType = (str) =>
 	str.replace(new RegExp('[;]', 'g'), ''); // Strip out those semicolons
 
 export const formatAttrString = (input: string) =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4576,16 +4576,6 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@2.34.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz#d3524b644cdb40eebceca67f8cf3e4cc9c8f980f"
-  integrity sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==
-  dependencies:
-    "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.34.0"
-    eslint-scope "^5.0.0"
-    eslint-utils "^2.0.0"
-
 "@typescript-eslint/experimental-utils@3.3.0":
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-3.3.0.tgz#d72a946e056a83d4edf97f3411cceb639b0b8c87"
@@ -4608,16 +4598,6 @@
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
-"@typescript-eslint/parser@^2.3.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.34.0.tgz#50252630ca319685420e9a39ca05fe185a256bc8"
-  integrity sha512-03ilO0ucSD0EPTw2X4PntSIRFtDPWjrVq7C3/Z3VQHRC7+13YB55rcJI3Jt+YgeHbjUdJPcPa7b23rXCBokuyA==
-  dependencies:
-    "@types/eslint-visitor-keys" "^1.0.0"
-    "@typescript-eslint/experimental-utils" "2.34.0"
-    "@typescript-eslint/typescript-estree" "2.34.0"
-    eslint-visitor-keys "^1.1.0"
-
 "@typescript-eslint/parser@^3.0.0":
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-3.3.0.tgz#fcae40012ded822aa8b2739a1a03a4e3c5bbb7bb"
@@ -4638,6 +4618,16 @@
     "@typescript-eslint/typescript-estree" "4.14.2"
     debug "^4.1.1"
 
+"@typescript-eslint/parser@^4.4.1":
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.15.0.tgz#8df94365b4b7161f9e8514fe28aef19954810b6b"
+  integrity sha512-L6Dtbq8Bc7g2aZwnIBETpmUa9XDKCMzKVwAArnGp5Mn7PRNFjf3mUzq8UeBjL3K8t311hvevnyqXAMSmxO8Gpg==
+  dependencies:
+    "@typescript-eslint/scope-manager" "4.15.0"
+    "@typescript-eslint/types" "4.15.0"
+    "@typescript-eslint/typescript-estree" "4.15.0"
+    debug "^4.1.1"
+
 "@typescript-eslint/scope-manager@4.14.2":
   version "4.14.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.14.2.tgz#64cbc9ca64b60069aae0c060b2bf81163243b266"
@@ -4646,23 +4636,23 @@
     "@typescript-eslint/types" "4.14.2"
     "@typescript-eslint/visitor-keys" "4.14.2"
 
+"@typescript-eslint/scope-manager@4.15.0":
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.15.0.tgz#c42703558ea6daaaba51a9c3a86f2902dbab9432"
+  integrity sha512-CSNBZnCC2jEA/a+pR9Ljh8Y+5TY5qgbPz7ICEk9WCpSEgT6Pi7H2RIjxfrrbUXvotd6ta+i27sssKEH8Azm75g==
+  dependencies:
+    "@typescript-eslint/types" "4.15.0"
+    "@typescript-eslint/visitor-keys" "4.15.0"
+
 "@typescript-eslint/types@4.14.2":
   version "4.14.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.14.2.tgz#d96da62be22dc9dc6a06647f3633815350fb3174"
   integrity sha512-LltxawRW6wXy4Gck6ZKlBD05tCHQUj4KLn4iR69IyRiDHX3d3NCAhO+ix5OR2Q+q9bjCrHE/HKt+riZkd1At8Q==
 
-"@typescript-eslint/typescript-estree@2.34.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz#14aeb6353b39ef0732cc7f1b8285294937cf37d5"
-  integrity sha512-OMAr+nJWKdlVM9LOqCqh3pQQPwxHAN7Du8DR6dmwCrAmxtiXQnhHJ6tBNtf+cggqfo51SG/FCwnKhXCIM7hnVg==
-  dependencies:
-    debug "^4.1.1"
-    eslint-visitor-keys "^1.1.0"
-    glob "^7.1.6"
-    is-glob "^4.0.1"
-    lodash "^4.17.15"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
+"@typescript-eslint/types@4.15.0":
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.15.0.tgz#3011ae1ac3299bb9a5ac56bdd297cccf679d3662"
+  integrity sha512-su4RHkJhS+iFwyqyXHcS8EGPlUVoC+XREfy5daivjLur9JP8GhvTmDipuRpcujtGC4M+GYhUOJCPDE3rC5NJrg==
 
 "@typescript-eslint/typescript-estree@3.3.0":
   version "3.3.0"
@@ -4691,12 +4681,33 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
+"@typescript-eslint/typescript-estree@4.15.0":
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.15.0.tgz#402c86a7d2111c1f7a2513022f22a38a395b7f93"
+  integrity sha512-jG6xTmcNbi6xzZq0SdWh7wQ9cMb2pqXaUp6bUZOMsIlu5aOlxGxgE/t6L/gPybybQGvdguajXGkZKSndZJpksA==
+  dependencies:
+    "@typescript-eslint/types" "4.15.0"
+    "@typescript-eslint/visitor-keys" "4.15.0"
+    debug "^4.1.1"
+    globby "^11.0.1"
+    is-glob "^4.0.1"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
+
 "@typescript-eslint/visitor-keys@4.14.2":
   version "4.14.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.14.2.tgz#997cbe2cb0690e1f384a833f64794e98727c70c6"
   integrity sha512-KBB+xLBxnBdTENs/rUgeUKO0UkPBRs2vD09oMRRIkj5BEN8PX1ToXV532desXfpQnZsYTyLLviS7JrPhdL154w==
   dependencies:
     "@typescript-eslint/types" "4.14.2"
+    eslint-visitor-keys "^2.0.0"
+
+"@typescript-eslint/visitor-keys@4.15.0":
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.15.0.tgz#2a07768df30c8a5673f1bce406338a07fdec38ca"
+  integrity sha512-RnDtJwOwFucWFAMjG3ghCG/ikImFJFEg20DI7mn4pHEx3vC48lIAoyjhffvfHmErRDboUPC7p9Z2il4CLb7qxA==
+  dependencies:
+    "@typescript-eslint/types" "4.15.0"
     eslint-visitor-keys "^2.0.0"
 
 "@webassemblyjs/ast@1.11.0":
@@ -8799,7 +8810,7 @@ escodegen@1.x.x, escodegen@^1.14.1, escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-airbnb-base@^14.0.0, eslint-config-airbnb-base@^14.2.1:
+eslint-config-airbnb-base@^14.0.0, eslint-config-airbnb-base@^14.2.0, eslint-config-airbnb-base@^14.2.1:
   version "14.2.1"
   resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz#8a2eb38455dc5a312550193b319cdaeef042cd1e"
   integrity sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==
@@ -8808,14 +8819,14 @@ eslint-config-airbnb-base@^14.0.0, eslint-config-airbnb-base@^14.2.1:
     object.assign "^4.1.2"
     object.entries "^1.1.2"
 
-eslint-config-airbnb-typescript@^6.3.0:
-  version "6.3.1"
-  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-typescript/-/eslint-config-airbnb-typescript-6.3.1.tgz#28bd09099355324353a074a71951dd879cce7df0"
-  integrity sha512-+tkkVysaN63zXz+oiPfkfYSRMIY5QfHI4qFeyb1ZhRGF2jR6JslqDv5GkrW/eciySNTVTigFvf9hkqHT9vklJw==
+eslint-config-airbnb-typescript@^12.3.1:
+  version "12.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-typescript/-/eslint-config-airbnb-typescript-12.3.1.tgz#83ab40d76402c208eb08516260d1d6fac8f8acbc"
+  integrity sha512-ql/Pe6/hppYuRp4m3iPaHJqkBB7dgeEmGPQ6X0UNmrQOfTF+dXw29/ZjU2kQ6RDoLxaxOA+Xqv07Vbef6oVTWw==
   dependencies:
-    "@typescript-eslint/parser" "^2.3.0"
-    eslint-config-airbnb "^18.0.1"
-    eslint-config-airbnb-base "^14.0.0"
+    "@typescript-eslint/parser" "^4.4.1"
+    eslint-config-airbnb "^18.2.0"
+    eslint-config-airbnb-base "^14.2.0"
 
 eslint-config-airbnb@^18.0.1:
   version "18.0.1"
@@ -8825,6 +8836,15 @@ eslint-config-airbnb@^18.0.1:
     eslint-config-airbnb-base "^14.0.0"
     object.assign "^4.1.0"
     object.entries "^1.1.0"
+
+eslint-config-airbnb@^18.2.0:
+  version "18.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb/-/eslint-config-airbnb-18.2.1.tgz#b7fe2b42f9f8173e825b73c8014b592e449c98d9"
+  integrity sha512-glZNDEZ36VdlZWoxn/bUR1r/sdFKPd1mHPbqUtkctgNG4yT2DLLtJ3D+yCV+jzZCc2V1nBVkmdknOJBZ5Hc0fg==
+  dependencies:
+    eslint-config-airbnb-base "^14.2.1"
+    object.assign "^4.1.2"
+    object.entries "^1.1.2"
 
 eslint-config-prettier@^6.15.0:
   version "6.15.0"


### PR DESCRIPTION
## What does this change?
Turn `@typescript-eslint/camelcase` back on

## What has changed?
- remove `@typescript-eslint/camelcase` from exception
- fix`Definition for rule '@typescript-eslint/camelcase' was not found` by updating `eslint-config-airbnb-typescript`
- fix `Type Alias name XXX must match one of the following formats: PascalCase  @typescript-eslint/naming-convention` by convert all TS types to using PascalCase
