### PR TITLE
Add ophan tracking

### DIFF
--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -54,7 +54,6 @@ type Props = {
 	alwaysVertical?: boolean;
 	minWidthInPixels?: number;
 	// Ophan tracking
-	dataComponent?: string;
 	dataLinkName?: string;
 };
 
@@ -147,7 +146,6 @@ export const Card = ({
 	starRating,
 	alwaysVertical,
 	minWidthInPixels,
-	dataComponent,
 	dataLinkName,
 }: Props) => {
 	// Decide how we position the image on the card
@@ -169,7 +167,6 @@ export const Card = ({
 			linkTo={linkTo}
 			format={format}
 			palette={palette}
-			dataComponent={dataComponent}
 			dataLinkName={dataLinkName}
 		>
 			<TopBar palette={palette} isFullCardImage={isFullCardImage}>

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -53,6 +53,9 @@ type Props = {
 	starRating?: number;
 	alwaysVertical?: boolean;
 	minWidthInPixels?: number;
+	// Ophan tracking
+	dataComponent?: string;
+	dataLinkName?: string;
 };
 
 type ImageSizeType = 'small' | 'medium' | 'large' | 'jumbo';
@@ -144,6 +147,8 @@ export const Card = ({
 	starRating,
 	alwaysVertical,
 	minWidthInPixels,
+	dataComponent,
+	dataLinkName,
 }: Props) => {
 	// Decide how we position the image on the card
 	let imageCoverage: CardPercentageType | undefined;
@@ -160,7 +165,13 @@ export const Card = ({
 	const { long: longCount, short: shortCount } = formatCount(commentCount);
 
 	return (
-		<CardLink linkTo={linkTo} format={format} palette={palette}>
+		<CardLink
+			linkTo={linkTo}
+			format={format}
+			palette={palette}
+			dataComponent={dataComponent}
+			dataLinkName={dataLinkName}
+		>
 			<TopBar palette={palette} isFullCardImage={isFullCardImage}>
 				<CardLayout
 					imagePosition={imagePosition}

--- a/src/web/components/Card/components/CardLink.tsx
+++ b/src/web/components/Card/components/CardLink.tsx
@@ -83,13 +83,23 @@ type Props = {
 	linkTo: string;
 	format: Format;
 	palette: Palette;
+	dataComponent?: string;
+	dataLinkName?: string;
 };
 
-export const CardLink = ({ children, linkTo, format, palette }: Props) => (
+export const CardLink = ({
+	children,
+	linkTo,
+	format,
+	palette,
+	dataComponent,
+	dataLinkName = 'article',
+}: Props) => (
 	<a
 		href={linkTo}
 		className={linkStyles(format, palette)}
-		data-link-name="article"
+		data-component={dataComponent}
+		data-link-name={dataLinkName}
 	>
 		{children}
 	</a>

--- a/src/web/components/Card/components/CardLink.tsx
+++ b/src/web/components/Card/components/CardLink.tsx
@@ -83,7 +83,6 @@ type Props = {
 	linkTo: string;
 	format: Format;
 	palette: Palette;
-	dataComponent?: string;
 	dataLinkName?: string;
 };
 
@@ -92,13 +91,11 @@ export const CardLink = ({
 	linkTo,
 	format,
 	palette,
-	dataComponent,
 	dataLinkName = 'article',
 }: Props) => (
 	<a
 		href={linkTo}
 		className={linkStyles(format, palette)}
-		data-component={dataComponent}
 		data-link-name={dataLinkName}
 	>
 		{children}

--- a/src/web/components/Onwards/Carousel/Carousel.tsx
+++ b/src/web/components/Onwards/Carousel/Carousel.tsx
@@ -309,6 +309,8 @@ type CarouselCardProps = {
 	kickerText?: string;
 	imageUrl?: string;
 	isFullCardImage?: boolean;
+	dataComponent?: string;
+	dataLinkName?: string;
 };
 
 export const CarouselCard: React.FC<CarouselCardProps> = ({
@@ -321,6 +323,8 @@ export const CarouselCard: React.FC<CarouselCardProps> = ({
 	kickerText,
 	isFirst,
 	isFullCardImage,
+	dataComponent,
+	dataLinkName,
 }: CarouselCardProps) => (
 	<LI
 		stretch={true}
@@ -343,6 +347,8 @@ export const CarouselCard: React.FC<CarouselCardProps> = ({
 			minWidthInPixels={220}
 			isFullCardImage={isFullCardImage}
 			showQuotes={format.design === Design.Comment}
+			dataComponent={dataComponent}
+			dataLinkName={dataLinkName}
 		/>
 	</LI>
 );
@@ -384,6 +390,9 @@ const HeaderAndNav: React.FC<HeaderAndNavProps> = ({
 							isFullCardImage,
 						),
 					)}
+					data-link-name={`${
+						isFullCardImage ? 'carousel-large' : 'carousel-small'
+					}-nav-dot-${i}`}
 				/>
 			))}
 		</div>
@@ -400,6 +409,13 @@ export const Carousel: React.FC<OnwardsType> = ({
 	const carouselRef = useRef<HTMLUListElement>(null);
 
 	const [index, setIndex] = useState(0);
+	const [maxIndex, setMaxIndex] = useState(0);
+
+	const variantComponentName = isFullCardImage
+		? 'carousel-large'
+		: 'carousel-small';
+
+	const arrowName = `${variantComponentName}-arrow`;
 
 	const notPresentation = (el: HTMLElement): boolean =>
 		el.getAttribute('role') !== 'presentation';
@@ -483,13 +499,20 @@ export const Carousel: React.FC<OnwardsType> = ({
 	};
 
 	useEffect(() => {
-		if (carouselRef.current) {
-			carouselRef.current.addEventListener(
+		const carousel = carouselRef.current;
+		if (carousel) {
+			carousel.addEventListener('scroll', libDebounce(getSetIndex, 100));
+			return carousel.removeEventListener(
 				'scroll',
 				libDebounce(getSetIndex, 100),
 			);
 		}
 	});
+
+	// No idea if this is the best approach but it prevents issues with libDebounce
+	// using old data to determine the max index. Instead we say update maxIndex
+	// when index changes and compare it against the prior maxIndex only.
+	useEffect(() => setMaxIndex((m) => Math.max(index, m)), [index]);
 
 	if (isFullCardImage) trails = convertToImmersive(trails);
 
@@ -513,6 +536,7 @@ export const Carousel: React.FC<OnwardsType> = ({
 					onClick={prev}
 					aria-label="Move carousel backwards"
 					className={cx(buttonStyle, prevButtonStyle(index))}
+					data-link-name={`${arrowName}-prev`}
 				>
 					<SvgChevronLeftSingle />
 				</button>
@@ -526,6 +550,7 @@ export const Carousel: React.FC<OnwardsType> = ({
 						buttonStyle,
 						nextButtonStyle(index, trails.length),
 					)}
+					data-link-name={`${arrowName}-next`}
 				>
 					<SvgChevronRightSingle />
 				</button>
@@ -553,6 +578,7 @@ export const Carousel: React.FC<OnwardsType> = ({
 									buttonStyle,
 									prevButtonStyle(index),
 								)}
+								data-link-name={`${arrowName}-prev`}
 							>
 								<SvgChevronLeftSingle />
 							</button>
@@ -563,6 +589,7 @@ export const Carousel: React.FC<OnwardsType> = ({
 									buttonStyle,
 									nextButtonStyle(index, trails.length),
 								)}
+								data-link-name={`${arrowName}-next`}
 							>
 								<SvgChevronRightSingle />
 							</button>
@@ -596,6 +623,8 @@ export const Carousel: React.FC<OnwardsType> = ({
 								imageUrl={imageUrl}
 								kickerText={kickerText}
 								isFullCardImage={isFullCardImage}
+								dataComponent={`${variantComponentName} | maxIndex-${maxIndex}`}
+								dataLinkName={`${variantComponentName}-card-position-${i}`}
 							/>
 						);
 					})}

--- a/src/web/components/Onwards/Carousel/Carousel.tsx
+++ b/src/web/components/Onwards/Carousel/Carousel.tsx
@@ -323,7 +323,6 @@ export const CarouselCard: React.FC<CarouselCardProps> = ({
 	kickerText,
 	isFirst,
 	isFullCardImage,
-	dataComponent,
 	dataLinkName,
 }: CarouselCardProps) => (
 	<LI
@@ -347,7 +346,6 @@ export const CarouselCard: React.FC<CarouselCardProps> = ({
 			minWidthInPixels={220}
 			isFullCardImage={isFullCardImage}
 			showQuotes={format.design === Design.Comment}
-			dataComponent={dataComponent}
 			dataLinkName={dataLinkName}
 		/>
 	</LI>
@@ -600,6 +598,7 @@ export const Carousel: React.FC<OnwardsType> = ({
 				<ul
 					className={carouselStyle(isFullCardImage)}
 					ref={carouselRef}
+					data-component={`${variantComponentName} | maxIndex-${maxIndex}`}
 				>
 					{trails.map((trail, i) => {
 						const {
@@ -623,7 +622,6 @@ export const Carousel: React.FC<OnwardsType> = ({
 								imageUrl={imageUrl}
 								kickerText={kickerText}
 								isFullCardImage={isFullCardImage}
-								dataComponent={`${variantComponentName} | maxIndex-${maxIndex}`}
 								dataLinkName={`${variantComponentName}-card-position-${i}`}
 							/>
 						);


### PR DESCRIPTION
Adds tracking for:
 - Interactive elements e.g. buttons and cards
 - The index of the clicked card
 - The maximum index scrolled to by the user

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
### Screenshots
![carousel-tracking](https://user-images.githubusercontent.com/9122944/107406373-46fba100-6b00-11eb-8e84-664d5952a1d7.gif)

![image](https://user-images.githubusercontent.com/9122944/107406505-67c3f680-6b00-11eb-870c-e3195016adc8.png)


## Why?
AB test tracking