### PR TITLE
Orange Kicker

### DIFF
--- a/src/web/lib/decidePalette.ts
+++ b/src/web/lib/decidePalette.ts
@@ -162,7 +162,9 @@ const textCardKicker = (format: Format): string => {
 		format.theme === Special.SpecialReport &&
 		format.design === Design.Comment
 	)
-		return pillarPalette[Pillar.Opinion][500];
+		// TODO: Pull this in from souce once we see it here:
+		// https://theguardian.design/2a1e5182b/p/492a30-light-palette
+		return '#ff9941';
 	if (format.theme === Special.SpecialReport)
 		return brandAltBackground.primary;
 	if (format.display === Display.Immersive)

--- a/src/web/lib/decidePalette.ts
+++ b/src/web/lib/decidePalette.ts
@@ -158,6 +158,11 @@ const textCardHeadline = (format: Format): string => {
 };
 
 const textCardKicker = (format: Format): string => {
+	if (
+		format.theme === Special.SpecialReport &&
+		format.design === Design.Comment
+	)
+		return pillarPalette[Pillar.Opinion][500];
 	if (format.theme === Special.SpecialReport)
 		return brandAltBackground.primary;
 	if (format.display === Display.Immersive)

--- a/src/web/lib/decidePalette.ts
+++ b/src/web/lib/decidePalette.ts
@@ -5,6 +5,8 @@ import {
 	text,
 	specialReport,
 	opinion,
+	news,
+	sport,
 	brandAltBackground,
 	border,
 } from '@guardian/src-foundations';
@@ -173,9 +175,9 @@ const textCardKicker = (format: Format): string => {
 		case Design.Live:
 			switch (format.theme) {
 				case Pillar.News:
-					return '#ffbac8';
+					return news[600];
 				case Pillar.Sport:
-					return '#90dcff';
+					return sport[600];
 				default:
 					return pillarPalette[format.theme].main;
 			}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Makes the kicker orange for special report comment pieces

### Before
![Screenshot 2021-02-11 at 08 41 45](https://user-images.githubusercontent.com/1336821/107615952-ffcaf880-6c44-11eb-94ad-42de0e125dc1.jpg)

### After
![Screenshot 2021-02-11 at 08 40 14](https://user-images.githubusercontent.com/1336821/107615926-f346a000-6c44-11eb-995f-4581f90bacac.jpg)


## Why?
So that we correctly represent both the fact the piece is opinion but also a special report
