### PR TITLE
Fix banner last closed at parsing

### DIFF
--- a/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -19,10 +19,11 @@ type Props = {
 };
 
 const getBannerLastClosedAt = (key: string): string | undefined => {
-	const item: { [key: string]: string } = JSON.parse(
-		localStorage.getItem(`gu.prefs.${key}`) || '',
-	);
-	return item.value;
+	const item = localStorage.getItem(`gu.prefs.${key}`);
+
+	if (item) {
+		return JSON.parse(item).value;
+	}
 };
 
 const DEFAULT_BANNER_TIMEOUT_MILLIS = 2000;


### PR DESCRIPTION
Fixes an issue where we end up JSON parsing empty string which causes an error. When the reader doesn't have a last closed at value in localStorage for a banner this results in an error, preventing the banner from showing:

![Screenshot 2021-02-11 at 09 52 41](https://user-images.githubusercontent.com/379839/107621908-e9299f00-6c4e-11eb-8309-d9ca5c52f700.png)