### PR TITLE
More Card Stories

### DIFF
--- a/src/web/components/Card/Card.Format.stories.tsx
+++ b/src/web/components/Card/Card.Format.stories.tsx
@@ -52,7 +52,7 @@ export const Format = (format: Format, title: string) => () => (
 								...format,
 								theme: Pillar.Culture,
 							})}
-							headlineText="Sport"
+							headlineText="Culture"
 							standfirst={standfirsts[0]}
 							headlineSize="medium"
 							kickerText={title}
@@ -75,7 +75,7 @@ export const Format = (format: Format, title: string) => () => (
 								...format,
 								theme: Pillar.Sport,
 							})}
-							headlineText="Culture"
+							headlineText="Sport"
 							standfirst={standfirsts[0]}
 							headlineSize="medium"
 							kickerText={title}
@@ -98,7 +98,7 @@ export const Format = (format: Format, title: string) => () => (
 								...format,
 								theme: Pillar.Opinion,
 							})}
-							headlineText="Lifestyle"
+							headlineText="Opinion"
 							standfirst={standfirsts[0]}
 							headlineSize="medium"
 							kickerText={title}
@@ -119,7 +119,7 @@ export const Format = (format: Format, title: string) => () => (
 								...format,
 								theme: Pillar.Lifestyle,
 							})}
-							headlineText="Opinion"
+							headlineText="Lifestyle"
 							standfirst={standfirsts[0]}
 							headlineSize="medium"
 							kickerText={title}

--- a/src/web/components/Card/Card.Format.stories.tsx
+++ b/src/web/components/Card/Card.Format.stories.tsx
@@ -1,0 +1,183 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import React from 'react';
+
+import { Section } from '@frontend/web/components/Section';
+import { Flex } from '@frontend/web/components/Flex';
+import { LeftColumn } from '@frontend/web/components/LeftColumn';
+import { ArticleContainer } from '@frontend/web/components/ArticleContainer';
+import { decidePalette } from '@root/src/web/lib/decidePalette';
+import { Pillar, Special } from '@guardian/types';
+
+import { Card } from './Card';
+import { UL } from './components/UL';
+import { LI } from './components/LI';
+import { images, standfirsts } from './Card.mocks';
+
+export const Format = (format: Format, title: string) => () => (
+	<Section>
+		<Flex>
+			<LeftColumn showRightBorder={false}>
+				<></>
+			</LeftColumn>
+			<ArticleContainer>
+				<UL direction="row" bottomMargin={true}>
+					<LI padSides={true}>
+						<Card
+							linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+							format={{ ...format, theme: Pillar.News }}
+							palette={decidePalette({
+								...format,
+								theme: Pillar.News,
+							})}
+							headlineText="News"
+							standfirst={standfirsts[0]}
+							headlineSize="medium"
+							kickerText={title}
+							webPublicationDate="2019-11-11T09:45:30.000Z"
+							imageUrl={images[4]}
+							imagePosition="top"
+							showClock={true}
+							commentCount={99}
+						/>
+					</LI>
+					<LI
+						padSides={true}
+						showDivider={true}
+						showTopMarginWhenStacked={true}
+					>
+						<Card
+							linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+							format={{ ...format, theme: Pillar.Culture }}
+							palette={decidePalette({
+								...format,
+								theme: Pillar.Culture,
+							})}
+							headlineText="Sport"
+							standfirst={standfirsts[0]}
+							headlineSize="medium"
+							kickerText={title}
+							webPublicationDate="2019-11-11T09:45:30.000Z"
+							imageUrl={images[4]}
+							imagePosition="top"
+							showClock={true}
+							commentCount={99}
+						/>
+					</LI>
+					<LI
+						padSides={true}
+						showDivider={true}
+						showTopMarginWhenStacked={true}
+					>
+						<Card
+							linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+							format={{ ...format, theme: Pillar.Sport }}
+							palette={decidePalette({
+								...format,
+								theme: Pillar.Sport,
+							})}
+							headlineText="Culture"
+							standfirst={standfirsts[0]}
+							headlineSize="medium"
+							kickerText={title}
+							webPublicationDate="2019-11-11T09:45:30.000Z"
+							imageUrl={images[4]}
+							imagePosition="top"
+							showClock={true}
+							commentCount={99}
+						/>
+					</LI>
+					<LI
+						padSides={true}
+						showDivider={true}
+						showTopMarginWhenStacked={true}
+					>
+						<Card
+							linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+							format={{ ...format, theme: Pillar.Opinion }}
+							palette={decidePalette({
+								...format,
+								theme: Pillar.Opinion,
+							})}
+							headlineText="Lifestyle"
+							standfirst={standfirsts[0]}
+							headlineSize="medium"
+							kickerText={title}
+							webPublicationDate="2019-11-11T09:45:30.000Z"
+							imageUrl={images[4]}
+							imagePosition="top"
+							showClock={true}
+							commentCount={99}
+						/>
+					</LI>
+				</UL>
+				<UL direction="row">
+					<LI padSides={true}>
+						<Card
+							linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+							format={{ ...format, theme: Pillar.Lifestyle }}
+							palette={decidePalette({
+								...format,
+								theme: Pillar.Lifestyle,
+							})}
+							headlineText="Opinion"
+							standfirst={standfirsts[0]}
+							headlineSize="medium"
+							kickerText={title}
+							webPublicationDate="2019-11-11T09:45:30.000Z"
+							imageUrl={images[4]}
+							imagePosition="top"
+							showClock={true}
+							commentCount={99}
+						/>
+					</LI>
+					<LI
+						padSides={true}
+						showDivider={true}
+						showTopMarginWhenStacked={true}
+					>
+						<Card
+							linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+							format={{ ...format, theme: Special.Labs }}
+							palette={decidePalette({
+								...format,
+								theme: Special.Labs,
+							})}
+							headlineText="Labs"
+							standfirst={standfirsts[0]}
+							headlineSize="medium"
+							kickerText={title}
+							webPublicationDate="2019-11-11T09:45:30.000Z"
+							imageUrl={images[4]}
+							imagePosition="top"
+							showClock={true}
+							commentCount={99}
+						/>
+					</LI>
+					<LI
+						padSides={true}
+						showDivider={true}
+						showTopMarginWhenStacked={true}
+					>
+						<Card
+							linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
+							format={{ ...format, theme: Special.SpecialReport }}
+							palette={decidePalette({
+								...format,
+								theme: Special.SpecialReport,
+							})}
+							headlineText="SpecialReport"
+							standfirst={standfirsts[0]}
+							headlineSize="medium"
+							kickerText={title}
+							webPublicationDate="2019-11-11T09:45:30.000Z"
+							imageUrl={images[4]}
+							imagePosition="top"
+							showClock={true}
+							commentCount={99}
+						/>
+					</LI>
+				</UL>
+			</ArticleContainer>
+		</Flex>
+	</Section>
+);

--- a/src/web/components/Card/Card.Format.stories.tsx
+++ b/src/web/components/Card/Card.Format.stories.tsx
@@ -6,7 +6,7 @@ import { Flex } from '@frontend/web/components/Flex';
 import { LeftColumn } from '@frontend/web/components/LeftColumn';
 import { ArticleContainer } from '@frontend/web/components/ArticleContainer';
 import { decidePalette } from '@root/src/web/lib/decidePalette';
-import { Pillar, Special } from '@guardian/types';
+import { Display, Pillar, Special } from '@guardian/types';
 
 import { Card } from './Card';
 import { UL } from './components/UL';
@@ -21,7 +21,7 @@ export const Format = (format: Format, title: string) => () => (
 			</LeftColumn>
 			<ArticleContainer>
 				<UL direction="row" bottomMargin={true}>
-					<LI padSides={true}>
+					<LI padSides={true} percentage="25%">
 						<Card
 							linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
 							format={{ ...format, theme: Pillar.News }}
@@ -30,7 +30,11 @@ export const Format = (format: Format, title: string) => () => (
 								theme: Pillar.News,
 							})}
 							headlineText="News"
-							standfirst={standfirsts[0]}
+							standfirst={
+								format.display === Display.Immersive
+									? ''
+									: standfirsts[0]
+							}
 							headlineSize="medium"
 							kickerText={title}
 							webPublicationDate="2019-11-11T09:45:30.000Z"
@@ -38,9 +42,13 @@ export const Format = (format: Format, title: string) => () => (
 							imagePosition="top"
 							showClock={true}
 							commentCount={99}
+							isFullCardImage={
+								format.display === Display.Immersive
+							}
 						/>
 					</LI>
 					<LI
+						percentage="25%"
 						padSides={true}
 						showDivider={true}
 						showTopMarginWhenStacked={true}
@@ -53,7 +61,11 @@ export const Format = (format: Format, title: string) => () => (
 								theme: Pillar.Culture,
 							})}
 							headlineText="Culture"
-							standfirst={standfirsts[0]}
+							standfirst={
+								format.display === Display.Immersive
+									? ''
+									: standfirsts[0]
+							}
 							headlineSize="medium"
 							kickerText={title}
 							webPublicationDate="2019-11-11T09:45:30.000Z"
@@ -61,9 +73,13 @@ export const Format = (format: Format, title: string) => () => (
 							imagePosition="top"
 							showClock={true}
 							commentCount={99}
+							isFullCardImage={
+								format.display === Display.Immersive
+							}
 						/>
 					</LI>
 					<LI
+						percentage="25%"
 						padSides={true}
 						showDivider={true}
 						showTopMarginWhenStacked={true}
@@ -76,7 +92,11 @@ export const Format = (format: Format, title: string) => () => (
 								theme: Pillar.Sport,
 							})}
 							headlineText="Sport"
-							standfirst={standfirsts[0]}
+							standfirst={
+								format.display === Display.Immersive
+									? ''
+									: standfirsts[0]
+							}
 							headlineSize="medium"
 							kickerText={title}
 							webPublicationDate="2019-11-11T09:45:30.000Z"
@@ -84,9 +104,13 @@ export const Format = (format: Format, title: string) => () => (
 							imagePosition="top"
 							showClock={true}
 							commentCount={99}
+							isFullCardImage={
+								format.display === Display.Immersive
+							}
 						/>
 					</LI>
 					<LI
+						percentage="25%"
 						padSides={true}
 						showDivider={true}
 						showTopMarginWhenStacked={true}
@@ -99,7 +123,11 @@ export const Format = (format: Format, title: string) => () => (
 								theme: Pillar.Opinion,
 							})}
 							headlineText="Opinion"
-							standfirst={standfirsts[0]}
+							standfirst={
+								format.display === Display.Immersive
+									? ''
+									: standfirsts[0]
+							}
 							headlineSize="medium"
 							kickerText={title}
 							webPublicationDate="2019-11-11T09:45:30.000Z"
@@ -107,11 +135,14 @@ export const Format = (format: Format, title: string) => () => (
 							imagePosition="top"
 							showClock={true}
 							commentCount={99}
+							isFullCardImage={
+								format.display === Display.Immersive
+							}
 						/>
 					</LI>
 				</UL>
 				<UL direction="row">
-					<LI padSides={true}>
+					<LI percentage="33%" padSides={true}>
 						<Card
 							linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
 							format={{ ...format, theme: Pillar.Lifestyle }}
@@ -120,7 +151,11 @@ export const Format = (format: Format, title: string) => () => (
 								theme: Pillar.Lifestyle,
 							})}
 							headlineText="Lifestyle"
-							standfirst={standfirsts[0]}
+							standfirst={
+								format.display === Display.Immersive
+									? ''
+									: standfirsts[0]
+							}
 							headlineSize="medium"
 							kickerText={title}
 							webPublicationDate="2019-11-11T09:45:30.000Z"
@@ -128,9 +163,13 @@ export const Format = (format: Format, title: string) => () => (
 							imagePosition="top"
 							showClock={true}
 							commentCount={99}
+							isFullCardImage={
+								format.display === Display.Immersive
+							}
 						/>
 					</LI>
 					<LI
+						percentage="33%"
 						padSides={true}
 						showDivider={true}
 						showTopMarginWhenStacked={true}
@@ -143,7 +182,11 @@ export const Format = (format: Format, title: string) => () => (
 								theme: Special.Labs,
 							})}
 							headlineText="Labs"
-							standfirst={standfirsts[0]}
+							standfirst={
+								format.display === Display.Immersive
+									? ''
+									: standfirsts[0]
+							}
 							headlineSize="medium"
 							kickerText={title}
 							webPublicationDate="2019-11-11T09:45:30.000Z"
@@ -151,9 +194,13 @@ export const Format = (format: Format, title: string) => () => (
 							imagePosition="top"
 							showClock={true}
 							commentCount={99}
+							isFullCardImage={
+								format.display === Display.Immersive
+							}
 						/>
 					</LI>
 					<LI
+						percentage="33%"
 						padSides={true}
 						showDivider={true}
 						showTopMarginWhenStacked={true}
@@ -166,7 +213,11 @@ export const Format = (format: Format, title: string) => () => (
 								theme: Special.SpecialReport,
 							})}
 							headlineText="SpecialReport"
-							standfirst={standfirsts[0]}
+							standfirst={
+								format.display === Display.Immersive
+									? ''
+									: standfirsts[0]
+							}
 							headlineSize="medium"
 							kickerText={title}
 							webPublicationDate="2019-11-11T09:45:30.000Z"
@@ -174,6 +225,9 @@ export const Format = (format: Format, title: string) => () => (
 							imagePosition="top"
 							showClock={true}
 							commentCount={99}
+							isFullCardImage={
+								format.display === Display.Immersive
+							}
 						/>
 					</LI>
 				</UL>

--- a/src/web/components/Card/Card.Layout.stories.tsx
+++ b/src/web/components/Card/Card.Layout.stories.tsx
@@ -16,7 +16,7 @@ import { images, headlines, standfirsts, kickers } from './Card.mocks';
 
 export default {
 	component: Card,
-	title: 'Components/Card',
+	title: 'Components/Card/Layouts',
 	parameters: {
 		viewport: {
 			// This has the effect of turning off the viewports addon by default

--- a/src/web/components/Card/Card.Layout.stories.tsx
+++ b/src/web/components/Card/Card.Layout.stories.tsx
@@ -453,7 +453,7 @@ export const Related = () => (
 			</LeftColumn>
 			<ArticleContainer>
 				<UL direction="row" bottomMargin={true}>
-					<LI padSides={true}>
+					<LI padSides={true} percentage="33%">
 						<Card
 							linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
 							format={{
@@ -475,6 +475,7 @@ export const Related = () => (
 						/>
 					</LI>
 					<LI
+						percentage="33%"
 						padSides={true}
 						showDivider={true}
 						showTopMarginWhenStacked={true}
@@ -501,6 +502,7 @@ export const Related = () => (
 						/>
 					</LI>
 					<LI
+						percentage="33%"
 						padSides={true}
 						showDivider={true}
 						showTopMarginWhenStacked={true}
@@ -527,7 +529,7 @@ export const Related = () => (
 					</LI>
 				</UL>
 				<UL direction="row">
-					<LI padSides={true}>
+					<LI padSides={true} percentage="25%">
 						<Card
 							linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
 							format={{
@@ -547,6 +549,7 @@ export const Related = () => (
 						/>
 					</LI>
 					<LI
+						percentage="25%"
 						padSides={true}
 						showDivider={true}
 						showTopMarginWhenStacked={true}
@@ -570,6 +573,7 @@ export const Related = () => (
 						/>
 					</LI>
 					<LI
+						percentage="25%"
 						padSides={true}
 						showDivider={true}
 						showTopMarginWhenStacked={true}
@@ -593,6 +597,7 @@ export const Related = () => (
 						/>
 					</LI>
 					<LI
+						percentage="25%"
 						padSides={true}
 						showDivider={true}
 						showTopMarginWhenStacked={true}
@@ -663,7 +668,7 @@ export const Quad = () => (
 			</LeftColumn>
 			<ArticleContainer>
 				<UL direction="row">
-					<LI padSides={true}>
+					<LI percentage="25%" padSides={true}>
 						<Card
 							linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
 							format={{
@@ -691,6 +696,7 @@ export const Quad = () => (
 						/>
 					</LI>
 					<LI
+						percentage="25%"
 						padSides={true}
 						showDivider={true}
 						showTopMarginWhenStacked={true}
@@ -719,6 +725,7 @@ export const Quad = () => (
 						/>
 					</LI>
 					<LI
+						percentage="25%"
 						padSides={true}
 						showDivider={true}
 						showTopMarginWhenStacked={true}
@@ -746,6 +753,7 @@ export const Quad = () => (
 						/>
 					</LI>
 					<LI
+						percentage="25%"
 						padSides={true}
 						showDivider={true}
 						showTopMarginWhenStacked={true}

--- a/src/web/components/Card/Card.Theme.stories.tsx
+++ b/src/web/components/Card/Card.Theme.stories.tsx
@@ -1,8 +1,8 @@
-import { Card } from './Card';
-
 import { Design, Display, Pillar } from '@guardian/types';
 
 import { Format } from './Card.Format.stories';
+
+import { Card } from './Card';
 
 export default {
 	component: Card,

--- a/src/web/components/Card/Card.Theme.stories.tsx
+++ b/src/web/components/Card/Card.Theme.stories.tsx
@@ -1,0 +1,169 @@
+import { Card } from './Card';
+
+import { Design, Display, Pillar } from '@guardian/types';
+
+import { Format } from './Card.Format.stories';
+
+export default {
+	component: Card,
+	title: 'Components/Card/Themes',
+	parameters: {
+		viewport: {
+			// This has the effect of turning off the viewports addon by default
+			defaultViewport: 'doesNotExist',
+		},
+	},
+};
+
+const Review = Format(
+	{
+		display: Display.Standard,
+		theme: Pillar.News,
+		design: Design.Review,
+	},
+	'Review',
+);
+
+const Interview = Format(
+	{
+		display: Display.Standard,
+		theme: Pillar.News,
+		design: Design.Interview,
+	},
+	'Interview',
+);
+
+const PhotoEssay = Format(
+	{
+		display: Display.Standard,
+		theme: Pillar.News,
+		design: Design.PhotoEssay,
+	},
+	'PhotoEssay',
+);
+
+const Feature = Format(
+	{
+		display: Display.Standard,
+		theme: Pillar.News,
+		design: Design.Feature,
+	},
+	'Feature',
+);
+
+const Article = Format(
+	{
+		display: Display.Standard,
+		theme: Pillar.News,
+		design: Design.Article,
+	},
+	'Article',
+);
+
+const Immersive = Format(
+	{
+		display: Display.Immersive,
+		theme: Pillar.News,
+		design: Design.Article,
+	},
+	'Immersive',
+);
+
+const Showcase = Format(
+	{
+		display: Display.Showcase,
+		theme: Pillar.News,
+		design: Design.Article,
+	},
+	'Showcase',
+);
+
+const GuardianView = Format(
+	{
+		display: Display.Standard,
+		theme: Pillar.News,
+		design: Design.GuardianView,
+	},
+	'GuardianView',
+);
+
+const Interactive = Format(
+	{
+		display: Display.Standard,
+		theme: Pillar.News,
+		design: Design.Interactive,
+	},
+	'Interactive',
+);
+
+const MatchReport = Format(
+	{
+		display: Display.Standard,
+		theme: Pillar.News,
+		design: Design.MatchReport,
+	},
+	'MatchReport',
+);
+
+const Media = Format(
+	{
+		display: Display.Standard,
+		theme: Pillar.News,
+		design: Design.Media,
+	},
+	'Media',
+);
+
+const Live = Format(
+	{
+		display: Display.Standard,
+		theme: Pillar.News,
+		design: Design.Live,
+	},
+	'Live',
+);
+
+const PrintShop = Format(
+	{
+		display: Display.Standard,
+		theme: Pillar.News,
+		design: Design.PrintShop,
+	},
+	'PrintShop',
+);
+
+const Comment = Format(
+	{
+		display: Display.Standard,
+		theme: Pillar.News,
+		design: Design.Comment,
+	},
+	'Comment',
+);
+
+const Recipe = Format(
+	{
+		display: Display.Standard,
+		theme: Pillar.News,
+		design: Design.Recipe,
+	},
+	'Recipe',
+);
+
+export {
+	Review,
+	Interview,
+	Comment,
+	PhotoEssay,
+	Feature,
+	Article,
+	Immersive,
+	Showcase,
+	GuardianView,
+	Interactive,
+	MatchReport,
+	Media,
+	Live,
+	PrintShop,
+	Recipe,
+};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds more stories for `Card`, showing a range of variations for different `format` values

Eg. For `Design.Live` we see
![Screenshot 2021-02-11 at 12 42 24](https://user-images.githubusercontent.com/1336821/107637819-9fe54980-6c66-11eb-9f95-474852a2c176.jpg)


