### PR TITLE
No more Trump (video diffs)

### DIFF
--- a/src/web/components/elements/WitnessBlockComponent.stories.tsx
+++ b/src/web/components/elements/WitnessBlockComponent.stories.tsx
@@ -11,6 +11,11 @@ import {
 
 export default {
 	title: 'Components/WitnessBlockComponent',
+	parameters: {
+		chromatic: {
+			disable: true,
+		},
+	},
 };
 
 export const WitnessTextBlockComponentDefault = () => (


### PR DESCRIPTION
## What?
Turns off Chromatic snapshots for the Witness YouTube story.

## Why?
These stories are causing false negatives because a Watch on YourTube logo is appearing intermittently. We're already disabling Chromatic on other youtube stories where we're not using the poster overlay. 