### PR TITLE
Asset loading refactoring

### DIFF
--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -39,7 +39,7 @@ export const getScriptArrayFromFilename = (filename: string) => {
 	];
 };
 
-export const getByChunkName = (
+export const getScriptArrayFromChunkName = (
 	chunkName: string,
 ): { src: string; legacy?: boolean }[] | [] => {
 	const chunks: string[] | undefined =

--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -103,33 +103,44 @@ export const document = ({ data }: Props): string => {
 		// @ts-ignore
 		loadableExtractor.addChunk(chunk.chunkName); // addChunk is *undocumented* and not in TS types. It allows manually adding chunks to extractor.
 	});
-	// Pass the array of extracted (read: built with addChunk) scripts to
-	// generatedScriptTags so that we can build a script tag array of
-	// modern and legacy scripts.
-	const arrayOfLoadableScriptObjects: {
+
+	let arrayOfLoadableScriptObjects: {
 		src: string;
-		module: boolean;
-	}[] = loadableExtractor
+		legacy: boolean;
+	}[] = [];
+
+	// Pre assets returns an array of objects structured as:
+	// {
+	//     filename: 'elements-RichLinkComponent.js',
+	//     scriptType: 'script',
+	//     chunk: 'elements-RichLinkComponent',
+	//     url: '/elements-RichLinkComponent.js',
+	//     path: '/Users/gareth_trufitt/code/dotcom-rendering/dist/elements-RichLinkComponent.js',
+	//     type: 'mainAsset',
+	//     linkType: 'preload'
+	// }
+	//
+
+	const preAssets: {
+		filename: string;
+		scriptType: string;
+		chunk: string;
+		url: string;
+		path: string;
+		type: string;
+		linkType: string;
+	}[] =
+		// PreAssets is *undocumented* and not in TS types. It returns the webpack asset for each script.
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
-		.getPreAssets() // PreAssets is *undocumented* and not in TS types. It returns the webpack asset for each script.
-		// Pre assets returns an array of objects structured as:
-		// {
-		//     filename: 'elements-RichLinkComponent.js',
-		//     scriptType: 'script',
-		//     chunk: 'elements-RichLinkComponent',
-		//     url: '/elements-RichLinkComponent.js',
-		//     path: '/Users/gareth_trufitt/code/dotcom-rendering/dist/elements-RichLinkComponent.js',
-		//     type: 'mainAsset',
-		//     linkType: 'preload'
-		// }
-		.reduce(
-			(scriptArr: [], script: { filename: string }) => [
-				...scriptArr,
-				...getScriptArrayFromFilename(script.filename),
-			],
-			[],
-		);
+		loadableExtractor.getPreAssets();
+
+	preAssets.forEach((script) => {
+		arrayOfLoadableScriptObjects = [
+			...arrayOfLoadableScriptObjects,
+			...getScriptArrayFromFilename(script.filename),
+		];
+	});
 
 	// Loadable generates configuration script elements as the first two items
 	// of the script element array. We need to generate the react component version

--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -7,7 +7,7 @@ import { CacheProvider } from '@emotion/core';
 import { escapeData } from '@root/src/lib/escapeData';
 import {
 	getScriptArrayFromFilename,
-	getByChunkName,
+	getScriptArrayFromChunkName,
 	loadableManifestJson,
 } from '@root/src/lib/assets';
 
@@ -172,10 +172,10 @@ export const document = ({ data }: Props): string => {
 	const priorityScriptTags = generateScriptTags(
 		[
 			{ src: polyfillIO },
-			...getByChunkName('ophan'),
+			...getScriptArrayFromChunkName('ophan'),
 			CAPI.config && { src: CAPI.config.commercialBundleUrl },
-			...getByChunkName('sentryLoader'),
-			...getByChunkName('dynamicImport'),
+			...getScriptArrayFromChunkName('sentryLoader'),
+			...getScriptArrayFromChunkName('dynamicImport'),
 			...arrayOfLoadableScriptObjects, // This includes the 'react' entry point
 		].filter(Boolean),
 	);
@@ -188,13 +188,13 @@ export const document = ({ data }: Props): string => {
 	 * unlikely.
 	 */
 	const lowPriorityScriptTags = generateScriptTags([
-		...getByChunkName('lotame'),
-		...getByChunkName('atomIframe'),
-		...getByChunkName('embedIframe'),
-		...getByChunkName('newsletterEmbedIframe'),
+		...getScriptArrayFromChunkName('lotame'),
+		...getScriptArrayFromChunkName('atomIframe'),
+		...getScriptArrayFromChunkName('embedIframe'),
+		...getScriptArrayFromChunkName('newsletterEmbedIframe'),
 	]);
 
-	const gaChunk = getByChunkName('ga');
+	const gaChunk = getScriptArrayFromChunkName('ga');
 	const gaPath = {
 		modern: gaChunk.filter((script) => script.legacy === false)[0].src,
 		legacy: gaChunk.filter((script) => script.legacy === true)[0].src,


### PR DESCRIPTION
## What does this change?

Refactoring from: https://github.com/guardian/dotcom-rendering/pull/2521

- Rename `getByChunkName` to `getScriptArrayFromChunkName`. Matches `getScriptArrayFromFilename`
- Refactor `reduce` into `forEach` for easier reading & type preAssets return.
