### PR TITLE
Add basic Cypress test to cover RR banner request

### DIFF
--- a/cypress/integration/e2e/banner.e2e.spec.js
+++ b/cypress/integration/e2e/banner.e2e.spec.js
@@ -1,0 +1,25 @@
+import { disableCMP } from '../../lib/disableCMP.js';
+
+const optOutOfArticleCountConsent = () => {
+	cy.setCookie('gu_article_count_opt_out', 'true');
+};
+
+describe('The banner', function () {
+	it('makes a request to the support-dotcom-components service', function () {
+		disableCMP();
+		optOutOfArticleCountConsent();
+		const articleUrl =
+			'https://www.theguardian.com/politics/2019/nov/20/jeremy-corbyn-boris-johnson-tv-debate-watched-by-67-million-people';
+		const rrBannerUrl = 'https://contributions.guardianapis.com/banner';
+
+		cy.intercept(rrBannerUrl, (req) => {
+			expect(req.body).to.have.property('targeting');
+			expect(req.body).to.have.property('tracking');
+
+			req.reply({});
+		}).as('rrBannerRequest');
+
+		cy.visit(`/Article?url=${articleUrl}`);
+		cy.wait('@rrBannerRequest');
+	});
+});


### PR DESCRIPTION
## What does this change?

Adds a basic test to ensure that a request is made to the support-dotcom-components service to find out if there's a banner to show.

## Why?

To give us confidence that platform changes haven't affected the banner logic (for example changes to the message picker logic). This is a follow up to #2524 as I think it would have caught the issue which that PR fixed.
