### PR TITLE
Respect Accessibility Preferences

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
         "@guardian/braze-components": "^0.0.19",
         "@guardian/consent-management-platform": "^6.11.2",
         "@guardian/discussion-rendering": "^6.1.0",
+        "@guardian/libs": "^1.6.3",
         "@guardian/shimport": "^1.0.2",
         "@guardian/src-button": "^2.7.1",
         "@guardian/src-checkbox": "^2.7.1",

--- a/src/web/components/PulsingDot.test.tsx
+++ b/src/web/components/PulsingDot.test.tsx
@@ -1,17 +1,11 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { PulsingDot, DISABLE_FLASHING_ELEMENTS_CLASS } from './PulsingDot';
+import { PulsingDot } from './PulsingDot';
 
 describe('PulsingDot', () => {
 	it('It should render pulsing dot as expected', () => {
 		const dotColour = 'blue';
 		const { container } = render(<PulsingDot colour={dotColour} />);
 		expect(container.firstChild).toHaveStyle(`color: ${dotColour}`);
-	});
-
-	it('It should not render pulsing dot if the no flashing class is present in the container', () => {
-		document.body.className += `${''} ${DISABLE_FLASHING_ELEMENTS_CLASS}`;
-		const { container } = render(<PulsingDot colour="green" />);
-		expect(container.firstChild).toBeNull();
 	});
 });

--- a/src/web/components/PulsingDot.tsx
+++ b/src/web/components/PulsingDot.tsx
@@ -28,6 +28,9 @@ const livePulse = keyframes`{
 
 const animate = css`
 	animation: ${livePulse} 1s infinite;
+	@media (prefers-reduced-motion: reduce) {
+		animation: none;
+	}
 `;
 
 interface Props {

--- a/src/web/components/PulsingDot.tsx
+++ b/src/web/components/PulsingDot.tsx
@@ -1,17 +1,10 @@
 import React from 'react';
-import { css } from 'emotion';
+import { css, cx } from 'emotion';
 import { keyframes } from '@emotion/core';
 
-export const DISABLE_FLASHING_ELEMENTS_CLASS = 'disable-flashing-elements';
+import { storage } from '@guardian/libs';
 
-const livePulse = keyframes`{
-    0% {opacity: 1;}
-    10% {opacity: .25;}
-    40% {opacity: 1;}
-    100% {opacity: 1;}
-}`;
-
-const pulsingDot = (colour?: string) => css`
+const dotStyles = (colour?: string) => css`
 	color: ${colour && colour};
 	::before {
 		border-radius: 62.5rem;
@@ -23,8 +16,18 @@ const pulsingDot = (colour?: string) => css`
 		content: '';
 		margin-right: 0.1875rem;
 		vertical-align: initial;
-		animation: ${livePulse} 1s infinite;
 	}
+`;
+
+const livePulse = keyframes`{
+    0% {opacity: 1;}
+    10% {opacity: .25;}
+    40% {opacity: 1;}
+    100% {opacity: 1;}
+}`;
+
+const animate = css`
+	animation: ${livePulse} 1s infinite;
 `;
 
 interface Props {
@@ -34,12 +37,11 @@ interface Props {
 export const PulsingDot = ({ colour }: Props) => {
 	// Respect the accessibility flag set here
 	// https://www.theguardian.com/help/accessibility-help
-	const flashingIsDisabled = !!document.getElementsByClassName(
-		DISABLE_FLASHING_ELEMENTS_CLASS,
-	).length;
-	if (flashingIsDisabled) {
-		return null;
-	}
-
-	return <span className={pulsingDot(colour)} />;
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+	const flashingEnabled = storage.local.get(
+		'gu.prefs.accessibility.flashing-elements',
+	);
+	return (
+		<span className={cx(dotStyles(colour), flashingEnabled && animate)} />
+	);
 };

--- a/src/web/components/PulsingDot.tsx
+++ b/src/web/components/PulsingDot.tsx
@@ -44,7 +44,6 @@ export const PulsingDot = ({ colour }: Props) => {
 	// flashingPreference is null if no preference exists and explicitly
 	// false when the reader has said they don't want flashing
 	const flashingEnabled = flashingPreference !== false;
-	console.log('flashingEnabled', flashingEnabled);
 	return (
 		<span className={cx(dotStyles(colour), flashingEnabled && animate)} />
 	);

--- a/src/web/components/PulsingDot.tsx
+++ b/src/web/components/PulsingDot.tsx
@@ -38,9 +38,13 @@ export const PulsingDot = ({ colour }: Props) => {
 	// Respect the accessibility flag set here
 	// https://www.theguardian.com/help/accessibility-help
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-	const flashingEnabled = storage.local.get(
+	const flashingPreference = storage.local.get(
 		'gu.prefs.accessibility.flashing-elements',
 	);
+	// flashingPreference is null if no preference exists and explicitly
+	// false when the reader has said they don't want flashing
+	const flashingEnabled = flashingPreference !== false;
+	console.log('flashingEnabled', flashingEnabled);
 	return (
 		<span className={cx(dotStyles(colour), flashingEnabled && animate)} />
 	);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2130,6 +2130,11 @@
     react-focus-lock "^2.2.1"
     timeago.js "^4.0.2"
 
+"@guardian/libs@^1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-1.6.3.tgz#71ad9a5160708ae75d3bc182afb3f235b9c4de1f"
+  integrity sha512-CMTvDbIrfvla8OWHdO+tyjUUEp9XGGr2fQ8XDJptSiiJr1gKJsWV6NvFXQi1ypqDRsPYiJ8h1DxvBtyuyWATOA==
+
 "@guardian/prettier@^0.4.2":
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/@guardian/prettier/-/prettier-0.4.2.tgz#2d08a8a50aad3911a88c9b53f92a37748694d551"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Fixing an issue where we were looking for the reader's flashing preference as a class on the page when it is actually being saved in localStorage

## Before
![2021-02-15 09 01 50](https://user-images.githubusercontent.com/1336821/107925657-a298b500-6f6c-11eb-9d08-201099d2fdcd.gif)


## After
![2021-02-15 08 55 49](https://user-images.githubusercontent.com/1336821/107925673-a6c4d280-6f6c-11eb-88d4-fc752661051f.gif)

## Support for `prefers-reduced-motion`
The css media query [prefers reduced motion](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion) is also supported
![2021-02-15 14 35 04](https://user-images.githubusercontent.com/1336821/107959384-413c0a80-6f9b-11eb-859d-0cb8e8dae66b.gif)


### I've added the `storage` lib
Reading from local storage can typically involve a lot of boilerplate but this is even more so on dotcom where there is a convention of storing data using the `{ value: obj }` pattern where data needs to be serialised and parsed. To address this I'm using [storage](https://github.com/guardian/libs/blob/main/src/storage.README.md) from `@guardian/libs` which expects this object pattern and contains all the required boilerplate.

### I've removed a test
The previous version of this code was removing the dot completely and there was a test to check for this. I've removed that test because we now continue to render the dot, we just stop it flashing. I did briefly look at testing for if this animation was occurring or not but there didn't seem a good way to do this and I don't think this use case warrants a complex, potentially brittle, solution so I've left it out
