### PR TITLE
Special Card Comments

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -62,7 +62,7 @@ type Palette = {
 		cardHeadline: Colour;
 		cardKicker: Colour;
 		linkKicker: Colour;
-		cardAge: Colour;
+		cardFooter: Colour;
 	},
 	background: {
 		article: Colour;
@@ -76,7 +76,7 @@ type Palette = {
 		commentCount: Colour;
 		shareIcon: Colour;
 		captionTriangle: Colour;
-		cardClock: Colour;
+		cardIcon: Colour;
 	},
 	border: {
 		syndicationButton: Colour;

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -293,8 +293,7 @@ export const Card = ({
 										longCount &&
 										shortCount ? (
 											<CardCommentCount
-												design={format.design}
-												pillar={format.theme}
+												palette={palette}
 												long={longCount}
 												short={shortCount}
 											/>

--- a/src/web/components/Card/components/CardAge.tsx
+++ b/src/web/components/Card/components/CardAge.tsx
@@ -21,7 +21,7 @@ type Props = {
 const ageStyles = (format: Format, palette: Palette) => {
 	return css`
 		${textSans.xsmall()};
-		color: ${palette.text.cardAge};
+		color: ${palette.text.cardFooter};
 
 		/* Provide side padding for positioning and also to keep spacing
     between any sibings (like GuardianLines) */
@@ -32,7 +32,7 @@ const ageStyles = (format: Format, palette: Palette) => {
 		}
 
 		svg {
-			fill: ${palette.fill.cardClock};
+			fill: ${palette.fill.cardIcon};
 			margin-bottom: -1px;
 			height: 11px;
 			width: 11px;

--- a/src/web/components/CardCommentCount.stories.tsx
+++ b/src/web/components/CardCommentCount.stories.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { css } from 'emotion';
 
-import { Design, Pillar } from '@guardian/types';
+import { Design, Pillar, Display } from '@guardian/types';
 
 import { CardCommentCount } from './CardCommentCount';
+import { decidePalette } from '../lib/decidePalette';
 
 export default {
 	component: CardCommentCount,
@@ -24,8 +25,11 @@ export const CommentCountStory = () => {
 	return (
 		<Container>
 			<CardCommentCount
-				design={Design.Article}
-				pillar={Pillar.News}
+				palette={decidePalette({
+					design: Design.Article,
+					theme: Pillar.News,
+					display: Display.Standard,
+				})}
 				short="11k"
 				long="10,899"
 			/>
@@ -38,8 +42,11 @@ export const MediaStory = () => {
 	return (
 		<Container>
 			<CardCommentCount
-				design={Design.Media}
-				pillar={Pillar.Culture}
+				palette={decidePalette({
+					design: Design.Media,
+					theme: Pillar.Culture,
+					display: Display.Standard,
+				})}
 				short="11k"
 				long="10,899"
 			/>

--- a/src/web/components/CardCommentCount.tsx
+++ b/src/web/components/CardCommentCount.tsx
@@ -1,36 +1,33 @@
 import React from 'react';
-import { css, cx } from 'emotion';
+import { css } from 'emotion';
 
-import { Design, Pillar } from '@guardian/types';
-import { neutral } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 import { between } from '@guardian/src-foundations/mq';
 
 import CommentIcon from '@frontend/static/icons/comment.svg';
-import { decidePillarLight } from '@root/src/web/lib/decidePillarLight';
-import { pillarPalette } from '@frontend/lib/pillars';
 
 type Props = {
-	design: Design;
-	pillar: Theme;
+	palette: Palette;
 	short: string;
 	long: string;
 };
 
-const containerStyles = css`
+const containerStyles = (palette: Palette) => css`
 	display: flex;
 	flex-direction: row;
 	${textSans.xsmall()};
 	padding-left: 5px;
 	padding-right: 5px;
+	color: ${palette.text.cardAge};
 `;
 
-const svgStyles = css`
+const svgStyles = (palette: Palette) => css`
 	svg {
 		margin-bottom: -5px;
 		height: 14px;
 		width: 14px;
 		margin-right: 2px;
+		fill: ${palette.fill.cardClock};
 	}
 `;
 
@@ -50,50 +47,13 @@ const shortStyles = css`
 	}
 `;
 
-const mediaStyles = (pillar: Theme) => css`
-	/* Below we force the colour to be bright if the pillar is news (because it looks better) */
-	color: ${pillar === Pillar.News
-		? pillarPalette[pillar].bright
-		: pillarPalette[pillar].main};
-
-	svg {
-		fill: ${pillar === Pillar.News
-			? pillarPalette[pillar].bright
-			: pillarPalette[pillar].main};
-	}
-`;
-
-const colourStyles = (design: Design, pillar: Theme) => {
-	switch (design) {
-		case Design.Live:
-			return css`
-				color: ${decidePillarLight(pillar)};
-				svg {
-					fill: ${decidePillarLight(pillar)};
-				}
-			`;
-		default:
-			return css`
-				color: ${neutral[60]};
-				svg {
-					fill: ${neutral[46]};
-				}
-			`;
-	}
-};
-
-export const CardCommentCount = ({ design, pillar, short, long }: Props) => {
+export const CardCommentCount = ({ palette, short, long }: Props) => {
 	return (
 		<div
-			className={cx(
-				containerStyles,
-				design === Design.Media
-					? mediaStyles(pillar)
-					: colourStyles(design, pillar),
-			)}
+			className={containerStyles(palette)}
 			aria-label={`${short} Comments`}
 		>
-			<div className={svgStyles}>
+			<div className={svgStyles(palette)}>
 				<CommentIcon />
 			</div>
 			<div className={longStyles} aria-hidden="true">

--- a/src/web/components/CardCommentCount.tsx
+++ b/src/web/components/CardCommentCount.tsx
@@ -18,7 +18,7 @@ const containerStyles = (palette: Palette) => css`
 	${textSans.xsmall()};
 	padding-left: 5px;
 	padding-right: 5px;
-	color: ${palette.text.cardAge};
+	color: ${palette.text.cardFooter};
 `;
 
 const svgStyles = (palette: Palette) => css`
@@ -27,7 +27,7 @@ const svgStyles = (palette: Palette) => css`
 		height: 14px;
 		width: 14px;
 		margin-right: 2px;
-		fill: ${palette.fill.cardClock};
+		fill: ${palette.fill.cardIcon};
 	}
 `;
 

--- a/src/web/lib/decidePalette.ts
+++ b/src/web/lib/decidePalette.ts
@@ -192,7 +192,7 @@ const textCardKicker = (format: Format): string => {
 	}
 };
 
-const textCardAge = (format: Format): string => {
+const textCardFooter = (format: Format): string => {
 	switch (format.design) {
 		case Design.Comment:
 			switch (format.theme) {
@@ -318,7 +318,7 @@ const fillCaptionTriangle = (format: Format): string => {
 	return pillarPalette[format.theme].main;
 };
 
-const fillCardClock = (format: Format): string => {
+const fillCardIcon = (format: Format): string => {
 	switch (format.design) {
 		case Design.Comment:
 			switch (format.theme) {
@@ -395,7 +395,7 @@ export const decidePalette = (format: Format): Palette => {
 			cardHeadline: textCardHeadline(format),
 			cardKicker: textCardKicker(format),
 			linkKicker: textLinkKicker(format),
-			cardAge: textCardAge(format),
+			cardFooter: textCardFooter(format),
 		},
 		background: {
 			article: backgroundArticle(format),
@@ -409,7 +409,7 @@ export const decidePalette = (format: Format): Palette => {
 			commentCount: fillCommentCount(format),
 			shareIcon: fillShareIcon(format),
 			captionTriangle: fillCaptionTriangle(format),
-			cardClock: fillCardClock(format),
+			cardIcon: fillCardIcon(format),
 		},
 		border: {
 			syndicationButton: borderSyndicationButton(),


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds `palette` to `CardComments`

### Before
![Screenshot 2021-02-15 at 09 31 38](https://user-images.githubusercontent.com/1336821/107928746-a1698700-6f70-11eb-89ce-df244fcc2c01.jpg)


### After
![Screenshot 2021-02-15 at 09 30 40](https://user-images.githubusercontent.com/1336821/107928652-826af500-6f70-11eb-9366-82f7e850a633.jpg)


## Why?
Because this allows us to support special reports
