### PR TITLE
Special Card Standfirst

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -63,6 +63,7 @@ type Palette = {
 		cardKicker: Colour;
 		linkKicker: Colour;
 		cardAge: Colour;
+		cardStandfirst: Colour;
 	},
 	background: {
 		article: Colour;

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -248,7 +248,7 @@ export const Card = ({
 								)}
 							>
 								{standfirst && (
-									<StandfirstWrapper>
+									<StandfirstWrapper palette={palette}>
 										{standfirst}
 									</StandfirstWrapper>
 								)}

--- a/src/web/components/Card/components/StandfirstWrapper.tsx
+++ b/src/web/components/Card/components/StandfirstWrapper.tsx
@@ -6,13 +6,15 @@ import { body } from '@guardian/src-foundations/typography';
 
 type Props = {
 	children: string;
+	palette: Palette;
 };
 
-export const StandfirstWrapper = ({ children }: Props) => (
+export const StandfirstWrapper = ({ children, palette }: Props) => (
 	<div
 		className={css`
 			display: flex;
 			flex-direction: column;
+			color: ${palette.text.cardStandfirst};
 
 			${body.small()};
 			font-size: 14px;

--- a/src/web/lib/decidePalette.ts
+++ b/src/web/lib/decidePalette.ts
@@ -161,6 +161,8 @@ const textCardHeadline = (format: Format): string => {
 	}
 };
 
+const textCardStandfirst = textCardHeadline;
+
 const textCardKicker = (format: Format): string => {
 	if (
 		format.theme === Special.SpecialReport &&
@@ -396,6 +398,7 @@ export const decidePalette = (format: Format): Palette => {
 			cardKicker: textCardKicker(format),
 			linkKicker: textLinkKicker(format),
 			cardAge: textCardAge(format),
+			cardStandfirst: textCardStandfirst(format),
 		},
 		background: {
 			article: backgroundArticle(format),


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Uses `palette` to decide the colour for standfirsts on cards

### Before
![Screenshot 2021-02-15 at 09 43 43](https://user-images.githubusercontent.com/1336821/107930001-518bbf80-6f72-11eb-97bf-1a9141ef5ac0.jpg)


### After
![Screenshot 2021-02-15 at 09 40 54](https://user-images.githubusercontent.com/1336821/107929958-459ffd80-6f72-11eb-9e36-dcd77305d81b.jpg)


## Why?
So that we can support special reporta
