### PR TITLE
Update media colours

### DIFF
--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -282,7 +282,7 @@ export const Card = ({
 										format.design === Design.Media &&
 										mediaType ? (
 											<MediaMeta
-												pillar={format.theme}
+												palette={palette}
 												mediaType={mediaType}
 												mediaDuration={mediaDuration}
 											/>

--- a/src/web/components/MediaMeta.tsx
+++ b/src/web/components/MediaMeta.tsx
@@ -3,25 +3,20 @@ import { css } from 'emotion';
 
 import { textSans } from '@guardian/src-foundations/typography';
 
-import { pillarPalette } from '@frontend/lib/pillars';
 import Audio from '@frontend/static/icons/audio.svg';
 import Photo from '@frontend/static/icons/photo.svg';
 import Video from '@frontend/static/icons/video.svg';
-import { Pillar } from '@guardian/types';
 
 type Props = {
 	mediaType: MediaType;
-	pillar: Theme;
+	palette: Palette;
 	mediaDuration?: number;
 };
 
-const iconWrapperStyles = (mediaType: MediaType, pillar: Theme) => css`
+const iconWrapperStyles = (mediaType: MediaType, palette: Palette) => css`
 	width: 24px;
 	height: 23px;
-	/* Below we force the colour to be bright if the pillar is news (because it looks better) */
-	background-color: ${pillar === Pillar.News
-		? pillarPalette[pillar].bright
-		: pillarPalette[pillar].main};
+	background-color: ${palette.fill.cardIcon};
 	border-radius: 50%;
 	display: inline-block;
 
@@ -36,11 +31,8 @@ const iconWrapperStyles = (mediaType: MediaType, pillar: Theme) => css`
 	}
 `;
 
-const durationStyles = (pillar: Theme) => css`
-	/* Below we force the colour to be bright if the pillar is news (because it looks better) */
-	color: ${pillar === Pillar.News
-		? pillarPalette[pillar].bright
-		: pillarPalette[pillar].main};
+const durationStyles = (palette: Palette) => css`
+	color: ${palette.text.cardFooter};
 	${textSans.xsmall({ fontWeight: `bold` })}
 `;
 
@@ -87,32 +79,34 @@ const Icon = ({ mediaType }: { mediaType: MediaType }) => {
 
 const MediaIcon = ({
 	mediaType,
-	pillar,
+	palette,
 }: {
 	mediaType: MediaType;
-	pillar: Theme;
+	palette: Palette;
 }) => (
-	<span className={iconWrapperStyles(mediaType, pillar)}>
+	<span className={iconWrapperStyles(mediaType, palette)}>
 		<Icon mediaType={mediaType} />
 	</span>
 );
 
 const MediaDuration = ({
 	mediaDuration,
-	pillar,
+	palette,
 }: {
 	mediaDuration: number;
-	pillar: Theme;
+	palette: Palette;
 }) => (
-	<p className={durationStyles(pillar)}>{secondsToDuration(mediaDuration)}</p>
+	<p className={durationStyles(palette)}>
+		{secondsToDuration(mediaDuration)}
+	</p>
 );
 
-export const MediaMeta = ({ mediaType, mediaDuration, pillar }: Props) => (
+export const MediaMeta = ({ mediaType, mediaDuration, palette }: Props) => (
 	<div className={wrapperStyles}>
-		<MediaIcon mediaType={mediaType} pillar={pillar} />
+		<MediaIcon mediaType={mediaType} palette={palette} />
 		&nbsp;
 		{mediaDuration && (
-			<MediaDuration mediaDuration={mediaDuration} pillar={pillar} />
+			<MediaDuration mediaDuration={mediaDuration} palette={palette} />
 		)}
 	</div>
 );

--- a/src/web/lib/decidePalette.ts
+++ b/src/web/lib/decidePalette.ts
@@ -9,6 +9,7 @@ import {
 	sport,
 	brandAltBackground,
 	border,
+	brandAlt,
 } from '@guardian/src-foundations';
 
 import { pillarPalette } from '@root/src/lib/pillars';
@@ -166,11 +167,10 @@ const textCardKicker = (format: Format): string => {
 		format.theme === Special.SpecialReport &&
 		format.design === Design.Comment
 	)
-		// TODO: Pull this in from souce once we see it here:
+		// TODO: Pull this in from source as opinion[550]
 		// https://theguardian.design/2a1e5182b/p/492a30-light-palette
 		return '#ff9941';
-	if (format.theme === Special.SpecialReport)
-		return brandAltBackground.primary;
+	if (format.theme === Special.SpecialReport) return brandAlt[400];
 	if (format.display === Display.Immersive)
 		return pillarPalette[format.theme].bright;
 	switch (format.design) {
@@ -184,9 +184,20 @@ const textCardKicker = (format: Format): string => {
 					return pillarPalette[format.theme].main;
 			}
 		case Design.Media:
-			if (format.theme === Pillar.News)
-				return pillarPalette[format.theme].bright;
-			return pillarPalette[format.theme].main;
+			switch (format.theme) {
+				case Pillar.News:
+					return news[600];
+				case Pillar.Sport:
+					return sport[600];
+				case Pillar.Opinion:
+					// TODO: Pull this in from source as opinion[550]
+					// https://theguardian.design/2a1e5182b/p/492a30-light-palette
+					return '#ff9941';
+				case Pillar.Lifestyle:
+				case Pillar.Culture:
+				default:
+					return pillarPalette[format.theme][500];
+			}
 		default:
 			return pillarPalette[format.theme].main;
 	}
@@ -215,7 +226,22 @@ const textCardFooter = (format: Format): string => {
 					return pillarPalette[format.theme].main;
 			}
 		case Design.Media:
-			return WHITE;
+			switch (format.theme) {
+				case Special.SpecialReport:
+					return brandAlt[400];
+				case Pillar.News:
+					return news[600];
+				case Pillar.Sport:
+					return sport[600];
+				case Pillar.Opinion:
+					// TODO: Pull this in from source as opinion[550]
+					// https://theguardian.design/2a1e5182b/p/492a30-light-palette
+					return '#ff9941';
+				case Pillar.Lifestyle:
+				case Pillar.Culture:
+				default:
+					return pillarPalette[format.theme][500];
+			}
 		default:
 			switch (format.theme) {
 				case Special.SpecialReport:
@@ -341,7 +367,22 @@ const fillCardIcon = (format: Format): string => {
 					return pillarPalette[format.theme].main;
 			}
 		case Design.Media:
-			return WHITE;
+			switch (format.theme) {
+				case Special.SpecialReport:
+					return brandAlt[400];
+				case Pillar.News:
+					return news[600];
+				case Pillar.Sport:
+					return sport[600];
+				case Pillar.Opinion:
+					// TODO: Pull this in from source as opinion[550]
+					// https://theguardian.design/2a1e5182b/p/492a30-light-palette
+					return '#ff9941';
+				case Pillar.Lifestyle:
+				case Pillar.Culture:
+				default:
+					return pillarPalette[format.theme][500];
+			}
 		default:
 			switch (format.theme) {
 				case Special.SpecialReport:


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Replaces plain white with a palette of specific colours for Media

### Before
![Screenshot 2021-02-15 at 10 52 09](https://user-images.githubusercontent.com/1336821/107937472-de874680-6f7b-11eb-8c2e-fd5f42b55b6a.jpg)

![Screenshot 2021-02-15 at 11 18 01](https://user-images.githubusercontent.com/1336821/107940002-7b97ae80-6f7f-11eb-9859-baa169c90169.jpg)



### After
![Screenshot 2021-02-15 at 10 51 11](https://user-images.githubusercontent.com/1336821/107937395-c3b4d200-6f7b-11eb-829e-5c8155650e0a.jpg)

![Screenshot 2021-02-15 at 11 16 53](https://user-images.githubusercontent.com/1336821/107939980-70448300-6f7f-11eb-8f88-70fc6095c7ca.jpg)


## Why?
Because this dark background needs slightly different colours to pass accessibillity checks