### PR TITLE
Record Google Core Vitals and store in BigQuery

### DIFF
--- a/scripts/webpack/browser.js
+++ b/scripts/webpack/browser.js
@@ -41,6 +41,7 @@ module.exports = ({ isLegacyJS }) => ({
 		lotame: scriptPath('lotame'),
 		dynamicImport: scriptPath('dynamicImport'),
 		atomIframe: scriptPath('atomIframe'),
+		coreVitals: scriptPath('coreVitals'),
 		embedIframe: scriptPath('embedIframe'),
 		newsletterEmbedIframe: scriptPath('newsletterEmbedIframe'),
 	},

--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -27,6 +27,7 @@ export interface WindowGuardianConfig {
 	tests?: { [key: string]: string };
 	ophan: {
 		pageViewId: string;
+		browserId: string;
 	};
 }
 
@@ -62,6 +63,7 @@ const makeWindowGuardianConfig = (
 		tests: config.abTests || {},
 		ophan: {
 			pageViewId: '',
+			browserId: ''
 		},
 	} as WindowGuardianConfig;
 };

--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -63,7 +63,7 @@ const makeWindowGuardianConfig = (
 		tests: config.abTests || {},
 		ophan: {
 			pageViewId: '',
-			browserId: ''
+			browserId: '',
 		},
 	} as WindowGuardianConfig;
 };

--- a/src/web/browser/coreVitals/coreVitals.ts
+++ b/src/web/browser/coreVitals/coreVitals.ts
@@ -74,7 +74,7 @@ export const coreVitals = (): void => {
 				redirect: 'follow',
 				referrerPolicy: 'no-referrer', // no-referrer, *no-referrer-w
 				body: JSON.stringify(jsonData),
-			});
+			}).catch(() => {});
 		}
 	};
 

--- a/src/web/browser/coreVitals/coreVitals.ts
+++ b/src/web/browser/coreVitals/coreVitals.ts
@@ -54,23 +54,27 @@ export const coreVitals = (): void => {
 				break;
 		}
 
+		const endpoint =
+			window.location.hostname === 'm.code.dev-theguardian.com' ||
+			window.location.hostname === 'localhost' ||
+			window.location.hostname === 'preview.gutools.co.uk'
+				? 'http://performance-events.code.dev-guardianapis.com/core-web-vitals'
+				: 'https://performance-events.guardianapis.com/core-web-vitals';
+
 		// If CLS has been calculated
 		if (jsonData.cls !== null) {
-			fetch(
-				'https://performance-events.guardianapis.com/core-web-vitals',
-				{
-					method: 'POST', // *GET, POST, PUT, DELETE, etc.
-					mode: 'cors', // no-cors, *cors, same-origin
-					cache: 'no-cache', // *default, no-cache, reload, force-cache, only-if-cached
-					credentials: 'same-origin', // include, *same-origin, omit
-					headers: {
-						'Content-Type': 'application/json',
-					},
-					redirect: 'follow',
-					referrerPolicy: 'no-referrer', // no-referrer, *no-referrer-w
-					body: JSON.stringify(jsonData),
+			fetch(endpoint, {
+				method: 'POST', // *GET, POST, PUT, DELETE, etc.
+				mode: 'cors', // no-cors, *cors, same-origin
+				cache: 'no-cache', // *default, no-cache, reload, force-cache, only-if-cached
+				credentials: 'same-origin', // include, *same-origin, omit
+				headers: {
+					'Content-Type': 'application/json',
 				},
-			);
+				redirect: 'follow',
+				referrerPolicy: 'no-referrer', // no-referrer, *no-referrer-w
+				body: JSON.stringify(jsonData),
+			});
 		}
 	};
 

--- a/src/web/browser/coreVitals/coreVitals.ts
+++ b/src/web/browser/coreVitals/coreVitals.ts
@@ -1,18 +1,29 @@
 import { getCLS, getFID, getLCP, getFCP, getTTFB } from 'web-vitals';
 
-// Stops ts assuming json values are null
-const temp: any = null;
+// This sends data to the test table
 
-const jsonData = {
+type CoreWebVitalsPayload = {
+	page_view_id: string;
+	received_timestamp: string;
+	id: string;
+	received_date: string;
+	fid: null | number;
+	cls: null | number;
+	lcp: null | number;
+	fcp: null | number;
+	ttfb: null | number;
+};
+
+const jsonData: CoreWebVitalsPayload = {
+	id: '',
 	page_view_id: '',
-	received_timestamp: `${new Date().toISOString()}`,
-	id: 'prod',
+	received_timestamp: new Date().toISOString(),
 	received_date: new Date().toISOString().slice(0, 10),
-	fid: temp,
-	cls: temp,
-	lcp: temp,
-	fcp: temp,
-	ttfb: temp,
+	fid: null,
+	cls: null,
+	lcp: null,
+	fcp: null,
+	ttfb: null,
 };
 
 export const coreVitals = (): void => {
@@ -21,22 +32,22 @@ export const coreVitals = (): void => {
 		value: number;
 	};
 
-	const getValue = ({ name, value }: CoreVitalsArgs): void => {
+	const addToJson = ({ name, value }: CoreVitalsArgs): void => {
 		switch (name) {
 			case 'FCP':
-				jsonData.fcp = parseFloat(value.toFixed(6));
+				jsonData.fcp = Math.round(value * 1000000) / 1000000;
 				break;
 			case 'CLS':
-				jsonData.cls = parseFloat(value.toFixed(6));
+				jsonData.cls = Math.round(value * 1000000) / 1000000;
 				break;
 			case 'LCP':
-				jsonData.lcp = parseFloat(value.toFixed(6));
+				jsonData.lcp = Math.round(value * 1000000) / 1000000;
 				break;
 			case 'FID':
-				jsonData.fid = parseFloat(value.toFixed(6));
+				jsonData.fid = Math.round(value * 1000000) / 1000000;
 				break;
 			case 'TTFB':
-				jsonData.ttfb = parseFloat(value.toFixed(6));
+				jsonData.ttfb = Math.round(value * 1000000) / 1000000;
 				break;
 		}
 
@@ -66,9 +77,9 @@ export const coreVitals = (): void => {
 		jsonData.id = window.guardian.config.ophan.browserId;
 	}
 
-	getCLS(getValue, false);
-	getFID(getValue);
-	getLCP(getValue);
-	getFCP(getValue);
-	getTTFB(getValue);
+	getCLS(addToJson, false);
+	getFID(addToJson);
+	getLCP(addToJson);
+	getFCP(addToJson);
+	getTTFB(addToJson);
 };

--- a/src/web/browser/coreVitals/coreVitals.ts
+++ b/src/web/browser/coreVitals/coreVitals.ts
@@ -5,7 +5,7 @@ import { getCLS, getFID, getLCP, getFCP, getTTFB } from 'web-vitals';
 type CoreWebVitalsPayload = {
 	page_view_id: string | null;
 	received_timestamp: string | null;
-	id: string | null;
+	browser_id: string | null;
 	received_date: string;
 	fid: null | number;
 	cls: null | number;
@@ -18,7 +18,7 @@ const timestamp = new Date();
 const date = new Date().toISOString().slice(0, 10);
 
 const jsonData: CoreWebVitalsPayload = {
-	id: null,
+	browser_id: null,
 	page_view_id: null,
 	received_timestamp: timestamp.toISOString(),
 	received_date: date,
@@ -77,7 +77,7 @@ export const coreVitals = (): void => {
 	// Set page view and browser ID
 	if (window.guardian && window.guardian.ophan) {
 		jsonData.page_view_id = window.guardian.ophan.pageViewId;
-		jsonData.id = window.guardian.config.ophan.browserId;
+		jsonData.browser_id = window.guardian.config.ophan.browserId;
 	}
 
 	getCLS(addToJson, false);

--- a/src/web/browser/coreVitals/coreVitals.ts
+++ b/src/web/browser/coreVitals/coreVitals.ts
@@ -1,0 +1,100 @@
+import { getCLS, getFID, getLCP, getFCP, getTTFB } from 'web-vitals';
+
+
+const jsonData = {
+    'page_view_id': '',
+    'fid': 0,
+    'cls': 0,
+    'lcp': 0,
+    'fcp': 0,
+    'ttfb': 0,
+}
+
+export const coreVitals = (): void =>
+{
+    type coreVitalsArgs = {
+        name: string;
+        value: number;
+    };
+
+
+const getValue = ({ name, value }: coreVitalsArgs): void => {
+    switch(name){
+        case('FCP'):
+            console.log(`FCP: ${  value}`);
+            jsonData.fcp = value;
+            break;
+        case('CLS'):
+            console.log(`CLS: ${value}`)
+            jsonData.cls = value;
+            break;
+        case('LCP'):
+            console.log(`LCP: ${value}`)
+            jsonData.lcp = value;
+            break;
+        case('FID'):
+            console.log(`FID: ${value}`)
+            jsonData.fid = value;
+            break;
+        case('TTFB'):
+            console.log(`TTFB: ${value}`)
+            jsonData.ttfb = value;
+            break;
+    }
+	if(jsonData.cls !== null)
+	{
+		/*fetch('https://performance-events.guardianapis.com/core-web-vitals', {
+  		method: 'POST',
+  		headers: {
+    		'Content-Type': 'application/json',
+  		},
+  		body: JSON.stringify(jsonData),
+		})
+	.then(response => response.json())
+	.then(data => {
+  	console.log('Success:', data);
+	})
+	.catch((error) => {
+  	console.error('Error:', error);
+	});*/
+
+
+	let headers = {
+    type: 'application/json'
+  	};
+  let blob = new Blob([JSON.stringify(jsonData)], headers);
+  navigator.sendBeacon('https://performance-events.guardianapis.com/core-web-vitals', blob);
+
+
+	}
+
+}
+
+if(window.guardian && window.guardian.ophan)
+        {
+            jsonData.page_view_id = window.guardian.ophan.pageViewId;
+        }
+        getFID(getValue);
+        getLCP(getValue);
+        getFCP(getValue);
+        getTTFB(getValue);
+
+        // At the moment a final CLS score is only reported on a 'visiblitychange' event (which is far from ideal)
+        // https://github.com/WICG/layout-instability#computing-dcls-with-the-api
+        // We need to find a more reliable way to record CLS without switching tabs.
+        // I looked at using the 'unload' event but it only returns the cls delta for that event, which is incorrect.
+        getCLS(getValue);
+
+
+    document.addEventListener("DOMContentLoaded", function() {
+
+
+    });
+
+};
+
+
+
+
+
+

--- a/src/web/browser/coreVitals/coreVitals.ts
+++ b/src/web/browser/coreVitals/coreVitals.ts
@@ -3,9 +3,9 @@ import { getCLS, getFID, getLCP, getFCP, getTTFB } from 'web-vitals';
 // This sends data to the test table
 
 type CoreWebVitalsPayload = {
-	page_view_id: string;
-	received_timestamp: string;
-	id: string;
+	page_view_id: string | null;
+	received_timestamp: string | null;
+	id: string | null;
 	received_date: string;
 	fid: null | number;
 	cls: null | number;
@@ -14,11 +14,14 @@ type CoreWebVitalsPayload = {
 	ttfb: null | number;
 };
 
+const timestamp = new Date();
+const date = new Date().toISOString().slice(0, 10);
+
 const jsonData: CoreWebVitalsPayload = {
-	id: '',
-	page_view_id: '',
-	received_timestamp: new Date().toISOString(),
-	received_date: new Date().toISOString().slice(0, 10),
+	id: null,
+	page_view_id: null,
+	received_timestamp: timestamp.toISOString(),
+	received_date: date,
 	fid: null,
 	cls: null,
 	lcp: null,

--- a/src/web/browser/coreVitals/coreVitals.ts
+++ b/src/web/browser/coreVitals/coreVitals.ts
@@ -1,79 +1,74 @@
 import { getCLS, getFID, getLCP, getFCP, getTTFB } from 'web-vitals';
 
-
 // Stops ts assuming json values are null
-const temp : any = null;
+const temp: any = null;
 
 const jsonData = {
-	'page_view_id': '',
-	'received_timestamp': `${new Date().toISOString()}`,
-	'id': 'prod',
-	'received_date': new Date().toISOString().slice(0, 10),
-    'fid': temp,
-    'cls': temp,
-    'lcp': temp,
-    'fcp': temp,
-    'ttfb': temp,
-}
+	page_view_id: '',
+	received_timestamp: `${new Date().toISOString()}`,
+	id: 'prod',
+	received_date: new Date().toISOString().slice(0, 10),
+	fid: temp,
+	cls: temp,
+	lcp: temp,
+	fcp: temp,
+	ttfb: temp,
+};
 
-export const coreVitals = (): void =>
-{
-    type CoreVitalsArgs = {
-        name: string;
-        value: number;
-    };
+export const coreVitals = (): void => {
+	type CoreVitalsArgs = {
+		name: string;
+		value: number;
+	};
 
 	const getValue = ({ name, value }: CoreVitalsArgs): void => {
+		switch (name) {
+			case 'FCP':
+				jsonData.fcp = parseFloat(value.toFixed(6));
+				break;
+			case 'CLS':
+				jsonData.cls = parseFloat(value.toFixed(6));
+				break;
+			case 'LCP':
+				jsonData.lcp = parseFloat(value.toFixed(6));
+				break;
+			case 'FID':
+				jsonData.fid = parseFloat(value.toFixed(6));
+				break;
+			case 'TTFB':
+				jsonData.ttfb = parseFloat(value.toFixed(6));
+				break;
+		}
 
-    switch(name){
-        case('FCP'):
-            jsonData.fcp = parseFloat(value.toFixed(6));
-            break;
-        case('CLS'):
-            jsonData.cls = parseFloat(value.toFixed(6));
-            break;
-        case('LCP'):
-            jsonData.lcp = parseFloat(value.toFixed(6));
-            break;
-        case('FID'):
-            jsonData.fid = parseFloat(value.toFixed(6));
-            break;
-        case('TTFB'):
-            jsonData.ttfb = parseFloat(value.toFixed(6));
-            break;
-	}
-
-	// If CLS has been calculated
-    if(jsonData.cls !== null)
-    {
-        fetch('https://performance-events.guardianapis.com/core-web-vitals', {
-            method: 'POST', // *GET, POST, PUT, DELETE, etc.
-            mode: 'cors', // no-cors, *cors, same-origin
-            cache: 'no-cache', // *default, no-cache, reload, force-cache, only-if-cached
-            credentials: 'same-origin', // include, *same-origin, omit
-            headers: {
-              'Content-Type': 'application/json'
-            },
-            redirect: 'follow',
-            referrerPolicy: 'no-referrer', // no-referrer, *no-referrer-w
-            body: JSON.stringify(jsonData)
-		})
-    };
-}
+		// If CLS has been calculated
+		if (jsonData.cls !== null) {
+			fetch(
+				'https://performance-events.guardianapis.com/core-web-vitals',
+				{
+					method: 'POST', // *GET, POST, PUT, DELETE, etc.
+					mode: 'cors', // no-cors, *cors, same-origin
+					cache: 'no-cache', // *default, no-cache, reload, force-cache, only-if-cached
+					credentials: 'same-origin', // include, *same-origin, omit
+					headers: {
+						'Content-Type': 'application/json',
+					},
+					redirect: 'follow',
+					referrerPolicy: 'no-referrer', // no-referrer, *no-referrer-w
+					body: JSON.stringify(jsonData),
+				},
+			);
+		}
+	};
 
 	// Set page view and browser ID
-	if(window.guardian && window.guardian.ophan)
-    {
+	if (window.guardian && window.guardian.ophan) {
 		jsonData.page_view_id = window.guardian.ophan.pageViewId;
 		jsonData.id = window.guardian.config.ophan.browserId;
 	}
 
-
 	getCLS(getValue, false);
 	getFID(getValue);
-    getLCP(getValue);
-    getFCP(getValue);
-    getTTFB(getValue);
-
-
+	getLCP(getValue);
+	getFCP(getValue);
+	getTTFB(getValue);
 };

--- a/src/web/browser/coreVitals/coreVitals.ts
+++ b/src/web/browser/coreVitals/coreVitals.ts
@@ -1,15 +1,19 @@
 import { getCLS, getFID, getLCP, getFCP, getTTFB } from 'web-vitals';
 
+
+// Stops ts assuming json values are null
+const temp : any = null;
+
 const jsonData = {
 	'page_view_id': '',
 	'received_timestamp': `${new Date().toISOString()}`,
 	'id': 'prod',
 	'received_date': new Date().toISOString().slice(0, 10),
-    'fid': null,
-    'cls': null,
-    'lcp': null,
-    'fcp': null,
-    'ttfb': null,
+    'fid': temp,
+    'cls': temp,
+    'lcp': temp,
+    'fcp': temp,
+    'ttfb': temp,
 }
 
 export const coreVitals = (): void =>

--- a/src/web/browser/coreVitals/init.ts
+++ b/src/web/browser/coreVitals/init.ts
@@ -3,7 +3,7 @@ import { startup } from '@root/src/web/browser/startup';
 import { coreVitals } from './coreVitals';
 
 const init = async (): Promise<void> => {
-	// Sample every page between 1 and 100
+	// Sample between 1 and 100
 	const inSample = Math.floor(Math.random() * 100);
 	if (inSample === 1) {
 		coreVitals();

--- a/src/web/browser/coreVitals/init.ts
+++ b/src/web/browser/coreVitals/init.ts
@@ -3,7 +3,7 @@ import { startup } from '@root/src/web/browser/startup';
 import { coreVitals } from './coreVitals';
 
 const init = async (): Promise<void> => {
-	// Sample between 1 and 100
+	// Sample 1 out of 100
 	const inSample = Math.floor(Math.random() * 100);
 	if (inSample === 1) {
 		coreVitals();

--- a/src/web/browser/coreVitals/init.ts
+++ b/src/web/browser/coreVitals/init.ts
@@ -1,0 +1,10 @@
+import '../webpackPublicPath';
+import { startup } from '@root/src/web/browser/startup';
+import { coreVitals } from './coreVitals';
+
+const init = (): Promise<void> => {
+    coreVitals();
+    return Promise.resolve();
+};
+
+startup('coreVitals', null, init);

--- a/src/web/browser/coreVitals/init.ts
+++ b/src/web/browser/coreVitals/init.ts
@@ -3,12 +3,11 @@ import { startup } from '@root/src/web/browser/startup';
 import { coreVitals } from './coreVitals';
 
 const init = async (): Promise<void> => {
-	// Potential method for sampling
-	/* const inSample = Math.floor(Math.random()*100);
-	if(inSample === 1){
+	// Sample every page between 1 and 100
+	const inSample = Math.floor(Math.random() * 100);
+	if (inSample === 1) {
 		coreVitals();
-	} */
-	coreVitals();
+	}
 	return Promise.resolve();
 };
 

--- a/src/web/browser/coreVitals/init.ts
+++ b/src/web/browser/coreVitals/init.ts
@@ -2,7 +2,12 @@ import '../webpackPublicPath';
 import { startup } from '@root/src/web/browser/startup';
 import { coreVitals } from './coreVitals';
 
-const init = (): Promise<void> => {
+const init = async (): Promise<void> => {
+	// Potential method for sampling
+	/* const inSample = Math.floor(Math.random()*100);
+	if(inSample === 1){
+		coreVitals();
+	} */
 	coreVitals();
 	return Promise.resolve();
 };

--- a/src/web/browser/coreVitals/init.ts
+++ b/src/web/browser/coreVitals/init.ts
@@ -3,8 +3,8 @@ import { startup } from '@root/src/web/browser/startup';
 import { coreVitals } from './coreVitals';
 
 const init = (): Promise<void> => {
-    coreVitals();
-    return Promise.resolve();
+	coreVitals();
+	return Promise.resolve();
 };
 
 startup('coreVitals', null, init);

--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -201,6 +201,7 @@ export const document = ({ data }: Props): string => {
 			CAPI.config && { src: CAPI.config.commercialBundleUrl },
 			...getScriptArrayFromChunkName('sentryLoader'),
 			...getScriptArrayFromChunkName('dynamicImport'),
+			...getScriptArrayFromChunkName('coreVitals'),
 			pageHasInteractiveElements && {
 				src: `${CDN}static/frontend/js/curl-with-js-and-domReady.js`,
 			},


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This uses the [web vitals library](https://github.com/GoogleChrome/web-vitals) to record core vitals from a page, via Fastly which is then sent to BigQuery, these metrics are:

- First Input Delay
- Cumulative Layout Shift
- Largest Contentful Paint
- First Contentful Paint
- Time To First Byte

[For more info on these check this.](https://web.dev/vitals/)

Once CLS has been collected (one of the key metrics) a Post is sent to Fastly, which then stores the results in BigQuery for later analysis.

**Things to note**

- If a user does not click on the page first input delay will be null
- The ID in the example below is from the localhost, which is why it is wrong

Example data:
<img width="902" alt="Screenshot 2021-02-15 at 14 36 01" src="https://user-images.githubusercontent.com/35331926/107959313-2a95b380-6f9b-11eb-9188-d83c98b4ae98.png">
