### PR TITLE
Set DropCap when length is exactly 199

### DIFF
--- a/src/web/components/elements/TextBlockComponent.tsx
+++ b/src/web/components/elements/TextBlockComponent.tsx
@@ -32,7 +32,7 @@ const isLongEnough = (html: string): boolean => {
 	// a good discussion on how this can be done. Of the two approaches, regex and
 	// DOM, both have unikely failure scenarios but the impact for failure with DOM
 	// manipulation carries a potential security risk so we're using a regex.
-	return html.replace(/(<([^>]+)>)/gi, '').length > 199;
+	return html.replace(/(<([^>]+)>)/gi, '').length >= 199;
 };
 
 const decideDropCapLetter = (html: string): string => {


### PR DESCRIPTION
## What does this change?
Allows a dropcap when the number of charators in a paragraph is greater than, _or equal_, to 199.

### Before
![Screenshot 2021-02-17 at 08 58 57](https://user-images.githubusercontent.com/1336821/108180579-db689380-70fe-11eb-80fc-4b60c1ea9e44.jpg)


### After
![Screenshot 2021-02-17 at 08 58 34](https://user-images.githubusercontent.com/1336821/108180594-df94b100-70fe-11eb-91db-31fe298f8ea4.jpg)

## Why?
An issue was raised by CP highlighting that an article (which had 199 charaters exactly in the first paragraph) was showing inconsistent results. The [code in Frontend](https://github.com/guardian/frontend/blob/9468d4bc3e35dc9213f8f5c18d4b88c70b8667cc/common/app/views/support/HtmlCleaner.scala#L539) does specify 199 as the limit but it appears the `text` value being used is calculated in a different way to DCR, giving rise to this difference.
