### PR TITLE
Move related stories container to be before Pillar

### DIFF
--- a/src/web/components/Onwards/OnwardsUpper.tsx
+++ b/src/web/components/Onwards/OnwardsUpper.tsx
@@ -305,16 +305,6 @@ export const OnwardsUpper = ({
 	if (inSmallCardCarouselTest) {
 		return (
 			<div className={onwardsWrapper}>
-				<Section showTopBorder={true}>
-					<OnwardsData
-						url={curatedDataUrl}
-						limit={8}
-						ophanComponentName="curated-content"
-						Container={Carousel}
-						isCuratedContent={true}
-						pillar={pillar}
-					/>
-				</Section>
 				{url && (
 					<Section>
 						<OnwardsData
@@ -326,23 +316,22 @@ export const OnwardsUpper = ({
 						/>
 					</Section>
 				)}
-			</div>
-		);
-	}
-	if (inLargeCardCarouselTest) {
-		return (
-			<div className={onwardsWrapper}>
 				<Section showTopBorder={true}>
 					<OnwardsData
 						url={curatedDataUrl}
 						limit={8}
 						ophanComponentName="curated-content"
 						Container={Carousel}
-						pillar={pillar}
 						isCuratedContent={true}
-						isFullCardImage={true}
+						pillar={pillar}
 					/>
 				</Section>
+			</div>
+		);
+	}
+	if (inLargeCardCarouselTest) {
+		return (
+			<div className={onwardsWrapper}>
 				{url && (
 					<Section>
 						<OnwardsData
@@ -355,11 +344,33 @@ export const OnwardsUpper = ({
 						/>
 					</Section>
 				)}
+				<Section showTopBorder={true}>
+					<OnwardsData
+						url={curatedDataUrl}
+						limit={8}
+						ophanComponentName="curated-content"
+						Container={Carousel}
+						pillar={pillar}
+						isCuratedContent={true}
+						isFullCardImage={true}
+					/>
+				</Section>
 			</div>
 		);
 	}
 	return (
 		<div className={onwardsWrapper}>
+			{url && (
+				<Section>
+					<OnwardsData
+						url={url}
+						limit={8}
+						ophanComponentName={ophanComponentName}
+						Container={OnwardsLayout}
+						pillar={pillar}
+					/>
+				</Section>
+			)}
 			{inControlCarouselTest && (
 				<Section showTopBorder={true}>
 					<OnwardsData
@@ -368,18 +379,6 @@ export const OnwardsUpper = ({
 						ophanComponentName="curated-content"
 						Container={OnwardsLayout}
 						isCuratedContent={true}
-						pillar={pillar}
-					/>
-				</Section>
-			)}
-
-			{url && (
-				<Section>
-					<OnwardsData
-						url={url}
-						limit={8}
-						ophanComponentName={ophanComponentName}
-						Container={OnwardsLayout}
 						pillar={pillar}
 					/>
 				</Section>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Move content related to the story to be before the Pillar.

### Before
![image](https://user-images.githubusercontent.com/9122944/108222465-bb51c800-7130-11eb-97a1-3d6449e2e238.png)

### After
![image](https://user-images.githubusercontent.com/9122944/108222415-ad03ac00-7130-11eb-878b-854717c1de40.png)

## Why?
Better flow and context for users