### PR TITLE
Add Badges to Immersive articles on DCR

### DIFF
--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -96,7 +96,7 @@ const titleBadgeWrapper = css`
 	margin-right: ${space[2]}px;
 `;
 
-const immersiveTitleBadgeStyle = css`
+const immersiveTitleBadgeStyle = (palette: Palette) => css`
 	display: flex;
 	flex-direction: row;
 	align-items: center;
@@ -105,6 +105,9 @@ const immersiveTitleBadgeStyle = css`
 	line-height: 1.15;
 	/* Offset parent container margins when Immersive */
 	margin-bottom: -10px;
+	background-color: ${palette.background.seriesTitle};
+	box-shadow: -6px 0 0 0 ${palette.background.seriesTitle},
+		6px 0 0 0 ${palette.background.seriesTitle};
 `;
 
 export const SeriesSectionLink = ({
@@ -224,18 +227,7 @@ export const SeriesSectionLink = ({
 						return (
 							<div
 								className={cx(
-									invertedStyle,
-									css`
-										background-color: ${palette.background
-											.seriesTitle};
-										box-shadow: -6px 0 0 0
-												${palette.background
-													.seriesTitle},
-											6px 0 0 0
-												${palette.background
-													.seriesTitle};
-									`,
-									immersiveTitleBadgeStyle,
+									badge && immersiveTitleBadgeStyle(palette),
 								)}
 							>
 								{badge && (
@@ -252,8 +244,16 @@ export const SeriesSectionLink = ({
 										sectionLabelLink,
 										css`
 											color: ${palette.text.seriesTitle};
-											flex: 1 1 auto;
+											background-color: ${palette
+												.background.seriesTitle};
+											box-shadow: -6px 0 0 0
+													${palette.background
+														.seriesTitle},
+												6px 0 0 0
+													${palette.background
+														.seriesTitle};
 										`,
+										invertedStyle,
 									)}
 									href={`${guardianBaseURL}/${tag.id}`}
 									data-component="series"

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -103,6 +103,8 @@ const immersiveTitleBadgeStyle = css`
 	padding-bottom: 0px;
 	max-width: max-content;
 	line-height: 1.15;
+	/* Offset parent container margins when Immersive */
+	margin-bottom: -10px;
 `;
 
 export const SeriesSectionLink = ({

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -7,6 +7,7 @@ import { space } from '@guardian/src-foundations';
 
 import { Hide } from '@frontend/web/components/Hide';
 import { Display, Design } from '@guardian/types';
+import { Badge } from '@frontend/web/components/Badge';
 
 type Props = {
 	format: Format;
@@ -87,6 +88,21 @@ const fontStyles = css`
 const secondaryStyle = css`
 	${headline.xxxsmall({ fontWeight: 'regular' })};
 	display: block;
+`;
+
+const titleBadgeWrapper = css`
+	margin-bottom: ${space[1]}px;
+	margin-top: ${space[1]}px;
+	margin-right: ${space[2]}px;
+`;
+
+const immersiveTitleBadgeStyle = css`
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	padding-bottom: 0px;
+	max-width: max-content;
+	line-height: 1.15;
 `;
 
 export const SeriesSectionLink = ({
@@ -204,12 +220,10 @@ export const SeriesSectionLink = ({
 					if (hasSeriesTag) {
 						if (!tag) return null; // Just to keep ts happy
 						return (
-							<a
-								href={`${guardianBaseURL}/${tag.id}`}
+							<div
 								className={cx(
-									sectionLabelLink,
+									invertedStyle,
 									css`
-										color: ${palette.text.seriesTitle};
 										background-color: ${palette.background
 											.seriesTitle};
 										box-shadow: -6px 0 0 0
@@ -219,13 +233,33 @@ export const SeriesSectionLink = ({
 												${palette.background
 													.seriesTitle};
 									`,
-									invertedStyle,
+									immersiveTitleBadgeStyle,
 								)}
-								data-component="series"
-								data-link-name="article series"
 							>
-								<span>{tag.title}</span>
-							</a>
+								{badge && (
+									<div className={titleBadgeWrapper}>
+										<Badge
+											imageUrl={badge.imageUrl}
+											seriesTag={badge.seriesTag}
+										/>
+									</div>
+								)}
+
+								<a
+									className={cx(
+										sectionLabelLink,
+										css`
+											color: ${palette.text.seriesTitle};
+											flex: 1 1 auto;
+										`,
+									)}
+									href={`${guardianBaseURL}/${tag.id}`}
+									data-component="series"
+									data-link-name="article series"
+								>
+									<span>{tag.title}</span>
+								</a>
+							</div>
 						);
 					}
 					// Immersives show nothing at all if there's no series tag


### PR DESCRIPTION
## What does this change?
Add series badges where display type is `Display.Immersive` and badge is available. Styling done to try match up against current Frontend.

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->


### Before
![image](https://user-images.githubusercontent.com/9122944/108236122-716fde80-713e-11eb-8be2-4218d955750c.png)


### After
![image](https://user-images.githubusercontent.com/9122944/108236906-50f45400-713f-11eb-92d0-eb42bf85cce3.png)

## Why?
https://trello.com/c/LqveAsMD/1550-immersive-badges
