### PR TITLE
TS should be infered from node_moduels

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,6 @@
     "workbench.colorCustomizations": {
         "titleBar.activeBackground": "#648FFF",
         "titleBar.activeForeground": "#000000"
-    }
+	},
+	"typescript.tsdk": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
VSCode should infer the version of TS we are using from `node_moduels`

