### PR TITLE
Remove compose labs css

### DIFF
--- a/src/amp/components/elements/SubheadingBlockComponent.tsx
+++ b/src/amp/components/elements/SubheadingBlockComponent.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { css, cx } from 'emotion';
+
+import { Special } from '@guardian/types';
 import { palette } from '@guardian/src-foundations';
 import { headline, textSans } from '@guardian/src-foundations/typography';
+
 import { pillarPalette } from '@root/src/lib/pillars';
-import { composeLabsCSS } from '@root/src/amp/lib/compose-labs-css';
 
 const style = (pillar: Theme) => css`
 	h2 {
@@ -45,11 +47,15 @@ export const SubheadingBlockComponent: React.FC<{
 	isImmersive: boolean;
 }> = ({ html, pillar, isImmersive }) => (
 	<span
-		className={composeLabsCSS(
-			pillar,
-			cx(style(pillar), { [immersiveBodyStyle]: isImmersive }),
-			subHeadingStyleLabs,
-		)}
+		className={
+			pillar === Special.Labs
+				? cx(
+						style(pillar),
+						{ [immersiveBodyStyle]: isImmersive },
+						subHeadingStyleLabs,
+				  )
+				: style(pillar)
+		}
 		dangerouslySetInnerHTML={{
 			__html: html,
 		}}

--- a/src/amp/components/elements/SubheadingBlockComponent.tsx
+++ b/src/amp/components/elements/SubheadingBlockComponent.tsx
@@ -51,7 +51,7 @@ export const SubheadingBlockComponent: React.FC<{
 			pillar === Special.Labs
 				? cx(
 						style(pillar),
-						{ [immersiveBodyStyle]: isImmersive },
+						isImmersive && immersiveBodyStyle,
 						subHeadingStyleLabs,
 				  )
 				: style(pillar)

--- a/src/amp/components/elements/TextBlockComponent.tsx
+++ b/src/amp/components/elements/TextBlockComponent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'emotion';
+import { css, cx } from 'emotion';
 
 import { Special } from '@guardian/types';
 import { palette } from '@guardian/src-foundations';

--- a/src/amp/components/elements/TextBlockComponent.tsx
+++ b/src/amp/components/elements/TextBlockComponent.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { css } from 'emotion';
+
+import { Special } from '@guardian/types';
 import { palette } from '@guardian/src-foundations';
 import { body, textSans } from '@guardian/src-foundations/typography';
+
 import { pillarPalette, neutralBorder } from '@root/src/lib/pillars';
 import { sanitise } from '@frontend/lib/sanitise-html';
-import { composeLabsCSS } from '@root/src/amp/lib/compose-labs-css';
 
 // Note, this should only apply basic text styling. It is a case where we want
 // to re-use styling, but generally we should avoid this as it couples
@@ -77,7 +79,11 @@ export const TextBlockComponent: React.FC<{
 	pillar: Theme;
 }> = ({ html, pillar }) => (
 	<span
-		className={composeLabsCSS(pillar, TextStyle(pillar), textStyleLabs)}
+		className={
+			pillar === Special.Labs
+				? cx(TextStyle(pillar), textStyleLabs)
+				: TextStyle(pillar)
+		}
 		dangerouslySetInnerHTML={{
 			__html: sanitise(html),
 		}}

--- a/src/amp/components/topMeta/Standfirst.tsx
+++ b/src/amp/components/topMeta/Standfirst.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { css, cx } from 'emotion';
+
 import { palette } from '@guardian/src-foundations';
 import { headline, textSans } from '@guardian/src-foundations/typography';
+import { Special } from '@guardian/types';
+
 import { neutralBorder } from '@root/src/lib/pillars';
-import { composeLabsCSS } from '@root/src/amp/lib/compose-labs-css';
 import {
 	ListStyle,
 	LinkStyle,
@@ -43,11 +45,11 @@ export const Standfirst: React.SFC<{
 	return (
 		<div
 			data-print-layout="hide"
-			className={composeLabsCSS(
-				pillar,
-				cx(standfirstCss(pillar)),
-				labsStyle,
-			)}
+			className={
+				pillar === Special.Labs
+					? cx(standfirstCss(pillar), labsStyle)
+					: standfirstCss(pillar)
+			}
 			dangerouslySetInnerHTML={{
 				__html: text,
 			}}

--- a/src/amp/lib/compose-labs-css.ts
+++ b/src/amp/lib/compose-labs-css.ts
@@ -1,9 +1,0 @@
-import { cx } from 'emotion';
-
-import { Special } from '@guardian/types';
-
-export const composeLabsCSS = (
-	pillar: Theme,
-	baseCSS: string,
-	labsCSS: string,
-): string => (pillar === Special.Labs ? cx(baseCSS, labsCSS) : baseCSS);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Remove the use of `composeLabsCSS`

## Why?
Its an unnessesary abstraction