### PR TITLE
Standalone Photo Essay Captions

### DIFF
--- a/src/model/enhance-photoessay.ts
+++ b/src/model/enhance-photoessay.ts
@@ -157,7 +157,21 @@ const enhanceImages = (elements: CAPIElement[]): CAPIElement[] => {
 				if (nextCaption) elements.splice(i, 1);
 				break;
 			case 'model.dotcomrendering.pageElements.TextBlockElement':
-				if (buffer.length === 0 && !getCaption(element)) {
+				if (buffer.length === 0) {
+					// If there are no images in the buffer, pass it through
+					if (getCaption(element)) {
+						enhanced.push({
+							_type:
+								'model.dotcomrendering.pageElements.CaptionBlockElement',
+							captionText: element.html,
+						});
+					} else {
+						enhanced.push(element);
+					}
+					break;
+				}
+
+				if (buffer.length === 0 && getCaption(element)) {
 					// If this text block isn't a caption and there are no images
 					// in the buffer, pass it through
 					enhanced.push(element);


### PR DESCRIPTION
## What does this change?
Always inserts a caption when the `<ul><li>` pattern is seen in photo essays, regardless of if the preceeding element was an image or not

## Why?
Sometimes we want to add captions to other types of embeds outside of `ImageBlockElement`s. A good example of this is `InteractiveBlockElements` which are [often used in photo essays](https://www.theguardian.com/politics/2019/dec/10/on-the-road-with-boris-johnson-a-photo-essay)

### What next?
We're missing the ability to decide what position the caption should be placed on the page. Sometimes captions are positioned relative to the element they're related to (see "Johnson in 10 Downing Street..." in [this example](https://www.theguardian.com/politics/2019/dec/10/on-the-road-with-boris-johnson-a-photo-essay)) but because in our model these elements are unrealted (we're using the `ul/li` trick) there's no clear way to do this. As things stand, these independent captions will always appear inline.

