### PR TITLE
Remove restrict-plus-operands exception

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -65,7 +65,6 @@ module.exports = {
         '@typescript-eslint/no-implied-eval': 'off',
         '@typescript-eslint/no-use-before-define': 'off',
         '@typescript-eslint/prefer-as-const': 'off',
-        '@typescript-eslint/restrict-plus-operands': 'off',
         'no-shadow': 'off',
 
         '@typescript-eslint/explicit-function-return-type': [0],

--- a/src/web/components/Onwards/Carousel/Carousel.tsx
+++ b/src/web/components/Onwards/Carousel/Carousel.tsx
@@ -631,7 +631,7 @@ export const Carousel: React.FC<OnwardsType> = ({
 								: fallbackImageUrl;
 						return (
 							<CarouselCard
-								key={trail.url + i}
+								key={`${trail.url}${i}`}
 								isFirst={i === 0}
 								format={format}
 								trailPalette={trailPalette}

--- a/src/web/lib/dateTime.ts
+++ b/src/web/lib/dateTime.ts
@@ -139,19 +139,19 @@ export const makeRelativeDate = (
 		return false;
 	} else if (delta < 55) {
 		// Seconds
-		return delta + getSuffix('s', format, delta);
+		return `${delta}${getSuffix('s', format, delta)}`;
 	} else if (delta < 55 * 60) {
 		// Minutes
 		minutes = Math.round(delta / 60);
-		return minutes + getSuffix('m', format, minutes);
+		return `${minutes}${getSuffix('m', format, minutes)}`;
 	} else if (isToday(then) || (extendedFormatting && isWithin24Hours(then))) {
 		// Hours
 		hours = Math.round(delta / 3600);
-		return hours + getSuffix('h', format, hours);
+		return `${hours}${getSuffix('h', format, hours)}`;
 	} else if (extendedFormatting && isWithinPastWeek(then)) {
 		// Days
 		days = Math.round(delta / 3600 / 24);
-		return days + getSuffix('d', format, days);
+		return `${days}${getSuffix('d', format, days)}`;
 	} else if (isYesterday(then)) {
 		// Yesterday
 		return `Yesterday${withTime(then)}`;

--- a/src/web/lib/isLight.ts
+++ b/src/web/lib/isLight.ts
@@ -9,7 +9,7 @@ function hexToRgb(
 	// Expand shorthand form (e.g. "03F") to full form (e.g. "0033FF")
 	const shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
 	hex = hex.replace(shorthandRegex, (m, r, g, b) => {
-		return r + r + g + g + b + b;
+		return `${r}${r}${g}${g}${b}${b}`;
 	});
 
 	const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
- Remove `@typescript-eslint/restrict-plus-operands` from TS lint exception rules
- Fix related linting errors

## Why?
It was turned off after an update to TS and TS linting packages, we are progressively removing these linting rules exceptions