### PR TITLE
Bump to 5% and extend end date

### DIFF
--- a/src/web/experiments/tests/curated-content-carousel-test.ts
+++ b/src/web/experiments/tests/curated-content-carousel-test.ts
@@ -2,12 +2,12 @@ import { ABTest } from '@guardian/ab-core';
 
 export const curatedContentCarouselTest: ABTest = {
 	id: 'CuratedContent3Carousel',
-	start: '2021-02-10',
-	expiry: '2021-02-26',
+	start: '2021-02-18',
+	expiry: '2021-03-08',
 	author: 'buck06191',
 	description:
 		'Compare two carousel designs against existing fixed content for onwards journeys',
-	audience: 0.0,
+	audience: 0.05,
 	audienceOffset: 0.95,
 	successMeasure:
 		'The carousel drives increased engagement with onwards content as compared to control',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Bumps AB test to 5% and extends end date.

## Why?
Collect data for the AB test