### PR TITLE
Revert prefer-as-const lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -64,7 +64,6 @@ module.exports = {
         '@typescript-eslint/no-floating-promises': 'off',
         '@typescript-eslint/no-implied-eval': 'off',
         '@typescript-eslint/no-use-before-define': 'off',
-        '@typescript-eslint/prefer-as-const': 'off',
         '@typescript-eslint/restrict-plus-operands': 'off',
         'no-shadow': 'off',
 

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -128,6 +128,8 @@ interface EmbedBlockElement extends ThirdPartyEmbeddedContent {
 	safe?: boolean;
 	role?: RoleType;
 	alt?: string;
+	height?: number;
+	width?: number;
 	html: string;
 	isMandatory: boolean;
 	embedIndex?: number;
@@ -364,6 +366,7 @@ interface VideoVimeoBlockElement extends ThirdPartyEmbeddedContent {
 	caption?: string;
 	credit?: string;
 	title?: string;
+	originalUrl?: string;
 	role?: RoleType;
 }
 

--- a/src/web/components/ClickToView.stories.tsx
+++ b/src/web/components/ClickToView.stories.tsx
@@ -179,261 +179,257 @@ export const ThumbnailStory = () => {
 };
 ThumbnailStory.story = { name: "Click to view in 'thumbnail' role" };
 
-const SoundcloudBlockElementType: 'model.dotcomrendering.pageElements.SoundcloudBlockElement' =
-	'model.dotcomrendering.pageElements.SoundcloudBlockElement';
-const TweetBlockElementType: 'model.dotcomrendering.pageElements.TweetBlockElement' =
-	'model.dotcomrendering.pageElements.TweetBlockElement';
-const InstagramBlockElementType: 'model.dotcomrendering.pageElements.InstagramBlockElement' =
-	'model.dotcomrendering.pageElements.InstagramBlockElement';
 const Inline: RoleType = 'inline';
 
-const EmbeddedElements = {
-	instagramEmbedEmbed: {
-		source: 'Instagram',
-		sourceDomain: 'instagram.com',
-		height: undefined,
-		width: undefined,
-		isThirdPartyTracking: true,
-		safe: false,
-		alt: 'Idris Elba wedding',
-		_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
-		html:
-			'<blockquote class="instagram-media" data-instgrm-captioned data-instgrm-permalink="https://www.instagram.com/p/BwwONCplEyj/" data-instgrm-version="12" style=" background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin: 1px; max-width:540px; min-width:326px; padding:0; width:99.375%; width:-webkit-calc(100% - 2px); width:calc(100% - 2px);"><div style="padding:16px;"> <a href="https://www.instagram.com/p/BwwONCplEyj/" style=" background:#FFFFFF; line-height:0; padding:0 0; text-align:center; text-decoration:none; width:100%;" target="_blank"> <div style=" display: flex; flex-direction: row; align-items: center;"> <div style="background-color: #F4F4F4; border-radius: 50%; flex-grow: 0; height: 40px; margin-right: 14px; width: 40px;"></div> <div style="display: flex; flex-direction: column; flex-grow: 1; justify-content: center;"> <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; margin-bottom: 6px; width: 100px;"></div> <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; width: 60px;"></div></div></div><div style="padding: 19% 0;"></div> <div style="display:block; height:50px; margin:0 auto 12px; width:50px;"><svg width="50px" height="50px" viewBox="0 0 60 60" version="1.1" xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g transform="translate(-511.000000, -20.000000)" fill="#000000"><g><path d="M556.869,30.41 C554.814,30.41 553.148,32.076 553.148,34.131 C553.148,36.186 554.814,37.852 556.869,37.852 C558.924,37.852 560.59,36.186 560.59,34.131 C560.59,32.076 558.924,30.41 556.869,30.41 M541,60.657 C535.114,60.657 530.342,55.887 530.342,50 C530.342,44.114 535.114,39.342 541,39.342 C546.887,39.342 551.658,44.114 551.658,50 C551.658,55.887 546.887,60.657 541,60.657 M541,33.886 C532.1,33.886 524.886,41.1 524.886,50 C524.886,58.899 532.1,66.113 541,66.113 C549.9,66.113 557.115,58.899 557.115,50 C557.115,41.1 549.9,33.886 541,33.886 M565.378,62.101 C565.244,65.022 564.756,66.606 564.346,67.663 C563.803,69.06 563.154,70.057 562.106,71.106 C561.058,72.155 560.06,72.803 558.662,73.347 C557.607,73.757 556.021,74.244 553.102,74.378 C549.944,74.521 548.997,74.552 541,74.552 C533.003,74.552 532.056,74.521 528.898,74.378 C525.979,74.244 524.393,73.757 523.338,73.347 C521.94,72.803 520.942,72.155 519.894,71.106 C518.846,70.057 518.197,69.06 517.654,67.663 C517.244,66.606 516.755,65.022 516.623,62.101 C516.479,58.943 516.448,57.996 516.448,50 C516.448,42.003 516.479,41.056 516.623,37.899 C516.755,34.978 517.244,33.391 517.654,32.338 C518.197,30.938 518.846,29.942 519.894,28.894 C520.942,27.846 521.94,27.196 523.338,26.654 C524.393,26.244 525.979,25.756 528.898,25.623 C532.057,25.479 533.004,25.448 541,25.448 C548.997,25.448 549.943,25.479 553.102,25.623 C556.021,25.756 557.607,26.244 558.662,26.654 C560.06,27.196 561.058,27.846 562.106,28.894 C563.154,29.942 563.803,30.938 564.346,32.338 C564.756,33.391 565.244,34.978 565.378,37.899 C565.522,41.056 565.552,42.003 565.552,50 C565.552,57.996 565.522,58.943 565.378,62.101 M570.82,37.631 C570.674,34.438 570.167,32.258 569.425,30.349 C568.659,28.377 567.633,26.702 565.965,25.035 C564.297,23.368 562.623,22.342 560.652,21.575 C558.743,20.834 556.562,20.326 553.369,20.18 C550.169,20.033 549.148,20 541,20 C532.853,20 531.831,20.033 528.631,20.18 C525.438,20.326 523.257,20.834 521.349,21.575 C519.376,22.342 517.703,23.368 516.035,25.035 C514.368,26.702 513.342,28.377 512.574,30.349 C511.834,32.258 511.326,34.438 511.181,37.631 C511.035,40.831 511,41.851 511,50 C511,58.147 511.035,59.17 511.181,62.369 C511.326,65.562 511.834,67.743 512.574,69.651 C513.342,71.625 514.368,73.296 516.035,74.965 C517.703,76.634 519.376,77.658 521.349,78.425 C523.257,79.167 525.438,79.673 528.631,79.82 C531.831,79.965 532.853,80.001 541,80.001 C549.148,80.001 550.169,79.965 553.369,79.82 C556.562,79.673 558.743,79.167 560.652,78.425 C562.623,77.658 564.297,76.634 565.965,74.965 C567.633,73.296 568.659,71.625 569.425,69.651 C570.167,67.743 570.674,65.562 570.82,62.369 C570.966,59.17 571,58.147 571,50 C571,41.851 570.966,40.831 570.82,37.631"></path></g></g></g></svg></div><div style="padding-top: 8px;"> <div style=" color:#3897f0; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:550; line-height:18px;"> View this post on Instagram</div></div><div style="padding: 12.5% 0;"></div> <div style="display: flex; flex-direction: row; margin-bottom: 14px; align-items: center;"><div> <div style="background-color: #F4F4F4; border-radius: 50%; height: 12.5px; width: 12.5px; transform: translateX(0px) translateY(7px);"></div> <div style="background-color: #F4F4F4; height: 12.5px; transform: rotate(-45deg) translateX(3px) translateY(1px); width: 12.5px; flex-grow: 0; margin-right: 14px; margin-left: 2px;"></div> <div style="background-color: #F4F4F4; border-radius: 50%; height: 12.5px; width: 12.5px; transform: translateX(9px) translateY(-18px);"></div></div><div style="margin-left: 8px;"> <div style=" background-color: #F4F4F4; border-radius: 50%; flex-grow: 0; height: 20px; width: 20px;"></div> <div style=" width: 0; height: 0; border-top: 2px solid transparent; border-left: 6px solid #f4f4f4; border-bottom: 2px solid transparent; transform: translateX(16px) translateY(-4px) rotate(30deg)"></div></div><div style="margin-left: auto;"> <div style=" width: 0px; border-top: 8px solid #F4F4F4; border-right: 8px solid transparent; transform: translateY(16px);"></div> <div style=" background-color: #F4F4F4; flex-grow: 0; height: 12px; width: 16px; transform: translateY(-4px);"></div> <div style=" width: 0; height: 0; border-top: 8px solid #F4F4F4; border-left: 8px solid transparent; transform: translateY(-4px) translateX(8px);"></div></div></div></a> <p style=" margin:8px 0 0 0; padding:0 4px;"> <a href="https://www.instagram.com/p/BwwONCplEyj/" style=" color:#000; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:normal; line-height:17px; text-decoration:none; word-wrap:break-word;" target="_blank">Congratulations to newlyweds #IdrisElba and #SabrinaDhowre who exchanged vows in Morocco on April 26 2019. Celebrations were spread over three days in Marrakech. See more in the world exclusive in the July 2019 issue of #BritishVogue. Photographed by @SeanThomas_Photo.</a></p> <p style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; line-height:17px; margin-bottom:0; margin-top:8px; overflow:hidden; padding:8px 0 7px; text-align:center; text-overflow:ellipsis; white-space:nowrap;">A post shared by <a href="https://www.instagram.com/britishvogue/" style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:normal; line-height:17px;" target="_blank"> British Vogue</a> (@britishvogue) on <time style=" font-family:Arial,sans-serif; font-size:14px; line-height:17px;" datetime="2019-04-27T09:10:49+00:00">Apr 27, 2019 at 2:10am PDT</time></p></div></blockquote> <script async src="//www.instagram.com/embed.js"></script>',
-		isMandatory: false,
-	},
-	instagramInstramEmbed: {
-		isThirdPartyTracking: true,
-		_type: InstagramBlockElementType,
-		html:
-			'<blockquote class="instagram-media" data-instgrm-version="7" style=" background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin: 1px; max-width:658px; padding:0; width:99.375%; width:-webkit-calc(100% - 2px); width:calc(100% - 2px);"><div style="padding:8px;"> <div style=" background:#F8F8F8; line-height:0; margin-top:40px; padding:50.0% 0; text-align:center; width:100%;"> <div style=" background:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACwAAAAsCAMAAAApWqozAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAMUExURczMzPf399fX1+bm5mzY9AMAAADiSURBVDjLvZXbEsMgCES5/P8/t9FuRVCRmU73JWlzosgSIIZURCjo/ad+EQJJB4Hv8BFt+IDpQoCx1wjOSBFhh2XssxEIYn3ulI/6MNReE07UIWJEv8UEOWDS88LY97kqyTliJKKtuYBbruAyVh5wOHiXmpi5we58Ek028czwyuQdLKPG1Bkb4NnM+VeAnfHqn1k4+GPT6uGQcvu2h2OVuIf/gWUFyy8OWEpdyZSa3aVCqpVoVvzZZ2VTnn2wU8qzVjDDetO90GSy9mVLqtgYSy231MxrY6I2gGqjrTY0L8fxCxfCBbhWrsYYAAAAAElFTkSuQmCC); display:block; height:44px; margin:0 auto -44px; position:relative; top:-22px; width:44px;"></div></div><p style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; line-height:17px; margin-bottom:0; margin-top:8px; overflow:hidden; padding:8px 0 7px; text-align:center; text-overflow:ellipsis; white-space:nowrap;"><a href="https://www.instagram.com/p/BYJLF9SnA7I/" style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:normal; line-height:17px; text-decoration:none;" target="_blank">A post shared by Taylor Swift (@taylorswift)</a> on <time style=" font-family:Arial,sans-serif; font-size:14px; line-height:17px;" datetime="2017-08-23T16:39:48+00:00">Aug 23, 2017 at 9:39am PDT</time></p></div></blockquote>\n<script async defer src="//platform.instagram.com/en_US/embeds.js"></script>',
-		source: 'Instagram',
-		sourceDomain: 'platform.instagram.com',
-		url: 'https://www.instagram.com/p/BYJLF9SnA7I/',
-		hasCaption: true,
-	},
-	formStackEmbed: {
-		source: 'Formstack',
-		sourceDomain: 'formstack.com',
-		height: undefined,
-		width: undefined,
-		isThirdPartyTracking: true,
-		safe: false,
-		alt: 'Book clinic form',
-		_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
-		html:
-			'<script type="text/javascript" src="https://guardiannewsandmedia.formstack.com/forms/js.php/observer_book_clinic"></script>',
-		isMandatory: true,
-	},
-	facebookEmbed: {
-		source: 'Facebook',
-		sourceDomain: 'facebook.com',
-		height: 221,
-		width: 500,
-		isThirdPartyTracking: true,
-		safe: true,
-		alt: 'Facebook post',
-		_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
-		html:
-			'<iframe src="https://www.facebook.com/plugins/post.php?href=https%3A%2F%2Fwww.facebook.com%2Fmaureen.shrimpton%2Fposts%2F2165642433537707&width=500" width="500" height="211" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>',
-		isMandatory: false,
-	},
-	vimeoEmbedEmbed: {
-		source: 'Vimeo',
-		sourceDomain: 'vimeo.com',
-		height: 360,
-		width: 640,
-		isThirdPartyTracking: false,
-		safe: true,
-		alt: 'the documentary Injustice',
-		_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
-		html:
-			'<iframe src="https://player.vimeo.com/video/34633260?dnt=true" width="640" height="360" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>',
-		isMandatory: false,
-	},
-	vimeoVideoEmbed: {
-		source: 'Vimeo',
-		sourceDomain: 'vimeo.com',
-		embedUrl:
-			'https://player.vimeo.com/video/21693673?app_id=122963&dnt=true',
-		role: 'inline',
-		isThirdPartyTracking: false,
-		width: 460,
-		_type: 'model.dotcomrendering.pageElements.VideoVimeoBlockElement',
-		caption: 'How many beers is that?',
-		originalUrl: 'https://vimeo.com/21693673',
-		url: 'https://vimeo.com/21693673',
-		height: 259,
-		credit: undefined,
-		title: undefined,
-	},
-	scribdDocumentEmbed: {
-		source: 'Scribd',
-		sourceDomain: 'scribd.com',
-		embedUrl: 'https://www.scribd.com/embeds/469886680/content',
-		isThirdPartyTracking: true,
-		width: 613,
-		_type: 'model.dotcomrendering.pageElements.DocumentBlockElement',
-		title: 'Russia Report',
-		isMandatory: false,
-		height: 460,
-	},
-	scribdEmbedEmbed: {
-		source: 'Scribd',
-		sourceDomain: 'scribd.com',
-		height: undefined,
-		width: undefined,
-		isThirdPartyTracking: true,
-		safe: false,
-		alt: 'Letter',
-		_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
-		html:
-			'<p  style=" margin: 12px auto 6px auto; font-family: Helvetica,Arial,Sans-serif; font-style: normal; font-variant: normal; font-weight: normal; font-size: 14px; line-height: normal; font-size-adjust: none; font-stretch: normal; -x-system-font: none; display: block;"> <a title="View Climate Change Letter UN on Scribd" href="https://www.scribd.com/document/482633239/Climate-Change-Letter-UN#from_embed"  style="text-decoration: underline;" >Climate Change Letter UN</a> by <a title="View The Guardian\'s profile on Scribd" href="https://www.scribd.com/user/17081734/The-Guardian#from_embed"  style="text-decoration: underline;" >The Guardian</a> on Scribd</p><iframe class="scribd_iframe_embed" title="Climate Change Letter UN" src="https://www.scribd.com/embeds/482633239/content?start_page=1&view_mode=scroll&access_key=key-u8wwc0Osw6NCcbfolTy0" data-auto-height="false" data-aspect-ratio="0.7080062794348508" scrolling="no" id="doc_24425" width="100%" height="600" frameborder="0"></iframe>',
-		isMandatory: false,
-	},
-	tiktokEmbedEmbed: {
-		source: 'TikTok',
-		sourceDomain: 'tiktok.com',
-		height: undefined,
-		width: undefined,
-		isThirdPartyTracking: true,
-		safe: false,
-		alt: 'Everything is cake on TikTok',
-		_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
-		html:
-			'<blockquote class="tiktok-embed" cite="https://www.tiktok.com/@danbanbam/video/6849106362224413958" data-video-id="6849106362224413958" style="max-width: 605px;min-width: 325px;" > <section> <a target="_blank" title="@danbanbam" href="https://www.tiktok.com/@danbanbam">@danbanbam</a> <p>Cake: The Movie. Coming this Fall. <a title="cake" target="_blank" href="https://www.tiktok.com/tag/cake">##cake</a> <a title="serve" target="_blank" href="https://www.tiktok.com/tag/serve">##serve</a> <a title="vibezone" target="_blank" href="https://www.tiktok.com/tag/vibezone">##VibeZone</a> <a title="movie" target="_blank" href="https://www.tiktok.com/tag/movie">##movie</a></p> <a target="_blank" title="♬ original sound - Daniel Spencer" href="https://www.tiktok.com/music/original-sound-6849097596150303493">♬ original sound - Daniel Spencer</a> </section> </blockquote> <script async src="https://www.tiktok.com/embed.js"></script>',
-		isMandatory: false,
-	},
-	soundcloudAudioEmbed: {
-		source: 'Soundcloud',
-		sourceDomain: 'soundcloud.com',
-		height: 460,
-		width: 460,
-		isTrack: true,
-		isThirdPartyTracking: true,
-		_type: SoundcloudBlockElementType,
-		html:
-			'\n            <iframe\n                height="460"\n                width="460"\n                src="https://w.soundcloud.com/player/?visual=true&url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F875169979&show_artwork=true"\n                frameborder="0"\n                allowfullscreen\n            ></iframe>\n        ',
-		id: '875169979',
-		isMandatory: true,
-	},
-	soundcloudEmbedEmbed: {
-		source: 'Soundcloud',
-		sourceDomain: 'soundcloud.com',
-		height: 300,
-		width: undefined,
-		isTrack: true,
-		isThirdPartyTracking: true,
-		_type: SoundcloudBlockElementType,
-		html:
-			'<iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/881588431&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe><div style="font-size: 10px; color: #cccccc;line-break: anywhere;word-break: normal;overflow: hidden;white-space: nowrap;text-overflow: ellipsis; font-family: Interstate,Lucida Grande,Lucida Sans Unicode,Lucida Sans,Garuda,Verdana,Tahoma,sans-serif;font-weight: 100;"><a href="https://soundcloud.com/planetmurecords" title="Planet Mu Records" target="_blank" style="color: #cccccc; text-decoration: none;">Planet Mu Records</a> · <a href="https://soundcloud.com/planetmurecords/john-frusciante-amethblowl-timesig" title="John Frusciante - Amethblowl (TIMESIG011)" target="_blank" style="color: #cccccc; text-decoration: none;">John Frusciante - Amethblowl (TIMESIG011)</a></div>',
-		id: '881588431',
-		isMandatory: false,
-	},
-	youtubeEmbedEmbed: {
-		source: 'Youtube',
-		sourceDomain: 'youtube.com',
-		height: 315,
-		width: undefined,
-		isThirdPartyTracking: false,
-		safe: true,
-		alt: 'Watch the video for Sleaford Mods’ Second',
-		_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
-		html:
-			'<iframe width="100%" height="315" src="https://www.youtube-nocookie.com/embed/IT09DGuXwYQ" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>',
-		isMandatory: false,
-	},
-	spotifyAudioEmbed: {
-		source: 'Spotify',
-		sourceDomain: 'spotify.com',
-		embedUrl:
-			'https://embed.spotify.com/?uri=spotify:user:matthew.holmes.guardian:playlist:6UQ1JOduKGyS46SThaxy0B',
-		isThirdPartyTracking: true,
-		width: 300,
-		_type: 'model.dotcomrendering.pageElements.SpotifyBlockElement',
-		caption: 'Listen to the list on Spotify.',
-		title:
-			"Fuel RR playlist: 'love is...', a playlist by matthew.holmes.guardian on Spotify",
-		height: 380,
-	},
-	spotifyEmbedEmbed: {
-		source: 'Spotify',
-		sourceDomain: 'spotify.com',
-		height: 380,
-		width: 300,
-		isThirdPartyTracking: true,
-		safe: true,
-		alt: 'Joy Division Ranked Spotify Playlist',
-		_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
-		html:
-			'<iframe src="https://embed.spotify.com/?uri=spotify%3Auser%3Aguardianmusic%3Aplaylist%3A1XUwszj7DC0uRY5L7Anj6I" width="300" height="380" frameborder="0" allowtransparency="true"></iframe>',
-		isMandatory: true,
-	},
-	bandcampEmbedEmbed: {
-		source: 'Bandcamp',
-		sourceDomain: 'bandcamp.com',
-		height: undefined,
-		width: undefined,
-		isThirdPartyTracking: true,
-		safe: true,
-		alt: 'Isaac by Jonny and the Baptists',
-		_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
-		html:
-			'<iframe style="border: 0; width: 100%; height: 120px;" src="https://bandcamp.com/EmbeddedPlayer/album=1077257657/size=large/bgcol=ffffff/linkcol=0687f5/tracklist=false/artwork=small/track=2222104579/transparent=true/" seamless><a href="https://jonnyandthebaptists.bandcamp.com/album/love-you-hate-bastards">Love You &amp; Hate Bastards by Jonny &amp; The Baptists</a></iframe>',
-		isMandatory: true,
-	},
-	twitterTweetEmbed: {
-		source: 'Twitter',
-		sourceDomain: 'twitter.com',
-		role: Inline,
-		isThirdPartyTracking: false,
-		_type: TweetBlockElementType,
-		html:
-			'<blockquote class="twitter-tweet"><p lang="en" dir="ltr">A staff member at MSNBC has died of coronavirus. It’s hitting them pretty hard as you can see from <a href="https://twitter.com/maddow?ref_src=twsrc%5Etfw">@maddow</a>’s sign-off today <a href="https://t.co/nbqRRaammr">pic.twitter.com/nbqRRaammr</a></p>&mdash; Matt Bevan 🎙 (@MatthewBevan) <a href="https://twitter.com/MatthewBevan/status/1241244758653071360?ref_src=twsrc%5Etfw">March 21, 2020</a></blockquote>\n',
-		hasMedia: false,
-		id: '1241244758653071360',
-		url: 'https://twitter.com/MatthewBevan/status/1241244758653071360',
-		height: undefined,
-		width: undefined,
-	},
-	twitterEmbedEmbed: {
-		source: 'Twitter',
-		sourceDomain: 'twitter.com',
-		height: undefined,
-		width: undefined,
-		isThirdPartyTracking: false,
-		safe: false,
-		alt: 'Video: social distancing',
-		_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
-		html:
-			'<blockquote class="twitter-tweet"><p lang="en" dir="ltr">Confused about the difference between self-isolation and social distancing - and who should do it? 🤷🏻‍♀️ Watch this as <a href="https://twitter.com/robosborneitv?ref_src=twsrc%5Etfw">@robosborneitv</a> explains, with the help of his mum, and <a href="https://twitter.com/ckkhaira?ref_src=twsrc%5Etfw">@ckkhaira</a> <a href="https://t.co/SNzpDRFxsz">https://t.co/SNzpDRFxsz</a> <a href="https://twitter.com/hashtag/coronavirus?src=hash&amp;ref_src=twsrc%5Etfw">#coronavirus</a> <a href="https://twitter.com/hashtag/covid19?src=hash&amp;ref_src=twsrc%5Etfw">#covid19</a> <a href="https://t.co/wC6ezmAqRC">pic.twitter.com/wC6ezmAqRC</a></p>&mdash; ITV Wales News (@ITVWales) <a href="https://twitter.com/ITVWales/status/1241068501076410376?ref_src=twsrc%5Etfw">March 20, 2020</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>',
-		isMandatory: false,
-	},
-	ourworldindataEmbedEmbed: {
-		source: undefined,
-		sourceDomain: 'ourworldindata.com',
-		height: undefined,
-		width: undefined,
-		isThirdPartyTracking: true,
-		safe: true,
-		alt: 'Our World in Data',
-		_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
-		html:
-			'<iframe src="https://ourworldindata.org/grapher/daily-covid-deaths-3-day-average" style="width: 100%; height: 600px; border: 0px none;"></iframe>',
-		isMandatory: false,
-	},
-	bbcEmbedEmbed: {
-		source: 'BBC',
-		sourceDomain: 'bbc.co.uk',
-		height: 500,
-		width: undefined,
-		isThirdPartyTracking: true,
-		safe: true,
-		alt: 'Watch a trailer for Enslaved',
-		_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
-		html:
-			'<iframe width="fullwidth" height="500" frameborder="0" src="https://www.bbc.co.uk/programmes/p08tfnfb/player"></iframe>',
-		isMandatory: false,
-	},
+const instagramEmbedEmbed: EmbedBlockElement = {
+	source: 'Instagram',
+	sourceDomain: 'instagram.com',
+	height: undefined,
+	width: undefined,
+	isThirdPartyTracking: true,
+	safe: false,
+	alt: 'Idris Elba wedding',
+	_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
+	html:
+		'<blockquote class="instagram-media" data-instgrm-captioned data-instgrm-permalink="https://www.instagram.com/p/BwwONCplEyj/" data-instgrm-version="12" style=" background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin: 1px; max-width:540px; min-width:326px; padding:0; width:99.375%; width:-webkit-calc(100% - 2px); width:calc(100% - 2px);"><div style="padding:16px;"> <a href="https://www.instagram.com/p/BwwONCplEyj/" style=" background:#FFFFFF; line-height:0; padding:0 0; text-align:center; text-decoration:none; width:100%;" target="_blank"> <div style=" display: flex; flex-direction: row; align-items: center;"> <div style="background-color: #F4F4F4; border-radius: 50%; flex-grow: 0; height: 40px; margin-right: 14px; width: 40px;"></div> <div style="display: flex; flex-direction: column; flex-grow: 1; justify-content: center;"> <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; margin-bottom: 6px; width: 100px;"></div> <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; width: 60px;"></div></div></div><div style="padding: 19% 0;"></div> <div style="display:block; height:50px; margin:0 auto 12px; width:50px;"><svg width="50px" height="50px" viewBox="0 0 60 60" version="1.1" xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g transform="translate(-511.000000, -20.000000)" fill="#000000"><g><path d="M556.869,30.41 C554.814,30.41 553.148,32.076 553.148,34.131 C553.148,36.186 554.814,37.852 556.869,37.852 C558.924,37.852 560.59,36.186 560.59,34.131 C560.59,32.076 558.924,30.41 556.869,30.41 M541,60.657 C535.114,60.657 530.342,55.887 530.342,50 C530.342,44.114 535.114,39.342 541,39.342 C546.887,39.342 551.658,44.114 551.658,50 C551.658,55.887 546.887,60.657 541,60.657 M541,33.886 C532.1,33.886 524.886,41.1 524.886,50 C524.886,58.899 532.1,66.113 541,66.113 C549.9,66.113 557.115,58.899 557.115,50 C557.115,41.1 549.9,33.886 541,33.886 M565.378,62.101 C565.244,65.022 564.756,66.606 564.346,67.663 C563.803,69.06 563.154,70.057 562.106,71.106 C561.058,72.155 560.06,72.803 558.662,73.347 C557.607,73.757 556.021,74.244 553.102,74.378 C549.944,74.521 548.997,74.552 541,74.552 C533.003,74.552 532.056,74.521 528.898,74.378 C525.979,74.244 524.393,73.757 523.338,73.347 C521.94,72.803 520.942,72.155 519.894,71.106 C518.846,70.057 518.197,69.06 517.654,67.663 C517.244,66.606 516.755,65.022 516.623,62.101 C516.479,58.943 516.448,57.996 516.448,50 C516.448,42.003 516.479,41.056 516.623,37.899 C516.755,34.978 517.244,33.391 517.654,32.338 C518.197,30.938 518.846,29.942 519.894,28.894 C520.942,27.846 521.94,27.196 523.338,26.654 C524.393,26.244 525.979,25.756 528.898,25.623 C532.057,25.479 533.004,25.448 541,25.448 C548.997,25.448 549.943,25.479 553.102,25.623 C556.021,25.756 557.607,26.244 558.662,26.654 C560.06,27.196 561.058,27.846 562.106,28.894 C563.154,29.942 563.803,30.938 564.346,32.338 C564.756,33.391 565.244,34.978 565.378,37.899 C565.522,41.056 565.552,42.003 565.552,50 C565.552,57.996 565.522,58.943 565.378,62.101 M570.82,37.631 C570.674,34.438 570.167,32.258 569.425,30.349 C568.659,28.377 567.633,26.702 565.965,25.035 C564.297,23.368 562.623,22.342 560.652,21.575 C558.743,20.834 556.562,20.326 553.369,20.18 C550.169,20.033 549.148,20 541,20 C532.853,20 531.831,20.033 528.631,20.18 C525.438,20.326 523.257,20.834 521.349,21.575 C519.376,22.342 517.703,23.368 516.035,25.035 C514.368,26.702 513.342,28.377 512.574,30.349 C511.834,32.258 511.326,34.438 511.181,37.631 C511.035,40.831 511,41.851 511,50 C511,58.147 511.035,59.17 511.181,62.369 C511.326,65.562 511.834,67.743 512.574,69.651 C513.342,71.625 514.368,73.296 516.035,74.965 C517.703,76.634 519.376,77.658 521.349,78.425 C523.257,79.167 525.438,79.673 528.631,79.82 C531.831,79.965 532.853,80.001 541,80.001 C549.148,80.001 550.169,79.965 553.369,79.82 C556.562,79.673 558.743,79.167 560.652,78.425 C562.623,77.658 564.297,76.634 565.965,74.965 C567.633,73.296 568.659,71.625 569.425,69.651 C570.167,67.743 570.674,65.562 570.82,62.369 C570.966,59.17 571,58.147 571,50 C571,41.851 570.966,40.831 570.82,37.631"></path></g></g></g></svg></div><div style="padding-top: 8px;"> <div style=" color:#3897f0; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:550; line-height:18px;"> View this post on Instagram</div></div><div style="padding: 12.5% 0;"></div> <div style="display: flex; flex-direction: row; margin-bottom: 14px; align-items: center;"><div> <div style="background-color: #F4F4F4; border-radius: 50%; height: 12.5px; width: 12.5px; transform: translateX(0px) translateY(7px);"></div> <div style="background-color: #F4F4F4; height: 12.5px; transform: rotate(-45deg) translateX(3px) translateY(1px); width: 12.5px; flex-grow: 0; margin-right: 14px; margin-left: 2px;"></div> <div style="background-color: #F4F4F4; border-radius: 50%; height: 12.5px; width: 12.5px; transform: translateX(9px) translateY(-18px);"></div></div><div style="margin-left: 8px;"> <div style=" background-color: #F4F4F4; border-radius: 50%; flex-grow: 0; height: 20px; width: 20px;"></div> <div style=" width: 0; height: 0; border-top: 2px solid transparent; border-left: 6px solid #f4f4f4; border-bottom: 2px solid transparent; transform: translateX(16px) translateY(-4px) rotate(30deg)"></div></div><div style="margin-left: auto;"> <div style=" width: 0px; border-top: 8px solid #F4F4F4; border-right: 8px solid transparent; transform: translateY(16px);"></div> <div style=" background-color: #F4F4F4; flex-grow: 0; height: 12px; width: 16px; transform: translateY(-4px);"></div> <div style=" width: 0; height: 0; border-top: 8px solid #F4F4F4; border-left: 8px solid transparent; transform: translateY(-4px) translateX(8px);"></div></div></div></a> <p style=" margin:8px 0 0 0; padding:0 4px;"> <a href="https://www.instagram.com/p/BwwONCplEyj/" style=" color:#000; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:normal; line-height:17px; text-decoration:none; word-wrap:break-word;" target="_blank">Congratulations to newlyweds #IdrisElba and #SabrinaDhowre who exchanged vows in Morocco on April 26 2019. Celebrations were spread over three days in Marrakech. See more in the world exclusive in the July 2019 issue of #BritishVogue. Photographed by @SeanThomas_Photo.</a></p> <p style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; line-height:17px; margin-bottom:0; margin-top:8px; overflow:hidden; padding:8px 0 7px; text-align:center; text-overflow:ellipsis; white-space:nowrap;">A post shared by <a href="https://www.instagram.com/britishvogue/" style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:normal; line-height:17px;" target="_blank"> British Vogue</a> (@britishvogue) on <time style=" font-family:Arial,sans-serif; font-size:14px; line-height:17px;" datetime="2019-04-27T09:10:49+00:00">Apr 27, 2019 at 2:10am PDT</time></p></div></blockquote> <script async src="//www.instagram.com/embed.js"></script>',
+	isMandatory: false,
+};
+
+const instagramInstramEmbed: InstagramBlockElement = {
+	isThirdPartyTracking: true,
+	_type: 'model.dotcomrendering.pageElements.InstagramBlockElement',
+	html:
+		'<blockquote class="instagram-media" data-instgrm-version="7" style=" background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin: 1px; max-width:658px; padding:0; width:99.375%; width:-webkit-calc(100% - 2px); width:calc(100% - 2px);"><div style="padding:8px;"> <div style=" background:#F8F8F8; line-height:0; margin-top:40px; padding:50.0% 0; text-align:center; width:100%;"> <div style=" background:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACwAAAAsCAMAAAApWqozAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAMUExURczMzPf399fX1+bm5mzY9AMAAADiSURBVDjLvZXbEsMgCES5/P8/t9FuRVCRmU73JWlzosgSIIZURCjo/ad+EQJJB4Hv8BFt+IDpQoCx1wjOSBFhh2XssxEIYn3ulI/6MNReE07UIWJEv8UEOWDS88LY97kqyTliJKKtuYBbruAyVh5wOHiXmpi5we58Ek028czwyuQdLKPG1Bkb4NnM+VeAnfHqn1k4+GPT6uGQcvu2h2OVuIf/gWUFyy8OWEpdyZSa3aVCqpVoVvzZZ2VTnn2wU8qzVjDDetO90GSy9mVLqtgYSy231MxrY6I2gGqjrTY0L8fxCxfCBbhWrsYYAAAAAElFTkSuQmCC); display:block; height:44px; margin:0 auto -44px; position:relative; top:-22px; width:44px;"></div></div><p style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; line-height:17px; margin-bottom:0; margin-top:8px; overflow:hidden; padding:8px 0 7px; text-align:center; text-overflow:ellipsis; white-space:nowrap;"><a href="https://www.instagram.com/p/BYJLF9SnA7I/" style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:normal; line-height:17px; text-decoration:none;" target="_blank">A post shared by Taylor Swift (@taylorswift)</a> on <time style=" font-family:Arial,sans-serif; font-size:14px; line-height:17px;" datetime="2017-08-23T16:39:48+00:00">Aug 23, 2017 at 9:39am PDT</time></p></div></blockquote>\n<script async defer src="//platform.instagram.com/en_US/embeds.js"></script>',
+	source: 'Instagram',
+	sourceDomain: 'platform.instagram.com',
+	url: 'https://www.instagram.com/p/BYJLF9SnA7I/',
+	hasCaption: true,
+};
+
+const formStackEmbed: EmbedBlockElement = {
+	source: 'Formstack',
+	sourceDomain: 'formstack.com',
+	height: undefined,
+	width: undefined,
+	isThirdPartyTracking: true,
+	safe: false,
+	alt: 'Book clinic form',
+	_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
+	html:
+		'<script type="text/javascript" src="https://guardiannewsandmedia.formstack.com/forms/js.php/observer_book_clinic"></script>',
+	isMandatory: true,
+};
+
+const facebookEmbed: EmbedBlockElement = {
+	source: 'Facebook',
+	sourceDomain: 'facebook.com',
+	height: 221,
+	width: 500,
+	isThirdPartyTracking: true,
+	safe: true,
+	alt: 'Facebook post',
+	_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
+	html:
+		'<iframe src="https://www.facebook.com/plugins/post.php?href=https%3A%2F%2Fwww.facebook.com%2Fmaureen.shrimpton%2Fposts%2F2165642433537707&width=500" width="500" height="211" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>',
+	isMandatory: false,
+};
+
+const vimeoEmbedEmbed: EmbedBlockElement = {
+	source: 'Vimeo',
+	sourceDomain: 'vimeo.com',
+	isThirdPartyTracking: false,
+	safe: true,
+	alt: 'the documentary Injustice',
+	_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
+	html:
+		'<iframe src="https://player.vimeo.com/video/34633260?dnt=true" width="640" height="360" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>',
+	isMandatory: false,
+};
+
+const vimeoVideoEmbed: VideoVimeoBlockElement = {
+	source: 'Vimeo',
+	sourceDomain: 'vimeo.com',
+	embedUrl: 'https://player.vimeo.com/video/21693673?app_id=122963&dnt=true',
+	role: 'inline',
+	isThirdPartyTracking: false,
+	width: 460,
+	_type: 'model.dotcomrendering.pageElements.VideoVimeoBlockElement',
+	caption: 'How many beers is that?',
+	originalUrl: 'https://vimeo.com/21693673',
+	url: 'https://vimeo.com/21693673',
+	height: 259,
+	credit: undefined,
+	title: undefined,
+};
+
+const scribdDocumentEmbed: DocumentBlockElement = {
+	source: 'Scribd',
+	sourceDomain: 'scribd.com',
+	embedUrl: 'https://www.scribd.com/embeds/469886680/content',
+	isThirdPartyTracking: true,
+	width: 613,
+	_type: 'model.dotcomrendering.pageElements.DocumentBlockElement',
+	title: 'Russia Report',
+	height: 460,
+};
+
+const scribdEmbedEmbed: EmbedBlockElement = {
+	source: 'Scribd',
+	sourceDomain: 'scribd.com',
+	isThirdPartyTracking: true,
+	safe: false,
+	alt: 'Letter',
+	_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
+	html:
+		'<p  style=" margin: 12px auto 6px auto; font-family: Helvetica,Arial,Sans-serif; font-style: normal; font-variant: normal; font-weight: normal; font-size: 14px; line-height: normal; font-size-adjust: none; font-stretch: normal; -x-system-font: none; display: block;"> <a title="View Climate Change Letter UN on Scribd" href="https://www.scribd.com/document/482633239/Climate-Change-Letter-UN#from_embed"  style="text-decoration: underline;" >Climate Change Letter UN</a> by <a title="View The Guardian\'s profile on Scribd" href="https://www.scribd.com/user/17081734/The-Guardian#from_embed"  style="text-decoration: underline;" >The Guardian</a> on Scribd</p><iframe class="scribd_iframe_embed" title="Climate Change Letter UN" src="https://www.scribd.com/embeds/482633239/content?start_page=1&view_mode=scroll&access_key=key-u8wwc0Osw6NCcbfolTy0" data-auto-height="false" data-aspect-ratio="0.7080062794348508" scrolling="no" id="doc_24425" width="100%" height="600" frameborder="0"></iframe>',
+	isMandatory: false,
+};
+
+const tiktokEmbedEmbed: EmbedBlockElement = {
+	source: 'TikTok',
+	sourceDomain: 'tiktok.com',
+	isThirdPartyTracking: true,
+	safe: false,
+	alt: 'Everything is cake on TikTok',
+	_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
+	html:
+		'<blockquote class="tiktok-embed" cite="https://www.tiktok.com/@danbanbam/video/6849106362224413958" data-video-id="6849106362224413958" style="max-width: 605px;min-width: 325px;" > <section> <a target="_blank" title="@danbanbam" href="https://www.tiktok.com/@danbanbam">@danbanbam</a> <p>Cake: The Movie. Coming this Fall. <a title="cake" target="_blank" href="https://www.tiktok.com/tag/cake">##cake</a> <a title="serve" target="_blank" href="https://www.tiktok.com/tag/serve">##serve</a> <a title="vibezone" target="_blank" href="https://www.tiktok.com/tag/vibezone">##VibeZone</a> <a title="movie" target="_blank" href="https://www.tiktok.com/tag/movie">##movie</a></p> <a target="_blank" title="♬ original sound - Daniel Spencer" href="https://www.tiktok.com/music/original-sound-6849097596150303493">♬ original sound - Daniel Spencer</a> </section> </blockquote> <script async src="https://www.tiktok.com/embed.js"></script>',
+	isMandatory: false,
+};
+
+const soundcloudAudioEmbed: SoundcloudBlockElement = {
+	source: 'Soundcloud',
+	sourceDomain: 'soundcloud.com',
+	isTrack: true,
+	isThirdPartyTracking: true,
+	_type: 'model.dotcomrendering.pageElements.SoundcloudBlockElement',
+	html:
+		'\n            <iframe\n                height="460"\n                width="460"\n                src="https://w.soundcloud.com/player/?visual=true&url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F875169979&show_artwork=true"\n                frameborder="0"\n                allowfullscreen\n            ></iframe>\n        ',
+	id: '875169979',
+	isMandatory: true,
+};
+
+const soundcloudEmbedEmbed: SoundcloudBlockElement = {
+	source: 'Soundcloud',
+	sourceDomain: 'soundcloud.com',
+	isTrack: true,
+	isThirdPartyTracking: true,
+	_type: 'model.dotcomrendering.pageElements.SoundcloudBlockElement',
+	html:
+		'<iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/881588431&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe><div style="font-size: 10px; color: #cccccc;line-break: anywhere;word-break: normal;overflow: hidden;white-space: nowrap;text-overflow: ellipsis; font-family: Interstate,Lucida Grande,Lucida Sans Unicode,Lucida Sans,Garuda,Verdana,Tahoma,sans-serif;font-weight: 100;"><a href="https://soundcloud.com/planetmurecords" title="Planet Mu Records" target="_blank" style="color: #cccccc; text-decoration: none;">Planet Mu Records</a> · <a href="https://soundcloud.com/planetmurecords/john-frusciante-amethblowl-timesig" title="John Frusciante - Amethblowl (TIMESIG011)" target="_blank" style="color: #cccccc; text-decoration: none;">John Frusciante - Amethblowl (TIMESIG011)</a></div>',
+	id: '881588431',
+	isMandatory: false,
+};
+
+const youtubeEmbedEmbed: EmbedBlockElement = {
+	source: 'Youtube',
+	sourceDomain: 'youtube.com',
+	height: 315,
+	width: undefined,
+	isThirdPartyTracking: false,
+	safe: true,
+	alt: 'Watch the video for Sleaford Mods’ Second',
+	_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
+	html:
+		'<iframe width="100%" height="315" src="https://www.youtube-nocookie.com/embed/IT09DGuXwYQ" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>',
+	isMandatory: false,
+};
+
+const spotifyAudioEmbed: SpotifyBlockElement = {
+	source: 'Spotify',
+	sourceDomain: 'spotify.com',
+	embedUrl:
+		'https://embed.spotify.com/?uri=spotify:user:matthew.holmes.guardian:playlist:6UQ1JOduKGyS46SThaxy0B',
+	isThirdPartyTracking: true,
+	width: 300,
+	_type: 'model.dotcomrendering.pageElements.SpotifyBlockElement',
+	caption: 'Listen to the list on Spotify.',
+	title:
+		"Fuel RR playlist: 'love is...', a playlist by matthew.holmes.guardian on Spotify",
+	height: 380,
+};
+
+const spotifyEmbedEmbed: EmbedBlockElement = {
+	source: 'Spotify',
+	sourceDomain: 'spotify.com',
+	height: 380,
+	width: 300,
+	isThirdPartyTracking: true,
+	safe: true,
+	alt: 'Joy Division Ranked Spotify Playlist',
+	_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
+	html:
+		'<iframe src="https://embed.spotify.com/?uri=spotify%3Auser%3Aguardianmusic%3Aplaylist%3A1XUwszj7DC0uRY5L7Anj6I" width="300" height="380" frameborder="0" allowtransparency="true"></iframe>',
+	isMandatory: true,
+};
+
+const bandcampEmbedEmbed: EmbedBlockElement = {
+	source: 'Bandcamp',
+	sourceDomain: 'bandcamp.com',
+	height: undefined,
+	width: undefined,
+	isThirdPartyTracking: true,
+	safe: true,
+	alt: 'Isaac by Jonny and the Baptists',
+	_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
+	html:
+		'<iframe style="border: 0; width: 100%; height: 120px;" src="https://bandcamp.com/EmbeddedPlayer/album=1077257657/size=large/bgcol=ffffff/linkcol=0687f5/tracklist=false/artwork=small/track=2222104579/transparent=true/" seamless><a href="https://jonnyandthebaptists.bandcamp.com/album/love-you-hate-bastards">Love You &amp; Hate Bastards by Jonny &amp; The Baptists</a></iframe>',
+	isMandatory: true,
+};
+
+const twitterTweetEmbed: TweetBlockElement = {
+	source: 'Twitter',
+	sourceDomain: 'twitter.com',
+	role: Inline,
+	isThirdPartyTracking: false,
+	_type: 'model.dotcomrendering.pageElements.TweetBlockElement',
+	html:
+		'<blockquote class="twitter-tweet"><p lang="en" dir="ltr">A staff member at MSNBC has died of coronavirus. It’s hitting them pretty hard as you can see from <a href="https://twitter.com/maddow?ref_src=twsrc%5Etfw">@maddow</a>’s sign-off today <a href="https://t.co/nbqRRaammr">pic.twitter.com/nbqRRaammr</a></p>&mdash; Matt Bevan 🎙 (@MatthewBevan) <a href="https://twitter.com/MatthewBevan/status/1241244758653071360?ref_src=twsrc%5Etfw">March 21, 2020</a></blockquote>\n',
+	hasMedia: false,
+	id: '1241244758653071360',
+	url: 'https://twitter.com/MatthewBevan/status/1241244758653071360',
+};
+
+const twitterEmbedEmbed: EmbedBlockElement = {
+	source: 'Twitter',
+	sourceDomain: 'twitter.com',
+	height: undefined,
+	width: undefined,
+	isThirdPartyTracking: false,
+	safe: false,
+	alt: 'Video: social distancing',
+	_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
+	html:
+		'<blockquote class="twitter-tweet"><p lang="en" dir="ltr">Confused about the difference between self-isolation and social distancing - and who should do it? 🤷🏻‍♀️ Watch this as <a href="https://twitter.com/robosborneitv?ref_src=twsrc%5Etfw">@robosborneitv</a> explains, with the help of his mum, and <a href="https://twitter.com/ckkhaira?ref_src=twsrc%5Etfw">@ckkhaira</a> <a href="https://t.co/SNzpDRFxsz">https://t.co/SNzpDRFxsz</a> <a href="https://twitter.com/hashtag/coronavirus?src=hash&amp;ref_src=twsrc%5Etfw">#coronavirus</a> <a href="https://twitter.com/hashtag/covid19?src=hash&amp;ref_src=twsrc%5Etfw">#covid19</a> <a href="https://t.co/wC6ezmAqRC">pic.twitter.com/wC6ezmAqRC</a></p>&mdash; ITV Wales News (@ITVWales) <a href="https://twitter.com/ITVWales/status/1241068501076410376?ref_src=twsrc%5Etfw">March 20, 2020</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>',
+	isMandatory: false,
+};
+
+const ourworldindataEmbedEmbed = {
+	source: undefined,
+	sourceDomain: 'ourworldindata.com',
+	height: undefined,
+	width: undefined,
+	isThirdPartyTracking: true,
+	safe: true,
+	alt: 'Our World in Data',
+	_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
+	html:
+		'<iframe src="https://ourworldindata.org/grapher/daily-covid-deaths-3-day-average" style="width: 100%; height: 600px; border: 0px none;"></iframe>',
+	isMandatory: false,
+};
+
+const bbcEmbedEmbed: EmbedBlockElement = {
+	source: 'BBC',
+	sourceDomain: 'bbc.co.uk',
+	height: 500,
+	width: undefined,
+	isThirdPartyTracking: true,
+	safe: true,
+	alt: 'Watch a trailer for Enslaved',
+	_type: 'model.dotcomrendering.pageElements.EmbedBlockElement',
+	html:
+		'<iframe width="fullwidth" height="500" frameborder="0" src="https://www.bbc.co.uk/programmes/p08tfnfb/player"></iframe>',
+	isMandatory: false,
 };
 
 export const EmbedBlockComponentStory = () => {
@@ -458,17 +454,15 @@ export const EmbedBlockComponentStory = () => {
 				<Figure role="inline">
 					<ClickToView
 						isTracking={true}
-						source={EmbeddedElements.facebookEmbed.source}
-						sourceDomain={
-							EmbeddedElements.facebookEmbed.sourceDomain
-						}
+						source={facebookEmbed.source}
+						sourceDomain={facebookEmbed.sourceDomain}
 						role="inline"
 						abTests={abTests}
 					>
 						<EmbedBlockComponent
 							key={1}
-							html={EmbeddedElements.facebookEmbed.html}
-							alt={EmbeddedElements.facebookEmbed.alt}
+							html={facebookEmbed.html}
+							alt={facebookEmbed.alt}
 						/>
 					</ClickToView>
 				</Figure>
@@ -482,17 +476,15 @@ export const EmbedBlockComponentStory = () => {
 				<Figure role="inline">
 					<ClickToView
 						isTracking={true}
-						source={EmbeddedElements.vimeoEmbedEmbed.source}
-						sourceDomain={
-							EmbeddedElements.vimeoEmbedEmbed.sourceDomain
-						}
+						source={vimeoEmbedEmbed.source}
+						sourceDomain={vimeoEmbedEmbed.sourceDomain}
 						role="inline"
 						abTests={abTests}
 					>
 						<EmbedBlockComponent
 							key={1}
-							html={EmbeddedElements.vimeoEmbedEmbed.html}
-							alt={EmbeddedElements.vimeoEmbedEmbed.alt}
+							html={vimeoEmbedEmbed.html}
+							alt={vimeoEmbedEmbed.alt}
 						/>
 					</ClickToView>
 				</Figure>
@@ -506,17 +498,15 @@ export const EmbedBlockComponentStory = () => {
 				<Figure role="inline">
 					<ClickToView
 						isTracking={true}
-						source={EmbeddedElements.youtubeEmbedEmbed.source}
-						sourceDomain={
-							EmbeddedElements.youtubeEmbedEmbed.sourceDomain
-						}
+						source={youtubeEmbedEmbed.source}
+						sourceDomain={youtubeEmbedEmbed.sourceDomain}
 						role="inline"
 						abTests={abTests}
 					>
 						<EmbedBlockComponent
 							key={1}
-							html={EmbeddedElements.youtubeEmbedEmbed.html}
-							alt={EmbeddedElements.youtubeEmbedEmbed.alt}
+							html={youtubeEmbedEmbed.html}
+							alt={youtubeEmbedEmbed.alt}
 						/>
 					</ClickToView>
 				</Figure>
@@ -530,17 +520,15 @@ export const EmbedBlockComponentStory = () => {
 				<Figure role="inline">
 					<ClickToView
 						isTracking={true}
-						source={EmbeddedElements.spotifyEmbedEmbed.source}
-						sourceDomain={
-							EmbeddedElements.spotifyEmbedEmbed.sourceDomain
-						}
+						source={spotifyEmbedEmbed.source}
+						sourceDomain={spotifyEmbedEmbed.sourceDomain}
 						role="inline"
 						abTests={abTests}
 					>
 						<EmbedBlockComponent
 							key={1}
-							html={EmbeddedElements.spotifyEmbedEmbed.html}
-							alt={EmbeddedElements.spotifyEmbedEmbed.alt}
+							html={spotifyEmbedEmbed.html}
+							alt={spotifyEmbedEmbed.alt}
 						/>
 					</ClickToView>
 				</Figure>
@@ -554,17 +542,15 @@ export const EmbedBlockComponentStory = () => {
 				<Figure role="inline">
 					<ClickToView
 						isTracking={true}
-						source={EmbeddedElements.bandcampEmbedEmbed.source}
-						sourceDomain={
-							EmbeddedElements.bandcampEmbedEmbed.sourceDomain
-						}
+						source={bandcampEmbedEmbed.source}
+						sourceDomain={bandcampEmbedEmbed.sourceDomain}
 						role="inline"
 						abTests={abTests}
 					>
 						<EmbedBlockComponent
 							key={1}
-							html={EmbeddedElements.bandcampEmbedEmbed.html}
-							alt={EmbeddedElements.bandcampEmbedEmbed.alt}
+							html={bandcampEmbedEmbed.html}
+							alt={bandcampEmbedEmbed.alt}
 						/>
 					</ClickToView>
 				</Figure>
@@ -578,22 +564,15 @@ export const EmbedBlockComponentStory = () => {
 				<Figure role="inline">
 					<ClickToView
 						isTracking={true}
-						source={
-							EmbeddedElements.ourworldindataEmbedEmbed.source
-						}
-						sourceDomain={
-							EmbeddedElements.ourworldindataEmbedEmbed
-								.sourceDomain
-						}
+						source={ourworldindataEmbedEmbed.source}
+						sourceDomain={ourworldindataEmbedEmbed.sourceDomain}
 						role="inline"
 						abTests={abTests}
 					>
 						<EmbedBlockComponent
 							key={1}
-							html={
-								EmbeddedElements.ourworldindataEmbedEmbed.html
-							}
-							alt={EmbeddedElements.ourworldindataEmbedEmbed.alt}
+							html={ourworldindataEmbedEmbed.html}
+							alt={ourworldindataEmbedEmbed.alt}
 						/>
 					</ClickToView>
 				</Figure>
@@ -607,17 +586,15 @@ export const EmbedBlockComponentStory = () => {
 				<Figure role="inline">
 					<ClickToView
 						isTracking={true}
-						source={EmbeddedElements.bbcEmbedEmbed.source}
-						sourceDomain={
-							EmbeddedElements.bbcEmbedEmbed.sourceDomain
-						}
+						source={bbcEmbedEmbed.source}
+						sourceDomain={bbcEmbedEmbed.sourceDomain}
 						role="inline"
 						abTests={abTests}
 					>
 						<EmbedBlockComponent
 							key={1}
-							html={EmbeddedElements.bbcEmbedEmbed.html}
-							alt={EmbeddedElements.bbcEmbedEmbed.alt}
+							html={bbcEmbedEmbed.html}
+							alt={bbcEmbedEmbed.alt}
 						/>
 					</ClickToView>
 				</Figure>
@@ -652,10 +629,8 @@ export const UnsafeEmbedBlockComponentStory = () => {
 				<Figure role="inline">
 					<ClickToView
 						isTracking={true}
-						source={EmbeddedElements.instagramEmbedEmbed.source}
-						sourceDomain={
-							EmbeddedElements.instagramEmbedEmbed.sourceDomain
-						}
+						source={instagramEmbedEmbed.source}
+						sourceDomain={instagramEmbedEmbed.sourceDomain}
 						role="inline"
 						onAccept={() =>
 							updateIframeHeight('iframe[name="unsafe-embed-1"]')
@@ -664,8 +639,8 @@ export const UnsafeEmbedBlockComponentStory = () => {
 					>
 						<UnsafeEmbedBlockComponent
 							key="1"
-							html={EmbeddedElements.instagramEmbedEmbed.html}
-							alt={EmbeddedElements.instagramEmbedEmbed.alt}
+							html={instagramEmbedEmbed.html}
+							alt={instagramEmbedEmbed.alt || ''}
 							index={1}
 						/>
 					</ClickToView>
@@ -679,10 +654,8 @@ export const UnsafeEmbedBlockComponentStory = () => {
 				<Figure role="inline">
 					<ClickToView
 						isTracking={true}
-						source={EmbeddedElements.formStackEmbed.source}
-						sourceDomain={
-							EmbeddedElements.formStackEmbed.sourceDomain
-						}
+						source={formStackEmbed.source}
+						sourceDomain={formStackEmbed.sourceDomain}
 						role="inline"
 						onAccept={() =>
 							updateIframeHeight('iframe[name="unsafe-embed-2"]')
@@ -691,8 +664,8 @@ export const UnsafeEmbedBlockComponentStory = () => {
 					>
 						<UnsafeEmbedBlockComponent
 							key="2"
-							html={EmbeddedElements.formStackEmbed.html}
-							alt={EmbeddedElements.formStackEmbed.alt}
+							html={formStackEmbed.html}
+							alt={formStackEmbed.alt || ''}
 							index={2}
 						/>
 					</ClickToView>
@@ -707,10 +680,8 @@ export const UnsafeEmbedBlockComponentStory = () => {
 				<Figure role="inline">
 					<ClickToView
 						isTracking={true}
-						source={EmbeddedElements.scribdEmbedEmbed.source}
-						sourceDomain={
-							EmbeddedElements.scribdEmbedEmbed.sourceDomain
-						}
+						source={scribdEmbedEmbed.source}
+						sourceDomain={scribdEmbedEmbed.sourceDomain}
 						role="inline"
 						onAccept={() =>
 							updateIframeHeight('iframe[name="unsafe-embed-3"]')
@@ -719,8 +690,8 @@ export const UnsafeEmbedBlockComponentStory = () => {
 					>
 						<UnsafeEmbedBlockComponent
 							key="3"
-							html={EmbeddedElements.scribdEmbedEmbed.html}
-							alt={EmbeddedElements.scribdEmbedEmbed.alt}
+							html={scribdEmbedEmbed.html}
+							alt={scribdEmbedEmbed.alt || ''}
 							index={3}
 						/>
 					</ClickToView>
@@ -735,10 +706,8 @@ export const UnsafeEmbedBlockComponentStory = () => {
 				<Figure role="inline">
 					<ClickToView
 						isTracking={true}
-						source={EmbeddedElements.tiktokEmbedEmbed.source}
-						sourceDomain={
-							EmbeddedElements.tiktokEmbedEmbed.sourceDomain
-						}
+						source={tiktokEmbedEmbed.source}
+						sourceDomain={tiktokEmbedEmbed.sourceDomain}
 						role="inline"
 						onAccept={() =>
 							updateIframeHeight('iframe[name="unsafe-embed-4"]')
@@ -747,8 +716,8 @@ export const UnsafeEmbedBlockComponentStory = () => {
 					>
 						<UnsafeEmbedBlockComponent
 							key="4"
-							html={EmbeddedElements.tiktokEmbedEmbed.html}
-							alt={EmbeddedElements.tiktokEmbedEmbed.alt}
+							html={tiktokEmbedEmbed.html}
+							alt={tiktokEmbedEmbed.alt || ''}
 							index={4}
 						/>
 					</ClickToView>
@@ -763,10 +732,8 @@ export const UnsafeEmbedBlockComponentStory = () => {
 				<Figure role="inline">
 					<ClickToView
 						isTracking={true}
-						source={EmbeddedElements.twitterEmbedEmbed.source}
-						sourceDomain={
-							EmbeddedElements.twitterEmbedEmbed.sourceDomain
-						}
+						source={twitterEmbedEmbed.source}
+						sourceDomain={twitterEmbedEmbed.sourceDomain}
 						role="inline"
 						onAccept={() =>
 							updateIframeHeight('iframe[name="unsafe-embed-5"]')
@@ -775,8 +742,8 @@ export const UnsafeEmbedBlockComponentStory = () => {
 					>
 						<UnsafeEmbedBlockComponent
 							key="5"
-							html={EmbeddedElements.twitterEmbedEmbed.html}
-							alt={EmbeddedElements.twitterEmbedEmbed.alt}
+							html={twitterEmbedEmbed.html}
+							alt={twitterEmbedEmbed.alt || ''}
 							index={5}
 						/>
 					</ClickToView>
@@ -813,10 +780,8 @@ export const VimeoBlockComponentStory = () => {
 				<Figure role="inline">
 					<ClickToView
 						isTracking={true}
-						source={EmbeddedElements.vimeoVideoEmbed.source}
-						sourceDomain={
-							EmbeddedElements.vimeoVideoEmbed.sourceDomain
-						}
+						source={vimeoVideoEmbed.source}
+						sourceDomain={vimeoVideoEmbed.sourceDomain}
 						role="inline"
 						abTests={abTests}
 					>
@@ -831,12 +796,12 @@ export const VimeoBlockComponentStory = () => {
 								display: Display.Standard,
 								design: Design.Article,
 							})}
-							embedUrl={EmbeddedElements.vimeoVideoEmbed.embedUrl}
-							height={EmbeddedElements.vimeoVideoEmbed.height}
-							width={EmbeddedElements.vimeoVideoEmbed.width}
-							caption={EmbeddedElements.vimeoVideoEmbed.caption}
-							credit={EmbeddedElements.vimeoVideoEmbed.credit}
-							title={EmbeddedElements.vimeoVideoEmbed.title}
+							embedUrl={vimeoVideoEmbed.embedUrl}
+							height={vimeoVideoEmbed.height}
+							width={vimeoVideoEmbed.width}
+							caption={vimeoVideoEmbed.caption}
+							credit={vimeoVideoEmbed.credit}
+							title={vimeoVideoEmbed.title}
 						/>
 					</ClickToView>
 				</Figure>
@@ -872,20 +837,16 @@ export const DocumentBlockComponentStory = () => {
 				<Figure role="inline">
 					<ClickToView
 						isTracking={true}
-						source={EmbeddedElements.scribdDocumentEmbed.source}
-						sourceDomain={
-							EmbeddedElements.scribdDocumentEmbed.sourceDomain
-						}
+						source={scribdDocumentEmbed.source}
+						sourceDomain={scribdDocumentEmbed.sourceDomain}
 						role="inline"
 						abTests={abTests}
 					>
 						<DocumentBlockComponent
-							embedUrl={
-								EmbeddedElements.scribdDocumentEmbed.embedUrl
-							}
-							height={EmbeddedElements.scribdDocumentEmbed.height}
-							width={EmbeddedElements.scribdDocumentEmbed.width}
-							title={EmbeddedElements.scribdDocumentEmbed.title}
+							embedUrl={scribdDocumentEmbed.embedUrl}
+							height={scribdDocumentEmbed.height}
+							width={scribdDocumentEmbed.width}
+							title={scribdDocumentEmbed.title}
 						/>
 					</ClickToView>
 				</Figure>
@@ -921,15 +882,13 @@ export const SoundCloudBlockComponentStory = () => {
 				<Figure role="inline">
 					<ClickToView
 						isTracking={true}
-						source={EmbeddedElements.soundcloudAudioEmbed.source}
-						sourceDomain={
-							EmbeddedElements.soundcloudAudioEmbed.sourceDomain
-						}
+						source={soundcloudAudioEmbed.source}
+						sourceDomain={soundcloudAudioEmbed.sourceDomain}
 						role="inline"
 						abTests={abTests}
 					>
 						<SoundcloudBlockComponent
-							element={EmbeddedElements.soundcloudAudioEmbed}
+							element={soundcloudAudioEmbed}
 						/>
 					</ClickToView>
 				</Figure>
@@ -943,15 +902,13 @@ export const SoundCloudBlockComponentStory = () => {
 				<Figure role="inline">
 					<ClickToView
 						isTracking={true}
-						source={EmbeddedElements.soundcloudEmbedEmbed.source}
-						sourceDomain={
-							EmbeddedElements.soundcloudEmbedEmbed.sourceDomain
-						}
+						source={soundcloudEmbedEmbed.source}
+						sourceDomain={soundcloudEmbedEmbed.sourceDomain}
 						role="inline"
 						abTests={abTests}
 					>
 						<SoundcloudBlockComponent
-							element={EmbeddedElements.soundcloudEmbedEmbed}
+							element={soundcloudEmbedEmbed}
 						/>
 					</ClickToView>
 				</Figure>
@@ -987,21 +944,17 @@ export const SpotifyBlockComponentStory = () => {
 				<Figure role="inline">
 					<ClickToView
 						isTracking={true}
-						source={EmbeddedElements.spotifyAudioEmbed.source}
-						sourceDomain={
-							EmbeddedElements.spotifyAudioEmbed.sourceDomain
-						}
+						source={spotifyAudioEmbed.source}
+						sourceDomain={spotifyAudioEmbed.sourceDomain}
 						role="inline"
 						abTests={abTests}
 					>
 						<SpotifyBlockComponent
-							embedUrl={
-								EmbeddedElements.spotifyAudioEmbed.embedUrl
-							}
-							height={EmbeddedElements.spotifyAudioEmbed.height}
-							width={EmbeddedElements.spotifyAudioEmbed.width}
-							title={EmbeddedElements.spotifyAudioEmbed.title}
-							caption={EmbeddedElements.spotifyAudioEmbed.caption}
+							embedUrl={spotifyAudioEmbed.embedUrl}
+							height={spotifyAudioEmbed.height}
+							width={spotifyAudioEmbed.width}
+							title={spotifyAudioEmbed.title}
+							caption={spotifyAudioEmbed.caption}
 							format={{
 								theme: Pillar.News,
 								display: Display.Standard,
@@ -1049,16 +1002,12 @@ export const TweetBlockComponentStory = () => {
 				<Figure role="inline">
 					<ClickToView
 						isTracking={true}
-						source={EmbeddedElements.twitterTweetEmbed.source}
-						sourceDomain={
-							EmbeddedElements.twitterTweetEmbed.sourceDomain
-						}
+						source={twitterTweetEmbed.source}
+						sourceDomain={twitterTweetEmbed.sourceDomain}
 						role="inline"
 						abTests={abTests}
 					>
-						<TweetBlockComponent
-							element={EmbeddedElements.twitterTweetEmbed}
-						/>
+						<TweetBlockComponent element={twitterTweetEmbed} />
 					</ClickToView>
 				</Figure>
 				<p className={paragraphStyle}>The end.</p>,
@@ -1092,10 +1041,8 @@ export const InstagramBlockComponentStory = () => {
 				<Figure role="inline">
 					<ClickToView
 						isTracking={true}
-						source={EmbeddedElements.instagramInstramEmbed.source}
-						sourceDomain={
-							EmbeddedElements.instagramInstramEmbed.sourceDomain
-						}
+						source={instagramInstramEmbed.source}
+						sourceDomain={instagramInstramEmbed.sourceDomain}
 						role="inline"
 						abTests={abTests}
 						onAccept={() =>
@@ -1106,7 +1053,7 @@ export const InstagramBlockComponentStory = () => {
 					>
 						<InstagramBlockComponent
 							key={1}
-							element={EmbeddedElements.instagramInstramEmbed}
+							element={instagramInstramEmbed}
 							index={1}
 						/>
 					</ClickToView>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
- Revert `@typescript-eslint/prefer-as-const` rule
- split out `EmbeddedElements` into individual elements and set type

## Why?
When reverting `prefer-as-const` I noticed some type issues raised by `EmbeddedElements`. Ideally they should have be spun out into individual types.