### PR TITLE
Revert no-implied-eval lint exception

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -62,7 +62,6 @@ module.exports = {
         'no-console': 'off',
         '@typescript-eslint/ban-types': 'off',
         '@typescript-eslint/no-floating-promises': 'off',
-        '@typescript-eslint/no-implied-eval': 'off',
         '@typescript-eslint/no-use-before-define': 'off',
         '@typescript-eslint/prefer-as-const': 'off',
         'no-shadow': 'off',

--- a/src/web/browser/dynamicImport/init.ts
+++ b/src/web/browser/dynamicImport/init.ts
@@ -9,6 +9,7 @@ import { startup } from '@root/src/web/browser/startup';
 // browsers that cut the mustard (support modules).**
 const initialiseDynamicImport = () => {
 	try {
+		// eslint-disable-next-line @typescript-eslint/no-implied-eval
 		window.guardianPolyfilledImport = new Function(
 			'url',
 			`return import(url)`,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
- Revert `@typescript-eslint/no-implied-eval` lint exception
- Disable rule for only case when using `new Function`

## Why?
We want to test that `import(url)` works in the browser (to check if we can dynamically import content). In order for `import` not to be misinterpreted by webpack, we invoke it in the `Function` constructor.
```
window.guardianPolyfilledImport = new Function(
    'url',
    `return import(url)`,
) as (url: string) => Promise<any>;
```