### PR TITLE
Revert ban-types exception

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -60,7 +60,6 @@ module.exports = {
         '@typescript-eslint/ban-ts-comment': 'off',
         '@typescript-eslint/restrict-template-expressions': 'off',
         'no-console': 'off',
-        '@typescript-eslint/ban-types': 'off',
         '@typescript-eslint/no-floating-promises': 'off',
         '@typescript-eslint/no-use-before-define': 'off',
 		'no-shadow': 'off',

--- a/__mocks__/svgMock.tsx
+++ b/__mocks__/svgMock.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
 
-const SVG: React.SFC<{}> = () => null;
+const SVG: React.FC = () => null;
 
 module.exports = SVG;

--- a/index.d.ts
+++ b/index.d.ts
@@ -349,7 +349,7 @@ interface CAPIType {
 	openGraphData: { [key: string]: string };
 	twitterData: { [key: string]: string };
 	webURL: string;
-	linkedData: object[];
+	linkedData: { [key: string]: any }[];
 	config: ConfigType;
 	// The CAPI object sent from frontend can have designType Immersive. We force this to be Article
 	// in decideDesign but need to allow the type here before then
@@ -589,7 +589,7 @@ interface ConfigType extends CommercialConfigType {
 	googletagUrl: string;
 	stage: string;
 	frontendAssetsFullURL: string;
-	hbImpl: object | string;
+	hbImpl: { [key: string]: any } | string;
 	adUnit: string;
 	isSensitive: boolean;
 	videoDuration: number;
@@ -676,7 +676,7 @@ interface DCRServerDocumentData {
 	CAPI: CAPIType;
 	NAV: NavType;
 	GA: GADataType;
-	linkedData: object;
+	linkedData: { [key: string]: any; };
 }
 
 interface DCRBrowserDocumentData {
@@ -685,7 +685,7 @@ interface DCRBrowserDocumentData {
 	CAPI: CAPIBrowserType;
 	NAV: SubNavBrowserType;
 	GA: GADataType;
-	linkedData: object;
+	linkedData: { [key: string]: any; };
 }
 
 type IslandType =

--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
         "cypress-plugin-tab": "^1.0.5",
         "desvg-loader": "^0.1.0",
         "doctoc": "^1.4.0",
-        "eslint": "^6.8.0",
+        "eslint": "^7.20.0",
         "eslint-plugin-dcr": "https://github.com/guardian/eslint-plugin-dcr#v0.1.0",
         "fetch-mock": "^9.11.0",
         "find": "^0.3.0",

--- a/packages/frontend/lib/sanitise-html.ts
+++ b/packages/frontend/lib/sanitise-html.ts
@@ -1,4 +1,4 @@
 import sanitiszeHtml from 'sanitize-html';
 
-export const sanitise = (html: string, options: {} = {}): string =>
+export const sanitise = (html: string, options: { [key: string]: any } = {}): string =>
     sanitiszeHtml(html, options);

--- a/scripts/jest/setup.ts
+++ b/scripts/jest/setup.ts
@@ -25,7 +25,7 @@ const windowGuardian = {
     ophan: {
         setEventEmitter: () => null,
         trackComponentAttention: () => null,
-        record: ({}: {}) => null,
+        record: ({}: { [key: string]: any }) => null,
         viewId: '',
         pageViewId: '',
     },

--- a/src/amp/components/AdConsent.tsx
+++ b/src/amp/components/AdConsent.tsx
@@ -56,7 +56,7 @@ const clientConfigAus = {
 	},
 };
 
-export const AdConsent: React.FC<{}> = ({}) => {
+export const AdConsent: React.FC = ({}) => {
 	// To debug geolocation in dev, make sure you're on the experimental channel of AMP:
 	// https://cdn.ampproject.org/experiments.html
 	// Then you can load the url with #amp-geo=XX, where XX is the country code

--- a/src/amp/components/ShowMoreButton.tsx
+++ b/src/amp/components/ShowMoreButton.tsx
@@ -40,7 +40,7 @@ const showMore = css`
 	}
 `;
 
-export const ShowMoreButton: React.SFC<{}> = () => (
+export const ShowMoreButton: React.FC = () => (
 	<div className={showMore} aria-label="Show more">
 		<PlusIcon />
 		Show more

--- a/src/amp/components/Sidebar.tsx
+++ b/src/amp/components/Sidebar.tsx
@@ -203,7 +203,7 @@ const template = `
 export const Sidebar: React.FC<{ nav: NavType }> = () => {
 	// this next line is necessary cos react has a 'template' object with no 'type' property.
 	// By saying 'as {}' we can pretend we're not adding the 'type' property and thus avoid unhappy type errors
-	const props = { type: 'amp-mustache' } as {};
+	const props = { type: 'amp-mustache' } as { [key: string]: any };
 	return (
 		<amp-sidebar class={sidebarStyles} layout="nodisplay" id="sidebar1">
 			<amp-list

--- a/src/amp/components/moustache.tsx
+++ b/src/amp/components/moustache.tsx
@@ -20,10 +20,10 @@ export const MoustacheVariable: React.FC<{ name: string }> = ({ name }) => (
 	<>{moustacheVariable(name)}</>
 );
 
-export const MoustacheTemplate: React.FC<{}> = ({ children }) => {
+export const MoustacheTemplate: React.FC = ({ children }) => {
 	// this next line is necessary cos react has a 'template' object with no 'type' property.
 	// By saying 'as {}' we can pretend we're not adding the 'type' property and thus avoid unhappy type errors
-	const props = { type: 'amp-mustache' } as {};
+	const props = { type: 'amp-mustache' } as { [key: string]: any };
 	// eslint-disable-next-line react/jsx-props-no-spreading
 	return <template {...props}>{children}</template>;
 };

--- a/src/amp/components/topMeta/PaidForBand.tsx
+++ b/src/amp/components/topMeta/PaidForBand.tsx
@@ -103,7 +103,7 @@ const iconStyle = css`
 	height: 20px;
 `;
 
-export const PaidForBand: React.FC<{}> = () => (
+export const PaidForBand: React.FC = () => (
 	<header className={headerStyle}>
 		<div className={metaStyle}>
 			<span>Paid content</span>

--- a/src/amp/server/document.tsx
+++ b/src/amp/server/document.tsx
@@ -24,7 +24,7 @@ export const document = ({
 	scripts,
 	metadata,
 }: {
-	linkedData: object[];
+	linkedData: { [key: string]: any }[];
 	title: string;
 	body: React.ReactElement<any>;
 	scripts: string[];

--- a/src/lib/sanitise-html.ts
+++ b/src/lib/sanitise-html.ts
@@ -1,4 +1,6 @@
 import sanitiszeHtml from 'sanitize-html';
 
-export const sanitise = (html: string, options: {} = {}): string =>
-	sanitiszeHtml(html, options);
+export const sanitise = (
+	html: string,
+	options: { [key: string]: any } = {},
+): string => sanitiszeHtml(html, options);

--- a/src/model/extract-nav.ts
+++ b/src/model/extract-nav.ts
@@ -1,8 +1,11 @@
 import get from 'lodash.get';
+
 import { findPillar } from './find-pillar';
 
+type ObjectType = { [key: string]: any };
+
 const getString = (
-	obj: object,
+	obj: ObjectType,
 	selector: string,
 	fallbackValue?: string,
 ): string => {
@@ -22,7 +25,7 @@ const getString = (
 };
 
 const getArray = <T>(
-	obj: object,
+	obj: ObjectType,
 	selector: string,
 	fallbackValue?: T[],
 ): T[] => {
@@ -42,14 +45,17 @@ const getArray = <T>(
 	);
 };
 
-const getLink = (data: {}, { isPillar }: { isPillar: boolean }): LinkType => {
+const getLink = (
+	data: ObjectType,
+	{ isPillar }: { isPillar: boolean },
+): LinkType => {
 	const title = getString(data, 'title');
 	return {
 		title,
 		longTitle: getString(data, 'longTitle', '') || title,
 		url: getString(data, 'url'),
 		pillar: isPillar ? findPillar(getString(data, 'title')) : undefined,
-		children: getArray<object>(data, 'children', []).map(
+		children: getArray<ObjectType>(data, 'children', []).map(
 			(l) => getLink(l, { isPillar: false }), // children are never pillars
 		),
 		mobileOnly: false,
@@ -58,7 +64,7 @@ const getLink = (data: {}, { isPillar }: { isPillar: boolean }): LinkType => {
 
 const rrLinkConfig = 'readerRevenueLinks';
 const buildRRLinkCategories = (
-	data: {},
+	data: ObjectType,
 	position: ReaderRevenuePosition,
 ): ReaderRevenueCategories => ({
 	subscribe: getString(data, `${rrLinkConfig}.${position}.subscribe`, ''),
@@ -90,11 +96,11 @@ export const extractNAV = (data: any): NavType => {
 			title: 'More',
 			longTitle: 'More',
 			more: true,
-			children: getArray<object>(data, 'otherLinks', []).map((l) =>
+			children: getArray<ObjectType>(data, 'otherLinks', []).map((l) =>
 				getLink(l, { isPillar: false }),
 			),
 		},
-		brandExtensions: getArray<object>(
+		brandExtensions: getArray<ObjectType>(
 			data,
 			'brandExtensions',
 			[],
@@ -105,7 +111,7 @@ export const extractNAV = (data: any): NavType => {
 					parent: subnav.parent
 						? getLink(subnav.parent, { isPillar: false })
 						: undefined,
-					links: getArray<object>(subnav, 'links').map((l) =>
+					links: getArray<ObjectType>(subnav, 'links').map((l) =>
 						getLink(l, { isPillar: false }),
 					),
 			  }

--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -17,7 +17,7 @@ export interface WindowGuardianConfig {
 		adUnit: string;
 		showRelatedContent: boolean;
 		ajaxUrl: string;
-		hbImpl: object | string;
+		hbImpl: { [key: string]: any } | string;
 		shouldHideReaderRevenue: boolean;
 	} & ConfigType;
 	libs: {

--- a/src/web/browser/ophan/ophan.ts
+++ b/src/web/browser/ophan/ophan.ts
@@ -9,7 +9,7 @@ import {
 	TestMeta,
 } from '@guardian/types';
 
-export const record = (event: {}): void => {
+export const record = (event: { [key: string]: any }): void => {
 	if (
 		window.guardian &&
 		window.guardian.ophan &&

--- a/src/web/components/AdSlot.tsx
+++ b/src/web/components/AdSlot.tsx
@@ -429,6 +429,6 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 	}
 };
 
-export const MobileStickyContainer: React.FC<{}> = ({}) => {
+export const MobileStickyContainer: React.FC = () => {
 	return <div className={`mobilesticky-container ${mobileStickyAdStyles}`} />;
 };

--- a/src/web/components/ClickToView.tsx
+++ b/src/web/components/ClickToView.tsx
@@ -11,7 +11,7 @@ import { space } from '@guardian/src-foundations';
 type Props = {
 	children: React.ReactNode;
 	role?: RoleType;
-	onAccept?: Function;
+	onAccept?: () => void;
 	isTracking: boolean;
 	source?: string;
 	sourceDomain?: string;

--- a/src/web/components/CommentCount.tsx
+++ b/src/web/components/CommentCount.tsx
@@ -11,7 +11,7 @@ type Props = {
 	palette: Palette;
 	isCommentable: boolean;
 	commentCount: number;
-	setIsExpanded: Function;
+	setIsExpanded: (isExpanded: boolean) => void;
 };
 
 const containerStyles = (palette: Palette) => css`

--- a/src/web/components/Onwards/HeadlinesContainer.tsx
+++ b/src/web/components/Onwards/HeadlinesContainer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-type Props = {};
+type Props = { [key: string]: any };
 
 export const HeadlinesContainer: React.FC<Props> = ({}: Props) => {
 	// need funky layout

--- a/src/web/components/SlotBodyEnd/ReaderRevenueEpic.tsx
+++ b/src/web/components/SlotBodyEnd/ReaderRevenueEpic.tsx
@@ -33,7 +33,7 @@ type PreEpicConfig = {
 	meta: TestMeta;
 	module: {
 		url: string;
-		props: {};
+		props: { [key: string]: any };
 	};
 };
 
@@ -46,7 +46,7 @@ type EpicConfig = {
 };
 
 type EpicProps = {
-	onReminderOpen: Function;
+	onReminderOpen: () => void;
 	// Also anything specified by support-dotcom-components
 };
 

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -88,7 +88,10 @@ const buildPayload = (props: BuildPayloadProps) => {
 };
 
 // TODO replace this with an imported version from the client lib
-const getBanner = (meta: {}, url: string): Promise<Response> => {
+const getBanner = (
+	meta: { [key: string]: any },
+	url: string,
+): Promise<Response> => {
 	const json = JSON.stringify(meta);
 	return fetch(url, {
 		method: 'post',

--- a/src/web/components/elements/TextBlockComponent.tsx
+++ b/src/web/components/elements/TextBlockComponent.tsx
@@ -87,7 +87,7 @@ const sanitiserOptions = {
 	allowedTags: false, // Leave tags from CAPI alone
 	allowedAttributes: false, // Leave attributes from CAPI alone
 	transformTags: {
-		a: (tagName: string, attribs: {}) => ({
+		a: (tagName: string, attribs: { [key: string]: any }) => ({
 			tagName, // Just return anchors as is
 			attribs: {
 				...attribs, // Merge into the existing attributes

--- a/src/web/lib/getAbUrlHash.ts
+++ b/src/web/lib/getAbUrlHash.ts
@@ -2,7 +2,7 @@ import { Participations } from '@guardian/ab-core';
 
 export const getForcedParticipationsFromUrl = (
 	windowHash: string,
-): Participations | {} => {
+): Participations => {
 	if (windowHash.startsWith('#ab')) {
 		const tokens = windowHash.replace('#ab-', '').split(',');
 		return tokens.reduce((obj, token) => {

--- a/src/web/lib/useOnce.ts
+++ b/src/web/lib/useOnce.ts
@@ -5,7 +5,7 @@ import { useEffect, useState } from 'react';
  * @param {Function} task - The task to execute once
  * @param {Array} waitFor - An array of variables that must be defined before the task is executed
  * */
-export const useOnce = (task: Function, waitFor: unknown[]): void => {
+export const useOnce = (task: () => void, waitFor: unknown[]): void => {
 	const [alreadyRun, setAlreadyRun] = useState(false);
 	const isReady = waitFor.every((dep) => dep !== undefined);
 	useEffect(() => {

--- a/src/web/server/htmlTemplate.ts
+++ b/src/web/server/htmlTemplate.ts
@@ -23,7 +23,7 @@ export const htmlTemplate = ({
 }: {
 	title?: string;
 	description: string;
-	linkedData: object;
+	linkedData: { [key: string]: any };
 	loadableConfigScripts: string[];
 	priorityScriptTags: string[];
 	lowPriorityScriptTags: string[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,6 +24,13 @@
   dependencies:
     tunnel "0.0.6"
 
+"@babel/code-frame@7.12.11", "@babel/code-frame@^7.12.11":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
+  integrity sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==
+  dependencies:
+    "@babel/highlight" "^7.10.4"
+
 "@babel/code-frame@7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
@@ -35,13 +42,6 @@
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"
   integrity sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==
-  dependencies:
-    "@babel/highlight" "^7.10.4"
-
-"@babel/code-frame@^7.12.11":
-  version "7.12.11"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
-  integrity sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==
   dependencies:
     "@babel/highlight" "^7.10.4"
 
@@ -2336,6 +2336,22 @@
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
+
+"@eslint/eslintrc@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.3.0.tgz#d736d6963d7003b6514e6324bec9c602ac340318"
+  integrity sha512-1JTKgrOKAHVivSvOYw+sJOunkBjUOvjqWk1DPja7ZFhIS2mX/4EgTT8M7eTK9jrKhL/FvXXEbQwIs3pg1xp3dg==
+  dependencies:
+    ajv "^6.12.4"
+    debug "^4.1.1"
+    espree "^7.3.0"
+    globals "^12.1.0"
+    ignore "^4.0.6"
+    import-fresh "^3.2.1"
+    js-yaml "^3.13.1"
+    lodash "^4.17.20"
+    minimatch "^3.0.4"
+    strip-json-comments "^3.1.1"
 
 "@fimbul/bifrost@^0.17.0":
   version "0.17.0"
@@ -4945,7 +4961,7 @@ acorn-globals@^6.0.0:
     acorn "^7.1.1"
     acorn-walk "^7.1.1"
 
-acorn-jsx@^5.1.0:
+acorn-jsx@^5.1.0, acorn-jsx@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
   integrity sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==
@@ -4985,7 +5001,7 @@ acorn@^6.0.1, acorn@^6.4.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.1.tgz#531e58ba3f51b9dacb9a6646ca4debf5b14ca474"
   integrity sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==
 
-acorn@^7.1.0:
+acorn@^7.1.0, acorn@^7.4.0:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
@@ -5088,6 +5104,16 @@ ajv@^6.12.4, ajv@^6.12.5, ajv@^6.12.6:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^7.0.2:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-7.1.1.tgz#1e6b37a454021fa9941713f38b952fc1c8d32a84"
+  integrity sha512-ga/aqDYnUy/o7vbsRTFhhTsNeXiYb5JWDIcRIeZfwRNCefwjNTVYCGdGSUrEmiu3yDK3vFvNbgJxvrQW4JXrYQ==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
 ally.js@^1.4.1:
@@ -7842,7 +7868,7 @@ deep-extend@^0.6.0:
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
-deep-is@~0.1.3:
+deep-is@^0.1.3, deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
@@ -8489,7 +8515,7 @@ enhanced-resolve@^5.7.0:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
 
-enquirer@2.3.6, enquirer@^2.3.6:
+enquirer@2.3.6, enquirer@^2.3.5, enquirer@^2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
   integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
@@ -8926,6 +8952,11 @@ eslint-visitor-keys@^1.1.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
   integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
 
+eslint-visitor-keys@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
+  integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
+
 eslint-visitor-keys@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
@@ -8974,6 +9005,49 @@ eslint@^6.8.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
+eslint@^7.20.0:
+  version "7.20.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.20.0.tgz#db07c4ca4eda2e2316e7aa57ac7fc91ec550bdc7"
+  integrity sha512-qGi0CTcOGP2OtCQBgWZlQjcTuP0XkIpYFj25XtRTQSHC+umNnp7UMshr2G8SLsRFYDdAPFeHOsiteadmMH02Yw==
+  dependencies:
+    "@babel/code-frame" "7.12.11"
+    "@eslint/eslintrc" "^0.3.0"
+    ajv "^6.10.0"
+    chalk "^4.0.0"
+    cross-spawn "^7.0.2"
+    debug "^4.0.1"
+    doctrine "^3.0.0"
+    enquirer "^2.3.5"
+    eslint-scope "^5.1.1"
+    eslint-utils "^2.1.0"
+    eslint-visitor-keys "^2.0.0"
+    espree "^7.3.1"
+    esquery "^1.4.0"
+    esutils "^2.0.2"
+    file-entry-cache "^6.0.0"
+    functional-red-black-tree "^1.0.1"
+    glob-parent "^5.0.0"
+    globals "^12.1.0"
+    ignore "^4.0.6"
+    import-fresh "^3.0.0"
+    imurmurhash "^0.1.4"
+    is-glob "^4.0.0"
+    js-yaml "^3.13.1"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.4.1"
+    lodash "^4.17.20"
+    minimatch "^3.0.4"
+    natural-compare "^1.4.0"
+    optionator "^0.9.1"
+    progress "^2.0.0"
+    regexpp "^3.1.0"
+    semver "^7.2.1"
+    strip-ansi "^6.0.0"
+    strip-json-comments "^3.1.0"
+    table "^6.0.4"
+    text-table "^0.2.0"
+    v8-compile-cache "^2.0.3"
+
 esm@^3.2.25:
   version "3.2.25"
   resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
@@ -8987,6 +9061,15 @@ espree@^6.1.2, espree@^6.2.1:
     acorn "^7.1.1"
     acorn-jsx "^5.2.0"
     eslint-visitor-keys "^1.1.0"
+
+espree@^7.3.0, espree@^7.3.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-7.3.1.tgz#f2df330b752c6f55019f8bd89b7660039c1bbbb6"
+  integrity sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==
+  dependencies:
+    acorn "^7.4.0"
+    acorn-jsx "^5.3.1"
+    eslint-visitor-keys "^1.3.0"
 
 esprima@3.x.x:
   version "3.1.3"
@@ -9004,6 +9087,13 @@ esquery@^1.0.1:
   integrity sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==
   dependencies:
     estraverse "^4.0.0"
+
+esquery@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
+  integrity sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==
+  dependencies:
+    estraverse "^5.1.0"
 
 esrecurse@^4.1.0:
   version "4.2.1"
@@ -9024,7 +9114,7 @@ estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
   integrity sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=
 
-estraverse@^5.2.0:
+estraverse@^5.1.0, estraverse@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
   integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
@@ -9372,7 +9462,7 @@ fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
   integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
 
-fast-levenshtein@~2.0.6:
+fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
@@ -9471,6 +9561,13 @@ file-entry-cache@^5.0.1:
   integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
   dependencies:
     flat-cache "^2.0.1"
+
+file-entry-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.0.tgz#7921a89c391c6d93efec2169ac6bf300c527ea0a"
+  integrity sha512-fqoO76jZ3ZnYrXLDRxBR1YvOvc0k844kcOg40bgsPrE25LAb/PDqTY+ho64Xh2c8ZXgIKldchCFHczG2UVRcWA==
+  dependencies:
+    flat-cache "^3.0.4"
 
 file-loader@^6.0.0:
   version "6.2.0"
@@ -9620,10 +9717,23 @@ flat-cache@^2.0.1:
     rimraf "2.6.3"
     write "1.0.3"
 
+flat-cache@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
+  integrity sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==
+  dependencies:
+    flatted "^3.1.0"
+    rimraf "^3.0.2"
+
 flatted@^2.0.0, flatted@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
+
+flatted@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.1.tgz#c4b489e80096d9df1dfc97c79871aea7c617c469"
+  integrity sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
 
 flush-write-stream@^1.0.0:
   version "1.1.1"
@@ -12251,6 +12361,11 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
 json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
@@ -12521,6 +12636,14 @@ levn@^0.3.0, levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
+
+levn@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
+  integrity sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==
+  dependencies:
+    prelude-ls "^1.2.1"
+    type-check "~0.4.0"
 
 lie@3.1.1:
   version "3.1.1"
@@ -14284,6 +14407,18 @@ optionator@^0.8.1, optionator@^0.8.3:
     type-check "~0.3.2"
     word-wrap "~1.2.3"
 
+optionator@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.1.tgz#4f236a6373dae0566a6d43e1326674f50c291499"
+  integrity sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==
+  dependencies:
+    deep-is "^0.1.3"
+    fast-levenshtein "^2.0.6"
+    levn "^0.4.1"
+    prelude-ls "^1.2.1"
+    type-check "^0.4.0"
+    word-wrap "^1.2.3"
+
 os-browserify@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
@@ -15190,6 +15325,11 @@ prebuild-install@^5.3.0:
     tar-fs "^1.13.0"
     tunnel-agent "^0.6.0"
     which-pm-runs "^1.0.0"
+
+prelude-ls@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
+  integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -16167,6 +16307,11 @@ regexpp@^3.0.0:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.0.0.tgz#dd63982ee3300e67b41c1956f850aa680d9d330e"
   integrity sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g==
 
+regexpp@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
+  integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
+
 regexpu-core@^4.5.4:
   version "4.5.4"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.5.4.tgz#080d9d02289aa87fe1667a4f5136bc98a6aebaae"
@@ -16870,7 +17015,7 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@^7.2, semver@^7.3.2, semver@^7.3.4:
+semver@^7.2, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4:
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
   integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
@@ -17693,6 +17838,11 @@ strip-json-comments@^3.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.0.tgz#7638d31422129ecf4457440009fba03f9f9ac180"
   integrity sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==
 
+strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
+  integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
 strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
@@ -17900,6 +18050,16 @@ table@^5.2.3:
     lodash "^4.17.14"
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
+
+table@^6.0.4:
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/table/-/table-6.0.7.tgz#e45897ffbcc1bcf9e8a87bf420f2c9e5a7a52a34"
+  integrity sha512-rxZevLGTUzWna/qBLObOe16kB2RTnnbhciwgPbMMlazz1yZGVEgnZK762xyVdVznhqxrfCeBMmMkgOOaPwjH7g==
+  dependencies:
+    ajv "^7.0.2"
+    lodash "^4.17.20"
+    slice-ansi "^4.0.0"
+    string-width "^4.2.0"
 
 tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"
@@ -18554,6 +18714,13 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
+
+type-check@^0.4.0, type-check@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
+  integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
+  dependencies:
+    prelude-ls "^1.2.1"
 
 type-check@~0.3.2:
   version "0.3.2"
@@ -19581,7 +19748,7 @@ window-size@^0.1.4:
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.4.tgz#f8e1aa1ee5a53ec5bf151ffa09742a6ad7697876"
   integrity sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=
 
-word-wrap@~1.2.3:
+word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
- Revert `@typescript-eslint/ban-types` exception
- change `Object` or `{}` types to `{ [key: string]: any }`
- change `Function` type to `() => void`

Note:
This requires an update of `eslint` to v7 which is done in https://github.com/guardian/dotcom-rendering/pull/2579