### PR TITLE
Use a defined ID for AMP ad wrapper divs

### DIFF
--- a/src/amp/components/WithAds.tsx
+++ b/src/amp/components/WithAds.tsx
@@ -49,10 +49,7 @@ export const WithAds = ({ items, adSlots, adClassName, adInfo }: Props) => {
 			return (
 				<>
 					{item}
-					{/* TODO: we should not be assuming the JSX has an ID property and using it as such, we should update `items` to contain IDs and JSX elements */}
-					{/*
-                    // @ts-ignore */}
-					{ad(`ad-${item.id}`)}
+					{ad(`ad-${i + 1}`)}
 				</>
 			);
 		}


### PR DESCRIPTION
### Before

`ad-undefined` as ID for all AMP ad wrappers

### After

`ad-1` (or 2, 3, etc)

## Why?

It doesn't seem to matter either way from a reader perspective, but it allows us to remove some mysterious and (type) unsafe code.

https://trello.com/c/G4Bi9N6h/2459-fix-scary-jsxelement-extraction-of-id
