### PR TITLE
Add GDPR consent string to Prebid RTC

### DIFF
--- a/src/amp/components/Ad.test.tsx
+++ b/src/amp/components/Ad.test.tsx
@@ -21,11 +21,11 @@ describe('AdComponent', () => {
 	const permutiveURL =
 		'https://guardian.amp.permutive.com/rtc?type=doubleclick';
 	const usPrebidURL =
-		'https://prebid.adnxs.com/pbs/v1/openrtb2/amp?tag_id=7&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF';
+		'https://prebid.adnxs.com/pbs/v1/openrtb2/amp?tag_id=7&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF&gdpr_consent=CONSENT_STRING';
 	const auPrebidURL =
-		'https://prebid.adnxs.com/pbs/v1/openrtb2/amp?tag_id=6&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF';
+		'https://prebid.adnxs.com/pbs/v1/openrtb2/amp?tag_id=6&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF&gdpr_consent=CONSENT_STRING';
 	const rowPrebidURL =
-		'https://prebid.adnxs.com/pbs/v1/openrtb2/amp?tag_id=4&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF';
+		'https://prebid.adnxs.com/pbs/v1/openrtb2/amp?tag_id=4&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF&gdpr_consent=CONSENT_STRING';
 
 	beforeEach(() => {
 		commercialConfig.usePermutive = true;

--- a/src/amp/components/Ad.tsx
+++ b/src/amp/components/Ad.tsx
@@ -122,6 +122,7 @@ const realTimeConfig = (
 		'timeout=TIMEOUT',
 		'adcid=ADCID',
 		'purl=HREF',
+		'gdpr_consent=CONSENT_STRING',
 	].join('&');
 
 	const data = {

--- a/src/amp/components/AdConsent.tsx
+++ b/src/amp/components/AdConsent.tsx
@@ -107,20 +107,6 @@ export const AdConsent: React.FC = ({}) => {
 					}}
 				/>
 			</amp-consent>
-			<amp-iframe
-				width="1"
-				title="User Sync"
-				height="1"
-				sandbox="allow-scripts allow-same-origin"
-				frameborder="0"
-				src="https://acdn.adnxs.com/prebid/amp/user-sync/load-cookie-with-consent.html?endpoint=appnexus&max_sync_count=5&gdpr_consent=CONSENT_STRING"
-			>
-				<amp-img
-					layout="fill"
-					src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
-					placeholder={true}
-				/>
-			</amp-iframe>
 		</>
 	);
 };

--- a/src/amp/components/AdConsent.tsx
+++ b/src/amp/components/AdConsent.tsx
@@ -107,6 +107,20 @@ export const AdConsent: React.FC = ({}) => {
 					}}
 				/>
 			</amp-consent>
+			<amp-iframe
+				width="1"
+				title="User Sync"
+				height="1"
+				sandbox="allow-scripts allow-same-origin"
+				frameborder="0"
+				src="https://acdn.adnxs.com/prebid/amp/user-sync/load-cookie-with-consent.html?endpoint=appnexus&max_sync_count=5&gdpr_consent=CONSENT_STRING"
+			>
+				<amp-img
+					layout="fill"
+					src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
+					placeholder={true}
+				/>
+			</amp-iframe>
 		</>
 	);
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Add `CONSENT_STRING` macro to Prebid RTC query string.

### Comparison

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/108424937-d04d5a80-7207-11eb-8e1d-cce380669307.png
[after]: https://user-images.githubusercontent.com/76776/108425095-025ebc80-7208-11eb-9512-1c0b5cff70fb.png


## Why?

This is required by law, and partners will stop processing request without it from March 2021.