### PR TITLE
Bugfix: Discussion Rendering fix for POST in Chrome 49

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "@guardian/automat-client": "^0.2.16",
         "@guardian/braze-components": "^0.0.19",
         "@guardian/consent-management-platform": "^6.11.2",
-        "@guardian/discussion-rendering": "^6.1.1",
+        "@guardian/discussion-rendering": "^6.1.3",
         "@guardian/libs": "^1.6.3",
         "@guardian/shimport": "^1.0.2",
         "@guardian/src-button": "^2.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2410,10 +2410,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.11.2.tgz#668d0f911aff5c3bc42cb54c606b07640d18f0b8"
   integrity sha512-tX+lZZFgn9PP8RUj14MnsYa7ikBAyTWfQJPNls4o2Q5c+o0uRVYHnlgifvspj0k1m05rFEmYjnmj7rxwpnH2Xw==
 
-"@guardian/discussion-rendering@^6.1.1":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-6.1.1.tgz#1ba93897366a37072777c30293d6ad181790397b"
-  integrity sha512-qkmABiX4Wk+uWkp+OrL2EpKmWRPzewxX5hlv6nGEAD7SiuLw12PH6slWfMixf0bQiUzCLrhiMJ53i4Q6acI0WQ==
+"@guardian/discussion-rendering@^6.1.3":
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-6.1.3.tgz#51f00bd7ad9e7c28a4269b8a53da95d12895a61b"
+  integrity sha512-l0hm3tfBtj8ihJYwuAfr/coDUb/B9Va7hlxnmsoSHXakDDljezs549kkT1pOnYZcaiHoyoPy8rvtB8XVzpvqYQ==
   dependencies:
     babel-plugin-emotion "^10.0.33"
     customize-cra "^1.0.0"


### PR DESCRIPTION
## What does this change?

Bumps discussion to fix commenting and preview in Chrome 49 - Details in https://github.com/guardian/discussion-rendering/pull/441