### PR TITLE
Hf carousel textsize

### DIFF
--- a/src/web/components/CardHeadline.tsx
+++ b/src/web/components/CardHeadline.tsx
@@ -89,7 +89,7 @@ const fullCardImageTextStyles = css`
 	box-decoration-break: clone;
 	line-height: 1.25;
 	/* white-space: pre-wrap; */
-	padding-right:${space[1]}px;
+	padding-right: ${space[1]}px;
 	${until.desktop} {
 		${headline.xxxsmall()};
 	}

--- a/src/web/components/CardHeadline.tsx
+++ b/src/web/components/CardHeadline.tsx
@@ -81,14 +81,18 @@ const underlinedStyles = (size: SmallHeadlineSize) => {
 };
 
 const fullCardImageTextStyles = css`
-	${headline.xxxsmall()};
+	${headline.xxsmall()};
 	color: ${neutral[100]};
 	background-color: rgba(0, 0, 0, 0.75);
 	box-shadow: -${space[1]}px 0 0 rgba(0, 0, 0, 0.75);
 	/* Box decoration is required to push the box shadow out on Firefox */
 	box-decoration-break: clone;
 	line-height: 1.25;
-	white-space: pre-wrap;
+	/* white-space: pre-wrap; */
+	padding-right:${space[1]}px;
+	${until.desktop} {
+		${headline.xxxsmall()};
+	}
 `;
 
 export const CardHeadline = ({


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Increases font size of immersive carousel cards above desktop breakpoint. Also removed pre-wrap:whitespace and replaced with padding-right so that all lines of text get wrapped with the background colour.

### Before
![Screenshot 2021-02-19 at 14 10 37](https://user-images.githubusercontent.com/20658471/108514948-6d69cb00-72bc-11eb-9c4c-67a4eb7987df.png)

### After
![Screenshot 2021-02-19 at 14 06 14](https://user-images.githubusercontent.com/20658471/108514975-75296f80-72bc-11eb-989d-244de5d62156.png)

## Why?
Headline was a bitt small before
