### PR TITLE
Braze Epic

### DIFF
--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -71,12 +71,14 @@ import {
 	StickyNavSimple,
 	StickyNavBackscroll,
 } from '@root/src/web/components/Nav/StickNavTest/StickyNav';
+import { BrazeMessagesInterface } from '@root/src/web/lib/braze/BrazeMessages';
 import {
 	submitComponentEvent,
 	OphanComponentEvent,
 } from '../browser/ophan/ophan';
 import { trackPerformance } from '../browser/ga/ga';
 import { decidePalette } from '../lib/decidePalette';
+import { buildBrazeMessages } from '../lib/braze/buildBrazeMessages';
 
 // *******************************
 // ****** Dynamic imports ********
@@ -164,6 +166,10 @@ export const App = ({ CAPI, NAV }: Props) => {
 	// executing their canShow logic until countryCode is available):
 	const [asyncCountryCode, setAsyncCountryCode] = useState<
 		Promise<string | void>
+	>();
+
+	const [brazeMessages, setBrazeMessages] = useState<
+		Promise<BrazeMessagesInterface>
 	>();
 
 	const pageViewId = window.guardian?.config?.ophan?.pageViewId;
@@ -329,6 +335,12 @@ export const App = ({ CAPI, NAV }: Props) => {
 			}
 		});
 	}, []);
+
+	useOnce(() => {
+		setBrazeMessages(
+			buildBrazeMessages(isSignedIn as boolean, CAPI.config.idApiUrl),
+		);
+	}, [isSignedIn, CAPI.config.idApiUrl]);
 
 	const display: Display = decideDisplay(CAPI);
 	const design: Design = decideDesign(
@@ -958,6 +970,7 @@ export const App = ({ CAPI, NAV }: Props) => {
 					isPaidContent={CAPI.pageType.isPaidContent}
 					tags={CAPI.tags}
 					contributionsServiceUrl={CAPI.contributionsServiceUrl}
+					brazeMessages={brazeMessages}
 				/>
 			</Portal>
 			<Portal
@@ -1049,7 +1062,7 @@ export const App = ({ CAPI, NAV }: Props) => {
 					isSignedIn={isSignedIn}
 					asyncCountryCode={asyncCountryCode}
 					CAPI={CAPI}
-					idApiUrl={CAPI.config.idApiUrl}
+					brazeMessages={brazeMessages}
 				/>
 			</Portal>
 		</React.StrictMode>

--- a/src/web/components/SlotBodyEnd/BrazeEpic.tsx
+++ b/src/web/components/SlotBodyEnd/BrazeEpic.tsx
@@ -1,0 +1,174 @@
+import React, { useState } from 'react';
+import * as emotion from 'emotion';
+import * as emotionCore from '@emotion/core';
+import * as emotionTheming from 'emotion-theming';
+import {
+	parseBrazeEpicParams,
+	EpicDataFromBraze,
+	Variant,
+} from '@root/src/web/lib/braze/parseBrazeEpicParams';
+import { BrazeMessagesInterface } from '@root/src/web/lib/braze/BrazeMessages';
+import { CanShowResult } from '@root/src/web/lib/messagePicker';
+import { useOnce } from '@root/src/web/lib/useOnce';
+import { joinUrl } from '@root/src/lib/joinUrl';
+
+const { css } = emotion;
+
+const wrapperMargins = css`
+	margin: 18px 0;
+`;
+
+const EPIC_COMPONENT_PATH = '/epic.js';
+
+type NoEpicDataFromBraze = {
+	componentName: 'NoEpic';
+};
+
+type DataFromBraze = EpicDataFromBraze | NoEpicDataFromBraze;
+
+type Meta = {
+	dataFromBraze?: DataFromBraze;
+	logImpressionWithBraze: () => void;
+	// logButtonClickWithBraze: (id: number) => void; // TODO: Handle button click tracking
+};
+
+type EpicConfig = {
+	meta: Meta;
+	contributionsServiceUrl: string;
+	countryCode: string;
+};
+
+type Tracking = {
+	ophanPageId: string;
+	platformId: string;
+	clientName: string;
+	referrerUrl: string;
+};
+
+type EpicProps = {
+	variant: Variant;
+	tracking: Tracking;
+	numArticles: number;
+	countryCode: string;
+};
+
+export const canShow = async (
+	brazeMessagesPromise: Promise<BrazeMessagesInterface>,
+): Promise<CanShowResult> => {
+	try {
+		const brazeMessages = await brazeMessagesPromise;
+		const message = await brazeMessages.getMessageForEndOfArticle();
+
+		return {
+			result: true,
+			meta: {
+				dataFromBraze: message.extras,
+				logImpressionWithBraze: () => {
+					message.logImpression();
+				},
+			},
+		};
+	} catch (e) {
+		return { result: false };
+	}
+};
+
+const buildEpicProps = (
+	dataFromBraze: EpicDataFromBraze,
+	countryCode: string,
+): EpicProps | null => {
+	const variant = parseBrazeEpicParams(dataFromBraze);
+	if (variant === null) return null;
+
+	const pageTracking = {
+		ophanPageId: window.guardian.config.ophan.pageViewId,
+		platformId: 'GUARDIAN_WEB',
+		clientName: 'dcr',
+		referrerUrl: window.location.origin + window.location.pathname,
+	};
+
+	const tracking = {
+		...pageTracking,
+	};
+
+	return { variant, tracking, numArticles: 0, countryCode };
+};
+
+const BrazeEpic = ({
+	contributionsServiceUrl,
+	meta,
+	countryCode,
+}: EpicConfig) => {
+	const [Epic, setEpic] = useState<React.FC<EpicProps>>();
+
+	useOnce(() => {
+		window.guardian.automat = {
+			react: React,
+			preact: React,
+			emotionCore,
+			emotionTheming,
+			emotion,
+		};
+
+		const componentUrl = joinUrl([
+			contributionsServiceUrl,
+			EPIC_COMPONENT_PATH,
+		]);
+
+		window
+			.guardianPolyfilledImport(componentUrl)
+			.then((epicModule: { ContributionsEpic: React.FC<EpicProps> }) => {
+				setEpic(() => epicModule.ContributionsEpic); // useState requires functions to be wrapped
+				// TODO: log the impression when the epic is in view (using hasBeenSeen probably)
+				meta.logImpressionWithBraze();
+			})
+			.catch((error) => {
+				window.guardian.modules.sentry.reportError(error, 'braze-epic');
+			});
+	}, [contributionsServiceUrl, meta]);
+
+	if (Epic && meta.dataFromBraze) {
+		// This will come from Braze via the meta from canShow
+		const props = buildEpicProps(
+			meta.dataFromBraze as EpicDataFromBraze,
+			countryCode,
+		);
+
+		if (props) {
+			return (
+				<div className={wrapperMargins}>
+					{/* eslint-disable-next-line react/jsx-props-no-spreading */}
+					<Epic {...props} />
+				</div>
+			);
+		}
+	}
+
+	return null;
+};
+
+const NoEpic = () => null;
+
+export const MaybeBrazeEpic = ({
+	contributionsServiceUrl,
+	meta,
+	countryCode,
+}: EpicConfig) => {
+	const componentName = meta.dataFromBraze?.componentName;
+
+	if (componentName === 'Epic') {
+		return (
+			<BrazeEpic
+				contributionsServiceUrl={contributionsServiceUrl}
+				meta={meta}
+				countryCode={countryCode}
+			/>
+		);
+	}
+
+	if (componentName === 'NoEpic') {
+		return <NoEpic />;
+	}
+
+	return null;
+};

--- a/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -13,13 +13,14 @@ import {
 	MaybeFC,
 	CandidateConfig,
 } from '@root/src/web/lib/messagePicker';
+import { BrazeMessagesInterface } from '@root/src/web/lib/braze/BrazeMessages';
 import { BrazeBanner, canShow as canShowBrazeBanner } from './BrazeBanner';
 
 type Props = {
 	isSignedIn?: boolean;
 	asyncCountryCode?: Promise<string | void>;
 	CAPI: CAPIBrowserType;
-	idApiUrl: string;
+	brazeMessages?: Promise<BrazeMessagesInterface>;
 };
 
 const getBannerLastClosedAt = (key: string): string | undefined => {
@@ -86,12 +87,11 @@ const buildReaderRevenueBannerConfig = (
 };
 
 const buildBrazeBanner = (
-	isSignedIn: boolean,
-	idApiUrl: string,
+	brazeMessages: Promise<BrazeMessagesInterface>,
 ): CandidateConfig => ({
 	candidate: {
 		id: 'braze-banner',
-		canShow: () => canShowBrazeBanner(isSignedIn, idApiUrl),
+		canShow: () => canShowBrazeBanner(brazeMessages),
 		show: (meta: any) => () => <BrazeBanner meta={meta} />,
 	},
 	timeoutMillis: DEFAULT_BANNER_TIMEOUT_MILLIS,
@@ -101,7 +101,7 @@ export const StickyBottomBanner = ({
 	isSignedIn,
 	asyncCountryCode,
 	CAPI,
-	idApiUrl,
+	brazeMessages,
 }: Props) => {
 	const [SelectedBanner, setSelectedBanner] = useState<React.FC | null>(null);
 	useOnce(() => {
@@ -111,7 +111,9 @@ export const StickyBottomBanner = ({
 			isSignedIn as boolean,
 			asyncCountryCode as Promise<string>,
 		);
-		const brazeBanner = buildBrazeBanner(isSignedIn as boolean, idApiUrl);
+		const brazeBanner = buildBrazeBanner(
+			brazeMessages as Promise<BrazeMessagesInterface>,
+		);
 		const bannerConfig: SlotConfig = {
 			candidates: [CMP, readerRevenue, brazeBanner],
 			name: 'banner',
@@ -124,7 +126,7 @@ export const StickyBottomBanner = ({
 			.catch((e) =>
 				console.error(`StickyBottomBanner pickMessage - error: ${e}`),
 			);
-	}, [isSignedIn, asyncCountryCode, CAPI]);
+	}, [isSignedIn, asyncCountryCode, CAPI, brazeMessages]);
 
 	if (SelectedBanner) {
 		return <SelectedBanner />;

--- a/src/web/lib/braze/BrazeMessages.test.ts
+++ b/src/web/lib/braze/BrazeMessages.test.ts
@@ -1,5 +1,8 @@
+import type appboy from '@braze/web-sdk-core';
 import { createNanoEvents, Emitter } from 'nanoevents';
-import { BrazeMessages, Message, Callback } from './BrazeMessages';
+import { BrazeMessages } from './BrazeMessages';
+
+const logInAppMessageImpressionSpy = jest.fn();
 
 class FakeAppBoy {
 	emitter: Emitter;
@@ -8,21 +11,34 @@ class FakeAppBoy {
 		this.emitter = createNanoEvents();
 	}
 
-	subscribeToInAppMessage(fn: Callback) {
+	subscribeToInAppMessage(
+		fn: (message: appboy.InAppMessage | appboy.ControlMessage) => void,
+	) {
 		this.emitter.on('inAppMessage', fn);
 		return 'FAKE_SUBSCRIPTION_ID';
 	}
 
-	emit(payload: Message) {
+	emit(payload: any) {
 		this.emitter.emit('inAppMessage', payload);
 	}
+
+	// eslint-disable-next-line class-methods-use-this
+	logInAppMessageImpression(message: appboy.InAppMessage): void {
+		logInAppMessageImpressionSpy(message);
+	}
 }
+
+beforeEach(() => {
+	logInAppMessageImpressionSpy.mockClear();
+});
 
 describe('BrazeMessages', () => {
 	describe('getMessageForBanner & getMessageForEndOfArticle', () => {
 		it('returns a promise which resolves with message data for the correct slot', async () => {
-			const appboy = new FakeAppBoy();
-			const brazeMessages = new BrazeMessages(appboy);
+			const fakeAppBoy = new FakeAppBoy();
+			const brazeMessages = new BrazeMessages(
+				(fakeAppBoy as unknown) as typeof appboy,
+			);
 
 			const bannerPromise = brazeMessages.getMessageForBanner();
 			const endOfArticlePromise = brazeMessages.getMessageForEndOfArticle();
@@ -30,7 +46,7 @@ describe('BrazeMessages', () => {
 			const bannerMessage = {
 				extras: { slotName: 'Banner', title: 'Example' },
 			};
-			appboy.emit(bannerMessage);
+			fakeAppBoy.emit(bannerMessage);
 
 			const endOfArticleMessage = {
 				extras: {
@@ -38,19 +54,21 @@ describe('BrazeMessages', () => {
 					title: 'Example',
 				},
 			};
-			appboy.emit(endOfArticleMessage);
+			fakeAppBoy.emit(endOfArticleMessage);
 
 			const data = await Promise.all([
 				bannerPromise,
 				endOfArticlePromise,
 			]);
-			expect(data[0]).toEqual(bannerMessage);
-			expect(data[1]).toEqual(endOfArticleMessage);
+			expect(data[0].extras).toEqual(bannerMessage.extras);
+			expect(data[1].extras).toEqual(endOfArticleMessage.extras);
 		});
 
 		it('supports multiple calls to the same slot, returning separate promises', async () => {
-			const appboy = new FakeAppBoy();
-			const brazeMessages = new BrazeMessages(appboy);
+			const fakeAppBoy = new FakeAppBoy();
+			const brazeMessages = new BrazeMessages(
+				(fakeAppBoy as unknown) as typeof appboy,
+			);
 
 			const bannerPromise = brazeMessages.getMessageForBanner();
 			const anotherBannerPromise = brazeMessages.getMessageForBanner();
@@ -58,14 +76,33 @@ describe('BrazeMessages', () => {
 			const message = {
 				extras: { slotName: 'Banner', title: 'Example' },
 			};
-			appboy.emit(message);
+			fakeAppBoy.emit(message);
 
 			const data = await Promise.all([
 				bannerPromise,
 				anotherBannerPromise,
 			]);
-			expect(data[0]).toEqual(message);
-			expect(data[1]).toEqual(message);
+			expect(data[0].extras).toEqual(message.extras);
+			expect(data[1].extras).toEqual(message.extras);
+		});
+
+		it('returns a message which is capable of logging an impression', async () => {
+			const fakeAppBoy = new FakeAppBoy();
+			const brazeMessages = new BrazeMessages(
+				(fakeAppBoy as unknown) as typeof appboy,
+			);
+
+			const bannerPromise = brazeMessages.getMessageForBanner();
+
+			const message = {
+				extras: { slotName: 'Banner', title: 'Example' },
+			};
+			fakeAppBoy.emit(message);
+
+			const bannerMessage = await bannerPromise;
+			bannerMessage.logImpression();
+
+			expect(logInAppMessageImpressionSpy).toHaveBeenCalledWith(message);
 		});
 	});
 });

--- a/src/web/lib/braze/NullBrazeMessages.ts
+++ b/src/web/lib/braze/NullBrazeMessages.ts
@@ -1,0 +1,13 @@
+import { BrazeMessagesInterface } from './BrazeMessages';
+
+export class NullBrazeMessages implements BrazeMessagesInterface {
+	// eslint-disable-next-line class-methods-use-this
+	getMessageForBanner() {
+		return Promise.reject(new Error('No banner message'));
+	}
+
+	// eslint-disable-next-line class-methods-use-this
+	getMessageForEndOfArticle() {
+		return Promise.reject(new Error('No end of article message'));
+	}
+}

--- a/src/web/lib/braze/buildBrazeMessages.ts
+++ b/src/web/lib/braze/buildBrazeMessages.ts
@@ -1,0 +1,79 @@
+import {
+	hasCurrentBrazeUser,
+	setHasCurrentBrazeUser,
+	clearHasCurrentBrazeUser,
+} from '@root/src/web/lib/hasCurrentBrazeUser';
+import { initPerf } from '@root/src/web/browser/initPerf';
+import { record } from '@root/src/web/browser/ophan/ophan';
+import { BrazeMessages, BrazeMessagesInterface } from './BrazeMessages';
+import { checkBrazeDependencies } from './checkBrazeDependencies';
+import { getInitialisedAppboy, SDK_OPTIONS } from './initialiseAppboy';
+import { NullBrazeMessages } from './NullBrazeMessages';
+
+const maybeWipeUserData = async (
+	apiKey?: string,
+	brazeUuid?: null | string,
+): Promise<void> => {
+	if (apiKey && !brazeUuid && hasCurrentBrazeUser()) {
+		const appboy = await getInitialisedAppboy(apiKey);
+
+		try {
+			appboy.wipeData();
+			clearHasCurrentBrazeUser();
+		} catch (error) {
+			window.guardian.modules.sentry.reportError(error, 'braze-banner');
+		}
+	}
+};
+
+export const buildBrazeMessages = async (
+	isSignedIn: boolean,
+	idApiUrl: string,
+): Promise<BrazeMessagesInterface> => {
+	const dependenciesResult = await checkBrazeDependencies(
+		isSignedIn,
+		idApiUrl,
+	);
+
+	if (!dependenciesResult.isSuccessful) {
+		const { failure, data } = dependenciesResult;
+
+		if (SDK_OPTIONS.enableLogging) {
+			console.log(
+				`Not attempting to show Braze messages. Dependency ${failure.field} failed with ${failure.data}.`,
+			);
+		}
+
+		await maybeWipeUserData(
+			data.apiKey as string | undefined,
+			data.brazeUuid as string | null | undefined,
+		);
+
+		return new NullBrazeMessages();
+	}
+
+	try {
+		const sdkLoadTiming = initPerf('braze-sdk-load');
+		sdkLoadTiming.start();
+
+		const appboy = await getInitialisedAppboy(
+			dependenciesResult.data.apiKey as string,
+		);
+
+		const sdkLoadTimeTaken = sdkLoadTiming.end();
+		record({
+			component: 'braze-sdk-load-timing',
+			value: sdkLoadTimeTaken,
+		});
+
+		const brazeMessages = new BrazeMessages(appboy);
+
+		appboy.changeUser(dependenciesResult.data.brazeUuid as string);
+		appboy.openSession();
+		setHasCurrentBrazeUser();
+
+		return brazeMessages;
+	} catch {
+		return new NullBrazeMessages();
+	}
+};

--- a/src/web/lib/braze/initialiseAppboy.ts
+++ b/src/web/lib/braze/initialiseAppboy.ts
@@ -1,3 +1,5 @@
+import type appboy from '@braze/web-sdk-core';
+
 const SDK_OPTIONS = {
 	enableLogging: false,
 	noCookies: true,
@@ -6,14 +8,26 @@ const SDK_OPTIONS = {
 	minimumIntervalBetweenTriggerActionsInSeconds: 0,
 };
 
-const getInitialisedAppboy = async (apiKey: string): Promise<typeof appboy> => {
-	const { default: appboy } = await import(
+const initialiseAppboy = async (apiKey: string): Promise<typeof appboy> => {
+	const importedAppboy = ((await import(
 		/* webpackChunkName: "braze-web-sdk-core" */ '@braze/web-sdk-core'
-	);
+	)) as unknown) as typeof appboy;
 
-	appboy.initialize(apiKey, SDK_OPTIONS);
+	importedAppboy.initialize(apiKey, SDK_OPTIONS);
 
-	return appboy;
+	return importedAppboy;
 };
+
+const getInitialisedAppboy = (() => {
+	let cache: Promise<typeof appboy>;
+
+	return (apiKey: string): Promise<typeof appboy> => {
+		if (cache === undefined) {
+			cache = initialiseAppboy(apiKey);
+		}
+
+		return cache;
+	};
+})();
 
 export { getInitialisedAppboy, SDK_OPTIONS };

--- a/src/web/lib/braze/parseBrazeEpicParams.test.ts
+++ b/src/web/lib/braze/parseBrazeEpicParams.test.ts
@@ -1,0 +1,143 @@
+import {
+	EpicDataFromBraze,
+	parseBrazeEpicParams,
+} from './parseBrazeEpicParams';
+
+describe('parseBrazeEpicParams', () => {
+	it('returns a variant when params from Braze are valid', () => {
+		const dataFromBraze: EpicDataFromBraze = {
+			componentName: 'Epic',
+			heading: 'Example Heading',
+			paragraph1: 'Paragraph 1',
+			paragraph2: 'Paragraph 2',
+			paragraph3: 'Paragraph 3',
+			highlightedText: 'Example highlighted text',
+			buttonText: 'Button',
+			buttonUrl: 'https://www.example.com',
+		};
+
+		const expected = {
+			heading: 'Example Heading',
+			paragraphs: ['Paragraph 1', 'Paragraph 2', 'Paragraph 3'],
+			highlightedText: 'Example highlighted text',
+			cta: { text: 'Button', baseUrl: 'https://www.example.com' },
+		};
+
+		const got = parseBrazeEpicParams(dataFromBraze);
+
+		expect(got).toEqual(expected);
+	});
+
+	it('is lenient if paragraphs are not contiguous', () => {
+		const dataFromBraze: EpicDataFromBraze = {
+			componentName: 'Epic',
+			paragraph1: 'First paragraph',
+			paragraph3: 'Another paragraph',
+			heading: 'Example Heading',
+			highlightedText: 'Example highlighted text',
+			buttonText: 'Button',
+			buttonUrl: 'https://www.example.com',
+		};
+
+		const expected = {
+			heading: 'Example Heading',
+			paragraphs: ['First paragraph', 'Another paragraph'],
+			highlightedText: 'Example highlighted text',
+			cta: { text: 'Button', baseUrl: 'https://www.example.com' },
+		};
+
+		const got = parseBrazeEpicParams(dataFromBraze);
+
+		expect(got).toEqual(expected);
+	});
+
+	it('returns null when the heading is missing', () => {
+		const dataFromBraze: EpicDataFromBraze = {
+			componentName: 'Epic',
+			paragraph1: 'Paragraph 1',
+			paragraph2: 'Paragraph 2',
+			highlightedText: 'Example highlighted text',
+			buttonText: 'Button',
+			buttonUrl: 'https://www.example.com',
+		};
+
+		const got = parseBrazeEpicParams(dataFromBraze);
+
+		expect(got).toBeNull();
+	});
+
+	it('returns null when the paragraphs are missing', () => {
+		const dataFromBraze: EpicDataFromBraze = {
+			componentName: 'Epic',
+			heading: 'Example Heading',
+			highlightedText: 'Example highlighted text',
+			buttonText: 'Button',
+			buttonUrl: 'https://www.example.com',
+		};
+
+		const got = parseBrazeEpicParams(dataFromBraze);
+
+		expect(got).toBeNull();
+	});
+
+	it('returns null when the paragraphs are not truthy', () => {
+		const dataFromBraze: EpicDataFromBraze = {
+			componentName: 'Epic',
+			paragraph1: '',
+			paragraph2: '',
+			heading: 'Example Heading',
+			highlightedText: 'Example highlighted text',
+			buttonText: 'Button',
+			buttonUrl: 'https://www.example.com',
+		};
+
+		const got = parseBrazeEpicParams(dataFromBraze);
+
+		expect(got).toBeNull();
+	});
+
+	it('returns null when the highlightedText is missing', () => {
+		const dataFromBraze: EpicDataFromBraze = {
+			componentName: 'Epic',
+			heading: 'Example Heading',
+			paragraph1: 'Paragraph 1',
+			paragraph2: 'Paragraph 2',
+			buttonText: 'Button',
+			buttonUrl: 'https://www.example.com',
+		};
+
+		const got = parseBrazeEpicParams(dataFromBraze);
+
+		expect(got).toBeNull();
+	});
+
+	it('returns null when the buttonText is missing', () => {
+		const dataFromBraze: EpicDataFromBraze = {
+			componentName: 'Epic',
+			heading: 'Example Heading',
+			paragraph1: 'Paragraph 1',
+			paragraph2: 'Paragraph 2',
+			highlightedText: 'Example highlighted text',
+			buttonUrl: 'https://www.example.com',
+		};
+
+		const got = parseBrazeEpicParams(dataFromBraze);
+
+		expect(got).toBeNull();
+	});
+
+	it('returns null when the buttonUrl is missing', () => {
+		const dataFromBraze: EpicDataFromBraze = {
+			componentName: 'Epic',
+			heading: 'Example Heading',
+			paragraph1: 'Paragraph 1',
+			paragraph2: 'Paragraph 2',
+			highlightedText: 'Example highlighted text',
+			buttonText: 'Button',
+		};
+
+		const got = parseBrazeEpicParams(dataFromBraze);
+
+		expect(got).toBeNull();
+	});
+});

--- a/src/web/lib/braze/parseBrazeEpicParams.ts
+++ b/src/web/lib/braze/parseBrazeEpicParams.ts
@@ -1,0 +1,68 @@
+export type EpicDataFromBraze = {
+	componentName: 'Epic';
+	heading?: string;
+	highlightedText?: string;
+	buttonText?: string;
+	buttonUrl?: string;
+	paragraph1?: string;
+	paragraph2?: string;
+	paragraph3?: string;
+	paragraph4?: string;
+	paragraph5?: string;
+	paragraph6?: string;
+	paragraph7?: string;
+	paragraph8?: string;
+	paragraph9?: string;
+};
+
+export type Variant = {
+	// name: string;
+	heading: string;
+	paragraphs: Array<string>;
+	highlightedText: string;
+	cta: {
+		text: string;
+		baseUrl: string;
+	};
+};
+
+const parseParagraphs = (dataFromBraze: EpicDataFromBraze): string[] => {
+	const isParagraphKey = (k: string): boolean => /^paragraph\d$/.test(k);
+	const orderedParagraphKeys = Object.keys(dataFromBraze)
+		.filter(isParagraphKey)
+		.sort();
+
+	const paragraphs = [];
+
+	for (const key of orderedParagraphKeys) {
+		const value = dataFromBraze[key as keyof EpicDataFromBraze];
+		if (value) paragraphs.push(value);
+	}
+
+	return paragraphs;
+};
+
+export const parseBrazeEpicParams = (
+	dataFromBraze: EpicDataFromBraze,
+): Variant | null => {
+	const { heading, highlightedText, buttonText, buttonUrl } = dataFromBraze;
+
+	if (!heading || !highlightedText || !buttonText || !buttonUrl) {
+		console.log('Braze Epic: props missing', dataFromBraze);
+		return null;
+	}
+
+	const paragraphs = parseParagraphs(dataFromBraze);
+	if (paragraphs.length < 1) {
+		console.log('Braze Epic: no valid paragraphs received', dataFromBraze);
+		return null;
+	}
+
+	return {
+		// name: 'BrazeEpic', // This may be useful for click tracking once we add it
+		heading,
+		paragraphs,
+		highlightedText,
+		cta: { text: buttonText, baseUrl: buttonUrl },
+	};
+};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->

## What does this change?

Adds the BrazeEpic to DCR.

### Before

There was only the ReaderRevenueEpic.

### After

The BrazeEpic is also available for the end of article slot. Copy can be passed in from Braze via key-value pairs on an InAppMessage campaign.

The `BrazeMessages` instance, which we wrap the Braze SDK with is now shared with `SlotBodyEnd` and `StickyBottomBanner` via state held in `App.tsx`. We found that this was a better fit, and gave us more control over the session start call etc than our initial approach of memoizing the Braze SDK instance.

## Why?

To allow Marketing to target custom Epics to supporters.

## Other information

As is this isn't _quite_ ready to be used in production. We're currently missing some tracking events for the epic. We'll follow up in another PR to add these. Epic's won't be configured in Braze until this work is done.

The actual epic component is dynamically imported from the `support-dotcom-components` service and we translate the data we get from Braze to the format that component expects for its props. For the paragraphs, which can vary in number, we've limited to 9 for simplicity (the component itself has no limit in theory). This should cover most scenarios and can always be tweaked in future.

`cta` is derived from two key-value pairs from Braze - 'buttonText' and 'buttonUrl'.

The current key-value pairs are:

```typescript
type DataFromBraze = {
  name?: string;
  heading?: string; 
  paragraph1?: string;
  paragraph2?: string;
  paragraph3?: string;
  paragraph4?: string;
  paragraph5?: string;
  paragraph6?: string;
  paragraph7?: string;
  paragraph8?: string;
  paragraph9?: string;
  highlightedText?: string;
  buttonText?: string;
  buttonUrl?: string;
};
```

I chose an essentially arbitrary timeout of 10,000ms. It seems useful to have a limit (to prevent the epic loading a long time after the rest of the page does) - but I don't think we need a short timeout like the brazeBanner does as users will probably not reach the endOfArticle slot as quickly.