### PR TITLE
Sticky nav (easier to review PR)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -195,6 +195,14 @@ interface BaseNavType {
 	readerRevenueLinks: ReaderRevenuePositions;
 }
 
+// TODO rename
+interface SimpleNavType {
+	pillars: PillarType[];
+	otherLinks: MoreType;
+	brandExtensions: LinkType[];
+	readerRevenueLinks: ReaderRevenuePositions;
+}
+
 interface NavType extends BaseNavType {
 	pillars: PillarType[];
 }
@@ -684,11 +692,17 @@ interface DCRServerDocumentData {
 	linkedData: { [key: string]: any; };
 }
 
+interface BrowserNavType {
+	topLevelPillars: PillarType[];
+	currentNavLink: string;
+	subNavSections?: SubNavType;
+}
+
 interface DCRBrowserDocumentData {
 	page: string;
 	site: string;
 	CAPI: CAPIBrowserType;
-	NAV: SubNavBrowserType;
+	NAV: BrowserNavType;
 	GA: GADataType;
 	linkedData: { [key: string]: any; };
 }
@@ -730,7 +744,8 @@ type IslandType =
 	| 'map-block-element'
 	| 'spotify-block-element'
 	| 'video-facebook-block-element'
-	| 'vine-block-element';
+	| 'vine-block-element'
+	| 'sticky-nav-root';
 
 // All Components that are loaded with loadable
 // should be added here, this is the chunk name as

--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -314,6 +314,17 @@ export interface WindowGuardian {
 	};
 }
 
+export const makeGuardianBrowserNav = (nav: NavType): BrowserNavType => {
+	return {
+		topLevelPillars: nav.pillars.map((p) => ({
+			...p,
+			children: undefined,
+		})),
+		currentNavLink: nav.currentNavLink,
+		subNavSections: nav.subNavSections,
+	};
+};
+
 export const makeWindowGuardian = (
 	dcrDocumentData: DCRServerDocumentData,
 	cssIDs: string[],
@@ -323,10 +334,7 @@ export const makeWindowGuardian = (
 			cssIDs,
 			data: {
 				...dcrDocumentData,
-				NAV: {
-					subNavSections: dcrDocumentData.NAV.subNavSections,
-					currentNavLink: dcrDocumentData.NAV.currentNavLink,
-				},
+				NAV: makeGuardianBrowserNav(dcrDocumentData.NAV),
 				CAPI: makeGuardianBrowserCAPI(dcrDocumentData.CAPI),
 			},
 		},

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -68,6 +68,10 @@ import { SpotifyBlockComponent } from '@root/src/web/components/elements/Spotify
 import { VideoFacebookBlockComponent } from '@root/src/web/components/elements/VideoFacebookBlockComponent';
 import { VineBlockComponent } from '@root/src/web/components/elements/VineBlockComponent';
 import {
+	StickyNavSimple,
+	StickyNavBackscroll,
+} from '@root/src/web/components/Nav/StickNavTest/StickyNav';
+import {
 	submitComponentEvent,
 	OphanComponentEvent,
 } from '../browser/ophan/ophan';
@@ -128,7 +132,7 @@ const GetMatchStats = React.lazy(() => {
 
 type Props = {
 	CAPI: CAPIBrowserType;
-	NAV: NavType;
+	NAV: BrowserNavType;
 };
 
 const componentEventHandler = (
@@ -346,6 +350,16 @@ export const App = ({ CAPI, NAV }: Props) => {
 
 	const adTargeting: AdTargeting = buildAdTargeting(CAPI.config);
 
+	// sticky nav test status
+	const inStickyNavBackscroll = ABTestAPI.isUserInVariant(
+		'stickyNavTest',
+		'sticky-nav-backscroll',
+	);
+	const inStickyNavSimple = ABTestAPI.isUserInVariant(
+		'stickyNavTest',
+		'sticky-nav-simple',
+	);
+
 	// There are docs on loadable in ./docs/loadable-components.md
 	const YoutubeBlockComponent = loadable(
 		() => {
@@ -493,6 +507,29 @@ export const App = ({ CAPI, NAV }: Props) => {
 					</>
 				</HydrateOnce>
 			))}
+
+			{inStickyNavBackscroll && (
+				<Portal root="sticky-nav-root">
+					<StickyNavBackscroll
+						capiData={CAPI}
+						navData={NAV}
+						format={format}
+						palette={palette}
+					/>
+				</Portal>
+			)}
+
+			{inStickyNavSimple && (
+				<Portal root="sticky-nav-root">
+					<StickyNavSimple
+						capiData={CAPI}
+						navData={NAV}
+						format={format}
+						palette={palette}
+					/>
+				</Portal>
+			)}
+
 			{NAV.subNavSections && (
 				<HydrateOnce root="sub-nav-root">
 					<>

--- a/src/web/components/HydrateApp.tsx
+++ b/src/web/components/HydrateApp.tsx
@@ -11,7 +11,7 @@ import { loadableReady } from '@loadable/component';
 
 type Props = {
 	CAPI: CAPIBrowserType;
-	NAV: NavType;
+	NAV: BrowserNavType;
 };
 
 export const HydrateApp = ({ CAPI, NAV }: Props) => {

--- a/src/web/components/Nav/StickNavTest/ExpandedMenu/CollapseColumnButton.tsx
+++ b/src/web/components/Nav/StickNavTest/ExpandedMenu/CollapseColumnButton.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { css, cx } from 'emotion';
+
+import { from } from '@guardian/src-foundations/mq';
+import { brandText, brandAlt } from '@guardian/src-foundations/palette';
+import { headline } from '@guardian/src-foundations/typography';
+
+const hideDesktop = css`
+	${from.desktop} {
+		display: none;
+	}
+`;
+
+const showColumnLinksStyle = (columnInputId: string) => css`
+	/*
+        IMPORTANT NOTE:
+        we need to specify the adjacent path to the a (current) tag
+        to apply styles to the nested tabs due to the fact we use ~
+        to support NoJS
+    */
+	/* stylelint-disable-next-line selector-type-no-unknown */
+	${`#${columnInputId}`}:checked ~ & {
+		:before {
+			margin-top: 8px;
+			transform: rotate(-135deg);
+		}
+	}
+`;
+
+const collapseColumnButton = css`
+	user-select: none;
+	background-color: transparent;
+	border: 0;
+	box-sizing: border-box;
+	cursor: pointer;
+	color: ${brandText.primary};
+	display: block;
+	${headline.xsmall()};
+	font-weight: 700;
+	outline: none;
+	padding: 6px 34px 18px 50px;
+	position: relative;
+	text-align: left;
+	width: 100%;
+	> * {
+		pointer-events: none;
+	}
+	text-transform: capitalize;
+	:before {
+		margin-top: 4px;
+		left: 25px;
+		position: absolute;
+		border: 2px solid currentColor;
+		border-top: 0;
+		border-left: 0;
+		content: '';
+		display: inline-block;
+		height: 10px;
+		transform: rotate(45deg);
+		width: 10px;
+	}
+	:hover,
+	:focus {
+		color: ${brandAlt[400]};
+	}
+`;
+
+export const CollapseColumnButton: React.FC<{
+	title: string;
+	columnInputId: string;
+	collapseColumnInputId: string;
+	ariaControls: string;
+}> = ({ title, columnInputId, collapseColumnInputId, ariaControls }) => (
+	/* eslint-disable @typescript-eslint/ban-ts-comment, jsx-a11y/label-has-associated-control, @typescript-eslint/no-unused-expressions, react/no-unknown-property, jsx-a11y/no-noninteractive-element-to-interactive-role */
+	// @ts-ignore
+	<label
+		id={collapseColumnInputId}
+		className={cx(
+			'selectableMenuItem',
+			collapseColumnButton,
+			showColumnLinksStyle(columnInputId),
+			hideDesktop,
+		)}
+		aria-label={`Toggle ${title}`}
+		htmlFor={columnInputId}
+		aria-haspopup="true"
+		aria-controls={ariaControls}
+		// @ts-ignore
+		tabIndex={-1}
+		role="menuitem"
+		data-cy={`column-collapse-${title}`}
+	>
+		{title}
+	</label>
+	/* eslint-enable @typescript-eslint/ban-ts-comment, jsx-a11y/label-has-associated-control, @typescript-eslint/no-unused-expressions, react/no-unknown-property, jsx-a11y/no-noninteractive-element-to-interactive-role  */
+);

--- a/src/web/components/Nav/StickNavTest/ExpandedMenu/Column.tsx
+++ b/src/web/components/Nav/StickNavTest/ExpandedMenu/Column.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { css, cx } from 'emotion';
 
 import { brand, brandText, brandAlt } from '@guardian/src-foundations/palette';
@@ -174,30 +174,37 @@ export const Column = ({
 	const columnInputId = `${column.title}-checkbox-input`;
 	const collapseColumnInputId = `${column.title}-button`;
 
+	/*
+        IMPORTANT NOTE: Supporting NoJS and accessibility is hard.
+
+        We therefore use JS to make the Nav elements more accessibile. We add a
+        keydown `addEventListener` to toggle the column drop down.
+        This is not a perfect solution as not all screen readers support JS
+        https://webaim.org/projects/screenreadersurvey8/#javascript
+    */
+	useEffect(() => {
+		const handler = (e: KeyboardEvent) => {
+			// keyCode: 13 => Enter key | keyCode: 32 => Space key
+			if (e.keyCode === 13 || e.keyCode === 32) {
+				e.preventDefault();
+				const el = document.getElementById(columnInputId);
+				el?.click();
+			}
+		};
+
+		document
+			.getElementById(collapseColumnInputId)
+			?.addEventListener('keydown', handler);
+
+		return () => {
+			document
+				.getElementById(collapseColumnInputId)
+				?.removeEventListener('keydown', handler);
+		};
+	}, [columnInputId, collapseColumnInputId]);
+
 	return (
 		<li className={cx(columnStyle, pillarDivider)} role="none">
-			{/*
-                IMPORTANT NOTE: Supporting NoJS and accessibility is hard.
-
-                We therefore use JS to make the Nav elements more accessibile. We add a
-                keydown `addEventListener` to toggle the column drop down.
-                This is not a perfect solution as not all screen readers support JS
-                https://webaim.org/projects/screenreadersurvey8/#javascript
-            */}
-			<script
-				dangerouslySetInnerHTML={{
-					__html: `document.addEventListener('DOMContentLoaded', function(){
-                        document.getElementById('${collapseColumnInputId}').addEventListener('keydown', function(e){
-                            // keyCode: 13 => Enter key | keyCode: 32 => Space key
-                            if (e.keyCode === 13 || e.keyCode === 32) {
-                                e.preventDefault()
-                                document.getElementById('${columnInputId}').click();
-                            }
-                        })
-                    })`,
-				}}
-			/>
-
 			{/*
                 IMPORTANT NOTE:
                 It is important to have the input as the 1st sibling for NoJS to work

--- a/src/web/components/Nav/StickNavTest/ExpandedMenu/Column.tsx
+++ b/src/web/components/Nav/StickNavTest/ExpandedMenu/Column.tsx
@@ -1,0 +1,262 @@
+import React from 'react';
+import { css, cx } from 'emotion';
+
+import { brand, brandText, brandAlt } from '@guardian/src-foundations/palette';
+import { textSans } from '@guardian/src-foundations/typography';
+import { from, until } from '@guardian/src-foundations/mq';
+import { visuallyHidden } from '@guardian/src-foundations/accessibility';
+
+import { CollapseColumnButton } from './CollapseColumnButton';
+
+// CSS
+export const hideDesktop = css`
+	${from.desktop} {
+		display: none;
+	}
+`;
+
+const pillarDivider = css`
+	${from.desktop} {
+		:before {
+			content: '';
+			display: block;
+			position: absolute;
+			right: 0;
+			top: 0;
+			bottom: 0;
+			width: 1px;
+			background-color: ${brand[600]};
+			z-index: 1;
+		}
+	}
+`;
+
+const columnLinkTitle = css`
+	${textSans.medium({ lineHeight: 'tight' })};
+	background-color: transparent;
+	text-decoration: none;
+	border: 0;
+	box-sizing: border-box;
+	color: ${brandText.primary};
+	cursor: pointer;
+	display: inline-block;
+	font-weight: 500;
+	outline: none;
+	padding: 8px 34px 8px 50px;
+	position: relative;
+	text-align: left;
+	width: 100%;
+
+	${from.tablet} {
+		padding-left: 60px;
+	}
+
+	${from.desktop} {
+		font-size: 16px;
+		padding: 6px 0;
+	}
+
+	:hover,
+	:focus {
+		color: ${brandAlt[400]};
+		text-decoration: underline;
+	}
+
+	> * {
+		pointer-events: none;
+	}
+`;
+
+const mainMenuLinkStyle = css`
+	box-sizing: border-box;
+	overflow: hidden;
+	position: relative;
+	width: 100%;
+	${from.desktop} {
+		display: list-item;
+	}
+`;
+
+const columnLinks = css`
+	${textSans.medium()};
+	box-sizing: border-box;
+	display: flex;
+	flex-wrap: wrap;
+	list-style: none;
+	margin: 0;
+	padding: 0 0 12px;
+	position: relative;
+	${from.desktop} {
+		display: flex;
+		flex-direction: column;
+		flex-wrap: nowrap;
+		order: 1;
+		height: 100%;
+		width: 100%;
+		padding: 0 9px;
+	}
+`;
+
+const firstColumnLinks = css`
+	${from.desktop} {
+		padding-left: 0;
+	}
+`;
+
+const pillarColumnLinks = css`
+	${until.tablet} {
+		background: ${brand[300]};
+	}
+`;
+
+const hideStyles = (columnInputId: string) => css`
+	${until.desktop} {
+		/* stylelint-disable-next-line selector-type-no-unknown */
+		${`#${columnInputId}`}:not(:checked) ~ & {
+			display: none;
+		}
+	}
+`;
+
+const columnStyle = css`
+	${textSans.medium()};
+	list-style: none;
+	margin: 0;
+	padding-bottom: 10px;
+	position: relative;
+
+	:after {
+		background-color: ${brand[600]};
+		top: 0;
+		content: '';
+		display: block;
+		height: 1px;
+		left: 50px;
+		position: absolute;
+		right: 0;
+	}
+
+	/* Remove the border from the top item on mobile */
+	:first-of-type:after {
+		content: none;
+	}
+
+	${from.desktop} {
+		width: 134px;
+		float: left;
+		position: relative;
+
+		:after {
+			content: none;
+		}
+
+		:first-of-type {
+			width: 123px;
+		}
+	}
+	${from.leftCol} {
+		width: 160px;
+
+		:first-of-type {
+			width: 150px;
+		}
+	}
+`;
+
+export const Column = ({
+	column,
+	index,
+}: {
+	column: PillarType;
+	index: number;
+}) => {
+	// As the elements are dynamic we need to specify the IDs here
+	const columnInputId = `${column.title}-checkbox-input`;
+	const collapseColumnInputId = `${column.title}-button`;
+
+	return (
+		<li className={cx(columnStyle, pillarDivider)} role="none">
+			{/*
+                IMPORTANT NOTE: Supporting NoJS and accessibility is hard.
+
+                We therefore use JS to make the Nav elements more accessibile. We add a
+                keydown `addEventListener` to toggle the column drop down.
+                This is not a perfect solution as not all screen readers support JS
+                https://webaim.org/projects/screenreadersurvey8/#javascript
+            */}
+			<script
+				dangerouslySetInnerHTML={{
+					__html: `document.addEventListener('DOMContentLoaded', function(){
+                        document.getElementById('${collapseColumnInputId}').addEventListener('keydown', function(e){
+                            // keyCode: 13 => Enter key | keyCode: 32 => Space key
+                            if (e.keyCode === 13 || e.keyCode === 32) {
+                                e.preventDefault()
+                                document.getElementById('${columnInputId}').click();
+                            }
+                        })
+                    })`,
+				}}
+			/>
+
+			{/*
+                IMPORTANT NOTE:
+                It is important to have the input as the 1st sibling for NoJS to work
+                as we use ~ to apply certain styles on checkbox checked and ~ can only
+                apply to styles with elements that are preceded
+            */}
+			<input
+				type="checkbox"
+				className={css`
+					${visuallyHidden};
+				`}
+				id={columnInputId}
+				tabIndex={-1}
+				key="OpenExpandedMenuCheckbox"
+				aria-hidden="true"
+			/>
+			<CollapseColumnButton
+				collapseColumnInputId={collapseColumnInputId}
+				title={column.title}
+				columnInputId={columnInputId}
+				ariaControls={`${column.title.toLowerCase()}Links`}
+			/>
+
+			{/* ColumnLinks */}
+			<ul
+				className={cx(
+					columnLinks,
+					{ [firstColumnLinks]: index === 0 },
+					{ [pillarColumnLinks]: !!column.pillar },
+					columnInputId && hideStyles(columnInputId),
+				)}
+				role="menu"
+				id={`${column.title.toLowerCase()}Links`}
+				data-cy={`${column.title.toLowerCase()}Links`}
+			>
+				{(column.children || []).map((link) => (
+					<li
+						key={link.title.toLowerCase()}
+						className={cx(mainMenuLinkStyle, {
+							[hideDesktop]: !!link.mobileOnly,
+						})}
+						role="none"
+					>
+						<a
+							className={cx(
+								'selectableMenuItem',
+								columnLinkTitle,
+							)}
+							href={link.url}
+							role="menuitem"
+							data-link-name={`nav2 : secondary : ${link.longTitle}`}
+							data-cy={`column-collapse-sublink-${link.title}`}
+							tabIndex={-1}
+						>
+							{link.longTitle}
+						</a>
+					</li>
+				))}
+			</ul>
+		</li>
+	);
+};

--- a/src/web/components/Nav/StickNavTest/ExpandedMenu/Columns.tsx
+++ b/src/web/components/Nav/StickNavTest/ExpandedMenu/Columns.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import { css, cx } from 'emotion';
+
+import { brand, brandText, brandAlt } from '@guardian/src-foundations/palette';
+import { headline, textSans } from '@guardian/src-foundations/typography';
+import { from } from '@guardian/src-foundations/mq';
+
+import { Column } from './Column';
+import { ReaderRevenueLinks } from './ReaderRevenueLinks';
+import { MoreColumn } from './MoreColumn';
+
+const ColumnsStyle = css`
+	box-sizing: border-box;
+	max-width: none;
+	${from.desktop} {
+		max-width: 980px;
+		padding: 0 20px;
+		position: relative;
+		margin: 0 auto;
+		display: flex;
+		border-left: 1px solid ${brand[600]};
+		border-right: 1px solid ${brand[600]};
+	}
+	${from.leftCol} {
+		max-width: 1140px;
+	}
+	${from.wide} {
+		max-width: 1300px;
+	}
+`;
+
+const desktopBrandExtensionColumn = css`
+	${from.desktop} {
+		display: block;
+	}
+	display: none;
+	position: absolute;
+	right: 20px;
+	top: 4px;
+	bottom: 0;
+`;
+
+const brandExtensionList = css`
+	width: 131px;
+	box-sizing: border-box;
+	${textSans.medium()};
+	flex-wrap: wrap;
+	list-style: none;
+	margin: 0;
+	padding: 0 0 12px;
+	display: flex;
+	flex-direction: column;
+	padding-bottom: 0;
+	${from.leftCol} {
+		width: 140px;
+	}
+	${from.wide} {
+		width: 300px;
+	}
+`;
+
+const brandExtensionListItem = css`
+	margin-right: 0;
+	margin-top: -6px;
+	padding-bottom: 0;
+`;
+
+const brandExtensionLink = css`
+	${headline.xxsmall()};
+	font-weight: 700;
+	background-color: transparent;
+	border: 0;
+	box-sizing: border-box;
+	color: ${brandText.primary};
+	cursor: pointer;
+	display: inline-block;
+	outline: none;
+	padding: 8px 34px 8px 50px;
+	position: relative;
+	text-align: left;
+	width: 100%;
+	text-decoration: none;
+	${from.tablet} {
+		padding-left: 60px;
+	}
+	${from.desktop} {
+		padding: 6px 0;
+	}
+	${from.wide} {
+		font-size: 24px;
+	}
+	:hover,
+	:focus {
+		color: ${brandAlt[400]};
+	}
+	> * {
+		pointer-events: none;
+	}
+`;
+
+export const Columns: React.FC<{
+	nav: NavType;
+}> = ({ nav }) => (
+	<ul className={ColumnsStyle} role="menubar" data-cy="nav-menu-columns">
+		{nav.pillars.map((column, i) => (
+			<Column
+				column={column}
+				key={column.title.toLowerCase()}
+				index={i}
+			/>
+		))}
+		<ReaderRevenueLinks readerRevenueLinks={nav.readerRevenueLinks} />
+		<MoreColumn
+			column={nav.otherLinks}
+			brandExtensions={nav.brandExtensions}
+			key="more"
+		/>
+		<li className={desktopBrandExtensionColumn} role="none">
+			<ul className={brandExtensionList} role="menu">
+				{nav.brandExtensions.map((brandExtension) => (
+					<li
+						className={brandExtensionListItem}
+						key={brandExtension.title}
+					>
+						<a
+							className={cx(
+								'selectableMenuItem',
+								brandExtensionLink,
+							)}
+							href={brandExtension.url}
+							key={brandExtension.title}
+							role="menuitem"
+							data-link-name={`nav2 : brand extension : ${brandExtension.longTitle}`}
+							tabIndex={-1}
+						>
+							{brandExtension.longTitle}
+						</a>
+					</li>
+				))}
+			</ul>
+		</li>
+	</ul>
+);

--- a/src/web/components/Nav/StickNavTest/ExpandedMenu/ExpandedMenu.tsx
+++ b/src/web/components/Nav/StickNavTest/ExpandedMenu/ExpandedMenu.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { brandBackground } from '@guardian/src-foundations/palette';
+import { textSans } from '@guardian/src-foundations/typography';
+import { from, until } from '@guardian/src-foundations/mq';
+
+import { Display } from '@guardian/types';
+import { ShowMoreMenu } from './ShowMoreMenu';
+import { VeggieBurgerMenu } from './VeggieBurgerMenu';
+import { Columns } from './Columns';
+import { navInputCheckboxId } from '../../config';
+
+const mainMenuStyles = css`
+	background-color: ${brandBackground.primary};
+	box-sizing: border-box;
+	${textSans.large()};
+	left: 0;
+	margin-right: 29px;
+	padding-bottom: 24px;
+	top: 0;
+	z-index: 1070;
+	overflow: hidden;
+
+	/*
+        IMPORTANT NOTE:
+        we need to specify the adjacent path to the a (current) tag
+        to apply styles to the nested tabs due to the fact we use ~
+        to support NoJS
+    */
+	/* stylelint-disable-next-line selector-type-no-unknown */
+	${`#${navInputCheckboxId}`}:checked ~ div & {
+		${from.desktop} {
+			display: block;
+			overflow: visible;
+		}
+	}
+
+	${from.desktop} {
+		display: none;
+		position: absolute;
+		padding-bottom: 0;
+		padding-top: 0;
+		top: 100%;
+		left: 0;
+		right: 0;
+		width: 100%;
+		@supports (width: 100vw) {
+			left: 50%;
+			right: 50%;
+			width: 100vw;
+			margin-left: -50vw;
+			margin-right: -50vw;
+		}
+	}
+
+	/* refer to comment above */
+	/* stylelint-disable */
+	${`#${navInputCheckboxId}`}:checked ~ div & {
+		${until.desktop} {
+			transform: translateX(
+				0%
+			); /* when translateX is set to 0% it reapears on the screen */
+		}
+	}
+
+	${until.desktop} {
+		transform: translateX(
+			-110%
+		); /* the negative translateX makes the nav hide to the side */
+		transition: transform 0.4s cubic-bezier(0.23, 1, 0.32, 1);
+		box-shadow: 3px 0 16px rgba(0, 0, 0, 0.4);
+		bottom: 0;
+		height: 100%;
+		overflow: auto;
+		padding-top: 6px;
+		position: fixed;
+		right: 0;
+		will-change: transform;
+	}
+
+	${from.mobileMedium} {
+		margin-right: 29px;
+	}
+	${from.mobileLandscape} {
+		margin-right: 70px;
+	}
+	${from.tablet} {
+		margin-right: 100px;
+	}
+`;
+
+export const ExpandedMenu: React.FC<{
+	display: Display;
+	nav: NavType;
+}> = ({ display, nav }) => {
+	return (
+		<div id="expanded-menu">
+			<ShowMoreMenu display={display} />
+			<VeggieBurgerMenu display={display} />
+			<div
+				id="expanded-menu"
+				className={mainMenuStyles}
+				data-testid="expanded-menu"
+				data-cy="expanded-menu"
+			>
+				<Columns nav={nav} />
+			</div>
+		</div>
+	);
+};

--- a/src/web/components/Nav/StickNavTest/ExpandedMenu/MoreColumn.tsx
+++ b/src/web/components/Nav/StickNavTest/ExpandedMenu/MoreColumn.tsx
@@ -1,0 +1,211 @@
+import React from 'react';
+import { css, cx } from 'emotion';
+
+import { brand, brandText, brandAlt } from '@guardian/src-foundations/palette';
+import { textSans } from '@guardian/src-foundations/typography';
+import { from, until } from '@guardian/src-foundations/mq';
+
+const pillarHeight = 42;
+
+export const hideDesktop = css`
+	${from.desktop} {
+		display: none;
+	}
+`;
+
+const pillarColumnLinks = css`
+	${until.tablet} {
+		background: ${brand[300]};
+	}
+`;
+
+const columnStyle = css`
+	${textSans.medium()};
+	list-style: none;
+	margin: 0;
+	padding-bottom: 10px;
+	position: relative;
+
+	:after {
+		background-color: ${brand[600]};
+		top: 0;
+		content: '';
+		display: block;
+		height: 1px;
+		left: 50px;
+		position: absolute;
+		right: 0;
+	}
+
+	/* Remove the border from the top item on mobile */
+	:first-of-type:after {
+		content: none;
+	}
+
+	${from.desktop} {
+		width: 134px;
+		float: left;
+		position: relative;
+
+		:after {
+			content: none;
+		}
+
+		:first-of-type {
+			width: 123px;
+		}
+	}
+	${from.leftCol} {
+		width: 160px;
+
+		:first-of-type {
+			width: 150px;
+		}
+	}
+`;
+
+const pillarDivider = css`
+	${from.desktop} {
+		:before {
+			content: '';
+			display: block;
+			position: absolute;
+			right: 0;
+			top: 0;
+			bottom: 0;
+			width: 1px;
+			background-color: ${brand[600]};
+			z-index: 1;
+		}
+	}
+`;
+
+const pillarDividerExtended = css`
+	${from.desktop} {
+		:before {
+			top: -${pillarHeight}px;
+		}
+	}
+`;
+
+const columnLinks = css`
+	${textSans.medium()};
+	box-sizing: border-box;
+	display: flex;
+	flex-wrap: wrap;
+	list-style: none;
+	margin: 0;
+	padding: 0 0 12px;
+	position: relative;
+	${from.desktop} {
+		display: flex;
+		flex-direction: column;
+		flex-wrap: nowrap;
+		order: 1;
+		height: 100%;
+		width: 100%;
+		padding: 0 9px;
+	}
+`;
+
+const columnLinkTitle = css`
+	${textSans.medium({ lineHeight: 'tight' })};
+	background-color: transparent;
+	text-decoration: none;
+	border: 0;
+	box-sizing: border-box;
+	color: ${brandText.primary};
+	cursor: pointer;
+	display: inline-block;
+	font-weight: 500;
+	outline: none;
+	padding: 8px 34px 8px 50px;
+	position: relative;
+	text-align: left;
+	width: 100%;
+
+	${from.tablet} {
+		padding-left: 60px;
+	}
+
+	${from.desktop} {
+		font-size: 16px;
+		padding: 6px 0;
+	}
+
+	:hover,
+	:focus {
+		color: ${brandAlt[400]};
+		text-decoration: underline;
+	}
+
+	> * {
+		pointer-events: none;
+	}
+`;
+
+const mainMenuLinkStyle = css`
+	box-sizing: border-box;
+	overflow: hidden;
+	position: relative;
+	width: 100%;
+	${from.desktop} {
+		display: list-item;
+	}
+`;
+
+export const MoreColumn: React.FC<{
+	column: LinkType;
+	brandExtensions: LinkType[];
+}> = ({ column, brandExtensions }) => {
+	const subNavId = `${column.title.toLowerCase()}Links`;
+	// Add the brand extensions to 'more' on mobile.
+	const moreColumn = {
+		...column,
+		children: [
+			...brandExtensions.map((brandExtension) => ({
+				...brandExtension,
+				mobileOnly: true,
+			})),
+			...(column.children || []),
+		],
+	};
+	return (
+		<li
+			className={cx(columnStyle, pillarDivider, pillarDividerExtended)}
+			role="none"
+		>
+			<ul
+				className={cx(columnLinks, {
+					[pillarColumnLinks]: !!moreColumn.pillar,
+				})}
+				role="menu"
+				id={subNavId}
+			>
+				{(moreColumn.children || []).map((link) => (
+					<li
+						key={link.title.toLowerCase()}
+						className={cx(mainMenuLinkStyle, {
+							[hideDesktop]: !!link.mobileOnly,
+						})}
+						role="none"
+					>
+						<a
+							className={cx(
+								'selectableMenuItem',
+								columnLinkTitle,
+							)}
+							href={link.url}
+							role="menuitem"
+							data-link-name={`nav2 : secondary : ${link.longTitle}`}
+							data-cy={`column-collapse-sublink-${link.title}`}
+							tabIndex={-1}
+						>
+							{link.longTitle}
+						</a>
+					</li>
+				))}
+			</ul>
+		</li>
+	);
+};

--- a/src/web/components/Nav/StickNavTest/ExpandedMenu/ReaderRevenueLinks.tsx
+++ b/src/web/components/Nav/StickNavTest/ExpandedMenu/ReaderRevenueLinks.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { css, cx } from 'emotion';
+
+import { from } from '@guardian/src-foundations/mq';
+import { brandText, brandAlt } from '@guardian/src-foundations/palette';
+import { textSans } from '@guardian/src-foundations/typography';
+
+export const hideDesktop = css`
+	${from.desktop} {
+		display: none;
+	}
+`;
+
+const columnLinkTitle = css`
+	${textSans.medium({ lineHeight: 'tight' })};
+	background-color: transparent;
+	text-decoration: none;
+	border: 0;
+	box-sizing: border-box;
+	color: ${brandText.primary};
+	cursor: pointer;
+	display: inline-block;
+	font-weight: 500;
+	outline: none;
+	padding: 8px 34px 8px 50px;
+	position: relative;
+	text-align: left;
+	width: 100%;
+
+	${from.tablet} {
+		padding-left: 60px;
+	}
+
+	${from.desktop} {
+		font-size: 16px;
+		padding: 6px 0;
+	}
+
+	:hover,
+	:focus {
+		color: ${brandAlt[400]};
+		text-decoration: underline;
+	}
+
+	> * {
+		pointer-events: none;
+	}
+`;
+
+const mainMenuLinkStyle = css`
+	box-sizing: border-box;
+	overflow: hidden;
+	position: relative;
+	width: 100%;
+	${from.desktop} {
+		display: list-item;
+	}
+`;
+
+export const ReaderRevenueLinks: React.FC<{
+	readerRevenueLinks: ReaderRevenuePositions;
+}> = ({ readerRevenueLinks }) => {
+	const links: LinkType[] = [
+		{
+			longTitle: 'Make a contribution',
+			title: 'Make a contribution',
+			mobileOnly: true,
+			url: readerRevenueLinks.sideMenu.contribute,
+		},
+		{
+			longTitle: 'Subscribe',
+			title: 'Subscribe',
+			mobileOnly: true,
+			url: readerRevenueLinks.sideMenu.subscribe,
+		},
+	];
+
+	return (
+		<ul className={hideDesktop}>
+			{links.map((link) => (
+				<li
+					key={link.title.toLowerCase()}
+					className={cx(mainMenuLinkStyle, {
+						[hideDesktop]: !!link.mobileOnly,
+					})}
+					role="none"
+				>
+					<a
+						className={cx('selectableMenuItem', columnLinkTitle)}
+						href={link.url}
+						role="menuitem"
+						data-link-name={`nav2 : secondary : ${link.longTitle}`}
+						data-cy={`column-collapse-sublink-${link.title}`}
+						tabIndex={-1}
+					>
+						{link.longTitle}
+					</a>
+				</li>
+			))}
+		</ul>
+	);
+};

--- a/src/web/components/Nav/StickNavTest/ExpandedMenu/ShowMoreMenu.tsx
+++ b/src/web/components/Nav/StickNavTest/ExpandedMenu/ShowMoreMenu.tsx
@@ -7,7 +7,7 @@ import { headline } from '@guardian/src-foundations/typography';
 import { brandText, brandAlt } from '@guardian/src-foundations/palette';
 
 import { Display } from '@guardian/types';
-import { navInputCheckboxId, showMoreButtonId } from '../../config';
+import { navInputCheckboxId, showMoreButtonId, buildID } from '../../config';
 
 const screenReadable = css`
 	${visuallyHidden};
@@ -75,17 +75,23 @@ const openExpandedMenuStyles = (display: Display) => css`
 	}
 `;
 
-export const ShowMoreMenu = ({ display }: { display: Display }) => (
+export const ShowMoreMenu = ({
+	display,
+	ID,
+}: {
+	display: Display;
+	ID: string;
+}) => (
 	<>
 		{/* eslint-disable @typescript-eslint/ban-ts-comment, jsx-a11y/label-has-associated-control, @typescript-eslint/no-unused-expressions, react/no-unknown-property, jsx-a11y/no-noninteractive-element-to-interactive-role */}
 		{/*
     // @ts-ignore */}
 		<label
-			id={showMoreButtonId}
+			id={buildID(ID, showMoreButtonId)}
 			className={openExpandedMenuStyles(display)}
 			aria-label="Toggle main menu"
 			key="OpenExpandedMenuButton"
-			htmlFor={navInputCheckboxId}
+			htmlFor={buildID(ID, navInputCheckboxId)}
 			data-link-name="nav2 : veggie-burger: show"
 			// @ts-ignore
 			tabIndex={0}

--- a/src/web/components/Nav/StickNavTest/ExpandedMenu/ShowMoreMenu.tsx
+++ b/src/web/components/Nav/StickNavTest/ExpandedMenu/ShowMoreMenu.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { from } from '@guardian/src-foundations/mq';
+import { visuallyHidden } from '@guardian/src-foundations/accessibility';
+import { headline } from '@guardian/src-foundations/typography';
+import { brandText, brandAlt } from '@guardian/src-foundations/palette';
+
+import { Display } from '@guardian/types';
+import { navInputCheckboxId, showMoreButtonId } from '../../config';
+
+const screenReadable = css`
+	${visuallyHidden};
+`;
+
+const showMoreTextStyles = css`
+	display: block;
+	height: 100%;
+	:after {
+		content: '';
+		border: 1px solid currentColor;
+		border-left: transparent;
+		border-top: transparent;
+		display: inline-block;
+		height: 8px;
+		margin-left: 6px;
+
+		/*
+            IMPORTANT NOTE:
+            we need to specify the adjacent path to the a (current) tag
+            to apply styles to the nested tabs due to the fact we use ~
+            to support NoJS
+        */
+		transform: translateY(-3px) rotate(45deg);
+		/* stylelint-disable-next-line selector-type-no-unknown */
+		${`#${navInputCheckboxId}`}:checked ~ div label & {
+			transform: translateY(1px) rotate(-135deg);
+		}
+
+		transition: transform 250ms ease-out;
+		vertical-align: middle;
+		width: 8px;
+	}
+	:hover:after {
+		transform: translateY(0) rotate(45deg);
+		/* refer to comment above */
+		/* stylelint-disable-next-line selector-type-no-unknown */
+		${`#${navInputCheckboxId}`}:checked ~ div label & {
+			transform: translateY(-2px) rotate(-135deg);
+		}
+	}
+`;
+
+const openExpandedMenuStyles = (display: Display) => css`
+	${headline.xsmall()};
+	font-weight: 300;
+	color: ${brandText.primary};
+	cursor: pointer;
+	display: none;
+	position: relative;
+	overflow: hidden;
+	border: 0;
+	background-color: transparent;
+	height: 48px;
+	padding-left: 9px;
+	padding-right: 20px;
+	${from.desktop} {
+		display: block;
+		padding-top: ${display === Display.Immersive ? '9px' : '5px'};
+		height: 42px;
+	}
+	:hover,
+	:focus {
+		color: ${brandAlt[400]};
+	}
+`;
+
+export const ShowMoreMenu = ({ display }: { display: Display }) => (
+	<>
+		{/* eslint-disable @typescript-eslint/ban-ts-comment, jsx-a11y/label-has-associated-control, @typescript-eslint/no-unused-expressions, react/no-unknown-property, jsx-a11y/no-noninteractive-element-to-interactive-role */}
+		{/*
+    // @ts-ignore */}
+		<label
+			id={showMoreButtonId}
+			className={openExpandedMenuStyles(display)}
+			aria-label="Toggle main menu"
+			key="OpenExpandedMenuButton"
+			htmlFor={navInputCheckboxId}
+			data-link-name="nav2 : veggie-burger: show"
+			// @ts-ignore
+			tabIndex={0}
+			role="button"
+			data-cy="nav-show-more-button"
+		>
+			<span className={screenReadable}>Show</span>
+			<span className={showMoreTextStyles}>More</span>
+		</label>
+		{/* eslint-enable @typescript-eslint/ban-ts-comment, jsx-a11y/label-has-associated-control, @typescript-eslint/no-unused-expressions, react/no-unknown-property, jsx-a11y/no-noninteractive-element-to-interactive-role  */}
+	</>
+);

--- a/src/web/components/Nav/StickNavTest/ExpandedMenu/VeggieBurgerMenu.tsx
+++ b/src/web/components/Nav/StickNavTest/ExpandedMenu/VeggieBurgerMenu.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { visuallyHidden } from '@guardian/src-foundations/accessibility';
+import { from } from '@guardian/src-foundations/mq';
+import { brandAlt, neutral } from '@guardian/src-foundations/palette';
+
+import { Display } from '@guardian/types';
+import { navInputCheckboxId, veggieBurgerId } from '../../config';
+
+const screenReadable = css`
+	${visuallyHidden};
+`;
+
+const veggieBurgerIconStyles = () => {
+	const beforeAfterStyles = css`
+		content: '';
+		background-color: currentColor;
+	`;
+	const lineStyles = css`
+		height: 2px;
+		left: 0;
+		position: absolute;
+		width: 20px;
+	`;
+
+	return css`
+		background-color: currentColor;
+		/*
+            IMPORTANT NOTE:
+            we need to specify the adjacent path to the a (current) tag
+            to apply styles to the nested tabs due to the fact we use ~
+            to support NoJS
+        */
+		/* stylelint-disable-next-line selector-type-no-unknown */
+		${`#${navInputCheckboxId}`}:checked ~ div & {
+			background-color: transparent;
+		}
+
+		top: 50%;
+		right: 0;
+		margin-top: -1px;
+		margin-left: auto;
+		margin-right: auto;
+		${lineStyles};
+
+		:before {
+			${lineStyles};
+			${beforeAfterStyles};
+			top: -6px;
+			/* refer to comment above */
+			/* stylelint-disable-next-line selector-type-no-unknown */
+			${`#${navInputCheckboxId}`}:checked ~ div & {
+				top: 0;
+				transform: rotate(-45deg);
+			}
+		}
+		:after {
+			${lineStyles};
+			${beforeAfterStyles};
+			bottom: -6px;
+			/* refer to comment above */
+			/* stylelint-disable-next-line selector-type-no-unknown */
+			${`#${navInputCheckboxId}`}:checked ~ div & {
+				bottom: 0;
+				transform: rotate(45deg);
+			}
+		}
+	`;
+};
+
+const veggieBurgerStyles = (display: Display) => css`
+	background-color: ${brandAlt[400]};
+	color: ${neutral[7]};
+	cursor: pointer;
+	height: 42px;
+	min-width: 42px;
+	position: absolute;
+	border: 0;
+	border-radius: 50%;
+	outline: none;
+
+	/* TODO: we should not use such a hight z-index number  */
+	z-index: 1071;
+
+	right: 5px;
+	bottom: 48px;
+	${from.mobileMedium} {
+		bottom: ${display === Display.Immersive ? '3px' : '-3px'};
+		right: 5px;
+	}
+	${from.mobileLandscape} {
+		right: 18px;
+	}
+	${from.tablet} {
+		bottom: 3px;
+	}
+	${from.desktop} {
+		display: none;
+	}
+
+	:focus {
+		outline: 5px auto -webkit-focus-ring-color;
+	}
+`;
+
+export const VeggieBurgerMenu: React.FC<{
+	display: Display;
+}> = ({ display }) => {
+	return (
+		/* eslint-disable @typescript-eslint/ban-ts-comment, jsx-a11y/label-has-associated-control, @typescript-eslint/no-unused-expressions, react/no-unknown-property, jsx-a11y/no-noninteractive-element-to-interactive-role */
+		// @ts-ignore
+		<label
+			id={veggieBurgerId}
+			className={veggieBurgerStyles(display)}
+			aria-label="Toggle main menu"
+			key="OpenExpandedMenuButton"
+			htmlFor={navInputCheckboxId}
+			data-link-name="nav2 : veggie-burger: show"
+			// @ts-ignore
+			tabIndex={0}
+			role="button"
+			data-cy="veggie-burger"
+		>
+			<span className={screenReadable}>Show More</span>
+			<span className={veggieBurgerIconStyles()} />
+		</label>
+		/* eslint-enable @typescript-eslint/ban-ts-comment, jsx-a11y/label-has-associated-control, @typescript-eslint/no-unused-expressions, react/no-unknown-property, jsx-a11y/no-noninteractive-element-to-interactive-role  */
+	);
+};

--- a/src/web/components/Nav/StickNavTest/ExpandedMenu/VeggieBurgerMenu.tsx
+++ b/src/web/components/Nav/StickNavTest/ExpandedMenu/VeggieBurgerMenu.tsx
@@ -6,13 +6,13 @@ import { from } from '@guardian/src-foundations/mq';
 import { brandAlt, neutral } from '@guardian/src-foundations/palette';
 
 import { Display } from '@guardian/types';
-import { navInputCheckboxId, veggieBurgerId } from '../../config';
+import { navInputCheckboxId, veggieBurgerId, buildID } from '../../config';
 
 const screenReadable = css`
 	${visuallyHidden};
 `;
 
-const veggieBurgerIconStyles = () => {
+const veggieBurgerIconStyles = (navInputCheckboxID: string) => {
 	const beforeAfterStyles = css`
 		content: '';
 		background-color: currentColor;
@@ -33,7 +33,7 @@ const veggieBurgerIconStyles = () => {
             to support NoJS
         */
 		/* stylelint-disable-next-line selector-type-no-unknown */
-		${`#${navInputCheckboxId}`}:checked ~ div & {
+		${`#${navInputCheckboxID}`}:checked ~ div & {
 			background-color: transparent;
 		}
 
@@ -50,7 +50,7 @@ const veggieBurgerIconStyles = () => {
 			top: -6px;
 			/* refer to comment above */
 			/* stylelint-disable-next-line selector-type-no-unknown */
-			${`#${navInputCheckboxId}`}:checked ~ div & {
+			${`#${navInputCheckboxID}`}:checked ~ div & {
 				top: 0;
 				transform: rotate(-45deg);
 			}
@@ -61,7 +61,7 @@ const veggieBurgerIconStyles = () => {
 			bottom: -6px;
 			/* refer to comment above */
 			/* stylelint-disable-next-line selector-type-no-unknown */
-			${`#${navInputCheckboxId}`}:checked ~ div & {
+			${`#${navInputCheckboxID}`}:checked ~ div & {
 				bottom: 0;
 				transform: rotate(45deg);
 			}
@@ -106,16 +106,17 @@ const veggieBurgerStyles = (display: Display) => css`
 
 export const VeggieBurgerMenu: React.FC<{
 	display: Display;
-}> = ({ display }) => {
+	ID: string;
+}> = ({ display, ID }) => {
 	return (
 		/* eslint-disable @typescript-eslint/ban-ts-comment, jsx-a11y/label-has-associated-control, @typescript-eslint/no-unused-expressions, react/no-unknown-property, jsx-a11y/no-noninteractive-element-to-interactive-role */
 		// @ts-ignore
 		<label
-			id={veggieBurgerId}
+			id={buildID(ID, veggieBurgerId)}
 			className={veggieBurgerStyles(display)}
 			aria-label="Toggle main menu"
 			key="OpenExpandedMenuButton"
-			htmlFor={navInputCheckboxId}
+			htmlFor={buildID(ID, navInputCheckboxId)}
 			data-link-name="nav2 : veggie-burger: show"
 			// @ts-ignore
 			tabIndex={0}
@@ -123,7 +124,11 @@ export const VeggieBurgerMenu: React.FC<{
 			data-cy="veggie-burger"
 		>
 			<span className={screenReadable}>Show More</span>
-			<span className={veggieBurgerIconStyles()} />
+			<span
+				className={veggieBurgerIconStyles(
+					buildID(ID, navInputCheckboxId),
+				)}
+			/>
 		</label>
 		/* eslint-enable @typescript-eslint/ban-ts-comment, jsx-a11y/label-has-associated-control, @typescript-eslint/no-unused-expressions, react/no-unknown-property, jsx-a11y/no-noninteractive-element-to-interactive-role  */
 	);

--- a/src/web/components/Nav/StickNavTest/Nav.tsx
+++ b/src/web/components/Nav/StickNavTest/Nav.tsx
@@ -1,0 +1,228 @@
+import React from 'react';
+import { css, cx } from 'emotion';
+
+import { visuallyHidden } from '@guardian/src-foundations/accessibility';
+import { Pillars } from '@root/src/web/components/Pillars';
+import { GuardianRoundel } from '@root/src/web/components/GuardianRoundel';
+import { space } from '@guardian/src-foundations';
+import { until } from '@guardian/src-foundations/mq';
+import { ThemeProvider } from 'emotion-theming';
+import { Button, buttonReaderRevenueBrand } from '@guardian/src-button';
+import { SvgArrowRightStraight } from '@guardian/src-icons';
+
+import { Hide } from '@frontend/web/components/Hide';
+
+import { clearFix } from '@root/src/lib/mixins';
+
+import { Display } from '@guardian/types';
+import {
+	navInputCheckboxId,
+	showMoreButtonId,
+	veggieBurgerId,
+} from '../config';
+import { ExpandedMenu } from './ExpandedMenu/ExpandedMenu';
+
+type Props = {
+	format: Format;
+	nav: NavType;
+	subscribeUrl: string;
+	edition: Edition;
+};
+
+const clearFixStyle = css`
+	${clearFix};
+`;
+
+const rowStyles = css`
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+`;
+
+const minHeight = css`
+	min-height: 48px;
+`;
+
+const PositionRoundel = ({ children }: { children: React.ReactNode }) => (
+	<div
+		className={css`
+			margin-top: 3px;
+			z-index: 2;
+
+			${until.desktop} {
+				margin-right: 51px;
+			}
+
+			margin-right: 24px;
+		`}
+	>
+		{children}
+	</div>
+);
+
+const PositionButton = ({ children }: { children: React.ReactNode }) => (
+	<div
+		className={css`
+			margin-top: ${space[1]}px;
+			margin-left: ${space[2]}px;
+		`}
+	>
+		{children}
+	</div>
+);
+
+export const Nav = ({ format, nav, subscribeUrl, edition }: Props) => {
+	return (
+		<div className={rowStyles}>
+			{/*
+                IMPORTANT NOTE: Supporting NoJS and accessibility is hard.
+
+                We therefore use JS to make the Nav elements more accessibile. We add a
+                keydown `addEventListener` to both the veggie burger button and the show
+                more menu buttons. We also listen to escape key presses to close the Nav menu.
+                We also toggle the tabindex of clickable items to make sure that even when we
+                are displaying the menu on mobile and tablet, that it doesnt get highlighted
+                when tabbing though the page.
+                This is not a perfect solution as not all screen readers support JS
+                https://webaim.org/projects/screenreadersurvey8/#javascript
+            */}
+			<script
+				dangerouslySetInnerHTML={{
+					__html: `document.addEventListener('DOMContentLoaded', function(){
+                        // Used to toggle data-link-name on label buttons
+                        var navInputCheckbox = document.getElementById('${navInputCheckboxId}')
+                        var showMoreButton = document.getElementById('${showMoreButtonId}')
+                        var veggieBurger = document.getElementById('${veggieBurgerId}')
+                        var expandedMenuClickableTags = document.querySelectorAll('.selectableMenuItem')
+                        var expandedMenu = document.getElementById('expanded-menu')
+
+                        // We assume News is the 1st column
+                        var firstColLabel = document.getElementById('News-button')
+                        var firstColLink = document.querySelectorAll('#newsLinks > li:first-of-type > a')[0]
+
+                        var focusOnFirstNavElement = function(){
+                          // need to focus on first element in list, firstColLabel is not viewable on desktop
+                          if(window.getComputedStyle(firstColLabel).display === 'none'){
+                            firstColLink.focus()
+                          } else {
+                            firstColLabel.focus()
+                          }
+                        }
+                        navInputCheckbox.addEventListener('click',function(){
+                          if(!navInputCheckbox.checked) {
+                            showMoreButton.setAttribute('data-link-name','nav2 : veggie-burger: show')
+                            veggieBurger.setAttribute('data-link-name','nav2 : veggie-burger: show')
+                            expandedMenuClickableTags.forEach(function($selectableElement){
+                                $selectableElement.setAttribute('tabindex','-1')
+                            })
+                          } else {
+                            showMoreButton.setAttribute('data-link-name','nav2 : veggie-burger: hide')
+                            veggieBurger.setAttribute('data-link-name','nav2 : veggie-burger: hide')
+                            expandedMenuClickableTags.forEach(function($selectableElement){
+                                $selectableElement.setAttribute('tabindex','0')
+                            })
+                            focusOnFirstNavElement()
+                          }
+                        })
+                        var toggleMainMenu = function(e){
+                          navInputCheckbox.click()
+                        }
+                        // Close hide menu on press enter
+                        var keydownToggleMainMenu = function(e){
+                          // keyCode: 13 => Enter key | keyCode: 32 => Space key
+                          if (e.keyCode === 13 || e.keyCode === 32) {
+                            e.preventDefault()
+                            toggleMainMenu()
+                          }
+                        }
+                        showMoreButton.addEventListener('keydown', keydownToggleMainMenu)
+                        veggieBurger.addEventListener('keydown', keydownToggleMainMenu)
+                        // Accessibility to hide Nav when pressing escape key
+                        document.addEventListener('keydown', function(e){
+                          // keyCode: 27 => esc
+                          if (e.keyCode === 27) {
+                            if(navInputCheckbox.checked) {
+                              toggleMainMenu()
+                              if(window.getComputedStyle(veggieBurger).display === 'none'){
+                                showMoreButton.focus()
+                              }else{
+                                veggieBurger.focus()
+                              }
+                            }
+                          }
+                        })
+                        // onBlur close dialog
+                        document.addEventListener('mousedown', function(e){
+                          if(navInputCheckbox.checked && !expandedMenu.contains(e.target)){
+                            toggleMainMenu()
+                          }
+                        });
+                      })`,
+				}}
+			/>
+			<nav
+				className={cx(
+					clearFixStyle,
+					rowStyles,
+					format.display === Display.Immersive && minHeight,
+				)}
+				role="navigation"
+				aria-label="Guardian sections"
+				data-component="nav2"
+			>
+				{format.display === Display.Immersive && (
+					<Hide when="above" breakpoint="tablet">
+						<ThemeProvider theme={buttonReaderRevenueBrand}>
+							<PositionButton>
+								<Button
+									priority="primary"
+									size="small"
+									iconSide="right"
+									icon={<SvgArrowRightStraight />}
+									data-link-name="nav2 : support-cta"
+									data-edition={edition}
+									onClick={() => {
+										window.location.href = subscribeUrl;
+										return false;
+									}}
+								>
+									Subscribe
+								</Button>
+							</PositionButton>
+						</ThemeProvider>
+					</Hide>
+				)}
+				{/*
+                IMPORTANT NOTE:
+                It is important to have the input as the 1st sibling for NoJS to work
+                as we use ~ to apply certain styles on checkbox checked and ~ can only
+                apply to styles with elements that are preceded
+            */}
+				<input
+					type="checkbox"
+					className={css`
+						${visuallyHidden};
+					`}
+					id={navInputCheckboxId}
+					name="more"
+					tabIndex={-1}
+					key="OpenExpandedMenuCheckbox"
+					aria-hidden="true"
+				/>
+				<Pillars
+					display={format.display}
+					pillars={nav.pillars}
+					pillar={format.theme}
+					dataLinkName="nav2"
+					isTopNav={true}
+				/>
+				<ExpandedMenu nav={nav} display={format.display} />
+			</nav>
+			{format.display === Display.Immersive && (
+				<PositionRoundel>
+					<GuardianRoundel />
+				</PositionRoundel>
+			)}
+		</div>
+	);
+};

--- a/src/web/components/Nav/StickNavTest/StickyNav.tsx
+++ b/src/web/components/Nav/StickNavTest/StickyNav.tsx
@@ -1,0 +1,228 @@
+import React, { useEffect, useState } from 'react';
+import { css } from 'emotion';
+import { neutralBorder } from '@root/src/lib/pillars';
+
+import { Section } from '@root/src/web/components/Section';
+import { SubNav } from '@root/src/web/components/SubNav/SubNav';
+import { brandBackground, brandLine } from '@guardian/src-foundations/palette';
+
+import libDebounce from 'lodash.debounce';
+import { decideTheme } from '@root/src/web/lib/decideTheme';
+import { decideDesign } from '@root/src/web/lib/decideDesign';
+import { getZIndex } from '@root/src/web/lib/getZIndex';
+import { getCurrentPillar } from '@root/src/web/lib/layoutHelpers';
+import { Nav as LazyNav } from './Nav';
+import { Nav } from '../Nav';
+
+interface BrowserProps {
+	capiData: CAPIBrowserType;
+	navData: BrowserNavType;
+	format: Format;
+	palette: Palette;
+}
+
+interface NavGroupLazyProps extends BrowserProps {
+	ID: string;
+}
+
+interface NavGroupEagerProps {
+	capiData: CAPIType;
+	navData: NavType;
+	format: Format;
+	palette: Palette;
+}
+
+const stickyStyle = (theme: Theme) => css`
+	position: sticky;
+	top: 0;
+	${getZIndex('stickyNav')}
+	background-color: white;
+	box-shadow: 0 0 transparent, 0 0 transparent,
+		1px 3px 6px ${neutralBorder(theme)};
+`;
+
+const fixedStyle = (theme: Theme, shouldDisplay: boolean) => css`
+	width: 100%;
+	position: fixed;
+	top: 0;
+	${getZIndex('stickyNav')}
+	background-color: white;
+	box-shadow: 0 0 transparent, 0 0 transparent,
+		1px 3px 6px ${neutralBorder(theme)};
+
+	display: ${shouldDisplay ? 'block' : 'none'};
+`;
+
+export const NavGroupEager: React.FC<NavGroupEagerProps> = ({
+	capiData,
+	navData,
+	format,
+	palette,
+}: NavGroupEagerProps) => (
+	<>
+		<Section
+			showSideBorders={true}
+			borderColour={brandLine.primary}
+			showTopBorder={false}
+			padded={false}
+			backgroundColour={brandBackground.primary}
+		>
+			<Nav
+				nav={navData}
+				format={{
+					...format,
+					theme: getCurrentPillar(capiData),
+				}}
+				subscribeUrl={capiData.nav.readerRevenueLinks.header.subscribe}
+				edition={capiData.editionId}
+			/>
+		</Section>
+		{navData.subNavSections && (
+			<Section
+				backgroundColour={palette.background.article}
+				padded={false}
+				sectionId="sub-nav-root"
+			>
+				<SubNav
+					subNavSections={navData.subNavSections}
+					currentNavLink={navData.currentNavLink}
+					palette={palette}
+				/>
+			</Section>
+		)}
+	</>
+);
+
+const NavGroupLazy: React.FC<NavGroupLazyProps> = ({
+	capiData,
+	navData,
+	format,
+	palette,
+	ID,
+}: NavGroupLazyProps) => (
+	<div>
+		<Section
+			showSideBorders={true}
+			borderColour={brandLine.primary}
+			showTopBorder={false}
+			padded={false}
+			backgroundColour={brandBackground.primary}
+		>
+			<LazyNav
+				topLevelPillars={navData.topLevelPillars}
+				format={format}
+				subscribeUrl={capiData.nav.readerRevenueLinks.header.subscribe}
+				edition={capiData.editionId}
+				currentNavLinkTitle={navData.currentNavLink}
+				ID={ID || 'lazy-nav'}
+				ajaxUrl={capiData.config.ajaxUrl}
+			/>
+		</Section>
+		{navData.subNavSections && (
+			<Section
+				backgroundColour={palette.background.article}
+				padded={false}
+				sectionId="sub-nav-root"
+			>
+				<SubNav
+					subNavSections={navData.subNavSections}
+					currentNavLink={navData.currentNavLink}
+					palette={palette}
+				/>
+			</Section>
+		)}
+	</div>
+);
+
+// StickyNavSimple is a basic, CSS only, sticky nav. The nav stays at the top of
+// the viewport as the user scrolls past it's initial placement.
+//
+// *Note:* this uses position:sticky, which only works if the parent element is
+// scrollable and has a fixed height.
+export const StickyNavSimple: React.FC<BrowserProps> = ({
+	capiData,
+	navData,
+	palette,
+	format,
+}: BrowserProps) => {
+	const theme = decideTheme({
+		pillar: capiData.pillar,
+		design: decideDesign(capiData.designType, capiData.tags),
+	});
+
+	return (
+		<div className={stickyStyle(theme)}>
+			<NavGroupLazy
+				capiData={capiData}
+				navData={navData}
+				palette={palette}
+				format={format}
+				ID="sticky-nav-simple"
+			/>
+		</div>
+	);
+};
+
+// StickyNavBackScroll reappears fixed to top of viewport if below initial buffer and user
+// is scrolling back. The idea is that scrolling back up may indicate intent to
+// reach nav.
+export const StickyNavBackscroll: React.FC<BrowserProps> = ({
+	capiData,
+	navData,
+	format,
+	palette,
+}: BrowserProps) => {
+	const initialState = { shouldFix: false, scrollY: 0 };
+	const [state, setState] = useState(initialState);
+
+	const pillar = decideTheme({
+		pillar: capiData.pillar,
+		design: decideDesign(capiData.designType, capiData.tags),
+	});
+
+	useEffect(() => {
+		const handle = () => {
+			setState((oldState) => {
+				const buffer = 300;
+				const newY = window.scrollY;
+				const goingBack = newY < oldState.scrollY;
+				const beforeRange = newY < buffer;
+
+				return {
+					shouldFix: goingBack && !beforeRange,
+					scrollY: newY,
+				};
+			});
+		};
+
+		window.addEventListener('scroll', libDebounce(handle, 20), {
+			passive: true,
+		});
+
+		return () => {
+			window.removeEventListener('scroll', handle);
+		};
+	}, []);
+
+	return (
+		<>
+			<NavGroupLazy
+				capiData={capiData}
+				navData={navData}
+				palette={palette}
+				format={format}
+				ID="nav"
+			/>
+
+			<div className={fixedStyle(pillar, state.shouldFix)}>
+				<NavGroupLazy
+					capiData={capiData}
+					navData={navData}
+					palette={palette}
+					format={format}
+					ID="sticky-nav-backscroll"
+				/>
+			</div>
+		</>
+	);
+};

--- a/src/web/components/Nav/config.ts
+++ b/src/web/components/Nav/config.ts
@@ -1,3 +1,7 @@
 export const navInputCheckboxId = 'top-nav-input-checkbox';
 export const showMoreButtonId = 'show-more-button';
 export const veggieBurgerId = 'veggie-burger';
+
+// Used for sticky nav test only
+export const buildID = (ID: string, prefix: string): string =>
+	`${prefix}${ID ? `-${ID}` : ''}`;

--- a/src/web/components/Pillars.tsx
+++ b/src/web/components/Pillars.tsx
@@ -50,13 +50,13 @@ const pillarsStyles = (display: Display) => css`
 		bottom: 0;
 		left: 0;
 		right: 0;
-		height: ${display === Display.Immersive ? '49px' : '37px'};
+		height: ${display === Display.Immersive ? '48px' : '36px'};
 		${from.tablet} {
 			border-bottom: 0;
 			height: 49px;
 		}
 		${from.desktop} {
-			height: ${display === Display.Immersive ? '49px' : '43px'};
+			height: ${display === Display.Immersive ? '48px' : '42px'};
 		}
 	}
 `;

--- a/src/web/experiments/ab-tests.ts
+++ b/src/web/experiments/ab-tests.ts
@@ -8,6 +8,7 @@ import {
 	newsletterMerchUnitLighthouseControl,
 	newsletterMerchUnitLighthouseVariants,
 } from '@root/src/web/experiments/tests/newsletter-merch-unit-test';
+import { stickyNavTest } from '@root/src/web/experiments/tests/sticky-nav-test';
 
 export const tests: ABTest[] = [
 	abTestTest,
@@ -17,4 +18,5 @@ export const tests: ABTest[] = [
 	newsletterMerchUnitLighthouseControl,
 	newsletterMerchUnitLighthouseVariants,
 	deeplyReadTest,
+	stickyNavTest,
 ];

--- a/src/web/experiments/tests/sticky-nav-test.ts
+++ b/src/web/experiments/tests/sticky-nav-test.ts
@@ -1,0 +1,32 @@
+import { ABTest } from '@guardian/ab-core';
+
+export const stickyNavTest: ABTest = {
+	id: 'stickyNavTest',
+	start: '2021-02-10',
+	expiry: '2021-05-03',
+	author: 'nlong',
+	description: 'Tests sticky nav behaviour.',
+	audience: 0,
+	audienceOffset: 0,
+	successMeasure:
+		'Increased CTR on sticky variant, more visits to fronts, increase in number of pillars visited per user.',
+	audienceCriteria: 'Everyone',
+	idealOutcome:
+		'Significant increase in the metrics mentioned, consistent with hypothesis that sticky nav improves pillar understanding and engagement.',
+	showForSensitive: true,
+	canRun: () => true,
+	variants: [
+		{
+			id: 'control',
+			test: (): void => {},
+		},
+		{
+			id: 'sticky-nav-simple',
+			test: (): void => {},
+		},
+		{
+			id: 'sticky-nav-backscroll',
+			test: (): void => {},
+		},
+	],
+};

--- a/src/web/layouts/Immersive.stories.tsx
+++ b/src/web/layouts/Immersive.stories.tsx
@@ -2,7 +2,10 @@ import React, { useEffect } from 'react';
 
 import { breakpoints } from '@guardian/src-foundations/mq';
 
-import { makeGuardianBrowserCAPI } from '@root/src/model/window-guardian';
+import {
+	makeGuardianBrowserCAPI,
+	makeGuardianBrowserNav,
+} from '@root/src/model/window-guardian';
 import { Article } from '@root/fixtures/articles/Article';
 import { PhotoEssay } from '@root/fixtures/articles/PhotoEssay';
 import { Review } from '@root/fixtures/articles/Review';
@@ -53,7 +56,7 @@ const HydratedLayout = ({ ServerCAPI }: { ServerCAPI: CAPIType }) => {
 
 	useEffect(() => {
 		const CAPI = makeGuardianBrowserCAPI(ServerCAPI);
-		HydrateApp({ CAPI, NAV });
+		HydrateApp({ CAPI, NAV: makeGuardianBrowserNav(NAV) });
 		embedIframe().catch((e) =>
 			console.error(`HydratedLayout embedIframe - error: ${e}`),
 		);

--- a/src/web/layouts/Showcase.stories.tsx
+++ b/src/web/layouts/Showcase.stories.tsx
@@ -1,6 +1,9 @@
 import React, { useEffect } from 'react';
 
-import { makeGuardianBrowserCAPI } from '@root/src/model/window-guardian';
+import {
+	makeGuardianBrowserCAPI,
+	makeGuardianBrowserNav,
+} from '@root/src/model/window-guardian';
 import { Article } from '@root/fixtures/articles/Article';
 import { PhotoEssay } from '@root/fixtures/articles/PhotoEssay';
 import { Review } from '@root/fixtures/articles/Review';
@@ -49,7 +52,7 @@ const HydratedLayout = ({ ServerCAPI }: { ServerCAPI: CAPIType }) => {
 
 	useEffect(() => {
 		const CAPI = makeGuardianBrowserCAPI(ServerCAPI);
-		HydrateApp({ CAPI, NAV });
+		HydrateApp({ CAPI, NAV: makeGuardianBrowserNav(NAV) });
 		embedIframe().catch((e) =>
 			console.error(`HydratedLayout embedIframe - error: ${e}`),
 		);

--- a/src/web/layouts/Standard.stories.tsx
+++ b/src/web/layouts/Standard.stories.tsx
@@ -1,6 +1,9 @@
 import React, { useEffect } from 'react';
 
-import { makeGuardianBrowserCAPI } from '@root/src/model/window-guardian';
+import {
+	makeGuardianBrowserCAPI,
+	makeGuardianBrowserNav,
+} from '@root/src/model/window-guardian';
 import { Article } from '@root/fixtures/articles/Article';
 import { PhotoEssay } from '@root/fixtures/articles/PhotoEssay';
 import { Review } from '@root/fixtures/articles/Review';
@@ -50,7 +53,7 @@ const HydratedLayout = ({ ServerCAPI }: { ServerCAPI: CAPIType }) => {
 
 	useEffect(() => {
 		const CAPI = makeGuardianBrowserCAPI(ServerCAPI);
-		HydrateApp({ CAPI, NAV });
+		HydrateApp({ CAPI, NAV: makeGuardianBrowserNav(NAV) });
 		embedIframe().catch((e) =>
 			console.error(`HydratedLayout embedIframe - error: ${e}`),
 		);

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -5,7 +5,6 @@ import {
 	neutral,
 	brandAltBackground,
 	brandBackground,
-	brandLine,
 	brandBorder,
 } from '@guardian/src-foundations/palette';
 import { from, until } from '@guardian/src-foundations/mq';
@@ -29,7 +28,6 @@ import { Header } from '@root/src/web/components/Header';
 import { Footer } from '@root/src/web/components/Footer';
 import { SubNav } from '@root/src/web/components/SubNav/SubNav';
 import { Section } from '@root/src/web/components/Section';
-import { Nav } from '@root/src/web/components/Nav/Nav';
 import { HeaderAdSlot } from '@root/src/web/components/HeaderAdSlot';
 import { MobileStickyContainer, AdSlot } from '@root/src/web/components/AdSlot';
 import { Border } from '@root/src/web/components/Border';
@@ -44,13 +42,13 @@ import { getAgeWarning } from '@root/src/lib/age-warning';
 import {
 	decideLineCount,
 	decideLineEffect,
-	getCurrentPillar,
 } from '@root/src/web/lib/layoutHelpers';
 import {
 	Stuck,
 	SendToBack,
 	BannerWrapper,
 } from '@root/src/web/layouts/lib/stickiness';
+import { NavGroupEager } from '@root/src/web/components/Nav/StickNavTest/StickyNav';
 
 const StandardGrid = ({
 	children,
@@ -286,6 +284,10 @@ const ageWarningMargins = css`
 	}
 `;
 
+const stickyNavRootStyle = css`
+	display: inline;
+`;
+
 interface Props {
 	CAPI: CAPIType;
 	NAV: NavType;
@@ -352,237 +354,220 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 							mmaUrl={CAPI.config.mmaUrl}
 						/>
 					</Section>
-
-					<Section
-						showSideBorders={true}
-						borderColour={brandLine.primary}
-						showTopBorder={false}
-						padded={false}
-						backgroundColour={brandBackground.primary}
-					>
-						<Nav
-							nav={NAV}
-							format={{
-								...format,
-								theme: getCurrentPillar(CAPI),
-							}}
-							subscribeUrl={
-								CAPI.nav.readerRevenueLinks.header.subscribe
-							}
-							edition={CAPI.editionId}
-						/>
-					</Section>
-
-					{NAV.subNavSections && (
-						<Section
-							backgroundColour={palette.background.article}
-							padded={false}
-							sectionId="sub-nav-root"
-						>
-							<SubNav
-								subNavSections={NAV.subNavSections}
-								currentNavLink={NAV.currentNavLink}
-								palette={palette}
-							/>
-						</Section>
-					)}
-
-					<Section
-						backgroundColour={palette.background.article}
-						padded={false}
-						showTopBorder={false}
-					>
-						<GuardianLines count={4} pillar={format.theme} />
-					</Section>
 				</SendToBack>
 			</div>
 
-			<Section
-				data-print-layout="hide"
-				showTopBorder={false}
-				backgroundColour={palette.background.article}
-			>
-				<StandardGrid isMatchReport={isMatchReport}>
-					<GridItem area="title">
-						<ArticleTitle
-							format={format}
+			<div>
+				<div id="sticky-nav-root" className={stickyNavRootStyle}>
+					<div data-name="placeholder">
+						<NavGroupEager
+							capiData={CAPI}
+							navData={NAV}
 							palette={palette}
-							tags={CAPI.tags}
-							sectionLabel={CAPI.sectionLabel}
-							sectionUrl={CAPI.sectionUrl}
-							guardianBaseURL={CAPI.guardianBaseURL}
-							badge={CAPI.badge}
+							format={format}
 						/>
-					</GridItem>
-					<GridItem area="border">
-						<Border />
-					</GridItem>
-					<GridItem area="matchNav">
-						<div className={maxWidth}>
-							{format.design === Design.MatchReport &&
-								CAPI.matchUrl && (
-									<Placeholder
-										rootId="match-nav"
-										height={230}
-									/>
-								)}
-						</div>
-					</GridItem>
-					<GridItem area="headline">
-						<div className={maxWidth}>
-							<ArticleHeadlinePadding design={format.design}>
-								{age && (
-									<div className={ageWarningMargins}>
-										<AgeWarning age={age} />
-									</div>
-								)}
-								<ArticleHeadline
-									format={format}
-									headlineString={CAPI.headline}
-									tags={CAPI.tags}
-									byline={CAPI.author.byline}
-									palette={palette}
-								/>
-								{age && (
-									<AgeWarning
-										age={age}
-										isScreenReader={true}
-									/>
-								)}
-							</ArticleHeadlinePadding>
-						</div>
-						{CAPI.starRating || CAPI.starRating === 0 ? (
-							<div className={starWrapper}>
-								<StarRating
-									rating={CAPI.starRating}
-									size="large"
-								/>
-							</div>
-						) : (
-							<></>
-						)}
-					</GridItem>
-					<GridItem area="standfirst">
-						<ArticleStandfirst
-							display={format.display}
-							design={format.design}
-							pillar={format.theme}
-							standfirst={CAPI.standfirst}
-						/>
-					</GridItem>
-					<GridItem area="media">
-						<div className={maxWidth}>
-							<MainMedia
+					</div>
+				</div>
+
+				<Section
+					backgroundColour={palette.background.article}
+					padded={false}
+					showTopBorder={false}
+				>
+					<GuardianLines count={4} pillar={format.theme} />
+				</Section>
+
+				<Section
+					data-print-layout="hide"
+					showTopBorder={false}
+					backgroundColour={palette.background.article}
+				>
+					<StandardGrid isMatchReport={isMatchReport}>
+						<GridItem area="title">
+							<ArticleTitle
 								format={format}
 								palette={palette}
-								elements={CAPI.mainMediaElements}
-								adTargeting={adTargeting}
-								host={host}
-								abTests={CAPI.config.abTests}
-							/>
-						</div>
-					</GridItem>
-					<GridItem area="lines">
-						<div className={maxWidth}>
-							<div className={stretchLines}>
-								<GuardianLines
-									count={decideLineCount(format.design)}
-									pillar={format.theme}
-									effect={decideLineEffect(
-										format.design,
-										format.theme,
-									)}
-								/>
-							</div>
-						</div>
-					</GridItem>
-					<GridItem area="meta">
-						<div className={maxWidth}>
-							<ArticleMeta
-								branding={branding}
-								format={format}
-								palette={palette}
-								pageId={CAPI.pageId}
-								webTitle={CAPI.webTitle}
-								author={CAPI.author}
 								tags={CAPI.tags}
-								primaryDateline={CAPI.webPublicationDateDisplay}
-								secondaryDateline={
-									CAPI.webPublicationSecondaryDateDisplay
-								}
+								sectionLabel={CAPI.sectionLabel}
+								sectionUrl={CAPI.sectionUrl}
+								guardianBaseURL={CAPI.guardianBaseURL}
+								badge={CAPI.badge}
 							/>
-						</div>
-					</GridItem>
-					<GridItem area="body">
-						<ArticleContainer>
-							<main className={articleWidth}>
-								<ArticleBody
+						</GridItem>
+						<GridItem area="border">
+							<Border />
+						</GridItem>
+						<GridItem area="matchNav">
+							<div className={maxWidth}>
+								{format.design === Design.MatchReport &&
+									CAPI.matchUrl && (
+										<Placeholder
+											rootId="match-nav"
+											height={230}
+										/>
+									)}
+							</div>
+						</GridItem>
+						<GridItem area="headline">
+							<div className={maxWidth}>
+								<ArticleHeadlinePadding design={format.design}>
+									{age && (
+										<div className={ageWarningMargins}>
+											<AgeWarning age={age} />
+										</div>
+									)}
+									<ArticleHeadline
+										format={format}
+										headlineString={CAPI.headline}
+										tags={CAPI.tags}
+										byline={CAPI.author.byline}
+										palette={palette}
+									/>
+									{age && (
+										<AgeWarning
+											age={age}
+											isScreenReader={true}
+										/>
+									)}
+								</ArticleHeadlinePadding>
+							</div>
+							{CAPI.starRating || CAPI.starRating === 0 ? (
+								<div className={starWrapper}>
+									<StarRating
+										rating={CAPI.starRating}
+										size="large"
+									/>
+								</div>
+							) : (
+								<></>
+							)}
+						</GridItem>
+						<GridItem area="standfirst">
+							<ArticleStandfirst
+								display={format.display}
+								design={format.design}
+								pillar={format.theme}
+								standfirst={CAPI.standfirst}
+							/>
+						</GridItem>
+						<GridItem area="media">
+							<div className={maxWidth}>
+								<MainMedia
 									format={format}
 									palette={palette}
-									blocks={CAPI.blocks}
+									elements={CAPI.mainMediaElements}
 									adTargeting={adTargeting}
 									host={host}
 									abTests={CAPI.config.abTests}
 								/>
-								{isMatchReport && <div id="match-stats" />}
-
-								{showBodyEndSlot && <div id="slot-body-end" />}
-								<GuardianLines
-									data-print-layout="hide"
-									count={4}
-									pillar={format.theme}
-								/>
-								<SubMeta
+							</div>
+						</GridItem>
+						<GridItem area="lines">
+							<div className={maxWidth}>
+								<div className={stretchLines}>
+									<GuardianLines
+										count={decideLineCount(format.design)}
+										pillar={format.theme}
+										effect={decideLineEffect(
+											format.design,
+											format.theme,
+										)}
+									/>
+								</div>
+							</div>
+						</GridItem>
+						<GridItem area="meta">
+							<div className={maxWidth}>
+								<ArticleMeta
+									branding={branding}
+									format={format}
 									palette={palette}
-									subMetaKeywordLinks={
-										CAPI.subMetaKeywordLinks
-									}
-									subMetaSectionLinks={
-										CAPI.subMetaSectionLinks
-									}
 									pageId={CAPI.pageId}
-									webUrl={CAPI.webURL}
 									webTitle={CAPI.webTitle}
-									showBottomSocialButtons={
-										CAPI.showBottomSocialButtons
+									author={CAPI.author}
+									tags={CAPI.tags}
+									primaryDateline={
+										CAPI.webPublicationDateDisplay
 									}
-									badge={CAPI.badge}
+									secondaryDateline={
+										CAPI.webPublicationSecondaryDateDisplay
+									}
 								/>
-							</main>
-						</ArticleContainer>
-					</GridItem>
-					<GridItem area="right-column">
-						<div
-							className={css`
-								padding-top: 6px;
-								height: 100%;
-								${from.desktop} {
-									/* above 980 */
-									margin-left: 20px;
-									margin-right: -20px;
-								}
-								${from.leftCol} {
-									/* above 1140 */
-									margin-left: 0px;
-									margin-right: 0px;
-								}
-							`}
-						>
-							<RightColumn>
-								<AdSlot
-									position="right"
-									display={format.display}
-								/>
-								{!isPaidContent ? (
-									<MostViewedRightIsland />
-								) : (
-									<></>
-								)}
-							</RightColumn>
-						</div>
-					</GridItem>
-				</StandardGrid>
-			</Section>
+							</div>
+						</GridItem>
+						<GridItem area="body">
+							<ArticleContainer>
+								<main className={articleWidth}>
+									<ArticleBody
+										format={format}
+										palette={palette}
+										blocks={CAPI.blocks}
+										adTargeting={adTargeting}
+										host={host}
+										abTests={CAPI.config.abTests}
+									/>
+									{isMatchReport && <div id="match-stats" />}
+
+									{showBodyEndSlot && (
+										<div id="slot-body-end" />
+									)}
+									<GuardianLines
+										data-print-layout="hide"
+										count={4}
+										pillar={format.theme}
+									/>
+									<SubMeta
+										palette={palette}
+										subMetaKeywordLinks={
+											CAPI.subMetaKeywordLinks
+										}
+										subMetaSectionLinks={
+											CAPI.subMetaSectionLinks
+										}
+										pageId={CAPI.pageId}
+										webUrl={CAPI.webURL}
+										webTitle={CAPI.webTitle}
+										showBottomSocialButtons={
+											CAPI.showBottomSocialButtons
+										}
+										badge={CAPI.badge}
+									/>
+								</main>
+							</ArticleContainer>
+						</GridItem>
+						<GridItem area="right-column">
+							<div
+								className={css`
+									padding-top: 6px;
+									height: 100%;
+									${from.desktop} {
+										/* above 980 */
+										margin-left: 20px;
+										margin-right: -20px;
+									}
+									${from.leftCol} {
+										/* above 1140 */
+										margin-left: 0px;
+										margin-right: 0px;
+									}
+								`}
+							>
+								<RightColumn>
+									<AdSlot
+										position="right"
+										display={format.display}
+									/>
+									{!isPaidContent ? (
+										<MostViewedRightIsland />
+									) : (
+										<></>
+									)}
+								</RightColumn>
+							</div>
+						</GridItem>
+					</StandardGrid>
+				</Section>
+			</div>
 
 			<Section
 				data-print-layout="hide"

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -49,6 +49,7 @@ import {
 	BannerWrapper,
 } from '@root/src/web/layouts/lib/stickiness';
 import { NavGroupEager } from '@root/src/web/components/Nav/StickNavTest/StickyNav';
+import { getZIndex } from '../lib/getZIndex';
 
 const StandardGrid = ({
 	children,
@@ -286,6 +287,8 @@ const ageWarningMargins = css`
 
 const stickyNavRootStyle = css`
 	display: inline;
+	position: relative;
+	${getZIndex('stickyNavWrapper')}
 `;
 
 interface Props {

--- a/src/web/lib/getZIndex.test.tsx
+++ b/src/web/lib/getZIndex.test.tsx
@@ -2,7 +2,10 @@ import { getZIndex } from './getZIndex';
 
 describe('getZIndex', () => {
 	it('gets the correct zindex for group and sibling', () => {
-		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 9;');
+		expect(getZIndex('banner')).toBe('z-index: 12;');
+		expect(getZIndex('stickyNav')).toBe('z-index: 11;');
+		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 10;');
+		expect(getZIndex('stickyNavWrapper')).toBe('z-index: 9;');
 		expect(getZIndex('headerWrapper')).toBe('z-index: 8;');
 		expect(getZIndex('headerLinks')).toBe('z-index: 7;');
 		expect(getZIndex('TheGuardian')).toBe('z-index: 6;');

--- a/src/web/lib/getZIndex.tsx
+++ b/src/web/lib/getZIndex.tsx
@@ -26,6 +26,9 @@ const indices = [
 
 	'banner',
 
+	// Stick-nav test
+	'stickyNav',
+
 	// Header
 	'stickyAdWrapper',
 	'headerWrapper',

--- a/src/web/lib/getZIndex.tsx
+++ b/src/web/lib/getZIndex.tsx
@@ -31,6 +31,7 @@ const indices = [
 
 	// Header
 	'stickyAdWrapper',
+	'stickyNavWrapper',
 	'headerWrapper',
 
 	// Header links (should be above The Guardian svg)


### PR DESCRIPTION
A cleaner version of https://github.com/guardian/dotcom-rendering/pull/2495. 

**The copy of nav files has been separated out into a commit. So recommend viewing the second commit only to get a sense of the specific changes.**

Why duplicate the nav files?

* to avoid lots of branching in the existing code, which would make test cleanup more difficult
* to speed up development by reducing the risk of breaking existing behaviour
* to make reviewing the changes easier

### Before

(No sticky nav behaviour)

### After

Three variants in a (initially) zero-percent test:

    control
    sticky-nav-simple // nav fixed to viewport
    sticky-nav-backscroll // nav appears on backscroll

Use the hash parameters to see a particular variant. E.g. `#ab-stickyNavTest=sticky-nav-backscroll`.

![Kapture 2021-02-01 at 15 12 34](https://user-images.githubusercontent.com/858402/108546245-c3e90080-72e0-11eb-91bb-a85dcc3493fa.gif)

![Kapture 2021-02-03 at 10 34 25](https://user-images.githubusercontent.com/858402/108546267-cfd4c280-72e0-11eb-93a1-091fece8da81.gif)

## Why?

https://trello.com/c/fy5HsbwD/2347-sticky-nav-test

## Performance concerns

There *is* an increase in the client-side bundle, of **7kb** here (due to the nav-related code). I think this is acceptable for a 2-week test, but would require further optimisation if successful (some of this would naturally disappear due to test-specific code being removed).

Due to the lazy-loading, the window.guardian size only changes from **44,674kb** to **45,287kb** on our default test article. The increase is caused by the addition of top level pillars to the client-side nav model. (We use top-level to minimise data transfer as the children are populated lazily.)

The bulk of the performance hit from client-side nav has been addressed though via lazy-loading. See https://github.com/guardian/frontend/pull/23543 for the relevant work here.