### PR TITLE
Tiny headline

### DIFF
--- a/src/web/components/LinkHeadline.stories.tsx
+++ b/src/web/components/LinkHeadline.stories.tsx
@@ -230,3 +230,107 @@ export const linkStory = () => (
 	</Section>
 );
 linkStory.story = { name: 'With linkTo provided' };
+
+export const LiveSizes = () => (
+	<Section showTopBorder={false} showSideBorders={false}>
+		<LinkHeadline
+			headlineText="Revealed: how US and UK spy agencies defeat internet privacy and security"
+			format={{
+				display: Display.Standard,
+				design: Design.Live,
+				theme: Pillar.News,
+			}}
+			palette={decidePalette({
+				display: Display.Standard,
+				design: Design.Live,
+				theme: Pillar.News,
+			})}
+			showQuotes={true}
+			kickerText="Large live"
+			showSlash={true}
+			showPulsingDot={true}
+			size="large"
+		/>
+		<br />
+		<LinkHeadline
+			headlineText="Revealed: how US and UK spy agencies defeat internet privacy and security"
+			format={{
+				display: Display.Standard,
+				design: Design.Live,
+				theme: Pillar.News,
+			}}
+			palette={decidePalette({
+				display: Display.Standard,
+				design: Design.Live,
+				theme: Pillar.News,
+			})}
+			showQuotes={true}
+			kickerText="Medium live"
+			showSlash={true}
+			showPulsingDot={true}
+			size="medium"
+		/>
+		<br />
+		<LinkHeadline
+			headlineText="Revealed: how US and UK spy agencies defeat internet privacy and security"
+			format={{
+				display: Display.Standard,
+				design: Design.Live,
+				theme: Pillar.News,
+			}}
+			palette={decidePalette({
+				display: Display.Standard,
+				design: Design.Live,
+				theme: Pillar.News,
+			})}
+			showQuotes={true}
+			kickerText="Small live"
+			showSlash={true}
+			showPulsingDot={true}
+			size="small"
+		/>
+		<br />
+		<LinkHeadline
+			headlineText="Revealed: how US and UK spy agencies defeat internet privacy and security"
+			format={{
+				display: Display.Standard,
+				design: Design.Live,
+				theme: Pillar.News,
+			}}
+			palette={decidePalette({
+				display: Display.Standard,
+				design: Design.Live,
+				theme: Pillar.News,
+			})}
+			showQuotes={true}
+			kickerText="Tiny live"
+			showSlash={true}
+			showPulsingDot={true}
+			size="tiny"
+		/>
+	</Section>
+);
+LiveSizes.story = { name: 'with various sizes' };
+
+export const Updated = () => (
+	<Section showTopBorder={false} showSideBorders={false}>
+		<LinkHeadline
+			headlineText=""
+			format={{
+				display: Display.Standard,
+				design: Design.Live,
+				theme: Pillar.News,
+			}}
+			palette={decidePalette({
+				display: Display.Standard,
+				design: Design.Live,
+				theme: Pillar.News,
+			})}
+			showPulsingDot={true}
+			showSlash={false}
+			kickerText="Updated 7m ago"
+			size="tiny"
+		/>
+	</Section>
+);
+Updated.story = { name: 'Last updated' };

--- a/src/web/components/QuoteIcon.tsx
+++ b/src/web/components/QuoteIcon.tsx
@@ -66,11 +66,11 @@ const sizeStyles = (size: SmallHeadlineSize) => {
 };
 
 type Props = {
-	colour?: string;
-	size?: SmallHeadlineSize;
+	colour: string;
+	size: SmallHeadlineSize;
 };
 
-export const QuoteIcon = ({ colour, size = 'medium' }: Props) => (
+export const QuoteIcon = ({ colour, size }: Props) => (
 	<span className={sizeStyles(size)}>
 		<svg
 			width="70"

--- a/src/web/components/QuoteIcon.tsx
+++ b/src/web/components/QuoteIcon.tsx
@@ -15,8 +15,8 @@ const quoteStyles = (colour?: string) => css`
 const sizeStyles = (size: SmallHeadlineSize) => {
 	const tinySvg = css`
 		svg {
-			height: 12px;
-			width: 6px;
+			height: 13px;
+			width: 7px;
 		}
 	`;
 	const smallSvg = css`

--- a/src/web/components/QuoteIcon.tsx
+++ b/src/web/components/QuoteIcon.tsx
@@ -13,6 +13,12 @@ const quoteStyles = (colour?: string) => css`
 `;
 
 const sizeStyles = (size: SmallHeadlineSize) => {
+	const tinySvg = css`
+		svg {
+			height: 12px;
+			width: 6px;
+		}
+	`;
 	const smallSvg = css`
 		svg {
 			height: 16px;
@@ -34,6 +40,10 @@ const sizeStyles = (size: SmallHeadlineSize) => {
 		}
 	`;
 	switch (size) {
+		case 'tiny':
+			return css`
+				${tinySvg}
+			`;
 		case 'small':
 			return css`
 				${smallSvg}
@@ -51,10 +61,6 @@ const sizeStyles = (size: SmallHeadlineSize) => {
 				${until.desktop} {
 					${mediumSvg}
 				}
-			`;
-		default:
-			return css`
-				${mediumSvg}
 			`;
 	}
 };

--- a/src/web/components/elements/PullQuoteBlockComponent.tsx
+++ b/src/web/components/elements/PullQuoteBlockComponent.tsx
@@ -159,7 +159,10 @@ export const PullQuoteBlockComponent: React.FC<{
 						`,
 					)}
 				>
-					<QuoteIcon colour={pillarPalette[pillar].main} />
+					<QuoteIcon
+						colour={pillarPalette[pillar].main}
+						size="medium"
+					/>
 					<blockquote
 						className={css`
 							display: inline;
@@ -241,7 +244,10 @@ export const PullQuoteBlockComponent: React.FC<{
 						`,
 					)}
 				>
-					<QuoteIcon colour={pillarPalette[pillar].main} />
+					<QuoteIcon
+						colour={pillarPalette[pillar].main}
+						size="medium"
+					/>
 					<blockquote
 						className={css`
 							display: inline;


### PR DESCRIPTION
## What?
Builds out better support for the `tiny` headline size, mainly around the `QuoteIcon`

## Why?
To ensure we fully support the api that exists and also so that we can show a tiny `Updated 7 min ago` headline with a pulsing dot on a liveblog