### PR TITLE
Reduce > map

### DIFF
--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -68,25 +68,21 @@ const makeWindowGuardianConfig = (
 
 export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
 	// For some elements it is important to keep thier index in the `elements` array
-
 	const blockElementWithIndex = <T extends CAPIElement>(
 		blocks: { elements: CAPIElement[] }[],
 		blockElementType: CAPIElement['_type'],
 		indexName: string,
 	): T[] => {
 		if (blocks.length === 0) return [];
-		return blocks[0].elements.reduce(
-			(acc: T[], element: CAPIElement, index: number) => {
-				if (element._type === blockElementType) {
-					acc.push({
-						...element,
-						[indexName]: index,
-					} as T);
-				}
-				return acc;
-			},
-			[] as T[],
-		);
+		return blocks[0].elements.map((element: CAPIElement, index: number) => {
+			if (element._type === blockElementType) {
+				return {
+					...element,
+					[indexName]: index,
+				};
+			}
+			return element;
+		}) as T[];
 	};
 
 	// If our element type is one that can contain third party content that can track user, but hasn't been marked

--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -67,7 +67,9 @@ const makeWindowGuardianConfig = (
 };
 
 export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
-	// For some elements it is important to keep thier index in the `elements` array
+	// For some elements it is important to keep thier index in the `elements` array. We do this because
+	// we need a way to tell the client which element to hydrate. Could we do this better? Yes, we could
+	// set an elementId on Frontend and use that to id each element instead.
 	const blockElementWithIndex = <T extends CAPIElement>(
 		blocks: { elements: CAPIElement[] }[],
 		blockElementType: CAPIElement['_type'],

--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -74,15 +74,14 @@ export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
 		indexName: string,
 	): T[] => {
 		if (blocks.length === 0) return [];
-		return blocks[0].elements.map((element: CAPIElement, index: number) => {
-			if (element._type === blockElementType) {
+		return blocks[0].elements
+			.map((element: CAPIElement, index: number) => {
 				return {
 					...element,
 					[indexName]: index,
 				};
-			}
-			return element;
-		}) as T[];
+			})
+			.filter((element) => element._type === blockElementType) as T[];
 	};
 
 	// If our element type is one that can contain third party content that can track user, but hasn't been marked


### PR DESCRIPTION
## What?
Replaces a reduce function with a map function

## Why?
Because I find it hard to read reduce functions

Plus, Twitter told me to do it
https://twitter.com/jaffathecake/status/1213077702300852224
https://twitter.com/dan_abramov/status/1338253118199508992

### Why are we even using indexes?
Because we need a way to identify an element between the server and client. A better root solution would be to have some form of `elementId` property on the model.