### PR TITLE
Revert no-use-before-define lint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -60,7 +60,6 @@ module.exports = {
         '@typescript-eslint/ban-ts-comment': 'off',
         '@typescript-eslint/restrict-template-expressions': 'off',
         'no-console': 'off',
-        '@typescript-eslint/no-use-before-define': 'off',
 		'no-shadow': 'off',
 
         '@typescript-eslint/explicit-function-return-type': [0],

--- a/src/web/components/BylineLink.tsx
+++ b/src/web/components/BylineLink.tsx
@@ -22,6 +22,19 @@ const bylineAsTokens = (byline: string, tags: TagType[]): string[] => {
 	return byline.split(regex);
 };
 
+const ContributorLink: React.FC<{
+	contributor: string;
+	contributorTagId: string;
+}> = ({ contributor, contributorTagId }) => (
+	<a
+		rel="author"
+		data-link-name="auto tag link"
+		href={`//www.theguardian.com/${contributorTagId}`}
+	>
+		{contributor}
+	</a>
+);
+
 export const BylineLink = ({ byline, tags }: Props) => {
 	const renderedTokens = bylineAsTokens(byline, tags).map((token, i) => {
 		const associatedTags = getContributorTags(tags).filter(
@@ -41,16 +54,3 @@ export const BylineLink = ({ byline, tags }: Props) => {
 
 	return <>{renderedTokens}</>;
 };
-
-const ContributorLink: React.FC<{
-	contributor: string;
-	contributorTagId: string;
-}> = ({ contributor, contributorTagId }) => (
-	<a
-		rel="author"
-		data-link-name="auto tag link"
-		href={`//www.theguardian.com/${contributorTagId}`}
-	>
-		{contributor}
-	</a>
-);

--- a/src/web/components/RichLink.tsx
+++ b/src/web/components/RichLink.tsx
@@ -226,39 +226,6 @@ const imageStyles = css`
 	height: auto;
 `;
 
-type DefaultProps = {
-	index: number;
-	headlineText: string;
-	url: string;
-	isPlaceholder?: boolean;
-};
-
-export const DefaultRichLink: React.FC<DefaultProps> = ({
-	index,
-	headlineText,
-	url,
-	isPlaceholder,
-}) => {
-	return (
-		<RichLink
-			richLinkIndex={index}
-			cardStyle="news"
-			thumbnailUrl=""
-			headlineText={headlineText}
-			contentType="article"
-			url={url}
-			format={{
-				display: Display.Standard,
-				design: Design.Article,
-				theme: Pillar.News,
-			}}
-			tags={[]}
-			sponsorName=""
-			isPlaceholder={isPlaceholder}
-		/>
-	);
-};
-
 export const RichLink = ({
 	richLinkIndex,
 	cardStyle,
@@ -369,5 +336,38 @@ export const RichLink = ({
 				</a>
 			</div>
 		</div>
+	);
+};
+
+type DefaultProps = {
+	index: number;
+	headlineText: string;
+	url: string;
+	isPlaceholder?: boolean;
+};
+
+export const DefaultRichLink: React.FC<DefaultProps> = ({
+	index,
+	headlineText,
+	url,
+	isPlaceholder,
+}) => {
+	return (
+		<RichLink
+			richLinkIndex={index}
+			cardStyle="news"
+			thumbnailUrl=""
+			headlineText={headlineText}
+			contentType="article"
+			url={url}
+			format={{
+				display: Display.Standard,
+				design: Design.Article,
+				theme: Pillar.News,
+			}}
+			tags={[]}
+			sponsorName=""
+			isPlaceholder={isPlaceholder}
+		/>
 	);
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
- Revert `@typescript-eslint/no-use-before-define` lint exception
- fix errors by moving Component up in file (define before use)
