### PR TITLE
Handle undefined sectionName/sectionID

### DIFF
--- a/src/amp/components/Analytics.test.tsx
+++ b/src/amp/components/Analytics.test.tsx
@@ -2,33 +2,33 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { Analytics, AnalyticsModel } from '@root/src/amp/components/Analytics';
 
-describe('AnalyticsComponent', () => {
-	const analytics: AnalyticsModel = {
-		gaTracker: 'UA-XXXXXXX-X',
-		title: 'Foo',
-		fbPixelaccount: 'XXXXXXXXXX',
-		comscoreID: 'XXXXXXX',
-		contentType: 'Article',
-		id: 'some/page',
-		beacon: `localhost/count/pv.gif`,
-		neilsenAPIID: 'XXXXXX-XXXX-XXXX-XXXX-XXXXXXXXX',
-		domain: 'amp.theguardian.com',
-		permutive: {
-			namespace: 'guardian',
-			apiKey: '42-2020',
-			payload: {
-				'properties.content.title': 'article title',
-			},
+const analyticsBase: AnalyticsModel = {
+	gaTracker: 'UA-XXXXXXX-X',
+	title: 'Foo',
+	fbPixelaccount: 'XXXXXXXXXX',
+	comscoreID: 'XXXXXXX',
+	contentType: 'Article',
+	id: 'some/page',
+	beacon: `localhost/count/pv.gif`,
+	neilsenAPIID: 'XXXXXX-XXXX-XXXX-XXXX-XXXXXXXXX',
+	domain: 'amp.theguardian.com',
+	permutive: {
+		namespace: 'guardian',
+		apiKey: '42-2020',
+		payload: {
+			'properties.content.title': 'article title',
 		},
-		ipsosSectionName: 'section',
-	};
+	},
+	ipsosSectionName: 'section',
+};
 
-	beforeEach(() => {
-		delete analytics.section;
-	});
-
+describe('AnalyticsComponent', () => {
 	it('if section is business then include the MoDI snowplow tag', () => {
-		analytics.section = 'business';
+		const analytics = {
+			...analyticsBase,
+			section: 'business',
+		};
+
 		const { container } = render(<Analytics analytics={analytics} />);
 
 		const ampAnalyticsSnowplowElement = container.querySelectorAll(
@@ -47,6 +47,9 @@ describe('AnalyticsComponent', () => {
 	});
 
 	it('if section is undefined then do not include the MoDI snowplow tag', () => {
+		const analytics = {
+			...analyticsBase,
+		};
 		const { container } = render(<Analytics analytics={analytics} />);
 
 		const ampAnalyticsSnowplowElement = container.querySelector(
@@ -57,7 +60,10 @@ describe('AnalyticsComponent', () => {
 	});
 
 	it('if section is not business then do not include the MoDI snowplow tag', () => {
-		analytics.section = 'politics';
+		const analytics = {
+			...analyticsBase,
+			section: 'politics',
+		};
 		const { container } = render(<Analytics analytics={analytics} />);
 
 		const ampAnalyticsSnowplowElement = container.querySelector(

--- a/src/amp/components/Onward.tsx
+++ b/src/amp/components/Onward.tsx
@@ -95,15 +95,16 @@ export const Onward: React.FC<{
 	);
 
 	const hasSectionMostViewed = sectionID && sectionHasMostViewed(sectionID);
-	const sectionMostViewed = hasSectionMostViewed
-		? container(
-				`${ampBaseURL}/container/count/1/offset/0/section/${sectionID}/mf2.json`,
-				`most-viewed-in-${sectionID}`,
-		  )
-		: container(
-				`${ampBaseURL}/container/count/1/offset/0/mf2.json`,
-				'most-viewed',
-		  );
+	const sectionMostViewed =
+		sectionID && hasSectionMostViewed
+			? container(
+					`${ampBaseURL}/container/count/1/offset/0/section/${sectionID}/mf2.json`,
+					`most-viewed-in-${sectionID}`,
+			  )
+			: container(
+					`${ampBaseURL}/container/count/1/offset/0/mf2.json`,
+					'most-viewed',
+			  );
 
 	const headlines = container(
 		`${ampBaseURL}/container/count/3/offset/${

--- a/src/amp/server/render.tsx
+++ b/src/amp/server/render.tsx
@@ -25,6 +25,7 @@ export const render = ({ body }: express.Request, res: express.Response) => {
 		const scripts = [...extractScripts(elements, CAPI.mainMediaElements)];
 
 		const sectionName = CAPI.sectionName || '';
+		const neilsenAPIID = findBySubsection(sectionName).apiID;
 
 		const analytics: AnalyticsModel = {
 			gaTracker: 'UA-78705427-1',
@@ -35,7 +36,7 @@ export const render = ({ body }: express.Request, res: express.Response) => {
 			contentType: CAPI.contentType,
 			id: CAPI.pageId,
 			beacon: `${CAPI.beaconURL}/count/pv.gif`,
-			neilsenAPIID: findBySubsection(sectionName).apiID,
+			neilsenAPIID,
 			domain: 'amp.theguardian.com',
 			permutive: {
 				namespace: 'guardian',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
- Simplify `Analytics.test.tsx` by creating a new object in each test rather than mutating object

It is clearer to see what variations you are testing by simply defining a new object with the relavant fields

- add `sectionID &&` as condition to setting `sectionMostViewed`

TS does not pick up on the fact that `hasSectionMostViewed` already checks if `sectionID` is defined, so we need to add an extra check `sectionID && ` to make sure we can use it in the string

- lift `neilsenAPIID` definition up to put it next to `sectionName` for clarity

