### PR TITLE
MainMedia adTests prop

### DIFF
--- a/src/web/layouts/LiveLayout.tsx
+++ b/src/web/layouts/LiveLayout.tsx
@@ -478,6 +478,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 								elements={CAPI.mainMediaElements}
 								adTargeting={adTargeting}
 								host={host}
+								abTests={CAPI.config.abTests}
 							/>
 						</div>
 					</GridItem>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Add missing prop on MainMedia to fix main

## Why?
To fix `main`