### PR TITLE
Make InteractiveBlockElements their own component in AMP

### DIFF
--- a/src/amp/components/Elements.tsx
+++ b/src/amp/components/Elements.tsx
@@ -10,6 +10,7 @@ import { GuVideoBlockComponent } from '@root/src/amp/components/elements/GuVideo
 import { ImageBlockComponent } from '@root/src/amp/components/elements/ImageBlockComponent';
 import { InstagramBlockComponent } from '@root/src/amp/components/elements/InstagramBlockComponent';
 import { InteractiveAtomBlockComponent } from '@root/src/amp/components/elements/InteractiveAtomBlockComponent';
+import { InteractiveBlockComponent } from '@root/src/amp/components/elements/InteractiveBlockComponent';
 import { MapBlockComponent } from '@root/src/amp/components/elements/MapBlockComponent';
 import { PullquoteBlockComponent } from '@root/src/amp/components/elements/PullquoteBlockComponent';
 import { RichLinkBlockComponent } from '@root/src/amp/components/elements/RichLinkBlockComponent';
@@ -103,7 +104,12 @@ export const Elements = (
 					/>
 				); // element.placeholderUrl
 			case 'model.dotcomrendering.pageElements.InteractiveBlockElement': // Plain Interactive Embeds
-				return <InteractiveAtomBlockComponent url={element.url} />;
+				return (
+					<InteractiveBlockComponent
+						url={element.url}
+						isMandatory={element.isMandatory}
+					/>
+				);
 			case 'model.dotcomrendering.pageElements.MapBlockElement':
 				return (
 					<MapBlockComponent

--- a/src/amp/components/elements/InteractiveBlockComponent.tsx
+++ b/src/amp/components/elements/InteractiveBlockComponent.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { css } from 'emotion';
+import { ShowMoreButton } from '@root/src/amp/components/ShowMoreButton';
+
+const styles = css`
+	height: 100px;
+	width: 100%;
+	margin-top: 16px;
+	margin-bottom: 12px;
+`;
+
+const showMore = css`
+	&[overflow] {
+		position: absolute;
+		bottom: 0;
+		left: 0;
+		right: 0;
+	}
+`;
+
+export const InteractiveBlockComponent: React.SFC<{
+	url: string;
+	isMandatory: boolean | undefined;
+}> = ({ url, isMandatory }) => {
+	// If this element is mandatory, we don't know if we can render it properly, so we have to
+	// throw an error and chuck the whole page out of AMP. You're barred son.
+	if (isMandatory) {
+		throw new Error(
+			'This page cannot be rendered due to incompatible content that is marked as mandatory.',
+		);
+	}
+
+	return (
+		<amp-iframe
+			className={styles}
+			src={url}
+			layout="responsive"
+			sandbox="allow-scripts allow-same-origin allow-top-navigation-by-user-activation allow-popups"
+			height="1"
+			width="1"
+			resizable=""
+			data-cy="atom-embed-url"
+		>
+			<div overflow="" className={showMore}>
+				<ShowMoreButton />
+			</div>
+		</amp-iframe>
+	);
+};

--- a/src/amp/components/elements/InteractiveBlockComponent.tsx
+++ b/src/amp/components/elements/InteractiveBlockComponent.tsx
@@ -19,8 +19,8 @@ const showMore = css`
 `;
 
 export const InteractiveBlockComponent: React.SFC<{
-	url: string;
-	isMandatory: boolean | undefined;
+	url?: string;
+	isMandatory?: boolean;
 }> = ({ url, isMandatory }) => {
 	// If this element is mandatory, we don't know if we can render it properly, so we have to
 	// throw an error and chuck the whole page out of AMP. You're barred son.
@@ -28,6 +28,10 @@ export const InteractiveBlockComponent: React.SFC<{
 		throw new Error(
 			'This page cannot be rendered due to incompatible content that is marked as mandatory.',
 		);
+	}
+
+	if (!url) {
+		return null;
 	}
 
 	return (

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -215,8 +215,13 @@ interface InteractiveAtomBlockElement extends InteractiveAtomBlockElementBase {
 	role?: RoleType;
 }
 
-interface InteractiveBlockElement extends InteractiveAtomBlockElementBase {
+interface InteractiveBlockElement {
 	_type: 'model.dotcomrendering.pageElements.InteractiveBlockElement';
+	url: string;
+	isMandatory?: boolean;
+	scriptUrl?: string;
+	alt?: string;
+	role?: RoleType;
 }
 
 interface MapBlockElement extends ThirdPartyEmbeddedContent {

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -217,7 +217,7 @@ interface InteractiveAtomBlockElement extends InteractiveAtomBlockElementBase {
 
 interface InteractiveBlockElement {
 	_type: 'model.dotcomrendering.pageElements.InteractiveBlockElement';
-	url: string;
+	url?: string;
 	isMandatory?: boolean;
 	scriptUrl?: string;
 	alt?: string;

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -1759,25 +1759,21 @@
                 "url": {
                     "type": "string"
                 },
-                "placeholderUrl": {
+                "isMandatory": {
+                    "type": "boolean"
+                },
+                "scriptUrl": {
                     "type": "string"
                 },
-                "id": {
+                "alt": {
                     "type": "string"
                 },
-                "html": {
-                    "type": "string"
-                },
-                "css": {
-                    "type": "string"
-                },
-                "js": {
-                    "type": "string"
+                "role": {
+                    "$ref": "#/definitions/RoleType"
                 }
             },
             "required": [
-                "_type",
-                "url"
+                "_type"
             ]
         },
         "MapBlockElement": {


### PR DESCRIPTION
## What does this change?

Breaks out interactiveBlockElement from interactiveAtomBlockElement.

We also throw an error if the interactive is mandatory to force the article not to appear in AMP.