### PR TITLE
Add github action for browser bundles

### DIFF
--- a/.github/workflows/bundle-analyser.yml
+++ b/.github/workflows/bundle-analyser.yml
@@ -28,12 +28,3 @@ jobs:
               with:
                 name: bundle-analyser-report
                 path: dist/browser-bundles.html
-
-            - uses: actions/download-artifact@v2
-              id: download
-              with: 
-                name: 'bundle-analyser-report'
-                path: path/to/artifacts
-
-            - name: 'Echo download path'
-              run: echo ${{steps.download.outputs.download-path}}

--- a/.github/workflows/bundle-analyser.yml
+++ b/.github/workflows/bundle-analyser.yml
@@ -1,0 +1,30 @@
+name: Bundle Analyser
+on: push
+
+jobs:
+    build_check:
+        name: Bundle Analyser
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v1
+
+            - name: Use Node.js 14.15
+              uses: actions/setup-node@v1
+              with:
+                  node-version: '14.15'
+
+            # Cache npm dependencies using https://github.com/bahmutov/npm-install
+            - uses: bahmutov/npm-install@v1
+
+            - name: Install
+              run: yarn
+
+            - name: Generate production build
+              run: make build
+
+						- name: Archive code coverage results
+							uses: actions/upload-artifact@v2
+							with:
+								name: bundle-analyser-report
+								path: dist/browser-bundles.html

--- a/.github/workflows/bundle-analyser.yml
+++ b/.github/workflows/bundle-analyser.yml
@@ -23,8 +23,8 @@ jobs:
             - name: Generate production build
               run: make build
 
-						- name: Archive code coverage results
-							uses: actions/upload-artifact@v2
-							with:
-								name: bundle-analyser-report
-								path: dist/browser-bundles.html
+            - name: Archive code coverage results
+              uses: actions/upload-artifact@v2
+              with:
+                name: bundle-analyser-report
+                path: dist/browser-bundles.html

--- a/.github/workflows/bundle-analyser.yml
+++ b/.github/workflows/bundle-analyser.yml
@@ -28,3 +28,12 @@ jobs:
               with:
                 name: bundle-analyser-report
                 path: dist/browser-bundles.html
+
+            - uses: actions/download-artifact@v2
+              id: download
+              with: 
+                name: 'bundle-analyser-report'
+                path: path/to/artifacts
+
+            - name: 'Echo download path'
+              run: echo ${{steps.download.outputs.download-path}}


### PR DESCRIPTION
## What does this change?

Creates the bundle analyser results as a downloadable artefact as discussed in  https://chat.google.com/room/AAAAG9rU0m0/94TFO2HTlMw

![image](https://user-images.githubusercontent.com/638051/109304588-64d14180-7834-11eb-9a86-0da6b09a05e1.png)

## Why?
It's useful to get this straight from the PR sometimes rather than having to clone and run the branch.