### PR TITLE
Modify logo max widths to align with current practice

### DIFF
--- a/src/web/components/Branding.tsx
+++ b/src/web/components/Branding.tsx
@@ -17,9 +17,9 @@ const brandingLabelStyle = css`
 
 const brandingLogoStyle = css`
 	${until.phablet} {
-		max-width: 150px;
+		max-width: 140px;
 	}
-	max-width: 220px;
+	max-width: 280px;
 	width: 100%;
 	padding: 10px 0;
 	img {


### PR DESCRIPTION
### Before

Sizing inconsistent with what CP upload (140px or 280px wide) and also to align with Frontend.

### After

![Kapture 2021-02-26 at 17 57 46](https://user-images.githubusercontent.com/858402/109337083-323b3f00-785c-11eb-9632-b9c02e47690f.gif)

## Why?

To provide consistent widths for logos and align this with our typical logo sizes.
