### PR TITLE
Accessible Donuts

### DIFF
--- a/src/web/components/Donut.stories.tsx
+++ b/src/web/components/Donut.stories.tsx
@@ -25,7 +25,7 @@ const twoSections = [
 	{
 		value: 29,
 		label: 'Dat1',
-		color: '#eb121a',
+		color: '#fff',
 	},
 	{
 		value: 71,

--- a/src/web/components/Donut.stories.tsx
+++ b/src/web/components/Donut.stories.tsx
@@ -25,7 +25,7 @@ const twoSections = [
 	{
 		value: 29,
 		label: 'Dat1',
-		color: '#fff',
+		color: '#9fe111',
 	},
 	{
 		value: 71,

--- a/src/web/components/Donut.tsx
+++ b/src/web/components/Donut.tsx
@@ -4,6 +4,8 @@ import { css } from 'emotion';
 import { headline, textSans } from '@guardian/src-foundations/typography';
 import { text } from '@guardian/src-foundations/palette';
 
+import { isLight } from '@frontend/web/lib/isLight';
+
 type Props = {
 	sections: Section[];
 	percentCutout?: number;
@@ -22,15 +24,15 @@ const unitStyles = css`
 	text-anchor: middle;
 `;
 
-const valueStyles = css`
+const valueStyles = (background: string) => css`
 	${headline.small({ fontWeight: 'bold' })}
-	fill: ${text.ctaPrimary};
+	fill: ${isLight(background) ? text.ctaSecondary : text.ctaPrimary};
 	text-anchor: middle;
 `;
 
-const labelStyles = css`
+const labelStyles = (background: string) => css`
 	${textSans.small()}
-	fill: ${text.ctaPrimary};
+	fill: ${isLight(background) ? text.ctaSecondary : text.ctaPrimary};
 	text-anchor: middle;
 `;
 
@@ -169,10 +171,18 @@ export const Donut = ({
 				<g>
 					<path d={segment.d} fill={segment.color} />
 					<text transform={segment.transform}>
-						<tspan className={labelStyles} x="0" dy="0">
+						<tspan
+							className={labelStyles(segment.color)}
+							x="0"
+							dy="0"
+						>
 							{segment.label}
 						</tspan>
-						<tspan className={valueStyles} x="0" dy=".9em">
+						<tspan
+							className={valueStyles(segment.color)}
+							x="0"
+							dy=".9em"
+						>
 							{segment.value}
 						</tspan>
 					</text>


### PR DESCRIPTION
## What?
Adds the `isLight` function to the `Donut` component so that we can use it to decide what colour to set the text relative to the contrast of the background colour

## Why?
This was raised as an issue where if the background is white and the text is white, you see nothing but we also want to make changes like this to improve accessibility

## Before
![Screenshot 2021-03-01 at 12 21 07](https://user-images.githubusercontent.com/1336821/109496492-a0644980-7a88-11eb-9998-16485f6ccf6b.jpg)


## After
![Screenshot 2021-03-01 at 12 07 32](https://user-images.githubusercontent.com/1336821/109495868-c5a48800-7a87-11eb-9c06-581f75a15217.jpg)
