### PR TITLE
Add Text Egyptian and Text Sans Bold Italic fonts

### DIFF
--- a/src/lib/fonts-css.ts
+++ b/src/lib/fonts-css.ts
@@ -198,6 +198,28 @@ const fontList: FontDisplay[] = [
 		weight: 700,
 		style: 'normal',
 	},
+	{
+		family: 'GuardianTextEgyptian',
+		woff2:
+			'fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BoldItalic.woff2',
+		woff:
+			'fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-BoldItalic.woff',
+		ttf:
+			'fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-BoldItalic.ttf',
+		weight: 700,
+		style: 'italic',
+	},
+	{
+		family: 'Guardian Text Egyptian Web',
+		woff2:
+			'fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BoldItalic.woff2',
+		woff:
+			'fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-BoldItalic.woff',
+		ttf:
+			'fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-BoldItalic.ttf',
+		weight: 700,
+		style: 'italic',
+	},
 	// GuardianTextSans, with legacy family name of Guardian Text Sans Web
 	{
 		family: 'GuardianTextSans',

--- a/src/lib/fonts-css.ts
+++ b/src/lib/fonts-css.ts
@@ -287,6 +287,28 @@ const fontList: FontDisplay[] = [
 		weight: 700,
 		style: 'normal',
 	},
+	{
+		family: 'GuardianTextSans',
+		woff2:
+			'fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BoldItalic.woff2',
+		woff:
+			'fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-BoldItalic.woff',
+		ttf:
+			'fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-BoldItalic.ttf',
+		weight: 700,
+		style: 'italic',
+	},
+	{
+		family: 'Guardian Text Sans Web',
+		woff2:
+			'fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BoldItalic.woff2',
+		woff:
+			'fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-BoldItalic.woff',
+		ttf:
+			'fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-BoldItalic.ttf',
+		weight: 700,
+		style: 'italic',
+	},
 ];
 
 const assetsUrl = (path: string): string =>


### PR DESCRIPTION
## What does this change?
This PR adds Bold Italic styles for both Text Egyptian and Text Sans font families. I believe the fonts are not requested if they are not used on the page, so this should not incur extra downloads in most circumstances. Having them for Text Egyptian is also for frontend parity.

This is a proposal, please shot it down if there are performance implications I haven’t thought of. OTOH, I won’t go down without a good fight ;-)
cc @sndrs 

### Before
Firefox, [URL](https://www.theguardian.com/politics/2020/sep/03/margaret-thatcher-wasnt-for-turning-but-boris-johnson-is):
<img width="877" alt="image" src="https://user-images.githubusercontent.com/6032869/109738218-5631b400-7bbf-11eb-9faf-5dc1ccc22e59.png">
Chrome:
<img width="855" alt="image" src="https://user-images.githubusercontent.com/6032869/109738305-795c6380-7bbf-11eb-8b67-fe3a44e10cc2.png">

### After (current frontend; `dcr=false`)
Firefox:
<img width="880" alt="image" src="https://user-images.githubusercontent.com/6032869/109738344-92fdab00-7bbf-11eb-983f-67e14ec1c4ee.png">
Chrome:
<img width="861" alt="image" src="https://user-images.githubusercontent.com/6032869/109738393-a90b6b80-7bbf-11eb-80e3-6fb44e2e9f9c.png">

Text Sans Bold Italic is much less common, mostly in comments. Take a look at [this example](https://www.theguardian.com/commentisfree/2021/mar/02/healthcare-professionals-uk-moral-duty-covid-jab-vaccine#comment-147811921). No screenshots, but the discrepancy and odd rendering is even worse. Also, unrelatedly, note how we may have a bug in discussion-rendering (?) because only the first word (_ask_) is italicised in Firefox versus Chrome).

## Why?
Because faux styles are evil and naff. If we have content that calls for a font style, we must have a font style available for it. Also, because different browsers render them differently (Firefox, shown above, worse than eg. Chrome). Also, because they are used sparingly, so will be requested sparingly. And then they will stay in cache (if one believes in browser cache, that is).