### PR TITLE
Remove “G” roundel placeholder in Ads

### DIFF
--- a/src/amp/components/Ad.tsx
+++ b/src/amp/components/Ad.tsx
@@ -14,9 +14,6 @@ const sizes = [
 
 const adStyle = css`
 	background: ${palette.neutral[93]};
-	background-size: 105px;
-	background-repeat: no-repeat;
-	background-position: center;
 	border-top: 1px solid ${palette.neutral[86]};
 	width: min-content;
 	height: min-content;

--- a/src/amp/components/Ad.tsx
+++ b/src/amp/components/Ad.tsx
@@ -6,10 +6,6 @@ import { palette } from '@guardian/src-foundations';
 import { textSans } from '@guardian/src-foundations/typography';
 import { adJson, stringify } from '@root/src/amp/lib/ad-json';
 
-const svgBackground = encodeURIComponent(
-	`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 86 76"><path fill="${palette.neutral[86]}" d="M51 16c0-12-4-14-8-14s-8 2-8 14 4 13 8 13 8-1 8-13M35 61c-5 0-7 4-7 7 0 4 4 8 15 8 13 0 16-4 16-8 1-4-3-7-8-7H35zM25 1a43 43 0 00-13 69v-1c0-7 8-10 15-12-7-1-10-6-10-10 0-6 7-12 10-14-6-4-10-9-10-17 0-7 3-12 8-15m61 39C86 22 75 7 60 0c5 3 8 9 9 15v2c0 12-11 19-26 19l-10-1-2 4c0 2 2 4 4 4h21c13 0 20 5 20 17 0 4-1 7-3 10 8-7 13-18 13-30"/></svg>`,
-);
-
 // Largest size first
 const sizes = [
 	{ width: 300, height: 250 }, // MPU
@@ -18,7 +14,6 @@ const sizes = [
 
 const adStyle = css`
 	background: ${palette.neutral[93]};
-	background-image: url('data:image/svg+xml;utf-8,${svgBackground}');
 	background-size: 105px;
 	background-repeat: no-repeat;
 	background-position: center;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

The roundel in ads is an old, deprecated logo. It was missing until 23283440 and currently is overlaid with AMP’s “Ad” loading placeholder.

### Screenshot comparison

An alternative would be to replace it with the [latest roundel](https://theguardian.design/2a1e5182b/p/8909e0-assets/t/37168b). This, however, was deemed unnecessary by @HarryFischer.

| Old Roundel | No Roundel | New Roundel | New Roundel Alt |
|-------------|------------|-------------|-----------------|
| ![old][]    | ![no][]    | ![new]      | ![new-alt]      |

[old]: https://user-images.githubusercontent.com/76776/109967075-f91d2780-7cbe-11eb-82e1-faccd6dc84f4.png
[no]: https://user-images.githubusercontent.com/76776/109967028-ec003880-7cbe-11eb-8aa8-f7ddad772b85.png
[new]: https://user-images.githubusercontent.com/76776/109966984-e145a380-7cbe-11eb-9e8a-62345fb884ba.png
[new-alt]: https://user-images.githubusercontent.com/76776/109967311-40a3b380-7cbf-11eb-9c04-31d309017718.png

## Why?

The lowercase `g` roundel is a relic of a bygone era, and it clashes with the AMP built-in placeholder Ad loader.

🧹💨 