### PR TITLE
Add capability to cache Braze messages in local storage

### DIFF
--- a/src/web/lib/braze/BrazeMessages.test.ts
+++ b/src/web/lib/braze/BrazeMessages.test.ts
@@ -1,14 +1,25 @@
-import type appboy from '@braze/web-sdk-core';
+import appboy from '@braze/web-sdk-core';
 import { createNanoEvents, Emitter } from 'nanoevents';
 import { BrazeMessages } from './BrazeMessages';
+import {
+	LocalMessageCache,
+	InMemoryCache,
+	hydrateMessage,
+} from './LocalMessageCache';
 
 const logInAppMessageImpressionSpy = jest.fn();
+
+const message1Json: string = `{"message":"","messageAlignment":"CENTER","duration":5000,"slideFrom":"BOTTOM","extras":{"heading":"Tom Epic Title 1","slotName":"EndOfArticle","step":"1","componentName":"Epic","highlightedText":"This text is important %%CURRENCY_SYMBOL%%1","buttonText":"Button","buttonUrl":"https://www.example.com","paragraph1":"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."},"triggerId":"NjAzNjhmNDFkZTNmMTAxMjE4YmE5Y2E0XyRfY2MmZGkmbXY9NjAzNjhmNDFkZTNmMTAxMjE4YmE5YzZiJnBpPXdmcyZ3PTYwMzY4ZjQxZGUzZjEwMTIxOGJhOWM1OCZ3cD0xNjE0MjQxNTkyJnd2PTYwMzY4ZjQxZGUzZjEwMTIxOGJhOWM5ZA==","clickAction":"NONE","uri":null,"openTarget":"NONE","dismissType":"SWIPE","icon":null,"imageUrl":null,"imageStyle":"TOP","iconColor":4294967295,"iconBackgroundColor":4278219733,"backgroundColor":4294967295,"textColor":4281545523,"closeButtonColor":4288387995,"animateIn":true,"animateOut":true,"header":null,"headerAlignment":"CENTER","headerTextColor":4281545523,"frameColor":3224580915,"buttons":[],"cropType":"FIT_CENTER","Rd":true,"Ma":false,"Qd":false,"X":{"qb":{}},"Ub":{"qb":{}},"Lg":false,"Uf":"WEB_HTML"}`;
+const message2Json: string = `{"message":"","messageAlignment":"CENTER","duration":5000,"slideFrom":"BOTTOM","extras":{"heading":"Tom Epic Title 2","slotName":"EndOfArticle","step":"1","componentName":"Epic","highlightedText":"This text is important %%CURRENCY_SYMBOL%%1","buttonText":"Button","buttonUrl":"https://www.example.com","paragraph1":"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."},"triggerId":"NjAzNjhmNDFkZTNmMTAxMjE4YmE5Y2E0XyRfY2MmZGkmbXY9NjAzNjhmNDFkZTNmMTAxMjE4YmE5YzZiJnBpPXdmcyZ3PTYwMzY4ZjQxZGUzZjEwMTIxOGJhOWM1OCZ3cD0xNjE0MjQxNTkyJnd2PTYwMzY4ZjQxZGUzZjEwMTIxOGJhOWM5ZA==","clickAction":"NONE","uri":null,"openTarget":"NONE","dismissType":"SWIPE","icon":null,"imageUrl":null,"imageStyle":"TOP","iconColor":4294967295,"iconBackgroundColor":4278219733,"backgroundColor":4294967295,"textColor":4281545523,"closeButtonColor":4288387995,"animateIn":true,"animateOut":true,"header":null,"headerAlignment":"CENTER","headerTextColor":4281545523,"frameColor":3224580915,"buttons":[],"cropType":"FIT_CENTER","Rd":true,"Ma":false,"Qd":false,"X":{"qb":{}},"Ub":{"qb":{}},"Lg":false,"Uf":"WEB_HTML"}`;
 
 class FakeAppBoy {
 	emitter: Emitter;
 
+	HtmlMessage: typeof appboy.HtmlMessage;
+
 	constructor() {
 		this.emitter = createNanoEvents();
+		this.HtmlMessage = appboy.HtmlMessage;
 	}
 
 	subscribeToInAppMessage(
@@ -32,77 +43,289 @@ beforeEach(() => {
 	logInAppMessageImpressionSpy.mockClear();
 });
 
+const buildMessage = (data: any) => hydrateMessage(data, appboy);
+
 describe('BrazeMessages', () => {
-	describe('getMessageForBanner & getMessageForEndOfArticle', () => {
-		it('returns a promise which resolves with message data for the correct slot', async () => {
-			const fakeAppBoy = new FakeAppBoy();
-			const brazeMessages = new BrazeMessages(
-				(fakeAppBoy as unknown) as typeof appboy,
-			);
-
-			const bannerPromise = brazeMessages.getMessageForBanner();
-			const endOfArticlePromise = brazeMessages.getMessageForEndOfArticle();
-
-			const bannerMessage = {
-				extras: { slotName: 'Banner', title: 'Example' },
-			};
-			fakeAppBoy.emit(bannerMessage);
-
-			const endOfArticleMessage = {
-				extras: {
-					slotName: 'EndOfArticle',
-					title: 'Example',
-				},
-			};
-			fakeAppBoy.emit(endOfArticleMessage);
-
-			const data = await Promise.all([
-				bannerPromise,
-				endOfArticlePromise,
-			]);
-			expect(data[0].extras).toEqual(bannerMessage.extras);
-			expect(data[1].extras).toEqual(endOfArticleMessage.extras);
+	describe(`When the cache is enabled`, () => {
+		beforeEach(() => {
+			LocalMessageCache.clear();
 		});
 
-		it('supports multiple calls to the same slot, returning separate promises', async () => {
-			const fakeAppBoy = new FakeAppBoy();
-			const brazeMessages = new BrazeMessages(
-				(fakeAppBoy as unknown) as typeof appboy,
-			);
+		describe('getMessageForBanner & getMessageForEndOfArticle', () => {
+			it('returns a promise which resolves with message data for the correct slot', async () => {
+				const fakeAppBoy = new FakeAppBoy();
+				const brazeMessages = new BrazeMessages(
+					(fakeAppBoy as unknown) as typeof appboy,
+					LocalMessageCache,
+				);
 
-			const bannerPromise = brazeMessages.getMessageForBanner();
-			const anotherBannerPromise = brazeMessages.getMessageForBanner();
+				const bannerPromise = brazeMessages.getMessageForBanner();
+				const endOfArticlePromise = brazeMessages.getMessageForEndOfArticle();
 
-			const message = {
-				extras: { slotName: 'Banner', title: 'Example' },
-			};
-			fakeAppBoy.emit(message);
+				const bannerMessage = buildMessage({
+					...JSON.parse(message1Json),
+					extras: { slotName: 'Banner', title: 'Example' },
+				});
+				fakeAppBoy.emit(bannerMessage);
 
-			const data = await Promise.all([
-				bannerPromise,
-				anotherBannerPromise,
-			]);
-			expect(data[0].extras).toEqual(message.extras);
-			expect(data[1].extras).toEqual(message.extras);
+				const endOfArticleMessage = buildMessage({
+					...JSON.parse(message2Json),
+					extras: {
+						slotName: 'EndOfArticle',
+						title: 'Example',
+					},
+				});
+				fakeAppBoy.emit(endOfArticleMessage);
+
+				const data = await Promise.all([
+					bannerPromise,
+					endOfArticlePromise,
+				]);
+				expect(data[0].extras).toEqual(bannerMessage.extras);
+				expect(data[1].extras).toEqual(endOfArticleMessage.extras);
+			});
+
+			it('returns a message which is capable of logging an impression', async () => {
+				const fakeAppBoy = new FakeAppBoy();
+				const brazeMessages = new BrazeMessages(
+					(fakeAppBoy as unknown) as typeof appboy,
+					LocalMessageCache,
+				);
+
+				const bannerPromise = brazeMessages.getMessageForBanner();
+
+				const message = buildMessage({
+					...JSON.parse(message1Json),
+					extras: { slotName: 'Banner', title: 'Example' },
+				});
+				fakeAppBoy.emit(message);
+
+				const bannerMessage = await bannerPromise;
+				bannerMessage.logImpression();
+
+				expect(logInAppMessageImpressionSpy).toHaveBeenCalledWith(
+					message,
+				);
+			});
+
+			it('returns a message with an id', async () => {
+				const fakeAppBoy = new FakeAppBoy();
+				const brazeMessages = new BrazeMessages(
+					(fakeAppBoy as unknown) as typeof appboy,
+					LocalMessageCache,
+				);
+
+				const bannerPromise = brazeMessages.getMessageForBanner();
+
+				const message = buildMessage({
+					...JSON.parse(message1Json),
+					extras: { slotName: 'Banner', title: 'Example' },
+				});
+				fakeAppBoy.emit(message);
+
+				const bannerMessage = await bannerPromise;
+
+				expect(bannerMessage.id).toMatch(/\w{11,13}-\d{13}/);
+			});
+
+			it('returns a cached message if one is available', async () => {
+				const cachedMessage = buildMessage(JSON.parse(message1Json));
+				LocalMessageCache.push('EndOfArticle', {
+					message: cachedMessage,
+					id: '1',
+				});
+				const freshMessage = buildMessage(JSON.parse(message2Json));
+				const fakeAppBoy = new FakeAppBoy();
+				const brazeMessages = new BrazeMessages(
+					(fakeAppBoy as unknown) as typeof appboy,
+					LocalMessageCache,
+				);
+				fakeAppBoy.emit(freshMessage);
+
+				const gotMessage = await brazeMessages.getMessageForEndOfArticle();
+
+				expect(gotMessage.message).toEqual(cachedMessage);
+			});
+
+			it('logging an impression results in the message being removed from the cache', async () => {
+				const cachedMessage = buildMessage(JSON.parse(message1Json));
+				LocalMessageCache.push('EndOfArticle', {
+					message: cachedMessage,
+					id: '1',
+				});
+				const freshMessage = buildMessage(JSON.parse(message2Json));
+				const fakeAppBoy = new FakeAppBoy();
+				const brazeMessages = new BrazeMessages(
+					(fakeAppBoy as unknown) as typeof appboy,
+					LocalMessageCache,
+				);
+				fakeAppBoy.emit(freshMessage);
+
+				const firstMessage = await brazeMessages.getMessageForEndOfArticle();
+				firstMessage.logImpression();
+
+				const anotherMessage = await brazeMessages.getMessageForEndOfArticle();
+				expect(anotherMessage.message).toEqual(freshMessage);
+			});
+
+			it('returns the same cached message multiple times if an impression is not logged', async () => {
+				const cachedMessage = buildMessage(JSON.parse(message1Json));
+				LocalMessageCache.push('EndOfArticle', {
+					message: cachedMessage,
+					id: '1',
+				});
+				const freshMessage = buildMessage(JSON.parse(message2Json));
+				const fakeAppBoy = new FakeAppBoy();
+				const brazeMessages = new BrazeMessages(
+					(fakeAppBoy as unknown) as typeof appboy,
+					LocalMessageCache,
+				);
+				fakeAppBoy.emit(freshMessage);
+
+				const firstMessage = await brazeMessages.getMessageForEndOfArticle();
+				const secondMessage = await brazeMessages.getMessageForEndOfArticle();
+
+				expect(firstMessage).toEqual(secondMessage);
+			});
 		});
+	});
 
-		it('returns a message which is capable of logging an impression', async () => {
-			const fakeAppBoy = new FakeAppBoy();
-			const brazeMessages = new BrazeMessages(
-				(fakeAppBoy as unknown) as typeof appboy,
-			);
+	describe(`When the cache is not enabled`, () => {
+		beforeEach(() => {
+			InMemoryCache.clear();
+		});
+		describe('getMessageForBanner & getMessageForEndOfArticle', () => {
+			it('returns a promise which resolves with message data for the correct slot', async () => {
+				const fakeAppBoy = new FakeAppBoy();
+				const brazeMessages = new BrazeMessages(
+					(fakeAppBoy as unknown) as typeof appboy,
+					InMemoryCache,
+				);
 
-			const bannerPromise = brazeMessages.getMessageForBanner();
+				const bannerPromise = brazeMessages.getMessageForBanner();
+				const endOfArticlePromise = brazeMessages.getMessageForEndOfArticle();
 
-			const message = {
-				extras: { slotName: 'Banner', title: 'Example' },
-			};
-			fakeAppBoy.emit(message);
+				const bannerMessage = buildMessage({
+					extras: { slotName: 'Banner', title: 'Example' },
+				});
+				fakeAppBoy.emit(bannerMessage);
 
-			const bannerMessage = await bannerPromise;
-			bannerMessage.logImpression();
+				const endOfArticleMessage = buildMessage({
+					extras: {
+						slotName: 'EndOfArticle',
+						title: 'Example',
+					},
+				});
+				fakeAppBoy.emit(endOfArticleMessage);
 
-			expect(logInAppMessageImpressionSpy).toHaveBeenCalledWith(message);
+				const data = await Promise.all([
+					bannerPromise,
+					endOfArticlePromise,
+				]);
+				expect(data[0].extras).toEqual(bannerMessage.extras);
+				expect(data[1].extras).toEqual(endOfArticleMessage.extras);
+			});
+
+			it('returns a message which is capable of logging an impression', async () => {
+				const fakeAppBoy = new FakeAppBoy();
+				const brazeMessages = new BrazeMessages(
+					(fakeAppBoy as unknown) as typeof appboy,
+					InMemoryCache,
+				);
+
+				const bannerPromise = brazeMessages.getMessageForBanner();
+
+				const message = buildMessage({
+					extras: { slotName: 'Banner', title: 'Example' },
+				});
+				fakeAppBoy.emit(message);
+
+				const bannerMessage = await bannerPromise;
+				bannerMessage.logImpression();
+
+				expect(logInAppMessageImpressionSpy).toHaveBeenCalledWith(
+					message,
+				);
+			});
+
+			it('returns a message with an id', async () => {
+				const fakeAppBoy = new FakeAppBoy();
+				const brazeMessages = new BrazeMessages(
+					(fakeAppBoy as unknown) as typeof appboy,
+					InMemoryCache,
+				);
+
+				const bannerPromise = brazeMessages.getMessageForBanner();
+
+				const message = buildMessage({
+					extras: { slotName: 'Banner', title: 'Example' },
+				});
+				fakeAppBoy.emit(message);
+
+				const bannerMessage = await bannerPromise;
+
+				expect(bannerMessage.id).toMatch(/\w{11,13}-\d{13}/);
+			});
+
+			it('returns a cached message if one is available', async () => {
+				const cachedMessage = buildMessage(JSON.parse(message1Json));
+				InMemoryCache.push('EndOfArticle', {
+					message: cachedMessage,
+					id: '1',
+				});
+				const freshMessage = buildMessage(JSON.parse(message2Json));
+				const fakeAppBoy = new FakeAppBoy();
+				const brazeMessages = new BrazeMessages(
+					(fakeAppBoy as unknown) as typeof appboy,
+					InMemoryCache,
+				);
+				fakeAppBoy.emit(freshMessage);
+
+				const gotMessage = await brazeMessages.getMessageForEndOfArticle();
+
+				expect(gotMessage.message).toEqual(cachedMessage);
+			});
+
+			it('logging an impression results in the message being removed from the cache', async () => {
+				const cachedMessage = buildMessage(JSON.parse(message1Json));
+				InMemoryCache.push('EndOfArticle', {
+					message: cachedMessage,
+					id: '1',
+				});
+				const freshMessage = buildMessage(JSON.parse(message2Json));
+				const fakeAppBoy = new FakeAppBoy();
+				const brazeMessages = new BrazeMessages(
+					(fakeAppBoy as unknown) as typeof appboy,
+					InMemoryCache,
+				);
+				fakeAppBoy.emit(freshMessage);
+
+				const firstMessage = await brazeMessages.getMessageForEndOfArticle();
+				firstMessage.logImpression();
+
+				const anotherMessage = await brazeMessages.getMessageForEndOfArticle();
+				expect(anotherMessage.message).toEqual(freshMessage);
+			});
+
+			it('returns the same cached message multiple times if an impression is not logged', async () => {
+				const cachedMessage = buildMessage(JSON.parse(message1Json));
+				InMemoryCache.push('EndOfArticle', {
+					message: cachedMessage,
+					id: '1',
+				});
+				const freshMessage = buildMessage(JSON.parse(message2Json));
+				const fakeAppBoy = new FakeAppBoy();
+				const brazeMessages = new BrazeMessages(
+					(fakeAppBoy as unknown) as typeof appboy,
+					InMemoryCache,
+				);
+				fakeAppBoy.emit(freshMessage);
+
+				const firstMessage = await brazeMessages.getMessageForEndOfArticle();
+				const secondMessage = await brazeMessages.getMessageForEndOfArticle();
+
+				expect(firstMessage).toEqual(secondMessage);
+			});
 		});
 	});
 });

--- a/src/web/lib/braze/LocalMessageCache.test.ts
+++ b/src/web/lib/braze/LocalMessageCache.test.ts
@@ -1,0 +1,292 @@
+import appboy from '@braze/web-sdk-core';
+import { storage } from '@guardian/libs';
+import {
+	LocalMessageCache,
+	CachedMessage,
+	setQueue,
+	hydrateMessage,
+} from './LocalMessageCache';
+import type { SlotName } from './types';
+
+const message1Json: string = `{"message":"","messageAlignment":"CENTER","duration":5000,"slideFrom":"BOTTOM","extras":{"heading":"Tom Epic Title 1","slotName":"EndOfArticle","step":"1","componentName":"Epic","highlightedText":"This text is important %%CURRENCY_SYMBOL%%1","buttonText":"Button","buttonUrl":"https://www.example.com","paragraph1":"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."},"triggerId":"NjAzNjhmNDFkZTNmMTAxMjE4YmE5Y2E0XyRfY2MmZGkmbXY9NjAzNjhmNDFkZTNmMTAxMjE4YmE5YzZiJnBpPXdmcyZ3PTYwMzY4ZjQxZGUzZjEwMTIxOGJhOWM1OCZ3cD0xNjE0MjQxNTkyJnd2PTYwMzY4ZjQxZGUzZjEwMTIxOGJhOWM5ZA==","clickAction":"NONE","uri":null,"openTarget":"NONE","dismissType":"SWIPE","icon":null,"imageUrl":null,"imageStyle":"TOP","iconColor":4294967295,"iconBackgroundColor":4278219733,"backgroundColor":4294967295,"textColor":4281545523,"closeButtonColor":4288387995,"animateIn":true,"animateOut":true,"header":null,"headerAlignment":"CENTER","headerTextColor":4281545523,"frameColor":3224580915,"buttons":[],"cropType":"FIT_CENTER","Rd":true,"Ma":false,"Qd":false,"X":{"qb":{}},"Ub":{"qb":{}},"Lg":false,"Uf":"WEB_HTML"}`;
+const message2Json: string = `{"message":"","messageAlignment":"CENTER","duration":5000,"slideFrom":"BOTTOM","extras":{"heading":"Tom Epic Title 2","slotName":"EndOfArticle","step":"1","componentName":"Epic","highlightedText":"This text is important %%CURRENCY_SYMBOL%%1","buttonText":"Button","buttonUrl":"https://www.example.com","paragraph1":"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."},"triggerId":"NjAzNjhmNDFkZTNmMTAxMjE4YmE5Y2E0XyRfY2MmZGkmbXY9NjAzNjhmNDFkZTNmMTAxMjE4YmE5YzZiJnBpPXdmcyZ3PTYwMzY4ZjQxZGUzZjEwMTIxOGJhOWM1OCZ3cD0xNjE0MjQxNTkyJnd2PTYwMzY4ZjQxZGUzZjEwMTIxOGJhOWM5ZA==","clickAction":"NONE","uri":null,"openTarget":"NONE","dismissType":"SWIPE","icon":null,"imageUrl":null,"imageStyle":"TOP","iconColor":4294967295,"iconBackgroundColor":4278219733,"backgroundColor":4294967295,"textColor":4281545523,"closeButtonColor":4288387995,"animateIn":true,"animateOut":true,"header":null,"headerAlignment":"CENTER","headerTextColor":4281545523,"frameColor":3224580915,"buttons":[],"cropType":"FIT_CENTER","Rd":true,"Ma":false,"Qd":false,"X":{"qb":{}},"Ub":{"qb":{}},"Lg":false,"Uf":"WEB_HTML"}`;
+const message3Json: string = `{"message":"","messageAlignment":"CENTER","duration":5000,"slideFrom":"BOTTOM","extras":{"heading":"Tom Epic Title 3","slotName":"EndOfArticle","step":"1","componentName":"Epic","highlightedText":"This text is important %%CURRENCY_SYMBOL%%1","buttonText":"Button","buttonUrl":"https://www.example.com","paragraph1":"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."},"triggerId":"NjAzNjhmNDFkZTNmMTAxMjE4YmE5Y2E0XyRfY2MmZGkmbXY9NjAzNjhmNDFkZTNmMTAxMjE4YmE5YzZiJnBpPXdmcyZ3PTYwMzY4ZjQxZGUzZjEwMTIxOGJhOWM1OCZ3cD0xNjE0MjQxNTkyJnd2PTYwMzY4ZjQxZGUzZjEwMTIxOGJhOWM5ZA==","clickAction":"NONE","uri":null,"openTarget":"NONE","dismissType":"SWIPE","icon":null,"imageUrl":null,"imageStyle":"TOP","iconColor":4294967295,"iconBackgroundColor":4278219733,"backgroundColor":4294967295,"textColor":4281545523,"closeButtonColor":4288387995,"animateIn":true,"animateOut":true,"header":null,"headerAlignment":"CENTER","headerTextColor":4281545523,"frameColor":3224580915,"buttons":[],"cropType":"FIT_CENTER","Rd":true,"Ma":false,"Qd":false,"X":{"qb":{}},"Ub":{"qb":{}},"Lg":false,"Uf":"WEB_HTML"}`;
+
+type Message = appboy.InAppMessage;
+
+beforeEach(() => {
+	storage.local.clear();
+});
+
+const getQueueSizeFor = (slotName: SlotName): number => {
+	const queue = storage.local.get(
+		`gu.brazeMessageCache.${slotName}`,
+	) as CachedMessage[];
+
+	return queue.length;
+};
+
+const anHourAgo = () => {
+	const hourInMilliseconds = 1000 * 60 * 60;
+	return Date.now() - hourInMilliseconds;
+};
+
+const anHourFromNow = () => {
+	const hourInMilliseconds = 1000 * 60 * 60;
+	return Date.now() + hourInMilliseconds;
+};
+
+const buildUnexpiredMessage = (
+	message: Message,
+	id: string,
+): CachedMessage => ({
+	message: {
+		id,
+		message,
+	},
+	expires: anHourFromNow(),
+});
+
+const buildExpiredMessage = (message: Message, id: string): CachedMessage => ({
+	message: {
+		id,
+		message,
+	},
+	expires: anHourAgo(),
+});
+
+describe('LocalMessageCache', () => {
+	describe('peek', () => {
+		it('returns the first item on the queue', () => {
+			const message1 = JSON.parse(message1Json);
+			const message2 = JSON.parse(message2Json);
+			const queue = [
+				buildUnexpiredMessage(message1, '1'),
+				buildUnexpiredMessage(message2, '2'),
+			];
+			setQueue('EndOfArticle', queue);
+
+			const m = LocalMessageCache.peek('EndOfArticle', appboy);
+
+			expect(m?.message).toEqual(hydrateMessage(message1, appboy));
+		});
+
+		it('does not remove items from the queue', () => {
+			const message1 = JSON.parse(message1Json);
+			const message2 = JSON.parse(message2Json);
+			const queue = [
+				buildUnexpiredMessage(message1, '1'),
+				buildUnexpiredMessage(message2, '2'),
+			];
+			setQueue('EndOfArticle', queue);
+
+			LocalMessageCache.peek('EndOfArticle', appboy);
+
+			const newQueueLength = getQueueSizeFor('EndOfArticle');
+			expect(newQueueLength).toEqual(queue.length);
+		});
+
+		it('returns undefined if the queue is empty', () => {
+			setQueue('EndOfArticle', []);
+
+			const m = LocalMessageCache.peek('EndOfArticle', appboy);
+
+			expect(m).toBeUndefined();
+		});
+
+		it('returns the first unexpired message', () => {
+			const message1 = JSON.parse(message1Json);
+			const message2 = JSON.parse(message2Json);
+			const queue = [
+				buildExpiredMessage(message1, '1'),
+				buildUnexpiredMessage(message2, '2'),
+			];
+			setQueue('EndOfArticle', queue);
+
+			const m = LocalMessageCache.peek('EndOfArticle', appboy);
+
+			expect(m?.message).toEqual(hydrateMessage(message2, appboy));
+		});
+
+		it('removes expired items from the queue', () => {
+			const message1 = JSON.parse(message1Json);
+			const message2 = JSON.parse(message2Json);
+			const queue = [
+				buildExpiredMessage(message1, '1'),
+				buildUnexpiredMessage(message2, '2'),
+			];
+			setQueue('EndOfArticle', queue);
+
+			LocalMessageCache.peek('EndOfArticle', appboy);
+
+			const queueSize = getQueueSizeFor('EndOfArticle');
+			expect(queueSize).toEqual(1);
+		});
+
+		it('filters invalid items from the queue', () => {
+			const nonsenseMessage = ('nonsense' as unknown) as CachedMessage;
+			const anotherNonsenseMessage = ({
+				expires: anHourFromNow(),
+				message: {
+					id: '1',
+					message: 'more nonsense',
+				},
+			} as unknown) as CachedMessage;
+			const messageWithBadExpiration = ({
+				expires: '9999999999999999',
+				message: {
+					id: '1',
+					message: 'more nonsense',
+				},
+			} as unknown) as CachedMessage;
+			const validMessage = JSON.parse(message1Json);
+			const queue = [
+				nonsenseMessage,
+				anotherNonsenseMessage,
+				messageWithBadExpiration,
+				buildUnexpiredMessage(validMessage, '2'),
+			];
+			setQueue('EndOfArticle', queue);
+
+			const gotMessage = LocalMessageCache.peek('EndOfArticle', appboy);
+
+			expect(gotMessage?.message).toEqual(
+				hydrateMessage(validMessage, appboy),
+			);
+		});
+	});
+
+	describe('remove', () => {
+		it('removes a message by id', () => {
+			const message1 = buildUnexpiredMessage(
+				JSON.parse(message1Json),
+				'1',
+			);
+			const message2 = buildUnexpiredMessage(
+				JSON.parse(message2Json),
+				'2',
+			);
+			const queue = [message1, message2];
+			setQueue('EndOfArticle', queue);
+
+			LocalMessageCache.remove('EndOfArticle', '1');
+
+			const newQueue = storage.local.get(
+				'gu.brazeMessageCache.EndOfArticle',
+			) as CachedMessage[];
+
+			expect(newQueue).toEqual([message2]);
+		});
+	});
+
+	describe('push', () => {
+		it('adds an item to the end of the queue', () => {
+			const message1 = JSON.parse(message1Json);
+			LocalMessageCache.push('EndOfArticle', {
+				message: message1,
+				id: '1',
+			});
+
+			const message2 = JSON.parse(message2Json);
+			LocalMessageCache.push('EndOfArticle', {
+				message: message2,
+				id: '2',
+			});
+
+			const newQueue = storage.local.get(
+				'gu.brazeMessageCache.EndOfArticle',
+			) as CachedMessage[];
+			expect(newQueue.map(({ message: m }) => m.message)).toEqual([
+				message1,
+				message2,
+			]);
+		});
+
+		it('returns true when the push is successful', () => {
+			const message1 = JSON.parse(message1Json);
+
+			const result = LocalMessageCache.push('EndOfArticle', {
+				message: message1,
+				id: '1',
+			});
+
+			expect(result).toEqual(true);
+		});
+
+		it('lazily creates the queue if not already defined', () => {
+			const message = JSON.parse(message1Json);
+
+			LocalMessageCache.push('EndOfArticle', { message, id: '1' });
+
+			const newQueue = storage.local.get(
+				'gu.brazeMessageCache.EndOfArticle',
+			) as CachedMessage[];
+			expect(newQueue.map(({ message: m }) => m.message)).toEqual([
+				message,
+			]);
+		});
+
+		it('enforces a two item limit', () => {
+			const message1 = JSON.parse(message1Json);
+			LocalMessageCache.push('EndOfArticle', {
+				message: message1,
+				id: '1',
+			});
+
+			const message2 = JSON.parse(message2Json);
+			LocalMessageCache.push('EndOfArticle', {
+				message: message2,
+				id: '2',
+			});
+
+			const message3 = JSON.parse(message3Json);
+			LocalMessageCache.push('EndOfArticle', {
+				message: message3,
+				id: '3',
+			});
+
+			const newQueue = storage.local.get(
+				'gu.brazeMessageCache.EndOfArticle',
+			) as CachedMessage[];
+			expect(newQueue.map(({ message: m }) => m.message)).toEqual([
+				message1,
+				message2,
+			]);
+		});
+
+		it('returns false when the push is unsuccessful', () => {
+			const message1 = JSON.parse(message1Json);
+			const message2 = JSON.parse(message2Json);
+			const queue = [
+				buildUnexpiredMessage(message1, '1'),
+				buildUnexpiredMessage(message2, '2'),
+			];
+			setQueue('Banner', queue);
+
+			const message3 = JSON.parse(message2Json);
+			const result = LocalMessageCache.push('Banner', {
+				message: message3,
+				id: '3',
+			});
+
+			expect(result).toEqual(false);
+		});
+	});
+
+	describe('clear', () => {
+		it('wipes all queues', () => {
+			const message1 = JSON.parse(message1Json);
+			const queue1 = [buildUnexpiredMessage(message1, '1')];
+			const queue2 = [buildUnexpiredMessage(message1, '1')];
+			setQueue('EndOfArticle', queue1);
+			setQueue('Banner', queue2);
+
+			LocalMessageCache.clear();
+
+			expect(
+				LocalMessageCache.peek('EndOfArticle', appboy),
+			).toBeUndefined();
+			expect(LocalMessageCache.peek('Banner', appboy)).toBeUndefined();
+		});
+	});
+});

--- a/src/web/lib/braze/LocalMessageCache.ts
+++ b/src/web/lib/braze/LocalMessageCache.ts
@@ -1,0 +1,241 @@
+/* eslint-disable class-methods-use-this */
+/* eslint-disable max-classes-per-file */
+
+import type appboy from '@braze/web-sdk-core';
+import { storage } from '@guardian/libs';
+import { SlotName, SlotNames } from './types';
+
+const localStorageKeyBase = 'gu.brazeMessageCache';
+export const millisecondsBeforeExpiry = 1000 * 60 * 60 * 24; // 24 hours: 60 seconds * 60 minutes
+
+type Message = appboy.InAppMessage;
+
+type MessageWithId = {
+	id: string;
+	message: Message;
+};
+
+type CachedMessage = {
+	message: {
+		id: string;
+		message: Record<string, any>; // From the serialized JSON
+	};
+	expires: number; // Expiry date in Unix time
+};
+
+const MAX_QUEUE_SIZE = 2;
+
+const keyFromSlotName = (slotName: SlotName): string =>
+	`${localStorageKeyBase}.${slotName}`;
+
+const hasNotExpired = (cachedMessage: CachedMessage) =>
+	cachedMessage.expires > Date.now();
+
+// setQueue is effectively private, but it's useful to expose it publicly
+// so that we can use it in the tests
+const setQueue = (slotName: SlotName, queue: CachedMessage[]) => {
+	const key = keyFromSlotName(slotName);
+	storage.local.set(key, queue);
+};
+
+const readQueue = (slotName: SlotName): CachedMessage[] => {
+	const key = keyFromSlotName(slotName);
+	const queue = storage.local.get(key);
+
+	if (Array.isArray(queue)) {
+		return queue;
+	}
+
+	return [];
+};
+
+const hydrateMessage = (
+	messageData: Record<string, any>,
+	appboyInstance: typeof appboy,
+): appboy.InAppMessage => {
+	/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+	const hydratedMessage = new appboyInstance.HtmlMessage(
+		messageData.message as string,
+		messageData.extras,
+		messageData.campaignId,
+		messageData.cardId,
+		messageData.triggerId,
+		messageData.dismissType,
+		messageData.duration,
+		messageData.animateIn,
+		messageData.animateOut,
+		messageData.frameColor,
+		messageData.htmlId,
+		messageData.css,
+		messageData.messageFields,
+	);
+	/* eslint-enable @typescript-eslint/no-unsafe-member-access */
+
+	return hydratedMessage;
+};
+
+const isValid = (m: CachedMessage): boolean => {
+	return (
+		m?.expires &&
+		Number.isFinite(m?.expires) &&
+		m?.message?.id &&
+		m?.message?.message?.triggerId &&
+		m?.message?.message?.extras
+	);
+};
+
+const getQueue = (slotName: SlotName): CachedMessage[] => {
+	const queue = readQueue(slotName);
+	const validQueue = queue.filter((i) => isValid(i));
+	const unexpiredQueue = validQueue.filter((i) => hasNotExpired(i));
+
+	if (queue.length !== unexpiredQueue.length) {
+		setQueue(slotName, unexpiredQueue);
+	}
+
+	return unexpiredQueue;
+};
+
+interface MessageCache {
+	peek: (
+		slotName: SlotName,
+		appboyInstance: typeof appboy,
+	) => MessageWithId | undefined;
+	remove: (slotName: SlotName, id: string) => boolean;
+	push: (slotName: SlotName, message: MessageWithId) => boolean;
+	clear: () => void;
+}
+
+class LocalMessageCache {
+	static peek(
+		slotName: SlotName,
+		appboyInstance: typeof appboy,
+	): MessageWithId | undefined {
+		const queue = getQueue(slotName);
+		const topItem = queue[0];
+
+		if (topItem) {
+			return {
+				id: topItem.message.id,
+				message: hydrateMessage(
+					topItem.message.message,
+					appboyInstance,
+				),
+			};
+		}
+	}
+
+	static remove(slotName: SlotName, id: string): boolean {
+		const queue = getQueue(slotName);
+		const idx = queue.findIndex((i) => i.message.id === id);
+
+		if (idx >= 0) {
+			const removedItem = queue.splice(idx, 1);
+
+			if (removedItem) {
+				setQueue(slotName, queue);
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	static push(slotName: SlotName, message: MessageWithId): boolean {
+		const queue = getQueue(slotName);
+
+		if (queue.length < MAX_QUEUE_SIZE) {
+			const expires = Date.now() + millisecondsBeforeExpiry;
+
+			const messageToCache: CachedMessage = {
+				message,
+				expires,
+			};
+
+			queue.push(messageToCache);
+
+			setQueue(slotName, queue);
+			return true;
+		}
+
+		return false;
+	}
+
+	static clear() {
+		// eslint-disable-next-line guard-for-in
+		for (const slotName in SlotNames) {
+			const key = keyFromSlotName(slotName as SlotName);
+			storage.local.remove(key);
+		}
+	}
+}
+
+type InMemoryCachedMessage = {
+	message: MessageWithId;
+	expires: number; // Expiry date in Unix time
+};
+
+const inMemoryQueue: Record<SlotName, InMemoryCachedMessage[]> = {
+	EndOfArticle: [],
+	Banner: [],
+};
+
+// Until we're ready to turn caching on we can use this as a swap in replacement
+// for LocalMessageCache.
+class InMemoryCache {
+	static peek(slotName: SlotName): MessageWithId | undefined {
+		const unexpiredMessages = inMemoryQueue[slotName].filter((i) =>
+			hasNotExpired(i),
+		);
+		return unexpiredMessages[0]?.message;
+	}
+
+	static remove(slotName: SlotName, id: string): boolean {
+		const idx = inMemoryQueue[slotName].findIndex(
+			(i) => i.message.id === id,
+		);
+
+		if (idx >= 0) {
+			const removedItem = inMemoryQueue[slotName].splice(idx, 1);
+
+			if (removedItem) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	static push(slotName: SlotName, message: MessageWithId): boolean {
+		if (inMemoryQueue[slotName].length < MAX_QUEUE_SIZE) {
+			const expires = Date.now() + millisecondsBeforeExpiry;
+
+			const messageToCache = {
+				message,
+				expires,
+			};
+
+			inMemoryQueue[slotName].push(messageToCache);
+
+			return true;
+		}
+
+		return false;
+	}
+
+	static clear() {
+		// eslint-disable-next-line guard-for-in
+		for (const slotName in SlotNames) {
+			inMemoryQueue[slotName as SlotName] = [];
+		}
+	}
+}
+
+export {
+	LocalMessageCache,
+	CachedMessage,
+	InMemoryCache,
+	MessageCache,
+	setQueue,
+	hydrateMessage,
+};

--- a/src/web/lib/braze/types.ts
+++ b/src/web/lib/braze/types.ts
@@ -1,0 +1,8 @@
+enum SlotNames {
+	Banner = 'Banner',
+	EndOfArticle = 'EndOfArticle',
+}
+
+type SlotName = keyof typeof SlotNames;
+
+export { SlotNames, SlotName };


### PR DESCRIPTION
## What does this change?

Adds capability to cache Braze messages. The cache implementation used by `BrazeMessages` is configurable. This PR uses an in memory cache (`InMemoryCache`) so no data will persist across pageviews. We need to ensure that we're clearing the cache on logout and consent change on DCR and frontend before switching to the real localStorage backed cache (`LocalMessageCache`). This PR includes clearing data DCR, but we still need to make the change for frontend.

## Why?

The delivery behaviour of Braze messages to the browser don't exactly fit our use cases. Once Braze has given us a message via the `subscribeToInAppMessage` callback they consider it delivered, and it won't be delivered again. But there are many reasons why we might not be able to show a message in that same pageview. For example: banner timeout limit is reached, a higher priority message is shown instead, the page isn't suitable (e.g. paid content) or doesn't have the required slot (e.g. an epic message is delivered on a page without that slot).

## Notes

The TTL for messages in the cache is 1 day currently (though that's not so relevant for this PR which uses the in memory cache). We limit the cache size to two messages per slot. If a message is pushed to the queue for a slot which already has 2 messages it will be discarded. Given our current usage of Braze this should be plenty, and means we won't take up excessive local storage space.
