### PR TITLE
Drop box shadow on sticky navs

### DIFF
--- a/src/web/components/Nav/StickNavTest/StickyNav.tsx
+++ b/src/web/components/Nav/StickNavTest/StickyNav.tsx
@@ -37,8 +37,7 @@ const stickyStyle = (theme: Theme) => css`
 	top: 0;
 	${getZIndex('stickyNav')}
 	background-color: white;
-	box-shadow: 0 0 transparent, 0 0 transparent,
-		1px 3px 6px ${neutralBorder(theme)};
+	border-bottom: 1px solid ${neutralBorder(theme)};
 `;
 
 const fixedStyle = (theme: Theme, shouldDisplay: boolean) => css`
@@ -47,9 +46,7 @@ const fixedStyle = (theme: Theme, shouldDisplay: boolean) => css`
 	top: 0;
 	${getZIndex('stickyNav')}
 	background-color: white;
-	box-shadow: 0 0 transparent, 0 0 transparent,
-		1px 3px 6px ${neutralBorder(theme)};
-
+	border-bottom: 1px solid ${neutralBorder(theme)};
 	display: ${shouldDisplay ? 'block' : 'none'};
 `;
 


### PR DESCRIPTION
cc @HarryFischer 

### Before
![Screenshot 2021-03-04 at 12 43 49](https://user-images.githubusercontent.com/858402/109966013-a60b9a80-7ce7-11eb-905a-8d57e54ff88e.png)

### After
![Screenshot 2021-03-04 at 12 43 05](https://user-images.githubusercontent.com/858402/109966038-b02d9900-7ce7-11eb-9e76-5f6bb4009fbe.png)

## Why?

The drop-shadow was an improvisation shall we say that has since been corrected by design.
