### PR TITLE
Change how Vitals are collected

### DIFF
--- a/src/web/browser/coreVitals/coreVitals.ts
+++ b/src/web/browser/coreVitals/coreVitals.ts
@@ -36,19 +36,19 @@ export const coreVitals = (): void => {
 	const addToJson = ({ name, value }: CoreVitalsArgs): void => {
 		switch (name) {
 			case 'FCP':
-				jsonData.fcp = Math.round(value * 1000000) / 1000000;
+				jsonData.fcp = value;
 				break;
 			case 'CLS':
-				jsonData.cls = Math.round(value * 1000000) / 1000000;
+				jsonData.cls = value;
 				break;
 			case 'LCP':
-				jsonData.lcp = Math.round(value * 1000000) / 1000000;
+				jsonData.lcp = value;
 				break;
 			case 'FID':
-				jsonData.fid = Math.round(value * 1000000) / 1000000;
+				jsonData.fid = value;
 				break;
 			case 'TTFB':
-				jsonData.ttfb = Math.round(value * 1000000) / 1000000;
+				jsonData.ttfb = value;
 				break;
 		}
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

The core vitals are now collected directly as they are provided.

