### PR TITLE
Go live on 1% initially for sticky-nav

### DIFF
--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -364,11 +364,11 @@ export const App = ({ CAPI, NAV }: Props) => {
 
 	// sticky nav test status
 	const inStickyNavBackscroll = ABTestAPI.isUserInVariant(
-		'stickyNavTest',
+		'StickyNavTest',
 		'sticky-nav-backscroll',
 	);
 	const inStickyNavSimple = ABTestAPI.isUserInVariant(
-		'stickyNavTest',
+		'StickyNavTest',
 		'sticky-nav-simple',
 	);
 

--- a/src/web/experiments/tests/sticky-nav-test.ts
+++ b/src/web/experiments/tests/sticky-nav-test.ts
@@ -6,7 +6,7 @@ export const stickyNavTest: ABTest = {
 	expiry: '2021-05-03',
 	author: 'nlong',
 	description: 'Tests sticky nav behaviour.',
-	audience: 0,
+	audience: 0.01,
 	audienceOffset: 0,
 	successMeasure:
 		'Increased CTR on sticky variant, more visits to fronts, increase in number of pillars visited per user.',

--- a/src/web/experiments/tests/sticky-nav-test.ts
+++ b/src/web/experiments/tests/sticky-nav-test.ts
@@ -1,7 +1,7 @@
 import { ABTest } from '@guardian/ab-core';
 
 export const stickyNavTest: ABTest = {
-	id: 'stickyNavTest',
+	id: 'StickyNavTest',
 	start: '2021-02-10',
 	expiry: '2021-05-03',
 	author: 'nlong',


### PR DESCRIPTION
Initial go-live of this test. See the original Trello card for wider context: https://trello.com/c/fy5HsbwD/2347-sticky-nav-test
