### PR TITLE
Prevent subnav hydrating twice

### DIFF
--- a/src/web/components/Nav/StickNavTest/StickyNav.tsx
+++ b/src/web/components/Nav/StickNavTest/StickyNav.tsx
@@ -119,7 +119,7 @@ const NavGroupLazy: React.FC<NavGroupLazyProps> = ({
 			<Section
 				backgroundColour={palette.background.article}
 				padded={false}
-				sectionId="sub-nav-root"
+				sectionId="sub-nav-root-lazy"
 			>
 				<SubNav
 					subNavSections={navData.subNavSections}


### PR DESCRIPTION
### Before
![Screenshot 2021-03-04 at 16 56 12](https://user-images.githubusercontent.com/858402/110000150-e3355400-7d0a-11eb-8acb-59c378050a4a.png)

(doubling of the 'More' in subnav which happens in narrower mobile breakpoints.)

### After
![Screenshot 2021-03-04 at 16 55 42](https://user-images.githubusercontent.com/858402/110000203-f21c0680-7d0a-11eb-9dd2-c8bc9233543c.png)

(fixed)

## Why?
To make sure sticky nav behaves well.