### PR TITLE
Catch nav errors to fix Cypress tests (and main)

### DIFF
--- a/src/web/components/Nav/ExpandedMenu/Column.tsx
+++ b/src/web/components/Nav/ExpandedMenu/Column.tsx
@@ -187,7 +187,11 @@ export const Column = ({
 			<script
 				dangerouslySetInnerHTML={{
 					__html: `document.addEventListener('DOMContentLoaded', function(){
-                        document.getElementById('${collapseColumnInputId}').addEventListener('keydown', function(e){
+                        var columnInput = document.getElementById('${collapseColumnInputId}');
+
+						if (!columnInput) return; // Sticky nav replaces the nav so element no longer exists for users in test.
+
+						columnInput.addEventListener('keydown', function(e){
                             // keyCode: 13 => Enter key | keyCode: 32 => Space key
                             if (e.keyCode === 13 || e.keyCode === 32) {
                                 e.preventDefault()

--- a/src/web/components/Nav/Nav.tsx
+++ b/src/web/components/Nav/Nav.tsx
@@ -104,6 +104,9 @@ export const Nav = ({ format, nav, subscribeUrl, edition }: Props) => {
                             firstColLabel.focus()
                           }
                         }
+
+						if (!navInputCheckbox) return; // Sticky nav replaces the nav so element no longer exists for users in test.
+
                         navInputCheckbox.addEventListener('click',function(){
                           if(!navInputCheckbox.checked) {
                             showMoreButton.setAttribute('data-link-name','nav2 : veggie-burger: show')


### PR DESCRIPTION
The inlined Nav JS errors for users in the sticky nav test (1% atm). This is because the nav is replaced but the initial JS still executes, leading to runtime errors. The errors don't affect user experience but do cause Cypress to fail - at least the tests which involved an overlapping MVT ID.

Initially this passed `main` (I think) because the relevant (Frontend) test switch was not on yet.

<img width="459" alt="Screenshot 2021-03-05 at 11 59 39" src="https://user-images.githubusercontent.com/858402/110113019-678ae400-7daa-11eb-98e0-aec3f166cb34.png">
