### PR TITLE
ARM/Graviton testing

### DIFF
--- a/scripts/deploy/riff-raff.yaml
+++ b/scripts/deploy/riff-raff.yaml
@@ -9,12 +9,12 @@ deployments:
       cloudFormationStackName: rendering
       templateStageParameters:
         CODE:
-          InstanceType: t3.micro
+          InstanceType: t4g.micro
         PROD:
-          InstanceType: t3.small
+          InstanceType: t4g.small
       amiParametersToTags:
         AMI:
-          Recipe: dotcom-rendering-node14-test
+          Recipe: dotcom-rendering-ARM
           BuiltBy: amigo
           AmigoStage: PROD
   rendering:

--- a/src/app/aws/metrics-baseline.ts
+++ b/src/app/aws/metrics-baseline.ts
@@ -1,4 +1,6 @@
-import os from 'os';
+// TODO re-enable after Graviton testing complete (the diskusage module doesn't work on ARM).
+
+/* import os from 'os';
 import disk from 'diskusage';
 import { BytesMetric, collectAndSendAWSMetrics } from './aws-metrics';
 
@@ -43,4 +45,4 @@ export const recordBaselineCloudWatchMetrics = () => {
 			}
 		}
 	});
-};
+}; */

--- a/src/app/aws/metrics-baseline.ts
+++ b/src/app/aws/metrics-baseline.ts
@@ -1,11 +1,11 @@
-// TODO re-enable after Graviton testing complete (the diskusage module doesn't work on ARM).
+// TODO re-enable disk space checks after Graviton testing complete (the diskusage module doesn't work on ARM).
 
-/* import os from 'os';
-import disk from 'diskusage';
+import os from 'os';
+// import disk from 'diskusage';
 import { BytesMetric, collectAndSendAWSMetrics } from './aws-metrics';
 
 const maxHeapMemory = BytesMetric('rendering', 'PROD', 'max-heap-memory');
-const freeDiskSpace = BytesMetric('rendering', 'PROD', 'free-disk-memory');
+// const freeDiskSpace = BytesMetric('rendering', 'PROD', 'free-disk-memory');
 const usedHeapMemory = BytesMetric('rendering', 'PROD', 'used-heap-memory');
 const freePhysicalMemory = BytesMetric(
 	'rendering',
@@ -25,24 +25,30 @@ collectAndSendAWSMetrics(
 	usedHeapMemory,
 	totalPhysicalMemory,
 	freePhysicalMemory,
-	freeDiskSpace,
+	// freeDiskSpace,
 );
 
 // records system metrics
 
 export const recordBaselineCloudWatchMetrics = () => {
-	disk.check('/', (err, diskinfo) => {
-		if (err) {
-			// eslint-disable-next-line no-console
-			console.error(err);
-		} else {
-			maxHeapMemory.record(process.memoryUsage().heapTotal);
-			usedHeapMemory.record(process.memoryUsage().heapUsed);
-			totalPhysicalMemory.record(os.totalmem());
-			freePhysicalMemory.record(os.freemem());
-			if (diskinfo) {
-				freeDiskSpace.record(diskinfo.free);
-			}
-		}
-	});
-}; */
+	// TODO re-enable once ARM testing complete
+	// disk.check('/', (err, diskinfo) => {
+	// 	if (err) {
+	// 		// eslint-disable-next-line no-console
+	// 		console.error(err);
+	// 	} else {
+	// 		maxHeapMemory.record(process.memoryUsage().heapTotal);
+	// 		usedHeapMemory.record(process.memoryUsage().heapUsed);
+	// 		totalPhysicalMemory.record(os.totalmem());
+	// 		freePhysicalMemory.record(os.freemem());
+	// 		if (diskinfo) {
+	// 			freeDiskSpace.record(diskinfo.free);
+	// 		}
+	// 	}
+	// });
+
+	maxHeapMemory.record(process.memoryUsage().heapTotal);
+	usedHeapMemory.record(process.memoryUsage().heapUsed);
+	totalPhysicalMemory.record(os.totalmem());
+	freePhysicalMemory.record(os.freemem());
+};

--- a/src/app/server.ts
+++ b/src/app/server.ts
@@ -19,7 +19,7 @@ import {
 	getGuardianConfiguration,
 	GuardianConfiguration,
 } from './aws/aws-parameters';
-import { recordBaselineCloudWatchMetrics } from './aws/metrics-baseline';
+// import { recordBaselineCloudWatchMetrics } from './aws/metrics-baseline';
 import { logger } from './logging';
 
 // this export is the function used by webpackHotServerMiddleware in /scripts/frontend-dev-server
@@ -149,11 +149,12 @@ if (process.env.NODE_ENV === 'production') {
 		res.status(500).send(`<pre>${error.stack}</pre>`);
 	});
 
-	if (process.env.DISABLE_LOGGING_AND_METRICS !== 'true') {
+	// TODO re-enable after Graviton testing complete (the diskusage module doesn't work on ARM).
+	/* 	if (process.env.DISABLE_LOGGING_AND_METRICS !== 'true') {
 		setInterval(() => {
 			recordBaselineCloudWatchMetrics();
 		}, 10 * 1000);
-	}
+	} */
 
 	app.listen(port);
 	// eslint-disable-next-line no-console

--- a/src/app/server.ts
+++ b/src/app/server.ts
@@ -19,7 +19,7 @@ import {
 	getGuardianConfiguration,
 	GuardianConfiguration,
 } from './aws/aws-parameters';
-// import { recordBaselineCloudWatchMetrics } from './aws/metrics-baseline';
+import { recordBaselineCloudWatchMetrics } from './aws/metrics-baseline';
 import { logger } from './logging';
 
 // this export is the function used by webpackHotServerMiddleware in /scripts/frontend-dev-server
@@ -149,12 +149,11 @@ if (process.env.NODE_ENV === 'production') {
 		res.status(500).send(`<pre>${error.stack}</pre>`);
 	});
 
-	// TODO re-enable after Graviton testing complete (the diskusage module doesn't work on ARM).
-	/* 	if (process.env.DISABLE_LOGGING_AND_METRICS !== 'true') {
+	if (process.env.DISABLE_LOGGING_AND_METRICS !== 'true') {
 		setInterval(() => {
 			recordBaselineCloudWatchMetrics();
 		}, 10 * 1000);
-	} */
+	}
 
 	app.listen(port);
 	// eslint-disable-next-line no-console


### PR DESCRIPTION
**Note: plan is to run this for a few days (assuming no issues) and then switch back to x86 for the rest of the month.**

## What?

The changes necessary to test Graviton for a few days:

* Amigo AMI changes (already done)
* cloudformation updates to instance type and AMI (via riffraff.yaml)
* disable `disksage` module (as breaks on ARM) 

Note the latter means we won't get diskusage stats for the duration of the test. I consider this a reasonable risk, as we rarely check these metrics and still have regular autoscaling, CPU, latency, errors etc. If the test is successful we can think of an alternative disk-monitoring solution that is ARM friendly.

In preliminary testing we see:

1. no change in CPU usage
![Screenshot 2021-03-05 at 14 33 56](https://user-images.githubusercontent.com/858402/110131323-ef301d00-7dc1-11eb-8674-10bdbea95344.png)
(light blue is the new ARM instance - you can see an initial CPU spike before settling at ~20% which is the same as our x86 instances)

2. an improvement in latency
![Screenshot 2021-03-05 at 14 43 46](https://user-images.githubusercontent.com/858402/110131435-08d16480-7dc2-11eb-8322-e40c632f900d.png)
(note the dip on the right side of around 20% from 40ms to just over 30ms average around the 14:40 mark)

![Screenshot 2021-03-05 at 15 20 27](https://user-images.githubusercontent.com/858402/110138253-ae3c0680-7dc9-11eb-8226-8e448720b297.png)
(percentiles are always nicer :) - here we can see the gain is especially at the higher percentiles)

## Why?

To save $$$ (ARM instances are 20% cheaper) and possibly improve performance.

https://trello.com/c/bs16BYKE/2466-aws-reservations
