### PR TITLE
Set instance types in riff-raff.yaml

### DIFF
--- a/scripts/deploy/riff-raff.yaml
+++ b/scripts/deploy/riff-raff.yaml
@@ -7,6 +7,11 @@ deployments:
       templatePath: cloudformation.yml
       cloudFormationStackByTags: false
       cloudFormationStackName: rendering
+      templateStageParameters:
+        CODE:
+          InstanceType: t3.micro
+        PROD:
+          InstanceType: t3.small
       amiParametersToTags:
         AMI:
           Recipe: dotcom-rendering-node14-test


### PR DESCRIPTION
This enables easy migration to/from ARM as all relevant changes are handled by the Riffraff deploy and no manual Cloudformation changes in the AWS Console are required.

*Precursor to: https://github.com/guardian/dotcom-rendering/pull/2657/files.*