### PR TITLE
Log render time onExpand for Discussion

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "@guardian/automat-client": "^0.2.16",
         "@guardian/braze-components": "^0.0.19",
         "@guardian/consent-management-platform": "^6.11.2",
-        "@guardian/discussion-rendering": "^6.1.3",
+        "@guardian/discussion-rendering": "6.1.4-2",
         "@guardian/libs": "^1.6.3",
         "@guardian/shimport": "^1.0.2",
         "@guardian/src-button": "^2.7.1",

--- a/src/web/components/Discussion.tsx
+++ b/src/web/components/Discussion.tsx
@@ -101,6 +101,21 @@ export const Discussion = ({
 		return false;
 	};
 
+	const handleExpanded = (value: number): void => {
+		const { ga } = window;
+
+		if (!ga) {
+			return;
+		}
+
+		ga('allEditorialPropertyTracker.send', 'event', {
+			eventCategory: 'Performance',
+			eventAction: 'DiscussionExpanded',
+			eventValue: Math.round(value),
+			nonInteraction: true,
+		});
+	};
+
 	useEffect(() => {
 		const callFetch = async () => {
 			const response = await getDiscussion(discussionApiUrl, shortUrlId);
@@ -215,6 +230,9 @@ export const Discussion = ({
 								commentToScrollTo={hashCommentId}
 								onPermalinkClick={handlePermalink}
 								apiKey="dotcom-rendering"
+								onExpanded={(value) => {
+									handleExpanded(value);
+								}}
 							/>
 						)}
 
@@ -240,6 +258,9 @@ export const Discussion = ({
 									commentToScrollTo={hashCommentId}
 									onPermalinkClick={handlePermalink}
 									apiKey="dotcom-rendering"
+									onExpanded={(value) => {
+										handleExpanded(value);
+									}}
 								/>
 							</Lazy>
 						)}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2416,10 +2416,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.11.2.tgz#668d0f911aff5c3bc42cb54c606b07640d18f0b8"
   integrity sha512-tX+lZZFgn9PP8RUj14MnsYa7ikBAyTWfQJPNls4o2Q5c+o0uRVYHnlgifvspj0k1m05rFEmYjnmj7rxwpnH2Xw==
 
-"@guardian/discussion-rendering@^6.1.3":
-  version "6.1.3"
-  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-6.1.3.tgz#51f00bd7ad9e7c28a4269b8a53da95d12895a61b"
-  integrity sha512-l0hm3tfBtj8ihJYwuAfr/coDUb/B9Va7hlxnmsoSHXakDDljezs549kkT1pOnYZcaiHoyoPy8rvtB8XVzpvqYQ==
+"@guardian/discussion-rendering@6.1.4-2":
+  version "6.1.4-2"
+  resolved "https://registry.yarnpkg.com/@guardian/discussion-rendering/-/discussion-rendering-6.1.4-2.tgz#e0c4ab73b692bac40761a84e80c8792c20882d42"
+  integrity sha512-lmiiZHYw5/e+Ea5RQXpgshQ83F79lD66J5p2dVSk+Lke6ChTx0rpiDB76GJ19ncjjIGjmjPtjYvFVPhNtFoYCA==
   dependencies:
     babel-plugin-emotion "^10.0.33"
     customize-cra "^1.0.0"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Logs out performance stats to ga when expanding discussion


## Why?
So that we can track an issue that was identified with render speed on Emotion 11
