### PR TITLE
We plan on handling the no-epic case differently

### DIFF
--- a/src/web/components/SlotBodyEnd/BrazeEpic.tsx
+++ b/src/web/components/SlotBodyEnd/BrazeEpic.tsx
@@ -21,14 +21,8 @@ const wrapperMargins = css`
 
 const EPIC_COMPONENT_PATH = '/epic.js';
 
-type NoEpicDataFromBraze = {
-	componentName: 'NoEpic';
-};
-
-type DataFromBraze = EpicDataFromBraze | NoEpicDataFromBraze;
-
 type Meta = {
-	dataFromBraze?: DataFromBraze;
+	dataFromBraze?: EpicDataFromBraze;
 	logImpressionWithBraze: () => void;
 	// logButtonClickWithBraze: (id: number) => void; // TODO: Handle button click tracking
 };
@@ -140,10 +134,7 @@ const BrazeEpic = ({
 
 	if (Epic && meta.dataFromBraze) {
 		// This will come from Braze via the meta from canShow
-		const props = buildEpicProps(
-			meta.dataFromBraze as EpicDataFromBraze,
-			countryCode,
-		);
+		const props = buildEpicProps(meta.dataFromBraze, countryCode);
 
 		if (props) {
 			return (
@@ -157,8 +148,6 @@ const BrazeEpic = ({
 
 	return null;
 };
-
-const NoEpic = () => null;
 
 export const MaybeBrazeEpic = ({
 	contributionsServiceUrl,
@@ -175,10 +164,6 @@ export const MaybeBrazeEpic = ({
 				countryCode={countryCode}
 			/>
 		);
-	}
-
-	if (componentName === 'NoEpic') {
-		return <NoEpic />;
 	}
 
 	return null;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Don't render the `NoEpic` no-op component when no epic should be shown. D&I report that it will be simpler to handle the data if the no epic case is handled via a webhook in the Braze canvas.

### Before

When the epic should not be shown, send a Braze message with a componentName of `NoEpic` which results in a no-op component being rendered (purely for tracking purposes for the A/B test).

### After

When the epic should not be show, no in-app message send from Braze. So no need to handle the `NoEpic` component name.