### PR TITLE
Identity | Sign In Gate | Mandatory Sign In Gate Test

### DIFF
--- a/cypress/integration/parallel-1/sign-in-gate.spec.js
+++ b/cypress/integration/parallel-1/sign-in-gate.spec.js
@@ -233,5 +233,4 @@ describe('Sign In Gate Tests', function () {
 			});
 		});
 	});
-
 });

--- a/cypress/integration/parallel-6/consent.spec.js
+++ b/cypress/integration/parallel-6/consent.spec.js
@@ -1,6 +1,7 @@
 /* eslint-disable mocha/no-setup-in-describe */
 import { setLocalBaseUrl } from '../../lib/setLocalBaseUrl.js';
 import { skipOn } from '@cypress/skip-test';
+import { isRunningInCI } from '../../lib/isRunningInCi';
 
 const firstPage =
 	'https://www.theguardian.com/environment/2020/oct/13/maverick-rewilders-endangered-species-extinction-conservation-uk-wildlife';
@@ -38,60 +39,56 @@ describe('Consent tests', function () {
 
 	// Skipping only on CI because, these tests work fine locally but can fail on CI is the server
 	// being used is in the US
-	skipOn(
-		Cypress.env('TEAMCITY') === 'true' ||
-			Cypress.env('GITHUB_ACTIONS') === 'true',
-		() => {
-			it('should make calls to Google Analytics after the reader consents', function () {
-				cy.visit(`Article?url=${firstPage}`);
-				waitForAnalyticsToInit();
-				cy.window().its('ga').should('not.exist');
-				// Open the Privacy setting dialogue
-				cmpIframe().contains("It's your choice");
-				cmpIframe().find("[title='Manage my cookies']").click();
-				// Accept tracking cookies
-				privacySettingsIframe().contains('Privacy settings');
-				privacySettingsIframe().find("[title='Accept all']").click();
-				// Make a second page load now that we have the CMP cookies set to accept tracking
-				cy.visit(`Article?url=${secondPage}`);
-				// Wait for a call to Google Analytics to be made - we expect this to happen
-				cy.intercept('POST', 'https://www.google-analytics.com/**');
-			});
+	skipOn(isRunningInCI(), () => {
+		it('should make calls to Google Analytics after the reader consents', function () {
+			cy.visit(`Article?url=${firstPage}`);
+			waitForAnalyticsToInit();
+			cy.window().its('ga').should('not.exist');
+			// Open the Privacy setting dialogue
+			cmpIframe().contains("It's your choice");
+			cmpIframe().find("[title='Manage my cookies']").click();
+			// Accept tracking cookies
+			privacySettingsIframe().contains('Privacy settings');
+			privacySettingsIframe().find("[title='Accept all']").click();
+			// Make a second page load now that we have the CMP cookies set to accept tracking
+			cy.visit(`Article?url=${secondPage}`);
+			// Wait for a call to Google Analytics to be made - we expect this to happen
+			cy.intercept('POST', 'https://www.google-analytics.com/**');
+		});
 
-			it('should not add GA tracking scripts onto the window object after the reader rejects consent', function () {
-				cy.visit(`Article?url=${firstPage}`);
-				waitForAnalyticsToInit();
-				cy.window().its('ga').should('not.exist');
-				// Open the Privacy setting dialogue
-				cmpIframe().contains("It's your choice");
-				cmpIframe().find("[title='Manage my cookies']").click();
-				// Reject tracking cookies
-				privacySettingsIframe().contains('Privacy settings');
-				privacySettingsIframe().find("[title='Reject all']").click();
-				// Make a second page load now that we have the CMP cookies set to reject tracking and check
-				// to see if the ga property was set by Google on the window object
-				cy.visit(`Article?url=${secondPage}`);
-				waitForAnalyticsToInit();
-				// We force window.ga to be null on consent rejection to prevent subsequent requests
-				cy.window().its('ga').should('equal', null);
-			});
+		it('should not add GA tracking scripts onto the window object after the reader rejects consent', function () {
+			cy.visit(`Article?url=${firstPage}`);
+			waitForAnalyticsToInit();
+			cy.window().its('ga').should('not.exist');
+			// Open the Privacy setting dialogue
+			cmpIframe().contains("It's your choice");
+			cmpIframe().find("[title='Manage my cookies']").click();
+			// Reject tracking cookies
+			privacySettingsIframe().contains('Privacy settings');
+			privacySettingsIframe().find("[title='Reject all']").click();
+			// Make a second page load now that we have the CMP cookies set to reject tracking and check
+			// to see if the ga property was set by Google on the window object
+			cy.visit(`Article?url=${secondPage}`);
+			waitForAnalyticsToInit();
+			// We force window.ga to be null on consent rejection to prevent subsequent requests
+			cy.window().its('ga').should('equal', null);
+		});
 
-			it('should add GA tracking scripts onto the window object after the reader accepts consent', function () {
-				cy.visit(`Article?url=${firstPage}`);
-				waitForAnalyticsToInit();
-				cy.window().its('ga').should('not.exist');
-				// Open the Privacy setting dialogue
-				cmpIframe().contains("It's your choice");
-				cmpIframe().find("[title='Manage my cookies']").click();
-				// Reject tracking cookies
-				privacySettingsIframe().contains('Privacy settings');
-				privacySettingsIframe().find("[title='Accept all']").click();
-				// Make a second page load now that we have the CMP cookies set to reject tracking and check
-				// to see if the ga property was set by Google on the window object
-				cy.visit(`Article?url=${secondPage}`);
-				waitForAnalyticsToInit();
-				cy.window().its('ga').should('exist');
-			});
-		},
-	);
+		it('should add GA tracking scripts onto the window object after the reader accepts consent', function () {
+			cy.visit(`Article?url=${firstPage}`);
+			waitForAnalyticsToInit();
+			cy.window().its('ga').should('not.exist');
+			// Open the Privacy setting dialogue
+			cmpIframe().contains("It's your choice");
+			cmpIframe().find("[title='Manage my cookies']").click();
+			// Reject tracking cookies
+			privacySettingsIframe().contains('Privacy settings');
+			privacySettingsIframe().find("[title='Accept all']").click();
+			// Make a second page load now that we have the CMP cookies set to reject tracking and check
+			// to see if the ga property was set by Google on the window object
+			cy.visit(`Article?url=${secondPage}`);
+			waitForAnalyticsToInit();
+			cy.window().its('ga').should('exist');
+		});
+	});
 });

--- a/cypress/lib/isRunningInCi.js
+++ b/cypress/lib/isRunningInCi.js
@@ -1,0 +1,6 @@
+export const isRunningInCI = () => {
+	return (
+		Cypress.env('TEAMCITY') === 'true' ||
+		Cypress.env('GITHUB_ACTIONS') === 'true'
+	);
+};

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,3 +23,4 @@
 //
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+import 'cypress-localstorage-commands';

--- a/package.json
+++ b/package.json
@@ -179,6 +179,7 @@
         "babel-plugin-transform-runtime": "^6.23.0",
         "bundlesize": "^0.18.0",
         "chromatic": "^5.6.1",
+        "cypress-localstorage-commands": "^1.4.1",
         "cypress-plugin-tab": "^1.0.5",
         "desvg-loader": "^0.1.0",
         "doctoc": "^1.4.0",

--- a/src/web/components/SignInGate/SignInGate.stories.tsx
+++ b/src/web/components/SignInGate/SignInGate.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Section } from '@frontend/web/components/Section';
+import { SignInGateMandatory } from '@root/src/web/components/SignInGate/gateDesigns/SignInGateMandatory';
 import { SignInGateSelector } from './SignInGateSelector';
 import { SignInGateMain } from './gateDesigns/SignInGateMain';
 
@@ -24,3 +25,17 @@ export const mainStandalone = () => {
 	);
 };
 mainStandalone.story = { name: 'main_standalone' };
+
+export const mandatoryGateStandalone = () => {
+	return (
+		<Section>
+			<SignInGateMandatory
+				guUrl="https://theguardian.com"
+				signInUrl="https://profile.theguardian.com/"
+				dismissGate={() => {}}
+				ophanComponentId="test"
+			/>
+		</Section>
+	);
+};
+mandatoryGateStandalone.story = { name: 'mandatory_gate_standalone' };

--- a/src/web/components/SignInGate/displayRule.test.ts
+++ b/src/web/components/SignInGate/displayRule.test.ts
@@ -9,9 +9,24 @@ import {
 	isValidSection,
 	isValidTag,
 	isCountry,
+	hasRequiredConsents,
 } from './displayRule';
 
 const CAPI = Article;
+
+let mockOnConsentChangeResult: any;
+jest.mock('@guardian/consent-management-platform', () => ({
+	onConsentChange: (callback: any) => {
+		callback(mockOnConsentChangeResult);
+	},
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+	getConsentFor: jest.requireActual('@guardian/consent-management-platform')
+		.getConsentFor,
+}));
+
+afterEach(() => {
+	mockOnConsentChangeResult = undefined;
+});
 
 describe('SignInGate - displayRule methods', () => {
 	describe('isNPageOrHigherPageView', () => {
@@ -227,6 +242,90 @@ describe('SignInGate - displayRule methods', () => {
 			];
 
 			expect(isValidTag(CAPIBrowser)).toBe(false);
+		});
+	});
+
+	describe('hasRequiredConsents', () => {
+		const generateConsents: () => { [key: string]: boolean } = () => {
+			return {
+				consentId1: true,
+				consentId2: true,
+				consentId3: true,
+				consentId4: true,
+			};
+		};
+
+		test('returns true when the user has consented to all', async () => {
+			const testConsents = generateConsents();
+
+			mockOnConsentChangeResult = {
+				tcfv2: {
+					vendorConsents: testConsents,
+					consents: testConsents,
+				},
+			};
+			await expect(hasRequiredConsents()).resolves.toBe(true);
+		});
+
+		test('returns false when the user has not consented to one of the consents', async () => {
+			const testConsents = generateConsents();
+
+			mockOnConsentChangeResult = {
+				tcfv2: {
+					vendorConsents: testConsents,
+					consents: { ...testConsents, additionalConsent: false },
+				},
+			};
+			await expect(hasRequiredConsents()).resolves.toBe(false);
+
+			mockOnConsentChangeResult = {
+				tcfv2: {
+					consents: testConsents,
+					vendorConsents: {
+						...testConsents,
+						additionalConsent: false,
+					},
+				},
+			};
+			await expect(hasRequiredConsents()).resolves.toBe(false);
+		});
+
+		test('returns false when a consents list is empty', async () => {
+			const testConsents = generateConsents();
+
+			mockOnConsentChangeResult = {
+				tcfv2: {
+					vendorConsents: {},
+					consents: testConsents,
+				},
+			};
+			await expect(hasRequiredConsents()).resolves.toBe(false);
+
+			mockOnConsentChangeResult = {
+				tcfv2: {
+					vendorConsents: testConsents,
+					consents: {},
+				},
+			};
+			await expect(hasRequiredConsents()).resolves.toBe(false);
+		});
+
+		test('returns false when a consents list is undefined', async () => {
+			const testConsents = generateConsents();
+
+			mockOnConsentChangeResult = {
+				tcfv2: {
+					consents: testConsents,
+				},
+			};
+			await expect(hasRequiredConsents()).resolves.toBe(false);
+
+			mockOnConsentChangeResult = {
+				tcfv2: {
+					vendorConsents: testConsents,
+				},
+			};
+			await expect(hasRequiredConsents()).resolves.toBe(false);
 		});
 	});
 });

--- a/src/web/components/SignInGate/displayRule.ts
+++ b/src/web/components/SignInGate/displayRule.ts
@@ -6,6 +6,8 @@ import {
 import { getCountryCodeFromLocalStorage } from '@frontend/web/lib/getCountryCode';
 import { CurrentABTest } from '@root/src/web/components/SignInGate/gateDesigns/types';
 import { hasUserDismissedGateMoreThanCount } from '@root/src/web/components/SignInGate/dismissGate';
+import { onConsentChange } from '@root/node_modules/@guardian/consent-management-platform';
+import { ConsentState } from '@root/node_modules/@guardian/consent-management-platform/dist/types';
 
 // in our case if this is the n-numbered article or higher the user has viewed then set the gate
 export const isNPageOrHigherPageView = (n: number = 2): boolean => {
@@ -79,15 +81,57 @@ export const canShow = (
 	CAPI: CAPIBrowserType,
 	isSignedIn: boolean,
 	currentTest: CurrentABTest,
-): boolean =>
-	!isSignedIn &&
-	!hasUserDismissedGateMoreThanCount(
-		currentTest.variant,
-		currentTest.name,
-		5,
-	) &&
-	isNPageOrHigherPageView(3) &&
-	isValidContentType(CAPI) &&
-	isValidSection(CAPI) &&
-	isValidTag(CAPI) &&
-	!isIOS9();
+): Promise<boolean> => {
+	return Promise.resolve(
+		!isSignedIn &&
+			!hasUserDismissedGateMoreThanCount(
+				currentTest.variant,
+				currentTest.name,
+				5,
+			) &&
+			isNPageOrHigherPageView(3) &&
+			isValidContentType(CAPI) &&
+			isValidSection(CAPI) &&
+			isValidTag(CAPI) &&
+			!isIOS9(),
+	);
+};
+
+export const hasRequiredConsents = (): Promise<boolean> => {
+	const hasConsentedToAll = (state: ConsentState) => {
+		const consentFlags = state.tcfv2?.consents
+			? Object.values(state.tcfv2.consents)
+			: [];
+		const vendorConsentFlags = state.tcfv2?.vendorConsents
+			? Object.values(state.tcfv2.vendorConsents)
+			: [];
+		const isEmpty =
+			consentFlags.length === 0 || vendorConsentFlags.length === 0;
+
+		return (
+			!isEmpty && [...consentFlags, ...vendorConsentFlags].every(Boolean)
+		);
+	};
+
+	return new Promise((resolve) => {
+		onConsentChange((state) => {
+			resolve(hasConsentedToAll(state));
+		});
+	});
+};
+
+export const canShowMandatoryGate: (
+	CAPI: CAPIBrowserType,
+	isSignedIn: boolean,
+	currentTest: CurrentABTest,
+) => Promise<boolean> = async (
+	CAPI: CAPIBrowserType,
+	isSignedIn: boolean,
+	currentTest: CurrentABTest,
+) => {
+	return (
+		isCountry('GB') &&
+		(await canShow(CAPI, isSignedIn, currentTest)) &&
+		(await hasRequiredConsents())
+	);
+};

--- a/src/web/components/SignInGate/gateDesigns/SignInGateMandatory.tsx
+++ b/src/web/components/SignInGate/gateDesigns/SignInGateMandatory.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { cx } from 'emotion';
+
+import { LinkButton } from '@guardian/src-button';
+import { Link } from '@guardian/src-link';
+import { cmp } from '@guardian/consent-management-platform';
+import { trackLink } from '@frontend/web/components/SignInGate/componentEventTracking';
+import { SignInGateProps } from './types';
+import {
+	actionButtons,
+	bodyBold,
+	bodyText,
+	faq,
+	firstParagraphOverlay,
+	headingStyles,
+	hideElementsCss,
+	privacyLink,
+	registerButton,
+	signInGateContainer,
+	signInHeader,
+	signInLink,
+} from './shared';
+
+export const SignInGateMandatory = ({
+	signInUrl,
+	guUrl,
+	abTest,
+	ophanComponentId,
+	isComment,
+}: SignInGateProps) => {
+	return (
+		<div className={signInGateContainer} data-cy="sign-in-gate-mandatory">
+			<style>{hideElementsCss}</style>
+			<div className={firstParagraphOverlay(!!isComment)} />
+			<h1 className={headingStyles}>
+				Register for free and continue reading
+			</h1>
+			<p className={bodyBold}>
+				It’s important to say this is not a step towards a paywall
+			</p>
+			<p className={bodyText}>
+				Registering is a free and simple way to help us sustain our
+				independent Guardian journalism.
+			</p>
+			<p className={bodyText}>
+				When you register with us we are able to improve our news
+				experience for you and for others. You will always be able to
+				control your own&nbsp;
+				<button
+					data-cy="sign-in-gate-mandatory_privacy"
+					className={privacyLink}
+					onClick={() => {
+						cmp.showPrivacyManager();
+						trackLink(ophanComponentId, 'privacy', abTest);
+					}}
+				>
+					privacy settings
+				</button>
+				. Thank you.
+			</p>
+			<div className={actionButtons}>
+				<LinkButton
+					data-cy="sign-in-gate-mandatory_register"
+					className={registerButton}
+					priority="primary"
+					size="small"
+					href={signInUrl}
+					onClick={() => {
+						trackLink(ophanComponentId, 'register-link', abTest);
+					}}
+				>
+					Register for free
+				</LinkButton>
+			</div>
+
+			<p className={cx([bodyBold, signInHeader])}>
+				Have a subscription? Made a contribution? Already registered?
+			</p>
+
+			<Link
+				data-cy="sign-in-gate-mandatory_signin"
+				className={signInLink}
+				href={signInUrl}
+				onClick={() => {
+					trackLink(ophanComponentId, 'sign-in-link', abTest);
+				}}
+			>
+				Sign In
+			</Link>
+
+			<div className={faq}>
+				<Link
+					href={`${guUrl}/membership/2019/dec/20/signing-in-to-the-guardian`}
+					onClick={() => {
+						trackLink(ophanComponentId, 'how-link', abTest);
+					}}
+				>
+					Why register & how does it help?
+				</Link>
+
+				<Link
+					href={`${guUrl}/info/2014/nov/03/why-your-data-matters-to-us-full-text`}
+					onClick={() => {
+						trackLink(ophanComponentId, 'why-link', abTest);
+					}}
+				>
+					How will my information & data be used?
+				</Link>
+
+				<Link
+					href={`${guUrl}/help/identity-faq`}
+					onClick={() => {
+						trackLink(ophanComponentId, 'help-link', abTest);
+					}}
+				>
+					Get help with registering or signing in
+				</Link>
+			</div>
+		</div>
+	);
+};

--- a/src/web/components/SignInGate/gateDesigns/types.ts
+++ b/src/web/components/SignInGate/gateDesigns/types.ts
@@ -1,10 +1,12 @@
+export type CanShow = (
+	CAPI: CAPIBrowserType,
+	isSignedIn: boolean,
+	currentTest: CurrentABTest,
+) => Promise<boolean>;
+
 export type SignInGateComponent = {
 	gate?: (props: SignInGateProps) => JSX.Element;
-	canShow: (
-		CAPI: CAPIBrowserType,
-		isSignedIn: boolean,
-		currentTest: CurrentABTest,
-	) => boolean;
+	canShow: CanShow;
 };
 
 export interface SignInGateProps {

--- a/src/web/components/SignInGate/gates/main-control.ts
+++ b/src/web/components/SignInGate/gates/main-control.ts
@@ -15,14 +15,16 @@ const canShow = (
 	CAPI: CAPIBrowserType,
 	isSignedIn: boolean,
 	currentTest: CurrentABTest,
-): boolean =>
-	!isSignedIn &&
-	!hasUserDismissedGate(currentTest.variant, currentTest.name) &&
-	isNPageOrHigherPageView(3) &&
-	isValidContentType(CAPI) &&
-	isValidSection(CAPI) &&
-	isValidTag(CAPI) &&
-	!isIOS9();
+): Promise<boolean> =>
+	Promise.resolve(
+		!isSignedIn &&
+			!hasUserDismissedGate(currentTest.variant, currentTest.name) &&
+			isNPageOrHigherPageView(3) &&
+			isValidContentType(CAPI) &&
+			isValidSection(CAPI) &&
+			isValidTag(CAPI) &&
+			!isIOS9(),
+	);
 
 export const signInGateComponent: SignInGateComponent = {
 	canShow,

--- a/src/web/components/SignInGate/gates/main-variant.tsx
+++ b/src/web/components/SignInGate/gates/main-variant.tsx
@@ -1,8 +1,10 @@
 import React, { Suspense } from 'react';
 import { Lazy } from '@root/src/web/components/Lazy';
 
-import { SignInGateComponent } from '@frontend/web/components/SignInGate/gateDesigns/types';
-import { canShow } from '@frontend/web/components/SignInGate/displayRule';
+import {
+	CanShow,
+	SignInGateComponent,
+} from '@frontend/web/components/SignInGate/gateDesigns/types';
 import { initPerf } from '@root/src/web/browser/initPerf';
 
 const SignInGateMain = React.lazy(() => {
@@ -16,27 +18,30 @@ const SignInGateMain = React.lazy(() => {
 	});
 });
 
-export const signInGateComponent: SignInGateComponent = {
-	gate: ({
-		ophanComponentId,
-		dismissGate,
-		guUrl,
-		signInUrl,
-		abTest,
-		isComment,
-	}) => (
-		<Lazy margin={300}>
-			<Suspense fallback={<></>}>
-				<SignInGateMain
-					ophanComponentId={ophanComponentId}
-					dismissGate={dismissGate}
-					guUrl={guUrl}
-					signInUrl={signInUrl}
-					abTest={abTest}
-					isComment={isComment}
-				/>
-			</Suspense>
-		</Lazy>
-	),
-	canShow,
+export const signInGateComponent = (canShow: CanShow) => {
+	const gateComponent: SignInGateComponent = {
+		gate: ({
+			ophanComponentId,
+			dismissGate,
+			guUrl,
+			signInUrl,
+			abTest,
+			isComment,
+		}) => (
+			<Lazy margin={300}>
+				<Suspense fallback={<></>}>
+					<SignInGateMain
+						ophanComponentId={ophanComponentId}
+						dismissGate={dismissGate}
+						guUrl={guUrl}
+						signInUrl={signInUrl}
+						abTest={abTest}
+						isComment={isComment}
+					/>
+				</Suspense>
+			</Lazy>
+		),
+		canShow,
+	};
+	return gateComponent;
 };

--- a/src/web/components/SignInGate/gates/mandatory-gate.tsx
+++ b/src/web/components/SignInGate/gates/mandatory-gate.tsx
@@ -1,0 +1,42 @@
+import React, { Suspense } from 'react';
+import { Lazy } from '@root/src/web/components/Lazy';
+
+import { SignInGateComponent } from '@frontend/web/components/SignInGate/gateDesigns/types';
+import { canShowMandatoryGate } from '@frontend/web/components/SignInGate/displayRule';
+import { initPerf } from '@root/src/web/browser/initPerf';
+
+const SignInGateMandatory = React.lazy(() => {
+	const { start, end } = initPerf('SignInGateMain');
+	start();
+	return import(
+		/* webpackChunkName: "SignInGateMain" */ '../gateDesigns/SignInGateMandatory'
+	).then((module) => {
+		end();
+		return { default: module.SignInGateMandatory };
+	});
+});
+
+export const signInGateComponent: SignInGateComponent = {
+	gate: ({
+		ophanComponentId,
+		dismissGate, // TODO if this becomes the winner we can remove the unused dismissGate
+		guUrl,
+		signInUrl,
+		abTest,
+		isComment,
+	}) => (
+		<Lazy margin={300}>
+			<Suspense fallback={<></>}>
+				<SignInGateMandatory
+					ophanComponentId={ophanComponentId}
+					dismissGate={dismissGate}
+					guUrl={guUrl}
+					signInUrl={signInUrl}
+					abTest={abTest}
+					isComment={isComment}
+				/>
+			</Suspense>
+		</Lazy>
+	),
+	canShow: canShowMandatoryGate,
+};

--- a/src/web/experiments/ab-tests.ts
+++ b/src/web/experiments/ab-tests.ts
@@ -8,11 +8,13 @@ import {
 	newsletterMerchUnitLighthouseVariants,
 } from '@root/src/web/experiments/tests/newsletter-merch-unit-test';
 import { stickyNavTest } from '@root/src/web/experiments/tests/sticky-nav-test';
+import { signInGateMandoryTest } from '@root/src/web/experiments/tests/sign-in-gate-mandatory';
 
 export const tests: ABTest[] = [
 	abTestTest,
 	signInGateMainVariant,
 	signInGateMainControl,
+	signInGateMandoryTest,
 	newsletterMerchUnitLighthouseControl,
 	newsletterMerchUnitLighthouseVariants,
 	deeplyReadTest,

--- a/src/web/experiments/cypress-switches.ts
+++ b/src/web/experiments/cypress-switches.ts
@@ -13,6 +13,7 @@ const cypressSwitches = {
 	abAbTestTest: true, // Test switch, used for Cypress integration test
 	abSignInGateMainControl: true,
 	abSignInGateMainVariant: true,
+	abSignInGateMandatory: true,
 };
 
 // Function to retrieve the switches if running in Cypress

--- a/src/web/experiments/tests/sign-in-gate-main-variant.ts
+++ b/src/web/experiments/tests/sign-in-gate-main-variant.ts
@@ -7,7 +7,7 @@ export const signInGateMainVariant: ABTest = {
 	author: 'Mahesh Makani',
 	description:
 		'Show sign in gate to 100% of users on 3rd article view of simple article templates, and show a further 5 times after the first dismissal, with higher priority over banners and epic. Main/Variant Audience.',
-	audience: 0.9,
+	audience: 0.89,
 	audienceOffset: 0.0,
 	successMeasure: 'Users sign in or create a Guardian account',
 	audienceCriteria:

--- a/src/web/experiments/tests/sign-in-gate-mandatory.ts
+++ b/src/web/experiments/tests/sign-in-gate-mandatory.ts
@@ -1,0 +1,30 @@
+import { ABTest } from '@guardian/ab-core';
+
+export const signInGateMandoryTest: ABTest = {
+	id: 'SignInGateMandatory',
+	start: '2021-03-04',
+	expiry: '2021-06-04',
+	author: 'Peter Colley',
+	description:
+		'Compare mandatory gate (an article sigin gate without the dismiss button) with the main signin gate',
+	audience: 0.01,
+	audienceOffset: 0.69,
+	successMeasure: 'Users sign in or create a Guardian account',
+	audienceCriteria:
+		'3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss or reshown after 5 dismisses, not on help, info sections etc. exclude iOS 9 and guardian-live-australia, UK only, only users with specific CMP consents. Suppresses other banners, and appears over epics',
+	dataLinkNames: 'SignInGateMandatory',
+	idealOutcome:
+		'We believe that a mandatory sign in gate will increase sign in conversion by 30% vs a dismissable sign in gate.',
+	showForSensitive: false,
+	canRun: () => true,
+	variants: [
+		{
+			id: 'mandatory-gate-control',
+			test: (): void => {},
+		},
+		{
+			id: 'mandatory-gate-variant',
+			test: (): void => {},
+		},
+	],
+};

--- a/src/web/experiments/tests/sign-in-gate-mandatory.ts
+++ b/src/web/experiments/tests/sign-in-gate-mandatory.ts
@@ -8,7 +8,7 @@ export const signInGateMandoryTest: ABTest = {
 	description:
 		'Compare mandatory gate (an article sigin gate without the dismiss button) with the main signin gate',
 	audience: 0.01,
-	audienceOffset: 0.69,
+	audienceOffset: 0.89,
 	successMeasure: 'Users sign in or create a Guardian account',
 	audienceCriteria:
 		'3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss or reshown after 5 dismisses, not on help, info sections etc. exclude iOS 9 and guardian-live-australia, UK only, only users with specific CMP consents. Suppresses other banners, and appears over epics',

--- a/yarn.lock
+++ b/yarn.lock
@@ -7965,6 +7965,11 @@ cyclist@~0.2.2:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
   integrity sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=
 
+cypress-localstorage-commands@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/cypress-localstorage-commands/-/cypress-localstorage-commands-1.4.1.tgz#3df86b88b98919332af7720be2d10314bdb1222d"
+  integrity sha512-rO8/hWu04o9w+gv8l70ew8QWBy3bGUiablQQzm4l3bWkGBVa4+kWXTuokrq6AZdO1/xv4rs4OBjN7sKDRl1JhQ==
+
 cypress-plugin-tab@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/cypress-plugin-tab/-/cypress-plugin-tab-1.0.5.tgz#a40714148104004bb05ed62b1bf46bb544f8eb4a"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Add new signin gate. We are testing the affects of a mandatory signin gate. This is a gate asking users to login for articles without a dismiss button.

Additional requirements are:
- UK only 
- Only if accepted specific CMP consents

## Why?

We are experimenting with ways of making the signin gate more effective without having a negative impact of other parts of the site.

![image](https://user-images.githubusercontent.com/29203769/110371047-5957f480-8044-11eb-8775-2f8efcab8c5a.png)
