### PR TITLE
Add print layout story

### DIFF
--- a/src/web/layouts/Standard.stories.tsx
+++ b/src/web/layouts/Standard.stories.tsx
@@ -48,7 +48,13 @@ const convertToStandard = (CAPI: CAPIType) => {
 // HydratedLayout is used here to simulated the hydration that happens after we init react on
 // the client. We need a separate component so that we can make use of useEffect to ensure
 // the hydrate step only runs once the dom has been rendered.
-const HydratedLayout = ({ ServerCAPI }: { ServerCAPI: CAPIType }) => {
+const HydratedLayout = ({
+	ServerCAPI,
+	modifyPage,
+}: {
+	ServerCAPI: CAPIType;
+	modifyPage?: () => void;
+}) => {
 	const NAV = extractNAV(ServerCAPI.nav);
 
 	useEffect(() => {
@@ -57,6 +63,9 @@ const HydratedLayout = ({ ServerCAPI }: { ServerCAPI: CAPIType }) => {
 		embedIframe().catch((e) =>
 			console.error(`HydratedLayout embedIframe - error: ${e}`),
 		);
+		if (modifyPage) {
+			modifyPage();
+		}
 	}, [ServerCAPI, NAV]);
 	return <DecideLayout CAPI={ServerCAPI} NAV={NAV} />;
 };
@@ -66,6 +75,30 @@ export const ArticleStory = (): React.ReactNode => {
 	return <HydratedLayout ServerCAPI={ServerCAPI} />;
 };
 ArticleStory.story = { name: 'Article' };
+
+export const ArticlePrintStory = (): React.ReactNode => {
+	const ServerCAPI = convertToStandard(Article);
+	return (
+		<HydratedLayout
+			ServerCAPI={ServerCAPI}
+			modifyPage={() => {
+				const styleTag = document.createElement('link');
+				styleTag.setAttribute('href', '/css/print.css');
+				styleTag.setAttribute('rel', 'stylesheet');
+				document.getElementById('root')?.prepend(styleTag);
+			}}
+		/>
+	);
+};
+ArticlePrintStory.story = {
+	name: 'Article Print',
+};
+
+ArticlePrintStory.parameters = {
+	viewport: {
+		defaultViewport: 'tablet',
+	},
+};
 
 export const ReviewStory = (): React.ReactNode => {
 	const ServerCAPI = convertToStandard(Review);

--- a/src/web/layouts/Standard.stories.tsx
+++ b/src/web/layouts/Standard.stories.tsx
@@ -98,6 +98,7 @@ ArticlePrintStory.parameters = {
 	viewport: {
 		defaultViewport: 'tablet',
 	},
+	chromatic: { viewports: [740] },
 };
 
 export const ReviewStory = (): React.ReactNode => {


### PR DESCRIPTION
## What does this change?

Adds a story to view a standard article in Print layout. https://5dfcbf3012392c0020e7140b-hfrgqqgqdw.chromatic.com/?path=/story/layouts-standard--article-print-story


| Print      | Chromatic |
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/638051/110141794-68813d00-7dcd-11eb-83f6-4c3abf5957f5.png)      | ![image](https://user-images.githubusercontent.com/638051/110141700-543d4000-7dcd-11eb-8b31-51dff6ef587b.png)|

## Why?

Visibility over changes to the print layout are useful from a UX POV.

cc/ @SiAdcock