### PR TITLE
use actions-setup-node

### DIFF
--- a/.github/workflows/amp-validation.yml
+++ b/.github/workflows/amp-validation.yml
@@ -9,10 +9,8 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v1
 
-            - name: Use Node.js 14.15
-              uses: actions/setup-node@v1
-              with:
-                  node-version: '14.15'
+            - name: Install Node
+              uses: guardian/actions-setup-node@main
 
             # Cache npm dependencies using https://github.com/bahmutov/npm-install
             - uses: bahmutov/npm-install@v1

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -9,10 +9,8 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v1
 
-            - name: Use Node.js 14.15
-              uses: actions/setup-node@v1
-              with:
-                  node-version: '14.15'
+            - name: Install Node
+              uses: guardian/actions-setup-node@main
 
             # Cache npm dependencies using https://github.com/bahmutov/npm-install
             - uses: bahmutov/npm-install@v1

--- a/.github/workflows/bundle-analyser.yml
+++ b/.github/workflows/bundle-analyser.yml
@@ -9,10 +9,8 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v1
 
-            - name: Use Node.js 14.15
-              uses: actions/setup-node@v1
-              with:
-                  node-version: '14.15'
+            - name: Install Node
+              uses: guardian/actions-setup-node@main
 
             # Cache npm dependencies using https://github.com/bahmutov/npm-install
             - uses: bahmutov/npm-install@v1

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -7,9 +7,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v1
-            - uses: actions/setup-node@v1
-              with:
-                  node-version: '14.15'
+            - uses: guardian/actions-setup-node@main
 
             # Cache npm dependencies using https://github.com/bahmutov/npm-install
             - uses: bahmutov/npm-install@v1

--- a/.github/workflows/compress.yml
+++ b/.github/workflows/compress.yml
@@ -9,9 +9,7 @@ jobs:
 
         steps:
             - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
-              with:
-                  node-version: '14.15'
+            - uses: guardian/actions-setup-node@main
             - uses: preactjs/compressed-size-action@v1
               with:
                   repo-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -7,9 +7,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
-              with:
-                  node-version: '14.15'
+            - uses: guardian/actions-setup-node@main
 
             # Cache npm dependencies using https://github.com/bahmutov/npm-install
             - uses: bahmutov/npm-install@v1

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -7,10 +7,8 @@ jobs:
         steps:
             - name: Checkout code
               uses: actions/checkout@v1
-            - name: Use Node.js 14.15
-              uses: actions/setup-node@v1
-              with:
-                  node-version: 14.15
+            - name: Install Node
+              uses: guardian/actions-setup-node@main
             - run: make build
             - name: Install and run Lighthouse CI
               env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,9 +7,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
-              with:
-                  node-version: '14.15'
+            - uses: guardian/actions-setup-node@main
 
             # Cache npm dependencies using https://github.com/bahmutov/npm-install
             - uses: bahmutov/npm-install@v1

--- a/.github/workflows/pr-deployment.yml
+++ b/.github/workflows/pr-deployment.yml
@@ -13,10 +13,8 @@ jobs:
         steps:
             - name: Checkout code
               uses: actions/checkout@v1
-            - name: Use Node.js 14.15
-              uses: actions/setup-node@v1
-              with:
-                  node-version: 14.15
+            - name: Install Node
+              uses: guardian/actions-setup-node@main
             - run: make build
             - name: Boot server and run ngrok
               run: |

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -7,9 +7,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
-              with:
-                  node-version: '14.15'
+            - uses: guardian/actions-setup-node@main
 
             # Cache npm dependencies using https://github.com/bahmutov/npm-install
             - uses: bahmutov/npm-install@v1


### PR DESCRIPTION
## What does this change?

uses `guardian/actions-setup-node` in github actions

## Why?

[it uses your .nvmrc](https://github.com/guardian/actions-setup-node#about-this-fork) to pick the node version you want