### PR TITLE
Remove padding-top of top-above-nav ad slot to match Frontend rendering

### DIFF
--- a/src/web/components/AdSlot.tsx
+++ b/src/web/components/AdSlot.tsx
@@ -269,7 +269,6 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 				margin: 0 auto;
 				height: 151px;
 				padding-bottom: 18px;
-				padding-top: 18px;
 				text-align: left;
 				display: table;
 				width: 728px;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Remove `padding-top` of `top-above-nav` ad slot to match Frontend rendering

### Before

<img width="1959" alt="Screenshot 2021-03-08 at 11 58 50" src="https://user-images.githubusercontent.com/7014230/110319076-47eff780-8006-11eb-9f97-1a92210a7f10.png">

### After - DCR

<img width="826" alt="Screenshot 2021-03-08 at 12 11 54" src="https://user-images.githubusercontent.com/7014230/110320234-e597f680-8007-11eb-98e0-11c8ff3b300a.png">


## Why?

- Align DCR and Frontend rendering
- Remove whitespace