### PR TITLE
Enable custom link styles in the article body

### DIFF
--- a/src/web/components/ArticleBody.tsx
+++ b/src/web/components/ArticleBody.tsx
@@ -38,7 +38,7 @@ const bodyStyle = (display: Display) => css`
 `;
 
 const linkColour = (palette: Palette) => css`
-	a {
+	a:not([data-ignore-global-link-styling]) {
 		text-decoration: none;
 		border-bottom: 1px solid ${palette.border.articleLink};
 		color: ${palette.text.articleLink};

--- a/src/web/components/ShareIcons.tsx
+++ b/src/web/components/ShareIcons.tsx
@@ -86,6 +86,7 @@ export const ShareIcons: React.FC<{
 						role="button"
 						aria-label="Share on Facebook"
 						target="_blank"
+						data-ignore-global-link-styling={true}
 					>
 						<span className={iconStyles(palette)}>
 							<FacebookIcon />
@@ -103,6 +104,7 @@ export const ShareIcons: React.FC<{
 						role="button"
 						aria-label="Share on Twitter"
 						target="_blank"
+						data-ignore-global-link-styling={true}
 					>
 						<span className={iconStyles(palette)}>
 							<TwitterIconPadded />
@@ -120,6 +122,7 @@ export const ShareIcons: React.FC<{
 						role="button"
 						aria-label="Share via Email"
 						target="_blank"
+						data-ignore-global-link-styling={true}
 					>
 						<span className={iconStyles(palette)}>
 							<EmailIcon />
@@ -137,6 +140,7 @@ export const ShareIcons: React.FC<{
 						role="button"
 						aria-label="Share on LinkedIn"
 						target="_blank"
+						data-ignore-global-link-styling={true}
 					>
 						<span className={iconStyles(palette)}>
 							<LinkedInIcon />
@@ -154,6 +158,7 @@ export const ShareIcons: React.FC<{
 						role="button"
 						aria-label="Share on Pinterest"
 						target="_blank"
+						data-ignore-global-link-styling={true}
 					>
 						<span className={iconStyles(palette)}>
 							<PinterestIcon />
@@ -172,6 +177,7 @@ export const ShareIcons: React.FC<{
 							role="button"
 							aria-label="Share on WhatsApp"
 							target="_blank"
+							data-ignore-global-link-styling={true}
 						>
 							<span className={iconStyles(palette)}>
 								<WhatsAppIcon />
@@ -191,6 +197,7 @@ export const ShareIcons: React.FC<{
 							role="button"
 							aria-label="Share on Messanger>"
 							target="_blank"
+							data-ignore-global-link-styling={true}
 						>
 							<span className={iconStyles(palette)}>
 								<MessengerIcon />


### PR DESCRIPTION
## What?
Adds a pattern to allow the global link styles that we set on the article body to be ignored. Any element with the `data-ignore-global-link-styling` data attribute will not be selected and can have it's own a tag css

## Why?
Because the global selector has a high specificity and is hard to override but we sometimes need to. One upcoming example is if we place share icons inside each block on a live blog. These share icons use a tags and would pick up the global styles.

### What about making the global selector more targeted?
I could have used `a p {` but that would miss lists. So I'd have to have `a p, a li {` but... etc. It's perhaps just easier to use `:not`?

### Why not have different global styles for different contexts?
Another appoach is to have a separate or dynamic set of global styles depending on the type of article. But dynamic global styles probably isn't a path we want to go down.