### PR TITLE
Convert className to adCss prop

### DIFF
--- a/src/amp/components/Ad.test.tsx
+++ b/src/amp/components/Ad.test.tsx
@@ -40,7 +40,7 @@ describe('AdComponent', () => {
 				contentType={contentType}
 				config={commercialConfig}
 				commercialProperties={commercialProperties}
-				adCss=""
+				cssOverrides=""
 			/>,
 		);
 
@@ -94,7 +94,7 @@ describe('AdComponent', () => {
 				contentType={contentType}
 				config={commercialConfig}
 				commercialProperties={commercialProperties}
-				adCss=""
+				cssOverrides=""
 			/>,
 		);
 
@@ -139,7 +139,7 @@ describe('AdComponent', () => {
 				contentType={contentType}
 				config={commercialConfig}
 				commercialProperties={commercialProperties}
-				adCss=""
+				cssOverrides=""
 			/>,
 		);
 
@@ -185,7 +185,7 @@ describe('AdComponent', () => {
 				contentType={contentType}
 				config={commercialConfig}
 				commercialProperties={commercialProperties}
-				adCss=""
+				cssOverrides=""
 			/>,
 		);
 

--- a/src/amp/components/Ad.test.tsx
+++ b/src/amp/components/Ad.test.tsx
@@ -40,7 +40,7 @@ describe('AdComponent', () => {
 				contentType={contentType}
 				config={commercialConfig}
 				commercialProperties={commercialProperties}
-				className=""
+				adCss=""
 			/>,
 		);
 
@@ -94,7 +94,7 @@ describe('AdComponent', () => {
 				contentType={contentType}
 				config={commercialConfig}
 				commercialProperties={commercialProperties}
-				className=""
+				adCss=""
 			/>,
 		);
 
@@ -139,7 +139,7 @@ describe('AdComponent', () => {
 				contentType={contentType}
 				config={commercialConfig}
 				commercialProperties={commercialProperties}
-				className=""
+				adCss=""
 			/>,
 		);
 
@@ -185,7 +185,7 @@ describe('AdComponent', () => {
 				contentType={contentType}
 				config={commercialConfig}
 				commercialProperties={commercialProperties}
-				className=""
+				adCss=""
 			/>,
 		);
 

--- a/src/amp/components/Ad.tsx
+++ b/src/amp/components/Ad.tsx
@@ -170,16 +170,16 @@ export const Ad: React.SFC<{
 	contentType: string;
 	config: CommercialConfig;
 	commercialProperties: CommercialProperties;
-	className: string;
+	adCss: string;
 }> = ({
 	edition,
 	section,
 	contentType,
 	config,
 	commercialProperties,
-	className,
+	adCss,
 }) => (
-	<div className={cx(adStyle, className)}>
+	<div className={cx(adStyle, adCss)}>
 		{ampAdElem(
 			'US',
 			edition,

--- a/src/amp/components/Ad.tsx
+++ b/src/amp/components/Ad.tsx
@@ -170,16 +170,16 @@ export const Ad: React.SFC<{
 	contentType: string;
 	config: CommercialConfig;
 	commercialProperties: CommercialProperties;
-	adCss: string;
+	cssOverrides: string;
 }> = ({
 	edition,
 	section,
 	contentType,
 	config,
 	commercialProperties,
-	adCss,
+	cssOverrides,
 }) => (
-	<div className={cx(adStyle, adCss)}>
+	<div className={cx(adStyle, cssOverrides)}>
 		{ampAdElem(
 			'US',
 			edition,

--- a/src/amp/components/Blocks.tsx
+++ b/src/amp/components/Blocks.tsx
@@ -109,7 +109,7 @@ export const Blocks: React.SFC<{
 			<WithAds
 				items={liveBlogBlocks}
 				adSlots={slotIndexes}
-				adCss=""
+				cssOverrides=""
 				adInfo={adInfo}
 			/>
 		</>

--- a/src/amp/components/Blocks.tsx
+++ b/src/amp/components/Blocks.tsx
@@ -109,7 +109,7 @@ export const Blocks: React.SFC<{
 			<WithAds
 				items={liveBlogBlocks}
 				adSlots={slotIndexes}
-				adClassName=""
+				adCss=""
 				adInfo={adInfo}
 			/>
 		</>

--- a/src/amp/components/BodyArticle.tsx
+++ b/src/amp/components/BodyArticle.tsx
@@ -95,7 +95,7 @@ export const Body: React.FC<{
 		<WithAds
 			items={elementsWithoutAds}
 			adSlots={slotIndexes}
-			adClassName={adStyle}
+			adCss={adStyle}
 			adInfo={adInfo}
 		/>
 	);

--- a/src/amp/components/BodyArticle.tsx
+++ b/src/amp/components/BodyArticle.tsx
@@ -95,7 +95,7 @@ export const Body: React.FC<{
 		<WithAds
 			items={elementsWithoutAds}
 			adSlots={slotIndexes}
-			adCss={adStyle}
+			cssOverrides={adStyle}
 			adInfo={adInfo}
 		/>
 	);

--- a/src/amp/components/WithAds.tsx
+++ b/src/amp/components/WithAds.tsx
@@ -20,11 +20,11 @@ interface AdInfo {
 type Props = {
 	items: JSX.Element[];
 	adSlots: number[];
-	adCss: string;
+	cssOverrides: string;
 	adInfo: AdInfo;
 };
 
-export const WithAds = ({ items, adSlots, adCss, adInfo }: Props) => {
+export const WithAds = ({ items, adSlots, cssOverrides, adInfo }: Props) => {
 	const commercialConfig = {
 		usePrebid: adInfo.switches.ampPrebid,
 		usePermutive: adInfo.switches.permutive,
@@ -34,7 +34,7 @@ export const WithAds = ({ items, adSlots, adCss, adInfo }: Props) => {
 		// data-sort-time and id needed for amp-live-list validation
 		<div id={id} data-sort-time="1">
 			<Ad
-				adCss={adCss}
+				cssOverrides={cssOverrides}
 				edition={adInfo.edition}
 				section={adInfo.section}
 				contentType={adInfo.contentType}

--- a/src/amp/components/WithAds.tsx
+++ b/src/amp/components/WithAds.tsx
@@ -34,7 +34,7 @@ export const WithAds = ({ items, adSlots, adClassName, adInfo }: Props) => {
 		// data-sort-time and id needed for amp-live-list validation
 		<div id={id} data-sort-time="1">
 			<Ad
-				className={adClassName}
+				adCss={adClassName}
 				edition={adInfo.edition}
 				section={adInfo.section}
 				contentType={adInfo.contentType}

--- a/src/amp/components/WithAds.tsx
+++ b/src/amp/components/WithAds.tsx
@@ -20,11 +20,11 @@ interface AdInfo {
 type Props = {
 	items: JSX.Element[];
 	adSlots: number[];
-	adClassName: string;
+	adCss: string;
 	adInfo: AdInfo;
 };
 
-export const WithAds = ({ items, adSlots, adClassName, adInfo }: Props) => {
+export const WithAds = ({ items, adSlots, adCss, adInfo }: Props) => {
 	const commercialConfig = {
 		usePrebid: adInfo.switches.ampPrebid,
 		usePermutive: adInfo.switches.permutive,
@@ -34,7 +34,7 @@ export const WithAds = ({ items, adSlots, adClassName, adInfo }: Props) => {
 		// data-sort-time and id needed for amp-live-list validation
 		<div id={id} data-sort-time="1">
 			<Ad
-				adCss={adClassName}
+				adCss={adCss}
 				edition={adInfo.edition}
 				section={adInfo.section}
 				contentType={adInfo.contentType}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Convert `className` prop to `adCss`  prop

## Why?
Avoid prop names that could be confused for acctual DOM attributes