### PR TITLE
Simplify AMP pagination logic

### DIFF
--- a/src/amp/components/Pagination.stories.tsx
+++ b/src/amp/components/Pagination.stories.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import { Pagination } from './Pagination';
+
+export default {
+	component: Pagination,
+	title: 'AMP/Components/Pagination',
+};
+
+const pagination: Pagination = {
+	currentPage: 1,
+	totalPages: 2,
+	oldest: '?page=with:block-5b3ad778e4b05bcf5a69676d',
+	older: '?page=with:block-5b3b2ef5e4b05bcf5a6968f4',
+	newest: '?page=with:block-5b3ad778e4b05bcf5a69676d',
+	newer: '?page=with:block-5b3b2ef5e4b05bcf5a6968f4',
+};
+
+export const PaginationDefault = () => (
+	<Pagination pagination={pagination} guardianURL="" />
+);
+
+const paginationOlder: Pagination = {
+	currentPage: 1,
+	totalPages: 2,
+	oldest: '?page=with:block-5b3ad778e4b05bcf5a69676d',
+	older: '?page=with:block-5b3b2ef5e4b05bcf5a6968f4',
+};
+
+export const PaginationWithOlder = () => (
+	<Pagination pagination={paginationOlder} guardianURL="" />
+);
+
+const paginationNewer: Pagination = {
+	currentPage: 1,
+	totalPages: 2,
+	newest: '?page=with:block-5b3ad778e4b05bcf5a69676d',
+	newer: '?page=with:block-5b3b2ef5e4b05bcf5a6968f4',
+};
+
+export const PaginationWithNewer = () => (
+	<Pagination pagination={paginationNewer} guardianURL="" />
+);
+
+export const EmptyPagination = () => <Pagination guardianURL="" />;

--- a/src/amp/components/Pagination.tsx
+++ b/src/amp/components/Pagination.tsx
@@ -76,8 +76,8 @@ export const Pagination: React.SFC<{
 				</a>
 
 				<a
-					className={cx(
-						paginationLinkStyle(pagination.newest !== undefined),
+					className={paginationLinkStyle(
+						pagination.newest !== undefined,
 					)}
 					href={
 						pagination.newest
@@ -113,8 +113,8 @@ export const Pagination: React.SFC<{
 				</a>
 
 				<a
-					className={cx(
-						paginationLinkStyle(pagination.older !== undefined),
+					className={paginationLinkStyle(
+						pagination.older !== undefined,
 					)}
 					href={
 						pagination.older

--- a/src/amp/components/Pagination.tsx
+++ b/src/amp/components/Pagination.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'emotion';
+import { css, cx } from 'emotion';
 
 import { neutral } from '@guardian/src-foundations/palette';
 import { palette } from '@guardian/src-foundations';
@@ -18,7 +18,7 @@ const paginationStyle = css`
 	align-items: center;
 `;
 
-const paginationLinkStyle = (isActive: boolean, isMarginRight: boolean) => css`
+const paginationLinkStyle = (isActive: boolean) => css`
 	width: 36px;
 	border-radius: 100%;
 
@@ -28,7 +28,7 @@ const paginationLinkStyle = (isActive: boolean, isMarginRight: boolean) => css`
 	height: 36px;
 	display: inline-block;
 
-	margin-right: ${isMarginRight ? '5px' : '0px'};
+	margin-right: 0px;
 
 	span {
 		fill: ${palette.neutral[100]};
@@ -44,34 +44,14 @@ const paginationLinkStyle = (isActive: boolean, isMarginRight: boolean) => css`
 	}
 `;
 
+const marginRightStyle = css`
+	margin-right: 5px;
+`;
+
 export const Pagination: React.SFC<{
 	pagination?: Pagination;
 	guardianURL: string;
 }> = ({ pagination, guardianURL }) => {
-	const link = (
-		url: string,
-		icon: JSX.Element,
-		suffix?: string,
-		hasRightMargin: boolean = false,
-	): JSX.Element => {
-		const styles = paginationLinkStyle(
-			suffix !== undefined,
-			hasRightMargin,
-		);
-
-		const attrs = {
-			className: styles,
-			href: suffix ? url + suffix : undefined,
-		};
-
-		return (
-			// eslint-disable-next-line react/jsx-props-no-spreading
-			<a {...attrs}>
-				<span>{icon}</span>
-			</a>
-		);
-	};
-
 	if (!pagination) {
 		return null;
 	}
@@ -79,13 +59,36 @@ export const Pagination: React.SFC<{
 	return (
 		<div className={paginationStyle}>
 			<p>
-				{link(
-					guardianURL,
-					<ChevronLeftDouble />,
-					pagination.newest,
-					true,
-				)}
-				{link(guardianURL, <ChevronLeftSingle />, pagination.newer)}
+				<a
+					className={cx(
+						paginationLinkStyle(pagination.newest !== undefined),
+						marginRightStyle,
+					)}
+					href={
+						pagination.newest
+							? `${guardianURL}${pagination.newest}`
+							: ''
+					}
+				>
+					<span>
+						<ChevronLeftDouble />
+					</span>
+				</a>
+
+				<a
+					className={cx(
+						paginationLinkStyle(pagination.newest !== undefined),
+					)}
+					href={
+						pagination.newest
+							? `${guardianURL}${pagination.newest}`
+							: ''
+					}
+				>
+					<span>
+						<ChevronLeftSingle />
+					</span>
+				</a>
 			</p>
 
 			<p>
@@ -93,13 +96,36 @@ export const Pagination: React.SFC<{
 			</p>
 
 			<p>
-				{link(
-					guardianURL,
-					<ChevronRightSingle />,
-					pagination.older,
-					true,
-				)}
-				{link(guardianURL, <ChevronRightDouble />, pagination.oldest)}
+				<a
+					className={cx(
+						paginationLinkStyle(pagination.older !== undefined),
+						marginRightStyle,
+					)}
+					href={
+						pagination.older
+							? `${guardianURL}${pagination.older}`
+							: ''
+					}
+				>
+					<span>
+						<ChevronRightSingle />
+					</span>
+				</a>
+
+				<a
+					className={cx(
+						paginationLinkStyle(pagination.older !== undefined),
+					)}
+					href={
+						pagination.older
+							? `${guardianURL}${pagination.older}`
+							: ''
+					}
+				>
+					<span>
+						<ChevronRightDouble />
+					</span>
+				</a>
 			</p>
 		</div>
 	);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
- Convert `link` function to instead using `<a>` tag directly
- Overload styles rather than using a ternary

## Why?
Easier to understand