### PR TITLE
Live widths

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -473,6 +473,8 @@ type MediaType = 'Video' | 'Audio' | 'Gallery';
 
 type LineEffectType = 'squiggly' | 'dotted' | 'straight';
 
+type LeftColSize = 'compact'|'wide';
+
 type CardPercentageType = '25%' | '33%' | '50%' | '67%' | '75%' | '100%';
 
 type HeadlineLink = {

--- a/src/web/components/ContainerLayout.tsx
+++ b/src/web/components/ContainerLayout.tsx
@@ -111,6 +111,7 @@ export const ContainerLayout = ({
 				showRightBorder={centralBorder === 'full'}
 				borderColour={borderColour}
 				showPartialRightBorder={centralBorder === 'partial'}
+				size="wide"
 			>
 				<>
 					<ContainerTitle

--- a/src/web/components/ContainerLayout.tsx
+++ b/src/web/components/ContainerLayout.tsx
@@ -27,6 +27,7 @@ type Props = {
 	leftContent?: React.ReactNode;
 	children?: React.ReactNode;
 	stretchRight?: boolean;
+	leftColSize?: LeftColSize;
 };
 
 const Container = ({
@@ -97,6 +98,7 @@ export const ContainerLayout = ({
 	children,
 	leftContent,
 	stretchRight = false,
+	leftColSize,
 }: Props) => (
 	<Section
 		sectionId={sectionId}
@@ -111,7 +113,7 @@ export const ContainerLayout = ({
 				showRightBorder={centralBorder === 'full'}
 				borderColour={borderColour}
 				showPartialRightBorder={centralBorder === 'partial'}
-				size="wide"
+				size={leftColSize}
 			>
 				<>
 					<ContainerTitle

--- a/src/web/components/LeftColumn.tsx
+++ b/src/web/components/LeftColumn.tsx
@@ -3,27 +3,50 @@ import { css, cx } from 'emotion';
 import { border } from '@guardian/src-foundations/palette';
 import { from, between, until } from '@guardian/src-foundations/mq';
 
-const leftWidth = css`
-	padding-right: 10px;
-	${until.leftCol} {
-		/* below 1140 */
-		display: none;
-	}
+const leftWidth = (size: LeftColSize) => {
+	switch (size) {
+		case 'wide': {
+			return css`
+				padding-right: 10px;
+				${until.desktop} {
+					/* below 980 */
+					display: none;
+				}
 
-	${between.leftCol.and.wide} {
-		/* above 1140, below 1300 */
-		flex-basis: 151px;
-		flex-grow: 0;
-		flex-shrink: 0;
-	}
+				${from.desktop} {
+					/* above 1300 */
+					flex-basis: 320px;
+					flex-grow: 0;
+					flex-shrink: 0;
+				}
+			`;
+		}
+		case 'compact':
+		default: {
+			return css`
+				padding-right: 10px;
+				${until.leftCol} {
+					/* below 1140 */
+					display: none;
+				}
 
-	${from.wide} {
-		/* above 1300 */
-		flex-basis: 230px;
-		flex-grow: 0;
-		flex-shrink: 0;
+				${between.leftCol.and.wide} {
+					/* above 1140, below 1300 */
+					flex-basis: 151px;
+					flex-grow: 0;
+					flex-shrink: 0;
+				}
+
+				${from.wide} {
+					/* above 1300 */
+					flex-basis: 230px;
+					flex-grow: 0;
+					flex-shrink: 0;
+				}
+			`;
+		}
 	}
-`;
+};
 
 const positionRelative = css`
 	position: relative;
@@ -51,6 +74,7 @@ type Props = {
 	showRightBorder?: boolean;
 	showPartialRightBorder?: boolean;
 	borderColour?: string;
+	size?: LeftColSize;
 };
 
 export const LeftColumn = ({
@@ -58,6 +82,7 @@ export const LeftColumn = ({
 	showRightBorder = true,
 	borderColour = border.secondary,
 	showPartialRightBorder = false,
+	size = 'compact',
 }: Props) => {
 	// Make sure we can never have both borders at the same time
 	const shouldShowPartialBorder = showRightBorder
@@ -68,7 +93,7 @@ export const LeftColumn = ({
 		<section
 			className={cx(
 				positionRelative,
-				leftWidth,
+				leftWidth(size),
 				showRightBorder && rightBorder(borderColour),
 			)}
 		>

--- a/src/web/layouts/LiveLayout.tsx
+++ b/src/web/layouts/LiveLayout.tsx
@@ -70,7 +70,7 @@ const LiveGrid = ({ children }: { children: React.ReactNode }) => (
 
 				grid-column-gap: 10px;
 
-				${from.desktop} {
+				${from.wide} {
 					grid-template-columns:
 						309px /* Left Column (220 - 1px border) */
 						1px /* Empty border for spacing */
@@ -81,6 +81,18 @@ const LiveGrid = ({ children }: { children: React.ReactNode }) => (
 						'meta  border media        right-column'
 						'meta  border body         right-column'
 						'.     border .            right-column';
+				}
+
+				${from.desktop} {
+					grid-template-columns:
+						309px /* Left Column (220 - 1px border) */
+						1px /* Empty border for spacing */
+						1fr /* Main content */;
+					grid-template-areas:
+						'lines border media'
+						'meta  border media'
+						'meta  border body'
+						'.     border .';
 				}
 
 				${until.desktop} {

--- a/src/web/layouts/LiveLayout.tsx
+++ b/src/web/layouts/LiveLayout.tsx
@@ -56,14 +56,11 @@ const LiveGrid = ({ children }: { children: React.ReactNode }) => (
 			/* IE Fallback */
 			display: flex;
 			flex-direction: column;
-			${until.leftCol} {
+			${until.desktop} {
 				margin-left: 0px;
 			}
-			${from.leftCol} {
-				margin-left: 151px;
-			}
-			${from.wide} {
-				margin-left: 230px;
+			${from.desktop} {
+				margin-left: 320px;
 			}
 
 			@supports (display: grid) {
@@ -73,42 +70,17 @@ const LiveGrid = ({ children }: { children: React.ReactNode }) => (
 
 				grid-column-gap: 10px;
 
-				${from.wide} {
+				${from.desktop} {
 					grid-template-columns:
-						219px /* Left Column (220 - 1px border) */
+						309px /* Left Column (220 - 1px border) */
 						1px /* Empty border for spacing */
 						1fr /* Main content */
-						300px; /* Right Column */
+						340px; /* Right Column */
 					grid-template-areas:
 						'lines border media        right-column'
 						'meta  border media        right-column'
 						'meta  border body         right-column'
 						'.     border .            right-column';
-				}
-
-				${until.wide} {
-					grid-template-columns:
-						140px /* Left Column */
-						1px /* Empty border for spacing */
-						1fr /* Main content */
-						300px; /* Right Column */
-					grid-template-areas:
-						'lines border media        right-column'
-						'meta  border media        right-column'
-						'meta  border body         right-column'
-						'.     border .            right-column';
-				}
-
-				${until.leftCol} {
-					grid-template-columns:
-						1fr /* Main content */
-						300px; /* Right Column */
-					grid-template-areas:
-						'media         right-column'
-						'lines         right-column'
-						'meta          right-column'
-						'body          right-column'
-						'.             right-column';
 				}
 
 				${until.desktop} {

--- a/src/web/layouts/LiveLayout.tsx
+++ b/src/web/layouts/LiveLayout.tsx
@@ -290,6 +290,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				backgroundColour={palette.background.header}
 				borderColour={palette.border.headline}
 				sideBorders={true}
+				leftColSize="wide"
 				leftContent={
 					// eslint-disable-next-line react/jsx-wrap-multilines
 					<ArticleTitle
@@ -333,6 +334,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				backgroundColour={palette.background.standfirst}
 				borderColour={palette.border.standfirst}
 				sideBorders={true}
+				leftColSize="wide"
 			>
 				<Standfirst format={format} standfirst={CAPI.standfirst} />
 			</ContainerLayout>
@@ -342,6 +344,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				backgroundColour={palette.background.article}
 				borderColour={neutral[86]}
 				sideBorders={true}
+				leftColSize="wide"
 			/>
 
 			<Section


### PR DESCRIPTION
## What?
Adds support for different columns widths for LiveBlogs


![2021-03-09 16 38 59](https://user-images.githubusercontent.com/1336821/110505542-2706cf80-80f6-11eb-9ccc-b2ea62cb633c.gif)



## Why?
So that we give more space to key events (left column) and keep them on the page for longer

### What about main content width?
There are two divergences with the main column width here:

1. On frontend this is sometimes using a max width of `610px`. In DCR we have always used `620px` and I don't want to break that pattern.
2. Between `leftCol` and `wide` Frontend breaks out of the max width for article content and stretchs to the sides, up to 7 or 800px wide. This is outside of the conventional max width of `620px` so I wanted to approach this separately.