### PR TITLE
Don't use AMD loader for 99% of interactives

### DIFF
--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -578,13 +578,13 @@ export const App = ({ CAPI, NAV }: Props) => {
 				</HydrateOnce>
 			))}
 			{interactiveElements.map((interactiveBlock) => (
-				<Portal rootId={interactiveBlock.elementId}>
+				<HydrateOnce rootId={interactiveBlock.elementId}>
 					<InteractiveBlockComponent
 						url={interactiveBlock.url}
 						scriptUrl={interactiveBlock.scriptUrl}
 						alt={interactiveBlock.alt}
 					/>
-				</Portal>
+				</HydrateOnce>
 			))}
 			{quizAtoms.map((quizAtom) => (
 				<HydrateOnce rootId={quizAtom.elementId}>

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -583,6 +583,7 @@ export const App = ({ CAPI, NAV }: Props) => {
 						url={interactiveBlock.url}
 						scriptUrl={interactiveBlock.scriptUrl}
 						alt={interactiveBlock.alt}
+						role={interactiveBlock.role}
 					/>
 				</HydrateOnce>
 			))}

--- a/src/web/components/elements/InteractiveBlockComponent.stories.tsx
+++ b/src/web/components/elements/InteractiveBlockComponent.stories.tsx
@@ -40,6 +40,7 @@ export const Default = () => {
 					url="https://interactive.guim.co.uk/uploader/embed/2018/01/archive-zip/giv-3902O7VEVpcWiCO7/"
 					scriptUrl="https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js"
 					alt="map"
+					role="supporting"
 				/>
 			</Figure>
 			<SomeText />
@@ -64,6 +65,7 @@ export const InlineMap = () => {
 					url="https://interactive.guim.co.uk/uploader/embed/2020/11/nagorno_karabakh_map/giv-3902efc3KhF4zInV/"
 					scriptUrl="https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js"
 					alt="The agreement mediated by Russia in Nagorno-Karabakh"
+					role="inline"
 				/>
 			</Figure>
 			<SomeText />
@@ -87,6 +89,7 @@ export const Showcase = () => {
 					url="https://interactive.guim.co.uk/embed/from-tool/photo-collage/index.html?vertical=News&opinion-tint=false&left-image=https%3A%2F%2Fmedia.gutools.co.uk%2Fimages%2F84bd48ec5962601f8550286bfb5c2093fa0a3ffe%3Fcrop%3D0_70_3500_2100&left-caption=A%20woman%20stands%20during%20a%20song%20ahead%20of%20Trump’s%20remarks%20at%20the%20King%20Jesus%20International%20Ministry%20in%20Miami.%20Photo%3A%20Tom%20Brenner%2FReuters&right-image=https%3A%2F%2Fmedia.gutools.co.uk%2Fimages%2F9eb6381555963f1dc58c637adf2f3dc08f283e58%3Fcrop%3D0_26_3000_1800&right-caption=People%20give%20thumbs%20down%20to%20media%20covering%20the%20Trump%20campaign%20event%20held%20at%20the%20King%20Jesus%20International%20Ministry.%20Photo%3A%20Joe%20Raedle%2FGetty&always-place-captions-below=false"
 					scriptUrl="https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js"
 					alt="Photo collage"
+					role="showcase"
 				/>
 			</Figure>
 			<SomeText />
@@ -111,6 +114,7 @@ export const NonBootJs = () => {
 					url="https://gdn-cdn.s3.amazonaws.com/quiz-builder/c65f1acf-eefd-4985-913d-74ae12eb1f35/boot.js"
 					scriptUrl="https://gdn-cdn.s3.amazonaws.com/quiz-builder/c65f1acf-eefd-4985-913d-74ae12eb1f35/boot.js"
 					alt="Bird Quiz"
+					role="inline"
 				/>
 			</Figure>
 			<SomeText />

--- a/src/web/components/elements/InteractiveBlockComponent.stories.tsx
+++ b/src/web/components/elements/InteractiveBlockComponent.stories.tsx
@@ -26,13 +26,20 @@ const SomeText = () => (
 	/>
 );
 
+const Container = ({ children }: { children: React.ReactNode }) => (
+	<div
+		className={css`
+			padding-left: 250px;
+			padding-right: 20px;
+		`}
+	>
+		{children}
+	</div>
+);
+
 export const Default = () => {
 	return (
-		<div
-			className={css`
-				padding-left: 250px;
-			`}
-		>
+		<Container>
 			<SomeText />
 			<SomeText />
 			<Figure role="supporting">
@@ -46,18 +53,14 @@ export const Default = () => {
 			<SomeText />
 			<SomeText />
 			<SomeText />
-		</div>
+		</Container>
 	);
 };
 Default.story = { name: 'default' };
 
 export const InlineMap = () => {
 	return (
-		<div
-			className={css`
-				padding-left: 20px;
-			`}
-		>
+		<Container>
 			<SomeText />
 			<SomeText />
 			<Figure role="inline">
@@ -70,18 +73,14 @@ export const InlineMap = () => {
 			</Figure>
 			<SomeText />
 			<SomeText />
-		</div>
+		</Container>
 	);
 };
 InlineMap.story = { name: 'Inline interactive Map' };
 
 export const Showcase = () => {
 	return (
-		<div
-			className={css`
-				padding-left: 20px;
-			`}
-		>
+		<Container>
 			<SomeText />
 			<SomeText />
 			<Figure role="showcase">
@@ -95,18 +94,14 @@ export const Showcase = () => {
 			<SomeText />
 			<SomeText />
 			<SomeText />
-		</div>
+		</Container>
 	);
 };
 Showcase.story = { name: 'Showcase interactive element' };
 
 export const NonBootJs = () => {
 	return (
-		<div
-			className={css`
-				padding-left: 250px;
-			`}
-		>
+		<Container>
 			<SomeText />
 			<SomeText />
 			<Figure role="inline">
@@ -120,7 +115,7 @@ export const NonBootJs = () => {
 			<SomeText />
 			<SomeText />
 			<SomeText />
-		</div>
+		</Container>
 	);
 };
 NonBootJs.story = { name: 'Non-boot.js interactive element' };

--- a/src/web/components/elements/InteractiveBlockComponent.tsx
+++ b/src/web/components/elements/InteractiveBlockComponent.tsx
@@ -9,7 +9,7 @@ type Props = {
 	url?: string;
 	scriptUrl?: string;
 	alt?: string;
-	role?: string;
+	role?: RoleType;
 };
 
 /*
@@ -70,17 +70,21 @@ and to avoid loading the boot.js file.
 For the remaining few we dynamically load and AMD loader and support the contract as defined with curl AMD loader
 
 */
-const supportingMinHeight = 200;
-const inlineMinHeight = 500;
-const getMinHeight = (role: string, loaded: boolean) => {
+const decideHeight = (role: RoleType) => {
+	switch (role) {
+		case 'supporting':
+			return 200;
+		default:
+			return 500;
+	}
+};
+const getMinHeight = (role: RoleType, loaded: boolean) => {
 	if (loaded) {
 		return `auto`;
 	}
-	return role === 'supporting'
-		? `${supportingMinHeight}px`
-		: `${inlineMinHeight}px`;
+	return `${decideHeight(role)}px`;
 };
-const wrapperStyle = (role: string, loaded: boolean) => css`
+const wrapperStyle = (role: RoleType, loaded: boolean) => css`
 	${body.medium()};
 	background-color: ${neutral[100]};
 	font-weight: 300;
@@ -216,10 +220,7 @@ export const InteractiveBlockComponent = ({
 			const iframe = document.createElement('iframe');
 			iframe.style.width = '100%';
 			iframe.style.border = 'none';
-			iframe.height =
-				role === 'supporting'
-					? supportingMinHeight.toString()
-					: inlineMinHeight.toString(); // default height
+			iframe.height = decideHeight(role).toString();
 			iframe.src = url;
 
 			setupWindowListeners(iframe);
@@ -261,11 +262,7 @@ export const InteractiveBlockComponent = ({
 		>
 			{!loaded && (
 				<Placeholder
-					height={
-						role === 'supporting'
-							? supportingMinHeight
-							: inlineMinHeight
-					}
+					height={decideHeight(role)}
 					shouldShimmer={false}
 				/>
 			)}

--- a/src/web/components/elements/InteractiveBlockComponent.tsx
+++ b/src/web/components/elements/InteractiveBlockComponent.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
+import { useOnce } from '@root/src/web/lib/useOnce';
 import { css } from 'emotion';
 import { body } from '@guardian/src-foundations/typography';
 import { space } from '@guardian/src-foundations';
@@ -216,12 +217,7 @@ export const InteractiveBlockComponent = ({
 	const wrapperRef = useRef<HTMLDivElement>(null);
 	const placeholderLinkRef = useRef<HTMLAnchorElement>(null);
 	const [loaded, setLoaded] = useState(false);
-	useEffect(() => {
-		// Once loaded, we don't touch it.
-		if (loaded) {
-			return;
-		}
-
+	useOnce(() => {
 		// We've brought the behavior from boot.js into this file to avoid loading 2 extra scripts
 		if (
 			scriptUrl ===
@@ -264,7 +260,7 @@ export const InteractiveBlockComponent = ({
 
 			setLoaded(true);
 		}
-	}, [scriptUrl, role, url, loaded]);
+	}, [loaded]);
 
 	return (
 		<div

--- a/src/web/components/elements/InteractiveBlockComponent.tsx
+++ b/src/web/components/elements/InteractiveBlockComponent.tsx
@@ -245,7 +245,7 @@ export const InteractiveBlockComponent = ({
 
 			setLoaded(true);
 		}
-	}, [scriptUrl]);
+	}, [scriptUrl, role, url]);
 
 	return (
 		<div

--- a/src/web/components/elements/InteractiveBlockComponent.tsx
+++ b/src/web/components/elements/InteractiveBlockComponent.tsx
@@ -266,6 +266,7 @@ export const InteractiveBlockComponent = ({
 							? supportingMinHeight
 							: inlineMinHeight
 					}
+					shouldShimmer={false}
 				/>
 			)}
 			{!loaded && (

--- a/src/web/components/elements/InteractiveBlockComponent.tsx
+++ b/src/web/components/elements/InteractiveBlockComponent.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { css } from 'emotion';
 import { body } from '@guardian/src-foundations/typography';
+import { space } from '@guardian/src-foundations';
 import { neutral } from '@guardian/src-foundations/palette';
 import { Placeholder } from '@root/src/web/components/Placeholder';
 import libDebounce from 'lodash.debounce';
@@ -87,15 +88,14 @@ const getMinHeight = (role: RoleType, loaded: boolean) => {
 const wrapperStyle = (role: RoleType, loaded: boolean) => css`
 	${body.medium()};
 	background-color: ${neutral[100]};
-	font-weight: 300;
 	min-height: ${getMinHeight(role, loaded)};
 	position: relative;
 `;
 
 const placeholderLinkStyle = css`
 	position: absolute;
-	bottom: 1rem;
-	left: 1rem;
+	bottom: ${space[1]}px;
+	left: ${space[1]}px;
 `;
 
 // https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js

--- a/src/web/components/elements/InteractiveBlockComponent.tsx
+++ b/src/web/components/elements/InteractiveBlockComponent.tsx
@@ -201,6 +201,11 @@ export const InteractiveBlockComponent = ({
 	const placeholderLinkRef = useRef<HTMLAnchorElement>(null);
 	const [loaded, setLoaded] = useState(false);
 	useEffect(() => {
+		// Once loaded, we don't touch it.
+		if (loaded) {
+			return;
+		}
+
 		// We've brought the behavior from boot.js into this file to avoid loading 2 extra scripts
 		if (
 			scriptUrl ===
@@ -246,7 +251,7 @@ export const InteractiveBlockComponent = ({
 
 			setLoaded(true);
 		}
-	}, [scriptUrl, role, url]);
+	}, [scriptUrl, role, url, loaded]);
 
 	return (
 		<div

--- a/src/web/components/elements/InteractiveBlockComponent.tsx
+++ b/src/web/components/elements/InteractiveBlockComponent.tsx
@@ -107,15 +107,12 @@ const setupWindowListeners = (iframe: HTMLIFrameElement) => {
 	window.addEventListener(
 		'message',
 		(event) => {
-			console.log(event);
 			if (event.source !== iframe.contentWindow) {
-				console.log('nope');
 				return;
 			}
 
-			// IE 8 + 9 only support strings
 			const message: Record<string, unknown> = JSON.parse(event.data);
-			console.log(message);
+
 			const postPositionMessage = (subscribe?: boolean) => {
 				const iframeBox = iframe.getBoundingClientRect();
 				postMessage({
@@ -203,7 +200,6 @@ export const InteractiveBlockComponent = ({
 	const wrapperRef = useRef<HTMLDivElement>(null);
 	const placeholderLinkRef = useRef<HTMLAnchorElement>(null);
 	const [loaded, setLoaded] = useState(false);
-	console.log(role);
 	useEffect(() => {
 		if (
 			scriptUrl ===

--- a/src/web/components/elements/InteractiveBlockComponent.tsx
+++ b/src/web/components/elements/InteractiveBlockComponent.tsx
@@ -115,13 +115,25 @@ const setupWindowListeners = (iframe: HTMLIFrameElement) => {
 				return;
 			}
 
-			const message: Record<string, unknown> = JSON.parse(event.data);
+			let message: Record<string, unknown> | undefined;
+			try {
+				message = JSON.parse(event.data);
+			} catch (e) {
+				window?.guardian?.modules?.sentry?.reportError(
+					e,
+					'Json parse Failed on in interactiveBlockComponent',
+				);
+			}
+
+			if (message === undefined) {
+				return;
+			}
 
 			const postPositionMessage = (subscribe?: boolean) => {
 				const iframeBox = iframe.getBoundingClientRect();
 				postMessage({
-					id: message.id || '',
-					type: message.type || '',
+					id: message?.id || '',
+					type: message?.type || '',
 					subscribe: !!subscribe,
 					iframeTop: iframeBox.top,
 					iframeRight: iframeBox.right,

--- a/src/web/components/elements/InteractiveBlockComponent.tsx
+++ b/src/web/components/elements/InteractiveBlockComponent.tsx
@@ -201,6 +201,7 @@ export const InteractiveBlockComponent = ({
 	const placeholderLinkRef = useRef<HTMLAnchorElement>(null);
 	const [loaded, setLoaded] = useState(false);
 	useEffect(() => {
+		// We've brought the behavior from boot.js into this file to avoid loading 2 extra scripts
 		if (
 			scriptUrl ===
 				'https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js' &&

--- a/src/web/components/elements/InteractiveBlockComponent.tsx
+++ b/src/web/components/elements/InteractiveBlockComponent.tsx
@@ -1,4 +1,7 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { css } from 'emotion';
+import { body } from '@guardian/src-foundations/typography';
+import { neutral } from '@guardian/src-foundations/palette';
 
 type Props = {
 	url?: string;
@@ -65,8 +68,29 @@ For the remaining few we dynamically load and AMD loader and support the contrac
 
 */
 
+const wrapperStyle = css`
+	${body.medium()};
+	font-weight: 300;
+	min-height: 350px;
+	position: relative;
+`;
+
+const placeholderStyle = css`
+	background-color: ${neutral[93]};
+	height: 100%;
+	width: 100%;
+	position: absolute;
+`;
+
+const placeholderLinkStyle = css`
+	position: absolute;
+	bottom: 1rem;
+	left: 1rem;
+`;
+
 export const InteractiveBlockComponent = ({ url, scriptUrl, alt }: Props) => {
 	const wrapperRef = useRef<HTMLDivElement>(null);
+	const [loaded, setLoaded] = useState(false);
 	useEffect(() => {
 		if (scriptUrl) {
 			// We're going to use curl AMD loader to load the script that the
@@ -89,6 +113,8 @@ export const InteractiveBlockComponent = ({ url, scriptUrl, alt }: Props) => {
 					}
 				},
 			);
+
+			setLoaded(true);
 		}
 	}, [scriptUrl]);
 
@@ -96,8 +122,14 @@ export const InteractiveBlockComponent = ({ url, scriptUrl, alt }: Props) => {
 		<div
 			data-cypress={`interactive-element-${encodeURI(alt || '')}`}
 			ref={wrapperRef}
+			className={wrapperStyle}
 		>
-			<a data-name="placeholder" href={url}>
+			{!loaded && <div className={placeholderStyle} />}
+			<a
+				data-name="placeholder"
+				className={placeholderLinkStyle}
+				href={url}
+			>
 				{alt}
 			</a>
 		</div>

--- a/src/web/components/elements/InteractiveBlockComponent.tsx
+++ b/src/web/components/elements/InteractiveBlockComponent.tsx
@@ -3,6 +3,7 @@ import { css } from 'emotion';
 import { body } from '@guardian/src-foundations/typography';
 import { neutral } from '@guardian/src-foundations/palette';
 import { Placeholder } from '@root/src/web/components/Placeholder';
+import libDebounce from 'lodash.debounce';
 
 type Props = {
 	url?: string;
@@ -93,18 +94,6 @@ const placeholderLinkStyle = css`
 	left: 1rem;
 `;
 
-const debounce = <F extends (...params: any[]) => void>(
-	fn: F,
-	delay: number,
-) => {
-	let timeoutID: number;
-	// eslint-disable-next-line func-names
-	return function (this: any, ...args: any[]) {
-		clearTimeout(timeoutID);
-		timeoutID = window.setTimeout(() => fn.apply(this, args), delay);
-	} as F;
-};
-
 // https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js
 const setupWindowListeners = (iframe: HTMLIFrameElement) => {
 	// Calls func on trailing edge of the wait period
@@ -188,13 +177,13 @@ const setupWindowListeners = (iframe: HTMLIFrameElement) => {
 					// Send updated position on scroll or resize
 					window.addEventListener(
 						'scroll',
-						debounce(() => {
+						libDebounce(() => {
 							postPositionMessage(true);
 						}, 50),
 					);
 					window.addEventListener(
 						'resize',
-						debounce(() => {
+						libDebounce(() => {
 							postPositionMessage(true);
 						}, 50),
 					);

--- a/src/web/components/elements/InteractiveBlockComponent.tsx
+++ b/src/web/components/elements/InteractiveBlockComponent.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { css } from 'emotion';
 import { body } from '@guardian/src-foundations/typography';
 import { neutral } from '@guardian/src-foundations/palette';
+import { Placeholder } from '@root/src/web/components/Placeholder';
 
 type Props = {
 	url?: string;
@@ -84,13 +85,6 @@ const wrapperStyle = (role: string, loaded: boolean) => css`
 	font-weight: 300;
 	min-height: ${getMinHeight(role, loaded)};
 	position: relative;
-`;
-
-const placeholderStyle = css`
-	background-color: ${neutral[93]};
-	height: 100%;
-	width: 100%;
-	position: absolute;
 `;
 
 const placeholderLinkStyle = css`
@@ -274,7 +268,15 @@ export const InteractiveBlockComponent = ({
 			ref={wrapperRef}
 			className={wrapperStyle(role, loaded)}
 		>
-			{!loaded && <div className={placeholderStyle} />}
+			{!loaded && (
+				<Placeholder
+					height={
+						role === 'supporting'
+							? supportingMinHeight
+							: inlineMinHeight
+					}
+				/>
+			)}
 			{!loaded && (
 				<a
 					ref={placeholderLinkRef}

--- a/src/web/layouts/Immersive.stories.tsx
+++ b/src/web/layouts/Immersive.stories.tsx
@@ -141,6 +141,10 @@ export const SpecialReportStory = (): React.ReactNode => {
 SpecialReportStory.story = {
 	name: 'SpecialReport',
 };
+SpecialReportStory.parameters = {
+	// Wait for the interactives to load
+	chromatic: { delay: 300 },
+};
 
 export const FeatureStory = (): React.ReactNode => {
 	const ServerCAPI = convertToImmersive(Feature);

--- a/src/web/layouts/Immersive.stories.tsx
+++ b/src/web/layouts/Immersive.stories.tsx
@@ -143,7 +143,7 @@ SpecialReportStory.story = {
 };
 SpecialReportStory.parameters = {
 	// Wait for the interactives to load
-	chromatic: { delay: 300 },
+	chromatic: { delay: 1000 },
 };
 
 export const FeatureStory = (): React.ReactNode => {

--- a/src/web/lib/ElementRenderer.tsx
+++ b/src/web/lib/ElementRenderer.tsx
@@ -340,6 +340,7 @@ export const ElementRenderer = ({
 						url={element.url}
 						scriptUrl={element.scriptUrl}
 						alt={element.alt}
+						role={element.role}
 					/>
 				</Figure>
 			);

--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -178,10 +178,12 @@ export const document = ({ data }: Props): string => {
 	const polyfillIO =
 		'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,es2018,es2019,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,fetch,NodeList.prototype.forEach&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1';
 
-	const pageHasInteractiveElements = CAPIElements.some(
+	const pageHasNonBootInteractiveElements = CAPIElements.some(
 		(element) =>
 			element._type ===
-			'model.dotcomrendering.pageElements.InteractiveBlockElement',
+				'model.dotcomrendering.pageElements.InteractiveBlockElement' &&
+			element.scriptUrl !==
+				'https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js', // We have rewritten this standard behaviour into Dotcom Rendering
 	);
 
 	function isDefined<T>(argument: T | boolean): argument is T {
@@ -202,7 +204,7 @@ export const document = ({ data }: Props): string => {
 			...getScriptArrayFromChunkName('sentryLoader'),
 			...getScriptArrayFromChunkName('coreVitals'),
 			...getScriptArrayFromChunkName('dynamicImport'),
-			pageHasInteractiveElements && {
+			pageHasNonBootInteractiveElements && {
 				src: `${CDN}static/frontend/js/curl-with-js-and-domReady.js`,
 			},
 			...arrayOfLoadableScriptObjects, // This includes the 'react' entry point


### PR DESCRIPTION
## What does this change?
- Brings in the behaviour of boot.js into the platform to avoid loading the AMD loader and the boot.js script.
- Adds the placeholder to reduce CLS, and avoid going from 0 height -> interactive height, not perfect but better than it was

![2021-03-11 10 45 35](https://user-images.githubusercontent.com/638051/110775796-3ea99980-8257-11eb-8a0f-876d37dcfbaa.gif)

![2021-03-11 10 46 01](https://user-images.githubusercontent.com/638051/110775803-40735d00-8257-11eb-968b-77dc93f3b4b8.gif)

![2021-03-11 10 46 22](https://user-images.githubusercontent.com/638051/110775813-42d5b700-8257-11eb-8412-51885ed49230.gif)
