### PR TITLE
Revert "ARM/Graviton testing"

### DIFF
--- a/scripts/deploy/riff-raff.yaml
+++ b/scripts/deploy/riff-raff.yaml
@@ -9,12 +9,12 @@ deployments:
       cloudFormationStackName: rendering
       templateStageParameters:
         CODE:
-          InstanceType: t4g.micro
+          InstanceType: t3.micro
         PROD:
-          InstanceType: t4g.small
+          InstanceType: t3.small
       amiParametersToTags:
         AMI:
-          Recipe: dotcom-rendering-ARM
+          Recipe: dotcom-rendering-node14-test
           BuiltBy: amigo
           AmigoStage: PROD
   rendering:

--- a/src/app/aws/metrics-baseline.ts
+++ b/src/app/aws/metrics-baseline.ts
@@ -1,11 +1,9 @@
-// TODO re-enable disk space checks after Graviton testing complete (the diskusage module doesn't work on ARM).
-
 import os from 'os';
-// import disk from 'diskusage';
+import disk from 'diskusage';
 import { BytesMetric, collectAndSendAWSMetrics } from './aws-metrics';
 
 const maxHeapMemory = BytesMetric('rendering', 'PROD', 'max-heap-memory');
-// const freeDiskSpace = BytesMetric('rendering', 'PROD', 'free-disk-memory');
+const freeDiskSpace = BytesMetric('rendering', 'PROD', 'free-disk-memory');
 const usedHeapMemory = BytesMetric('rendering', 'PROD', 'used-heap-memory');
 const freePhysicalMemory = BytesMetric(
 	'rendering',
@@ -25,30 +23,24 @@ collectAndSendAWSMetrics(
 	usedHeapMemory,
 	totalPhysicalMemory,
 	freePhysicalMemory,
-	// freeDiskSpace,
+	freeDiskSpace,
 );
 
 // records system metrics
 
 export const recordBaselineCloudWatchMetrics = () => {
-	// TODO re-enable once ARM testing complete
-	// disk.check('/', (err, diskinfo) => {
-	// 	if (err) {
-	// 		// eslint-disable-next-line no-console
-	// 		console.error(err);
-	// 	} else {
-	// 		maxHeapMemory.record(process.memoryUsage().heapTotal);
-	// 		usedHeapMemory.record(process.memoryUsage().heapUsed);
-	// 		totalPhysicalMemory.record(os.totalmem());
-	// 		freePhysicalMemory.record(os.freemem());
-	// 		if (diskinfo) {
-	// 			freeDiskSpace.record(diskinfo.free);
-	// 		}
-	// 	}
-	// });
-
-	maxHeapMemory.record(process.memoryUsage().heapTotal);
-	usedHeapMemory.record(process.memoryUsage().heapUsed);
-	totalPhysicalMemory.record(os.totalmem());
-	freePhysicalMemory.record(os.freemem());
+	disk.check('/', (err, diskinfo) => {
+		if (err) {
+			// eslint-disable-next-line no-console
+			console.error(err);
+		} else {
+			maxHeapMemory.record(process.memoryUsage().heapTotal);
+			usedHeapMemory.record(process.memoryUsage().heapUsed);
+			totalPhysicalMemory.record(os.totalmem());
+			freePhysicalMemory.record(os.freemem());
+			if (diskinfo) {
+				freeDiskSpace.record(diskinfo.free);
+			}
+		}
+	});
 };


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#2657 to temporarily switch back for the rest of the month before our new reservations.