### PR TITLE
Small ShareIcons

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -473,6 +473,8 @@ type MediaType = 'Video' | 'Audio' | 'Gallery';
 
 type LineEffectType = 'squiggly' | 'dotted' | 'straight';
 
+type ShareIconSize = 'small' | 'medium';
+
 type CardPercentageType = '25%' | '33%' | '50%' | '67%' | '75%' | '100%';
 
 type HeadlineLink = {

--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -281,6 +281,7 @@ export const ArticleMeta = ({
 							webTitle={webTitle}
 							palette={palette}
 							displayIcons={['facebook', 'twitter', 'email']}
+							size="medium"
 						/>
 					</div>
 					<div className={metaNumbers}>

--- a/src/web/components/ShareIcons.stories.tsx
+++ b/src/web/components/ShareIcons.stories.tsx
@@ -30,6 +30,7 @@ export const Medium = () => {
 				design: Design.Article,
 				display: Display.Standard,
 			})}
+			size="medium"
 		/>
 	);
 };

--- a/src/web/components/ShareIcons.stories.tsx
+++ b/src/web/components/ShareIcons.stories.tsx
@@ -11,7 +11,7 @@ export default {
 	title: 'Components/ShareIcons',
 };
 
-export const All = () => {
+export const Medium = () => {
 	return (
 		<ShareIcons
 			pageId=""
@@ -33,4 +33,29 @@ export const All = () => {
 		/>
 	);
 };
-All.story = { name: 'All' };
+Medium.story = { name: 'Medium' };
+
+export const Small = () => {
+	return (
+		<ShareIcons
+			pageId=""
+			webTitle=""
+			displayIcons={[
+				'facebook',
+				'email',
+				'linkedIn',
+				'messenger',
+				'pinterest',
+				'twitter',
+				'whatsApp',
+			]}
+			palette={decidePalette({
+				theme: Pillar.News,
+				design: Design.Article,
+				display: Display.Standard,
+			})}
+			size="small"
+		/>
+	);
+};
+Small.story = { name: 'Small' };

--- a/src/web/components/ShareIcons.tsx
+++ b/src/web/components/ShareIcons.tsx
@@ -14,6 +14,13 @@ import MessengerIcon from '@frontend/static/icons/messenger.svg';
 
 import { Hide } from './Hide';
 
+type Props = {
+	pageId: string;
+	webTitle: string;
+	displayIcons: SharePlatform[];
+	palette: Palette;
+};
+
 const ulStyles = css`
 	float: left;
 	${from.wide} {
@@ -69,12 +76,12 @@ const encodeUrl = (pageId: string): string => {
 const encodeTitle = (webTitle: string): string => {
 	return encodeURIComponent(webTitle.replace(/Leave.EU/gi, 'Leave. EU'));
 };
-export const ShareIcons: React.FC<{
-	pageId: string;
-	webTitle: string;
-	displayIcons: SharePlatform[];
-	palette: Palette;
-}> = ({ pageId, webTitle, displayIcons, palette }) => {
+export const ShareIcons = ({
+	pageId,
+	webTitle,
+	displayIcons,
+	palette,
+}: Props) => {
 	return (
 		<ul className={ulStyles}>
 			{displayIcons.includes('facebook') && (

--- a/src/web/components/ShareIcons.tsx
+++ b/src/web/components/ShareIcons.tsx
@@ -22,7 +22,7 @@ const ulStyles = css`
 `;
 
 const liStyles = css`
-	padding: 0 3px 6px 0;
+	padding-right: 3px;
 	float: left;
 	min-width: 32px;
 	cursor: pointer;

--- a/src/web/components/ShareIcons.tsx
+++ b/src/web/components/ShareIcons.tsx
@@ -19,7 +19,7 @@ type Props = {
 	webTitle: string;
 	displayIcons: SharePlatform[];
 	palette: Palette;
-	size?: ShareIconSize;
+	size: ShareIconSize;
 };
 
 const ulStyles = css`
@@ -88,7 +88,7 @@ export const ShareIcons = ({
 	webTitle,
 	displayIcons,
 	palette,
-	size = 'medium',
+	size,
 }: Props) => {
 	return (
 		<ul className={ulStyles}>

--- a/src/web/components/ShareIcons.tsx
+++ b/src/web/components/ShareIcons.tsx
@@ -19,6 +19,7 @@ type Props = {
 	webTitle: string;
 	displayIcons: SharePlatform[];
 	palette: Palette;
+	size?: ShareIconSize;
 };
 
 const ulStyles = css`
@@ -28,22 +29,28 @@ const ulStyles = css`
 	}
 `;
 
-const liStyles = css`
+const liStyles = (size: ShareIconSize) => css`
 	padding-right: 3px;
 	float: left;
-	min-width: 32px;
+	min-width: ${size === 'small' ? '23px' : '32px'};
 	cursor: pointer;
 `;
 
-const iconStyles = (palette: Palette) => css`
+const iconStyles = ({
+	palette,
+	size,
+}: {
+	palette: Palette;
+	size: ShareIconSize;
+}) => css`
 	border: 1px solid ${border.secondary};
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
-	min-width: 32px;
+	min-width: ${size === 'small' ? '23px' : '32px'};
 	max-width: 100%;
 	width: auto;
-	height: 32px;
+	height: ${size === 'small' ? '23px' : '32px'};
 	border-radius: 50%;
 	display: inline-block;
 	vertical-align: middle;
@@ -81,11 +88,12 @@ export const ShareIcons = ({
 	webTitle,
 	displayIcons,
 	palette,
+	size = 'medium',
 }: Props) => {
 	return (
 		<ul className={ulStyles}>
 			{displayIcons.includes('facebook') && (
-				<li className={liStyles} key="facebook">
+				<li className={liStyles(size)} key="facebook">
 					<a
 						href={`https://www.facebook.com/dialog/share?app_id=202314643182694&href=${encodeUrl(
 							pageId,
@@ -95,7 +103,7 @@ export const ShareIcons = ({
 						target="_blank"
 						data-ignore="global-link-styling"
 					>
-						<span className={iconStyles(palette)}>
+						<span className={iconStyles({ palette, size })}>
 							<FacebookIcon />
 						</span>
 					</a>
@@ -103,7 +111,7 @@ export const ShareIcons = ({
 			)}
 
 			{displayIcons.includes('twitter') && (
-				<li className={liStyles} key="twitter">
+				<li className={liStyles(size)} key="twitter">
 					<a
 						href={`https://twitter.com/intent/tweet?text=${encodeTitle(
 							webTitle,
@@ -113,7 +121,7 @@ export const ShareIcons = ({
 						target="_blank"
 						data-ignore="global-link-styling"
 					>
-						<span className={iconStyles(palette)}>
+						<span className={iconStyles({ palette, size })}>
 							<TwitterIconPadded />
 						</span>
 					</a>
@@ -121,7 +129,7 @@ export const ShareIcons = ({
 			)}
 
 			{displayIcons.includes('email') && (
-				<li className={liStyles} key="email">
+				<li className={liStyles(size)} key="email">
 					<a
 						href={`mailto:?subject=${encodeTitle(
 							webTitle,
@@ -131,7 +139,7 @@ export const ShareIcons = ({
 						target="_blank"
 						data-ignore="global-link-styling"
 					>
-						<span className={iconStyles(palette)}>
+						<span className={iconStyles({ palette, size })}>
 							<EmailIcon />
 						</span>
 					</a>
@@ -139,7 +147,7 @@ export const ShareIcons = ({
 			)}
 
 			{displayIcons.includes('linkedIn') && (
-				<li className={liStyles} key="linkedIn">
+				<li className={liStyles(size)} key="linkedIn">
 					<a
 						href={`http://www.linkedin.com/shareArticle?title=${encodeTitle(
 							webTitle,
@@ -149,7 +157,7 @@ export const ShareIcons = ({
 						target="_blank"
 						data-ignore="global-link-styling"
 					>
-						<span className={iconStyles(palette)}>
+						<span className={iconStyles({ palette, size })}>
 							<LinkedInIcon />
 						</span>
 					</a>
@@ -157,7 +165,7 @@ export const ShareIcons = ({
 			)}
 
 			{displayIcons.includes('pinterest') && (
-				<li className={liStyles} key="pinterest">
+				<li className={liStyles(size)} key="pinterest">
 					<a
 						href={`http://www.pinterest.com/pin/find/?url=${encodeUrl(
 							pageId,
@@ -167,7 +175,7 @@ export const ShareIcons = ({
 						target="_blank"
 						data-ignore="global-link-styling"
 					>
-						<span className={iconStyles(palette)}>
+						<span className={iconStyles({ palette, size })}>
 							<PinterestIcon />
 						</span>
 					</a>
@@ -176,7 +184,7 @@ export const ShareIcons = ({
 
 			{displayIcons.includes('whatsApp') && (
 				<Hide when="above" breakpoint="phablet">
-					<li className={liStyles} key="whatsApp">
+					<li className={liStyles(size)} key="whatsApp">
 						<a
 							href={`whatsapp://send?text="${encodeTitle(
 								webTitle,
@@ -186,7 +194,7 @@ export const ShareIcons = ({
 							target="_blank"
 							data-ignore="global-link-styling"
 						>
-							<span className={iconStyles(palette)}>
+							<span className={iconStyles({ palette, size })}>
 								<WhatsAppIcon />
 							</span>
 						</a>
@@ -196,7 +204,7 @@ export const ShareIcons = ({
 
 			{displayIcons.includes('messenger') && (
 				<Hide when="above" breakpoint="phablet">
-					<li className={liStyles} key="messenger">
+					<li className={liStyles(size)} key="messenger">
 						<a
 							href={`fb-messenger://share?link=${encodeUrl(
 								pageId,
@@ -206,7 +214,7 @@ export const ShareIcons = ({
 							target="_blank"
 							data-ignore="global-link-styling"
 						>
-							<span className={iconStyles(palette)}>
+							<span className={iconStyles({ palette, size })}>
 								<MessengerIcon />
 							</span>
 						</a>

--- a/src/web/components/SubMeta.tsx
+++ b/src/web/components/SubMeta.tsx
@@ -196,6 +196,7 @@ export const SubMeta = ({
 							'whatsApp',
 							'messenger',
 						]}
+						size="medium"
 					/>
 					<div className={syndicationButtonOverrides(palette)}>
 						<LinkButton


### PR DESCRIPTION
## What?
Introduces a new, smaller, share icons size.

![2021-03-10 09 40 12](https://user-images.githubusercontent.com/1336821/110608981-aba02f00-8184-11eb-852c-fe35da0469e4.gif)


## Why?
Because live blocks need these icons to have a 23px width and height

I also removed the bottom padding that was being set on these as this doesn't seem to be used anywhere in normal articles and interferes with live blocks.