### PR TITLE
Flatten blocks for hydration

### DIFF
--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -88,9 +88,9 @@ export const document = ({ data }: Props): string => {
 	];
 	// We want to only insert script tags for the elements or main media elements on this page view
 	// so we need to check what elements we have and use the mapping to the the chunk name
-	const CAPIElements: CAPIElement[] = CAPI.blocks[0]
-		? CAPI.blocks[0].elements
-		: [];
+	const CAPIElements: CAPIElement[] = CAPI.blocks
+		.map((block) => block.elements)
+		.flat();
 	const { mainMediaElements } = CAPI;
 	// Filter the chunks defined above by whether
 	// the 'addWhen' value is 'always' or matches

--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -176,7 +176,7 @@ export const document = ({ data }: Props): string => {
 	];
 
 	const polyfillIO =
-		'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,es2018,es2019,default-3.6,Array.prototype.flat,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,fetch,NodeList.prototype.forEach&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1';
+		'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,es2018,es2019,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,fetch,NodeList.prototype.forEach&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1';
 
 	const pageHasInteractiveElements = CAPIElements.some(
 		(element) =>

--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -176,7 +176,7 @@ export const document = ({ data }: Props): string => {
 	];
 
 	const polyfillIO =
-		'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,es2018,es2019,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,fetch,NodeList.prototype.forEach&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1';
+		'https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,es2018,es2019,default-3.6,Array.prototype.flat,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,fetch,NodeList.prototype.forEach&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1';
 
 	const pageHasInteractiveElements = CAPIElements.some(
 		(element) =>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
We currently only list the elements from the first block to send to the client for hydration. Here we check all elments, from all blocks

## Why?
Better data integrity and to also enable hydration for live blogs
