### PR TITLE
Add a bool check to stop the data being sent more than once

### DIFF
--- a/src/web/browser/coreVitals/coreVitals.ts
+++ b/src/web/browser/coreVitals/coreVitals.ts
@@ -63,16 +63,19 @@ export const coreVitals = (): void => {
 				break;
 		}
 
-		// Set page view and browser ID
-		if (window.guardian.config.ophan.browserId && window.guardian.ophan) {
-			jsonData.page_view_id = window.guardian.ophan.pageViewId;
-			jsonData.browser_id = window.guardian.config.ophan.browserId;
-		}
-
 		// Check if POST has been sent
 		if (!hasBeenSent) {
 			// If CLS has been calculated
 			if (jsonData.cls !== null) {
+				// Set page view and browser ID
+				if (
+					window.guardian.config.ophan.browserId &&
+					window.guardian.ophan
+				) {
+					jsonData.page_view_id = window.guardian.ophan.pageViewId;
+					jsonData.browser_id =
+						window.guardian.config.ophan.browserId;
+				}
 				fetch(endpoint, {
 					method: 'POST', // *GET, POST, PUT, DELETE, etc.
 					mode: 'cors', // no-cors, *cors, same-origin


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds a boolean to check if the post has already been fired, hopefully this will stop the duplicates we seem to be getting.
