### PR TITLE
Add IAM permissions required by Wazuh agent.

### DIFF
--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -145,6 +145,13 @@ Resources:
             - cloudwatch:*
             - logs:*
             Resource: '*'
+          - Effect: Allow
+            Action:
+            - ec2:DescribeTags
+            - ec2:DescribeInstances
+            - autoscaling:DescribeAutoScalingGroups
+            - autoscaling:DescribeAutoScalingInstances
+            Resource: '*'
 
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile


### PR DESCRIPTION
## What does this change?
Following from https://github.com/guardian/platform/pull/1436 on the frontend stack, this adds a new policy to DCRwhich allows the instances to use the ec2 metadata service/autoscaling apis to find their own tags. These permissions are [required by the wazuh agent](https://github.com/guardian/security-hq/blob/main/hq/markdown/wazuh.md#iam-policy-for-querying-tags).

These permissions are being rolled out across the guardian as part of the wazuh rollout.

## How to test
I've tested this on CODE - there are no changes expected as it's just a permissions change

## Why?
With the wazuh agent installed, it will be possible to centrally monitor wazuh instances for security incidents
