### PR TITLE
Sticky nav data renamings

### DIFF
--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -68,7 +68,7 @@ import { SpotifyBlockComponent } from '@root/src/web/components/elements/Spotify
 import { VideoFacebookBlockComponent } from '@root/src/web/components/elements/VideoFacebookBlockComponent';
 import { VineBlockComponent } from '@root/src/web/components/elements/VineBlockComponent';
 import {
-	StickyNavSimple,
+	StickyNavAnchor,
 	StickyNavBackscroll,
 } from '@root/src/web/components/Nav/StickNavTest/StickyNav';
 import { BrazeMessagesInterface } from '@root/src/web/lib/braze/BrazeMessages';
@@ -368,9 +368,9 @@ export const App = ({ CAPI, NAV }: Props) => {
 		'StickyNavTest',
 		'sticky-nav-backscroll',
 	);
-	const inStickyNavSimple = ABTestAPI.isUserInVariant(
+	const inStickyNavAnchor = ABTestAPI.isUserInVariant(
 		'StickyNavTest',
-		'sticky-nav-simple',
+		'sticky-nav-anchor',
 	);
 
 	// There are docs on loadable in ./docs/loadable-components.md
@@ -618,9 +618,9 @@ export const App = ({ CAPI, NAV }: Props) => {
 				</Portal>
 			)}
 
-			{inStickyNavSimple && (
+			{inStickyNavAnchor && (
 				<Portal rootId="sticky-nav-root">
-					<StickyNavSimple
+					<StickyNavAnchor
 						capiData={CAPI}
 						navData={NAV}
 						format={format}

--- a/src/web/components/Nav/StickNavTest/Nav.tsx
+++ b/src/web/components/Nav/StickNavTest/Nav.tsx
@@ -192,7 +192,7 @@ export const Nav = ({
 				)}
 				role="navigation"
 				aria-label="Guardian sections"
-				data-component="nav2"
+				data-component="stickynav"
 			>
 				{format.display === Display.Immersive && (
 					<Hide when="above" breakpoint="tablet">

--- a/src/web/components/Nav/StickNavTest/StickyNav.tsx
+++ b/src/web/components/Nav/StickNavTest/StickyNav.tsx
@@ -130,12 +130,12 @@ const NavGroupLazy: React.FC<NavGroupLazyProps> = ({
 	</div>
 );
 
-// StickyNavSimple is a basic, CSS only, sticky nav. The nav stays at the top of
+// StickyNavAnchor is a basic, CSS only, sticky nav. The nav stays at the top of
 // the viewport as the user scrolls past it's initial placement.
 //
 // *Note:* this uses position:sticky, which only works if the parent element is
 // scrollable and has a fixed height.
-export const StickyNavSimple: React.FC<BrowserProps> = ({
+export const StickyNavAnchor: React.FC<BrowserProps> = ({
 	capiData,
 	navData,
 	palette,
@@ -148,7 +148,7 @@ export const StickyNavSimple: React.FC<BrowserProps> = ({
 				navData={navData}
 				palette={palette}
 				format={format}
-				ID="sticky-nav-simple"
+				ID="sticky-nav-anchor"
 			/>
 		</div>
 	);

--- a/src/web/experiments/tests/sticky-nav-test.ts
+++ b/src/web/experiments/tests/sticky-nav-test.ts
@@ -21,7 +21,7 @@ export const stickyNavTest: ABTest = {
 			test: (): void => {},
 		},
 		{
-			id: 'sticky-nav-simple',
+			id: 'sticky-nav-anchor',
 			test: (): void => {},
 		},
 		{


### PR DESCRIPTION
## What

'simple' is replaced by 'anchor' in variant naming and other uses (with appropriate casing).

The data-component attribute for sticky navs changes from `nav2`to `sticknav`.

## Why

To make it easier to identify test-related data in the data lake and also for improved clarity (`anchor` is more descriptive than `simple`).