### PR TITLE
RichLinks use Figure

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -904,6 +904,24 @@ interface MostViewedFooterPayloadType {
 	mostShared: CAPITrailType;
 }
 
+// ------------
+// RichLinks //
+// ------------
+type RichLinkCardType =
+	| 'special-report'
+	| 'live'
+	| 'dead'
+	| 'feature'
+	| 'editorial'
+	| 'comment'
+	| 'podcast'
+	| 'media'
+	| 'analysis'
+	| 'review'
+	| 'letters'
+	| 'external'
+	| 'news';
+
 // ----------
 // AdSlots //
 // ----------

--- a/src/web/components/DefaultRichLink.tsx
+++ b/src/web/components/DefaultRichLink.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import { Design, Display, Pillar } from '@guardian/types';
+
+import { RichLink } from '@root/src/web/components/RichLink';
+
+type DefaultProps = {
+	index: number;
+	headlineText: string;
+	url: string;
+	isPlaceholder?: boolean;
+};
+
+export const DefaultRichLink: React.FC<DefaultProps> = ({
+	index,
+	headlineText,
+	url,
+	isPlaceholder,
+}) => {
+	return (
+		<RichLink
+			richLinkIndex={index}
+			cardStyle="news"
+			thumbnailUrl=""
+			headlineText={headlineText}
+			contentType="article"
+			url={url}
+			format={{
+				display: Display.Standard,
+				design: Design.Article,
+				theme: Pillar.News,
+			}}
+			tags={[]}
+			sponsorName=""
+			isPlaceholder={isPlaceholder}
+		/>
+	);
+};

--- a/src/web/components/Figure.tsx
+++ b/src/web/components/Figure.tsx
@@ -7,7 +7,7 @@ import { space } from '@guardian/src-foundations';
 type Props = {
 	children: React.ReactNode;
 	isMainMedia?: boolean;
-	role?: RoleType;
+	role?: RoleType | 'richLink';
 	id?: string;
 };
 
@@ -98,6 +98,27 @@ const roleCss = {
 		}
 	`,
 
+	// This is a special use case where we want RichLinks to appear wider when in the left col
+	richLink: css`
+		margin-bottom: ${space[1]}px;
+		float: left;
+		clear: left;
+		width: 140px;
+		margin-right: 20px;
+		${from.tablet} {
+			width: 140px;
+		}
+		${from.leftCol} {
+			position: relative;
+			margin-left: -160px;
+			width: 140px;
+		}
+		${from.wide} {
+			margin-left: -240px;
+			width: 220px;
+		}
+	`,
+
 	halfWidth: css`
 		margin-top: ${space[3]}px;
 		margin-bottom: ${space[3]}px;
@@ -108,7 +129,7 @@ const roleCss = {
 	`,
 };
 
-const decidePosition = (role: RoleType) => {
+const decidePosition = (role: RoleType | 'richLink') => {
 	switch (role) {
 		case 'inline':
 			return roleCss.inline;
@@ -120,6 +141,8 @@ const decidePosition = (role: RoleType) => {
 			return roleCss.showcase;
 		case 'thumbnail':
 			return roleCss.thumbnail;
+		case 'richLink':
+			return roleCss.richLink;
 		case 'halfWidth':
 			return roleCss.halfWidth;
 		default:

--- a/src/web/components/RichLink.stories.tsx
+++ b/src/web/components/RichLink.stories.tsx
@@ -9,9 +9,6 @@ import { Flex } from '@frontend/web/components/Flex';
 
 import { RichLink } from './RichLink';
 
-// cardStyle = "news" | "special-report" | "live" | "dead" | "feature" | "editorial" | "comment" | "podcast" | "media" | "analysis" | "review" | "letters" | "external"
-// ContentType = "article" | "network" | "section" | "imageContent" | "interactive" | "gallery" | "video" | "audio" | "liveBlog" | "tag" | "index" | "crossword" | "survey" | "signup" | "userid"
-
 const someImage =
 	'https://i.guim.co.uk/img/media/268d42accabbe8168fdbdee51ad31ab2f156b211/137_0_2088_1253/master/2088.jpg?width=460&quality=85&auto=format&fit=max&s=cf5abc39fb2af7a56b10306df21ab8e6';
 const someContributor =

--- a/src/web/components/RichLink.stories.tsx
+++ b/src/web/components/RichLink.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/aria-role */
 import React from 'react';
 
 import { Design, Display, Pillar, Special } from '@guardian/types';
@@ -5,6 +6,7 @@ import { Design, Display, Pillar, Special } from '@guardian/types';
 import { Section } from '@frontend/web/components/Section';
 import { ArticleContainer } from '@frontend/web/components/ArticleContainer';
 import { LeftColumn } from '@frontend/web/components/LeftColumn';
+import { Figure } from '@frontend/web/components/Figure';
 import { Flex } from '@frontend/web/components/Flex';
 
 import { RichLink } from './RichLink';
@@ -27,21 +29,23 @@ export const Article = () => {
 					<p />
 				</LeftColumn>
 				<ArticleContainer>
-					<RichLink
-						richLinkIndex={1}
-						cardStyle="news"
-						thumbnailUrl={someImage}
-						headlineText="Rich link headline"
-						contentType="article"
-						url=""
-						format={{
-							display: Display.Standard,
-							design: Design.Article,
-							theme: Pillar.Culture,
-						}}
-						tags={[]}
-						sponsorName=""
-					/>
+					<Figure role="richLink">
+						<RichLink
+							richLinkIndex={1}
+							cardStyle="news"
+							thumbnailUrl={someImage}
+							headlineText="Rich link headline"
+							contentType="article"
+							url=""
+							format={{
+								display: Display.Standard,
+								design: Design.Article,
+								theme: Pillar.Culture,
+							}}
+							tags={[]}
+							sponsorName=""
+						/>
+					</Figure>
 				</ArticleContainer>
 			</Flex>
 		</Section>
@@ -56,21 +60,23 @@ export const Network = () => {
 					<p />
 				</LeftColumn>
 				<ArticleContainer>
-					<RichLink
-						richLinkIndex={1}
-						cardStyle="special-report"
-						thumbnailUrl={someImage}
-						headlineText="Rich link headline"
-						contentType="network"
-						url=""
-						format={{
-							display: Display.Standard,
-							design: Design.Article,
-							theme: Pillar.Culture,
-						}}
-						tags={[]}
-						sponsorName=""
-					/>
+					<Figure role="richLink">
+						<RichLink
+							richLinkIndex={1}
+							cardStyle="special-report"
+							thumbnailUrl={someImage}
+							headlineText="Rich link headline"
+							contentType="network"
+							url=""
+							format={{
+								display: Display.Standard,
+								design: Design.Article,
+								theme: Pillar.Culture,
+							}}
+							tags={[]}
+							sponsorName=""
+						/>
+					</Figure>
 				</ArticleContainer>
 			</Flex>
 		</Section>
@@ -91,21 +97,23 @@ export const SectionStory = () => {
 					<p />
 				</LeftColumn>
 				<ArticleContainer>
-					<RichLink
-						richLinkIndex={1}
-						cardStyle="live"
-						thumbnailUrl={someImage}
-						headlineText="Rich link headline"
-						contentType="section"
-						url=""
-						format={{
-							display: Display.Standard,
-							design: Design.Article,
-							theme: Pillar.Sport,
-						}}
-						tags={[]}
-						sponsorName=""
-					/>
+					<Figure role="richLink">
+						<RichLink
+							richLinkIndex={1}
+							cardStyle="live"
+							thumbnailUrl={someImage}
+							headlineText="Rich link headline"
+							contentType="section"
+							url=""
+							format={{
+								display: Display.Standard,
+								design: Design.Article,
+								theme: Pillar.Sport,
+							}}
+							tags={[]}
+							sponsorName=""
+						/>
+					</Figure>
 				</ArticleContainer>
 			</Flex>
 		</Section>
@@ -123,21 +131,23 @@ export const ImageContent = () => {
 					<p />
 				</LeftColumn>
 				<ArticleContainer>
-					<RichLink
-						richLinkIndex={1}
-						cardStyle="dead"
-						thumbnailUrl={someImage}
-						headlineText="Rich link headline"
-						contentType="imageContent"
-						url=""
-						format={{
-							display: Display.Standard,
-							design: Design.Article,
-							theme: Pillar.News,
-						}}
-						tags={[]}
-						sponsorName=""
-					/>
+					<Figure role="richLink">
+						<RichLink
+							richLinkIndex={1}
+							cardStyle="dead"
+							thumbnailUrl={someImage}
+							headlineText="Rich link headline"
+							contentType="imageContent"
+							url=""
+							format={{
+								display: Display.Standard,
+								design: Design.Article,
+								theme: Pillar.News,
+							}}
+							tags={[]}
+							sponsorName=""
+						/>
+					</Figure>
 				</ArticleContainer>
 			</Flex>
 		</Section>
@@ -158,21 +168,23 @@ export const Interactive = () => {
 					<p />
 				</LeftColumn>
 				<ArticleContainer>
-					<RichLink
-						richLinkIndex={1}
-						cardStyle="feature"
-						thumbnailUrl={someImage}
-						headlineText="Rich link headline"
-						contentType="interactive"
-						url=""
-						format={{
-							display: Display.Standard,
-							design: Design.Article,
-							theme: Pillar.Lifestyle,
-						}}
-						tags={[]}
-						sponsorName=""
-					/>
+					<Figure role="richLink">
+						<RichLink
+							richLinkIndex={1}
+							cardStyle="feature"
+							thumbnailUrl={someImage}
+							headlineText="Rich link headline"
+							contentType="interactive"
+							url=""
+							format={{
+								display: Display.Standard,
+								design: Design.Article,
+								theme: Pillar.Lifestyle,
+							}}
+							tags={[]}
+							sponsorName=""
+						/>
+					</Figure>
 				</ArticleContainer>
 			</Flex>
 		</Section>
@@ -192,22 +204,24 @@ export const Gallery = () => {
 					<p />
 				</LeftColumn>
 				<ArticleContainer>
-					<RichLink
-						richLinkIndex={1}
-						cardStyle="comment"
-						thumbnailUrl={someImage}
-						headlineText="Rich link headline"
-						contentType="gallery"
-						url=""
-						format={{
-							display: Display.Standard,
-							design: Design.Article,
-							theme: Special.Labs,
-						}}
-						tags={[]}
-						sponsorName=""
-						contributorImage={someContributor}
-					/>
+					<Figure role="richLink">
+						<RichLink
+							richLinkIndex={1}
+							cardStyle="comment"
+							thumbnailUrl={someImage}
+							headlineText="Rich link headline"
+							contentType="gallery"
+							url=""
+							format={{
+								display: Display.Standard,
+								design: Design.Article,
+								theme: Special.Labs,
+							}}
+							tags={[]}
+							sponsorName=""
+							contributorImage={someContributor}
+						/>
+					</Figure>
 				</ArticleContainer>
 			</Flex>
 		</Section>
@@ -227,22 +241,24 @@ export const Video = () => {
 					<p />
 				</LeftColumn>
 				<ArticleContainer>
-					<RichLink
-						richLinkIndex={1}
-						cardStyle="comment"
-						thumbnailUrl={someImage}
-						headlineText="Rich link headline"
-						contentType="video"
-						url=""
-						format={{
-							display: Display.Standard,
-							design: Design.Article,
-							theme: Pillar.News,
-						}}
-						tags={[]}
-						sponsorName=""
-						contributorImage={someContributor}
-					/>
+					<Figure role="richLink">
+						<RichLink
+							richLinkIndex={1}
+							cardStyle="comment"
+							thumbnailUrl={someImage}
+							headlineText="Rich link headline"
+							contentType="video"
+							url=""
+							format={{
+								display: Display.Standard,
+								design: Design.Article,
+								theme: Pillar.News,
+							}}
+							tags={[]}
+							sponsorName=""
+							contributorImage={someContributor}
+						/>
+					</Figure>
 				</ArticleContainer>
 			</Flex>
 		</Section>
@@ -263,21 +279,23 @@ export const Audio = () => {
 					<p />
 				</LeftColumn>
 				<ArticleContainer>
-					<RichLink
-						richLinkIndex={1}
-						cardStyle="podcast"
-						thumbnailUrl={someImage}
-						headlineText="Rich link headline"
-						contentType="audio"
-						url=""
-						format={{
-							display: Display.Standard,
-							design: Design.Article,
-							theme: Pillar.Culture,
-						}}
-						tags={[]}
-						sponsorName=""
-					/>
+					<Figure role="richLink">
+						<RichLink
+							richLinkIndex={1}
+							cardStyle="podcast"
+							thumbnailUrl={someImage}
+							headlineText="Rich link headline"
+							contentType="audio"
+							url=""
+							format={{
+								display: Display.Standard,
+								design: Design.Article,
+								theme: Pillar.Culture,
+							}}
+							tags={[]}
+							sponsorName=""
+						/>
+					</Figure>
 				</ArticleContainer>
 			</Flex>
 		</Section>
@@ -292,21 +310,23 @@ export const LiveBlog = () => {
 					<p />
 				</LeftColumn>
 				<ArticleContainer>
-					<RichLink
-						richLinkIndex={1}
-						cardStyle="media"
-						thumbnailUrl={someImage}
-						headlineText="Rich link headline"
-						contentType="liveBlog"
-						url=""
-						format={{
-							display: Display.Standard,
-							design: Design.Article,
-							theme: Pillar.Sport,
-						}}
-						tags={[]}
-						sponsorName=""
-					/>
+					<Figure role="richLink">
+						<RichLink
+							richLinkIndex={1}
+							cardStyle="media"
+							thumbnailUrl={someImage}
+							headlineText="Rich link headline"
+							contentType="liveBlog"
+							url=""
+							format={{
+								display: Display.Standard,
+								design: Design.Article,
+								theme: Pillar.Sport,
+							}}
+							tags={[]}
+							sponsorName=""
+						/>
+					</Figure>
 				</ArticleContainer>
 			</Flex>
 		</Section>
@@ -327,21 +347,23 @@ export const Tag = () => {
 					<p />
 				</LeftColumn>
 				<ArticleContainer>
-					<RichLink
-						richLinkIndex={1}
-						cardStyle="analysis"
-						thumbnailUrl={someImage}
-						headlineText="Rich link headline"
-						contentType="tag"
-						url=""
-						format={{
-							display: Display.Standard,
-							design: Design.Article,
-							theme: Pillar.Culture,
-						}}
-						tags={[]}
-						sponsorName=""
-					/>
+					<Figure role="richLink">
+						<RichLink
+							richLinkIndex={1}
+							cardStyle="analysis"
+							thumbnailUrl={someImage}
+							headlineText="Rich link headline"
+							contentType="tag"
+							url=""
+							format={{
+								display: Display.Standard,
+								design: Design.Article,
+								theme: Pillar.Culture,
+							}}
+							tags={[]}
+							sponsorName=""
+						/>
+					</Figure>
 				</ArticleContainer>
 			</Flex>
 		</Section>
@@ -356,28 +378,30 @@ export const Index = () => {
 					<p />
 				</LeftColumn>
 				<ArticleContainer>
-					<RichLink
-						richLinkIndex={1}
-						cardStyle="review"
-						thumbnailUrl={someImage}
-						headlineText="Rich link headline"
-						contentType="index"
-						url=""
-						format={{
-							display: Display.Standard,
-							design: Design.Article,
-							theme: Pillar.Opinion,
-						}}
-						tags={[
-							{
-								id: '',
-								type: 'Contributor',
-								title: 'Contributor Name',
-							},
-						]}
-						sponsorName=""
-						starRating={3}
-					/>
+					<Figure role="richLink">
+						<RichLink
+							richLinkIndex={1}
+							cardStyle="review"
+							thumbnailUrl={someImage}
+							headlineText="Rich link headline"
+							contentType="index"
+							url=""
+							format={{
+								display: Display.Standard,
+								design: Design.Article,
+								theme: Pillar.Opinion,
+							}}
+							tags={[
+								{
+									id: '',
+									type: 'Contributor',
+									title: 'Contributor Name',
+								},
+							]}
+							sponsorName=""
+							starRating={3}
+						/>
+					</Figure>
 				</ArticleContainer>
 			</Flex>
 		</Section>
@@ -392,21 +416,23 @@ export const Crossword = () => {
 					<p />
 				</LeftColumn>
 				<ArticleContainer>
-					<RichLink
-						richLinkIndex={1}
-						cardStyle="letters"
-						thumbnailUrl={someImage}
-						headlineText="Rich link headline"
-						contentType="crossword"
-						url=""
-						format={{
-							display: Display.Standard,
-							design: Design.Article,
-							theme: Pillar.Opinion,
-						}}
-						tags={[]}
-						sponsorName=""
-					/>
+					<Figure role="richLink">
+						<RichLink
+							richLinkIndex={1}
+							cardStyle="letters"
+							thumbnailUrl={someImage}
+							headlineText="Rich link headline"
+							contentType="crossword"
+							url=""
+							format={{
+								display: Display.Standard,
+								design: Design.Article,
+								theme: Pillar.Opinion,
+							}}
+							tags={[]}
+							sponsorName=""
+						/>
+					</Figure>
 				</ArticleContainer>
 			</Flex>
 		</Section>
@@ -421,21 +447,23 @@ export const Survey = () => {
 					<p />
 				</LeftColumn>
 				<ArticleContainer>
-					<RichLink
-						richLinkIndex={1}
-						cardStyle="external"
-						thumbnailUrl={someImage}
-						headlineText="Rich link headline"
-						contentType="survey"
-						url=""
-						format={{
-							display: Display.Standard,
-							design: Design.Article,
-							theme: Pillar.Culture,
-						}}
-						tags={[]}
-						sponsorName=""
-					/>
+					<Figure role="richLink">
+						<RichLink
+							richLinkIndex={1}
+							cardStyle="external"
+							thumbnailUrl={someImage}
+							headlineText="Rich link headline"
+							contentType="survey"
+							url=""
+							format={{
+								display: Display.Standard,
+								design: Design.Article,
+								theme: Pillar.Culture,
+							}}
+							tags={[]}
+							sponsorName=""
+						/>
+					</Figure>
 				</ArticleContainer>
 			</Flex>
 		</Section>
@@ -450,22 +478,24 @@ export const Signup = () => {
 					<p />
 				</LeftColumn>
 				<ArticleContainer>
-					<RichLink
-						richLinkIndex={1}
-						cardStyle="comment"
-						thumbnailUrl={someImage}
-						headlineText="Rich link headline"
-						contentType="signup"
-						url=""
-						format={{
-							display: Display.Standard,
-							design: Design.Article,
-							theme: Pillar.Culture,
-						}}
-						tags={[]}
-						sponsorName=""
-						contributorImage={someContributor}
-					/>
+					<Figure role="richLink">
+						<RichLink
+							richLinkIndex={1}
+							cardStyle="comment"
+							thumbnailUrl={someImage}
+							headlineText="Rich link headline"
+							contentType="signup"
+							url=""
+							format={{
+								display: Display.Standard,
+								design: Design.Article,
+								theme: Pillar.Culture,
+							}}
+							tags={[]}
+							sponsorName=""
+							contributorImage={someContributor}
+						/>
+					</Figure>
 				</ArticleContainer>
 			</Flex>
 		</Section>
@@ -480,21 +510,23 @@ export const Userid = () => {
 					<p />
 				</LeftColumn>
 				<ArticleContainer>
-					<RichLink
-						richLinkIndex={1}
-						cardStyle="editorial"
-						thumbnailUrl={someImage}
-						headlineText="Rich link headline"
-						contentType="userid"
-						url=""
-						format={{
-							display: Display.Standard,
-							design: Design.Article,
-							theme: Pillar.Culture,
-						}}
-						tags={[]}
-						sponsorName=""
-					/>
+					<Figure role="richLink">
+						<RichLink
+							richLinkIndex={1}
+							cardStyle="editorial"
+							thumbnailUrl={someImage}
+							headlineText="Rich link headline"
+							contentType="userid"
+							url=""
+							format={{
+								display: Display.Standard,
+								design: Design.Article,
+								theme: Pillar.Culture,
+							}}
+							tags={[]}
+							sponsorName=""
+						/>
+					</Figure>
 				</ArticleContainer>
 			</Flex>
 		</Section>
@@ -509,27 +541,29 @@ export const PaidFor = () => {
 					<p />
 				</LeftColumn>
 				<ArticleContainer>
-					<RichLink
-						richLinkIndex={1}
-						cardStyle="news"
-						thumbnailUrl={someImage}
-						headlineText="Rich link headline"
-						contentType="userid"
-						url=""
-						format={{
-							display: Display.Standard,
-							design: Design.Article,
-							theme: Pillar.Culture,
-						}}
-						tags={[
-							{
-								id: 'tone/advertisement-features',
-								type: '',
-								title: '',
-							},
-						]}
-						sponsorName="Sponsor name"
-					/>
+					<Figure role="richLink">
+						<RichLink
+							richLinkIndex={1}
+							cardStyle="news"
+							thumbnailUrl={someImage}
+							headlineText="Rich link headline"
+							contentType="userid"
+							url=""
+							format={{
+								display: Display.Standard,
+								design: Design.Article,
+								theme: Pillar.Culture,
+							}}
+							tags={[
+								{
+									id: 'tone/advertisement-features',
+									type: '',
+									title: '',
+								},
+							]}
+							sponsorName="Sponsor name"
+						/>
+					</Figure>
 				</ArticleContainer>
 			</Flex>
 		</Section>

--- a/src/web/components/RichLink.tsx
+++ b/src/web/components/RichLink.tsx
@@ -219,7 +219,7 @@ export const RichLink = ({
 			className={pillarBackground(format)}
 			data-name={(isPlaceholder && 'placeholder') || ''}
 		>
-			<div className={cx(neutralBackground)}>
+			<div className={neutralBackground}>
 				<a className={richLinkLink} href={url}>
 					<div className={richLinkTopBorder(format)} />
 					{showImage && (

--- a/src/web/components/RichLink.tsx
+++ b/src/web/components/RichLink.tsx
@@ -7,7 +7,7 @@ import {
 	neutral,
 } from '@guardian/src-foundations/palette';
 import { headline, textSans } from '@guardian/src-foundations/typography';
-import { from, until, between } from '@guardian/src-foundations/mq';
+import { from } from '@guardian/src-foundations/mq';
 import { Pillar } from '@guardian/types';
 import type { Format } from '@guardian/types';
 
@@ -36,31 +36,6 @@ interface Props {
 	contributorImage?: string;
 	isPlaceholder?: boolean; // use 'true' for server-side default prior to client-side enrichment
 }
-
-const richLinkContainer = css`
-	/*
-        TODO: avoid this edge case from appearing in editorials
-        edge case:
-        If rich link div is pushed further inline to the page the "margin-left: -240px;" wont work.
-        Using "clear: left;" allows us to igrnore the effects of other elements on the left.
-    */
-	clear: left;
-
-	${until.wide} {
-		width: 140px;
-	}
-	float: left;
-	margin-right: 20px;
-	margin-bottom: 5px;
-	margin-left: 0px;
-	${between.leftCol.and.wide} {
-		margin-left: -160px;
-	}
-	${from.wide} {
-		margin-left: -240px;
-		width: 220px;
-	}
-`;
 
 const neutralBackground = css`
 	background-color: ${neutral[97]};
@@ -244,7 +219,7 @@ export const RichLink = ({
 			className={pillarBackground(format)}
 			data-name={(isPlaceholder && 'placeholder') || ''}
 		>
-			<div className={cx(richLinkContainer, neutralBackground)}>
+			<div className={cx(neutralBackground)}>
 				<a className={richLinkLink} href={url}>
 					<div className={richLinkTopBorder(format)} />
 					{showImage && (

--- a/src/web/components/RichLink.tsx
+++ b/src/web/components/RichLink.tsx
@@ -8,7 +8,7 @@ import {
 } from '@guardian/src-foundations/palette';
 import { headline, textSans } from '@guardian/src-foundations/typography';
 import { from, until, between } from '@guardian/src-foundations/mq';
-import { Design, Display, Pillar } from '@guardian/types';
+import { Pillar } from '@guardian/types';
 import type { Format } from '@guardian/types';
 
 import ArrowInCircle from '@frontend/static/icons/arrow-in-circle.svg';
@@ -321,38 +321,5 @@ export const RichLink = ({
 				</a>
 			</div>
 		</div>
-	);
-};
-
-type DefaultProps = {
-	index: number;
-	headlineText: string;
-	url: string;
-	isPlaceholder?: boolean;
-};
-
-export const DefaultRichLink: React.FC<DefaultProps> = ({
-	index,
-	headlineText,
-	url,
-	isPlaceholder,
-}) => {
-	return (
-		<RichLink
-			richLinkIndex={index}
-			cardStyle="news"
-			thumbnailUrl=""
-			headlineText={headlineText}
-			contentType="article"
-			url={url}
-			format={{
-				display: Display.Standard,
-				design: Design.Article,
-				theme: Pillar.News,
-			}}
-			tags={[]}
-			sponsorName=""
-			isPlaceholder={isPlaceholder}
-		/>
 	);
 };

--- a/src/web/components/RichLink.tsx
+++ b/src/web/components/RichLink.tsx
@@ -20,26 +20,11 @@ import { Hide } from '@root/src/web/components/Hide';
 import { Avatar } from '@frontend/web/components/Avatar';
 import { decidePalette } from '../lib/decidePalette';
 
-type CardStyle =
-	| 'special-report'
-	| 'live'
-	| 'dead'
-	| 'feature'
-	| 'editorial'
-	| 'comment'
-	| 'podcast'
-	| 'media'
-	| 'analysis'
-	| 'review'
-	| 'letters'
-	| 'external'
-	| 'news';
-
 type ColourType = string;
 
 interface Props {
 	richLinkIndex: number;
-	cardStyle: CardStyle;
+	cardStyle: RichLinkCardType;
 	thumbnailUrl: string;
 	headlineText: string;
 	contentType: ContentType;

--- a/src/web/components/elements/RichLinkComponent.tsx
+++ b/src/web/components/elements/RichLinkComponent.tsx
@@ -6,6 +6,13 @@ import { useApi } from '@root/src/web/lib/api';
 import { decideTheme } from '@root/src/web/lib/decideTheme';
 import { Design, Display } from '@guardian/types';
 
+type Props = {
+	element: RichLinkBlockElement;
+	pillar: Theme;
+	ajaxEndpoint: string;
+	richLinkIndex: number;
+};
+
 type CardStyle =
 	| 'special-report'
 	| 'live'
@@ -42,12 +49,11 @@ const buildUrl: (element: RichLinkBlockElement, ajaxUrl: string) => string = (
 	return `${ajaxUrl}/embed/card${path}.json?dcr=true`;
 };
 
-export const RichLinkComponent: React.FC<{
-	element: RichLinkBlockElement;
-	pillar: Theme;
-	ajaxEndpoint: string;
-	richLinkIndex: number;
-}> = ({ element, ajaxEndpoint, richLinkIndex }) => {
+export const RichLinkComponent = ({
+	element,
+	ajaxEndpoint,
+	richLinkIndex,
+}: Props) => {
 	const url = buildUrl(element, ajaxEndpoint);
 	const { data, loading, error } = useApi<CAPIRichLinkType>(url);
 

--- a/src/web/components/elements/RichLinkComponent.tsx
+++ b/src/web/components/elements/RichLinkComponent.tsx
@@ -13,23 +13,8 @@ type Props = {
 	richLinkIndex: number;
 };
 
-type CardStyle =
-	| 'special-report'
-	| 'live'
-	| 'dead'
-	| 'feature'
-	| 'editorial'
-	| 'comment'
-	| 'podcast'
-	| 'media'
-	| 'analysis'
-	| 'review'
-	| 'letters'
-	| 'external'
-	| 'news';
-
 interface CAPIRichLinkType {
-	cardStyle: CardStyle;
+	cardStyle: RichLinkCardType;
 	thumbnailUrl: string;
 	headline: string;
 	contentType: ContentType;

--- a/src/web/components/elements/RichLinkComponent.tsx
+++ b/src/web/components/elements/RichLinkComponent.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import { RichLink, DefaultRichLink } from '@root/src/web/components/RichLink';
+import { RichLink } from '@root/src/web/components/RichLink';
+import { DefaultRichLink } from '@root/src/web/components/DefaultRichLink';
 
 import { useApi } from '@root/src/web/lib/api';
 import { decideTheme } from '@root/src/web/lib/decideTheme';

--- a/src/web/lib/ElementRenderer.tsx
+++ b/src/web/lib/ElementRenderer.tsx
@@ -463,14 +463,20 @@ export const ElementRenderer = ({
 			);
 		case 'model.dotcomrendering.pageElements.RichLinkBlockElement':
 			return (
-				<div key={index} id={element.elementId}>
+				<Figure
+					id={element.elementId}
+					isMainMedia={isMainMedia}
+					key={index}
+					// eslint-disable-next-line jsx-a11y/aria-role
+					role="richLink"
+				>
 					<DefaultRichLink
 						index={index}
 						headlineText={element.text}
 						url={element.url}
 						isPlaceholder={true}
 					/>
-				</div>
+				</Figure>
 			);
 		case 'model.dotcomrendering.pageElements.SoundcloudBlockElement':
 			return (

--- a/src/web/lib/ElementRenderer.tsx
+++ b/src/web/lib/ElementRenderer.tsx
@@ -5,7 +5,7 @@ import { CalloutBlockComponent } from '@root/src/web/components/elements/Callout
 import { CaptionBlockComponent } from '@root/src/web/components/elements/CaptionBlockComponent';
 import { CommentBlockComponent } from '@root/src/web/components/elements/CommentBlockComponent';
 import { CodeBlockComponent } from '@root/src/web/components/elements/CodeBlockComponent';
-import { DefaultRichLink } from '@root/src/web/components/RichLink';
+import { DefaultRichLink } from '@root/src/web/components/DefaultRichLink';
 import { DocumentBlockComponent } from '@root/src/web/components/elements/DocumentBlockComponent';
 import { DisclaimerBlockComponent } from '@root/src/web/components/elements/DisclaimerBlockComponent';
 import { DividerBlockComponent } from '@root/src/web/components/elements/DividerBlockComponent';


### PR DESCRIPTION
## What?
Here we refactor the `RichLink` component to make it easier to adapt it for Liveblogs later as well as  wrapping `RichLink` in the `Figure` component for positioning

## Why?
Rich links very closely follow the positioning given to other element types based on `role` so instead of having duplicate css, I've migrated `RichLink` to using the `Figure` component.

Unfortunately, the `thubnail` role isn't exactly what we want, it's too narrow at some breakpoints, so I've created a supplementary `role` of `richLink`.

