### PR TITLE
LiveBlock RichLinks

### DIFF
--- a/src/web/components/LiveBlock.stories.tsx
+++ b/src/web/components/LiveBlock.stories.tsx
@@ -170,6 +170,47 @@ export const Video = () => {
 };
 Video.story = { name: 'with a video as the second element' };
 
+export const RichLink = () => {
+	const block: Block = {
+		...baseBlock,
+		elements: [
+			{
+				elementId: 'ae950f92-bc9b-4725-bac2-94fce86d8191',
+				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+				html:
+					'<p>Now that Perseverance persevered through the “seven minutes of terror” – a new era of space exploration has officially begun. </p>',
+			},
+			{
+				elementId: 'b49c134e-54d6-4445-a3fe-bb52a1370375',
+				role: 'thumbnail',
+				prefix: 'Related: ',
+				_type:
+					'model.dotcomrendering.pageElements.RichLinkBlockElement',
+				text: 'Ireland election: latest results',
+				url:
+					'https://www.theguardian.com/world/2020/feb/10/ireland-election-latest-results-live-sinn-fein-fine-gael-fianna-fail',
+			},
+		],
+	};
+	return (
+		<Wrapper>
+			<LiveBlock
+				adTargeting={{ adUnit: '', customParams: {} }}
+				format={{
+					theme: Pillar.News,
+					design: Design.LiveBlog,
+					display: Display.Standard,
+				}}
+				block={block}
+				pageId=""
+				webTitle=""
+				abTests={{}}
+			/>
+		</Wrapper>
+	);
+};
+RichLink.story = { name: 'with a rich link being forced inline' };
+
 export const FirstImage = () => {
 	const block: Block = {
 		...baseBlock,

--- a/src/web/components/LiveBlock.tsx
+++ b/src/web/components/LiveBlock.tsx
@@ -277,7 +277,7 @@ export const LiveBlock = ({
 				{mainElements.map((element, index) => {
 					if (typesWeStretch.includes(element._type)) {
 						return (
-							<BlockMedia key={index}>
+							<BlockMedia key={`${element._type}-${index}`}>
 								<ElementRenderer
 									isMainMedia={false}
 									isLiveBlog={true}
@@ -294,7 +294,7 @@ export const LiveBlock = ({
 					}
 
 					return (
-						<BlockText key={index}>
+						<BlockText key={`${element._type}-${index}`}>
 							<ElementRenderer
 								isMainMedia={false}
 								isLiveBlog={true}

--- a/src/web/components/LiveBlock.tsx
+++ b/src/web/components/LiveBlock.tsx
@@ -261,6 +261,7 @@ export const LiveBlock = ({
 				{headerElement && (
 					<ElementRenderer
 						isMainMedia={false}
+						isLiveBlog={true}
 						adTargeting={adTargeting}
 						index={0}
 						element={headerElement}
@@ -279,6 +280,7 @@ export const LiveBlock = ({
 							<BlockMedia key={index}>
 								<ElementRenderer
 									isMainMedia={false}
+									isLiveBlog={true}
 									adTargeting={adTargeting}
 									index={index}
 									element={element}
@@ -294,6 +296,8 @@ export const LiveBlock = ({
 					return (
 						<BlockText key={index}>
 							<ElementRenderer
+								isMainMedia={false}
+								isLiveBlog={true}
 								index={index}
 								element={element}
 								format={format}

--- a/src/web/components/LiveBlock.tsx
+++ b/src/web/components/LiveBlock.tsx
@@ -276,7 +276,7 @@ export const LiveBlock = ({
 				{mainElements.map((element, index) => {
 					if (typesWeStretch.includes(element._type)) {
 						return (
-							<BlockMedia>
+							<BlockMedia key={index}>
 								<ElementRenderer
 									isMainMedia={false}
 									adTargeting={adTargeting}
@@ -292,7 +292,7 @@ export const LiveBlock = ({
 					}
 
 					return (
-						<BlockText>
+						<BlockText key={index}>
 							<ElementRenderer
 								index={index}
 								element={element}

--- a/src/web/components/RichLink.stories.tsx
+++ b/src/web/components/RichLink.stories.tsx
@@ -123,6 +123,40 @@ SectionStory.story = {
 	name: 'Section',
 };
 
+export const Inline = () => {
+	return (
+		<Section>
+			<Flex>
+				<LeftColumn>
+					<p />
+				</LeftColumn>
+				<ArticleContainer>
+					<Figure role="inline">
+						<RichLink
+							richLinkIndex={1}
+							cardStyle="audio"
+							thumbnailUrl={someImage}
+							headlineText="Rich link when inline"
+							contentType="section"
+							url=""
+							format={{
+								display: Display.Standard,
+								design: Design.Article,
+								theme: Pillar.Lifestyle,
+							}}
+							tags={[]}
+							sponsorName=""
+						/>
+					</Figure>
+				</ArticleContainer>
+			</Flex>
+		</Section>
+	);
+};
+Inline.story = {
+	name: 'Inline',
+};
+
 export const ImageContent = () => {
 	return (
 		<Section>

--- a/src/web/components/RichLink.stories.tsx
+++ b/src/web/components/RichLink.stories.tsx
@@ -105,7 +105,7 @@ export const Inline = () => {
 			<Figure role="inline">
 				<RichLink
 					richLinkIndex={1}
-					cardStyle="audio"
+					cardStyle="external"
 					thumbnailUrl={someImage}
 					headlineText="Rich link when inline"
 					contentType="section"

--- a/src/web/components/RichLink.stories.tsx
+++ b/src/web/components/RichLink.stories.tsx
@@ -3,11 +3,8 @@ import React from 'react';
 
 import { Design, Display, Pillar, Special } from '@guardian/types';
 
-import { Section } from '@frontend/web/components/Section';
-import { ArticleContainer } from '@frontend/web/components/ArticleContainer';
-import { LeftColumn } from '@frontend/web/components/LeftColumn';
 import { Figure } from '@frontend/web/components/Figure';
-import { Flex } from '@frontend/web/components/Flex';
+import { ContainerLayout } from '@frontend/web/components/ContainerLayout';
 
 import { RichLink } from './RichLink';
 
@@ -23,63 +20,49 @@ export default {
 
 export const Article = () => {
 	return (
-		<Section>
-			<Flex>
-				<LeftColumn>
-					<p />
-				</LeftColumn>
-				<ArticleContainer>
-					<Figure role="richLink">
-						<RichLink
-							richLinkIndex={1}
-							cardStyle="news"
-							thumbnailUrl={someImage}
-							headlineText="Rich link headline"
-							contentType="article"
-							url=""
-							format={{
-								display: Display.Standard,
-								design: Design.Article,
-								theme: Pillar.Culture,
-							}}
-							tags={[]}
-							sponsorName=""
-						/>
-					</Figure>
-				</ArticleContainer>
-			</Flex>
-		</Section>
+		<ContainerLayout centralBorder="full">
+			<Figure role="richLink">
+				<RichLink
+					richLinkIndex={1}
+					cardStyle="news"
+					thumbnailUrl={someImage}
+					headlineText="Rich link headline"
+					contentType="article"
+					url=""
+					format={{
+						display: Display.Standard,
+						design: Design.Article,
+						theme: Pillar.Culture,
+					}}
+					tags={[]}
+					sponsorName=""
+				/>
+			</Figure>
+		</ContainerLayout>
 	);
 };
 
 export const Network = () => {
 	return (
-		<Section>
-			<Flex>
-				<LeftColumn>
-					<p />
-				</LeftColumn>
-				<ArticleContainer>
-					<Figure role="richLink">
-						<RichLink
-							richLinkIndex={1}
-							cardStyle="special-report"
-							thumbnailUrl={someImage}
-							headlineText="Rich link headline"
-							contentType="network"
-							url=""
-							format={{
-								display: Display.Standard,
-								design: Design.Article,
-								theme: Pillar.Culture,
-							}}
-							tags={[]}
-							sponsorName=""
-						/>
-					</Figure>
-				</ArticleContainer>
-			</Flex>
-		</Section>
+		<ContainerLayout centralBorder="full">
+			<Figure role="richLink">
+				<RichLink
+					richLinkIndex={1}
+					cardStyle="special-report"
+					thumbnailUrl={someImage}
+					headlineText="Rich link headline"
+					contentType="network"
+					url=""
+					format={{
+						display: Display.Standard,
+						design: Design.Article,
+						theme: Pillar.Culture,
+					}}
+					tags={[]}
+					sponsorName=""
+				/>
+			</Figure>
+		</ContainerLayout>
 	);
 };
 Network.story = {
@@ -91,32 +74,25 @@ Network.story = {
 
 export const SectionStory = () => {
 	return (
-		<Section>
-			<Flex>
-				<LeftColumn>
-					<p />
-				</LeftColumn>
-				<ArticleContainer>
-					<Figure role="richLink">
-						<RichLink
-							richLinkIndex={1}
-							cardStyle="live"
-							thumbnailUrl={someImage}
-							headlineText="Rich link headline"
-							contentType="section"
-							url=""
-							format={{
-								display: Display.Standard,
-								design: Design.Article,
-								theme: Pillar.Sport,
-							}}
-							tags={[]}
-							sponsorName=""
-						/>
-					</Figure>
-				</ArticleContainer>
-			</Flex>
-		</Section>
+		<ContainerLayout centralBorder="full">
+			<Figure role="richLink">
+				<RichLink
+					richLinkIndex={1}
+					cardStyle="live"
+					thumbnailUrl={someImage}
+					headlineText="Rich link headline"
+					contentType="section"
+					url=""
+					format={{
+						display: Display.Standard,
+						design: Design.Article,
+						theme: Pillar.Sport,
+					}}
+					tags={[]}
+					sponsorName=""
+				/>
+			</Figure>
+		</ContainerLayout>
 	);
 };
 SectionStory.story = {
@@ -125,32 +101,25 @@ SectionStory.story = {
 
 export const Inline = () => {
 	return (
-		<Section>
-			<Flex>
-				<LeftColumn>
-					<p />
-				</LeftColumn>
-				<ArticleContainer>
-					<Figure role="inline">
-						<RichLink
-							richLinkIndex={1}
-							cardStyle="audio"
-							thumbnailUrl={someImage}
-							headlineText="Rich link when inline"
-							contentType="section"
-							url=""
-							format={{
-								display: Display.Standard,
-								design: Design.Article,
-								theme: Pillar.Lifestyle,
-							}}
-							tags={[]}
-							sponsorName=""
-						/>
-					</Figure>
-				</ArticleContainer>
-			</Flex>
-		</Section>
+		<ContainerLayout centralBorder="full">
+			<Figure role="inline">
+				<RichLink
+					richLinkIndex={1}
+					cardStyle="audio"
+					thumbnailUrl={someImage}
+					headlineText="Rich link when inline"
+					contentType="section"
+					url=""
+					format={{
+						display: Display.Standard,
+						design: Design.Article,
+						theme: Pillar.Lifestyle,
+					}}
+					tags={[]}
+					sponsorName=""
+				/>
+			</Figure>
+		</ContainerLayout>
 	);
 };
 Inline.story = {
@@ -159,32 +128,25 @@ Inline.story = {
 
 export const ImageContent = () => {
 	return (
-		<Section>
-			<Flex>
-				<LeftColumn>
-					<p />
-				</LeftColumn>
-				<ArticleContainer>
-					<Figure role="richLink">
-						<RichLink
-							richLinkIndex={1}
-							cardStyle="dead"
-							thumbnailUrl={someImage}
-							headlineText="Rich link headline"
-							contentType="imageContent"
-							url=""
-							format={{
-								display: Display.Standard,
-								design: Design.Article,
-								theme: Pillar.News,
-							}}
-							tags={[]}
-							sponsorName=""
-						/>
-					</Figure>
-				</ArticleContainer>
-			</Flex>
-		</Section>
+		<ContainerLayout centralBorder="full">
+			<Figure role="richLink">
+				<RichLink
+					richLinkIndex={1}
+					cardStyle="dead"
+					thumbnailUrl={someImage}
+					headlineText="Rich link headline"
+					contentType="imageContent"
+					url=""
+					format={{
+						display: Display.Standard,
+						design: Design.Article,
+						theme: Pillar.News,
+					}}
+					tags={[]}
+					sponsorName=""
+				/>
+			</Figure>
+		</ContainerLayout>
 	);
 };
 ImageContent.story = {
@@ -196,32 +158,25 @@ ImageContent.story = {
 
 export const Interactive = () => {
 	return (
-		<Section>
-			<Flex>
-				<LeftColumn>
-					<p />
-				</LeftColumn>
-				<ArticleContainer>
-					<Figure role="richLink">
-						<RichLink
-							richLinkIndex={1}
-							cardStyle="feature"
-							thumbnailUrl={someImage}
-							headlineText="Rich link headline"
-							contentType="interactive"
-							url=""
-							format={{
-								display: Display.Standard,
-								design: Design.Article,
-								theme: Pillar.Lifestyle,
-							}}
-							tags={[]}
-							sponsorName=""
-						/>
-					</Figure>
-				</ArticleContainer>
-			</Flex>
-		</Section>
+		<ContainerLayout centralBorder="full">
+			<Figure role="richLink">
+				<RichLink
+					richLinkIndex={1}
+					cardStyle="feature"
+					thumbnailUrl={someImage}
+					headlineText="Rich link headline"
+					contentType="interactive"
+					url=""
+					format={{
+						display: Display.Standard,
+						design: Design.Article,
+						theme: Pillar.Lifestyle,
+					}}
+					tags={[]}
+					sponsorName=""
+				/>
+			</Figure>
+		</ContainerLayout>
 	);
 };
 Interactive.story = {
@@ -232,33 +187,26 @@ Interactive.story = {
 
 export const Gallery = () => {
 	return (
-		<Section>
-			<Flex>
-				<LeftColumn>
-					<p />
-				</LeftColumn>
-				<ArticleContainer>
-					<Figure role="richLink">
-						<RichLink
-							richLinkIndex={1}
-							cardStyle="comment"
-							thumbnailUrl={someImage}
-							headlineText="Rich link headline"
-							contentType="gallery"
-							url=""
-							format={{
-								display: Display.Standard,
-								design: Design.Article,
-								theme: Special.Labs,
-							}}
-							tags={[]}
-							sponsorName=""
-							contributorImage={someContributor}
-						/>
-					</Figure>
-				</ArticleContainer>
-			</Flex>
-		</Section>
+		<ContainerLayout centralBorder="full">
+			<Figure role="richLink">
+				<RichLink
+					richLinkIndex={1}
+					cardStyle="comment"
+					thumbnailUrl={someImage}
+					headlineText="Rich link headline"
+					contentType="gallery"
+					url=""
+					format={{
+						display: Display.Standard,
+						design: Design.Article,
+						theme: Special.Labs,
+					}}
+					tags={[]}
+					sponsorName=""
+					contributorImage={someContributor}
+				/>
+			</Figure>
+		</ContainerLayout>
 	);
 };
 Gallery.story = {
@@ -269,33 +217,26 @@ Gallery.story = {
 
 export const Video = () => {
 	return (
-		<Section>
-			<Flex>
-				<LeftColumn>
-					<p />
-				</LeftColumn>
-				<ArticleContainer>
-					<Figure role="richLink">
-						<RichLink
-							richLinkIndex={1}
-							cardStyle="comment"
-							thumbnailUrl={someImage}
-							headlineText="Rich link headline"
-							contentType="video"
-							url=""
-							format={{
-								display: Display.Standard,
-								design: Design.Article,
-								theme: Pillar.News,
-							}}
-							tags={[]}
-							sponsorName=""
-							contributorImage={someContributor}
-						/>
-					</Figure>
-				</ArticleContainer>
-			</Flex>
-		</Section>
+		<ContainerLayout centralBorder="full">
+			<Figure role="richLink">
+				<RichLink
+					richLinkIndex={1}
+					cardStyle="comment"
+					thumbnailUrl={someImage}
+					headlineText="Rich link headline"
+					contentType="video"
+					url=""
+					format={{
+						display: Display.Standard,
+						design: Design.Article,
+						theme: Pillar.News,
+					}}
+					tags={[]}
+					sponsorName=""
+					contributorImage={someContributor}
+				/>
+			</Figure>
+		</ContainerLayout>
 	);
 };
 Video.story = {
@@ -307,63 +248,49 @@ Video.story = {
 
 export const Audio = () => {
 	return (
-		<Section>
-			<Flex>
-				<LeftColumn>
-					<p />
-				</LeftColumn>
-				<ArticleContainer>
-					<Figure role="richLink">
-						<RichLink
-							richLinkIndex={1}
-							cardStyle="podcast"
-							thumbnailUrl={someImage}
-							headlineText="Rich link headline"
-							contentType="audio"
-							url=""
-							format={{
-								display: Display.Standard,
-								design: Design.Article,
-								theme: Pillar.Culture,
-							}}
-							tags={[]}
-							sponsorName=""
-						/>
-					</Figure>
-				</ArticleContainer>
-			</Flex>
-		</Section>
+		<ContainerLayout centralBorder="full">
+			<Figure role="richLink">
+				<RichLink
+					richLinkIndex={1}
+					cardStyle="podcast"
+					thumbnailUrl={someImage}
+					headlineText="Rich link headline"
+					contentType="audio"
+					url=""
+					format={{
+						display: Display.Standard,
+						design: Design.Article,
+						theme: Pillar.Culture,
+					}}
+					tags={[]}
+					sponsorName=""
+				/>
+			</Figure>
+		</ContainerLayout>
 	);
 };
 
 export const LiveBlog = () => {
 	return (
-		<Section>
-			<Flex>
-				<LeftColumn>
-					<p />
-				</LeftColumn>
-				<ArticleContainer>
-					<Figure role="richLink">
-						<RichLink
-							richLinkIndex={1}
-							cardStyle="media"
-							thumbnailUrl={someImage}
-							headlineText="Rich link headline"
-							contentType="liveBlog"
-							url=""
-							format={{
-								display: Display.Standard,
-								design: Design.Article,
-								theme: Pillar.Sport,
-							}}
-							tags={[]}
-							sponsorName=""
-						/>
-					</Figure>
-				</ArticleContainer>
-			</Flex>
-		</Section>
+		<ContainerLayout centralBorder="full">
+			<Figure role="richLink">
+				<RichLink
+					richLinkIndex={1}
+					cardStyle="media"
+					thumbnailUrl={someImage}
+					headlineText="Rich link headline"
+					contentType="liveBlog"
+					url=""
+					format={{
+						display: Display.Standard,
+						design: Design.Article,
+						theme: Pillar.Sport,
+					}}
+					tags={[]}
+					sponsorName=""
+				/>
+			</Figure>
+		</ContainerLayout>
 	);
 };
 LiveBlog.story = {
@@ -375,231 +302,182 @@ LiveBlog.story = {
 
 export const Tag = () => {
 	return (
-		<Section>
-			<Flex>
-				<LeftColumn>
-					<p />
-				</LeftColumn>
-				<ArticleContainer>
-					<Figure role="richLink">
-						<RichLink
-							richLinkIndex={1}
-							cardStyle="analysis"
-							thumbnailUrl={someImage}
-							headlineText="Rich link headline"
-							contentType="tag"
-							url=""
-							format={{
-								display: Display.Standard,
-								design: Design.Article,
-								theme: Pillar.Culture,
-							}}
-							tags={[]}
-							sponsorName=""
-						/>
-					</Figure>
-				</ArticleContainer>
-			</Flex>
-		</Section>
+		<ContainerLayout centralBorder="full">
+			<Figure role="richLink">
+				<RichLink
+					richLinkIndex={1}
+					cardStyle="analysis"
+					thumbnailUrl={someImage}
+					headlineText="Rich link headline"
+					contentType="tag"
+					url=""
+					format={{
+						display: Display.Standard,
+						design: Design.Article,
+						theme: Pillar.Culture,
+					}}
+					tags={[]}
+					sponsorName=""
+				/>
+			</Figure>
+		</ContainerLayout>
 	);
 };
 
 export const Index = () => {
 	return (
-		<Section>
-			<Flex>
-				<LeftColumn>
-					<p />
-				</LeftColumn>
-				<ArticleContainer>
-					<Figure role="richLink">
-						<RichLink
-							richLinkIndex={1}
-							cardStyle="review"
-							thumbnailUrl={someImage}
-							headlineText="Rich link headline"
-							contentType="index"
-							url=""
-							format={{
-								display: Display.Standard,
-								design: Design.Article,
-								theme: Pillar.Opinion,
-							}}
-							tags={[
-								{
-									id: '',
-									type: 'Contributor',
-									title: 'Contributor Name',
-								},
-							]}
-							sponsorName=""
-							starRating={3}
-						/>
-					</Figure>
-				</ArticleContainer>
-			</Flex>
-		</Section>
+		<ContainerLayout centralBorder="full">
+			<Figure role="richLink">
+				<RichLink
+					richLinkIndex={1}
+					cardStyle="review"
+					thumbnailUrl={someImage}
+					headlineText="Rich link headline"
+					contentType="index"
+					url=""
+					format={{
+						display: Display.Standard,
+						design: Design.Article,
+						theme: Pillar.Opinion,
+					}}
+					tags={[
+						{
+							id: '',
+							type: 'Contributor',
+							title: 'Contributor Name',
+						},
+					]}
+					sponsorName=""
+					starRating={3}
+				/>
+			</Figure>
+		</ContainerLayout>
 	);
 };
 
 export const Crossword = () => {
 	return (
-		<Section>
-			<Flex>
-				<LeftColumn>
-					<p />
-				</LeftColumn>
-				<ArticleContainer>
-					<Figure role="richLink">
-						<RichLink
-							richLinkIndex={1}
-							cardStyle="letters"
-							thumbnailUrl={someImage}
-							headlineText="Rich link headline"
-							contentType="crossword"
-							url=""
-							format={{
-								display: Display.Standard,
-								design: Design.Article,
-								theme: Pillar.Opinion,
-							}}
-							tags={[]}
-							sponsorName=""
-						/>
-					</Figure>
-				</ArticleContainer>
-			</Flex>
-		</Section>
+		<ContainerLayout centralBorder="full">
+			<Figure role="richLink">
+				<RichLink
+					richLinkIndex={1}
+					cardStyle="letters"
+					thumbnailUrl={someImage}
+					headlineText="Rich link headline"
+					contentType="crossword"
+					url=""
+					format={{
+						display: Display.Standard,
+						design: Design.Article,
+						theme: Pillar.Opinion,
+					}}
+					tags={[]}
+					sponsorName=""
+				/>
+			</Figure>
+		</ContainerLayout>
 	);
 };
 
 export const Survey = () => {
 	return (
-		<Section>
-			<Flex>
-				<LeftColumn>
-					<p />
-				</LeftColumn>
-				<ArticleContainer>
-					<Figure role="richLink">
-						<RichLink
-							richLinkIndex={1}
-							cardStyle="external"
-							thumbnailUrl={someImage}
-							headlineText="Rich link headline"
-							contentType="survey"
-							url=""
-							format={{
-								display: Display.Standard,
-								design: Design.Article,
-								theme: Pillar.Culture,
-							}}
-							tags={[]}
-							sponsorName=""
-						/>
-					</Figure>
-				</ArticleContainer>
-			</Flex>
-		</Section>
+		<ContainerLayout centralBorder="full">
+			<Figure role="richLink">
+				<RichLink
+					richLinkIndex={1}
+					cardStyle="external"
+					thumbnailUrl={someImage}
+					headlineText="Rich link headline"
+					contentType="survey"
+					url=""
+					format={{
+						display: Display.Standard,
+						design: Design.Article,
+						theme: Pillar.Culture,
+					}}
+					tags={[]}
+					sponsorName=""
+				/>
+			</Figure>
+		</ContainerLayout>
 	);
 };
 
 export const Signup = () => {
 	return (
-		<Section>
-			<Flex>
-				<LeftColumn>
-					<p />
-				</LeftColumn>
-				<ArticleContainer>
-					<Figure role="richLink">
-						<RichLink
-							richLinkIndex={1}
-							cardStyle="comment"
-							thumbnailUrl={someImage}
-							headlineText="Rich link headline"
-							contentType="signup"
-							url=""
-							format={{
-								display: Display.Standard,
-								design: Design.Article,
-								theme: Pillar.Culture,
-							}}
-							tags={[]}
-							sponsorName=""
-							contributorImage={someContributor}
-						/>
-					</Figure>
-				</ArticleContainer>
-			</Flex>
-		</Section>
+		<ContainerLayout centralBorder="full">
+			<Figure role="richLink">
+				<RichLink
+					richLinkIndex={1}
+					cardStyle="comment"
+					thumbnailUrl={someImage}
+					headlineText="Rich link headline"
+					contentType="signup"
+					url=""
+					format={{
+						display: Display.Standard,
+						design: Design.Article,
+						theme: Pillar.Culture,
+					}}
+					tags={[]}
+					sponsorName=""
+					contributorImage={someContributor}
+				/>
+			</Figure>
+		</ContainerLayout>
 	);
 };
 
 export const Userid = () => {
 	return (
-		<Section>
-			<Flex>
-				<LeftColumn>
-					<p />
-				</LeftColumn>
-				<ArticleContainer>
-					<Figure role="richLink">
-						<RichLink
-							richLinkIndex={1}
-							cardStyle="editorial"
-							thumbnailUrl={someImage}
-							headlineText="Rich link headline"
-							contentType="userid"
-							url=""
-							format={{
-								display: Display.Standard,
-								design: Design.Article,
-								theme: Pillar.Culture,
-							}}
-							tags={[]}
-							sponsorName=""
-						/>
-					</Figure>
-				</ArticleContainer>
-			</Flex>
-		</Section>
+		<ContainerLayout centralBorder="full">
+			<Figure role="richLink">
+				<RichLink
+					richLinkIndex={1}
+					cardStyle="editorial"
+					thumbnailUrl={someImage}
+					headlineText="Rich link headline"
+					contentType="userid"
+					url=""
+					format={{
+						display: Display.Standard,
+						design: Design.Article,
+						theme: Pillar.Culture,
+					}}
+					tags={[]}
+					sponsorName=""
+				/>
+			</Figure>
+		</ContainerLayout>
 	);
 };
 
 export const PaidFor = () => {
 	return (
-		<Section>
-			<Flex>
-				<LeftColumn>
-					<p />
-				</LeftColumn>
-				<ArticleContainer>
-					<Figure role="richLink">
-						<RichLink
-							richLinkIndex={1}
-							cardStyle="news"
-							thumbnailUrl={someImage}
-							headlineText="Rich link headline"
-							contentType="userid"
-							url=""
-							format={{
-								display: Display.Standard,
-								design: Design.Article,
-								theme: Pillar.Culture,
-							}}
-							tags={[
-								{
-									id: 'tone/advertisement-features',
-									type: '',
-									title: '',
-								},
-							]}
-							sponsorName="Sponsor name"
-						/>
-					</Figure>
-				</ArticleContainer>
-			</Flex>
-		</Section>
+		<ContainerLayout centralBorder="full">
+			<Figure role="richLink">
+				<RichLink
+					richLinkIndex={1}
+					cardStyle="news"
+					thumbnailUrl={someImage}
+					headlineText="Rich link headline"
+					contentType="userid"
+					url=""
+					format={{
+						display: Display.Standard,
+						design: Design.Article,
+						theme: Pillar.Culture,
+					}}
+					tags={[
+						{
+							id: 'tone/advertisement-features',
+							type: '',
+							title: '',
+						},
+					]}
+					sponsorName="Sponsor name"
+				/>
+			</Figure>
+		</ContainerLayout>
 	);
 };

--- a/src/web/lib/ElementRenderer.tsx
+++ b/src/web/lib/ElementRenderer.tsx
@@ -491,7 +491,6 @@ export const ElementRenderer = ({
 				</Figure>
 			);
 		case 'model.dotcomrendering.pageElements.RichLinkBlockElement':
-			console.log('isLiveBlog', isLiveBlog);
 			return (
 				<Figure
 					id={element.elementId}

--- a/src/web/lib/ElementRenderer.tsx
+++ b/src/web/lib/ElementRenderer.tsx
@@ -62,6 +62,7 @@ type Props = {
 	index: number;
 	hideCaption?: boolean;
 	isMainMedia?: boolean;
+	isLiveBlog?: boolean;
 	starRating?: number;
 };
 
@@ -75,6 +76,7 @@ export const ElementRenderer = ({
 	index,
 	hideCaption,
 	isMainMedia,
+	isLiveBlog,
 	starRating,
 }: Props) => {
 	switch (element._type) {
@@ -83,7 +85,7 @@ export const ElementRenderer = ({
 				<Figure
 					isMainMedia={isMainMedia}
 					id={element.elementId}
-					role={element.role}
+					role={isLiveBlog ? 'inline' : element.role}
 				>
 					<AudioAtom
 						id={element.id}
@@ -108,7 +110,7 @@ export const ElementRenderer = ({
 				<Figure
 					isMainMedia={isMainMedia}
 					id={element.elementId}
-					role={element.role}
+					role={isLiveBlog ? 'inline' : element.role}
 				>
 					<CalloutBlockComponent
 						callout={element}
@@ -132,7 +134,10 @@ export const ElementRenderer = ({
 			);
 		case 'model.dotcomrendering.pageElements.ChartAtomBlockElement':
 			return (
-				<Figure isMainMedia={isMainMedia} role={element.role}>
+				<Figure
+					isMainMedia={isMainMedia}
+					role={isLiveBlog ? 'inline' : element.role}
+				>
 					<ChartAtom id={element.id} html={element.html} />
 				</Figure>
 			);
@@ -145,7 +150,10 @@ export const ElementRenderer = ({
 			);
 		case 'model.dotcomrendering.pageElements.CommentBlockElement':
 			return (
-				<Figure isMainMedia={isMainMedia} role={element.role}>
+				<Figure
+					isMainMedia={isMainMedia}
+					role={isLiveBlog ? 'inline' : element.role}
+				>
 					<CommentBlockComponent
 						body={element.body}
 						avatarURL={element.avatarURL}
@@ -158,7 +166,10 @@ export const ElementRenderer = ({
 			);
 		case 'model.dotcomrendering.pageElements.DisclaimerBlockElement':
 			return (
-				<Figure isMainMedia={isMainMedia} role={element.role}>
+				<Figure
+					isMainMedia={isMainMedia}
+					role={isLiveBlog ? 'inline' : element.role}
+				>
 					<DisclaimerBlockComponent
 						html={element.html}
 						pillar={format.theme}
@@ -171,11 +182,11 @@ export const ElementRenderer = ({
 			return (
 				<Figure
 					isMainMedia={isMainMedia}
-					role={element.role}
+					role={isLiveBlog ? 'inline' : element.role}
 					id={element.elementId}
 				>
 					<ClickToView
-						role={element.role}
+						role={isLiveBlog ? 'inline' : element.role}
 						isTracking={element.isThirdPartyTracking}
 						isMainMedia={isMainMedia}
 						source={element.source}
@@ -196,11 +207,11 @@ export const ElementRenderer = ({
 				return (
 					<Figure
 						isMainMedia={isMainMedia}
-						role={element.role}
+						role={isLiveBlog ? 'inline' : element.role}
 						id={element.elementId}
 					>
 						<ClickToView
-							role={element.role}
+							role={isLiveBlog ? 'inline' : element.role}
 							isTracking={element.isThirdPartyTracking}
 							isMainMedia={isMainMedia}
 							source={element.source}
@@ -220,11 +231,11 @@ export const ElementRenderer = ({
 			return (
 				<Figure
 					isMainMedia={isMainMedia}
-					role={element.role}
+					role={isLiveBlog ? 'inline' : element.role}
 					id={element.elementId}
 				>
 					<ClickToView
-						role={element.role}
+						role={isLiveBlog ? 'inline' : element.role}
 						isTracking={element.isThirdPartyTracking}
 						isMainMedia={isMainMedia}
 						source={element.source}
@@ -241,7 +252,10 @@ export const ElementRenderer = ({
 			);
 		case 'model.dotcomrendering.pageElements.ExplainerAtomBlockElement':
 			return (
-				<Figure isMainMedia={isMainMedia} role={element.role}>
+				<Figure
+					isMainMedia={isMainMedia}
+					role={isLiveBlog ? 'inline' : element.role}
+				>
 					<ExplainerAtom
 						key={index}
 						id={element.id}
@@ -255,7 +269,7 @@ export const ElementRenderer = ({
 				<Figure
 					isMainMedia={isMainMedia}
 					id={element.elementId}
-					role={element.role}
+					role={isLiveBlog ? 'inline' : element.role}
 				>
 					<GuideAtom
 						id={element.id}
@@ -272,7 +286,10 @@ export const ElementRenderer = ({
 			);
 		case 'model.dotcomrendering.pageElements.GuVideoBlockElement':
 			return (
-				<Figure isMainMedia={isMainMedia} role={element.role}>
+				<Figure
+					isMainMedia={isMainMedia}
+					role={isLiveBlog ? 'inline' : element.role}
+				>
 					<GuVideoBlockComponent
 						html={element.html}
 						format={format}
@@ -286,7 +303,10 @@ export const ElementRenderer = ({
 			return <HighlightBlockComponent key={index} html={element.html} />;
 		case 'model.dotcomrendering.pageElements.ImageBlockElement':
 			return (
-				<Figure isMainMedia={isMainMedia} role={element.role}>
+				<Figure
+					isMainMedia={isMainMedia}
+					role={isLiveBlog ? 'inline' : element.role}
+				>
 					<ImageBlockComponent
 						format={format}
 						palette={palette}
@@ -303,11 +323,11 @@ export const ElementRenderer = ({
 			return (
 				<Figure
 					isMainMedia={isMainMedia}
-					role={element.role}
+					role={isLiveBlog ? 'inline' : element.role}
 					id={element.elementId}
 				>
 					<ClickToView
-						role={element.role}
+						role={isLiveBlog ? 'inline' : element.role}
 						isTracking={element.isThirdPartyTracking}
 						isMainMedia={isMainMedia}
 						source={element.source}
@@ -324,7 +344,10 @@ export const ElementRenderer = ({
 			);
 		case 'model.dotcomrendering.pageElements.InteractiveAtomBlockElement':
 			return (
-				<Figure isMainMedia={isMainMedia} role={element.role}>
+				<Figure
+					isMainMedia={isMainMedia}
+					role={isLiveBlog ? 'inline' : element.role}
+				>
 					<InteractiveAtom
 						id={element.id}
 						html={element.html}
@@ -335,7 +358,10 @@ export const ElementRenderer = ({
 			);
 		case 'model.dotcomrendering.pageElements.InteractiveBlockElement':
 			return (
-				<Figure role={element.role} id={element.elementId}>
+				<Figure
+					role={isLiveBlog ? 'inline' : element.role}
+					id={element.elementId}
+				>
 					<InteractiveBlockComponent
 						url={element.url}
 						scriptUrl={element.scriptUrl}
@@ -347,11 +373,11 @@ export const ElementRenderer = ({
 			return (
 				<Figure
 					isMainMedia={isMainMedia}
-					role={element.role}
+					role={isLiveBlog ? 'inline' : element.role}
 					id={element.elementId}
 				>
 					<ClickToView
-						role={element.role}
+						role={isLiveBlog ? 'inline' : element.role}
 						isTracking={element.isThirdPartyTracking}
 						isMainMedia={isMainMedia}
 						source={element.source}
@@ -380,7 +406,10 @@ export const ElementRenderer = ({
 			);
 		case 'model.dotcomrendering.pageElements.MultiImageBlockElement':
 			return (
-				<Figure isMainMedia={isMainMedia} role={element.role}>
+				<Figure
+					isMainMedia={isMainMedia}
+					role={isLiveBlog ? 'inline' : element.role}
+				>
 					<MultiImageBlockComponent
 						format={format}
 						palette={palette}
@@ -395,7 +424,7 @@ export const ElementRenderer = ({
 				<Figure
 					isMainMedia={isMainMedia}
 					id={element.elementId}
-					role={element.role}
+					role={isLiveBlog ? 'inline' : element.role}
 				>
 					<ProfileAtom
 						id={element.id}
@@ -418,7 +447,7 @@ export const ElementRenderer = ({
 					pillar={format.theme}
 					design={format.design}
 					attribution={element.attribution}
-					role={element.role}
+					role={isLiveBlog ? 'inline' : element.role}
 				/>
 			);
 		case 'model.dotcomrendering.pageElements.QABlockElement':
@@ -426,7 +455,7 @@ export const ElementRenderer = ({
 				<Figure
 					isMainMedia={isMainMedia}
 					id={element.elementId}
-					role={element.role}
+					role={isLiveBlog ? 'inline' : element.role}
 				>
 					<QandaAtom
 						id={element.id}
@@ -462,13 +491,13 @@ export const ElementRenderer = ({
 				</Figure>
 			);
 		case 'model.dotcomrendering.pageElements.RichLinkBlockElement':
+			console.log('isLiveBlog', isLiveBlog);
 			return (
 				<Figure
 					id={element.elementId}
 					isMainMedia={isMainMedia}
 					key={index}
-					// eslint-disable-next-line jsx-a11y/aria-role
-					role="richLink"
+					role={isLiveBlog ? 'inline' : 'richLink'}
 				>
 					<DefaultRichLink
 						index={index}
@@ -483,7 +512,7 @@ export const ElementRenderer = ({
 				<Figure
 					isMainMedia={isMainMedia}
 					key={index}
-					role={element.role}
+					role={isLiveBlog ? 'inline' : element.role}
 				>
 					<SoundcloudBlockComponent element={element} />
 				</Figure>
@@ -492,11 +521,11 @@ export const ElementRenderer = ({
 			return (
 				<Figure
 					isMainMedia={isMainMedia}
-					role={element.role}
+					role={isLiveBlog ? 'inline' : element.role}
 					id={element.elementId}
 				>
 					<ClickToView
-						role={element.role}
+						role={isLiveBlog ? 'inline' : element.role}
 						isTracking={element.isThirdPartyTracking}
 						isMainMedia={isMainMedia}
 						source={element.source}
@@ -520,7 +549,10 @@ export const ElementRenderer = ({
 			return <SubheadingBlockComponent key={index} html={element.html} />;
 		case 'model.dotcomrendering.pageElements.TableBlockElement':
 			return (
-				<Figure isMainMedia={isMainMedia} role={element.role}>
+				<Figure
+					isMainMedia={isMainMedia}
+					role={isLiveBlog ? 'inline' : element.role}
+				>
 					<TableBlockComponent element={element} />
 				</Figure>
 			);
@@ -540,7 +572,7 @@ export const ElementRenderer = ({
 			return (
 				<Figure
 					isMainMedia={isMainMedia}
-					role={element.role}
+					role={isLiveBlog ? 'inline' : element.role}
 					id={element.elementId}
 				>
 					<TimelineAtom
@@ -559,7 +591,7 @@ export const ElementRenderer = ({
 				<Figure
 					isMainMedia={isMainMedia}
 					key={index}
-					role={element.role}
+					role={isLiveBlog ? 'inline' : element.role}
 				>
 					<TweetBlockComponent element={element} />
 				</Figure>
@@ -568,11 +600,11 @@ export const ElementRenderer = ({
 			return (
 				<Figure
 					isMainMedia={isMainMedia}
-					role={element.role}
+					role={isLiveBlog ? 'inline' : element.role}
 					id={element.elementId}
 				>
 					<ClickToView
-						role={element.role}
+						role={isLiveBlog ? 'inline' : element.role}
 						isTracking={element.isThirdPartyTracking}
 						isMainMedia={isMainMedia}
 						source={element.source}
@@ -594,7 +626,10 @@ export const ElementRenderer = ({
 			);
 		case 'model.dotcomrendering.pageElements.VideoVimeoBlockElement':
 			return (
-				<Figure isMainMedia={isMainMedia} role={element.role}>
+				<Figure
+					isMainMedia={isMainMedia}
+					role={isLiveBlog ? 'inline' : element.role}
+				>
 					<VimeoBlockComponent
 						format={format}
 						palette={palette}
@@ -609,7 +644,10 @@ export const ElementRenderer = ({
 			);
 		case 'model.dotcomrendering.pageElements.VideoYoutubeBlockElement':
 			return (
-				<Figure isMainMedia={isMainMedia} role={element.role}>
+				<Figure
+					isMainMedia={isMainMedia}
+					role={isLiveBlog ? 'inline' : element.role}
+				>
 					<YoutubeEmbedBlockComponent
 						format={format}
 						palette={palette}
@@ -699,7 +737,7 @@ export const ElementRenderer = ({
 			return (
 				<Figure
 					isMainMedia={isMainMedia}
-					role={element.role}
+					role={isLiveBlog ? 'inline' : element.role}
 					id={element.elementId}
 				>
 					<YoutubeBlockComponent


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
All elements appearing inside `LiveBlock`s are now forced to be inline

### Before
![Screenshot 2021-03-11 at 09 44 28](https://user-images.githubusercontent.com/1336821/110767670-6b0ce800-824e-11eb-8974-c2d6a226c9b9.jpg)


### After
![Screenshot 2021-03-11 at 09 43 56](https://user-images.githubusercontent.com/1336821/110767658-67796100-824e-11eb-9542-ba55736d9e7d.jpg)


## Why?
This means `RichLink`s are no longer rendered with a negative left margin, putting them in the leftCol.
