### PR TITLE
LiveBlogRenderer

### DIFF
--- a/src/web/components/ArticleBody.tsx
+++ b/src/web/components/ArticleBody.tsx
@@ -4,7 +4,8 @@ import { css, cx } from 'emotion';
 import { headline } from '@guardian/src-foundations/typography';
 import { between } from '@guardian/src-foundations/mq';
 import { ArticleRenderer } from '@root/src/web/lib/ArticleRenderer';
-import { Display } from '@guardian/types';
+import { LiveBlogRenderer } from '@root/src/web/lib/LiveBlogRenderer';
+import { Design, Display } from '@guardian/types';
 import type { Format } from '@guardian/types';
 
 type Props = {
@@ -16,28 +17,34 @@ type Props = {
 	abTests: CAPIType['config']['abTests'];
 };
 
-const bodyStyle = (display: Display) => css`
-	${between.tablet.and.desktop} {
-		padding-right: 80px;
-	}
-
+const globalH2Styles = (display: Display) => css`
 	h2 {
 		${display === Display.Immersive
 			? headline.medium({ fontWeight: 'light' })
 			: headline.xxsmall({ fontWeight: 'bold' })};
 	}
+`;
 
+const globalStrongStyles = css`
 	strong {
 		font-weight: bold;
 	}
+`;
 
+const globalImgStyles = css`
 	img {
 		width: 100%;
 		height: auto;
 	}
 `;
 
-const linkColour = (palette: Palette) => css`
+const bodyPadding = css`
+	${between.tablet.and.desktop} {
+		padding-right: 80px;
+	}
+`;
+
+const globalLinkStyles = (palette: Palette) => css`
 	a:not([data-ignore='global-link-styling']) {
 		text-decoration: none;
 		border-bottom: 1px solid ${palette.border.articleLink};
@@ -58,8 +65,40 @@ export const ArticleBody = ({
 	host,
 	abTests,
 }: Props) => {
+	if (
+		format.design === Design.LiveBlog ||
+		format.design === Design.DeadBlog
+	) {
+		return (
+			<div
+				className={cx(
+					globalStrongStyles,
+					globalImgStyles,
+					globalLinkStyles(palette),
+				)}
+			>
+				<LiveBlogRenderer
+					format={format}
+					blocks={blocks}
+					adTargeting={adTargeting}
+					host={host}
+					abTests={abTests}
+					pageId=""
+					webTitle=""
+				/>
+			</div>
+		);
+	}
 	return (
-		<div className={cx(bodyStyle(format.display), linkColour(palette))}>
+		<div
+			className={cx(
+				bodyPadding,
+				globalH2Styles(format.display),
+				globalStrongStyles,
+				globalImgStyles,
+				globalLinkStyles(palette),
+			)}
+		>
 			<ArticleRenderer
 				format={format}
 				palette={palette}

--- a/src/web/components/ArticleBody.tsx
+++ b/src/web/components/ArticleBody.tsx
@@ -15,6 +15,8 @@ type Props = {
 	adTargeting: AdTargeting;
 	host?: string;
 	abTests: CAPIType['config']['abTests'];
+	pageId: string;
+	webTitle: string;
 };
 
 const globalH2Styles = (display: Display) => css`
@@ -64,6 +66,8 @@ export const ArticleBody = ({
 	adTargeting,
 	host,
 	abTests,
+	pageId,
+	webTitle,
 }: Props) => {
 	if (
 		format.design === Design.LiveBlog ||
@@ -83,8 +87,8 @@ export const ArticleBody = ({
 					adTargeting={adTargeting}
 					host={host}
 					abTests={abTests}
-					pageId=""
-					webTitle=""
+					pageId={pageId}
+					webTitle={webTitle}
 				/>
 			</div>
 		);

--- a/src/web/components/LiveBlock.tsx
+++ b/src/web/components/LiveBlock.tsx
@@ -149,7 +149,7 @@ const FirstPublished = ({
 	return (
 		<a
 			href={blockLink}
-			data-ignore-global-link-styling={true}
+			data-ignore="global-link-styling"
 			// title={publishedDate.toLocaleString()}
 			className={css`
 				${textSans.xsmall({ fontWeight: 'bold' })}

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -512,6 +512,8 @@ export const CommentLayout = ({
 									adTargeting={adTargeting}
 									host={host}
 									abTests={CAPI.config.abTests}
+									pageId={CAPI.pageId}
+									webTitle={CAPI.webTitle}
 								/>
 								{showBodyEndSlot && <div id="slot-body-end" />}
 								<GuardianLines

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -512,6 +512,8 @@ export const ImmersiveLayout = ({
 									adTargeting={adTargeting}
 									host={host}
 									abTests={CAPI.config.abTests}
+									pageId={CAPI.pageId}
+									webTitle={CAPI.webTitle}
 								/>
 								{showBodyEndSlot && <div id="slot-body-end" />}
 								<GuardianLines

--- a/src/web/layouts/LiveLayout.tsx
+++ b/src/web/layouts/LiveLayout.tsx
@@ -408,6 +408,8 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 									adTargeting={adTargeting}
 									host={host}
 									abTests={CAPI.config.abTests}
+									pageId={CAPI.pageId}
+									webTitle={CAPI.webTitle}
 								/>
 								{showBodyEndSlot && <div id="slot-body-end" />}
 								<GuardianLines

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -433,6 +433,8 @@ export const ShowcaseLayout = ({
 									adTargeting={adTargeting}
 									host={host}
 									abTests={CAPI.config.abTests}
+									pageId={CAPI.pageId}
+									webTitle={CAPI.webTitle}
 								/>
 								{showBodyEndSlot && <div id="slot-body-end" />}
 								<GuardianLines

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -506,6 +506,8 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 										adTargeting={adTargeting}
 										host={host}
 										abTests={CAPI.config.abTests}
+										pageId={CAPI.pageId}
+										webTitle={CAPI.webTitle}
 									/>
 									{isMatchReport && <div id="match-stats" />}
 

--- a/src/web/lib/LiveBlogRenderer.tsx
+++ b/src/web/lib/LiveBlogRenderer.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+import { LiveBlock } from '../components/LiveBlock';
+
+type Props = {
+	format: Format;
+	blocks: Block[];
+	adTargeting: AdTargeting;
+	host?: string;
+	abTests: CAPIType['config']['abTests'];
+	pageId: string;
+	webTitle: string;
+};
+
+export const LiveBlogRenderer = ({
+	format,
+	blocks,
+	adTargeting,
+	host,
+	abTests,
+	pageId,
+	webTitle,
+}: Props) => {
+	return (
+		<>
+			{blocks.map((block) => {
+				return (
+					<LiveBlock
+						format={format}
+						block={block}
+						pageId={pageId}
+						webTitle={webTitle}
+						abTests={abTests}
+						adTargeting={adTargeting}
+						host={host}
+					/>
+				);
+			})}
+		</>
+	);
+};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds a sibling to the `ArticleRenderer` component, `LiveBlogRenderer`

```typescript
type Props = {
	format: Format;
	blocks: Block[];
	adTargeting: AdTargeting;
	host?: string;
	abTests: CAPIType['config']['abTests'];
	pageId: string;
	webTitle: string;
};
```

![Screenshot 2021-03-11 at 10 18 46](https://user-images.githubusercontent.com/1336821/110772140-33546f00-8253-11eb-80a4-c229e09b27a6.jpg)


## Why?
Multiple block lovelyness

### What's happened with the global styles we apply to articles?
I've broken these blobs of global css down into smaller names chunks so that we have better control over what global styles go where. I've also renamed them so it's clear that they are global css.
