### PR TITLE
Adding componentEvent tracking to the click to view component

### DIFF
--- a/src/web/components/SignInGate/componentEventTracking.tsx
+++ b/src/web/components/SignInGate/componentEventTracking.tsx
@@ -4,7 +4,7 @@ import {
 } from '@root/src/web/browser/ophan/ophan';
 import { CurrentABTest } from '@frontend/web/components/SignInGate/gateDesigns/types';
 
-type ABTestVariant = {
+export type ABTestVariant = {
 	name: string;
 	variant: string;
 };
@@ -26,13 +26,13 @@ type ComponentEventWithoutAction = {
 	abTest?: ABTestVariant;
 };
 
-const ophan = window?.guardian?.ophan;
+const ophan = () => window?.guardian?.ophan;
 
 // ophan helper methods
 export const submitComponentEventTracking = (
 	componentEvent: OphanComponentEvent,
 ) => {
-	ophan.record({ componentEvent });
+	ophan().record({ componentEvent });
 };
 
 export const submitViewEventTracking = (


### PR DESCRIPTION
The ClickToView component renders an placeholder for third party embedded contents like embedded instagram posts. Users need to click the 'accept' button, consenting to being tracked by the third party provider, before they can see the embedded content.

This PR contains the changes to add ophan tracking to help us understand if users are clicking on the 'accept' button, or if they are being put off viewing the content by the presence of the placeholder.

This is modelled using ophan componentEvents. 

An event is trigger with an 'View' action when the embed is rendered on the page, and then an event with a  'Click' action is sent when the user clicks on the 'accept' button.

The following additional fields are send with the componentEvent to provide additional context:

- component.componentType=CLICK_TO_VIEW_EMBED_OVERLAY
- component.labels=[$providerSourceDomain, $providerName]
- component.abTest={name: 'clickToViewVariant',variant: 'variant',}

TODO
- The types library needs to be updated to add the CLICK_TO_VIEW_EMBED_OVERLAY componentType