### PR TITLE
Change Browser ID collection order

### DIFF
--- a/src/web/browser/coreVitals/coreVitals.ts
+++ b/src/web/browser/coreVitals/coreVitals.ts
@@ -52,6 +52,13 @@ export const coreVitals = (): void => {
 				break;
 		}
 
+		// Some browser ID's are not caputured (and if they have no cookie there won't be on)
+		// but there are occassions of reoccuring users without a browser ID being sent
+		if (window.guardian && window.guardian.ophan) {
+			jsonData.page_view_id = window.guardian.ophan.pageViewId;
+			jsonData.browser_id = window.guardian.config.ophan.browserId;
+		}
+
 		const endpoint =
 			window.location.hostname === 'm.code.dev-theguardian.com' ||
 			window.location.hostname === 'localhost' ||
@@ -62,23 +69,19 @@ export const coreVitals = (): void => {
 		// If CLS has been calculated
 		if (jsonData.cls !== null) {
 			// Set page view and browser ID
-			if (window.guardian && window.guardian.ophan) {
-				jsonData.page_view_id = window.guardian.ophan.pageViewId;
-				jsonData.browser_id = window.guardian.config.ophan.browserId;
 
-				fetch(endpoint, {
-					method: 'POST', // *GET, POST, PUT, DELETE, etc.
-					mode: 'cors', // no-cors, *cors, same-origin
-					cache: 'no-cache', // *default, no-cache, reload, force-cache, only-if-cached
-					credentials: 'same-origin', // include, *same-origin, omit
-					headers: {
-						'Content-Type': 'application/json',
-					},
-					redirect: 'follow',
-					referrerPolicy: 'no-referrer', // no-referrer, *no-referrer-w
-					body: JSON.stringify(jsonData),
-				}).catch(() => {});
-			}
+			fetch(endpoint, {
+				method: 'POST', // *GET, POST, PUT, DELETE, etc.
+				mode: 'cors', // no-cors, *cors, same-origin
+				cache: 'no-cache', // *default, no-cache, reload, force-cache, only-if-cached
+				credentials: 'same-origin', // include, *same-origin, omit
+				headers: {
+					'Content-Type': 'application/json',
+				},
+				redirect: 'follow',
+				referrerPolicy: 'no-referrer', // no-referrer, *no-referrer-w
+				body: JSON.stringify(jsonData),
+			}).catch(() => {});
 		}
 	};
 

--- a/src/web/browser/coreVitals/coreVitals.ts
+++ b/src/web/browser/coreVitals/coreVitals.ts
@@ -36,6 +36,7 @@ export const coreVitals = (): void => {
 
 	const addToJson = ({ name, value }: CoreVitalsArgs): void => {
 		switch (name) {
+			// The math functions are to length of number to <= 9
 			case 'FCP':
 				jsonData.fcp = Math.round(value * 1000000) / 1000000;
 				break;

--- a/src/web/browser/coreVitals/coreVitals.ts
+++ b/src/web/browser/coreVitals/coreVitals.ts
@@ -36,7 +36,7 @@ export const coreVitals = (): void => {
 
 	const addToJson = ({ name, value }: CoreVitalsArgs): void => {
 		switch (name) {
-			// The math functions are to length of number to <= 9
+			// The math functions are to make sure the length of number is <= 9
 			case 'FCP':
 				jsonData.fcp = Math.round(value * 1000000) / 1000000;
 				break;

--- a/src/web/browser/coreVitals/coreVitals.ts
+++ b/src/web/browser/coreVitals/coreVitals.ts
@@ -52,7 +52,7 @@ export const coreVitals = (): void => {
 				break;
 		}
 
-		// Some browser ID's are not caputured (and if they have no cookie there won't be on)
+		// Some browser ID's are not caputured (and if they have no cookie there won't be one)
 		// but there are occassions of reoccuring users without a browser ID being sent
 		if (window.guardian && window.guardian.ophan) {
 			jsonData.page_view_id = window.guardian.ophan.pageViewId;

--- a/src/web/browser/coreVitals/coreVitals.ts
+++ b/src/web/browser/coreVitals/coreVitals.ts
@@ -1,4 +1,5 @@
 import { getCLS, getFID, getLCP, getFCP, getTTFB } from 'web-vitals';
+import { getCookie } from '../cookie';
 
 type CoreWebVitalsPayload = {
 	page_view_id: string | null;
@@ -57,6 +58,11 @@ export const coreVitals = (): void => {
 		if (window.guardian && window.guardian.ophan) {
 			jsonData.page_view_id = window.guardian.ophan.pageViewId;
 			jsonData.browser_id = window.guardian.config.ophan.browserId;
+		}
+
+		// Fallback to check for browser ID
+		if (getCookie('bwid')) {
+			jsonData.browser_id = getCookie('bwid');
 		}
 
 		const endpoint =


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

This checks for the browser and page view ID each time an item is added to the vitals object.

## Why?

Because sometimes browser_ID is not captured in the table.