### PR TITLE
Adding componentEvent tracking to the click to view component

### DIFF
--- a/src/web/components/ClickToView.tsx
+++ b/src/web/components/ClickToView.tsx
@@ -202,7 +202,7 @@ export const ClickToView = ({
 						icon={<SvgCheckmark />}
 						iconSide="left"
 						onClick={() => handleClick()}
-						data-link-name="accept-button"
+						data-link-name="allow-button"
 					>
 						{roleButtonText(role)}
 					</Button>

--- a/src/web/components/ClickToView.tsx
+++ b/src/web/components/ClickToView.tsx
@@ -144,6 +144,7 @@ export const ClickToView = ({
 					padding: ${space[3]}px;
 					margin-bottom: 8px;
 				`}
+				data-component={`click-to-view:${sourceDomain}`}
 			>
 				<div
 					className={css`
@@ -201,6 +202,7 @@ export const ClickToView = ({
 						icon={<SvgCheckmark />}
 						iconSide="left"
 						onClick={() => handleClick()}
+						data-link-name="accept-button"
 					>
 						{roleButtonText(role)}
 					</Button>


### PR DESCRIPTION
The ClickToView component renders an placeholder for third party embedded contents like embedded instagram posts. Users need to click the 'accept' button, consenting to being tracked by the third party provider, before they can see the embedded content.

This PR contains the changes to add ophan tracking to help us understand if users are clicking on the 'accept' button, or if they are being put off viewing the content by the presence of the placeholder.

Details:
- The data-component attribute of the components surrounding div is set to 'click-to-view:${sourceDomain}'
- The data-link-name attribute of the button that uncovers the embedded content "accept-button"
- This results in the 'pageview' table being updated with the following:
  - The rendered-components array field will have an element with the value 'click-to-view:${sourceDomain}'
  - The array of structured data field 'in_page_click' will contain an entry of the form {component= 'click-to-view:${sourceDomain}', link_name='accept-button'} if the button has been clicked. If it hasnt been clicked this element will not exist.