### PR TITLE
Remove unused Source SVG package

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
         "@guardian/src-icons": "^2.7.1",
         "@guardian/src-link": "^2.7.1",
         "@guardian/src-radio": "^2.7.1",
-        "@guardian/src-svgs": "^2.8.2",
         "@guardian/src-text-area": "^2.7.1",
         "@guardian/src-text-input": "^2.7.1",
         "@guardian/types": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2461,11 +2461,6 @@
     "@guardian/src-label" "^2.7.1"
     "@guardian/src-user-feedback" "^2.7.1"
 
-"@guardian/src-svgs@^2.8.2":
-  version "2.8.2"
-  resolved "https://registry.yarnpkg.com/@guardian/src-svgs/-/src-svgs-2.8.2.tgz#4e05c4f144c8507d39166aa6aa8c146c8a3612ae"
-  integrity sha512-PyZJ6jwUKUMsHdKywz/Pgk7oHjvSDdEqTZq6vkiOPJLTjEraEdyO6amu7L7ynVO58CmgzJ+6SwOOAtilHU/LRw==
-
 "@guardian/src-text-area@^2.7.1":
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/@guardian/src-text-area/-/src-text-area-2.7.1.tgz#d1b9e0ea3cb9bd1c2f7e02735af2fb5eb512b1e2"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Remove `@guardian/src-svgs`

## Why?
Not used