### PR TITLE
Do not add byline component unless there is a byline

### DIFF
--- a/src/web/components/HeadlineByline.tsx
+++ b/src/web/components/HeadlineByline.tsx
@@ -88,6 +88,10 @@ type Props = {
 };
 
 export const HeadlineByline = ({ format, byline, tags }: Props) => {
+	if (byline === '') {
+		return null;
+	}
+
 	const palette = decidePalette(format);
 
 	switch (format.display) {

--- a/src/web/layouts/Immersive.stories.tsx
+++ b/src/web/layouts/Immersive.stories.tsx
@@ -84,6 +84,13 @@ ArticleStory.story = {
 	},
 };
 
+export const ArticleWithNoBylineStory = (): React.ReactNode => {
+	const ServerCAPI = convertToImmersive(Article);
+	ServerCAPI.author.byline = '';
+	return <HydratedLayout ServerCAPI={ServerCAPI} />;
+};
+ArticleWithNoBylineStory.story = { name: 'Article with no byline' };
+
 export const ReviewStory = (): React.ReactNode => {
 	const ServerCAPI = convertToImmersive(Review);
 	return <HydratedLayout ServerCAPI={ServerCAPI} />;


### PR DESCRIPTION
## What does this change?
If the byline is an empty string we `return null`

Adds a new immersive layout story to capture it. 

### Before
![Screen Shot 2021-03-12 at 12 24 36](https://user-images.githubusercontent.com/638051/110940810-65d39a00-832f-11eb-9329-06cf53cd7cb5.png)

### After
![Screen Shot 2021-03-12 at 12 24 53](https://user-images.githubusercontent.com/638051/110940816-6835f400-832f-11eb-9725-5386df6cc422.png)

## Why?
No 'by' when no byline
