### PR TITLE
Log Braze Epic views to Ophan

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
         "@guardian/src-radio": "^2.7.1",
         "@guardian/src-text-area": "^2.7.1",
         "@guardian/src-text-input": "^2.7.1",
-        "@guardian/types": "^5.0.0",
+        "@guardian/types": "^5.1.0",
         "@hkdobrev/run-if-changed": "^0.3.1",
         "@loadable/component": "^5.14.1",
         "@loadable/server": "^5.14.0",

--- a/src/web/components/SlotBodyEnd/BrazeEpic.tsx
+++ b/src/web/components/SlotBodyEnd/BrazeEpic.tsx
@@ -12,7 +12,7 @@ import { CanShowResult } from '@root/src/web/lib/messagePicker';
 import { useOnce } from '@root/src/web/lib/useOnce';
 import { joinUrl } from '@root/src/lib/joinUrl';
 import { useHasBeenSeen } from '@root/src/web/lib/useHasBeenSeen';
-import { submitComponentEvent } from 'src/web/browser/ophan/ophan';
+import { submitComponentEvent } from '@root/src/web/browser/ophan/ophan';
 
 const { css } = emotion;
 

--- a/src/web/components/SlotBodyEnd/BrazeEpic.tsx
+++ b/src/web/components/SlotBodyEnd/BrazeEpic.tsx
@@ -12,6 +12,7 @@ import { CanShowResult } from '@root/src/web/lib/messagePicker';
 import { useOnce } from '@root/src/web/lib/useOnce';
 import { joinUrl } from '@root/src/lib/joinUrl';
 import { useHasBeenSeen } from '@root/src/web/lib/useHasBeenSeen';
+import { submitComponentEvent } from 'src/web/browser/ophan/ophan';
 
 const { css } = emotion;
 
@@ -127,8 +128,17 @@ const BrazeEpic = ({
 	}, [contributionsServiceUrl, meta]);
 
 	useEffect(() => {
-		if (hasBeenSeen && meta) {
+		if (hasBeenSeen && meta && meta.dataFromBraze) {
 			meta.logImpressionWithBraze();
+
+			// Log VIEW event with Ophan
+			submitComponentEvent({
+				component: {
+					componentType: 'RETENTION_EPIC',
+					id: meta.dataFromBraze.componentName,
+				},
+				action: 'VIEW',
+			});
 		}
 	}, [hasBeenSeen, meta]);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2485,10 +2485,10 @@
     "@guardian/src-helpers" "^2.7.1"
     "@guardian/src-icons" "^2.7.1"
 
-"@guardian/types@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/types/-/types-5.0.0.tgz#adcf632b0c0bd587db94b93ec9d73d87ad71f6c1"
-  integrity sha512-NrdQlFmnTU41Z98zgDegjoQ/+DswcKIPIv1zQwGj9+exxnPKz3fWCv5ieNsNBVrwZNeG6jUmBDM3a+1cPEnROA==
+"@guardian/types@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/types/-/types-5.1.0.tgz#d83e4fe911c0d4d460551855d47d07df0f0af8f2"
+  integrity sha512-8JQFfHqskOyc1ruSwWiJD8W4XuCsGorMpwEMRsBM3/zHykAiizsJu7827UbeFCWJ5FUquO/blXzm7oK8ZO99CQ==
 
 "@hapi/hoek@^9.0.0":
   version "9.1.0"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

### Before
Braze Epic views are only logged to Braze.

### After
Logs a view `ComponentEvent` to Ophan for the Braze Epic. This new event was recently added to [Ophan](https://github.com/guardian/ophan/pull/4046) and [@guardian/types](https://github.com/guardian/types/pull/94).

@guardian/types has also been bumped to version 5.1.0.

## Why?
In order to facilitate analysis of upcoming marketing via the Braze Epic channel.