### PR TITLE
feat: added pollInterval option to useApi

### DIFF
--- a/src/web/lib/api.tsx
+++ b/src/web/lib/api.tsx
@@ -1,8 +1,6 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
-// Not meant to be an exhaustive type definition of the fetch API,
-// just a starting point to get us going on 99% of our possible use cases
-interface FetchOptions {
+type FetchOptions = {
 	method?:
 		| 'GET'
 		| 'HEAD'
@@ -22,6 +20,10 @@ interface FetchOptions {
 	};
 	body?: string;
 	credentials?: 'omit' | 'include' | 'same-origin';
+};
+
+interface Options extends FetchOptions {
+	pollInterval?: number;
 }
 
 function checkForErrors(response: Response) {
@@ -34,8 +36,8 @@ function checkForErrors(response: Response) {
 	return response;
 }
 
-export const callApi = (url: string, options?: FetchOptions) => {
-	return fetch(url, options)
+export const callApi = (url: string, fetchOptions?: FetchOptions) => {
+	return fetch(url, fetchOptions)
 		.then(checkForErrors)
 		.then((response) => response.json());
 };
@@ -46,10 +48,19 @@ interface ApiResponse<T> {
 	error?: Error;
 }
 
-export const useApi = <T,>(
-	url: string,
-	options?: FetchOptions,
-): ApiResponse<T> => {
+/**
+ * @description
+ * A custom hook to make a GET request using the given url
+ * returning { loading, error, data }
+ * @param {String} url - The url to fetch
+ * @param {Object} options
+ * @param {Number} options.method - If supplied, the api will be called using this value
+ * @param {Number} options.headers - If supplied, the api will be called using this value
+ * @param {Number} options.body - If supplied, the api will be called using this value
+ * @param {Number} options.credentials - If supplied, the api will be called using this value
+ * @param {Number} options.pollInterval - If supplied, the api will be polled at this interval
+ * */
+export const useApi = <T,>(url: string, options?: Options): ApiResponse<T> => {
 	const [request, setRequest] = useState<{
 		loading: boolean;
 		data?: T;
@@ -58,20 +69,60 @@ export const useApi = <T,>(
 		loading: true,
 	});
 
+	const alreadyFetched = useRef<boolean>(false);
+	const pollRef = useRef<number | undefined>();
+
 	useEffect(() => {
-		callApi(url, options)
-			.then((data) => {
-				setRequest({
-					data,
-					loading: false,
-				});
-			})
-			.catch((error) => {
-				setRequest({
-					error,
-					loading: false,
-				});
+		const fetchOptions = {
+			method: options?.method || 'GET',
+			credentials: options?.credentials,
+			headers: options?.headers,
+			body: options?.body,
+		};
+
+		const handleData = (data: T) => {
+			setRequest({
+				data,
+				loading: false,
 			});
+		};
+
+		const handleError = (error: Error) => {
+			setRequest({
+				error,
+				loading: false,
+			});
+		};
+
+		const poll = (delay: number) => {
+			// We use window.setTimeout so we're sure to get a number back (and not the NodeJS.Timeout type)
+			const timeoutId = window.setTimeout(() => {
+				callApi(url, fetchOptions)
+					.then(handleData)
+					.then(() => {
+						// If successfull, enqueue the next poll
+						poll(delay);
+					})
+					.catch(handleError);
+			}, delay);
+			pollRef.current = timeoutId;
+		};
+
+		if (alreadyFetched.current === false) {
+			callApi(url, fetchOptions).then(handleData).catch(handleError);
+			alreadyFetched.current = true;
+		}
+
+		if (options?.pollInterval) {
+			const delay = options.pollInterval;
+			poll(delay);
+			return () => {
+				if (pollRef.current) {
+					clearTimeout(pollRef.current);
+					pollRef.current = undefined;
+				}
+			};
+		}
 	}, [url, options]);
 
 	return request;


### PR DESCRIPTION
## What?
Adds the `pollInterval` option to `useApi`

## Usage
```typescript
    const { data, loading, error } = useApi<MyResponseType>(url, {
        pollInterval: 15000,
    });

```


## Why?
Because we want to be able to poll apis at a defined interval so that we automatically update the page with the latest data. Because `useApi` is a custom hook, returning react state, we automatically get rerenders out of the box so all we had to do here was refetch the data to make it live.

## Why this api?
The structure of an api matters. We need it to be intuitive and easy to use. Here I am following the [pattern used by the Apollo team](https://www.apollographql.com/docs/react/data/queries/#polling). They have some addition features, such as returning `startPolling` and `stopPolling` functions that we could decide to emulate if our use case were to grow in that direction.

## What about callApi
This function is exported and used by Braze for making POST calls. This is the only place in our codebase where this abstraction is used. I plan on breaking this function out from this file so that we can simplify the custom useApi hook and keep the pure api fetching logic separate. I'll do this in a follow up PR