### PR TITLE
Hf review padding headline

### DIFF
--- a/src/web/components/ArticleHeadlinePadding.tsx
+++ b/src/web/components/ArticleHeadlinePadding.tsx
@@ -4,19 +4,24 @@ import { css } from 'emotion';
 import { Design } from '@guardian/types';
 import { from } from '@guardian/src-foundations/mq';
 
-
-const determinePadding = ({ design, starRating } : { design: Design, starRating?: boolean }) => {
+const determinePadding = ({
+	design,
+	starRating,
+}: {
+	design: Design;
+	starRating?: boolean;
+}) => {
 	switch (design) {
 		case Design.Interview:
 			return css`
 				padding-top: 3px;
 			`;
 		case Design.Review:
-		if (starRating) {
-			return ''
-		}
-		return css`
-			padding-bottom: 24px;
+			if (starRating) {
+				return '';
+			}
+			return css`
+				padding-bottom: 24px;
 				${from.tablet} {
 					padding-bottom: 36px;
 				}
@@ -35,10 +40,7 @@ const determinePadding = ({ design, starRating } : { design: Design, starRating?
 export const ArticleHeadlinePadding: React.FC<{
 	children: React.ReactNode;
 	design: Design;
-	starRating?: boolean
+	starRating?: boolean;
 }> = ({ children, design, starRating }) => (
 	<div className={determinePadding({ design, starRating })}>{children}</div>
 );
-
-
-

--- a/src/web/components/ArticleHeadlinePadding.tsx
+++ b/src/web/components/ArticleHeadlinePadding.tsx
@@ -4,12 +4,22 @@ import { css } from 'emotion';
 import { Design } from '@guardian/types';
 import { from } from '@guardian/src-foundations/mq';
 
-const determinePadding = (design: Design) => {
+
+const determinePadding = ({ design, starRating } : { design: Design, starRating?: boolean }) => {
 	switch (design) {
-		case Design.Review:
 		case Design.Interview:
 			return css`
 				padding-top: 3px;
+			`;
+		case Design.Review:
+		if (starRating) {
+			return ''
+		}
+		return css`
+			padding-bottom: 24px;
+				${from.tablet} {
+					padding-bottom: 36px;
+				}
 			`;
 		default:
 			return css`
@@ -25,6 +35,10 @@ const determinePadding = (design: Design) => {
 export const ArticleHeadlinePadding: React.FC<{
 	children: React.ReactNode;
 	design: Design;
-}> = ({ children, design }) => (
-	<div className={determinePadding(design)}>{children}</div>
+	starRating?: boolean
+}> = ({ children, design, starRating }) => (
+	<div className={determinePadding({ design, starRating })}>{children}</div>
 );
+
+
+

--- a/src/web/layouts/Standard.stories.tsx
+++ b/src/web/layouts/Standard.stories.tsx
@@ -76,8 +76,8 @@ ReviewStory.story = { name: 'Review' };
 export const ReviewNoStarStory = (): React.ReactNode => {
 	const ReviewWithoutStars = {
 		...Review,
-		starRating: undefined
-	}
+		starRating: undefined,
+	};
 	const ServerCAPI = convertToStandard(ReviewWithoutStars);
 	return <HydratedLayout ServerCAPI={ServerCAPI} />;
 };

--- a/src/web/layouts/Standard.stories.tsx
+++ b/src/web/layouts/Standard.stories.tsx
@@ -73,6 +73,16 @@ export const ReviewStory = (): React.ReactNode => {
 };
 ReviewStory.story = { name: 'Review' };
 
+export const ReviewNoStarStory = (): React.ReactNode => {
+	const ReviewWithoutStars = {
+		...Review,
+		starRating: undefined
+	}
+	const ServerCAPI = convertToStandard(ReviewWithoutStars);
+	return <HydratedLayout ServerCAPI={ServerCAPI} />;
+};
+ReviewNoStarStory.story = { name: 'Review without stars' };
+
 export const PrintShopStory = (): React.ReactNode => {
 	const ServerCAPI = convertToStandard(PrintShop);
 	return <HydratedLayout ServerCAPI={ServerCAPI} />;

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -413,7 +413,7 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						</GridItem>
 						<GridItem area="headline">
 							<div className={maxWidth}>
-								<ArticleHeadlinePadding design={format.design}>
+								<ArticleHeadlinePadding design={format.design} starRating={!!CAPI.starRating || CAPI.starRating === 0}>
 									{age && (
 										<div className={ageWarningMargins}>
 											<AgeWarning age={age} />

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -413,7 +413,13 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						</GridItem>
 						<GridItem area="headline">
 							<div className={maxWidth}>
-								<ArticleHeadlinePadding design={format.design} starRating={!!CAPI.starRating || CAPI.starRating === 0}>
+								<ArticleHeadlinePadding
+									design={format.design}
+									starRating={
+										!!CAPI.starRating ||
+										CAPI.starRating === 0
+									}
+								>
 									{age && (
 										<div className={ageWarningMargins}>
 											<AgeWarning age={age} />


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds padding below the headline on review articles that don't have stars

### Before
![image](https://user-images.githubusercontent.com/20658471/111465928-8f6b3780-871a-11eb-9065-39231b7969a8.png)

### After
![image](https://user-images.githubusercontent.com/20658471/111465971-98f49f80-871a-11eb-8c60-bdba39c01c2e.png)

## Why?
Headline and standfirst too tight before
