### PR TITLE
Identity | Sign In Gate | Mandatory Sign In Gate Test Audience

### DIFF
--- a/src/web/experiments/tests/sign-in-gate-main-variant.ts
+++ b/src/web/experiments/tests/sign-in-gate-main-variant.ts
@@ -7,7 +7,7 @@ export const signInGateMainVariant: ABTest = {
 	author: 'Mahesh Makani',
 	description:
 		'Show sign in gate to 100% of users on 3rd article view of simple article templates, and show a further 5 times after the first dismissal, with higher priority over banners and epic. Main/Variant Audience.',
-	audience: 0.89,
+	audience: 0.70,
 	audienceOffset: 0.0,
 	successMeasure: 'Users sign in or create a Guardian account',
 	audienceCriteria:

--- a/src/web/experiments/tests/sign-in-gate-mandatory.ts
+++ b/src/web/experiments/tests/sign-in-gate-mandatory.ts
@@ -7,8 +7,8 @@ export const signInGateMandoryTest: ABTest = {
 	author: 'Peter Colley',
 	description:
 		'Compare mandatory gate (an article sigin gate without the dismiss button) with the main signin gate',
-	audience: 0.01,
-	audienceOffset: 0.89,
+	audience: 0.20,
+	audienceOffset: 0.70,
 	successMeasure: 'Users sign in or create a Guardian account',
 	audienceCriteria:
 		'3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss or reshown after 5 dismisses, not on help, info sections etc. exclude iOS 9 and guardian-live-australia, UK only, only users with specific CMP consents. Suppresses other banners, and appears over epics',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

increase mandatory gate audience to 20%

### Before

It was 1%

### After

It will be 20%

## Why?

We want to achieve 170K browser views of the variant in the next 11 days
