### PR TITLE
Update Ophan Tracker-JS for Attention-Time unskew

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
         "lodash.get": "^4.4.2",
         "log4js": "6.3.0",
         "minify-css-string": "^1.0.0",
-        "ophan-tracker-js": "^1.3.23",
+        "ophan-tracker-js": "^1.3.24",
         "pm2": "^4.5.0",
         "preact": "^10.5.12",
         "preact-render-to-string": "^5.1.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14623,10 +14623,10 @@ openurl@^1.1.1:
   resolved "https://registry.yarnpkg.com/openurl/-/openurl-1.1.1.tgz#3875b4b0ef7a52c156f0db41d4609dbb0f94b387"
   integrity sha1-OHW0sO96UsFW8NtB1GCduw+Us4c=
 
-ophan-tracker-js@^1.3.23:
-  version "1.3.23"
-  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.3.23.tgz#e63ca951370b98f265ba654ec4c0db86c15cd822"
-  integrity sha512-MfNMDKUJ0uv9tq3j2B2ISjht8EPs73No8r0NH+H9D3ExrHi8wL9SlPcuVC/Ma2vI7quibduko2RzzuhvAX3BIQ==
+ophan-tracker-js@^1.3.24:
+  version "1.3.24"
+  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.3.24.tgz#8bee64a8dfcba840d097cc816c5d7ed3e0a50dcc"
+  integrity sha512-bFm5nh12KWwy2jxMSHlnVOPNj/3YvlQiGykUqVpMqiIVIgr8GETfVaWHS3SZzZ73pk4oV8kEBphBUT6zl5IlxA==
 
 optionator@^0.8.1, optionator@^0.8.3:
   version "0.8.3"


### PR DESCRIPTION
This upgrade of Ophan's Tracker JS contains two updates:

* https://github.com/guardian/ophan/pull/4063 - work towards removing a possible source of Attention Time metric bias, that is likely to have caused [Attention Times of zero seconds to have been relatively over-reported for dotcom-rendering](https://trello.com/c/Vomnrhwe/39-pageview-underreporting-of-attention-time-on-dcr) (DCR).
  
* https://github.com/guardian/ophan/pull/4065 - gather stats on browser support for the `performance.now()` API, as a potential way to avoid _negative_ attention times being reported by browsers undergoing clock-skew.

See https://github.com/guardian/frontend/pull/23612 for the corresponding update there.

`yarn install` initially failed for this project on my dev laptop, but then I reinstalled XCode and it passed!