### PR TITLE
Fix some z-index issues

### DIFF
--- a/src/web/components/Dropdown.tsx
+++ b/src/web/components/Dropdown.tsx
@@ -12,6 +12,7 @@ import {
 import { textSans } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
 import { visuallyHidden } from '@guardian/src-foundations/accessibility';
+import { getZIndex } from '../lib/getZIndex';
 
 export interface DropdownLinkType {
 	url: string;
@@ -28,7 +29,7 @@ interface Props {
 }
 
 const ulStyles = css`
-	z-index: 1072;
+	${getZIndex('dropdown')}
 	list-style: none;
 	background-color: white;
 	padding: 6px 0;

--- a/src/web/components/EditionDropdown.tsx
+++ b/src/web/components/EditionDropdown.tsx
@@ -4,12 +4,13 @@ import { css } from 'emotion';
 import { Dropdown } from '@root/src/web/components/Dropdown';
 import { brand } from '@guardian/src-foundations/palette';
 import { from } from '@guardian/src-foundations/mq';
+import { getZIndex } from '../lib/getZIndex';
 
 const editionDropdown = css`
 	display: flex;
 	position: absolute;
 	right: 11px;
-	z-index: 1072;
+	${getZIndex('dropdown')}
 	transform: translateX(100%);
 
 	:before {

--- a/src/web/components/Links.tsx
+++ b/src/web/components/Links.tsx
@@ -12,7 +12,6 @@ import { DropdownLinkType, Dropdown } from '@root/src/web/components/Dropdown';
 
 import ProfileIcon from '@frontend/static/icons/profile.svg';
 import GiftingIcon from '@frontend/static/icons/gifting.svg';
-import { getZIndex } from '@frontend/web/lib/getZIndex';
 import { createAuthenticationEventParams } from '@root/src/lib/identity-component-event';
 import { useOnce } from '@frontend/web/lib/useOnce';
 
@@ -123,8 +122,6 @@ const linksStyles = css`
 	${from.wide} {
 		right: 342px;
 	}
-
-	${getZIndex('headerLinks')}
 `;
 
 export const Links = ({

--- a/src/web/components/Nav/ExpandedMenu/VeggieBurgerMenu.tsx
+++ b/src/web/components/Nav/ExpandedMenu/VeggieBurgerMenu.tsx
@@ -6,6 +6,7 @@ import { from } from '@guardian/src-foundations/mq';
 import { brandAlt, neutral } from '@guardian/src-foundations/palette';
 
 import { Display } from '@guardian/types';
+import { getZIndex } from '@root/src/web/lib/getZIndex';
 import { navInputCheckboxId, veggieBurgerId } from '../config';
 
 const screenReadable = css`
@@ -80,8 +81,7 @@ const veggieBurgerStyles = (display: Display) => css`
 	border-radius: 50%;
 	outline: none;
 
-	/* TODO: we should not use such a hight z-index number  */
-	z-index: 1071;
+	${getZIndex('burger')}
 
 	right: 5px;
 	bottom: 48px;

--- a/src/web/components/Nav/StickNavTest/ExpandedMenu/VeggieBurgerMenu.tsx
+++ b/src/web/components/Nav/StickNavTest/ExpandedMenu/VeggieBurgerMenu.tsx
@@ -6,6 +6,7 @@ import { from } from '@guardian/src-foundations/mq';
 import { brandAlt, neutral } from '@guardian/src-foundations/palette';
 
 import { Display } from '@guardian/types';
+import { getZIndex } from '@root/src/web/lib/getZIndex';
 import { navInputCheckboxId, veggieBurgerId, buildID } from '../../config';
 
 const screenReadable = css`
@@ -80,8 +81,7 @@ const veggieBurgerStyles = (display: Display) => css`
 	border-radius: 50%;
 	outline: none;
 
-	/* TODO: we should not use such a hight z-index number  */
-	z-index: 1071;
+	${getZIndex('burger')}
 
 	right: 5px;
 	bottom: 48px;

--- a/src/web/experiments/tests/sign-in-gate-main-variant.ts
+++ b/src/web/experiments/tests/sign-in-gate-main-variant.ts
@@ -7,7 +7,7 @@ export const signInGateMainVariant: ABTest = {
 	author: 'Mahesh Makani',
 	description:
 		'Show sign in gate to 100% of users on 3rd article view of simple article templates, and show a further 5 times after the first dismissal, with higher priority over banners and epic. Main/Variant Audience.',
-	audience: 0.70,
+	audience: 0.7,
 	audienceOffset: 0.0,
 	successMeasure: 'Users sign in or create a Guardian account',
 	audienceCriteria:

--- a/src/web/experiments/tests/sign-in-gate-mandatory.ts
+++ b/src/web/experiments/tests/sign-in-gate-mandatory.ts
@@ -7,8 +7,8 @@ export const signInGateMandoryTest: ABTest = {
 	author: 'Peter Colley',
 	description:
 		'Compare mandatory gate (an article sigin gate without the dismiss button) with the main signin gate',
-	audience: 0.20,
-	audienceOffset: 0.70,
+	audience: 0.2,
+	audienceOffset: 0.7,
 	successMeasure: 'Users sign in or create a Guardian account',
 	audienceCriteria:
 		'3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss or reshown after 5 dismisses, not on help, info sections etc. exclude iOS 9 and guardian-live-australia, UK only, only users with specific CMP consents. Suppresses other banners, and appears over epics',

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -43,13 +43,8 @@ import {
 	decideLineCount,
 	decideLineEffect,
 } from '@root/src/web/lib/layoutHelpers';
-import {
-	Stuck,
-	SendToBack,
-	BannerWrapper,
-} from '@root/src/web/layouts/lib/stickiness';
+import { Stuck, BannerWrapper } from '@root/src/web/layouts/lib/stickiness';
 import { NavGroupEager } from '@root/src/web/components/Nav/StickNavTest/StickyNav';
-import { getZIndex } from '../lib/getZIndex';
 
 const StandardGrid = ({
 	children,
@@ -288,7 +283,6 @@ const ageWarningMargins = css`
 const stickyNavRootStyle = css`
 	display: inline;
 	position: relative;
-	${getZIndex('stickyNavWrapper')}
 `;
 
 interface Props {
@@ -344,20 +338,18 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						/>
 					</Section>
 				</Stuck>
-				<SendToBack>
-					<Section
-						showTopBorder={false}
-						showSideBorders={false}
-						padded={false}
-						backgroundColour={brandBackground.primary}
-					>
-						<Header
-							edition={CAPI.editionId}
-							idUrl={CAPI.config.idUrl}
-							mmaUrl={CAPI.config.mmaUrl}
-						/>
-					</Section>
-				</SendToBack>
+				<Section
+					showTopBorder={false}
+					showSideBorders={false}
+					padded={false}
+					backgroundColour={brandBackground.primary}
+				>
+					<Header
+						edition={CAPI.editionId}
+						idUrl={CAPI.config.idUrl}
+						mmaUrl={CAPI.config.mmaUrl}
+					/>
+				</Section>
 			</div>
 
 			<div>

--- a/src/web/lib/getZIndex.test.tsx
+++ b/src/web/lib/getZIndex.test.tsx
@@ -2,8 +2,9 @@ import { getZIndex } from './getZIndex';
 
 describe('getZIndex', () => {
 	it('gets the correct zindex for group and sibling', () => {
-		expect(getZIndex('banner')).toBe('z-index: 12;');
-		expect(getZIndex('dropdown')).toBe('z-index: 11;');
+		expect(getZIndex('banner')).toBe('z-index: 13;');
+		expect(getZIndex('dropdown')).toBe('z-index: 12;');
+		expect(getZIndex('burger')).toBe('z-index: 11;');
 		expect(getZIndex('stickyNav')).toBe('z-index: 10;');
 		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 9;');
 		expect(getZIndex('headerLinks')).toBe('z-index: 8;');

--- a/src/web/lib/getZIndex.test.tsx
+++ b/src/web/lib/getZIndex.test.tsx
@@ -3,12 +3,12 @@ import { getZIndex } from './getZIndex';
 describe('getZIndex', () => {
 	it('gets the correct zindex for group and sibling', () => {
 		expect(getZIndex('banner')).toBe('z-index: 12;');
-		expect(getZIndex('stickyNav')).toBe('z-index: 11;');
-		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 10;');
-		expect(getZIndex('stickyNavWrapper')).toBe('z-index: 9;');
-		expect(getZIndex('headerWrapper')).toBe('z-index: 8;');
-		expect(getZIndex('headerLinks')).toBe('z-index: 7;');
-		expect(getZIndex('TheGuardian')).toBe('z-index: 6;');
+		expect(getZIndex('dropdown')).toBe('z-index: 11;');
+		expect(getZIndex('stickyNav')).toBe('z-index: 10;');
+		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 9;');
+		expect(getZIndex('headerLinks')).toBe('z-index: 8;');
+		expect(getZIndex('TheGuardian')).toBe('z-index: 7;');
+		expect(getZIndex('headerWrapper')).toBe('z-index: 6;');
 		expect(getZIndex('articleHeadline')).toBe('z-index: 5;');
 		expect(getZIndex('immersiveBlackBox')).toBe('z-index: 4;');
 		expect(getZIndex('bodyArea')).toBe('z-index: 3;');

--- a/src/web/lib/getZIndex.tsx
+++ b/src/web/lib/getZIndex.tsx
@@ -25,18 +25,18 @@ const indices = [
 	// Modals will go here at the top
 
 	'banner',
-
-	// Stick-nav test
+	'dropdown',
 	'stickyNav',
 
 	// Header
 	'stickyAdWrapper',
-	'stickyNavWrapper',
-	'headerWrapper',
 
 	// Header links (should be above The Guardian svg)
 	'headerLinks',
 	'TheGuardian',
+
+	// Wrapper after nav stuff
+	'headerWrapper',
 
 	// Article headline (should be above main media)
 	'articleHeadline',

--- a/src/web/lib/getZIndex.tsx
+++ b/src/web/lib/getZIndex.tsx
@@ -26,6 +26,7 @@ const indices = [
 
 	'banner',
 	'dropdown',
+	'burger',
 	'stickyNav',
 
 	// Header


### PR DESCRIPTION
## What does this change?

Fixes two unrelated z-index issues.

### Nav link dropdown:
![image](https://user-images.githubusercontent.com/858402/111661435-ed754900-8806-11eb-9236-27a5845ff4dd.png)

### Banner and burger menu:
![image](https://user-images.githubusercontent.com/858402/111661402-e817fe80-8806-11eb-946f-e1457e5c1266.png)

These now do what you'd expect.

I've tried to extend the use of `getZIndex` as part of this to help with clarity.