### PR TITLE
Revert "Revert "ARM/Graviton testing""

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
         "cpy": "^8.1.1",
         "curlyquotes": "^1.5.5",
         "cypress": "^6.1.0",
-        "diskusage": "^1.1.3",
         "dompurify": "^2.2.6",
         "dynamic-import-polyfill": "^0.1.1",
         "emotion": "^10.0.27",

--- a/scripts/deploy/riff-raff.yaml
+++ b/scripts/deploy/riff-raff.yaml
@@ -9,12 +9,12 @@ deployments:
       cloudFormationStackName: rendering
       templateStageParameters:
         CODE:
-          InstanceType: t3.micro
+          InstanceType: t4g.micro
         PROD:
-          InstanceType: t3.small
+          InstanceType: t4g.small
       amiParametersToTags:
         AMI:
-          Recipe: dotcom-rendering-node14-test
+          Recipe: dotcom-rendering-ARM
           BuiltBy: amigo
           AmigoStage: PROD
   rendering:

--- a/src/app/aws/metrics-baseline.ts
+++ b/src/app/aws/metrics-baseline.ts
@@ -1,9 +1,11 @@
+// TODO re-enable disk space checks after Graviton testing complete (the diskusage module doesn't work on ARM).
+
 import os from 'os';
-import disk from 'diskusage';
+// import disk from 'diskusage';
 import { BytesMetric, collectAndSendAWSMetrics } from './aws-metrics';
 
 const maxHeapMemory = BytesMetric('rendering', 'PROD', 'max-heap-memory');
-const freeDiskSpace = BytesMetric('rendering', 'PROD', 'free-disk-memory');
+// const freeDiskSpace = BytesMetric('rendering', 'PROD', 'free-disk-memory');
 const usedHeapMemory = BytesMetric('rendering', 'PROD', 'used-heap-memory');
 const freePhysicalMemory = BytesMetric(
 	'rendering',
@@ -23,24 +25,30 @@ collectAndSendAWSMetrics(
 	usedHeapMemory,
 	totalPhysicalMemory,
 	freePhysicalMemory,
-	freeDiskSpace,
+	// freeDiskSpace,
 );
 
 // records system metrics
 
 export const recordBaselineCloudWatchMetrics = () => {
-	disk.check('/', (err, diskinfo) => {
-		if (err) {
-			// eslint-disable-next-line no-console
-			console.error(err);
-		} else {
-			maxHeapMemory.record(process.memoryUsage().heapTotal);
-			usedHeapMemory.record(process.memoryUsage().heapUsed);
-			totalPhysicalMemory.record(os.totalmem());
-			freePhysicalMemory.record(os.freemem());
-			if (diskinfo) {
-				freeDiskSpace.record(diskinfo.free);
-			}
-		}
-	});
+	// TODO re-enable once ARM testing complete
+	// disk.check('/', (err, diskinfo) => {
+	// 	if (err) {
+	// 		// eslint-disable-next-line no-console
+	// 		console.error(err);
+	// 	} else {
+	// 		maxHeapMemory.record(process.memoryUsage().heapTotal);
+	// 		usedHeapMemory.record(process.memoryUsage().heapUsed);
+	// 		totalPhysicalMemory.record(os.totalmem());
+	// 		freePhysicalMemory.record(os.freemem());
+	// 		if (diskinfo) {
+	// 			freeDiskSpace.record(diskinfo.free);
+	// 		}
+	// 	}
+	// });
+
+	maxHeapMemory.record(process.memoryUsage().heapTotal);
+	usedHeapMemory.record(process.memoryUsage().heapUsed);
+	totalPhysicalMemory.record(os.totalmem());
+	freePhysicalMemory.record(os.freemem());
 };

--- a/src/app/aws/metrics-baseline.ts
+++ b/src/app/aws/metrics-baseline.ts
@@ -1,5 +1,4 @@
-// TODO re-enable disk space checks after Graviton testing complete (the diskusage module doesn't work on ARM).
-
+// TODO replace disk-usage code with an ARM-friendly solution (probably in a separate process)
 import os from 'os';
 // import disk from 'diskusage';
 import { BytesMetric, collectAndSendAWSMetrics } from './aws-metrics';
@@ -18,8 +17,6 @@ const totalPhysicalMemory = BytesMetric(
 	'total-physical-memory',
 );
 
-// transmits metrics to AWS
-
 collectAndSendAWSMetrics(
 	maxHeapMemory,
 	usedHeapMemory,
@@ -28,10 +25,7 @@ collectAndSendAWSMetrics(
 	// freeDiskSpace,
 );
 
-// records system metrics
-
 export const recordBaselineCloudWatchMetrics = () => {
-	// TODO re-enable once ARM testing complete
 	// disk.check('/', (err, diskinfo) => {
 	// 	if (err) {
 	// 		// eslint-disable-next-line no-console

--- a/src/app/aws/metrics-baseline.ts
+++ b/src/app/aws/metrics-baseline.ts
@@ -1,10 +1,7 @@
-// TODO replace disk-usage code with an ARM-friendly solution (probably in a separate process)
 import os from 'os';
-// import disk from 'diskusage';
 import { BytesMetric, collectAndSendAWSMetrics } from './aws-metrics';
 
 const maxHeapMemory = BytesMetric('rendering', 'PROD', 'max-heap-memory');
-// const freeDiskSpace = BytesMetric('rendering', 'PROD', 'free-disk-memory');
 const usedHeapMemory = BytesMetric('rendering', 'PROD', 'used-heap-memory');
 const freePhysicalMemory = BytesMetric(
 	'rendering',
@@ -22,25 +19,9 @@ collectAndSendAWSMetrics(
 	usedHeapMemory,
 	totalPhysicalMemory,
 	freePhysicalMemory,
-	// freeDiskSpace,
 );
 
 export const recordBaselineCloudWatchMetrics = () => {
-	// disk.check('/', (err, diskinfo) => {
-	// 	if (err) {
-	// 		// eslint-disable-next-line no-console
-	// 		console.error(err);
-	// 	} else {
-	// 		maxHeapMemory.record(process.memoryUsage().heapTotal);
-	// 		usedHeapMemory.record(process.memoryUsage().heapUsed);
-	// 		totalPhysicalMemory.record(os.totalmem());
-	// 		freePhysicalMemory.record(os.freemem());
-	// 		if (diskinfo) {
-	// 			freeDiskSpace.record(diskinfo.free);
-	// 		}
-	// 	}
-	// });
-
 	maxHeapMemory.record(process.memoryUsage().heapTotal);
 	usedHeapMemory.record(process.memoryUsage().heapUsed);
 	totalPhysicalMemory.record(os.totalmem());

--- a/yarn.lock
+++ b/yarn.lock
@@ -8360,14 +8360,6 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-diskusage@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/diskusage/-/diskusage-1.1.3.tgz#680d7dbf1b679168a195c9240eb3552cbd2c067b"
-  integrity sha512-EAyaxl8hy4Ph07kzlzGTfpbZMNAAAHXSZtNEMwdlnSd1noHzvA6HsgKt4fEMSvaEXQYLSphe5rPMxN4WOj0hcQ==
-  dependencies:
-    es6-promise "^4.2.5"
-    nan "^2.14.0"
-
 dlv@^1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/dlv/-/dlv-1.1.3.tgz#5c198a8a11453596e751494d49874bc7732f2e79"
@@ -8981,7 +8973,7 @@ es6-iterator@~2.0.3:
     es5-ext "^0.10.35"
     es6-symbol "^3.1.1"
 
-es6-promise@^4.0.3, es6-promise@^4.2.5:
+es6-promise@^4.0.3:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
   integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
@@ -14028,7 +14020,7 @@ mute-stream@0.0.8, mute-stream@~0.0.4:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-nan@^2.12.1, nan@^2.13.2, nan@^2.14.0:
+nan@^2.12.1, nan@^2.13.2:
   version "2.14.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#2684. We have now reserved our instances so can turn this on.

We still don't have a solution to disk-usage monitoring but I don't think that's a blocker. Any solution we do adopt will likely be outside of the DCR node process itself (perhaps using Fluentbit).