### PR TITLE
feat: Live counts

### DIFF
--- a/src/web/lib/useComments.ts
+++ b/src/web/lib/useComments.ts
@@ -75,7 +75,9 @@ export function useComments(onwardsSections: OnwardsType[]) {
 	const [counts, setCounts] = useState<CommentType[]>([]);
 
 	const url = buildUrl(onwardsSections);
-	const { data } = useApi<CommentsType>(url);
+	const { data } = useApi<CommentsType>(url, {
+		pollInterval: 15000,
+	});
 
 	useEffect(() => {
 		setCounts((data && data.counts) || []);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Comment counts are now "live". Where live is as live as you can get when discussion data is cached for 30 seconds

### Before
Counts were a snapshot in time when the article was rendered

### After
Counts are kept up to date

## Why?
Because the little things matter. And also because seeing that number change can draw the eye and engage readers more.
