### PR TITLE
feat: Hide header for Labs

### DIFF
--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -8,7 +8,7 @@ import {
 	brandLine,
 } from '@guardian/src-foundations/palette';
 import { from, until } from '@guardian/src-foundations/mq';
-import { Display, Design } from '@guardian/types';
+import { Display, Design, Special } from '@guardian/types';
 import type { Format } from '@guardian/types';
 
 import { GuardianLines } from '@root/src/web/components/GuardianLines';
@@ -320,18 +320,20 @@ export const CommentLayout = ({
 					</Section>
 				</Stuck>
 				<SendToBack>
-					<Section
-						showTopBorder={false}
-						showSideBorders={false}
-						padded={false}
-						backgroundColour={brandBackground.primary}
-					>
-						<Header
-							edition={CAPI.editionId}
-							idUrl={CAPI.config.idUrl}
-							mmaUrl={CAPI.config.mmaUrl}
-						/>
-					</Section>
+					{format.theme !== Special.Labs && (
+						<Section
+							showTopBorder={false}
+							showSideBorders={false}
+							padded={false}
+							backgroundColour={brandBackground.primary}
+						>
+							<Header
+								edition={CAPI.editionId}
+								idUrl={CAPI.config.idUrl}
+								mmaUrl={CAPI.config.mmaUrl}
+							/>
+						</Section>
+					)}
 
 					<Section
 						showSideBorders={true}

--- a/src/web/layouts/Showcase.stories.tsx
+++ b/src/web/layouts/Showcase.stories.tsx
@@ -16,6 +16,7 @@ import { Quiz } from '@root/fixtures/generated/articles/Quiz';
 import { Recipe } from '@root/fixtures/generated/articles/Recipe';
 import { Comment } from '@root/fixtures/generated/articles/Comment';
 import { MatchReport } from '@root/fixtures/generated/articles/MatchReport';
+import { Labs } from '@root/fixtures/generated/articles/Labs';
 
 import { BootReact } from '@root/src/web/components/BootReact';
 import { embedIframe } from '@root/src/web/browser/embedIframe/embedIframe';
@@ -169,3 +170,11 @@ export const MatchReportStory = (): React.ReactNode => {
 	return <HydratedLayout ServerCAPI={ServerCAPI} />;
 };
 MatchReportStory.story = { name: 'MatchReport' };
+
+export const LabsStory = (): React.ReactNode => {
+	const ServerCAPI = convertToShowcase(Labs);
+	return <HydratedLayout ServerCAPI={ServerCAPI} />;
+};
+LabsStory.story = {
+	name: 'Labs',
+};

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -9,7 +9,7 @@ import {
 } from '@guardian/src-foundations/palette';
 import { from, until } from '@guardian/src-foundations/mq';
 import { GuardianLines } from '@root/src/web/components/GuardianLines';
-import { Design } from '@guardian/types';
+import { Design, Special } from '@guardian/types';
 import type { Format } from '@guardian/types';
 
 import { ArticleBody } from '@root/src/web/components/ArticleBody';
@@ -264,18 +264,20 @@ export const ShowcaseLayout = ({
 					</Section>
 				</Stuck>
 				<SendToBack>
-					<Section
-						showTopBorder={false}
-						showSideBorders={false}
-						padded={false}
-						backgroundColour={brandBackground.primary}
-					>
-						<Header
-							edition={CAPI.editionId}
-							idUrl={CAPI.config.idUrl}
-							mmaUrl={CAPI.config.mmaUrl}
-						/>
-					</Section>
+					{format.theme !== Special.Labs && (
+						<Section
+							showTopBorder={false}
+							showSideBorders={false}
+							padded={false}
+							backgroundColour={brandBackground.primary}
+						>
+							<Header
+								edition={CAPI.editionId}
+								idUrl={CAPI.config.idUrl}
+								mmaUrl={CAPI.config.mmaUrl}
+							/>
+						</Section>
+					)}
 
 					<Section
 						showSideBorders={true}

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -338,18 +338,20 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						/>
 					</Section>
 				</Stuck>
-				<Section
-					showTopBorder={false}
-					showSideBorders={false}
-					padded={false}
-					backgroundColour={brandBackground.primary}
-				>
-					<Header
-						edition={CAPI.editionId}
-						idUrl={CAPI.config.idUrl}
-						mmaUrl={CAPI.config.mmaUrl}
-					/>
-				</Section>
+				{format.theme !== Special.Labs && (
+					<Section
+						showTopBorder={false}
+						showSideBorders={false}
+						padded={false}
+						backgroundColour={brandBackground.primary}
+					>
+						<Header
+							edition={CAPI.editionId}
+							idUrl={CAPI.config.idUrl}
+							mmaUrl={CAPI.config.mmaUrl}
+						/>
+					</Section>
+				)}
 			</div>
 
 			<div>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Don't show the `Header` component for `Special.Labs` articles

### Before
![Screenshot 2021-03-19 at 15 24 37](https://user-images.githubusercontent.com/1336821/111803808-53c1a080-88c7-11eb-9273-b9c042e54231.jpg)


### After
![Screenshot 2021-03-19 at 15 23 05](https://user-images.githubusercontent.com/1336821/111803819-57552780-88c7-11eb-9bd7-588b1f60f903.jpg)

## Why?
To reduce brand association (I presume) and perhaps also because labs articles have their own header bar below Nav? Parity basically