### PR TITLE
Main media unsafe EmbedBlockElement

### DIFF
--- a/src/web/components/elements/MainMediaEmbedBlockComponent.tsx
+++ b/src/web/components/elements/MainMediaEmbedBlockComponent.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { css } from 'emotion';
+
+type Props = {
+	title: string;
+	srcDoc: string;
+};
+
+export const MainMediaEmbedBlockComponent = ({ title, srcDoc }: Props) => (
+	<iframe
+		className={css`
+			width: 100%;
+			height: 100vh;
+		`}
+		title={title}
+		srcDoc={srcDoc}
+	/>
+);

--- a/src/web/lib/ElementRenderer.tsx
+++ b/src/web/lib/ElementRenderer.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { css } from 'emotion';
 
 import { BlockquoteBlockComponent } from '@root/src/web/components/elements/BlockquoteBlockComponent';
 import { CalloutBlockComponent } from '@root/src/web/components/elements/CalloutBlockComponent';
@@ -201,6 +202,25 @@ export const ElementRenderer = ({
 			);
 		case 'model.dotcomrendering.pageElements.EmbedBlockElement':
 			if (!element.safe) {
+				if (isMainMedia) {
+					return (
+						<Figure
+							isMainMedia={isMainMedia}
+							role={isLiveBlog ? 'inline' : element.role}
+							id={element.elementId}
+						>
+							<iframe
+								className={css`
+									width: 100%;
+									height: 100vh;
+								`}
+								title={element.alt || ''}
+								srcDoc={element.html}
+							/>
+						</Figure>
+					);
+				}
+
 				return (
 					<Figure
 						isMainMedia={isMainMedia}

--- a/src/web/lib/ElementRenderer.tsx
+++ b/src/web/lib/ElementRenderer.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { css } from 'emotion';
 
 import { BlockquoteBlockComponent } from '@root/src/web/components/elements/BlockquoteBlockComponent';
 import { CalloutBlockComponent } from '@root/src/web/components/elements/CalloutBlockComponent';
@@ -17,6 +16,7 @@ import { HighlightBlockComponent } from '@root/src/web/components/elements/Highl
 import { ImageBlockComponent } from '@root/src/web/components/elements/ImageBlockComponent';
 import { InstagramBlockComponent } from '@root/src/web/components/elements/InstagramBlockComponent';
 import { InteractiveBlockComponent } from '@root/src/web/components/elements/InteractiveBlockComponent';
+import { MainMediaEmbedBlockComponent } from '@root/src/web/components/elements/MainMediaEmbedBlockComponent';
 import { MapEmbedBlockComponent } from '@root/src/web/components/elements/MapEmbedBlockComponent';
 import { MultiImageBlockComponent } from '@root/src/web/components/elements/MultiImageBlockComponent';
 import { PullQuoteBlockComponent } from '@root/src/web/components/elements/PullQuoteBlockComponent';
@@ -209,11 +209,7 @@ export const ElementRenderer = ({
 							role={element.role}
 							id={element.elementId}
 						>
-							<iframe
-								className={css`
-									width: 100%;
-									height: 100vh;
-								`}
+							<MainMediaEmbedBlockComponent
 								title={element.alt || ''}
 								srcDoc={element.html}
 							/>

--- a/src/web/lib/ElementRenderer.tsx
+++ b/src/web/lib/ElementRenderer.tsx
@@ -206,7 +206,7 @@ export const ElementRenderer = ({
 					return (
 						<Figure
 							isMainMedia={isMainMedia}
-							role={isLiveBlog ? 'inline' : element.role}
+							role={element.role}
 							id={element.elementId}
 						>
 							<iframe


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Add support for unsafe main media embed block elements

### Before
![Screenshot 2021-03-19 at 17 18 35](https://user-images.githubusercontent.com/8831403/111818512-2bda3900-88d7-11eb-8776-865ca62ad15f.png)


### After
![Screenshot 2021-03-19 at 17 06 32](https://user-images.githubusercontent.com/8831403/111818524-2ed52980-88d7-11eb-88f3-f4b29b245847.png)


## Why?
`EmbedBlockElement` iframe resize no longer needed as we know what main media height should be