### PR TITLE
Labs standfirst

### DIFF
--- a/src/web/components/Standfirst.tsx
+++ b/src/web/components/Standfirst.tsx
@@ -4,8 +4,8 @@ import { css, cx } from 'emotion';
 import { neutral } from '@guardian/src-foundations/palette';
 import { space } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
-import { headline } from '@guardian/src-foundations/typography';
-import { Display, Design } from '@guardian/types';
+import { headline, textSans } from '@guardian/src-foundations/typography';
+import { Display, Design, Special } from '@guardian/types';
 import { sanitise } from '@frontend/lib/sanitise-html';
 import { decidePalette } from '../lib/decidePalette';
 
@@ -76,9 +76,11 @@ const standfirstStyles = (format: Format, palette: Palette) => {
 					`;
 				default:
 					return css`
-						${headline.xsmall({
-							fontWeight: 'light',
-						})};
+						${format.theme === Special.Labs
+							? textSans.large()
+							: headline.xsmall({
+									fontWeight: 'light',
+							  })};
 						padding-top: ${space[4]}px;
 
 						max-width: 280px;
@@ -110,9 +112,11 @@ const standfirstStyles = (format: Format, palette: Palette) => {
 					`;
 				default:
 					return css`
-						${headline.xxxsmall({
-							fontWeight: 'bold',
-						})};
+						${format.theme === Special.Labs
+							? textSans.large()
+							: headline.xxxsmall({
+									fontWeight: 'bold',
+							  })};
 						line-height: 20px;
 						margin-bottom: ${space[3]}px;
 						max-width: 540px;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Changes the font used in the standfirst for Labs articles

### Before
![Screenshot 2021-03-22 at 08 22 15](https://user-images.githubusercontent.com/1336821/111960496-bf825400-8ae7-11eb-8008-b61b8badb53d.jpg)



### After
![Screenshot 2021-03-22 at 08 21 45](https://user-images.githubusercontent.com/1336821/111960455-af6a7480-8ae7-11eb-84a8-448428430487.jpg)


## Why?
Labs are special
