### PR TITLE
Labs body text

### DIFF
--- a/src/web/components/elements/TextBlockComponent.tsx
+++ b/src/web/components/elements/TextBlockComponent.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 import { neutral } from '@guardian/src-foundations/palette';
-import { body } from '@guardian/src-foundations/typography';
+import { body, textSans } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 import { sanitise } from '@frontend/lib/sanitise-html';
 
@@ -10,7 +10,7 @@ import { unwrapHtml } from '@root/src/model/unwrapHtml';
 import { RewrappedComponent } from '@root/src/web/components/elements/RewrappedComponent';
 
 import { DropCap } from '@frontend/web/components/DropCap';
-import { Display, Design, Format } from '@guardian/types';
+import { Display, Design, Format, Special } from '@guardian/types';
 import { decidePalette } from '@root/src/web/lib/decidePalette';
 
 type Props = {
@@ -102,7 +102,7 @@ const sanitiserOptions = {
 
 const paraStyles = (format: Format) => css`
 	margin-bottom: 16px;
-	${body.medium()};
+	${format.theme === Special.Labs ? textSans.medium() : body.medium()};
 
 	ul {
 		margin-bottom: 12px;


### PR DESCRIPTION
## What?
Use a different font for body text when the theme is `Special.Labs`

### Before
![Screenshot 2021-03-22 at 08 30 00](https://user-images.githubusercontent.com/1336821/111961301-ceb5d180-8ae8-11eb-91d8-18e59d490353.jpg)


### After
![Screenshot 2021-03-22 at 08 28 37](https://user-images.githubusercontent.com/1336821/111961279-c493d300-8ae8-11eb-8d22-0054e98531a9.jpg)


## Why?
Labs are special