### PR TITLE
Labs dropcap

### DIFF
--- a/src/web/components/elements/TextBlockComponent.tsx
+++ b/src/web/components/elements/TextBlockComponent.tsx
@@ -10,7 +10,7 @@ import { unwrapHtml } from '@root/src/model/unwrapHtml';
 import { RewrappedComponent } from '@root/src/web/components/elements/RewrappedComponent';
 
 import { DropCap } from '@frontend/web/components/DropCap';
-import { Display, Design, Format } from '@guardian/types';
+import { Display, Design, Format, Special } from '@guardian/types';
 import { decidePalette } from '@root/src/web/lib/decidePalette';
 
 type Props = {
@@ -50,6 +50,22 @@ const decideDropCapLetter = (html: string): string => {
 	return isLetter(first) ? first : '';
 };
 
+const allowsDropCaps = (format: Format) => {
+	if (format.theme === Special.Labs) return false;
+	if (format.display === Display.Immersive) return true;
+	switch (format.design) {
+		case Design.Feature:
+		case Design.Comment:
+		case Design.Review:
+		case Design.Interview:
+		case Design.PhotoEssay:
+		case Design.Recipe:
+			return true;
+		default:
+			return false;
+	}
+};
+
 const shouldShowDropCap = ({
 	format,
 	isFirstParagraph,
@@ -59,20 +75,7 @@ const shouldShowDropCap = ({
 	isFirstParagraph: boolean;
 	forceDropCap?: boolean;
 }): boolean => {
-	function allowsDropCaps(design: Design) {
-		switch (design) {
-			case Design.Feature:
-			case Design.Comment:
-			case Design.Review:
-			case Design.Interview:
-			case Design.PhotoEssay:
-			case Design.Recipe:
-				return true;
-			default:
-				return false;
-		}
-	}
-	if (allowsDropCaps(format.design) || format.display === Display.Immersive) {
+	if (allowsDropCaps(format)) {
 		// When dropcaps are allowed, we always mark the first paragraph as a drop cap
 		if (isFirstParagraph) return true;
 		// For subsequent blocks of text, we only add a dropcap if a dinkus was inserted

--- a/src/web/layouts/Immersive.stories.tsx
+++ b/src/web/layouts/Immersive.stories.tsx
@@ -20,6 +20,7 @@ import { Recipe } from '@root/fixtures/generated/articles/Recipe';
 import { Comment } from '@root/fixtures/generated/articles/Comment';
 import { MatchReport } from '@root/fixtures/generated/articles/MatchReport';
 import { PrintShop } from '@root/fixtures/generated/articles/PrintShop';
+import { Labs } from '@root/fixtures/generated/articles/Labs';
 
 import { BootReact } from '@root/src/web/components/BootReact';
 import { embedIframe } from '@root/src/web/browser/embedIframe/embedIframe';
@@ -232,3 +233,11 @@ export const PrintShopStory = (): React.ReactNode => {
 	return <HydratedLayout ServerCAPI={ServerCAPI} />;
 };
 PrintShopStory.story = { name: 'PrintShop' };
+
+export const LabsStory = (): React.ReactNode => {
+	const ServerCAPI = convertToImmersive(Labs);
+	return <HydratedLayout ServerCAPI={ServerCAPI} />;
+};
+LabsStory.story = {
+	name: 'Labs',
+};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Prevents dropcaps showing on all Labs articles

### Before
![Screenshot 2021-03-22 at 08 33 41](https://user-images.githubusercontent.com/1336821/111962054-babe9f80-8ae9-11eb-9e25-b0b6d84b994f.jpg)


### After
![Screenshot 2021-03-22 at 08 35 00](https://user-images.githubusercontent.com/1336821/111962064-be522680-8ae9-11eb-8c33-ea4c61a73f68.jpg)

## Why?
They are not part of the design
