### PR TITLE
Wrap long words in article titles

### DIFF
--- a/src/web/components/ArticleTitle.stories.tsx
+++ b/src/web/components/ArticleTitle.stories.tsx
@@ -10,7 +10,7 @@ import { ArticleTitle } from './ArticleTitle';
 const Container = ({ children }: { children: React.ReactNode }) => (
 	<div
 		className={css`
-			width: 620px;
+			width: 200px;
 			padding: 20px;
 		`}
 	>
@@ -357,3 +357,62 @@ export const LabsStory = () => {
 	);
 };
 LabsStory.story = { name: 'Labs' };
+
+export const LongStory = () => {
+	return (
+		<Container>
+			<ArticleTitle
+				// eslint-disable-next-line react/jsx-props-no-spreading
+				{...CAPI}
+				format={{
+					display: Display.Standard,
+					theme: Pillar.News,
+					design: Design.Article,
+				}}
+				palette={decidePalette({
+					display: Display.Standard,
+					theme: Pillar.News,
+					design: Design.Article,
+				})}
+				tags={[
+					{
+						id: '',
+						title:
+							"Edward Snowden's choice of Hong Kong as haven is a high-stakes gamble",
+						type: 'Series',
+					},
+				]}
+			/>
+		</Container>
+	);
+};
+LongStory.story = { name: 'Long title' };
+
+export const LongWord = () => {
+	return (
+		<Container>
+			<ArticleTitle
+				// eslint-disable-next-line react/jsx-props-no-spreading
+				{...CAPI}
+				format={{
+					display: Display.Standard,
+					theme: Pillar.News,
+					design: Design.Article,
+				}}
+				palette={decidePalette({
+					display: Display.Standard,
+					theme: Pillar.News,
+					design: Design.Article,
+				})}
+				tags={[
+					{
+						id: '',
+						title: 'Antidisestablishmentarianism',
+						type: 'Series',
+					},
+				]}
+			/>
+		</Container>
+	);
+};
+LongWord.story = { name: 'Long word' };

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -101,6 +101,10 @@ const displayBlock = css`
 	display: block;
 `;
 
+const breakWord = css`
+	word-break: break-word;
+`;
+
 const titleBadgeWrapper = css`
 	margin-bottom: ${space[1]}px;
 	margin-top: ${space[1]}px;
@@ -156,6 +160,7 @@ export const SeriesSectionLink = ({
 										sectionLabelLink,
 										marginRight,
 										fontStyles(format),
+										breakWord,
 										css`
 											color: ${palette.text.seriesTitle};
 											background-color: ${palette
@@ -181,6 +186,7 @@ export const SeriesSectionLink = ({
 											sectionLabelLink,
 											fontStyles(format),
 											displayBlock,
+											breakWord,
 											css`
 												color: ${palette.text
 													.sectionTitle};
@@ -212,6 +218,7 @@ export const SeriesSectionLink = ({
 									sectionLabelLink,
 									marginRight,
 									fontStyles(format),
+									breakWord,
 									css`
 										color: ${palette.text.sectionTitle};
 										background-color: ${palette.background
@@ -255,6 +262,7 @@ export const SeriesSectionLink = ({
 										sectionLabelLink,
 										fontStyles(format),
 										invertedStyle,
+										breakWord,
 										css`
 											color: ${palette.text.seriesTitle};
 											background-color: ${palette
@@ -300,6 +308,7 @@ export const SeriesSectionLink = ({
 								`,
 								marginRight,
 								fontStyles(format),
+								breakWord,
 								css`
 									box-shadow: -6px 0 0 0
 											${palette.background.seriesTitle},
@@ -320,6 +329,7 @@ export const SeriesSectionLink = ({
 									sectionLabelLink,
 									secondaryFontStyles(format),
 									displayBlock,
+									breakWord,
 									css`
 										color: ${palette.text.sectionTitle};
 										background-color: ${palette.background
@@ -348,6 +358,7 @@ export const SeriesSectionLink = ({
 						`,
 						marginRight,
 						fontStyles(format),
+						breakWord,
 					)}
 					data-component="section"
 					data-link-name="article section"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Ensures that longer words in the article title are wrapped to a new line

### Before
![Screenshot 2021-03-22 at 11 07 26](https://user-images.githubusercontent.com/1336821/111981058-1182a400-8aff-11eb-870f-0b13ef705eff.jpg)


### After
![Screenshot 2021-03-22 at 11 08 16](https://user-images.githubusercontent.com/1336821/111981066-13e4fe00-8aff-11eb-8388-d5ff0ce18622.jpg)

## Why?
To stop text escaping out of the left column
