### PR TITLE
Reactive stars

### DIFF
--- a/src/amp/components/StarRating.tsx
+++ b/src/amp/components/StarRating.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css, cx } from 'emotion';
-import Star from '@frontend/static/icons/star.svg';
+import { Star } from '@frontend/static/icons/Star';
 import { palette } from '@guardian/src-foundations';
 
 const ratingsWrapper = css`
@@ -24,11 +24,6 @@ const smallSize = css`
 	}
 `;
 
-const emptyStar = css`
-	fill: transparent;
-	stroke: ${palette.neutral[7]};
-`;
-
 export const StarRating: React.FC<{
 	rating: number;
 	size: string;
@@ -37,12 +32,9 @@ export const StarRating: React.FC<{
 	const stars = (n: number) => {
 		return Array(5)
 			.fill(0)
-			.map((el, i) => {
-				if (i < n) {
-					return <Star key={i} />;
-				}
-				return <Star className={emptyStar} key={i} />;
-			});
+			.map((el, i) => (
+				<Star starId={`${size}${i}`} isEmpty={i >= n} key={i} />
+			));
 	};
 	return <div className={cx(ratingsWrapper, sizeClass)}>{stars(rating)}</div>;
 };

--- a/src/static/icons/Star.tsx
+++ b/src/static/icons/Star.tsx
@@ -1,0 +1,37 @@
+import { neutral } from '@guardian/src-foundations/palette';
+import React from 'react';
+
+export const Star = ({
+	starId = '000',
+	isEmpty,
+}: {
+	starId: string;
+	isEmpty: boolean;
+}) => {
+	if (isEmpty)
+		return (
+			<svg width="14" height="13" viewBox="0 0 14 13">
+				<path
+					id={`star-${starId}`}
+					clipPath={`url(#clip-${starId})`}
+					strokeWidth="2"
+					stroke={neutral[7]}
+					fill="transparent"
+					d="M0 5.2L3.7 8l-1.4 4.6.5.4 3.7-2.8 3.7 2.8.5-.4L9.3 8 13 5.2l-.2-.6H8.2L6.8 0h-.6L4.8 4.6H.2l-.2.6z"
+				/>
+				<clipPath id={`clip-${starId}`}>
+					<use xlinkHref={`#star-${starId}`} stroke="none" />
+				</clipPath>
+			</svg>
+		);
+
+	return (
+		<svg width="14" height="13" viewBox="0 0 14 13">
+			<path
+				fill={neutral[7]}
+				strokeWidth="0"
+				d="M0 5.2L3.7 8l-1.4 4.6.5.4 3.7-2.8 3.7 2.8.5-.4L9.3 8 13 5.2l-.2-.6H8.2L6.8 0h-.6L4.8 4.6H.2l-.2.6z"
+			/>
+		</svg>
+	);
+};

--- a/src/static/icons/Star.tsx
+++ b/src/static/icons/Star.tsx
@@ -2,7 +2,7 @@ import { neutral } from '@guardian/src-foundations/palette';
 import React from 'react';
 
 export const Star = ({
-	starId = '000',
+	starId,
 	isEmpty,
 }: {
 	starId: string;

--- a/src/static/icons/star.svg
+++ b/src/static/icons/star.svg
@@ -1,8 +1,0 @@
-<svg width="14" height="13" viewBox="0 0 14 13">
-    <path id="star" clip-path="url(#clip)" stroke-width="2"
-        d="M0 5.2L3.7 8l-1.4 4.6.5.4 3.7-2.8 3.7 2.8.5-.4L9.3 8 13 5.2l-.2-.6H8.2L6.8 0h-.6L4.8 4.6H.2l-.2.6z">
-    </path>
-    <clipPath id="clip">
-        <use xlink:href="#star" stroke="none" />
-    </clipPath>
-</svg>

--- a/src/web/components/StarRating/StarRating.tsx
+++ b/src/web/components/StarRating/StarRating.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { css } from 'emotion';
 import { Star } from '@frontend/static/icons/Star';
-import { neutral } from '@guardian/src-foundations/palette';
 
 // https://docs.google.com/spreadsheets/d/1QUa5Kh734J4saFc8ERjCYHZu10_-Hj7llNa2rr8urNg/edit?usp=sharing
 // A list style variations for each breakpoint
@@ -12,11 +11,6 @@ const starWrapper = css`
 `;
 
 type SizeType = 'large' | 'medium' | 'small';
-
-const emptyStar = css`
-	fill: transparent;
-	stroke: ${neutral[7]};
-`;
 
 const determineSize = (size: SizeType) => {
 	switch (size) {

--- a/src/web/components/StarRating/StarRating.tsx
+++ b/src/web/components/StarRating/StarRating.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from 'emotion';
-import Star from '@frontend/static/icons/star.svg';
+import { Star } from '@frontend/static/icons/Star';
 import { neutral } from '@guardian/src-foundations/palette';
 
 // https://docs.google.com/spreadsheets/d/1QUa5Kh734J4saFc8ERjCYHZu10_-Hj7llNa2rr8urNg/edit?usp=sharing
@@ -53,19 +53,19 @@ export const StarRating: React.FC<{
 }> = ({ rating, size }) => (
 	<div className={determineSize(size)}>
 		<div className={starWrapper}>
-			<Star className={rating < 1 && emptyStar} />
+			<Star starId={`${size}1`} isEmpty={rating < 1} />
 		</div>
 		<div className={starWrapper}>
-			<Star className={rating < 2 && emptyStar} />
+			<Star starId={`${size}2`} isEmpty={rating < 2} />
 		</div>
 		<div className={starWrapper}>
-			<Star className={rating < 3 && emptyStar} />
+			<Star starId={`${size}3`} isEmpty={rating < 3} />
 		</div>
 		<div className={starWrapper}>
-			<Star className={rating < 4 && emptyStar} />
+			<Star starId={`${size}4`} isEmpty={rating < 4} />
 		</div>
 		<div className={starWrapper}>
-			<Star className={rating < 5 && emptyStar} />
+			<Star starId={`${size}5`} isEmpty={rating < 5} />
 		</div>
 	</div>
 );


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Make star SVG component a first-class React citizen. Remove unused code and ensure that `id` is _more_ unique.

This fixes an issue in onward content cards where the `clip-path` might not be displayed.

### Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/112175694-d69b7180-8bcd-11eb-9855-5c25e08fe3ba.png
[after]: https://user-images.githubusercontent.com/76776/112175827-f337a980-8bcd-11eb-9357-d7dddc0d489b.png

## Why?

Follow-up and improvement from #2479.
