### PR TITLE
Stop long word edge cases overflowing in narrow viewports

### DIFF
--- a/src/web/components/elements/TextBlockComponent.stories.tsx
+++ b/src/web/components/elements/TextBlockComponent.stories.tsx
@@ -19,6 +19,8 @@ const badMarkup =
 	'<html>\n <head></head>\n <body>\n  <p>In its <a href="https://www.admiral.com/magazine/guides/home/the-jargon-free-guide-to-bicycle-insurance" title="">guide to protecting your bike</a>, the insurer Admiral cites the Kryptonite New York M18 U-lock as being good quality. It costs <a href="http://go.theguardian.com/?id=114047X1572903&amp;url=https%3A%2F%2Fwww.wiggle.co.uk%2Fkryptonite-new-york-m18-u-lock&amp;sref=https://www.theguardian.com/money/2020/jul/18/bike-theft-uk-cycle-sales-best-locks-insurance-bicycle.json?dcr" title="">£82.99 at Wiggle.co.uk</a>. Add a <a href="http://go.theguardian.com/?id=114047X1572903&amp;url=https%3A%2F%2Fwww.wiggle.co.uk%2Fkryptonite-kryptoflex-7-foot-cable-bike-lock%2F&amp;sref=https://www.theguardian.com/money/2020/jul/18/bike-theft-uk-cycle-sales-best-locks-insurance-bicycle.json?dcr" title="">cable</a> for another tenner, so you can loop it through the wheels and secure them, too.</p>\n </body>\n</html>';
 const htmlWithDot =
 	'<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesquepharetra libero nec varius feugiat. Nulla commodo sagittis erat amalesuada. Ut iaculis interdum eros, et tristique ex. In veldignissim arcu. Nulla nisi urna, laoreet a aliquam at, viverra eueros. Proin imperdiet pellentesque turpis sed luctus. Donecdignissim lacus in risus fermentum maximus eu vel justo. Duis nontortor ac elit dapibus imperdiet ut at risus. Etiam pretium, odioeget accumsan venenatis, tortor mi aliquet nisl, vel ullamcorperneque nulla vel elit.<br><span data-dcr-style="bullet"></span> Etiam porta mauris nec sagittis luctus.</p>';
+const longWords =
+	'<p>Test In Mobile Modes</p><br><p>This is to test whether extremely long edge case words are wrapped when in mobile portrait. Word one: Pneumonoultramicroscopicsilicovolcanoconiosis. Word two: Hippopotomonstrosesquippedaliophobia. Word three: Pseudopseudohypoparathyroidism. Link test: https://www.theguardian.com/commentisfree/2021/mar/24/trust-britain-covid-vaccine-compromise?dcr</p>';
 
 const containerStyles = css`
 	max-width: 620px;
@@ -209,3 +211,20 @@ export const dotStory = () => {
 	);
 };
 dotStory.story = { name: 'With Dot' };
+
+export const longWordStory = () => {
+	return (
+		<div className={containerStyles}>
+			<TextBlockComponent
+				html={longWords}
+				format={{
+					theme: Pillar.News,
+					design: Design.Article,
+					display: Display.Standard,
+				}}
+				isFirstParagraph={false}
+			/>
+		</div>
+	);
+};
+longWordStory.story = { name: 'Long Words' };

--- a/src/web/components/elements/TextBlockComponent.tsx
+++ b/src/web/components/elements/TextBlockComponent.tsx
@@ -3,7 +3,7 @@ import { css } from 'emotion';
 
 import { neutral } from '@guardian/src-foundations/palette';
 import { body, textSans } from '@guardian/src-foundations/typography';
-import { from } from '@guardian/src-foundations/mq';
+import { from, until } from '@guardian/src-foundations/mq';
 import { sanitise } from '@frontend/lib/sanitise-html';
 
 import { unwrapHtml } from '@root/src/model/unwrapHtml';
@@ -162,6 +162,13 @@ const paraStyles = (format: Format) => css`
 		width: 0.75rem;
 		margin-right: 0.125rem;
 		background-color: ${decidePalette(format).background.bullet};
+	}
+
+	${until.tablet} {
+		/* 	To stop long words going outside of the view port.
+			For compatibility */
+		overflow-wrap: anywhere;
+		word-wrap: break-word;
 	}
 `;
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

In extremely rare cases (usually on mobile and when URLs are written in the article) they can break out of the viewport. This fix should hopefully stop that from happening.

This is only set until tablet at which point it shouldn't cause a problem.

### Before

<img width="428" alt="Screenshot 2021-03-24 at 10 35 32" src="https://user-images.githubusercontent.com/35331926/112307385-cac8b180-8c98-11eb-8258-24bc9272afeb.png">

### After

<img width="428" alt="Screenshot 2021-03-24 at 10 36 27" src="https://user-images.githubusercontent.com/35331926/112307418-d1efbf80-8c98-11eb-99f7-83eb0e833d05.png">

