### PR TITLE
Update Facebook App ID

### DIFF
--- a/src/web/components/ShareIcons.tsx
+++ b/src/web/components/ShareIcons.tsx
@@ -94,7 +94,7 @@ export const ShareIcons = ({
 			{displayIcons.includes('facebook') && (
 				<li className={liStyles(size)} key="facebook">
 					<a
-						href={`https://www.facebook.com/dialog/share?app_id=202314643182694&href=${encodeUrl(
+						href={`https://www.facebook.com/dialog/share?app_id=180444840287&href=${encodeUrl(
 							pageId,
 						)}&CMP=share_btn_fb`}
 						role="button"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Uses the PROD Facebook app ID - looks like we were using the DEV one by accident and that suddenly stopped working today.