### PR TITLE
Update Facebook App ID for AMP

### DIFF
--- a/src/lib/sharing-urls.ts
+++ b/src/lib/sharing-urls.ts
@@ -34,7 +34,7 @@ export const getSharingUrls = (
 		facebook: {
 			userMessage: 'Share on Facebook',
 			params: {
-				app_id: '202314643182694',
+				app_id: '180444840287',
 				href: articleUrl,
 				CMP: 'share_btn_fb',
 			},


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Updates to use the PROD facebook app ID for AMP as well. Note: this is just temporary quick fix - ideally this should be in env-specific config somewhere.