### PR TITLE
Move BrazeEpic to new epic url

### DIFF
--- a/src/web/components/SlotBodyEnd/BrazeEpic.tsx
+++ b/src/web/components/SlotBodyEnd/BrazeEpic.tsx
@@ -20,7 +20,7 @@ const wrapperMargins = css`
 	margin: 18px 0;
 `;
 
-const EPIC_COMPONENT_PATH = '/epic.js';
+const EPIC_COMPONENT_PATH = '/modules/v1/epics/ContributionsEpic.js';
 
 type Meta = {
 	dataFromBraze?: EpicDataFromBraze;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

This updates the epic URL used by BrazeEpic. The endpoint used by contributions has changed, so we also need to change.

The new endpoint is [https://contributions.guardianapis.com/modules/v1/epics/ContributionsEpic.js](https://contributions.guardianapis.com/modules/v1/epics/ContributionsEpic.js)