### PR TITLE
fix: Prevent layout shift for top above nav slot by using toggled ad …

### DIFF
--- a/src/web/components/AdSlot.tsx
+++ b/src/web/components/AdSlot.tsx
@@ -1,10 +1,9 @@
-/* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 import { css, cx } from 'emotion';
 
 import { border, neutral, text } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
-import { from } from '@guardian/src-foundations/mq';
+import { from, until } from '@guardian/src-foundations/mq';
 import { Display } from '@guardian/types';
 
 type Props = {
@@ -46,18 +45,34 @@ enum Size {
 	empty = '2,2',
 }
 
+const adSlotLabelStyles = css`
+	${textSans.xsmall()};
+	position: relative;
+	height: 24px;
+	background-color: ${neutral[97]};
+	padding: 0 8px;
+	border-top: 1px solid ${border.secondary};
+	color: ${text.supporting};
+	text-align: left;
+	box-sizing: border-box;
+	&.visible {
+		visibility: initial;
+	}
+	&.hidden {
+		visibility: hidden;
+	}
+	&.ad-slot__label--toggle {
+		margin: 0 auto;
+		${until.tablet} {
+			display: none;
+		}
+	}
+`;
+
 export const labelStyles = css`
 	.ad-slot__label,
 	.ad-slot__scroll {
-		${textSans.xsmall()};
-		position: relative;
-		height: 24px;
-		background-color: ${neutral[97]};
-		padding: 0 8px;
-		border-top: 1px solid ${border.secondary};
-		color: ${text.supporting};
-		text-align: left;
-		box-sizing: border-box;
+		${adSlotLabelStyles}
 	}
 
 	.ad-slot__close-button {
@@ -126,6 +141,19 @@ const mobileStickyAdStyles = css`
 		${textSans.xsmall()};
 	}
 `;
+
+const AdSlotLabelToggled: React.FC = () => (
+	<div
+		className={cx(
+			'ad-slot__label',
+			'ad-slot__label--toggle',
+			'hidden',
+			adSlotLabelStyles,
+		)}
+	>
+		Advertisement
+	</div>
+);
 
 export const AdSlot: React.FC<Props> = ({ position, display }) => {
 	switch (position) {
@@ -267,52 +295,55 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 		case 'top-above-nav': {
 			const adSlotAboveNav = css`
 				margin: 0 auto;
-				height: 151px;
+				min-height: 108px;
 				padding-bottom: 18px;
 				text-align: left;
 				display: table;
 				width: 728px;
 			`;
 			return (
-				<div
-					id="dfp-ad--top-above-nav"
-					className={cx(
-						'js-ad-slot',
-						'ad-slot',
-						'ad-slot--top-above-nav',
-						'ad-slot--mpu-banner-ad',
-						'ad-slot--rendered',
-						css`
-							position: relative;
-						`,
-						labelStyles,
-						adSlotAboveNav,
-					)}
-					data-link-name="ad slot top-above-nav"
-					data-name="top-above-nav"
-					// The sizes here come from two places in the frontend code
-					// 1. file mark: 432b3a46-90c1-4573-90d3-2400b51af8d0
-					// 2. file mark: c66fae4e-1d29-467a-a081-caad7a90cacd
-					data-tablet={[
-						`${Size.outOfPage}`,
-						`${Size.empty}`,
-						`${Size.fabric}`,
-						`${Size.fluid}`,
-						`${Size.leaderboard}`,
-					].join('|')}
-					data-desktop={[
-						`${Size.outOfPage}`,
-						`${Size.empty}`,
-						`${Size.leaderboard}`,
-						`940,230`,
-						`900,250`,
-						`${Size.billboard}`,
-						`${Size.fabric}`,
-						`${Size.fluid}`,
-					].join('|')}
-					// Values from file mark: c66fae4e-1d29-467a-a081-caad7a90cacd
-					aria-hidden="true"
-				/>
+				<>
+					<AdSlotLabelToggled />
+					<div
+						id="dfp-ad--top-above-nav"
+						className={cx(
+							'js-ad-slot',
+							'ad-slot',
+							'ad-slot--top-above-nav',
+							'ad-slot--mpu-banner-ad',
+							'ad-slot--rendered',
+							css`
+								position: relative;
+							`,
+							labelStyles,
+							adSlotAboveNav,
+						)}
+						data-link-name="ad slot top-above-nav"
+						data-name="top-above-nav"
+						// The sizes here come from two places in the frontend code
+						// 1. file mark: 432b3a46-90c1-4573-90d3-2400b51af8d0
+						// 2. file mark: c66fae4e-1d29-467a-a081-caad7a90cacd
+						data-tablet={[
+							`${Size.outOfPage}`,
+							`${Size.empty}`,
+							`${Size.fabric}`,
+							`${Size.fluid}`,
+							`${Size.leaderboard}`,
+						].join('|')}
+						data-desktop={[
+							`${Size.outOfPage}`,
+							`${Size.empty}`,
+							`${Size.leaderboard}`,
+							`940,230`,
+							`900,250`,
+							`${Size.billboard}`,
+							`${Size.fabric}`,
+							`${Size.fluid}`,
+						].join('|')}
+						// Values from file mark: c66fae4e-1d29-467a-a081-caad7a90cacd
+						aria-hidden="true"
+					/>
+				</>
 			);
 		}
 		case 'mostpop': {


### PR DESCRIPTION
## What does this change?

DCR counterpart to: https://github.com/guardian/frontend/pull/23613

Removes the layout shift caused by the dynamic insertion of the advertisement label into the top banner (aka top-above-nav).

The change is to add the label to the top banner template.

This reserves its height so when shown it does not shift content downwards.

At runtime, when an ad is available, [render-advert-label](https://github.com/guardian/frontend/blob/1d462478295c13a2f3dbc47ad96609f824a8d9e8/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts#L68):
- checks if the label should be shown
- detects if a toggled label exists

If so the toggled label is:

- made visible
- has its width set to match the advert and centre it correctly

Fyi we are planning another look at the way labels are handled. Ideally we'd like to push everything into GAM and remove any custom code.

### Before

![layout-shift-before-dcr](https://user-images.githubusercontent.com/7014230/112859896-32bd3480-90ab-11eb-935f-a5c6cef43960.gif)

### After

![layout-shift-after-dcr](https://user-images.githubusercontent.com/7014230/112859928-3cdf3300-90ab-11eb-9d47-877ffcaef6f5.gif)

## Why?

Reduces annoyance to users
Improves core web vitals scores