### PR TITLE
`DeadBlog` | Colours and spacing

### DIFF
--- a/src/web/components/ArticleHeadlinePadding.tsx
+++ b/src/web/components/ArticleHeadlinePadding.tsx
@@ -15,29 +15,29 @@ const determinePadding = ({
 	switch (design) {
 		case Design.Interview:
 			return css`
-				${space[1]}px;
+				padding-top: ${space[1]}px;
 			`;
 		case Design.Review:
 			if (starRating) {
 				return '';
 			}
 			return css`
-				${space[6]}px;
+				padding-bottom: ${space[6]}px;
 				${from.tablet} {
-					${space[9]}px;
+					padding-bottom: ${space[9]}px;
 				}
 			`;
 		case Design.LiveBlog:
 		case Design.DeadBlog:
 			return css`
-				${space[1]}px;
+				padding-top: ${space[1]}px;
 			`;
 		default:
 			return css`
-				${space[1]}px;
-				${space[6]}px;
+				padding-top: ${space[1]}px;
+				padding-bottom: ${space[6]}px;
 				${from.tablet} {
-					${space[9]}px;
+					padding-bottom: ${space[9]}px;
 				}
 			`;
 	}

--- a/src/web/components/ArticleHeadlinePadding.tsx
+++ b/src/web/components/ArticleHeadlinePadding.tsx
@@ -3,6 +3,7 @@ import { css } from 'emotion';
 
 import { Design } from '@guardian/types';
 import { from } from '@guardian/src-foundations/mq';
+import { space } from '@guardian/src-foundations';
 
 const determinePadding = ({
 	design,
@@ -14,29 +15,29 @@ const determinePadding = ({
 	switch (design) {
 		case Design.Interview:
 			return css`
-				padding-top: 3px;
+				${space[1]}px;
 			`;
 		case Design.Review:
 			if (starRating) {
 				return '';
 			}
 			return css`
-				padding-bottom: 24px;
+				${space[6]}px;
 				${from.tablet} {
-					padding-bottom: 36px;
+					${space[9]}px;
 				}
 			`;
 		case Design.LiveBlog:
 		case Design.DeadBlog:
 			return css`
-				padding-top: 3px;
+				${space[1]}px;
 			`;
 		default:
 			return css`
-				padding-top: 3px;
-				padding-bottom: 24px;
+				${space[1]}px;
+				${space[6]}px;
 				${from.tablet} {
-					padding-bottom: 36px;
+					${space[9]}px;
 				}
 			`;
 	}

--- a/src/web/components/ArticleHeadlinePadding.tsx
+++ b/src/web/components/ArticleHeadlinePadding.tsx
@@ -29,9 +29,8 @@ const determinePadding = ({
 			`;
 		case Design.LiveBlog:
 		case Design.DeadBlog:
-			return css`
-				padding-top: ${space[1]}px;
-			`;
+			// Don't add extra padding for live or dead blogs
+			return css``;
 		default:
 			return css`
 				padding-top: ${space[1]}px;

--- a/src/web/components/ArticleHeadlinePadding.tsx
+++ b/src/web/components/ArticleHeadlinePadding.tsx
@@ -26,6 +26,11 @@ const determinePadding = ({
 					padding-bottom: 36px;
 				}
 			`;
+		case Design.LiveBlog:
+		case Design.DeadBlog:
+			return css`
+				padding-top: 3px;
+			`;
 		default:
 			return css`
 				padding-top: 3px;

--- a/src/web/components/Standfirst.tsx
+++ b/src/web/components/Standfirst.tsx
@@ -110,6 +110,16 @@ const standfirstStyles = (format: Format, palette: Palette) => {
 						max-width: 540px;
 						color: ${palette.text.standfirst};
 					`;
+				case Design.LiveBlog:
+				case Design.DeadBlog:
+					return css`
+						${headline.xxxsmall({
+							fontWeight: 'bold',
+						})};
+						line-height: 20px;
+						max-width: 540px;
+						color: ${palette.text.standfirst};
+					`;
 				default:
 					return css`
 						${format.theme === Special.Labs

--- a/src/web/components/Standfirst.tsx
+++ b/src/web/components/Standfirst.tsx
@@ -117,6 +117,8 @@ const standfirstStyles = (format: Format, palette: Palette) => {
 							fontWeight: 'bold',
 						})};
 						line-height: 20px;
+						margin-top: ${space[1]}px;
+						margin-bottom: ${space[3]}px;
 						max-width: 540px;
 						color: ${palette.text.standfirst};
 					`;

--- a/src/web/layouts/LiveLayout.tsx
+++ b/src/web/layouts/LiveLayout.tsx
@@ -18,7 +18,6 @@ import { RightColumn } from '@root/src/web/components/RightColumn';
 import { ArticleTitle } from '@root/src/web/components/ArticleTitle';
 import { ArticleContainer } from '@root/src/web/components/ArticleContainer';
 import { ArticleMeta } from '@root/src/web/components/ArticleMeta';
-import { MostViewedRightIsland } from '@root/src/web/components/MostViewedRightIsland';
 import { SubMeta } from '@root/src/web/components/SubMeta';
 import { MainMedia } from '@root/src/web/components/MainMedia';
 import { ArticleHeadline } from '@root/src/web/components/ArticleHeadline';
@@ -71,19 +70,6 @@ const LiveGrid = ({ children }: { children: React.ReactNode }) => (
 
 				grid-column-gap: 10px;
 
-				${from.wide} {
-					grid-template-columns:
-						309px /* Left Column (220 - 1px border) */
-						1px /* Empty border for spacing */
-						1fr /* Main content */
-						340px; /* Right Column */
-					grid-template-areas:
-						'lines border media        right-column'
-						'meta  border media        right-column'
-						'meta  border body         right-column'
-						'.     border .            right-column';
-				}
-
 				${from.desktop} {
 					grid-template-columns:
 						309px /* Left Column (220 - 1px border) */
@@ -94,6 +80,19 @@ const LiveGrid = ({ children }: { children: React.ReactNode }) => (
 						'meta  border media'
 						'meta  border body'
 						'.     border .';
+				}
+
+				${from.wide} {
+					grid-template-columns:
+						309px
+						1px
+						1fr
+						340px;
+					grid-template-areas:
+						'lines border media right-column'
+						'meta  border media right-column'
+						'meta  border body  right-column'
+						'.     border .     right-column';
 				}
 
 				${until.desktop} {
@@ -467,11 +466,6 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 									position="right"
 									display={format.display}
 								/>
-								{!isPaidContent ? (
-									<MostViewedRightIsland />
-								) : (
-									<></>
-								)}
 							</RightColumn>
 						</div>
 					</GridItem>

--- a/src/web/layouts/LiveLayout.tsx
+++ b/src/web/layouts/LiveLayout.tsx
@@ -267,6 +267,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 							backgroundColour={palette.background.article}
 							padded={false}
 							sectionId="sub-nav-root"
+							borderColour={palette.border.article}
 						>
 							<SubNav
 								subNavSections={NAV.subNavSections}
@@ -280,6 +281,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 						backgroundColour={palette.background.article}
 						padded={false}
 						showTopBorder={false}
+						borderColour={palette.border.article}
 					>
 						<GuardianLines count={4} pillar={format.theme} />
 					</Section>
@@ -342,7 +344,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 			<ContainerLayout
 				showTopBorder={false}
 				backgroundColour={palette.background.article}
-				borderColour={neutral[86]}
+				borderColour={palette.border.article}
 				sideBorders={true}
 				leftColSize="wide"
 			/>
@@ -350,6 +352,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 			<Section
 				showTopBorder={false}
 				backgroundColour={palette.background.article}
+				borderColour={palette.border.article}
 			>
 				<LiveGrid>
 					<GridItem area="media">

--- a/src/web/layouts/LiveLayout.tsx
+++ b/src/web/layouts/LiveLayout.tsx
@@ -337,6 +337,7 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				borderColour={palette.border.standfirst}
 				sideBorders={true}
 				leftColSize="wide"
+				verticalMargins={false}
 			>
 				<Standfirst format={format} standfirst={CAPI.standfirst} />
 			</ContainerLayout>

--- a/src/web/layouts/LiveLayout.tsx
+++ b/src/web/layouts/LiveLayout.tsx
@@ -48,6 +48,7 @@ import {
 	SendToBack,
 	BannerWrapper,
 } from '@root/src/web/layouts/lib/stickiness';
+import { space } from '@guardian/src-foundations';
 import { ContainerLayout } from '../components/ContainerLayout';
 
 const LiveGrid = ({ children }: { children: React.ReactNode }) => (
@@ -341,13 +342,17 @@ export const LiveLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				<Standfirst format={format} standfirst={CAPI.standfirst} />
 			</ContainerLayout>
 
-			<ContainerLayout
+			<Section
 				showTopBorder={false}
-				backgroundColour={palette.background.article}
 				borderColour={palette.border.article}
-				sideBorders={true}
-				leftColSize="wide"
-			/>
+				backgroundColour={palette.background.article}
+			>
+				<div
+					className={css`
+						height: ${space[4]}px;
+					`}
+				/>
+			</Section>
 
 			<Section
 				showTopBorder={false}

--- a/src/web/layouts/Standard.stories.tsx
+++ b/src/web/layouts/Standard.stories.tsx
@@ -24,7 +24,6 @@ import { embedIframe } from '@root/src/web/browser/embedIframe/embedIframe';
 import { mockRESTCalls } from '@root/src/web/lib/mockRESTCalls';
 
 import { extractNAV } from '@root/src/model/extract-nav';
-import { Design } from '@guardian/types';
 import { DecideLayout } from './DecideLayout';
 
 mockRESTCalls();

--- a/src/web/layouts/Standard.stories.tsx
+++ b/src/web/layouts/Standard.stories.tsx
@@ -24,6 +24,7 @@ import { embedIframe } from '@root/src/web/browser/embedIframe/embedIframe';
 import { mockRESTCalls } from '@root/src/web/lib/mockRESTCalls';
 
 import { extractNAV } from '@root/src/model/extract-nav';
+import { Design } from '@guardian/types';
 import { DecideLayout } from './DecideLayout';
 
 mockRESTCalls();
@@ -122,9 +123,9 @@ FeatureStory.story = { name: 'Feature' };
 export const LiveStory = (): React.ReactNode => {
 	const LiveBlog = {
 		...Live,
-		config: {
-			...Live.config,
-			isLive: true,
+		format: {
+			...Live.format,
+			design: 'LiveBlogDesign' as CAPIDesign,
 		},
 	};
 	const ServerCAPI = convertToStandard(LiveBlog);
@@ -135,9 +136,9 @@ LiveStory.story = { name: 'LiveBlog' };
 export const DeadStory = (): React.ReactNode => {
 	const DeadBlog = {
 		...Live,
-		config: {
-			...Live.config,
-			isLive: false,
+		format: {
+			...Live.format,
+			design: 'DeadBlogDesign' as CAPIDesign,
 		},
 	};
 	const ServerCAPI = convertToStandard(DeadBlog);

--- a/src/web/lib/decidePalette.ts
+++ b/src/web/lib/decidePalette.ts
@@ -462,6 +462,8 @@ const backgroundStandfirst = (format: Format): string => {
 	switch (format.design) {
 		case Design.LiveBlog:
 			return pillarPalette[format.theme][300];
+		case Design.DeadBlog:
+			return neutral[86];
 		default:
 			return backgroundArticle(format);
 	}

--- a/src/web/lib/decidePalette.ts
+++ b/src/web/lib/decidePalette.ts
@@ -582,11 +582,13 @@ const borderStandfirstLink = (format: Format): string => {
 
 const borderHeadline = (format: Format): string => {
 	if (format.design === Design.LiveBlog) return '#9F2423';
+	if (format.design === Design.DeadBlog) return '#CDCDCD';
 	return border.secondary;
 };
 
 const borderStandfirst = (format: Format): string => {
 	if (format.design === Design.LiveBlog) return '#8C2222';
+	if (format.design === Design.DeadBlog) return '#BDBDBD';
 	return border.secondary;
 };
 
@@ -624,6 +626,8 @@ const borderNavPillar: (format: Format) => string = (format) =>
 	pillarPalette[format.theme].bright;
 
 const borderArticle: (format: Format) => string = (format) => {
+	if (format.design === Design.LiveBlog || format.design === Design.DeadBlog)
+		return '#CDCDCD';
 	if (format.theme === Special.Labs) return neutral[60];
 	return border.secondary;
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Fixes the palette used for DeadBlogs

### Before
![Screenshot 2021-03-30 at 11 42 11](https://user-images.githubusercontent.com/1336821/112976607-fcd08c80-914c-11eb-96a9-8a0b544b3713.jpg)


### After
![Screenshot 2021-03-30 at 11 40 38](https://user-images.githubusercontent.com/1336821/112976566-ee827080-914c-11eb-8e25-b6a4ce1b8b5c.jpg)


## Why?
Now that we're using CAPI `format` we have the right types set but this exposed some issues with the stories.