### PR TITLE
Add data-link-name attribute to mobile nav column toggle clicks

### DIFF
--- a/src/web/components/Nav/ExpandedMenu/CollapseColumnButton.tsx
+++ b/src/web/components/Nav/ExpandedMenu/CollapseColumnButton.tsx
@@ -89,6 +89,7 @@ export const CollapseColumnButton: React.FC<{
 		tabIndex={-1}
 		role="menuitem"
 		data-cy={`column-collapse-${title}`}
+		data-link-name={`nav2 : column-toggle-${title}: show`}
 	>
 		{title}
 	</label>

--- a/src/web/components/Nav/StickNavTest/ExpandedMenu/CollapseColumnButton.tsx
+++ b/src/web/components/Nav/StickNavTest/ExpandedMenu/CollapseColumnButton.tsx
@@ -89,6 +89,7 @@ export const CollapseColumnButton: React.FC<{
 		tabIndex={-1}
 		role="menuitem"
 		data-cy={`column-collapse-${title}`}
+		data-link-name={`nav2 : column-toggle-${title}: show`}
 	>
 		{title}
 	</label>


### PR DESCRIPTION
Very small tweak to add better tracking data for mobile nav column toggling. Motivated by the stick nav test.
