### PR TITLE
Simplify type relations

### DIFF
--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -6,16 +6,6 @@ interface ThirdPartyEmbeddedContent {
 	source?: string;
 	sourceDomain?: string;
 }
-
-interface InteractiveAtomBlockElementBase {
-	url: string;
-	placeholderUrl?: string;
-	id?: string;
-	html?: string;
-	css?: string;
-	js?: string;
-}
-
 interface AudioAtomBlockElement {
 	_type: 'model.dotcomrendering.pageElements.AudioAtomBlockElement';
 	elementId: string;
@@ -66,12 +56,16 @@ interface CalloutBlockElement {
 	role?: RoleType;
 }
 
-interface ChartAtomBlockElement extends InteractiveAtomBlockElementBase {
+interface ChartAtomBlockElement {
 	_type: 'model.dotcomrendering.pageElements.ChartAtomBlockElement';
 	elementId: string;
 	id: string;
+	url: string;
 	html: string;
+    css?: string;
+    js?: string;
 	role?: RoleType;
+	placeholderUrl?: string;
 }
 
 interface QuizAtomBlockElement {
@@ -157,8 +151,14 @@ interface ExplainerAtomBlockElement {
 	role?: RoleType;
 }
 
-interface GenericAtomBlockElement extends InteractiveAtomBlockElementBase {
+interface GenericAtomBlockElement {
 	_type: 'model.dotcomrendering.pageElements.GenericAtomBlockElement';
+    url: string;
+    placeholderUrl?: string;
+    id?: string;
+    html?: string;
+    css?: string;
+    js?: string;
 	elementId: string;
 }
 
@@ -218,13 +218,15 @@ interface InstagramBlockElement extends ThirdPartyEmbeddedContent {
 	role?: RoleType;
 }
 
-interface InteractiveAtomBlockElement extends InteractiveAtomBlockElementBase {
+interface InteractiveAtomBlockElement {
 	_type: 'model.dotcomrendering.pageElements.InteractiveAtomBlockElement';
 	elementId: string;
+	url: string;
 	id: string;
 	js: string;
 	html?: string;
 	css?: string;
+	placeholderUrl?: string;
 	role?: RoleType;
 }
 

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -62,8 +62,8 @@ interface ChartAtomBlockElement {
 	id: string;
 	url: string;
 	html: string;
-    css?: string;
-    js?: string;
+	css?: string;
+	js?: string;
 	role?: RoleType;
 	placeholderUrl?: string;
 }
@@ -153,12 +153,12 @@ interface ExplainerAtomBlockElement {
 
 interface GenericAtomBlockElement {
 	_type: 'model.dotcomrendering.pageElements.GenericAtomBlockElement';
-    url: string;
-    placeholderUrl?: string;
-    id?: string;
-    html?: string;
-    css?: string;
-    js?: string;
+	url: string;
+	placeholderUrl?: string;
+	id?: string;
+	html?: string;
+	css?: string;
+	js?: string;
 	elementId: string;
 }
 

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -946,22 +946,22 @@
                 "id": {
                     "type": "string"
                 },
-                "html": {
-                    "type": "string"
-                },
-                "role": {
-                    "$ref": "#/definitions/RoleType"
-                },
                 "url": {
                     "type": "string"
                 },
-                "placeholderUrl": {
+                "html": {
                     "type": "string"
                 },
                 "css": {
                     "type": "string"
                 },
                 "js": {
+                    "type": "string"
+                },
+                "role": {
+                    "$ref": "#/definitions/RoleType"
+                },
+                "placeholderUrl": {
                     "type": "string"
                 }
             },
@@ -1393,9 +1393,6 @@
                         "model.dotcomrendering.pageElements.GenericAtomBlockElement"
                     ]
                 },
-                "elementId": {
-                    "type": "string"
-                },
                 "url": {
                     "type": "string"
                 },
@@ -1412,6 +1409,9 @@
                     "type": "string"
                 },
                 "js": {
+                    "type": "string"
+                },
+                "elementId": {
                     "type": "string"
                 }
             },
@@ -1797,6 +1797,9 @@
                 "elementId": {
                     "type": "string"
                 },
+                "url": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -1809,14 +1812,11 @@
                 "css": {
                     "type": "string"
                 },
-                "role": {
-                    "$ref": "#/definitions/RoleType"
-                },
-                "url": {
-                    "type": "string"
-                },
                 "placeholderUrl": {
                     "type": "string"
+                },
+                "role": {
+                    "$ref": "#/definitions/RoleType"
                 }
             },
             "required": [
@@ -3946,6 +3946,9 @@
                     "type": "string"
                 },
                 "supporter": {
+                    "type": "string"
+                },
+                "gifting": {
                     "type": "string"
                 }
             },


### PR DESCRIPTION
This mostly removes the confusing fact that `GenericAtomBlockElement` extends from `InteractiveAtomBlockElement(Base)`, also there is no reason why our basic types should have some some sort of hierarchy between them (if not to abstract something really common, which wasn't the case here).

 