### PR TITLE
Hack Cards to fix display issue

### DIFF
--- a/src/web/components/Card/Card.Designs.stories.tsx
+++ b/src/web/components/Card/Card.Designs.stories.tsx
@@ -6,7 +6,7 @@ import { Card } from './Card';
 
 export default {
 	component: Card,
-	title: 'Components/Card/Themes',
+	title: 'Components/Card/Designs',
 	parameters: {
 		viewport: {
 			// This has the effect of turning off the viewports addon by default

--- a/src/web/components/Card/Card.Displays.stories.tsx
+++ b/src/web/components/Card/Card.Displays.stories.tsx
@@ -1,0 +1,45 @@
+import { Design, Display, Pillar } from '@guardian/types';
+
+import { Format } from './Card.Format.stories';
+
+import { Card } from './Card';
+
+export default {
+	component: Card,
+	title: 'Components/Card/Displays',
+	parameters: {
+		viewport: {
+			// This has the effect of turning off the viewports addon by default
+			defaultViewport: 'doesNotExist',
+		},
+	},
+};
+
+const Standard = Format(
+	{
+		display: Display.Standard,
+		theme: Pillar.News,
+		design: Design.Article,
+	},
+	'Standard',
+);
+
+const Showcase = Format(
+	{
+		display: Display.Showcase,
+		theme: Pillar.News,
+		design: Design.Article,
+	},
+	'Showcase',
+);
+
+const Immersive = Format(
+	{
+		display: Display.Immersive,
+		theme: Pillar.News,
+		design: Design.Article,
+	},
+	'Immersive',
+);
+
+export { Immersive, Showcase, Standard };

--- a/src/web/components/Card/Card.Format.stories.tsx
+++ b/src/web/components/Card/Card.Format.stories.tsx
@@ -5,7 +5,6 @@ import { Section } from '@frontend/web/components/Section';
 import { Flex } from '@frontend/web/components/Flex';
 import { LeftColumn } from '@frontend/web/components/LeftColumn';
 import { ArticleContainer } from '@frontend/web/components/ArticleContainer';
-import { decidePalette } from '@root/src/web/lib/decidePalette';
 import { Display, Pillar, Special } from '@guardian/types';
 
 import { Card } from './Card';
@@ -25,10 +24,6 @@ export const Format = (format: Format, title: string) => () => (
 						<Card
 							linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
 							format={{ ...format, theme: Pillar.News }}
-							palette={decidePalette({
-								...format,
-								theme: Pillar.News,
-							})}
 							headlineText="News"
 							standfirst={
 								format.display === Display.Immersive
@@ -56,10 +51,6 @@ export const Format = (format: Format, title: string) => () => (
 						<Card
 							linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
 							format={{ ...format, theme: Pillar.Culture }}
-							palette={decidePalette({
-								...format,
-								theme: Pillar.Culture,
-							})}
 							headlineText="Culture"
 							standfirst={
 								format.display === Display.Immersive
@@ -87,10 +78,6 @@ export const Format = (format: Format, title: string) => () => (
 						<Card
 							linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
 							format={{ ...format, theme: Pillar.Sport }}
-							palette={decidePalette({
-								...format,
-								theme: Pillar.Sport,
-							})}
 							headlineText="Sport"
 							standfirst={
 								format.display === Display.Immersive
@@ -118,10 +105,6 @@ export const Format = (format: Format, title: string) => () => (
 						<Card
 							linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
 							format={{ ...format, theme: Pillar.Opinion }}
-							palette={decidePalette({
-								...format,
-								theme: Pillar.Opinion,
-							})}
 							headlineText="Opinion"
 							standfirst={
 								format.display === Display.Immersive
@@ -146,10 +129,6 @@ export const Format = (format: Format, title: string) => () => (
 						<Card
 							linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
 							format={{ ...format, theme: Pillar.Lifestyle }}
-							palette={decidePalette({
-								...format,
-								theme: Pillar.Lifestyle,
-							})}
 							headlineText="Lifestyle"
 							standfirst={
 								format.display === Display.Immersive
@@ -177,10 +156,6 @@ export const Format = (format: Format, title: string) => () => (
 						<Card
 							linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
 							format={{ ...format, theme: Special.Labs }}
-							palette={decidePalette({
-								...format,
-								theme: Special.Labs,
-							})}
 							headlineText="Labs"
 							standfirst={
 								format.display === Display.Immersive
@@ -208,10 +183,6 @@ export const Format = (format: Format, title: string) => () => (
 						<Card
 							linkTo="/lifeandstyle/2018/mar/10/meera-sodhas-vegan-recipe-for-peanut-and-broccoli-pad-thai"
 							format={{ ...format, theme: Special.SpecialReport }}
-							palette={decidePalette({
-								...format,
-								theme: Special.SpecialReport,
-							})}
 							headlineText="SpecialReport"
 							standfirst={
 								format.display === Display.Immersive

--- a/src/web/components/Card/Card.Layout.stories.tsx
+++ b/src/web/components/Card/Card.Layout.stories.tsx
@@ -7,7 +7,6 @@ import { Section } from '@frontend/web/components/Section';
 import { Flex } from '@frontend/web/components/Flex';
 import { LeftColumn } from '@frontend/web/components/LeftColumn';
 import { ArticleContainer } from '@frontend/web/components/ArticleContainer';
-import { decidePalette } from '@root/src/web/lib/decidePalette';
 
 import { Card } from './Card';
 import { UL } from './components/UL';
@@ -41,11 +40,6 @@ export const News = () => (
 								theme: Pillar.News,
 								design: Design.Article,
 							}}
-							palette={decidePalette({
-								display: Display.Standard,
-								theme: Pillar.News,
-								design: Design.Article,
-							})}
 							headlineText={headlines[0]}
 							headlineSize="large"
 							kickerText={kickers[4]}
@@ -68,11 +62,6 @@ export const News = () => (
 								theme: Pillar.News,
 								design: Design.Article,
 							}}
-							palette={decidePalette({
-								display: Display.Standard,
-								theme: Pillar.News,
-								design: Design.Article,
-							})}
 							headlineText={headlines[1]}
 							headlineSize="large"
 							kickerText={kickers[0]}
@@ -91,11 +80,6 @@ export const News = () => (
 								theme: Pillar.Culture,
 								design: Design.Article,
 							}}
-							palette={decidePalette({
-								display: Display.Standard,
-								theme: Pillar.Culture,
-								design: Design.Article,
-							})}
 							headlineText={headlines[2]}
 							kickerText={kickers[1]}
 							imageUrl={images[3]}
@@ -118,11 +102,6 @@ export const News = () => (
 										theme: Pillar.Opinion,
 										design: Design.Editorial,
 									}}
-									palette={decidePalette({
-										display: Display.Standard,
-										theme: Pillar.Opinion,
-										design: Design.Editorial,
-									})}
 									headlineText={headlines[3]}
 									kickerText="Editorial"
 									imageUrl={images[6]}
@@ -138,11 +117,6 @@ export const News = () => (
 										theme: Special.SpecialReport,
 										design: Design.Article,
 									}}
-									palette={decidePalette({
-										display: Display.Standard,
-										theme: Special.SpecialReport,
-										design: Design.Article,
-									})}
 									headlineText={headlines[4]}
 									headlineSize="small"
 								/>
@@ -155,11 +129,6 @@ export const News = () => (
 										theme: Pillar.News,
 										design: Design.Article,
 									}}
-									palette={decidePalette({
-										display: Display.Standard,
-										theme: Pillar.News,
-										design: Design.Article,
-									})}
 									headlineText={headlines[5]}
 									headlineSize="small"
 									kickerText={kickers[3]}
@@ -182,11 +151,6 @@ export const News = () => (
 										theme: Pillar.Sport,
 										design: Design.Article,
 									}}
-									palette={decidePalette({
-										display: Display.Standard,
-										theme: Pillar.Sport,
-										design: Design.Article,
-									})}
 									headlineText={headlines[6]}
 									headlineSize="small"
 									kickerText={kickers[3]}
@@ -201,11 +165,6 @@ export const News = () => (
 										theme: Pillar.News,
 										design: Design.Article,
 									}}
-									palette={decidePalette({
-										display: Display.Standard,
-										theme: Pillar.News,
-										design: Design.Article,
-									})}
 									headlineText={headlines[7]}
 									headlineSize="small"
 									kickerText={kickers[1]}
@@ -219,11 +178,6 @@ export const News = () => (
 										theme: Pillar.News,
 										design: Design.Article,
 									}}
-									palette={decidePalette({
-										display: Display.Standard,
-										theme: Pillar.News,
-										design: Design.Article,
-									})}
 									headlineText={headlines[8]}
 									headlineSize="small"
 									kickerText={kickers[0]}
@@ -237,11 +191,6 @@ export const News = () => (
 										theme: Pillar.News,
 										design: Design.Article,
 									}}
-									palette={decidePalette({
-										display: Display.Standard,
-										theme: Pillar.News,
-										design: Design.Article,
-									})}
 									headlineText={headlines[9]}
 									headlineSize="small"
 									kickerText={kickers[2]}
@@ -255,11 +204,6 @@ export const News = () => (
 										theme: Pillar.Lifestyle,
 										design: Design.Article,
 									}}
-									palette={decidePalette({
-										display: Display.Standard,
-										theme: Pillar.Lifestyle,
-										design: Design.Article,
-									})}
 									headlineText={headlines[10]}
 									headlineSize="small"
 									kickerText={kickers[0]}
@@ -273,11 +217,6 @@ export const News = () => (
 										theme: Pillar.News,
 										design: Design.Article,
 									}}
-									palette={decidePalette({
-										display: Display.Standard,
-										theme: Pillar.News,
-										design: Design.Article,
-									})}
 									headlineText={headlines[11]}
 									headlineSize="small"
 									kickerText={kickers[3]}
@@ -311,11 +250,6 @@ export const InDepth = () => (
 										theme: Pillar.Sport,
 										design: Design.Article,
 									}}
-									palette={decidePalette({
-										display: Display.Standard,
-										theme: Pillar.Sport,
-										design: Design.Article,
-									})}
 									headlineText={headlines[6]}
 									headlineSize="medium"
 									kickerText={kickers[4]}
@@ -332,11 +266,6 @@ export const InDepth = () => (
 										theme: Pillar.Sport,
 										design: Design.Article,
 									}}
-									palette={decidePalette({
-										display: Display.Standard,
-										theme: Pillar.Sport,
-										design: Design.Article,
-									})}
 									headlineText={headlines[6]}
 									headlineSize="small"
 									kickerText={kickers[3]}
@@ -354,11 +283,6 @@ export const InDepth = () => (
 										theme: Pillar.Sport,
 										design: Design.Article,
 									}}
-									palette={decidePalette({
-										display: Display.Standard,
-										theme: Pillar.Sport,
-										design: Design.Article,
-									})}
 									headlineText={headlines[6]}
 									headlineSize="small"
 									kickerText={kickers[2]}
@@ -375,11 +299,6 @@ export const InDepth = () => (
 										theme: Pillar.Sport,
 										design: Design.Article,
 									}}
-									palette={decidePalette({
-										display: Display.Standard,
-										theme: Pillar.Sport,
-										design: Design.Article,
-									})}
 									headlineText={headlines[2]}
 									headlineSize="small"
 									kickerText={kickers[1]}
@@ -396,11 +315,6 @@ export const InDepth = () => (
 										theme: Pillar.Sport,
 										design: Design.Article,
 									}}
-									palette={decidePalette({
-										display: Display.Standard,
-										theme: Pillar.Sport,
-										design: Design.Article,
-									})}
 									headlineText={headlines[7]}
 									headlineSize="small"
 									kickerText={kickers[0]}
@@ -424,11 +338,6 @@ export const InDepth = () => (
 								theme: Pillar.Opinion,
 								design: Design.Comment,
 							}}
-							palette={decidePalette({
-								display: Display.Standard,
-								theme: Pillar.Opinion,
-								design: Design.Comment,
-							})}
 							headlineText={headlines[7]}
 							headlineSize="large"
 							kickerText={kickers[0]}
@@ -461,11 +370,6 @@ export const Related = () => (
 								theme: Pillar.Sport,
 								design: Design.Article,
 							}}
-							palette={decidePalette({
-								display: Display.Standard,
-								theme: Pillar.Sport,
-								design: Design.Article,
-							})}
 							headlineText={headlines[7]}
 							headlineSize="medium"
 							kickerText={kickers[3]}
@@ -487,11 +391,6 @@ export const Related = () => (
 								theme: Pillar.Sport,
 								design: Design.DeadBlog,
 							}}
-							palette={decidePalette({
-								display: Display.Standard,
-								theme: Pillar.Sport,
-								design: Design.DeadBlog,
-							})}
 							headlineText={headlines[8]}
 							headlineSize="medium"
 							kickerText={kickers[0]}
@@ -514,11 +413,6 @@ export const Related = () => (
 								theme: Special.SpecialReport,
 								design: Design.Comment,
 							}}
-							palette={decidePalette({
-								display: Display.Standard,
-								theme: Special.SpecialReport,
-								design: Design.Comment,
-							})}
 							headlineText={headlines[8]}
 							headlineSize="medium"
 							kickerText={kickers[1]}
@@ -537,11 +431,6 @@ export const Related = () => (
 								theme: Pillar.News,
 								design: Design.Article,
 							}}
-							palette={decidePalette({
-								display: Display.Standard,
-								theme: Pillar.News,
-								design: Design.Article,
-							})}
 							headlineText={headlines[9]}
 							headlineSize="small"
 							kickerText={kickers[0]}
@@ -561,11 +450,6 @@ export const Related = () => (
 								theme: Pillar.Sport,
 								design: Design.Article,
 							}}
-							palette={decidePalette({
-								display: Display.Standard,
-								theme: Pillar.Sport,
-								design: Design.Article,
-							})}
 							headlineText={headlines[10]}
 							headlineSize="small"
 							kickerText={kickers[2]}
@@ -585,11 +469,6 @@ export const Related = () => (
 								theme: Pillar.Culture,
 								design: Design.Interview,
 							}}
-							palette={decidePalette({
-								display: Display.Standard,
-								theme: Pillar.Culture,
-								design: Design.Interview,
-							})}
 							headlineText={headlines[1]}
 							headlineSize="small"
 							kickerText={kickers[1]}
@@ -609,11 +488,6 @@ export const Related = () => (
 								theme: Pillar.Lifestyle,
 								design: Design.Feature,
 							}}
-							palette={decidePalette({
-								display: Display.Standard,
-								theme: Pillar.Lifestyle,
-								design: Design.Feature,
-							})}
 							headlineText={headlines[3]}
 							headlineSize="small"
 							kickerText={kickers[0]}
@@ -641,11 +515,6 @@ export const Spotlight = () => (
 						theme: Pillar.Sport,
 						design: Design.Feature,
 					}}
-					palette={decidePalette({
-						display: Display.Standard,
-						theme: Pillar.Sport,
-						design: Design.Feature,
-					})}
 					headlineText={headlines[11]}
 					headlineSize="large"
 					kickerText={kickers[1]}
@@ -676,11 +545,6 @@ export const Quad = () => (
 								theme: Pillar.Opinion,
 								design: Design.Comment,
 							}}
-							palette={decidePalette({
-								display: Display.Standard,
-								theme: Pillar.Opinion,
-								design: Design.Comment,
-							})}
 							headlineText={headlines[11]}
 							headlineSize="medium"
 							showQuotes={true}
@@ -708,11 +572,6 @@ export const Quad = () => (
 								theme: Special.SpecialReport,
 								design: Design.LiveBlog,
 							}}
-							palette={decidePalette({
-								display: Display.Standard,
-								theme: Special.SpecialReport,
-								design: Design.LiveBlog,
-							})}
 							headlineText={headlines[11]}
 							headlineSize="medium"
 							webPublicationDate="2019-11-11T09:45:30.000Z"
@@ -737,11 +596,6 @@ export const Quad = () => (
 								theme: Pillar.News,
 								design: Design.Article,
 							}}
-							palette={decidePalette({
-								display: Display.Standard,
-								theme: Pillar.News,
-								design: Design.Article,
-							})}
 							headlineText={headlines[11]}
 							headlineSize="medium"
 							kickerText={kickers[0]}
@@ -765,11 +619,6 @@ export const Quad = () => (
 								theme: Pillar.News,
 								design: Design.Article,
 							}}
-							palette={decidePalette({
-								display: Display.Standard,
-								theme: Pillar.News,
-								design: Design.Article,
-							})}
 							headlineText={headlines[11]}
 							headlineSize="medium"
 							kickerText={kickers[2]}
@@ -806,11 +655,6 @@ export const Media = () => (
 								theme: Pillar.Culture,
 								design: Design.Media,
 							}}
-							palette={decidePalette({
-								display: Display.Standard,
-								theme: Pillar.Culture,
-								design: Design.Media,
-							})}
 							headlineText={headlines[11]}
 							headlineSize="medium"
 							webPublicationDate="2019-11-11T09:45:30.000Z"
@@ -833,11 +677,6 @@ export const Media = () => (
 								theme: Pillar.News,
 								design: Design.Media,
 							}}
-							palette={decidePalette({
-								display: Display.Standard,
-								theme: Pillar.News,
-								design: Design.Media,
-							})}
 							headlineText={headlines[11]}
 							headlineSize="medium"
 							kickerText={kickers[0]}
@@ -861,11 +700,6 @@ export const Media = () => (
 								theme: Pillar.Sport,
 								design: Design.Media,
 							}}
-							palette={decidePalette({
-								display: Display.Standard,
-								theme: Pillar.Sport,
-								design: Design.Media,
-							})}
 							headlineText={headlines[11]}
 							headlineSize="medium"
 							kickerText={kickers[1]}

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -29,7 +29,6 @@ import { CardAge } from './components/CardAge';
 type Props = {
 	linkTo: string;
 	format: Format;
-	palette: Palette;
 	headlineText: string;
 	headlineSize?: SmallHeadlineSize;
 	showQuotes?: boolean; // Even with design !== Comment, a piece can be opinion
@@ -124,7 +123,6 @@ const fullCardImageAgeStyles = css`
 export const Card = ({
 	linkTo,
 	format,
-	palette,
 	headlineText,
 	headlineSize,
 	showQuotes,

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -12,6 +12,7 @@ import { Hide } from '@frontend/web/components/Hide';
 import { MediaMeta } from '@frontend/web/components/MediaMeta';
 import { CardCommentCount } from '@frontend/web/components/CardCommentCount';
 
+import { decidePalette } from '@root/src/web/lib/decidePalette';
 import { formatCount } from '@root/src/web/lib/formatCount';
 
 import { ContentWrapper } from './components/ContentWrapper';
@@ -162,14 +163,16 @@ export const Card = ({
 	const showCommentCount = commentCount || commentCount === 0;
 	const { long: longCount, short: shortCount } = formatCount(commentCount);
 
+	const cardPalette = decidePalette(format);
+
 	return (
 		<CardLink
 			linkTo={linkTo}
 			format={format}
-			palette={palette}
+			palette={cardPalette}
 			dataLinkName={dataLinkName}
 		>
-			<TopBar palette={palette} isFullCardImage={isFullCardImage}>
+			<TopBar palette={cardPalette} isFullCardImage={isFullCardImage}>
 				<CardLayout
 					imagePosition={imagePosition}
 					alwaysVertical={alwaysVertical}
@@ -207,7 +210,7 @@ export const Card = ({
 									<CardHeadline
 										headlineText={headlineText}
 										format={format}
-										palette={palette}
+										palette={cardPalette}
 										size={headlineSize}
 										showQuotes={showQuotes}
 										kickerText={
@@ -235,7 +238,7 @@ export const Card = ({
 												<Avatar
 													imageSrc={avatar.src}
 													imageAlt={avatar.alt}
-													palette={palette}
+													palette={cardPalette}
 												/>
 											</AvatarContainer>
 										</Hide>
@@ -248,7 +251,7 @@ export const Card = ({
 								)}
 							>
 								{standfirst && (
-									<StandfirstWrapper palette={palette}>
+									<StandfirstWrapper palette={cardPalette}>
 										{standfirst}
 									</StandfirstWrapper>
 								)}
@@ -258,7 +261,7 @@ export const Card = ({
 											<Avatar
 												imageSrc={avatar.src}
 												imageAlt={avatar.alt}
-												palette={palette}
+												palette={cardPalette}
 											/>
 										</AvatarContainer>
 									</Hide>
@@ -269,7 +272,7 @@ export const Card = ({
 										webPublicationDate ? (
 											<CardAge
 												format={format}
-												palette={palette}
+												palette={cardPalette}
 												webPublicationDate={
 													webPublicationDate
 												}
@@ -282,7 +285,7 @@ export const Card = ({
 										format.design === Design.Media &&
 										mediaType ? (
 											<MediaMeta
-												palette={palette}
+												palette={cardPalette}
 												mediaType={mediaType}
 												mediaDuration={mediaDuration}
 											/>
@@ -293,7 +296,7 @@ export const Card = ({
 										longCount &&
 										shortCount ? (
 											<CardCommentCount
-												palette={palette}
+												palette={cardPalette}
 												long={longCount}
 												short={shortCount}
 											/>

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -163,6 +163,19 @@ export const Card = ({
 	const showCommentCount = commentCount || commentCount === 0;
 	const { long: longCount, short: shortCount } = formatCount(commentCount);
 
+	/**
+	 * Why are we setting cardPalette like this?
+	 *
+	 * Good question. Basically, we had a production issue and this was the easiest and
+	 * quickest way to fix it rather than fixing Card's properly 😱
+	 *
+	 * Once:
+	 * 1. Cards have been refactored to remove `isFullSizeImage`
+	 * 2. We support the concept of a container type and
+	 * 3. We  and are able to handle Carousels natively - in
+	 *    the model
+	 * Then this should be removed.
+	 */
 	const cardPalette = decidePalette(format);
 
 	return (

--- a/src/web/components/Onwards/Carousel/Carousel.tsx
+++ b/src/web/components/Onwards/Carousel/Carousel.tsx
@@ -339,7 +339,6 @@ export const CarouselCard: React.FC<CarouselCardProps> = ({
 		<Card
 			linkTo={linkTo}
 			format={format}
-			palette={trailPalette}
 			headlineText={headlineText}
 			webPublicationDate={webPublicationDate}
 			kickerText={kickerText || ''}

--- a/src/web/components/Onwards/Carousel/Carousel.tsx
+++ b/src/web/components/Onwards/Carousel/Carousel.tsx
@@ -318,7 +318,6 @@ type CarouselCardProps = {
 
 export const CarouselCard: React.FC<CarouselCardProps> = ({
 	format,
-	trailPalette,
 	linkTo,
 	imageUrl,
 	headlineText,

--- a/src/web/components/Onwards/ExactlyFive.tsx
+++ b/src/web/components/Onwards/ExactlyFive.tsx
@@ -18,7 +18,6 @@ export const ExactlyFive = ({ content }: Props) => (
 				<Card
 					linkTo={content[0].url}
 					format={content[0].format}
-					palette={content[0].palette}
 					headlineText={content[0].headline}
 					headlineSize="medium"
 					byline={content[0].byline}
@@ -45,7 +44,6 @@ export const ExactlyFive = ({ content }: Props) => (
 				<Card
 					linkTo={content[1].url}
 					format={content[1].format}
-					palette={content[1].palette}
 					headlineText={content[1].headline}
 					headlineSize="medium"
 					byline={content[1].byline}
@@ -74,7 +72,6 @@ export const ExactlyFive = ({ content }: Props) => (
 						<Card
 							linkTo={content[2].url}
 							format={content[2].format}
-							palette={content[2].palette}
 							headlineText={content[2].headline}
 							headlineSize="medium"
 							byline={content[2].byline}
@@ -97,7 +94,6 @@ export const ExactlyFive = ({ content }: Props) => (
 						<Card
 							linkTo={content[3].url}
 							format={content[3].format}
-							palette={content[3].palette}
 							headlineText={content[3].headline}
 							headlineSize="medium"
 							byline={content[3].byline}
@@ -120,7 +116,6 @@ export const ExactlyFive = ({ content }: Props) => (
 						<Card
 							linkTo={content[4].url}
 							format={content[4].format}
-							palette={content[4].palette}
 							headlineText={content[4].headline}
 							headlineSize="medium"
 							byline={content[4].byline}

--- a/src/web/components/Onwards/FourOrLess.tsx
+++ b/src/web/components/Onwards/FourOrLess.tsx
@@ -41,7 +41,6 @@ export const FourOrLess = ({ content }: Props) => {
 						<Card
 							linkTo={trail.url}
 							format={trail.format}
-							palette={trail.palette}
 							headlineText={trail.headline}
 							headlineSize="medium"
 							byline={trail.byline}

--- a/src/web/components/Onwards/MoreThanFive.tsx
+++ b/src/web/components/Onwards/MoreThanFive.tsx
@@ -35,7 +35,6 @@ export const MoreThanFive = ({ content }: Props) => {
 					<Card
 						linkTo={content[0].url}
 						format={content[0].format}
-						palette={content[0].palette}
 						headlineText={content[0].headline}
 						headlineSize="medium"
 						byline={content[0].byline}
@@ -62,7 +61,6 @@ export const MoreThanFive = ({ content }: Props) => {
 					<Card
 						linkTo={content[1].url}
 						format={content[1].format}
-						palette={content[1].palette}
 						headlineText={content[1].headline}
 						headlineSize="medium"
 						byline={content[1].byline}
@@ -89,7 +87,6 @@ export const MoreThanFive = ({ content }: Props) => {
 					<Card
 						linkTo={content[2].url}
 						format={content[2].format}
-						palette={content[2].palette}
 						headlineText={content[2].headline}
 						headlineSize="medium"
 						byline={content[2].byline}
@@ -116,7 +113,6 @@ export const MoreThanFive = ({ content }: Props) => {
 					<Card
 						linkTo={content[3].url}
 						format={content[3].format}
-						palette={content[3].palette}
 						headlineText={content[3].headline}
 						headlineSize="medium"
 						byline={content[3].byline}
@@ -146,7 +142,6 @@ export const MoreThanFive = ({ content }: Props) => {
 						<Card
 							linkTo={trail.url}
 							format={trail.format}
-							palette={trail.palette}
 							headlineText={trail.headline}
 							headlineSize={
 								trail.format.theme === Special.Labs

--- a/src/web/components/Onwards/OnwardsLayout.tsx
+++ b/src/web/components/Onwards/OnwardsLayout.tsx
@@ -36,6 +36,22 @@ const decideLayout = (trails: TrailType[]) => {
 export const OnwardsLayout: React.FC<OnwardsType> = (data: OnwardsType) => {
 	const sections = useComments([data]);
 
+	/**
+	 * Why are we overriding display like this?
+	 *
+	 * Good question. Basically, we had a production issue and this was the easiest and
+	 * quickest way to fix it rather than fixing Card's properly 😱
+	 *
+	 * Carousels use display.Immersive to change some Card styles and this was bleeding
+	 * into normal onwards cards that linked through to Immersive articles.
+	 *
+	 * Once:
+	 * 1. Cards have been refactored to remove `isFullSizeImage`
+	 * 2. We support the concept of a container type and
+	 * 3. We  and are able to handle Carousels natively - in
+	 *    the model
+	 * Then this should be removed.
+	 */
 	const sectionsForcedToStandard = sections.map((section) => {
 		return {
 			...section,

--- a/src/web/components/Onwards/OnwardsLayout.tsx
+++ b/src/web/components/Onwards/OnwardsLayout.tsx
@@ -7,6 +7,7 @@ import { Hide } from '@frontend/web/components/Hide';
 import { useComments } from '@root/src/web/lib/useComments';
 import { formatAttrString } from '@frontend/web/lib/formatAttrString';
 
+import { Display } from '@guardian/types';
 import { ContainerTitle } from '../ContainerTitle';
 import { OnwardsContainer } from './OnwardsContainer';
 import { MoreThanFive } from './MoreThanFive';
@@ -35,9 +36,24 @@ const decideLayout = (trails: TrailType[]) => {
 export const OnwardsLayout: React.FC<OnwardsType> = (data: OnwardsType) => {
 	const sections = useComments([data]);
 
+	const sectionsForcedToStandard = sections.map((section) => {
+		return {
+			...section,
+			trails: section.trails.map((trail) => {
+				return {
+					...trail,
+					format: {
+						...trail.format,
+						display: Display.Standard,
+					},
+				};
+			}),
+		};
+	});
+
 	return (
 		<>
-			{sections.map((section, index) => (
+			{sectionsForcedToStandard.map((section, index) => (
 				<Flex key={`${section.heading}-${index}`}>
 					<LeftColumn
 						showRightBorder={false}

--- a/src/web/components/Onwards/Spotlight.tsx
+++ b/src/web/components/Onwards/Spotlight.tsx
@@ -13,7 +13,6 @@ export const Spotlight = ({ content }: Props) => (
 	<Card
 		linkTo={content[0].url}
 		format={content[0].format}
-		palette={content[0].palette}
 		headlineText={content[0].headline}
 		headlineSize="large"
 		byline={content[0].byline}

--- a/src/web/examples/Front.stories.tsx
+++ b/src/web/examples/Front.stories.tsx
@@ -9,7 +9,6 @@ import { UL } from '@frontend/web/components/Card/components/UL';
 import { LI } from '@frontend/web/components/Card/components/LI';
 import { GuardianLines } from '@root/src/web/components/GuardianLines';
 import { Nav } from '@root/src/web/components/Nav/Nav';
-import { decidePalette } from '@root/src/web/lib/decidePalette';
 
 import { Card } from '@frontend/web/components/Card/Card';
 
@@ -96,11 +95,6 @@ export const Front = () => (
 							design: Design.Article,
 							theme: Pillar.News,
 						}}
-						palette={decidePalette({
-							display: Display.Standard,
-							design: Design.Article,
-							theme: Pillar.News,
-						})}
 						headlineText={headlines[0]}
 						headlineSize="large"
 						kickerText={kickers[4]}
@@ -123,11 +117,6 @@ export const Front = () => (
 							design: Design.Article,
 							theme: Pillar.News,
 						}}
-						palette={decidePalette({
-							display: Display.Standard,
-							design: Design.Article,
-							theme: Pillar.News,
-						})}
 						headlineText="Munroe Bergdorf to advise Labour on LGBT issues"
 						headlineSize="medium"
 						kickerText={kickers[0]}
@@ -157,11 +146,6 @@ export const Front = () => (
 							design: Design.Article,
 							theme: Pillar.Culture,
 						}}
-						palette={decidePalette({
-							display: Display.Standard,
-							design: Design.Article,
-							theme: Pillar.Culture,
-						})}
 						headlineText={headlines[2]}
 						kickerText={kickers[1]}
 						imageUrl={images[3]}
@@ -184,11 +168,6 @@ export const Front = () => (
 									design: Design.Editorial,
 									theme: Pillar.Opinion,
 								}}
-								palette={decidePalette({
-									display: Display.Standard,
-									design: Design.Editorial,
-									theme: Pillar.Opinion,
-								})}
 								headlineText={headlines[3]}
 								kickerText="Editorial"
 								imageUrl={images[6]}
@@ -204,11 +183,6 @@ export const Front = () => (
 									design: Design.Article,
 									theme: Pillar.News,
 								}}
-								palette={decidePalette({
-									display: Display.Standard,
-									design: Design.Article,
-									theme: Pillar.News,
-								})}
 								headlineText={headlines[4]}
 								headlineSize="small"
 							/>
@@ -230,11 +204,6 @@ export const Front = () => (
 									design: Design.Article,
 									theme: Pillar.Sport,
 								}}
-								palette={decidePalette({
-									display: Display.Standard,
-									design: Design.Article,
-									theme: Pillar.Sport,
-								})}
 								headlineText={headlines[6]}
 								headlineSize="small"
 								kickerText={kickers[3]}
@@ -249,11 +218,6 @@ export const Front = () => (
 									design: Design.Article,
 									theme: Pillar.News,
 								}}
-								palette={decidePalette({
-									display: Display.Standard,
-									design: Design.Article,
-									theme: Pillar.News,
-								})}
 								headlineText={headlines[7]}
 								headlineSize="small"
 								kickerText={kickers[1]}
@@ -267,11 +231,6 @@ export const Front = () => (
 									design: Design.Article,
 									theme: Pillar.News,
 								}}
-								palette={decidePalette({
-									display: Display.Standard,
-									design: Design.Article,
-									theme: Pillar.News,
-								})}
 								headlineText={headlines[8]}
 								headlineSize="small"
 								kickerText={kickers[0]}
@@ -285,11 +244,6 @@ export const Front = () => (
 									design: Design.Article,
 									theme: Pillar.News,
 								}}
-								palette={decidePalette({
-									display: Display.Standard,
-									design: Design.Article,
-									theme: Pillar.News,
-								})}
 								headlineText={headlines[9]}
 								headlineSize="small"
 								kickerText={kickers[2]}
@@ -320,11 +274,6 @@ export const Front = () => (
 							design: Design.LiveBlog,
 							theme: Pillar.News,
 						}}
-						palette={decidePalette({
-							display: Display.Standard,
-							design: Design.LiveBlog,
-							theme: Pillar.News,
-						})}
 						headlineText={headlines[7]}
 						headlineSize="medium"
 						kickerText={kickers[3]}
@@ -345,11 +294,6 @@ export const Front = () => (
 							design: Design.DeadBlog,
 							theme: Pillar.Sport,
 						}}
-						palette={decidePalette({
-							display: Display.Standard,
-							design: Design.DeadBlog,
-							theme: Pillar.Sport,
-						})}
 						headlineText={headlines[8]}
 						headlineSize="medium"
 						kickerText={kickers[0]}
@@ -371,11 +315,6 @@ export const Front = () => (
 							design: Design.Comment,
 							theme: Pillar.Sport,
 						}}
-						palette={decidePalette({
-							display: Display.Standard,
-							design: Design.Comment,
-							theme: Pillar.Sport,
-						})}
 						headlineText={headlines[8]}
 						headlineSize="medium"
 						kickerText={kickers[1]}
@@ -394,11 +333,6 @@ export const Front = () => (
 							design: Design.Article,
 							theme: Pillar.News,
 						}}
-						palette={decidePalette({
-							display: Display.Standard,
-							design: Design.Article,
-							theme: Pillar.News,
-						})}
 						headlineText={headlines[9]}
 						headlineSize="small"
 						kickerText={kickers[0]}
@@ -417,11 +351,6 @@ export const Front = () => (
 							design: Design.Article,
 							theme: Pillar.Sport,
 						}}
-						palette={decidePalette({
-							display: Display.Standard,
-							design: Design.Article,
-							theme: Pillar.Sport,
-						})}
 						headlineText={headlines[10]}
 						headlineSize="small"
 						kickerText={kickers[2]}
@@ -440,11 +369,6 @@ export const Front = () => (
 							design: Design.Interview,
 							theme: Pillar.Culture,
 						}}
-						palette={decidePalette({
-							display: Display.Standard,
-							design: Design.Interview,
-							theme: Pillar.Culture,
-						})}
 						headlineText={headlines[1]}
 						headlineSize="small"
 						kickerText={kickers[1]}
@@ -463,11 +387,6 @@ export const Front = () => (
 							design: Design.Feature,
 							theme: Pillar.Lifestyle,
 						}}
-						palette={decidePalette({
-							display: Display.Standard,
-							design: Design.Feature,
-							theme: Pillar.Lifestyle,
-						})}
 						headlineText={headlines[3]}
 						headlineSize="small"
 						kickerText={kickers[0]}
@@ -492,11 +411,6 @@ export const Front = () => (
 							design: Design.Comment,
 							theme: Pillar.Opinion,
 						}}
-						palette={decidePalette({
-							display: Display.Standard,
-							design: Design.Comment,
-							theme: Pillar.Opinion,
-						})}
 						headlineText={headlines[11]}
 						headlineSize="medium"
 						showQuotes={true}
@@ -523,11 +437,6 @@ export const Front = () => (
 							design: Design.Article,
 							theme: Pillar.Opinion,
 						}}
-						palette={decidePalette({
-							display: Display.Standard,
-							design: Design.Article,
-							theme: Pillar.Opinion,
-						})}
 						headlineText={headlines[11]}
 						headlineSize="medium"
 						webPublicationDate={'2019-11-11T09={45={30.000Z'}
@@ -549,11 +458,6 @@ export const Front = () => (
 							design: Design.Article,
 							theme: Pillar.News,
 						}}
-						palette={decidePalette({
-							display: Display.Standard,
-							design: Design.Article,
-							theme: Pillar.News,
-						})}
 						headlineText={headlines[11]}
 						headlineSize="medium"
 						kickerText={kickers[0]}
@@ -576,11 +480,6 @@ export const Front = () => (
 							design: Design.Article,
 							theme: Pillar.News,
 						}}
-						palette={decidePalette({
-							display: Display.Standard,
-							design: Design.Article,
-							theme: Pillar.News,
-						})}
 						headlineText={headlines[11]}
 						headlineSize="medium"
 						kickerText={kickers[2]}
@@ -610,11 +509,6 @@ export const Front = () => (
 						design: Design.Media,
 						theme: Pillar.Sport,
 					}}
-					palette={decidePalette({
-						display: Display.Standard,
-						design: Design.Media,
-						theme: Pillar.Sport,
-					})}
 					headlineText={headlines[11]}
 					headlineSize="large"
 					kickerText={kickers[1]}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This PR introduces a hack that we're using to fix a display issue in Production instead of refactoring the Card component to fix the root issue properly

### The History
After https://github.com/guardian/dotcom-rendering/pull/2634 was merged we noticed that Cards for immersive articles were not appearing correctly

![Screenshot 2021-03-30 at 17 48 45](https://user-images.githubusercontent.com/1336821/113026912-74b8aa00-9181-11eb-9da3-a77fbca691a2.jpg)

This happened because we had previously put in some hacks to hardcode the `display` value for onwards Cards to `Standard`. We did this because the definition of an 'immersive' card had "moved" as part of the Carousel work. But it had only really kind of shifted and we still aren't sure what we will do with them. But that uncertainty was okay because it was just an AB test. Or so we thought.

However, as time moved on other work around `format` was progressing and one of the major steps was to hoist the decision about what `format` an article is up into CAPI. This was great but it meant we were no longer hard coding it, so we ended up again having conflicting model problems.

### The Hack
Is to, once again, hardcode the `display` value for all Cards in Onwards. This is scary and dangerous because it breaks the model. Any sub component below a Card will get an unexpected value.


### After
![Screenshot 2021-03-30 at 17 57 50](https://user-images.githubusercontent.com/1336821/113028094-cada1d00-9182-11eb-9ef1-06c90d6a246e.jpg)


### Why did we do this if it's so bad?
The real solution is to refactor how we model Cards and correctly incorporate Carousels and immersive cards into it. But we can't do that until we know 1) if we even want to have a Carousel or 2) what an 'immersive' card means. Those choices affect the direction any refactor will take.

### Where should we aim to be
We want to be able to correctly model Cards, in all their glorious variation, as part of the DCR data model. This can either be part of `format` or an extension to `format`.

The extra layer of variation is this:

Sometimes, when a Card is in a special container, it changes. It might get a different background colour, or different sizing and some elements might show or appear. The Container impacts the styling of the card so we need to model the containers. There's an ongoing piece of work to start looking at this but in this particular case you can say that `Carousel` is a type of container and when a Card appears inside it then in _that context_ `Display.Immersive` means one thing, but in the normal context, it might mean something else, or probably just nothing.

So we need to extend the logic where we make design decisions to include this new ContainerType variable and to also use that when making decisions.

