### PR TITLE
Workaround for missing "Letter" design and incorrectly chosen theme

### DIFF
--- a/src/web/lib/decideDesign.ts
+++ b/src/web/lib/decideDesign.ts
@@ -12,9 +12,8 @@ export const decideDesign = (format: CAPIFormat): Design => {
 		case 'AnalysisDesign':
 			return Design.Analysis;
 		case 'CommentDesign':
-			return Design.Comment;
 		case 'LetterDesign':
-			return Design.Letter;
+			return Design.Comment;
 		case 'FeatureDesign':
 			return Design.Feature;
 		case 'LiveBlogDesign':

--- a/src/web/lib/decideTheme.ts
+++ b/src/web/lib/decideTheme.ts
@@ -1,7 +1,9 @@
 import { Pillar, Special } from '@guardian/types';
 
 export const decideTheme = (format: CAPIFormat): Theme => {
-	const { theme } = format;
+	const { theme, design } = format;
+
+	if ((design === "CommentDesign" || design === "LetterDesign") && theme === 'NewsPillar') return Pillar.Opinion;
 	switch (theme) {
 		case 'NewsPillar':
 			return Pillar.News;

--- a/src/web/lib/decideTheme.ts
+++ b/src/web/lib/decideTheme.ts
@@ -3,7 +3,11 @@ import { Pillar, Special } from '@guardian/types';
 export const decideTheme = (format: CAPIFormat): Theme => {
 	const { theme, design } = format;
 
-	if ((design === "CommentDesign" || design === "LetterDesign") && theme === 'NewsPillar') return Pillar.Opinion;
+	if (
+		(design === 'CommentDesign' || design === 'LetterDesign') &&
+		theme === 'NewsPillar'
+	)
+		return Pillar.Opinion;
 	switch (theme) {
 		case 'NewsPillar':
 			return Pillar.News;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds a direct workaround for the fact we have no special treatment for the _Letters_ design, and that the theme is not adjusted for this design to be Opinion. We need to move some of this logic into the CAPI client directly (or create a specific treatment for letters if they're meant to be different) but this is the quick way to resolve the live issue.

### Before
![image](https://user-images.githubusercontent.com/8754692/113125488-8f853000-920e-11eb-89c4-e29b3a310338.png)


### After
![image](https://user-images.githubusercontent.com/8754692/113125432-7d0af680-920e-11eb-9262-e50b4b01f0be.png)


## Why?
To resolve a live issue.
