### PR TITLE
Add some basic focus styling

### DIFF
--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterItem.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterItem.tsx
@@ -55,6 +55,8 @@ const headlineLink = css`
 	color: ${text.anchorSecondary};
 	font-weight: 500;
 	${headline.xxxsmall()};
+
+	display: block; /* To ensure focus outline works okay */
 `;
 
 const ageWarningStyles = css`

--- a/src/web/components/MostViewed/MostViewedFooter/SecondTierItem.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/SecondTierItem.tsx
@@ -52,6 +52,8 @@ const headlineLink = css`
 	color: ${text.anchorSecondary};
 	font-weight: 500;
 	${headline.xxxsmall()};
+
+	display: block; /* To ensure focus outline works okay */
 `;
 
 const ageWarningStyles = css`

--- a/src/web/components/Nav/ExpandedMenu/VeggieBurgerMenu.tsx
+++ b/src/web/components/Nav/ExpandedMenu/VeggieBurgerMenu.tsx
@@ -79,7 +79,6 @@ const veggieBurgerStyles = (display: Display) => css`
 	position: absolute;
 	border: 0;
 	border-radius: 50%;
-	outline: none;
 
 	${getZIndex('burger')}
 

--- a/src/web/components/Nav/StickNavTest/ExpandedMenu/VeggieBurgerMenu.tsx
+++ b/src/web/components/Nav/StickNavTest/ExpandedMenu/VeggieBurgerMenu.tsx
@@ -79,7 +79,6 @@ const veggieBurgerStyles = (display: Display) => css`
 	position: absolute;
 	border: 0;
 	border-radius: 50%;
-	outline: none;
 
 	${getZIndex('burger')}
 

--- a/src/web/components/SubNav/SubNav.tsx
+++ b/src/web/components/SubNav/SubNav.tsx
@@ -76,6 +76,17 @@ const linkStyle = css`
 	:hover {
 		text-decoration: underline;
 	}
+
+	:focus {
+		line-height: 26px;
+		height: 26px;
+		margin-top: 5px;
+
+		${from.tablet} {
+			height: 32px;
+			line-height: 32px;
+		}
+	}
 `;
 
 const selected = css`
@@ -180,6 +191,7 @@ export const SubNav = ({ subNavSections, palette, currentNavLink }: Props) => {
 						className={listItemStyles(palette)}
 					>
 						<a
+							data-src-focus-disabled={true}
 							className={parentLinkStyle}
 							href={subNavSections.parent.url}
 						>
@@ -193,6 +205,7 @@ export const SubNav = ({ subNavSections, palette, currentNavLink }: Props) => {
 							className={cx(linkStyle, {
 								[selected]: link.title === currentNavLink,
 							})}
+							data-src-focus-disabled={true}
 							href={link.url}
 							data-link-name={`nav2 : subnav : ${trimLeadingSlash(
 								link.url,

--- a/src/web/layouts/DecideLayout.tsx
+++ b/src/web/layouts/DecideLayout.tsx
@@ -8,6 +8,8 @@ import { decideDisplay } from '@root/src/web/lib/decideDisplay';
 import { decidePalette } from '@root/src/web/lib/decidePalette';
 import { decideDesign } from '@root/src/web/lib/decideDesign';
 
+import { injectGlobal } from 'emotion';
+import { focusHalo } from '@guardian/src-foundations/accessibility';
 import { StandardLayout } from './StandardLayout';
 import { ShowcaseLayout } from './ShowcaseLayout';
 import { CommentLayout } from './CommentLayout';
@@ -18,6 +20,15 @@ type Props = {
 	CAPI: CAPIType;
 	NAV: NavType;
 };
+
+// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+injectGlobal`
+	/* Crude but effective mechanism. Specific components may need to improve on this behaviour. */
+	/* The not(.src...) selector is to work with Source's FocusStyleManager. */
+	*:focus {
+		${focusHalo}
+	}
+`;
 
 export const DecideLayout = ({ CAPI, NAV }: Props): JSX.Element => {
 	const display: Display = decideDisplay(CAPI.format);


### PR DESCRIPTION
## What does this change?

A very crude (attempted) improvement on the status quo. There is a long way to go to really fix focus visuals. It would be great here to figure out a sensible default, which we can then refine for specific components. 

~Note, https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/32e9fb strongly recommends the blue halo around focused elements. I've tweaked the implementation slightly from box-shadow to outline as there appear to be some downsides to box-shadow (see https://stackoverflow.com/questions/52589391/css-box-shadow-vs-outline) but happy to be corrected on this.~ Going to use `focusHalo` for now and we will consider updating Source if/as necessary.

### Before

The issue differs across browsers. Chrome default focus styling is a bit better here, but FF out of the box is pretty useless alas (speaking as someone who loves FF). The examples below are for FF anyway.

![Kapture 2021-03-31 at 16 30 27](https://user-images.githubusercontent.com/858402/113170406-7005fb80-923e-11eb-9a97-1ba182057cc3.gif)

### After

![Kapture 2021-03-31 at 16 14 06](https://user-images.githubusercontent.com/858402/113170086-24ebe880-923e-11eb-8f23-fdaeeaccd35e.gif)

## Why?

https://theguardian.design/2a1e5182b/p/6691bb-accessibility/t/24562a is the starting point.

https://www.w3.org/TR/2016/NOTE-WCAG20-TECHS-20161007/G195 is the kind of approach I think we are aiming for here.