### PR TITLE
Remove `Display.Column` from codebase

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -42,7 +42,7 @@ type CAPIDesign =
 
 // CAPIDisplay is the display information passed through from CAPI and dictates the displaystyle of the content e.g. Immersive
 // https://github.com/guardian/content-api-scala-client/blob/master/client/src/main/scala/com.gu.contentapi.client/utils/format/Display.scala
-type CAPIDisplay = 'StandardDisplay' | 'ImmersiveDisplay' | 'ShowcaseDisplay' | 'NumberedListDisplay' | 'ColumnDisplay';
+type CAPIDisplay = 'StandardDisplay' | 'ImmersiveDisplay' | 'ShowcaseDisplay' | 'NumberedListDisplay';
 
 // CAPIFormat is the stringified version of Format passed through from CAPI.
 // It gets converted to the @guardian/types format on platform

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
         "@guardian/src-radio": "^2.7.1",
         "@guardian/src-text-area": "^2.7.1",
         "@guardian/src-text-input": "^2.7.1",
-        "@guardian/types": "^5.1.0",
+        "@guardian/types": "^6.0.0",
         "@hkdobrev/run-if-changed": "^0.3.1",
         "@loadable/component": "^5.14.1",
         "@loadable/server": "^5.14.0",

--- a/src/web/lib/decideDisplay.ts
+++ b/src/web/lib/decideDisplay.ts
@@ -11,8 +11,6 @@ export const decideDisplay = (format: CAPIFormat): Display => {
 			return Display.Showcase;
 		case 'NumberedListDisplay':
 			return Display.NumberedList;
-		case 'ColumnDisplay':
-			return Display.Column;
 		default:
 			return Display.Standard;
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2485,10 +2485,10 @@
     "@guardian/src-helpers" "^2.7.1"
     "@guardian/src-icons" "^2.7.1"
 
-"@guardian/types@^5.1.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/types/-/types-5.1.0.tgz#d83e4fe911c0d4d460551855d47d07df0f0af8f2"
-  integrity sha512-8JQFfHqskOyc1ruSwWiJD8W4XuCsGorMpwEMRsBM3/zHykAiizsJu7827UbeFCWJ5FUquO/blXzm7oK8ZO99CQ==
+"@guardian/types@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/types/-/types-6.0.0.tgz#65f4001e390fc8c22f196676742121b89ff28651"
+  integrity sha512-HAYOUfy+Xm1WodByJ7fUH4emSSzVh3YW8euJx1r4TopsG/tIsI94IntOI38s6kwtsClY90gFKG25UiasKJL/Jw==
 
 "@hapi/hoek@^9.0.0":
   version "9.1.0"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Removes the Column Display type from DCR following [its removal from `@guardian/types` in `v6.0.0](https://github.com/guardian/types/pull/108)`

## Why?
Deprecated in favour of `Showcase` as a `Display` format.