### PR TITLE
Use getZIndex to make searching easier

### DIFF
--- a/src/web/components/Links.tsx
+++ b/src/web/components/Links.tsx
@@ -7,6 +7,7 @@ import { brand, brandText, brandAlt } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 
+import { getZIndex } from '@root/src/web/lib/getZIndex';
 import { getCookie } from '@root/src/web/browser/cookie';
 import { DropdownLinkType, Dropdown } from '@root/src/web/components/Dropdown';
 
@@ -121,6 +122,8 @@ const linksStyles = css`
 	${from.wide} {
 		right: 342px;
 	}
+
+	${getZIndex('headerLinks')}
 `;
 
 export const Links = ({


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
We lost the z-index on the header links at some point so this PR reintroduces it so that the guardian logo doesn't shadow the Search link, hijacking the click event

### Before
![2021-04-01 15 06 05](https://user-images.githubusercontent.com/1336821/113306341-e583d180-92fb-11eb-9bad-6752f3bc4abd.gif)


### After
![2021-04-01 15 05 43](https://user-images.githubusercontent.com/1336821/113306299-da30a600-92fb-11eb-9db7-158520b6aa8a.gif)


