### PR TITLE
force-braze-message to use URL fragment

### DIFF
--- a/src/web/components/SlotBodyEnd/BrazeEpic.tsx
+++ b/src/web/components/SlotBodyEnd/BrazeEpic.tsx
@@ -8,6 +8,7 @@ import {
 	Variant,
 } from '@root/src/web/lib/braze/parseBrazeEpicParams';
 import { BrazeMessagesInterface } from '@root/src/web/lib/braze/BrazeMessages';
+import { getBrazeMetaFromQueryString } from '@root/src/web/lib/braze/forceBrazeMessage';
 import { CanShowResult } from '@root/src/web/lib/messagePicker';
 import { useOnce } from '@root/src/web/lib/useOnce';
 import { joinUrl } from '@root/src/lib/joinUrl';
@@ -51,6 +52,14 @@ type EpicProps = {
 export const canShow = async (
 	brazeMessagesPromise: Promise<BrazeMessagesInterface>,
 ): Promise<CanShowResult> => {
+	const forcedBrazeMeta = getBrazeMetaFromQueryString();
+	if (forcedBrazeMeta) {
+		return {
+			result: true,
+			meta: forcedBrazeMeta,
+		};
+	}
+
 	try {
 		const brazeMessages = await brazeMessagesPromise;
 		const message = await brazeMessages.getMessageForEndOfArticle();

--- a/src/web/components/SlotBodyEnd/BrazeEpic.tsx
+++ b/src/web/components/SlotBodyEnd/BrazeEpic.tsx
@@ -8,7 +8,7 @@ import {
 	Variant,
 } from '@root/src/web/lib/braze/parseBrazeEpicParams';
 import { BrazeMessagesInterface } from '@root/src/web/lib/braze/BrazeMessages';
-import { getBrazeMetaFromQueryString } from '@root/src/web/lib/braze/forceBrazeMessage';
+import { getBrazeMetaFromUrlFragment } from '@root/src/web/lib/braze/forceBrazeMessage';
 import { CanShowResult } from '@root/src/web/lib/messagePicker';
 import { useOnce } from '@root/src/web/lib/useOnce';
 import { joinUrl } from '@root/src/lib/joinUrl';
@@ -52,7 +52,7 @@ type EpicProps = {
 export const canShow = async (
 	brazeMessagesPromise: Promise<BrazeMessagesInterface>,
 ): Promise<CanShowResult> => {
-	const forcedBrazeMeta = getBrazeMetaFromQueryString();
+	const forcedBrazeMeta = getBrazeMetaFromUrlFragment();
 	if (forcedBrazeMeta) {
 		return {
 			result: true,

--- a/src/web/components/StickyBottomBanner/BrazeBanner.tsx
+++ b/src/web/components/StickyBottomBanner/BrazeBanner.tsx
@@ -5,7 +5,7 @@ import * as emotionTheming from 'emotion-theming';
 import { getZIndex } from '@root/src/web/lib/getZIndex';
 import { Props as BrazeBannerProps } from '@guardian/braze-components';
 import { submitComponentEvent } from '@root/src/web/browser/ophan/ophan';
-import { getBrazeMetaFromQueryString } from '@root/src/web/lib/braze/forceBrazeMessage';
+import { getBrazeMetaFromUrlFragment } from '@root/src/web/lib/braze/forceBrazeMessage';
 import { BrazeMessagesInterface } from '@root/src/web/lib/braze/BrazeMessages';
 import { CanShowResult } from '@root/src/web/lib/messagePicker';
 
@@ -42,7 +42,7 @@ const containerStyles = emotion.css`
 export const canShow = async (
 	brazeMessagesPromise: Promise<BrazeMessagesInterface>,
 ): Promise<CanShowResult> => {
-	const forcedBrazeMeta = getBrazeMetaFromQueryString();
+	const forcedBrazeMeta = getBrazeMetaFromUrlFragment();
 	if (forcedBrazeMeta) {
 		return {
 			result: true,

--- a/src/web/components/StickyBottomBanner/BrazeBanner.tsx
+++ b/src/web/components/StickyBottomBanner/BrazeBanner.tsx
@@ -5,6 +5,7 @@ import * as emotionTheming from 'emotion-theming';
 import { getZIndex } from '@root/src/web/lib/getZIndex';
 import { Props as BrazeBannerProps } from '@guardian/braze-components';
 import { submitComponentEvent } from '@root/src/web/browser/ophan/ophan';
+import { getBrazeMetaFromQueryString } from '@root/src/web/lib/braze/forceBrazeMessage';
 import { BrazeMessagesInterface } from '@root/src/web/lib/braze/BrazeMessages';
 import { CanShowResult } from '@root/src/web/lib/messagePicker';
 
@@ -26,49 +27,6 @@ const containerStyles = emotion.css`
     width: 100%;
     ${getZIndex('banner')}
 `;
-
-const FORCE_BRAZE_ALLOWLIST = [
-	'preview.gutools.co.uk',
-	'preview.code.dev-gutools.co.uk',
-	'localhost',
-	'm.thegulocal.com',
-];
-
-const getBrazeMetaFromQueryString = (): Meta | null => {
-	if (URLSearchParams) {
-		const qsArg = 'force-braze-message';
-
-		const params = new URLSearchParams(window.location.search);
-		const value = params.get(qsArg);
-		if (value) {
-			if (!FORCE_BRAZE_ALLOWLIST.includes(window.location.hostname)) {
-				// eslint-disable-next-line no-console
-				console.log(`${qsArg} is not supported on this domain`);
-				return null;
-			}
-
-			try {
-				const dataFromBraze = JSON.parse(value);
-
-				return {
-					dataFromBraze,
-					logImpressionWithBraze: () => {},
-					logButtonClickWithBraze: () => {},
-				};
-			} catch (e) {
-				const error = e as Error;
-				// Parsing failed. Log a message and fall through.
-				// eslint-disable-next-line no-console
-				console.log(
-					`There was an error with ${qsArg}: `,
-					error.message,
-				);
-			}
-		}
-	}
-
-	return null;
-};
 
 // We can show a Braze banner if:
 // - The Braze switch is on

--- a/src/web/lib/braze/forceBrazeMessage.ts
+++ b/src/web/lib/braze/forceBrazeMessage.ts
@@ -1,0 +1,50 @@
+const FORCE_BRAZE_ALLOWLIST = [
+	'preview.gutools.co.uk',
+	'preview.code.dev-gutools.co.uk',
+	'localhost',
+	'm.thegulocal.com',
+];
+
+type Meta = {
+	dataFromBraze: {
+		[key: string]: string;
+	};
+	logImpressionWithBraze: () => void;
+	logButtonClickWithBraze: (id: number) => void;
+};
+
+export const getBrazeMetaFromQueryString = (): Meta | null => {
+	if (URLSearchParams) {
+		const qsArg = 'force-braze-message';
+
+		const params = new URLSearchParams(window.location.search);
+		const value = params.get(qsArg);
+		if (value) {
+			if (!FORCE_BRAZE_ALLOWLIST.includes(window.location.hostname)) {
+				// eslint-disable-next-line no-console
+				console.log(`${qsArg} is not supported on this domain`);
+				return null;
+			}
+
+			try {
+				const dataFromBraze = JSON.parse(value);
+
+				return {
+					dataFromBraze,
+					logImpressionWithBraze: () => {},
+					logButtonClickWithBraze: () => {},
+				};
+			} catch (e) {
+				const error = e as Error;
+				// Parsing failed. Log a message and fall through.
+				// eslint-disable-next-line no-console
+				console.log(
+					`There was an error with ${qsArg}: `,
+					error.message,
+				);
+			}
+		}
+	}
+
+	return null;
+};

--- a/src/web/lib/braze/forceBrazeMessage.ts
+++ b/src/web/lib/braze/forceBrazeMessage.ts
@@ -38,8 +38,6 @@ export const getBrazeMetaFromUrlFragment = (): Meta | null => {
 					decodeURIComponent(forcedMessage),
 				);
 
-				console.log(dataFromBraze);
-
 				return {
 					dataFromBraze,
 					logImpressionWithBraze: () => {},

--- a/src/web/lib/braze/forceBrazeMessage.ts
+++ b/src/web/lib/braze/forceBrazeMessage.ts
@@ -14,20 +14,28 @@ type Meta = {
 };
 
 export const getBrazeMetaFromQueryString = (): Meta | null => {
-	if (URLSearchParams) {
-		const qsArg = 'force-braze-message';
+	if (window.location.hash) {
+		const key = 'force-braze-message';
 
-		const params = new URLSearchParams(window.location.search);
-		const value = params.get(qsArg);
-		if (value) {
+		const hashString = window.location.hash;
+		const forcedMessage = hashString.slice(
+			hashString.indexOf(`${key}=`) + key.length + 1,
+			hashString.length,
+		);
+
+		if (forcedMessage) {
 			if (!FORCE_BRAZE_ALLOWLIST.includes(window.location.hostname)) {
 				// eslint-disable-next-line no-console
-				console.log(`${qsArg} is not supported on this domain`);
+				console.log(`${key} is not supported on this domain`);
 				return null;
 			}
 
 			try {
-				const dataFromBraze = JSON.parse(value);
+				const dataFromBraze = JSON.parse(
+					decodeURIComponent(forcedMessage),
+				);
+
+				console.log(dataFromBraze);
 
 				return {
 					dataFromBraze,
@@ -38,10 +46,7 @@ export const getBrazeMetaFromQueryString = (): Meta | null => {
 				const error = e as Error;
 				// Parsing failed. Log a message and fall through.
 				// eslint-disable-next-line no-console
-				console.log(
-					`There was an error with ${qsArg}: `,
-					error.message,
-				);
+				console.log(`There was an error with ${key}: `, error.message);
 			}
 		}
 	}

--- a/src/web/lib/braze/forceBrazeMessage.ts
+++ b/src/web/lib/braze/forceBrazeMessage.ts
@@ -13,8 +13,11 @@ type Meta = {
 	logButtonClickWithBraze: (id: number) => void;
 };
 
-export const getBrazeMetaFromQueryString = (): Meta | null => {
+export const getBrazeMetaFromUrlFragment = (): Meta | null => {
 	if (window.location.hash) {
+		// This is intended for use on development domains for preview purposes.
+		// It won't run in PROD.
+
 		const key = 'force-braze-message';
 
 		const hashString = window.location.hash;

--- a/src/web/lib/braze/forceBrazeMessage.ts
+++ b/src/web/lib/braze/forceBrazeMessage.ts
@@ -21,17 +21,18 @@ export const getBrazeMetaFromUrlFragment = (): Meta | null => {
 		const key = 'force-braze-message';
 
 		const hashString = window.location.hash;
-		const forcedMessage = hashString.slice(
-			hashString.indexOf(`${key}=`) + key.length + 1,
-			hashString.length,
-		);
 
-		if (forcedMessage) {
+		if (hashString.includes(key)) {
 			if (!FORCE_BRAZE_ALLOWLIST.includes(window.location.hostname)) {
 				// eslint-disable-next-line no-console
 				console.log(`${key} is not supported on this domain`);
 				return null;
 			}
+
+			const forcedMessage = hashString.slice(
+				hashString.indexOf(`${key}=`) + key.length + 1,
+				hashString.length,
+			);
 
 			try {
 				const dataFromBraze = JSON.parse(


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Moves `force-braze-message` to use the URL fragment rather than query strings because the new Epic exceeded the 1024 character limit set for query strings.

This also adds `force-braze-message` as an option for the Braze Epic.

Example local url [here](http://localhost:3030/Article#force-braze-message=%7B%22heading%22%3A%22Since%20you%E2%80%99re%20forcing%20a%20Braze%20Message...%22%2C%22highlightedText%22%3A%22Support%20The%20Guardian%20from%20as%20little%20as%20%25%25CURRENCY_SYMBOL%25%251%20-%20and%20it%20only%20takes%20a%20minute.%20Thank%20you.%22%2C%22buttonText%22%3A%22Support%20The%20Guardian%22%2C%22buttonUrl%22%3A%22https%3A%2F%2Fsupport.theguardian.com%2Fcontribute%22%2C%22componentName%22%3A%22Epic%22%2C%22slotName%22%3A%22EndOfArticle%22%2C%22paragraph0%22%3A%22...%20we%20have%20a%20small%20favour%20to%20ask.%20More%20people%2C%20like%20you%2C%20are%20reading%20and%20supporting%20the%20Guardian%E2%80%99s%20independent%2C%20investigative%20journalism%20than%20ever%20before.%20And%20unlike%20many%20news%20organisations%2C%20we%20made%20the%20choice%20to%20keep%20our%20reporting%20open%20for%20all%2C%20regardless%20of%20where%20they%20live%20or%20what%20they%20can%20afford%20to%20pay.%22%2C%22paragraph1%22%3A%22The%20Guardian%20will%20engage%20with%20the%20most%20critical%20issues%20of%20our%20time%20%E2%80%93%20from%20the%20escalating%20climate%20catastrophe%20to%20widespread%20inequality%20to%20the%20influence%20of%20big%20tech%20on%20our%20lives.%20At%20a%20time%20when%20factual%20information%20is%20a%20necessity%2C%20we%20believe%20that%20each%20of%20us%2C%20around%20the%20world%2C%20deserves%20access%20to%20accurate%20reporting%20with%20integrity%20at%20its%20heart.%22%2C%22paragraph2%22%3A%22Our%20editorial%20independence%20means%20we%20set%20our%20own%20agenda%20and%20voice%20our%20own%20opinions.%20Guardian%20journalism%20is%20free%20from%20commercial%20and%20political%20bias%20and%20not%20influenced%20by%20billionaire%20owners%20or%20shareholders.%20This%20means%20we%20can%20give%20a%20voice%20to%20those%20less%20heard%2C%20explore%20where%20others%20turn%20away%2C%20and%20rigorously%20challenge%20those%20in%20power.%22%2C%22paragraph3%22%3A%22We%20hope%20you%20will%20consider%20supporting%20us%20today.%20We%20need%20your%20support%20to%20keep%20delivering%20quality%20journalism%20that%E2%80%99s%20open%20and%20independent.%20Every%20reader%20contribution%2C%20however%20big%20or%20small%2C%20is%20so%20valuable.%20%22%7D).

### Before

- URL query parameters are used for `force-braze-message`
- The Braze Epic cannot be forced

### After

- URL fragment is used for `force-braze-message`
- The Braze Epic can be forced

### In use

![image](https://user-images.githubusercontent.com/34686302/113316777-a149fe80-9306-11eb-8679-83f5aadd0180.png)
