### PR TITLE
Re-add width adjustment for headline bylines

### DIFF
--- a/src/web/components/ContributorAvatar.tsx
+++ b/src/web/components/ContributorAvatar.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import { css } from 'emotion';
+import { from } from '@guardian/src-foundations/mq';
 
 const imageStyles = css`
-	height: 11.25rem;
+	height: 9.375rem;
+
+	${from.mobileLandscape} {
+		height: 11.25rem;
+	}
 `;
 
 export const ContributorAvatar: React.FC<{

--- a/src/web/components/HeadlineByline.tsx
+++ b/src/web/components/HeadlineByline.tsx
@@ -97,7 +97,8 @@ type Props = {
 	tags: TagType[];
 };
 
-const hasSingleContributor = (tags: TagType[]) => tags.filter((tag) => tag.type === 'Contributor').length === 1
+const hasSingleContributor = (tags: TagType[]) =>
+	tags.filter((tag) => tag.type === 'Contributor').length === 1;
 
 export const HeadlineByline = ({ format, byline, tags }: Props) => {
 	if (byline === '') {
@@ -132,7 +133,11 @@ export const HeadlineByline = ({ format, byline, tags }: Props) => {
 				case Design.Comment:
 					return (
 						<div
-							className={cx(opinionWrapperStyles, { [authorBylineWithImage]: hasSingleContributor(tags) })}
+							className={cx(opinionWrapperStyles, {
+								[authorBylineWithImage]: hasSingleContributor(
+									tags,
+								),
+							})}
 						>
 							<div className={opinionStyles(palette, format)}>
 								<BylineLink byline={byline} tags={tags} />

--- a/src/web/components/HeadlineByline.tsx
+++ b/src/web/components/HeadlineByline.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'emotion';
+import { css, cx } from 'emotion';
 import { brandAltBackground } from '@guardian/src-foundations/palette';
 import { headline, textSans } from '@guardian/src-foundations/typography';
 import { space } from '@guardian/src-foundations';
@@ -36,6 +36,10 @@ const yellowBoxStyles = (format: Format) => css`
 			text-decoration: underline;
 		}
 	}
+`;
+
+const opinionWrapperStyles = css`
+	display: inline-block;
 `;
 
 const opinionStyles = (palette: Palette, format: Format) => css`
@@ -93,6 +97,8 @@ type Props = {
 	tags: TagType[];
 };
 
+const hasSingleContributor = (tags: TagType[]) => tags.filter((tag) => tag.type === 'Contributor').length === 1
+
 export const HeadlineByline = ({ format, byline, tags }: Props) => {
 	if (byline === '') {
 		return null;
@@ -126,14 +132,11 @@ export const HeadlineByline = ({ format, byline, tags }: Props) => {
 				case Design.Comment:
 					return (
 						<div
-							className={`${opinionStyles(palette, format)} ${
-								tags.filter((tag) => tag.type === 'Contributor')
-									.length === 1
-									? authorBylineWithImage
-									: ''
-							}`}
+							className={cx(opinionWrapperStyles, { [authorBylineWithImage]: hasSingleContributor(tags) })}
 						>
-							<BylineLink byline={byline} tags={tags} />
+							<div className={opinionStyles(palette, format)}>
+								<BylineLink byline={byline} tags={tags} />
+							</div>
 						</div>
 					);
 				default:


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This adds back some width adjustment for contributor bylines that also have a contributor image, which was originally added to avoid overlapping of byline and image when the byline is a bit longer.

I think this was accidentally removed when we added `display:inline` (hence removing the width) to the div containing the byline in order to only highlight the words, not the entire width of the container in special reports. See https://github.com/guardian/dotcom-rendering/pull/2641

In order to preserve the intention of the fix for opinion special reports I've added an additional wrapper div which is what get's its width set explicitly, and the byline itself remains `display:inline` for highlighting goodness. (Hard to test this thorough because opinion special reports are currently formatted incorrectly)

I think there's still a better longer term fix where structurally the byline and contributor cutout sit alongside each other and the byline just wraps around the image... but that will require a bit more work.

### Before
![image](https://user-images.githubusercontent.com/8754692/113319037-f6870f80-9308-11eb-8580-801d14c14fa8.png)


### After
![image](https://user-images.githubusercontent.com/8754692/113318940-dd7e5e80-9308-11eb-8cf6-547297761bb3.png)

## Why?
To avoid overlapping contributor cutouts and bylines