### PR TITLE
`SWR` (React Hooks library for data fetching)

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
         "prismjs": "^1.23.0",
         "reset-css": "^5.0.1",
         "sanitize-html": "^2.3.2",
+        "swr": "^0.5.5",
         "web-vitals": "^0.2.4",
         "youtube-player": "^5.5.2"
     },

--- a/src/web/lib/api.tsx
+++ b/src/web/lib/api.tsx
@@ -1,8 +1,4 @@
-import useSWR from 'swr';
-
-type Options = {
-	pollInterval?: number;
-};
+import useSWR, { SWRConfiguration } from 'swr';
 
 function checkForErrors(response: Response) {
 	if (!response.ok) {
@@ -30,13 +26,13 @@ interface ApiResponse<T> {
  * A custom hook to make a GET request using the given url
  * returning { loading, error, data }
  * @param {String} url - The url to fetch
- * @param {Object} options
- * @param {Number} options.pollInterval - If supplied, the api will be polled at this interval
+ * @param {SWRConfiguration} options - The SWR config object - https://swr.vercel.app/docs/options
  * */
-export const useApi = <T,>(url: string, options?: Options): ApiResponse<T> => {
-	const { data, error } = useSWR(url, fetcher, {
-		refreshInterval: options?.pollInterval,
-	});
+export const useApi = <T,>(
+	url: string,
+	options?: SWRConfiguration,
+): ApiResponse<T> => {
+	const { data, error } = useSWR(url, fetcher, options);
 
 	return {
 		data,

--- a/src/web/lib/api.tsx
+++ b/src/web/lib/api.tsx
@@ -23,8 +23,8 @@ interface ApiResponse<T> {
 
 /**
  * @description
- * A custom hook to make a GET request using the given url
- * returning { loading, error, data }
+ * A custom hook to make a GET request using the given url using the SWR lib (https://swr.vercel.app/)
+ * returns { loading, error, data }
  * @param {String} url - The url to fetch
  * @param {SWRConfiguration} options - The SWR config object - https://swr.vercel.app/docs/options
  * */

--- a/src/web/lib/api.tsx
+++ b/src/web/lib/api.tsx
@@ -36,7 +36,7 @@ function checkForErrors(response: Response) {
 	return response;
 }
 
-export const callApi = (url: string, fetchOptions?: FetchOptions) => {
+const callApi = (url: string, fetchOptions?: FetchOptions) => {
 	return fetch(url, fetchOptions)
 		.then(checkForErrors)
 		.then((response) => response.json());

--- a/src/web/lib/getIdapiUserData.ts
+++ b/src/web/lib/getIdapiUserData.ts
@@ -1,5 +1,4 @@
 import { joinUrl } from '@root/src/lib/joinUrl';
-import { callApi } from '@root/src/web/lib/api';
 
 export interface IdApiUserData {
 	user?: {
@@ -10,14 +9,30 @@ export interface IdApiUserData {
 	};
 }
 
+function checkForErrors(response: Response) {
+	if (!response.ok) {
+		throw Error(
+			response.statusText ||
+				`getIdApiUserData | An api call returned HTTP status ${response.status}`,
+		);
+	}
+	return response;
+}
+
+const callApi = (url: string) => {
+	return fetch(url, {
+		credentials: 'include',
+	})
+		.then(checkForErrors)
+		.then((response) => response.json());
+};
+
 const cache: { [url: string]: Promise<IdApiUserData> } = {};
 
 export const getIdApiUserData = (ajaxUrl: string): Promise<IdApiUserData> => {
 	if (!(ajaxUrl in cache)) {
 		const url = joinUrl([ajaxUrl, 'user/me']);
-		const response = callApi(url, {
-			credentials: 'include',
-		});
+		const response = callApi(url);
 		cache[ajaxUrl] = response;
 	}
 	return cache[ajaxUrl];

--- a/src/web/lib/getUser.ts
+++ b/src/web/lib/getUser.ts
@@ -1,11 +1,26 @@
 import { joinUrl } from '@root/src/lib/joinUrl';
-import { callApi } from '@root/src/web/lib/api';
+
+function checkForErrors(response: Response) {
+	if (!response.ok) {
+		throw Error(
+			response.statusText ||
+				`getUser | An api call returned HTTP status ${response.status}`,
+		);
+	}
+	return response;
+}
+
+const callApi = (url: string) => {
+	return fetch(url, {
+		credentials: 'include',
+	})
+		.then(checkForErrors)
+		.then((response) => response.json());
+};
 
 export const getUser = async (ajaxUrl: string): Promise<UserProfile | void> => {
 	const url = joinUrl([ajaxUrl, 'profile/me']);
-	return callApi(url, {
-		credentials: 'include',
-	})
+	return callApi(url)
 		.catch((error) => {
 			window.guardian.modules.sentry.reportError(error, 'get-user');
 		})

--- a/src/web/lib/useComments.ts
+++ b/src/web/lib/useComments.ts
@@ -76,7 +76,7 @@ export function useComments(onwardsSections: OnwardsType[]) {
 
 	const url = buildUrl(onwardsSections);
 	const { data } = useApi<CommentsType>(url, {
-		pollInterval: 15000,
+		refreshInterval: 15000,
 	});
 
 	useEffect(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8257,6 +8257,11 @@ deprecation@^2.0.0, deprecation@^2.3.1:
   resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
   integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
 
+dequal@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.2.tgz#85ca22025e3a87e65ef75a7a437b35284a7e319d"
+  integrity sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==
+
 des.js@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.0.tgz#c074d2e2aa6a8a9a07dbd61f9a15c2cd83ec8ecc"
@@ -18252,6 +18257,13 @@ svg-tags@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/svg-tags/-/svg-tags-1.0.0.tgz#58f71cee3bd519b59d4b2a843b6c7de64ac04764"
   integrity sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=
+
+swr@^0.5.5:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-0.5.5.tgz#c72c1615765f33570a16bbb13699e3ac87eaaa3a"
+  integrity sha512-u4mUorK9Ipt+6LEITvWRWiRWAQjAysI6cHxbMmMV1dIdDzxMnswWo1CyGoyBHXX91CchxcuoqgFZ/ycx+YfhCA==
+  dependencies:
+    dequal "2.0.2"
 
 symbol-observable@1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## What?
Adds the SWR (https://swr.vercel.app/) library for fetching data.

Under the hood, this PR completely rebuilds the `useApi` custom hook, but it does this whilst still supporting, more or less*, the same api. Existing components that already use `useApi` don't need to change but they will now automatically benefit from additional features.

Eg. This code does not need to change

```typescript
  const { data, error } = useApi<CAPITrailTabType>(endpointUrl);
```

This still works but now if the reader backgrounds the tab and then returns to it the trail data will be automatically refetched and, if the response has changed, the component re-rendered

\*More or less means the api is the same but the `options` object is different. We only used it in one place though, to pass in `pollingInterval`. I changed it so that we can now pass the entire set of options [that swr allows](https://swr.vercel.app/docs/options).

## Why?
There's no one killer reason, just a series of small positives that, when combined, make a compelling case.

### ✅ Deduplication
If the same request is made twice, the second attempt will be served from the cache

### ✅ Fewer re-renders
Smart (deep) comparisons of api data responses prevent needless re-renders

In addition to comparisons, re-renders are only triggered if the component is actually using any changed state

### ✅ Smart re-fetching
Data is refreshed when readers return focus to the page or tab or when their network connection is restored

### ✅ Prefetching
Because SWR implements a cache, we can use techniques such as hidden divs, manually mutating the cache or link hovers to pre-fetch data that we think the reader may be about to need. The next page of comments, for example

### ✅ Smart polling
Data can be polled via `refreshInterval`. Polling is automatically disabled when the tab is backgrounded

### ✅ Retry logic
Errors are automatically retried after a defined period

### ✅ Less code
There are several places in DCR where we've written code to implement some of the features that are now provided by SWR. With this PR, we will have the opportunity to refactor that custom fetching logic, replacing it with `useApi`

### ✅ The future
If we ever wanted to adopt something like React Server Components then a precursor to that is to ensure our data fetching logic is neatly separated from our local state logic. This PR doesn't do that but it does offer a robust data fetching solution that hopefully meets all our use cases, making it easier for us to create that clean separation

## How does this change our traffic profile?
It both increases and decreases the volume of requests the page will make.

It increases requests because we will make additional calls as users refocus on tabs. It decreases requests because some calls will now be returned from the cache, and not result in a network roundtrip.

The exact profile change is dependent on reader behaviour but is unlikely to be make a big difference in either direction.

## What if I want to POST something?
Then just post it. We don't need any of the features talked about here for post requests, you don't cache posts. swr does allow [mutation of the cache](https://swr.vercel.app/docs/mutation) though which can be useful when editing data. 

## What about persistence?
SWR only uses an in memory cache by default. This is already a big improvement on what we have now. In order to persist this in memory cache over page reloads logic needs to be added to do this.

There are [examples](https://gist.github.com/derindutz/179990f266e25306601dd53b8fbd8c6a) of this being done by others online and also [a lib](https://github.com/sergiodxa/swr-sync-storage) that can be imported to offload this work but given we already have our own custom lib for accessing local storage ([@guardian/libs/storage](https://github.com/guardian/libs/blob/main/src/storage.ts)) it's perhaps logical, and probably better, for us to write this code ourselves.

The SWR cache is implemented here https://github.com/vercel/swr/blob/master/src/cache.ts and can be accessed using `import { cache } from 'swr'`. Essentially you want to subscribe to changes on the cache, writing them to the persistence store, and then implement something to read the store at boot time and populate the cache with it

## Why not React Query?
I originally looked at [React Query](https://react-query.tanstack.com/), which is also really great, but SWR has the features we need and comes in at a much smaller bundle size (5.1Kb vs. 11.5Kb). Both libs are active and popular and both expose very similar apis.