### PR TITLE
Remove unused code from getCountryCode

### DIFF
--- a/src/web/components/SignInGate/displayRule.test.ts
+++ b/src/web/components/SignInGate/displayRule.test.ts
@@ -1,14 +1,12 @@
 import { incrementDailyArticleCount } from '@frontend/web/lib/dailyArticleCount';
 import { Article } from '@root/fixtures/generated/articles/Article';
 import { makeGuardianBrowserCAPI } from '@root/src/model/window-guardian';
-import { setCountryCodeSynchronous } from '@root/src/web/lib/getCountryCode';
 import {
 	isNPageOrHigherPageView,
 	isIOS9,
 	isValidContentType,
 	isValidSection,
 	isValidTag,
-	isCountry,
 } from './displayRule';
 
 const CAPI = Article;
@@ -64,24 +62,6 @@ describe('SignInGate - displayRule methods', () => {
 			const output = isNPageOrHigherPageView(5);
 
 			expect(output).toBe(false);
-		});
-	});
-
-	describe("isCountry('countryCode')", () => {
-		beforeEach(() => {
-			localStorage.clear();
-		});
-		test('geolocation is US', () => {
-			setCountryCodeSynchronous('US');
-			expect(isCountry('US')).toBe(true);
-		});
-
-		test('geolocation is not US', () => {
-			setCountryCodeSynchronous('GB');
-			expect(isCountry('US')).toBe(false);
-		});
-		test('geolocation is false if not set', () => {
-			expect(isCountry('US')).toBe(false);
 		});
 	});
 

--- a/src/web/components/SignInGate/displayRule.ts
+++ b/src/web/components/SignInGate/displayRule.ts
@@ -3,7 +3,6 @@ import {
 	DailyArticle,
 	getDailyArticleCount,
 } from '@frontend/web/lib/dailyArticleCount';
-import { getCountryCodeFromLocalStorage } from '@frontend/web/lib/getCountryCode';
 import { CurrentABTest } from '@root/src/web/components/SignInGate/gateDesigns/types';
 import { hasUserDismissedGateMoreThanCount } from '@root/src/web/components/SignInGate/dismissGate';
 
@@ -15,13 +14,6 @@ export const isNPageOrHigherPageView = (n: number = 2): boolean => {
 	const { count = 0 } = dailyCount;
 
 	return count >= n;
-};
-
-// use gu.location to determine is the browser is in the specified country
-// Note, use country codes specified in guardian/frontend/static/src/javascripts/lib/geolocation.js
-export const isCountry = (countryCode: string): boolean => {
-	const countryCodeFromStorage = getCountryCodeFromLocalStorage();
-	return countryCodeFromStorage === countryCode;
 };
 
 // determine if the useragent is running iOS 9 (known to be buggy for sign in flow)

--- a/src/web/lib/getCountryCode.ts
+++ b/src/web/lib/getCountryCode.ts
@@ -33,30 +33,6 @@ export const setCountryCode = (countryCode: string): void => {
 	});
 };
 
-export const setCountryCodeSynchronous = (countryCode: string): void => {
-	if (countryCode) {
-		localStorage.setItem(
-			COUNTRY_CODE_KEY,
-			JSON.stringify({
-				value: countryCode,
-				expires: new Date().getTime() + TEN_DAYS,
-			}),
-		);
-	}
-};
-
-export const getCountryCodeFromLocalStorage = (): string | null => {
-	try {
-		const item = localStorage.getItem(COUNTRY_CODE_KEY);
-		const localCountryCode: { [key: string]: any } = JSON.parse(
-			item || '{}',
-		);
-		return localCountryCode.value || null;
-	} catch (error) {
-		return null;
-	}
-};
-
 export const getCountryCode = async (): Promise<string | void> => {
 	// Read local storage to see if we already have a value
 	let localCountryCode: LocalCountryCodeType | null;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Removes some code that is no longer being used.

## Why?
Dead code makes it harder to understand what is happening in a file. Less code is simpler.

## What if we need this code in the future?
Sometimes it can be tempting to keep code which seems to be doing something useful because it just feels nice to offer a great api but our primary goals in DCR are maintainability and performance so we should only keep code if it is needed and used