### PR TITLE
`Design.Letter`

### DIFF
--- a/fixtures/generated/articles/Analysis.ts
+++ b/fixtures/generated/articles/Analysis.ts
@@ -1787,7 +1787,7 @@ export const Analysis: CAPIType = {
 				},
 			],
 			_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-			elementId: '7dcd0d47-ebd8-4221-9885-1dfb2df2becd',
+			elementId: '41cf5ee3-d257-4ec3-8b44-4d12f51154f2',
 		},
 	],
 	webPublicationDate: '2020-02-10T12:31:25.000Z',
@@ -1799,21 +1799,21 @@ export const Analysis: CAPIType = {
 					html: '<h2>Who won Ireland’s general election?</h2>',
 					_type:
 						'model.dotcomrendering.pageElements.SubheadingBlockElement',
-					elementId: '6cc620a2-8f59-408b-8b12-cbd5b0f370fa',
+					elementId: '3b790553-e5c8-4f21-adfc-d15d51385be0',
 				},
 				{
 					html:
 						'<p>Sinn Féin <a href="https://www.theguardian.com/world/2020/feb/09/sinn-fein-to-try-to-form-ruling-coalition-after-irish-election-success">won the most first-preference votes</a> – 24.5% – making it the most popular party and a strong contender to be included in the next government. <a href="https://www.theguardian.com/world/2020/jan/31/leo-varadkar-paradox-feted-abroad-can-pm-arrest-polls-slump-in-ireland-election">Leo Varadkar</a>’s ruling Fine Gael party slid to 20.8%, coming third, and Fianna Fáil, the main opposition party, also slipped, falling to 22.1% in second place. The rest of the vote was split between the Greens, on 7.1%, and small leftwing parties and independent candidates.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '0a699a68-e6e5-49f2-8c02-6a939fb5bd94',
+					elementId: 'f356e0e7-71e4-4cda-b30e-9c5b36072fef',
 				},
 				{
 					html:
 						'<p>Sinn Féin fielded too few candidates to fully translate its support into seats so Fianna Fáil is expected to be the biggest party in Dáil Éireann, the Irish parliament’s lower house, which has 160 members, when all seats are allocated under Ireland’s single transferrable vote system of proportional representation.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '0df7c45d-0ead-45d8-bc78-e8572580e3c6',
+					elementId: '14b7c926-d1f3-4c97-88de-90606642c207',
 				},
 				{
 					url:
@@ -1823,40 +1823,40 @@ export const Analysis: CAPIType = {
 					role: 'thumbnail',
 					_type:
 						'model.dotcomrendering.pageElements.RichLinkBlockElement',
-					elementId: '60861c8e-b1a3-445b-b42d-f1b8a2431cab',
+					elementId: '04ca30e0-cf69-4404-a583-c693613ebb75',
 				},
 				{
 					html:
 						'<p>Current projections give Fianna Fáil around 42, with Sinn Féin and <a href="https://www.theguardian.com/world/fine-gael" data-component="auto-linked-tag">Fine Gael</a> each in the mid to high 30s. Full results are expected later on Monday or Tuesday.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '8a8d6722-e746-441a-b32e-928e78e44e56',
+					elementId: '518affeb-7642-445a-96be-cb8341249b0d',
 				},
 				{
 					html: '<h2>Was Sinn Féin’s success a surprise?</h2>',
 					_type:
 						'model.dotcomrendering.pageElements.SubheadingBlockElement',
-					elementId: 'da6e1ac3-2cc8-489c-9381-d5c616c3748a',
+					elementId: '18344521-65ba-40ac-b08c-68bf584e61bd',
 				},
 				{
 					html:
 						'<p>An opinion poll signalled it last week but the result is still a big shock. Fine Gael and Fianna Fáil, centrist rivals, dominated Irish politics for the past century, taking turns to rule. That era appears over.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'caa80b4e-7a20-432c-92ee-7a43aa78ee69',
+					elementId: '1eedf91c-a234-4d3d-b300-352c8faa54b2',
 				},
 				{
 					html: '<h2>Is Varadkar going to lose power?</h2>',
 					_type:
 						'model.dotcomrendering.pageElements.SubheadingBlockElement',
-					elementId: '828e9c82-4c0c-4aa5-9d82-a143bf414f6e',
+					elementId: '99e88744-c0eb-472b-917c-5f8186ae20f2',
 				},
 				{
 					html:
 						'<p>Very possibly, but there’s a chance he could hang on as taoiseach after negotiations between party leaders to form a coalition with 80 seats, the magic number for a parliamentary majority. Varadkar says he would be willing to lead Fine Gael in opposition.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'e038e498-a54d-40c0-9892-858304d24cb6',
+					elementId: '2c036d35-205a-4c5e-9bd4-0e468774789f',
 				},
 				{
 					id: '95c8ba09-ecce-4bfa-9140-a262990fbdce',
@@ -1865,81 +1865,81 @@ export const Analysis: CAPIType = {
 						'<p><a href="https://www.theguardian.com/politics/fine-gael">Fine Gael</a><br></p><p>Its name can be translated as family or tribe of the Irish. A centre-right party with a socially progressive tilt. In office since 2011, first led by Enda Kenny, then&nbsp;<a href="https://www.theguardian.com/world/leo-varadkar">Leo Varadkar</a>, with support from smaller coalition partners. Traces roots to Michael Collins and the winning side in Ireland’s 1922-23 civil war. The party traditionally advocates market economics and fiscal discipline. Appeals to the urban middle class and well-off farmers.</p><p><a href="https://www.theguardian.com/politics/fianna-fail">Fianna Fáil</a></p><p>Its name means Soldiers of Destiny. A centrist, ideologically malleable party that dominated Irish politics until it steered the Celtic Tiger economy over a cliff, prompting decade-long banishment to opposition benches. Under Micheál Martin, a nimble political veteran, it has clawed back support and may overtake Fine Gael as the biggest party and lead the next coalition government. Founded by Éamon de Valera, who backed the civil war’s losing side but turned Fianna Fáil into an election-winning machine.</p><p><a href="https://www.theguardian.com/politics/sinn-fein">Sinn Féin</a></p><p>Its name means We Ourselves, signifying Irish sovereignty. A leftwing republican party that competes in Northern Ireland as well as the Republic. Traces roots to 1905. Emerged in current form during the Troubles, when it was linked to the IRA. Peace in Northern Ireland helped Sinn Féin rebrand as a working-class advocate opposed to austerity. Under Mary Lou McDonald, a Dubliner without paramilitary baggage, Sinn Féin has become the third-biggest party, and its vote share surged in the 2020 election.&nbsp;</p><p>Others</p><p>Partnership with Fine Gael during post-Celtic Tiger austerity tainted the centre-left <b>Labour</b> party. The political arm of the trade union movement, it is led by Brendan Howlin, a former teacher and government minister.</p><p>The <b>Social Democrats</b> and <b>Solidarity-People Before Profit</b> are part of an alphabet soup of smaller, more leftwing parties. The <b>Greens</b>, wiped out in 2011 after a ruinous coalition with Fianna Fáil, have campaigned on the back of climate crisis anxiety and youth-led protests. Independent TDs have prospered in recent elections, turning some into outsized players in ruling coalitions. <b>Rory Carroll</b></p>',
 					credit: '',
 					_type: 'model.dotcomrendering.pageElements.QABlockElement',
-					elementId: 'a551cdca-8e93-46b2-bc4d-963c4b674a18',
+					elementId: '8374d748-dce9-482b-a48b-d6a2869cb8eb',
 				},
 				{
 					html: '<h2>Why did Sinn Féin do so well?</h2>',
 					_type:
 						'model.dotcomrendering.pageElements.SubheadingBlockElement',
-					elementId: '02518751-15e8-48d7-bfb9-72ea5b4df83f',
+					elementId: 'ac50dcc6-a054-46d9-8857-4de0f51414db',
 				},
 				{
 					html:
 						'<p>It rode a wave of anger over homelessness, soaring rents, hospital waiting lists and and fraying public services. Its leader, <a href="https://www.theguardian.com/politics/2020/feb/07/mary-lou-mcdonald-sinn-fein-leader-kingmaker-ireland-election-ireland">Mary Lou McDonald</a>, and party colleagues such as Eoin Ó Broin and Pearse Doherty offered leftwing solutions, such as an ambitious public housing building programme, that enthused voters, especially those under 50.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '87af808e-a1c2-4568-a459-a96be6554180',
+					elementId: '86ea7db7-e57b-4752-b55d-8c2a23dd8c31',
 				},
 				{
 					html:
 						'<p>Varadkar’s attempt to frame the election around his Brexit diplomacy and the humming economy fell flat. Fianna Fáil was contaminated by its confidence-and-supply deal that had propped up Varadkar’s minority administration, leaving Sinn Féin to cast itself as the agent of real change. Voters forgot, forgave or did not care about its past as the IRA’s political wing during the Troubles.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '6d07a071-94d8-4676-a8f4-fe2623793430',
+					elementId: 'a8a563f0-de7c-4466-85d2-fabdbf59688f',
 				},
 				{
 					html: '<h2>What happens next?</h2>',
 					_type:
 						'model.dotcomrendering.pageElements.SubheadingBlockElement',
-					elementId: '2920a259-7dd4-416a-af81-1ad13c7d87be',
+					elementId: '3c356474-03c5-4f72-906a-04c345e5fa3d',
 				},
 				{
 					html:
 						'<p>Weeks – possibly months – of negotiations between party leaders. McDonald is floating an alliance of leftwing parties led by Sinn Féin but that’s unlikely – it would be far short of 80 seats. The only viable looking option entails an alliance between two of the three main parties plus perhaps the Greens.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '83af6ade-ca31-4d27-94bf-4fc2c410d283',
+					elementId: 'e7223a4e-ab5c-4f6d-8e38-954c704fa41a',
 				},
 				{
 					html:
 						'<p>Varadkar has ruled out a pact with Sinn Féin and floated a deal with Fianna Fáil. During the campaign the Fianna Fáil leader, Micheál Martin, ruled out entering government with Fine Gael or Sinn Féin but since Sunday has hinted he may do a deal with one or the other.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '99079b27-60ab-4efa-8be3-7fd53686644d',
+					elementId: '09836228-def8-453a-bd5d-2f3becedb1e2',
 				},
 				{
 					html:
 						'<p>Expect shadow boxing. Sinn Féin will be very wary about entering government as a junior partner – a recipe for punishment at the next election, as other parties have discovered. Some suspect its preferred outcome is a Fianna Fáil-Fine Gael government – an unpopular continuation of the status quo that would consolidate Sinn Féin as leader-in-waiting of the subsequent government.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'd8f1a2ae-f1ce-4e10-ab3f-8f506e0a86a2',
+					elementId: '66140547-f7f0-4bee-8f78-46b0df0cc3fa',
 				},
 				{
 					html:
 						'<p>For that reason Fianna Fáil will hesitate to do a deal with Fine Gael. But Fianna Fáil may oust Martin if he does not become taoiseach.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '126fad17-5e15-4474-a8e4-00d652e9e7df',
+					elementId: '5ce4b6d5-5425-4b08-9905-af4188396cfd',
 				},
 				{
 					html:
 						'<p>One plausible outcome: deadlock, and another election.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '7175997a-dc8b-427e-a551-c22713f1d8ec',
+					elementId: '4d7be7cd-eac1-47e8-b037-0f4b94512309',
 				},
 				{
 					html: '<p><strong>Read more</strong></p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'dfa39878-1baa-46ae-8aab-eb56ac5cc51b',
+					elementId: 'b8844b5f-c4f4-4f58-b18e-4a0b3a44a646',
 				},
 				{
 					html:
 						'<p><a href="https://www.theguardian.com/politics/2020/feb/07/mary-lou-mcdonald-sinn-fein-leader-kingmaker-ireland-election-ireland">Mary Lou McDonald: Sinn Féin leader who may play Dublin kingmaker</a><br><a href="https://www.theguardian.com/world/2020/feb/08/sinn-fein-on-election-day-shane-obrien">‘It’s a sea change’: Sinn Féin dares to dream on election day</a><br><a href="https://www.theguardian.com/commentisfree/2020/jan/31/sinn-fein-ireland-left-election-ira">Opinion: Can Sinn Féin’s young voters finally pull Ireland to the left?</a><br><a href="https://www.theguardian.com/world/2020/jan/31/leo-varadkar-paradox-feted-abroad-can-pm-arrest-polls-slump-in-ireland-election">The Varadkar paradox: feted abroad, can PM arrest polls slump in Ireland?</a></p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '206a863d-1f47-4970-a435-39d87db8588b',
+					elementId: 'ff7a8d16-0e29-41dd-bfff-759aa6ce0c52',
 				},
 			],
 			createdOn: 1581333561000,

--- a/fixtures/generated/articles/Article.ts
+++ b/fixtures/generated/articles/Article.ts
@@ -1760,7 +1760,7 @@ export const Article: CAPIType = {
 				},
 			],
 			_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-			elementId: 'f4040c45-3600-4f95-9c2b-4d2f89b44873',
+			elementId: '733f07f9-23d6-4f8d-a06b-7925ac56a5ae',
 		},
 	],
 	webPublicationDate: '2020-02-10T06:00:27.000Z',
@@ -1773,63 +1773,63 @@ export const Article: CAPIType = {
 						'<p>A <a href="https://experience.arcgis.com/stemapp/5f6596de6c4445a58aec956532b9813d">series of detailed maps</a> have laid bare the scale of possible forest fires, floods, droughts and deluges that Europe could face by the end of the century without urgent action to adapt to and confront global heating.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'da030e1e-2df2-4303-8aff-4e481fb5b4f0',
+					elementId: '4fa030a5-b272-449f-a785-f9e6d3dd0c73',
 				},
 				{
 					html:
 						'<p>An average one-metre rise in sea levels by the end of the century – without any flood prevention action – would mean 90% of the surface of Hull would be under water, according to the European Environment Agency.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '822329ba-60ed-478c-ae5b-64ed76da9bcc',
+					elementId: '969719bb-1fee-4f04-a18a-ef3d5c41b409',
 				},
 				{
 					html:
 						'<p>English cities including Norwich, Margate, Southend-on-Sea, Runcorn and Blackpool could also experience flooding covering more than 40% of the urban area.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'c9518369-ff99-4eea-b7c4-e20b2242db26',
+					elementId: 'c8cb78d1-5531-4b2f-b8b4-563f0e47de1e',
 				},
 				{
 					html:
 						'<p>Across the North Sea, Dutch cities including the Hague, Rotterdam and Leiden were predicted to face severe floods from an average one metre sea-level rise, which is forecast if emissions rise enough to cause an increase in global temperature of 4C–6C above pre-industrial levels.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'acdaa2e3-0e13-42fe-97f9-c096b8a7554c',
+					elementId: '9dc13e5b-c3fd-4504-b669-ebdebebbbcbb',
 				},
 				{
 					html:
 						'<p>The model does not account for the Netherlands’ extensive flood-prevention measures, although many other countries have not taken such action.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '85e134b7-5aaa-4ded-aeb0-b68072cde2f4',
+					elementId: '3463b69d-5a91-4284-b25e-edb83d78a29a',
 				},
 				{
 					html:
 						'<p>Meanwhile, large areas of Spain, Portugal and France would be grappling with desertification, with the worst-affected zones experiencing a two and half-fold increase in droughts under the worst-case scenario.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '9cce65a5-8841-4ca9-aeaf-b6231397d483',
+					elementId: '80eee338-3588-4473-a817-6fd92d192d0f',
 				},
 				{
 					html:
 						'<p>Hotter summers increase the risk of forest fires, which <a href="https://www.theguardian.com/world/2018/jul/18/sweden-calls-for-help-as-arctic-circle-hit-by-wildfires">hit record levels in Sweden in 2018</a>. If emissions exceed 4C, France, southern Germany, the Balkans and the Arctic Circle could experience a greatly increased fire risk. However, the absolute fire danger would remain highest in southern European countries, which are already prone to blazes.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'c57eebcd-08ee-4469-94b4-2e1b2cca02eb',
+					elementId: '6bf1da27-8ecd-45ed-b7b5-e34bcbbe24d7',
 				},
 				{
 					html:
 						'<p>Further north, winters are becoming wetter. Failure to limit global heating below 2C could mean a swath of central and eastern Europe, from Bratislava in the west to Yaroslavl in the east, will be in line for sharp increase in “heavy rain events” during autumn and winter by the end of the century.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '0f3e84d3-39d8-4a93-a5e2-39b6ed643a53',
+					elementId: '314e3c43-e020-4cc4-b9fc-085bb336bbff',
 				},
 				{
 					html:
 						'<p>In some areas of central and eastern Europe there is predicted to be a 35% increase in heavy rain events, meaning torrential downpours would be more frequent.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '3aae0482-eb96-476b-8e80-ed29658a381c',
+					elementId: '395d5427-6dd6-4b56-bb38-1bf2d6be62cd',
 				},
 				{
 					media: {
@@ -2204,70 +2204,70 @@ export const Article: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: '3e5de465-4892-4c2d-bf0f-5232b11d4ba6',
+					elementId: '6a77d662-f84a-417b-b36b-13a770994a2e',
 				},
 				{
 					html:
 						'<p>While the climate data has been published before, this is the first time the EU-agency has presented it using detailed maps on one site. Users can zoom in on small areas, for example, to discover that one-third of the London borough of Hammersmith and Fulham could be exposed to flooding by 2071.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'cc14293a-6fd1-4304-b789-24e69824b085',
+					elementId: '65876ceb-07c2-46a5-9356-cc7cf38ee07f',
 				},
 				{
 					html:
 						'<p>The Copenhagen-based agency hopes the maps will reach decision-makers in governments and EU institutions, who would not usually read a lengthy EEA report on the impact of the climate emergency.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '1f63cdf8-83a4-4162-b06a-a8e213e5fa69',
+					elementId: '3b181f02-35e3-46f8-8fd4-78d229a4c973',
 				},
 				{
 					html:
 						'<p>“It’s very urgent and we need to act now,” said Blaž Kurnik, an EEA expert in climate change impacts and adaptation.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '470ad4ea-15fa-4d47-ba05-a5a582effae1',
+					elementId: 'ef638e9c-85c8-4d89-9a36-a8914905b727',
 				},
 				{
 					html:
 						'<p>Even if countries succeed in restricting global temperature rise, existing CO<strong><sub>2</sub></strong> in the atmosphere would still have an impact, he said.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '41422b9b-3a54-4360-87ce-8350f599352a',
+					elementId: '1e0e0313-416d-41e3-95ca-605ed9f4437e',
 				},
 				{
 					html:
 						'<p>“The number of extreme events and sea level rise will still continue to increase for the next decades to a century,” Kurnik said. “Sea level rise, especially, can be problematic, because it is still increasing because of past emissions and the current concentration of greenhouse gases.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'c21e453d-5ed9-4c45-8932-4e6a0e1884b5',
+					elementId: '70363dfa-e8cb-4923-8be2-2664e77963c4',
 				},
 				{
 					html:
 						'<p>The agency wants governments to focus on adapting to unavoidable global heating. “Adaptation is crucial in the next decades of the century. Even if we are able to increase the temperature by 2C, adaptation is crucial for the next decades.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '8f4ec7e5-52d4-46ed-8b6d-d1fbd82d495a',
+					elementId: 'b31fd57c-ec20-46d9-8310-e6ab4b504030',
 				},
 				{
 					html:
 						'<p>The EEA has concluded it is <a href="https://www.eea.europa.eu/data-and-maps/indicators/atmospheric-greenhouse-gas-concentrations-6/assessment-1">possible to limit the rise in global temperatures to 2C above pre-industrial levels</a>, as long as greenhouse gas concentrations peak during the next 15 to 29 years.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '812e0213-2e57-4465-b275-87789bbfc7bf',
+					elementId: 'c9f82fb5-c8d0-4e10-915f-68eaa405f0e9',
 				},
 				{
 					html:
 						'<p>Meeting a more demanding<a href="https://www.theguardian.com/environment/2018/oct/08/global-warming-must-not-exceed-15c-warns-landmark-un-report"> 1.5C limit</a> requires concentrations to peak in the next three to 13 years. Under both scenarios, there is a 50% chance of overshooting the temperature.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'd048f201-3114-489d-ae65-712f755d3839',
+					elementId: '8a22ec0d-78cc-4786-94eb-1cd6488975e4',
 				},
 				{
 					html:
 						'<p>• This article was amended on 10 February and 14 May 2020. An earlier version said that the EEA concluded “it is possible to keep global temperatures 2C below pre-industrial levels, as long as emissions peak during the next 15 to 29 years”. That meant to say greenhouse gas concentrations, not emissions; and the 2C referred to a rise in temperature above pre-industrial levels, not the temperature below pre-industrial levels. This article was further amended because an earlier version omitted “enough to cause an increase in global temperature of” from the sentence: “… an average one metre sea-level rise, which is forecast if emissions rise enough to cause an increase in global temperature of 4C–6C above pre-industrial levels”. This has been corrected.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '801fa0fe-9113-4091-94a8-241a6e685f82',
+					elementId: 'a36ad6ad-9294-4b45-86fd-b20d8c732102',
 				},
 			],
 			createdOn: 1581071176000,

--- a/fixtures/generated/articles/Comment.ts
+++ b/fixtures/generated/articles/Comment.ts
@@ -1835,7 +1835,7 @@ export const Comment: CAPIType = {
 				},
 			],
 			_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-			elementId: '728581f4-5c56-4204-b483-13810ce94230',
+			elementId: 'fe8daf0f-8185-4fc3-85a6-4c8ad85931e9',
 		},
 	],
 	webPublicationDate: '2020-02-10T06:00:27.000Z',
@@ -1848,7 +1848,7 @@ export const Comment: CAPIType = {
 						'<p>Seven years ago, pretty much to the week, I paid my <a href="https://www.theguardian.com/commentisfree/2013/feb/04/newcastle-cold-fear-little-sense-of-hope" title="">first visit as a journalist</a> to Newcastle upon Tyne. The ostensible reason was a fuss about the city council’s proposal to cut its arts budget to zero, and a <a href="https://www.theguardian.com/uk/2012/dec/16/newcastle-arts-cuts-disastrous-stars" title="">campaign of opposition</a> endorsed by such alumni of the city as Bryan Ferry and Gordon “Sting” Sumner. But that controversy was only a small, distracting aspect of a much bigger story: the fact that the coalition government’s austerity was now threatening some of the most basic parts of Newcastle’s social fabric, as councillors faced cuts of around £100m, spread over three years. Then as now, they were led by Nick Forbes, the imaginative, engaging politician who remains in post, and is these days also the leader of the Local Government Association’s Labour group, which represents councillors from across England and Wales, and had its annual conference at the weekend.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '57c9e412-bcd6-48b6-9dde-24efc5546a38',
+					elementId: '7c52bf6e-4987-4ad3-81a8-6f33c32b798a',
 				},
 				{
 					html:
@@ -1857,49 +1857,49 @@ export const Comment: CAPIType = {
 					isThirdPartyTracking: false,
 					_type:
 						'model.dotcomrendering.pageElements.PullquoteBlockElement',
-					elementId: '74baf3a3-ee0a-455b-b3c8-a60f720381cb',
+					elementId: 'be44e1ef-716f-4d3c-8a3c-6b8a698b12b3',
 				},
 				{
 					html:
 						'<p>As the government hacked back the money that went from Whitehall to councils and the need for child and adult social care services continued to rise, <a href="https://www.chroniclelive.co.uk/news/north-east-news/tax-freeze-cuts-newcastle-city-6464052" title="">£37m</a> was cut from Newcastle’s budgets in 2013-14, followed by <a href="https://www.chroniclelive.co.uk/news/north-east-news/newcastle-city-council-reveals-40m-7276999" title="">£38m, then £40m</a> and <a href="https://www.bbc.co.uk/news/uk-england-tyne-38145319" title="">£30m</a> – and so on, until the council had lost <a href="https://www.chroniclelive.co.uk/news/north-east-news/20m-cuts-newcastle-council-mean-17414937" title="">an estimated £300m</a> by the end of 2019. Each time I have gone back, I have heard about what has happened to libraries, seen closed youth clubs that were among the first things to be axed, and talked to people about cuts to early-years provision leading to four in 10 of the north-east’s children’s centres being shut. There is an awful symbolism in the fall in the <a href="https://www.bbc.co.uk/news/uk-politics-46514670" title="">number of lollipop men and women</a> from 64 to seven; on one trip, I was struck by the quiet poignancy of parks smattered with broken slides and swings.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'cee3c02c-6036-4e0d-a1f9-91375482ae41',
+					elementId: 'f236cf88-c836-4037-8b1e-67f683f16e4f',
 				},
 				{
 					html:
 						'<p>But despite cliches about places in “the north” being social deserts, Newcastle is full of initiative and innovation – and as austerity hit, there was plenty of <a href="https://www.theguardian.com/business/2015/nov/23/newcastle-cuts-save-library-lose-pool-john-harris" title="">grassroots work</a> aimed at parrying the cuts, bringing in new approaches and making parts of the city more resilient. But hacked-back spending has taken an inevitable toll, and reflects something happening all over the country: the government using local and city government to administer policies that reflect ideological prejudices coursing through Westminster and Whitehall.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'a3959ae9-0efb-4c53-9e95-e2a982ec7816',
+					elementId: '8e2e1c3b-b703-4c6f-bdaa-cfec6f5ca513',
 				},
 				{
 					html:
 						'<p>Of late, by contrast, we have heard a lot of talk about Boris Johnson and his allies turning on the fiscal taps, and somehow marking the “end of austerity”. When he moved into Downing Street, <a href="https://www.bbc.co.uk/news/uk-politics-49102495" title="">the prime minister said</a> he would be “answering at last the plea of the forgotten people and left-behind towns, by physically and literally renewing the ties that bind us together, so that with safer streets and better education, and fantastic new road and rail infrastructure and full-fibre broadband, we level up across Britain”. Some of this is likely to happen, but all over the country austerity is nonetheless grinding on.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'cab9a0c3-fd10-48ef-a8ce-902b8035c85e',
+					elementId: '03d6c897-97c3-4651-9d80-2487358cc8d0',
 				},
 				{
 					html:
 						'<p>Whatever paltry financial extras the government may now be granting councils, rising costs and increased need far outstrip them. Leeds <a href="https://www.yorkshireeveningpost.co.uk/news/politics/leeds-council-reveals-ps28m-cuts-coming-year-1385168" title="">faces cuts</a> in the next financial year of £28m. On the Wirral, the <a href="https://www.wirralglobe.co.uk/news/18213040.council-budget-clash/" title="">figure is £30m</a>; across the water in Liverpool, where <a href="https://www.liverpoolecho.co.uk/news/liverpool-news/joe-anderson-refuse-carry-out-17659928" title="">the mayor, Joe Anderson</a>, now says he will refuse to put through any further cuts beyond April 2021, there is a funding gap of £30m, only £7.2m of which will come from putting up council tax. In Doncaster, <a href="https://www.doncasterfreepress.co.uk/news/politics/council-tax-rise-and-job-cuts-way-doncaster-council-announces-its-budget-1384199" title="">new cuts</a> must total £18m; in Blackpool, to meet its obligations in children’s services, the council must somehow <a href="https://www.blackpoolgazette.co.uk/news/politics/ps20m-savings-plus-more-job-losses-blackpool-council-unveils-budget-proposals-1380603" title="">save £20m</a> from its other work. In Newcastle, the council will have to <a href="https://www.chroniclelive.co.uk/news/north-east-news/20m-cuts-newcastle-council-mean-17414937" title="">cut £20m</a> across its budgets in 2020-21 – and, on current projections, another £17-18m the year after that.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'f26a3d96-9ea8-44db-bbd4-215b79a2d607',
+					elementId: '589b7633-ccc7-4941-8a78-5bbcc5a464af',
 				},
 				{
 					html:
 						'<p>I spoke to Forbes last week. “We’ve cut every other service that the council provides to the absolute minimum, to try to protect social care,” he told me. “This is the first year we haven’t been able to do anything other than take money out of social care budgets … in some cases, we’re going to have to take away support that people have previously had.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'bdbe4563-b2b1-4273-9e1f-b7eaee756deb',
+					elementId: 'e376c30c-182d-46a0-8091-ce9b992c5cd4',
 				},
 				{
 					html:
 						'<p>By way of cold comfort, last year’s autumn statement meant an injection by the government of £11m into the city’s finances, but it will be largely eaten up by the recent increase in the minimum wage. Embracing the Conservatives’ proposal that councils can raise council tax by up to 2% to cover rising pressures on adult social care, Forbes says, will bring a paltry £2m. Next year “looks even more scary, because it looks like we’re going to have to start dismantling various aspects of our social work teams”. This seems set to affect children’s services, which up to now have been protected.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '606586ef-eef7-44ba-953f-ede5eb2033b0',
+					elementId: 'da2c302e-d587-4889-a660-0ad8507fcd41',
 				},
 				{
 					url:
@@ -1910,41 +1910,41 @@ export const Comment: CAPIType = {
 					role: 'thumbnail',
 					_type:
 						'model.dotcomrendering.pageElements.RichLinkBlockElement',
-					elementId: '3f090606-875c-48bc-a700-16e93abbc710',
+					elementId: '52aeda17-5a14-4fa1-ac5a-01ae0d599e03',
 				},
 				{
 					html:
 						'<p>The politics of continuing austerity are often maddeningly contradictory. I have been to plenty of places where cuts have intensified people’s conviction that they have been neglected by Westminster and Whitehall. That impulse was one of the reasons behind the Brexit vote. In turn, the frustrations of three years of post-referendum politics and Johnson’s cynical approximation of optimism convinced people in lots of these areas to vote Conservative. And so it is that austerity continues, while the government tries to escape the blame by cosmetically positioning itself against its own policies.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '36cee386-ab11-47fc-9b15-aeb41fcba030',
+					elementId: 'f14e97e1-3862-481c-a87e-10f6d007c9c9',
 				},
 				{
 					html:
 						'<p>For the people involved in councils, other aspects of the picture are equally confounding. Rather than being able to plan for the long term, they have to wait every year for news of what the government will give them; thanks partly to the December election, even with the start of the next financial year looming, the next set of figures was confirmed only last week. In the spring, the government will reveal its new system of so-called “fair funding”. Recent reports have suggested that allocations for social care in some of England’s most deprived areas (including many places that were until recently part of the “red wall” of Labour constituencies) will <a href="https://www.theguardian.com/society/2020/jan/25/former-red-wall-areas-could-lose-millions-in-council-funding-review" title="">fall by £320m</a>, while those in more affluent places will rise by around the same amount.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '9309f724-eb07-43c9-9db6-58bc2db1846a',
+					elementId: 'a611357a-71e8-4462-af31-12e6ce1cdadb',
 				},
 				{
 					html:
 						'<p>Possibly in response to the anxiety these projections sparked, subsequent predictions have suggested that other changes could balance these unfairnesses out – although many injustices would seemingly get worse. <a href="https://www.countycouncilsnetwork.org.uk/lgc-article-on-fair-funding-review-modelling-ccn-response/" title="">One report</a> suggests that inner London boroughs could lose as much as a quarter of their funding. The consequences of that would be unimaginable. To cap it all, there is the mess of uncertainty surrounding Brexit, and what it may mean for the public finances.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '740be7ca-06ec-44b5-a6ad-185a22cb695a',
+					elementId: 'e08f90c5-ef08-4fe1-a15c-7211f57a0cb4',
 				},
 				{
 					html:
 						'<p>We know that the chancellor has already told departments to come up with <a href="https://www.theguardian.com/society/2020/jan/29/ministers-told-to-find-5-savings-to-refocus-on-pms-priorities" title="">savings of 5%</a>. Some people say that if the government has any intention of easing the predicament of councils and the people who need their services, the last chance for a rethink will come with the autumn statement. But whatever happens, most of the people I have spoken to are worried and angry for one incurable reason: the fact that after 10 years of cuts, so much damage has been done. Most of what has been closed will not come back; countless instances of need and hardship now feel like they are locked in. Brexit flags and banners, and some of those overhyped infrastructure projects, are hardly going to make up for the pain.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '99ee0ba1-a174-4734-b075-a84b4ac4025b',
+					elementId: '761afe87-5739-45f9-ba3e-abc9a50bed04',
 				},
 				{
 					html: '<p>• John Harris is a Guardian columnist</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '7dc9e3f8-e212-4f0a-91f3-8696883cc6e4',
+					elementId: '7c0fda5a-b80b-4de2-9eb4-6a30df12b272',
 				},
 			],
 			createdOn: 1581250344000,

--- a/fixtures/generated/articles/Dead.ts
+++ b/fixtures/generated/articles/Dead.ts
@@ -1969,7 +1969,7 @@ export const Dead: CAPIType = {
 				},
 			],
 			_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-			elementId: '29e9587e-6ddc-4374-980b-4f159ba61f52',
+			elementId: '4baf5b4a-2fb1-46d6-915a-3d5ef246e0fb',
 		},
 	],
 	webPublicationDate: '2021-02-19T19:41:53.000Z',
@@ -1982,20 +1982,20 @@ export const Dead: CAPIType = {
 						'<p>That’s it for our live coverage of Nasa’s celebratory news conference and Q&amp;A following the successful landing of the rover Perseverance on Mars. </p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '0e5c96b4-c7b5-46a7-8f77-96dbf025669e',
+					elementId: '97e3d94b-ec08-4a79-9f59-73dc2f97aada',
 				},
 				{
 					html: '<p>To recap:</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'e4e09ee6-d11d-495f-8412-12c5878ed313',
+					elementId: '415bb741-6730-4dae-a441-39eb98032279',
 				},
 				{
 					html:
 						'<ul> \n <li>The rover is “healthy” and undergoing systems testing.</li> \n <li>It already has beamed back stunning photos from the surface of <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> promising significant scientific discoveries ahead.</li> \n <li>The images include the first color images beamed directly from <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> as opposed to images touched up later.</li> \n <li>The rover documented its own touchdown via an ingenious system of booster rockets and a “space crane”.</li> \n <li>It landed in a “pool-table flat” crater in a prime location for searching for traces of ancient life.</li> \n <li>The wheeled rover could begin to move around its new home as early as late February.</li> \n <li>The rover’s mini helicopter could launch as early as April.</li> \n <li>Its broad mission is to stay on <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> for a couple years, gather data and harvest samples to be collected and returned to Earth on a future mission.</li> \n <li>The point is to determine whether there was life on <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> and subsidiary questions.</li> \n <li>The team at Nasa is very happy and excited, “on cloud nine” in a “weird, dreamlike state”... with lots of work ahead.</li> \n</ul>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '85f720fe-4fae-4e12-bd50-0bf7ecff1143',
+					elementId: '5a80237c-ad3c-439c-9bdd-08ed0b9adeba',
 				},
 			],
 			createdOn: 1613762399000,
@@ -2020,7 +2020,7 @@ export const Dead: CAPIType = {
 					html: '<p>#TBT</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '884c6811-37b9-49f0-af6a-9cfc14f78ac9',
+					elementId: '0def8a90-9fd2-4231-b778-a2cfea5afa81',
 				},
 				{
 					id: '60606947-4f1f-4343-9bb7-000e91502129',
@@ -2059,7 +2059,7 @@ export const Dead: CAPIType = {
 					duration: 142,
 					_type:
 						'model.dotcomrendering.pageElements.YoutubeBlockElement',
-					elementId: 'dcb0736b-5688-4611-be27-0c3840755aad',
+					elementId: 'dafa4873-e375-4ee5-b41d-504aaf7a36e9',
 				},
 			],
 			createdOn: 1613762355000,
@@ -2084,7 +2084,7 @@ export const Dead: CAPIType = {
 					html: '<p>#FF</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '27a9bb13-cb2c-4bae-9f55-de9a8d2cbd06',
+					elementId: '8804d33f-b45f-42e9-8de6-c94536b70039',
 				},
 				{
 					html:
@@ -2098,7 +2098,7 @@ export const Dead: CAPIType = {
 					source: 'Twitter',
 					_type:
 						'model.dotcomrendering.pageElements.TweetBlockElement',
-					elementId: '14b6cd7a-f153-4731-a42c-542664d173b2',
+					elementId: '8c460180-ff73-4a53-a514-c093c368b98b',
 				},
 				{
 					html:
@@ -2112,7 +2112,7 @@ export const Dead: CAPIType = {
 					source: 'Twitter',
 					_type:
 						'model.dotcomrendering.pageElements.TweetBlockElement',
-					elementId: '347461e6-1beb-42d6-abd5-389f41f806a2',
+					elementId: 'edaf5bcc-651f-48fd-b4ff-d1e239e7e958',
 				},
 			],
 			createdOn: 1613761882000,
@@ -2138,7 +2138,7 @@ export const Dead: CAPIType = {
 						'<p>Have you typed “<a href="https://www.google.com/search?q=perseverance&amp;oq=pers&amp;aqs=chrome.0.69i59j69i57j0l3j46j69i60j69i61.1091j0j7&amp;sourceid=chrome&amp;ie=UTF-8">perseverance</a>” into Google today? </p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'ce344bc6-98dd-4e0e-bc30-59195be58c6e',
+					elementId: 'c91e307a-e701-4a99-8e24-9c3bca37ebc2',
 				},
 			],
 			createdOn: 1613761671000,
@@ -2164,14 +2164,14 @@ export const Dead: CAPIType = {
 						'<p>Now that Perseverance persevered through the “seven minutes of terror” – a new era of space exploration has officially begun. </p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '64254243-cd4f-4dcd-826a-ad13d135f5c5',
+					elementId: '7b210499-e516-45ac-a400-64f02e27ba83',
 				},
 				{
 					html:
 						'<p>Next up, the science team will make crucial decisions on which direction to take the rover in as it kicks off its search for ancient life. <br></p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '15f7eff9-d909-4bdc-81a7-a940eb829664',
+					elementId: '9c1f1b79-6b89-4c46-a57b-0cb4b5e9c70c',
 				},
 			],
 			createdOn: 1613761187000,
@@ -2197,20 +2197,20 @@ export const Dead: CAPIType = {
 						'<p>The event is concluding. They’ll be back for a 2pm ET news conference on Monday. Mission updates can be found meanwhile on the <a href="https://mars.nasa.gov/mars2020/">Nasa web site</a>.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'c5d7ae80-d6e0-4732-9739-e2c1214e353a',
+					elementId: 'e65f8e6e-0ca5-456b-8ea9-dc890232d48b',
 				},
 				{
 					html: '<p>McGregor signs off:</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '1f0346bf-0631-4d88-b794-7e13f5ac54c9',
+					elementId: 'c330991a-741a-4d13-abc4-7131901e19a3',
 				},
 				{
 					html:
 						'<p>“Everyone have a great day, on Earth and on <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a>.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '4f79c3da-00b9-41a3-ac54-6af56279e34b',
+					elementId: 'a23813f5-1505-4ae3-be9a-79fc996b063d',
 				},
 			],
 			createdOn: 1613761082000,
@@ -2236,14 +2236,14 @@ export const Dead: CAPIType = {
 						'<p>Nasa scientists have worked for years to support this mission, and kept things going despite the ongoing coronavirus disruption. </p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'ab244e35-7737-4957-93c1-8d2187fef26f',
+					elementId: '9f5e95dd-34f1-4518-b0e1-3fe11b8bd343',
 				},
 				{
 					html:
 						'<p>After the landing success yesterday, one team says they had a “socially distanced ice cream” event, while the engineering team had a virtual happy hour! <br></p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'c66b7bec-c3eb-4b48-979f-b50c78e43d49',
+					elementId: '4b5b1328-73e3-4006-8dce-c8eefb408b6f',
 				},
 			],
 			createdOn: 1613760877000,
@@ -2269,20 +2269,20 @@ export const Dead: CAPIType = {
 						'<p>Next question: <strong>How did you celebrate?</strong></p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '6db7d21d-1028-4c7a-964e-d4eda9b014ff',
+					elementId: '428854f8-3cc9-442d-953f-2f80b193ce41',
 				},
 				{
 					html: '<p>Answers include: </p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '22593447-7d78-4df1-8a9a-634a9acbb23a',
+					elementId: 'ebab82ed-535e-4598-88fc-c02f778727a4',
 				},
 				{
 					html:
 						'<ul> \n <li>Virtual happy hour</li> \n <li>“Socially distanced consumption of ice cream outdoors”</li> \n <li>“I went home and just passed out from just the excitement of the day”</li> \n <li>“In the coming days I’ll definitely be having a glass of wine”</li> \n <li>“It was super-exciting”</li> \n <li>“We’re working two shifts a day almost 20 hours a day... it is kind of a really cool thing”</li> \n <li>“Business as usual for a science team working on a <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> rover”</li> \n</ul>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '2475d3d1-f413-4ed9-a5ea-2a83227dda51',
+					elementId: 'f216c387-e988-462a-8613-e88b68b8c64c',
 				},
 			],
 			createdOn: 1613760692000,
@@ -2308,35 +2308,35 @@ export const Dead: CAPIType = {
 						'<p>Another key question: <strong>When will the rover drive? </strong></p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '32a12986-3def-4ede-a35d-90036aa849ae',
+					elementId: '6c79e649-28d5-46f1-b8c6-567a6e97df40',
 				},
 				{
 					html:
 						'<p>“We’re anticipating the earliest... would be sol 8 or 9... our current best estimate.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'c96b2e93-2b93-4c98-b9d2-6993aa17331f',
+					elementId: 'f2ac92f9-93b9-419a-b839-2526a9a8de73',
 				},
 				{
 					html:
 						'<p>“Maybe a short drive just to check everything out...</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'aa586af9-1f55-476d-aa74-35d4ce74699d',
+					elementId: '047a11ab-86f4-4e0d-b0e2-7c59e2e7dc1a',
 				},
 				{
 					html:
 						'<p>“We’ll also be figuring out the route and direction we need to go.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '4a404e9f-b2ce-4d06-b262-7b3af5cd8ec6',
+					elementId: '2b07c853-97d0-42e8-b16f-5e7d215d4c16',
 				},
 				{
 					html:
 						'<p>That means rover could rove before February is out. </p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '0caddaa5-ac5b-472b-8f7e-4b9408378b5f',
+					elementId: 'f364ba17-019d-4d82-93a2-6aad8a86711b',
 				},
 			],
 			createdOn: 1613760568000,
@@ -2362,7 +2362,7 @@ export const Dead: CAPIType = {
 						'<p>The team members have described their fascination with the holes in the rocks visible next to the rover’s wheel in this photograph just released by <a href="https://www.theguardian.com/science/nasa" data-component="auto-linked-tag">Nasa</a>. It is unknown whether the holes indicate volcanic or sedimentary rock. </p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '3038d4ae-ed73-49fd-810e-49bf83593f0e',
+					elementId: '8f05d739-95e2-48cd-a65d-7b0baaa707a1',
 				},
 				{
 					media: {
@@ -2749,7 +2749,7 @@ export const Dead: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: 'ce307cda-2755-41aa-986a-137b0f6df653',
+					elementId: '5df6e3a2-fa70-4063-a62e-dee440f24afe',
 				},
 			],
 			createdOn: 1613760452000,
@@ -2775,14 +2775,14 @@ export const Dead: CAPIType = {
 						'<p>Attached to the rover’s belly is a diminutive helicopter called Ingenuity. </p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '97c155fe-da99-41d9-aea9-7cc8b88a625f',
+					elementId: '5e30b4f6-a6b1-497f-be1e-3a51f1e88434',
 				},
 				{
 					html:
 						'<p>The 1.8kg drone-like rotorcraft is the first flying machine ever sent to another planet — it has the ability to take colour pictures and video. The rover can also take images of Ingenuity. <br></p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '846ce87e-cc8d-48ed-af41-0d1db71b9d07',
+					elementId: '6aeea49d-a798-488a-ad12-346903272dc6',
 				},
 				{
 					media: {
@@ -3169,7 +3169,7 @@ export const Dead: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: 'dfd84b95-0d33-45dd-a33b-ce35dec3685a',
+					elementId: 'a7aa160a-88bd-41fe-9070-48a62b6f052c',
 				},
 			],
 			createdOn: 1613760365000,
@@ -3195,14 +3195,14 @@ export const Dead: CAPIType = {
 						'<p>Key question: <strong>how long till they fly the helicopter?</strong> </p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'dd81cefd-2f18-420a-b12c-02212768d1ed',
+					elementId: 'a5ee60ad-ed89-4e33-962b-9619f325b4d2',
 				},
 				{
 					html:
 						'<p>“Caveat caveat caveat,” the scientist says. “Super-fast” would be “sol 60.” With a sol being 37 minutes longer than and earth days, that would be 60 earth days plus 37 hours = 61 days, 13 hours. Sometime in April. Best-case scenario. </p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '1a9f2809-4ce0-41ec-9fb5-49145ae07762',
+					elementId: 'fbb78dcf-5a1c-4efd-bf50-cc2ccbdf32b0',
 				},
 			],
 			createdOn: 1613760134000,
@@ -3608,7 +3608,7 @@ export const Dead: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: '42087bed-d060-4305-8bea-83dcbe62bebf',
+					elementId: '1b1fa0cb-2058-4b4c-bc44-0a9177e54fab',
 				},
 			],
 			createdOn: 1613760107000,
@@ -4776,7 +4776,7 @@ export const Dead: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: 'f66ce908-c29b-49d4-812c-0347299fe791',
+					elementId: '3df725fd-4bd5-4026-af85-53f0a223691d',
 				},
 			],
 			createdOn: 1613758905000,
@@ -4804,14 +4804,14 @@ export const Dead: CAPIType = {
 						'<p>Steltzner is showing some of the most fantastic images from space explorations past, from moonshots to the Hubble telescope. </p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'b54d0860-9834-4be1-950b-1f4d285cb69d',
+					elementId: '3580af4b-3d90-4e7f-adc4-eb44060e2f72',
 				},
 				{
 					html:
 						'<p>He proposes an image of the dangling Perseverance Rover taken yesterday – it looks like a futuristic marionette – as the next entry in this cosmic scrapbook. <br></p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '44dee41e-700b-4657-8ee3-aea35c8d0a5f',
+					elementId: '949b0511-cf5a-4118-9970-19cb4921a809',
 				},
 			],
 			createdOn: 1613757849000,
@@ -4839,35 +4839,35 @@ export const Dead: CAPIType = {
 						'<p>Members of the National Aeronautics and <a href="https://www.theguardian.com/science/space" data-component="auto-linked-tag">Space</a> Administration (Nasa) team that put a rover on Mars on Thursday are preparing to host a news conference and answer questions about the mission.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '834e9b35-a9e3-45de-8770-e605486781b1',
+					elementId: 'edac024b-3c8c-46d0-9a67-3a5024d1d138',
 				},
 				{
 					html:
 						'<p>The rover, called Perseverance or Percy for short, is on <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> to search for signs of ancient life and collect samples to be returned by a future mission. About the size of a car, the wheeled rover is equipped with cameras, microphones, drills and even a small helicopter. </p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '29c2e378-914d-4d26-a14b-c5e2bbbd0d79',
+					elementId: 'baea4a1f-6e88-4743-889f-2dedd50a9db3',
 				},
 				{
 					html:
 						'<p>Guardian science correspondent Natalie Grover reports of Percy’s mission:</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '00b60f91-1ccd-4f81-abc2-d973a794265f',
+					elementId: '2a9a6935-2959-44cf-b503-97ca6287fd81',
 				},
 				{
 					html:
 						'<blockquote class="quoted"> \n <p>Previous Mars missions including <a href="https://viewer.gutools.co.uk/science/2013/jul/28/curiosity-rover-descent-mars-nasa">Curiosity</a> and Opportunity have suggested Mars was once a wet planet with an environment likely to have been supportive of life billions of years ago. Astrobiologists hope this latest mission can offer some evidence to prove whether that was the case.</p> \n</blockquote>',
 					_type:
 						'model.dotcomrendering.pageElements.BlockquoteBlockElement',
-					elementId: '9888f078-bfa7-4fd6-8ba8-e5d1ae7f5ab7',
+					elementId: 'b9527164-db32-48fb-a99c-6a1f32d681bd',
 				},
 				{
 					html:
 						'<p>The <a href="https://www.theguardian.com/science/nasa" data-component="auto-linked-tag">Nasa</a> scientists appear to feel they may be tantalizingly close to a discovery that could change the way we see the universe and our home in it. Here was the scene in the control room near Los Angeles just before 1pm local time on Thursday when Percy’s safe touchdown on Mars was confirmed:<br></p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '69b91b97-f83d-4ff7-8b84-04cc4ccd64b9',
+					elementId: 'bc7916c2-2e96-49dd-9b10-0c06ee34c198',
 				},
 				{
 					url: 'https://www.youtube.com/watch?v=Ew24GrPKi3Y',
@@ -4881,20 +4881,20 @@ export const Dead: CAPIType = {
 					source: 'YouTube',
 					_type:
 						'model.dotcomrendering.pageElements.VideoYoutubeBlockElement',
-					elementId: '895c493f-8085-444a-b509-f0579ff459f3',
+					elementId: '4999346f-824e-40e1-9d72-7ddeb2b1ecd1',
 				},
 				{
 					html:
 						'<p>The robotic vehicle sailed through space for nearly seven months, covering 293m miles (472m km) before piercing the Martian atmosphere at 12,000mph (19,000km/h) to begin its approach to touchdown on the planet’s surface.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '6dfe4706-4dd0-43aa-ad5b-9ff6be00c497',
+					elementId: '5e044415-54f9-4e51-a8e5-968478095745',
 				},
 				{
 					html: '<p>Thank you for joining our live coverage. </p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '387a74a2-4104-436f-b7e8-0a211871e665',
+					elementId: '1be1aeef-2744-4623-bec5-8598662b53fc',
 				},
 			],
 			createdOn: 1613746372000,

--- a/fixtures/generated/articles/Editorial.ts
+++ b/fixtures/generated/articles/Editorial.ts
@@ -1784,7 +1784,7 @@ export const Editorial: CAPIType = {
 				},
 			],
 			_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-			elementId: '92394dd3-7797-40f6-91ad-4daad15148cf',
+			elementId: 'cbf35cc6-4434-4e68-a6d2-121277717c4b',
 		},
 	],
 	webPublicationDate: '2021-02-03T18:54:37.000Z',
@@ -1797,42 +1797,42 @@ export const Editorial: CAPIType = {
 						'<p>The greatest advances in the battle against the coronavirus have been made by modern science, but before there were vaccines, countries had to rely on older techniques: stopping people mingling; preventing new cases of the disease arriving from overseas. Britain’s record with lockdowns is not great (late to implement, premature in lifting), but with quarantine at the border there is barely even a record to defend. For much of last year there was a notional obligation on travellers from various countries to self-isolate on arrival in the UK, but with a shifting roster of places that qualified for “safe” travel corridors.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'c9783ee4-7d35-46a2-8c3a-aef4b81a745e',
+					elementId: 'fefdfa7f-bee6-440f-b1e3-66f0b85b1daa',
 				},
 				{
 					html:
 						'<p>There were many categories of exemption. The regulations were unclear and poorly implemented. <a href="https://www.theguardian.com/world/commentisfree/2021/jan/28/uk-covid-travel-quarantine-hotel" title="">Efforts at enforcement have been patchy</a>. Essentially, self-isolation has been self-policed. Only towards the end of last year, as it became clear that mutant strains of the virus were spreading – and that Britain’s approach was persistently failing – did the government start focusing on <a href="https://www.theguardian.com/world/2021/jan/27/how-quarantine-rules-work-and-what-uk-government-is-planning" title="">quarantine as part of the anti-virus arsenal</a>. More travellers are now required to show proof of a negative Covid test and there are tighter restrictions on arrivals from certain “hotspot” countries. That approach is still flawed. People, and the virus they might carry, do not always travel straight from the heart of an outbreak to the UK. Mutations are dispersed along multiple paths.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'f816f20d-7cad-4e6d-8b41-b0c33f123e1d',
+					elementId: 'c513f845-2d36-443a-bc99-bd35fb500bc1',
 				},
 				{
 					html:
 						'<p>Ministers have said further border measures are required, but cannot say when they will be applied. The new regime is expected to involve diverting large numbers of arrivals to government-approved hotels for up to 10 days, with an option of getting out sooner with a negative test. The Department for Transport and the Treasury <a href="https://www.theguardian.com/world/2021/feb/03/grant-shapps-resists-blanket-border-controls-to-stem-covid-in-britain" title="">have been squeamish</a> about the cost of such a regime. Passengers would get a bill, but the whole system would still be expensive and inflict another wound on an already injured aviation sector.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'ef6c9a59-5ed7-4a17-8b1e-0aaf88d6d0b4',
+					elementId: 'd9c4158f-3dbc-425a-9497-363d46d592e2',
 				},
 				{
 					html:
 						'<p>But, as has been demonstrated many times in the pandemic, resisting tighter restrictions to avoid an immediate financial burden is a false economy. Delay allows the disease to spread. The onerous measures are still required and have to be in place for longer. That remains true even as the vaccination programme is rolled out. Not enough is yet known about vaccine resilience in the face of recently discovered coronavirus variants, let alone any future mutations. <a href="https://www.theguardian.com/world/2021/jan/22/covid-vaccines-what-are-the-implications-of-new-variants-of-virus" title="">The risk is not negligible.</a></p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '8a944e31-0c50-418b-8a8e-6901dca9f102',
+					elementId: '36ef80d5-a182-4d63-a9fd-deaf6f531ad3',
 				},
 				{
 					html:
 						'<p>Countries with the strongest records against disease have applied the full range of containment measures quickly and thoroughly, including efficient testing, contact tracing, and a presumption that all new arrivals face quarantine (with some flexibility for humanitarian exceptions, naturally). That principle should be the basis for the UK’s regime. A speedy vaccination roll-out has given Boris Johnson <a href="https://www.theguardian.com/society/2021/jan/31/daily-record-as-600000-people-in-the-uk-receive-covid-jabs-on-saturday" title="">cause to celebrate</a> his government’s accomplishments relative to other countries. Ministerial relief at having something to cheer is palpable, but it must not lead to neglect of other fronts in the battle or feed the culture of impatience and denial that causes many Conservative MPs to demand unwarranted easing of restrictions.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'b9dfb916-ac5f-416a-adaf-67e7498f79e1',
+					elementId: 'b0f2fe3d-e0e7-4d4d-b405-c318e1f16554',
 				},
 				{
 					html:
 						'<p>No one should belittle the social, economic and psychological cost of anti-Covid restrictions. Quarantine, like lockdown, is a harsh instrument to be used only as an emergency resort. But we are now a year into such an emergency. The government’s haphazard approach, justified by a pursuit of short-term economic relief, has only prolonged the ordeal. The vaccine programme illuminates a way out. It would be a tragic squandering of that success if overreliance on new technology were to breed complacency regarding older but no less vital methods of protecting the public.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'cede0f88-9ee3-497b-9551-0b398aef2a01',
+					elementId: '7c5a4d63-9652-433a-8545-5a8ef16e9666',
 				},
 			],
 			createdOn: 1584705172000,

--- a/fixtures/generated/articles/Feature.ts
+++ b/fixtures/generated/articles/Feature.ts
@@ -1410,7 +1410,7 @@ export const Feature: CAPIType = {
 			altText:
 				"Press Room - 92nd Academy Awards<br>epa08208148 Joaquin Phoenix poses in the press room with the Oscar for Best Actor for his performance in 'Joker' during the 92nd annual Academy Awards ceremony at the Dolby Theatre in Hollywood, California, USA, 09 February 2020. The Oscars are presented for outstanding individual or collective efforts in filmmaking in 24 categories.  EPA/DAVID SWANSON",
 			_type: 'model.dotcomrendering.pageElements.YoutubeBlockElement',
-			elementId: '54ae2cf7-fa76-4f19-a0e3-407f98447465',
+			elementId: '9ed3e302-ab37-47be-9815-b6cb70341753',
 		},
 	],
 	webPublicationDate: '2020-02-10T06:59:35.000Z',
@@ -1423,28 +1423,28 @@ export const Feature: CAPIType = {
 						'<h2>Chris Rock on Jeff Bezos and Marriage Story</h2>',
 					_type:
 						'model.dotcomrendering.pageElements.SubheadingBlockElement',
-					elementId: '645739f2-5e32-45eb-b862-784f574df1c8',
+					elementId: 'ae1e1343-2a81-4768-b5a2-31b988955ca2',
 				},
 				{
 					html:
 						'<p>“Bezos is so rich, he got divorced and he is still the richest man in the world. He saw <a href="https://www.theguardian.com/film/2019/nov/15/marriage-story-review-noah-baumbach-adam-driver-scarlett-johansson">Marriage Story</a> and thought it was a comedy.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '5c58899e-9cd6-4b3b-916c-7a8030016d04',
+					elementId: '62ed94e9-7f25-430d-92aa-bfdb767e3369',
 				},
 				{
 					html:
 						'<h2><strong><a href="https://www.theguardian.com/film/2020/feb/10/joaquin-phoenixs-oscars-speech-in-full">Joaquin Phoenix</a> …</strong></h2>',
 					_type:
 						'model.dotcomrendering.pageElements.SubheadingBlockElement',
-					elementId: '03645263-18bd-48eb-b55a-a528602f9be9',
+					elementId: '9047d5a1-989a-4007-a3f3-775ed976fe17',
 				},
 				{
 					html:
 						'<p><strong>… on veganism</strong><strong> and social justice<br></strong>“I think at times we feel or are made to feel that we champion different causes. But for me I see commonality. I think whether we’re talking about gender inequality or racism or queer rights or indigenous rights, or animal rights – we’re talking about the fight against injustice.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '869aabc5-9037-4c24-a31a-213199174184',
+					elementId: '65f0e18e-42f6-47fd-bac2-c4cc88d1c124',
 				},
 				{
 					url:
@@ -1455,28 +1455,28 @@ export const Feature: CAPIType = {
 					role: 'thumbnail',
 					_type:
 						'model.dotcomrendering.pageElements.RichLinkBlockElement',
-					elementId: '1436b6e2-8ec1-4d7b-8299-2c118e482bb4',
+					elementId: 'eefff318-11c3-4a0c-ba60-efb1bc9c7845',
 				},
 				{
 					html:
 						'<p>“We’re talking about the fight against the belief that one nation, one people, one race, one gender, one species has the right to dominate, use and control another with impunity.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '14a36699-06dd-47f4-9e3c-9700f5080209',
+					elementId: 'f1978d86-ab4e-4f55-88b3-a2b45d556ffb',
 				},
 				{
 					html:
 						'<p><strong>… on dairy products<br></strong>“I think we’ve become very disconnected from the natural world, many of us are guilty of an egocentric worldview and we believe that we’re the centre of the universe. We go into the natural world and we plunder it for its resources, we feel entitled to artificially inseminate a cow and steal her baby even though her cries of anguish are unmistakeable. Then we take her milk intended for her calf and we put it in our coffee and our cereal.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '9cb24d2a-cf6f-4e4a-8ca8-fbdb6b809af9',
+					elementId: 'd0635097-52f3-405a-bd7c-970cbd38b48c',
 				},
 				{
 					html:
 						'<p><strong>… on forgiveness<br></strong>“I have been a scoundrel all my life, I’ve been selfish. I’ve been cruel at times, hard to work with and I’m grateful that so many of you in this room have given me a second chance. I think that’s when we’re at our best: when we support each other. Not when we cancel each other out for our past mistakes, but when we help each other to grow. When we educate each other. When we guide each other to redemption.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '5d21e94c-fffb-4f10-935c-5dd532d8e486',
+					elementId: '7c718a2e-5a57-4b3d-8446-4d7ec0412565',
 				},
 				{
 					url:
@@ -1487,21 +1487,21 @@ export const Feature: CAPIType = {
 					role: 'thumbnail',
 					_type:
 						'model.dotcomrendering.pageElements.RichLinkBlockElement',
-					elementId: '706a5b3f-9e36-4e93-ba1b-8844f273b2cb',
+					elementId: '87468551-24be-40de-9d08-f250cf663fd0',
 				},
 				{
 					html:
 						'<h2><strong>Laura Dern on meeting your heroes</strong></h2>',
 					_type:
 						'model.dotcomrendering.pageElements.SubheadingBlockElement',
-					elementId: 'fe598d40-bf80-4fae-8c7e-d30e1ce855b2',
+					elementId: 'a62fdf79-538d-4d1a-bd86-67f052141bd2',
 				},
 				{
 					html:
 						'<p>“Noah [Baumbach] wrote a movie about love and breaching divisions in the name and the honour of family and home and hopefully for our planet. Some say never meet your heroes. I say if you’re really blessed you get them as your parents. I share this with my acting legends Diane Ladd and Bruce Dern. You got game, I love you. Thank you all for this gift. This is the best birthday present ever.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'd085b27d-dbee-4ee2-b63d-508e541ae7e7',
+					elementId: '6b40aac3-7fc7-4fe1-a9e9-c940e6beb423',
 				},
 				{
 					media: {
@@ -1887,42 +1887,42 @@ export const Feature: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: '25576812-2d3e-4cbd-b15c-9700793316be',
+					elementId: 'bc35cccc-4f9b-4cbc-820a-c543fd5a55d1',
 				},
 				{
 					html:
 						'<h2><strong>Taika Waititi on far-right extremism and indigenous kids</strong></h2>',
 					_type:
 						'model.dotcomrendering.pageElements.SubheadingBlockElement',
-					elementId: '034d716b-29ea-4058-abca-27b8f86c24c2',
+					elementId: 'e0fae24e-b490-4dad-8936-9673dfb698a1',
 				},
 				{
 					html:
 						'<p>Backstage: “If you were a Nazi, you would go to jail. Now you’re a Nazi, feel free to have a rally down in the square with your mates.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '5fe9e671-f402-45cf-89ff-7cc36b8e8bf7',
+					elementId: '2019aee8-8b2f-4d65-8999-4fb107a427c4',
 				},
 				{
 					html:
 						'<p>On stage he said: “I want to dedicate this to all the indigenous kids in the world who want to do art, we are the original storytellers and we can make it here as well.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'afc242c5-3f7f-4e68-9814-ac842d42363d',
+					elementId: '6f2cec92-ead0-42bb-b38f-038190e0cde3',
 				},
 				{
 					html:
 						'<h2><strong>Brad Pitt on Trump’s impeachment, John Bolton and the Republican party</strong></h2>',
 					_type:
 						'model.dotcomrendering.pageElements.SubheadingBlockElement',
-					elementId: '74b21fd4-062a-4518-b890-ebcca758e5e7',
+					elementId: '3ce025d9-5392-4481-bfdc-8cf2b9400dda',
 				},
 				{
 					html:
 						'<p>“Thank you to the Academy for this honour of honours. They told me I only have 45 seconds up here which is 45 more than the Senate gave John Bolton.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'fc708e9b-57ea-4973-8c50-92a819dd5546',
+					elementId: 'd57fdb85-2bcd-40f0-98c2-5623e17f33fb',
 				},
 				{
 					url:
@@ -1933,42 +1933,42 @@ export const Feature: CAPIType = {
 					role: 'thumbnail',
 					_type:
 						'model.dotcomrendering.pageElements.RichLinkBlockElement',
-					elementId: '972cc212-70a0-44e5-818b-b181ef2c4118',
+					elementId: '53933347-13bc-4a70-b6ce-3044a709ffe5',
 				},
 				{
 					html:
 						'<h2>Bong Joon-Ho on booze and Scorsese and Tarantino</h2>',
 					_type:
 						'model.dotcomrendering.pageElements.SubheadingBlockElement',
-					elementId: '736f96d5-456e-4d09-80a4-0598ea7120b2',
+					elementId: '1fcce877-0470-409a-bfd6-0f092229a11d',
 				},
 				{
 					html:
 						'<p>“The [international feature film] category has a new name and I’m so happy to be its first recipient under its new name. I applaud and support the new direction that this change symbolises. I’m ready to drink tonight.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '9b9105b2-a279-4f8b-8e6f-bc4b0f5a68c9',
+					elementId: '58f5b506-7542-4652-baee-ce36d41e13f9',
 				},
 				{
 					html:
 						'<p>“When I was young and starting in cinema there was a saying that I carved deep into my heart, which is, ‘The most personal is the most creative.’ That quote was from our great Martin Scorsese. When I was in school I studied Scorsese’s films. Just to be nominated was a huge honour, I never felt I would win. When people in the US were not familiar with my films Quentin [Tarantino] would always put my films on his list – Quentin, I love you.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'ecf9aa35-c120-4e2c-aa93-7786607ee1b3',
+					elementId: '8a184cad-8462-4fdd-b224-19dbaf423af5',
 				},
 				{
 					html:
 						'<h2><strong>Hildur Guðnadóttir on female composers</strong></h2>',
 					_type:
 						'model.dotcomrendering.pageElements.SubheadingBlockElement',
-					elementId: '96bf3180-c323-4043-98c2-15fd1ee2e504',
+					elementId: '34628b11-3c66-46b3-a89b-2c56446384e5',
 				},
 				{
 					html:
 						'<p>“To the girls to the women, to the mothers to the daughters who hear the music bubbling within please speak up – we need to hear your voices.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '4704f6bd-fae3-41ac-bd35-43e15a1ff01b',
+					elementId: 'c28749b5-2c3a-4e6e-b8cb-db287d4c4d6c',
 				},
 				{
 					media: {
@@ -2355,56 +2355,56 @@ export const Feature: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: '95aa3c81-72a3-4794-b3e7-26c7dc7ef2e7',
+					elementId: '496ee30d-bb9e-4c87-b67d-3c03c0da611a',
 				},
 				{
 					html:
 						'<h2>Sigourney Weaver, Gal Gadot and Brie Larson’s Fight Club</h2>',
 					_type:
 						'model.dotcomrendering.pageElements.SubheadingBlockElement',
-					elementId: 'c1445b84-5710-4e81-81ff-2fe6d79f2834',
+					elementId: 'ede10a1c-5367-4ac6-bf36-3de805b6838a',
 				},
 				{
 					html:
 						'<p>“We decided that after the show we’re going to start a fight club. Men are invited but no shirts allowed. The winner will get a lifetime’s supply of deodorant, sushi, and tequila. The loser gets a lifetime of questions about what it’s like as a woman in Hollywood.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '4cfc3408-7898-4e76-8947-729e624a64f6',
+					elementId: '6de5ee75-cb7a-4906-bf8f-8c2329136dd2',
 				},
 				{
 					html:
 						'<h2><strong>Ford v Ferrari</strong><strong> sound editor Donald Sylvester</strong><strong> on sharing</strong></h2>',
 					_type:
 						'model.dotcomrendering.pageElements.SubheadingBlockElement',
-					elementId: 'ea962c61-92b9-46bd-b6cd-7eb5f3bedb41',
+					elementId: 'e5229223-0bf1-45c1-9473-da286e3cdb82',
 				},
 				{
 					html:
 						'<p>“If I could I would break this off [statuette] and give James [Mangold] the head so he could put it in a jar.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'ff4e34dd-fc6e-4d84-bbda-9e5d85022593',
+					elementId: 'ef257b32-d13c-484e-acbf-ed19a760516c',
 				},
 				{
 					html:
 						'<h2><strong>Hair Love’s directors on … hair</strong></h2>',
 					_type:
 						'model.dotcomrendering.pageElements.SubheadingBlockElement',
-					elementId: '0a9695ab-1dce-48aa-86fa-e5d6a40d1962',
+					elementId: '4046d5cd-a25e-468c-b8a3-507528def21f',
 				},
 				{
 					html:
 						'<p>Matthew A Cherry and Karen Rupert Toliver said their film Hair Love, which won for best animated short, was made because they “wanted to normalise black hair” and make cartoons more diverse. The directors invited black teenager <a href="https://www.theguardian.com/us-news/2020/jan/23/deandre-arnold-texas-school-district-student-dreadlocks">Deandre Arnold</a>, who was told he wouldn’t be able to take part in his graduation if he didn’t cut his dreadlocks, as their guest.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '150d7234-7326-4d32-aa2d-bbadc359976e',
+					elementId: '6f01be9c-4a2d-4237-81cb-462bb8e3c642',
 				},
 				{
 					html:
 						'<p>“We have a firm belief that representation matters deeply, especially in cartoons because in cartoons that’s how we first see our movies and think about how we shape the world,” said Karen Rupert Toliver.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '4b13084c-17aa-42b9-87b9-d5af109ee2f1',
+					elementId: 'bccd2d42-47a8-4cf0-b3dc-d3a57ff90c4f',
 				},
 			],
 			createdOn: 1581309832000,

--- a/fixtures/generated/articles/Interview.ts
+++ b/fixtures/generated/articles/Interview.ts
@@ -1937,7 +1937,7 @@ export const Interview: CAPIType = {
 				},
 			],
 			_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-			elementId: 'fab3bef9-897c-4c85-a210-44d8a8f8bb9c',
+			elementId: '527ec680-dddf-484e-a7fc-3548348e6aa9',
 		},
 	],
 	webPublicationDate: '2020-02-09T11:00:04.000Z',
@@ -1950,28 +1950,28 @@ export const Interview: CAPIType = {
 						'<p>Halima Aden, then aged 19, became the first contestant in the Miss USA 2016 beauty pageant to wear a hijab and burkini, attracting the attention of French fashion legend <a href="https://www.theguardian.com/fashion/carine-roitfeld" title="">Carine Roitfeld</a>. The following year she became the first hijab-wearing model to sign with a global modelling agency, IMG, and then the first to walk at New York fashion week, for Yeezy, the Kanye West brand. She later became the first hijab-wearing model to make the cover of <em>Vogue</em> – twice (first <em>Vogue Arabia</em>, then British <em>Vogue</em>) – and soon afterwards a <em>Sports Illustrated</em> swimsuit shoot followed. By that point she’d already become a Unicef ambassador, and a go-to voice on diversity in the fashion industry. In 2017 she gave the first <a href="https://www.ted.com/talks/halima_aden_how_i_went_from_child_refugee_to_international_model?language=en" title="">TED</a> talk at a refugee camp in Kakuma, Kenya. <em>Teen Vogue</em> went with her.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '46501144-0bb5-48b5-b462-fd7ab5d6b3a9',
+					elementId: '159e3297-aa12-4151-8c06-5087a43dc57c',
 				},
 				{
 					html:
 						'<p>When we meet, at a hotel near King’s Cross, I ask if it ever gets tiring, being the first in so many different ways, shouldering the burden of representation. “Somebody needs to,” Aden says. “I want my sister, my little nieces, even my nephews to see representations of somebody who wears a hijab in modern ways, in such a way that they can relate to.” We’re sitting side by side on a window seat, Aden holding court before a little audience of PRs, management and her best friend, Lizeth, who has travelled with her from the US. Though she looks very much the high-fashion figure, all in black – sequins and brocade lace, knee-high stiletto boots – she seems younger than her 22 years, gabbing away in the stream-of-conscious slang and asides of a teenager still starstruck by the turns her life has taken.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '84d57b2b-07a5-4c20-9a0b-7dcac72e31bc',
+					elementId: '4df1322c-6149-4048-bd70-49a50612c035',
 				},
 				{
 					html:
 						'<p>But on the topics of diversity, representation and sustainability, she speaks with passion and conviction. She has said in the past that, growing up in the US: “The only times I saw somebody dressed like me was on CNN – and they weren’t doing anything I approve of.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '648877db-04cc-4ae6-95b5-8491a7b0aa5d',
+					elementId: 'd20f46f0-fdb3-4d19-9ca1-e9c753a40d27',
 				},
 				{
 					html:
 						'<p>“I feel like we all deserve representation and I didn’t have that,” Aden says now. “I never got to flip through a magazine and see somebody who looks like me.” Lizeth digs out the latest issue of <em>Essence</em> magazine, Aden proud in pink on the cover. Aden takes it from her, somewhat wonderingly. “Sometimes it’s so wild for me,” she says. “I still catch myself… When my friend went and got that from the newsstand, I was like: ‘Oh my God.’”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'a02acab9-5f0a-4492-b811-85bf16eccac2',
+					elementId: '925d5b86-54ae-483e-998d-0944b200f10c',
 				},
 				{
 					media: {
@@ -2359,35 +2359,35 @@ export const Interview: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: 'a65c0a59-9da4-4391-bacd-de495f2ca0f7',
+					elementId: 'c8fc816f-fa03-4a8e-8c6a-3c17104c0aac',
 				},
 				{
 					html:
 						'<p>The fact she has been able to have a global career in fashion at all is proof that the industry is increasingly open to diversity. Aden is 5ft 5in, petite for a model, and a resident of Minnesota, far from the industry capitals of New York, London, Paris or Milan. “And the fact that I’m able to do runway, the fact that I have graced these magazine covers and wear a hijab on top of that, be who I am, have my identity, wear it proudly… I think fashion is doing a beautiful job.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'fee9e2f1-9019-45dc-9b56-109c63639fc9',
+					elementId: 'f0f18244-e307-4149-a1ba-1b2e24c2dabc',
 				},
 				{
 					html:
 						'<p>Aden now has her own 47-piece hijab collection, Halima x Modanisa, and her hijab is stipulated as non-negotiable in her contract with IMG. “It’s a big part of my identity,” she says. “It’s not because I don’t think people are going to listen – it’s more so they know what to expect. I always bring extras – my own set of turbans, turtlenecks, tights – because it’s a collaboration. I also recognise that for a lot of people, in my first year especially, I was the only hijab-wearing girl they’d worked with. So they’re not going to necessarily know 100% what to expect, just like I didn’t know what to expect with fashion, because it’s not the world that I come from.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'ba19f541-0294-4929-8429-344f42872cd5',
+					elementId: 'f3629ec8-e248-4bf1-86ff-6ef2df3695e0',
 				},
 				{
 					html:
 						'<p>She does have certain requirements, such as a pop-up tent in which to change backstage at shows, but she says she’s never been uncomfortably set apart, or made to feel othered. She remembers her experience of walking for Yeezy at New York fashion week in 2017, her breakout year, as a watershed moment. The first outfit she was presented with “was just not going to work,” she says, gesturing above her knee – too short. “Even then I knew: walking away when something doesn’t fit is always better than feeling you need to force something.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'eb09aa0c-a962-4d43-91de-ebdf8da59812',
+					elementId: 'b572d020-e616-45a2-808a-c44274a7567e',
 				},
 				{
 					html:
 						'<p>She returned to her hotel, disappointed but resolute. “And then, without having to say anything, they called back: ‘We have a second option.’ I tried it on and it was perfect. I just knew it was a pivotal moment in my life. The people who you want to work with, they’re willing to work with you just the way you are.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '0291324d-b4d3-4795-99a2-ea6452ba5411',
+					elementId: 'bd467d02-aaeb-422f-9806-6b3406ba15a6',
 				},
 				{
 					media: {
@@ -2763,42 +2763,42 @@ export const Interview: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: 'b587578e-2449-404c-bb22-ae50a3474b40',
+					elementId: '2a76b671-0500-48d0-bb51-8903c78b0abd',
 				},
 				{
 					html:
 						'<p>That same year, Aden remembers walking for MaxMara at Milan fashion week in a look that had been designed with her in mind. When she posted it on Instagram, a woman commented: “He keeps you in mind, he keeps us in mind. Now this Muslim shopper will keep MaxMara in mind.” Aden shared it with the brand. “I was like – wink-wink-wink!”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '1341cb49-e982-49ed-93b6-611496f487cd',
+					elementId: '12a6e13e-5e8e-4993-96d1-de5cc2638741',
 				},
 				{
 					html:
 						'<p>It led to an exclusive capsule collection in the Middle East, for which Aden was the face. “It’s a win for designers when they’re diverse; it’s a win for the brand, it’s a win for everybody – we all want to see a little piece of ourselves reflecting back.” And it makes a difference, she says. The year after Aden became the first contestant to wear a hijab in Miss USA, there were seven others. Last year she was one of two hijabi models on the MaxMara catwalk in Milan, and one of three for her second <em>Vogue Arabia</em> cover.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'f78fe86e-bee3-4852-9fdd-feeef6fe16f0',
+					elementId: '92adfd99-fb93-4b0c-a716-87c73607f308',
 				},
 				{
 					html:
 						'<p>When Aden was seven, she used to pray for rain – the kind of torrential rain that would wash away her new home in the American Midwest. “I remember thinking: ‘Then our neighbours could come out and play,’” she says. Even the structure of her apartment building felt alienating. “I was like, ‘God, everybody is so isolated.’”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '3c051fad-db55-4c40-adf5-48a8d2e6dbf7',
+					elementId: '39e3c2fc-9f4a-464e-8b97-60578d084224',
 				},
 				{
 					html:
 						'<p>Aden was born a refugee in the United Nations Kakuma camp in northwestern Kenya, where her mother had fled the Somali civil war in 1994. There their house was made of mud, scraps, sticks – anything her mother could find. “It would be normal for me to go to nursery school, come back and find it had washed away,” she says. But then the community would come together to rebuild it, “and then it’s the kids’ time to play around.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'bf0be9f5-51c4-4956-8eb8-5ec9c0972d1a',
+					elementId: '1b2af67a-9654-4700-923e-7973f8170d27',
 				},
 				{
 					html:
 						'<p>The model remembers her childhood in the camp as being joyful and supportive. “There’s no walls keeping you apart from your neighbour,” she says. In her new home in Missouri, where she was relocated with her family in 2004, before moving to Minnesota, where they live today, the barriers stood strong.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '5110b938-8f59-4725-810e-128bed07a68c',
+					elementId: '7b6e18c6-d114-4a87-acba-13ae39fd53b8',
 				},
 				{
 					media: {
@@ -3186,35 +3186,35 @@ export const Interview: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: 'e0f9be96-ede4-4e5b-8124-0b9b2550abd8',
+					elementId: '0c2aefb3-fcb0-45e5-8448-7c1c1799962d',
 				},
 				{
 					html:
 						'<p>“Kakuma” translates from Swahili as “middle of nowhere”. “Sometimes, when I’m like, ‘I was born in the middle of nowhere,’ people think I’m joking,” Aden says. “But if you actually look at Google Maps…” People tend to think of a refugee camp as being a temporary settlement. But Kakuma is “more of a city of its own,” says Aden, in both permanence and size. Established by the UN in 1992 with a 70,000-person capacity, it has since ballooned to about 192,000 registered refugees and asylum seekers, the vast majority of whom are never resettled (the global figure is less than 1%).</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'd992f894-6664-4004-bf6f-5cb88e329a81',
+					elementId: '04153ed2-a84e-4fb2-877d-ceb346430be0',
 				},
 				{
 					html:
 						'<p>As a child, Aden remembers thriving under the collective care of the community, which was two thirds women and children. She was bright – she spoke Somali and Swahili, sometimes translating for the grown-ups – and popular, roaming the camp with up to 30 playmates of mixed ages and ethnicities. (“If you could keep up, you were in the group.”)</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'e043331a-5771-4fb7-bd97-0ba3ba9603c9',
+					elementId: '2909ad93-529c-4976-9000-17dbbf67a964',
 				},
 				{
 					html:
 						'<p>Aden is well aware that her happy stories of childhood challenge the stereotype of the “tragic refugee”, though she credits her mother with working hard to shield her young family from hardship. Aden never knew her father. He was lost during the Somali civil war, and assumed dead by her mother; he made contact after they had moved to the US, but died before Aden could develop a relationship. “It was both the scars and the smiles,” she says. “It was a happy childhood and also, we lived in uncertainty.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '9e828523-37e3-46da-b79e-fddf8c4b6b7f',
+					elementId: '4ce2aefb-6c9a-479b-8a6c-0ec903af86ec',
 				},
 				{
 					html:
 						'<p>Symbolic of this limbo was a noticeboard that was updated with the names and destinations of those lucky few bound for resettlement. Aden remembers it as larger than life, “like something out of <em>The Hunger Games</em>”: “It would control your entire future – it was literally the difference between life and death. For parents it meant a brand new life: ‘We’re starting over, we won the lottery.’ But for the kids it is: ‘I’m never seeing my friends again’.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '60efe054-f473-494f-b6fb-c5f261d9efd9',
+					elementId: '4eb59498-f7e2-4d76-a6b6-93523ecce31d',
 				},
 				{
 					media: {
@@ -3590,42 +3590,42 @@ export const Interview: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: '3d0810f7-4c1c-4441-b89a-369096ebc9e7',
+					elementId: 'e724bc26-887d-4c4f-a57d-a39f0de60a44',
 				},
 				{
 					html:
 						'<p>Another common misconception of being a refugee, Aden says, “is that you get a say where you go”. Her family were relocated to a poverty-stricken, crime-rife neighbourhood in St Louis, Missouri, which – compared to the “nurturing” community of Kakuma – came as a shock. That was when she felt most isolated, when she wished for her house to wash away. It was the first time she’d heard gunshots. “But nonetheless, did I have the fear of malaria? No – so, in a way, it was like trading one obstacle for another.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'ef82bd71-1d14-4a32-8f11-67e417d43d84',
+					elementId: 'e6c5f8b3-0621-45d5-85ee-79e1bdec2cdb',
 				},
 				{
 					html:
 						'<p>The biggest hurdle was learning English: Aden’s school in St Louis did not have an English language programme. After two weeks of presenteeism, Aden recalls her mother asking her to read some written English aloud. “I literally started mouthing the words to <a href="https://www.youtube.com/watch?v=8WYHDfJDPDc" title="">Dilemma</a>” – rapper Nelly and Kelly Rowland’s syrupy duet, which she knew from the radio. Aden mimics a haltering recital: “‘No matt-er. Whatido. All I think about. Is you’ – I just couldn’t stand the idea of disappointing her.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'f02b5d8a-865e-4d29-8111-2dc201048b62',
+					elementId: '99564f1e-ddbd-4151-9df1-5f326c023450',
 				},
 				{
 					html:
 						'<p>Eventually Aden’s mother decided to relocate the family to St Cloud, Minnesota, where they found a community like the one that they had left at the camp. At first they were heavily reliant on it, living on food stamps and even, for six months, in a women’s shelter. Aden remembers the kindness of neighbours, taking the family to the grocery store during the punishing winters, giving her mother lifts when she couldn’t drive. “It’s why I’m so loyal,” she says. “I love my state.” She lives in St Paul now, closer to the airport, but only 40 minutes from her mother, who’s still in St Cloud. Minnesota is known for high taxes, but Aden says she is happy to pay them. “I relied on welfare when I was little... I think of it as my way of paying back.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'cb3dcd89-ff24-437a-9ee7-94168831a16e',
+					elementId: '6641d7f5-1aca-40f1-8b21-6c981d14b892',
 				},
 				{
 					html:
 						'<p>Before we meet, Aden’s team is adamant that I don’t ask her about Trump or US politics, so instead I ask her how superficial diversity in fashion tallies with a more fractious, divided world.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '9cadbcec-0ecc-4e4f-b227-016cf91079ad',
+					elementId: '414f44ce-ae84-462e-be13-f49598c1cbb2',
 				},
 				{
 					html:
 						'<p>“I don’t even really avoid politics,” she says, “but it’s not something that I’ve needed in order to connect with people. Once I share my story, there’s always some common ground. It doesn’t have to be: ‘I grew up in a refugee camp.’ I get just as many messages, believe it or not, from parents who are not Muslim, who are not black, who say, ‘Thank you for making modesty look cool and young’.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'c4028bf4-2ea9-478c-979a-8d2aaeb4e1ac',
+					elementId: 'a493b6d2-9761-41d4-b5cb-3c2f35a6da85',
 				},
 				{
 					media: {
@@ -4001,91 +4001,91 @@ export const Interview: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: '4b8c6de8-4c0e-4840-9dbe-c62041e63603',
+					elementId: '7473d9b8-8d61-4221-b088-f6a96cf1f7fd',
 				},
 				{
 					html:
 						'<p>When she entered the Miss Minnesota USA pageant in 2016, as a freshman at St Cloud State University, Aden told local media that she wanted to represent Muslim women and counter the image that they were oppressed. “The hijab is a symbol we wear on our heads,” she said. “But I want people to know that it is my choice.” Today she says her motivations for entering were less lofty. “College tuition is expensive in the States, muuuuuucho expensive!” And the top 15 at the pageant were offered scholarships. Did Aden think she’d win? “No, God, no.” She laughs. “But top 15? I was like, ‘I think I could do that’.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'c722d1e2-0a21-41f1-850f-8fecdac3dc23',
+					elementId: '81561846-1909-486c-a876-3eb7b208b84f',
 				},
 				{
 					html:
 						'<p>Aden’s mother was strongly against her entering the pageant, arguing it would distract from her studies, and that the two-piece burkini was too skimpy. Though they have since been able to find common ground through her advocacy and work with Unicef, it can feel like they are from two different cultures sometimes. She didn’t tell her mum about the <em>Sports Illustrated</em> shoot “until it hit newsstands”.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '914f7546-6cfa-4e6d-9b6d-b19b003892e1',
+					elementId: '6c4b3d8c-f394-4d1c-afe0-26169b87c357',
 				},
 				{
 					html:
 						'<p>She was also criticised by members of the Muslim community who saw modelling as <em>haram – </em>forbidden by Islamic law. “It was scary to put myself out there, because I didn’t know if I would get backlash, or how bad it was going to be,” she says. Two days before the pageant, Aden almost pulled out. But as she told the newspaper at the time: “You don’t let being the first to do it stop you.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '60b8a8db-1b39-41e8-b559-b5405e9b1366',
+					elementId: 'd7e7b4dc-12a4-4bc8-846c-8e332ecf587e',
 				},
 				{
 					html:
 						'<p>She ended up making the semi-finals, “braces and all. And then IMG came calling – like, ‘Well, well, <em>well</em>… maybe I don’t need school.’” She leans back, for a second jokily triumphant – then seems to feel a chill coming in from across the Atlantic. “I’m kidding. Sorry, Mom!”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'c334d779-c170-41cf-a64b-814b9b2fb9ef',
+					elementId: '2a7be7db-003c-44c6-a33d-bea41c55a3ab',
 				},
 				{
 					html:
 						'<p>The global spotlight on Aden caught the eye of Carine Roitfeld, who flew her to New York to shoot the cover of <em><a href="https://www.crfashionbook.com/" title="">CR Fashion Book</a></em> with <a href="https://www.theguardian.com/fashion/gigi-hadid" title="">Gigi Hadid</a>, Paris Jackson and legendary photographer Mario Sorrenti. Aden agonised about asking for a selfie with Gigi (“So cringy,” she says now). As for Sorrenti, though, she had to Google her later.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'a3d28700-3d56-4d7c-9c8d-cd5330ae79af',
+					elementId: 'b67f565c-59e6-43d5-995b-7b707b3d35be',
 				},
 				{
 					html:
 						'<p>His direction to her was, “Give me sexy”, she seems a little abashed to say. “I didn’t know fashion lingo, I didn’t know photographers. I’m a Minnesota girl – very small town.” Even after signing with IMG, she watched all of Tyra Banks’s outlandish reality series <em>America’s Next Top Model</em> “to practise”. Seven months into her modelling career, she was still working part-time as a housekeeper in St Cloud.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '42914e16-b424-4504-a05e-157cb089ddcc',
+					elementId: '66d85512-e327-44bf-b925-98e92fe797df',
 				},
 				{
 					html:
 						'<p>But rather than asking Aden to change, fashion’s royalty has made room for her as she is. Last week she was back in Kenya for a shoot and “I was just thinking, how crazy is it that, in one lifetime, I’ve gotten to experience both extremes.” Aden says she does not feel angry about the inequality she has seen – partly because she does not find it to be productive. “It’s like when I say: ‘We don’t want your pity.’ Let’s talk about solutions, invite refugees to the table. They’re part of the conversation – no policies should be enacted without their say.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '1589da0e-aed1-420c-a1a4-b2831289a8bb',
+					elementId: '502802a2-38ea-4d0c-ab14-302dabad99c2',
 				},
 				{
 					html:
 						'<p>Though she rules out a career in politics (“for now”), in the future she hopes to return to Kakuma with Unicef to inspire hope within the camp for a new life beyond it. “I couldn’t tell you what that would have meant to me as a six or seven-year-old – like, ‘Wait, there’s a life outside these walls?’ Hopefully, it’s not going to be so rare to see kids from the camps grow up and become teachers, lawmakers, presidents and CEOs of Fortune 500 companies. There’s talent everywhere.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '34674a1a-1aed-4373-95e2-8bf112e9e7b1',
+					elementId: 'fc99ecbe-948e-4c32-823f-72967a441d88',
 				},
 				{
 					html:
 						'<p>For now Aden is pursuing opportunities in “fashion activism”. This month she was announced as the new face of the British accessories brand <a href="https://bottletop.org/" title="">Bottletop</a>, which was ahead of its time in positioning itself as “sustainable luxury” in 2002. Its handbags and clutches, which are made from sustainable leather and upcycled metal ring pulls, help to alleviate poverty in Brazil, Nepal and Kenya. Aden is optimistic in general, but particularly about the potential for consumer choice to be a force for positive change: “I think we’re at a place where people want to support brands and organisations they know are giving back.” She is also an ambassador for Bottletop’s <a href="https://togetherband.org/" title="">#Togetherband</a> campaign, which is tasked with raising awareness of the <a href="https://www.un.org/sustainabledevelopment/sustainable-development-goals/" title="">UN’s Sustainable Development Goals</a>. Aden is probably one of the few celebrities who can “relate personally” to all 17 of them. She has been assigned the eighth goal: “Decent work and economic growth.” The fact that the Swiss multinational bank UBS is a founding partner seems to suggest which way the wind is blowing.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '6fdec18e-0bc3-47d6-974f-e3913f9a7e54',
+					elementId: '85a2440b-44d4-4e81-bc06-0ac880bc0eda',
 				},
 				{
 					html:
 						'<p>“My career in fashion is not just, ‘I want to work with this brand, I want to get on that catwalk’ – we’re not sitting here talking about ‘Buy this heel, because this heel will make you feel sexy.’” She kicks up her stiletto boot, knee-high in black patent leather (admittedly very sexy). “I’m proud that I can say I combined fashion and activism. I can’t do one without the other.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'a8de90f5-a4f5-4aec-bc0d-263f54ce8c15',
+					elementId: '26642a99-149b-4264-b879-57fb18a76f0b',
 				},
 				{
 					html:
 						'<p>Aden sees that her story, from refugee camp to the cover of <em>Vogue</em>, is an unusual one. But she has had to navigate it herself – down to mentioning, at her very first meeting with IMG as a teenager in New York, that she would like to work with Unicef. “I had to learn, in the beginning especially, that maybe I’d never find another model who I could relate to. But I’m making my own path, and it works perfectly for me.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '5adf56d5-b100-41b1-9d7e-eab9b50f2d82',
+					elementId: '9adb06df-0718-4391-8873-f2b5f82f1092',
 				},
 				{
 					html:
 						'<p><em>Fashion editor Jo Jones; photographer’s assistant Dan Ross; fashion assistant Lena Young; makeup by Dina at Frank Agency using Dior Forever and Dior Capture Totale C.E.L.L. Energy; nails by Kim Nkosi at Premier Hair and Makeup using Dior Vernis and Miss Dior Hand Cream; shot at Waddington Studios</em></p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'a6041235-5a3f-41d6-8700-f194c8890919',
+					elementId: 'edb1306e-12c2-4daf-9854-ee09f9a6859b',
 				},
 			],
 			createdOn: 1580751734000,

--- a/fixtures/generated/articles/Labs.ts
+++ b/fixtures/generated/articles/Labs.ts
@@ -1733,7 +1733,7 @@ export const Labs: CAPIType = {
 				},
 			],
 			_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-			elementId: '0d874c98-b15e-46c4-bb32-45341a31eee3',
+			elementId: '11b4d9c9-693d-496a-a44e-cae31878af79',
 		},
 	],
 	webPublicationDate: '2021-03-16T13:02:21.000Z',
@@ -1746,21 +1746,21 @@ export const Labs: CAPIType = {
 						'<p>Women’s football has been a travelling show since it began. In the years of its infancy, in the late 19th century, exhibition matches featuring all-female teams were staged all over the UK, from Brighton to Newcastle, Bristol to Edinburgh. They were also hugely popular, drawing crowds of tens of thousands.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'ed2ef009-f10c-406d-8b2d-b58a98a3d1b7',
+					elementId: 'd6fc02c8-43ff-42f7-99ed-5da10331c9f1',
 				},
 				{
 					html:
 						'<p>Some drew too much attention. The first recorded “international” games took place in 1881 when a team of English players travelled to Scotland and during their second encounter, in Glasgow, heckles turned into a pitch invasion, forcing the women to take shelter in their horse-drawn bus. Not long after that, Scotland banned women from playing, which is another theme that returns frequently in the history of the game across the globe. It’s no small miracle that women’s football is thriving today, given the decades of neglect and opposition it has endured.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '8743be0a-0694-4237-90d8-c54e320ba2da',
+					elementId: '66ce097e-e252-4536-9ed8-e47f356dc2c2',
 				},
 				{
 					html:
 						'<p>For no less than half of the 20th century, the English Football Association (FA) refused to allow women to play on any of its grounds. It claimed that the game was damaging to women’s health and many doctors supported its stance. In reality, the ban was a panicked response to the increasing take-up of the game by women during the first world war.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '57e40ec7-1bbf-4e17-ae95-006e70fe65ed',
+					elementId: '376ba00d-e23c-4fb3-b092-b26b502d1dd3',
 				},
 				{
 					media: {
@@ -2147,49 +2147,49 @@ export const Labs: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: '2799f2d3-d6b5-428d-bc90-44071f08ba47',
+					elementId: 'd9afb86c-0fe8-4b2d-abea-2a00458c89ed',
 				},
 				{
 					html:
 						'<p>After its Victorian beginnings, it was the social upheaval of war that had established the women’s game in Britain. With the football league cancelled as young men were sent to battle, the women who replaced them at the munitions factories had kickabouts in their break times, and played matches on their days off. Soon, ladies’ tournaments began to take hold. The Dick, Kerr Ladies FC, based in Preston, garnered such a powerful reputation that they played two matches a week, and in 1920 staged a pioneering European fixture when they took on a French team assembled by sporting activist Alice Milliat.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'be10d7d8-d158-4779-bdeb-f70fde7dd92e',
+					elementId: '3e96ca13-7095-4a40-9a1b-9ea71e725d7c',
 				},
 				{
 					html:
 						'<p>A year later, the FA issued its ban, and levels of participation in the UK collapsed. A few determined souls kept the flame burning. The Manchester Corinthians Ladies – formed in 1949 by Percy Ashley because his daughter Doris wanted a team to play for – became the centre of the game in Britain, but they had to travel to find people to play. Over the next decade, “Dynamite” Doris and her Corinthians teammates would tour Europe, South America and North Africa in their hunt for opposition.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '5ea6c483-0f14-4520-a908-bf17ec9d886b',
+					elementId: 'd4241688-3b97-4957-bdda-9991dee4a99b',
 				},
 				{
 					html:
 						'<p>Plenty of countries had their own bans on women’s football: Norway, France, Brazil and West Germany all outlawed it at various times, and an entire generation of women were relegated to playing in public parks, rugby pitches, and even greyhound tracks. The women’s game developed sporadically as a result, whenever and wherever it could find a home.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'e6e4a002-3fb8-4257-afc9-9db28f31d28f',
+					elementId: '63644fc9-cbde-4224-a22f-ac8abdc9349a',
 				},
 				{
 					html:
 						'<p>It was Italy who took up the baton, hosting the first women’s European tournament in 1969 (the European Competition for Women’s Football) and the first unofficial women’s world cup – sponsored by Italian drinks company Martini &amp; Rossi – a year later. Both events were popular and another “Women’s World Cup” was staged in 1971 – an all-singing, all-dancing affair at the Azteca stadium in Mexico, dressed in pink livery and surrounded by pop-up hair and beauty salons.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'e19af649-3a60-4997-bacf-250d1da95dfe',
+					elementId: '66e47e87-82da-4584-a4c3-fde9c9d81693',
 				},
 				{
 					html:
 						'<p>The English FA’s ban had only just been lifted, and it was an unofficial team, under the management of Harry Batt, who played Mexico and Argentina in the group stages. Despite losing all three of their games, they were received like rock stars by Mexican sports fans – and banned from representative football for three months on their return to England.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '9e0e9b95-5d86-44e6-a657-d2a7c4c49e7e',
+					elementId: 'd353898d-f8b5-4a41-9934-5f187dc900a6',
 				},
 				{
 					html:
 						'<p>The first official England women’s team played its debut match against Scotland in 1972; they came back from 2-1 down at half time to win 3-2, Pat “Thunder” Davies scoring the decisive goals. Davies was a member of the Southampton team that had won the first women’s FA Cup the previous year, and which went on to dominate the game throughout the 1970s.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'ef1c71a6-b904-4725-b9d7-e7f31d0c6200',
+					elementId: '2f09b30e-c620-4c1a-b472-516a863f0b37',
 				},
 				{
 					media: {
@@ -2577,42 +2577,42 @@ export const Labs: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: 'c9bce784-bad7-4622-895e-cd39c5f38173',
+					elementId: '72cca13e-05c0-4b23-8e49-7d8fa0cb47ff',
 				},
 				{
 					html:
 						'<p>Sweden, Norway and Denmark were all establishing themselves as powerhouses of the women’s game, and Sweden would become the first ever champions of the European Competition for Women’s Football<strong> </strong>in 1984 (the women’s equivalent of the Uefa <a href="https://en.wikipedia.org/wiki/UEFA_European_Championship" rel="nofollow">European Championship</a>) after beating England on penalties at Kenilworth Road. Throughout the 1980s, England’s players – an eclectic, amateur mix of office workers, sales assistants, civil servants and engineers – were increasingly drawn from the all-conquering Doncaster Rovers Belles, under the leadership of captain Gillian Coultard.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'ee4ebdf7-410a-4084-a074-db6ccb48ad01',
+					elementId: 'feab3b6e-1e1f-4d83-ad30-c4f250c59300',
 				},
 				{
 					html:
 						'<p>But other nations were rising, too. It was China who hosted Fifa’s first international championship for women, the Women’s World Cup, in 1991, and the United States that won it, beating Norway 2-1 in the final. That victory marked the beginning of more than 20 years of US excellence, including one of the most memorable and defining moments in women’s football: Brandi Chastain’s left-footed penalty to beat Chinese goalkeeper Gao Hong and win the 1999 World Cup. The picture of her shirt-waving celebration made the cover of Time magazine.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '591f2107-91cf-44df-afca-5699fa6e08c7',
+					elementId: '097bccf8-7644-4355-9d37-bd184336e4c8',
 				},
 				{
 					html:
 						'<p>A subsequent attempt to establish a pioneering professional league in the US was not successful and Women’s United Soccer Association (WUSA) was wound up after three years, in 2003, despite a roster of global talent. But the venture was proof of the game’s new ambition and presaged a 21st-century revolution in women’s sport. More and more footballing superstars followed Chastain into mainstream fame: US striker Mia Hamm, Germany’s Birgit Prinz, Brazil’s Marta Vieira da Silva, England’s Kelly Smith, Japan’s Homare Sawa. By 2015, the women’s World Cup had expanded to 24 teams and was reaching record-breaking audiences.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '72cedd4e-8d01-425d-be79-a4607882786d',
+					elementId: '3b5e9c40-d20f-4578-be95-4524a41517bf',
 				},
 				{
 					html:
 						'<p>And things started getting more legitimate over time – in England, the Women’s Super and Champions leagues finally became full-time, professional affairs. And after an immensely successful Women’s World Cup in 2019 – which included the largest viewership in the game’s history – there are now 34 countries in the world where women play professional football. That number is only set to grow.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'd4fd94d5-2b44-4a2f-92fb-bc16af066dca',
+					elementId: 'b758cb62-607a-4122-baa2-3a3d3a779ca9',
 				},
 				{
 					html:
 						'<p><em>Expedia believes that travel, like football, is better experienced together. That’s why – as the official travel companion of Liverpool FC – Expedia will be with you all the way, as soon as we can travel together again. To get inspiration for your next trip, visit <a href="https://withyoualltheway.expedia.co.uk/en/" rel="nofollow">expedia.co.uk</a></em></p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '2bfb2418-cc15-4b7f-b0c5-f6b180f0dc38',
+					elementId: '2bf00a0e-78cf-45f7-a8ac-81f2b1a8f5e6',
 				},
 			],
 			createdOn: 1614599498000,
@@ -2835,7 +2835,7 @@ export const Labs: CAPIType = {
 		discussionApiClientHeader: 'nextgen',
 		shouldHideReaderRevenue: false,
 		sentryHost: 'app.getsentry.com/35463',
-		isPaidContent: false,
+		isPaidContent: true,
 		headline:
 			'Fires and floods: maps of Europe predict scale of climate catastrophe',
 		idApiUrl: 'https://idapi.theguardian.com',

--- a/fixtures/generated/articles/Letter.ts
+++ b/fixtures/generated/articles/Letter.ts
@@ -11,14 +11,14 @@
  *    gen-fixtures.ts directly.
  */
 
-export const MatchReport: CAPIType = {
+export const Letter: CAPIType = {
 	slotMachineFlags: '',
 	main:
-		'<figure class="element element-image" data-media-id="cc1d3dc14ab9104587323ef12ac477004b369637"> <img src="https://media.guim.co.uk/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/1000.jpg" alt="André Ayew celebrates after giving Swansea the lead in their 2-0 home victory against Championship leaders Norwich." width="1000" height="600" class="gu-image" /> <figcaption> <span class="element-image__caption">André Ayew celebrates after giving Swansea the lead in their 2-0 home victory against Championship leaders Norwich.</span> <span class="element-image__credit">Photograph: Kieran McManus/BPI/Shutterstock</span> </figcaption> </figure>',
+		'<figure class="element element-image" data-media-id="0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0"> <img src="https://media.guim.co.uk/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/1000.jpg" alt="Margaret Thatcher cooking in the kitchen of her Chelsea flat for the benefit of the cameras a week before making her challenge for the Conservative party leadership in 1975." width="1000" height="797" class="gu-image" /> <figcaption> <span class="element-image__caption">Margaret Thatcher cooking in the kitchen of her Chelsea flat for the benefit of the cameras, a week before making her challenge for the Conservative party leadership in 1975.</span> <span class="element-image__credit">Photograph: taken from picture library</span> </figcaption> </figure>',
 	subMetaSectionLinks: [
 		{
-			url: '/football/championship',
-			title: 'Championship',
+			url: '/world/gender',
+			title: 'Gender',
 		},
 	],
 	commercialProperties: {
@@ -29,19 +29,12 @@ export const MatchReport: CAPIType = {
 					value: 'uk',
 				},
 				{
-					name: 'url',
-					value:
-						'/football/2021/feb/05/andre-ayew-sparks-swansea-victory-over-norwich-to-close-gap-at-top',
+					name: 'k',
+					value: ['women', 'family', 'gender'],
 				},
 				{
-					name: 'k',
-					value: [
-						'norwichcity',
-						'swansea',
-						'championship',
-						'sport',
-						'football',
-					],
+					name: 'tn',
+					value: ['letters'],
 				},
 				{
 					name: 'su',
@@ -57,34 +50,23 @@ export const MatchReport: CAPIType = {
 				},
 				{
 					name: 'sh',
-					value: 'https://www.theguardian.com/p/gba7d',
+					value: 'https://www.theguardian.com/p/hx6ty',
 				},
 				{
-					name: 'co',
-					value: ['ben-fisher'],
-				},
-				{
-					name: 'tn',
-					value: ['matchreports'],
+					name: 'url',
+					value: '/world/2021/apr/05/why-is-a-womans-work-never-done',
 				},
 			],
 		},
 		US: {
 			adTargeting: [
 				{
-					name: 'url',
-					value:
-						'/football/2021/feb/05/andre-ayew-sparks-swansea-victory-over-norwich-to-close-gap-at-top',
+					name: 'k',
+					value: ['women', 'family', 'gender'],
 				},
 				{
-					name: 'k',
-					value: [
-						'norwichcity',
-						'swansea',
-						'championship',
-						'sport',
-						'football',
-					],
+					name: 'tn',
+					value: ['letters'],
 				},
 				{
 					name: 'su',
@@ -97,41 +79,30 @@ export const MatchReport: CAPIType = {
 				{
 					name: 'p',
 					value: 'ng',
-				},
-				{
-					name: 'sh',
-					value: 'https://www.theguardian.com/p/gba7d',
-				},
-				{
-					name: 'co',
-					value: ['ben-fisher'],
 				},
 				{
 					name: 'edition',
 					value: 'us',
 				},
 				{
-					name: 'tn',
-					value: ['matchreports'],
+					name: 'sh',
+					value: 'https://www.theguardian.com/p/hx6ty',
+				},
+				{
+					name: 'url',
+					value: '/world/2021/apr/05/why-is-a-womans-work-never-done',
 				},
 			],
 		},
 		AU: {
 			adTargeting: [
 				{
-					name: 'url',
-					value:
-						'/football/2021/feb/05/andre-ayew-sparks-swansea-victory-over-norwich-to-close-gap-at-top',
+					name: 'k',
+					value: ['women', 'family', 'gender'],
 				},
 				{
-					name: 'k',
-					value: [
-						'norwichcity',
-						'swansea',
-						'championship',
-						'sport',
-						'football',
-					],
+					name: 'tn',
+					value: ['letters'],
 				},
 				{
 					name: 'su',
@@ -147,15 +118,11 @@ export const MatchReport: CAPIType = {
 				},
 				{
 					name: 'sh',
-					value: 'https://www.theguardian.com/p/gba7d',
+					value: 'https://www.theguardian.com/p/hx6ty',
 				},
 				{
-					name: 'co',
-					value: ['ben-fisher'],
-				},
-				{
-					name: 'tn',
-					value: ['matchreports'],
+					name: 'url',
+					value: '/world/2021/apr/05/why-is-a-womans-work-never-done',
 				},
 				{
 					name: 'edition',
@@ -166,19 +133,12 @@ export const MatchReport: CAPIType = {
 		INT: {
 			adTargeting: [
 				{
-					name: 'url',
-					value:
-						'/football/2021/feb/05/andre-ayew-sparks-swansea-victory-over-norwich-to-close-gap-at-top',
+					name: 'k',
+					value: ['women', 'family', 'gender'],
 				},
 				{
-					name: 'k',
-					value: [
-						'norwichcity',
-						'swansea',
-						'championship',
-						'sport',
-						'football',
-					],
+					name: 'tn',
+					value: ['letters'],
 				},
 				{
 					name: 'edition',
@@ -198,44 +158,40 @@ export const MatchReport: CAPIType = {
 				},
 				{
 					name: 'sh',
-					value: 'https://www.theguardian.com/p/gba7d',
+					value: 'https://www.theguardian.com/p/hx6ty',
 				},
 				{
-					name: 'co',
-					value: ['ben-fisher'],
-				},
-				{
-					name: 'tn',
-					value: ['matchreports'],
+					name: 'url',
+					value: '/world/2021/apr/05/why-is-a-womans-work-never-done',
 				},
 			],
 		},
 	},
 	beaconURL: '//phar.gu-web.net',
 	webPublicationSecondaryDateDisplay:
-		'Last modified on Sat 6 Feb 2021 05.27 GMT',
+		'Last modified on Mon 5 Apr 2021 18.36 BST',
 	editionLongForm: 'UK edition',
 	hasRelated: true,
 	publication: 'The Guardian',
 	trailText:
-		'André Ayew and Conor Hourihane scored in the 2-0 home win against Norwich to lift Swansea to second, only two points behind the leaders',
+		'Letters: <strong>Rosemary Johnson</strong> and <strong>Margaret Davis</strong> reflect on changes in attitudes to women and work – including unpaid work at home – since the 1970s, while <strong>Brian Saperia</strong> looks back to 1939',
 	subMetaKeywordLinks: [
 		{
-			url: '/football/swansea',
-			title: 'Swansea City',
+			url: '/lifeandstyle/women',
+			title: 'Women',
 		},
 		{
-			url: '/football/norwichcity',
-			title: 'Norwich City',
+			url: '/lifeandstyle/family',
+			title: 'Family',
 		},
 		{
-			url: '/tone/matchreports',
-			title: 'match reports',
+			url: '/tone/letters',
+			title: 'letters',
 		},
 	],
 	contentType: 'Article',
 	nav: {
-		currentUrl: '/football',
+		currentUrl: '/lifeandstyle/family',
 		pillars: [
 			{
 				title: 'News',
@@ -926,75 +882,81 @@ export const MatchReport: CAPIType = {
 				url: 'https://puzzles.theguardian.com/download',
 			},
 		],
-		currentNavLinkTitle: 'Football',
-		currentPillarTitle: 'Sport',
+		currentNavLinkTitle: 'Family',
+		currentPillarTitle: 'Lifestyle',
 		subNavSections: {
-			parent: {
-				title: 'Football',
-				url: '/football',
-				children: [
-					{
-						title: 'Live scores',
-						url: '/football/live',
-						longTitle: 'football/live',
-					},
-					{
-						title: 'Tables',
-						url: '/football/tables',
-						longTitle: 'football/tables',
-					},
-					{
-						title: 'Fixtures',
-						url: '/football/fixtures',
-						longTitle: 'football/fixtures',
-					},
-					{
-						title: 'Results',
-						url: '/football/results',
-						longTitle: 'football/results',
-					},
-					{
-						title: 'Competitions',
-						url: '/football/competitions',
-						longTitle: 'football/competitions',
-					},
-					{
-						title: 'Clubs',
-						url: '/football/teams',
-						longTitle: 'football/teams',
-					},
-				],
-			},
 			links: [
 				{
-					title: 'Live scores',
-					url: '/football/live',
-					longTitle: 'football/live',
+					title: 'Fashion',
+					url: '/fashion',
 				},
 				{
-					title: 'Tables',
-					url: '/football/tables',
-					longTitle: 'football/tables',
+					title: 'Food',
+					url: '/food',
 				},
 				{
-					title: 'Fixtures',
-					url: '/football/fixtures',
-					longTitle: 'football/fixtures',
+					title: 'Recipes',
+					url: '/tone/recipes',
 				},
 				{
-					title: 'Results',
-					url: '/football/results',
-					longTitle: 'football/results',
+					title: 'Love & sex',
+					url: '/lifeandstyle/love-and-sex',
 				},
 				{
-					title: 'Competitions',
-					url: '/football/competitions',
-					longTitle: 'football/competitions',
+					title: 'Home & garden',
+					url: '/lifeandstyle/home-and-garden',
 				},
 				{
-					title: 'Clubs',
-					url: '/football/teams',
-					longTitle: 'football/teams',
+					title: 'Health & fitness',
+					url: '/lifeandstyle/health-and-wellbeing',
+				},
+				{
+					title: 'Family',
+					url: '/lifeandstyle/family',
+				},
+				{
+					title: 'Travel',
+					url: '/travel',
+					children: [
+						{
+							title: 'US',
+							url: '/travel/usa',
+						},
+						{
+							title: 'Europe',
+							url: '/travel/europe',
+						},
+						{
+							title: 'UK',
+							url: '/travel/uk',
+						},
+					],
+				},
+				{
+					title: 'Money',
+					url: '/money',
+					children: [
+						{
+							title: 'Property',
+							url: '/money/property',
+						},
+						{
+							title: 'Pensions',
+							url: '/money/pensions',
+						},
+						{
+							title: 'Savings',
+							url: '/money/savings',
+						},
+						{
+							title: 'Borrowing',
+							url: '/money/debt',
+						},
+						{
+							title: 'Careers',
+							url: '/money/work-and-careers',
+						},
+					],
 				},
 			],
 		},
@@ -1062,70 +1024,59 @@ export const MatchReport: CAPIType = {
 		},
 	},
 	author: {
-		byline: 'Ben Fisher at the Liberty Stadium',
+		byline: 'Letters',
 	},
-	designType: 'MatchReport',
+	designType: 'Comment',
 	editionId: 'UK',
 	format: {
-		design: 'MatchReportDesign',
-		theme: 'SportPillar',
+		design: 'LetterDesign',
+		theme: 'NewsPillar',
 		display: 'StandardDisplay',
 	},
-	standfirst: '',
+	standfirst:
+		'<p><strong>Rosemary Johnson</strong> and <strong>Margaret Davis</strong> reflect on changes in attitudes to women and work – including unpaid work at home – since the 1970s, while <strong>Brian Saperia</strong> looks back to 1939</p>',
 	openGraphData: {
 		'og:url':
-			'http://www.theguardian.com/football/2021/feb/05/andre-ayew-sparks-swansea-victory-over-norwich-to-close-gap-at-top',
-		'article:author': 'https://www.theguardian.com/profile/ben-fisher',
+			'http://www.theguardian.com/world/2021/apr/05/why-is-a-womans-work-never-done',
+		'article:author': 'Letters',
 		'og:image:height': '720',
 		'og:description':
-			'André Ayew and Conor Hourihane scored in the 2-0 home win against Norwich to lift Swansea to second, only two points behind the leaders',
+			'Letters: Rosemary Johnson and Margaret Davis reflect on changes in attitudes to women and work – including unpaid work at home – since the 1970s, while Brian Saperia looks back to 1939',
 		'og:image:width': '1200',
 		'og:image':
-			'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctZGVmYXVsdC5wbmc&enable=upscale&s=b8519d3db69446bfb443279cd19db7b5',
+			'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_187_1969_1182/master/1969.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctZGVmYXVsdC5wbmc&enable=upscale&s=dcd621765221570f91e3ac722f3a4b02',
 		'al:ios:url':
-			'gnmguardian://football/2021/feb/05/andre-ayew-sparks-swansea-victory-over-norwich-to-close-gap-at-top?contenttype=Article&source=applinks',
+			'gnmguardian://world/2021/apr/05/why-is-a-womans-work-never-done?contenttype=Article&source=applinks',
 		'article:publisher': 'https://www.facebook.com/theguardian',
 		'og:type': 'article',
 		'al:ios:app_store_id': '409128287',
-		'article:section': 'Football',
-		'article:published_time': '2021-02-05T22:16:43.000Z',
-		'og:title':
-			'André Ayew sparks Swansea victory over Norwich to close gap at top',
+		'article:section': 'World news',
+		'article:published_time': '2021-04-05T16:04:21.000Z',
+		'og:title': 'Why is a woman’s work never done? | Letters',
 		'fb:app_id': '180444840287',
-		'article:tag': 'Championship,Swansea City,Norwich City,Football,Sport',
+		'article:tag': 'Gender,Women,Family',
 		'al:ios:app_name': 'The Guardian',
 		'og:site_name': 'the Guardian',
-		'article:modified_time': '2021-02-06T05:27:20.000Z',
+		'article:modified_time': '2021-04-05T17:36:25.000Z',
 	},
-	sectionUrl: 'football/championship',
-	pageId:
-		'football/2021/feb/05/andre-ayew-sparks-swansea-victory-over-norwich-to-close-gap-at-top',
+	sectionUrl: 'world/gender',
+	pageId: 'world/2021/apr/05/why-is-a-womans-work-never-done',
 	version: 3,
 	tags: [
 		{
-			id: 'football/championship',
+			id: 'world/gender',
 			type: 'Keyword',
-			title: 'Championship',
+			title: 'Gender',
 		},
 		{
-			id: 'football/swansea',
+			id: 'lifeandstyle/women',
 			type: 'Keyword',
-			title: 'Swansea City',
+			title: 'Women',
 		},
 		{
-			id: 'football/norwichcity',
+			id: 'lifeandstyle/family',
 			type: 'Keyword',
-			title: 'Norwich City',
-		},
-		{
-			id: 'football/football',
-			type: 'Keyword',
-			title: 'Football',
-		},
-		{
-			id: 'sport/sport',
-			type: 'Keyword',
-			title: 'Sport',
+			title: 'Family',
 		},
 		{
 			id: 'type/article',
@@ -1133,16 +1084,9 @@ export const MatchReport: CAPIType = {
 			title: 'Article',
 		},
 		{
-			id: 'tone/matchreports',
+			id: 'tone/letters',
 			type: 'Tone',
-			title: 'Match reports',
-		},
-		{
-			id: 'profile/ben-fisher',
-			type: 'Contributor',
-			title: 'Ben Fisher',
-			bylineImageUrl:
-				'https://i.guim.co.uk/img/uploads/2017/11/06/Ben_Fisher,_L.png?width=300&quality=85&auto=format&fit=max&s=c7012d74bff5e3b4952656e3a8ceb105',
+			title: 'Letters',
 		},
 		{
 			id: 'publication/theguardian',
@@ -1150,27 +1094,27 @@ export const MatchReport: CAPIType = {
 			title: 'The Guardian',
 		},
 		{
-			id: 'theguardian/sport',
+			id: 'theguardian/journal',
 			type: 'NewspaperBook',
-			title: 'Sport',
+			title: 'Journal',
 		},
 		{
-			id: 'theguardian/sport/news',
+			id: 'theguardian/journal/letters',
 			type: 'NewspaperBookSection',
-			title: 'News & features',
+			title: 'Letters',
 		},
 		{
-			id: 'tracking/commissioningdesk/uk-sport',
+			id: 'tracking/commissioningdesk/uk-letters-and-leader-writers',
 			type: 'Tracking',
-			title: 'UK Sport',
+			title: 'UK Letters and Leader Writers',
 		},
 	],
-	pillar: 'sport',
+	pillar: 'news',
 	webURL:
-		'https://www.theguardian.com/football/2021/feb/05/andre-ayew-sparks-swansea-victory-over-norwich-to-close-gap-at-top',
+		'https://www.theguardian.com/world/2021/apr/05/why-is-a-womans-work-never-done',
 	showBottomSocialButtons: true,
 	isImmersive: false,
-	sectionLabel: 'Championship',
+	sectionLabel: 'Gender',
 	shouldHideReaderRevenue: false,
 	isAdFreeUser: false,
 	pageFooter: {
@@ -1330,20 +1274,20 @@ export const MatchReport: CAPIType = {
 		'twitter:app:name:googleplay': 'The Guardian',
 		'twitter:app:name:ipad': 'The Guardian',
 		'twitter:image':
-			'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctZGVmYXVsdC5wbmc&s=63f5549570734f5edf36122ad2d62b30',
+			'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_187_1969_1182/master/1969.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctZGVmYXVsdC5wbmc&s=c2fa1bf478107e8638d4ec680e498e54',
 		'twitter:site': '@guardian',
 		'twitter:app:url:ipad':
-			'gnmguardian://football/2021/feb/05/andre-ayew-sparks-swansea-victory-over-norwich-to-close-gap-at-top?contenttype=Article&source=twitter',
+			'gnmguardian://world/2021/apr/05/why-is-a-womans-work-never-done?contenttype=Article&source=twitter',
 		'twitter:card': 'summary_large_image',
 		'twitter:app:name:iphone': 'The Guardian',
 		'twitter:app:id:ipad': '409128287',
 		'twitter:app:id:googleplay': 'com.guardian',
 		'twitter:app:url:googleplay':
-			'guardian://www.theguardian.com/football/2021/feb/05/andre-ayew-sparks-swansea-victory-over-norwich-to-close-gap-at-top',
+			'guardian://www.theguardian.com/world/2021/apr/05/why-is-a-womans-work-never-done',
 		'twitter:app:url:iphone':
-			'gnmguardian://football/2021/feb/05/andre-ayew-sparks-swansea-victory-over-norwich-to-close-gap-at-top?contenttype=Article&source=twitter',
+			'gnmguardian://world/2021/apr/05/why-is-a-womans-work-never-done?contenttype=Article&source=twitter',
 	},
-	sectionName: 'football',
+	sectionName: 'world',
 	pageType: {
 		hasShowcaseMainElement: false,
 		isFront: false,
@@ -1355,10 +1299,7 @@ export const MatchReport: CAPIType = {
 	},
 	hasStoryPackage: false,
 	contributionsServiceUrl: 'https://contributions.guardianapis.com',
-	matchUrl:
-		'https://api.nextgen.guardianapps.co.uk/football/api/match-nav/2021/02/05/65/14.json?dcr=true&page=football%2F2021%2Ffeb%2F05%2Fandre-ayew-sparks-swansea-victory-over-norwich-to-close-gap-at-top',
-	headline:
-		'André Ayew sparks Swansea victory over Norwich to close gap at top',
+	headline: 'Why is a woman’s work never done?',
 	guardianBaseURL: 'https://www.theguardian.com',
 	mainMediaElements: [
 		{
@@ -1367,67 +1308,67 @@ export const MatchReport: CAPIType = {
 					{
 						index: 0,
 						fields: {
-							height: '600',
+							height: '797',
 							width: '1000',
 						},
 						mediaType: 'Image',
 						mimeType: 'image/jpeg',
 						url:
-							'https://media.guim.co.uk/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/1000.jpg',
+							'https://media.guim.co.uk/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/1000.jpg',
 					},
 					{
 						index: 1,
 						fields: {
-							height: '300',
+							height: '398',
 							width: '500',
 						},
 						mediaType: 'Image',
 						mimeType: 'image/jpeg',
 						url:
-							'https://media.guim.co.uk/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/500.jpg',
+							'https://media.guim.co.uk/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/500.jpg',
 					},
 					{
 						index: 2,
 						fields: {
-							height: '84',
+							height: '112',
 							width: '140',
 						},
 						mediaType: 'Image',
 						mimeType: 'image/jpeg',
 						url:
-							'https://media.guim.co.uk/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/140.jpg',
+							'https://media.guim.co.uk/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/140.jpg',
 					},
 					{
 						index: 3,
 						fields: {
-							height: '1028',
-							width: '1713',
+							height: '1569',
+							width: '1969',
 						},
 						mediaType: 'Image',
 						mimeType: 'image/jpeg',
 						url:
-							'https://media.guim.co.uk/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/1713.jpg',
+							'https://media.guim.co.uk/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/1969.jpg',
 					},
 					{
 						index: 4,
 						fields: {
 							isMaster: 'true',
-							height: '1028',
-							width: '1713',
+							height: '1569',
+							width: '1969',
 						},
 						mediaType: 'Image',
 						mimeType: 'image/jpeg',
 						url:
-							'https://media.guim.co.uk/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg',
+							'https://media.guim.co.uk/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg',
 					},
 				],
 			},
 			data: {
 				alt:
-					'André Ayew celebrates after giving Swansea the lead in their 2-0 home victory against Championship leaders Norwich.',
+					'Margaret Thatcher cooking in the kitchen of her Chelsea flat for the benefit of the cameras a week before making her challenge for the Conservative party leadership in 1975.',
 				caption:
-					'André Ayew celebrates after giving Swansea the lead in their 2-0 home victory against Championship leaders Norwich.',
-				credit: 'Photograph: Kieran McManus/BPI/Shutterstock',
+					'Margaret Thatcher cooking in the kitchen of her Chelsea flat for the benefit of the cameras, a week before making her challenge for the Conservative party leadership in 1975.',
+				credit: 'Photograph: taken from picture library',
 			},
 			displayCredit: true,
 			role: 'inline',
@@ -1437,32 +1378,32 @@ export const MatchReport: CAPIType = {
 					srcSet: [
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=620&quality=85&auto=format&fit=max&s=2e852cd56aed3ab41675e2dbb380a93c',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=620&quality=85&auto=format&fit=max&s=1f3d2604f5f42157c0f835704df3df5b',
 							width: 620,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=208554c4cb446786a0856ec41f97b550',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=57358d92e519b7c9465d844b8a5e78a7',
 							width: 1240,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=605&quality=85&auto=format&fit=max&s=7cf31e91b66cdff430159385c573848c',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=605&quality=85&auto=format&fit=max&s=523408d4a75b2461b54276f9f7c47b51',
 							width: 605,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=b3f503e873cba7ab501ca0bcc90ba063',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=9cec40a73aab51303b5de42fccc6624f',
 							width: 1210,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=445&quality=85&auto=format&fit=max&s=226d9fc8084be99e0dfe08f66421fcba',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=445&quality=85&auto=format&fit=max&s=5d923c2dee1cacd4171fd07d292a49a6',
 							width: 445,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=33fa0d7a99e09629baad6038c09d29a2',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=0ef67ab59f237c7d3a5c711d2f9b7eb5',
 							width: 890,
 						},
 					],
@@ -1472,22 +1413,22 @@ export const MatchReport: CAPIType = {
 					srcSet: [
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=140&quality=85&auto=format&fit=max&s=ca1fc952b0b5bfcbfb7a8666c110e597',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=140&quality=85&auto=format&fit=max&s=315a58a7e4268057744bbd81fec0faca',
 							width: 140,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=9490e2983dc38e7abcc0819d07358e2d',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=140&quality=45&auto=format&fit=max&dpr=2&s=b9d41a0f55da571db68c731b18c2a0b1',
 							width: 280,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=120&quality=85&auto=format&fit=max&s=fc7bf55b34904547630abb290e07ba2b',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=120&quality=85&auto=format&fit=max&s=e7efc626212727e051a6d6868bfce282',
 							width: 120,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=7f7b2be69723c4c6571336362b432805',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=120&quality=45&auto=format&fit=max&dpr=2&s=07f8a8608fa333a735355acd28000231',
 							width: 240,
 						},
 					],
@@ -1497,52 +1438,52 @@ export const MatchReport: CAPIType = {
 					srcSet: [
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=380&quality=85&auto=format&fit=max&s=0b6cd1334b62c2cdf3a69e7b8fb5682e',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=380&quality=85&auto=format&fit=max&s=55750953e119bd634ae70e82594c00d2',
 							width: 380,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=3ceac779c69416232712bf4c8e99032f',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=380&quality=45&auto=format&fit=max&dpr=2&s=ac5813c3fbd208964c909943713e3a98',
 							width: 760,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=300&quality=85&auto=format&fit=max&s=ebcc0889e3b990c755a1f2674f55b139',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=300&quality=85&auto=format&fit=max&s=b1d004fcf4a24193a0a23c9062543884',
 							width: 300,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=3acf7faad2c14d8fb8ce977dc8d74399',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=300&quality=45&auto=format&fit=max&dpr=2&s=e394898ac67de3b4032791b3ec26ea33',
 							width: 600,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=620&quality=85&auto=format&fit=max&s=2e852cd56aed3ab41675e2dbb380a93c',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=620&quality=85&auto=format&fit=max&s=1f3d2604f5f42157c0f835704df3df5b',
 							width: 620,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=208554c4cb446786a0856ec41f97b550',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=57358d92e519b7c9465d844b8a5e78a7',
 							width: 1240,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=605&quality=85&auto=format&fit=max&s=7cf31e91b66cdff430159385c573848c',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=605&quality=85&auto=format&fit=max&s=523408d4a75b2461b54276f9f7c47b51',
 							width: 605,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=b3f503e873cba7ab501ca0bcc90ba063',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=9cec40a73aab51303b5de42fccc6624f',
 							width: 1210,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=445&quality=85&auto=format&fit=max&s=226d9fc8084be99e0dfe08f66421fcba',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=445&quality=85&auto=format&fit=max&s=5d923c2dee1cacd4171fd07d292a49a6',
 							width: 445,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=33fa0d7a99e09629baad6038c09d29a2',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=0ef67ab59f237c7d3a5c711d2f9b7eb5',
 							width: 890,
 						},
 					],
@@ -1552,72 +1493,72 @@ export const MatchReport: CAPIType = {
 					srcSet: [
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=1020&quality=85&auto=format&fit=max&s=218bd7173095566fc62bc0e5b6f19f31',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=1020&quality=85&auto=format&fit=max&s=01977e915850756ef009921e35451689',
 							width: 1020,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=1020&quality=45&auto=format&fit=max&dpr=2&s=921d1bac4fa4864c5834c185c1440596',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=1020&quality=45&auto=format&fit=max&dpr=2&s=7db29d90d0358e8a4aa7011da6547d92',
 							width: 2040,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=940&quality=85&auto=format&fit=max&s=33cee4387567d8dc5989a2cb74744605',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=940&quality=85&auto=format&fit=max&s=c54597c69361d189cbea06a6b5bc5e06',
 							width: 940,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=940&quality=45&auto=format&fit=max&dpr=2&s=efe8f8ce7874db475bad461e7e6c37a2',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=940&quality=45&auto=format&fit=max&dpr=2&s=4b92d2d3876eacf153fc898762e34892',
 							width: 1880,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=700&quality=85&auto=format&fit=max&s=c26150091859708116bb6f3b1d8e6fd7',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=700&quality=85&auto=format&fit=max&s=305c14aa09350922fa5a797582a8aac3',
 							width: 700,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=e5badc76e3ddac60f7166895d09d444e',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=b6f129625fdc59832270453bcf3ce20a',
 							width: 1400,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=700&quality=85&auto=format&fit=max&s=c26150091859708116bb6f3b1d8e6fd7',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=700&quality=85&auto=format&fit=max&s=305c14aa09350922fa5a797582a8aac3',
 							width: 700,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=e5badc76e3ddac60f7166895d09d444e',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=b6f129625fdc59832270453bcf3ce20a',
 							width: 1400,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=660&quality=85&auto=format&fit=max&s=8e9b081837d4367f83a7633713e45eee',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=660&quality=85&auto=format&fit=max&s=0e27793c5d46a0d77625b8f714dada4f',
 							width: 660,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=660&quality=45&auto=format&fit=max&dpr=2&s=2dd8e33f8868179ff7bc099e4170f224',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=660&quality=45&auto=format&fit=max&dpr=2&s=bdd2ed73acbd2b05e31c5a46086bf6ac',
 							width: 1320,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=645&quality=85&auto=format&fit=max&s=3137a1577d4433cdf7b6e95fd8d4cf78',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=645&quality=85&auto=format&fit=max&s=12645523c60c498f296c1b0f94696459',
 							width: 645,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=09f4336af469ce67ced5fe9df7c83e5e',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=ab91a38b049c3661442d65bce068f763',
 							width: 1290,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=465&quality=85&auto=format&fit=max&s=271e6711f51b1c0055793baf2749bd32',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=465&quality=85&auto=format&fit=max&s=96f5ed2e131330bc05e6ba8430582f4a',
 							width: 465,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=d7df199c9bd479a283c3a7afb80736e8',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=d2027d3d7649734adac3b725ba7028ba',
 							width: 930,
 						},
 					],
@@ -1627,32 +1568,32 @@ export const MatchReport: CAPIType = {
 					srcSet: [
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=620&quality=85&auto=format&fit=max&s=2e852cd56aed3ab41675e2dbb380a93c',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=620&quality=85&auto=format&fit=max&s=1f3d2604f5f42157c0f835704df3df5b',
 							width: 620,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=208554c4cb446786a0856ec41f97b550',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=620&quality=45&auto=format&fit=max&dpr=2&s=57358d92e519b7c9465d844b8a5e78a7',
 							width: 1240,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=605&quality=85&auto=format&fit=max&s=7cf31e91b66cdff430159385c573848c',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=605&quality=85&auto=format&fit=max&s=523408d4a75b2461b54276f9f7c47b51',
 							width: 605,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=b3f503e873cba7ab501ca0bcc90ba063',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=605&quality=45&auto=format&fit=max&dpr=2&s=9cec40a73aab51303b5de42fccc6624f',
 							width: 1210,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=445&quality=85&auto=format&fit=max&s=226d9fc8084be99e0dfe08f66421fcba',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=445&quality=85&auto=format&fit=max&s=5d923c2dee1cacd4171fd07d292a49a6',
 							width: 445,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=33fa0d7a99e09629baad6038c09d29a2',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=445&quality=45&auto=format&fit=max&dpr=2&s=0ef67ab59f237c7d3a5c711d2f9b7eb5',
 							width: 890,
 						},
 					],
@@ -1662,202 +1603,122 @@ export const MatchReport: CAPIType = {
 					srcSet: [
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=1300&quality=85&auto=format&fit=max&s=da89361749c2db884b396202fe281df2',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=1300&quality=85&auto=format&fit=max&s=ae5e780efa6b0cb123859e6ac313bdfe',
 							width: 1300,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=1300&quality=45&auto=format&fit=max&dpr=2&s=7ee884b9c6840d7993cdff8bb5b608e2',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=1300&quality=45&auto=format&fit=max&dpr=2&s=f87640448b719826caeb1bc3309f4d3b',
 							width: 2600,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=1140&quality=85&auto=format&fit=max&s=73dda51a11db9bc1df0f918c2d0222ef',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=1140&quality=85&auto=format&fit=max&s=b8f9a9f85ddb9a2104e438c9a3a573dd',
 							width: 1140,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=1140&quality=45&auto=format&fit=max&dpr=2&s=e54589b2000f6314ab8083e69b199edc',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=1140&quality=45&auto=format&fit=max&dpr=2&s=ced4a9dd31c246dc579f0ad358b8dee8',
 							width: 2280,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=1125&quality=85&auto=format&fit=max&s=b37a0e995403ea1f5e2b9c7a3cd4ec2a',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=1125&quality=85&auto=format&fit=max&s=247a0e51131502fc06ee399293af001d',
 							width: 1125,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=1125&quality=45&auto=format&fit=max&dpr=2&s=d87c09c55375ad9095089dca71189b38',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=1125&quality=45&auto=format&fit=max&dpr=2&s=f48a34b4c044fd087f143816d638440c',
 							width: 2250,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=965&quality=85&auto=format&fit=max&s=ef553179832fe351026879cd5cca4017',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=965&quality=85&auto=format&fit=max&s=c2609818c8065f564cefa634494ebd6c',
 							width: 965,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=965&quality=45&auto=format&fit=max&dpr=2&s=f7992d9e3a74bca6f832ef8d7156bdf4',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=965&quality=45&auto=format&fit=max&dpr=2&s=ad8d80b267e268674f419c786bcd96e9',
 							width: 1930,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=725&quality=85&auto=format&fit=max&s=474e255381529f0047dff2dd11389d1b',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=725&quality=85&auto=format&fit=max&s=1b8fb7c2fac8b3efedbdc729ff9ca60d',
 							width: 725,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=725&quality=45&auto=format&fit=max&dpr=2&s=28c4b267f9038263223f14307704c4fa',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=725&quality=45&auto=format&fit=max&dpr=2&s=c0a82ac6d696a0734089d543b31d643b',
 							width: 1450,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=645&quality=85&auto=format&fit=max&s=3137a1577d4433cdf7b6e95fd8d4cf78',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=645&quality=85&auto=format&fit=max&s=12645523c60c498f296c1b0f94696459',
 							width: 645,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=09f4336af469ce67ced5fe9df7c83e5e',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=645&quality=45&auto=format&fit=max&dpr=2&s=ab91a38b049c3661442d65bce068f763',
 							width: 1290,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=465&quality=85&auto=format&fit=max&s=271e6711f51b1c0055793baf2749bd32',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=465&quality=85&auto=format&fit=max&s=96f5ed2e131330bc05e6ba8430582f4a',
 							width: 465,
 						},
 						{
 							src:
-								'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=d7df199c9bd479a283c3a7afb80736e8',
+								'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_0_1969_1569/master/1969.jpg?width=465&quality=45&auto=format&fit=max&dpr=2&s=d2027d3d7649734adac3b725ba7028ba',
 							width: 930,
 						},
 					],
 				},
 			],
 			_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-			elementId: '29e9f9af-d8f2-400e-a876-7e0a893db687',
+			elementId: '6f2e7dd0-3535-4f03-9558-b678491a644a',
 		},
 	],
-	webPublicationDate: '2021-02-05T22:16:43.000Z',
+	webPublicationDate: '2021-04-05T16:04:21.000Z',
 	blocks: [
 		{
-			id: '601d96ef8f0862592e4b23ca',
+			id: '5e74b1928f089367b3d0b644',
 			elements: [
 				{
 					html:
-						'<p>When does a blip become something more major? Whatever this sticky patch is for <a href="https://www.theguardian.com/football/norwichcity" data-component="auto-linked-tag">Norwich City</a>, it is impossible to ignore the changing landscape at the top of the Championship after Swansea cut their lead at the summit to two points courtesy of goals by André Ayew and Conor Hourihane.</p>',
+						'<p>Your article (<a href="https://www.theguardian.com/society/2021/mar/30/bob-pape-was-a-beloved-father-and-foster-carer-did-eat-out-to-help-out-cost-him-his-life">Lost to the virus</a>, 30 March) and the <a href="https://www.theguardian.com/uk-news/2021/apr/01/peace-camp-support-for-swiss-army-underwear-move">subsequent letter</a> about women at home “not working” (1 April) reminded me of the 1971-72 television series Budgie,&nbsp;written by Keith Waterhouse and Willis Hall. In one episode, the Soho&nbsp;gangster Charlie&nbsp;Endell (played by Iain Cuthbertson) declared proudly: “Mrs Endell, since the day&nbsp;I married her, has not done a stroke of work – except cooking, cleaning, and bringing up the kids.”<br><strong>Rosemary </strong><strong>Johnson<br></strong><em>Byfield, Northamptonshire</em></p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '12258ce8-6f1f-42a3-84b3-4a34a90009f9',
+					elementId: 'bcb41d13-316b-43fe-bc6b-a90f76f44af2',
 				},
 				{
 					html:
-						'<p>Norwich may have fired blanks for the fourth successive game but Hourihane is on quite the streak, with a superb strike here his third goal since arriving on loan from Aston Villa a fortnight ago. It looks an increasingly shrewd piece of business.</p>',
+						'<p>• In the 1970s, when feminism was&nbsp;working well, before it lost its way, we referred to women who stay at home as “women who&nbsp;don’t work outside the home”. In other words they had one job, unlike women who “work outside the home”, having two jobs. Then&nbsp;along came Thatcher.<br><strong>Margaret Davis<br></strong><em>Loanhead, Midlothian</em></p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '351a0ff5-2050-43c8-8be8-295fb8b64884',
+					elementId: '1b5c940c-79b6-411f-b1a3-e1adeaf78d0a',
 				},
 				{
 					html:
-						'<p>Swansea have a game in hand on the leaders but Brentford and Reading, both of whom also have games up their sleeve, will be equally encouraged by a Norwich team stuck in a rut. Ayew capitalised on an uncharacteristic error by Tim Krul to open the scoring before Hourihane sent a rasping strike beyond the Norwich goalkeeper from distance after the interval.</p>',
+						'<p>• Maybe the hurried “census” carried out in 1939 got it right by defining wives as undertaking “<a href="https://www.theguardian.com/news/datablog/2015/nov/02/the-1939-register-a-tale-of-a-country-ravaged-by-war">unpaid domestic duties</a>”.<br><strong>Brian Saperia<br></strong><em>Harrow, London</em></p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'd64af820-8ed5-4f17-a3f3-8468df1d3407',
-				},
-				{
-					url:
-						'https://www.theguardian.com/football/football-league-blog/2021/jan/29/tim-krul-way-we-play-norwich-similar-holland-netherlands-goalkeeper',
-					text:
-						"Tim Krul: 'The way we play at Norwich is similar to Holland'",
-					prefix: 'Related: ',
-					role: 'thumbnail',
-					_type:
-						'model.dotcomrendering.pageElements.RichLinkBlockElement',
-					elementId: '6fe51c43-ec2d-4698-8a87-0b7193af2caf',
-				},
-				{
-					html:
-						'<p>Swansea should have had a late penalty too, but the referee Simon Hooper waved away appeals despite Ben Gibson appearing to fell the substitute Jordan Morris after Grant Hanley collided with the all-action Connor Roberts.</p>',
-					_type:
-						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'd9a52140-386d-4168-b2aa-b8a256a28bd9',
-				},
-				{
-					html:
-						'<p>On the eve of this game, Swansea’s unpopular American owners gave a rare interview in which they broke their silence on a multitude of longstanding issues but also made a point of stressing they have not been “taking a victory lap” on the back of their impressive start under Steve Cooper.</p>',
-					_type:
-						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'aa0a39b7-5dd1-4fbf-95cc-58743fa0c9ba',
-				},
-				{
-					html:
-						'<p>“There were no expectations at the start of the season so I think it would be unfair to start doing it [building them] now with 19 games to go,” Cooper said. “There are clubs not even in the top 10 with much more resources than us but we’re going well and enjoying the journey and that’s how we work.”</p>',
-					_type:
-						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '023fb16a-770d-4510-8c75-73ab9ee162bb',
-				},
-				{
-					html:
-						'<p>Perhaps it was kidology but Daniel Farke had been at pains to play down the significance of the occasion after stuttering to a point at Millwall on Tuesday. Todd Cantwell, among those of interest to the watching England Under-21s manager Aidy Boothroyd, showed touches of class, setting Teemu Pukki free with a wonderfully weighted pass and later Kenny McLean after twirling away from Matt Grimes but the killer instinct again eluded them.</p>',
-					_type:
-						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'a4dbe794-0a71-4a08-b3ac-494e1a6f1e1c',
-				},
-				{
-					html:
-						'<p>Swansea seized the advantage three minutes before the interval but the goal was a tragicomedy from a Norwich perspective. Krul flapped at Roberts’ in-swinging corner and when the ball dropped, Marc Guehi, another player on Boothroyd’s radar, scooped the ball away from the Norwich goalkeeper’s grasp, allowing Swansea to feast on the leftovers. Jake Bidwell tried his luck and then Ayew fired in his ninth goal of the season. Farke sought a response and Freddie Woodman saved superbly to keep out Grant Hanley’s header on the brink of the interval after the captain met Przemyslaw Placheta’s free-kick.</p>',
-					_type:
-						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'da9edb08-e9e0-48c9-8723-3a224449c384',
-				},
-				{
-					html:
-						'<p>Krul came out early to limber up for the second half but, before Norwich had a chance to write the wrongs, they found themselves two goals down. Jay Fulton gobbled up possession following a loose pass by McLean and played a sliderule pass infield to Hourihane, who joined on loan last month in search of regular game time. The midfielder steadied himself with first touch and then arrowed a piercing left-footed strike into the corner with his second.</p>',
-					_type:
-						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'd5281163-426a-4ca9-b69d-85749c999723',
-				},
-				{
-					html:
-						'<iframe id="the-fiver" name="the-fiver" src="https://www.theguardian.com/email/form/plaintone/the-fiver" scrolling="no" seamless="" class="iframed--overflow-hidden email-sub__iframe" height="52px" frameborder="0" data-component="email-embed--the-fiver"></iframe>',
-					safe: true,
-					alt: 'Fiver',
-					isMandatory: false,
-					isThirdPartyTracking: false,
-					source: 'The Guardian',
-					sourceDomain: 'theguardian.com',
-					_type:
-						'model.dotcomrendering.pageElements.EmbedBlockElement',
-					elementId: '277abbc0-91e2-493a-88b1-48a4178aedef',
-				},
-				{
-					html:
-						'<p>“We didn’t think he was going to come in and score three goals in first three league games, but we’ll take it,” said Cooper. “As soon as it fell to Conor I think everybody in the stadium thought ‘there’s a good chance of this going in.’ Once we lost Morgan [Gibbs-White, who returned to Wolves], I felt we needed a player you fancy to get goals. Conor’s numbers are really good.”</p>',
-					_type:
-						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '203daef0-a229-4121-b132-27ccbe967fe3',
-				},
-				{
-					html:
-						'<p>Krul shook his head in disbelief and Farke admitted his players are hurting. “When you lose such a spotlight game, of course, you are disappointed,” he said. “I will allow my players to be disappointed because it’s important to feel this and be greedy for this next game. We want this winning feeling back.”</p>',
-					_type:
-						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '4eaec5e2-5fd5-4925-9574-19a257a94ff0',
+					elementId: '44a6e45f-4804-4958-8edb-93118d88977d',
 				},
 			],
-			createdOn: 1612551919000,
-			createdOnDisplay: '19.05 GMT',
-			blockCreatedOn: 1612551919000,
-			blockCreatedOnDisplay: '19.05 GMT',
-			lastUpdated: 1612589240000,
-			lastUpdatedDisplay: '05.27 GMT',
-			blockLastUpdated: 1612570264000,
-			blockLastUpdatedDisplay: '00.11 GMT',
-			firstPublished: 1612563403000,
-			firstPublishedDisplay: '22.16 GMT',
-			blockFirstPublished: 1612563105000,
-			blockFirstPublishedDisplay: '22.11 GMT',
-			primaryDateLine: 'Fri 5 Feb 2021 22.16 GMT',
-			secondaryDateLine: 'Last modified on Sat 6 Feb 2021 05.27 GMT',
+			createdOn: 1584705938000,
+			createdOnDisplay: '12.05 GMT',
+			blockCreatedOn: 1584705938000,
+			blockCreatedOnDisplay: '12.05 GMT',
+			lastUpdated: 1617644185000,
+			lastUpdatedDisplay: '18.36 BST',
+			blockLastUpdated: 1617631119000,
+			blockLastUpdatedDisplay: '14.58 BST',
+			firstPublished: 1617638661000,
+			firstPublishedDisplay: '17.04 BST',
+			blockFirstPublished: 1617631111000,
+			blockFirstPublishedDisplay: '14.58 BST',
+			primaryDateLine: 'Mon 5 Apr 2021 17.04 BST',
+			secondaryDateLine: 'Last modified on Mon 5 Apr 2021 18.36 BST',
 		},
 	],
 	linkedData: [
@@ -1865,7 +1726,7 @@ export const MatchReport: CAPIType = {
 			'@type': 'NewsArticle',
 			'@context': 'https://schema.org',
 			'@id':
-				'https://amp.theguardian.com/football/2021/feb/05/andre-ayew-sparks-swansea-victory-over-norwich-to-close-gap-at-top',
+				'https://amp.theguardian.com/world/2021/apr/05/why-is-a-womans-work-never-done',
 			publisher: {
 				'@type': 'Organization',
 				'@context': 'https://schema.org',
@@ -1892,43 +1753,40 @@ export const MatchReport: CAPIType = {
 				productID: 'theguardian.com:basic',
 			},
 			image: [
-				'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctZGVmYXVsdC5wbmc&enable=upscale&s=b8519d3db69446bfb443279cd19db7b5',
-				'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=1200&height=1200&quality=85&auto=format&fit=crop&s=4d76500f0c4bff87eb6979e12fc4eaf4',
-				'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=1200&height=900&quality=85&auto=format&fit=crop&s=4933194a6d7519d92ed3cf410aa9f8a8',
-				'https://i.guim.co.uk/img/media/cc1d3dc14ab9104587323ef12ac477004b369637/67_36_1713_1028/master/1713.jpg?width=1200&quality=85&auto=format&fit=max&s=56ea2121d733fa61be9fa2792b52aefa',
+				'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_187_1969_1182/master/1969.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctZGVmYXVsdC5wbmc&enable=upscale&s=dcd621765221570f91e3ac722f3a4b02',
+				'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_187_1969_1182/master/1969.jpg?width=1200&height=1200&quality=85&auto=format&fit=crop&s=39389ef31ece58316e6c3e82452d88f1',
+				'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_187_1969_1182/master/1969.jpg?width=1200&height=900&quality=85&auto=format&fit=crop&s=fe6ceca60281b25ca63d71a1cdd110dd',
+				'https://i.guim.co.uk/img/media/0c2ce442da04f953c3e7a67d419f8c2f8caa9cc0/0_187_1969_1182/master/1969.jpg?width=1200&quality=85&auto=format&fit=max&s=962bb541216e2a5117b6b71475778ad8',
 			],
 			author: [
 				{
 					'@type': 'Person',
-					name: 'Ben Fisher',
-					sameAs: 'https://www.theguardian.com/profile/ben-fisher',
+					name: 'Guardian staff reporter',
 				},
 			],
-			datePublished: '2021-02-05T22:16:43.000Z',
-			headline:
-				'André Ayew sparks Swansea victory over Norwich to close gap at top',
-			dateModified: '2021-02-06T05:27:20.000Z',
+			datePublished: '2021-04-05T16:04:21.000Z',
+			headline: 'Why is a woman’s work never done?',
+			dateModified: '2021-04-05T17:36:25.000Z',
 			mainEntityOfPage:
-				'https://www.theguardian.com/football/2021/feb/05/andre-ayew-sparks-swansea-victory-over-norwich-to-close-gap-at-top',
+				'https://www.theguardian.com/world/2021/apr/05/why-is-a-womans-work-never-done',
 		},
 		{
 			'@type': 'WebPage',
 			'@context': 'https://schema.org',
 			'@id':
-				'https://www.theguardian.com/football/2021/feb/05/andre-ayew-sparks-swansea-victory-over-norwich-to-close-gap-at-top',
+				'https://www.theguardian.com/world/2021/apr/05/why-is-a-womans-work-never-done',
 			potentialAction: {
 				'@type': 'ViewAction',
 				target:
-					'android-app://com.guardian/https/www.theguardian.com/football/2021/feb/05/andre-ayew-sparks-swansea-victory-over-norwich-to-close-gap-at-top',
+					'android-app://com.guardian/https/www.theguardian.com/world/2021/apr/05/why-is-a-womans-work-never-done',
 			},
 		},
 	],
-	webPublicationDateDisplay: 'Fri 5 Feb 2021 22.16 GMT',
+	webPublicationDateDisplay: 'Mon 5 Apr 2021 17.04 BST',
 	shouldHideAds: false,
-	webTitle:
-		'André Ayew sparks Swansea victory over Norwich to close gap at top',
+	webTitle: 'Why is a woman’s work never done? | Letters',
 	isSpecialReport: false,
-	isCommentable: true,
+	isCommentable: false,
 	keyEvents: [],
 	config: {
 		references: [

--- a/fixtures/generated/articles/Live.ts
+++ b/fixtures/generated/articles/Live.ts
@@ -1969,7 +1969,7 @@ export const Live: CAPIType = {
 				},
 			],
 			_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-			elementId: '580b8fbe-4193-491e-8ed9-72f87c282d15',
+			elementId: '4baf5b4a-2fb1-46d6-915a-3d5ef246e0fb',
 		},
 	],
 	webPublicationDate: '2021-02-19T19:41:53.000Z',
@@ -1982,20 +1982,20 @@ export const Live: CAPIType = {
 						'<p>That’s it for our live coverage of Nasa’s celebratory news conference and Q&amp;A following the successful landing of the rover Perseverance on Mars. </p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '36e2fde4-8f3f-412d-8a7e-728fad7417ed',
+					elementId: '97e3d94b-ec08-4a79-9f59-73dc2f97aada',
 				},
 				{
 					html: '<p>To recap:</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'eaae7d30-c683-4aa7-9489-0f2911acccc5',
+					elementId: '415bb741-6730-4dae-a441-39eb98032279',
 				},
 				{
 					html:
 						'<ul> \n <li>The rover is “healthy” and undergoing systems testing.</li> \n <li>It already has beamed back stunning photos from the surface of <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> promising significant scientific discoveries ahead.</li> \n <li>The images include the first color images beamed directly from <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> as opposed to images touched up later.</li> \n <li>The rover documented its own touchdown via an ingenious system of booster rockets and a “space crane”.</li> \n <li>It landed in a “pool-table flat” crater in a prime location for searching for traces of ancient life.</li> \n <li>The wheeled rover could begin to move around its new home as early as late February.</li> \n <li>The rover’s mini helicopter could launch as early as April.</li> \n <li>Its broad mission is to stay on <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> for a couple years, gather data and harvest samples to be collected and returned to Earth on a future mission.</li> \n <li>The point is to determine whether there was life on <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> and subsidiary questions.</li> \n <li>The team at Nasa is very happy and excited, “on cloud nine” in a “weird, dreamlike state”... with lots of work ahead.</li> \n</ul>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'ccd86208-4f24-4d72-bba0-704249aecfe3',
+					elementId: '5a80237c-ad3c-439c-9bdd-08ed0b9adeba',
 				},
 			],
 			createdOn: 1613762399000,
@@ -2020,7 +2020,7 @@ export const Live: CAPIType = {
 					html: '<p>#TBT</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'ea0760e5-f0c4-48a8-8954-76857e1a8d68',
+					elementId: '0def8a90-9fd2-4231-b778-a2cfea5afa81',
 				},
 				{
 					id: '60606947-4f1f-4343-9bb7-000e91502129',
@@ -2059,7 +2059,7 @@ export const Live: CAPIType = {
 					duration: 142,
 					_type:
 						'model.dotcomrendering.pageElements.YoutubeBlockElement',
-					elementId: '0c0f1397-92bd-44a8-ba85-77b2034419ed',
+					elementId: 'dafa4873-e375-4ee5-b41d-504aaf7a36e9',
 				},
 			],
 			createdOn: 1613762355000,
@@ -2084,7 +2084,7 @@ export const Live: CAPIType = {
 					html: '<p>#FF</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'f7a865ba-4c9d-44f3-acba-9f8b8d9feb7b',
+					elementId: '8804d33f-b45f-42e9-8de6-c94536b70039',
 				},
 				{
 					html:
@@ -2098,7 +2098,7 @@ export const Live: CAPIType = {
 					source: 'Twitter',
 					_type:
 						'model.dotcomrendering.pageElements.TweetBlockElement',
-					elementId: 'e1e2e450-8723-4720-be4f-316d69b87cae',
+					elementId: '8c460180-ff73-4a53-a514-c093c368b98b',
 				},
 				{
 					html:
@@ -2112,7 +2112,7 @@ export const Live: CAPIType = {
 					source: 'Twitter',
 					_type:
 						'model.dotcomrendering.pageElements.TweetBlockElement',
-					elementId: '4c206229-a055-429f-b92d-80b59d5e0e41',
+					elementId: 'edaf5bcc-651f-48fd-b4ff-d1e239e7e958',
 				},
 			],
 			createdOn: 1613761882000,
@@ -2138,7 +2138,7 @@ export const Live: CAPIType = {
 						'<p>Have you typed “<a href="https://www.google.com/search?q=perseverance&amp;oq=pers&amp;aqs=chrome.0.69i59j69i57j0l3j46j69i60j69i61.1091j0j7&amp;sourceid=chrome&amp;ie=UTF-8">perseverance</a>” into Google today? </p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'c8c5ef5f-6a52-4282-b5c1-a3b3ca69e03a',
+					elementId: 'c91e307a-e701-4a99-8e24-9c3bca37ebc2',
 				},
 			],
 			createdOn: 1613761671000,
@@ -2164,14 +2164,14 @@ export const Live: CAPIType = {
 						'<p>Now that Perseverance persevered through the “seven minutes of terror” – a new era of space exploration has officially begun. </p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'e95b4dc8-8bfb-46a0-8d63-3188cb90f881',
+					elementId: '7b210499-e516-45ac-a400-64f02e27ba83',
 				},
 				{
 					html:
 						'<p>Next up, the science team will make crucial decisions on which direction to take the rover in as it kicks off its search for ancient life. <br></p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '35b585ce-635c-4927-966d-b121b8d01a4d',
+					elementId: '9c1f1b79-6b89-4c46-a57b-0cb4b5e9c70c',
 				},
 			],
 			createdOn: 1613761187000,
@@ -2197,20 +2197,20 @@ export const Live: CAPIType = {
 						'<p>The event is concluding. They’ll be back for a 2pm ET news conference on Monday. Mission updates can be found meanwhile on the <a href="https://mars.nasa.gov/mars2020/">Nasa web site</a>.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '1d891d17-5df7-41ab-8d36-39eb39a56d4e',
+					elementId: 'e65f8e6e-0ca5-456b-8ea9-dc890232d48b',
 				},
 				{
 					html: '<p>McGregor signs off:</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '177494bd-c7f5-4d1e-bae8-303c1243960c',
+					elementId: 'c330991a-741a-4d13-abc4-7131901e19a3',
 				},
 				{
 					html:
 						'<p>“Everyone have a great day, on Earth and on <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a>.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '50bf209b-0331-44e0-9ba3-49e684db5142',
+					elementId: 'a23813f5-1505-4ae3-be9a-79fc996b063d',
 				},
 			],
 			createdOn: 1613761082000,
@@ -2236,14 +2236,14 @@ export const Live: CAPIType = {
 						'<p>Nasa scientists have worked for years to support this mission, and kept things going despite the ongoing coronavirus disruption. </p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '9c5ffddc-cfb8-4e58-bcc6-b6b7b0e0814b',
+					elementId: '9f5e95dd-34f1-4518-b0e1-3fe11b8bd343',
 				},
 				{
 					html:
 						'<p>After the landing success yesterday, one team says they had a “socially distanced ice cream” event, while the engineering team had a virtual happy hour! <br></p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '3b966ec4-e45b-42c0-a9e7-b1b0716f8402',
+					elementId: '4b5b1328-73e3-4006-8dce-c8eefb408b6f',
 				},
 			],
 			createdOn: 1613760877000,
@@ -2269,20 +2269,20 @@ export const Live: CAPIType = {
 						'<p>Next question: <strong>How did you celebrate?</strong></p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'd48bbbb8-6b9a-44a4-a336-8947557ae5cc',
+					elementId: '428854f8-3cc9-442d-953f-2f80b193ce41',
 				},
 				{
 					html: '<p>Answers include: </p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'f448f1d7-42ab-4aa9-b81a-fe833bbc1651',
+					elementId: 'ebab82ed-535e-4598-88fc-c02f778727a4',
 				},
 				{
 					html:
 						'<ul> \n <li>Virtual happy hour</li> \n <li>“Socially distanced consumption of ice cream outdoors”</li> \n <li>“I went home and just passed out from just the excitement of the day”</li> \n <li>“In the coming days I’ll definitely be having a glass of wine”</li> \n <li>“It was super-exciting”</li> \n <li>“We’re working two shifts a day almost 20 hours a day... it is kind of a really cool thing”</li> \n <li>“Business as usual for a science team working on a <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> rover”</li> \n</ul>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '49360df0-0b70-4e46-a239-d67b08e30a8b',
+					elementId: 'f216c387-e988-462a-8613-e88b68b8c64c',
 				},
 			],
 			createdOn: 1613760692000,
@@ -2308,35 +2308,35 @@ export const Live: CAPIType = {
 						'<p>Another key question: <strong>When will the rover drive? </strong></p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'f1a9da7a-8858-4d5a-bf39-264e72246388',
+					elementId: '6c79e649-28d5-46f1-b8c6-567a6e97df40',
 				},
 				{
 					html:
 						'<p>“We’re anticipating the earliest... would be sol 8 or 9... our current best estimate.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'e443f660-1db9-4593-9898-1d1862460b0d',
+					elementId: 'f2ac92f9-93b9-419a-b839-2526a9a8de73',
 				},
 				{
 					html:
 						'<p>“Maybe a short drive just to check everything out...</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '09129a1b-caa8-4938-af76-8142a88c6604',
+					elementId: '047a11ab-86f4-4e0d-b0e2-7c59e2e7dc1a',
 				},
 				{
 					html:
 						'<p>“We’ll also be figuring out the route and direction we need to go.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'e195d148-b331-4008-9f85-183c1979e5dc',
+					elementId: '2b07c853-97d0-42e8-b16f-5e7d215d4c16',
 				},
 				{
 					html:
 						'<p>That means rover could rove before February is out. </p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '318f09b7-e719-432f-915d-a576acdcb82e',
+					elementId: 'f364ba17-019d-4d82-93a2-6aad8a86711b',
 				},
 			],
 			createdOn: 1613760568000,
@@ -2362,7 +2362,7 @@ export const Live: CAPIType = {
 						'<p>The team members have described their fascination with the holes in the rocks visible next to the rover’s wheel in this photograph just released by <a href="https://www.theguardian.com/science/nasa" data-component="auto-linked-tag">Nasa</a>. It is unknown whether the holes indicate volcanic or sedimentary rock. </p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '6e67396f-e5d5-4679-8d82-9473de0d7cef',
+					elementId: '8f05d739-95e2-48cd-a65d-7b0baaa707a1',
 				},
 				{
 					media: {
@@ -2749,7 +2749,7 @@ export const Live: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: '053f1b03-1ef6-4cc5-88c2-a5a8465b85f2',
+					elementId: '5df6e3a2-fa70-4063-a62e-dee440f24afe',
 				},
 			],
 			createdOn: 1613760452000,
@@ -2775,14 +2775,14 @@ export const Live: CAPIType = {
 						'<p>Attached to the rover’s belly is a diminutive helicopter called Ingenuity. </p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '39d4a237-1f6b-4cf8-8900-7446b3b529b4',
+					elementId: '5e30b4f6-a6b1-497f-be1e-3a51f1e88434',
 				},
 				{
 					html:
 						'<p>The 1.8kg drone-like rotorcraft is the first flying machine ever sent to another planet — it has the ability to take colour pictures and video. The rover can also take images of Ingenuity. <br></p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'ca089c55-4f96-4652-9c25-200516fc74c1',
+					elementId: '6aeea49d-a798-488a-ad12-346903272dc6',
 				},
 				{
 					media: {
@@ -3169,7 +3169,7 @@ export const Live: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: 'f04a9323-8319-492e-8895-eee6b133659a',
+					elementId: 'a7aa160a-88bd-41fe-9070-48a62b6f052c',
 				},
 			],
 			createdOn: 1613760365000,
@@ -3195,14 +3195,14 @@ export const Live: CAPIType = {
 						'<p>Key question: <strong>how long till they fly the helicopter?</strong> </p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '84a70dd8-10fe-479d-9f7d-372e64325925',
+					elementId: 'a5ee60ad-ed89-4e33-962b-9619f325b4d2',
 				},
 				{
 					html:
 						'<p>“Caveat caveat caveat,” the scientist says. “Super-fast” would be “sol 60.” With a sol being 37 minutes longer than and earth days, that would be 60 earth days plus 37 hours = 61 days, 13 hours. Sometime in April. Best-case scenario. </p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '62f23cc9-84a3-4294-b6fd-9430f83134d2',
+					elementId: 'fbb78dcf-5a1c-4efd-bf50-cc2ccbdf32b0',
 				},
 			],
 			createdOn: 1613760134000,
@@ -3608,7 +3608,7 @@ export const Live: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: '821e3f0c-641b-4671-8b1b-6951eccdbdcb',
+					elementId: '1b1fa0cb-2058-4b4c-bc44-0a9177e54fab',
 				},
 			],
 			createdOn: 1613760107000,
@@ -4776,7 +4776,7 @@ export const Live: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: 'cbb1339c-36dd-48a8-bd6f-7a4f60ae154d',
+					elementId: '3df725fd-4bd5-4026-af85-53f0a223691d',
 				},
 			],
 			createdOn: 1613758905000,
@@ -4804,14 +4804,14 @@ export const Live: CAPIType = {
 						'<p>Steltzner is showing some of the most fantastic images from space explorations past, from moonshots to the Hubble telescope. </p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '33bdc4af-229c-4220-b456-86dd45084da1',
+					elementId: '3580af4b-3d90-4e7f-adc4-eb44060e2f72',
 				},
 				{
 					html:
 						'<p>He proposes an image of the dangling Perseverance Rover taken yesterday – it looks like a futuristic marionette – as the next entry in this cosmic scrapbook. <br></p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'c0ce376c-1c2b-4307-93ff-2e7c094aa0ff',
+					elementId: '949b0511-cf5a-4118-9970-19cb4921a809',
 				},
 			],
 			createdOn: 1613757849000,
@@ -4839,35 +4839,35 @@ export const Live: CAPIType = {
 						'<p>Members of the National Aeronautics and <a href="https://www.theguardian.com/science/space" data-component="auto-linked-tag">Space</a> Administration (Nasa) team that put a rover on Mars on Thursday are preparing to host a news conference and answer questions about the mission.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '7c547f9d-a54c-4a3d-ba43-6c4aa35dfc54',
+					elementId: 'edac024b-3c8c-46d0-9a67-3a5024d1d138',
 				},
 				{
 					html:
 						'<p>The rover, called Perseverance or Percy for short, is on <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> to search for signs of ancient life and collect samples to be returned by a future mission. About the size of a car, the wheeled rover is equipped with cameras, microphones, drills and even a small helicopter. </p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '7db9d7d3-5f97-40aa-82a8-470b80eada0e',
+					elementId: 'baea4a1f-6e88-4743-889f-2dedd50a9db3',
 				},
 				{
 					html:
 						'<p>Guardian science correspondent Natalie Grover reports of Percy’s mission:</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'e18e1991-ee3d-40ae-8b62-27388171a6b7',
+					elementId: '2a9a6935-2959-44cf-b503-97ca6287fd81',
 				},
 				{
 					html:
 						'<blockquote class="quoted"> \n <p>Previous Mars missions including <a href="https://viewer.gutools.co.uk/science/2013/jul/28/curiosity-rover-descent-mars-nasa">Curiosity</a> and Opportunity have suggested Mars was once a wet planet with an environment likely to have been supportive of life billions of years ago. Astrobiologists hope this latest mission can offer some evidence to prove whether that was the case.</p> \n</blockquote>',
 					_type:
 						'model.dotcomrendering.pageElements.BlockquoteBlockElement',
-					elementId: '3743bd5f-c15a-4921-96af-1a219ad72d91',
+					elementId: 'b9527164-db32-48fb-a99c-6a1f32d681bd',
 				},
 				{
 					html:
 						'<p>The <a href="https://www.theguardian.com/science/nasa" data-component="auto-linked-tag">Nasa</a> scientists appear to feel they may be tantalizingly close to a discovery that could change the way we see the universe and our home in it. Here was the scene in the control room near Los Angeles just before 1pm local time on Thursday when Percy’s safe touchdown on Mars was confirmed:<br></p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '68e6cb40-bfec-43f5-86cb-8b980c74660d',
+					elementId: 'bc7916c2-2e96-49dd-9b10-0c06ee34c198',
 				},
 				{
 					url: 'https://www.youtube.com/watch?v=Ew24GrPKi3Y',
@@ -4881,20 +4881,20 @@ export const Live: CAPIType = {
 					source: 'YouTube',
 					_type:
 						'model.dotcomrendering.pageElements.VideoYoutubeBlockElement',
-					elementId: 'ad8fa44c-3d4a-406a-9db6-15e067886667',
+					elementId: '4999346f-824e-40e1-9d72-7ddeb2b1ecd1',
 				},
 				{
 					html:
 						'<p>The robotic vehicle sailed through space for nearly seven months, covering 293m miles (472m km) before piercing the Martian atmosphere at 12,000mph (19,000km/h) to begin its approach to touchdown on the planet’s surface.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'a133ac97-f0c9-4983-9b8d-2de2b33786e0',
+					elementId: '5e044415-54f9-4e51-a8e5-968478095745',
 				},
 				{
 					html: '<p>Thank you for joining our live coverage. </p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'af36ec4f-3746-468f-ad65-5b9bee3ea28e',
+					elementId: '1be1aeef-2744-4623-bec5-8598662b53fc',
 				},
 			],
 			createdOn: 1613746372000,

--- a/fixtures/generated/articles/PhotoEssay.ts
+++ b/fixtures/generated/articles/PhotoEssay.ts
@@ -1039,9 +1039,9 @@ export const PhotoEssay: CAPIType = {
 	designType: 'Feature',
 	editionId: 'UK',
 	format: {
-		design: 'FeatureDesign',
+		design: 'PhotoEssayDesign',
 		theme: 'LifestylePillar',
-		display: 'StandardDisplay',
+		display: 'ImmersiveDisplay',
 	},
 	standfirst:
 		'<p>Photographer Cat Vinton’s work follows nomadic people in the natural world, but the pandemic meant being closer to home – living out of her vehicle and exploring the Cornish way of life </p>',
@@ -1703,7 +1703,7 @@ export const PhotoEssay: CAPIType = {
 				},
 			],
 			_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-			elementId: '62f619eb-8879-4166-a103-0d5a32483906',
+			elementId: '0a700a8e-c65c-4eaa-a15a-77bfe81fbbb3',
 		},
 	],
 	webPublicationDate: '2020-12-09T06:30:30.000Z',
@@ -1716,21 +1716,21 @@ export const PhotoEssay: CAPIType = {
 						'<p>The last embers of my fire flicker orange and red in the dark. It has warmed me after my evening swim shared with a grey seal, a curious female at the water’s edge, under the soft pink hues of the setting sun.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'fce0beea-71cc-485b-9e41-441c2ede752c',
+					elementId: '25c3bc89-380f-4fe1-bb7a-a2dddd0eb950',
 				},
 				{
 					html:
 						'<p>The nights are beginning to draw in and the temperature is dropping. Tonight’s home is a magical one: a hidden spot somewhere on the Roseland Heritage coast.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'd33f57fc-5da9-4c27-827e-f10eea89f3d9',
+					elementId: '61ad78d8-be73-4b02-a939-6b2a6868c72e',
 				},
 				{
 					html:
 						'<p>I am curled up in my tiny space with only a canvas shell between me and the elements. Tonight is calm: a beautiful moon path marks the ocean and is my view through the open back of my family’s Land Rover. I drift off to sleep to the sound of waves lapping the shore and the call of tawny owls across the night sky.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'f981d484-5553-47e7-902c-ada13cead213',
+					elementId: '4d3ad2f8-2aa5-4185-9317-5ed45e160895',
 				},
 				{
 					media: {
@@ -2115,42 +2115,42 @@ export const PhotoEssay: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: 'e47677a3-7455-48ac-b0ba-f5b96db220e5',
+					elementId: 'f3a8f1be-6b02-4452-b042-154bf39487c3',
 				},
 				{
 					html:
 						'<ul> \n <li><p>Cat Vinton’s home for the past eight months has been her Land Rover</p></li> \n</ul>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'd74ca0a0-1a70-4b5b-b678-daefe8791238',
+					elementId: 'b54c9217-0075-481f-a9d3-50535b519340',
 				},
 				{
 					html:
 						'<p>For the last few years I’ve not called one place home. Instead, I’ve roamed across the globe – from the High Himalaya to the Arctic Circle, the Gobi Desert to the Andaman Sea<strong> </strong>– weaving my life and work as a photographer, more in tune with a wilder spirit and those who still live connected to nature.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'bff9f280-1049-4255-9019-120553a7f276',
+					elementId: '28dd943b-aa55-4d7f-ac88-a4c7862273a7',
 				},
 				{
 					html:
 						'<p>As the world locked down in March, not only my work but my entire way of life ground to a quiet halt, forcing me to look inward and to grapple with the meaning<em> </em>of “home”.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '09a9af9c-18e9-4d0f-98ad-2b3ef8edc078',
+					elementId: '4667215c-2a18-4a26-9a9c-5a0f3f44ccd6',
 				},
 				{
 					html:
 						'<p>My pull was to the ocean of the south-west of England. Thanks to my friend Louise Middleton, for those three months of lockdown I watched over a wild pocket of the north Cornish coast – an old slate quarry that overlooks the sea at Trebarwith Strand. It is a beautifully curated space, totally off-grid, that Louise has named <a href="https://kudhva.com/">Kudhva</a> (meaning hideout in Cornish). Kudhva is a visionary architectural hideout that draws creative people who thrive on a life connected to the outdoors.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '7c285ac4-12bc-4cbf-82e2-36bfcc3e8f8a',
+					elementId: '28cda1c7-b813-4c1e-8b7b-36e6611204f7',
 				},
 				{
 					html:
 						'<p>I became part of a community at Kudhva and my days were spent in fascinating conversation, working on the land with the locals. This is what I do on my projects – immerse myself in a way of life, documenting people who are connected to their land and community around the world. I fell into a way of doing the same on home shores.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '2cadda0c-a023-4996-bda9-4bc2ec5c496a',
+					elementId: 'e4307676-75d5-4e5e-8097-db837ca1101d',
 				},
 				{
 					media: {
@@ -2535,7 +2535,7 @@ export const PhotoEssay: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: 'b455f8cb-6b05-4d38-ac9f-4c33c923fd06',
+					elementId: '899b1e03-02a0-43c9-a9ff-410160796b18',
 				},
 				{
 					media: {
@@ -2920,21 +2920,21 @@ export const PhotoEssay: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: 'c62df049-9196-4344-a366-646796e2f10f',
+					elementId: '4b268c44-2edd-4b69-9e04-f4233cb9bc76',
 				},
 				{
 					html:
 						'<ul> \n <li><p>Louise Middleton bought a 45-acre abandoned quarry in 2015 that she named Kudhva, meaning hideout in Cornish</p></li> \n</ul>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '080785da-5aea-45fd-9f2a-254b28a90001',
+					elementId: 'ad5ff5c2-0da3-4235-8453-c0b848cf5d8f',
 				},
 				{
 					html:
 						'<p>Sidetracked, an adventure journal which has shared my stories from the remotest corners of the world, joined us as lockdown lifted for some backyard adventures – climbing, biking, cold-water swimming and surfing – with the people who know this land best.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '12257928-998c-4909-ab34-0c488683cc9a',
+					elementId: '657e3a75-6c9a-4ddf-bda9-b45c5dc3dd43',
 				},
 				{
 					media: {
@@ -3319,7 +3319,7 @@ export const PhotoEssay: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: 'c778002e-dc9b-415a-9bc3-d512be2be95a',
+					elementId: 'b10b56c0-9a6c-49d7-8a24-81a5c26188cc',
 				},
 				{
 					media: {
@@ -3704,7 +3704,7 @@ export const PhotoEssay: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: '2e057858-cc99-4723-9a3a-7e3d3a29ada8',
+					elementId: '6d3d095f-5cf1-4935-b800-b8acd9dac917',
 				},
 				{
 					media: {
@@ -4089,7 +4089,7 @@ export const PhotoEssay: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: 'dd9f60ba-2da8-47ff-80ce-08d17c24300a',
+					elementId: '306f8b2d-3568-4468-b442-7a40134ec66a',
 				},
 				{
 					media: {
@@ -4474,14 +4474,14 @@ export const PhotoEssay: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: '96f8ccf8-96be-481e-82f5-45cd9cfd5a97',
+					elementId: '6c35d7d5-f7d6-4ca4-ae26-991de579f94e',
 				},
 				{
 					html:
 						'<ul> \n <li><p>Backyard adventures in Cornwall with the locals included cold-water swimming, biking and surfing. Shot for Sidetracked magazine at Kudhva and Trebarwith Strand</p></li> \n</ul>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'b7bea281-f0a3-468c-adc7-2e1012319389',
+					elementId: '76b77953-a9d7-486b-9b48-8b55dfd7ba37',
 				},
 				{
 					media: {
@@ -4854,14 +4854,14 @@ export const PhotoEssay: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: 'eb2c3a2a-1495-4812-9ed0-c684451a02bf',
+					elementId: 'e15a6335-fe12-4fbe-8d02-63cf5c676149',
 				},
 				{
 					html:
 						'<p>Then, as the country began to open up again, and Kudhva began to welcome back guests, it was time to move on. I decided this was a gift of time I may never get again. Usually, I’m moving with my work. I had my cameras and a Land Rover that could take me off the beaten track – the perfect companion to explore the Cornish coast and its way of life, and to see if I could still find pockets of solitude, as the tourist floodgates opened.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '4911a657-17c7-4252-92e3-3d79ed0e1448',
+					elementId: 'ae5e3ec2-22ab-41d4-b6d5-f1358ce0c1f1',
 				},
 				{
 					html:
@@ -4870,21 +4870,21 @@ export const PhotoEssay: CAPIType = {
 					isThirdPartyTracking: false,
 					_type:
 						'model.dotcomrendering.pageElements.PullquoteBlockElement',
-					elementId: '0965c708-a798-4b6b-b58d-9e31a7c3d27b',
+					elementId: '6b87910c-bdb4-4588-96cb-d08549aae4f3',
 				},
 				{
 					html:
 						'<p>A small pile of books is stacked between the seats of the Land Rover; a head torch, tide tables, bikini and my knife are at hand. Everything else I need is packed neatly in the open back, covered with a piece of wood that doubles as a table and my bed. It’s simple – I’m free, independent and happy. With no real plan, I set off west along the north coast.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '76f99c5f-e79f-401c-85bf-ab228b70dd4c',
+					elementId: 'f771632f-748c-4877-960c-f8df27c4f3b3',
 				},
 				{
 					html:
 						'<p>Cornwall has always felt like a haven to me, but even more so now with its gift of space, fresh air, ocean and local produce far from the hustle of city life. Slate and granite cliffs, small rocky coves and headlands, sand dunes, reefs, sandy beaches, green pathways and water shape Cornwall’s 400 miles of coastline.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'dbf2fba9-deba-47c5-bedd-36a34b9a4dc8',
+					elementId: '54e581a4-062c-4f11-8d43-bf449a95d1fe',
 				},
 				{
 					media: {
@@ -5269,7 +5269,7 @@ export const PhotoEssay: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: '846e1834-882a-441f-9649-75e3bf864c71',
+					elementId: '884ad825-d237-4b23-bea5-5b6fd6f80d13',
 				},
 				{
 					media: {
@@ -5654,7 +5654,7 @@ export const PhotoEssay: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: '6dc7be3e-551b-4264-9e83-c518eb8c53b0',
+					elementId: '09daafcc-f165-4607-a951-91018f9c70d2',
 				},
 				{
 					media: {
@@ -6039,21 +6039,21 @@ export const PhotoEssay: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: 'c811f623-c5c6-4fa7-b509-48ee7ea3a238',
+					elementId: '401f3e2a-2c29-48c2-a0bd-3275ac9347d0',
 				},
 				{
 					html:
 						'<ul> \n <li><p>Turquoise waters, green pathways and rocky pools shape Cornwall’s 400 miles of coastline</p></li> \n</ul>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '766e0ab5-7b5b-44d4-ab5c-8f470cce6be2',
+					elementId: '9a691f78-23c7-4cfd-a17c-3e1b28255c95',
 				},
 				{
 					html:
 						'<p>As my days slowed, I noticed every detail in the shifting light, the sounds, smells and colours, and tuned into the tidal rhythm, mesmerised by the waves that roll in perfect lines.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'a81efbbd-1846-48ee-b634-0d8cc5c6dd5a',
+					elementId: 'b4305908-ec11-4029-8c00-9bf7168aa39b',
 				},
 				{
 					media: {
@@ -6437,21 +6437,21 @@ export const PhotoEssay: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: '66fd9eec-8a86-48ca-b91a-2c3188f80eea',
+					elementId: 'cffaa4e4-d335-4ec8-beaf-90094819f16d',
 				},
 				{
 					html:
 						'<p>I weaved my way along the north coast from Trebarwith Strand to the lighthouse on Pendeen Point, almost 100 miles of coast flanked by the Atlantic Ocean. This part of the coast is punctuated with derelict buildings and still-noble chimneys of tin and copper mines that once thrived in a harsh industrial past. Climbers are drawn to the granite cliffs and crags of the Penwith peninsula, and I spent some epic days here, with friends, climbing and exploring the Penwith heritage coast.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '6e798932-bb04-4499-9414-91c1fa09a0de',
+					elementId: 'd81e7a6f-0246-4fd1-9ed8-ddbb60b36e96',
 				},
 				{
 					html:
 						'<p>The weather had been mostly kind until late August, but the rumblings of thunder carried a wild energy that stirred up the ocean and I lay awake as lightning lit up the night sky, and wind and driving rain whipped the canvas covering of the Land Rover. For 10 days storms Ellen and Francis raged across the ocean, swirled around the end of land and made me appreciate everything – especially how privileged I am to be able to make the choice to live like this. It’s not the easiest way to live and not what most people would choose – but it’s stripped back, simple and connected. Being immersed in the elements is where I find my energy and my balance, giving me a sense of purpose.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '2ec5bbda-286f-4d1f-a9e0-3135e8e7028e',
+					elementId: '379eb19c-2148-43a7-8765-ad8966f757d7',
 				},
 				{
 					media: {
@@ -6836,21 +6836,21 @@ export const PhotoEssay: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: 'ce53813a-1283-4d81-9ad6-8e26299c07d5',
+					elementId: '1fa3d68a-6505-42c8-831d-779bc29e186c',
 				},
 				{
 					html:
 						'<ul> \n <li><p>Storm Francis raging across the ocean in August</p></li> \n</ul>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '8038594d-d5ff-45c6-a391-d8d69dffab05',
+					elementId: '7dc25478-8372-401e-a561-f7ea0162c009',
 				},
 				{
 					html:
 						'<p>Every day is different as I move slowly along this stunning coast. I’ve seen pilot whales, dolphins, seals, barn owls, kestrels, peregrines and choughs, met old Cornish fishermen and made new local friends. I have, of course, also seen the hordes of people who’ve flocked here – but I’ve also found so many empty pockets of Kernow magic. The sea mist comes and goes, as do the sun and the clouds. The sea changes every day, every hour, every minute, as do we – our emotions, our energy and our perspectives. It feels like a lesson – a constant reminder that we are part of nature, not separated from it.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '7498c128-43a6-42cf-ae9c-e90d58189666',
+					elementId: '772c3962-8390-43fd-98c5-1cfc34c9e1c3',
 				},
 				{
 					html:
@@ -6859,7 +6859,7 @@ export const PhotoEssay: CAPIType = {
 					isThirdPartyTracking: false,
 					_type:
 						'model.dotcomrendering.pageElements.PullquoteBlockElement',
-					elementId: '4abdf2df-a71a-4b9a-8878-4289cd8bbdea',
+					elementId: '8e232dbb-ee8f-4132-96e9-0ee6396ffaf4',
 				},
 				{
 					media: {
@@ -7244,7 +7244,7 @@ export const PhotoEssay: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: 'fcc7b6ea-ea25-46ca-ba78-823986af796c',
+					elementId: '69cb8430-4e5a-4e0c-9c91-860d4ac9a7b3',
 				},
 				{
 					media: {
@@ -7628,7 +7628,7 @@ export const PhotoEssay: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: 'a7400284-38c6-43a9-8ff1-d8cd81d10ea2',
+					elementId: '670ec8c3-754a-467f-9834-44b27953d079',
 				},
 				{
 					media: {
@@ -8013,28 +8013,28 @@ export const PhotoEssay: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: 'c481ba72-771b-4118-96b1-aa7e1b92e5d7',
+					elementId: '36c85d75-c02c-4887-bc0e-0dea6fadaab9',
 				},
 				{
 					html:
 						'<ul> \n <li><p>Clockwise from top: White horses carried on the on-shore wind at Dollar Cove, on the Lizard; two different views of Logan Rock</p></li> \n</ul>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '0429363a-5e69-4d2e-a2f4-40270f2a0406',
+					elementId: 'e14e5c88-79bf-4b78-b18a-345bfee27881',
 				},
 				{
 					html:
 						'<p>Friends have joined me, I’ve swum every day, I’ve climbed, explored and watched the days turn to night by a fire on the beach most evenings. I’ve witnessed the change in the coastal palette of the native wildflowers and fallen into the pace of life here. I navigated the coast around the Lizard, up to Falmouth and on to the Roseland Heritage coast; the south coast is gentler, with sheltered beaches, woodland valleys, tree-lined estuaries, tiny winding roads, and picturesque fishing villages scattered along its shores.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '36d25d73-ee2d-4760-94aa-042e13373eb9',
+					elementId: 'e6b869ca-cd00-414c-b958-9b31e2ad9519',
 				},
 				{
 					html:
 						'<p>I’ve been drawn to like-minded people, who share the same values, who’ve made a home on this coast and who are passionately driven to protect the ocean and the land. Conversations, ideas and projects are the beginnings of collaborations, now and in the future.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '792a7d3c-6fde-4a9a-b292-cfbb4309c69b',
+					elementId: 'd6cce9d2-e6a6-46d2-a8eb-18e5e483a5d8',
 				},
 				{
 					media: {
@@ -8419,21 +8419,21 @@ export const PhotoEssay: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: '996e9c63-3349-4fca-be1a-1c72287d2ac2',
+					elementId: '2ed5c0ac-26d5-433b-9e33-140000c028b0',
 				},
 				{
 					html:
 						'<ul> \n <li><p>Joya Burrow, <a href="https://www.therighttoroam.com/">The Right to Roam Films</a> shot for Finisterre, at Kudhva and Trebarwith Strand</p></li> \n</ul>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'dea04bfb-b2b2-4bde-868a-7eb3f45b2c5a',
+					elementId: 'd74b25e4-c413-4987-bccf-fedacaa7d675',
 				},
 				{
 					html:
 						'<p>I made it to Mevagissey on the south coast by the beginning of October, with warnings of another storm. I had a commitment to be on Cornwall’s highest point, Brown Willy on Bodmin Moor, by 3 October to photograph an amazing man, explorer <a href="https://www.theguardian.com/travel/2020/oct/14/nature-has-healing-power-britains-covid-heroes-share-their-favourite-outdoor-spaces">Robin Hanbury-Tenison</a> and his family. His story is one of a remarkable recovery from Covid-19, having spent five weeks in an induced coma with little chance of survival. The key moment in his recovery was when he was wheeled into the healing garden of Derriford hospital. Now raising funds for healing gardens across Cornwall, Robin braved the 60mph winds of Storm Alex to reach the summit and fly the Cornish flag of Saint Piran. Another story of the power of nature.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '0acf5538-c705-4f0c-be83-0a2d8c6f8ddf',
+					elementId: '93478a59-0b87-4860-8fbd-bf62e92490ba',
 				},
 				{
 					media: {
@@ -8817,7 +8817,7 @@ export const PhotoEssay: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: 'f8ed2527-aaa7-4fc3-aefd-1a1c2b9054c6',
+					elementId: '9670e0d1-979d-4687-b579-3c03255931d9',
 				},
 				{
 					media: {
@@ -9201,21 +9201,21 @@ export const PhotoEssay: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: '51fafe8e-5bc6-40fb-bee8-f875d525ed8b',
+					elementId: '446b2744-b291-4098-8c58-f24041a4fd03',
 				},
 				{
 					html:
 						'<ul> \n <li><p>Explorer and Covid-19 survivor Robin Hanbury-Tenison climbs Brown Willy on Bodmin Moor in October to raise funds for healing gardens across Cornwall</p></li> \n</ul>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '1631a7ea-9bd7-48e1-bc5b-59c2d8c42ace',
+					elementId: '89b7fa61-78fa-4612-9eb5-58420f65aa9c',
 				},
 				{
 					html:
 						'<p>I’ve been in Cornwall for eight months now. That’s the longest I’ve been in one place for a long time. Cornwall has had my heart for many years, but to have lived through the seasons, entirely off-grid, has connected me more deeply.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '00a391f2-5a37-48c8-b9ce-a49ea9c00471',
+					elementId: 'fed0af74-94bf-4cd6-b1ce-4eece059a7ff',
 				},
 				{
 					html:
@@ -9224,21 +9224,21 @@ export const PhotoEssay: CAPIType = {
 					isThirdPartyTracking: false,
 					_type:
 						'model.dotcomrendering.pageElements.PullquoteBlockElement',
-					elementId: 'bec05236-5172-464d-a92f-07e06758ae2a',
+					elementId: 'f5444e40-d887-4db0-8f2e-a9f282598111',
 				},
 				{
 					html:
 						'<p>There is something incredibly powerful about living so close to nature, in the elements. I think it’s something we miss living inside closed walls – we are disconnected.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '9c78cbed-f4c3-4709-bc95-8ab0ae2fe6bb',
+					elementId: 'd3d9ad40-42bd-4d20-81fb-adc8e804b19d',
 				},
 				{
 					html:
 						'<p>As the world of free movent has new rules and the future is unknown and precarious, I think it has forced many of us to rethink our pace of life, our relationship to nature, what we really need to be happy and fulfilled, and how we will live our lives on the other side of this.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '2937b598-1fe7-4bce-8af1-7df0e40d180d',
+					elementId: '8227e22a-6115-46e5-80bb-b77e00748924',
 				},
 				{
 					media: {
@@ -9622,7 +9622,7 @@ export const PhotoEssay: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: '7029c702-6c01-436f-bc29-2f7b1214489d',
+					elementId: 'ba4f8876-1334-400d-8023-47ff3b0b56ac',
 				},
 				{
 					media: {
@@ -10006,7 +10006,7 @@ export const PhotoEssay: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: 'c9f7df3e-5db7-4902-938b-2acbfb733dd7',
+					elementId: '78858ec0-0d66-47fd-9ada-a0bdf9b6d1ca',
 				},
 				{
 					media: {
@@ -10390,21 +10390,21 @@ export const PhotoEssay: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: '8ddd7e67-d395-4b3a-ada4-4f49eea87e85',
+					elementId: '20bfbcc8-d6de-434a-b47b-a891b188530c',
 				},
 				{
 					html:
 						'<ul> \n <li><p>Clockwise from top left: Sunrise at Towan Beach, full corn moon on the Penwith Heritage coast and Cat Vinton’s Land Rover parked up on the Cornish coast</p></li> \n</ul>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '61a81493-2d04-458b-b85e-176170697743',
+					elementId: 'a8cbe808-e99b-4970-9b23-85a26e814c7d',
 				},
 				{
 					html:
 						'<p>I have learned so much about the importance and the purpose of life – a moral and ethical code – from the nomadic people of the world’s most remote corners. About the fragile connection between people and nature, and that wealth and success are not measured in belongings and status, but in the strength of our human spirit. I feel, more than ever, that we have so much to learn from these people who have never lost those visceral connections.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '570cea7d-dcd1-4492-8c43-804ba4757cf6',
+					elementId: '50dde500-de2f-4d14-8f59-df4bd0580244',
 				},
 			],
 			createdOn: 1606741266000,

--- a/fixtures/generated/articles/PrintShop.ts
+++ b/fixtures/generated/articles/PrintShop.ts
@@ -1695,61 +1695,61 @@ export const PrintShop: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: 'fc18be47-a5c9-44d8-be0b-44c745057838',
+					elementId: 'abae2a99-fd03-4c63-9c92-31a1cdc8753c',
 				},
 				{
 					html:
 						'<p>This photograph captures Bobby Moore in 1973, standing statuesque in the twilight of his international career, just a few months after winning his 100th cap for England. It was shot prior to a 1-0 friendly win over Scotland which would prove to be Moore’s final victory in an England shirt at Wembley. It possesses a kind of majesty reminiscent of the bronze statue of him at the new Wembley, beneath which an inscription reads: <em>‘Immaculate footballer. Imperial <a href="https://en.wikipedia.org/wiki/Defender_(association_football)">defender</a>. Immortal hero of <a href="https://en.wikipedia.org/wiki/1966_FIFA_World_Cup_Final">1966</a>. First <a href="https://en.wikipedia.org/wiki/List_of_England_international_footballers">Englishman</a> to raise the <a href="https://en.wikipedia.org/wiki/FIFA_World_Cup_Trophy">World Cup</a> aloft. Favourite son of London’s <a href="https://en.wikipedia.org/wiki/East_End_of_London">East End</a>. Finest legend of <a href="https://en.wikipedia.org/wiki/West_Ham_United_F.C.">West Ham United</a>. National Treasure. Master of <a href="https://en.wikipedia.org/wiki/Wembley_Stadium_(1923)">Wembley</a>. Lord of the game. <a href="https://en.wikipedia.org/wiki/List_of_England_national_football_team_captains">Captain</a> extraordinary. Gentleman of all time.’</em></p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '001a3c61-7d8f-420c-bb6f-41d32926f106',
+					elementId: '8ab2ef82-10f1-4fec-9660-a26eacedff9d',
 				},
 				{
 					html: '<p><em>Photograph: Gerry Cranham / Offside</em></p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'c8176406-eca9-4a6a-bb29-11794bfa4e0a',
+					elementId: '537deca7-8678-42ca-987c-7c17c9f21065',
 				},
 				{
 					html: '<p><em>Words: Jonny Weeks</em></p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '12a7b376-b5e8-4c32-9218-cd67d143d6d2',
+					elementId: '07aa3e19-0e1e-4df3-9c4e-393132d4ce5a',
 				},
 				{
 					html:
 						'<p><strong>Buy your exclusive print <a href="https://guardianprintshop.com/collections/the-big-sport-picture">here</a></strong></p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '7e684e2c-5a20-4ed4-b2b2-2da165604ae4',
+					elementId: 'e75be40d-4f90-4ac5-be80-26c1bec19dbb',
 				},
 				{
 					html:
 						'<p><strong>Price</strong> <br>£55 including free delivery (30x40cm print size).</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'caa1a9bb-d38c-40dc-9d0e-cb864cd96ca3',
+					elementId: 'b4aaeda6-307e-4902-950d-fbd51f76502a',
 				},
 				{
 					html:
 						'<p><strong>Prints<br></strong>Photographs are presented on museum-grade, fine-art paper stocks, with archival standards guaranteeing quality for 100-plus years. All editions are printed and quality checked by experts at theprintspace, the UK’s leading photo and fine-art print provider.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '13e274bc-6c83-4949-b412-117bece12312',
+					elementId: '94526f40-bb3e-4c7a-a34e-21646e55d7d6',
 				},
 				{
 					html:
 						'<p><strong>Delivery<br></strong>Artworks are dispatched via Royal Mail and delivered within three to five working days. Theprintspace takes great care in packaging your artwork, with a no-quibble satisfaction guarantee should you be unhappy in any way. Global shipping is available.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'de72f018-bc28-454d-ac7e-cf0f63db677d',
+					elementId: 'c0e15e62-3d1f-41ec-8e67-63059e3a62d4',
 				},
 				{
 					html:
 						'<p><strong>Contact</strong><br>Email: <a href="mailto:guardianprintsales@theprintspace.co.uk">guardianprintsales@theprintspace.co.uk</a></p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'a7819df4-834a-435d-9363-84bd9f9db500',
+					elementId: '75b83a33-f376-4e6b-a94e-fd969e0576cd',
 				},
 			],
 			createdOn: 1572887180000,

--- a/fixtures/generated/articles/Quiz.ts
+++ b/fixtures/generated/articles/Quiz.ts
@@ -1725,7 +1725,7 @@ export const Quiz: CAPIType = {
 				},
 			],
 			_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-			elementId: 'e2681883-a4c6-49e0-967d-4675ec409513',
+			elementId: '33a75600-bc84-4b2c-a546-64471feaa52c',
 		},
 	],
 	webPublicationDate: '2020-06-12T09:09:24.000Z',
@@ -2357,7 +2357,7 @@ export const Quiz: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.QuizAtomBlockElement',
-					elementId: '2823ea2c-fe7e-460a-a606-f4e902387147',
+					elementId: '91d004ac-07e3-468c-8063-0f260e4acf87',
 				},
 			],
 			createdOn: 1591866131000,

--- a/fixtures/generated/articles/Recipe.ts
+++ b/fixtures/generated/articles/Recipe.ts
@@ -1824,7 +1824,7 @@ export const Recipe: CAPIType = {
 				},
 			],
 			_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-			elementId: '6926b8e7-ec34-423c-a53a-82ee09ab8c06',
+			elementId: '130bc789-5417-44c1-9268-21f61f372555',
 		},
 	],
 	webPublicationDate: '2021-02-06T10:30:38.000Z',
@@ -1837,83 +1837,83 @@ export const Recipe: CAPIType = {
 						'<p> The world of pancakes is so vast, it is hard to think that on <a href="https://en.wikipedia.org/wiki/Shrove_Tuesday">Pancake Day</a>, there could be only one type proffered across the world. Of course, traditionally, pancakes were a way to use up eggs and animal fats before the Lent fast, but with those ingredients off the table in vegan cooking, a new array of pancakes can take centre stage. Today’s offering is for <em>cong you bing</em>, a flaky, coiled, spring onion pancake ubiquitous across China. It’s as enjoyable to make as it is to eat and, happily, there’s no whiff of abstinence about it.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '22b39bd3-ec30-4d66-bbab-0c3e70867e52',
+					elementId: 'dd4ca65b-961a-43be-8b9c-453a0392bc97',
 				},
 				{
 					html: '<h2>Spring onion pancakes with sesame sauce</h2>',
 					_type:
 						'model.dotcomrendering.pageElements.SubheadingBlockElement',
-					elementId: '0dd7a123-fdcd-4c56-b911-01a4bdddb49e',
+					elementId: '2e88d510-d56a-4713-909b-05e7290afc67',
 				},
 				{
 					html:
 						'<p>Prep <strong>5 min<br></strong>Rest <strong>30 min<br></strong>Cook<strong> 1 hr<br></strong>Makes <strong>4, to serve 2 for lunch</strong></p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '28fd135f-d921-4a94-82df-61749a82d058',
+					elementId: '61d9f63f-fbc8-4e82-8e24-02312bcf9fe4',
 				},
 				{
 					html:
 						'<p>Making these involves a particular set of processes that includes binding, rolling, folding, squashing and frying. I would have had trouble learning them by myself during the pandemic were it not for the help of a library of online cooks, and in particular Wei Guo of the wonderful <a href="https://redhousespice.com/">Red House Spice blog</a>.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'ea468021-b1a6-4cc6-869a-f036c675ca05',
+					elementId: '4ebb557f-66b5-40c8-b972-c48416599a96',
 				},
 				{
 					html:
 						'<p>For the pancakes<br><strong>275g plain flour</strong>, plus 2 tbsp extra<br><strong>Fine sea salt<br>Coconut oil</strong><br><strong>½ tsp Chinese five spice</strong> powder – I like <a href="https://bart.co.uk/products/chinese-five-spice-powder">Bart Ingredients</a> <br><strong>6 spring onions</strong>, trimmed and finely sliced</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '410ec9f6-c6c4-46c8-a695-d297bfba34aa',
+					elementId: '01c0faa7-550f-43b5-8171-59b3b14004b0',
 				},
 				{
 					html:
 						'<p>For the sesame sauce<br><strong>30g tahini<br>75g sweet white miso</strong> – I like <a href="https://www.clearspring.co.uk/products/organic-japanese-sweet-white-miso-paste-pasteurised">Clearspring</a><br><strong>1 tbsp toasted sesame oil<br>2 tbsp white-wine vinegar<br>½ tsp chilli oil sediment plus 1 tbsp oil </strong>– I like <a href="https://uk.lkk.com/products/chiu-chow-chilli-oil">Lee Kum Kee</a></p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'e4d2fb88-0729-4969-bb15-cd3b629a25e8',
+					elementId: '7dd91ae5-b039-474f-9066-03d356a8f4f5',
 				},
 				{
 					html:
 						'<p>Fill and boil half a kettle of water. In a large heatproof bowl, use a fork to mix the flour, a big pinch of salt and 165ml freshly boiled water until it comes together into a rough dough and is cool enough to handle. Knead for five minutes, then cover with a clean tea towel and set aside to rest for 30 minutes.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '074e0f1c-a383-4dce-8b98-7fee9e33436c',
+					elementId: '3d93c904-362b-47de-9e8e-d6929d05d3fe',
 				},
 				{
 					html:
 						'<p>While the dough is resting, prepare the filling. Melt two tablespoons of coconut oil in a nonstick pan, then pour into a small heatproof bowl. Put the pan to one side, but don’t wash it up – you’ll use it again later, to cook the pancakes. Add the five spice, the two extra tablespoons of flour and a quarter-teaspoon of salt to the melted oil, stir to combine and set aside.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '0fb89dcc-68f0-4701-b3eb-24874cdda2b3',
+					elementId: '4cc73527-d11e-46d2-87ad-e6e7668262ab',
 				},
 				{
 					html:
 						'<p>Mix all the sauce ingredients in a small bowl, add two tablespoons of cold water to loosen it a little, and set aside.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '5b540929-a295-42f2-830d-01217d8f4582',
+					elementId: 'cd095fdc-5d63-4209-8152-13b5046326f2',
 				},
 				{
 					html:
 						'<p>Once the dough has rested, rub a little coconut oil on a worktop and on a rolling pin, then roll the dough into a roughly 20cm x 30cm rectangle. Spread the five spice mix evenly over the top (take care not to tear the dough) and sprinkle the sliced spring onions on top of that. Starting at one short end of the dough rectangle, roll up the whole thing into a tight cigar. Move the dough sausage so it’s horizontally in line with the edge of the worktop, then cut into four even slices. Put the slices cut side down on the worktop and, using the greased rolling pin, gently press each slice into a round pancake shape measuring about 13cm across.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '00ec0536-db99-4e35-a81c-5c7d5f807886',
+					elementId: '33049b33-f53e-4804-ac0d-fe81655dbe99',
 				},
 				{
 					html:
 						'<p>When you are ready to cook the pancakes, melt two tablespoons of coconut oil in the nonstick pan, gently lift in one pancake and cook for three to four minutes on each side, until golden brown all over. Remove from the pan and keep somewhere warm while you repeat with the remaining oil and pancakes (keep a close eye on the heat under the pan – you may need to reduce it to make sure the pan doesn’t get too hot).</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'ee65c36f-296b-4905-b6a0-cd130850ad53',
+					elementId: 'f092b0fd-0075-4348-842f-667dff1d6a3b',
 				},
 				{
 					html:
 						'<p>Serve the pancakes hot with the sauce for dipping or drizzling over the top.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'a3797248-1775-4df8-bb60-f185cb9098c8',
+					elementId: '5af54711-165c-4a86-9990-fc29b0fa678c',
 				},
 			],
 			createdOn: 1592302354000,

--- a/fixtures/generated/articles/Review.ts
+++ b/fixtures/generated/articles/Review.ts
@@ -1804,7 +1804,7 @@ export const Review: CAPIType = {
 				},
 			],
 			_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-			elementId: '3a34fac1-4145-4bc3-9c47-3598c87310c2',
+			elementId: '4741cd53-bc03-4672-b37f-a5015aace5bb',
 		},
 	],
 	webPublicationDate: '2020-01-17T12:00:05.000Z',
@@ -1817,14 +1817,14 @@ export const Review: CAPIType = {
 						'<p>The new season of <a href="https://www.theguardian.com/tv-and-radio/2019/jan/17/sex-education-asa-butterfield-gillian-anderson-netflix">Sex Education</a> (Netflix) opens with a bravura sequence that swiftly takes its place in the pantheon of peen-based comedy greats. Suffice to say that since we left Otis at the end of the <a href="https://www.theguardian.com/tv-and-radio/2019/jan/11/sex-education-review-netflix-asa-butterfield-gillian-anderson">glorious inaugural run</a> having successfully masturbated for the first time, he has taken gleefully to his new hobby and – I don’t know if you know the French expression to encourage reluctant diners, “the appetite comes with eating”? – but we need to come up with the carnal equivalent for his joyful daily pursuits of the big O.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '3f6dac6c-6ee2-46b3-bdbf-e63d147d3e03',
+					elementId: '87aad1b1-883c-462f-9267-68cc9be5d56e',
 				},
 				{
 					html:
 						'<p>The scene establishes the tone of the new season – furiously fast, furiously funny, and not for the faint of heart any more than the first series was. And, just like the first series, it underpins the comedy arising from the sixth form students’ sexual escapades, experiments and baffled queries (“My cum tastes like kimchi! Why do I have a fermented dick?”) with deeper explorations of the main characters and the emotional pressures engendered by bigger problems.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '9dc6fed9-cc6e-49e6-bb4b-f78c7f087d8e',
+					elementId: '91477b8c-19c3-4b55-b38b-05c641fbb8f3',
 				},
 				{
 					url: 'https://www.youtube.com/watch?v=qZhb0Vl_BaM',
@@ -1839,14 +1839,14 @@ export const Review: CAPIType = {
 					sourceDomain: 'youtube-nocookie.com',
 					_type:
 						'model.dotcomrendering.pageElements.VideoYoutubeBlockElement',
-					elementId: 'e800773d-6f89-4d89-9669-ab7243062bea',
+					elementId: '3da4adef-270e-422c-8cae-81e033263513',
 				},
 				{
 					html:
 						'<p>With the help of Miss Sands, Maeve (Emma Mackey) finagles her way back into school and the special ability programme. All she has to do thereafter is wrestle with her unwelcoming and far more privileged peers and the return of her errant mother Erin (Anne-Marie Duff), allegedly clean for a year and with a three-year-old half-sister in tow. Otis (<a href="https://www.theguardian.com/tv-and-radio/2019/dec/28/sex-education-asa-butterfield-feel-more-confident-talking-about-sex">Asa Butterfield</a>) must negotiate his new relationship with Ola (Patricia Allison) while his mother Jean (Gillian Anderson, given a whole heap more to do this time round and rightly relishing every moment) throws more spanners in to his sexual works by dating Ola’s dad. Adam – poor beleaguered Adam (Connor Swindells) – is unjustly expelled from military school and sent back home to a dead-end job and his ever more hateful father. Swindells gives an extraordinary performance with what amounts to barely a hundred lines in the entire eight episodes, and if your heart doesn’t break at at least three points for him then I have no use for you. I don’t want to spoil Eric’s storyline because it doesn’t get going until a few episodes in, but <a href="https://www.theguardian.com/culture/2020/jan/05/ncuti-gatwa-i-will-say-yes-to-anything-sex-education">Ncuti Gatwa</a> remains the find of the age and handles everything thrown at him with such deftness and authenticity that you can only boggle at the fact that Laurie Nunn’s creation is his first major role.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '6692ff89-4202-4316-b2bc-31a0b86a7f0e',
+					elementId: 'c2febb81-2b29-4e45-880c-effd81a8615b',
 				},
 				{
 					media: {
@@ -2232,21 +2232,21 @@ export const Review: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: '905f7d75-059c-4e32-8663-f4762330b4fe',
+					elementId: '28909b6b-4a5c-4a64-af36-31ee2170638a',
 				},
 				{
 					html:
 						'<p>Every performer is wonderful, not least because the script is wonderful, playing the sex for laughs and the search for intimacy as something serious, good and noble. Not a single character is a cipher – even the smallest parts have a sketched backstory and some good gags. It’s all of a piece with the charm and generosity of spirit that suffuses the whole thing. <a href="https://www.theguardian.com/tv-and-radio/sex-education" data-component="auto-linked-tag">Sex Education</a> sets so many conventions cheerily but firmly aside that you feel like an entire forest of received wisdom is being clear-cut. Light floods in, new growth springs up. Such a sense of revelry and optimism abounds that you can feel it doing your heart and soul good as you watch. And all without missing a comic or emotional beat or deviating from its moral core, which urges us all to connect.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '886cb652-c98d-4b4d-9240-2d88dcd4fee9',
+					elementId: '5633eaae-a048-458f-ad6b-47dc0f00745d',
 				},
 				{
 					html:
 						'<p>So welcome once more, Otis (and your newly excitable penis), Maeve with her troubles to seek, Jackson (Kedar Williams-Stirling) whose mental health plummets to new lows as his swimming career reaches new heights, Aimee through whose experience on a local bus the issue of sexual assault is channelled, and all the magnificent rest of you. Nobody does it better. In fact, nobody does anything quite like it at all.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'b1e3fd61-6b16-4b87-8428-6215da1a766f',
+					elementId: '28f8be20-f62c-46ef-bd29-daa202995c42',
 				},
 			],
 			createdOn: 1579021298000,

--- a/fixtures/generated/articles/SpecialReport.ts
+++ b/fixtures/generated/articles/SpecialReport.ts
@@ -1787,7 +1787,7 @@ export const SpecialReport: CAPIType = {
 				},
 			],
 			_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-			elementId: 'd27362ef-3c67-43f6-af20-5999756a61c0',
+			elementId: '854bddd5-b419-43a0-85e4-3f3bbaae5e42',
 		},
 	],
 	webPublicationDate: '2019-10-12T11:00:19.000Z',
@@ -1800,21 +1800,21 @@ export const SpecialReport: CAPIType = {
 						'<p>The world’s three largest money managers have built a combined $300bn fossil fuel investment portfolio using money from people’s private savings and pension contributions, the Guardian can reveal.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '08009340-af95-46b8-973f-dc39cccaf225',
+					elementId: '7f3d18db-e447-4b15-9ff0-dd3706358983',
 				},
 				{
 					html:
 						'<p>BlackRock, Vanguard and State Street, which together oversee assets worth more than China’s entire GDP, have continued to grow billion-dollar stakes in some of the most carbon-intensive companies since the Paris agreement, financial data shows.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '83a28e06-2b9f-4467-b9a5-7df7a2738ecd',
+					elementId: '99895220-aa55-4eb3-8bf3-978e9fbbf7db',
 				},
 				{
 					html:
 						'<p>The two largest asset managers, BlackRock and Vanguard, have also routinely opposed motions at fossil fuel companies that would have forced directors to take more action on climate change, the analysis reveals.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'c7d66a01-6529-4233-afa1-252cb2bfa517',
+					elementId: '17508cd9-0378-436e-9161-f942cc5fd4df',
 				},
 				{
 					media: {
@@ -2187,28 +2187,28 @@ export const SpecialReport: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: 'a3908e62-1c7b-476e-ab7f-a0642dc02557',
+					elementId: 'cc6e7c4c-411f-4b08-8f8a-977160b73e1a',
 				},
 				{
 					html:
 						'<p>The investment rise is driven by the success in the last decade of tracker funds that use algorithms to follow major stock exchange indices such as the FTSE 100 and S&amp;P 500. </p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '65a4e354-1bd9-4b13-85b6-adda01fcc811',
+					elementId: '9beac025-dc7c-4123-bd21-64a49f98176d',
 				},
 				{
 					html:
 						'<p>The Guardian has worked with the thinktank InfluenceMap and the business data specialists ProxyInsight to analyse the role played by asset managers in the financing and management of some of the world’s biggest fossil fuel companies.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '10b030d9-7d8d-4740-a277-7e62113e1f2f',
+					elementId: '03095a92-13e0-427d-b657-db542483ab1f',
 				},
 				{
 					html:
 						'<p> Figures compiled by <a href="https://influencemap.org/index.html">InfluenceMap</a> show how Blackrock, Vanguard and State Street – known as the big three – have become crucial climate actors in the financial world. They are the largest money managers in the $74tn industry.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'bfd90e65-8ae9-4cc1-a47f-07046b306953',
+					elementId: '3e08bd8f-e03b-43c6-8d50-68e74a0b4b92',
 				},
 				{
 					media: {
@@ -2581,28 +2581,28 @@ export const SpecialReport: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: '9f474d05-7eed-4a65-a9f1-e975010283cd',
+					elementId: 'c51df191-ec68-41b6-85b9-70279b56f53b',
 				},
 				{
 					html:
 						'<p>According to an analysis of the data, their effective thermal coal, oil and gas reserve holdings through the companies they manage have surged 34.8% since 2016.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '756105e1-95ae-404d-befc-683996a30055',
+					elementId: 'a2fbe880-e311-4342-8c60-43b23fdd0bf3',
 				},
 				{
 					html:
 						'<p>This means they are now the largest investors in public oil, gas and coal companies, managing funds for large pension funds, university endowments and insurance companies.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '3c2bdd3b-44e4-4ab2-a20b-4634e8cbcc49',
+					elementId: 'c8b9af69-65ae-4f0d-9333-64c71ba58b90',
 				},
 				{
 					html:
 						'<p>While asset managers do not own the companies in which they invest, they often exercise shareholders rights on behalf of clients to vote on board members and company policy issues. </p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'fd807698-39f7-4c7d-9c92-1182283f5304',
+					elementId: 'e2caa3b2-1a9a-4dd7-ab30-149a362db477',
 				},
 				{
 					media: {
@@ -2975,27 +2975,27 @@ export const SpecialReport: CAPIType = {
 					],
 					_type:
 						'model.dotcomrendering.pageElements.ImageBlockElement',
-					elementId: 'a3fe2cd7-f313-4318-84d9-555de1dd00c5',
+					elementId: 'ec4e826b-5a38-428a-bb31-4ffe08e47cdf',
 				},
 				{
 					html:
 						'<p>Disclosures for publicly available company reports show that from 2015 to 2019 Vanguard and BlackRock used their votes to frequently oppose efforts to improve climate-related financial disclosures.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'cdca18d9-2703-40c8-87c1-0746373e2559',
+					elementId: 'a00c19ca-10e7-4d24-aa49-18503e6d2faf',
 				},
 				{
 					html: '<p>The investigation by the Guardian has found:</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '37ddeacf-1367-43fc-8f34-37edb9e8880d',
+					elementId: '4347fb92-3fc7-46be-945a-d65a97055a07',
 				},
 				{
 					html:
 						'<ul> \n <li><p>Vanguard ($161.1bn), BlackRock ($87.3bn) and State Street ($38.3bn) oversee a combined $286.7bn of shares in oil, coal and gas companies through 1,712 funds. Their total combined portfolio is likely to be higher as the calculation excludes direct holdings and non-listed fund holdings.</p></li> \n <li><p>The potential CO<sub>2</sub> emissions from the investments have increased from 10.593 gigatonnes (Gt) to 14.283Gt since the Paris agreement, equivalent to 38% of global fossil fuel CO<sub>2</sub> emissions last year.</p></li> \n <li><p>BlackRock and Vanguard opposed or abstained on more than 80% of climate-related motions at FTSE 100 and S&amp;P 500 fossil fuel companies between 2015 and 2019, according to data provided by <a href="https://www.proxyinsight.com/about/overview/">ProxyInsight</a>.</p></li> \n <li><p>The big three are among a number of asset managers that offer “climate-friendly” and “sustainable” investment funds that have substantial holdings in fossil fuel companies.</p></li> \n</ul>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '549f54ca-ea61-4d7f-b347-7125125a5dfa',
+					elementId: 'b732543a-c934-4921-9e00-63fc5af546a9',
 				},
 				{
 					url:
@@ -3007,84 +3007,84 @@ export const SpecialReport: CAPIType = {
 					isMandatory: false,
 					_type:
 						'model.dotcomrendering.pageElements.InteractiveBlockElement',
-					elementId: '396ed973-c65f-407e-9656-c3aa55c798a3',
+					elementId: '02f9b386-3212-43dd-9791-9742807a8259',
 				},
 				{
 					html:
 						'<p>BlackRock, Vanguard and State Street did not challenge the findings.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '86d48845-1e50-4108-a98b-f16eacb89615',
+					elementId: '164d9d44-6b8f-4868-9ff7-ff99e1f78920',
 				},
 				{
 					html:
 						'<p>They told the Guardian they prioritised private engagements with company boards, where the climate crisis was regularly discussed. They said they had increased the size of their teams responsible for investment stewardship, opting to use their votes as a final resort.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '41d494ae-36e0-4773-9426-4cd723cecdd1',
+					elementId: 'a1db1b82-1429-4f2e-a940-614dddfc0b9c',
 				},
 				{
 					html:
 						'<p>Vanguard said it neither managed the companies in which it invested nor sought to influence their business strategy. “As a steward of lifetime savings for more than 20 million people around the world, and a practically permanent investor in more than 10,000 companies, Vanguard is concerned about the long-term impact of climate risk,” a spokesman said.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'adac1a0d-bf39-48da-9478-388ae4a705af',
+					elementId: '3070ec6e-04ae-4d2b-a90f-87276cd47e44',
 				},
 				{
 					html:
 						'<p>“While voting at shareholder meetings is important … it is only one part of the larger corporate governance process. We regularly engage with companies on our shareholders’ behalf and believe that engagement and broader advocacy, in addition to voting, can effect meaningful changes that generate long-term value for all shareholders.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'f3e077cb-04dd-42e5-a3c9-204a7c59b045',
+					elementId: '2e9068bf-1c18-413f-a998-6374bf86e6bb',
 				},
 				{
 					html:
 						'<p>BlackRock said it “offers investors a wide range of environmentally sustainable investment options … [and] is also a leading investor in renewable power generation globally. Our award-winning climate research helps investors understand and mitigate the impact of climate change on their portfolios.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '67d4a011-96c9-4e6a-9b3d-34ebe9aabf60',
+					elementId: '92172464-9e91-4b58-aca5-058e2124f40b',
 				},
 				{
 					html:
 						'<p> State Street said: “If an investor wants to buy an ETF [exchange-traded fund] that tracks the FTSE 100, we would purchase the shares (proportionately) of all the companies in that FTSE 100 index in order to meet the objective of that strategy. That will today undoubtedly include energy companies.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '728ae712-37b6-435f-97e0-4f6ae6308d30',
+					elementId: '285fb5d0-7c17-4dac-a5ce-5f79aad9a579',
 				},
 				{
 					html:
 						'<p>“We do not proactively determine whether to exclude a particular company or sector since it would be inconsistent with the stated ETF objective. If an investor did want a strategy that considered climate issues or other ESG [environmental, social and governance] factors, that would be a different product with a different index; we can provide that too.”</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'f395a7be-8d93-40f9-8ef3-cd5cc9406759',
+					elementId: '48ff8e85-28da-4de1-a10a-cc4a0522b85b',
 				},
 				{
 					html:
 						'<p>Asset managers are increasingly finding themselves at the heart of social and environmental issues, and corporate governance experts have <a href="https://papers.ssrn.com/sol3/papers.cfm?abstract_id=3282794">raised concerns</a> about conflicts of interest in their business models.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'a7a7b506-36f4-43e7-8971-23095d33b886',
+					elementId: '21b76313-5de8-4a36-82a0-74512dafb676',
 				},
 				{
 					html:
 						'<p>Campaigners are demanding asset managers vote out company directors who are not deemed to be taking sufficient action.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '05266c3a-f822-456f-aa5f-98a8b5cb0ac1',
+					elementId: '6a4a5a62-7835-4cce-8697-3a97449ded5e',
 				},
 				{
 					html:
 						'<p>In June, the London-based Legal &amp; General, formerly a top 20 investor in ExxonMobil, announced it was selling a $300m stake in the company and would use remaining shares to vote against the chief executive, Darren Woods.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '3d3c0867-df9b-4ff3-87e9-fd48e7389112',
+					elementId: '31a46346-2bb8-4d30-9281-013bad171896',
 				},
 				{
 					html:
 						'<p>But environmental shareholder proposals face increasing challenges from the management of fossil fuel companies, which are being sustained by the American regulator, the Securities and Exchange Commission. The SEC declined to comment.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '153811b7-c0f7-43c2-8db0-07eb88463d06',
+					elementId: 'ca3c292b-3a68-44c3-8aea-b322723b934e',
 				},
 				{
 					url:
@@ -3095,21 +3095,21 @@ export const SpecialReport: CAPIType = {
 					isMandatory: false,
 					_type:
 						'model.dotcomrendering.pageElements.InteractiveBlockElement',
-					elementId: 'cd4afe91-19f5-4fda-8324-e756937319a4',
+					elementId: '47433d98-e933-4031-955a-6f97c326151f',
 				},
 				{
 					html:
 						'<p>In April, ExxonMobil shareholders were denied a vote on whether the company should set targets for cutting greenhouse gas emissions by the SEC, which called the proposal an attempt to “micromanage” the company.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'c9e5c95d-76b9-4cf7-85d7-6e0de0b4e1ce',
+					elementId: 'e6cfd927-b5f9-4d5a-9dbe-a8b08ffded0a',
 				},
 				{
 					html:
 						'<p>Data for the 2019 season of annual general meetings for shareholders, provided by Institutional Shareholder Services, shows that only a quarter of proposals made it to a vote at companies in the US, with 79 of the 105 motions either withdrawn or omitted.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'c079a095-8af6-4579-9586-026fd1b54c66',
+					elementId: '387d395b-689d-45c2-8517-c81d10daaeb8',
 				},
 				{
 					id: 'e182ee5f-c378-4474-b7da-79f6b0a671b3',
@@ -3118,28 +3118,28 @@ export const SpecialReport: CAPIType = {
 						'<p>The Guardian has collaborated with leading scientists and NGOs to expose, with exclusive data, investigations and analysis, the fossil fuel companies that are perpetuating the climate crisis – some of which have accelerated their extraction of coal, oil and gas even as the devastating impact on the planet and humanity was becoming clear.<br></p><p>The investigation has involved more than 20 Guardian journalists working across the world for the past six months.</p><p>The project focuses on what the companies have extracted from the ground, and the subsequent emissions they are responsible for, since 1965. The analysis, undertaken by Richard Heede at the <a href="http://climateaccountability.org/">Climate Accountability Institute</a>,&nbsp;calculates how much carbon is emitted throughout the supply chain, from extraction to use by consumers. Heede said: "The fact that consumers combust the fuels to carbon dioxide, water, heat and pollutants does not absolve the fossil fuel companies from responsibility for knowingly perpetuating the carbon era and accelerating the climate crisis toward the existential threat it has now become."</p><p>One aim of the project is to move the focus of debate from individual responsibilities to power structures – so our reporters also examined the financial and lobbying structures that let fossil fuel firms keep growing, and discovered which elected politicians were voting for change.&nbsp;</p><p>Another aim of the project is to press governments and corporations to close the gap between ambitious long-term promises and lacklustre short-term action. The UN says the coming decade is crucial if the world is to avoid the most catastrophic consequences of global heating. Reining in our dependence on fossil fuels and dramatically accelerating the transition to renewable energy has never been more urgent.</p>',
 					credit: '',
 					_type: 'model.dotcomrendering.pageElements.QABlockElement',
-					elementId: '9777f024-a973-48de-9801-f7357d0a1494',
+					elementId: '4cb420ff-1854-4ad3-98e0-5ac62c48c6f3',
 				},
 				{
 					html:
 						'<p>Despite setbacks, other proposals and engagements by asset managers have been more successful. In an industry first last year, intense pressure from shareholders forced Royal Dutch Shell to set carbon emission targets linked to executive pay. The decision was backed by Climate Action 100+, a group of $35tn investors who are pushing fossil fuel companies to react to the crisis.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'a2a2b180-c3c1-48fa-bc1a-302125fefe18',
+					elementId: 'cc316723-91c8-41df-adfd-32c338e7dfe1',
 				},
 				{
 					html:
 						'<p>Many pension funds and asset managers support schemes to improve information about how climate-critical companies are responding to environmental concerns, including the Transition Pathway Initiative, which grades the boards of fossil fuel, energy and transport companies on their response.</p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: 'cd3ffcff-c85b-47b8-84d9-0bb3a68b43f4',
+					elementId: 'def727e4-6530-43a6-b2dd-447caf4805b2',
 				},
 				{
 					html:
 						'<p>BlackRock, Vanguard and State Street are supporters of the Task Force on Climate-related Financial Disclosures, a voluntary scheme chaired by the former New York mayor Michael Bloomberg to improve information.<br></p>',
 					_type:
 						'model.dotcomrendering.pageElements.TextBlockElement',
-					elementId: '567bfe96-514a-4a71-954d-f9d52f59cf44',
+					elementId: '2298fd16-829d-4773-8125-af703ce5427b',
 				},
 			],
 			createdOn: 1569225927000,

--- a/fixtures/generated/images.ts
+++ b/fixtures/generated/images.ts
@@ -394,7 +394,7 @@ export const images: ImageBlockElement[] = [
 			},
 		],
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-		elementId: 'e51113f1-8ab4-4b3a-af97-d07291a71e1f',
+		elementId: 'f3a8f1be-6b02-4452-b042-154bf39487c3',
 	},
 	{
 		media: {
@@ -777,7 +777,7 @@ export const images: ImageBlockElement[] = [
 			},
 		],
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-		elementId: 'e62e9685-0c9b-4724-9e5b-40b8a41a4601',
+		elementId: '899b1e03-02a0-43c9-a9ff-410160796b18',
 	},
 	{
 		media: {
@@ -1161,7 +1161,7 @@ export const images: ImageBlockElement[] = [
 			},
 		],
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-		elementId: '14de85bf-8bef-4bed-a403-b38e3e338930',
+		elementId: '4b268c44-2edd-4b69-9e04-f4233cb9bc76',
 	},
 	{
 		media: {
@@ -1545,7 +1545,7 @@ export const images: ImageBlockElement[] = [
 			},
 		],
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-		elementId: '154fa8d4-1a1d-453a-8acf-bbaa25b0a28c',
+		elementId: 'b10b56c0-9a6c-49d7-8a24-81a5c26188cc',
 	},
 	{
 		media: {
@@ -1929,7 +1929,7 @@ export const images: ImageBlockElement[] = [
 			},
 		],
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-		elementId: 'e91a1ec5-d537-48d4-8dfa-64e58c6ae685',
+		elementId: '6d3d095f-5cf1-4935-b800-b8acd9dac917',
 	},
 	{
 		media: {
@@ -2313,7 +2313,7 @@ export const images: ImageBlockElement[] = [
 			},
 		],
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-		elementId: '019b0819-dfa6-4a91-b547-264fbd2d31ee',
+		elementId: '306f8b2d-3568-4468-b442-7a40134ec66a',
 	},
 	{
 		media: {
@@ -2697,7 +2697,7 @@ export const images: ImageBlockElement[] = [
 			},
 		],
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-		elementId: 'b419be00-d716-43b6-b26d-46da3f754eb8',
+		elementId: '6c35d7d5-f7d6-4ca4-ae26-991de579f94e',
 	},
 	{
 		media: {
@@ -3069,7 +3069,7 @@ export const images: ImageBlockElement[] = [
 			},
 		],
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-		elementId: '17b6379f-7d35-47dc-9925-9b31cd4b25f3',
+		elementId: 'e15a6335-fe12-4fbe-8d02-63cf5c676149',
 	},
 	{
 		media: {
@@ -3452,7 +3452,7 @@ export const images: ImageBlockElement[] = [
 			},
 		],
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-		elementId: '127d007b-0aa9-487f-b8c0-ef56471f3b95',
+		elementId: '884ad825-d237-4b23-bea5-5b6fd6f80d13',
 	},
 	{
 		media: {
@@ -3836,7 +3836,7 @@ export const images: ImageBlockElement[] = [
 			},
 		],
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-		elementId: 'e39dca9d-8124-4f98-9b0a-6b12c513de43',
+		elementId: '09daafcc-f165-4607-a951-91018f9c70d2',
 	},
 	{
 		media: {
@@ -4220,7 +4220,7 @@ export const images: ImageBlockElement[] = [
 			},
 		],
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-		elementId: '54f61821-9280-4156-9583-2d2b5111051a',
+		elementId: '401f3e2a-2c29-48c2-a0bd-3275ac9347d0',
 	},
 	{
 		media: {
@@ -4603,7 +4603,7 @@ export const images: ImageBlockElement[] = [
 			},
 		],
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-		elementId: '58721e90-0eba-48af-bb5e-fa5c2da44cfe',
+		elementId: 'cffaa4e4-d335-4ec8-beaf-90094819f16d',
 	},
 	{
 		media: {
@@ -4987,7 +4987,7 @@ export const images: ImageBlockElement[] = [
 			},
 		],
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-		elementId: '45d41de1-345e-4e78-b4b2-e6e2c5b50d58',
+		elementId: '1fa3d68a-6505-42c8-831d-779bc29e186c',
 	},
 	{
 		media: {
@@ -5371,7 +5371,7 @@ export const images: ImageBlockElement[] = [
 			},
 		],
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-		elementId: '086ec8d9-d35b-43e5-befa-07fa7f4f92be',
+		elementId: '69cb8430-4e5a-4e0c-9c91-860d4ac9a7b3',
 	},
 	{
 		media: {
@@ -5754,7 +5754,7 @@ export const images: ImageBlockElement[] = [
 			},
 		],
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-		elementId: 'f23456cb-d290-41ff-9401-521903224803',
+		elementId: '670ec8c3-754a-467f-9834-44b27953d079',
 	},
 	{
 		media: {
@@ -6138,7 +6138,7 @@ export const images: ImageBlockElement[] = [
 			},
 		],
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-		elementId: 'ce6c6d10-422c-4f32-8331-a1cc2886b703',
+		elementId: '36c85d75-c02c-4887-bc0e-0dea6fadaab9',
 	},
 	{
 		media: {
@@ -6522,7 +6522,7 @@ export const images: ImageBlockElement[] = [
 			},
 		],
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-		elementId: '87b5f59f-0fe8-4d91-93ad-9275f5bff045',
+		elementId: '2ed5c0ac-26d5-433b-9e33-140000c028b0',
 	},
 	{
 		media: {
@@ -6905,7 +6905,7 @@ export const images: ImageBlockElement[] = [
 			},
 		],
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-		elementId: '901b2770-5d23-48d4-90f1-50004057c590',
+		elementId: '9670e0d1-979d-4687-b579-3c03255931d9',
 	},
 	{
 		media: {
@@ -7288,7 +7288,7 @@ export const images: ImageBlockElement[] = [
 			},
 		],
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-		elementId: '246eeb7e-6bb2-47db-a6d3-7b34fdf3a4bc',
+		elementId: '446b2744-b291-4098-8c58-f24041a4fd03',
 	},
 	{
 		media: {
@@ -7671,7 +7671,7 @@ export const images: ImageBlockElement[] = [
 			},
 		],
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-		elementId: 'de91f809-2ebd-4ee5-9c3d-1c3d173b36f6',
+		elementId: 'ba4f8876-1334-400d-8023-47ff3b0b56ac',
 	},
 	{
 		media: {
@@ -8054,7 +8054,7 @@ export const images: ImageBlockElement[] = [
 			},
 		],
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-		elementId: 'd01e4d22-278e-4fd5-9bcc-367eda526281',
+		elementId: '78858ec0-0d66-47fd-9ada-a0bdf9b6d1ca',
 	},
 	{
 		media: {
@@ -8437,6 +8437,6 @@ export const images: ImageBlockElement[] = [
 			},
 		],
 		_type: 'model.dotcomrendering.pageElements.ImageBlockElement',
-		elementId: 'd1cd01f8-a711-4886-a4b0-172392445b5f',
+		elementId: '20bfbcc8-d6de-434a-b47b-a891b188530c',
 	},
 ];

--- a/fixtures/generated/related.ts
+++ b/fixtures/generated/related.ts
@@ -16,6 +16,34 @@ export const related = {
 	trails: [
 		{
 			url:
+				'https://www.theguardian.com/uk-news/2021/apr/04/if-your-dog-goes-for-my-sheep-then-i-will-shoot-uk-farmers-warn-walkers',
+			linkText:
+				'If your dog goes for my sheep, then I will shoot, UK farmers warn walkers',
+			showByline: false,
+			byline: 'Robyn Vinter',
+			image:
+				'https://i.guim.co.uk/img/media/adf6cb2056b61cc05ae22e38c4f2b975624c612b/0_120_3600_2160/master/3600.jpg?width=300&quality=85&auto=format&fit=max&s=e42e28a11d514f91623bd6737c055f86',
+			carouselImages: {
+				'300':
+					'https://i.guim.co.uk/img/media/adf6cb2056b61cc05ae22e38c4f2b975624c612b/0_120_3600_2160/master/3600.jpg?width=300&quality=85&auto=format&fit=max&s=e42e28a11d514f91623bd6737c055f86',
+				'460':
+					'https://i.guim.co.uk/img/media/adf6cb2056b61cc05ae22e38c4f2b975624c612b/0_120_3600_2160/master/3600.jpg?width=460&quality=85&auto=format&fit=max&s=1d27920bfe7e4bd6f6bc105d48b7b666',
+			},
+			isLiveBlog: false,
+			pillar: 'news',
+			designType: 'Article',
+			format: {
+				design: 'ArticleDesign',
+				theme: 'NewsPillar',
+				display: 'StandardDisplay',
+			},
+			webPublicationDate: '2021-04-04T08:30:03.000Z',
+			headline:
+				'If your dog goes for my sheep, then I will shoot, UK farmers warn walkers',
+			shortUrl: 'https://www.theguardian.com/p/hvb2x',
+		},
+		{
+			url:
 				'https://www.theguardian.com/world/2021/mar/26/buying-lockdown-dogs-whim-trouble-rspca-freddie-seal',
 			linkText:
 				'Buying lockdown dogs on a whim can lead to trouble, says RSPCA',
@@ -127,6 +155,24 @@ export const related = {
 			headline:
 				'RSPCA urges caution over buying puppies online after spate of deaths',
 			shortUrl: 'https://www.theguardian.com/p/d55qg',
+			branding: {
+				brandingType: {
+					name: 'foundation',
+				},
+				sponsorName: 'Animals farmed',
+				logo: {
+					src:
+						'https://static.theguardian.com/commercial/sponsor/16/Feb/2018/464c4fe9-0e97-450c-966c-2e1710914aa9-OPP.jpg',
+					dimensions: {
+						width: 140,
+						height: 90,
+					},
+					link: 'https://www.openphilanthropy.org/',
+					label: 'Animals farmed is supported by',
+				},
+				aboutThisLink:
+					'https://www.theguardian.com/animals-farmed/2018/feb/21/about-animals-farmed-investigating-modern-farming-around-the-world',
+			},
 		},
 		{
 			url:
@@ -212,35 +258,6 @@ export const related = {
 			headline:
 				"Michael Heseltine's alsatian-strangling tale was shaggy dog story",
 			shortUrl: 'https://www.theguardian.com/p/5aad8',
-		},
-		{
-			url:
-				'https://www.theguardian.com/uk-news/2016/apr/23/croydon-cat-killer-mystery-100-animal-deaths',
-			linkText:
-				'London cat killer mystery deepens as charities investigate 100 animal deaths',
-			showByline: false,
-			byline: 'Jamie Doward and Emma Supple',
-			image:
-				'https://i.guim.co.uk/img/media/8154600a7d82a242f5d090899eba6dac35bd72d8/0_19_3000_1799/3000.jpg?width=300&quality=85&auto=format&fit=max&s=dcf81430375b404f4776ca64603ffe3d',
-			carouselImages: {
-				'300':
-					'https://i.guim.co.uk/img/media/8154600a7d82a242f5d090899eba6dac35bd72d8/0_19_3000_1799/3000.jpg?width=300&quality=85&auto=format&fit=max&s=dcf81430375b404f4776ca64603ffe3d',
-				'460':
-					'https://i.guim.co.uk/img/media/8154600a7d82a242f5d090899eba6dac35bd72d8/0_19_3000_1799/3000.jpg?width=460&quality=85&auto=format&fit=max&s=c2e053dcffb8988279a7b4216c4bfa9d',
-			},
-			ageWarning: '4 years',
-			isLiveBlog: false,
-			pillar: 'news',
-			designType: 'Article',
-			format: {
-				design: 'ArticleDesign',
-				theme: 'NewsPillar',
-				display: 'StandardDisplay',
-			},
-			webPublicationDate: '2016-04-23T20:04:12.000Z',
-			headline:
-				'London cat killer mystery deepens as charities investigate 100 animal deaths',
-			shortUrl: 'https://www.theguardian.com/p/4thq9',
 		},
 		{
 			url:

--- a/fixtures/generated/series.ts
+++ b/fixtures/generated/series.ts
@@ -20,47 +20,18 @@ export const series = {
 	trails: [
 		{
 			url:
-				'https://www.theguardian.com/tv-and-radio/2021/mar/25/black-power-a-british-story-of-resistance-review-a-tortuous-fight-for-justice',
+				'https://www.theguardian.com/tv-and-radio/2021/apr/05/intruder-review-sally-lindsay-channel-5',
 			linkText:
-				'Black Power: A British Story of Resistance review – a tortuous fight for justice',
-			showByline: false,
-			byline: 'Ellen E Jones',
-			image:
-				'https://i.guim.co.uk/img/media/054de2cd08b4cb23bc04d3a2838a2379b5110538/440_189_1560_937/master/1560.jpg?width=300&quality=85&auto=format&fit=max&s=e3450250226a575c3dcfb33ddb71bc36',
-			carouselImages: {
-				'300':
-					'https://i.guim.co.uk/img/media/054de2cd08b4cb23bc04d3a2838a2379b5110538/440_189_1560_937/master/1560.jpg?width=300&quality=85&auto=format&fit=max&s=e3450250226a575c3dcfb33ddb71bc36',
-				'460':
-					'https://i.guim.co.uk/img/media/054de2cd08b4cb23bc04d3a2838a2379b5110538/440_189_1560_937/master/1560.jpg?width=460&quality=85&auto=format&fit=max&s=ec8bb2442221a0c9dcc5923c12c6938f',
-			},
-			isLiveBlog: false,
-			pillar: 'culture',
-			designType: 'Review',
-			format: {
-				design: 'ReviewDesign',
-				theme: 'CulturePillar',
-				display: 'StandardDisplay',
-			},
-			webPublicationDate: '2021-03-25T22:30:26.000Z',
-			headline:
-				'Black Power: A British Story of Resistance review – a tortuous fight for justice',
-			shortUrl: 'https://www.theguardian.com/p/gpxqy',
-			starRating: 5,
-		},
-		{
-			url:
-				'https://www.theguardian.com/tv-and-radio/2021/mar/24/this-is-my-house-review-through-the-keyhole-with-stacey-dooley',
-			linkText:
-				'This Is My House review – through the keyhole with Stacey Dooley',
+				'Intruder review – Sally Lindsay stars in thriller that quickly turns high farce',
 			showByline: false,
 			byline: 'Lucy Mangan',
 			image:
-				'https://i.guim.co.uk/img/media/20696b46d52bce6f8420ad23fe1c981dc3042a0d/0_81_2400_1440/master/2400.jpg?width=300&quality=85&auto=format&fit=max&s=c37911932e839eade5f7b766dfbd9904',
+				'https://i.guim.co.uk/img/media/1d841350edc33b00de7a72fc0011dc470f19fefd/0_300_4500_2700/master/4500.jpg?width=300&quality=85&auto=format&fit=max&s=e8c766fe84bc8c6081032676515f2a68',
 			carouselImages: {
 				'300':
-					'https://i.guim.co.uk/img/media/20696b46d52bce6f8420ad23fe1c981dc3042a0d/0_81_2400_1440/master/2400.jpg?width=300&quality=85&auto=format&fit=max&s=c37911932e839eade5f7b766dfbd9904',
+					'https://i.guim.co.uk/img/media/1d841350edc33b00de7a72fc0011dc470f19fefd/0_300_4500_2700/master/4500.jpg?width=300&quality=85&auto=format&fit=max&s=e8c766fe84bc8c6081032676515f2a68',
 				'460':
-					'https://i.guim.co.uk/img/media/20696b46d52bce6f8420ad23fe1c981dc3042a0d/0_81_2400_1440/master/2400.jpg?width=460&quality=85&auto=format&fit=max&s=08a6d8ffbc107caa4157bf2ebce12070',
+					'https://i.guim.co.uk/img/media/1d841350edc33b00de7a72fc0011dc470f19fefd/0_300_4500_2700/master/4500.jpg?width=460&quality=85&auto=format&fit=max&s=bc5f26819281aa6bf3081c1c7dee1073',
 			},
 			isLiveBlog: false,
 			pillar: 'culture',
@@ -70,200 +41,26 @@ export const series = {
 				theme: 'CulturePillar',
 				display: 'StandardDisplay',
 			},
-			webPublicationDate: '2021-03-24T22:00:09.000Z',
+			webPublicationDate: '2021-04-05T21:00:46.000Z',
 			headline:
-				'This Is My House review – through the keyhole with Stacey Dooley',
-			shortUrl: 'https://www.theguardian.com/p/gpvap',
-			starRating: 5,
-		},
-		{
-			url:
-				'https://www.theguardian.com/tv-and-radio/2021/mar/23/kate-garraway-finding-derek-review-devotion-and-honesty-in-the-face-of-covid',
-			linkText:
-				'Kate Garraway: Finding Derek review – devotion and honesty in the face of Covid',
-			showByline: false,
-			byline: 'Lucy Mangan',
-			image:
-				'https://i.guim.co.uk/img/media/2664bac97a56087898a40c0287c1981952fd2edc/0_361_6000_3600/master/6000.jpg?width=300&quality=85&auto=format&fit=max&s=6737b1ba0fcd380599e43f90d0d9ba5d',
-			carouselImages: {
-				'300':
-					'https://i.guim.co.uk/img/media/2664bac97a56087898a40c0287c1981952fd2edc/0_361_6000_3600/master/6000.jpg?width=300&quality=85&auto=format&fit=max&s=6737b1ba0fcd380599e43f90d0d9ba5d',
-				'460':
-					'https://i.guim.co.uk/img/media/2664bac97a56087898a40c0287c1981952fd2edc/0_361_6000_3600/master/6000.jpg?width=460&quality=85&auto=format&fit=max&s=a459abce502ee515055e8c93a6cc54b2',
-			},
-			isLiveBlog: false,
-			pillar: 'culture',
-			designType: 'Review',
-			format: {
-				design: 'ReviewDesign',
-				theme: 'CulturePillar',
-				display: 'StandardDisplay',
-			},
-			webPublicationDate: '2021-03-23T22:00:21.000Z',
-			headline:
-				'Kate Garraway: Finding Derek review – devotion and honesty in the face of Covid',
-			shortUrl: 'https://www.theguardian.com/p/gzk23',
-			starRating: 4,
-		},
-		{
-			url:
-				'https://www.theguardian.com/tv-and-radio/2021/mar/22/footballs-darkest-secret-review-spare-and-unrelenting',
-			linkText:
-				"Football's Darkest Secret review – spare and unrelenting",
-			showByline: false,
-			byline: 'Lucy Mangan',
-			image:
-				'https://i.guim.co.uk/img/media/4969fb8962d76157d7f0f1b0973d54df53da77a8/0_0_3828_2298/master/3828.jpg?width=300&quality=85&auto=format&fit=max&s=6f848d276decaabc2d29a31ce8d08501',
-			carouselImages: {
-				'300':
-					'https://i.guim.co.uk/img/media/4969fb8962d76157d7f0f1b0973d54df53da77a8/0_0_3828_2298/master/3828.jpg?width=300&quality=85&auto=format&fit=max&s=6f848d276decaabc2d29a31ce8d08501',
-				'460':
-					'https://i.guim.co.uk/img/media/4969fb8962d76157d7f0f1b0973d54df53da77a8/0_0_3828_2298/master/3828.jpg?width=460&quality=85&auto=format&fit=max&s=2e830fbb951788f933241c6f436670f4',
-			},
-			isLiveBlog: false,
-			pillar: 'culture',
-			designType: 'Review',
-			format: {
-				design: 'ReviewDesign',
-				theme: 'CulturePillar',
-				display: 'StandardDisplay',
-			},
-			webPublicationDate: '2021-03-22T22:00:43.000Z',
-			headline:
-				"Football's Darkest Secret review – spare and unrelenting",
-			shortUrl: 'https://www.theguardian.com/p/gzank',
-			starRating: 5,
-		},
-		{
-			url:
-				'https://www.theguardian.com/tv-and-radio/2021/mar/21/line-of-duty-review-the-bent-copper-bashers-bbc',
-			linkText:
-				'Line of Duty review – bent-copper bashers prepare to suck diesel',
-			showByline: false,
-			byline: 'Lucy Mangan',
-			image:
-				'https://i.guim.co.uk/img/media/14e78645984896c29199e7589d69f7dd490f494b/0_177_4096_2458/master/4096.jpg?width=300&quality=85&auto=format&fit=max&s=4c065696cb52c22ca878fc0d9418d99f',
-			carouselImages: {
-				'300':
-					'https://i.guim.co.uk/img/media/14e78645984896c29199e7589d69f7dd490f494b/0_177_4096_2458/master/4096.jpg?width=300&quality=85&auto=format&fit=max&s=4c065696cb52c22ca878fc0d9418d99f',
-				'460':
-					'https://i.guim.co.uk/img/media/14e78645984896c29199e7589d69f7dd490f494b/0_177_4096_2458/master/4096.jpg?width=460&quality=85&auto=format&fit=max&s=cf6d8b2ac492b23c925b0b688f69a380',
-			},
-			isLiveBlog: false,
-			pillar: 'culture',
-			designType: 'Review',
-			format: {
-				design: 'ReviewDesign',
-				theme: 'CulturePillar',
-				display: 'StandardDisplay',
-			},
-			webPublicationDate: '2021-03-21T22:00:06.000Z',
-			headline:
-				'Line of Duty review – bent-copper bashers prepare to suck diesel',
-			shortUrl: 'https://www.theguardian.com/p/gneag',
-			starRating: 4,
-		},
-		{
-			url:
-				'https://www.theguardian.com/tv-and-radio/2021/mar/19/the-flight-attendant-review-kaley-cuoco',
-			linkText:
-				'The Flight Attendant review – strap in for a first-class murder mystery',
-			showByline: false,
-			byline: 'Lucy Mangan',
-			image:
-				'https://i.guim.co.uk/img/media/89dff67d7776102d610b4c95e3146cddb577298d/0_0_6240_3744/master/6240.jpg?width=300&quality=85&auto=format&fit=max&s=aeed04b5b0f173b787eb43c1de3a1401',
-			carouselImages: {
-				'300':
-					'https://i.guim.co.uk/img/media/89dff67d7776102d610b4c95e3146cddb577298d/0_0_6240_3744/master/6240.jpg?width=300&quality=85&auto=format&fit=max&s=aeed04b5b0f173b787eb43c1de3a1401',
-				'460':
-					'https://i.guim.co.uk/img/media/89dff67d7776102d610b4c95e3146cddb577298d/0_0_6240_3744/master/6240.jpg?width=460&quality=85&auto=format&fit=max&s=a49441dc5c6390f7acdbf9d680393edb',
-			},
-			isLiveBlog: false,
-			pillar: 'culture',
-			designType: 'Review',
-			format: {
-				design: 'ReviewDesign',
-				theme: 'CulturePillar',
-				display: 'StandardDisplay',
-			},
-			webPublicationDate: '2021-03-19T22:00:08.000Z',
-			headline:
-				'The Flight Attendant review – strap in for a first-class murder mystery',
-			shortUrl: 'https://www.theguardian.com/p/gne76',
-			starRating: 5,
-		},
-		{
-			url:
-				'https://www.theguardian.com/tv-and-radio/2021/mar/19/sky-rojo-review-spanish-trafficking-drama-revels-in-trashy-glamour',
-			linkText:
-				'Sky Rojo review – Spanish trafficking drama revels in trashy glamour',
-			showByline: false,
-			byline: 'Ellen E Jones',
-			image:
-				'https://i.guim.co.uk/img/media/56c6b0e8c64af5e0ce962823b69b52e3013fe4fd/0_345_7268_4363/master/7268.jpg?width=300&quality=85&auto=format&fit=max&s=dcb14d0a0e179794fb1a645dea6bda34',
-			carouselImages: {
-				'300':
-					'https://i.guim.co.uk/img/media/56c6b0e8c64af5e0ce962823b69b52e3013fe4fd/0_345_7268_4363/master/7268.jpg?width=300&quality=85&auto=format&fit=max&s=dcb14d0a0e179794fb1a645dea6bda34',
-				'460':
-					'https://i.guim.co.uk/img/media/56c6b0e8c64af5e0ce962823b69b52e3013fe4fd/0_345_7268_4363/master/7268.jpg?width=460&quality=85&auto=format&fit=max&s=dab1c7ee880072c4f492aff2978fe90f',
-			},
-			isLiveBlog: false,
-			pillar: 'culture',
-			designType: 'Review',
-			format: {
-				design: 'ReviewDesign',
-				theme: 'CulturePillar',
-				display: 'StandardDisplay',
-			},
-			webPublicationDate: '2021-03-19T09:00:03.000Z',
-			headline:
-				'Sky Rojo review – Spanish trafficking drama revels in trashy glamour',
-			shortUrl: 'https://www.theguardian.com/p/gnx7h',
-			starRating: 4,
-		},
-		{
-			url:
-				'https://www.theguardian.com/tv-and-radio/2021/mar/18/the-falcon-and-the-winter-soldier-review-marvel-disney-plus-avengers',
-			linkText:
-				"The Falcon and the Winter Soldier review – sturdy start to Marvel's latest",
-			showByline: false,
-			byline: 'Benjamin Lee',
-			image:
-				'https://i.guim.co.uk/img/media/40d0ed44e1db42043e7357b72edca6a5e970eb54/0_12_4096_2459/master/4096.jpg?width=300&quality=85&auto=format&fit=max&s=5dd08566ba93c5d339a7f7a742851904',
-			carouselImages: {
-				'300':
-					'https://i.guim.co.uk/img/media/40d0ed44e1db42043e7357b72edca6a5e970eb54/0_12_4096_2459/master/4096.jpg?width=300&quality=85&auto=format&fit=max&s=5dd08566ba93c5d339a7f7a742851904',
-				'460':
-					'https://i.guim.co.uk/img/media/40d0ed44e1db42043e7357b72edca6a5e970eb54/0_12_4096_2459/master/4096.jpg?width=460&quality=85&auto=format&fit=max&s=5ac87414b413f8c547cbceeb97dbc3cf',
-			},
-			isLiveBlog: false,
-			pillar: 'culture',
-			designType: 'Review',
-			format: {
-				design: 'ReviewDesign',
-				theme: 'CulturePillar',
-				display: 'StandardDisplay',
-			},
-			webPublicationDate: '2021-03-18T16:02:50.000Z',
-			headline:
-				"The Falcon and the Winter Soldier review – sturdy start to Marvel's latest",
-			shortUrl: 'https://www.theguardian.com/p/gnvx7',
+				'Intruder review – Sally Lindsay stars in thriller that quickly turns high farce',
+			shortUrl: 'https://www.theguardian.com/p/hxcay',
 			starRating: 3,
 		},
 		{
 			url:
-				'https://www.theguardian.com/tv-and-radio/2021/mar/17/caroline-flack-her-life-and-death-review-a-compassionate-eulogy-suffused-with-pain',
+				'https://www.theguardian.com/tv-and-radio/2021/apr/04/queen-elizabeth-and-the-spy-in-the-palace-review-a-rather-blunt-documentary',
 			linkText:
-				'Caroline Flack: Her Life and Death review – a compassionate eulogy suffused with pain',
+				'Queen Elizabeth and the Spy in the Palace review – a rather Blunt documentary',
 			showByline: false,
 			byline: 'Lucy Mangan',
 			image:
-				'https://i.guim.co.uk/img/media/0618a00e60d94514d86aa8bacc3f498827078ec4/147_109_899_539/master/899.jpg?width=300&quality=85&auto=format&fit=max&s=9cb14ca383df2ff7bc0cf3603f28f979',
+				'https://i.guim.co.uk/img/media/9110f086a9fae5e8197359c0745edd2fc12b98e8/0_26_3140_1884/master/3140.jpg?width=300&quality=85&auto=format&fit=max&s=b289db8c39445208e8cb83f888dc300c',
 			carouselImages: {
 				'300':
-					'https://i.guim.co.uk/img/media/0618a00e60d94514d86aa8bacc3f498827078ec4/147_109_899_539/master/899.jpg?width=300&quality=85&auto=format&fit=max&s=9cb14ca383df2ff7bc0cf3603f28f979',
+					'https://i.guim.co.uk/img/media/9110f086a9fae5e8197359c0745edd2fc12b98e8/0_26_3140_1884/master/3140.jpg?width=300&quality=85&auto=format&fit=max&s=b289db8c39445208e8cb83f888dc300c',
 				'460':
-					'https://i.guim.co.uk/img/media/0618a00e60d94514d86aa8bacc3f498827078ec4/147_109_899_539/master/899.jpg?width=460&quality=85&auto=format&fit=max&s=92892d17a37644d660a01c4cff78afaa',
+					'https://i.guim.co.uk/img/media/9110f086a9fae5e8197359c0745edd2fc12b98e8/0_26_3140_1884/master/3140.jpg?width=460&quality=85&auto=format&fit=max&s=fb5411993c51e72c722062244e3052aa',
 			},
 			isLiveBlog: false,
 			pillar: 'culture',
@@ -273,26 +70,82 @@ export const series = {
 				theme: 'CulturePillar',
 				display: 'StandardDisplay',
 			},
-			webPublicationDate: '2021-03-17T22:00:12.000Z',
+			webPublicationDate: '2021-04-04T21:00:17.000Z',
 			headline:
-				'Caroline Flack: Her Life and Death review – a compassionate eulogy suffused with pain',
-			shortUrl: 'https://www.theguardian.com/p/gmtqh',
+				'Queen Elizabeth and the Spy in the Palace review – a rather Blunt documentary',
+			shortUrl: 'https://www.theguardian.com/p/hva3k',
+			starRating: 3,
+		},
+		{
+			url:
+				'https://www.theguardian.com/tv-and-radio/2021/apr/02/churchill-review-channel-5',
+			linkText: 'Churchill review – the character behind the caricature',
+			showByline: false,
+			byline: 'Lucy Mangan',
+			image:
+				'https://i.guim.co.uk/img/media/77eff3504946f87059c2736501e963b61ed39e80/0_524_3005_1803/master/3005.jpg?width=300&quality=85&auto=format&fit=max&s=1473e1c59be6ac603c0618ca58a70919',
+			carouselImages: {
+				'300':
+					'https://i.guim.co.uk/img/media/77eff3504946f87059c2736501e963b61ed39e80/0_524_3005_1803/master/3005.jpg?width=300&quality=85&auto=format&fit=max&s=1473e1c59be6ac603c0618ca58a70919',
+				'460':
+					'https://i.guim.co.uk/img/media/77eff3504946f87059c2736501e963b61ed39e80/0_524_3005_1803/master/3005.jpg?width=460&quality=85&auto=format&fit=max&s=cbed50d88f6da89610d238ad29ad0b89',
+			},
+			isLiveBlog: false,
+			pillar: 'culture',
+			designType: 'Review',
+			format: {
+				design: 'ReviewDesign',
+				theme: 'CulturePillar',
+				display: 'StandardDisplay',
+			},
+			webPublicationDate: '2021-04-02T21:00:19.000Z',
+			headline: 'Churchill review – the character behind the caricature',
+			shortUrl: 'https://www.theguardian.com/p/hvfn6',
+			starRating: 3,
+		},
+		{
+			url:
+				'https://www.theguardian.com/tv-and-radio/2021/apr/01/pandemic-2020-review-a-masterly-mapping-of-the-covid-outbreak',
+			linkText:
+				'Pandemic 2020 review – a masterly mapping of the Covid outbreak',
+			showByline: false,
+			byline: 'Lucy Mangan',
+			image:
+				'https://i.guim.co.uk/img/media/cb947ff5f7d70004e3c560a0dfe9831322502ced/0_263_6667_4000/master/6667.jpg?width=300&quality=85&auto=format&fit=max&s=9c961f57939799740fc2f7d0b4a8d172',
+			carouselImages: {
+				'300':
+					'https://i.guim.co.uk/img/media/cb947ff5f7d70004e3c560a0dfe9831322502ced/0_263_6667_4000/master/6667.jpg?width=300&quality=85&auto=format&fit=max&s=9c961f57939799740fc2f7d0b4a8d172',
+				'460':
+					'https://i.guim.co.uk/img/media/cb947ff5f7d70004e3c560a0dfe9831322502ced/0_263_6667_4000/master/6667.jpg?width=460&quality=85&auto=format&fit=max&s=7bbb903b1c08c8db868686b536968439',
+			},
+			isLiveBlog: false,
+			pillar: 'culture',
+			designType: 'Review',
+			format: {
+				design: 'ReviewDesign',
+				theme: 'CulturePillar',
+				display: 'StandardDisplay',
+			},
+			webPublicationDate: '2021-04-01T21:00:50.000Z',
+			headline:
+				'Pandemic 2020 review – a masterly mapping of the Covid outbreak',
+			shortUrl: 'https://www.theguardian.com/p/hv2cz',
 			starRating: 4,
 		},
 		{
 			url:
-				'https://www.theguardian.com/tv-and-radio/2021/mar/17/genius-aretha-franklin-review-clunky-franklin-biopic-needs-more-respect',
+				'https://www.theguardian.com/tv-and-radio/2021/apr/01/worn-stories-review-netflix',
 			linkText:
-				'Genius: Aretha review – clunky Franklin biopic needs more respect',
+				'Worn Stories review – a well spun yarn about the clothes that define us',
 			showByline: false,
-			byline: 'Beatrice Loayza',
+			byline: 'Lucy Mangan',
 			image:
-				'https://i.guim.co.uk/img/media/75a5ef54c93385d77cf73885afac1e6cc5fb6b40/0_86_6000_3602/master/6000.jpg?width=300&quality=85&auto=format&fit=max&s=ffd8a1656e8cd9312004fecb6561f502',
+				'https://i.guim.co.uk/img/media/67b3c244155e00d2baf96bfeec99456b9d58de7a/390_150_2932_1760/master/2932.jpg?width=300&quality=85&auto=format&fit=max&s=4ffaa59ce7b494d28b17924837315bbc',
 			carouselImages: {
 				'300':
-					'https://i.guim.co.uk/img/media/75a5ef54c93385d77cf73885afac1e6cc5fb6b40/0_86_6000_3602/master/6000.jpg?width=300&quality=85&auto=format&fit=max&s=ffd8a1656e8cd9312004fecb6561f502',
+					'https://i.guim.co.uk/img/media/67b3c244155e00d2baf96bfeec99456b9d58de7a/390_150_2932_1760/master/2932.jpg?width=300&quality=85&auto=format&fit=max&s=4ffaa59ce7b494d28b17924837315bbc',
 				'460':
-					'https://i.guim.co.uk/img/media/75a5ef54c93385d77cf73885afac1e6cc5fb6b40/0_86_6000_3602/master/6000.jpg?width=460&quality=85&auto=format&fit=max&s=5bbfcaed478dc2ac568ce33d4c543fc2',
+					'https://i.guim.co.uk/img/media/67b3c244155e00d2baf96bfeec99456b9d58de7a/390_150_2932_1760/master/2932.jpg?width=460&quality=85&auto=format&fit=max&s=eb1aab206db9d5af4129e1e08ea6fe3e',
 			},
 			isLiveBlog: false,
 			pillar: 'culture',
@@ -302,11 +155,156 @@ export const series = {
 				theme: 'CulturePillar',
 				display: 'StandardDisplay',
 			},
-			webPublicationDate: '2021-03-17T13:30:55.000Z',
+			webPublicationDate: '2021-04-01T07:00:06.000Z',
 			headline:
-				'Genius: Aretha review – clunky Franklin biopic needs more respect',
-			shortUrl: 'https://www.theguardian.com/p/gmqph',
-			starRating: 2,
+				'Worn Stories review – a well spun yarn about the clothes that define us',
+			shortUrl: 'https://www.theguardian.com/p/gqqqm',
+			starRating: 4,
+		},
+		{
+			url:
+				'https://www.theguardian.com/tv-and-radio/2021/mar/31/made-for-love-review-black-mirror-esque-comedy',
+			linkText:
+				'Made for Love review – Black Mirror-esque comedy needs an upgrade',
+			showByline: false,
+			byline: 'Benjamin Lee',
+			image:
+				'https://i.guim.co.uk/img/media/1c52668ee74dec11237adaa82370d92661ec1714/0_3_1920_1152/master/1920.jpg?width=300&quality=85&auto=format&fit=max&s=e176b1d77d05e8138bb228212e1b635b',
+			carouselImages: {
+				'300':
+					'https://i.guim.co.uk/img/media/1c52668ee74dec11237adaa82370d92661ec1714/0_3_1920_1152/master/1920.jpg?width=300&quality=85&auto=format&fit=max&s=e176b1d77d05e8138bb228212e1b635b',
+				'460':
+					'https://i.guim.co.uk/img/media/1c52668ee74dec11237adaa82370d92661ec1714/0_3_1920_1152/master/1920.jpg?width=460&quality=85&auto=format&fit=max&s=5d821c2496a99cb78ae3db1dc93b1ac8',
+			},
+			isLiveBlog: false,
+			pillar: 'culture',
+			designType: 'Review',
+			format: {
+				design: 'ReviewDesign',
+				theme: 'CulturePillar',
+				display: 'StandardDisplay',
+			},
+			webPublicationDate: '2021-03-31T21:25:59.000Z',
+			headline:
+				'Made for Love review – Black Mirror-esque comedy needs an upgrade',
+			shortUrl: 'https://www.theguardian.com/p/gqmdp',
+			starRating: 3,
+		},
+		{
+			url:
+				'https://www.theguardian.com/tv-and-radio/2021/mar/30/the-syndicate-review-a-triumphant-return-for-the-witty-lottery-drama',
+			linkText:
+				'The Syndicate review – a triumphant return for the witty lottery drama ',
+			showByline: false,
+			byline: 'Rebecca Nicholson',
+			image:
+				'https://i.guim.co.uk/img/media/a9d5fc2405357cf108348d928ec9de2007925219/0_0_4285_2571/master/4285.jpg?width=300&quality=85&auto=format&fit=max&s=19d390878b6249440cada02b9be14ee1',
+			carouselImages: {
+				'300':
+					'https://i.guim.co.uk/img/media/a9d5fc2405357cf108348d928ec9de2007925219/0_0_4285_2571/master/4285.jpg?width=300&quality=85&auto=format&fit=max&s=19d390878b6249440cada02b9be14ee1',
+				'460':
+					'https://i.guim.co.uk/img/media/a9d5fc2405357cf108348d928ec9de2007925219/0_0_4285_2571/master/4285.jpg?width=460&quality=85&auto=format&fit=max&s=26029c16bdf76be935f6dc2c3660aa66',
+			},
+			isLiveBlog: false,
+			pillar: 'culture',
+			designType: 'Review',
+			format: {
+				design: 'ReviewDesign',
+				theme: 'CulturePillar',
+				display: 'StandardDisplay',
+			},
+			webPublicationDate: '2021-03-30T21:00:53.000Z',
+			headline:
+				'The Syndicate review – a triumphant return for the witty lottery drama ',
+			shortUrl: 'https://www.theguardian.com/p/gqj2q',
+			starRating: 4,
+		},
+		{
+			url:
+				'https://www.theguardian.com/tv-and-radio/2021/mar/29/finding-jack-charlton-review-how-an-englishman-became-an-irish-hero',
+			linkText:
+				'Finding Jack Charlton review – how an Englishman became an Irish hero',
+			showByline: false,
+			byline: 'Stuart Jeffries',
+			image:
+				'https://i.guim.co.uk/img/media/3b111028b051b9891770d8817382bb3a7219ed6d/0_164_3010_1806/master/3010.jpg?width=300&quality=85&auto=format&fit=max&s=d545c060f97c07eef1e460025b82cf2f',
+			carouselImages: {
+				'300':
+					'https://i.guim.co.uk/img/media/3b111028b051b9891770d8817382bb3a7219ed6d/0_164_3010_1806/master/3010.jpg?width=300&quality=85&auto=format&fit=max&s=d545c060f97c07eef1e460025b82cf2f',
+				'460':
+					'https://i.guim.co.uk/img/media/3b111028b051b9891770d8817382bb3a7219ed6d/0_164_3010_1806/master/3010.jpg?width=460&quality=85&auto=format&fit=max&s=5227931bb1652cee7089589852f08347',
+			},
+			isLiveBlog: false,
+			pillar: 'culture',
+			designType: 'Review',
+			format: {
+				design: 'ReviewDesign',
+				theme: 'CulturePillar',
+				display: 'StandardDisplay',
+			},
+			webPublicationDate: '2021-03-29T21:40:24.000Z',
+			headline:
+				'Finding Jack Charlton review – how an Englishman became an Irish hero',
+			shortUrl: 'https://www.theguardian.com/p/gqbcj',
+			starRating: 4,
+		},
+		{
+			url:
+				'https://www.theguardian.com/tv-and-radio/2021/mar/28/tina-review-celebration-of-a-singer-who-is-simply-the-best',
+			linkText:
+				'Tina review – celebration of a singer who is simply the best',
+			showByline: false,
+			byline: 'Lucy Mangan',
+			image:
+				'https://i.guim.co.uk/img/media/2fa27750cd4e845f69b606af95635b56f7760ebc/1377_958_4831_2900/master/4831.jpg?width=300&quality=85&auto=format&fit=max&s=55669d46c43e80588d64a9ad7c9001e3',
+			carouselImages: {
+				'300':
+					'https://i.guim.co.uk/img/media/2fa27750cd4e845f69b606af95635b56f7760ebc/1377_958_4831_2900/master/4831.jpg?width=300&quality=85&auto=format&fit=max&s=55669d46c43e80588d64a9ad7c9001e3',
+				'460':
+					'https://i.guim.co.uk/img/media/2fa27750cd4e845f69b606af95635b56f7760ebc/1377_958_4831_2900/master/4831.jpg?width=460&quality=85&auto=format&fit=max&s=9f5f99c608b263a613a140a3a1ff1679',
+			},
+			isLiveBlog: false,
+			pillar: 'culture',
+			designType: 'Review',
+			format: {
+				design: 'ReviewDesign',
+				theme: 'CulturePillar',
+				display: 'StandardDisplay',
+			},
+			webPublicationDate: '2021-03-28T22:10:53.000Z',
+			headline:
+				'Tina review – celebration of a singer who is simply the best',
+			shortUrl: 'https://www.theguardian.com/p/gpa2n',
+			starRating: 3,
+		},
+		{
+			url:
+				'https://www.theguardian.com/tv-and-radio/2021/mar/26/hausen-grim-and-grimy-german-horror',
+			linkText:
+				'Hausen – grim and grimy German chiller casts a dark shadow',
+			showByline: false,
+			byline: 'Jack Seale',
+			image:
+				'https://i.guim.co.uk/img/media/89c0ca71f25e2a39bb9982748f9e98a0bc58c646/0_244_6048_3628/master/6048.jpg?width=300&quality=85&auto=format&fit=max&s=a1e7b2f3aa5e400e02fc9f4bd864d223',
+			carouselImages: {
+				'300':
+					'https://i.guim.co.uk/img/media/89c0ca71f25e2a39bb9982748f9e98a0bc58c646/0_244_6048_3628/master/6048.jpg?width=300&quality=85&auto=format&fit=max&s=a1e7b2f3aa5e400e02fc9f4bd864d223',
+				'460':
+					'https://i.guim.co.uk/img/media/89c0ca71f25e2a39bb9982748f9e98a0bc58c646/0_244_6048_3628/master/6048.jpg?width=460&quality=85&auto=format&fit=max&s=25296d821759e891684ba54278e68638',
+			},
+			isLiveBlog: false,
+			pillar: 'culture',
+			designType: 'Review',
+			format: {
+				design: 'ReviewDesign',
+				theme: 'CulturePillar',
+				display: 'StandardDisplay',
+			},
+			webPublicationDate: '2021-03-26T23:20:00.000Z',
+			headline:
+				'Hausen – grim and grimy German chiller casts a dark shadow',
+			shortUrl: 'https://www.theguardian.com/p/gpfza',
+			starRating: 3,
 		},
 	],
 };

--- a/fixtures/generated/story-package.ts
+++ b/fixtures/generated/story-package.ts
@@ -87,7 +87,7 @@ export const storyPackage = {
 				'460':
 					'https://i.guim.co.uk/img/media/5333924754eeb72e956aaa81a54d229f36b09b99/199_417_3159_1896/master/3159.jpg?width=460&quality=85&auto=format&fit=max&s=c7e1a84a64ebcee67a2478299a29e746',
 			},
-			ageWarning: '7 months',
+			ageWarning: '8 months',
 			isLiveBlog: false,
 			pillar: 'news',
 			designType: 'Article',
@@ -116,7 +116,7 @@ export const storyPackage = {
 				'460':
 					'https://i.guim.co.uk/img/media/df7b691328f658cdcd2f9153bd07344601ac895f/0_147_3500_2101/master/3500.jpg?width=460&quality=85&auto=format&fit=max&s=8f6bd3fe6064e6c60453337969917935',
 			},
-			ageWarning: '7 months',
+			ageWarning: '8 months',
 			isLiveBlog: false,
 			pillar: 'news',
 			designType: 'Article',

--- a/scripts/test-data/gen-fixtures.js
+++ b/scripts/test-data/gen-fixtures.js
@@ -63,6 +63,11 @@ const articles = [
 			'https://www.theguardian.com/commentisfree/2021/feb/03/the-guardian-view-on-quarantine-an-old-method-and-a-vital-one',
 	},
 	{
+		name: 'Letter',
+		url:
+			'https://www.theguardian.com/world/2021/apr/05/why-is-a-womans-work-never-done',
+	},
+	{
 		name: 'SpecialReport',
 		url:
 			'https://www.theguardian.com/environment/2019/oct/12/top-three-asset-managers-fossil-fuel-investments',

--- a/src/amp/components/BodyArticle.tsx
+++ b/src/amp/components/BodyArticle.tsx
@@ -43,6 +43,7 @@ const decideBackground = (design: Design, pillar: Theme): string => {
 	if (pillar === Special.Labs) return palette.neutral[86];
 	switch (design) {
 		case Design.Comment:
+		case Design.Letter:
 			return palette.opinion[800];
 		default:
 			return palette.neutral[100];

--- a/src/amp/components/topMeta/TopMeta.tsx
+++ b/src/amp/components/topMeta/TopMeta.tsx
@@ -17,6 +17,7 @@ export const TopMeta: React.FunctionComponent<{
 		return <TopMetaPaidContent articleData={data} pillar={pillar} />;
 	switch (design) {
 		case Design.Comment:
+		case Design.Letter:
 			return <TopMetaOpinion articleData={data} pillar={pillar} />;
 		default:
 			return (

--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -232,6 +232,7 @@ export const ArticleHeadline = ({
 					);
 				case Design.Comment:
 				case Design.Editorial:
+				case Design.Letter:
 					return (
 						<>
 							<h1
@@ -305,6 +306,7 @@ export const ArticleHeadline = ({
 					);
 				case Design.Comment:
 				case Design.Editorial:
+				case Design.Letter:
 					return (
 						<>
 							<h1

--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -306,7 +306,6 @@ export const ArticleHeadline = ({
 					);
 				case Design.Comment:
 				case Design.Editorial:
-				case Design.Letter:
 					return (
 						<>
 							<h1
@@ -326,6 +325,22 @@ export const ArticleHeadline = ({
 									tags={tags}
 								/>
 							)}
+						</>
+					);
+
+				case Design.Letter:
+					return (
+						<>
+							<h1
+								className={cx(
+									lightFont,
+									css`
+										color: ${palette.text.headline};
+									`,
+								)}
+							>
+								{curly(headlineString)}
+							</h1>
 						</>
 					);
 				case Design.Analysis:

--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -179,6 +179,7 @@ const shouldShowContributor = (format: Format) => {
 			switch (format.design) {
 				case Design.Comment:
 				case Design.Editorial:
+				case Design.Letter:
 					return false;
 				default:
 					return true;

--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -179,7 +179,6 @@ const shouldShowContributor = (format: Format) => {
 			switch (format.design) {
 				case Design.Comment:
 				case Design.Editorial:
-				case Design.Letter:
 					return false;
 				default:
 					return true;

--- a/src/web/components/Card/components/CardFooter.tsx
+++ b/src/web/components/Card/components/CardFooter.tsx
@@ -50,7 +50,9 @@ export const CardFooter = ({
 }: Props) => {
 	if (
 		!isFullCardImage &&
-		(format.design === Design.Comment || format.design === Design.Editorial)
+		(format.design === Design.Comment ||
+			format.design === Design.Editorial ||
+			format.design === Design.Letter)
 	) {
 		return (
 			<footer className={spaceBetween}>

--- a/src/web/components/Card/components/CardLink.tsx
+++ b/src/web/components/Card/components/CardLink.tsx
@@ -49,6 +49,7 @@ const linkStyles = (format: Format, palette: Palette) => {
 
 	switch (format.design) {
 		case Design.Editorial:
+		case Design.Letter:
 		case Design.Comment:
 			return css`
 				${baseLinkStyles};

--- a/src/web/components/DropCap.tsx
+++ b/src/web/components/DropCap.tsx
@@ -34,6 +34,7 @@ const innerStyles = (format: Format) => {
 
 	switch (format.design) {
 		case Design.Editorial:
+		case Design.Letter:
 		case Design.Comment:
 			return css`
 				${baseStyles};

--- a/src/web/components/HeadlineByline.tsx
+++ b/src/web/components/HeadlineByline.tsx
@@ -130,6 +130,7 @@ export const HeadlineByline = ({ format, byline, tags }: Props) => {
 						</div>
 					);
 				case Design.Editorial:
+				case Design.Letter:
 				case Design.Comment:
 					return (
 						<div

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterItem.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterItem.tsx
@@ -86,7 +86,10 @@ export const MostViewedFooterItem = ({ trail, position }: Props) => (
 						kickerText="Live"
 						showSlash={true}
 						showPulsingDot={true}
-						showQuotes={trail.format.design === Design.Comment}
+						showQuotes={
+							trail.format.design === Design.Comment ||
+							trail.format.design === Design.Letter
+						}
 					/>
 				) : (
 					<LinkHeadline
@@ -94,7 +97,10 @@ export const MostViewedFooterItem = ({ trail, position }: Props) => (
 						palette={trail.palette}
 						format={trail.format}
 						size="small"
-						showQuotes={trail.format.design === Design.Comment}
+						showQuotes={
+							trail.format.design === Design.Comment ||
+							trail.format.design === Design.Letter
+						}
 					/>
 				)}
 			</div>

--- a/src/web/components/Onwards/Carousel/Carousel.tsx
+++ b/src/web/components/Onwards/Carousel/Carousel.tsx
@@ -346,7 +346,10 @@ export const CarouselCard: React.FC<CarouselCardProps> = ({
 			alwaysVertical={true}
 			minWidthInPixels={220}
 			isFullCardImage={isFullCardImage}
-			showQuotes={format.design === Design.Comment}
+			showQuotes={
+				format.design === Design.Comment ||
+				format.design === Design.Letter
+			}
 			dataLinkName={dataLinkName}
 		/>
 	</LI>

--- a/src/web/components/Onwards/Carousel/cardColours.tsx
+++ b/src/web/components/Onwards/Carousel/cardColours.tsx
@@ -6,6 +6,7 @@ import { pillarPalette } from '@frontend/lib/pillars';
 export const headlineBackgroundColour = (design: Design, pillar: Theme) => {
 	switch (design) {
 		case Design.Editorial:
+		case Design.Letter:
 		case Design.Comment:
 			return css`
 				background-color: ${opinion[800]};

--- a/src/web/components/Onwards/ExactlyFive.tsx
+++ b/src/web/components/Onwards/ExactlyFive.tsx
@@ -22,7 +22,10 @@ export const ExactlyFive = ({ content }: Props) => (
 					headlineSize="medium"
 					byline={content[0].byline}
 					showByline={content[0].showByline}
-					showQuotes={content[0].format.design === Design.Comment}
+					showQuotes={
+						content[0].format.design === Design.Comment ||
+						content[0].format.design === Design.Letter
+					}
 					webPublicationDate={content[0].webPublicationDate}
 					kickerText={content[0].kickerText}
 					showPulsingDot={content[0].isLiveBlog}
@@ -48,7 +51,10 @@ export const ExactlyFive = ({ content }: Props) => (
 					headlineSize="medium"
 					byline={content[1].byline}
 					showByline={content[1].showByline}
-					showQuotes={content[1].format.design === Design.Comment}
+					showQuotes={
+						content[1].format.design === Design.Comment ||
+						content[1].format.design === Design.Letter
+					}
 					webPublicationDate={content[1].webPublicationDate}
 					kickerText={content[1].kickerText}
 					showPulsingDot={content[1].isLiveBlog}
@@ -77,7 +83,8 @@ export const ExactlyFive = ({ content }: Props) => (
 							byline={content[2].byline}
 							showByline={content[2].showByline}
 							showQuotes={
-								content[2].format.design === Design.Comment
+								content[2].format.design === Design.Comment ||
+								content[2].format.design === Design.Letter
 							}
 							webPublicationDate={content[2].webPublicationDate}
 							kickerText={content[2].kickerText}
@@ -99,7 +106,8 @@ export const ExactlyFive = ({ content }: Props) => (
 							byline={content[3].byline}
 							showByline={content[3].showByline}
 							showQuotes={
-								content[3].format.design === Design.Comment
+								content[3].format.design === Design.Comment ||
+								content[3].format.design === Design.Letter
 							}
 							webPublicationDate={content[3].webPublicationDate}
 							kickerText={content[3].kickerText}
@@ -121,7 +129,8 @@ export const ExactlyFive = ({ content }: Props) => (
 							byline={content[4].byline}
 							showByline={content[4].showByline}
 							showQuotes={
-								content[4].format.design === Design.Comment
+								content[4].format.design === Design.Comment ||
+								content[4].format.design === Design.Letter
 							}
 							webPublicationDate={content[4].webPublicationDate}
 							kickerText={content[4].kickerText}

--- a/src/web/components/Onwards/FourOrLess.tsx
+++ b/src/web/components/Onwards/FourOrLess.tsx
@@ -45,7 +45,10 @@ export const FourOrLess = ({ content }: Props) => {
 							headlineSize="medium"
 							byline={trail.byline}
 							showByline={trail.showByline}
-							showQuotes={trail.format.design === Design.Comment}
+							showQuotes={
+								trail.format.design === Design.Comment ||
+								trail.format.design === Design.Letter
+							}
 							webPublicationDate={trail.webPublicationDate}
 							kickerText={trail.kickerText}
 							showPulsingDot={trail.isLiveBlog}

--- a/src/web/components/Onwards/MoreThanFive.tsx
+++ b/src/web/components/Onwards/MoreThanFive.tsx
@@ -39,7 +39,10 @@ export const MoreThanFive = ({ content }: Props) => {
 						headlineSize="medium"
 						byline={content[0].byline}
 						showByline={content[0].showByline}
-						showQuotes={content[0].format.design === Design.Comment}
+						showQuotes={
+							content[0].format.design === Design.Comment ||
+							content[0].format.design === Design.Letter
+						}
 						webPublicationDate={content[0].webPublicationDate}
 						kickerText={content[0].kickerText}
 						showPulsingDot={content[0].isLiveBlog}
@@ -65,7 +68,10 @@ export const MoreThanFive = ({ content }: Props) => {
 						headlineSize="medium"
 						byline={content[1].byline}
 						showByline={content[1].showByline}
-						showQuotes={content[1].format.design === Design.Comment}
+						showQuotes={
+							content[1].format.design === Design.Comment ||
+							content[1].format.design === Design.Letter
+						}
 						webPublicationDate={content[1].webPublicationDate}
 						kickerText={content[1].kickerText}
 						showPulsingDot={content[1].isLiveBlog}
@@ -91,7 +97,10 @@ export const MoreThanFive = ({ content }: Props) => {
 						headlineSize="medium"
 						byline={content[2].byline}
 						showByline={content[2].showByline}
-						showQuotes={content[2].format.design === Design.Comment}
+						showQuotes={
+							content[2].format.design === Design.Comment ||
+							content[2].format.design === Design.Letter
+						}
 						webPublicationDate={content[2].webPublicationDate}
 						kickerText={content[2].kickerText}
 						showPulsingDot={content[2].isLiveBlog}
@@ -117,7 +126,10 @@ export const MoreThanFive = ({ content }: Props) => {
 						headlineSize="medium"
 						byline={content[3].byline}
 						showByline={content[3].showByline}
-						showQuotes={content[3].format.design === Design.Comment}
+						showQuotes={
+							content[3].format.design === Design.Comment ||
+							content[3].format.design === Design.Letter
+						}
 						webPublicationDate={content[3].webPublicationDate}
 						kickerText={content[3].kickerText}
 						showPulsingDot={content[3].isLiveBlog}
@@ -150,7 +162,10 @@ export const MoreThanFive = ({ content }: Props) => {
 							}
 							byline={trail.byline}
 							showByline={trail.showByline}
-							showQuotes={trail.format.design === Design.Comment}
+							showQuotes={
+								trail.format.design === Design.Comment ||
+								trail.format.design === Design.Letter
+							}
 							webPublicationDate={trail.webPublicationDate}
 							kickerText={trail.kickerText}
 							showPulsingDot={trail.isLiveBlog}

--- a/src/web/components/Onwards/Spotlight.tsx
+++ b/src/web/components/Onwards/Spotlight.tsx
@@ -17,7 +17,10 @@ export const Spotlight = ({ content }: Props) => (
 		headlineSize="large"
 		byline={content[0].byline}
 		showByline={content[0].showByline}
-		showQuotes={content[0].format.design === Design.Comment}
+		showQuotes={
+			content[0].format.design === Design.Comment ||
+			content[0].format.design === Design.Letter
+		}
 		webPublicationDate={content[0].webPublicationDate}
 		kickerText={content[0].kickerText}
 		showPulsingDot={content[0].isLiveBlog}

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -148,7 +148,8 @@ export const SeriesSectionLink = ({
 		case Display.Immersive: {
 			switch (format.design) {
 				case Design.Comment:
-				case Design.Editorial: {
+				case Design.Editorial:
+				case Design.Letter: {
 					if (tag) {
 						// We have a tag, we're not immersive, show both series and section titles
 						return (

--- a/src/web/components/Standfirst.tsx
+++ b/src/web/components/Standfirst.tsx
@@ -99,6 +99,7 @@ const standfirstStyles = (format: Format, palette: Palette) => {
 			switch (format.design) {
 				case Design.Comment:
 				case Design.Editorial:
+				case Design.Letter:
 				case Design.Feature:
 				case Design.Recipe:
 				case Design.Review:

--- a/src/web/components/elements/PullQuoteBlockComponent.tsx
+++ b/src/web/components/elements/PullQuoteBlockComponent.tsx
@@ -123,6 +123,7 @@ export const PullQuoteBlockComponent: React.FC<{
 	if (!html) return <></>;
 	switch (design) {
 		case Design.Editorial:
+		case Design.Letter:
 		case Design.Comment:
 			return (
 				<aside

--- a/src/web/layouts/DecideLayout.tsx
+++ b/src/web/layouts/DecideLayout.tsx
@@ -46,6 +46,7 @@ export const DecideLayout = ({ CAPI, NAV }: Props): JSX.Element => {
 			switch (design) {
 				case Design.Comment:
 				case Design.Editorial:
+				case Design.Letter:
 					return (
 						<ImmersiveLayout
 							CAPI={CAPI}
@@ -79,6 +80,7 @@ export const DecideLayout = ({ CAPI, NAV }: Props): JSX.Element => {
 					);
 				case Design.Comment:
 				case Design.Editorial:
+				case Design.Letter:
 					return (
 						<CommentLayout
 							CAPI={CAPI}
@@ -113,6 +115,7 @@ export const DecideLayout = ({ CAPI, NAV }: Props): JSX.Element => {
 					);
 				case Design.Comment:
 				case Design.Editorial:
+				case Design.Letter:
 					return (
 						<CommentLayout
 							CAPI={CAPI}

--- a/src/web/layouts/Immersive.stories.tsx
+++ b/src/web/layouts/Immersive.stories.tsx
@@ -13,6 +13,7 @@ import { Analysis } from '@root/fixtures/generated/articles/Analysis';
 import { Feature } from '@root/fixtures/generated/articles/Feature';
 import { Live } from '@root/fixtures/generated/articles/Live';
 import { Editorial } from '@root/fixtures/generated/articles/Editorial';
+import { Letter } from '@root/fixtures/generated/articles/Letter';
 import { SpecialReport } from '@root/fixtures/generated/articles/SpecialReport';
 import { Interview } from '@root/fixtures/generated/articles/Interview';
 import { Quiz } from '@root/fixtures/generated/articles/Quiz';
@@ -183,16 +184,24 @@ export const DeadStory = (): React.ReactNode => {
 };
 DeadStory.story = { name: 'DeadBlog' };
 
-export const GEditorialStory = (): React.ReactNode => {
+export const EditorialStory = (): React.ReactNode => {
 	const ServerCAPI = convertToImmersive(Editorial);
 	return <HydratedLayout ServerCAPI={ServerCAPI} />;
 };
-GEditorialStory.story = {
+EditorialStory.story = {
 	name: 'Editorial',
 	parameters: {
 		viewport: { defaultViewport: 'leftCol' },
 		chromatic: { viewports: [1140] },
 	},
+};
+
+export const LetterStory = (): React.ReactNode => {
+	const ServerCAPI = convertToImmersive(Letter);
+	return <HydratedLayout ServerCAPI={ServerCAPI} />;
+};
+LetterStory.story = {
+	name: 'Letter',
 };
 
 export const InterviewStory = (): React.ReactNode => {

--- a/src/web/layouts/Showcase.stories.tsx
+++ b/src/web/layouts/Showcase.stories.tsx
@@ -11,6 +11,7 @@ import { Analysis } from '@root/fixtures/generated/articles/Analysis';
 import { Feature } from '@root/fixtures/generated/articles/Feature';
 import { Live } from '@root/fixtures/generated/articles/Live';
 import { Editorial } from '@root/fixtures/generated/articles/Editorial';
+import { Letter } from '@root/fixtures/generated/articles/Letter';
 import { Interview } from '@root/fixtures/generated/articles/Interview';
 import { Quiz } from '@root/fixtures/generated/articles/Quiz';
 import { Recipe } from '@root/fixtures/generated/articles/Recipe';
@@ -128,6 +129,12 @@ export const EditorialStory = (): React.ReactNode => {
 	return <HydratedLayout ServerCAPI={ServerCAPI} />;
 };
 EditorialStory.story = { name: 'Editorial' };
+
+export const LetterStory = (): React.ReactNode => {
+	const ServerCAPI = convertToShowcase(Letter);
+	return <HydratedLayout ServerCAPI={ServerCAPI} />;
+};
+LetterStory.story = { name: 'Letter' };
 
 export const InterviewStory = (): React.ReactNode => {
 	const ServerCAPI = convertToShowcase(Interview);

--- a/src/web/layouts/Standard.stories.tsx
+++ b/src/web/layouts/Standard.stories.tsx
@@ -12,6 +12,7 @@ import { Analysis } from '@root/fixtures/generated/articles/Analysis';
 import { Feature } from '@root/fixtures/generated/articles/Feature';
 import { Live } from '@root/fixtures/generated/articles/Live';
 import { Editorial } from '@root/fixtures/generated/articles/Editorial';
+import { Letter } from '@root/fixtures/generated/articles/Letter';
 import { Interview } from '@root/fixtures/generated/articles/Interview';
 import { Quiz } from '@root/fixtures/generated/articles/Quiz';
 import { Recipe } from '@root/fixtures/generated/articles/Recipe';
@@ -156,6 +157,14 @@ EditorialStory.story = {
 		viewport: { defaultViewport: 'phablet' },
 		chromatic: { viewports: [660] },
 	},
+};
+
+export const LetterStory = (): React.ReactNode => {
+	const ServerCAPI = convertToStandard(Letter);
+	return <HydratedLayout ServerCAPI={ServerCAPI} />;
+};
+LetterStory.story = {
+	name: 'Letter',
 };
 
 export const InterviewStory = (): React.ReactNode => {

--- a/src/web/lib/decideDesign.ts
+++ b/src/web/lib/decideDesign.ts
@@ -12,8 +12,9 @@ export const decideDesign = (format: CAPIFormat): Design => {
 		case 'AnalysisDesign':
 			return Design.Analysis;
 		case 'CommentDesign':
-		case 'LetterDesign':
 			return Design.Comment;
+		case 'LetterDesign':
+			return Design.Letter;
 		case 'FeatureDesign':
 			return Design.Feature;
 		case 'LiveBlogDesign':

--- a/src/web/lib/decidePalette.ts
+++ b/src/web/lib/decidePalette.ts
@@ -246,7 +246,7 @@ const textCardStandfirst = textCardHeadline;
 const textCardKicker = (format: Format): string => {
 	if (
 		format.theme === Special.SpecialReport &&
-		format.design === Design.Comment
+		(format.design === Design.Comment || format.design === Design.Letter)
 	)
 		// TODO: Pull this in from source as opinion[550]
 		// https://theguardian.design/2a1e5182b/p/492a30-light-palette
@@ -294,6 +294,7 @@ const textCardKicker = (format: Format): string => {
 const textCardFooter = (format: Format): string => {
 	switch (format.design) {
 		case Design.Comment:
+		case Design.Letter:
 			switch (format.theme) {
 				case Special.SpecialReport:
 					// TODO: Pull this in from souce once we see it here:
@@ -355,6 +356,7 @@ const backgroundArticle = (format: Format): string => {
 	if (format.design === Design.LiveBlog || format.design === Design.DeadBlog)
 		return neutral[93];
 	// Order matters. We want comment special report pieces to have the opinion background
+	if (format.design === Design.Letter) return opinion[800];
 	if (format.design === Design.Comment) return opinion[800];
 	if (format.design === Design.Editorial) return opinion[800];
 	if (format.theme === Special.SpecialReport) return specialReport[800]; // Note, check theme rather than design here
@@ -401,6 +403,7 @@ const backgroundCard = (format: Format): string => {
 	if (format.theme === Special.SpecialReport) return specialReport[300];
 	switch (format.design) {
 		case Design.Editorial:
+		case Design.Letter:
 		case Design.Comment:
 			return opinion[800];
 		case Design.Media:
@@ -503,6 +506,7 @@ const fillCardIcon = (format: Format): string => {
 	if (format.display === Display.Immersive) return neutral[60];
 	switch (format.design) {
 		case Design.Comment:
+		case Design.Letter:
 			switch (format.theme) {
 				case Special.SpecialReport:
 					// TODO: Pull this in from source once we see it here:
@@ -678,6 +682,7 @@ const textCalloutHeading = (): string => {
 const textDropCap = (format: Format): string => {
 	switch (format.design) {
 		case Design.Editorial:
+		case Design.Letter:
 		case Design.Comment:
 			return format.theme === Pillar.Opinion
 				? opinion[400]


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds support for `Design.Letter` to DCR

### Before
![Screenshot 2021-04-06 at 11 58 37](https://user-images.githubusercontent.com/1336821/113700995-762d2980-96cf-11eb-9dee-56f39312308d.jpg)


### After
![Screenshot 2021-04-06 at 11 56 17](https://user-images.githubusercontent.com/1336821/113700932-5990f180-96cf-11eb-9604-6a4b043fd239.jpg)


## Why?
We were passing this value in as part of `format` but DCR didn't have any code to handle it. To get around this, we forced the value to be `Design.Comment`, which was similar, but not quite the same. By adding the display logic we allow full support.
