### PR TITLE
useDiscussion (again)

### DIFF
--- a/cypress/integration/parallel-5/discussion.spec.js
+++ b/cypress/integration/parallel-5/discussion.spec.js
@@ -26,13 +26,13 @@ describe('Discussion', function () {
 		cy.contains(/comments \(\d*\)/);
 	});
 
-	// it('should expand the comments when the view more button is clicked', function () {
-	//     cy.visit(`/Article?url=${articleUrl}`);
-	//     const roughLoadPositionOfComments = 4000;
-	//     cy.scrollTo(0, roughLoadPositionOfComments, { duration: 500 });
-	//     cy.contains('View more comments').click();
-	//     cy.contains('Displaying threads');
-	// });
+	it('should expand the comments when the view more button is clicked', function () {
+		cy.visit(`/Article?url=${articleUrl}`);
+		const roughLoadPositionOfComments = 4000;
+		cy.scrollTo(0, roughLoadPositionOfComments, { duration: 500 });
+		cy.contains('View more comments').click();
+		cy.contains('Displaying threads');
+	});
 
 	it('should automatically expand and scroll to a comment if the reader loads a permalink', function () {
 		cy.visit(`/Article?url=${permalink}`);

--- a/src/web/components/Discussion.tsx
+++ b/src/web/components/Discussion.tsx
@@ -14,8 +14,9 @@ import { Flex } from '@frontend/web/components/Flex';
 import { SignedInAs } from '@frontend/web/components/SignedInAs';
 import { ContainerLayout } from '@frontend/web/components/ContainerLayout';
 import { Hide } from '@frontend/web/components/Hide';
-import { getDiscussion } from '@root/src/web/lib/getDiscussion';
 import { getCommentContext } from '@root/src/web/lib/getCommentContext';
+import { joinUrl } from '@root/src/lib/joinUrl';
+import { useDiscussion } from '@root/src/web/lib/useDiscussion';
 import { Display } from '@guardian/types';
 
 type Props = {
@@ -71,10 +72,6 @@ export const Discussion = ({
 	beingHydrated,
 	display,
 }: Props) => {
-	const [commentCount, setCommentCount] = useState<number>();
-	const [isClosedForComments, setIsClosedForComments] = useState<boolean>(
-		true,
-	);
 	const [commentPage, setCommentPage] = useState<number>();
 	const [commentPageSize, setCommentPageSize] = useState<25 | 50 | 100>();
 	const [commentOrderBy, setCommentOrderBy] = useState<
@@ -84,6 +81,11 @@ export const Discussion = ({
 	const [hashCommentId, setHashCommentId] = useState<number | undefined>(
 		commentIdFromUrl(),
 	);
+
+	const { commentCount, isClosedForComments } = useDiscussion(
+		joinUrl([discussionApiUrl, 'discussion', shortUrlId]),
+	);
+
 	const hasCommentsHash =
 		typeof window !== 'undefined' &&
 		window.location &&
@@ -115,20 +117,6 @@ export const Discussion = ({
 			nonInteraction: true,
 		});
 	};
-
-	useEffect(() => {
-		const callFetch = async () => {
-			const response = await getDiscussion(discussionApiUrl, shortUrlId);
-			setCommentCount(response && response.discussion.commentCount);
-			setIsClosedForComments(
-				response && response.discussion.isClosedForComments,
-			);
-		};
-
-		if (isCommentable) {
-			callFetch().catch((e) => console.error(`callFetch - error: ${e}`));
-		}
-	}, [discussionApiUrl, shortUrlId, isCommentable]);
 
 	// Check the url to see if there is a comment hash, e.g. ...crisis#comment-139113120
 	// If so, make a call to get the context of this comment so we know what page it is

--- a/src/web/lib/useDiscussion.ts
+++ b/src/web/lib/useDiscussion.ts
@@ -61,6 +61,6 @@ export const useDiscussion = (url: string) => {
 
 	return {
 		commentCount: data?.discussion?.commentCount,
-		isClosedForComments: data?.discussion?.isClosedForComments || true,
+		isClosedForComments: data?.discussion?.isClosedForComments,
 	};
 };

--- a/src/web/lib/useDiscussion.ts
+++ b/src/web/lib/useDiscussion.ts
@@ -56,7 +56,7 @@ export const useDiscussion = (url: string) => {
 	if (loading || error)
 		return {
 			commentCount: undefined,
-			isClosedForComments: true,
+			isClosedForComments: undefined,
 		};
 
 	return {

--- a/src/web/lib/useDiscussion.ts
+++ b/src/web/lib/useDiscussion.ts
@@ -1,4 +1,4 @@
-import { joinUrl } from '@root/src/lib/joinUrl';
+import { useApi } from '@root/src/web/lib/api';
 
 type DiscussionResponse = {
 	status: string;
@@ -50,24 +50,17 @@ type CommentType = {
 	};
 };
 
-export const getDiscussion = async (
-	ajaxUrl: string,
-	shortUrl: string,
-): Promise<DiscussionResponse> => {
-	const url = joinUrl([ajaxUrl, 'discussion', shortUrl]);
-	return fetch(url)
-		.then((response) => {
-			if (!response.ok) {
-				throw Error(
-					response.statusText ||
-						`getDiscussion | An api call returned HTTP status ${response.status}`,
-				);
-			}
-			return response;
-		})
-		.then((response) => response.json())
-		.then((json) => json)
-		.catch((error) => {
-			window.guardian.modules.sentry.reportError(error, 'get-discussion');
-		});
+export const useDiscussion = (url: string) => {
+	const { data, loading, error } = useApi<DiscussionResponse>(url);
+
+	if (loading || error)
+		return {
+			commentCount: undefined,
+			isClosedForComments: true,
+		};
+
+	return {
+		commentCount: data?.discussion?.commentCount,
+		isClosedForComments: data?.discussion?.isClosedForComments || true,
+	};
 };

--- a/src/web/lib/useDiscussion.ts
+++ b/src/web/lib/useDiscussion.ts
@@ -51,13 +51,7 @@ type CommentType = {
 };
 
 export const useDiscussion = (url: string) => {
-	const { data, loading, error } = useApi<DiscussionResponse>(url);
-
-	if (loading || error)
-		return {
-			commentCount: undefined,
-			isClosedForComments: undefined,
-		};
+	const { data } = useApi<DiscussionResponse>(url);
 
 	return {
 		commentCount: data?.discussion?.commentCount,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

This PR reverts [the revert](https://github.com/guardian/dotcom-rendering/pull/2787) to again reintroduce `useDiscussion` as a custom hook.

Original PR: https://github.com/guardian/dotcom-rendering/pull/2782

The difference here is we no longer return `true` if `isClosedForComments` is `false`

### Re-enabled Cypress test
Something of a drive-by change, I re-enabled a disabled Cypress test. I was trying to add more testing coverage but in the end I got blocked by restrictions with the identity api (not allowing logins from localhost) but this test does now seem to work and so I optimistically left it in.
