### PR TITLE
CommentCount: `...`

### DIFF
--- a/cypress/integration/parallel-5/discussion.spec.js
+++ b/cypress/integration/parallel-5/discussion.spec.js
@@ -26,13 +26,13 @@ describe('Discussion', function () {
 		cy.contains(/comments \(\d*\)/);
 	});
 
-	// it('should expand the comments when the view more button is clicked', function () {
-	//     cy.visit(`/Article?url=${articleUrl}`);
-	//     const roughLoadPositionOfComments = 4000;
-	//     cy.scrollTo(0, roughLoadPositionOfComments, { duration: 500 });
-	//     cy.contains('View more comments').click();
-	//     cy.contains('Displaying threads');
-	// });
+	it('should expand the comments when the view more button is clicked', function () {
+		cy.visit(`/Article?url=${articleUrl}`);
+		const roughLoadPositionOfComments = 4000;
+		cy.scrollTo(0, roughLoadPositionOfComments, { duration: 500 });
+		cy.contains('View more comments').click();
+		cy.contains('Displaying threads');
+	});
 
 	it('should automatically expand and scroll to a comment if the reader loads a permalink', function () {
 		cy.visit(`/Article?url=${permalink}`);

--- a/src/web/components/CommentCount.stories.tsx
+++ b/src/web/components/CommentCount.stories.tsx
@@ -83,3 +83,50 @@ export const LargeNumber = () => {
 	);
 };
 LargeNumber.story = { name: 'with a large number' };
+
+export const Zero = () => {
+	return (
+		<div
+			className={css`
+				display: flex;
+				flex-direction: row;
+				align-items: flex-start;
+			`}
+		>
+			<CommentCount
+				isCommentable={true}
+				setIsExpanded={() => {}}
+				commentCount={0}
+				palette={decidePalette({
+					theme: Pillar.Opinion,
+					display: Display.Standard,
+					design: Design.Article,
+				})}
+			/>
+		</div>
+	);
+};
+Zero.story = { name: 'with zero comments' };
+
+export const Undefined = () => {
+	return (
+		<div
+			className={css`
+				display: flex;
+				flex-direction: row;
+				align-items: flex-start;
+			`}
+		>
+			<CommentCount
+				isCommentable={true}
+				setIsExpanded={() => {}}
+				palette={decidePalette({
+					theme: Pillar.Opinion,
+					display: Display.Standard,
+					design: Design.Article,
+				})}
+			/>
+		</div>
+	);
+};
+Undefined.story = { name: 'with count undefined' };

--- a/src/web/components/CommentCount.test.tsx
+++ b/src/web/components/CommentCount.test.tsx
@@ -91,7 +91,7 @@ describe('CommentCount', () => {
 			/>,
 		);
 
-		expect(getByTestId('long-comment-count').innerHTML).toBe('...');
-		expect(getByTestId('short-comment-count').innerHTML).toBe('...');
+		expect(getByTestId('long-comment-count').innerHTML).toBe('…');
+		expect(getByTestId('short-comment-count').innerHTML).toBe('…');
 	});
 });

--- a/src/web/components/CommentCount.test.tsx
+++ b/src/web/components/CommentCount.test.tsx
@@ -60,7 +60,7 @@ describe('CommentCount', () => {
 		expect(getByTestId('short-comment-count').innerHTML).toBe('93k');
 	});
 
-	it('It should still render zero even when there are no comments', () => {
+	it('It should render 0 when there are zero comments', () => {
 		const { getByTestId } = render(
 			<CommentCount
 				isCommentable={true}
@@ -76,5 +76,22 @@ describe('CommentCount', () => {
 
 		expect(getByTestId('long-comment-count').innerHTML).toBe('0');
 		expect(getByTestId('short-comment-count').innerHTML).toBe('0');
+	});
+
+	it('It should render an elipsis when the comment count is not defined', () => {
+		const { getByTestId } = render(
+			<CommentCount
+				isCommentable={true}
+				palette={decidePalette({
+					theme: Pillar.News,
+					design: Design.Article,
+					display: Display.Standard,
+				})}
+				setIsExpanded={() => {}}
+			/>,
+		);
+
+		expect(getByTestId('long-comment-count').innerHTML).toBe('...');
+		expect(getByTestId('short-comment-count').innerHTML).toBe('...');
 	});
 });

--- a/src/web/components/CommentCount.tsx
+++ b/src/web/components/CommentCount.tsx
@@ -10,7 +10,7 @@ import CommentIcon from '@frontend/static/icons/comment.svg';
 type Props = {
 	palette: Palette;
 	isCommentable: boolean;
-	commentCount: number;
+	commentCount?: number;
 	setIsExpanded: (isExpanded: boolean) => void;
 };
 

--- a/src/web/components/Discussion.tsx
+++ b/src/web/components/Discussion.tsx
@@ -166,7 +166,7 @@ export const Discussion = ({
 						palette={palette}
 						enableDiscussionSwitch={enableDiscussionSwitch}
 						user={user}
-						commentCount={commentCount || 0}
+						commentCount={commentCount}
 						isClosedForComments={isClosedForComments}
 					/>
 				}

--- a/src/web/components/Discussion.tsx
+++ b/src/web/components/Discussion.tsx
@@ -14,8 +14,9 @@ import { Flex } from '@frontend/web/components/Flex';
 import { SignedInAs } from '@frontend/web/components/SignedInAs';
 import { ContainerLayout } from '@frontend/web/components/ContainerLayout';
 import { Hide } from '@frontend/web/components/Hide';
-import { getDiscussion } from '@root/src/web/lib/getDiscussion';
 import { getCommentContext } from '@root/src/web/lib/getCommentContext';
+import { joinUrl } from '@root/src/lib/joinUrl';
+import { useDiscussion } from '@root/src/web/lib/useDiscussion';
 import { Display } from '@guardian/types';
 
 type Props = {
@@ -71,10 +72,6 @@ export const Discussion = ({
 	beingHydrated,
 	display,
 }: Props) => {
-	const [commentCount, setCommentCount] = useState<number>();
-	const [isClosedForComments, setIsClosedForComments] = useState<boolean>(
-		true,
-	);
 	const [commentPage, setCommentPage] = useState<number>();
 	const [commentPageSize, setCommentPageSize] = useState<25 | 50 | 100>();
 	const [commentOrderBy, setCommentOrderBy] = useState<
@@ -84,6 +81,11 @@ export const Discussion = ({
 	const [hashCommentId, setHashCommentId] = useState<number | undefined>(
 		commentIdFromUrl(),
 	);
+
+	const { commentCount, isClosedForComments } = useDiscussion(
+		joinUrl([discussionApiUrl, 'discussion', shortUrlId]),
+	);
+
 	const hasCommentsHash =
 		typeof window !== 'undefined' &&
 		window.location &&
@@ -115,20 +117,6 @@ export const Discussion = ({
 			nonInteraction: true,
 		});
 	};
-
-	useEffect(() => {
-		const callFetch = async () => {
-			const response = await getDiscussion(discussionApiUrl, shortUrlId);
-			setCommentCount(response && response.discussion.commentCount);
-			setIsClosedForComments(
-				response && response.discussion.isClosedForComments,
-			);
-		};
-
-		if (isCommentable) {
-			callFetch().catch((e) => console.error(`callFetch - error: ${e}`));
-		}
-	}, [discussionApiUrl, shortUrlId, isCommentable]);
 
 	// Check the url to see if there is a comment hash, e.g. ...crisis#comment-139113120
 	// If so, make a call to get the context of this comment so we know what page it is

--- a/src/web/components/SignedInAs.tsx
+++ b/src/web/components/SignedInAs.tsx
@@ -99,7 +99,7 @@ export const SignedInAs = ({
 						color: ${neutral[60]};
 					`}
 				>
-					({commentCount || '...'})
+					({commentCount || '…'})
 				</span>
 			</h2>
 

--- a/src/web/components/SignedInAs.tsx
+++ b/src/web/components/SignedInAs.tsx
@@ -8,7 +8,7 @@ import { until } from '@guardian/src-foundations/mq';
 import { createAuthenticationEventParams } from '@root/src/lib/identity-component-event';
 
 type Props = {
-	commentCount: number;
+	commentCount?: number;
 	palette: Palette;
 	enableDiscussionSwitch: boolean;
 	user?: UserProfile;
@@ -99,7 +99,7 @@ export const SignedInAs = ({
 						color: ${neutral[60]};
 					`}
 				>
-					({commentCount})
+					({commentCount || '...'})
 				</span>
 			</h2>
 

--- a/src/web/lib/formatCount.ts
+++ b/src/web/lib/formatCount.ts
@@ -3,7 +3,8 @@ import { integerCommas } from '@root/src/lib/formatters';
 export const formatCount = (
 	count?: number,
 ): { short: string; long: string } => {
-	if (!count) return { short: '0', long: '0' };
+	if (count === 0) return { short: '0', long: '0' };
+	if (!count) return { short: '...', long: '...' };
 	const countAsInteger = parseInt(count.toFixed(0), 10);
 	const displayCountLong = integerCommas(countAsInteger);
 	const displayCountShort =

--- a/src/web/lib/formatCount.ts
+++ b/src/web/lib/formatCount.ts
@@ -4,13 +4,15 @@ export const formatCount = (
 	count?: number,
 ): { short: string; long: string } => {
 	if (count === 0) return { short: '0', long: '0' };
-	if (!count) return { short: '...', long: '...' };
+	if (!count) return { short: '…', long: '…' };
+
 	const countAsInteger = parseInt(count.toFixed(0), 10);
 	const displayCountLong = integerCommas(countAsInteger);
 	const displayCountShort =
 		countAsInteger > 10000
 			? `${Math.round(countAsInteger / 1000)}k`
 			: countAsInteger.toString();
+
 	return {
 		short: displayCountShort,
 		long: displayCountLong,

--- a/src/web/lib/useDiscussion.ts
+++ b/src/web/lib/useDiscussion.ts
@@ -61,6 +61,6 @@ export const useDiscussion = (url: string) => {
 
 	return {
 		commentCount: data?.discussion?.commentCount,
-		isClosedForComments: data?.discussion?.isClosedForComments || true,
+		isClosedForComments: data?.discussion?.isClosedForComments,
 	};
 };

--- a/src/web/lib/useDiscussion.ts
+++ b/src/web/lib/useDiscussion.ts
@@ -56,7 +56,7 @@ export const useDiscussion = (url: string) => {
 	if (loading || error)
 		return {
 			commentCount: undefined,
-			isClosedForComments: true,
+			isClosedForComments: undefined,
 		};
 
 	return {

--- a/src/web/lib/useDiscussion.ts
+++ b/src/web/lib/useDiscussion.ts
@@ -1,4 +1,4 @@
-import { joinUrl } from '@root/src/lib/joinUrl';
+import { useApi } from '@root/src/web/lib/api';
 
 type DiscussionResponse = {
 	status: string;
@@ -50,24 +50,17 @@ type CommentType = {
 	};
 };
 
-export const getDiscussion = async (
-	ajaxUrl: string,
-	shortUrl: string,
-): Promise<DiscussionResponse> => {
-	const url = joinUrl([ajaxUrl, 'discussion', shortUrl]);
-	return fetch(url)
-		.then((response) => {
-			if (!response.ok) {
-				throw Error(
-					response.statusText ||
-						`getDiscussion | An api call returned HTTP status ${response.status}`,
-				);
-			}
-			return response;
-		})
-		.then((response) => response.json())
-		.then((json) => json)
-		.catch((error) => {
-			window.guardian.modules.sentry.reportError(error, 'get-discussion');
-		});
+export const useDiscussion = (url: string) => {
+	const { data, loading, error } = useApi<DiscussionResponse>(url);
+
+	if (loading || error)
+		return {
+			commentCount: undefined,
+			isClosedForComments: true,
+		};
+
+	return {
+		commentCount: data?.discussion?.commentCount,
+		isClosedForComments: data?.discussion?.isClosedForComments || true,
+	};
 };

--- a/src/web/lib/useDiscussion.ts
+++ b/src/web/lib/useDiscussion.ts
@@ -51,13 +51,7 @@ type CommentType = {
 };
 
 export const useDiscussion = (url: string) => {
-	const { data, loading, error } = useApi<DiscussionResponse>(url);
-
-	if (loading || error)
-		return {
-			commentCount: undefined,
-			isClosedForComments: undefined,
-		};
+	const { data } = useApi<DiscussionResponse>(url);
 
 	return {
 		commentCount: data?.discussion?.commentCount,


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Shows an elipsis in place of the comment count when the data is still being fetched.

### Before
![Screenshot 2021-04-07 at 09 05 40](https://user-images.githubusercontent.com/1336821/113832355-746f6e80-9780-11eb-8885-c25da9616bcb.jpg)



### After
![Screenshot 2021-04-07 at 09 04 33](https://user-images.githubusercontent.com/1336821/113832221-4d18a180-9780-11eb-8e29-6bf8de63881e.jpg)


## Why?
Two reasons:

1. It's not valid to show `0` if there are not truly zero comments.
2. It's more semantically correct to support an `undefined` state for `commentCount` while the data is loading rather than defaulting to `0`. It also creates simpler, more decarative code. Now `undefined` means undefined and zero means there are zero comments.
