### PR TITLE
Introduce localisation

### DIFF
--- a/src/lib/localisation.test.ts
+++ b/src/lib/localisation.test.ts
@@ -1,0 +1,19 @@
+import { localise } from '@frontend/lib/localisation';
+
+describe('localise', () => {
+	it('Correctly localise against the relevant Edition', () => {
+		expect(localise('US', 'Film')).toBe('Movies');
+	});
+	it('Does not localise against an irrelevant Edition', () => {
+		expect(localise('UK', 'Film')).toBe('Film');
+	});
+	it('Does not localise when the edition is undefined', () => {
+		expect(localise(undefined, 'Film')).toBe('Film');
+	});
+	it('Correctly handle lowercase if case insensitive instruction', () => {
+		expect(localise('US', 'film')).toBe('movies');
+	});
+	it('Does not convert if case sensitive instruction', () => {
+		expect(localise('US', 'In film')).toBe('In film');
+	});
+});

--- a/src/lib/localisation.ts
+++ b/src/lib/localisation.ts
@@ -1,0 +1,60 @@
+/*
+	Date: April 2021
+	This is a reimplementation in DCR, for parity of the Localisation.scala file in frontend.
+	I realise that the replacement items are rather adhoc but again, we are just ensuring parity.
+*/
+
+// How to read the repacement instructions ?
+// ["US", "Film", "Movies"] , means: If the edition is US, then replace "Film" by "Movies"
+// Instructions in the caseInsensitive array must also work in lowecase, therefore replace "film" by "movies"
+
+type TranslationInstruction = [string, string, string];
+
+const caseInsensitive: TranslationInstruction[] = [
+	['US', 'Film', 'Movies'],
+	['US', 'Football', 'Soccer'],
+];
+
+const caseSensitive: TranslationInstruction[] = [
+	['US', 'in film', 'in movies'],
+	['US', 'in football', 'in soccer'],
+	[
+		'US',
+		'Football news, match reports and fixtures',
+		'Soccer news, match reports and fixtures',
+	],
+];
+
+const intructionToLowerCase = (
+	instr: TranslationInstruction,
+): TranslationInstruction => {
+	return [instr[0], instr[1].toLowerCase(), instr[2].toLowerCase()];
+};
+
+const instructionsToLowerCase = (
+	instrs: TranslationInstruction[],
+): TranslationInstruction[] => {
+	return instrs.map((i) => {
+		return intructionToLowerCase(i);
+	});
+};
+
+const allInstructions: TranslationInstruction[] = caseInsensitive.concat(
+	instructionsToLowerCase(caseInsensitive),
+	caseSensitive,
+);
+
+export const localise = (editionId: Edition | undefined, input: string) => {
+	const localiseReduceStep = (
+		str: string,
+		instr: TranslationInstruction,
+	): string => {
+		if (instr[0] === editionId) {
+			if (str === instr[1]) {
+				return instr[2];
+			}
+		}
+		return str;
+	};
+	return allInstructions.reduce(localiseReduceStep, input);
+};

--- a/src/lib/localisation.ts
+++ b/src/lib/localisation.ts
@@ -8,7 +8,7 @@
 // ["US", "Film", "Movies"] , means: If the edition is US, then replace "Film" by "Movies"
 // Instructions in the caseInsensitive array must also work in lowecase, therefore replace "film" by "movies"
 
-type TranslationInstruction = [string, string, string];
+type TranslationInstruction = [Edition, string, string];
 
 const caseInsensitive: TranslationInstruction[] = [
 	['US', 'Film', 'Movies'],

--- a/src/web/components/ArticleTitle.tsx
+++ b/src/web/components/ArticleTitle.tsx
@@ -14,6 +14,7 @@ type Props = {
 	sectionUrl: string;
 	guardianBaseURL: string;
 	badge?: BadgeType;
+	editionId?: Edition;
 };
 
 const sectionStyles = css`
@@ -66,6 +67,7 @@ export const ArticleTitle = ({
 	sectionUrl,
 	guardianBaseURL,
 	badge,
+	editionId,
 }: Props) => (
 	<div className={cx(sectionStyles, badge && badgeContainer)}>
 		{badge && format.display !== Display.Immersive && (
@@ -89,6 +91,7 @@ export const ArticleTitle = ({
 				sectionUrl={sectionUrl}
 				guardianBaseURL={guardianBaseURL}
 				badge={badge}
+				editionId={editionId}
 			/>
 		</div>
 	</div>

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -9,6 +9,8 @@ import { Hide } from '@frontend/web/components/Hide';
 import { Display, Design, Special } from '@guardian/types';
 import { Badge } from '@frontend/web/components/Badge';
 
+import { localise } from '@frontend/lib/localisation';
+
 type Props = {
 	format: Format;
 	palette: Palette;
@@ -17,6 +19,7 @@ type Props = {
 	sectionUrl: string;
 	guardianBaseURL: string;
 	badge?: BadgeType;
+	editionId?: Edition;
 };
 
 const sectionLabelLink = css`
@@ -133,6 +136,7 @@ export const SeriesSectionLink = ({
 	sectionUrl,
 	guardianBaseURL,
 	badge,
+	editionId,
 }: Props) => {
 	// If we have a tag, use it to show 2 section titles
 	const tag = tags.find(
@@ -143,6 +147,8 @@ export const SeriesSectionLink = ({
 	);
 
 	const hasSeriesTag = tag && tag.type === 'Series';
+
+	sectionLabel = localise(editionId, sectionLabel);
 
 	switch (format.display) {
 		case Display.Immersive: {

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -390,6 +390,7 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 								sectionUrl={CAPI.sectionUrl}
 								guardianBaseURL={CAPI.guardianBaseURL}
 								badge={CAPI.badge}
+								editionId={CAPI.editionId}
 							/>
 						</GridItem>
 						<GridItem area="border">


### PR DESCRIPTION
This change is the DCR implementation of this frontend file/functionality ( https://github.com/guardian/frontend/blob/efb9c6a2909cd3a1eba01d06ce11e2db482aeba6/common/app/common/Localisation.scala ).

More exactly: 

1. We add `editionId` as additional optional parameters to `ArticleTitle` and `SeriesSectionLink`
2. Implement `localise`.

This is just the introduction of `localise.ts` and its use in `SeriesSectionLink`, there are other places we might have to apply the same function, in future PRs