### PR TITLE
Fix CMP callbacks (v6.11.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "@guardian/atoms-rendering": "^10.0.2",
         "@guardian/automat-client": "^0.2.16",
         "@guardian/braze-components": "^0.0.20",
-        "@guardian/consent-management-platform": "^6.11.2",
+        "@guardian/consent-management-platform": "^6.11.3",
         "@guardian/discussion-rendering": "6.1.4-2",
         "@guardian/libs": "^1.7.0",
         "@guardian/shimport": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2357,10 +2357,10 @@
     "@guardian/src-grid" "2.7.1"
     "@guardian/src-icons" "2.7.1"
 
-"@guardian/consent-management-platform@^6.11.2":
-  version "6.11.2"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.11.2.tgz#668d0f911aff5c3bc42cb54c606b07640d18f0b8"
-  integrity sha512-tX+lZZFgn9PP8RUj14MnsYa7ikBAyTWfQJPNls4o2Q5c+o0uRVYHnlgifvspj0k1m05rFEmYjnmj7rxwpnH2Xw==
+"@guardian/consent-management-platform@^6.11.3":
+  version "6.11.3"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.11.3.tgz#92a7a6221587bcd86851e6a90198ad618f51b1e9"
+  integrity sha512-xKocfioFtkq5v9MuupT1ugo290NfSD4yIMl7m89xek6W+7B2fKjh0cAMHj4u2LQSXmEoyQ76vs2IaB3w5+98ZQ==
 
 "@guardian/discussion-rendering@6.1.4-2":
   version "6.1.4-2"


### PR DESCRIPTION
## What does this change?

Updated CMP library to fix `onConsentChange` callbacks.

https://github.com/guardian/frontend/pull/23673

## Why?

Callbacks were not fired on first pages.