### PR TITLE
Set modulesVersion in requests to dotcom-components

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "@guardian/ab-core": "^2.0.0",
         "@guardian/ab-react": "^2.0.1",
         "@guardian/atoms-rendering": "^10.0.2",
-        "@guardian/automat-client": "^0.2.16",
+        "@guardian/automat-client": "^0.2.17",
         "@guardian/braze-components": "^1.0.1",
         "@guardian/consent-management-platform": "^6.11.3",
         "@guardian/discussion-rendering": "6.1.4-2",

--- a/src/web/components/SlotBodyEnd/ReaderRevenueEpic.tsx
+++ b/src/web/components/SlotBodyEnd/ReaderRevenueEpic.tsx
@@ -13,6 +13,7 @@ import {
 	shouldHideSupportMessaging,
 	getArticleCountConsent,
 	getEmail,
+	MODULES_VERSION,
 } from '@root/src/web/lib/contributions';
 import { getForcedVariant } from '@root/src/web/lib/readerRevenueDevUtils';
 import { CanShowResult } from '@root/src/web/lib/messagePicker';
@@ -132,6 +133,7 @@ const buildPayload = async (props: Props): Promise<Metadata> => {
 			hasOptedOutOfArticleCount: !(await getArticleCountConsent()),
 			mvtId: Number(getCookie('GU_mvt_id')),
 			countryCode: props.countryCode,
+			modulesVersion: MODULES_VERSION,
 		},
 	} as Metadata; // Metadata type incorrectly does not include required hasOptedOutOfArticleCount property
 };

--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -11,6 +11,7 @@ import {
 	getArticleCountConsent,
 	withinLocalNoBannerCachePeriod,
 	setLocalNoBannerCachePeriod,
+	MODULES_VERSION,
 } from '@root/src/web/lib/contributions';
 import { getCookie } from '@root/src/web/browser/cookie';
 import {
@@ -83,6 +84,7 @@ const buildPayload = (props: BuildPayloadProps) => {
 			countryCode: props.countryCode,
 			weeklyArticleHistory: getWeeklyArticleHistory(),
 			hasOptedOutOfArticleCount: !props.hasConsentedToArticleCounts,
+			modulesVersion: MODULES_VERSION,
 		},
 	};
 };

--- a/src/web/lib/contributions.ts
+++ b/src/web/lib/contributions.ts
@@ -24,6 +24,9 @@ const DAILY_ARTICLE_COUNT_KEY = 'gu.history.dailyArticleCount';
 const WEEKLY_ARTICLE_COUNT_KEY = 'gu.history.weeklyArticleCount';
 export const NO_RR_BANNER_TIMESTAMP_KEY = 'gu.noRRBannerTimestamp'; // timestamp of when we were last told not to show a RR banner
 
+// See https://github.com/guardian/support-dotcom-components/blob/main/module-versions.md
+export const MODULES_VERSION = 'v1';
+
 // Cookie set by the User Attributes API upon signing in.
 // Value computed server-side and looks at all of the user's active products,
 // including but not limited to recurring & one-off contributions,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2725,10 +2725,10 @@
   dependencies:
     youtube-player "^5.5.2"
 
-"@guardian/automat-client@^0.2.16":
-  version "0.2.16"
-  resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.16.tgz#3ef47e7f49e633aea51c67f061d8d313a26fa9bc"
-  integrity sha512-SgNU2bgiyQaXNfqanx4SDmxqAhXW6QBCTk4tRnCgV9Ht6noRl7UsDfx4I0u+M4H3TRnK4I/i2mmlJBtnuwhxEg==
+"@guardian/automat-client@^0.2.17":
+  version "0.2.17"
+  resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.17.tgz#253724307312f4d5bc01b5749179193b8a29ae8b"
+  integrity sha512-SbNeBjoc1iqt/EZ+zQTy7EbbXbdEHOuKObcseLKWyy/LF+4FQtHNuYxLGQ3zjl6fR7s/nvcnIEBAPrnFv0gcqQ==
 
 "@guardian/braze-components@^1.0.1":
   version "1.0.1"


### PR DESCRIPTION
We now have versioning on the modules served by dotcom-components.
This change ensures that v1 is requested by DCR pages.
This will ensure backwards-compatibility when we do the upgrade to v2.

See [here](https://github.com/guardian/support-dotcom-components#module-versions)

[PR for v2 modules](https://github.com/guardian/support-dotcom-components/pull/361)

Epic request:
![Screen Shot 2021-04-08 at 08 21 36](https://user-images.githubusercontent.com/1513454/113984972-9120aa80-9843-11eb-96a3-7b544e412e25.png)

Banner request:
![Screen Shot 2021-04-08 at 08 21 45](https://user-images.githubusercontent.com/1513454/113984986-93830480-9843-11eb-8ff4-fbbc50e0d8a3.png)
