### PR TITLE
Slower checks for View More button

### DIFF
--- a/cypress/integration/parallel-5/discussion.spec.js
+++ b/cypress/integration/parallel-5/discussion.spec.js
@@ -29,7 +29,8 @@ describe('Discussion', function () {
 	it('should expand the comments when the view more button is clicked', function () {
 		cy.visit(`/Article?url=${articleUrl}`);
 		const roughLoadPositionOfComments = 4000;
-		cy.scrollTo(0, roughLoadPositionOfComments, { duration: 500 });
+		cy.scrollTo(0, roughLoadPositionOfComments, { duration: 3000 });
+		cy.contains('View more comments');
 		cy.contains('View more comments').click();
 		cy.contains('Displaying threads');
 	});


### PR DESCRIPTION
## What does this change?
This PR is a bit of a punt. I recently [re-enabled a failing Cypress](https://github.com/guardian/dotcom-rendering/pull/2788) test hoping that the test would continue to work well (it seemed to be okay) but looking at our recent PRs it again seems to be flakey in TeamCity (it works fine in Github 🤷 ).

So my hypothesis is that TeamCity is a slower environment and that by reducing the speed of the test and by checking things more I can add some resilience.

🤞 