### PR TITLE
Add mobile snapshot for opinion content

### DIFF
--- a/src/web/components/ArticleHeadline.stories.tsx
+++ b/src/web/components/ArticleHeadline.stories.tsx
@@ -46,39 +46,6 @@ export const ArticleStory = () => (
 );
 ArticleStory.story = { name: 'Article' };
 
-export const oldHeadline = () => (
-	<Section>
-		<Flex>
-			<LeftColumn>
-				<></>
-			</LeftColumn>
-			<ArticleContainer>
-				<ArticleHeadline
-					headlineString="This is an old headline"
-					palette={decidePalette({
-						display: Display.Standard,
-						design: Design.Article,
-						theme: Pillar.News,
-					})}
-					format={{
-						display: Display.Standard,
-						design: Design.Article,
-						theme: Pillar.News,
-					}}
-					tags={[
-						// Age warnings only show for old articles when the tone/news tag is present
-						{
-							id: 'tone/news',
-							type: '',
-							title: '',
-						},
-					]}
-				/>
-			</ArticleContainer>
-		</Flex>
-	</Section>
-);
-oldHeadline.story = { name: 'Article, with age warning' };
 
 export const Feature = () => (
 	<Section>
@@ -339,6 +306,43 @@ export const Comment = () => (
 	</Section>
 );
 Comment.story = { name: 'Comment' };
+
+export const CommentWithBylineAndCutout = () => (
+	<Section>
+		<Flex>
+			<LeftColumn>
+				<></>
+			</LeftColumn>
+			<ArticleContainer>
+				<ArticleHeadline
+					headlineString="Yes, the billionaire club is one we really need to shut down"
+					palette={decidePalette({
+						display: Display.Standard,
+						design: Design.Comment,
+						theme: Pillar.Opinion,
+					})}
+					format={{
+						display: Display.Showcase,
+						design: Design.Comment,
+						theme: Pillar.Opinion,
+					}}
+					byline="Marina Hyde"
+					tags={[
+						{
+							id: 'profile/marinahyde',
+							type: 'Contributor',
+							title: 'Marina Hyde',
+							twitterHandle: 'MarinaHyde',
+							bylineImageUrl:
+								'https://i.guim.co.uk/img/uploads/2018/01/10/Marina_Hyde,_L.png?width=300&quality=85&auto=format&fit=max&s=6476202195914952e48ef41aadb116ff',
+						},
+					]}
+				/>
+			</ArticleContainer>
+		</Flex>
+	</Section>
+);
+CommentWithBylineAndCutout.story = { name: 'Comment (with byline and cutout)' };
 
 export const Analysis = () => (
 	<Section>

--- a/src/web/components/ArticleHeadline.stories.tsx
+++ b/src/web/components/ArticleHeadline.stories.tsx
@@ -306,43 +306,6 @@ export const Comment = () => (
 );
 Comment.story = { name: 'Comment' };
 
-export const CommentWithBylineAndCutout = () => (
-	<Section>
-		<Flex>
-			<LeftColumn>
-				<></>
-			</LeftColumn>
-			<ArticleContainer>
-				<ArticleHeadline
-					headlineString="Yes, the billionaire club is one we really need to shut down"
-					palette={decidePalette({
-						display: Display.Standard,
-						design: Design.Comment,
-						theme: Pillar.Opinion,
-					})}
-					format={{
-						display: Display.Showcase,
-						design: Design.Comment,
-						theme: Pillar.Opinion,
-					}}
-					byline="Marina Hyde"
-					tags={[
-						{
-							id: 'profile/marinahyde',
-							type: 'Contributor',
-							title: 'Marina Hyde',
-							twitterHandle: 'MarinaHyde',
-							bylineImageUrl:
-								'https://i.guim.co.uk/img/uploads/2018/01/10/Marina_Hyde,_L.png?width=300&quality=85&auto=format&fit=max&s=6476202195914952e48ef41aadb116ff',
-						},
-					]}
-				/>
-			</ArticleContainer>
-		</Flex>
-	</Section>
-);
-CommentWithBylineAndCutout.story = { name: 'Comment (with byline and cutout)' };
-
 export const Analysis = () => (
 	<Section>
 		<Flex>

--- a/src/web/components/ArticleHeadline.stories.tsx
+++ b/src/web/components/ArticleHeadline.stories.tsx
@@ -46,7 +46,6 @@ export const ArticleStory = () => (
 );
 ArticleStory.story = { name: 'Article' };
 
-
 export const Feature = () => (
 	<Section>
 		<Flex>

--- a/src/web/layouts/Standard.stories.tsx
+++ b/src/web/layouts/Standard.stories.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect } from 'react';
 
+import { breakpoints } from '@guardian/src-foundations/mq';
+
 import {
 	makeGuardianBrowserCAPI,
 	makeGuardianBrowserNav,
@@ -32,7 +34,11 @@ mockRESTCalls();
 export default {
 	title: 'Layouts/Standard',
 	parameters: {
-		chromatic: { viewports: [1300], delay: 800, diffThreshold: 0.2 },
+		chromatic: {
+			viewports: [breakpoints.wide],
+			delay: 800,
+			diffThreshold: 0.2,
+		},
 	},
 };
 
@@ -94,11 +100,14 @@ export const CommentStory = (): React.ReactNode => {
 	const ServerCAPI = convertToStandard(Comment);
 	return <HydratedLayout ServerCAPI={ServerCAPI} />;
 };
-CommentStory.story = { name: 'Comment' };
-CommentStory.parameters = {
-	// Cutout/byline interaction is a specific issue
-	// we look out for on mobile on opinion content
-	chromatic: { viewports: [320, 1300] },
+CommentStory.story = {
+	name: 'Comment',
+	parameters: {
+		viewport: { defaultViewport: 'mobileMedium' },
+		// Cutout/byline interaction is a specific issue
+		// we look out for on mobile on opinion content
+		chromatic: { viewports: [breakpoints.mobile, breakpoints.wide] },
+	},
 };
 
 export const PhotoEssayStory = (): React.ReactNode => {
@@ -114,8 +123,8 @@ export const AnalysisStory = (): React.ReactNode => {
 AnalysisStory.story = {
 	name: 'Analysis',
 	parameters: {
-		viewport: { defaultViewport: 'mobileMedium' },
-		chromatic: { viewports: [480] },
+		viewport: { defaultViewport: 'mobileLandscape' },
+		chromatic: { viewports: [breakpoints.mobileLandscape] },
 	},
 };
 
@@ -159,7 +168,7 @@ EditorialStory.story = {
 	name: 'Editorial',
 	parameters: {
 		viewport: { defaultViewport: 'phablet' },
-		chromatic: { viewports: [660] },
+		chromatic: { viewports: [breakpoints.phablet] },
 	},
 };
 
@@ -171,7 +180,7 @@ InterviewStory.story = {
 	name: 'Interview',
 	parameters: {
 		viewport: { defaultViewport: 'desktop' },
-		chromatic: { viewports: [980] },
+		chromatic: { viewports: [breakpoints.desktop] },
 	},
 };
 
@@ -182,8 +191,7 @@ export const QuizStory = (): React.ReactNode => {
 QuizStory.story = {
 	name: 'Quiz',
 	parameters: {
-		viewport: { defaultViewport: 'desktop' },
-		chromatic: { viewports: [1300] },
+		viewport: { defaultViewport: 'wide' },
 	},
 };
 
@@ -195,7 +203,7 @@ RecipeStory.story = {
 	name: 'Recipe',
 	parameters: {
 		viewport: { defaultViewport: 'mobileMedium' },
-		chromatic: { viewports: [375] },
+		chromatic: { viewports: [breakpoints.mobileMedium] },
 	},
 };
 
@@ -206,8 +214,7 @@ export const MatchReportStory = (): React.ReactNode => {
 MatchReportStory.story = {
 	name: 'MatchReport',
 	parameters: {
-		viewport: { defaultViewport: 'desktop' },
-		chromatic: { viewports: [1330] },
+		viewport: { defaultViewport: 'wide' },
 	},
 };
 

--- a/src/web/layouts/Standard.stories.tsx
+++ b/src/web/layouts/Standard.stories.tsx
@@ -95,6 +95,11 @@ export const CommentStory = (): React.ReactNode => {
 	return <HydratedLayout ServerCAPI={ServerCAPI} />;
 };
 CommentStory.story = { name: 'Comment' };
+CommentStory.parameters = {
+	// Cutout/byline interaction is a specific issue
+	// we look out for on mobile on opinion content
+	chromatic: { viewports: [320, 1300] }
+};
 
 export const PhotoEssayStory = (): React.ReactNode => {
 	const ServerCAPI = convertToStandard(PhotoEssay);

--- a/src/web/layouts/Standard.stories.tsx
+++ b/src/web/layouts/Standard.stories.tsx
@@ -98,7 +98,7 @@ CommentStory.story = { name: 'Comment' };
 CommentStory.parameters = {
 	// Cutout/byline interaction is a specific issue
 	// we look out for on mobile on opinion content
-	chromatic: { viewports: [320, 1300] }
+	chromatic: { viewports: [320, 1300] },
 };
 
 export const PhotoEssayStory = (): React.ReactNode => {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This instructs Chromatic to take a snapshot at the mobile breakpoint for the comment story. We have had a couple of issues with the placement/wrapping of byline and contributor avatar, and we know that this is still a slightly brittle area until we complete some further work in the backlog. Hopefully this gives us more confidence that making changes will not result in overlapping byline and avatars.

### Before
![image](https://user-images.githubusercontent.com/8754692/114033718-664f4a00-9875-11eb-88ea-3ab260909bf6.png)


### After
![image](https://user-images.githubusercontent.com/8754692/114033442-2ee09d80-9875-11eb-9eb9-0ff734fc7ebf.png)


## Why?
More targeted snapshot coverage to areas of potential issues