### PR TITLE
Add environment for the Chromatic workflow

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -5,6 +5,7 @@ jobs:
     chromatic:
         name: Chromatic
         runs-on: ubuntu-latest
+        environment: chromatic
         steps:
             - uses: actions/checkout@v1
             - uses: guardian/actions-setup-node@main


### PR DESCRIPTION
## What does this change?

Added an env with an env variable under settings, and run chromatic workflow under it. Should hopefully allow access to the correct project code for dependabot.