### PR TITLE
Revert "Add environment for the Chromatic workflow"

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -5,7 +5,6 @@ jobs:
     chromatic:
         name: Chromatic
         runs-on: ubuntu-latest
-        environment: chromatic
         steps:
             - uses: actions/checkout@v1
             - uses: guardian/actions-setup-node@main


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#2810

It didn't fix what I hope it would fix (dependabot failing on chromatic env variable)