### PR TITLE
Filter out blank links in `SubMeta`

### DIFF
--- a/src/web/components/SubMeta.tsx
+++ b/src/web/components/SubMeta.tsx
@@ -121,8 +121,12 @@ export const SubMeta = ({
 	showBottomSocialButtons,
 	badge,
 }: Props) => {
-	const hasSectionLinks = subMetaSectionLinks.length > 0;
-	const hasKeywordLinks = subMetaKeywordLinks.length > 0;
+	// Filter out any links without titles (sometimes you get blank links which cause slash issues)
+	const filteredSections = subMetaSectionLinks.filter((link) => link.title);
+	const filteredKeywords = subMetaKeywordLinks.filter((link) => link.title);
+	const hasSectionLinks = filteredSections.length > 0;
+	const hasKeywordLinks = filteredKeywords.length > 0;
+
 	return (
 		<div data-print-layout="hide" className={bottomPadding}>
 			{badge && (
@@ -139,14 +143,13 @@ export const SubMeta = ({
 					<div className={listWrapper(palette)}>
 						{hasSectionLinks && (
 							<ul className={listStyleNone}>
-								{subMetaSectionLinks.map((link, i) => (
+								{filteredSections.map((link, i) => (
 									<li
 										className={cx(
 											listItemStyles(palette),
 											sectionStyles(format),
-											i ===
-												subMetaSectionLinks.length -
-													1 && hideSlash,
+											i === filteredSections.length - 1 &&
+												hideSlash,
 										)}
 										key={link.url}
 									>
@@ -162,14 +165,13 @@ export const SubMeta = ({
 						)}
 						{hasKeywordLinks && (
 							<ul className={listStyleNone}>
-								{subMetaKeywordLinks.map((link, i) => (
+								{filteredKeywords.map((link, i) => (
 									<li
 										className={cx(
 											listItemStyles(palette),
 											keywordStyles,
-											i ===
-												subMetaKeywordLinks.length -
-													1 && hideSlash,
+											i === filteredKeywords.length - 1 &&
+												hideSlash,
 										)}
 										key={link.url}
 									>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Ensures that we don't try to render links with blank titles

### Before
![Screenshot 2021-04-08 at 16 21 24](https://user-images.githubusercontent.com/1336821/114053035-7ae80e00-9886-11eb-8d84-37e81167be3d.jpg)


### After
![Screenshot 2021-04-08 at 16 20 15](https://user-images.githubusercontent.com/1336821/114052983-6f94e280-9886-11eb-87eb-a029f2025b1c.jpg)


## Why?
Because the slash looks odd sitting down there by itself

## Why not?
Because this type of data manipulation would be better done on the server, instead of the client. I can't think why a blank link would be valid
