### PR TITLE
AB test remote importing of RR links in header

### DIFF
--- a/cypress/integration/parallel-4/signedin.spec.js
+++ b/cypress/integration/parallel-4/signedin.spec.js
@@ -27,9 +27,9 @@ describe('Signed in readers', function () {
 			// this commercial error from failing this test
 			return false;
 		});
-		cy.visit(`Article?url=${articleUrl}`);
 		// Mock call to 'profile/me'
 		cy.intercept('GET', '**/profile/me', profileResponse);
+		cy.visit(`Article?url=${articleUrl}`);
 		// This text is shown in the header for signed in users
 		cy.contains('My account');
 	});

--- a/src/web/browser/ophan/ophan.ts
+++ b/src/web/browser/ophan/ophan.ts
@@ -9,7 +9,23 @@ import type {
 	TestMeta,
 } from '@guardian/types';
 
-export const record = (event: { [key: string]: any }): void => {
+export type OphanRecordFunction = (event: { [key: string]: any }) => void;
+
+export const getOphanRecordFunction = (): OphanRecordFunction => {
+	const record =
+		window &&
+		window.guardian &&
+		window.guardian.ophan &&
+		window.guardian.ophan.record;
+
+	if (record) {
+		return record;
+	}
+	console.log('window.guardian.ophan.record is not available');
+	return () => {};
+};
+
+export const record: OphanRecordFunction = (event) => {
 	if (
 		window.guardian &&
 		window.guardian.ophan &&
@@ -23,13 +39,15 @@ export const record = (event: { [key: string]: any }): void => {
 
 export const submitComponentEvent = (
 	componentEvent: OphanComponentEvent,
+	ophanRecord: OphanRecordFunction = record, // TODO - migrate uses and make this mandatory
 ): void => {
-	record({ componentEvent });
+	ophanRecord({ componentEvent });
 };
 
 export const sendOphanComponentEvent = (
 	action: OphanAction,
 	testMeta: TestMeta,
+	ophanRecord: OphanRecordFunction = record, // TODO - migrate uses and make this mandatory
 ): void => {
 	const {
 		abTestName,
@@ -53,7 +71,7 @@ export const sendOphanComponentEvent = (
 		action,
 	};
 
-	submitComponentEvent(componentEvent);
+	submitComponentEvent(componentEvent, ophanRecord);
 };
 
 export const abTestPayload = (tests: {

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -68,6 +68,8 @@ import { SpotifyBlockComponent } from '@root/src/web/components/elements/Spotify
 import { VideoFacebookBlockComponent } from '@root/src/web/components/elements/VideoFacebookBlockComponent';
 import { VineBlockComponent } from '@root/src/web/components/elements/VineBlockComponent';
 import type { BrazeMessagesInterface } from '@guardian/braze-components/logic';
+import { remoteRRHeaderLinksTestName } from '@root/src/web/experiments/tests/remoteRRHeaderLinksTest';
+import { OphanRecordFunction } from '@root/node_modules/@guardian/ab-core/dist/types';
 import {
 	submitComponentEvent,
 	OphanComponentEvent,
@@ -131,26 +133,10 @@ const GetMatchStats = React.lazy(() => {
 type Props = {
 	CAPI: CAPIBrowserType;
 	NAV: BrowserNavType;
+	ophanRecord: OphanRecordFunction;
 };
 
-const componentEventHandler = (
-	componentType: any,
-	id: any,
-	action: any,
-) => () => {
-	const componentEvent: OphanComponentEvent = {
-		component: {
-			componentType,
-			id,
-			products: [],
-			labels: [],
-		},
-		action,
-	};
-	submitComponentEvent(componentEvent);
-};
-
-export const App = ({ CAPI, NAV }: Props) => {
+export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 	const [isSignedIn, setIsSignedIn] = useState<boolean>();
 	const [user, setUser] = useState<UserProfile | null>();
 	const [countryCode, setCountryCode] = useState<string>();
@@ -169,6 +155,23 @@ export const App = ({ CAPI, NAV }: Props) => {
 	>();
 
 	const pageViewId = window.guardian?.config?.ophan?.pageViewId;
+
+	const componentEventHandler = (
+		componentType: any,
+		id: any,
+		action: any,
+	) => () => {
+		const componentEvent: OphanComponentEvent = {
+			component: {
+				componentType,
+				id,
+				products: [],
+				labels: [],
+			},
+			action,
+		};
+		submitComponentEvent(componentEvent, ophanRecord);
+	};
 
 	// *******************************
 	// ** Setup AB Test Tracking *****
@@ -351,6 +354,11 @@ export const App = ({ CAPI, NAV }: Props) => {
 
 	const adTargeting: AdTargeting = buildAdTargeting(CAPI.config);
 
+	const inRemoteModuleTest = ABTestAPI.isUserInVariant(
+		remoteRRHeaderLinksTestName,
+		'remote',
+	);
+
 	// There are docs on loadable in ./docs/loadable-components.md
 	const YoutubeBlockComponent = loadable(
 		() => {
@@ -510,8 +518,13 @@ export const App = ({ CAPI, NAV }: Props) => {
 				<ReaderRevenueLinks
 					urls={CAPI.nav.readerRevenueLinks.header}
 					edition={CAPI.editionId}
+					countryCode={countryCode}
 					dataLinkNamePrefix="nav2 : "
 					inHeader={true}
+					inRemoteModuleTest={inRemoteModuleTest}
+					pageViewId={pageViewId}
+					contributionsServiceUrl={CAPI.contributionsServiceUrl}
+					ophanRecord={ophanRecord}
 				/>
 			</Portal>
 			<HydrateOnce rootId="links-root" waitFor={[user]}>
@@ -1010,8 +1023,13 @@ export const App = ({ CAPI, NAV }: Props) => {
 					<ReaderRevenueLinks
 						urls={CAPI.nav.readerRevenueLinks.footer}
 						edition={CAPI.editionId}
+						countryCode={countryCode}
 						dataLinkNamePrefix="footer : "
 						inHeader={false}
+						inRemoteModuleTest={false}
+						pageViewId={pageViewId}
+						contributionsServiceUrl={CAPI.contributionsServiceUrl}
+						ophanRecord={ophanRecord}
 					/>
 				</Lazy>
 			</Portal>

--- a/src/web/components/BootReact.tsx
+++ b/src/web/components/BootReact.tsx
@@ -8,6 +8,7 @@ import { getCookie } from '@frontend/web/browser/cookie';
 import { getForcedParticipationsFromUrl } from '@frontend/web/lib/getAbUrlHash';
 import { getCypressSwitches } from '@frontend/web/experiments/cypress-switches';
 import { loadableReady } from '@loadable/component';
+import { getOphanRecordFunction } from '@root/src/web/browser/ophan/ophan';
 
 type Props = {
 	CAPI: CAPIBrowserType;
@@ -25,11 +26,7 @@ export const BootReact = ({ CAPI, NAV }: Props) => {
 		console.log('There is no MVT ID set, see BootReact.tsx');
 	}
 
-	const ophanRecordFunc =
-		window &&
-		window.guardian &&
-		window.guardian.ophan &&
-		window.guardian.ophan.record;
+	const ophanRecord = getOphanRecordFunction();
 
 	const windowHash = window && window.location && window.location.hash;
 
@@ -48,10 +45,10 @@ export const BootReact = ({ CAPI, NAV }: Props) => {
 				pageIsSensitive={CAPI.config.isSensitive}
 				mvtMaxValue={1000000}
 				mvtId={mvtId}
-				ophanRecord={ophanRecordFunc}
+				ophanRecord={ophanRecord}
 				forcedTestVariants={getForcedParticipationsFromUrl(windowHash)}
 			>
-				<App CAPI={CAPI} NAV={NAV} />
+				<App CAPI={CAPI} NAV={NAV} ophanRecord={ophanRecord} />
 			</ABProvider>,
 
 			document.getElementById('react-root'),

--- a/src/web/components/ReaderRevenueLinks.stories.tsx
+++ b/src/web/components/ReaderRevenueLinks.stories.tsx
@@ -31,6 +31,11 @@ const revenueUrls = {
 	contribute: '',
 };
 
+const contributionsServiceUrl =
+	'https://contributions.code.dev-guardianapis.com';
+
+const ophanRecord = () => {};
+
 const Container = ({ children }: { children: React.ReactNode }) => (
 	<div
 		className={css`
@@ -53,6 +58,10 @@ export const Header = () => {
 				urls={revenueUrls}
 				dataLinkNamePrefix=""
 				inHeader={true}
+				inRemoteModuleTest={false}
+				pageViewId="page-view-id"
+				contributionsServiceUrl={contributionsServiceUrl}
+				ophanRecord={ophanRecord}
 			/>
 		</Container>
 	);
@@ -73,6 +82,10 @@ export const HeaderMobile = () => {
 				urls={revenueUrls}
 				dataLinkNamePrefix=""
 				inHeader={true}
+				inRemoteModuleTest={false}
+				pageViewId="page-view-id"
+				contributionsServiceUrl={contributionsServiceUrl}
+				ophanRecord={ophanRecord}
 			/>
 		</Container>
 	);
@@ -93,6 +106,10 @@ export const Footer = () => {
 				urls={revenueUrls}
 				dataLinkNamePrefix=""
 				inHeader={false}
+				inRemoteModuleTest={false}
+				pageViewId="page-view-id"
+				contributionsServiceUrl={contributionsServiceUrl}
+				ophanRecord={ophanRecord}
 			/>
 		</Container>
 	);
@@ -113,6 +130,10 @@ export const FooterMobile = () => {
 				urls={revenueUrls}
 				dataLinkNamePrefix=""
 				inHeader={false}
+				inRemoteModuleTest={false}
+				pageViewId="page-view-id"
+				contributionsServiceUrl={contributionsServiceUrl}
+				ophanRecord={ophanRecord}
 			/>
 		</Container>
 	);

--- a/src/web/components/ReaderRevenueLinks.test.tsx
+++ b/src/web/components/ReaderRevenueLinks.test.tsx
@@ -12,6 +12,11 @@ jest.mock('@root/src/web/lib/contributions', () => ({
 	shouldHideSupportMessaging: jest.fn(() => true),
 }));
 
+const contributionsServiceUrl =
+	'https://contributions.code.dev-guardianapis.com';
+
+const ophanRecord = () => {};
+
 const AbProvider: React.FC = ({ children }) => {
 	return (
 		<ABProvider
@@ -44,6 +49,10 @@ describe('ReaderRevenueLinks', () => {
 					edition="US"
 					dataLinkNamePrefix="nav2 : "
 					inHeader={true}
+					inRemoteModuleTest={false}
+					pageViewId="page-view-id"
+					contributionsServiceUrl={contributionsServiceUrl}
+					ophanRecord={ophanRecord}
 				/>
 			</AbProvider>,
 		);
@@ -61,6 +70,10 @@ describe('ReaderRevenueLinks', () => {
 					edition={edition}
 					dataLinkNamePrefix="nav2 : "
 					inHeader={true}
+					inRemoteModuleTest={false}
+					pageViewId="page-view-id"
+					contributionsServiceUrl={contributionsServiceUrl}
+					ophanRecord={ophanRecord}
 				/>
 				,
 			</AbProvider>,

--- a/src/web/components/ReaderRevenueLinks.tsx
+++ b/src/web/components/ReaderRevenueLinks.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+
 import { css, cx } from 'emotion';
 
 import ArrowRightIcon from '@frontend/static/icons/arrow-right.svg';
@@ -11,16 +12,31 @@ import { textSans, headline } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
 
 import { shouldHideSupportMessaging } from '@root/src/web/lib/contributions';
+import { setAutomat } from '@root/src/web/lib/setAutomat';
+import { getCookie } from '@root/src/web/browser/cookie';
+import { remoteRRHeaderLinksTestName } from '@root/src/web/experiments/tests/remoteRRHeaderLinksTest';
+import type { TestMeta } from '@guardian/types';
+import { useHasBeenSeen } from '@root/src/web/lib/useHasBeenSeen';
+import { addTrackingCodesToUrl } from '@root/src/web/lib/acquisitions';
+import {
+	OphanRecordFunction,
+	sendOphanComponentEvent,
+} from '@root/src/web/browser/ophan/ophan';
 
 type Props = {
 	edition: Edition;
+	countryCode?: string;
+	dataLinkNamePrefix: string;
+	inHeader: boolean;
+	inRemoteModuleTest: boolean;
+	contributionsServiceUrl: string;
+	pageViewId: string;
+	ophanRecord: OphanRecordFunction;
 	urls: {
 		subscribe: string;
 		support: string;
 		contribute: string;
 	};
-	dataLinkNamePrefix: string;
-	inHeader: boolean;
 };
 
 const headerStyles = css`
@@ -117,13 +133,190 @@ const subMessageStyles = css`
 	margin: 5px 0;
 `;
 
-export const ReaderRevenueLinks: React.FC<Props> = ({
+interface Cta {
+	url: string;
+	text: string;
+}
+interface SupportHeaderProps {
+	content: {
+		heading: string;
+		subheading: string;
+		primaryCta?: Cta;
+		secondaryCta?: Cta;
+	};
+	tracking: TestMeta;
+}
+interface SupportHeaderData {
+	module: {
+		url: string;
+		name: string;
+		props: SupportHeaderProps;
+	};
+	meta: TestMeta;
+}
+
+const ReaderRevenueLinksRemote: React.FC<{
+	edition: Edition;
+	countryCode?: string;
+	pageViewId: string;
+	contributionsServiceUrl: string;
+	ophanRecord: OphanRecordFunction;
+}> = ({
 	edition,
-	urls,
+	countryCode,
+	pageViewId,
+	contributionsServiceUrl,
+	ophanRecord,
+}) => {
+	const [
+		supportHeaderResponse,
+		setSupportHeaderResponse,
+	] = useState<SupportHeaderData | null>(null);
+	const [
+		SupportHeader,
+		setSupportHeader,
+	] = useState<React.FC<SupportHeaderProps> | null>(null);
+
+	const [hasBeenSeen, setNode] = useHasBeenSeen({
+		threshold: 0,
+		debounce: true,
+	});
+
+	useEffect(() => {
+		if (hasBeenSeen && supportHeaderResponse) {
+			sendOphanComponentEvent(
+				'VIEW',
+				supportHeaderResponse.meta,
+				ophanRecord,
+			);
+		}
+	}, [hasBeenSeen, supportHeaderResponse, ophanRecord]);
+
+	useEffect((): void => {
+		setAutomat();
+
+		const requestData = {
+			tracking: {
+				ophanPageId: pageViewId,
+				platformId: 'GUARDIAN_WEB',
+				referrerUrl: window.location.origin + window.location.pathname,
+				clientName: 'dcr',
+			},
+			targeting: {
+				showSupportMessaging: !shouldHideSupportMessaging(),
+				edition,
+				countryCode,
+				modulesVersion: 'v1',
+				mvtId: Number(getCookie('GU_mvt_id')),
+			},
+		};
+		fetch(`${contributionsServiceUrl}/header`, {
+			method: 'post',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(requestData),
+		})
+			.then((result) => result.json())
+			.then((response: { data?: SupportHeaderData }) => {
+				if (!response.data) {
+					return null;
+				}
+
+				setSupportHeaderResponse(response.data);
+				const { module, meta } = response.data;
+				return window
+					.guardianPolyfilledImport(module.url)
+					.then(
+						(headerModule: {
+							Header: React.FC<SupportHeaderProps>;
+						}) => {
+							setSupportHeader(() => headerModule.Header);
+							sendOphanComponentEvent(
+								'INSERT',
+								meta,
+								ophanRecord,
+							);
+						},
+					);
+			})
+			.catch((error) => {
+				// TODO - sentry
+				// eslint-disable-next-line no-console
+				console.log(`header module - error is: ${error}`);
+			});
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
+	if (SupportHeader && supportHeaderResponse) {
+		return (
+			<div ref={setNode} className={headerStyles}>
+				{/* eslint-disable react/jsx-props-no-spreading */}
+				<SupportHeader {...supportHeaderResponse.module.props} />
+				{/* eslint-enable react/jsx-props-no-spreading */}
+			</div>
+		);
+	}
+
+	return null;
+};
+
+export const ReaderRevenueLinksNative: React.FC<Props> = ({
+	edition,
 	dataLinkNamePrefix,
 	inHeader,
+	urls,
+	ophanRecord,
+	pageViewId,
 }) => {
-	if (shouldHideSupportMessaging()) {
+	const hideSupportMessaging = shouldHideSupportMessaging();
+
+	// Only the header component is in the AB test
+	const testName = inHeader ? remoteRRHeaderLinksTestName : 'RRFooterLinks';
+	const campaignCode = `${testName}_control`;
+	const tracking: TestMeta = {
+		abTestName: testName,
+		abTestVariant: 'control',
+		componentType: inHeader ? 'ACQUISITIONS_HEADER' : 'ACQUISITIONS_FOOTER',
+		campaignCode,
+	};
+
+	const [hasBeenSeen, setNode] = useHasBeenSeen({
+		threshold: 0,
+		debounce: true,
+	});
+
+	useEffect(() => {
+		if (!hideSupportMessaging && inHeader) {
+			sendOphanComponentEvent('INSERT', tracking, ophanRecord);
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
+	useEffect(() => {
+		if (hasBeenSeen && inHeader) {
+			sendOphanComponentEvent('VIEW', tracking, ophanRecord);
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [hasBeenSeen]);
+
+	const getUrl = (rrType: 'contribute' | 'subscribe'): string => {
+		if (inHeader) {
+			return addTrackingCodesToUrl({
+				base: `https://support.theguardian.com/${rrType}`,
+				componentType: 'ACQUISITIONS_HEADER',
+				componentId: campaignCode,
+				campaignCode,
+				abTest: {
+					name: remoteRRHeaderLinksTestName,
+					variant: 'control',
+				},
+				pageViewId,
+				referrerUrl: window.location.origin + window.location.pathname,
+			});
+		}
+		return urls[rrType];
+	};
+
+	if (hideSupportMessaging) {
 		return (
 			<div className={cx(inHeader && headerStyles)}>
 				<div
@@ -140,7 +333,7 @@ export const ReaderRevenueLinks: React.FC<Props> = ({
 		);
 	}
 	return (
-		<div className={cx(inHeader && headerStyles)}>
+		<div ref={setNode} className={cx(inHeader && headerStyles)}>
 			<div
 				className={cx({
 					[hiddenUntilTablet]: inHeader,
@@ -154,14 +347,14 @@ export const ReaderRevenueLinks: React.FC<Props> = ({
 				</div>
 				<a
 					className={linkStyles}
-					href={urls.contribute}
+					href={getUrl('contribute')}
 					data-link-name={`${dataLinkNamePrefix}contribute-cta`}
 				>
 					Contribute <ArrowRightIcon />
 				</a>
 				<a
 					className={linkStyles}
-					href={urls.subscribe}
+					href={getUrl('subscribe')}
 					data-link-name={`${dataLinkNamePrefix}subscribe-cta`}
 				>
 					Subscribe <ArrowRightIcon />
@@ -177,7 +370,7 @@ export const ReaderRevenueLinks: React.FC<Props> = ({
 				{edition === 'UK' ? (
 					<a
 						className={linkStyles}
-						href={urls.subscribe}
+						href={getUrl('subscribe')}
 						data-link-name={`${dataLinkNamePrefix}contribute-cta`}
 					>
 						Subscribe <ArrowRightIcon />
@@ -185,7 +378,7 @@ export const ReaderRevenueLinks: React.FC<Props> = ({
 				) : (
 					<a
 						className={linkStyles}
-						href={urls.contribute}
+						href={getUrl('contribute')}
 						data-link-name={`${dataLinkNamePrefix}support-cta`}
 					>
 						Contribute <ArrowRightIcon />
@@ -193,5 +386,42 @@ export const ReaderRevenueLinks: React.FC<Props> = ({
 				)}
 			</div>
 		</div>
+	);
+};
+
+export const ReaderRevenueLinks: React.FC<Props> = ({
+	edition,
+	countryCode,
+	dataLinkNamePrefix,
+	inHeader,
+	inRemoteModuleTest,
+	urls,
+	contributionsServiceUrl,
+	ophanRecord,
+	pageViewId = '',
+}: Props) => {
+	if (inHeader && inRemoteModuleTest) {
+		return (
+			<ReaderRevenueLinksRemote
+				edition={edition}
+				countryCode={countryCode}
+				pageViewId={pageViewId}
+				contributionsServiceUrl={contributionsServiceUrl}
+				ophanRecord={ophanRecord}
+			/>
+		);
+	}
+	return (
+		<ReaderRevenueLinksNative
+			edition={edition}
+			countryCode={countryCode}
+			dataLinkNamePrefix={dataLinkNamePrefix}
+			inHeader={inHeader}
+			inRemoteModuleTest={inRemoteModuleTest}
+			urls={urls}
+			contributionsServiceUrl={contributionsServiceUrl}
+			ophanRecord={ophanRecord}
+			pageViewId={pageViewId}
+		/>
 	);
 };

--- a/src/web/experiments/ab-tests.ts
+++ b/src/web/experiments/ab-tests.ts
@@ -6,6 +6,7 @@ import {
 	newsletterMerchUnitLighthouseControl,
 	newsletterMerchUnitLighthouseVariants,
 } from '@root/src/web/experiments/tests/newsletter-merch-unit-test';
+import { remoteRRHeaderLinksTest } from '@root/src/web/experiments/tests/remoteRRHeaderLinksTest';
 
 export const tests: ABTest[] = [
 	abTestTest,
@@ -13,4 +14,5 @@ export const tests: ABTest[] = [
 	signInGateMainControl,
 	newsletterMerchUnitLighthouseControl,
 	newsletterMerchUnitLighthouseVariants,
+	remoteRRHeaderLinksTest,
 ];

--- a/src/web/experiments/tests/remoteRRHeaderLinksTest.ts
+++ b/src/web/experiments/tests/remoteRRHeaderLinksTest.ts
@@ -1,0 +1,30 @@
+import { ABTest } from '@guardian/ab-core';
+
+export const remoteRRHeaderLinksTestName = 'RemoteRRHeaderLinksTest';
+
+export const remoteRRHeaderLinksTest: ABTest = {
+	id: remoteRRHeaderLinksTestName,
+	start: '2021-04-10',
+	expiry: '2021-12-01',
+	author: 'Tom Forbes',
+	description:
+		'Use the dotcom-components service for serving the Reader Revenue header links',
+	audience: 1,
+	audienceOffset: 0.0,
+	successMeasure: 'AV is not worse',
+	audienceCriteria: 'all pageviews',
+	dataLinkNames: 'RRHeaderLinks',
+	idealOutcome: 'AV is not worse',
+	showForSensitive: true,
+	canRun: () => true,
+	variants: [
+		{
+			id: 'control',
+			test: (): void => {},
+		},
+		{
+			id: 'remote',
+			test: (): void => {},
+		},
+	],
+};

--- a/src/web/lib/useHasBeenSeen.ts
+++ b/src/web/lib/useHasBeenSeen.ts
@@ -25,18 +25,20 @@ const useHasBeenSeen = (
 			observer.current.disconnect();
 		}
 
-		observer.current = new window.IntersectionObserver(
-			intersectionCallback,
-			options,
-		);
+		if (window.IntersectionObserver) {
+			observer.current = new window.IntersectionObserver(
+				intersectionCallback,
+				options,
+			);
 
-		const { current: currentObserver } = observer;
+			const { current: currentObserver } = observer;
 
-		if (node) {
-			currentObserver.observe(node);
+			if (node) {
+				currentObserver.observe(node);
+			}
+
+			return () => currentObserver.disconnect();
 		}
-
-		return () => currentObserver.disconnect();
 	}, [node, options, intersectionCallback]);
 
 	return [hasBeenSeen, setNode];


### PR DESCRIPTION
Currently it's difficult to change and AB test the RR links space in the header.
This PR introduces an AB test to measure the impact of serving this component as a module from support-dotcom-components. See https://github.com/guardian/frontend/pull/23703
We already use this mechanism for epics and banners.

This AB test does not include frontend. If the variant performs no worse then we can migrate frontend to use the same mechanism.

The PR also changes `submitComponentEvent` to take the `ophanRecord` function as a dependency. This is to enable storybook testing of the component, where `ophan` is not on the window object. Various places in this codebase also use ophan, but I didn't want to do the full refactor in this PR.

There are slight style differences because the variant uses src-button, but I don't think it'll make a big difference.
### Mobile
#### control
![Screen Shot 2021-04-19 at 10 01 41](https://user-images.githubusercontent.com/1513454/115210359-68779b00-a0f6-11eb-8635-2419a1d1eb44.png)

#### remote
![Screen Shot 2021-04-19 at 10 18 31](https://user-images.githubusercontent.com/1513454/115212621-9d84ed00-a0f8-11eb-9ba5-6529c529857b.png)

### Mobile medium
#### control
![Screen Shot 2021-04-19 at 10 02 05](https://user-images.githubusercontent.com/1513454/115211807-d6709200-a0f7-11eb-88e4-032a1336f4f8.png)

#### remote
![Screen Shot 2021-04-19 at 10 02 14](https://user-images.githubusercontent.com/1513454/115211834-dbcddc80-a0f7-11eb-86c3-0bb13b56b19a.png)

### Tablet
#### control
![Screen Shot 2021-04-19 at 10 19 39](https://user-images.githubusercontent.com/1513454/115212801-cefdb880-a0f8-11eb-9432-80eae1cc8153.png)

#### variant
![Screen Shot 2021-04-19 at 10 19 15](https://user-images.githubusercontent.com/1513454/115212815-d1f8a900-a0f8-11eb-89f5-cc1847c6c888.png)

### Desktop
#### control
![Screen Shot 2021-04-19 at 10 20 42](https://user-images.githubusercontent.com/1513454/115212963-f94f7600-a0f8-11eb-9ea8-5ca73927b3d7.png)

#### variant
![Screen Shot 2021-04-19 at 10 20 52](https://user-images.githubusercontent.com/1513454/115212973-fce2fd00-a0f8-11eb-8682-8845558431d3.png)

### Leftcol
#### control
![Screen Shot 2021-04-19 at 10 21 53](https://user-images.githubusercontent.com/1513454/115213344-55b29580-a0f9-11eb-9a4f-27de39c59758.png)

#### variant
![Screen Shot 2021-04-19 at 10 21 45](https://user-images.githubusercontent.com/1513454/115213370-59deb300-a0f9-11eb-881a-15e72274f63c.png)
