### PR TITLE
Remove unused nanoevents package

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,7 +198,6 @@
         "load-json-file": "^6.2.0",
         "lodash.clonedeep": "^4.5.0",
         "mockdate": "^3.0.2",
-        "nanoevents": "^5.1.10",
         "node-fetch": "^2.6.1",
         "nodemon": "^2.0.7",
         "npm-run-all": "^4.1.5",
@@ -235,9 +234,9 @@
         "webpack-node-externals": "^2.5.2",
         "webpack-sources": "^2.2.0"
     },
-		"resolutions": {
-			"@types/serve-static": "^1.13.9"
-		},
+    "resolutions": {
+        "@types/serve-static": "^1.13.9"
+    },
     "jest": {
         "preset": "ts-jest/presets/js-with-ts",
         "testEnvironment": "jest-environment-jsdom-sixteen",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14273,11 +14273,6 @@ nan@^2.12.1, nan@^2.13.2:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
 
-nanoevents@^5.1.10:
-  version "5.1.10"
-  resolved "https://registry.yarnpkg.com/nanoevents/-/nanoevents-5.1.10.tgz#9165199eed228c4787086dd1ea579b64257b8f8e"
-  integrity sha512-QOE78g63vQ7V1JzhOLP8UNlaLOF/llDtfUhCj9GlbhQQc0YdPi5GNJKZdeWE0fvDtGF39un6uSf7RObeBm0eAg==
-
 nanoid@^3.1.16:
   version "3.1.16"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.16.tgz#b21f0a7d031196faf75314d7c65d36352beeef64"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
We do not use `nanoevents` therefore we should remove it
