### PR TITLE
Don't use `isLiveBlog`

### DIFF
--- a/fixtures/manual/most-read-geo.ts
+++ b/fixtures/manual/most-read-geo.ts
@@ -240,7 +240,7 @@ export const mostReadGeo = {
 			},
 			isLiveBlog: true,
 			format: {
-				design: 'ArticleDesign',
+				design: 'LiveBlogDesign',
 				theme: 'NewsPillar',
 				display: 'StandardDisplay',
 			},

--- a/src/amp/pages/Article.tsx
+++ b/src/amp/pages/Article.tsx
@@ -24,12 +24,12 @@ const Body: React.FunctionComponent<{
 	data: ArticleModel;
 	config: ConfigType;
 }> = ({ data, config }) => {
-	// TODO check if there is a better way to determine if liveblog
-	const isLiveBlog =
-		data.format.design === 'LiveBlogDesign' ||
-		data.format.design === 'DeadBlogDesign';
+	const { format } = data;
 
-	if (isLiveBlog) {
+	if (
+		format.design === 'LiveBlogDesign' ||
+		format.design === 'DeadBlogDesign'
+	) {
 		return <BodyLiveblog data={data} config={config} />;
 	}
 	return <BodyArticle data={data} config={config} />;

--- a/src/web/components/Card/Card.Layout.stories.tsx
+++ b/src/web/components/Card/Card.Layout.stories.tsx
@@ -579,7 +579,6 @@ export const Quad = () => (
 							imagePosition="top"
 							showClock={true}
 							commentCount={30989}
-							isLiveBlog={true}
 							showPulsingDot={true}
 						/>
 					</LI>

--- a/src/web/components/Card/Card.tsx
+++ b/src/web/components/Card/Card.tsx
@@ -33,7 +33,6 @@ type Props = {
 	headlineSize?: SmallHeadlineSize;
 	showQuotes?: boolean; // Even with design !== Comment, a piece can be opinion
 	byline?: string;
-	isLiveBlog?: boolean; // When design === Design.LiveBlog, this denotes if the liveblog is active or not
 	showByline?: boolean;
 	webPublicationDate?: string;
 	imageUrl?: string;

--- a/src/web/components/LiveBlock.tsx
+++ b/src/web/components/LiveBlock.tsx
@@ -278,7 +278,6 @@ export const LiveBlock = ({
 					{headerElement && (
 						<ElementRenderer
 							isMainMedia={false}
-							isLiveBlog={true}
 							adTargeting={adTargeting}
 							index={0}
 							element={headerElement}
@@ -299,7 +298,6 @@ export const LiveBlock = ({
 							<BlockMedia key={`${element._type}-${index}`}>
 								<ElementRenderer
 									isMainMedia={false}
-									isLiveBlog={true}
 									adTargeting={adTargeting}
 									index={index}
 									element={element}
@@ -317,7 +315,6 @@ export const LiveBlock = ({
 						<BlockText key={`${element._type}-${index}`}>
 							<ElementRenderer
 								isMainMedia={false}
-								isLiveBlog={true}
 								index={index}
 								element={element}
 								format={format}

--- a/src/web/components/MostViewed/MostViewed.mocks.ts
+++ b/src/web/components/MostViewed/MostViewed.mocks.ts
@@ -1,9 +1,3 @@
-const makeCAPIFormat = (theme: CAPITheme): CAPIFormat => ({
-	theme,
-	design: 'ArticleDesign',
-	display: 'StandardDisplay',
-});
-
 export const mockTab1: CAPITrailTabType = {
 	heading: 'Across The Guardian',
 	trails: [
@@ -17,7 +11,11 @@ export const mockTab1: CAPITrailTabType = {
 			image:
 				'https://i.guim.co.uk/img/media/85377038aacd71b2c0e55b0a55478165fe6d3014/0_0_6000_3600/master/6000.jpg?width=300&quality=85&auto=format&fit=max&s=de2cecf52b21492f01daa4520c4f2a97',
 			isLiveBlog: true,
-			format: makeCAPIFormat('NewsPillar'),
+			format: {
+				design: 'LiveBlogDesign',
+				theme: 'NewsPillar',
+				display: 'StandardDisplay',
+			},
 			pillar: 'news',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
@@ -31,7 +29,11 @@ export const mockTab1: CAPITrailTabType = {
 			image:
 				'https://i.guim.co.uk/img/media/579fd19481e46b9d6ed3c69c2a6992483df84478/0_0_6000_3600/master/6000.jpg?width=300&quality=85&auto=format&fit=max&s=63a6a5c13a8087e607a44ce5c7da2090',
 			isLiveBlog: false,
-			format: makeCAPIFormat('OpinionPillar'),
+			format: {
+				design: 'ArticleDesign',
+				theme: 'OpinionPillar',
+				display: 'StandardDisplay',
+			},
 			pillar: 'opinion',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			ageWarning: '1 year old',
@@ -47,7 +49,11 @@ export const mockTab1: CAPITrailTabType = {
 			image:
 				'https://i.guim.co.uk/img/media/0df1fc1a2b78aa1772b4b43c2e5ebfc7f43111a8/0_91_5445_3267/master/5445.jpg?width=300&quality=85&auto=format&fit=max&s=3da9f89b54b0126fec2677117e73487e',
 			isLiveBlog: true,
-			format: makeCAPIFormat('SportPillar'),
+			format: {
+				design: 'LiveBlogDesign',
+				theme: 'SportPillar',
+				display: 'StandardDisplay',
+			},
 			pillar: 'sport',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
@@ -62,7 +68,11 @@ export const mockTab1: CAPITrailTabType = {
 			image:
 				'https://i.guim.co.uk/img/media/57a9a1a56c7d319a8f57a9c8767793ae0481db4c/0_95_4950_2970/master/4950.jpg?width=300&quality=85&auto=format&fit=max&s=77949a713212b69499d0dc6b5bdb2faf',
 			isLiveBlog: true,
-			format: makeCAPIFormat('CulturePillar'),
+			format: {
+				design: 'LiveBlogDesign',
+				theme: 'CulturePillar',
+				display: 'StandardDisplay',
+			},
 			pillar: 'culture',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
@@ -77,7 +87,11 @@ export const mockTab1: CAPITrailTabType = {
 			image:
 				'https://i.guim.co.uk/img/media/e05185cce0a0c6953e666276caa98f6ea104c989/0_214_3600_2160/master/3600.jpg?width=300&quality=85&auto=format&fit=max&s=188a7a9ed42517b9462ae0788fe96a0a',
 			isLiveBlog: false,
-			format: makeCAPIFormat('LifestylePillar'),
+			format: {
+				design: 'ArticleDesign',
+				theme: 'LifestylePillar',
+				display: 'StandardDisplay',
+			},
 			pillar: 'lifestyle',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
@@ -93,7 +107,11 @@ export const mockTab1: CAPITrailTabType = {
 			image:
 				'https://i.guim.co.uk/img/media/5792a3b971914e21bd04cb13eed54159463ce90e/0_128_4991_2994/master/4991.jpg?width=300&quality=85&auto=format&fit=max&s=6d4eab73546172d576a1022c29bdbcd2',
 			isLiveBlog: false,
-			format: makeCAPIFormat('NewsPillar'),
+			format: {
+				design: 'ArticleDesign',
+				theme: 'NewsPillar',
+				display: 'StandardDisplay',
+			},
 			pillar: 'news',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
@@ -108,7 +126,11 @@ export const mockTab1: CAPITrailTabType = {
 			image:
 				'https://i.guim.co.uk/img/media/2e87f0ee5f1a6c292cfcfc5f6f99e9a54ba3cc05/0_139_4032_2419/master/4032.jpg?width=300&quality=85&auto=format&fit=max&s=e951b289eda050060201927e978d30ef',
 			isLiveBlog: false,
-			format: makeCAPIFormat('NewsPillar'),
+			format: {
+				design: 'ArticleDesign',
+				theme: 'NewsPillar',
+				display: 'StandardDisplay',
+			},
 			pillar: 'news',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
@@ -123,7 +145,11 @@ export const mockTab1: CAPITrailTabType = {
 			image:
 				'https://i.guim.co.uk/img/media/2d88f2493b6eff49b6b8d6dd35345f03fa2b4af2/0_721_3361_2017/master/3361.jpg?width=300&quality=85&auto=format&fit=max&s=8601a174c9dc594f75318da8e99932bf',
 			isLiveBlog: false,
-			format: makeCAPIFormat('NewsPillar'),
+			format: {
+				design: 'ArticleDesign',
+				theme: 'NewsPillar',
+				display: 'StandardDisplay',
+			},
 			pillar: 'news',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
@@ -138,7 +164,11 @@ export const mockTab1: CAPITrailTabType = {
 			image:
 				'https://i.guim.co.uk/img/media/bceaab691b06c3f3830e7794d24c6ada2b301fad/847_177_2750_1650/master/2750.jpg?width=300&quality=85&auto=format&fit=max&s=3af893de9c01e38a8635c83883ef17ef',
 			isLiveBlog: false,
-			format: makeCAPIFormat('NewsPillar'),
+			format: {
+				design: 'ArticleDesign',
+				theme: 'NewsPillar',
+				display: 'StandardDisplay',
+			},
 			pillar: 'news',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
@@ -153,7 +183,11 @@ export const mockTab1: CAPITrailTabType = {
 			image:
 				'https://i.guim.co.uk/img/media/bc4e5ed4448eafd6238656aefae98c832cacc148/32_13_1898_1139/master/1898.jpg?width=300&quality=85&auto=format&fit=max&s=a4b8c116c5e580482dfe727d126b57ae',
 			isLiveBlog: false,
-			format: makeCAPIFormat('NewsPillar'),
+			format: {
+				design: 'ArticleDesign',
+				theme: 'NewsPillar',
+				display: 'StandardDisplay',
+			},
 			pillar: 'news',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
@@ -174,7 +208,11 @@ export const mockTab2: CAPITrailTabType = {
 			image:
 				'https://i.guim.co.uk/img/media/eef1ed43631aa9088f26fca4a138f6e4250d9319/0_297_5400_3240/master/5400.jpg?width=300&quality=85&auto=format&fit=max&s=90f779a1a1ca85348a47ff19ccc50b12',
 			isLiveBlog: false,
-			format: makeCAPIFormat('NewsPillar'),
+			format: {
+				design: 'ArticleDesign',
+				theme: 'NewsPillar',
+				display: 'StandardDisplay',
+			},
 			pillar: 'news',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
@@ -189,7 +227,11 @@ export const mockTab2: CAPITrailTabType = {
 			image:
 				'https://i.guim.co.uk/img/media/ff131761ef56456073d4edfb52af4ec8b8b953c2/0_290_6355_3813/master/6355.jpg?width=300&quality=85&auto=format&fit=max&s=6f1d869f447a6389e1e4a05b457c2289',
 			isLiveBlog: false,
-			format: makeCAPIFormat('NewsPillar'),
+			format: {
+				design: 'ArticleDesign',
+				theme: 'NewsPillar',
+				display: 'StandardDisplay',
+			},
 			pillar: 'news',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
@@ -204,7 +246,11 @@ export const mockTab2: CAPITrailTabType = {
 			image:
 				'https://i.guim.co.uk/img/media/1ce9e4ae33c1be975ab83fdabc267fc081c9d73c/0_0_4000_2400/master/4000.jpg?width=300&quality=85&auto=format&fit=max&s=16240604b766e11e7d5846fa13c43102',
 			isLiveBlog: false,
-			format: makeCAPIFormat('NewsPillar'),
+			format: {
+				design: 'ArticleDesign',
+				theme: 'NewsPillar',
+				display: 'StandardDisplay',
+			},
 			pillar: 'news',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
@@ -219,7 +265,11 @@ export const mockTab2: CAPITrailTabType = {
 			image:
 				'https://i.guim.co.uk/img/media/6de53bbc2260febc167488209afe81844c47ecaa/0_225_5352_3211/master/5352.jpg?width=300&quality=85&auto=format&fit=max&s=d7da55f1e5f9d6b3a11f0c97237f3992',
 			isLiveBlog: false,
-			format: makeCAPIFormat('CulturePillar'),
+			format: {
+				design: 'ArticleDesign',
+				theme: 'CulturePillar',
+				display: 'StandardDisplay',
+			},
 			pillar: 'culture',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
@@ -234,7 +284,11 @@ export const mockTab2: CAPITrailTabType = {
 			image:
 				'https://i.guim.co.uk/img/media/5ee2bea12b92b28eff10b84d22e952c2681cb5f5/0_479_2239_1343/master/2239.jpg?width=300&quality=85&auto=format&fit=max&s=7b5cfb46f6a84b663d94a83c35acfe81',
 			isLiveBlog: false,
-			format: makeCAPIFormat('NewsPillar'),
+			format: {
+				design: 'ArticleDesign',
+				theme: 'NewsPillar',
+				display: 'StandardDisplay',
+			},
 			pillar: 'news',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
@@ -248,7 +302,11 @@ export const mockTab2: CAPITrailTabType = {
 			image:
 				'https://i.guim.co.uk/img/media/981e17d90b401754aae355d2e56bfedbe5b359b5/0_1000_2480_1488/master/2480.jpg?width=300&quality=85&auto=format&fit=max&s=facd8591d83abd4b0019370b6031be6e',
 			isLiveBlog: false,
-			format: makeCAPIFormat('NewsPillar'),
+			format: {
+				design: 'ArticleDesign',
+				theme: 'NewsPillar',
+				display: 'StandardDisplay',
+			},
 			pillar: 'news',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
@@ -263,7 +321,11 @@ export const mockTab2: CAPITrailTabType = {
 			image:
 				'https://i.guim.co.uk/img/media/ff17da45e26064e2666106902a90655e4db49ea4/955_135_1467_880/master/1467.jpg?width=300&quality=85&auto=format&fit=max&s=f6c5f055f7614d73f65ec193bb30c054',
 			isLiveBlog: false,
-			format: makeCAPIFormat('NewsPillar'),
+			format: {
+				design: 'ArticleDesign',
+				theme: 'NewsPillar',
+				display: 'StandardDisplay',
+			},
 			pillar: 'news',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
@@ -278,7 +340,11 @@ export const mockTab2: CAPITrailTabType = {
 			image:
 				'https://i.guim.co.uk/img/media/b819ca05b59cdbe5ee59684740d1d9fe181b5a22/0_69_3600_2160/master/3600.jpg?width=300&quality=85&auto=format&fit=max&s=2f001df53652440f4be489b695c03ad2',
 			isLiveBlog: false,
-			format: makeCAPIFormat('NewsPillar'),
+			format: {
+				design: 'ArticleDesign',
+				theme: 'NewsPillar',
+				display: 'StandardDisplay',
+			},
 			pillar: 'news',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
@@ -293,7 +359,11 @@ export const mockTab2: CAPITrailTabType = {
 			image:
 				'https://i.guim.co.uk/img/media/1e518e0996861201a7350f91f46d1f573ed2ea9c/0_823_6206_3724/master/6206.jpg?width=300&quality=85&auto=format&fit=max&s=149bde7a6699e526903598c690c214d0',
 			isLiveBlog: false,
-			format: makeCAPIFormat('NewsPillar'),
+			format: {
+				design: 'ArticleDesign',
+				theme: 'NewsPillar',
+				display: 'StandardDisplay',
+			},
 			pillar: 'news',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
@@ -308,7 +378,11 @@ export const mockTab2: CAPITrailTabType = {
 			image:
 				'https://i.guim.co.uk/img/media/478dcff6eee2cbd753f1956e420c4caaf7b00fdd/0_1208_8095_4859/master/8095.jpg?width=300&quality=85&auto=format&fit=max&s=44effc5b2ab10b9a588be02c55a0620a',
 			isLiveBlog: false,
-			format: makeCAPIFormat('NewsPillar'),
+			format: {
+				design: 'ArticleDesign',
+				theme: 'NewsPillar',
+				display: 'StandardDisplay',
+			},
 			pillar: 'news',
 			designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 			webPublicationDate: '',
@@ -346,7 +420,11 @@ export const mockMostShared = {
 	image:
 		'https://i.guim.co.uk/img/media/579fd19481e46b9d6ed3c69c2a6992483df84478/0_0_6000_3600/master/6000.jpg?width=300&quality=85&auto=format&fit=max&s=63a6a5c13a8087e607a44ce5c7da2090',
 	isLiveBlog: false,
-	format: makeCAPIFormat('OpinionPillar'),
+	format: {
+		design: 'ArticleDesign',
+		theme: 'OpinionPillar',
+		display: 'StandardDisplay',
+	},
 	pillar: 'opinion',
 	designType: 'not-applicable', // Needed for the type but never used. Will eventually be removed upstream and then here.
 	ageWarning: '1 year old',

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.test.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooter.test.tsx
@@ -125,10 +125,10 @@ describe('MostViewedFooterData', () => {
 							showByline: false,
 							byline: '',
 							image: '',
-							isLiveBlog: true,
+							isLiveBlog: false, // No longer used
 							format: {
 								theme: 'NewsPillar',
-								design: 'ArticleDesign',
+								design: 'LiveBlogDesign',
 								display: 'StandardDisplay',
 							},
 							pillar: 'news',
@@ -154,7 +154,7 @@ describe('MostViewedFooterData', () => {
 		expect(getByText('Live')).toBeInTheDocument();
 	});
 
-	it("should NOT display the text 'Live' when isLiveBlog is false", () => {
+	it("should NOT display the text 'Live' when design is Article is false", () => {
 		useApi.mockReturnValue({
 			data: [
 				{
@@ -166,7 +166,7 @@ describe('MostViewedFooterData', () => {
 							showByline: false,
 							byline: '',
 							image: '',
-							isLiveBlog: false,
+							isLiveBlog: true, // No longer used
 							format: {
 								theme: 'NewsPillar',
 								design: 'ArticleDesign',

--- a/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterItem.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/MostViewedFooterItem.tsx
@@ -77,7 +77,7 @@ export const MostViewedFooterItem = ({ trail, position }: Props) => (
 				<BigNumber index={position} />
 			</span>
 			<div className={headlineHeader}>
-				{trail.isLiveBlog ? (
+				{trail.format.design === Design.LiveBlog ? (
 					<LinkHeadline
 						headlineText={trail.headline}
 						palette={trail.palette}
@@ -86,10 +86,7 @@ export const MostViewedFooterItem = ({ trail, position }: Props) => (
 						kickerText="Live"
 						showSlash={true}
 						showPulsingDot={true}
-						showQuotes={
-							trail.format.design === Design.Comment ||
-							trail.format.design === Design.Letter
-						}
+						showQuotes={false}
 					/>
 				) : (
 					<LinkHeadline

--- a/src/web/components/MostViewed/MostViewedFooter/SecondTierItem.tsx
+++ b/src/web/components/MostViewed/MostViewedFooter/SecondTierItem.tsx
@@ -88,7 +88,6 @@ export const SecondTierItem = ({
 }: Props) => {
 	const {
 		url,
-		isLiveBlog,
 		avatarUrl,
 		image,
 		format,
@@ -111,23 +110,14 @@ export const SecondTierItem = ({
 				<Flex>
 					<div className={headlineStyles}>
 						<div className={titleStyles}>{title}</div>
-						{isLiveBlog ? (
-							<LinkHeadline
-								headlineText={headlineText}
-								palette={palette}
-								format={format}
-								size="small"
-								byline={showByline ? byline : undefined}
-							/>
-						) : (
-							<LinkHeadline
-								headlineText={headlineText}
-								palette={palette}
-								format={format}
-								size="small"
-								byline={showByline ? byline : undefined}
-							/>
-						)}
+						<LinkHeadline
+							headlineText={headlineText}
+							palette={palette}
+							format={format}
+							size="small"
+							byline={showByline ? byline : undefined}
+						/>
+
 						{ageWarning && (
 							<div className={ageWarningStyles}>
 								<AgeWarning age={ageWarning} size="small" />

--- a/src/web/components/MostViewed/MostViewedRight/MostViewedRightItem.tsx
+++ b/src/web/components/MostViewed/MostViewedRight/MostViewedRightItem.tsx
@@ -3,6 +3,7 @@ import { css } from 'emotion';
 
 import { neutral, border, text } from '@guardian/src-foundations/palette';
 import { headline } from '@guardian/src-foundations/typography';
+import { Design } from '@guardian/types';
 import { AgeWarning } from '@root/src/web/components/AgeWarning';
 import { Avatar } from '@root/src/web/components/Avatar';
 import { LinkHeadline } from '@root/src/web/components/LinkHeadline';
@@ -84,7 +85,7 @@ export const MostViewedRightItem = ({ trail, mostViewedItemIndex }: Props) => {
 						</div>
 					)}
 					<div className={headlineWrapperStyles}>
-						{trail.isLiveBlog ? (
+						{trail.format.design === Design.LiveBlog ? (
 							<LinkHeadline
 								headlineText={trail.headline}
 								palette={trail.palette}

--- a/src/web/components/Onwards/Carousel/Carousel.stories.tsx
+++ b/src/web/components/Onwards/Carousel/Carousel.stories.tsx
@@ -229,12 +229,12 @@ const trails: TrailType[] = [
 		format: {
 			display: Display.Standard,
 			theme: Pillar.News,
-			design: Design.Article,
+			design: Design.LiveBlog,
 		},
 		palette: decidePalette({
 			display: Display.Standard,
 			theme: Pillar.News,
-			design: Design.Article,
+			design: Design.LiveBlog,
 		}),
 		webPublicationDate: '2021-02-16T17:00:15.000Z',
 		headline:

--- a/src/web/components/Onwards/ExactlyFive.tsx
+++ b/src/web/components/Onwards/ExactlyFive.tsx
@@ -28,7 +28,9 @@ export const ExactlyFive = ({ content }: Props) => (
 					}
 					webPublicationDate={content[0].webPublicationDate}
 					kickerText={content[0].kickerText}
-					showPulsingDot={content[0].isLiveBlog}
+					showPulsingDot={
+						content[0].format.design === Design.LiveBlog
+					}
 					showSlash={true}
 					showClock={false}
 					imageUrl={content[0].image}
@@ -57,7 +59,9 @@ export const ExactlyFive = ({ content }: Props) => (
 					}
 					webPublicationDate={content[1].webPublicationDate}
 					kickerText={content[1].kickerText}
-					showPulsingDot={content[1].isLiveBlog}
+					showPulsingDot={
+						content[1].format.design === Design.LiveBlog
+					}
 					showSlash={true}
 					showClock={false}
 					imageUrl={content[1].image}
@@ -88,7 +92,9 @@ export const ExactlyFive = ({ content }: Props) => (
 							}
 							webPublicationDate={content[2].webPublicationDate}
 							kickerText={content[2].kickerText}
-							showPulsingDot={content[2].isLiveBlog}
+							showPulsingDot={
+								content[2].format.design === Design.LiveBlog
+							}
 							showSlash={true}
 							showClock={false}
 							mediaType={content[2].mediaType}
@@ -111,7 +117,9 @@ export const ExactlyFive = ({ content }: Props) => (
 							}
 							webPublicationDate={content[3].webPublicationDate}
 							kickerText={content[3].kickerText}
-							showPulsingDot={content[3].isLiveBlog}
+							showPulsingDot={
+								content[3].format.design === Design.LiveBlog
+							}
 							showSlash={true}
 							showClock={false}
 							mediaType={content[3].mediaType}
@@ -134,7 +142,9 @@ export const ExactlyFive = ({ content }: Props) => (
 							}
 							webPublicationDate={content[4].webPublicationDate}
 							kickerText={content[4].kickerText}
-							showPulsingDot={content[4].isLiveBlog}
+							showPulsingDot={
+								content[4].format.design === Design.LiveBlog
+							}
 							showSlash={true}
 							showClock={false}
 							mediaType={content[4].mediaType}

--- a/src/web/components/Onwards/FourOrLess.tsx
+++ b/src/web/components/Onwards/FourOrLess.tsx
@@ -51,7 +51,9 @@ export const FourOrLess = ({ content }: Props) => {
 							}
 							webPublicationDate={trail.webPublicationDate}
 							kickerText={trail.kickerText}
-							showPulsingDot={trail.isLiveBlog}
+							showPulsingDot={
+								trail.format.design === Design.LiveBlog
+							}
 							showSlash={true}
 							showClock={false}
 							imageUrl={trail.image}

--- a/src/web/components/Onwards/MoreThanFive.tsx
+++ b/src/web/components/Onwards/MoreThanFive.tsx
@@ -45,7 +45,9 @@ export const MoreThanFive = ({ content }: Props) => {
 						}
 						webPublicationDate={content[0].webPublicationDate}
 						kickerText={content[0].kickerText}
-						showPulsingDot={content[0].isLiveBlog}
+						showPulsingDot={
+							content[0].format.design === Design.LiveBlog
+						}
 						showSlash={true}
 						showClock={false}
 						imageUrl={content[0].image}
@@ -74,7 +76,9 @@ export const MoreThanFive = ({ content }: Props) => {
 						}
 						webPublicationDate={content[1].webPublicationDate}
 						kickerText={content[1].kickerText}
-						showPulsingDot={content[1].isLiveBlog}
+						showPulsingDot={
+							content[1].format.design === Design.LiveBlog
+						}
 						showSlash={true}
 						showClock={false}
 						imageUrl={content[1].image}
@@ -103,7 +107,9 @@ export const MoreThanFive = ({ content }: Props) => {
 						}
 						webPublicationDate={content[2].webPublicationDate}
 						kickerText={content[2].kickerText}
-						showPulsingDot={content[2].isLiveBlog}
+						showPulsingDot={
+							content[2].format.design === Design.LiveBlog
+						}
 						showSlash={true}
 						showClock={false}
 						imageUrl={content[2].image}
@@ -132,7 +138,9 @@ export const MoreThanFive = ({ content }: Props) => {
 						}
 						webPublicationDate={content[3].webPublicationDate}
 						kickerText={content[3].kickerText}
-						showPulsingDot={content[3].isLiveBlog}
+						showPulsingDot={
+							content[3].format.design === Design.LiveBlog
+						}
 						showSlash={true}
 						showClock={false}
 						imageUrl={content[3].image}
@@ -168,7 +176,9 @@ export const MoreThanFive = ({ content }: Props) => {
 							}
 							webPublicationDate={trail.webPublicationDate}
 							kickerText={trail.kickerText}
-							showPulsingDot={trail.isLiveBlog}
+							showPulsingDot={
+								trail.format.design === Design.LiveBlog
+							}
 							showSlash={true}
 							showClock={false}
 							imageUrl={

--- a/src/web/components/Onwards/Spotlight.tsx
+++ b/src/web/components/Onwards/Spotlight.tsx
@@ -23,7 +23,7 @@ export const Spotlight = ({ content }: Props) => (
 		}
 		webPublicationDate={content[0].webPublicationDate}
 		kickerText={content[0].kickerText}
-		showPulsingDot={content[0].isLiveBlog}
+		showPulsingDot={content[0].format.design === Design.LiveBlog}
 		showSlash={true}
 		showClock={false}
 		imageUrl={content[0].image}

--- a/src/web/lib/ElementRenderer.tsx
+++ b/src/web/lib/ElementRenderer.tsx
@@ -52,6 +52,7 @@ import {
 	PersonalityQuizAtom,
 	KnowledgeQuizAtom,
 } from '@guardian/atoms-rendering';
+import { Design } from '@guardian/types';
 
 type Props = {
 	format: Format;
@@ -63,7 +64,6 @@ type Props = {
 	index: number;
 	hideCaption?: boolean;
 	isMainMedia?: boolean;
-	isLiveBlog?: boolean;
 	starRating?: number;
 	isPreview: boolean;
 };
@@ -78,10 +78,12 @@ export const ElementRenderer = ({
 	index,
 	hideCaption,
 	isMainMedia,
-	isLiveBlog,
 	starRating,
 	isPreview,
 }: Props) => {
+	const isLiveBlog =
+		format.design === Design.LiveBlog || format.design === Design.DeadBlog;
+
 	switch (element._type) {
 		case 'model.dotcomrendering.pageElements.AudioAtomBlockElement':
 			return (


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
We have a legacy boolean `isLiveBlog` on the CAPI model that has been used in the past to denote articles that are liveblogs.  This PR replaces use of this boolean with `format` instead

## Why?
Because `format` is the place to be but also because often `isLiveBLog` doesn't distinguish between live and dead and this causes bugs (we're resurecting dead blogs)
