### PR TITLE
Use LocalMessageCache instead of InMemoryCache

### DIFF
--- a/src/web/lib/braze/buildBrazeMessages.ts
+++ b/src/web/lib/braze/buildBrazeMessages.ts
@@ -8,7 +8,6 @@ import { record } from '@root/src/web/browser/ophan/ophan';
 import {
 	BrazeMessages,
 	BrazeMessagesInterface,
-	InMemoryCache,
 	LocalMessageCache,
 	NullBrazeMessages,
 } from '@guardian/braze-components/logic';
@@ -86,7 +85,7 @@ export const buildBrazeMessages = async (
 		};
 		const brazeMessages = new BrazeMessages(
 			appboy,
-			InMemoryCache,
+			LocalMessageCache,
 			errorHandler,
 		);
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
We will start using the `LocalMessageCache` for Braze messages. This was required because the Braze Epic will often not be seen by users (as it's at the end of the article) and we will need a mechanism to persist the message beyond a single page/session.

I've tested the delivery of messages locally.

### Before
Braze messages uses the `InMemoryCache`

### After
Braze messages use the local storage-based `LocalMessageCache`.

## Why?
To support the Braze Epic and also to show Braze banners on a subsequent page if they did not display before the time limit specified by the platform.

Fronted PR is [here](https://github.com/guardian/frontend/pull/23692).