### PR TITLE
Fix account dropdown z-index issue

### DIFF
--- a/src/web/components/Links.tsx
+++ b/src/web/components/Links.tsx
@@ -13,6 +13,7 @@ import { DropdownLinkType, Dropdown } from '@root/src/web/components/Dropdown';
 import ProfileIcon from '@frontend/static/icons/profile.svg';
 import { createAuthenticationEventParams } from '@root/src/lib/identity-component-event';
 import { useOnce } from '@frontend/web/lib/useOnce';
+import { getZIndex } from '../lib/getZIndex';
 
 type Props = {
 	supporterCTA: string;
@@ -46,6 +47,11 @@ const linkStyles = css`
 		width: 18px;
 		margin: 3px 4px 0 0;
 	}
+`;
+
+const searchLinkStyles = css`
+	${linkStyles}
+	${getZIndex('searchHeaderLink')}
 `;
 
 const linkTablet = ({ showAtTablet }: { showAtTablet: boolean }) => css`
@@ -235,7 +241,10 @@ export const Links = ({
 			)}
 
 			<Search
-				className={cx(linkTablet({ showAtTablet: false }), linkStyles)}
+				className={cx(
+					linkTablet({ showAtTablet: false }),
+					searchLinkStyles,
+				)}
 				href="https://www.google.co.uk/advanced_search?q=site:www.theguardian.com"
 				dataLinkName="nav2 : search"
 			>

--- a/src/web/components/Links.tsx
+++ b/src/web/components/Links.tsx
@@ -7,7 +7,6 @@ import { brand, brandText, brandAlt } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 
-import { getZIndex } from '@root/src/web/lib/getZIndex';
 import { getCookie } from '@root/src/web/browser/cookie';
 import { DropdownLinkType, Dropdown } from '@root/src/web/components/Dropdown';
 
@@ -122,8 +121,6 @@ const linksStyles = css`
 	${from.wide} {
 		right: 342px;
 	}
-
-	${getZIndex('headerLinks')}
 `;
 
 export const Links = ({

--- a/src/web/lib/getZIndex.test.tsx
+++ b/src/web/lib/getZIndex.test.tsx
@@ -2,11 +2,12 @@ import { getZIndex } from './getZIndex';
 
 describe('getZIndex', () => {
 	it('gets the correct zindex for group and sibling', () => {
-		expect(getZIndex('banner')).toBe('z-index: 12;');
-		expect(getZIndex('dropdown')).toBe('z-index: 11;');
-		expect(getZIndex('burger')).toBe('z-index: 10;');
-		expect(getZIndex('stickyNav')).toBe('z-index: 9;');
-		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 8;');
+		expect(getZIndex('banner')).toBe('z-index: 13;');
+		expect(getZIndex('dropdown')).toBe('z-index: 12;');
+		expect(getZIndex('burger')).toBe('z-index: 11;');
+		expect(getZIndex('stickyNav')).toBe('z-index: 10;');
+		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 9;');
+		expect(getZIndex('searchHeaderLink')).toBe('z-index: 8;');
 		expect(getZIndex('TheGuardian')).toBe('z-index: 7;');
 		expect(getZIndex('headerWrapper')).toBe('z-index: 6;');
 		expect(getZIndex('articleHeadline')).toBe('z-index: 5;');

--- a/src/web/lib/getZIndex.test.tsx
+++ b/src/web/lib/getZIndex.test.tsx
@@ -2,12 +2,11 @@ import { getZIndex } from './getZIndex';
 
 describe('getZIndex', () => {
 	it('gets the correct zindex for group and sibling', () => {
-		expect(getZIndex('banner')).toBe('z-index: 13;');
-		expect(getZIndex('dropdown')).toBe('z-index: 12;');
-		expect(getZIndex('burger')).toBe('z-index: 11;');
-		expect(getZIndex('stickyNav')).toBe('z-index: 10;');
-		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 9;');
-		expect(getZIndex('headerLinks')).toBe('z-index: 8;');
+		expect(getZIndex('banner')).toBe('z-index: 12;');
+		expect(getZIndex('dropdown')).toBe('z-index: 11;');
+		expect(getZIndex('burger')).toBe('z-index: 10;');
+		expect(getZIndex('stickyNav')).toBe('z-index: 9;');
+		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 8;');
 		expect(getZIndex('TheGuardian')).toBe('z-index: 7;');
 		expect(getZIndex('headerWrapper')).toBe('z-index: 6;');
 		expect(getZIndex('articleHeadline')).toBe('z-index: 5;');

--- a/src/web/lib/getZIndex.tsx
+++ b/src/web/lib/getZIndex.tsx
@@ -32,6 +32,8 @@ const indices = [
 	// Header
 	'stickyAdWrapper',
 
+	// Search link should be above The Guardian svg
+	'searchHeaderLink',
 	'TheGuardian',
 
 	// Wrapper after nav stuff

--- a/src/web/lib/getZIndex.tsx
+++ b/src/web/lib/getZIndex.tsx
@@ -32,8 +32,6 @@ const indices = [
 	// Header
 	'stickyAdWrapper',
 
-	// Header links (should be above The Guardian svg)
-	'headerLinks',
 	'TheGuardian',
 
 	// Wrapper after nav stuff


### PR DESCRIPTION
## What does this change?

Fixes a z-index issue where the account dropdown to be partially obscured by the nav. Only affects users in the 'anchor' variant of the sticky-nav test who are also signed in. (%-wise there are 5/3 % of users in the test, so that is the upper bound, but in practice only a small number of these are signed in.)

### Before

![image](https://user-images.githubusercontent.com/858402/114545107-72f7e780-9c53-11eb-8f69-8c375e0b9aeb.png)

### After

![Screenshot 2021-04-13 at 12 11 41](https://user-images.githubusercontent.com/858402/114545127-79865f00-9c53-11eb-8bfe-737cff01a7d0.png)

## Why?

To fix things!