### PR TITLE
No credit

### DIFF
--- a/src/model/enhance-images.test.ts
+++ b/src/model/enhance-images.test.ts
@@ -55,6 +55,7 @@ describe('Enhance Images', () => {
 									...image.data,
 									caption:
 										'<ul><li>This new caption replaces the one on the image object.</li></ul>',
+									credit: '',
 								},
 							},
 						],
@@ -101,13 +102,21 @@ describe('Enhance Images', () => {
 										...image,
 										role: 'halfWidth',
 										displayCredit: false,
-										data: { ...image.data, caption: '' },
+										data: {
+											...image.data,
+											caption: '',
+											credit: '',
+										},
 									},
 									{
 										...image,
 										role: 'halfWidth',
 										displayCredit: false,
-										data: { ...image.data, caption: '' },
+										data: {
+											...image.data,
+											caption: '',
+											credit: '',
+										},
 									},
 								],
 								caption:
@@ -152,7 +161,11 @@ describe('Enhance Images', () => {
 								...image,
 								role: 'inline',
 								displayCredit: false,
-								data: { ...image.data, caption: '' },
+								data: {
+									...image.data,
+									caption: '',
+									credit: '',
+								},
 							},
 							{
 								...image,
@@ -162,6 +175,7 @@ describe('Enhance Images', () => {
 									...image.data,
 									caption:
 										'<ul><li><p>Judy, just sitting in the square on her own in Walworth.</p></li></ul>',
+									credit: '',
 								},
 							},
 						],
@@ -206,6 +220,7 @@ describe('Enhance Images', () => {
 									...image.data,
 									caption:
 										'<ul><li><p>Judy, just sitting in the square on her own in Walworth.</p></li></ul>',
+									credit: '',
 								},
 							},
 						],
@@ -247,6 +262,7 @@ describe('Enhance Images', () => {
 								data: {
 									...image.data,
 									caption: '',
+									credit: '',
 								},
 								title: 'Example title text',
 							},
@@ -303,6 +319,7 @@ describe('Enhance Images', () => {
 									...image.data,
 									caption:
 										'<ul><li><p>This is the caption</p></li></ul>',
+									credit: '',
 								},
 								title: 'The title',
 							},
@@ -357,13 +374,21 @@ describe('Enhance Images', () => {
 										...image,
 										role: 'halfWidth',
 										displayCredit: false,
-										data: { ...image.data, caption: '' },
+										data: {
+											...image.data,
+											caption: '',
+											credit: '',
+										},
 									},
 									{
 										...image,
 										role: 'halfWidth',
 										displayCredit: false,
-										data: { ...image.data, caption: '' },
+										data: {
+											...image.data,
+											caption: '',
+											credit: '',
+										},
 									},
 								],
 							},
@@ -375,6 +400,7 @@ describe('Enhance Images', () => {
 									...image.data,
 									caption:
 										'<ul><li><p>This is the caption</p></li></ul>',
+									credit: '',
 								},
 							},
 						],
@@ -430,6 +456,7 @@ describe('Enhance Images', () => {
 									...image.data,
 									caption:
 										'<ul><li><p>This is the caption</p></li></ul>',
+									credit: '',
 								},
 								title: 'The title',
 							},
@@ -470,6 +497,7 @@ describe('Enhance Images', () => {
 								data: {
 									...image.data,
 									caption: '',
+									credit: '',
 								},
 							},
 						],
@@ -526,6 +554,7 @@ describe('Enhance Images', () => {
 									...image.data,
 									caption:
 										'<ul><li><p>This is the caption</p></li></ul>',
+									credit: '',
 								},
 								title: 'The title',
 							},
@@ -539,13 +568,21 @@ describe('Enhance Images', () => {
 								...image,
 								role: 'inline',
 								displayCredit: false,
-								data: { ...image.data, caption: '' },
+								data: {
+									...image.data,
+									caption: '',
+									credit: '',
+								},
 							},
 							{
 								...image,
 								role: 'immersive',
 								displayCredit: false,
-								data: { ...image.data, caption: '' },
+								data: {
+									...image.data,
+									caption: '',
+									credit: '',
+								},
 							},
 						],
 					},
@@ -606,6 +643,7 @@ describe('Enhance Images', () => {
 								data: {
 									...image.data,
 									caption: '',
+									credit: '',
 								},
 								title: 'The title',
 							},

--- a/src/model/enhance-images.ts
+++ b/src/model/enhance-images.ts
@@ -255,6 +255,30 @@ const stripCaptions = (elements: CAPIElement[]): CAPIElement[] => {
 	return withoutCaptions;
 };
 
+const removeCredit = (elements: CAPIElement[]): CAPIElement[] => {
+	// Remove credit from all images
+	const withoutCredit: CAPIElement[] = [];
+	elements.forEach((thisElement) => {
+		if (
+			thisElement._type ===
+			'model.dotcomrendering.pageElements.ImageBlockElement'
+		) {
+			// Remove the credit from this image
+			withoutCredit.push({
+				...thisElement,
+				data: {
+					...thisElement.data,
+					credit: '',
+				},
+			} as ImageBlockElement);
+		} else {
+			// Pass through
+			withoutCredit.push(thisElement);
+		}
+	});
+	return withoutCredit;
+};
+
 class Enhancer {
 	elements: CAPIElement[];
 
@@ -286,6 +310,11 @@ class Enhancer {
 		this.elements = addCaptionsToImages(this.elements);
 		return this;
 	}
+
+	removeCredit() {
+		this.elements = removeCredit(this.elements);
+		return this;
+	}
 }
 
 const enhance = (
@@ -298,6 +327,8 @@ const enhance = (
 				// Photo essays by convention have all image captions removed and rely completely on
 				// special captions set using the ul/li trick
 				.stripCaptions()
+				// By convention, photo essays don't include credit for images in the caption
+				.removeCredit()
 				// Replace pairs of halfWidth images with MultiImageBlockElements
 				.addMultiImageElements()
 				// Photo essay have a convention of adding titles to images if the subsequent block is a h2


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Prevents credit from showing in the captions for photo essays

### Before
![Screenshot 2021-04-13 at 16 22 18](https://user-images.githubusercontent.com/1336821/114578505-d8100500-9c74-11eb-9993-ee6171fd51d3.jpg)

### After
![Screenshot 2021-04-13 at 16 22 29](https://user-images.githubusercontent.com/1336821/114578522-dba38c00-9c74-11eb-8399-81fc69c9e41a.jpg)

## Why?
Photo essays are different
