### PR TITLE
Decide Image Role

### DIFF
--- a/src/web/lib/ElementRenderer.tsx
+++ b/src/web/lib/ElementRenderer.tsx
@@ -68,6 +68,16 @@ type Props = {
 	isPreview: boolean;
 };
 
+function decideImageRole(role: RoleType, isLiveBlog: boolean): RoleType {
+	switch (role) {
+		case 'inline':
+		case 'thumbnail':
+			return role;
+		default:
+			return isLiveBlog ? 'inline' : role;
+	}
+}
+
 export const ElementRenderer = ({
 	format,
 	palette,
@@ -326,7 +336,7 @@ export const ElementRenderer = ({
 			return (
 				<Figure
 					isMainMedia={isMainMedia}
-					role={isLiveBlog ? 'inline' : element.role}
+					role={decideImageRole(element.role, isLiveBlog)}
 				>
 					<ImageBlockComponent
 						format={format}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds a small function to decide what `role` to use for images. We were already making ths decision usinig a ternary based on `isLiveBlog` but now we to be slightly cleverer

## Why?
Because I noticed [this blog post](https://www.theguardian.com/uk-news/live/2021/apr/09/prince-philip-duke-of-edinburgh-dies-latest-updates?page=with:block-5628d3c3e4b0666540ca5fef#block-5628d3c3e4b0666540ca5fef) had a thumbnail image, and then discovered [this piece of code](https://github.com/guardian/flexible-content/blob/f9d37a49b0690a67952d2ccccf5255ab3dd7a3a6/composer/src/js/controllers/content/common/body-block/elements/edit.js#L301) and realised DCR needed to be ever so slightly more sophisticated.

## Can we do better here?
Maybe. Maybe we want to think about hoisting the logic to decide a `role` up. Maybe into `LiveBlock` or, perhaps better, into an enhancer function? Thought I'd keep this PR clean though.
