### PR TITLE
Remove top padding above age warning

### DIFF
--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -22,7 +22,9 @@ type Props = {
 const curly = (x: any) => x;
 
 const topPadding = css`
-	padding-top: ${space[1]}px;
+	${from.leftCol} {
+		padding-top: ${space[1]}px;
+	}
 `;
 
 const standardFont = css`

--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -407,6 +407,20 @@ export const ArticleHeadline = ({
 							)}
 						</div>
 					);
+				case Design.LiveBlog:
+				case Design.DeadBlog:
+					return (
+						<h1
+							className={cx(
+								standardFont,
+								css`
+									color: ${palette.text.headline};
+								`,
+							)}
+						>
+							{curly(headlineString)}
+						</h1>
+					);
 				default:
 					return (
 						<h1

--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -21,6 +21,10 @@ type Props = {
 
 const curly = (x: any) => x;
 
+const topPadding = css`
+	padding-top: ${space[1]}px;
+`;
+
 const standardFont = css`
 	${headline.medium()};
 	${until.tablet} {
@@ -296,6 +300,7 @@ export const ArticleHeadline = ({
 						<h1
 							className={cx(
 								boldFont,
+								topPadding,
 								css`
 									color: ${palette.text.headline};
 								`,
@@ -311,6 +316,7 @@ export const ArticleHeadline = ({
 							<h1
 								className={cx(
 									lightFont,
+									topPadding,
 									css`
 										color: ${palette.text.headline};
 									`,
@@ -334,6 +340,7 @@ export const ArticleHeadline = ({
 							<h1
 								className={cx(
 									lightFont,
+									topPadding,
 									css`
 										color: ${palette.text.headline};
 									`,
@@ -348,6 +355,7 @@ export const ArticleHeadline = ({
 						<h1
 							className={cx(
 								standardFont,
+								topPadding,
 								underlinedStyles,
 								css`
 									color: ${palette.text.headline};
@@ -404,6 +412,7 @@ export const ArticleHeadline = ({
 								format.theme === Special.Labs
 									? labsFont
 									: standardFont,
+								topPadding,
 								css`
 									color: ${palette.text.headline};
 								`,

--- a/src/web/components/ArticleHeadlinePadding.tsx
+++ b/src/web/components/ArticleHeadlinePadding.tsx
@@ -13,10 +13,6 @@ const determinePadding = ({
 	starRating?: boolean;
 }) => {
 	switch (design) {
-		case Design.Interview:
-			return css`
-				padding-top: ${space[1]}px;
-			`;
 		case Design.Review:
 			if (starRating) {
 				return '';
@@ -27,13 +23,13 @@ const determinePadding = ({
 					padding-bottom: ${space[9]}px;
 				}
 			`;
+		case Design.Interview:
 		case Design.LiveBlog:
 		case Design.DeadBlog:
-			// Don't add extra padding for live or dead blogs
+			// Don't add extra padding
 			return css``;
 		default:
 			return css`
-				padding-top: ${space[1]}px;
 				padding-bottom: ${space[6]}px;
 				${from.tablet} {
 					padding-bottom: ${space[9]}px;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Moves 4 pixels of padding from `ArticleHeadlinePadding` where it appeared above the headline age warning, moving it into the `ArticleHeadline` comnponent

### Before
![Screenshot 2021-04-13 at 17 39 17](https://user-images.githubusercontent.com/1336821/114589041-3346f500-9c7f-11eb-8262-5723e42b10c7.jpg)


### After
![Screenshot 2021-04-13 at 17 38 57](https://user-images.githubusercontent.com/1336821/114589058-36da7c00-9c7f-11eb-965b-384bd8fc0995.jpg)


## Why?
Because this space was appearing in-between the age warning and the top of the page, which prevented the age warning alligning correctly