### PR TITLE
Change the size of middots

### DIFF
--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -9,6 +9,12 @@
 // ***********************************************************
 
 module.exports = (on, config) => {
+	on('task', {
+		log(message) {
+			console.log(message);
+			return null;
+		},
+	});
 	config.env = { ...config.env, ...process.env };
 	return config;
 };

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -9,12 +9,6 @@
 // ***********************************************************
 
 module.exports = (on, config) => {
-	on('task', {
-		log(message) {
-			console.log(message);
-			return null;
-		},
-	});
 	config.env = { ...config.env, ...process.env };
 	return config;
 };

--- a/src/web/components/Standfirst.tsx
+++ b/src/web/components/Standfirst.tsx
@@ -47,9 +47,9 @@ const nestedStyles = (palette: Palette) => css`
 		display: inline-block;
 		content: '';
 		border-radius: 100%;
-		height: 0.95rem;
-		width: 0.95rem;
-		margin-right: 0.125rem;
+		height: 15.2px;
+		width: 15.2px;
+		margin-right: 2px;
 		background-color: ${neutral[86]};
 	}
 

--- a/src/web/components/Standfirst.tsx
+++ b/src/web/components/Standfirst.tsx
@@ -46,9 +46,9 @@ const nestedStyles = (palette: Palette) => css`
 	[data-dcr-style='bullet'] {
 		display: inline-block;
 		content: '';
-		border-radius: 0.375rem;
-		height: 0.75rem;
-		width: 0.75rem;
+		border-radius: 100%;
+		height: 0.95rem;
+		width: 0.95rem;
 		margin-right: 0.125rem;
 		background-color: ${neutral[86]};
 	}

--- a/src/web/components/elements/TextBlockComponent.tsx
+++ b/src/web/components/elements/TextBlockComponent.tsx
@@ -158,9 +158,9 @@ const paraStyles = (format: Format) => css`
 		display: inline-block;
 		content: '';
 		border-radius: 100%;
-		height: 0.95rem;
-		width: 0.95rem;
-		margin-right: 0.125rem;
+		height: 15.2px;
+		width: 15.2px;
+		margin-right: 0.2px;
 		background-color: ${decidePalette(format).background.bullet};
 	}
 

--- a/src/web/components/elements/TextBlockComponent.tsx
+++ b/src/web/components/elements/TextBlockComponent.tsx
@@ -157,9 +157,9 @@ const paraStyles = (format: Format) => css`
 	[data-dcr-style='bullet'] {
 		display: inline-block;
 		content: '';
-		border-radius: 0.375rem;
-		height: 0.75rem;
-		width: 0.75rem;
+		border-radius: 100%;
+		height: 0.95rem;
+		width: 0.95rem;
 		margin-right: 0.125rem;
 		background-color: ${decidePalette(format).background.bullet};
 	}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Changes the standfirst middot so it's the same size as the text.

### Before

![Screenshot 2021-04-14 at 15 52 50](https://user-images.githubusercontent.com/35331926/114731722-e116da00-9d39-11eb-9c20-95a7238de216.png)


### After

![Screenshot 2021-04-14 at 15 52 28](https://user-images.githubusercontent.com/35331926/114731746-e5db8e00-9d39-11eb-9cf1-09d4fd1a6f3f.png)

