### PR TITLE
Blank spaces are not captions

### DIFF
--- a/src/web/components/Caption.tsx
+++ b/src/web/components/Caption.tsx
@@ -131,7 +131,8 @@ export const Caption = ({
 	shouldLimitWidth = false,
 	isOverlayed,
 }: Props) => {
-	const noCaption = !captionText;
+	// Sometimes captions come thorough as a single blank space, so we trim here to ignore those
+	const noCaption = !captionText?.trim();
 	const noCredit = !credit;
 	const hideCredit = !displayCredit;
 	if (noCaption && (noCredit || hideCredit)) return null;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Trims the caption before checking if it exists or not

### Before
![image](https://user-images.githubusercontent.com/1336821/114836278-63e77580-9dca-11eb-8814-1deccedceb3e.png)


### After
![Screenshot 2021-04-15 at 09 12 02](https://user-images.githubusercontent.com/1336821/114836513-a90ba780-9dca-11eb-8114-43258c3444a6.jpg)

## Why?
Because `" "` is truthy
