### PR TITLE
Add a TEMP in-memory cache to fetch the anniversary interactive atom

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -459,6 +459,8 @@ interface CAPIType {
 
 	matchUrl?: string;
 	isSpecialReport: boolean;
+
+	anniversaryInteractiveAtom?: InteractiveAtomBlockElement; // TEMPORARY, to be removed following 200th anniversary
 }
 
 // Browser data models. Note the CAPI prefix here means something different to

--- a/src/model/enhance-AnniversaryInteractiveAtom.ts
+++ b/src/model/enhance-AnniversaryInteractiveAtom.ts
@@ -1,0 +1,11 @@
+import { getAnniversaryAtomCache } from '@root/src/web/server/cacheForAnniversaryInteractiveAtom';
+
+export const enhanceAnniversaryAtom = (data: CAPIType): CAPIType => {
+	// TODO Add switch
+	// const {  } = data.config.switches;
+	if ('addAProperSwitchHere') {
+		data.anniversaryInteractiveAtom = getAnniversaryAtomCache();
+	}
+
+	return data;
+};

--- a/src/model/enhance-AnniversaryInteractiveAtom.ts
+++ b/src/model/enhance-AnniversaryInteractiveAtom.ts
@@ -2,8 +2,15 @@ import { getAnniversaryAtomCache } from '@root/src/web/server/cacheForAnniversar
 
 export const enhanceAnniversaryAtom = (data: CAPIType): CAPIType => {
 	// TODO Add switch
-	// const {  } = data.config.switches;
-	if ('addAProperSwitchHere') {
+	const {
+		anniversaryArticleHeader,
+		hideAnniversaryAtom,
+	} = data.config.switches;
+
+	// If the main anniversaryArticleHeader switch is ON
+	// and the AB test switch is NOT ON.
+	// Users will be opted-in to the AB Test IF THEY HIDE THE BANNER.
+	if (anniversaryArticleHeader && !hideAnniversaryAtom) {
 		data.anniversaryInteractiveAtom = getAnniversaryAtomCache();
 	}
 

--- a/src/web/server/cacheForAnniversaryInteractiveAtom.ts
+++ b/src/web/server/cacheForAnniversaryInteractiveAtom.ts
@@ -70,7 +70,7 @@ const refreshAnniversaryAtom = () => {
 		fetchAnniversaryAtom()
 			.then(refreshAnniversaryAtom)
 			.catch((e) => console.log(`fetchAnniversaryAtom - error: ${e}`));
-	}, oneMinute * 2);
+	}, oneMinute);
 };
 
 getGuardianConfiguration('prod')

--- a/src/web/server/cacheForAnniversaryInteractiveAtom.ts
+++ b/src/web/server/cacheForAnniversaryInteractiveAtom.ts
@@ -1,0 +1,79 @@
+import fetch from 'node-fetch';
+
+// WARNING
+// This is a TEMP solution.
+// It is the simplest route to showing the anniversary atom, while being able to then
+// strip out the code as easily as possible, as opposed to actors in Frontend.
+
+interface AtomResponse {
+	response: {
+		interactive: {
+			id: string;
+			data: {
+				interactive: {
+					css: string;
+					mainJS: string;
+					html: string;
+					id: string;
+				};
+			};
+		};
+	};
+}
+
+export const InteractiveAtomUrl =
+	'https://content.guardianapis.com/atom/interactive/interactives/thrashers/2021/04/g200-article-banner/default?api-key=HOWDOIGETTHIS';
+
+let AnniversaryAtomCache: InteractiveAtomBlockElement | undefined;
+export const getAnniversaryAtomCache = ():
+	| InteractiveAtomBlockElement
+	| undefined => AnniversaryAtomCache;
+
+const fetchAnniversaryAtom = (): Promise<void> => {
+	return fetch(InteractiveAtomUrl)
+		.then((rawResponse) => rawResponse.json())
+		.then((atom: AtomResponse) => {
+			const { id } = atom?.response?.interactive;
+
+			const {
+				css,
+				mainJS,
+				html,
+			} = atom?.response?.interactive?.data?.interactive;
+
+			if (css && mainJS && html && id) {
+				console.log('in here');
+				AnniversaryAtomCache = {
+					_type:
+						'model.dotcomrendering.pageElements.InteractiveAtomBlockElement',
+					url: InteractiveAtomUrl,
+					css,
+					js: mainJS,
+					html,
+					id,
+					elementId: 'anniversary_atom_main',
+				};
+			} else {
+				AnniversaryAtomCache = undefined;
+			}
+		});
+
+	// return fetch(InteractiveAtomUrl)
+	// 	.then((rawResponse) => rawResponse.json())
+	// 	.then((json) => {
+	// 		AnniversaryAtomCache = json;
+	// 	});
+};
+
+const oneMinute = 60_00;
+const refreshAnniversaryAtom = () => {
+	setTimeout(() => {
+		fetchAnniversaryAtom()
+			.then(refreshAnniversaryAtom)
+			.catch((e) => console.error(`fetchAnniversaryAtom - error: ${e}`));
+	}, oneMinute * 2);
+};
+
+fetchAnniversaryAtom()
+	.then(refreshAnniversaryAtom)
+	.catch((e) => console.error(`fetchIAnniversaryAtom - error: ${e}`));

--- a/src/web/server/cacheForAnniversaryInteractiveAtom.ts
+++ b/src/web/server/cacheForAnniversaryInteractiveAtom.ts
@@ -1,4 +1,8 @@
 import fetch from 'node-fetch';
+import {
+	getGuardianConfiguration,
+	GuardianConfiguration,
+} from '@frontend/app/aws/aws-parameters';
 
 // WARNING
 // This is a TEMP solution.
@@ -21,20 +25,22 @@ interface AtomResponse {
 	};
 }
 
-export const InteractiveAtomUrl =
-	'https://content.guardianapis.com/atom/interactive/interactives/thrashers/2021/04/g200-article-banner/default?api-key=HOWDOIGETTHIS';
-
+let InteractiveAtomUrl: string | undefined;
 let AnniversaryAtomCache: InteractiveAtomBlockElement | undefined;
+
 export const getAnniversaryAtomCache = ():
 	| InteractiveAtomBlockElement
 	| undefined => AnniversaryAtomCache;
 
 const fetchAnniversaryAtom = (): Promise<void> => {
+	if (InteractiveAtomUrl === undefined) {
+		return Promise.reject(new Error('Interactive Atom URL not set'));
+	}
+
 	return fetch(InteractiveAtomUrl)
 		.then((rawResponse) => rawResponse.json())
 		.then((atom: AtomResponse) => {
 			const { id } = atom?.response?.interactive;
-
 			const {
 				css,
 				mainJS,
@@ -42,11 +48,10 @@ const fetchAnniversaryAtom = (): Promise<void> => {
 			} = atom?.response?.interactive?.data?.interactive;
 
 			if (css && mainJS && html && id) {
-				console.log('in here');
 				AnniversaryAtomCache = {
 					_type:
 						'model.dotcomrendering.pageElements.InteractiveAtomBlockElement',
-					url: InteractiveAtomUrl,
+					url: InteractiveAtomUrl || '',
 					css,
 					js: mainJS,
 					html,
@@ -57,12 +62,6 @@ const fetchAnniversaryAtom = (): Promise<void> => {
 				AnniversaryAtomCache = undefined;
 			}
 		});
-
-	// return fetch(InteractiveAtomUrl)
-	// 	.then((rawResponse) => rawResponse.json())
-	// 	.then((json) => {
-	// 		AnniversaryAtomCache = json;
-	// 	});
 };
 
 const oneMinute = 60_00;
@@ -70,10 +69,17 @@ const refreshAnniversaryAtom = () => {
 	setTimeout(() => {
 		fetchAnniversaryAtom()
 			.then(refreshAnniversaryAtom)
-			.catch((e) => console.error(`fetchAnniversaryAtom - error: ${e}`));
+			.catch((e) => console.log(`fetchAnniversaryAtom - error: ${e}`));
 	}, oneMinute * 2);
 };
 
-fetchAnniversaryAtom()
+getGuardianConfiguration('prod')
+	.then((config: GuardianConfiguration) => {
+		const key = config.getParameter('anniversaryAtomCAPIKey');
+		if (key) {
+			InteractiveAtomUrl = `https://content.guardianapis.com/atom/interactive/interactives/thrashers/2021/04/g200-article-banner/default?api-key=${key}`;
+		}
+	})
+	.then(fetchAnniversaryAtom)
 	.then(refreshAnniversaryAtom)
-	.catch((e) => console.error(`fetchIAnniversaryAtom - error: ${e}`));
+	.catch((e) => console.log(`fetchIAnniversaryAtom - error: ${e}`));

--- a/src/web/server/cacheForAnniversaryInteractiveAtom.ts
+++ b/src/web/server/cacheForAnniversaryInteractiveAtom.ts
@@ -25,7 +25,7 @@ interface AtomResponse {
 	};
 }
 
-let InteractiveAtomUrl: string | undefined;
+let InteractiveAtomUrl: string;
 let AnniversaryAtomCache: InteractiveAtomBlockElement | undefined;
 
 export const getAnniversaryAtomCache = ():
@@ -33,10 +33,6 @@ export const getAnniversaryAtomCache = ():
 	| undefined => AnniversaryAtomCache;
 
 const fetchAnniversaryAtom = (): Promise<void> => {
-	if (InteractiveAtomUrl === undefined) {
-		return Promise.reject(new Error('Interactive Atom URL not set'));
-	}
-
 	return fetch(InteractiveAtomUrl)
 		.then((rawResponse) => rawResponse.json())
 		.then((atom: AtomResponse) => {
@@ -76,9 +72,12 @@ const refreshAnniversaryAtom = () => {
 getGuardianConfiguration('prod')
 	.then((config: GuardianConfiguration) => {
 		const key = config.getParameter('anniversaryAtomCAPIKey');
-		if (key) {
-			InteractiveAtomUrl = `https://content.guardianapis.com/atom/interactive/interactives/thrashers/2021/04/g200-article-banner/default?api-key=${key}`;
+		if (!key || key === '') {
+			throw new Error(
+				'Config parameter anniversaryAtomCAPIKey was not available',
+			);
 		}
+		InteractiveAtomUrl = `https://content.guardianapis.com/atom/interactive/interactives/thrashers/2021/04/g200-article-banner/default?api-key=${key}`;
 	})
 	.then(fetchAnniversaryAtom)
 	.then(refreshAnniversaryAtom)

--- a/src/web/server/cacheForAnniversaryInteractiveAtom.ts
+++ b/src/web/server/cacheForAnniversaryInteractiveAtom.ts
@@ -64,7 +64,7 @@ const fetchAnniversaryAtom = (): Promise<void> => {
 		});
 };
 
-const oneMinute = 60_00;
+const oneMinute = 60_000;
 const refreshAnniversaryAtom = () => {
 	setTimeout(() => {
 		fetchAnniversaryAtom()

--- a/src/web/server/render.ts
+++ b/src/web/server/render.ts
@@ -8,6 +8,7 @@ import { enhanceDots } from '@root/src/model/add-dots';
 import { setIsDev } from '@root/src/model/set-is-dev';
 import { enhanceImages } from '@root/src/model/enhance-images';
 import { enhanceBlockquotes } from '@root/src/model/enhance-blockquotes';
+import { enhanceAnniversaryAtom } from '@root/src/model/enhance-AnniversaryInteractiveAtom';
 import { extract as extractGA } from '@root/src/model/extract-ga';
 import { Article as ExampleArticle } from '@root/fixtures/generated/articles/Article';
 
@@ -47,6 +48,11 @@ class CAPIEnhancer {
 		this.capi = setIsDev(this.capi);
 		return this;
 	}
+
+	enhanceAnniversaryAtom() {
+		this.capi = enhanceAnniversaryAtom(this.capi);
+		return this;
+	}
 }
 
 export const render = (
@@ -59,7 +65,8 @@ export const render = (
 			.addDividers()
 			.enhanceBlockquotes()
 			.enhanceDots()
-			.enhanceImages().capi;
+			.enhanceImages()
+			.enhanceAnniversaryAtom().capi;
 		const resp = document({
 			data: {
 				CAPI,


### PR DESCRIPTION
*WARNING*

Do not copy this implementation for long-term implementations in products. In-memory caches are not tested, supported or planned for in DCR. This is a temp 10-day solution so that the removal of the implementation is quick and simple.

## What does this change?

Adds an in-memory cache for the Anniversary interactive-atom that will be shown on article pages.

It:

- Gets the CAPI key for the atom from param store
- Fetches the atom from CAPI every 60s
- Enhances the DCRCAPI JSON with the atom at the top level (it's not a block type)