### PR TITLE
Pagination component

### DIFF
--- a/src/web/components/Pagination.stories.tsx
+++ b/src/web/components/Pagination.stories.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { Design, Display, Pillar } from '@guardian/types';
+
+import { Pagination } from './Pagination';
+
+export default {
+	component: Pagination,
+	title: 'Components/Pagination',
+};
+
+const Container = ({ children }: { children: React.ReactNode }) => (
+	<div
+		className={css`
+			padding: 20px;
+		`}
+	>
+		{children}
+	</div>
+);
+
+export const defaultStory = () => {
+	return (
+		<Container>
+			<Pagination
+				format={{
+					display: Display.Standard,
+					design: Design.LiveBlog,
+					theme: Pillar.News,
+				}}
+				currentPage={2}
+				totalPages={6}
+			/>
+		</Container>
+	);
+};
+defaultStory.story = { name: 'default' };

--- a/src/web/components/Pagination.tsx
+++ b/src/web/components/Pagination.tsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { space } from '@guardian/src-foundations';
+import { LinkButton } from '@guardian/src-button';
+import { textSans } from '@guardian/src-foundations/typography';
+import {
+	SvgChevronLeftSingle,
+	SvgChevronRightSingle,
+} from '@guardian/src-icons';
+import { until } from '@guardian/src-foundations/mq';
+import { Hide } from './Hide';
+
+type Props = {
+	format: Format;
+	currentPage: number;
+	totalPages: number;
+	newest?: string;
+	newer?: string;
+	oldest?: string;
+	older?: string;
+};
+
+const Container = ({ children }: { children: React.ReactNode }) => (
+	<nav
+		// Used to scroll the page to this point when using permalinks
+		id="liveblog-navigation"
+		className={css`
+			display: flex;
+			flex-direction: row;
+			justify-content: space-between;
+		`}
+	>
+		{children}
+	</nav>
+);
+
+const Section = ({ children }: { children: React.ReactNode }) => (
+	<section
+		className={css`
+			display: flex;
+			align-items: center;
+		`}
+	>
+		{children}
+	</section>
+);
+
+const Bold = ({ children }: { children: React.ReactNode }) => (
+	<div
+		className={css`
+			font-weight: bold;
+		`}
+	>
+		{children}
+	</div>
+);
+
+const Position = ({ children }: { children: React.ReactNode }) => (
+	<div
+		className={css`
+			display: flex;
+			flex-direction: row;
+			${textSans.small()}
+		`}
+	>
+		{children}
+	</div>
+);
+
+const Of = () => <span>&nbsp;of&nbsp;</span>;
+
+const Space = () => (
+	<div
+		className={css`
+			${until.phablet} {
+				width: ${space[2]}px;
+			}
+			width: ${space[4]}px;
+		`}
+	/>
+);
+
+export const Pagination = ({
+	currentPage,
+	totalPages,
+	oldest,
+	older,
+	newest,
+	newer,
+}: Props) => {
+	return (
+		<Container>
+			<Section>
+				<LinkButton
+					size="small"
+					priority="tertiary"
+					icon={<SvgChevronLeftSingle />}
+					iconSide="left"
+					href={newest}
+				>
+					<Hide when="below" breakpoint="phablet">
+						Newest
+					</Hide>
+				</LinkButton>
+				<Space />
+				<LinkButton
+					size="small"
+					priority="tertiary"
+					icon={<SvgChevronLeftSingle />}
+					hideLabel={true}
+					href={newer}
+				>
+					<Hide when="below" breakpoint="phablet">
+						Previous
+					</Hide>
+				</LinkButton>
+			</Section>
+			<Section>
+				<Position>
+					<Bold>{currentPage}</Bold>
+					<Of />
+					<Bold>{totalPages}</Bold>
+				</Position>
+			</Section>
+			<Section>
+				<LinkButton
+					size="small"
+					priority="tertiary"
+					icon={<SvgChevronRightSingle />}
+					hideLabel={true}
+					href={older}
+				>
+					<Hide when="below" breakpoint="phablet">
+						Next
+					</Hide>
+				</LinkButton>
+				<Space />
+				<LinkButton
+					size="small"
+					priority="tertiary"
+					icon={<SvgChevronRightSingle />}
+					iconSide="right"
+					href={oldest}
+				>
+					<Hide when="below" breakpoint="phablet">
+						Oldest
+					</Hide>
+				</LinkButton>
+			</Section>
+		</Container>
+	);
+};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds a `Pagination` component.

```ts
type Props = {
	format: Format;
	currentPage: number;
	totalPages: number;
	newest?: string;
	newer?: string;
	oldest?: string;
	older?: string;
};
```

![Screenshot 2021-04-15 at 15 15 34](https://user-images.githubusercontent.com/1336821/114884165-74651380-9dfd-11eb-8ac6-616c5453f4b7.jpg)


## Why?
The real question is why another one? We already have a `Pagination` component for amp. This PR builds upon that but it is using Source for most things whereas the older amp version was not.

### Where are the double chevrons like in AMP?
Source doesn't currently offer a double chevron and rather than try to shoehorn the DCR version in here I've raised an issue [to update Source](https://github.com/guardian/source/issues/802), taking a more 'Source First' approach