### PR TITLE
Position Interactive MainMedia Better

### DIFF
--- a/src/web/components/ClickToView.stories.tsx
+++ b/src/web/components/ClickToView.stories.tsx
@@ -66,7 +66,7 @@ const RoleStory = ({
 					level. Truffaut street art edison bulb, banh mi cliche
 					post-ironic mixtape
 				</p>
-				<Figure role={role}>
+				<Figure isMainMedia={false} role={role}>
 					<ClickToView
 						role={role}
 						isTracking={true}
@@ -476,7 +476,7 @@ export const EmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure role="inline">
+				<Figure isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={facebookEmbed.source}
@@ -499,7 +499,7 @@ export const EmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure role="inline">
+				<Figure isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={vimeoEmbedEmbed.source}
@@ -522,7 +522,7 @@ export const EmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure role="inline">
+				<Figure isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={youtubeEmbedEmbed.source}
@@ -545,7 +545,7 @@ export const EmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure role="inline">
+				<Figure isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={spotifyEmbedEmbed.source}
@@ -568,7 +568,7 @@ export const EmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure role="inline">
+				<Figure isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={bandcampEmbedEmbed.source}
@@ -591,7 +591,7 @@ export const EmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure role="inline">
+				<Figure isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={ourworldindataEmbedEmbed.source}
@@ -614,7 +614,7 @@ export const EmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure role="inline">
+				<Figure isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={bbcEmbedEmbed.source}
@@ -661,7 +661,7 @@ export const UnsafeEmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure role="inline">
+				<Figure isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={instagramEmbedEmbed.source}
@@ -687,7 +687,7 @@ export const UnsafeEmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure role="inline">
+				<Figure isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={formStackEmbed.source}
@@ -714,7 +714,7 @@ export const UnsafeEmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure role="inline">
+				<Figure isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={scribdEmbedEmbed.source}
@@ -741,7 +741,7 @@ export const UnsafeEmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure role="inline">
+				<Figure isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={tiktokEmbedEmbed.source}
@@ -768,7 +768,7 @@ export const UnsafeEmbedBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure role="inline">
+				<Figure isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={twitterEmbedEmbed.source}
@@ -820,7 +820,7 @@ export const VimeoBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure role="inline">
+				<Figure isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={vimeoVideoEmbed.source}
@@ -881,7 +881,7 @@ export const DocumentBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure role="inline">
+				<Figure isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={scribdDocumentEmbed.source}
@@ -930,7 +930,7 @@ export const SoundCloudBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure role="inline">
+				<Figure isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={soundcloudAudioEmbed.source}
@@ -951,7 +951,7 @@ export const SoundCloudBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure role="inline">
+				<Figure isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={soundcloudEmbedEmbed.source}
@@ -997,7 +997,7 @@ export const SpotifyBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure role="inline">
+				<Figure isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={spotifyAudioEmbed.source}
@@ -1059,7 +1059,7 @@ export const TweetBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure role="inline">
+				<Figure isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={twitterTweetEmbed.source}
@@ -1102,7 +1102,7 @@ export const InstagramBlockComponentStory = () => {
 						here
 					</a>
 				</p>
-				<Figure role="inline">
+				<Figure isMainMedia={false} role="inline">
 					<ClickToView
 						isTracking={true}
 						source={instagramInstramEmbed.source}

--- a/src/web/components/Figure.stories.tsx
+++ b/src/web/components/Figure.stories.tsx
@@ -67,7 +67,7 @@ export const InlineStory = () => {
 				</LeftColumn>
 				<ArticleContainer>
 					<SomeText />
-					<Figure>
+					<Figure isMainMedia={false}>
 						<Grey />
 					</Figure>
 					<SomeText />
@@ -91,7 +91,7 @@ export const SupportingStory = () => {
 				<ArticleContainer>
 					<SomeText />
 					<SomeText />
-					<Figure role="supporting">
+					<Figure isMainMedia={false} role="supporting">
 						<Grey heightInPixels={500} />
 					</Figure>
 					<SomeText />
@@ -118,7 +118,7 @@ export const ImmersiveStory = () => {
 				</LeftColumn>
 				<ArticleContainer>
 					<SomeText />
-					<Figure role="immersive">
+					<Figure isMainMedia={false} role="immersive">
 						<Grey heightInPixels={700} />
 					</Figure>
 					<SomeText />
@@ -141,7 +141,7 @@ export const ThumbnailStory = () => {
 				</LeftColumn>
 				<ArticleContainer>
 					<SomeText />
-					<Figure role="thumbnail">
+					<Figure isMainMedia={false} role="thumbnail">
 						<Grey heightInPixels={200} />
 					</Figure>
 					<SomeText />
@@ -165,7 +165,7 @@ export const ShowcaseStory = () => {
 				</LeftColumn>
 				<ArticleContainer>
 					<SomeText />
-					<Figure role="showcase">
+					<Figure isMainMedia={false} role="showcase">
 						<Grey heightInPixels={500} />
 					</Figure>
 					<SomeText />
@@ -188,7 +188,7 @@ export const HalfWidthStory = () => {
 				</LeftColumn>
 				<ArticleContainer>
 					<SomeText />
-					<Figure role="halfWidth">
+					<Figure isMainMedia={false} role="halfWidth">
 						<Grey />
 					</Figure>
 					<SomeText />

--- a/src/web/components/Figure.tsx
+++ b/src/web/components/Figure.tsx
@@ -6,7 +6,7 @@ import { space } from '@guardian/src-foundations';
 
 type Props = {
 	children: React.ReactNode;
-	isMainMedia?: boolean;
+	isMainMedia: boolean;
 	role?: RoleType | 'richLink';
 	id?: string;
 };

--- a/src/web/components/RichLink.stories.tsx
+++ b/src/web/components/RichLink.stories.tsx
@@ -21,7 +21,7 @@ export default {
 export const Article = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure role="richLink">
+			<Figure isMainMedia={false} role="richLink">
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="news"
@@ -45,7 +45,7 @@ export const Article = () => {
 export const Network = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure role="richLink">
+			<Figure isMainMedia={false} role="richLink">
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="special-report"
@@ -75,7 +75,7 @@ Network.story = {
 export const SectionStory = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure role="richLink">
+			<Figure isMainMedia={false} role="richLink">
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="live"
@@ -102,7 +102,7 @@ SectionStory.story = {
 export const Inline = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure role="inline">
+			<Figure isMainMedia={false} role="inline">
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="external"
@@ -129,7 +129,7 @@ Inline.story = {
 export const ImageContent = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure role="richLink">
+			<Figure isMainMedia={false} role="richLink">
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="dead"
@@ -159,7 +159,7 @@ ImageContent.story = {
 export const Interactive = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure role="richLink">
+			<Figure isMainMedia={false} role="richLink">
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="feature"
@@ -188,7 +188,7 @@ Interactive.story = {
 export const Gallery = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure role="richLink">
+			<Figure isMainMedia={false} role="richLink">
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="comment"
@@ -218,7 +218,7 @@ Gallery.story = {
 export const Video = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure role="richLink">
+			<Figure isMainMedia={false} role="richLink">
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="comment"
@@ -249,7 +249,7 @@ Video.story = {
 export const Audio = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure role="richLink">
+			<Figure isMainMedia={false} role="richLink">
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="podcast"
@@ -273,7 +273,7 @@ export const Audio = () => {
 export const LiveBlog = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure role="richLink">
+			<Figure isMainMedia={false} role="richLink">
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="media"
@@ -303,7 +303,7 @@ LiveBlog.story = {
 export const Tag = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure role="richLink">
+			<Figure isMainMedia={false} role="richLink">
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="analysis"
@@ -327,7 +327,7 @@ export const Tag = () => {
 export const Index = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure role="richLink">
+			<Figure isMainMedia={false} role="richLink">
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="review"
@@ -358,7 +358,7 @@ export const Index = () => {
 export const Crossword = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure role="richLink">
+			<Figure isMainMedia={false} role="richLink">
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="letters"
@@ -382,7 +382,7 @@ export const Crossword = () => {
 export const Survey = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure role="richLink">
+			<Figure isMainMedia={false} role="richLink">
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="external"
@@ -406,7 +406,7 @@ export const Survey = () => {
 export const Signup = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure role="richLink">
+			<Figure isMainMedia={false} role="richLink">
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="comment"
@@ -431,7 +431,7 @@ export const Signup = () => {
 export const Userid = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure role="richLink">
+			<Figure isMainMedia={false} role="richLink">
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="editorial"
@@ -455,7 +455,7 @@ export const Userid = () => {
 export const PaidFor = () => {
 	return (
 		<ContainerLayout centralBorder="full">
-			<Figure role="richLink">
+			<Figure isMainMedia={false} role="richLink">
 				<RichLink
 					richLinkIndex={1}
 					cardStyle="news"

--- a/src/web/components/elements/ImageBlockComponent.stories.tsx
+++ b/src/web/components/elements/ImageBlockComponent.stories.tsx
@@ -57,7 +57,7 @@ const Container = ({ children }: { children: React.ReactNode }) => (
 export const StandardArticle = () => {
 	return (
 		<Container>
-			<Figure role="inline">
+			<Figure isMainMedia={false} role="inline">
 				<ImageBlockComponent
 					element={{ ...image, role: 'inline' }}
 					format={{
@@ -82,7 +82,7 @@ StandardArticle.story = {
 export const Immersive = () => {
 	return (
 		<Container>
-			<Figure role="immersive">
+			<Figure isMainMedia={false} role="immersive">
 				<ImageBlockComponent
 					element={{ ...image, role: 'immersive' }}
 					format={{
@@ -107,7 +107,7 @@ Immersive.story = {
 export const Showcase = () => {
 	return (
 		<Container>
-			<Figure role="showcase">
+			<Figure isMainMedia={false} role="showcase">
 				<ImageBlockComponent
 					element={{ ...image, role: 'showcase' }}
 					format={{
@@ -132,7 +132,7 @@ Showcase.story = {
 export const Thumbnail = () => {
 	return (
 		<Container>
-			<Figure role="thumbnail">
+			<Figure isMainMedia={false} role="thumbnail">
 				<ImageBlockComponent
 					element={{ ...image, role: 'thumbnail' }}
 					format={{
@@ -157,7 +157,7 @@ Thumbnail.story = {
 export const Supporting = () => {
 	return (
 		<Container>
-			<Figure role="supporting">
+			<Figure isMainMedia={false} role="supporting">
 				<ImageBlockComponent
 					element={{ ...image, role: 'supporting' }}
 					format={{
@@ -182,7 +182,7 @@ Supporting.story = {
 export const HideCaption = () => {
 	return (
 		<Container>
-			<Figure role="inline">
+			<Figure isMainMedia={false} role="inline">
 				<ImageBlockComponent
 					element={{ ...image, role: 'inline' }}
 					format={{
@@ -208,7 +208,7 @@ HideCaption.story = {
 export const InlineTitle = () => {
 	return (
 		<Container>
-			<Figure role="inline">
+			<Figure isMainMedia={false} role="inline">
 				<ImageBlockComponent
 					element={{ ...image, role: 'inline' }}
 					format={{
@@ -239,7 +239,7 @@ InlineTitle.story = {
 export const InlineTitleMobile = () => {
 	return (
 		<Container>
-			<Figure role="inline">
+			<Figure isMainMedia={false} role="inline">
 				<ImageBlockComponent
 					element={{ ...image, role: 'inline' }}
 					format={{
@@ -270,7 +270,7 @@ InlineTitleMobile.story = {
 export const ImmersiveTitle = () => {
 	return (
 		<Container>
-			<Figure role="immersive">
+			<Figure isMainMedia={false} role="immersive">
 				<ImageBlockComponent
 					element={{ ...image, role: 'immersive' }}
 					format={{
@@ -297,7 +297,7 @@ ImmersiveTitle.story = {
 export const ShowcaseTitle = () => {
 	return (
 		<Container>
-			<Figure role="showcase">
+			<Figure isMainMedia={false} role="showcase">
 				<ImageBlockComponent
 					element={{ ...image, role: 'showcase' }}
 					format={{
@@ -348,7 +348,7 @@ export const HalfWidth = () => {
 				cupidatat non proident, sunt in culpa qui officia deserunt
 				mollit anim id est laborum.
 			</p>
-			<Figure role="halfWidth">
+			<Figure isMainMedia={false} role="halfWidth">
 				<ImageBlockComponent
 					element={{ ...image, role: 'halfWidth' }}
 					format={{
@@ -413,7 +413,7 @@ export const HalfWidthMobile = () => {
 				cupidatat non proident, sunt in culpa qui officia deserunt
 				mollit anim id est laborum.
 			</p>
-			<Figure role="halfWidth">
+			<Figure isMainMedia={false} role="halfWidth">
 				<ImageBlockComponent
 					element={{ ...image, role: 'halfWidth' }}
 					format={{
@@ -478,7 +478,7 @@ export const HalfWidthWide = () => {
 				sint occaecat cupidatat non proident, sunt in culpa qui officia
 				deserunt mollit anim id est laborum.
 			</p>
-			<Figure role="halfWidth">
+			<Figure isMainMedia={false} role="halfWidth">
 				<ImageBlockComponent
 					element={{ ...image, role: 'halfWidth' }}
 					format={{

--- a/src/web/components/elements/InteractiveBlockComponent.stories.tsx
+++ b/src/web/components/elements/InteractiveBlockComponent.stories.tsx
@@ -43,7 +43,7 @@ export const Default = () => {
 		<Container>
 			<SomeText />
 			<SomeText />
-			<Figure role="supporting">
+			<Figure isMainMedia={false} role="supporting">
 				<InteractiveBlockComponent
 					url="https://interactive.guim.co.uk/uploader/embed/2018/01/archive-zip/giv-3902O7VEVpcWiCO7/"
 					scriptUrl="https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js"
@@ -74,7 +74,7 @@ export const InlineMap = () => {
 		<Container>
 			<SomeText />
 			<SomeText />
-			<Figure role="inline">
+			<Figure isMainMedia={false} role="inline">
 				<InteractiveBlockComponent
 					url="https://interactive.guim.co.uk/uploader/embed/2020/11/nagorno_karabakh_map/giv-3902efc3KhF4zInV/"
 					scriptUrl="https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js"
@@ -104,7 +104,7 @@ export const Showcase = () => {
 		<Container>
 			<SomeText />
 			<SomeText />
-			<Figure role="showcase">
+			<Figure isMainMedia={false} role="showcase">
 				<InteractiveBlockComponent
 					url="https://interactive.guim.co.uk/embed/from-tool/photo-collage/index.html?vertical=News&opinion-tint=false&left-image=https%3A%2F%2Fmedia.gutools.co.uk%2Fimages%2F84bd48ec5962601f8550286bfb5c2093fa0a3ffe%3Fcrop%3D0_70_3500_2100&left-caption=A%20woman%20stands%20during%20a%20song%20ahead%20of%20Trump’s%20remarks%20at%20the%20King%20Jesus%20International%20Ministry%20in%20Miami.%20Photo%3A%20Tom%20Brenner%2FReuters&right-image=https%3A%2F%2Fmedia.gutools.co.uk%2Fimages%2F9eb6381555963f1dc58c637adf2f3dc08f283e58%3Fcrop%3D0_26_3000_1800&right-caption=People%20give%20thumbs%20down%20to%20media%20covering%20the%20Trump%20campaign%20event%20held%20at%20the%20King%20Jesus%20International%20Ministry.%20Photo%3A%20Joe%20Raedle%2FGetty&always-place-captions-below=false"
 					scriptUrl="https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js"
@@ -135,7 +135,7 @@ export const WithCaption = () => {
 		<Container>
 			<SomeText />
 			<SomeText />
-			<Figure role="inline">
+			<Figure isMainMedia={false} role="inline">
 				<InteractiveBlockComponent
 					url="https://interactive.guim.co.uk/uploader/embed/2020/11/nagorno_karabakh_map/giv-3902efc3KhF4zInV/"
 					scriptUrl="https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js"
@@ -167,7 +167,7 @@ export const NonBootJs = () => {
 		<Container>
 			<SomeText />
 			<SomeText />
-			<Figure role="inline">
+			<Figure isMainMedia={false} role="inline">
 				<InteractiveBlockComponent
 					url="https://gdn-cdn.s3.amazonaws.com/quiz-builder/c65f1acf-eefd-4985-913d-74ae12eb1f35/boot.js"
 					scriptUrl="https://gdn-cdn.s3.amazonaws.com/quiz-builder/c65f1acf-eefd-4985-913d-74ae12eb1f35/boot.js"

--- a/src/web/lib/ElementRenderer.tsx
+++ b/src/web/lib/ElementRenderer.tsx
@@ -62,8 +62,8 @@ type Props = {
 	host?: string;
 	abTests: CAPIType['config']['abTests'];
 	index: number;
+	isMainMedia: boolean;
 	hideCaption?: boolean;
-	isMainMedia?: boolean;
 	starRating?: number;
 	isPreview: boolean;
 };

--- a/src/web/lib/ElementRenderer.tsx
+++ b/src/web/lib/ElementRenderer.tsx
@@ -391,6 +391,7 @@ export const ElementRenderer = ({
 		case 'model.dotcomrendering.pageElements.InteractiveBlockElement':
 			return (
 				<Figure
+					isMainMedia={isMainMedia}
 					role={isLiveBlog ? 'inline' : element.role}
 					id={element.elementId}
 				>
@@ -700,6 +701,7 @@ export const ElementRenderer = ({
 		case 'model.dotcomrendering.pageElements.VineBlockElement':
 			return (
 				<Figure
+					isMainMedia={isMainMedia}
 					// No role given by CAPI
 					// eslint-disable-next-line jsx-a11y/aria-role
 					role="inline"


### PR DESCRIPTION
## What?
This PR ensures that the `isMainMedia` prop is always passed into `Figure`. It explicitly passes it in the two places where it wasn't being set and then makes the prop required so that we can't forget to set it in future

## Why?
[This piece](https://www.theguardian.com/cities/2017/feb/03/skyscrapers-vanity-height-graphics-numbers) was putting an interactive element in main media but because we were not setting `isMainMedia` it defaulted to `false` causing `Figure` to style the element as though it were part of the article body and because the element `role` was `showcase` that meant it was given a negative left margin.

## Before
![Screenshot 2021-04-16 at 09 23 12](https://user-images.githubusercontent.com/1336821/114995129-695dc200-9e95-11eb-8d10-04964312ebff.jpg)


## After
![Screenshot 2021-04-16 at 09 22 22](https://user-images.githubusercontent.com/1336821/114995146-6d89df80-9e95-11eb-898d-8ec03e85029a.jpg)
