### PR TITLE
Identity | Sign In Gate | Update Sign In Gate Copy

### DIFF
--- a/cypress/integration/parallel-1/sign-in-gate.spec.js
+++ b/cypress/integration/parallel-1/sign-in-gate.spec.js
@@ -105,8 +105,8 @@ describe('Sign In Gate Tests', function () {
 				'gu.prefs.sign-in-gate',
 				`{
                     "value": {
-                        "SignInGateMain-main-variant-3": "2020-07-22T08:25:05.567Z",
-                        "gate-dismissed-count-SignInGateMain-main-variant-3": 6
+                        "SignInGateMain-main-variant-4": "2020-07-22T08:25:05.567Z",
+                        "gate-dismissed-count-SignInGateMain-main-variant-4": 6
                     }
                 }`,
 			);

--- a/src/web/components/SignInGate/SignInGateSelector.tsx
+++ b/src/web/components/SignInGate/SignInGateSelector.tsx
@@ -68,8 +68,8 @@ const tests: ReadonlyArray<ABTest> = [
 ];
 
 const testVariantToGateMapping: GateTestMap = {
-	'main-control-3': gateMainControl,
-	'main-variant-3': gateMainVariant,
+	'main-control-4': gateMainControl,
+	'main-variant-4': gateMainVariant,
 };
 
 const testIdToComponentId: { [key: string]: string } = {

--- a/src/web/components/SignInGate/gateDesigns/SignInGateMain.tsx
+++ b/src/web/components/SignInGate/gateDesigns/SignInGateMain.tsx
@@ -35,19 +35,17 @@ export const SignInGateMain = ({
 			<style>{hideElementsCss}</style>
 			<div className={firstParagraphOverlay(!!isComment)} />
 			<h1 className={headingStyles}>
-				Register for free and continue reading
+				You need to register to keep reading
 			</h1>
 			<p className={bodyBold}>
-				It’s important to say this is not a step towards a paywall
+				It’s still free to read - this is not a paywall
 			</p>
 			<p className={bodyText}>
-				Registering is a free and simple way to help us sustain our
-				independent Guardian journalism.
-			</p>
-			<p className={bodyText}>
-				When you register with us we are able to improve our news
-				experience for you and for others. You will always be able to
-				control your own&nbsp;
+				We’re committed to keeping our quality reporting open. By
+				registering and providing us with insight into your preferences,
+				you’re helping us to engage with you more deeply, and that
+				allows us to keep our journalism free for all. You’ll always be
+				able to control your own{' '}
 				<button
 					data-cy="sign-in-gate-main_privacy"
 					className={privacyLink}
@@ -58,7 +56,7 @@ export const SignInGateMain = ({
 				>
 					privacy settings
 				</button>
-				. Thank you.
+				.
 			</p>
 			<div className={actionButtons}>
 				<LinkButton

--- a/src/web/experiments/tests/sign-in-gate-main-control.ts
+++ b/src/web/experiments/tests/sign-in-gate-main-control.ts
@@ -19,7 +19,7 @@ export const signInGateMainControl: ABTest = {
 	canRun: () => true,
 	variants: [
 		{
-			id: 'main-control-3',
+			id: 'main-control-4',
 			test: (): void => {},
 		},
 	],

--- a/src/web/experiments/tests/sign-in-gate-main-variant.ts
+++ b/src/web/experiments/tests/sign-in-gate-main-variant.ts
@@ -19,7 +19,7 @@ export const signInGateMainVariant: ABTest = {
 	canRun: () => true,
 	variants: [
 		{
-			id: 'main-variant-3',
+			id: 'main-variant-4',
 			test: (): void => {},
 		},
 	],


### PR DESCRIPTION
## What does this change?

Update the copy of the main variant of the sign in gate to the winner of https://github.com/guardian/dotcom-rendering/pull/2622 and launch a new test in the form of `main-variant-4` and `main-control-4`

Frontend PR: https://github.com/guardian/frontend/pull/23716

## Screenshots
#### Mobile
![localhost_3030_Article_url=https___www theguardian com_music_2018_aug_31_eminem-kamikaze-album-review(iPhone 6_7_8)](https://user-images.githubusercontent.com/13315440/115014829-bef09980-9eaa-11eb-8d30-37507594ed43.png)

#### Desktop
![localhost_3030_Article_url=https___www theguardian com_music_2018_aug_31_eminem-kamikaze-album-review(Laptop with HiDPI screen)](https://user-images.githubusercontent.com/13315440/115014850-c617a780-9eaa-11eb-8899-acb015d021b9.png)

## Tested

- [x] Locally
- [x] On CODE (optional)