### PR TITLE
Reduce left col tag size to reduce chance of text-wrap

### DIFF
--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -79,7 +79,7 @@ const fontStyles = (format: Format) => {
 	}
 	return css`
 		${headline.xxxsmall({ fontWeight: 'bold' })}
-		${from.leftCol} {
+		${from.wide} {
 			${headline.xxsmall({ fontWeight: 'bold' })}
 		}
 	`;


### PR DESCRIPTION
## What does this change?

Reduce left col tag font-size to reduce chance that text will wrap on long words. Note, this only reduces the likelihood of this happening; a very long word will still wrap.

### Before
![image](https://user-images.githubusercontent.com/858402/115011724-e5143a80-9ea6-11eb-81a0-20f23b41289a.png)

### After
![Screenshot 2021-04-16 at 11 21 38](https://user-images.githubusercontent.com/858402/115011755-ec3b4880-9ea6-11eb-92bc-c308cf4de8a7.png)

## Why?
To reduce ugly wrapping.
