### PR TITLE
Veggie burger button z-index

### DIFF
--- a/src/web/components/Nav/ExpandedMenu/ExpandedMenu.tsx
+++ b/src/web/components/Nav/ExpandedMenu/ExpandedMenu.tsx
@@ -5,6 +5,7 @@ import { brandBackground } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
 
+import { getZIndex } from '@root/src/web/lib/getZIndex';
 import { Display } from '@guardian/types';
 import { ShowMoreMenu } from './ShowMoreMenu';
 import { VeggieBurgerMenu } from './VeggieBurgerMenu';
@@ -12,6 +13,8 @@ import { Columns } from './Columns';
 import { navInputCheckboxId } from '../config';
 
 const mainMenuStyles = css`
+	${getZIndex('expanded-veggie-menu')}
+
 	background-color: ${brandBackground.primary};
 	box-sizing: border-box;
 	${textSans.large()};
@@ -19,7 +22,6 @@ const mainMenuStyles = css`
 	margin-right: 29px;
 	padding-bottom: 24px;
 	top: 0;
-	z-index: 1070;
 	overflow: hidden;
 
 	/*
@@ -95,7 +97,7 @@ export const ExpandedMenu: React.FC<{
 	nav: NavType;
 }> = ({ display, nav }) => {
 	return (
-		<div id="expanded-menu">
+		<div id="expanded-menu-root">
 			<ShowMoreMenu display={display} />
 			<VeggieBurgerMenu display={display} />
 			<div

--- a/src/web/components/Nav/ExpandedMenu/VeggieBurgerMenu.tsx
+++ b/src/web/components/Nav/ExpandedMenu/VeggieBurgerMenu.tsx
@@ -13,62 +13,60 @@ const screenReadable = css`
 	${visuallyHidden};
 `;
 
-const veggieBurgerIconStyles = () => {
-	const beforeAfterStyles = css`
-		content: '';
-		background-color: currentColor;
-	`;
-	const lineStyles = css`
-		height: 2px;
-		left: 0;
-		position: absolute;
-		width: 20px;
-	`;
+const beforeAfterStyles = css`
+	content: '';
+	background-color: currentColor;
+`;
 
-	return css`
-		background-color: currentColor;
-		/*
+const lineStyles = css`
+	height: 2px;
+	left: 0;
+	position: absolute;
+	width: 20px;
+`;
+const veggieBurgerIconStyles = css`
+	background-color: currentColor;
+	/*
             IMPORTANT NOTE:
             we need to specify the adjacent path to the a (current) tag
             to apply styles to the nested tabs due to the fact we use ~
             to support NoJS
         */
+	/* stylelint-disable-next-line selector-type-no-unknown */
+	${`#${navInputCheckboxId}`}:checked ~ div & {
+		background-color: transparent;
+	}
+
+	top: 50%;
+	right: 0;
+	margin-top: -1px;
+	margin-left: auto;
+	margin-right: auto;
+	${lineStyles};
+
+	:before {
+		${lineStyles};
+		${beforeAfterStyles};
+		top: -6px;
+		/* refer to comment above */
 		/* stylelint-disable-next-line selector-type-no-unknown */
 		${`#${navInputCheckboxId}`}:checked ~ div & {
-			background-color: transparent;
+			top: 0;
+			transform: rotate(-45deg);
 		}
-
-		top: 50%;
-		right: 0;
-		margin-top: -1px;
-		margin-left: auto;
-		margin-right: auto;
+	}
+	:after {
 		${lineStyles};
-
-		:before {
-			${lineStyles};
-			${beforeAfterStyles};
-			top: -6px;
-			/* refer to comment above */
-			/* stylelint-disable-next-line selector-type-no-unknown */
-			${`#${navInputCheckboxId}`}:checked ~ div & {
-				top: 0;
-				transform: rotate(-45deg);
-			}
+		${beforeAfterStyles};
+		bottom: -6px;
+		/* refer to comment above */
+		/* stylelint-disable-next-line selector-type-no-unknown */
+		${`#${navInputCheckboxId}`}:checked ~ div & {
+			bottom: 0;
+			transform: rotate(45deg);
 		}
-		:after {
-			${lineStyles};
-			${beforeAfterStyles};
-			bottom: -6px;
-			/* refer to comment above */
-			/* stylelint-disable-next-line selector-type-no-unknown */
-			${`#${navInputCheckboxId}`}:checked ~ div & {
-				bottom: 0;
-				transform: rotate(45deg);
-			}
-		}
-	`;
-};
+	}
+`;
 
 const veggieBurgerStyles = (display: Display) => css`
 	background-color: ${brandAlt[400]};
@@ -122,7 +120,7 @@ export const VeggieBurgerMenu: React.FC<{
 			data-cy="veggie-burger"
 		>
 			<span className={screenReadable}>Show More</span>
-			<span className={veggieBurgerIconStyles()} />
+			<span className={veggieBurgerIconStyles} />
 		</label>
 		/* eslint-enable @typescript-eslint/ban-ts-comment, jsx-a11y/label-has-associated-control, @typescript-eslint/no-unused-expressions, react/no-unknown-property, jsx-a11y/no-noninteractive-element-to-interactive-role  */
 	);

--- a/src/web/components/Nav/Nav.tsx
+++ b/src/web/components/Nav/Nav.tsx
@@ -90,7 +90,7 @@ export const Nav = ({ format, nav, subscribeUrl, edition }: Props) => {
                         var showMoreButton = document.getElementById('${showMoreButtonId}')
                         var veggieBurger = document.getElementById('${veggieBurgerId}')
                         var expandedMenuClickableTags = document.querySelectorAll('.selectableMenuItem')
-                        var expandedMenu = document.getElementById('expanded-menu')
+                        var expandedMenu = document.getElementById('expanded-menu-root')
 
                         // We assume News is the 1st column
                         var firstColLabel = document.getElementById('News-button')

--- a/src/web/components/Nav/StickNavTest/ExpandedMenu/ExpandedMenu.tsx
+++ b/src/web/components/Nav/StickNavTest/ExpandedMenu/ExpandedMenu.tsx
@@ -26,7 +26,7 @@ const mainMenuStyles = (ID: string) => css`
 	margin-right: 29px;
 	padding-bottom: 24px;
 	top: 0;
-	${getZIndex('stickyNav')}
+	${getZIndex('expanded-veggie-menu')}
 	overflow: hidden;
 
 	/*

--- a/src/web/components/Nav/StickNavTest/ExpandedMenu/VeggieBurgerMenu.tsx
+++ b/src/web/components/Nav/StickNavTest/ExpandedMenu/VeggieBurgerMenu.tsx
@@ -118,7 +118,6 @@ export const VeggieBurgerMenu: React.FC<{
 			tabIndex={0}
 			role="button"
 			data-cy="veggie-burger"
-			data-type="sticky"
 		>
 			<span className={screenReadable}>Show More</span>
 			<span

--- a/src/web/components/Nav/StickNavTest/ExpandedMenu/VeggieBurgerMenu.tsx
+++ b/src/web/components/Nav/StickNavTest/ExpandedMenu/VeggieBurgerMenu.tsx
@@ -13,62 +13,59 @@ const screenReadable = css`
 	${visuallyHidden};
 `;
 
-const veggieBurgerIconStyles = (navInputCheckboxID: string) => {
-	const beforeAfterStyles = css`
-		content: '';
-		background-color: currentColor;
-	`;
-	const lineStyles = css`
-		height: 2px;
-		left: 0;
-		position: absolute;
-		width: 20px;
-	`;
-
-	return css`
-		background-color: currentColor;
-		/*
+const beforeAfterStyles = css`
+	content: '';
+	background-color: currentColor;
+`;
+const lineStyles = css`
+	height: 2px;
+	left: 0;
+	position: absolute;
+	width: 20px;
+`;
+const veggieBurgerIconStyles = (navInputCheckboxID: string) => css`
+	background-color: currentColor;
+	/*
             IMPORTANT NOTE:
             we need to specify the adjacent path to the a (current) tag
             to apply styles to the nested tabs due to the fact we use ~
             to support NoJS
         */
+	/* stylelint-disable-next-line selector-type-no-unknown */
+	${`#${navInputCheckboxID}`}:checked ~ div & {
+		background-color: transparent;
+	}
+
+	top: 50%;
+	right: 0;
+	margin-top: -1px;
+	margin-left: auto;
+	margin-right: auto;
+	${lineStyles};
+
+	:before {
+		${lineStyles};
+		${beforeAfterStyles};
+		top: -6px;
+		/* refer to comment above */
 		/* stylelint-disable-next-line selector-type-no-unknown */
 		${`#${navInputCheckboxID}`}:checked ~ div & {
-			background-color: transparent;
+			top: 0;
+			transform: rotate(-45deg);
 		}
-
-		top: 50%;
-		right: 0;
-		margin-top: -1px;
-		margin-left: auto;
-		margin-right: auto;
+	}
+	:after {
 		${lineStyles};
-
-		:before {
-			${lineStyles};
-			${beforeAfterStyles};
-			top: -6px;
-			/* refer to comment above */
-			/* stylelint-disable-next-line selector-type-no-unknown */
-			${`#${navInputCheckboxID}`}:checked ~ div & {
-				top: 0;
-				transform: rotate(-45deg);
-			}
+		${beforeAfterStyles};
+		bottom: -6px;
+		/* refer to comment above */
+		/* stylelint-disable-next-line selector-type-no-unknown */
+		${`#${navInputCheckboxID}`}:checked ~ div & {
+			bottom: 0;
+			transform: rotate(45deg);
 		}
-		:after {
-			${lineStyles};
-			${beforeAfterStyles};
-			bottom: -6px;
-			/* refer to comment above */
-			/* stylelint-disable-next-line selector-type-no-unknown */
-			${`#${navInputCheckboxID}`}:checked ~ div & {
-				bottom: 0;
-				transform: rotate(45deg);
-			}
-		}
-	`;
-};
+	}
+`;
 
 const veggieBurgerStyles = (display: Display) => css`
 	background-color: ${brandAlt[400]};
@@ -121,6 +118,7 @@ export const VeggieBurgerMenu: React.FC<{
 			tabIndex={0}
 			role="button"
 			data-cy="veggie-burger"
+			data-type="sticky"
 		>
 			<span className={screenReadable}>Show More</span>
 			<span

--- a/src/web/components/Nav/StickNavTest/StickyNav.tsx
+++ b/src/web/components/Nav/StickNavTest/StickyNav.tsx
@@ -34,7 +34,7 @@ interface NavGroupEagerProps {
 const stickyStyle = (theme: Theme) => css`
 	position: sticky;
 	top: 0;
-	${getZIndex('stickyNav')}
+	${getZIndex('expanded-veggie-menu')}
 	background-color: white;
 	border-bottom: 1px solid ${neutralBorder(theme)};
 `;
@@ -43,7 +43,7 @@ const fixedStyle = (theme: Theme, shouldDisplay: boolean) => css`
 	width: 100%;
 	position: fixed;
 	top: 0;
-	${getZIndex('stickyNav')}
+	${getZIndex('expanded-veggie-menu')}
 	background-color: white;
 	border-bottom: 1px solid ${neutralBorder(theme)};
 	display: ${shouldDisplay ? 'block' : 'none'};

--- a/src/web/lib/getZIndex.test.tsx
+++ b/src/web/lib/getZIndex.test.tsx
@@ -5,7 +5,7 @@ describe('getZIndex', () => {
 		expect(getZIndex('banner')).toBe('z-index: 13;');
 		expect(getZIndex('dropdown')).toBe('z-index: 12;');
 		expect(getZIndex('burger')).toBe('z-index: 11;');
-		expect(getZIndex('stickyNav')).toBe('z-index: 10;');
+		expect(getZIndex('expanded-veggie-menu')).toBe('z-index: 10;');
 		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 9;');
 		expect(getZIndex('searchHeaderLink')).toBe('z-index: 8;');
 		expect(getZIndex('TheGuardian')).toBe('z-index: 7;');

--- a/src/web/lib/getZIndex.tsx
+++ b/src/web/lib/getZIndex.tsx
@@ -27,7 +27,7 @@ const indices = [
 	'banner',
 	'dropdown',
 	'burger',
-	'stickyNav',
+	'expanded-veggie-menu',
 
 	// Header
 	'stickyAdWrapper',


### PR DESCRIPTION
<!-- In this repo, you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible URL -->
## What does this change?
Fix `Veggie Burger` z-index when showing the menu on mobile

### Before
<img width="379" alt="Screenshot 2021-04-16 at 17 02 58" src="https://user-images.githubusercontent.com/8831403/115052298-b3669800-9ed5-11eb-89d0-5d95e82f4f1a.png">

### After
<img width="421" alt="Screenshot 2021-04-16 at 16 58 20" src="https://user-images.githubusercontent.com/8831403/115051724-0a1fa200-9ed5-11eb-9832-799bac612a4a.png">

## Why?
Fix order of layout
