### PR TITLE
Comment messaging

### DIFF
--- a/src/web/components/SignedInAs.stories.tsx
+++ b/src/web/components/SignedInAs.stories.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { css } from 'emotion';
 
 import { Design, Display, Pillar } from '@guardian/types';
 import { decidePalette } from '@root/src/web/lib/decidePalette';
@@ -20,6 +21,17 @@ const aUser = {
 	},
 };
 
+const Container = ({ children }: { children: React.ReactNode }) => (
+	<div
+		className={css`
+			width: 220px;
+			padding: 20px;
+		`}
+	>
+		{children}
+	</div>
+);
+
 export default {
 	component: SignedInAs,
 	title: 'Components/SignedInAs',
@@ -27,223 +39,185 @@ export default {
 
 export const SignedIn = () => {
 	return (
-		<SignedInAs
-			palette={decidePalette({
-				theme: Pillar.News,
-				display: Display.Standard,
-				design: Design.Article,
-			})}
-			enableDiscussionSwitch={true}
-			commentCount={3}
-			user={aUser}
-		/>
+		<Container>
+			<SignedInAs
+				palette={decidePalette({
+					theme: Pillar.News,
+					display: Display.Standard,
+					design: Design.Article,
+				})}
+				enableDiscussionSwitch={true}
+				commentCount={3}
+				user={aUser}
+			/>
+		</Container>
 	);
 };
-SignedIn.story = { name: 'signed in' };
+SignedIn.story = { name: 'when signed in' };
 
 export const Image = () => {
 	return (
-		<SignedInAs
-			palette={decidePalette({
-				theme: Pillar.Culture,
-				display: Display.Standard,
-				design: Design.Article,
-			})}
-			enableDiscussionSwitch={true}
-			commentCount={32}
-			user={{
-				...aUser,
-				secureAvatarUrl: 'https://avatar.guim.co.uk/user/101885881',
-			}}
-		/>
+		<Container>
+			<SignedInAs
+				palette={decidePalette({
+					theme: Pillar.Culture,
+					display: Display.Standard,
+					design: Design.Article,
+				})}
+				enableDiscussionSwitch={true}
+				commentCount={32}
+				user={{
+					...aUser,
+					secureAvatarUrl: 'https://avatar.guim.co.uk/user/101885881',
+				}}
+			/>
+		</Container>
 	);
 };
-Image.story = { name: 'with image' };
+Image.story = { name: 'when signed in with an avatar set' };
 
 export const Banned = () => {
 	return (
-		<SignedInAs
-			palette={decidePalette({
-				theme: Pillar.Culture,
-				display: Display.Standard,
-				design: Design.Article,
-			})}
-			enableDiscussionSwitch={true}
-			commentCount={32}
-			user={{
-				...aUser,
-				privateFields: {
-					...aUser.privateFields,
-					canPostComment: false,
-				},
-			}}
-		/>
+		<Container>
+			<SignedInAs
+				palette={decidePalette({
+					theme: Pillar.Culture,
+					display: Display.Standard,
+					design: Design.Article,
+				})}
+				enableDiscussionSwitch={true}
+				commentCount={32}
+				user={{
+					...aUser,
+					privateFields: {
+						...aUser.privateFields,
+						canPostComment: false,
+					},
+				}}
+			/>
+		</Container>
 	);
 };
-Banned.story = { name: 'when banned' };
+Banned.story = { name: 'when user is banned' };
 
 export const NoDisplayName = () => {
 	return (
-		<SignedInAs
-			palette={decidePalette({
-				theme: Pillar.News,
-				display: Display.Standard,
-				design: Design.Article,
-			})}
-			enableDiscussionSwitch={true}
-			commentCount={32}
-			user={{
-				...aUser,
-				displayName: '',
-			}}
-		/>
+		<Container>
+			<SignedInAs
+				palette={decidePalette({
+					theme: Pillar.News,
+					display: Display.Standard,
+					design: Design.Article,
+				})}
+				enableDiscussionSwitch={true}
+				commentCount={32}
+				user={{
+					...aUser,
+					displayName: '',
+				}}
+			/>
+		</Container>
 	);
 };
 NoDisplayName.story = { name: 'before a display name has been set' };
 
 export const NotSignedIn = () => {
 	return (
-		<SignedInAs
-			palette={decidePalette({
-				theme: Pillar.Lifestyle,
-				display: Display.Standard,
-				design: Design.Article,
-			})}
-			enableDiscussionSwitch={true}
-			commentCount={32}
-		/>
+		<Container>
+			<SignedInAs
+				palette={decidePalette({
+					theme: Pillar.Lifestyle,
+					display: Display.Standard,
+					design: Design.Article,
+				})}
+				enableDiscussionSwitch={true}
+				commentCount={32}
+			/>
+		</Container>
 	);
 };
-NotSignedIn.story = { name: 'not signed in' };
-
-export const Culture = () => {
-	return (
-		<SignedInAs
-			palette={decidePalette({
-				theme: Pillar.Culture,
-				display: Display.Standard,
-				design: Design.Article,
-			})}
-			enableDiscussionSwitch={true}
-			commentCount={32}
-		/>
-	);
+NotSignedIn.story = {
+	name: 'when the discussion is open but user is not signed in',
 };
-Culture.story = { name: 'with culture pillar' };
-
-export const Opinion = () => {
-	return (
-		<SignedInAs
-			palette={decidePalette({
-				theme: Pillar.Opinion,
-				display: Display.Standard,
-				design: Design.Article,
-			})}
-			enableDiscussionSwitch={true}
-			commentCount={32}
-		/>
-	);
-};
-Opinion.story = { name: 'with opinion pillar' };
-
-export const news = () => {
-	return (
-		<SignedInAs
-			palette={decidePalette({
-				theme: Pillar.News,
-				display: Display.Standard,
-				design: Design.Article,
-			})}
-			enableDiscussionSwitch={true}
-			commentCount={32}
-		/>
-	);
-};
-news.story = { name: 'with news pillar' };
-
-export const Sport = () => {
-	return (
-		<SignedInAs
-			palette={decidePalette({
-				theme: Pillar.Sport,
-				display: Display.Standard,
-				design: Design.Article,
-			})}
-			enableDiscussionSwitch={true}
-			commentCount={32}
-		/>
-	);
-};
-Sport.story = { name: 'with sport pillar' };
 
 export const DiscussionClosed = () => {
 	return (
-		<SignedInAs
-			palette={decidePalette({
-				theme: Pillar.Opinion,
-				display: Display.Standard,
-				design: Design.Article,
-			})}
-			enableDiscussionSwitch={true}
-			commentCount={32}
-			isClosedForComments={true}
-			user={aUser}
-		/>
+		<Container>
+			<SignedInAs
+				palette={decidePalette({
+					theme: Pillar.Opinion,
+					display: Display.Standard,
+					design: Design.Article,
+				})}
+				enableDiscussionSwitch={true}
+				commentCount={32}
+				isClosedForComments={true}
+				user={aUser}
+			/>
+		</Container>
 	);
 };
-DiscussionClosed.story = { name: 'discussion closed, user signed in' };
+DiscussionClosed.story = {
+	name: 'when the discussion is closed and the user is signed in',
+};
 
 export const DiscussionClosedSignedOut = () => {
 	return (
-		<SignedInAs
-			palette={decidePalette({
-				theme: Pillar.Sport,
-				display: Display.Standard,
-				design: Design.Article,
-			})}
-			enableDiscussionSwitch={true}
-			commentCount={32}
-			isClosedForComments={true}
-		/>
+		<Container>
+			<SignedInAs
+				palette={decidePalette({
+					theme: Pillar.Sport,
+					display: Display.Standard,
+					design: Design.Article,
+				})}
+				enableDiscussionSwitch={true}
+				commentCount={32}
+				isClosedForComments={true}
+			/>
+		</Container>
 	);
 };
 DiscussionClosedSignedOut.story = {
-	name: 'discussion closed, user not signed in',
+	name: 'when the discussion is closed and the user is signed out',
 };
 
 export const DiscussionDisabled = () => {
 	return (
-		<SignedInAs
-			palette={decidePalette({
-				theme: Pillar.Opinion,
-				display: Display.Standard,
-				design: Design.Article,
-			})}
-			enableDiscussionSwitch={false}
-			commentCount={32}
-			isClosedForComments={false}
-			user={aUser}
-		/>
+		<Container>
+			<SignedInAs
+				palette={decidePalette({
+					theme: Pillar.Opinion,
+					display: Display.Standard,
+					design: Design.Article,
+				})}
+				enableDiscussionSwitch={false}
+				commentCount={32}
+				isClosedForComments={false}
+				user={aUser}
+			/>
+		</Container>
 	);
 };
 DiscussionDisabled.story = {
-	name: 'discussion disabled sitewide, user signed in',
+	name: 'with discussion disabled sitewide and the user signed in',
 };
 
 export const DiscussionDisabledSignedOut = () => {
 	return (
-		<SignedInAs
-			palette={decidePalette({
-				theme: Pillar.Opinion,
-				display: Display.Standard,
-				design: Design.Article,
-			})}
-			enableDiscussionSwitch={false}
-			commentCount={32}
-			isClosedForComments={false}
-		/>
+		<Container>
+			<SignedInAs
+				palette={decidePalette({
+					theme: Pillar.Opinion,
+					display: Display.Standard,
+					design: Design.Article,
+				})}
+				enableDiscussionSwitch={false}
+				commentCount={32}
+				isClosedForComments={false}
+			/>
+		</Container>
 	);
 };
 DiscussionDisabledSignedOut.story = {
-	name: 'discussion disabled sitewide, user signed out',
+	name: 'with discussion disabled sitewide and the user signed out',
 };

--- a/src/web/components/SignedInAs.tsx
+++ b/src/web/components/SignedInAs.tsx
@@ -140,7 +140,7 @@ export const SignedInAs = ({
 					>
 						create your Guardian account
 					</a>{' '}
-					to join the discussion when it's back
+					to join the discussion when it&apos;s back
 				</span>
 			</div>
 		);

--- a/src/web/components/SignedInAs.tsx
+++ b/src/web/components/SignedInAs.tsx
@@ -78,6 +78,21 @@ const rowUntilDesktop = css`
 	}
 `;
 
+const CommentCount = ({ count }: { count?: number }) => {
+	return (
+		<h2 className={headingStyles}>
+			comments{' '}
+			<span
+				className={css`
+					color: ${neutral[60]};
+				`}
+			>
+				({count || '…'})
+			</span>
+		</h2>
+	);
+};
+
 export const SignedInAs = ({
 	commentCount,
 	palette,
@@ -90,21 +105,52 @@ export const SignedInAs = ({
 		user.privateFields &&
 		user.privateFields.canPostComment === false;
 
-	return (
-		<div className={containerStyles}>
-			<h2 className={headingStyles}>
-				comments{' '}
-				<span
-					className={css`
-						color: ${neutral[60]};
-					`}
-				>
-					({commentCount || '…'})
+	if (enableDiscussionSwitch === false) {
+		// Discussion is disabled sitewide and user is signed in
+		if (user) {
+			return (
+				<div className={containerStyles}>
+					<CommentCount count={commentCount} />
+					<span className={headlineStyles}>
+						Commenting has been disabled at this time
+					</span>
+				</div>
+			);
+		}
+		// Discussion disabled sitewide and user logged out
+		return (
+			<div className={containerStyles}>
+				<CommentCount count={commentCount} />
+				<span className={headlineStyles}>
+					Commenting has been disabled at this time but you can still{' '}
+					<a
+						href={`https://profile.theguardian.com/signin?INTCMP=DOTCOM_COMMENTS_SIGNIN&${createAuthenticationEventParams(
+							'signin_to_comment',
+						)}`}
+						className={linkStyles(palette)}
+					>
+						Sign in
+					</a>{' '}
+					or{' '}
+					<a
+						href={`https://profile.theguardian.com/register?INTCMP=DOTCOM_COMMENTS_REG&${createAuthenticationEventParams(
+							'register_to_comment',
+						)}`}
+						className={linkStyles(palette)}
+					>
+						create your Guardian account
+					</a>{' '}
+					to join the discussion when it's back.
 				</span>
-			</h2>
+			</div>
+		);
+	}
 
-			{/* User is banned */}
-			{enableDiscussionSwitch && isBanned && (
+	if (isBanned) {
+		// User is banned
+		return (
+			<div className={containerStyles}>
+				<CommentCount count={commentCount} />
 				<span className={headlineStyles}>
 					Commenting has been disabled for this account (
 					<a
@@ -115,42 +161,57 @@ export const SignedInAs = ({
 					</a>{' '}
 					)
 				</span>
-			)}
+			</div>
+		);
+	}
 
-			{/* Discussion is disabled sitewide */}
-			{user && enableDiscussionSwitch === false && (
+	if (user && isClosedForComments) {
+		// The reader is logged in but the discussion is closed
+		return (
+			<div className={containerStyles}>
+				<CommentCount count={commentCount} />
 				<span className={headlineStyles}>
-					Commenting has been disabled at this time
+					This discussion is closed for comments
 				</span>
-			)}
+			</div>
+		);
+	}
 
-			{/* Discussion open and user logged in */}
-			{enableDiscussionSwitch &&
-				user &&
-				!isBanned &&
-				!isClosedForComments && (
-					<div className={rowUntilDesktop}>
-						<div className={imageWrapper}>
-							<img
-								src={
-									user.secureAvatarUrl ||
-									'https://avatar.guim.co.uk/no-user-image.gif'
-								}
-								alt={user.displayName || 'Guardian User'}
-								className={imageStyles}
-							/>
-						</div>
-						<div className={textStyles}>
-							Signed in as
-							<div className={usernameStyles}>
-								{user.displayName || 'Guardian User'}
-							</div>
-						</div>
-					</div>
-				)}
+	if (!user && isClosedForComments) {
+		// The discussion is closed and the reader is not logged in
+		return (
+			<div className={containerStyles}>
+				<CommentCount count={commentCount} />
+				<span className={headlineStyles}>
+					This discussion is now closed for comments but you can still{' '}
+					<a
+						href={`https://profile.theguardian.com/signin?INTCMP=DOTCOM_COMMENTS_SIGNIN&${createAuthenticationEventParams(
+							'signin_to_comment',
+						)}`}
+						className={linkStyles(palette)}
+					>
+						Sign in
+					</a>{' '}
+					or{' '}
+					<a
+						href={`https://profile.theguardian.com/register?INTCMP=DOTCOM_COMMENTS_REG&${createAuthenticationEventParams(
+							'register_to_comment',
+						)}`}
+						className={linkStyles(palette)}
+					>
+						create your Guardian account
+					</a>{' '}
+					to join the discussion next time.
+				</span>
+			</div>
+		);
+	}
 
-			{/* User is logged out (show this even if the discussion is closed) */}
-			{!user && (
+	if (!user) {
+		// The discussion is open but the reader is not logged in
+		return (
+			<div className={containerStyles}>
+				<CommentCount count={commentCount} />
 				<span className={headlineStyles}>
 					<a
 						href={`https://profile.theguardian.com/signin?INTCMP=DOTCOM_COMMENTS_SIGNIN&${createAuthenticationEventParams(
@@ -171,14 +232,32 @@ export const SignedInAs = ({
 					</a>{' '}
 					to join the discussion.
 				</span>
-			)}
+			</div>
+		);
+	}
 
-			{/* The discussion is closed (only appears for logged in users) */}
-			{enableDiscussionSwitch && user && isClosedForComments && (
-				<span className={headlineStyles}>
-					This discussion is closed for comments
-				</span>
-			)}
+	// Discussion open and user logged in
+	return (
+		<div className={containerStyles}>
+			<CommentCount count={commentCount} />
+			<div className={rowUntilDesktop}>
+				<div className={imageWrapper}>
+					<img
+						src={
+							user.secureAvatarUrl ||
+							'https://avatar.guim.co.uk/no-user-image.gif'
+						}
+						alt={user.displayName || 'Guardian User'}
+						className={imageStyles}
+					/>
+				</div>
+				<div className={textStyles}>
+					Signed in as
+					<div className={usernameStyles}>
+						{user.displayName || 'Guardian User'}
+					</div>
+				</div>
+			</div>
 		</div>
 	);
 };

--- a/src/web/components/SignedInAs.tsx
+++ b/src/web/components/SignedInAs.tsx
@@ -129,7 +129,7 @@ export const SignedInAs = ({
 						)}`}
 						className={linkStyles(palette)}
 					>
-						Sign in
+						sign in
 					</a>{' '}
 					or{' '}
 					<a
@@ -190,7 +190,7 @@ export const SignedInAs = ({
 						)}`}
 						className={linkStyles(palette)}
 					>
-						Sign in
+						sign in
 					</a>{' '}
 					or{' '}
 					<a

--- a/src/web/components/SignedInAs.tsx
+++ b/src/web/components/SignedInAs.tsx
@@ -140,7 +140,7 @@ export const SignedInAs = ({
 					>
 						create your Guardian account
 					</a>{' '}
-					to join the discussion when it's back.
+					to join the discussion when it's back
 				</span>
 			</div>
 		);
@@ -201,7 +201,7 @@ export const SignedInAs = ({
 					>
 						create your Guardian account
 					</a>{' '}
-					to join the discussion next time.
+					to join the discussion next time
 				</span>
 			</div>
 		);

--- a/src/web/components/SignedInAs.tsx
+++ b/src/web/components/SignedInAs.tsx
@@ -230,7 +230,7 @@ export const SignedInAs = ({
 					>
 						create your Guardian account
 					</a>{' '}
-					to join the discussion.
+					to join the discussion
 				</span>
 			</div>
 		);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Changes the messages that we display to readers alongside discussions based on their logged in status and the status of the discussion

### `Discussion open, reader signed in`
![open - in](https://user-images.githubusercontent.com/1336821/115204468-6dd1e700-a0f0-11eb-9d66-5780efcfaaf5.jpg)

### `Discussion open, reader signed out`
![Screenshot 2021-04-19 at 09 22 47](https://user-images.githubusercontent.com/1336821/115204851-dae57c80-a0f0-11eb-8129-0d4377aee42e.jpg)


### `Discussion closed, reader signed in`
![closed - in](https://user-images.githubusercontent.com/1336821/115204448-67dc0600-a0f0-11eb-96b2-0ae24dc413b9.jpg)

### `Discussion closed, reader signed out`
![Screenshot 2021-04-19 at 09 23 28](https://user-images.githubusercontent.com/1336821/115204911-ecc71f80-a0f0-11eb-877f-387d032c2b34.jpg)


### `Discussion disabled, reader signed in`
![diabled - in](https://user-images.githubusercontent.com/1336821/115204426-61e62500-a0f0-11eb-938e-a88dc2bd24a4.jpg)

### `Discussion disabled, reader signed out`
![Screenshot 2021-04-19 at 09 23 58](https://user-images.githubusercontent.com/1336821/115204975-fe102c00-a0f0-11eb-9013-8216cfc48eaa.jpg)


### `Reader banned`
![banned](https://user-images.githubusercontent.com/1336821/115204404-5bf04400-a0f0-11eb-8710-d9f013e4e7fd.jpg)

### `Reader has no profile`
![No profile set](https://user-images.githubusercontent.com/1336821/115204395-598dea00-a0f0-11eb-8b85-c05e32e648c1.jpg)

## Why?
It was raised in chat that sometimes we were not being as clear in the messages that we show as we could be