### PR TITLE
Support Braze Epic ophanComponentId parameter

### DIFF
--- a/src/web/components/SlotBodyEnd/BrazeEpic.tsx
+++ b/src/web/components/SlotBodyEnd/BrazeEpic.tsx
@@ -136,7 +136,7 @@ const BrazeEpic = ({
 			submitComponentEvent({
 				component: {
 					componentType: 'RETENTION_EPIC',
-					id: meta.dataFromBraze.componentName,
+					id: meta.dataFromBraze.ophanComponentId,
 				},
 				action: 'VIEW',
 			});

--- a/src/web/lib/braze/parseBrazeEpicParams.test.ts
+++ b/src/web/lib/braze/parseBrazeEpicParams.test.ts
@@ -14,6 +14,7 @@ describe('parseBrazeEpicParams', () => {
 			highlightedText: 'Example highlighted text',
 			buttonText: 'Button',
 			buttonUrl: 'https://www.example.com',
+			ophanComponentId: 'epic_123',
 		};
 
 		const expected = {
@@ -21,6 +22,7 @@ describe('parseBrazeEpicParams', () => {
 			paragraphs: ['Paragraph 1', 'Paragraph 2', 'Paragraph 3'],
 			highlightedText: 'Example highlighted text',
 			cta: { text: 'Button', baseUrl: 'https://www.example.com' },
+			ophanComponentId: 'epic_123',
 		};
 
 		const got = parseBrazeEpicParams(dataFromBraze);
@@ -37,6 +39,7 @@ describe('parseBrazeEpicParams', () => {
 			highlightedText: 'Example highlighted text',
 			buttonText: 'Button',
 			buttonUrl: 'https://www.example.com',
+			ophanComponentId: 'epic_123',
 		};
 
 		const expected = {
@@ -44,6 +47,7 @@ describe('parseBrazeEpicParams', () => {
 			paragraphs: ['First paragraph', 'Another paragraph'],
 			highlightedText: 'Example highlighted text',
 			cta: { text: 'Button', baseUrl: 'https://www.example.com' },
+			ophanComponentId: 'epic_123',
 		};
 
 		const got = parseBrazeEpicParams(dataFromBraze);
@@ -59,6 +63,7 @@ describe('parseBrazeEpicParams', () => {
 			highlightedText: 'Example highlighted text',
 			buttonText: 'Button',
 			buttonUrl: 'https://www.example.com',
+			ophanComponentId: 'epic_123',
 		};
 
 		const got = parseBrazeEpicParams(dataFromBraze);
@@ -73,6 +78,7 @@ describe('parseBrazeEpicParams', () => {
 			highlightedText: 'Example highlighted text',
 			buttonText: 'Button',
 			buttonUrl: 'https://www.example.com',
+			ophanComponentId: 'epic_123',
 		};
 
 		const got = parseBrazeEpicParams(dataFromBraze);
@@ -89,6 +95,7 @@ describe('parseBrazeEpicParams', () => {
 			highlightedText: 'Example highlighted text',
 			buttonText: 'Button',
 			buttonUrl: 'https://www.example.com',
+			ophanComponentId: 'epic_123',
 		};
 
 		const got = parseBrazeEpicParams(dataFromBraze);
@@ -104,6 +111,7 @@ describe('parseBrazeEpicParams', () => {
 			paragraph2: 'Paragraph 2',
 			buttonText: 'Button',
 			buttonUrl: 'https://www.example.com',
+			ophanComponentId: 'epic_123',
 		};
 
 		const got = parseBrazeEpicParams(dataFromBraze);
@@ -119,6 +127,7 @@ describe('parseBrazeEpicParams', () => {
 			paragraph2: 'Paragraph 2',
 			highlightedText: 'Example highlighted text',
 			buttonUrl: 'https://www.example.com',
+			ophanComponentId: 'epic_123',
 		};
 
 		const got = parseBrazeEpicParams(dataFromBraze);
@@ -127,6 +136,22 @@ describe('parseBrazeEpicParams', () => {
 	});
 
 	it('returns null when the buttonUrl is missing', () => {
+		const dataFromBraze: EpicDataFromBraze = {
+			componentName: 'Epic',
+			heading: 'Example Heading',
+			paragraph1: 'Paragraph 1',
+			paragraph2: 'Paragraph 2',
+			highlightedText: 'Example highlighted text',
+			buttonText: 'Button',
+			ophanComponentId: 'epic_123',
+		};
+
+		const got = parseBrazeEpicParams(dataFromBraze);
+
+		expect(got).toBeNull();
+	});
+
+	it('returns null when the trackingId is missing', () => {
 		const dataFromBraze: EpicDataFromBraze = {
 			componentName: 'Epic',
 			heading: 'Example Heading',

--- a/src/web/lib/braze/parseBrazeEpicParams.test.ts
+++ b/src/web/lib/braze/parseBrazeEpicParams.test.ts
@@ -151,7 +151,7 @@ describe('parseBrazeEpicParams', () => {
 		expect(got).toBeNull();
 	});
 
-	it('returns null when the trackingId is missing', () => {
+	it('returns null when the ophanComponentId is missing', () => {
 		const dataFromBraze: EpicDataFromBraze = {
 			componentName: 'Epic',
 			heading: 'Example Heading',
@@ -159,6 +159,7 @@ describe('parseBrazeEpicParams', () => {
 			paragraph2: 'Paragraph 2',
 			highlightedText: 'Example highlighted text',
 			buttonText: 'Button',
+			buttonUrl: 'https://www.example.com'
 		};
 
 		const got = parseBrazeEpicParams(dataFromBraze);

--- a/src/web/lib/braze/parseBrazeEpicParams.ts
+++ b/src/web/lib/braze/parseBrazeEpicParams.ts
@@ -13,6 +13,7 @@ export type EpicDataFromBraze = {
 	paragraph7?: string;
 	paragraph8?: string;
 	paragraph9?: string;
+	ophanComponentId?: string;
 };
 
 export type Variant = {
@@ -24,6 +25,7 @@ export type Variant = {
 		text: string;
 		baseUrl: string;
 	};
+	ophanComponentId: string;
 };
 
 const parseParagraphs = (dataFromBraze: EpicDataFromBraze): string[] => {
@@ -45,9 +47,21 @@ const parseParagraphs = (dataFromBraze: EpicDataFromBraze): string[] => {
 export const parseBrazeEpicParams = (
 	dataFromBraze: EpicDataFromBraze,
 ): Variant | null => {
-	const { heading, highlightedText, buttonText, buttonUrl } = dataFromBraze;
+	const {
+		heading,
+		highlightedText,
+		buttonText,
+		buttonUrl,
+		ophanComponentId,
+	} = dataFromBraze;
 
-	if (!heading || !highlightedText || !buttonText || !buttonUrl) {
+	if (
+		!heading ||
+		!highlightedText ||
+		!buttonText ||
+		!buttonUrl ||
+		!ophanComponentId
+	) {
 		console.log('Braze Epic: props missing', dataFromBraze);
 		return null;
 	}
@@ -64,5 +78,6 @@ export const parseBrazeEpicParams = (
 		paragraphs,
 		highlightedText,
 		cta: { text: buttonText, baseUrl: buttonUrl },
+		ophanComponentId,
 	};
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
The Braze Epic now required Marketing to specify an `ophanComponentId`, which is used as a specific campaign identifier in our logs to Ophan.

## Why?
To allow Marketing to analyse the performance of specific variants of the Braze Epic.

[Related PR for @guardian/braze-components](https://github.com/guardian/braze-components/pull/142).