### PR TITLE
Fix `SignedInAs` below `leftCol`

### DIFF
--- a/src/web/components/Discussion.tsx
+++ b/src/web/components/Discussion.tsx
@@ -192,7 +192,8 @@ export const Discussion = ({
 										enableDiscussionSwitch
 									}
 									user={user}
-									commentCount={commentCount || 0}
+									commentCount={commentCount}
+									isClosedForComments={isClosedForComments}
 								/>
 							</div>
 						</Hide>


### PR DESCRIPTION
## What?
This fixes a bug where the incorrect information was being shown in the `SignedInAs` component below a certain breakpoint. Instead of stating that a discussion was closed, we were incorrectly inferring that readers should have been able to comment by showing their profiles.

## Before
![Screenshot 2021-04-19 at 16 33 37](https://user-images.githubusercontent.com/1336821/115263254-2e75bb80-a12d-11eb-870e-6465e824ba1e.jpg)

## After
![Screenshot 2021-04-19 at 16 32 30](https://user-images.githubusercontent.com/1336821/115263269-3170ac00-a12d-11eb-9101-258a2339804a.jpg)



## Why?
We want to give readers the correct information
