### PR TITLE
Mobile Nav Background

### DIFF
--- a/src/web/components/Nav/ExpandedMenu/ExpandedMenu.tsx
+++ b/src/web/components/Nav/ExpandedMenu/ExpandedMenu.tsx
@@ -56,7 +56,6 @@ const wrapperMainMenuStyles = css`
 		bottom: 0;
 		height: 100%;
 		overflow: auto;
-		/* padding-top: 6px; */
 		position: fixed;
 		right: 0;
 		will-change: transform;

--- a/src/web/components/Nav/ExpandedMenu/ExpandedMenu.tsx
+++ b/src/web/components/Nav/ExpandedMenu/ExpandedMenu.tsx
@@ -7,22 +7,21 @@ import { from, until } from '@guardian/src-foundations/mq';
 
 import { getZIndex } from '@root/src/web/lib/getZIndex';
 import { Display } from '@guardian/types';
+
 import { ShowMoreMenu } from './ShowMoreMenu';
 import { VeggieBurgerMenu } from './VeggieBurgerMenu';
 import { Columns } from './Columns';
 import { navInputCheckboxId } from '../config';
 
-const mainMenuStyles = css`
-	${getZIndex('expanded-veggie-menu')}
-
-	background-color: ${brandBackground.primary};
-	box-sizing: border-box;
-	${textSans.large()};
+const wrapperMainMenuStyles = css`
+	background-color: rgba(0, 0, 0, 0.5);
+	${getZIndex('expanded-veggie-menu-wrapper')}
 	left: 0;
-	margin-right: 29px;
-	padding-bottom: 24px;
 	top: 0;
-	overflow: hidden;
+
+	${from.desktop} {
+		display: none;
+	}
 
 	/*
         IMPORTANT NOTE:
@@ -35,24 +34,6 @@ const mainMenuStyles = css`
 		${from.desktop} {
 			display: block;
 			overflow: visible;
-		}
-	}
-
-	${from.desktop} {
-		display: none;
-		position: absolute;
-		padding-bottom: 0;
-		padding-top: 0;
-		top: 100%;
-		left: 0;
-		right: 0;
-		width: 100%;
-		@supports (width: 100vw) {
-			left: 50%;
-			right: 50%;
-			width: 100vw;
-			margin-left: -50vw;
-			margin-right: -50vw;
 		}
 	}
 
@@ -75,10 +56,40 @@ const mainMenuStyles = css`
 		bottom: 0;
 		height: 100%;
 		overflow: auto;
-		padding-top: 6px;
+		/* padding-top: 6px; */
 		position: fixed;
 		right: 0;
 		will-change: transform;
+	}
+`;
+
+const mainMenuStyles = css`
+	background-color: ${brandBackground.primary};
+	box-sizing: border-box;
+	${textSans.large()};
+	margin-right: 29px;
+	/* padding-bottom: 24px; */
+	left: 0;
+	top: 0;
+	${getZIndex('expanded-veggie-menu')}
+	overflow: hidden;
+
+	${from.desktop} {
+		display: none;
+		position: absolute;
+		padding-bottom: 0;
+		padding-top: 0;
+		top: 100%;
+		left: 0;
+		right: 0;
+		width: 100%;
+		@supports (width: 100vw) {
+			left: 50%;
+			right: 50%;
+			width: 100vw;
+			margin-left: -50vw;
+			margin-right: -50vw;
+		}
 	}
 
 	${from.mobileMedium} {
@@ -100,13 +111,14 @@ export const ExpandedMenu: React.FC<{
 		<div id="expanded-menu-root">
 			<ShowMoreMenu display={display} />
 			<VeggieBurgerMenu display={display} />
-			<div
-				id="expanded-menu"
-				className={mainMenuStyles}
-				data-testid="expanded-menu"
-				data-cy="expanded-menu"
-			>
-				<Columns nav={nav} />
+			<div id="expanded-menu" className={wrapperMainMenuStyles}>
+				<div
+					className={mainMenuStyles}
+					data-testid="expanded-menu"
+					data-cy="expanded-menu"
+				>
+					<Columns nav={nav} />
+				</div>
 			</div>
 		</div>
 	);

--- a/src/web/components/Nav/ExpandedMenu/ExpandedMenu.tsx
+++ b/src/web/components/Nav/ExpandedMenu/ExpandedMenu.tsx
@@ -60,6 +60,9 @@ const wrapperMainMenuStyles = css`
 		right: 0;
 		will-change: transform;
 	}
+	${from.desktop} {
+		display: none;
+	}
 `;
 
 const mainMenuStyles = css`
@@ -73,7 +76,6 @@ const mainMenuStyles = css`
 	overflow: hidden;
 
 	${from.desktop} {
-		display: none;
 		position: absolute;
 		padding-bottom: 0;
 		padding-top: 0;

--- a/src/web/components/Nav/ExpandedMenu/ExpandedMenu.tsx
+++ b/src/web/components/Nav/ExpandedMenu/ExpandedMenu.tsx
@@ -68,7 +68,6 @@ const mainMenuStyles = css`
 	box-sizing: border-box;
 	${textSans.large()};
 	margin-right: 29px;
-	/* padding-bottom: 24px; */
 	left: 0;
 	top: 0;
 	${getZIndex('expanded-veggie-menu')}

--- a/src/web/components/Nav/StickNavTest/ExpandedMenu/ExpandedMenu.tsx
+++ b/src/web/components/Nav/StickNavTest/ExpandedMenu/ExpandedMenu.tsx
@@ -61,7 +61,6 @@ const wrapperMainMenuStyles = (ID: string) => css`
 		bottom: 0;
 		height: 100%;
 		overflow: auto;
-		/* padding-top: 6px; */
 		position: fixed;
 		right: 0;
 		will-change: transform;

--- a/src/web/components/Nav/StickNavTest/ExpandedMenu/ExpandedMenu.tsx
+++ b/src/web/components/Nav/StickNavTest/ExpandedMenu/ExpandedMenu.tsx
@@ -65,6 +65,9 @@ const wrapperMainMenuStyles = (ID: string) => css`
 		right: 0;
 		will-change: transform;
 	}
+	${from.desktop} {
+		display: none;
+	}
 `;
 const mainMenuStyles = css`
 	background-color: ${brandBackground.primary};
@@ -78,7 +81,6 @@ const mainMenuStyles = css`
 	overflow: hidden;
 
 	${from.desktop} {
-		display: none;
 		position: absolute;
 		padding-bottom: 0;
 		padding-top: 0;

--- a/src/web/components/Nav/StickNavTest/ExpandedMenu/ExpandedMenu.tsx
+++ b/src/web/components/Nav/StickNavTest/ExpandedMenu/ExpandedMenu.tsx
@@ -18,16 +18,15 @@ import { Columns } from './Columns';
 import { ShowMoreMenu } from './ShowMoreMenu';
 import { VeggieBurgerMenu } from './VeggieBurgerMenu';
 
-const mainMenuStyles = (ID: string) => css`
-	background-color: ${brandBackground.primary};
-	box-sizing: border-box;
-	${textSans.large()};
+const wrapperMainMenuStyles = (ID: string) => css`
+	background-color: rgba(0, 0, 0, 0.5);
+	${getZIndex('expanded-veggie-menu-wrapper')}
 	left: 0;
-	margin-right: 29px;
-	padding-bottom: 24px;
 	top: 0;
-	${getZIndex('expanded-veggie-menu')}
-	overflow: hidden;
+
+	${from.desktop} {
+		display: none;
+	}
 
 	/*
         IMPORTANT NOTE:
@@ -40,24 +39,6 @@ const mainMenuStyles = (ID: string) => css`
 		${from.desktop} {
 			display: block;
 			overflow: visible;
-		}
-	}
-
-	${from.desktop} {
-		display: none;
-		position: absolute;
-		padding-bottom: 0;
-		padding-top: 0;
-		top: 100%;
-		left: 0;
-		right: 0;
-		width: 100%;
-		@supports (width: 100vw) {
-			left: 50%;
-			right: 50%;
-			width: 100vw;
-			margin-left: -50vw;
-			margin-right: -50vw;
 		}
 	}
 
@@ -80,10 +61,39 @@ const mainMenuStyles = (ID: string) => css`
 		bottom: 0;
 		height: 100%;
 		overflow: auto;
-		padding-top: 6px;
+		/* padding-top: 6px; */
 		position: fixed;
 		right: 0;
 		will-change: transform;
+	}
+`;
+const mainMenuStyles = css`
+	background-color: ${brandBackground.primary};
+	box-sizing: border-box;
+	${textSans.large()};
+	margin-right: 29px;
+	padding-bottom: 24px;
+	left: 0;
+	top: 0;
+	${getZIndex('expanded-veggie-menu')}
+	overflow: hidden;
+
+	${from.desktop} {
+		display: none;
+		position: absolute;
+		padding-bottom: 0;
+		padding-top: 0;
+		top: 100%;
+		left: 0;
+		right: 0;
+		width: 100%;
+		@supports (width: 100vw) {
+			left: 50%;
+			right: 50%;
+			width: 100vw;
+			margin-left: -50vw;
+			margin-right: -50vw;
+		}
 	}
 
 	${from.mobileMedium} {
@@ -127,17 +137,21 @@ export const ExpandedMenu: React.FC<{
 			<VeggieBurgerMenu display={display} ID={ID} />
 			<div
 				id={buildID(ID, 'expanded-menu')}
-				className={mainMenuStyles(ID)}
-				data-testid="expanded-menu"
-				data-cy="expanded-menu"
+				className={wrapperMainMenuStyles(ID)}
 			>
-				{expand && (
-					<ExpandedMenuInner
-						currentNavLinkTitle={currentNavLinkTitle}
-						edition={edition}
-						ajaxUrl={ajaxUrl}
-					/>
-				)}
+				<div
+					className={mainMenuStyles}
+					data-testid="expanded-menu"
+					data-cy="expanded-menu"
+				>
+					{expand && (
+						<ExpandedMenuInner
+							currentNavLinkTitle={currentNavLinkTitle}
+							edition={edition}
+							ajaxUrl={ajaxUrl}
+						/>
+					)}
+				</div>
 			</div>
 		</div>
 	);

--- a/src/web/lib/getZIndex.test.tsx
+++ b/src/web/lib/getZIndex.test.tsx
@@ -2,9 +2,10 @@ import { getZIndex } from './getZIndex';
 
 describe('getZIndex', () => {
 	it('gets the correct zindex for group and sibling', () => {
-		expect(getZIndex('banner')).toBe('z-index: 13;');
-		expect(getZIndex('dropdown')).toBe('z-index: 12;');
-		expect(getZIndex('burger')).toBe('z-index: 11;');
+		expect(getZIndex('banner')).toBe('z-index: 14;');
+		expect(getZIndex('dropdown')).toBe('z-index: 13;');
+		expect(getZIndex('burger')).toBe('z-index: 12;');
+		expect(getZIndex('expanded-veggie-menu-wrapper')).toBe('z-index: 11;');
 		expect(getZIndex('expanded-veggie-menu')).toBe('z-index: 10;');
 		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 9;');
 		expect(getZIndex('searchHeaderLink')).toBe('z-index: 8;');

--- a/src/web/lib/getZIndex.tsx
+++ b/src/web/lib/getZIndex.tsx
@@ -27,6 +27,7 @@ const indices = [
 	'banner',
 	'dropdown',
 	'burger',
+	'expanded-veggie-menu-wrapper',
 	'expanded-veggie-menu',
 
 	// Header


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Add background to Navbar

### Before
<img width="373" alt="Screenshot 2021-04-20 at 09 34 33" src="https://user-images.githubusercontent.com/8831403/115365326-2fa1f980-a1bc-11eb-8917-f053578fdd88.png">

### After
<img width="378" alt="Screenshot 2021-04-20 at 09 34 02" src="https://user-images.githubusercontent.com/8831403/115365341-33ce1700-a1bc-11eb-836b-ecee480adab5.png">

## Why?
Prevents scroll of the article when on Nav