### PR TITLE
Veggie burger focus ring

### DIFF
--- a/src/web/components/Nav/ExpandedMenu/VeggieBurgerMenu.tsx
+++ b/src/web/components/Nav/ExpandedMenu/VeggieBurgerMenu.tsx
@@ -97,7 +97,7 @@ const veggieBurgerStyles = (display: Display) => css`
 	}
 
 	:focus {
-		outline: 5px auto -webkit-focus-ring-color;
+		outline: none;
 	}
 `;
 

--- a/src/web/components/Nav/StickNavTest/ExpandedMenu/VeggieBurgerMenu.tsx
+++ b/src/web/components/Nav/StickNavTest/ExpandedMenu/VeggieBurgerMenu.tsx
@@ -96,7 +96,7 @@ const veggieBurgerStyles = (display: Display) => css`
 	}
 
 	:focus {
-		outline: 5px auto -webkit-focus-ring-color;
+		outline: none;
 	}
 `;
 

--- a/src/web/lib/braze/parseBrazeEpicParams.test.ts
+++ b/src/web/lib/braze/parseBrazeEpicParams.test.ts
@@ -159,7 +159,7 @@ describe('parseBrazeEpicParams', () => {
 			paragraph2: 'Paragraph 2',
 			highlightedText: 'Example highlighted text',
 			buttonText: 'Button',
-			buttonUrl: 'https://www.example.com'
+			buttonUrl: 'https://www.example.com',
 		};
 
 		const got = parseBrazeEpicParams(dataFromBraze);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Remove outline CSS styles on the veggie burger

### Before
<img width="157" alt="Screenshot 2021-04-20 at 12 18 54" src="https://user-images.githubusercontent.com/8831403/115390571-49e8d100-a1d6-11eb-8d02-1d86c0b6356c.png">

### After
<img width="213" alt="Screenshot 2021-04-20 at 12 45 52" src="https://user-images.githubusercontent.com/8831403/115390766-8a484f00-a1d6-11eb-9d97-11da704c6e39.png">

## Why?
We already use Soure's focus