### PR TITLE
Bump @guardian/braze-components to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "@guardian/ab-react": "^2.0.1",
         "@guardian/atoms-rendering": "^10.0.2",
         "@guardian/automat-client": "^0.2.17",
-        "@guardian/braze-components": "^1.0.1",
+        "@guardian/braze-components": "^1.1.0",
         "@guardian/consent-management-platform": "^6.11.3",
         "@guardian/discussion-rendering": "6.1.4-2",
         "@guardian/libs": "^1.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2069,10 +2069,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.17.tgz#253724307312f4d5bc01b5749179193b8a29ae8b"
   integrity sha512-SbNeBjoc1iqt/EZ+zQTy7EbbXbdEHOuKObcseLKWyy/LF+4FQtHNuYxLGQ3zjl6fR7s/nvcnIEBAPrnFv0gcqQ==
 
-"@guardian/braze-components@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-1.0.1.tgz#427364b25c1288a1845c7ad49009a8f32efc7f01"
-  integrity sha512-mF63OjWy1YbQnC4nQlGhB8fPcwlgf8ed6YAr5NiyJ4S1QQow5vU/2gw6halI1a79UjmDIM6GNk21kJ1ZrK89Rg==
+"@guardian/braze-components@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-1.1.0.tgz#d5ac3e5152d23bb6006880b52cb71efd1a9efb76"
+  integrity sha512-YVfqckgIeF2Txqs6Z4QnXgFYhRP/nOLOJAWPaOt+msnxqr9MPysjcCHFoJ2iEPjnwRNibszJUx9ONsN3mx9spA==
   dependencies:
     "@guardian/src-button" "2.7.1"
     "@guardian/src-foundations" "2.7.1"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Bumps @guardian/braze-components to [v1.1.0](https://github.com/guardian/braze-components/releases/tag/v1.1.0) 

## Why?
In order to support the Braze Epic & `LocalMessageCache` with additional error logs.

(We are currently testing this and #2846 on CODE)