### PR TITLE
Add Json endpoint to view DCR Json after enhanceCAPI step

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,20 +6,21 @@ Frontend rendering framework for theguardian.com. It uses [React](https://reactj
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 <!-- Automatically created with yarn run createtoc and on push hook -->
 
-- [Quick start](#quick-start)
-  - [Install Node.js](#install-nodejs)
-  - [Running instructions](#running-instructions)
-  - [Detailed Setup](#detailed-setup)
-  - [Technologies](#technologies)
-  - [Architecture Diagram](#architecture-diagram)
-  - [Concepts](#concepts)
-  - [Feedback](#feedback)
-- [Where can I see Dotcom Rendering in Production?](#where-can-i-see-dotcom-rendering-in-production)
-- [Code Quality](#code-quality)
-- [IDE setup](#ide-setup)
-  - [Extensions](#extensions)
-  - [Auto fix on save](#auto-fix-on-save)
-- [Thanks](#thanks)
+- [Dotcom Rendering](#dotcom-rendering)
+	- [Quick start](#quick-start)
+		- [Install Node.js](#install-nodejs)
+		- [Running instructions](#running-instructions)
+		- [Detailed Setup](#detailed-setup)
+		- [Technologies](#technologies)
+		- [Architecture Diagram](#architecture-diagram)
+		- [Concepts](#concepts)
+		- [Feedback](#feedback)
+	- [Where can I see Dotcom Rendering in Production?](#where-can-i-see-dotcom-rendering-in-production)
+	- [Code Quality](#code-quality)
+	- [IDE setup](#ide-setup)
+		- [Extensions](#extensions)
+		- [Auto fix on save](#auto-fix-on-save)
+	- [Thanks](#thanks)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -46,6 +47,8 @@ $ make dev
 Visit the [root path of the dev server](http://localhost:3030) for some example URLs to visit.
 
 You can render a specific article by [specifying the production URL in the query string](http://localhost:3030/Article?url=https://www.theguardian.com/sport/2019/jul/28/tour-de-france-key-moments-egan-bernal-yellow-jersey).
+
+You can view the JSON representation of an article, as per the model sent to the renderer on the server, by going to [/ArticleJson](http://localhost:3030/ArticleJson?url=https://www.theguardian.com/sport/2019/jul/28/tour-de-france-key-moments-egan-bernal-yellow-jersey).
 
 ### Detailed Setup
 

--- a/scripts/frontend/dev-server.js
+++ b/scripts/frontend/dev-server.js
@@ -75,6 +75,28 @@ const go = () => {
 	);
 
 	app.get(
+		'/ArticleJson',
+		async (req, res, next) => {
+			try {
+				const url = buildUrlFromQueryParam(req);
+				const { html, ...config } = await fetch(url).then((article) =>
+					article.json(),
+				);
+
+				req.body = config;
+				next();
+			} catch (error) {
+				// eslint-disable-next-line no-console
+				console.error(error);
+			}
+		},
+		webpackHotServerMiddleware(compiler, {
+			chunkName: `${siteName}.server`,
+			serverRendererOptions: { json: true },
+		}),
+	);
+
+	app.get(
 		'/AMPArticle',
 		async (req, res, next) => {
 			try {

--- a/src/app/server.ts
+++ b/src/app/server.ts
@@ -14,6 +14,7 @@ import {
 import {
 	render as renderArticle,
 	renderPerfTest as renderArticlePerfTest,
+	renderArticleJson,
 } from '@root/src/web/server/render';
 
 import {
@@ -27,6 +28,10 @@ import { logger } from './logging';
 export default (options: any) => {
 	if ('amp' in options) {
 		return renderAMPArticle;
+	}
+
+	if ('json' in options) {
+		return renderArticleJson;
 	}
 
 	return renderArticle;
@@ -134,6 +139,8 @@ if (process.env.NODE_ENV === 'production') {
 
 	app.use('/ArticlePerfTest', renderArticlePerfTest);
 	app.use('/AMPArticlePerfTest', renderAMPArticlePerfTest);
+
+	app.use('/ArticleJson', renderArticleJson);
 
 	app.get('/', (req: Request, res: Response) => {
 		try {

--- a/src/web/server/render.ts
+++ b/src/web/server/render.ts
@@ -61,19 +61,23 @@ class CAPIEnhancer {
 	}
 }
 
+const buildCAPI = (body: CAPIType): CAPIType => {
+	return new CAPIEnhancer(body)
+		.validateAsCAPIType()
+		.addDividers()
+		.enhanceBlockquotes()
+		.enhanceDots()
+		.enhanceImages()
+		.enhanceNumberedLists()
+		.enhanceAnniversaryAtom().capi;
+};
+
 export const render = (
 	{ body }: express.Request,
 	res: express.Response,
 ): void => {
 	try {
-		const CAPI = new CAPIEnhancer(body)
-			.validateAsCAPIType()
-			.addDividers()
-			.enhanceBlockquotes()
-			.enhanceDots()
-			.enhanceImages()
-			.enhanceNumberedLists()
-			.enhanceAnniversaryAtom().capi;
+		const CAPI = buildCAPI(body);
 		const resp = document({
 			data: {
 				CAPI,
@@ -97,13 +101,7 @@ export const renderArticleJson = (
 	res: express.Response,
 ): void => {
 	try {
-		const CAPI = new CAPIEnhancer(body)
-			.validateAsCAPIType()
-			.addDividers()
-			.enhanceBlockquotes()
-			.enhanceDots()
-			.enhanceImages()
-			.enhanceAnniversaryAtom().capi;
+		const CAPI = buildCAPI(body);
 		const resp = {
 			data: {
 				CAPI,

--- a/src/web/server/render.ts
+++ b/src/web/server/render.ts
@@ -92,6 +92,36 @@ export const render = (
 	}
 };
 
+export const renderArticleJson = (
+	{ body }: express.Request,
+	res: express.Response,
+): void => {
+	try {
+		const CAPI = new CAPIEnhancer(body)
+			.validateAsCAPIType()
+			.addDividers()
+			.enhanceBlockquotes()
+			.enhanceDots()
+			.enhanceImages()
+			.enhanceAnniversaryAtom().capi;
+		const resp = {
+			data: {
+				CAPI,
+				site: 'frontend',
+				page: 'Article',
+				NAV: extractNAV(CAPI.nav),
+				GA: extractGA(CAPI),
+				linkedData: CAPI.linkedData,
+			},
+		};
+
+		res.status(200).send(resp);
+	} catch (e) {
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+		res.status(500).send(`<pre>${e.stack}</pre>`);
+	}
+};
+
 export const renderPerfTest = (
 	req: express.Request,
 	res: express.Response,


### PR DESCRIPTION
## What does this change?

Allows the viewing of the DCR Json used to server render. This is useful for easier viewing of the ultimate JSON passed to the article renderer as happens *after* enhanceCAPI.

Post enhance-CAPI DCR JSON vs DCR JSON from Frontend

![image](https://user-images.githubusercontent.com/638051/115405698-65f46e80-a1e6-11eb-9b23-63ce44b9ce4a.png)
