### PR TITLE
update remote RR links test name

### DIFF
--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -68,7 +68,7 @@ import { SpotifyBlockComponent } from '@root/src/web/components/elements/Spotify
 import { VideoFacebookBlockComponent } from '@root/src/web/components/elements/VideoFacebookBlockComponent';
 import { VineBlockComponent } from '@root/src/web/components/elements/VineBlockComponent';
 import type { BrazeMessagesInterface } from '@guardian/braze-components/logic';
-import { remoteRRHeaderLinksTestName } from '@root/src/web/experiments/tests/remoteRRHeaderLinksTest';
+import { remoteRrHeaderLinksTestName } from '@root/src/web/experiments/tests/remoteRrHeaderLinksTest';
 import { OphanRecordFunction } from '@root/node_modules/@guardian/ab-core/dist/types';
 import {
 	submitComponentEvent,
@@ -355,7 +355,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 	const adTargeting: AdTargeting = buildAdTargeting(CAPI.config);
 
 	const inRemoteModuleTest = ABTestAPI.isUserInVariant(
-		remoteRRHeaderLinksTestName,
+		remoteRrHeaderLinksTestName,
 		'remote',
 	);
 

--- a/src/web/components/ReaderRevenueLinks.tsx
+++ b/src/web/components/ReaderRevenueLinks.tsx
@@ -14,7 +14,7 @@ import { from, until } from '@guardian/src-foundations/mq';
 import { shouldHideSupportMessaging } from '@root/src/web/lib/contributions';
 import { setAutomat } from '@root/src/web/lib/setAutomat';
 import { getCookie } from '@root/src/web/browser/cookie';
-import { remoteRRHeaderLinksTestName } from '@root/src/web/experiments/tests/remoteRRHeaderLinksTest';
+import { remoteRrHeaderLinksTestName } from '@root/src/web/experiments/tests/remoteRrHeaderLinksTest';
 import type { TestMeta } from '@guardian/types';
 import { useHasBeenSeen } from '@root/src/web/lib/useHasBeenSeen';
 import { addTrackingCodesToUrl } from '@root/src/web/lib/acquisitions';
@@ -270,7 +270,7 @@ export const ReaderRevenueLinksNative: React.FC<Props> = ({
 	const hideSupportMessaging = shouldHideSupportMessaging();
 
 	// Only the header component is in the AB test
-	const testName = inHeader ? remoteRRHeaderLinksTestName : 'RRFooterLinks';
+	const testName = inHeader ? remoteRrHeaderLinksTestName : 'RRFooterLinks';
 	const campaignCode = `${testName}_control`;
 	const tracking: TestMeta = {
 		abTestName: testName,
@@ -306,7 +306,7 @@ export const ReaderRevenueLinksNative: React.FC<Props> = ({
 				componentId: campaignCode,
 				campaignCode,
 				abTest: {
-					name: remoteRRHeaderLinksTestName,
+					name: remoteRrHeaderLinksTestName,
 					variant: 'control',
 				},
 				pageViewId,

--- a/src/web/experiments/ab-tests.ts
+++ b/src/web/experiments/ab-tests.ts
@@ -6,7 +6,7 @@ import {
 	newsletterMerchUnitLighthouseControl,
 	newsletterMerchUnitLighthouseVariants,
 } from '@root/src/web/experiments/tests/newsletter-merch-unit-test';
-import { remoteRRHeaderLinksTest } from '@root/src/web/experiments/tests/remoteRRHeaderLinksTest';
+import { remoteRrHeaderLinksTest } from '@root/src/web/experiments/tests/remoteRrHeaderLinksTest';
 
 export const tests: ABTest[] = [
 	abTestTest,
@@ -14,5 +14,5 @@ export const tests: ABTest[] = [
 	signInGateMainControl,
 	newsletterMerchUnitLighthouseControl,
 	newsletterMerchUnitLighthouseVariants,
-	remoteRRHeaderLinksTest,
+	remoteRrHeaderLinksTest,
 ];

--- a/src/web/experiments/tests/remoteRrHeaderLinksTest.ts
+++ b/src/web/experiments/tests/remoteRrHeaderLinksTest.ts
@@ -1,9 +1,9 @@
 import { ABTest } from '@guardian/ab-core';
 
-export const remoteRRHeaderLinksTestName = 'RemoteRRHeaderLinksTest';
+export const remoteRrHeaderLinksTestName = 'RemoteRrHeaderLinksTest';
 
-export const remoteRRHeaderLinksTest: ABTest = {
-	id: remoteRRHeaderLinksTestName,
+export const remoteRrHeaderLinksTest: ABTest = {
+	id: remoteRrHeaderLinksTestName,
 	start: '2021-04-10',
 	expiry: '2021-12-01',
 	author: 'Tom Forbes',


### PR DESCRIPTION
The name needs to match precisely across frontend and dcr:
https://github.com/guardian/frontend/blob/main/static/src/javascripts/projects/common/modules/experiments/tests/remote-header-test.js#L2