### PR TITLE
Faux H3s

### DIFF
--- a/src/model/enhance-numbered-lists.test.ts
+++ b/src/model/enhance-numbered-lists.test.ts
@@ -26,7 +26,6 @@ describe('Enhance Numbered Lists', () => {
 				},
 			],
 		};
-
 		const expectedOutput: CAPIType = {
 			...NumberedList,
 			blocks: [
@@ -41,7 +40,6 @@ describe('Enhance Numbered Lists', () => {
 				},
 			],
 		};
-
 		expect(enhanceNumberedLists(input)).toEqual(expectedOutput);
 	});
 
@@ -60,7 +58,6 @@ describe('Enhance Numbered Lists', () => {
 				},
 			],
 		};
-
 		const expectedOutput: CAPIType = {
 			...Article,
 			blocks: [
@@ -75,7 +72,120 @@ describe('Enhance Numbered Lists', () => {
 				},
 			],
 		};
+		expect(enhanceNumberedLists(input)).toEqual(expectedOutput);
+	});
 
+	it('replaces faux h3s with real ones, prefixing them with a divider', () => {
+		const input: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							_type:
+								'model.dotcomrendering.pageElements.TextBlockElement',
+							elementId: 'mockId',
+							html: '<p><strong>Faux H3 text</strong></p>',
+						},
+					],
+				},
+			],
+		};
+		const expectedOutput: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							_type:
+								'model.dotcomrendering.pageElements.DividerBlockElement',
+						},
+						{
+							_type:
+								'model.dotcomrendering.pageElements.TextBlockElement',
+							elementId: 'mockId',
+							html: '<h3>Faux H3 text</h3>',
+						},
+					],
+				},
+			],
+		};
+		expect(enhanceNumberedLists(input)).toEqual(expectedOutput);
+	});
+
+	it('does not set a h3 if there is more than one strong tag', () => {
+		const input: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							_type:
+								'model.dotcomrendering.pageElements.TextBlockElement',
+							elementId: 'mockId',
+							html:
+								'<p><strong>Strong 1</strong><strong>Strong 2</strong></p>',
+						},
+					],
+				},
+			],
+		};
+		const expectedOutput: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							_type:
+								'model.dotcomrendering.pageElements.TextBlockElement',
+							elementId: 'mockId',
+							html:
+								'<p><strong>Strong 1</strong><strong>Strong 2</strong></p>',
+						},
+					],
+				},
+			],
+		};
+		expect(enhanceNumberedLists(input)).toEqual(expectedOutput);
+	});
+
+	it('does not set a h3 if there if the html does not end with a strong p tag combo', () => {
+		const input: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							_type:
+								'model.dotcomrendering.pageElements.TextBlockElement',
+							elementId: 'mockId',
+							html: '<p><strong>abc</strong>some other text</p>',
+						},
+					],
+				},
+			],
+		};
+		const expectedOutput: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							_type:
+								'model.dotcomrendering.pageElements.TextBlockElement',
+							elementId: 'mockId',
+							html: '<p><strong>abc</strong>some other text</p>',
+						},
+					],
+				},
+			],
+		};
 		expect(enhanceNumberedLists(input)).toEqual(expectedOutput);
 	});
 });

--- a/src/model/enhance-numbered-lists.ts
+++ b/src/model/enhance-numbered-lists.ts
@@ -72,7 +72,7 @@ const inlineImages = (elements: CAPIElement[]): CAPIElement[] => {
 const addH3s = (elements: CAPIElement[]): CAPIElement[] => {
 	/**
 	 * Why not just add H3s in Composer?
-	 * Truth is, you can't. So toget around this there's a convention that says if
+	 * Truth is, you can't. So to get around this there's a convention that says if
 	 * you insert <p><strong>Faux H3!</strong>,</p> then we replace it with a h3 tag
 	 * instead.
 	 *

--- a/src/web/components/ArticleBody.tsx
+++ b/src/web/components/ArticleBody.tsx
@@ -7,6 +7,7 @@ import { ArticleRenderer } from '@root/src/web/lib/ArticleRenderer';
 import { LiveBlogRenderer } from '@root/src/web/lib/LiveBlogRenderer';
 import { Design, Display } from '@guardian/types';
 import type { Format } from '@guardian/types';
+import { space } from '@guardian/src-foundations';
 
 type Props = {
 	format: Format;
@@ -25,6 +26,16 @@ const globalH2Styles = (display: Display) => css`
 			: headline.xxsmall({ fontWeight: 'bold' })};
 	}
 `;
+
+const globalH3Styles = (display: Display) => {
+	if (display !== Display.NumberedList) return null;
+	return css`
+		h3 {
+			${headline.xxsmall({ fontWeight: 'bold' })};
+			margin-bottom: ${space[2]}px;
+		}
+	`;
+};
 
 const globalStrongStyles = css`
 	strong {
@@ -95,6 +106,7 @@ export const ArticleBody = ({
 			className={cx(
 				bodyPadding,
 				globalH2Styles(format.display),
+				globalH3Styles(format.display),
 				globalStrongStyles,
 				globalImgStyles,
 				globalLinkStyles(palette),


### PR DESCRIPTION
## What?
Adds an enhancer step to replace `<p><strong>My Faux H3</strong></p>` with an actual `h3` element.

We area also prefixing this element with a `DividerBlockElement`

## Why?
To match the designs

## Why is the divider so short?
We only have one type of divider in DCR at the moment.We could look to add a full width one if needed, @HarryFischer ?