### PR TITLE
Anniversary Atom added to the templates

### DIFF
--- a/src/model/enhance-AnniversaryInteractiveAtom.ts
+++ b/src/model/enhance-AnniversaryInteractiveAtom.ts
@@ -3,13 +3,21 @@ import { getAnniversaryAtomCache } from '@root/src/web/server/cacheForAnniversar
 export const enhanceAnniversaryAtom = (data: CAPIType): CAPIType => {
 	// TODO Add switch
 	const { anniversaryArticleHeader } = data.config.switches;
+	const {
+		hideAnniversaryAtomVariant,
+		anniversaryAtomVariant,
+	} = data.config.abTests;
 
-	const { hideAnniversaryAtomVariant } = data.config.abTests;
-
-	// If the main anniversaryArticleHeader switch is ON
-	// and the user is NOT in the AB Tests VARIANT.
-	// Users will be opted-in to VARIANT of the AB Test IF THEY HIDE THE BANNER.
-	if (anniversaryArticleHeader && hideAnniversaryAtomVariant !== 'variant') {
+	// If
+	// - the main anniversaryArticleHeader switch is ON
+	// - the user is NOT in the hideAnniversaryAtom test VARIANT
+	// - the user IS in the anniversaryAtom test variant (for test purposes)
+	// Users will be opted-in to VARIANT of the AB Test IF THEY HAVE SEEN THE BANNER.
+	if (
+		anniversaryArticleHeader && // The main switch is set to ON
+		anniversaryAtomVariant === 'variant' && // Opted into the 0% test for testing purposes
+		hideAnniversaryAtomVariant !== 'variant' // Not opted into the 0% A/B test used for hiding the atom
+	) {
 		data.anniversaryInteractiveAtom = getAnniversaryAtomCache();
 	}
 

--- a/src/model/enhance-AnniversaryInteractiveAtom.ts
+++ b/src/model/enhance-AnniversaryInteractiveAtom.ts
@@ -2,15 +2,14 @@ import { getAnniversaryAtomCache } from '@root/src/web/server/cacheForAnniversar
 
 export const enhanceAnniversaryAtom = (data: CAPIType): CAPIType => {
 	// TODO Add switch
-	const {
-		anniversaryArticleHeader,
-		hideAnniversaryAtom,
-	} = data.config.switches;
+	const { anniversaryArticleHeader } = data.config.switches;
+
+	const { hideAnniversaryAtomVariant } = data.config.abTests;
 
 	// If the main anniversaryArticleHeader switch is ON
-	// and the AB test switch is NOT ON.
-	// Users will be opted-in to the AB Test IF THEY HIDE THE BANNER.
-	if (anniversaryArticleHeader && !hideAnniversaryAtom) {
+	// and the user is NOT in the AB Tests VARIANT.
+	// Users will be opted-in to VARIANT of the AB Test IF THEY HIDE THE BANNER.
+	if (anniversaryArticleHeader && hideAnniversaryAtomVariant !== 'variant') {
 		data.anniversaryInteractiveAtom = getAnniversaryAtomCache();
 	}
 

--- a/src/web/components/AdSlot.tsx
+++ b/src/web/components/AdSlot.tsx
@@ -70,7 +70,7 @@ const adSlotLabelStyles = css`
 `;
 
 const outOfPageStyles = css`
-	height:0;
+	height: 0;
 `;
 
 export const labelStyles = css`
@@ -466,16 +466,14 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 						'js-ad-slot',
 						'ad-slot',
 						'ad-slot--survey',
-						outOfPageStyles
+						outOfPageStyles,
 					)}
 					data-link-name="ad slot survey"
 					data-name="survey"
 					data-label="false"
 					data-refresh="false"
 					data-out-of-page="true"
-					data-desktop={[
-						`${Size.outOfPage}`
-					].join('|')}
+					data-desktop={[`${Size.outOfPage}`].join('|')}
 					aria-hidden="true"
 				/>
 			);

--- a/src/web/components/AnniversaryAtomComponent.tsx
+++ b/src/web/components/AnniversaryAtomComponent.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { css } from 'emotion';
+import { until } from '@guardian/src-foundations/mq';
 import { InteractiveAtom } from '@guardian/atoms-rendering';
 
 export const AnniversaryAtomComponent = ({
@@ -14,8 +15,6 @@ export const AnniversaryAtomComponent = ({
 				/* stylelint-disable color-no-hex */
 				background-color: #ffe500;
 				display: ${anniversaryInteractiveAtom ? 'block' : 'none'};
-				height: 145px;
-				margin: 0 -20px 0 -20px;
 			`}
 		>
 			{anniversaryInteractiveAtom && (

--- a/src/web/components/AnniversaryAtomComponent.tsx
+++ b/src/web/components/AnniversaryAtomComponent.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { css } from 'emotion';
+import { InteractiveAtom } from '@guardian/atoms-rendering';
+
+export const AnniversaryAtomComponent = ({
+	anniversaryInteractiveAtom,
+}: {
+	anniversaryInteractiveAtom: InteractiveAtomBlockElement | undefined;
+}) => {
+	return (
+		<div
+			className={css`
+				/* Temporarily support anniversary atom at top of articles */
+				/* stylelint-disable color-no-hex */
+				background-color: #ffe500;
+				display: ${anniversaryInteractiveAtom ? 'block' : 'none'};
+				height: 145px;
+				margin: 0 -20px 0 -20px;
+			`}
+		>
+			{anniversaryInteractiveAtom && (
+				<InteractiveAtom
+					html={anniversaryInteractiveAtom.html}
+					js={anniversaryInteractiveAtom.js}
+					css={anniversaryInteractiveAtom.css}
+					id={anniversaryInteractiveAtom.id}
+				/>
+			)}
+		</div>
+	);
+};

--- a/src/web/components/AnniversaryAtomComponent.tsx
+++ b/src/web/components/AnniversaryAtomComponent.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { css } from 'emotion';
-import { until } from '@guardian/src-foundations/mq';
 import { InteractiveAtom } from '@guardian/atoms-rendering';
 
 export const AnniversaryAtomComponent = ({

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -38,7 +38,7 @@ import { decideDesign } from '@root/src/web/lib/decideDesign';
 import { loadScript } from '@root/src/web/lib/loadScript';
 import { useOnce } from '@root/src/web/lib/useOnce';
 import { initPerf } from '@root/src/web/browser/initPerf';
-import { getCookie } from '@root/src/web/browser/cookie';
+import { getCookie, addCookie } from '@root/src/web/browser/cookie';
 import { getCountryCode } from '@frontend/web/lib/getCountryCode';
 import { getUser } from '@root/src/web/lib/getUser';
 
@@ -236,6 +236,14 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 			console.error(`incrementArticleCountsIfConsented - error: ${e}`),
 		);
 	}, []);
+
+	// AnniversaryAtom
+	// Add a cookie for the serverside A/B test that is checked to see if we should
+	// show the anniversary atom. This means that this user will not see the atom
+	// on the next and following page views.
+	useEffect(() => {
+		addCookie('X-GU-Experiment-0perc-B', 'true', 10); // 10 days to live for the life of the atom being shown
+	});
 
 	// Ensure the focus state of any buttons/inputs in any of the Source
 	// components are only applied when navigating via keyboard.

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -5,6 +5,7 @@ import {
 	neutral,
 	brandBorder,
 	brandBackground,
+	brandAltBackground,
 	brandLine,
 } from '@guardian/src-foundations/palette';
 import { from, until } from '@guardian/src-foundations/mq';
@@ -86,7 +87,6 @@ const StandardGrid = ({
 					${display === Display.Showcase
 						? css`
 								grid-template-areas:
-									'atom       atom    atom        atom'
 									'title      border  headline    headline'
 									'lines      border  headline    headline'
 									'meta       border  standfirst  standfirst'
@@ -96,7 +96,6 @@ const StandardGrid = ({
 						  `
 						: css`
 								grid-template-areas:
-									'atom       atom    atom        atom'
 									'title      border  headline    right-column'
 									'lines      border  headline    right-column'
 									'meta       border  standfirst  right-column'
@@ -116,7 +115,6 @@ const StandardGrid = ({
 					${display === Display.Showcase
 						? css`
 								grid-template-areas:
-									'atom       atom    atom        atom'
 									'title      border  headline    headline'
 									'lines      border  headline    headline'
 									'meta       border  standfirst  standfirst'
@@ -126,7 +124,6 @@ const StandardGrid = ({
 						  `
 						: css`
 								grid-template-areas:
-									'atom       atom    atom        atom'
 									'title      border  headline    right-column'
 									'lines      border  headline    right-column'
 									'meta       border  standfirst  right-column'
@@ -141,7 +138,6 @@ const StandardGrid = ({
 						1fr /* Main content */
 						300px; /* Right Column */
 					grid-template-areas:
-						'atom       atom'
 						'title      right-column'
 						'headline   right-column'
 						'standfirst right-column'
@@ -155,7 +151,6 @@ const StandardGrid = ({
 					grid-column-gap: 0px;
 					grid-template-columns: 1fr; /* Main content */
 					grid-template-areas:
-						'atom'
 						'title'
 						'headline'
 						'standfirst'
@@ -169,7 +164,6 @@ const StandardGrid = ({
 
 					grid-template-columns: 1fr; /* Main content */
 					grid-template-areas:
-						'atom'
 						'title'
 						'headline'
 						'standfirst'
@@ -389,19 +383,21 @@ export const CommentLayout = ({
 					</Section>
 				</SendToBack>
 			</div>
-
+			<Section
+				backgroundColour={brandAltBackground.primary}
+				padded={false}
+				showTopBorder={false}
+				showSideBorders={false}
+			>
+				<AnniversaryAtomComponent
+					anniversaryInteractiveAtom={CAPI.anniversaryInteractiveAtom}
+				/>
+			</Section>
 			<Section
 				showTopBorder={false}
 				backgroundColour={palette.background.article}
 			>
 				<StandardGrid display={format.display}>
-					<GridItem area="atom">
-						<AnniversaryAtomComponent
-							anniversaryInteractiveAtom={
-								CAPI.anniversaryInteractiveAtom
-							}
-						/>
-					</GridItem>
 					<GridItem area="title">
 						<ArticleTitle
 							format={format}

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -35,6 +35,7 @@ import { Border } from '@root/src/web/components/Border';
 import { GridItem } from '@root/src/web/components/GridItem';
 import { AgeWarning } from '@root/src/web/components/AgeWarning';
 import { Discussion } from '@frontend/web/components/Discussion';
+import { AnniversaryAtomComponent } from '@frontend/web/components/AnniversaryAtomComponent';
 
 import { buildAdTargeting } from '@root/src/lib/ad-targeting';
 import { parse } from '@frontend/lib/slot-machine-flags';
@@ -85,6 +86,7 @@ const StandardGrid = ({
 					${display === Display.Showcase
 						? css`
 								grid-template-areas:
+									'atom       atom    atom        atom'
 									'title      border  headline    headline'
 									'lines      border  headline    headline'
 									'meta       border  standfirst  standfirst'
@@ -94,6 +96,7 @@ const StandardGrid = ({
 						  `
 						: css`
 								grid-template-areas:
+									'atom       atom    atom        atom'
 									'title      border  headline    right-column'
 									'lines      border  headline    right-column'
 									'meta       border  standfirst  right-column'
@@ -113,6 +116,7 @@ const StandardGrid = ({
 					${display === Display.Showcase
 						? css`
 								grid-template-areas:
+									'atom       atom    atom        atom'
 									'title      border  headline    headline'
 									'lines      border  headline    headline'
 									'meta       border  standfirst  standfirst'
@@ -122,6 +126,7 @@ const StandardGrid = ({
 						  `
 						: css`
 								grid-template-areas:
+									'atom       atom    atom        atom'
 									'title      border  headline    right-column'
 									'lines      border  headline    right-column'
 									'meta       border  standfirst  right-column'
@@ -136,6 +141,7 @@ const StandardGrid = ({
 						1fr /* Main content */
 						300px; /* Right Column */
 					grid-template-areas:
+						'atom       atom'
 						'title      right-column'
 						'headline   right-column'
 						'standfirst right-column'
@@ -149,6 +155,7 @@ const StandardGrid = ({
 					grid-column-gap: 0px;
 					grid-template-columns: 1fr; /* Main content */
 					grid-template-areas:
+						'atom'
 						'title'
 						'headline'
 						'standfirst'
@@ -162,6 +169,7 @@ const StandardGrid = ({
 
 					grid-template-columns: 1fr; /* Main content */
 					grid-template-areas:
+						'atom'
 						'title'
 						'headline'
 						'standfirst'
@@ -387,6 +395,13 @@ export const CommentLayout = ({
 				backgroundColour={palette.background.article}
 			>
 				<StandardGrid display={format.display}>
+					<GridItem area="atom">
+						<AnniversaryAtomComponent
+							anniversaryInteractiveAtom={
+								CAPI.anniversaryInteractiveAtom
+							}
+						/>
+					</GridItem>
 					<GridItem area="title">
 						<ArticleTitle
 							format={format}

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -4,6 +4,7 @@ import { css } from 'emotion';
 import {
 	neutral,
 	brandBackground,
+	brandAltBackground,
 	brandLine,
 	brandBorder,
 	labs,
@@ -82,7 +83,6 @@ const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 						1fr /* Main content */
 						300px; /* Right Column */
 					grid-template-areas:
-						'atom   atom    atom         atom'
 						'title  border  headline    headline'
 						'lines  border  media       media'
 						'meta   border  media       media'
@@ -98,7 +98,6 @@ const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 						1fr /* Main content */
 						300px; /* Right Column */
 					grid-template-areas:
-						'atom   atom    atom         atom'
 						'title  border  headline    headline'
 						'lines  border  media       media'
 						'meta   border  media       media'
@@ -112,7 +111,6 @@ const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 						1fr /* Main content */
 						300px; /* Right Column */
 					grid-template-areas:
-						'atom       atom'
 						'title      right-column'
 						'headline   right-column'
 						'standfirst right-column'
@@ -127,7 +125,6 @@ const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 					grid-column-gap: 0px;
 					grid-template-columns: 1fr; /* Main content */
 					grid-template-areas:
-						'atom'
 						'title'
 						'headline'
 						'standfirst'
@@ -141,7 +138,6 @@ const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 					grid-column-gap: 0px;
 					grid-template-columns: 1fr; /* Main content */
 					grid-template-areas:
-						'atom'
 						'media'
 						'title'
 						'headline'
@@ -386,17 +382,21 @@ export const ShowcaseLayout = ({
 			)}
 
 			<Section
+				backgroundColour={brandAltBackground.primary}
+				padded={false}
+				showTopBorder={false}
+				showSideBorders={false}
+			>
+				<AnniversaryAtomComponent
+					anniversaryInteractiveAtom={CAPI.anniversaryInteractiveAtom}
+				/>
+			</Section>
+
+			<Section
 				showTopBorder={false}
 				backgroundColour={palette.background.article}
 			>
 				<ShowcaseGrid>
-					<GridItem area="atom">
-						<AnniversaryAtomComponent
-							anniversaryInteractiveAtom={
-								CAPI.anniversaryInteractiveAtom
-							}
-						/>
-					</GridItem>
 					<GridItem area="title">
 						<ArticleTitle
 							format={format}

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -36,6 +36,7 @@ import { GridItem } from '@root/src/web/components/GridItem';
 import { AgeWarning } from '@root/src/web/components/AgeWarning';
 import { Discussion } from '@frontend/web/components/Discussion';
 import { LabsHeader } from '@frontend/web/components/LabsHeader';
+import { AnniversaryAtomComponent } from '@frontend/web/components/AnniversaryAtomComponent';
 
 import { buildAdTargeting } from '@root/src/lib/ad-targeting';
 import { parse } from '@frontend/lib/slot-machine-flags';
@@ -81,6 +82,7 @@ const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 						1fr /* Main content */
 						300px; /* Right Column */
 					grid-template-areas:
+						'atom   atom    atom         atom'
 						'title  border  headline    headline'
 						'lines  border  media       media'
 						'meta   border  media       media'
@@ -96,6 +98,7 @@ const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 						1fr /* Main content */
 						300px; /* Right Column */
 					grid-template-areas:
+						'atom   atom    atom         atom'
 						'title  border  headline    headline'
 						'lines  border  media       media'
 						'meta   border  media       media'
@@ -109,6 +112,7 @@ const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 						1fr /* Main content */
 						300px; /* Right Column */
 					grid-template-areas:
+						'atom       atom'
 						'title      right-column'
 						'headline   right-column'
 						'standfirst right-column'
@@ -123,6 +127,7 @@ const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 					grid-column-gap: 0px;
 					grid-template-columns: 1fr; /* Main content */
 					grid-template-areas:
+						'atom'
 						'title'
 						'headline'
 						'standfirst'
@@ -136,6 +141,7 @@ const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 					grid-column-gap: 0px;
 					grid-template-columns: 1fr; /* Main content */
 					grid-template-areas:
+						'atom'
 						'media'
 						'title'
 						'headline'
@@ -384,6 +390,13 @@ export const ShowcaseLayout = ({
 				backgroundColour={palette.background.article}
 			>
 				<ShowcaseGrid>
+					<GridItem area="atom">
+						<AnniversaryAtomComponent
+							anniversaryInteractiveAtom={
+								CAPI.anniversaryInteractiveAtom
+							}
+						/>
+					</GridItem>
 					<GridItem area="title">
 						<ArticleTitle
 							format={format}

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -430,7 +430,9 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				</Stuck>
 			)}
 
-			{ CAPI.config.switches.surveys && <AdSlot position="survey" display={format.display} /> }
+			{CAPI.config.switches.surveys && (
+				<AdSlot position="survey" display={format.display} />
+			)}
 
 			<Section
 				data-print-layout="hide"

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -101,7 +101,6 @@ const StandardGrid = ({
 						  `
 						: css`
 								grid-template-areas:
-									'atom   atom    atom         atom'
 									'title  border  headline     right-column'
 									'.      border  standfirst    right-column'
 									'lines  border  media        right-column'
@@ -131,7 +130,6 @@ const StandardGrid = ({
 						  `
 						: css`
 								grid-template-areas:
-									'atom   atom    atom         atom'
 									'title  border  headline     right-column'
 									'.      border  standfirst    right-column'
 									'lines  border  media        right-column'
@@ -160,7 +158,6 @@ const StandardGrid = ({
 						  `
 						: css`
 								grid-template-areas:
-									'atom          atom'
 									'title         right-column'
 									'headline      right-column'
 									'standfirst    right-column'
@@ -188,7 +185,6 @@ const StandardGrid = ({
 						  `
 						: css`
 								grid-template-areas:
-									'atom'
 									'title'
 									'headline'
 									'standfirst'
@@ -217,7 +213,6 @@ const StandardGrid = ({
 						  `
 						: css`
 								grid-template-areas:
-									'atom'
 									'media'
 									'title'
 									'headline'
@@ -400,13 +395,27 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 			)}
 
 			{format.theme !== Special.Labs ? (
-				<Section
-					backgroundColour={palette.background.article}
-					padded={false}
-					showTopBorder={false}
-				>
-					<GuardianLines count={4} palette={palette} />
-				</Section>
+				<>
+					<Section
+						backgroundColour={brandAltBackground.primary}
+						padded={false}
+						showTopBorder={false}
+						showSideBorders={false}
+					>
+						<AnniversaryAtomComponent
+							anniversaryInteractiveAtom={
+								CAPI.anniversaryInteractiveAtom
+							}
+						/>
+					</Section>
+					<Section
+						backgroundColour={palette.background.article}
+						padded={false}
+						showTopBorder={false}
+					>
+						<GuardianLines count={4} palette={palette} />
+					</Section>
+				</>
 			) : (
 				<Stuck>
 					<Section

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -40,6 +40,7 @@ import { Discussion } from '@frontend/web/components/Discussion';
 import { Placeholder } from '@frontend/web/components/Placeholder';
 import { Nav } from '@frontend/web/components/Nav/Nav';
 import { LabsHeader } from '@frontend/web/components/LabsHeader';
+import { AnniversaryAtomComponent } from '@frontend/web/components/AnniversaryAtomComponent';
 
 import { buildAdTargeting } from '@root/src/lib/ad-targeting';
 import { parse } from '@frontend/lib/slot-machine-flags';
@@ -92,7 +93,7 @@ const StandardGrid = ({
 								grid-template-areas:
 									'title  border  matchNav     right-column'
 									'.      border  headline     right-column'
-									'.      border  standfirst   right-column'
+									'.      border  standfirst    right-column'
 									'lines  border  media        right-column'
 									'meta   border  media        right-column'
 									'meta   border  body         right-column'
@@ -100,8 +101,9 @@ const StandardGrid = ({
 						  `
 						: css`
 								grid-template-areas:
+									'atom   atom    atom         atom'
 									'title  border  headline     right-column'
-									'.      border  standfirst   right-column'
+									'.      border  standfirst    right-column'
 									'lines  border  media        right-column'
 									'meta   border  media        right-column'
 									'meta   border  body         right-column'
@@ -129,8 +131,9 @@ const StandardGrid = ({
 						  `
 						: css`
 								grid-template-areas:
+									'atom   atom    atom         atom'
 									'title  border  headline     right-column'
-									'.      border  standfirst   right-column'
+									'.      border  standfirst    right-column'
 									'lines  border  media        right-column'
 									'meta   border  media        right-column'
 									'meta   border  body         right-column'
@@ -157,6 +160,7 @@ const StandardGrid = ({
 						  `
 						: css`
 								grid-template-areas:
+									'atom          atom'
 									'title         right-column'
 									'headline      right-column'
 									'standfirst    right-column'
@@ -184,6 +188,7 @@ const StandardGrid = ({
 						  `
 						: css`
 								grid-template-areas:
+									'atom'
 									'title'
 									'headline'
 									'standfirst'
@@ -212,6 +217,7 @@ const StandardGrid = ({
 						  `
 						: css`
 								grid-template-areas:
+									'atom'
 									'media'
 									'title'
 									'headline'
@@ -424,6 +430,13 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				borderColour={palette.border.article}
 			>
 				<StandardGrid isMatchReport={isMatchReport}>
+					<GridItem area="atom">
+						<AnniversaryAtomComponent
+							anniversaryInteractiveAtom={
+								CAPI.anniversaryInteractiveAtom
+							}
+						/>
+					</GridItem>
 					<GridItem area="title">
 						<ArticleTitle
 							format={format}


### PR DESCRIPTION
## What does this change?

This adds the anniversary atom to the body of articles. There are some tweaks required to positioning but they'll follow so that we can being testing on prod via the 0% A/B test.

If:

- The anniversaryArticleHeader switch is on
- The user has opted into the anniversaryAtom 0% A/B test
- And they haven't seen the header, so the hideAnniversaryAtom A/B test cookie isn't dropped

Then they will see the atom.

On `hideAnniversaryAtom`, we drop a `X-GU-Experiment-0perc-B` cookie as soon as the page loads with a 10 day TTL. This will then prevent the user from seeing the atom on following page views *on the article page*.

The implementation is designed to be easily removed when the 10 days is complete.

## Screenshots

(Note, aware there is some adjustment needed on opinion articles)

|   |   | 
|---|---|
| ![Screen Shot 2021-04-21 at 17 24 50](https://user-images.githubusercontent.com/638051/115588672-e25e7e80-a2c6-11eb-8da3-d48ba9e1e9d1.png) | ![Screen Shot 2021-04-21 at 17 24 56](https://user-images.githubusercontent.com/638051/115588675-e38fab80-a2c6-11eb-8914-ea7ae09edcb9.png) | 
![Screen Shot 2021-04-21 at 17 25 01](https://user-images.githubusercontent.com/638051/115588676-e38fab80-a2c6-11eb-99bf-e992c026d7f7.png) | ![Screen Shot 2021-04-21 at 17 25 05](https://user-images.githubusercontent.com/638051/115588677-e4284200-a2c6-11eb-966e-154cf18f9738.png) | 
![Screen Shot 2021-04-21 at 17 25 07](https://user-images.githubusercontent.com/638051/115588681-e4c0d880-a2c6-11eb-8e20-def1d01e5ebd.png) |



