### PR TITLE
`StarRatingBlockElement`

### DIFF
--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -341,6 +341,13 @@ interface SpotifyBlockElement extends ThirdPartyEmbeddedContent {
 	role?: RoleType;
 }
 
+interface StarRatingBlockElement {
+	_type: 'model.dotcomrendering.pageElements.StarRatingBlockElement';
+	elementId: string;
+	rating: number;
+	size: RatingSizeType;
+}
+
 interface SubheadingBlockElement {
 	_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement';
 	elementId: string;
@@ -561,6 +568,7 @@ type CAPIElement =
 	| RichLinkBlockElement
 	| SoundcloudBlockElement
 	| SpotifyBlockElement
+	| StarRatingBlockElement
 	| SubheadingBlockElement
 	| TableBlockElement
 	| TextBlockElement
@@ -652,6 +660,8 @@ type Language =
 	| 'markup'
 	| 'scala'
 	| 'elm';
+
+type RatingSizeType = 'large' | 'medium' | 'small';
 
 // -------------------------------------
 // Callout Campaign

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -111,6 +111,9 @@
                         "$ref": "#/definitions/SpotifyBlockElement"
                     },
                     {
+                        "$ref": "#/definitions/StarRatingBlockElement"
+                    },
+                    {
                         "$ref": "#/definitions/SubheadingBlockElement"
                     },
                     {
@@ -2259,6 +2262,40 @@
                 "isThirdPartyTracking"
             ]
         },
+        "StarRatingBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.StarRatingBlockElement"
+                    ]
+                },
+                "elementId": {
+                    "type": "string"
+                },
+                "rating": {
+                    "type": "number"
+                },
+                "size": {
+                    "$ref": "#/definitions/RatingSizeType"
+                }
+            },
+            "required": [
+                "_type",
+                "elementId",
+                "rating",
+                "size"
+            ]
+        },
+        "RatingSizeType": {
+            "enum": [
+                "large",
+                "medium",
+                "small"
+            ],
+            "type": "string"
+        },
         "SubheadingBlockElement": {
             "type": "object",
             "properties": {
@@ -3205,6 +3242,9 @@
                             },
                             {
                                 "$ref": "#/definitions/SpotifyBlockElement"
+                            },
+                            {
+                                "$ref": "#/definitions/StarRatingBlockElement"
                             },
                             {
                                 "$ref": "#/definitions/SubheadingBlockElement"

--- a/src/web/components/StarRating/StarRating.tsx
+++ b/src/web/components/StarRating/StarRating.tsx
@@ -10,9 +10,7 @@ const starWrapper = css`
 	padding: 1px;
 `;
 
-type SizeType = 'large' | 'medium' | 'small';
-
-const determineSize = (size: SizeType) => {
+const determineSize = (size: RatingSizeType) => {
 	switch (size) {
 		case 'small':
 			return css`
@@ -43,7 +41,7 @@ const determineSize = (size: SizeType) => {
 
 export const StarRating: React.FC<{
 	rating: number;
-	size: SizeType;
+	size: RatingSizeType;
 }> = ({ rating, size }) => (
 	<div className={determineSize(size)}>
 		<div className={starWrapper}>

--- a/src/web/components/elements/StarRatingBlockComponent.stories.tsx
+++ b/src/web/components/elements/StarRatingBlockComponent.stories.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import { StarRatingBlockComponent } from '@root/src/web/components/elements/StarRatingBlockComponent';
+
+export default {
+	component: StarRatingBlockComponent,
+	title: 'Components/StarRatingBlockComponent',
+};
+
+export const AllSizes = () => (
+	<>
+		<h1>Small</h1>
+		<br />
+		<StarRatingBlockComponent rating={3} size="small" />
+		<br />
+		<br />
+		<h1>Medium</h1>
+		<br />
+		<StarRatingBlockComponent rating={3} size="medium" />
+		<br />
+		<br />
+		<h1>Large</h1>
+		<br />
+		<StarRatingBlockComponent rating={3} size="large" />
+	</>
+);
+AllSizes.story = { name: 'All stars sizes' };

--- a/src/web/components/elements/StarRatingBlockComponent.tsx
+++ b/src/web/components/elements/StarRatingBlockComponent.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { brandAltBackground } from '@guardian/src-foundations/palette';
+
+import { StarRating } from '@root/src/web/components/StarRating/StarRating';
+
+type Props = {
+	rating: number;
+	size: RatingSizeType;
+};
+
+const starsWrapper = css`
+	background-color: ${brandAltBackground.primary};
+	display: inline-block;
+`;
+
+export const StarRatingBlockComponent = ({ rating, size }: Props) => (
+	<div className={starsWrapper}>
+		<StarRating rating={rating} size={size} />
+	</div>
+);

--- a/src/web/lib/ElementRenderer.tsx
+++ b/src/web/lib/ElementRenderer.tsx
@@ -22,6 +22,7 @@ import { MultiImageBlockComponent } from '@root/src/web/components/elements/Mult
 import { PullQuoteBlockComponent } from '@root/src/web/components/elements/PullQuoteBlockComponent';
 import { SoundcloudBlockComponent } from '@root/src/web/components/elements/SoundcloudBlockComponent';
 import { SpotifyBlockComponent } from '@root/src/web/components/elements/SpotifyBlockComponent';
+import { StarRatingBlockComponent } from '@root/src/web/components/elements/StarRatingBlockComponent';
 import { SubheadingBlockComponent } from '@root/src/web/components/elements/SubheadingBlockComponent';
 import { TableBlockComponent } from '@root/src/web/components/elements/TableBlockComponent';
 import { TextBlockComponent } from '@root/src/web/components/elements/TextBlockComponent';
@@ -565,6 +566,14 @@ export const ElementRenderer = ({
 						/>
 					</ClickToView>
 				</Figure>
+			);
+		case 'model.dotcomrendering.pageElements.StarRatingBlockElement':
+			return (
+				<StarRatingBlockComponent
+					key={index}
+					rating={element.rating}
+					size={element.size}
+				/>
 			);
 		case 'model.dotcomrendering.pageElements.SubheadingBlockElement':
 			return <SubheadingBlockComponent key={index} html={element.html} />;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds a new `StarRatingBlockElement` element.

![Screenshot 2021-04-22 at 09 04 36](https://user-images.githubusercontent.com/1336821/115678824-d8319400-a349-11eb-9911-46c9e520295d.jpg)


## Why?
Because in numbered lists there is an expection for stars to appear inline. This is achieve in Frontend by the stars being inserted as ascii ★★★★☆ and then these get styled to look like stars. But we already have `StarRating` as a component so by creating this element we simplify things.

We also open up the possibility to bring this logic into Composer one day