### PR TITLE
★★★☆☆ > `StarRatingBlockElement`

### DIFF
--- a/src/model/enhance-numbered-lists.test.ts
+++ b/src/model/enhance-numbered-lists.test.ts
@@ -188,4 +188,190 @@ describe('Enhance Numbered Lists', () => {
 		};
 		expect(enhanceNumberedLists(input)).toEqual(expectedOutput);
 	});
+
+	it('replaces ★★★★☆ with the StarRating component', () => {
+		const input: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							_type:
+								'model.dotcomrendering.pageElements.TextBlockElement',
+							elementId: 'mockId',
+							html: '<p>★★★★☆</p>',
+						},
+					],
+				},
+			],
+		};
+
+		const expectedOutput: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							_type:
+								'model.dotcomrendering.pageElements.StarRatingBlockElement',
+							elementId: 'mockId',
+							rating: 4,
+							size: 'large',
+						},
+					],
+				},
+			],
+		};
+
+		expect(enhanceNumberedLists(input)).toEqual(expectedOutput);
+	});
+
+	it('ignores ascii stars when there is other text present', () => {
+		const input: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							_type:
+								'model.dotcomrendering.pageElements.TextBlockElement',
+							elementId: 'mockId',
+							html: '<p>I give this 4 ★★★★☆</p>',
+						},
+					],
+				},
+			],
+		};
+
+		const expectedOutput: CAPIType = input;
+
+		expect(enhanceNumberedLists(input)).toEqual(expectedOutput);
+	});
+
+	it('ignores ascii stars when there are not 5 stars', () => {
+		const input: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							_type:
+								'model.dotcomrendering.pageElements.TextBlockElement',
+							elementId: 'mockId',
+							html: '<p>★★☆</p>',
+						},
+					],
+				},
+			],
+		};
+
+		const expectedOutput: CAPIType = input;
+
+		expect(enhanceNumberedLists(input)).toEqual(expectedOutput);
+	});
+
+	it('ignores ascii stars that are not wrapped in p tags', () => {
+		const input: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							_type:
+								'model.dotcomrendering.pageElements.TextBlockElement',
+							elementId: 'mockId',
+							html: '<h2>★★★★☆</h2>',
+						},
+					],
+				},
+			],
+		};
+
+		const expectedOutput: CAPIType = input;
+
+		expect(enhanceNumberedLists(input)).toEqual(expectedOutput);
+	});
+
+	it('can handle zero (selected) stars', () => {
+		const input: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							_type:
+								'model.dotcomrendering.pageElements.TextBlockElement',
+							elementId: 'mockId',
+							html: '<p>☆☆☆☆☆</p>',
+						},
+					],
+				},
+			],
+		};
+
+		const expectedOutput: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							_type:
+								'model.dotcomrendering.pageElements.StarRatingBlockElement',
+							elementId: 'mockId',
+							rating: 0,
+							size: 'large',
+						},
+					],
+				},
+			],
+		};
+
+		expect(enhanceNumberedLists(input)).toEqual(expectedOutput);
+	});
+
+	it('can handle really good things that have five stars!', () => {
+		const input: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							_type:
+								'model.dotcomrendering.pageElements.TextBlockElement',
+							elementId: 'mockId',
+							html: '<p>★★★★★</p>',
+						},
+					],
+				},
+			],
+		};
+
+		const expectedOutput: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							_type:
+								'model.dotcomrendering.pageElements.StarRatingBlockElement',
+							elementId: 'mockId',
+							rating: 5,
+							size: 'large',
+						},
+					],
+				},
+			],
+		};
+
+		expect(enhanceNumberedLists(input)).toEqual(expectedOutput);
+	});
 });

--- a/src/model/enhance-numbered-lists.ts
+++ b/src/model/enhance-numbered-lists.ts
@@ -44,6 +44,67 @@ const extractH3 = (element: CAPIElement): string => {
 	return '';
 };
 
+const isStarRating = (element: CAPIElement): boolean => {
+	const isStar = (charactor: string): boolean => {
+		return charactor === '★' || charactor === '☆';
+	};
+
+	if (!element) return false;
+	// Checks if this element is a 'star rating' based on the convention: <p>★★★★☆</p>
+	if (element._type !== 'model.dotcomrendering.pageElements.TextBlockElement')
+		return false;
+	const frag = JSDOM.fragment(element.html);
+	const hasPTags = frag?.firstElementChild?.nodeName === 'P';
+	const text = frag.textContent || '';
+	// Loop the string making sure each letter is a star
+	for (const letter of text) {
+		if (!isStar(letter)) return false;
+	}
+	const hasFiveStars = text.length === 5;
+	return hasPTags && hasFiveStars;
+};
+
+const extractStarCount = (element: CAPIElement): number => {
+	const isSelectedStar = (charactor: string): boolean => {
+		return charactor === '★';
+	};
+	// Returns the count of stars
+	const textElement = element as TextBlockElement;
+	const frag = JSDOM.fragment(textElement.html);
+	const text = frag.textContent || '';
+	// Loop the string counting selected stars
+	let starCount = 0;
+	for (const letter of text) {
+		if (isSelectedStar(letter)) starCount += 1;
+	}
+	return starCount;
+};
+
+const addStarRatings = (elements: CAPIElement[]): CAPIElement[] => {
+	const withStars: CAPIElement[] = [];
+	elements.forEach((thisElement) => {
+		if (
+			thisElement._type ===
+				'model.dotcomrendering.pageElements.TextBlockElement' &&
+			isStarRating(thisElement)
+		) {
+			const rating = extractStarCount(thisElement);
+			// Inline this image
+			withStars.push({
+				_type:
+					'model.dotcomrendering.pageElements.StarRatingBlockElement',
+				elementId: thisElement.elementId,
+				rating,
+				size: 'large',
+			});
+		} else {
+			// Pass through
+			withStars.push(thisElement);
+		}
+	});
+	return withStars;
+};
+
 const inlineImages = (elements: CAPIElement[]): CAPIElement[] => {
 	// Inline all images
 	// Why?
@@ -122,6 +183,11 @@ class Enhancer {
 		this.elements = addH3s(this.elements);
 		return this;
 	}
+
+	addStarRatings() {
+		this.elements = addStarRatings(this.elements);
+		return this;
+	}
 }
 
 const enhance = (elements: CAPIElement[]): CAPIElement[] => {
@@ -129,6 +195,8 @@ const enhance = (elements: CAPIElement[]): CAPIElement[] => {
 		new Enhancer(elements)
 			// Turn false h3s into real ones
 			.addH3s()
+			// Turn ascii stars into components
+			.addStarRatings()
 			// Always use role `inline` for images
 			.inlineImages().elements
 	);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds the convention whereby if the enhancers sees `<p>★★★☆☆</p>` then it replaces it with a `StarRatingBlockElement`

This is restricted to `Display.NumberedList` but maybe we want this done on a wider basis,  thoughts?

![Screenshot 2021-04-22 at 10 26 28](https://user-images.githubusercontent.com/1336821/115691794-4714ea00-a356-11eb-9d87-be8239b02a40.jpg)


## Why?
Because this is a react app and so we want to add styles and features using components, not classnames and global css. `StarRatingBlockElement` offers consistent optimised svgs with a nice yellow background that can be resized based on props.

## Shouldn't those stars sit above the image?
Yes, this will be a later piece of work. But sometimes there isn't an image so we still need to support inline stars
