### PR TITLE
Overlay stars

### DIFF
--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -211,6 +211,7 @@ interface ImageBlockElement {
 	displayCredit?: boolean;
 	role: RoleType;
 	title?: string;
+	starRating?: number;
 }
 
 interface InstagramBlockElement extends ThirdPartyEmbeddedContent {

--- a/src/model/enhance-numbered-lists.test.ts
+++ b/src/model/enhance-numbered-lists.test.ts
@@ -386,6 +386,44 @@ describe('Enhance Numbered Lists', () => {
 							_type:
 								'model.dotcomrendering.pageElements.TextBlockElement',
 							elementId: 'mockId',
+							html: '<p>★☆☆☆☆</p>',
+						},
+						images[0],
+					],
+				},
+			],
+		};
+
+		const expectedOutput: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							...images[0],
+							starRating: 1,
+							role: 'inline',
+						},
+					],
+				},
+			],
+		};
+
+		expect(enhanceNumberedLists(input)).toEqual(expectedOutput);
+	});
+
+	it('When stars are found ahead of images, it updates the image and then removes the stars, even when rating is zero', () => {
+		const input: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							_type:
+								'model.dotcomrendering.pageElements.TextBlockElement',
+							elementId: 'mockId',
 							html: '<p>☆☆☆☆☆</p>',
 						},
 						images[0],

--- a/src/model/enhance-numbered-lists.test.ts
+++ b/src/model/enhance-numbered-lists.test.ts
@@ -374,4 +374,42 @@ describe('Enhance Numbered Lists', () => {
 
 		expect(enhanceNumberedLists(input)).toEqual(expectedOutput);
 	});
+
+	it('When stars are found ahead of images, it updates the image and then removes the stars', () => {
+		const input: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							_type:
+								'model.dotcomrendering.pageElements.TextBlockElement',
+							elementId: 'mockId',
+							html: '<p>☆☆☆☆☆</p>',
+						},
+						images[0],
+					],
+				},
+			],
+		};
+
+		const expectedOutput: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							...images[0],
+							starRating: 0,
+							role: 'inline',
+						},
+					],
+				},
+			],
+		};
+
+		expect(enhanceNumberedLists(input)).toEqual(expectedOutput);
+	});
 });

--- a/src/model/enhance-numbered-lists.ts
+++ b/src/model/enhance-numbered-lists.ts
@@ -89,7 +89,6 @@ const starifyImages = (elements: CAPIElement[]): CAPIElement[] => {
 				'model.dotcomrendering.pageElements.ImageBlockElement' &&
 			isStarRating(previousElement)
 		) {
-			console.log('FOUNNNDDD');
 			const rating = extractStarCount(previousElement);
 			// Add this image using the rating
 			starified.push({
@@ -109,7 +108,6 @@ const starifyImages = (elements: CAPIElement[]): CAPIElement[] => {
 const inlineStarRatings = (elements: CAPIElement[]): CAPIElement[] => {
 	const withStars: CAPIElement[] = [];
 	elements.forEach((thisElement) => {
-		console.log('inlineStarRatings', thisElement._type);
 		if (
 			thisElement._type ===
 				'model.dotcomrendering.pageElements.TextBlockElement' &&

--- a/src/model/enhance-numbered-lists.ts
+++ b/src/model/enhance-numbered-lists.ts
@@ -80,9 +80,36 @@ const extractStarCount = (element: CAPIElement): number => {
 	return starCount;
 };
 
-const addStarRatings = (elements: CAPIElement[]): CAPIElement[] => {
+const starifyImages = (elements: CAPIElement[]): CAPIElement[] => {
+	const starified: CAPIElement[] = [];
+	elements.forEach((thisElement, index) => {
+		const previousElement = elements[index - 1];
+		if (
+			thisElement._type ===
+				'model.dotcomrendering.pageElements.ImageBlockElement' &&
+			isStarRating(previousElement)
+		) {
+			console.log('FOUNNNDDD');
+			const rating = extractStarCount(previousElement);
+			// Add this image using the rating
+			starified.push({
+				...thisElement,
+				starRating: rating,
+			});
+			// Remove the previous element now that we've put the stars on top of the image
+			starified.splice(index - 1, 1);
+		} else {
+			// Pass through
+			starified.push(thisElement);
+		}
+	});
+	return starified;
+};
+
+const inlineStarRatings = (elements: CAPIElement[]): CAPIElement[] => {
 	const withStars: CAPIElement[] = [];
 	elements.forEach((thisElement) => {
+		console.log('inlineStarRatings', thisElement._type);
 		if (
 			thisElement._type ===
 				'model.dotcomrendering.pageElements.TextBlockElement' &&
@@ -184,8 +211,13 @@ class Enhancer {
 		return this;
 	}
 
-	addStarRatings() {
-		this.elements = addStarRatings(this.elements);
+	starifyImages() {
+		this.elements = starifyImages(this.elements);
+		return this;
+	}
+
+	inlineStarRatings() {
+		this.elements = inlineStarRatings(this.elements);
 		return this;
 	}
 }
@@ -195,8 +227,9 @@ const enhance = (elements: CAPIElement[]): CAPIElement[] => {
 		new Enhancer(elements)
 			// Turn false h3s into real ones
 			.addH3s()
+			.starifyImages()
 			// Turn ascii stars into components
-			.addStarRatings()
+			.inlineStarRatings()
 			// Always use role `inline` for images
 			.inlineImages().elements
 	);

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -1707,6 +1707,9 @@
                 },
                 "title": {
                     "type": "string"
+                },
+                "starRating": {
+                    "type": "number"
                 }
             },
             "required": [

--- a/src/web/lib/ElementRenderer.tsx
+++ b/src/web/lib/ElementRenderer.tsx
@@ -336,7 +336,7 @@ export const ElementRenderer = ({
 						element={element}
 						hideCaption={hideCaption}
 						isMainMedia={isMainMedia}
-						starRating={starRating}
+						starRating={starRating || element.starRating}
 						title={element.title}
 					/>
 				</Figure>


### PR DESCRIPTION
## What?
Adds an enhancer where if a numbered list element is preceded by stars, then we take that rating count and add it to the image (via the `starRating` prop)

## Why?
Because we already use this prop on `ImageComponent` so it makes sense to adapt to use it here as well.

## Before
![Screenshot 2021-04-22 at 14 23 48](https://user-images.githubusercontent.com/1336821/115721922-66237400-a376-11eb-988b-8163374879c3.jpg)

## After
![Screenshot 2021-04-22 at 14 23 18](https://user-images.githubusercontent.com/1336821/115721943-69b6fb00-a376-11eb-997d-e2f07d16ccf3.jpg)

