### PR TITLE
Round thumbnails

### DIFF
--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -212,6 +212,7 @@ interface ImageBlockElement {
 	role: RoleType;
 	title?: string;
 	starRating?: number;
+	isAvatar?: boolean;
 }
 
 interface InstagramBlockElement extends ThirdPartyEmbeddedContent {

--- a/src/model/enhance-numbered-lists.test.ts
+++ b/src/model/enhance-numbered-lists.test.ts
@@ -11,38 +11,6 @@ const metaData = {
 };
 
 describe('Enhance Numbered Lists', () => {
-	it('sets the role for the image to be inline', () => {
-		const input: CAPIType = {
-			...NumberedList,
-			blocks: [
-				{
-					...metaData,
-					elements: [
-						{
-							...images[0],
-							role: 'thumbnail',
-						},
-					],
-				},
-			],
-		};
-		const expectedOutput: CAPIType = {
-			...NumberedList,
-			blocks: [
-				{
-					...metaData,
-					elements: [
-						{
-							...images[0],
-							role: 'inline',
-						},
-					],
-				},
-			],
-		};
-		expect(enhanceNumberedLists(input)).toEqual(expectedOutput);
-	});
-
 	it('does not enhance articles if they are not numbered lists', () => {
 		const input: CAPIType = {
 			...Article,
@@ -403,7 +371,6 @@ describe('Enhance Numbered Lists', () => {
 						{
 							...images[0],
 							starRating: 1,
-							role: 'inline',
 						},
 					],
 				},
@@ -441,8 +408,33 @@ describe('Enhance Numbered Lists', () => {
 						{
 							...images[0],
 							starRating: 0,
-							role: 'inline',
 						},
+					],
+				},
+			],
+		};
+
+		expect(enhanceNumberedLists(input)).toEqual(expectedOutput);
+	});
+
+	it('Sets the isAvatar flag for thumbnail images', () => {
+		const input: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [{ ...images[0], role: 'thumbnail' }],
+				},
+			],
+		};
+
+		const expectedOutput: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{ ...images[0], role: 'thumbnail', isAvatar: true },
 					],
 				},
 			],

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -1710,6 +1710,9 @@
                 },
                 "starRating": {
                     "type": "number"
+                },
+                "isAvatar": {
+                    "type": "boolean"
                 }
             },
             "required": [

--- a/src/web/components/Figure.tsx
+++ b/src/web/components/Figure.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css, cx } from 'emotion';
+import { css } from 'emotion';
 
 import { from, until } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
@@ -129,13 +129,6 @@ const roleCss = {
 	`,
 };
 
-const round = css`
-	border-radius: 50%;
-	object-fit: cover;
-	height: 100%;
-	width: 100%;
-`;
-
 const decidePosition = (role: RoleType | 'richLink') => {
 	switch (role) {
 		case 'inline':
@@ -172,7 +165,7 @@ export const Figure = ({
 		return <figure id={id}>{children}</figure>;
 	}
 	return (
-		<figure id={id} className={cx(decidePosition(role), round)}>
+		<figure id={id} className={decidePosition(role)}>
 			{children}
 		</figure>
 	);

--- a/src/web/components/Figure.tsx
+++ b/src/web/components/Figure.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'emotion';
+import { css, cx } from 'emotion';
 
 import { from, until } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
@@ -129,6 +129,13 @@ const roleCss = {
 	`,
 };
 
+const round = css`
+	border-radius: 50%;
+	object-fit: cover;
+	height: 100%;
+	width: 100%;
+`;
+
 const decidePosition = (role: RoleType | 'richLink') => {
 	switch (role) {
 		case 'inline':
@@ -165,7 +172,7 @@ export const Figure = ({
 		return <figure id={id}>{children}</figure>;
 	}
 	return (
-		<figure id={id} className={decidePosition(role)}>
+		<figure id={id} className={cx(decidePosition(role), round)}>
 			{children}
 		</figure>
 	);

--- a/src/web/components/elements/ImageBlockComponent.tsx
+++ b/src/web/components/elements/ImageBlockComponent.tsx
@@ -9,6 +9,7 @@ type Props = {
 	title?: string;
 	isMainMedia?: boolean;
 	starRating?: number;
+	isAvatar?: boolean;
 };
 
 export const ImageBlockComponent = ({
@@ -19,6 +20,7 @@ export const ImageBlockComponent = ({
 	title,
 	isMainMedia,
 	starRating,
+	isAvatar,
 }: Props) => {
 	const { role } = element;
 	return (
@@ -31,6 +33,7 @@ export const ImageBlockComponent = ({
 			starRating={starRating}
 			role={role}
 			title={title}
+			isAvatar={isAvatar}
 		/>
 	);
 };

--- a/src/web/components/elements/ImageComponent.tsx
+++ b/src/web/components/elements/ImageComponent.tsx
@@ -20,6 +20,7 @@ type Props = {
 	isMainMedia?: boolean;
 	starRating?: number;
 	title?: string;
+	isAvatar?: boolean;
 };
 
 const starsWrapper = css`
@@ -215,6 +216,7 @@ export const ImageComponent = ({
 	isMainMedia,
 	starRating,
 	title,
+	isAvatar,
 }: Props) => {
 	const shouldLimitWidth =
 		!isMainMedia &&
@@ -280,6 +282,7 @@ export const ImageComponent = ({
 						height: 100%;
 						width: 100%;
 						object-fit: cover;
+						${isAvatar && 'border-radius: 50%;'}
 					}
 				`}
 			>
@@ -310,6 +313,7 @@ export const ImageComponent = ({
 						height: 100%;
 						width: 100%;
 						object-fit: cover;
+						${isAvatar && 'border-radius: 50%;'}
 					}
 				`}
 			>

--- a/src/web/lib/ElementRenderer.tsx
+++ b/src/web/lib/ElementRenderer.tsx
@@ -338,6 +338,7 @@ export const ElementRenderer = ({
 						isMainMedia={isMainMedia}
 						starRating={starRating || element.starRating}
 						title={element.title}
+						isAvatar={element.isAvatar}
 					/>
 				</Figure>
 			);


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
This reverts an earlier change where we were making all images inline. Instead, we now respect `role` and also mark `thumbnail` as round.

We use a new prop `isAvatar` to denote roundness.

### Before
![Screenshot 2021-04-22 at 15 19 26](https://user-images.githubusercontent.com/1336821/115730566-53ad3880-a37e-11eb-9101-fe83fe27a2ec.jpg)


### After
![Screenshot 2021-04-22 at 15 14 33](https://user-images.githubusercontent.com/1336821/115730586-56a82900-a37e-11eb-965c-d8a476d20ecc.jpg)


## Why not use `Avatar`?
Although the name is spot on we actually want to use the `ImageComponent` because that is using the Picture tag
