### PR TITLE
Use `LabsHeader`

### DIFF
--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -203,13 +203,13 @@ const Box = ({
 	<div
 		className={css`
 			/*
-									This pseudo css shows a black box to the right of the headline
-									so that the black background of the inverted text stretches
-									all the way right. But only from mobileLandscape because below
-									that we want to show a gap. To work properly it needs to wrap
-									the healine so it inherits the correct height based on the length
-									of the headline text
-							*/
+				This pseudo css shows a black box to the right of the headline
+				so that the black background of the inverted text stretches
+				all the way right. But only from mobileLandscape because below
+				that we want to show a gap. To work properly it needs to wrap
+				the healine so it inherits the correct height based on the length
+				of the headline text
+			*/
 			${from.mobileLandscape} {
 				position: relative;
 				:after {

--- a/src/web/layouts/ImmersiveLayout.tsx
+++ b/src/web/layouts/ImmersiveLayout.tsx
@@ -8,7 +8,7 @@ import {
 } from '@guardian/src-foundations/palette';
 import { from, until } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
-import { Design } from '@guardian/types';
+import { Design, Special } from '@guardian/types';
 import type { Format } from '@guardian/types';
 
 import { ArticleBody } from '@root/src/web/components/ArticleBody';
@@ -33,17 +33,18 @@ import { HeadlineByline } from '@root/src/web/components/HeadlineByline';
 import { ContainerLayout } from '@root/src/web/components/ContainerLayout';
 import { Discussion } from '@frontend/web/components/Discussion';
 import { Hide } from '@root/src/web/components/Hide';
+import { LabsHeader } from '@frontend/web/components/LabsHeader';
 
 import { buildAdTargeting } from '@root/src/lib/ad-targeting';
 import { getZIndex } from '@frontend/web/lib/getZIndex';
 import { parse } from '@frontend/lib/slot-machine-flags';
 
+import { Stuck, BannerWrapper } from '@root/src/web/layouts/lib/stickiness';
 import {
 	decideLineCount,
 	decideLineEffect,
 	getCurrentPillar,
 } from '@root/src/web/lib/layoutHelpers';
-import { BannerWrapper } from '@root/src/web/layouts/lib/stickiness';
 
 const ImmersiveGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
@@ -321,6 +322,12 @@ export const ImmersiveLayout = ({
 							/>
 						</Section>
 					</header>
+
+					{format.theme === Special.Labs && (
+						<Stuck>
+							<LabsHeader />
+						</Stuck>
+					)}
 
 					<MainMedia
 						format={format}

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -33,6 +33,7 @@ import { Border } from '@root/src/web/components/Border';
 import { GridItem } from '@root/src/web/components/GridItem';
 import { AgeWarning } from '@root/src/web/components/AgeWarning';
 import { Discussion } from '@frontend/web/components/Discussion';
+import { LabsHeader } from '@frontend/web/components/LabsHeader';
 
 import { buildAdTargeting } from '@root/src/lib/ad-targeting';
 import { parse } from '@frontend/lib/slot-machine-flags';
@@ -249,22 +250,22 @@ export const ShowcaseLayout = ({
 
 	return (
 		<>
-			<div>
-				<Stuck>
-					<Section
-						showTopBorder={false}
-						showSideBorders={false}
-						padded={false}
-					>
-						<HeaderAdSlot
-							isAdFreeUser={CAPI.isAdFreeUser}
-							shouldHideAds={CAPI.shouldHideAds}
-							display={format.display}
-						/>
-					</Section>
-				</Stuck>
-				<SendToBack>
-					{format.theme !== Special.Labs && (
+			{format.theme !== Special.Labs ? (
+				<div>
+					<Stuck>
+						<Section
+							showTopBorder={false}
+							showSideBorders={false}
+							padded={false}
+						>
+							<HeaderAdSlot
+								isAdFreeUser={CAPI.isAdFreeUser}
+								shouldHideAds={CAPI.shouldHideAds}
+								display={format.display}
+							/>
+						</Section>
+					</Stuck>
+					<SendToBack>
 						<Section
 							showTopBorder={false}
 							showSideBorders={false}
@@ -277,8 +278,53 @@ export const ShowcaseLayout = ({
 								mmaUrl={CAPI.config.mmaUrl}
 							/>
 						</Section>
-					)}
 
+						<Section
+							showSideBorders={true}
+							borderColour={brandLine.primary}
+							showTopBorder={false}
+							padded={false}
+							backgroundColour={brandBackground.primary}
+						>
+							<Nav
+								nav={NAV}
+								format={{
+									...format,
+									theme: getCurrentPillar(CAPI),
+								}}
+								subscribeUrl={
+									CAPI.nav.readerRevenueLinks.header.subscribe
+								}
+								edition={CAPI.editionId}
+							/>
+						</Section>
+
+						{NAV.subNavSections && (
+							<Section
+								backgroundColour={palette.background.article}
+								padded={false}
+								sectionId="sub-nav-root"
+							>
+								<SubNav
+									subNavSections={NAV.subNavSections}
+									currentNavLink={NAV.currentNavLink}
+									palette={palette}
+								/>
+							</Section>
+						)}
+
+						<Section
+							backgroundColour={palette.background.article}
+							padded={false}
+							showTopBorder={false}
+						>
+							<GuardianLines count={4} palette={palette} />
+						</Section>
+					</SendToBack>
+				</div>
+			) : (
+				// Else, this is a labs article so just show Nav and the Labs header
+				<>
 					<Section
 						showSideBorders={true}
 						borderColour={brandLine.primary}
@@ -299,29 +345,11 @@ export const ShowcaseLayout = ({
 						/>
 					</Section>
 
-					{NAV.subNavSections && (
-						<Section
-							backgroundColour={palette.background.article}
-							padded={false}
-							sectionId="sub-nav-root"
-						>
-							<SubNav
-								subNavSections={NAV.subNavSections}
-								currentNavLink={NAV.currentNavLink}
-								palette={palette}
-							/>
-						</Section>
-					)}
-
-					<Section
-						backgroundColour={palette.background.article}
-						padded={false}
-						showTopBorder={false}
-					>
-						<GuardianLines count={4} palette={palette} />
-					</Section>
-				</SendToBack>
-			</div>
+					<Stuck>
+						<LabsHeader />
+					</Stuck>
+				</>
+			)}
 
 			<Section
 				showTopBorder={false}

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -36,6 +36,8 @@ import { GridItem } from '@root/src/web/components/GridItem';
 import { AgeWarning } from '@root/src/web/components/AgeWarning';
 import { Discussion } from '@frontend/web/components/Discussion';
 import { Placeholder } from '@frontend/web/components/Placeholder';
+import { Nav } from '@frontend/web/components/Nav/Nav';
+import { LabsHeader } from '@frontend/web/components/LabsHeader';
 
 import { buildAdTargeting } from '@root/src/lib/ad-targeting';
 import { parse } from '@frontend/lib/slot-machine-flags';
@@ -46,7 +48,6 @@ import {
 	getCurrentPillar,
 } from '@root/src/web/lib/layoutHelpers';
 import { Stuck, BannerWrapper } from '@root/src/web/layouts/lib/stickiness';
-import { Nav } from '../components/Nav/Nav';
 
 const StandardGrid = ({
 	children,
@@ -321,33 +322,35 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 	return (
 		<>
 			<div data-print-layout="hide">
-				<Stuck>
-					<Section
-						showTopBorder={false}
-						showSideBorders={false}
-						padded={false}
-						shouldCenter={false}
-					>
-						<HeaderAdSlot
-							isAdFreeUser={CAPI.isAdFreeUser}
-							shouldHideAds={CAPI.shouldHideAds}
-							display={format.display}
-						/>
-					</Section>
-				</Stuck>
 				{format.theme !== Special.Labs && (
-					<Section
-						showTopBorder={false}
-						showSideBorders={false}
-						padded={false}
-						backgroundColour={brandBackground.primary}
-					>
-						<Header
-							edition={CAPI.editionId}
-							idUrl={CAPI.config.idUrl}
-							mmaUrl={CAPI.config.mmaUrl}
-						/>
-					</Section>
+					<>
+						<Stuck>
+							<Section
+								showTopBorder={false}
+								showSideBorders={false}
+								padded={false}
+								shouldCenter={false}
+							>
+								<HeaderAdSlot
+									isAdFreeUser={CAPI.isAdFreeUser}
+									shouldHideAds={CAPI.shouldHideAds}
+									display={format.display}
+								/>
+							</Section>
+						</Stuck>
+						<Section
+							showTopBorder={false}
+							showSideBorders={false}
+							padded={false}
+							backgroundColour={brandBackground.primary}
+						>
+							<Header
+								edition={CAPI.editionId}
+								idUrl={CAPI.config.idUrl}
+								mmaUrl={CAPI.config.mmaUrl}
+							/>
+						</Section>
+					</>
 				)}
 			</div>
 
@@ -369,7 +372,7 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				/>
 			</Section>
 
-			{NAV.subNavSections && (
+			{NAV.subNavSections && format.theme !== Special.Labs && (
 				<Section
 					backgroundColour={palette.background.article}
 					padded={false}
@@ -383,13 +386,19 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				</Section>
 			)}
 
-			<Section
-				backgroundColour={palette.background.article}
-				padded={false}
-				showTopBorder={false}
-			>
-				<GuardianLines count={4} palette={palette} />
-			</Section>
+			{format.theme !== Special.Labs ? (
+				<Section
+					backgroundColour={palette.background.article}
+					padded={false}
+					showTopBorder={false}
+				>
+					<GuardianLines count={4} palette={palette} />
+				</Section>
+			) : (
+				<Stuck>
+					<LabsHeader />
+				</Stuck>
+			)}
 
 			<Section
 				data-print-layout="hide"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds the `LabsHeader` component to the layout files so that it shows when `format.display  === Special.Labs`

### Before
![Screenshot 2021-04-23 at 09 34 16](https://user-images.githubusercontent.com/1336821/115843767-18127d00-a417-11eb-9d9e-ffa3204ef761.jpg)


### After
![Screenshot 2021-04-23 at 09 33 42](https://user-images.githubusercontent.com/1336821/115843716-09c46100-a417-11eb-98ba-7a32dcc12f06.jpg)

### Also
While in there I noticed that we were allowing the header ad slot to appear for Labs articles, which I assume we don't want? @rcrphillips ?
