### PR TITLE
DividerBlockComponent pass size prop

### DIFF
--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -118,6 +118,7 @@ interface DisclaimerBlockElement {
 
 interface DividerBlockElement {
 	_type: 'model.dotcomrendering.pageElements.DividerBlockElement';
+	size?: 'full' | 'partial';
 }
 
 interface DocumentBlockElement extends ThirdPartyEmbeddedContent {

--- a/src/web/lib/ElementRenderer.tsx
+++ b/src/web/lib/ElementRenderer.tsx
@@ -186,7 +186,7 @@ export const ElementRenderer = ({
 				</Figure>
 			);
 		case 'model.dotcomrendering.pageElements.DividerBlockElement':
-			return <DividerBlockComponent />;
+			return <DividerBlockComponent size={element.size} />;
 		case 'model.dotcomrendering.pageElements.DocumentBlockElement':
 			return (
 				<Figure


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Pass `size` prop to `DividerBlockComponent`

## Why?
We did not have any way of passing the prop