### PR TITLE
`NumberedTitle`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -103,6 +103,8 @@ type Palette = {
 		pullQuoteAttribution: Colour;
 		dropCap: Colour;
 		blockquote: Colour;
+		numberedTitle: Colour;
+		numberedPosition: Colour;
 	},
 	background: {
 		article: Colour;

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -118,6 +118,7 @@ interface DisclaimerBlockElement {
 
 interface DividerBlockElement {
 	_type: 'model.dotcomrendering.pageElements.DividerBlockElement';
+	size?: 'full' | 'partial';
 }
 
 interface DocumentBlockElement extends ThirdPartyEmbeddedContent {
@@ -279,6 +280,14 @@ interface MultiImageBlockElement {
 	images: ImageBlockElement[];
 	caption?: string;
 	role?: RoleType;
+}
+
+interface NumberedTitleBlockElement {
+	_type: 'model.dotcomrendering.pageElements.NumberedTitleBlockElement';
+	elementId: string;
+	position: number;
+	html: string;
+	format: CAPIFormat;
 }
 
 interface ProfileAtomBlockElement {
@@ -563,6 +572,7 @@ type CAPIElement =
 	| MapBlockElement
 	| MediaAtomBlockElement
 	| MultiImageBlockElement
+	| NumberedTitleBlockElement
 	| ProfileAtomBlockElement
 	| PullquoteBlockElement
 	| QABlockElement

--- a/src/model/enhance-numbered-lists.test.ts
+++ b/src/model/enhance-numbered-lists.test.ts
@@ -469,6 +469,11 @@ describe('Enhance Numbered Lists', () => {
 					elements: [
 						{
 							_type:
+								'model.dotcomrendering.pageElements.DividerBlockElement',
+							size: 'full',
+						},
+						{
+							_type:
 								'model.dotcomrendering.pageElements.NumberedTitleBlockElement',
 							elementId: 'mockId',
 							position: 1,
@@ -528,6 +533,11 @@ describe('Enhance Numbered Lists', () => {
 					elements: [
 						{
 							_type:
+								'model.dotcomrendering.pageElements.DividerBlockElement',
+							size: 'full',
+						},
+						{
+							_type:
 								'model.dotcomrendering.pageElements.NumberedTitleBlockElement',
 							elementId: 'mockId1',
 							position: 1,
@@ -540,11 +550,21 @@ describe('Enhance Numbered Lists', () => {
 						},
 						{
 							_type:
+								'model.dotcomrendering.pageElements.DividerBlockElement',
+							size: 'full',
+						},
+						{
+							_type:
 								'model.dotcomrendering.pageElements.NumberedTitleBlockElement',
 							elementId: 'mockId2',
 							position: 2,
 							html: '<h2>Other text</h2>',
 							format: NumberedList.format,
+						},
+						{
+							_type:
+								'model.dotcomrendering.pageElements.DividerBlockElement',
+							size: 'full',
 						},
 						{
 							_type:

--- a/src/model/enhance-numbered-lists.test.ts
+++ b/src/model/enhance-numbered-lists.test.ts
@@ -442,4 +442,124 @@ describe('Enhance Numbered Lists', () => {
 
 		expect(enhanceNumberedLists(input)).toEqual(expectedOutput);
 	});
+
+	it('replaces h2s with NumberedTitles', () => {
+		const input: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							_type:
+								'model.dotcomrendering.pageElements.SubheadingBlockElement',
+							elementId: 'mockId',
+							html: '<h2>Some text</h2>',
+						},
+					],
+				},
+			],
+		};
+
+		const expectedOutput: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							_type:
+								'model.dotcomrendering.pageElements.NumberedTitleBlockElement',
+							elementId: 'mockId',
+							position: 1,
+							html: '<h2>Some text</h2>',
+							format: NumberedList.format,
+						},
+					],
+				},
+			],
+		};
+
+		expect(enhanceNumberedLists(input)).toEqual(expectedOutput);
+	});
+
+	it('increments the position for multiple h2s', () => {
+		const input: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							_type:
+								'model.dotcomrendering.pageElements.SubheadingBlockElement',
+							elementId: 'mockId1',
+							html: '<h2>Some text</h2>',
+						},
+						{
+							_type:
+								'model.dotcomrendering.pageElements.TextBlockElement',
+							elementId: 'mockId',
+							html: '<p>☆☆☆☆☆</p>',
+						},
+						images[0],
+						{
+							_type:
+								'model.dotcomrendering.pageElements.SubheadingBlockElement',
+							elementId: 'mockId2',
+							html: '<h2>Other text</h2>',
+						},
+						{
+							_type:
+								'model.dotcomrendering.pageElements.SubheadingBlockElement',
+							elementId: 'mockId3',
+							html: '<h2>More text</h2>',
+						},
+					],
+				},
+			],
+		};
+
+		const expectedOutput: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							_type:
+								'model.dotcomrendering.pageElements.NumberedTitleBlockElement',
+							elementId: 'mockId1',
+							position: 1,
+							html: '<h2>Some text</h2>',
+							format: NumberedList.format,
+						},
+						{
+							...images[0],
+							starRating: 0,
+						},
+						{
+							_type:
+								'model.dotcomrendering.pageElements.NumberedTitleBlockElement',
+							elementId: 'mockId2',
+							position: 2,
+							html: '<h2>Other text</h2>',
+							format: NumberedList.format,
+						},
+						{
+							_type:
+								'model.dotcomrendering.pageElements.NumberedTitleBlockElement',
+
+							elementId: 'mockId3',
+							position: 3,
+							html: '<h2>More text</h2>',
+							format: NumberedList.format,
+						},
+					],
+				},
+			],
+		};
+
+		expect(enhanceNumberedLists(input)).toEqual(expectedOutput);
+	});
 });

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -93,6 +93,9 @@
                         "$ref": "#/definitions/MultiImageBlockElement"
                     },
                     {
+                        "$ref": "#/definitions/NumberedTitleBlockElement"
+                    },
+                    {
                         "$ref": "#/definitions/ProfileAtomBlockElement"
                     },
                     {
@@ -1254,6 +1257,13 @@
                     "enum": [
                         "model.dotcomrendering.pageElements.DividerBlockElement"
                     ]
+                },
+                "size": {
+                    "enum": [
+                        "full",
+                        "partial"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
@@ -2026,6 +2036,95 @@
                 "elementId",
                 "images"
             ]
+        },
+        "NumberedTitleBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "enum": [
+                        "model.dotcomrendering.pageElements.NumberedTitleBlockElement"
+                    ]
+                },
+                "elementId": {
+                    "type": "string"
+                },
+                "position": {
+                    "type": "number"
+                },
+                "html": {
+                    "type": "string"
+                },
+                "format": {
+                    "type": "object",
+                    "properties": {
+                        "design": {
+                            "$ref": "#/definitions/CAPIDesign"
+                        },
+                        "theme": {
+                            "$ref": "#/definitions/CAPITheme"
+                        },
+                        "display": {
+                            "$ref": "#/definitions/CAPIDisplay"
+                        }
+                    },
+                    "required": [
+                        "design",
+                        "display",
+                        "theme"
+                    ]
+                }
+            },
+            "required": [
+                "_type",
+                "elementId",
+                "format",
+                "html",
+                "position"
+            ]
+        },
+        "CAPIDesign": {
+            "enum": [
+                "AnalysisDesign",
+                "ArticleDesign",
+                "CommentDesign",
+                "DeadBlogDesign",
+                "EditorialDesign",
+                "FeatureDesign",
+                "InteractiveDesign",
+                "InterviewDesign",
+                "LetterDesign",
+                "LiveBlogDesign",
+                "MatchReportDesign",
+                "MediaDesign",
+                "PhotoEssayDesign",
+                "PrintShopDesign",
+                "QuizDesign",
+                "RecipeDesign",
+                "ReviewDesign"
+            ],
+            "type": "string"
+        },
+        "CAPITheme": {
+            "enum": [
+                "CulturePillar",
+                "Labs",
+                "LifestylePillar",
+                "NewsPillar",
+                "OpinionPillar",
+                "SpecialReportTheme",
+                "SportPillar"
+            ],
+            "type": "string"
+        },
+        "CAPIDisplay": {
+            "enum": [
+                "ImmersiveDisplay",
+                "NumberedListDisplay",
+                "ShowcaseDisplay",
+                "StandardDisplay"
+            ],
+            "type": "string"
         },
         "ProfileAtomBlockElement": {
             "type": "object",
@@ -3232,6 +3331,9 @@
                                 "$ref": "#/definitions/MultiImageBlockElement"
                             },
                             {
+                                "$ref": "#/definitions/NumberedTitleBlockElement"
+                            },
+                            {
                                 "$ref": "#/definitions/ProfileAtomBlockElement"
                             },
                             {
@@ -3421,49 +3523,6 @@
                 "title",
                 "type"
             ]
-        },
-        "CAPIDesign": {
-            "enum": [
-                "AnalysisDesign",
-                "ArticleDesign",
-                "CommentDesign",
-                "DeadBlogDesign",
-                "EditorialDesign",
-                "FeatureDesign",
-                "InteractiveDesign",
-                "InterviewDesign",
-                "LetterDesign",
-                "LiveBlogDesign",
-                "MatchReportDesign",
-                "MediaDesign",
-                "PhotoEssayDesign",
-                "PrintShopDesign",
-                "QuizDesign",
-                "RecipeDesign",
-                "ReviewDesign"
-            ],
-            "type": "string"
-        },
-        "CAPITheme": {
-            "enum": [
-                "CulturePillar",
-                "Labs",
-                "LifestylePillar",
-                "NewsPillar",
-                "OpinionPillar",
-                "SpecialReportTheme",
-                "SportPillar"
-            ],
-            "type": "string"
-        },
-        "CAPIDisplay": {
-            "enum": [
-                "ImmersiveDisplay",
-                "NumberedListDisplay",
-                "ShowcaseDisplay",
-                "StandardDisplay"
-            ],
-            "type": "string"
         },
         "LegacyPillar": {
             "enum": [

--- a/src/web/components/elements/NumberedTitleBlockComponent.stories.tsx
+++ b/src/web/components/elements/NumberedTitleBlockComponent.stories.tsx
@@ -7,7 +7,7 @@ export default {
 	title: 'Components/NumberedTitleBlockComponent',
 };
 
-export const Simple = () => (
+export const JustH2 = () => (
 	<div>
 		<NumberedTitleBlockComponent
 			position={1}
@@ -20,7 +20,7 @@ export const Simple = () => (
 		/>
 	</div>
 );
-Simple.story = { name: 'Simple' };
+JustH2.story = { name: 'with just h2 text' };
 
 export const Strong = () => (
 	<div>
@@ -35,9 +35,9 @@ export const Strong = () => (
 		/>
 	</div>
 );
-Strong.story = { name: 'Simple' };
+Strong.story = { name: 'with only strong text' };
 
-export const Both = () => (
+export const Leading = () => (
 	<div>
 		<NumberedTitleBlockComponent
 			position={1}
@@ -50,13 +50,13 @@ export const Both = () => (
 		/>
 	</div>
 );
-Both.story = { name: 'Both' };
+Leading.story = { name: 'with leading strong text' };
 
-export const Other = () => (
+export const Trailing = () => (
 	<div>
 		<NumberedTitleBlockComponent
 			position={1}
-			html={'<h2>Other text<strong>Strong text</strong></h2>'}
+			html={'<h2>Plain H2<strong>Strong text</strong></h2>'}
 			format={{
 				theme: 'LifestylePillar',
 				design: 'ArticleDesign',
@@ -65,4 +65,4 @@ export const Other = () => (
 		/>
 	</div>
 );
-Other.story = { name: 'Other' };
+Trailing.story = { name: 'with trailing strong text' };

--- a/src/web/components/elements/NumberedTitleBlockComponent.stories.tsx
+++ b/src/web/components/elements/NumberedTitleBlockComponent.stories.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+
+import { NumberedTitleBlockComponent } from './NumberedTitleBlockComponent';
+
+export default {
+	component: NumberedTitleBlockComponent,
+	title: 'Components/NumberedTitleBlockComponent',
+};
+
+export const Simple = () => (
+	<div>
+		<NumberedTitleBlockComponent
+			position={1}
+			html={'<h2>Simple text</h2>'}
+			format={{
+				theme: 'NewsPillar',
+				design: 'ArticleDesign',
+				display: 'StandardDisplay',
+			}}
+		/>
+	</div>
+);
+Simple.story = { name: 'Simple' };
+
+export const Strong = () => (
+	<div>
+		<NumberedTitleBlockComponent
+			position={1}
+			html={'<h2><strong>Strong text</strong></h2>'}
+			format={{
+				theme: 'NewsPillar',
+				design: 'ArticleDesign',
+				display: 'StandardDisplay',
+			}}
+		/>
+	</div>
+);
+Strong.story = { name: 'Simple' };
+
+export const Both = () => (
+	<div>
+		<NumberedTitleBlockComponent
+			position={1}
+			html={'<h2><strong>Strong text</strong> One Plus 7T Pro</h2>'}
+			format={{
+				theme: 'CulturePillar',
+				design: 'ArticleDesign',
+				display: 'StandardDisplay',
+			}}
+		/>
+	</div>
+);
+Both.story = { name: 'Both' };
+
+export const Other = () => (
+	<div>
+		<NumberedTitleBlockComponent
+			position={1}
+			html={'<h2>Other text<strong>Strong text</strong></h2>'}
+			format={{
+				theme: 'LifestylePillar',
+				design: 'ArticleDesign',
+				display: 'StandardDisplay',
+			}}
+		/>
+	</div>
+);
+Other.story = { name: 'Other' };

--- a/src/web/components/elements/NumberedTitleBlockComponent.tsx
+++ b/src/web/components/elements/NumberedTitleBlockComponent.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { css } from 'emotion';
+import { headline } from '@guardian/src-foundations/typography';
+import { decidePalette } from '@root/src/web/lib/decidePalette';
+import { decideDisplay } from '@root/src/web/lib/decideDisplay';
+import { decideDesign } from '@root/src/web/lib/decideDesign';
+import { decideTheme } from '@root/src/web/lib/decideTheme';
+
+type Props = {
+	position: number;
+	html: string;
+	format: CAPIFormat;
+};
+
+const titleStyles = (palette: Palette) => css`
+	h2 {
+		${headline.medium({ fontWeight: 'light' })}
+	}
+
+	strong {
+		${headline.medium({ fontWeight: 'bold' })}
+		display: block;
+		color: ${palette.text.numberedTitle};
+	}
+`;
+
+const numberStyles = (palette: Palette) => css`
+	${headline.large({ fontWeight: 'bold' })}
+	font-size: 56px;
+	color: ${palette.text.numberedPosition};
+`;
+
+export const NumberedTitleBlockComponent = ({
+	position,
+	html,
+	format,
+}: Props) => {
+	const dcrFormat = {
+		display: decideDisplay(format),
+		design: decideDesign(format),
+		theme: decideTheme(format),
+	};
+	const palette = decidePalette(dcrFormat);
+	return (
+		<>
+			<div className={numberStyles(palette)}>{position}</div>
+			<div
+				className={titleStyles(palette)}
+				dangerouslySetInnerHTML={{ __html: html }}
+			/>
+		</>
+	);
+};

--- a/src/web/lib/ElementRenderer.tsx
+++ b/src/web/lib/ElementRenderer.tsx
@@ -17,6 +17,7 @@ import { ImageBlockComponent } from '@root/src/web/components/elements/ImageBloc
 import { InstagramBlockComponent } from '@root/src/web/components/elements/InstagramBlockComponent';
 import { InteractiveBlockComponent } from '@root/src/web/components/elements/InteractiveBlockComponent';
 import { MainMediaEmbedBlockComponent } from '@root/src/web/components/elements/MainMediaEmbedBlockComponent';
+import { NumberedTitleBlockComponent } from '@root/src/web/components/elements/NumberedTitleBlockComponent';
 import { MapEmbedBlockComponent } from '@root/src/web/components/elements/MapEmbedBlockComponent';
 import { MultiImageBlockComponent } from '@root/src/web/components/elements/MultiImageBlockComponent';
 import { PullQuoteBlockComponent } from '@root/src/web/components/elements/PullQuoteBlockComponent';
@@ -186,7 +187,7 @@ export const ElementRenderer = ({
 				</Figure>
 			);
 		case 'model.dotcomrendering.pageElements.DividerBlockElement':
-			return <DividerBlockComponent />;
+			return <DividerBlockComponent size={element.size} />;
 		case 'model.dotcomrendering.pageElements.DocumentBlockElement':
 			return (
 				<Figure
@@ -441,6 +442,16 @@ export const ElementRenderer = ({
 						key={index}
 						images={element.images}
 						caption={element.caption}
+					/>
+				</Figure>
+			);
+		case 'model.dotcomrendering.pageElements.NumberedTitleBlockElement':
+			return (
+				<Figure isMainMedia={isMainMedia} id={element.elementId}>
+					<NumberedTitleBlockComponent
+						position={element.position}
+						html={element.html}
+						format={element.format}
 					/>
 				</Figure>
 			);

--- a/src/web/lib/decidePalette.ts
+++ b/src/web/lib/decidePalette.ts
@@ -702,6 +702,14 @@ const textBlockquote = (format: Format): string => {
 	}
 };
 
+const textNumberedTitle = (format: Format): string => {
+	return pillarPalette[format.theme].dark;
+};
+
+const textNumberedPosition = (): string => {
+	return text.supporting;
+};
+
 const backgroundHeadlineTag = (format: Format): string =>
 	pillarPalette[format.theme].dark;
 
@@ -754,6 +762,8 @@ export const decidePalette = (format: Format): Palette => {
 			calloutHeading: textCalloutHeading(),
 			dropCap: textDropCap(format),
 			blockquote: textBlockquote(format),
+			numberedTitle: textNumberedTitle(format),
+			numberedPosition: textNumberedPosition(),
 		},
 		background: {
 			article: backgroundArticle(format),


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds the `NumberedTitleBlockComponent` and uses it for `h2`s when `format.display === Display.NumberedList`

![2021-04-23 12 42 51](https://user-images.githubusercontent.com/1336821/115866370-7b110d80-a431-11eb-8202-d919fc8d9441.gif)


