### PR TITLE
fix: Also support `Display.NumberedList` for Standfirst

### DIFF
--- a/src/web/components/Standfirst.tsx
+++ b/src/web/components/Standfirst.tsx
@@ -95,7 +95,9 @@ const standfirstStyles = (format: Format, palette: Palette) => {
 			}
 
 		case Display.Showcase:
-		case Display.Standard: {
+		case Display.NumberedList:
+		case Display.Standard:
+		default: {
 			switch (format.design) {
 				case Design.Comment:
 				case Design.Editorial:


### PR DESCRIPTION
## What?
Adds decision logic for `Display.NumberedList` in `StandFirst`

## Before
![Screenshot 2021-04-23 at 13 17 33](https://user-images.githubusercontent.com/1336821/115869779-48b5df00-a436-11eb-96df-bc636a408a58.jpg)

## After
![Screenshot 2021-04-23 at 13 15 09](https://user-images.githubusercontent.com/1336821/115869694-291eb680-a436-11eb-9911-1ee2089b9832.jpg)

