### PR TITLE
Adding support for surveys on DCR

### DIFF
--- a/docs/commercial/overview.md
+++ b/docs/commercial/overview.md
@@ -31,7 +31,7 @@ config.get('isDotcomRendering', false)
 
 Dotcom rendering has components for the following ad types
 
--   Static ads (top-above, nav, top-right, most-viewed)
+-   Static ads (top-above, nav, top-right, most-viewed, survey)
 -   Dynamic ads (article in-body)
 -   Mechandising slots (such as masterclass below-content onward component) [in progress...]
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -890,7 +890,8 @@ type AdSlotType =
 	| 'mostpop'
 	| 'merchandising-high'
 	| 'merchandising'
-	| 'comments';
+	| 'comments'
+	| 'survey';
 
 // ------------------------------
 // 3rd party type declarations //

--- a/src/web/components/AdSlot.tsx
+++ b/src/web/components/AdSlot.tsx
@@ -69,6 +69,10 @@ const adSlotLabelStyles = css`
 	}
 `;
 
+const outOfPageStyles = css`
+	height:0;
+`;
+
 export const labelStyles = css`
 	.ad-slot__label,
 	.ad-slot__scroll {
@@ -449,6 +453,28 @@ export const AdSlot: React.FC<Props> = ({ position, display }) => {
 						`${Size.empty}`,
 						`${Size.merchandising}`,
 						`${Size.fluid}`,
+					].join('|')}
+					aria-hidden="true"
+				/>
+			);
+		}
+		case 'survey': {
+			return (
+				<div
+					id="dfp-ad--survey"
+					className={cx(
+						'js-ad-slot',
+						'ad-slot',
+						'ad-slot--survey',
+						outOfPageStyles
+					)}
+					data-link-name="ad slot survey"
+					data-name="survey"
+					data-label="false"
+					data-refresh="false"
+					data-out-of-page="true"
+					data-desktop={[
+						`${Size.outOfPage}`
 					].join('|')}
 					aria-hidden="true"
 				/>

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -410,6 +410,8 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				</Stuck>
 			)}
 
+			{ CAPI.config.switches.surveys && <AdSlot position="survey" display={format.display} /> }
+
 			<Section
 				data-print-layout="hide"
 				showTopBorder={false}


### PR DESCRIPTION
Surveys were supported by DCP but are not in DCR. The ad-slot is not present on page.
This change adds support for the survey ad-slot on page
### After
![Screenshot 2021-04-26 at 10 44 21](https://user-images.githubusercontent.com/768467/116069202-07fed580-a683-11eb-9af3-31bd547aa0fb.png)
### Before
Imagine the image the above, without the survey floating over the page.

## Why?
Since DCR went to 100% the team complained they weren't getting survey responses! This aims to fix that.