### PR TITLE
Change Numbered list title colour

### DIFF
--- a/src/web/lib/decidePalette.ts
+++ b/src/web/lib/decidePalette.ts
@@ -705,7 +705,7 @@ const textBlockquote = (format: Format): string => {
 };
 
 const textNumberedTitle = (format: Format): string => {
-	return pillarPalette[format.theme].dark;
+	return pillarPalette[format.theme].main;
 };
 
 const textNumberedPosition = (): string => {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Change the colour of Numbered List title to match the rest of the content

### Before
<img width="719" alt="Screenshot 2021-04-26 at 14 38 18" src="https://user-images.githubusercontent.com/8831403/116091979-4dc89780-a69d-11eb-866b-c639806c3663.png">

### After
![Screenshot 2021-04-26 at 14 35 02](https://user-images.githubusercontent.com/8831403/116091991-515c1e80-a69d-11eb-9c92-6584a2688b8c.png)

## Why?
Matches with our design