### PR TITLE
Use author name in title for Opinion pieces

### DIFF
--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -42,8 +42,8 @@ interface Props {
 	data: DCRServerDocumentData;
 }
 
-const makeTitle = (CAPI: CAPIType): string => {
-	if (CAPI.pillar === 'opinion' && CAPI.author.byline) {
+const decideTitle = (CAPI: CAPIType): string => {
+	if (format.theme === Pillar.Opinion && CAPI.author.byline) {
 		return `${CAPI.headline} | ${CAPI.author.byline} | The Guardian`;
 	}
 	return `${CAPI.headline} | ${CAPI.sectionLabel} | The Guardian`;

--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -42,9 +42,16 @@ interface Props {
 	data: DCRServerDocumentData;
 }
 
+const makeTitle = (CAPI: CAPIType): string => {
+	if (CAPI.pillar === 'opinion' && CAPI.author.byline) {
+		return `${CAPI.headline} | ${CAPI.author.byline} | The Guardian`;
+	}
+	return `${CAPI.headline} | ${CAPI.sectionLabel} | The Guardian`;
+};
+
 export const document = ({ data }: Props): string => {
 	const { CAPI, NAV, linkedData } = data;
-	const title = `${CAPI.headline} | ${CAPI.sectionLabel} | The Guardian`;
+	const title = makeTitle(CAPI);
 	const { html, css, ids: cssIDs }: RenderToStringResult = extractCritical(
 		renderToString(
 			// TODO: CacheProvider can be removed when we've moved over to using @emotion/core

--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -13,8 +13,10 @@ import {
 
 import { makeWindowGuardian } from '@root/src/model/window-guardian';
 import { ChunkExtractor } from '@loadable/server';
+import { Pillar } from '@guardian/types';
 import { DecideLayout } from '../layouts/DecideLayout';
 import { htmlTemplate } from './htmlTemplate';
+import { decideTheme } from '../lib/decideTheme';
 
 interface RenderToStringResult {
 	html: string;
@@ -43,7 +45,7 @@ interface Props {
 }
 
 const decideTitle = (CAPI: CAPIType): string => {
-	if (format.theme === Pillar.Opinion && CAPI.author.byline) {
+	if (decideTheme(CAPI.format) === Pillar.Opinion && CAPI.author.byline) {
 		return `${CAPI.headline} | ${CAPI.author.byline} | The Guardian`;
 	}
 	return `${CAPI.headline} | ${CAPI.sectionLabel} | The Guardian`;

--- a/src/web/server/document.tsx
+++ b/src/web/server/document.tsx
@@ -51,7 +51,7 @@ const decideTitle = (CAPI: CAPIType): string => {
 
 export const document = ({ data }: Props): string => {
 	const { CAPI, NAV, linkedData } = data;
-	const title = makeTitle(CAPI);
+	const title = decideTitle(CAPI);
 	const { html, css, ids: cssIDs }: RenderToStringResult = extractCritical(
 		renderToString(
 			// TODO: CacheProvider can be removed when we've moved over to using @emotion/core

--- a/src/web/server/htmlTemplate.ts
+++ b/src/web/server/htmlTemplate.ts
@@ -110,32 +110,32 @@ export const htmlTemplate = ({
 	const weAreHiringMessage = `
 <!--
 
-                                    GGGGGGGGG                                   
-                           GGGGGGGGGGGGGGGGGGGGGGGGGG                           
-                       GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG                      
-                    GGGGGGGGGGGGGGGGG      GG   GGGGGGGGGGGGG                   
-                  GGGGGGGGGGGG        GGGGGGGGG      GGGGGGGGGG                 
-                GGGGGGGGGGG         GGGGGGGGGGGGG       GGGGGGGGG               
-              GGGGGGGGGG          GGGGGGGGGGGGGGGGG     GGGGGGGGGGG             
-             GGGGGGGGG           GGGGGGGGGGGGGGGGGGG    GGGGGGGGGGGG            
-            GGGGGGGGG           GGGGGGGGGGGGGGGGGGGGGG  GGGGGGGGGGGGG           
-           GGGGGGGGG            GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG          
-           GGGGGGGG             GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG          
-          GGGGGGGG              GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG         
-          GGGGGGGG              GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG         
-          GGGGGGGG              GGGGGGGGGGGG              GGGGGGGGGGGGG         
-           GGGGGGG              GGGGGGGGGGGGG           GGGGGGGGGGGGGG          
-           GGGGGGGG             GGGGGGGGGGGGG           GGGGGGGGGGGGGG          
-            GGGGGGGG            GGGGGGGGGGGGG           GGGGGGGGGGGGG           
-             GGGGGGGG            GGGGGGGGGGGG           GGGGGGGGGGGG            
-              GGGGGGGGG           GGGGGGGGGGG           GGGGGGGGGGG             
-                GGGGGGGGGG         GGGGGGGGGG           GGGGGGGGG               
-                  GGGGGGGGGGG        GGGGGGGG        GGGGGGGGGG                 
-                    GGGGGGGGGGGGGG      GGGGG  GGGGGGGGGGGGGG                   
-                       GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG                      
-                            GGGGGGGGGGGGGGGGGGGGGGGGG                           
-                                    GGGGGGGGG                                   
-                                              
+                                    GGGGGGGGG
+                           GGGGGGGGGGGGGGGGGGGGGGGGGG
+                       GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG
+                    GGGGGGGGGGGGGGGGG      GG   GGGGGGGGGGGGG
+                  GGGGGGGGGGGG        GGGGGGGGG      GGGGGGGGGG
+                GGGGGGGGGGG         GGGGGGGGGGGGG       GGGGGGGGG
+              GGGGGGGGGG          GGGGGGGGGGGGGGGGG     GGGGGGGGGGG
+             GGGGGGGGG           GGGGGGGGGGGGGGGGGGG    GGGGGGGGGGGG
+            GGGGGGGGG           GGGGGGGGGGGGGGGGGGGGGG  GGGGGGGGGGGGG
+           GGGGGGGGG            GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG
+           GGGGGGGG             GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG
+          GGGGGGGG              GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG
+          GGGGGGGG              GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG
+          GGGGGGGG              GGGGGGGGGGGG              GGGGGGGGGGGGG
+           GGGGGGG              GGGGGGGGGGGGG           GGGGGGGGGGGGGG
+           GGGGGGGG             GGGGGGGGGGGGG           GGGGGGGGGGGGGG
+            GGGGGGGG            GGGGGGGGGGGGG           GGGGGGGGGGGGG
+             GGGGGGGG            GGGGGGGGGGGG           GGGGGGGGGGGG
+              GGGGGGGGG           GGGGGGGGGGG           GGGGGGGGGGG
+                GGGGGGGGGG         GGGGGGGGGG           GGGGGGGGG
+                  GGGGGGGGGGG        GGGGGGGG        GGGGGGGGGG
+                    GGGGGGGGGGGGGG      GGGGG  GGGGGGGGGGGGGG
+                       GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG
+                            GGGGGGGGGGGGGGGGGGGGGGGGG
+                                    GGGGGGGGG
+
 
         We are hiring, ever thought about joining us?
         https://workforus.theguardian.com/careers/product-engineering/


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

As per CP's request, this uses the author's name (byline) instead of the section label on opinion pieces.

SITUATION:

<img width="993" alt="situation" src="https://user-images.githubusercontent.com/6035518/116101598-dc411700-a6a5-11eb-86ba-7808d4b7a923.png">

BEFORE:

<img width="284" alt="Before1" src="https://user-images.githubusercontent.com/6035518/116101650-e8c56f80-a6a5-11eb-96e8-6db8fac114d9.png">

AFTER:

<img width="268" alt="after" src="https://user-images.githubusercontent.com/6035518/116101689-f24ed780-a6a5-11eb-9162-1eb52d0bb145.png">



