### PR TITLE
Better align veggie burger to menu on mobileLandscape

### DIFF
--- a/src/web/components/Nav/ExpandedMenu/ExpandedMenu.tsx
+++ b/src/web/components/Nav/ExpandedMenu/ExpandedMenu.tsx
@@ -96,7 +96,7 @@ const mainMenuStyles = css`
 		margin-right: 29px;
 	}
 	${from.mobileLandscape} {
-		margin-right: 70px;
+		margin-right: 40px;
 	}
 	${from.tablet} {
 		margin-right: 100px;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Reduce `margin-right` of menu on `mobileLandscape` to better match veggie burger

### Before
<img width="625" alt="Screenshot 2021-04-26 at 16 30 31" src="https://user-images.githubusercontent.com/8831403/116112865-e36d2280-a6af-11eb-8859-ef64fbe4e5b4.png">

### After
<img width="629" alt="Screenshot 2021-04-26 at 16 31 25" src="https://user-images.githubusercontent.com/8831403/116112874-e6681300-a6af-11eb-9d49-17b0e089746b.png">

## Why?
Looks better