### PR TITLE
Add SSM parameter role

### DIFF
--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -152,8 +152,8 @@ Resources:
               - ssm:GetParametersByPath
               - ssm:GetParameter
             Resource:
-              - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${App}/${Stage}
-              - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${App}/${Stage}/*
+              - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/frontend/${Stage}
+              - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/frontend/${Stage}/*
 
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -147,6 +147,13 @@ Resources:
             - autoscaling:DescribeAutoScalingGroups
             - autoscaling:DescribeAutoScalingInstances
             Resource: '*'
+          - Effect: Allow
+            Action:
+              - ssm:GetParametersByPath
+              - ssm:GetParameter
+            Resource:
+              - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${App}/${Stage}
+              - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${App}/${Stage}/*
 
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile


### PR DESCRIPTION
## What does this change?

Adds SSM permissions so that we can access the Parameter store from the instance.

Currently this is logged when accessing the parameter:

![image](https://user-images.githubusercontent.com/638051/116235967-5df07d80-a756-11eb-8182-ffd91d8d6eb9.png)
