### PR TITLE
DividerBlockElement spaceAbove prop support

### DIFF
--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -119,6 +119,7 @@ interface DisclaimerBlockElement {
 interface DividerBlockElement {
 	_type: 'model.dotcomrendering.pageElements.DividerBlockElement';
 	size?: 'full' | 'partial';
+	spaceAbove?: 'tight' | 'loose';
 }
 
 interface DocumentBlockElement extends ThirdPartyEmbeddedContent {

--- a/src/model/enhance-numbered-lists.test.ts
+++ b/src/model/enhance-numbered-lists.test.ts
@@ -69,6 +69,8 @@ describe('Enhance Numbered Lists', () => {
 						{
 							_type:
 								'model.dotcomrendering.pageElements.DividerBlockElement',
+							size: 'full',
+							spaceAbove: 'tight',
 						},
 						{
 							_type:
@@ -471,6 +473,7 @@ describe('Enhance Numbered Lists', () => {
 							_type:
 								'model.dotcomrendering.pageElements.DividerBlockElement',
 							size: 'full',
+							spaceAbove: 'loose',
 						},
 						{
 							_type:
@@ -535,6 +538,7 @@ describe('Enhance Numbered Lists', () => {
 							_type:
 								'model.dotcomrendering.pageElements.DividerBlockElement',
 							size: 'full',
+							spaceAbove: 'loose',
 						},
 						{
 							_type:
@@ -552,6 +556,7 @@ describe('Enhance Numbered Lists', () => {
 							_type:
 								'model.dotcomrendering.pageElements.DividerBlockElement',
 							size: 'full',
+							spaceAbove: 'loose',
 						},
 						{
 							_type:
@@ -565,6 +570,7 @@ describe('Enhance Numbered Lists', () => {
 							_type:
 								'model.dotcomrendering.pageElements.DividerBlockElement',
 							size: 'full',
+							spaceAbove: 'loose',
 						},
 						{
 							_type:

--- a/src/model/enhance-numbered-lists.ts
+++ b/src/model/enhance-numbered-lists.ts
@@ -198,6 +198,8 @@ const addH3s = (elements: CAPIElement[]): CAPIElement[] => {
 				{
 					_type:
 						'model.dotcomrendering.pageElements.DividerBlockElement',
+					size: 'full',
+					spaceAbove: 'tight',
 				},
 				{
 					...thisElement,
@@ -244,6 +246,7 @@ const addItemLinks = (elements: CAPIElement[]): CAPIElement[] => {
 					_type:
 						'model.dotcomrendering.pageElements.DividerBlockElement',
 					size: 'full',
+					spaceAbove: 'tight',
 				},
 				{
 					...thisElement,
@@ -286,6 +289,7 @@ const addTitles = (
 					_type:
 						'model.dotcomrendering.pageElements.DividerBlockElement',
 					size: 'full',
+					spaceAbove: 'loose',
 				},
 				{
 					_type:

--- a/src/web/components/elements/DividerBlockComponent.tsx
+++ b/src/web/components/elements/DividerBlockComponent.tsx
@@ -1,41 +1,45 @@
 import React from 'react';
-import { css } from 'emotion';
+import { css, cx } from 'emotion';
 
 import { border } from '@guardian/src-foundations/palette';
 
 type Props = {
 	size?: 'full' | 'partial';
+	spaceAbove?: 'tight' | 'loose';
 };
-export const DividerBlockComponent = ({ size = 'partial' }: Props) => {
-	switch (size) {
-		case 'full':
-			return (
-				<hr
-					className={css`
-						width: 100%;
-						height: 1px;
-						border: 0;
-						margin-left: -10px;
-						margin-top: 48px;
-						margin-bottom: 3px;
-						background-color: ${border.secondary};
-					`}
-				/>
-			);
-		case 'partial':
-		default:
-			return (
-				<hr
-					className={css`
-						width: 150px;
-						height: 1px;
-						border: 0;
-						margin-left: -10px;
-						margin-top: 48px;
-						margin-bottom: 3px;
-						background-color: ${border.secondary};
-					`}
-				/>
-			);
-	}
-};
+
+const baseStyles = css`
+	height: 1px;
+	border: 0;
+	margin-left: -10px;
+	margin-bottom: 3px;
+	background-color: ${border.secondary};
+`;
+const sizeFullStyle = css`
+	width: 100%;
+`;
+const sizePartialStyle = css`
+	width: 150px;
+`;
+
+const tightSpaceAboveStyle = css`
+	margin-top: 3px;
+`;
+const looseSpaceAboveStyle = css`
+	margin-top: 48px;
+`;
+
+export const DividerBlockComponent = ({
+	size = 'partial',
+	spaceAbove = 'loose',
+}: Props) => (
+	<hr
+		className={cx(
+			baseStyles,
+			size === 'partial' ? sizePartialStyle : sizeFullStyle,
+			spaceAbove === 'loose'
+				? looseSpaceAboveStyle
+				: tightSpaceAboveStyle,
+		)}
+	/>
+);

--- a/src/web/lib/ElementRenderer.tsx
+++ b/src/web/lib/ElementRenderer.tsx
@@ -188,7 +188,12 @@ export const ElementRenderer = ({
 				</Figure>
 			);
 		case 'model.dotcomrendering.pageElements.DividerBlockElement':
-			return <DividerBlockComponent size={element.size} />;
+			return (
+				<DividerBlockComponent
+					size={element.size}
+					spaceAbove={element.spaceAbove}
+				/>
+			);
 		case 'model.dotcomrendering.pageElements.DocumentBlockElement':
 			return (
 				<Figure


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
- add `spaceAbove` to `DividerBlockElement`

- Update `DividerBlockElement`s in `enhance-numbered-lists.ts`
We made `size` `full` for all elements based on feedback from design and added `spaceAbove` `loose` only for title numbered elements

### Before
<img width="682" alt="Screenshot 2021-04-27 at 14 23 45" src="https://user-images.githubusercontent.com/8831403/116249307-96975380-a764-11eb-9bf9-3076a4702679.png">

### After
<img width="719" alt="Screenshot 2021-04-27 at 14 23 08" src="https://user-images.githubusercontent.com/8831403/116249320-9ac37100-a764-11eb-83e5-44825944c89c.png">

## Why?
Need to add an extra dimension to `DividerBlockElement` to better handle divisions in numbered list