### PR TITLE
Relax Braze epic param validation

### DIFF
--- a/src/web/lib/braze/parseBrazeEpicParams.test.ts
+++ b/src/web/lib/braze/parseBrazeEpicParams.test.ts
@@ -56,22 +56,27 @@ describe('parseBrazeEpicParams', () => {
 		expect(got).toEqual(expected);
 	});
 
-	it('returns an error message when the heading is missing', () => {
+	it('does not care if non-required fields are missing', () => {
 		const dataFromBraze: EpicDataFromBraze = {
 			componentName: 'Epic',
 			paragraph1: 'Paragraph 1',
 			paragraph2: 'Paragraph 2',
-			highlightedText: 'Example highlighted text',
+			paragraph3: 'Paragraph 3',
 			buttonText: 'Button',
 			buttonUrl: 'https://www.example.com',
 			ophanComponentId: 'epic_123',
 		};
 
+		const expected = ok({
+			paragraphs: ['Paragraph 1', 'Paragraph 2', 'Paragraph 3'],
+			cta: { text: 'Button', baseUrl: 'https://www.example.com' },
+			ophanComponentId: 'epic_123',
+		});
+
 		const got = parseBrazeEpicParams(dataFromBraze);
 
-		expect(got).toEqual(err('Missing field(s): heading'));
+		expect(got).toEqual(expected);
 	});
-
 	it('returns an error message when the paragraphs are missing', () => {
 		const dataFromBraze: EpicDataFromBraze = {
 			componentName: 'Epic',
@@ -102,22 +107,6 @@ describe('parseBrazeEpicParams', () => {
 		const got = parseBrazeEpicParams(dataFromBraze);
 
 		expect(got).toEqual(err('Missing paragraphs'));
-	});
-
-	it('returns an error message when the highlightedText is missing', () => {
-		const dataFromBraze: EpicDataFromBraze = {
-			componentName: 'Epic',
-			heading: 'Example Heading',
-			paragraph1: 'Paragraph 1',
-			paragraph2: 'Paragraph 2',
-			buttonText: 'Button',
-			buttonUrl: 'https://www.example.com',
-			ophanComponentId: 'epic_123',
-		};
-
-		const got = parseBrazeEpicParams(dataFromBraze);
-
-		expect(got).toEqual(err('Missing field(s): highlightedText'));
 	});
 
 	it('returns an error message when the buttonText is missing', () => {
@@ -171,15 +160,17 @@ describe('parseBrazeEpicParams', () => {
 	it('returns the correct error message when multiple fields missing', () => {
 		const dataFromBraze: EpicDataFromBraze = {
 			componentName: 'Epic',
+			heading: 'Example Heading',
 			paragraph1: 'Paragraph 1',
 			paragraph2: 'Paragraph 2',
 			highlightedText: 'Example highlighted text',
-			buttonText: 'Button',
 			buttonUrl: 'https://www.example.com',
 		};
 
 		const got = parseBrazeEpicParams(dataFromBraze);
 
-		expect(got).toEqual(err('Missing field(s): heading,ophanComponentId'));
+		expect(got).toEqual(
+			err('Missing field(s): buttonText,ophanComponentId'),
+		);
 	});
 });

--- a/src/web/lib/braze/parseBrazeEpicParams.ts
+++ b/src/web/lib/braze/parseBrazeEpicParams.ts
@@ -19,10 +19,9 @@ export type EpicDataFromBraze = {
 };
 
 export type Variant = {
-	// name: string;
-	heading: string;
+	heading?: string;
 	paragraphs: Array<string>;
-	highlightedText: string;
+	highlightedText?: string;
 	cta: {
 		text: string;
 		baseUrl: string;
@@ -49,15 +48,15 @@ const parseParagraphs = (dataFromBraze: EpicDataFromBraze): string[] => {
 export const parseBrazeEpicParams = (
 	dataFromBraze: EpicDataFromBraze,
 ): Result<string, Variant> => {
-	const basicFields: Array<keyof EpicDataFromBraze> = [
-		'heading',
-		'highlightedText',
+	const requiredBasicFields: Array<keyof EpicDataFromBraze> = [
 		'buttonText',
 		'buttonUrl',
 		'ophanComponentId',
 	];
 
-	const missingBasicFields = basicFields.filter((key) => !dataFromBraze[key]);
+	const missingBasicFields = requiredBasicFields.filter(
+		(key) => !dataFromBraze[key],
+	);
 	if (missingBasicFields.length > 0) {
 		return err(`Missing field(s): ${missingBasicFields}`);
 	}


### PR DESCRIPTION
~~*Note: this PR depends on another branch so I'm opening it in draft mode. Once the base branch/PR (#2913) has been merged I'll update it to `main` and take out of draft.*~~

## What does this change?

The `heading` and `highlightedText` fields should not be required. The component renders fine without them, so we should not enforce that marketing specify these fields (and in fact the first campaign epic doesn't have a heading).

Example epic without a heading:

![Screenshot 2021-04-27 at 14 44 16](https://user-images.githubusercontent.com/379839/116253773-ad3fa980-a768-11eb-9d7b-c7815d5ca368.png)

### Before

If either of `heading` or `highlightedText` were missing the epic message wouldn't render.

### After

The message renders without `heading` or `highlightedText`.