### PR TITLE
Numbered list title negative margin

### DIFF
--- a/src/web/components/elements/NumberedTitleBlockComponent.tsx
+++ b/src/web/components/elements/NumberedTitleBlockComponent.tsx
@@ -44,7 +44,7 @@ export const NumberedTitleBlockComponent = ({
 	return (
 		<div
 			className={css`
-				margin-top: -20px; /* Hack used to align Title number closer to adjacent divider */
+				margin-top: -16px; /* Hack used to align Title number closer to adjacent divider */
 			`}
 		>
 			<div className={numberStyles(palette)}>{position}</div>

--- a/src/web/components/elements/NumberedTitleBlockComponent.tsx
+++ b/src/web/components/elements/NumberedTitleBlockComponent.tsx
@@ -42,12 +42,16 @@ export const NumberedTitleBlockComponent = ({
 	};
 	const palette = decidePalette(dcrFormat);
 	return (
-		<>
+		<div
+			className={css`
+				margin-top: -20px; /* Hack used to align Title number closer to adjacent divider */
+			`}
+		>
 			<div className={numberStyles(palette)}>{position}</div>
 			<div
 				className={titleStyles(palette)}
 				dangerouslySetInnerHTML={{ __html: html }}
 			/>
-		</>
+		</div>
 	);
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Adds negative margin to a numbered list titles

### Before
<img width="717" alt="Screenshot 2021-04-27 at 14 57 09" src="https://user-images.githubusercontent.com/8831403/116259115-6d2ef580-a76d-11eb-8be5-74aca84741b8.png">


### After
<img width="684" alt="Screenshot 2021-04-27 at 15 44 48" src="https://user-images.githubusercontent.com/8831403/116261490-9badd000-a76f-11eb-981c-130c1b86d61a.png">


## Why?
The Typography of the numbers has an effect on the height of the text, meaning we get a lot of unwanted blank space. To negate that we use a negative margin for the title contents