### PR TITLE
Set resource to not use stage when fetching parameters

### DIFF
--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -152,8 +152,7 @@ Resources:
               - ssm:GetParametersByPath
               - ssm:GetParameter
             Resource:
-              - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/frontend/${Stage}
-              - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/frontend/${Stage}/*
+              - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/frontend/*
 
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile


### PR DESCRIPTION
## What does this change?

Removes the stage from the `ssm:GetParameter` request as the stage in key store is lowercase, and Stage in the cloudformation parameter is uppercase...

This matches Frontend.