### PR TITLE
Design tweaks to align logo

### DIFF
--- a/src/web/components/Logo.tsx
+++ b/src/web/components/Logo.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 import { brandText } from '@guardian/src-foundations/palette';
-import { from } from '@guardian/src-foundations/mq';
+import { from, until } from '@guardian/src-foundations/mq';
 import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 
 import TheGuardianLogoSVG from '@frontend/static/logos/the-guardian.svg';
@@ -10,20 +10,25 @@ import GuardianAnniversaryLogoSVG from '@frontend/static/logos/guardian-annivers
 
 import { getZIndex } from '@frontend/web/lib/getZIndex';
 
-const link = css`
+const link = (isAnniversary?: boolean) => css`
 	float: right;
 	margin-top: 10px;
 	margin-right: 54px;
 	margin-bottom: 21px;
 
+	${until.mobileMedium} {
+		margin-top: ${isAnniversary ? '25px' : ''};
+	}
+
 	${from.mobileMedium} {
 		margin-right: 10px;
+		margin-top: ${isAnniversary ? '14px' : ''};
 	}
 	${from.mobileLandscape} {
 		margin-right: 20px;
 	}
 	${from.desktop} {
-		margin-top: 5px;
+		margin-top: ${isAnniversary ? '10px' : '5px'};
 		margin-bottom: 15px;
 		position: relative;
 	}
@@ -35,18 +40,18 @@ const link = css`
 `;
 
 const style = (isAnniversary?: boolean) => css`
-	height: 44px;
+	height: ${isAnniversary ? 'auto' : '44px'};
 	width: 135px;
 	${from.mobileMedium} {
-		height: 56px;
+		height: ${isAnniversary ? 'auto' : '56px'};
 		width: 175px;
 	}
 	${from.tablet} {
-		height: 72px;
+		height: ${isAnniversary ? 'auto' : '72px'};
 		width: 224px;
 	}
 	${from.desktop} {
-		height: 95px;
+		height: ${isAnniversary ? 'auto' : '95px'};
 		width: 295px;
 	}
 
@@ -65,7 +70,7 @@ const SVG = ({ isAnniversary }: { isAnniversary?: boolean }) =>
 export const Logo: React.FC<{
 	isAnniversary?: boolean;
 }> = ({ isAnniversary }) => (
-	<a className={link} href="/" data-link-name="nav2 : logo">
+	<a className={link(isAnniversary)} href="/" data-link-name="nav2 : logo">
 		<span
 			className={css`
 				${visuallyHidden};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
- Change logo height to `auto` to have parity with Frontend
- Amend `margin-top` for anniversary logo to preserve correct alignment
### Before
![logo-original](https://user-images.githubusercontent.com/9122944/116277842-c7d04d80-a77d-11eb-85be-ff437378f5c6.png)

### After
![logo-edit](https://user-images.githubusercontent.com/9122944/116277849-c99a1100-a77d-11eb-84db-bcc0b1f0a6ef.png)

## Why?
Design requirements