### PR TITLE
Anniversary Atom: Design tweaks

### DIFF
--- a/src/web/components/AnniversaryAtomComponent.tsx
+++ b/src/web/components/AnniversaryAtomComponent.tsx
@@ -1,21 +1,39 @@
 import React from 'react';
 import { css } from 'emotion';
 import { InteractiveAtom } from '@guardian/atoms-rendering';
+import { from } from '@guardian/src-foundations/mq';
 
+const atomStyles = (
+	anniversaryInteractiveAtom: interactiveAtomBlockElement | undefined,
+) => css`
+	/* Temporarily support anniversary atom at top of articles */
+	/* stylelint-disable color-no-hex */
+	background-color: #ffe500;
+	display: ${anniversaryInteractiveAtom ? 'block' : 'none'};
+
+	${from.tablet} {
+		margin-bottom: 25px;
+		position: relative;
+
+		&:after {
+			content: '';
+			height: 25px;
+			background-color: transparent;
+			border-bottom: 1px solid #dcdcdc;
+			width: 100%;
+			display: block;
+			position: absolute;
+			bottom: -25px;
+		}
+	}
+`;
 export const AnniversaryAtomComponent = ({
 	anniversaryInteractiveAtom,
 }: {
 	anniversaryInteractiveAtom: InteractiveAtomBlockElement | undefined;
 }) => {
 	return (
-		<div
-			className={css`
-				/* Temporarily support anniversary atom at top of articles */
-				/* stylelint-disable color-no-hex */
-				background-color: #ffe500;
-				display: ${anniversaryInteractiveAtom ? 'block' : 'none'};
-			`}
-		>
+		<div className={atomStyles(anniversaryInteractiveAtom)}>
 			{anniversaryInteractiveAtom && (
 				<InteractiveAtom
 					html={anniversaryInteractiveAtom.html}

--- a/src/web/components/AnniversaryAtomComponent.tsx
+++ b/src/web/components/AnniversaryAtomComponent.tsx
@@ -11,19 +11,34 @@ const atomStyles = (
 	background-color: #ffe500;
 	display: ${anniversaryInteractiveAtom ? 'block' : 'none'};
 
+	height: 202px;
+	--space-below: 16px;
+
+	${from.phablet} {
+		height: 155px;
+	}
 	${from.tablet} {
-		margin-bottom: 25px;
+		height: 160px;
+		--space-below: 24px;
+	}
+	${from.desktop} {
+		height: 180px;
+	}
+
+	/* IE11 will not have the space below */
+	@supports (--css: variables) {
+		margin-bottom: var(--space-below);
 		position: relative;
 
 		&:after {
 			content: '';
-			height: 25px;
+			height: var(--space-below);
 			background-color: transparent;
 			border-bottom: 1px solid #dcdcdc;
 			width: 100%;
 			display: block;
 			position: absolute;
-			bottom: -25px;
+			bottom: calc(var(--space-below) * -1); /* negate the css var */
 		}
 	}
 `;

--- a/src/web/components/AnniversaryAtomComponent.tsx
+++ b/src/web/components/AnniversaryAtomComponent.tsx
@@ -4,7 +4,7 @@ import { InteractiveAtom } from '@guardian/atoms-rendering';
 import { from } from '@guardian/src-foundations/mq';
 
 const atomStyles = (
-	anniversaryInteractiveAtom: interactiveAtomBlockElement | undefined,
+	anniversaryInteractiveAtom: InteractiveAtomBlockElement | undefined,
 ) => css`
 	/* Temporarily support anniversary atom at top of articles */
 	/* stylelint-disable color-no-hex */

--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -381,18 +381,21 @@ export const CommentLayout = ({
 					>
 						<GuardianLines count={4} palette={palette} />
 					</Section>
+					<Section
+						backgroundColour={brandAltBackground.primary}
+						padded={false}
+						showTopBorder={false}
+						showSideBorders={false}
+					>
+						<AnniversaryAtomComponent
+							anniversaryInteractiveAtom={
+								CAPI.anniversaryInteractiveAtom
+							}
+						/>
+					</Section>
 				</SendToBack>
 			</div>
-			<Section
-				backgroundColour={brandAltBackground.primary}
-				padded={false}
-				showTopBorder={false}
-				showSideBorders={false}
-			>
-				<AnniversaryAtomComponent
-					anniversaryInteractiveAtom={CAPI.anniversaryInteractiveAtom}
-				/>
-			</Section>
+
 			<Section
 				showTopBorder={false}
 				backgroundColour={palette.background.article}

--- a/src/web/layouts/ShowcaseLayout.tsx
+++ b/src/web/layouts/ShowcaseLayout.tsx
@@ -329,6 +329,18 @@ export const ShowcaseLayout = ({
 						>
 							<GuardianLines count={4} palette={palette} />
 						</Section>
+						<Section
+							backgroundColour={brandAltBackground.primary}
+							padded={false}
+							showTopBorder={false}
+							showSideBorders={false}
+						>
+							<AnniversaryAtomComponent
+								anniversaryInteractiveAtom={
+									CAPI.anniversaryInteractiveAtom
+								}
+							/>
+						</Section>
 					</SendToBack>
 				</div>
 			) : (
@@ -380,17 +392,6 @@ export const ShowcaseLayout = ({
 					</Stuck>
 				</>
 			)}
-
-			<Section
-				backgroundColour={brandAltBackground.primary}
-				padded={false}
-				showTopBorder={false}
-				showSideBorders={false}
-			>
-				<AnniversaryAtomComponent
-					anniversaryInteractiveAtom={CAPI.anniversaryInteractiveAtom}
-				/>
-			</Section>
 
 			<Section
 				showTopBorder={false}

--- a/src/web/layouts/StandardLayout.tsx
+++ b/src/web/layouts/StandardLayout.tsx
@@ -397,6 +397,13 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 			{format.theme !== Special.Labs ? (
 				<>
 					<Section
+						backgroundColour={palette.background.article}
+						padded={false}
+						showTopBorder={false}
+					>
+						<GuardianLines count={4} palette={palette} />
+					</Section>
+					<Section
 						backgroundColour={brandAltBackground.primary}
 						padded={false}
 						showTopBorder={false}
@@ -407,13 +414,6 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 								CAPI.anniversaryInteractiveAtom
 							}
 						/>
-					</Section>
-					<Section
-						backgroundColour={palette.background.article}
-						padded={false}
-						showTopBorder={false}
-					>
-						<GuardianLines count={4} palette={palette} />
 					</Section>
 				</>
 			) : (
@@ -441,13 +441,6 @@ export const StandardLayout = ({ CAPI, NAV, format, palette }: Props) => {
 				borderColour={palette.border.article}
 			>
 				<StandardGrid isMatchReport={isMatchReport}>
-					<GridItem area="atom">
-						<AnniversaryAtomComponent
-							anniversaryInteractiveAtom={
-								CAPI.anniversaryInteractiveAtom
-							}
-						/>
-					</GridItem>
 					<GridItem area="title">
 						<ArticleTitle
 							format={format}


### PR DESCRIPTION
# What does this change?

- Adds some spacing below the atom using css vars to adjust at the different breakpoints
- Adds the height to the wrapper so there's no jump as the iframe loads
- Moves the atom below the 'lines'

![2021-04-29 12 43 48](https://user-images.githubusercontent.com/638051/116545712-a8096880-a8e8-11eb-8617-6a6c1fb72448.gif)

![2021-04-29 12 44 13](https://user-images.githubusercontent.com/638051/116545726-ab045900-a8e8-11eb-8c15-8cbbe1666c86.gif)


![Screen Shot 2021-04-29 at 12 39 11](https://user-images.githubusercontent.com/638051/116545433-56f97480-a8e8-11eb-9da5-94a7985d1eaa.png)
![Screen Shot 2021-04-29 at 12 39 20](https://user-images.githubusercontent.com/638051/116545438-57920b00-a8e8-11eb-9543-cf66f33048d0.png)
![Screen Shot 2021-04-29 at 12 39 23](https://user-images.githubusercontent.com/638051/116545440-582aa180-a8e8-11eb-8535-2582687e0d3e.png)
![Screen Shot 2021-04-29 at 12 39 48](https://user-images.githubusercontent.com/638051/116545441-58c33800-a8e8-11eb-9060-584f1cd2c66a.png)
![Screen Shot 2021-04-29 at 12 39 53](https://user-images.githubusercontent.com/638051/116545445-58c33800-a8e8-11eb-9fd7-1bbd349326bc.png)
![Screen Shot 2021-04-29 at 12 39 57](https://user-images.githubusercontent.com/638051/116545448-595bce80-a8e8-11eb-9bfe-65f17d57fe5b.png)






