### PR TITLE
Add AB test check to CommentLayout

### DIFF
--- a/src/web/layouts/CommentLayout.tsx
+++ b/src/web/layouts/CommentLayout.tsx
@@ -334,7 +334,9 @@ export const CommentLayout = ({
 								idUrl={CAPI.config.idUrl}
 								mmaUrl={CAPI.config.mmaUrl}
 								isAnniversary={
-									CAPI.config.switches.anniversaryHeaderSvg
+									CAPI.config.switches.anniversaryHeaderSvg &&
+									CAPI.config.abTests
+										.anniversaryAtomVariant === 'variant'
 								}
 							/>
 						</Section>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
There was no AB test check for the CommentLayout which allowed the logo to display to people outside the test. 

## Why?
Shouldn't display until the day!