### PR TITLE
Fix fauxH3 enhance for numbered list

### DIFF
--- a/src/model/enhance-numbered-lists.test.ts
+++ b/src/model/enhance-numbered-lists.test.ts
@@ -123,6 +123,120 @@ describe('Enhance Numbered Lists', () => {
 		expect(enhanceNumberedLists(input)).toEqual(expectedOutput);
 	});
 
+	it('does not set a h3 if there is text before the strong tag', () => {
+		const input: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							_type:
+								'model.dotcomrendering.pageElements.TextBlockElement',
+							elementId: 'mockId',
+							html:
+								'<p>Some text before <strong>Strong 1</strong></p>',
+						},
+					],
+				},
+			],
+		};
+		const expectedOutput: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							_type:
+								'model.dotcomrendering.pageElements.TextBlockElement',
+							elementId: 'mockId',
+							html:
+								'<p>Some text before <strong>Strong 1</strong></p>',
+						},
+					],
+				},
+			],
+		};
+		expect(enhanceNumberedLists(input)).toEqual(expectedOutput);
+	});
+
+	it('does not set a h3 if there is text after the strong tag', () => {
+		const input: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							_type:
+								'model.dotcomrendering.pageElements.TextBlockElement',
+							elementId: 'mockId',
+							html:
+								'<p><strong>Strong 1</strong>Some text after</p>',
+						},
+					],
+				},
+			],
+		};
+		const expectedOutput: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							_type:
+								'model.dotcomrendering.pageElements.TextBlockElement',
+							elementId: 'mockId',
+							html:
+								'<p><strong>Strong 1</strong>Some text after</p>',
+						},
+					],
+				},
+			],
+		};
+		expect(enhanceNumberedLists(input)).toEqual(expectedOutput);
+	});
+
+	it('does not set a h3 if there is text before and after the strong tag', () => {
+		const input: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							_type:
+								'model.dotcomrendering.pageElements.TextBlockElement',
+							elementId: 'mockId',
+							html:
+								'<p>Some text before <strong>Strong 1</strong>Some text after</p>',
+						},
+					],
+				},
+			],
+		};
+		const expectedOutput: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							_type:
+								'model.dotcomrendering.pageElements.TextBlockElement',
+							elementId: 'mockId',
+							html:
+								'<p>Some text before <strong>Strong 1</strong>Some text after</p>',
+						},
+					],
+				},
+			],
+		};
+		expect(enhanceNumberedLists(input)).toEqual(expectedOutput);
+	});
+
 	it('does not set a h3 if there if the html does not end with a strong p tag combo', () => {
 		const input: CAPIType = {
 			...NumberedList,

--- a/src/model/enhance-numbered-lists.ts
+++ b/src/model/enhance-numbered-lists.ts
@@ -23,6 +23,7 @@ const isFalseH3 = (element: CAPIElement): boolean => {
 	const textLength = text?.length;
 	const htmlLength = html.length;
 	const onlyHasOneStrongTag = textLength === htmlLength - 24;
+	const startStrong = html.substr(0, 11) === '<p><strong>';
 	const endsStrong = html.substr(htmlLength - 13) === '</strong></p>';
 
 	return (
@@ -30,6 +31,7 @@ const isFalseH3 = (element: CAPIElement): boolean => {
 		containsStrongtags &&
 		doesNotContainLinks &&
 		onlyHasOneStrongTag &&
+		startStrong &&
 		endsStrong
 	);
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Fix `fauxH3` enhancer to only detect `p` and `strong` tags without adjacent text

### Before
<img width="714" alt="Screenshot 2021-04-28 at 12 20 18" src="https://user-images.githubusercontent.com/8831403/116395593-37951580-a81c-11eb-97a9-a74a8f9f3367.png">

### After
<img width="664" alt="Screenshot 2021-04-28 at 12 11 00" src="https://user-images.githubusercontent.com/8831403/116395608-3a900600-a81c-11eb-8d34-e79647a688e9.png">

## Why?
Because we were accidentally enhancing a normal `TextBlockElement`