### PR TITLE
Dynamically set spaceAbove of DividerBlockElement for h3

### DIFF
--- a/src/model/enhance-numbered-lists.test.ts
+++ b/src/model/enhance-numbered-lists.test.ts
@@ -273,6 +273,116 @@ describe('Enhance Numbered Lists', () => {
 		expect(enhanceNumberedLists(input)).toEqual(expectedOutput);
 	});
 
+	it('does set divider `spaceAbove` to `loose` if ItemLinkBlockElement is followed by fauxH3', () => {
+		const input: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							_type:
+								'model.dotcomrendering.pageElements.ItemLinkBlockElement',
+							elementId: 'mockId',
+							html:
+								'<ul><li><strong>Item link block</strong><a href="https://www.theguardian.com">Link</a></li></ul>',
+						},
+						{
+							_type:
+								'model.dotcomrendering.pageElements.TextBlockElement',
+							elementId: 'mockId',
+							html: '<p><strong>Faux H3 text</strong></p>',
+						},
+					],
+				},
+			],
+		};
+		const expectedOutput: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							_type:
+								'model.dotcomrendering.pageElements.ItemLinkBlockElement',
+							elementId: 'mockId',
+							html:
+								'<ul><li><strong>Item link block</strong><a href="https://www.theguardian.com">Link</a></li></ul>',
+						},
+						{
+							_type:
+								'model.dotcomrendering.pageElements.DividerBlockElement',
+							size: 'full',
+							spaceAbove: 'loose',
+						},
+						{
+							_type:
+								'model.dotcomrendering.pageElements.TextBlockElement',
+							elementId: 'mockId',
+							html: '<h3>Faux H3 text</h3>',
+						},
+					],
+				},
+			],
+		};
+		expect(enhanceNumberedLists(input)).toEqual(expectedOutput);
+	});
+
+	it('does set divider `spaceAbove` to `tight` if fauxH3 is not proceeded by ItemLinkBlockElement', () => {
+		const input: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							_type:
+								'model.dotcomrendering.pageElements.TextBlockElement',
+							elementId: 'mockId',
+							html: 'some HTML text',
+						},
+						{
+							_type:
+								'model.dotcomrendering.pageElements.TextBlockElement',
+							elementId: 'mockId',
+							html: '<p><strong>Faux H3 text</strong></p>',
+						},
+					],
+				},
+			],
+		};
+		const expectedOutput: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							_type:
+								'model.dotcomrendering.pageElements.TextBlockElement',
+							elementId: 'mockId',
+							html: 'some HTML text',
+						},
+						{
+							_type:
+								'model.dotcomrendering.pageElements.DividerBlockElement',
+							size: 'full',
+							spaceAbove: 'tight',
+						},
+						{
+							_type:
+								'model.dotcomrendering.pageElements.TextBlockElement',
+							elementId: 'mockId',
+							html: '<h3>Faux H3 text</h3>',
+						},
+					],
+				},
+			],
+		};
+		expect(enhanceNumberedLists(input)).toEqual(expectedOutput);
+	});
+
 	it('replaces ★★★★☆ with the StarRating component', () => {
 		const input: CAPIType = {
 			...NumberedList,

--- a/src/model/enhance-numbered-lists.ts
+++ b/src/model/enhance-numbered-lists.ts
@@ -177,45 +177,6 @@ const makeThumbnailsRound = (elements: CAPIElement[]): CAPIElement[] => {
 	return inlined;
 };
 
-const addH3s = (elements: CAPIElement[]): CAPIElement[] => {
-	/**
-	 * Why not just add H3s in Composer?
-	 * Truth is, you can't. So to get around this there's a convention that says if
-	 * you insert <p><strong>Faux H3!</strong>,</p> then we replace it with a h3 tag
-	 * instead.
-	 *
-	 * Note. H3s don't have any styles so we have to add them. In Frontend, they use
-	 * a 'fauxH3' class for this. In DCR we add `globalH3Styles` which was added at
-	 * the same time as this code.
-	 */
-	const withH3s: CAPIElement[] = [];
-	elements.forEach((thisElement) => {
-		if (
-			thisElement._type ===
-				'model.dotcomrendering.pageElements.TextBlockElement' &&
-			isFalseH3(thisElement)
-		) {
-			const h3Text = extractH3(thisElement);
-			withH3s.push(
-				{
-					_type:
-						'model.dotcomrendering.pageElements.DividerBlockElement',
-					size: 'full',
-					spaceAbove: 'tight',
-				},
-				{
-					...thisElement,
-					html: `<h3>${h3Text}</h3>`,
-				},
-			);
-		} else {
-			// Pass through
-			withH3s.push(thisElement);
-		}
-	});
-	return withH3s;
-};
-
 const isItemLink = (element: CAPIElement): boolean => {
 	if (!element) return false;
 	// Checks if this element is a 'item link' based on the convention: <ul> <li>...</li> </ul>
@@ -233,6 +194,55 @@ const isItemLink = (element: CAPIElement): boolean => {
 		frag.firstElementChild?.firstElementChild?.nodeName === 'LI';
 
 	return hasULWrapper && hasOnlyOneChild && hasLINestedWrapper;
+};
+
+const addH3s = (elements: CAPIElement[]): CAPIElement[] => {
+	/**
+	 * Why not just add H3s in Composer?
+	 * Truth is, you can't. So to get around this there's a convention that says if
+	 * you insert <p><strong>Faux H3!</strong>,</p> then we replace it with a h3 tag
+	 * instead.
+	 *
+	 * Note. H3s don't have any styles so we have to add them. In Frontend, they use
+	 * a 'fauxH3' class for this. In DCR we add `globalH3Styles` which was added at
+	 * the same time as this code.
+	 */
+	const withH3s: CAPIElement[] = [];
+	let previousItem: CAPIElement | undefined;
+	elements.forEach((thisElement) => {
+		if (
+			thisElement._type ===
+				'model.dotcomrendering.pageElements.TextBlockElement' &&
+			isFalseH3(thisElement)
+		) {
+			const h3Text = extractH3(thisElement);
+
+			// To avoid having to depend on the ordering of the enhancer (which could easily be a source of bugs)
+			// We determin if previous items are `ItemLinkBlockElement` through type and `isItemLink` functions
+			const isPreviousItemLink =
+				previousItem?._type ===
+					'model.dotcomrendering.pageElements.ItemLinkBlockElement' ||
+				(previousItem && isItemLink(previousItem));
+
+			withH3s.push(
+				{
+					_type:
+						'model.dotcomrendering.pageElements.DividerBlockElement',
+					size: 'full',
+					spaceAbove: isPreviousItemLink ? 'loose' : 'tight',
+				},
+				{
+					...thisElement,
+					html: `<h3>${h3Text}</h3>`,
+				},
+			);
+		} else {
+			// Pass through
+			withH3s.push(thisElement);
+		}
+		previousItem = thisElement;
+	});
+	return withH3s;
 };
 
 const addItemLinks = (elements: CAPIElement[]): CAPIElement[] => {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Set `spaceAbove` on `DividerBlockElement` to  `loose` on dividers that sit between Links and h3

### Before
<img width="654" alt="Screenshot 2021-04-28 at 16 20 29" src="https://user-images.githubusercontent.com/8831403/116429336-b51d4d80-a83d-11eb-819b-083b31f56eba.png">

### After
<img width="672" alt="Screenshot 2021-04-28 at 16 08 45" src="https://user-images.githubusercontent.com/8831403/116429352-b8b0d480-a83d-11eb-9e81-f8274cad2022.png">

## Why?
We need to have larger spacing between links and h3 blocks, without applying spacing to all h3 blocks