### PR TITLE
Add removeCookie function to clear people's opt in to server side test

### DIFF
--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -38,7 +38,7 @@ import { decideDesign } from '@root/src/web/lib/decideDesign';
 import { loadScript } from '@root/src/web/lib/loadScript';
 import { useOnce } from '@root/src/web/lib/useOnce';
 import { initPerf } from '@root/src/web/browser/initPerf';
-import { getCookie, addCookie } from '@root/src/web/browser/cookie';
+import { getCookie, removeCookie } from '@root/src/web/browser/cookie';
 import { getCountryCode } from '@frontend/web/lib/getCountryCode';
 import { getUser } from '@root/src/web/lib/getUser';
 
@@ -242,7 +242,8 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 	// show the anniversary atom. This means that this user will not see the atom
 	// on the next and following page views.
 	useEffect(() => {
-		addCookie('X-GU-Experiment-0perc-B', 'true', 10); // 10 days to live for the life of the atom being shown
+		// addCookie('X-GU-Experiment-0perc-B', 'true', 10); // 10 days to live for the life of the atom being shown
+		removeCookie('X-GU-Experiment-0perc-B');
 	});
 
 	// Ensure the focus state of any buttons/inputs in any of the Source


### PR DESCRIPTION
## What does this change?

I realised we have been prematurely opting people into the 'HideAnniversaryAtom' server side test, so visitors to the site would not see the atom. This is to try and clear those browsers.