### PR TITLE
Anniversary Atom: Remove tests switches and switch a/b test over to correct one

### DIFF
--- a/src/model/enhance-AnniversaryInteractiveAtom.ts
+++ b/src/model/enhance-AnniversaryInteractiveAtom.ts
@@ -1,22 +1,16 @@
 import { getAnniversaryAtomCache } from '@root/src/web/server/cacheForAnniversaryInteractiveAtom';
 
 export const enhanceAnniversaryAtom = (data: CAPIType): CAPIType => {
-	// TODO Add switch
 	const { anniversaryArticleHeader } = data.config.switches;
-	const {
-		hideAnniversaryAtomVariant,
-		anniversaryAtomVariant,
-	} = data.config.abTests;
+	const { hideAnniversaryAtomVariant } = data.config.abTests;
 	const { editionId, pageType, shouldHideAds } = data;
 
 	// If
 	// - the main anniversaryArticleHeader switch is ON
 	// - the user is NOT in the hideAnniversaryAtom test VARIANT
-	// - the user IS in the anniversaryAtom test variant (for test purposes)
 	// Users will be opted-in to VARIANT of the AB Test IF THEY HAVE SEEN THE BANNER.
 	if (
 		anniversaryArticleHeader && // The main switch is set to ON
-		anniversaryAtomVariant === 'variant' && // Opted into the 0% test for testing purposes
 		hideAnniversaryAtomVariant !== 'variant' && // Not opted into the 0% A/B test used for hiding the atom
 		editionId !== 'AU' && // Not in the AU edition
 		!pageType.isSensitive && // The page isn't sensitive

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -38,7 +38,7 @@ import { decideDesign } from '@root/src/web/lib/decideDesign';
 import { loadScript } from '@root/src/web/lib/loadScript';
 import { useOnce } from '@root/src/web/lib/useOnce';
 import { initPerf } from '@root/src/web/browser/initPerf';
-import { getCookie, removeCookie } from '@root/src/web/browser/cookie';
+import { getCookie, addCookie } from '@root/src/web/browser/cookie';
 import { getCountryCode } from '@frontend/web/lib/getCountryCode';
 import { getUser } from '@root/src/web/lib/getUser';
 
@@ -242,8 +242,9 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 	// show the anniversary atom. This means that this user will not see the atom
 	// on the next and following page views.
 	useEffect(() => {
-		// addCookie('X-GU-Experiment-0perc-B', 'true', 10); // 10 days to live for the life of the atom being shown
-		removeCookie('X-GU-Experiment-0perc-B');
+		if (CAPI.config.switches.anniversaryArticleHeader) {
+			addCookie('X-GU-Experiment-0perc-D', 'true', 2); // 2 days to live means that the atom will show when the switch is on Wednesday AND Saturday
+		}
 	});
 
 	// Ensure the focus state of any buttons/inputs in any of the Source


### PR DESCRIPTION
## What does this change?

- Remove the testing 0% test from the checks whether to show the atom
- Adds a cookie for 0% a/b test D with a 2 day TTL (so that it drops on Wednesday, and expires by Saturday)