### PR TITLE
Anniversary Atom: Inline the atom instead of iframing

### DIFF
--- a/src/web/components/AnniversaryAtomComponent.tsx
+++ b/src/web/components/AnniversaryAtomComponent.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { css } from 'emotion';
-import { InteractiveAtom } from '@guardian/atoms-rendering';
 import { from } from '@guardian/src-foundations/mq';
 
 const atomStyles = (
@@ -42,19 +41,40 @@ const atomStyles = (
 		}
 	}
 `;
+
+export const InlineAnniversaryAtom = ({
+	html,
+	atomCss,
+	js,
+}: {
+	html: string | undefined;
+	atomCss: string | undefined;
+	js: string;
+}) => {
+	return (
+		<>
+			{atomCss && <style dangerouslySetInnerHTML={{ __html: atomCss }} />}
+
+			{html && <div dangerouslySetInnerHTML={{ __html: html }} />}
+			<script dangerouslySetInnerHTML={{ __html: js }} />
+		</>
+	);
+};
 export const AnniversaryAtomComponent = ({
 	anniversaryInteractiveAtom,
 }: {
 	anniversaryInteractiveAtom: InteractiveAtomBlockElement | undefined;
 }) => {
 	return (
-		<div className={atomStyles(anniversaryInteractiveAtom)}>
+		<div
+			className={atomStyles(anniversaryInteractiveAtom)}
+			data-visuals-hook="article-anniversary-atom"
+		>
 			{anniversaryInteractiveAtom && (
-				<InteractiveAtom
+				<InlineAnniversaryAtom
 					html={anniversaryInteractiveAtom.html}
 					js={anniversaryInteractiveAtom.js}
-					css={anniversaryInteractiveAtom.css}
-					id={anniversaryInteractiveAtom.id}
+					atomCss={anniversaryInteractiveAtom.css}
 				/>
 			)}
 		</div>


### PR DESCRIPTION
## What does this change?

This breaks the atom out of the iframe so that:

- We match what is happening with the atom on Fronts (they're not iframed)
- We can target the atom in the CSS with the data attribute

There should be no visual difference between the two as there are no global styles targeting anything outside of the article container.