### PR TITLE
Remove unique strong tag condition for falseH3

### DIFF
--- a/src/model/enhance-numbered-lists.test.ts
+++ b/src/model/enhance-numbered-lists.test.ts
@@ -85,7 +85,7 @@ describe('Enhance Numbered Lists', () => {
 		expect(enhanceNumberedLists(input)).toEqual(expectedOutput);
 	});
 
-	it('does not set a h3 if there is more than one strong tag', () => {
+	it('does set a h3 if there is more than one strong tag', () => {
 		const input: CAPIType = {
 			...NumberedList,
 			blocks: [
@@ -97,7 +97,7 @@ describe('Enhance Numbered Lists', () => {
 								'model.dotcomrendering.pageElements.TextBlockElement',
 							elementId: 'mockId',
 							html:
-								'<p><strong>Strong 1</strong><strong>Strong 2</strong></p>',
+								'<p><strong>Strong 1</strong> <strong>Strong 2</strong></p>',
 						},
 					],
 				},
@@ -111,10 +111,15 @@ describe('Enhance Numbered Lists', () => {
 					elements: [
 						{
 							_type:
+								'model.dotcomrendering.pageElements.DividerBlockElement',
+							size: 'full',
+							spaceAbove: 'tight',
+						},
+						{
+							_type:
 								'model.dotcomrendering.pageElements.TextBlockElement',
 							elementId: 'mockId',
-							html:
-								'<p><strong>Strong 1</strong><strong>Strong 2</strong></p>',
+							html: '<h3>Strong 1 Strong 2</h3>',
 						},
 					],
 				},

--- a/src/model/enhance-numbered-lists.ts
+++ b/src/model/enhance-numbered-lists.ts
@@ -11,7 +11,7 @@ const isFalseH3 = (element: CAPIElement): boolean => {
 	const frag = JSDOM.fragment(element.html);
 	if (!frag || !frag.firstElementChild) return false;
 	const html = frag.firstElementChild.outerHTML;
-	const text = frag.firstElementChild.textContent;
+	// const text = frag.firstElementChild.textContent;
 	// The following things must be true for an element to be a faux H3
 	const hasPwrapper = frag.firstElementChild.nodeName === 'P';
 	const containsStrongtags = frag.firstElementChild.outerHTML.includes(
@@ -20,9 +20,7 @@ const isFalseH3 = (element: CAPIElement): boolean => {
 	const doesNotContainLinks = !frag.firstElementChild.outerHTML.includes(
 		'<a>',
 	);
-	const textLength = text?.length;
 	const htmlLength = html.length;
-	const onlyHasOneStrongTag = textLength === htmlLength - 24;
 	const startStrong = html.substr(0, 11) === '<p><strong>';
 	const endsStrong = html.substr(htmlLength - 13) === '</strong></p>';
 
@@ -30,7 +28,6 @@ const isFalseH3 = (element: CAPIElement): boolean => {
 		hasPwrapper &&
 		containsStrongtags &&
 		doesNotContainLinks &&
-		onlyHasOneStrongTag &&
 		startStrong &&
 		endsStrong
 	);

--- a/src/model/enhance-numbered-lists.ts
+++ b/src/model/enhance-numbered-lists.ts
@@ -11,7 +11,6 @@ const isFalseH3 = (element: CAPIElement): boolean => {
 	const frag = JSDOM.fragment(element.html);
 	if (!frag || !frag.firstElementChild) return false;
 	const html = frag.firstElementChild.outerHTML;
-	// const text = frag.firstElementChild.textContent;
 	// The following things must be true for an element to be a faux H3
 	const hasPwrapper = frag.firstElementChild.nodeName === 'P';
 	const containsStrongtags = frag.firstElementChild.outerHTML.includes(

--- a/src/web/components/ArticleBody.tsx
+++ b/src/web/components/ArticleBody.tsx
@@ -28,7 +28,7 @@ const globalH2Styles = (display: Display) => css`
 `;
 
 const globalH3Styles = (display: Display) => {
-	// if (display !== Display.NumberedList) return null;
+	if (display !== Display.NumberedList) return null;
 	return css`
 		h3 {
 			${headline.xxsmall({ fontWeight: 'bold' })};

--- a/src/web/components/ArticleBody.tsx
+++ b/src/web/components/ArticleBody.tsx
@@ -28,7 +28,7 @@ const globalH2Styles = (display: Display) => css`
 `;
 
 const globalH3Styles = (display: Display) => {
-	if (display !== Display.NumberedList) return null;
+	// if (display !== Display.NumberedList) return null;
 	return css`
 		h3 {
 			${headline.xxsmall({ fontWeight: 'bold' })};


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Allow support of multiple `strong` tags in fauxH3

### Before
<img width="681" alt="Screenshot 2021-04-29 at 17 03 30" src="https://user-images.githubusercontent.com/8831403/116582028-d7ca6780-a90c-11eb-880c-153a7f3acbdd.png">

### After
![Screenshot 2021-04-29 at 13 58 09](https://user-images.githubusercontent.com/8831403/116582042-da2cc180-a90c-11eb-8b4a-a001d16bdac7.png)

## Why?
The assumption of only having 1 `strong` tag was incorrect

example article: 
https://www.theguardian.com/world/2020/mar/25/coronavirus-key-questions-answers-everything-you-need-to-know-covid-19 