### PR TITLE
Numbered list standfirst styles

### DIFF
--- a/src/web/components/Standfirst.tsx
+++ b/src/web/components/Standfirst.tsx
@@ -103,6 +103,7 @@ const standfirstStyles = (format: Format, palette: Palette) => {
 				max-width: 540px;
 				color: ${palette.text.standfirst};
 			`;
+
 		case Display.Showcase:
 		case Display.Standard:
 		default: {

--- a/src/web/components/Standfirst.tsx
+++ b/src/web/components/Standfirst.tsx
@@ -94,8 +94,16 @@ const standfirstStyles = (format: Format, palette: Palette) => {
 					`;
 			}
 
-		case Display.Showcase:
 		case Display.NumberedList:
+			return css`
+				${headline.xxsmall({
+					fontWeight: 'bold',
+				})};
+				margin-bottom: ${space[3]}px;
+				max-width: 540px;
+				color: ${palette.text.standfirst};
+			`;
+		case Display.Showcase:
 		case Display.Standard:
 		default: {
 			switch (format.design) {
@@ -104,7 +112,6 @@ const standfirstStyles = (format: Format, palette: Palette) => {
 				case Design.Letter:
 				case Design.Feature:
 				case Design.Recipe:
-				case Design.Review:
 					return css`
 						${headline.xxsmall({
 							fontWeight: 'light',

--- a/src/web/components/Standfirst.tsx
+++ b/src/web/components/Standfirst.tsx
@@ -112,6 +112,7 @@ const standfirstStyles = (format: Format, palette: Palette) => {
 				case Design.Letter:
 				case Design.Feature:
 				case Design.Recipe:
+				case Design.Review:
 					return css`
 						${headline.xxsmall({
 							fontWeight: 'light',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Numbered list has its own styles for `standfirst`

### Before
<img width="816" alt="Screenshot 2021-04-30 at 14 19 08" src="https://user-images.githubusercontent.com/8831403/116706654-be392680-a9c5-11eb-8589-cf4b19088c25.png">

### After
<img width="988" alt="Screenshot 2021-04-30 at 15 06 27" src="https://user-images.githubusercontent.com/8831403/116706665-c1341700-a9c5-11eb-9da6-58137a92786b.png">

## Why?
Numbered list benefits from `fontWeight: 'bold',` as it contains larger headers in its content