### PR TITLE
Remove global image styles

### DIFF
--- a/src/web/components/ArticleBody.tsx
+++ b/src/web/components/ArticleBody.tsx
@@ -43,13 +43,6 @@ const globalStrongStyles = css`
 	}
 `;
 
-const globalImgStyles = css`
-	img {
-		width: 100%;
-		height: auto;
-	}
-`;
-
 const bodyPadding = css`
 	${between.tablet.and.desktop} {
 		padding-right: 80px;
@@ -83,13 +76,7 @@ export const ArticleBody = ({
 		format.design === Design.DeadBlog
 	) {
 		return (
-			<div
-				className={cx(
-					globalStrongStyles,
-					globalImgStyles,
-					globalLinkStyles(palette),
-				)}
-			>
+			<div className={cx(globalStrongStyles, globalLinkStyles(palette))}>
 				<LiveBlogRenderer
 					format={format}
 					blocks={blocks}
@@ -108,7 +95,6 @@ export const ArticleBody = ({
 				globalH2Styles(format.display),
 				globalH3Styles(format.display),
 				globalStrongStyles,
-				globalImgStyles,
 				globalLinkStyles(palette),
 			)}
 		>


### PR DESCRIPTION
## What does this change?

Removes the global image styles:

- Global styles are not ideal and we should aim to always style within components directly
- These global styles were interfering with Interactive Atoms that already existed.
- There does not seem to be anywhere in the platform that required the global styles as far as chromatic is concerned

