### PR TITLE
Identity | Sign In Gate | Remove sign in gate from isPaidContent

### DIFF
--- a/cypress/integration/parallel-1/sign-in-gate.spec.js
+++ b/cypress/integration/parallel-1/sign-in-gate.spec.js
@@ -125,6 +125,15 @@ describe('Sign In Gate Tests', function () {
 			cy.get('[data-cy=sign-in-gate-main]').should('not.exist');
 		});
 
+		it('should not load the sign in gate if the article is a paid article', function () {
+			visitArticleAndScrollToGateForLazyLoad({
+				url:
+					'https://www.theguardian.com/with-you-all-the-way/2021/mar/16/kettlebells-companionship-and-bedroom-parkour-nine-tips-for-keeping-fit-in-lockdown-or-long-haul',
+			});
+
+			cy.get('[data-cy=sign-in-gate-main]').should('not.exist');
+		});
+
 		it('should not load the sign in gate on a device with an ios9 user agent string', function () {
 			// can't use visitArticleAndScrollToGateForLazyLoad for this method as overriding user agent
 			cy.visit(

--- a/src/web/components/SignInGate/displayRule.ts
+++ b/src/web/components/SignInGate/displayRule.ts
@@ -67,6 +67,10 @@ export const isValidTag = (CAPI: CAPIBrowserType): boolean => {
 	);
 };
 
+// hide the sign in gate on isPaidContent
+export const isPaidContent = (CAPI: CAPIBrowserType): boolean =>
+	CAPI.pageType.isPaidContent;
+
 export const canShow = (
 	CAPI: CAPIBrowserType,
 	isSignedIn: boolean,
@@ -82,4 +86,5 @@ export const canShow = (
 	isValidContentType(CAPI) &&
 	isValidSection(CAPI) &&
 	isValidTag(CAPI) &&
+	!isPaidContent(CAPI) &&
 	!isIOS9();

--- a/src/web/components/SignInGate/gates/main-control.ts
+++ b/src/web/components/SignInGate/gates/main-control.ts
@@ -8,6 +8,7 @@ import {
 	isValidSection,
 	isValidTag,
 	isIOS9,
+	isPaidContent,
 } from '@frontend/web/components/SignInGate/displayRule';
 import { hasUserDismissedGate } from '../dismissGate';
 
@@ -22,6 +23,7 @@ const canShow = (
 	isValidContentType(CAPI) &&
 	isValidSection(CAPI) &&
 	isValidTag(CAPI) &&
+	!isPaidContent(CAPI) &&
 	!isIOS9();
 
 export const signInGateComponent: SignInGateComponent = {


### PR DESCRIPTION
It was brought to our attention by @jfsoul that the Sign In Gate would appear on paid/sponsored articles. We came to the conclusion that it should not appear on these pages. On frontend there is already a check to see if an article is paid/sponsored, but this was not ported over to DCR.

This PR adds a check for this by looking for the `isPaidContent` value in the the CAPI response, and uses this to determine if the gate should show or not.
