### PR TITLE
Set braze epic timeout to 5 seconds.

### DIFF
--- a/src/web/components/SlotBodyEnd/SlotBodyEnd.tsx
+++ b/src/web/components/SlotBodyEnd/SlotBodyEnd.tsx
@@ -83,7 +83,7 @@ const buildBrazeEpicConfig = (
 				/>
 			),
 		},
-		timeoutMillis: null,
+		timeoutMillis: 5000,
 	};
 };
 


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

### Before
If there was a slot body end candidate after the Braze Epic, it would never show if Braze didn't respond.

### After
After a 5 seconds of trying to request a message to show from Braze, slot body end will give up and show next Epic candidate.

## Why?
This is necessary requirement before switching the priority to show the Braze epic before the RR epic.
