### PR TITLE
Increase divider block margin top on tigtht

### DIFF
--- a/src/web/components/elements/DividerBlockComponent.tsx
+++ b/src/web/components/elements/DividerBlockComponent.tsx
@@ -24,7 +24,7 @@ const sizePartialStyle = css`
 `;
 
 const tightSpaceAboveStyle = css`
-	margin-top: ${space[5]}px;
+	margin-top: ${space[6]}px;
 `;
 const looseSpaceAboveStyle = css`
 	margin-top: ${space[12]}px;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Use 24px top margin rather than 20px

### Before
![margin-top-before](https://user-images.githubusercontent.com/8831403/117017947-f4d7af80-aceb-11eb-95ba-61f8b15289d0.PNG)

### After
![margin-top-afterPNG](https://user-images.githubusercontent.com/8831403/117017999-05882580-acec-11eb-8013-bff5566822eb.PNG)

## Why?
We were using the wrong top margin