### PR TITLE
Numbered list show author name

### DIFF
--- a/src/web/components/ArticleMeta.tsx
+++ b/src/web/components/ArticleMeta.tsx
@@ -172,6 +172,8 @@ const shouldShowAvatar = (format: Format) => {
 
 const shouldShowContributor = (format: Format) => {
 	switch (format.display) {
+		case Display.NumberedList:
+			return true;
 		case Display.Immersive:
 			return false;
 		case Display.Showcase:


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Display author's name on numbered lists

### Before
![numbered list author name old](https://user-images.githubusercontent.com/8831403/117037447-628cd700-acfe-11eb-9da2-413df512222e.PNG)

### After
![numbered list author name](https://user-images.githubusercontent.com/8831403/117037458-64569a80-acfe-11eb-82d1-e8848e756f15.PNG)

## Why?
We should show authors on numbered list
