### PR TITLE
Numbered list h2 bold

### DIFF
--- a/src/web/components/elements/NumberedTitleBlockComponent.tsx
+++ b/src/web/components/elements/NumberedTitleBlockComponent.tsx
@@ -14,7 +14,7 @@ type Props = {
 
 const titleStyles = (palette: Palette) => css`
 	h2 {
-		${headline.medium({ fontWeight: 'light' })}
+		${headline.medium({ fontWeight: 'bold' })}
 	}
 
 	strong {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
All h2 in numbered list have bold

### Before
![normal](https://user-images.githubusercontent.com/8831403/117052555-c8ce2580-ad0f-11eb-8ea7-72a6f8d07798.PNG)

### After
![bold](https://user-images.githubusercontent.com/8831403/117052558-cb307f80-ad0f-11eb-8ae9-a9c38928a5b6.PNG)

## Why?
headers should be bold