### PR TITLE
Hardcode ImmersiveComment as ImmersiveArticle

### DIFF
--- a/src/web/lib/decideDesign.ts
+++ b/src/web/lib/decideDesign.ts
@@ -12,7 +12,10 @@ export const decideDesign = (format: CAPIFormat): Design => {
 		case 'AnalysisDesign':
 			return Design.Analysis;
 		case 'CommentDesign':
-			return Design.Comment;
+			// Temporary hack until we can handle Immersive Opinion pieces
+			return format.display === 'ImmersiveDisplay'
+				? Design.Article
+				: Design.Comment;
 		case 'LetterDesign':
 			return Design.Letter;
 		case 'FeatureDesign':


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
We can't currently handle `ImmersiveDisplay` and `CommentDesign`
together so this override `CommentDesign` to be `ArticleDesign` when the
display type is `ImmersiveDisplay`.

### Before
![before](https://user-images.githubusercontent.com/9122944/117117862-f2c32e80-ad87-11eb-8110-686beea43dc3.png)

### After
![after](https://user-images.githubusercontent.com/9122944/117117887-fb1b6980-ad87-11eb-9e4f-604db21371a1.png)


## Why?
Temporary fix for a broken format combination