### PR TITLE
Fix FauxH3 title link

### DIFF
--- a/src/model/enhance-numbered-lists.test.ts
+++ b/src/model/enhance-numbered-lists.test.ts
@@ -128,6 +128,94 @@ describe('Enhance Numbered Lists', () => {
 		expect(enhanceNumberedLists(input)).toEqual(expectedOutput);
 	});
 
+	it('does set a h3 if there is more than one strong tag', () => {
+		const input: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							_type:
+								'model.dotcomrendering.pageElements.TextBlockElement',
+							elementId: 'mockId',
+							html:
+								'<p><strong>Strong 1</strong> <strong>Strong 2 <a href="example.com">Some Link</a></strong></p>',
+						},
+					],
+				},
+			],
+		};
+		const expectedOutput: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							_type:
+								'model.dotcomrendering.pageElements.DividerBlockElement',
+							size: 'full',
+							spaceAbove: 'tight',
+						},
+						{
+							_type:
+								'model.dotcomrendering.pageElements.TextBlockElement',
+							elementId: 'mockId',
+							html:
+								'<h3>Strong 1 Strong 2 <a href="example.com">Some Link</a></h3>',
+						},
+					],
+				},
+			],
+		};
+		expect(enhanceNumberedLists(input)).toEqual(expectedOutput);
+	});
+
+	it('does set an h3 and extract all text even if it is between stong tages', () => {
+		const input: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							_type:
+								'model.dotcomrendering.pageElements.TextBlockElement',
+							elementId: 'mockId',
+							html:
+								'<p><strong>Strong 1</strong> some text inbetween <strong>Strong 2</strong></p>',
+						},
+					],
+				},
+			],
+		};
+		const expectedOutput: CAPIType = {
+			...NumberedList,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							_type:
+								'model.dotcomrendering.pageElements.DividerBlockElement',
+							size: 'full',
+							spaceAbove: 'tight',
+						},
+						{
+							_type:
+								'model.dotcomrendering.pageElements.TextBlockElement',
+							elementId: 'mockId',
+							html:
+								'<h3>Strong 1 some text inbetween Strong 2</h3>',
+						},
+					],
+				},
+			],
+		};
+		expect(enhanceNumberedLists(input)).toEqual(expectedOutput);
+	});
+
 	it('does not set a h3 if there is text before the strong tag', () => {
 		const input: CAPIType = {
 			...NumberedList,

--- a/src/model/enhance-numbered-lists.ts
+++ b/src/model/enhance-numbered-lists.ts
@@ -37,7 +37,13 @@ const extractH3 = (element: CAPIElement): string => {
 	const textElement = element as TextBlockElement;
 	const frag = JSDOM.fragment(textElement.html);
 	if (isFalseH3(element)) {
-		return frag.firstElementChild?.firstElementChild?.innerHTML || '';
+		return (
+			frag.firstElementChild?.innerHTML
+				.split('<strong>')
+				.join('')
+				.split('</strong>')
+				.join('') || ''
+		);
 	}
 	return '';
 };

--- a/src/model/enhance-numbered-lists.ts
+++ b/src/model/enhance-numbered-lists.ts
@@ -37,7 +37,7 @@ const extractH3 = (element: CAPIElement): string => {
 	const textElement = element as TextBlockElement;
 	const frag = JSDOM.fragment(textElement.html);
 	if (isFalseH3(element)) {
-		return frag.firstElementChild?.textContent || '';
+		return frag.firstElementChild?.firstElementChild?.innerHTML || '';
 	}
 	return '';
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Use `innerHTML` instead of `textContent` as not to loose other HTML tags in text (notably links)

### Before
![title link DCR](https://user-images.githubusercontent.com/8831403/117164705-c7a70200-adbc-11eb-9354-9916464b81aa.PNG)

### After
![fix DCR link title](https://user-images.githubusercontent.com/8831403/117164972-0046db80-adbd-11eb-83b7-427893256eeb.PNG)

## Why?
We should not loose nested HTML