### PR TITLE
Labs: Updating series/standfirst/headline weightings

### DIFF
--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -35,10 +35,10 @@ const standardFont = css`
 `;
 
 const labsFont = css`
-	${textSans.xlarge()};
+	${textSans.xlarge({ fontWeight: 'bold' })};
 	line-height: 32px;
 	${from.tablet} {
-		${textSans.xxxlarge()};
+		${textSans.xxxlarge({ fontWeight: 'bold' })};
 		line-height: 38px;
 	}
 `;

--- a/src/web/components/SeriesSectionLink.tsx
+++ b/src/web/components/SeriesSectionLink.tsx
@@ -69,10 +69,10 @@ const invertedStyle = css`
 const fontStyles = (format: Format) => {
 	if (format.theme === Special.Labs) {
 		return css`
-			${textSans.medium({ fontWeight: 'bold' })}
+			${textSans.large()}
 			line-height: 23px;
 			${from.leftCol} {
-				${textSans.large({ fontWeight: 'bold' })}
+				${textSans.large()}
 				line-height: 20px;
 			}
 		`;

--- a/src/web/components/Standfirst.tsx
+++ b/src/web/components/Standfirst.tsx
@@ -77,7 +77,7 @@ const standfirstStyles = (format: Format, palette: Palette) => {
 				default:
 					return css`
 						${format.theme === Special.Labs
-							? textSans.large()
+							? textSans.medium()
 							: headline.xsmall({
 									fontWeight: 'light',
 							  })};
@@ -137,7 +137,7 @@ const standfirstStyles = (format: Format, palette: Palette) => {
 				default:
 					return css`
 						${format.theme === Special.Labs
-							? textSans.large()
+							? textSans.medium()
 							: headline.xxxsmall({
 									fontWeight: 'bold',
 							  })};


### PR DESCRIPTION
Before:
<img width="920" alt="Screen Shot 2021-05-06 at 14 53 19" src="https://user-images.githubusercontent.com/2051501/117310128-ec61af00-ae7a-11eb-900b-19b36fa91113.png">

After:
<img width="920" alt="Screen Shot 2021-05-06 at 14 50 44" src="https://user-images.githubusercontent.com/2051501/117310113-e9ff5500-ae7a-11eb-914e-d1d409ffd31e.png">

For parity with new labs designs