### PR TITLE
Remove email embed using alt as caption and move to iframe title

### DIFF
--- a/src/model/enhance-embeds.test.ts
+++ b/src/model/enhance-embeds.test.ts
@@ -1,0 +1,68 @@
+import { Article } from '@root/fixtures/generated/articles/Article';
+import { enhanceEmbeds } from './enhance-embeds';
+
+const example = Article;
+const metaData = {
+	id: '123',
+	primaryDateLine: 'Wed 9 Dec 2020 06.30 GMT',
+	secondaryDateLine: 'Last modified on Wed 9 Dec 2020 13.40 GMT',
+};
+
+describe('Enhance Embeds', () => {
+	it('creates an identical but new object when no changes are needed', () => {
+		expect(enhanceEmbeds(example)).not.toBe(example); // We created a new object
+		expect(enhanceEmbeds(example)).toEqual(example); // The new object is what we expect
+	});
+
+	it('sets the divider flag correctly', () => {
+		const input: CAPIType = {
+			...example,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							html:
+								'<iframe id="the-fiver" name="the-fiver" src="https://www.theguardian.com/email/form/plaintone/the-fiver" scrolling="no" seamless="" class="iframed--overflow-hidden email-sub__iframe" height="52px" frameborder="0" data-component="email-embed--the-fiver"></iframe>',
+							safe: true,
+							alt: 'Sign up to The Fiver',
+							isMandatory: true,
+							isThirdPartyTracking: false,
+							source: 'The Guardian',
+							sourceDomain: 'theguardian.com',
+							_type:
+								'model.dotcomrendering.pageElements.EmbedBlockElement',
+							elementId: '17bb4750-37c3-4cef-a535-82a5c40509fd',
+						},
+					],
+				},
+			],
+		};
+
+		const expectedOutput = {
+			...example,
+			blocks: [
+				{
+					...metaData,
+					elements: [
+						{
+							html:
+								'<iframe id="the-fiver" name="the-fiver" src="https://www.theguardian.com/email/form/plaintone/the-fiver" scrolling="no" seamless="" class="iframed--overflow-hidden email-sub__iframe" height="52px" frameborder="0" data-component="email-embed--the-fiver" title="Sign up to The Fiver"></iframe>',
+							safe: true,
+							alt: 'Sign up to The Fiver',
+							isMandatory: true,
+							isThirdPartyTracking: false,
+							source: 'The Guardian',
+							sourceDomain: 'theguardian.com',
+							_type:
+								'model.dotcomrendering.pageElements.EmbedBlockElement',
+							elementId: '17bb4750-37c3-4cef-a535-82a5c40509fd',
+						},
+					],
+				},
+			],
+		};
+
+		expect(enhanceEmbeds(input)).toEqual(expectedOutput);
+	});
+});

--- a/src/model/enhance-embeds.ts
+++ b/src/model/enhance-embeds.ts
@@ -1,0 +1,44 @@
+import { JSDOM } from 'jsdom';
+
+const addTitleToIframe = (elements: CAPIElement[]): CAPIElement[] => {
+	const enhanced: CAPIElement[] = [];
+	elements.forEach((element) => {
+		switch (element._type) {
+			case 'model.dotcomrendering.pageElements.EmbedBlockElement':
+				// Parse the embed block element, find the iframe and add
+				// the alt text as a title attribute if it exists
+				// https://dequeuniversity.com/tips/provide-iframe-titles
+				const dom = JSDOM.fragment(element.html);
+				const iframe = dom.querySelector('iframe');
+				if (iframe && element.alt) {
+					iframe.setAttribute('title', element.alt);
+					enhanced.push({
+						...element,
+						...{
+							html: iframe.outerHTML,
+						},
+					});
+				} else {
+					enhanced.push(element);
+				}
+				break;
+			default:
+				enhanced.push(element);
+		}
+	});
+	return enhanced;
+};
+
+export const enhanceEmbeds = (data: CAPIType): CAPIType => {
+	const enhancedBlocks = data.blocks.map((block: Block) => {
+		return {
+			...block,
+			elements: addTitleToIframe(block.elements),
+		};
+	});
+
+	return {
+		...data,
+		blocks: enhancedBlocks,
+	} as CAPIType;
+};

--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -804,10 +804,7 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 							source={embed.source}
 							sourceDomain={embed.sourceDomain}
 						>
-							<EmbedBlockComponent
-								html={embed.html}
-								alt={embed.alt}
-							/>
+							<EmbedBlockComponent html={embed.html} />
 						</ClickToView>
 					) : (
 						<ClickToView

--- a/src/web/components/ClickToView.stories.tsx
+++ b/src/web/components/ClickToView.stories.tsx
@@ -480,7 +480,6 @@ export const EmbedBlockComponentStory = () => {
 						<EmbedBlockComponent
 							key={1}
 							html={facebookEmbed.html}
-							alt={facebookEmbed.alt}
 						/>
 					</ClickToView>
 				</Figure>
@@ -501,7 +500,6 @@ export const EmbedBlockComponentStory = () => {
 						<EmbedBlockComponent
 							key={1}
 							html={vimeoEmbedEmbed.html}
-							alt={vimeoEmbedEmbed.alt}
 						/>
 					</ClickToView>
 				</Figure>
@@ -522,7 +520,6 @@ export const EmbedBlockComponentStory = () => {
 						<EmbedBlockComponent
 							key={1}
 							html={youtubeEmbedEmbed.html}
-							alt={youtubeEmbedEmbed.alt}
 						/>
 					</ClickToView>
 				</Figure>
@@ -543,7 +540,6 @@ export const EmbedBlockComponentStory = () => {
 						<EmbedBlockComponent
 							key={1}
 							html={spotifyEmbedEmbed.html}
-							alt={spotifyEmbedEmbed.alt}
 						/>
 					</ClickToView>
 				</Figure>
@@ -564,7 +560,6 @@ export const EmbedBlockComponentStory = () => {
 						<EmbedBlockComponent
 							key={1}
 							html={bandcampEmbedEmbed.html}
-							alt={bandcampEmbedEmbed.alt}
 						/>
 					</ClickToView>
 				</Figure>
@@ -585,7 +580,6 @@ export const EmbedBlockComponentStory = () => {
 						<EmbedBlockComponent
 							key={1}
 							html={ourworldindataEmbedEmbed.html}
-							alt={ourworldindataEmbedEmbed.alt}
 						/>
 					</ClickToView>
 				</Figure>
@@ -606,7 +600,6 @@ export const EmbedBlockComponentStory = () => {
 						<EmbedBlockComponent
 							key={1}
 							html={bbcEmbedEmbed.html}
-							alt={bbcEmbedEmbed.alt}
 						/>
 					</ClickToView>
 				</Figure>

--- a/src/web/components/elements/EmbedBlockComponent.tsx
+++ b/src/web/components/elements/EmbedBlockComponent.tsx
@@ -5,7 +5,6 @@ import { css } from 'emotion';
 
 type Props = {
 	html: string;
-	alt?: string;
 };
 
 const embedContainer = css`
@@ -15,7 +14,7 @@ const embedContainer = css`
 	}
 `;
 
-export const EmbedBlockComponent = ({ html, alt }: Props) => {
+export const EmbedBlockComponent = ({ html }: Props) => {
 	return (
 		<div data-cy="embed-block" className={embedContainer}>
 			<div dangerouslySetInnerHTML={{ __html: unescapeData(html) }} />

--- a/src/web/components/elements/EmbedBlockComponent.tsx
+++ b/src/web/components/elements/EmbedBlockComponent.tsx
@@ -2,19 +2,11 @@ import React from 'react';
 
 import { unescapeData } from '@root/src/lib/escapeData';
 import { css } from 'emotion';
-import { textSans } from '@guardian/src-foundations/typography';
-import { text } from '@guardian/src-foundations/palette';
 
 type Props = {
 	html: string;
 	alt?: string;
 };
-
-const emailCaptionStyle = css`
-	${textSans.xsmall()};
-	word-break: break-all;
-	color: ${text.supporting};
-`;
 
 const embedContainer = css`
 	iframe {
@@ -24,14 +16,9 @@ const embedContainer = css`
 `;
 
 export const EmbedBlockComponent = ({ html, alt }: Props) => {
-	// TODO: Email embeds are being turned into atoms, so we can remove this hack when that happens
-	const isEmailEmbed = html.includes('email/form');
 	return (
 		<div data-cy="embed-block" className={embedContainer}>
 			<div dangerouslySetInnerHTML={{ __html: unescapeData(html) }} />
-			{isEmailEmbed && alt && (
-				<div className={emailCaptionStyle}>{alt}</div>
-			)}
 		</div>
 	);
 };

--- a/src/web/lib/ElementRenderer.tsx
+++ b/src/web/lib/ElementRenderer.tsx
@@ -271,11 +271,7 @@ export const ElementRenderer = ({
 						source={element.source}
 						sourceDomain={element.sourceDomain}
 					>
-						<EmbedBlockComponent
-							key={index}
-							html={element.html}
-							alt={element.alt}
-						/>
+						<EmbedBlockComponent key={index} html={element.html} />
 					</ClickToView>
 				</Figure>
 			);

--- a/src/web/server/render.ts
+++ b/src/web/server/render.ts
@@ -10,6 +10,7 @@ import { enhanceImages } from '@root/src/model/enhance-images';
 import { enhanceNumberedLists } from '@root/src/model/enhance-numbered-lists';
 import { enhanceBlockquotes } from '@root/src/model/enhance-blockquotes';
 import { enhanceAnniversaryAtom } from '@root/src/model/enhance-AnniversaryInteractiveAtom';
+import { enhanceEmbeds } from '@root/src/model/enhance-embeds';
 import { extract as extractGA } from '@root/src/model/extract-ga';
 import { Article as ExampleArticle } from '@root/fixtures/generated/articles/Article';
 
@@ -45,6 +46,11 @@ class CAPIEnhancer {
 		return this;
 	}
 
+	enhanceEmbeds() {
+		this.capi = enhanceEmbeds(this.capi);
+		return this;
+	}
+
 	validateAsCAPIType() {
 		this.capi = validateAsCAPIType(this.capi);
 		return this;
@@ -69,6 +75,7 @@ const buildCAPI = (body: CAPIType): CAPIType => {
 		.enhanceDots()
 		.enhanceImages()
 		.enhanceNumberedLists()
+		.enhanceEmbeds()
 		.enhanceAnniversaryAtom().capi;
 };
 


### PR DESCRIPTION
## What does this change?

- Removes the `alt` field from Composer being used as `Caption`. 
- Adds `alt` to the `title` attribute on the iframe 

There is a separate field for caption that isn't currently passed through in CAPI that we will use in the Caption location when it arrives.