### PR TITLE
Add custom className to figure component

### DIFF
--- a/src/web/components/Figure.tsx
+++ b/src/web/components/Figure.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'emotion';
+import { cx, css } from 'emotion';
 
 import { from, until } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
@@ -9,6 +9,7 @@ type Props = {
 	isMainMedia: boolean;
 	role?: RoleType | 'richLink';
 	id?: string;
+	customClassName?: string;
 };
 
 const roleCss = {
@@ -155,6 +156,7 @@ export const Figure = ({
 	children,
 	id,
 	isMainMedia,
+	customClassName,
 }: Props) => {
 	if (isMainMedia) {
 		// Don't add in-body styles for main media elements
@@ -165,7 +167,7 @@ export const Figure = ({
 		return <figure id={id}>{children}</figure>;
 	}
 	return (
-		<figure id={id} className={decidePosition(role)}>
+		<figure id={id} className={cx(customClassName, decidePosition(role))}>
 			{children}
 		</figure>
 	);

--- a/src/web/lib/ElementRenderer.tsx
+++ b/src/web/lib/ElementRenderer.tsx
@@ -335,6 +335,7 @@ export const ElementRenderer = ({
 				<Figure
 					isMainMedia={isMainMedia}
 					role={decideImageRole(element.role, isLiveBlog)}
+					customClassName="element--image-block" // tell spacefinder to treat this as 1 block
 				>
 					<ImageBlockComponent
 						format={format}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
- Add custom className to Figure component
- Add string to Figure in image block component

### Before
![Ad in between starts and image](https://user-images.githubusercontent.com/8831403/117480371-69fbec80-af59-11eb-9e22-47fc3c9c2995.PNG)

### After

## Why?
We want to prevent `spacefinder` from inserting an advert in between stars and images

## Related PR
https://github.com/guardian/frontend/pull/23788