### PR TITLE
Introduce a basic interctive endpoint

### DIFF
--- a/scripts/frontend/dev-server.js
+++ b/scripts/frontend/dev-server.js
@@ -10,10 +10,14 @@ const webpackHotServerMiddleware = require('webpack-hot-server-middleware');
 
 const { siteName, root } = require('./config');
 
-function buildUrlFromQueryParam(req) {
-	const DEFAULT_URL =
-		'https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software';
-	const url = new URL(req.query.url || DEFAULT_URL);
+const defaultArticleURL =
+	'https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software';
+
+const defaultInteractiveURL =
+	'https://www.theguardian.com/environment/ng-interactive/2021/feb/23/beneath-the-blue-dive-into-a-dazzling-ocean-under-threat-interactive';
+
+function buildUrlFromQueryParam(req, defaultURL) {
+	const url = new URL(req.query.url || defaultURL);
 	// searchParams will only work for the first set of query params because 'url' is already a query param itself
 	const searchparams = url.searchParams && url.searchParams.toString();
 	// Reconstruct the parsed url adding .json?dcr which we need to force dcr to return json
@@ -57,7 +61,7 @@ const go = () => {
 		'/Article',
 		async (req, res, next) => {
 			try {
-				const url = buildUrlFromQueryParam(req);
+				const url = buildUrlFromQueryParam(req, defaultArticleURL);
 				const { html, ...config } = await fetch(url).then((article) =>
 					article.json(),
 				);
@@ -71,6 +75,7 @@ const go = () => {
 		},
 		webpackHotServerMiddleware(compiler, {
 			chunkName: `${siteName}.server`,
+			serverRendererOptions: { path: '/Article' },
 		}),
 	);
 
@@ -78,7 +83,7 @@ const go = () => {
 		'/ArticleJson',
 		async (req, res, next) => {
 			try {
-				const url = buildUrlFromQueryParam(req);
+				const url = buildUrlFromQueryParam(req, defaultArticleURL);
 				const { html, ...config } = await fetch(url).then((article) =>
 					article.json(),
 				);
@@ -92,7 +97,7 @@ const go = () => {
 		},
 		webpackHotServerMiddleware(compiler, {
 			chunkName: `${siteName}.server`,
-			serverRendererOptions: { json: true },
+			serverRendererOptions: { path: '/ArticleJson' },
 		}),
 	);
 
@@ -100,7 +105,7 @@ const go = () => {
 		'/AMPArticle',
 		async (req, res, next) => {
 			try {
-				const url = buildUrlFromQueryParam(req);
+				const url = buildUrlFromQueryParam(req, defaultArticleURL);
 				const { html, ...config } = await fetch(
 					ampifyUrl(url),
 				).then((article) => article.json());
@@ -113,7 +118,29 @@ const go = () => {
 		},
 		webpackHotServerMiddleware(compiler, {
 			chunkName: `${siteName}.server`,
-			serverRendererOptions: { amp: true },
+			serverRendererOptions: { path: '/AMPArticle' },
+		}),
+	);
+
+	app.get(
+		'/Interactive',
+		async (req, res, next) => {
+			try {
+				const url = buildUrlFromQueryParam(req, defaultInteractiveURL);
+				const { html, ...config } = await fetch(
+					url,
+				).then((interactive) => interactive.json());
+
+				req.body = config;
+				next();
+			} catch (error) {
+				// eslint-disable-next-line no-console
+				console.error(error);
+			}
+		},
+		webpackHotServerMiddleware(compiler, {
+			chunkName: `${siteName}.server`,
+			serverRendererOptions: { path: '/Interactive' },
 		}),
 	);
 

--- a/scripts/frontend/landing/index.html
+++ b/scripts/frontend/landing/index.html
@@ -32,6 +32,7 @@
         <ul>
             <li><a href="/Article">Article</a></li>
             <li><a href="/AMPArticle">⚡️Article</a></li>
+			<li><a href="/Interactive">Interactive</a></li>
         </ul>
 
         <h2>Test Articles By Content Type</h2>

--- a/src/app/server.ts
+++ b/src/app/server.ts
@@ -12,9 +12,10 @@ import {
 	renderPerfTest as renderAMPArticlePerfTest,
 } from '@root/src/amp/server/render';
 import {
-	render as renderArticle,
+	renderArticle,
 	renderPerfTest as renderArticlePerfTest,
 	renderArticleJson,
+	renderInteractive,
 } from '@root/src/web/server/render';
 
 import {
@@ -26,12 +27,16 @@ import { logger } from './logging';
 
 // this export is the function used by webpackHotServerMiddleware in /scripts/frontend-dev-server
 export default (options: any) => {
-	if ('amp' in options) {
-		return renderAMPArticle;
-	}
-
-	if ('json' in options) {
-		return renderArticleJson;
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+	switch (options.path) {
+		case '/Article':
+			return renderArticle;
+		case '/ArticleJson':
+			return renderArticleJson;
+		case '/AMPArticle':
+			return renderAMPArticle;
+		case '/Interactive':
+			return renderInteractive;
 	}
 
 	return renderArticle;
@@ -139,8 +144,8 @@ if (process.env.NODE_ENV === 'production') {
 
 	app.use('/ArticlePerfTest', renderArticlePerfTest);
 	app.use('/AMPArticlePerfTest', renderAMPArticlePerfTest);
-
 	app.use('/ArticleJson', renderArticleJson);
+	app.use('/Interactive', renderInteractive);
 
 	app.get('/', (req: Request, res: Response) => {
 		try {

--- a/src/web/server/render.ts
+++ b/src/web/server/render.ts
@@ -72,7 +72,7 @@ const buildCAPI = (body: CAPIType): CAPIType => {
 		.enhanceAnniversaryAtom().capi;
 };
 
-export const render = (
+export const renderArticle = (
 	{ body }: express.Request,
 	res: express.Response,
 ): void => {
@@ -125,5 +125,29 @@ export const renderPerfTest = (
 	res: express.Response,
 ): void => {
 	req.body = ExampleArticle;
-	render(req, res);
+	renderArticle(req, res);
+};
+
+export const renderInteractive = (
+	{ body }: express.Request,
+	res: express.Response,
+): void => {
+	try {
+		const CAPI = buildCAPI(body);
+		const resp = document({
+			data: {
+				CAPI,
+				site: 'frontend',
+				page: 'Interactive',
+				NAV: extractNAV(CAPI.nav),
+				GA: extractGA(CAPI),
+				linkedData: CAPI.linkedData,
+			},
+		});
+
+		res.status(200).send(resp);
+	} catch (e) {
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+		res.status(500).send(`<pre>${e.stack}</pre>`);
+	}
 };


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Adds a new `/Interactive` endpoint that, for now, does the same thing as the vanilla article endpoint. Note that, it requires https://github.com/guardian/frontend/pull/23786 to go live before this will be useful.

## Why?

Part of supporting interactive pages on DCR!