### PR TITLE
Fix negative margin on divider

### DIFF
--- a/src/web/components/elements/DividerBlockComponent.tsx
+++ b/src/web/components/elements/DividerBlockComponent.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { css, cx } from 'emotion';
 
+import { from } from '@guardian/src-foundations/mq';
 import { border } from '@guardian/src-foundations/palette';
 import { space } from '@guardian/src-foundations';
 
@@ -12,12 +13,19 @@ type Props = {
 const baseStyles = css`
 	height: 1px;
 	border: 0;
-	margin-left: -10px;
 	margin-bottom: 3px;
 	background-color: ${border.secondary};
 `;
 const sizeFullStyle = css`
 	width: 100%;
+	${from.tablet} {
+		margin-left: -20px;
+		width: calc(100% + 20px);
+	}
+	${from.leftCol} {
+		margin-left: -10px;
+		width: calc(100% + 10px);
+	}
 `;
 const sizePartialStyle = css`
 	width: 150px;

--- a/src/web/components/elements/DividerBlockComponent.tsx
+++ b/src/web/components/elements/DividerBlockComponent.tsx
@@ -29,6 +29,13 @@ const sizeFullStyle = css`
 `;
 const sizePartialStyle = css`
 	width: 150px;
+	margin-left: 0px;
+	${from.tablet} {
+		margin-left: -20px;
+	}
+	${from.leftCol} {
+		margin-left: -10px;
+	}
 `;
 
 const tightSpaceAboveStyle = css`


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
We extend the width of the divider to compensate for the negative margin

### Before
#### Desktop
![desktop-before-fix](https://user-images.githubusercontent.com/8831403/117687207-78dbdc80-b1af-11eb-8fb1-1fe019fbd2cd.PNG)

#### Tablet
![tablet-before-fix](https://user-images.githubusercontent.com/8831403/117687653-e851cc00-b1af-11eb-87eb-d19df09bbbcc.PNG)

#### Mobile
![mobile-before-fix](https://user-images.githubusercontent.com/8831403/117687191-74172880-b1af-11eb-9497-25ec753f7dad.PNG)

### After
#### Desktop
![desktop-after-fix](https://user-images.githubusercontent.com/8831403/117686833-26022500-b1af-11eb-8b07-eca217787ef3.PNG)

#### Tablet
![tablet-after-fix](https://user-images.githubusercontent.com/8831403/117686860-2d293300-b1af-11eb-8832-dcd4fa6ffc04.PNG)

#### Mobile
![mobile-after-fix](https://user-images.githubusercontent.com/8831403/117687363-a2950380-b1af-11eb-83cd-7323b2dd2612.PNG)


## Why?
The divider does not match the full width of the content (thus looking unaligned) 