### PR TITLE
Immersive labs articles should have a white (not off-white) background

### DIFF
--- a/src/web/lib/decidePalette.ts
+++ b/src/web/lib/decidePalette.ts
@@ -363,7 +363,8 @@ const backgroundArticle = (format: Format): string => {
 	if (format.design === Design.Comment) return opinion[800];
 	if (format.design === Design.Editorial) return opinion[800];
 	if (format.theme === Special.SpecialReport) return specialReport[800]; // Note, check theme rather than design here
-	if (format.theme === Special.Labs && format.display !== Display.Immersive) return neutral[97];
+	if (format.theme === Special.Labs && format.display !== Display.Immersive)
+		return neutral[97];
 
 	return 'transparent';
 };

--- a/src/web/lib/decidePalette.ts
+++ b/src/web/lib/decidePalette.ts
@@ -363,14 +363,7 @@ const backgroundArticle = (format: Format): string => {
 	if (format.design === Design.Comment) return opinion[800];
 	if (format.design === Design.Editorial) return opinion[800];
 	if (format.theme === Special.SpecialReport) return specialReport[800]; // Note, check theme rather than design here
-	if (format.theme === Special.Labs) {
-		switch (format.display) {
-			case Display.Immersive:
-				return neutral[100];
-			default:
-				return neutral[97];
-		}
-	}
+	if (format.theme === Special.Labs && !Display.Immersive) return neutral[97];
 
 	return 'transparent';
 };

--- a/src/web/lib/decidePalette.ts
+++ b/src/web/lib/decidePalette.ts
@@ -363,7 +363,7 @@ const backgroundArticle = (format: Format): string => {
 	if (format.design === Design.Comment) return opinion[800];
 	if (format.design === Design.Editorial) return opinion[800];
 	if (format.theme === Special.SpecialReport) return specialReport[800]; // Note, check theme rather than design here
-	if (format.theme === Special.Labs && !Display.Immersive) return neutral[97];
+	if (format.theme === Special.Labs && format.display !== Display.Immersive) return neutral[97];
 
 	return 'transparent';
 };

--- a/src/web/lib/decidePalette.ts
+++ b/src/web/lib/decidePalette.ts
@@ -363,7 +363,15 @@ const backgroundArticle = (format: Format): string => {
 	if (format.design === Design.Comment) return opinion[800];
 	if (format.design === Design.Editorial) return opinion[800];
 	if (format.theme === Special.SpecialReport) return specialReport[800]; // Note, check theme rather than design here
-	if (format.theme === Special.Labs) return neutral[97];
+	if (format.theme === Special.Labs) {
+		switch (format.display) {
+			case Display.Immersive:
+				return neutral[100];
+			default:
+				return neutral[97];
+		}
+	}
+
 	return 'transparent';
 };
 


### PR DESCRIPTION
### Before
All labs articles have off-white background:
<img width="820" alt="before" src="https://user-images.githubusercontent.com/3300789/117813280-cb260780-b25a-11eb-8d59-842e91449896.png">

### After
Immersive labs articles have pure white background:
<img width="822" alt="after" src="https://user-images.githubusercontent.com/3300789/117813288-cd886180-b25a-11eb-9aa9-f378bae4e1b4.png">

## Why?
https://trello.com/c/bBUXyPQ1/197-labs-immersive-white-background