### PR TITLE
Revert removal of alt for email embeds caption

### DIFF
--- a/src/web/components/App.tsx
+++ b/src/web/components/App.tsx
@@ -804,7 +804,10 @@ export const App = ({ CAPI, NAV, ophanRecord }: Props) => {
 							source={embed.source}
 							sourceDomain={embed.sourceDomain}
 						>
-							<EmbedBlockComponent html={embed.html} />
+							<EmbedBlockComponent
+								html={embed.html}
+								alt={embed.alt}
+							/>
 						</ClickToView>
 					) : (
 						<ClickToView

--- a/src/web/components/ClickToView.stories.tsx
+++ b/src/web/components/ClickToView.stories.tsx
@@ -480,6 +480,7 @@ export const EmbedBlockComponentStory = () => {
 						<EmbedBlockComponent
 							key={1}
 							html={facebookEmbed.html}
+							alt={facebookEmbed.alt}
 						/>
 					</ClickToView>
 				</Figure>
@@ -500,6 +501,7 @@ export const EmbedBlockComponentStory = () => {
 						<EmbedBlockComponent
 							key={1}
 							html={vimeoEmbedEmbed.html}
+							alt={vimeoEmbedEmbed.alt}
 						/>
 					</ClickToView>
 				</Figure>
@@ -520,6 +522,7 @@ export const EmbedBlockComponentStory = () => {
 						<EmbedBlockComponent
 							key={1}
 							html={youtubeEmbedEmbed.html}
+							alt={youtubeEmbedEmbed.alt}
 						/>
 					</ClickToView>
 				</Figure>
@@ -540,6 +543,7 @@ export const EmbedBlockComponentStory = () => {
 						<EmbedBlockComponent
 							key={1}
 							html={spotifyEmbedEmbed.html}
+							alt={spotifyEmbedEmbed.alt}
 						/>
 					</ClickToView>
 				</Figure>
@@ -560,6 +564,7 @@ export const EmbedBlockComponentStory = () => {
 						<EmbedBlockComponent
 							key={1}
 							html={bandcampEmbedEmbed.html}
+							alt={bandcampEmbedEmbed.alt}
 						/>
 					</ClickToView>
 				</Figure>
@@ -580,6 +585,7 @@ export const EmbedBlockComponentStory = () => {
 						<EmbedBlockComponent
 							key={1}
 							html={ourworldindataEmbedEmbed.html}
+							alt={ourworldindataEmbedEmbed.alt}
 						/>
 					</ClickToView>
 				</Figure>
@@ -600,6 +606,7 @@ export const EmbedBlockComponentStory = () => {
 						<EmbedBlockComponent
 							key={1}
 							html={bbcEmbedEmbed.html}
+							alt={bbcEmbedEmbed.alt}
 						/>
 					</ClickToView>
 				</Figure>

--- a/src/web/components/elements/EmbedBlockComponent.tsx
+++ b/src/web/components/elements/EmbedBlockComponent.tsx
@@ -2,11 +2,19 @@ import React from 'react';
 
 import { unescapeData } from '@root/src/lib/escapeData';
 import { css } from 'emotion';
+import { textSans } from '@guardian/src-foundations/typography';
+import { text } from '@guardian/src-foundations/palette';
 
 type Props = {
 	html: string;
 	alt?: string;
 };
+
+const emailCaptionStyle = css`
+	${textSans.xsmall()};
+	word-break: break-all;
+	color: ${text.supporting};
+`;
 
 const embedContainer = css`
 	iframe {
@@ -16,9 +24,14 @@ const embedContainer = css`
 `;
 
 export const EmbedBlockComponent = ({ html, alt }: Props) => {
+	// TODO: Email embeds are being turned into atoms, so we can remove this hack when that happens
+	const isEmailEmbed = html.includes('email/form');
 	return (
 		<div data-cy="embed-block" className={embedContainer}>
 			<div dangerouslySetInnerHTML={{ __html: unescapeData(html) }} />
+			{isEmailEmbed && alt && (
+				<div className={emailCaptionStyle}>{alt}</div>
+			)}
 		</div>
 	);
 };

--- a/src/web/components/elements/EmbedBlockComponent.tsx
+++ b/src/web/components/elements/EmbedBlockComponent.tsx
@@ -5,6 +5,7 @@ import { css } from 'emotion';
 
 type Props = {
 	html: string;
+	alt?: string;
 };
 
 const embedContainer = css`
@@ -14,7 +15,7 @@ const embedContainer = css`
 	}
 `;
 
-export const EmbedBlockComponent = ({ html }: Props) => {
+export const EmbedBlockComponent = ({ html, alt }: Props) => {
 	return (
 		<div data-cy="embed-block" className={embedContainer}>
 			<div dangerouslySetInnerHTML={{ __html: unescapeData(html) }} />

--- a/src/web/lib/ElementRenderer.tsx
+++ b/src/web/lib/ElementRenderer.tsx
@@ -271,7 +271,11 @@ export const ElementRenderer = ({
 						source={element.source}
 						sourceDomain={element.sourceDomain}
 					>
-						<EmbedBlockComponent key={index} html={element.html} />
+						<EmbedBlockComponent
+							key={index}
+							html={element.html}
+							alt={element.alt}
+						/>
 					</ClickToView>
 				</Figure>
 			);


### PR DESCRIPTION
## What does this change?

Reverts the removal of the use of alt text for email embed captions. This is so that email sign-ups still have *a* caption, even if it is not the *right* caption.

Before 

![image](https://user-images.githubusercontent.com/638051/117837016-fddafa80-b270-11eb-9186-6cfdafc38822.png)


After 

![image](https://user-images.githubusercontent.com/638051/117836961-f1ef3880-b270-11eb-8a66-c4e00fd50379.png)
