### PR TITLE
Make config values optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -675,7 +675,7 @@ interface ConfigType extends CommercialConfigType {
 	hbImpl: { [key: string]: any } | string;
 	adUnit: string;
 	isSensitive: boolean;
-	videoDuration: number;
+	videoDuration?: number;
 	edition: string;
 	section: string;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -688,15 +688,15 @@ interface ConfigType extends CommercialConfigType {
 	discussionApiUrl: string;
 	discussionD2Uid: string;
 	discussionApiClientHeader: string;
-	isPhotoEssay: boolean;
+	isPhotoEssay?: boolean;
 	references?: { [key: string]: string }[];
 	host?: string;
 	idUrl?: string;
 	mmaUrl?: string;
 	brazeApiKey?: string;
 	ipsosTag?: string;
-	isLiveBlog: boolean;
-	isLive: boolean;
+	isLiveBlog?: boolean;
+	isLive?: boolean;
 }
 
 interface ConfigTypeBrowser {

--- a/src/model/enhance-blockquotes.ts
+++ b/src/model/enhance-blockquotes.ts
@@ -52,7 +52,7 @@ export const enhanceBlockquotes = (data: CAPIType): CAPIType => {
 	const enhancedBlocks = data.blocks.map((block: Block) => {
 		return {
 			...block,
-			elements: enhance(block.elements, isPhotoEssay),
+			elements: enhance(block.elements, isPhotoEssay || false),
 		};
 	});
 

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -1267,6 +1267,13 @@
                         "partial"
                     ],
                     "type": "string"
+                },
+                "spaceAbove": {
+                    "enum": [
+                        "loose",
+                        "tight"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
@@ -3762,9 +3769,6 @@
                 "googletagUrl",
                 "hbImpl",
                 "idApiUrl",
-                "isLive",
-                "isLiveBlog",
-                "isPhotoEssay",
                 "isSensitive",
                 "keywordIds",
                 "pageId",
@@ -3776,8 +3780,7 @@
                 "shortUrlId",
                 "showRelatedContent",
                 "stage",
-                "switches",
-                "videoDuration"
+                "switches"
             ]
         },
         "CommercialProperties": {

--- a/src/model/window-guardian.ts
+++ b/src/model/window-guardian.ts
@@ -153,7 +153,7 @@ export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
 
 			// used by lib/ad-targeting.ts
 			isSensitive: CAPI.config.isSensitive,
-			videoDuration: CAPI.config.videoDuration,
+			videoDuration: CAPI.config.videoDuration || 0,
 			edition: CAPI.config.edition,
 			section: CAPI.config.section,
 			sharedAdTargeting: CAPI.config.sharedAdTargeting, // missing type definition
@@ -194,10 +194,10 @@ export const makeGuardianBrowserCAPI = (CAPI: CAPIType): CAPIBrowserType => {
 		},
 		contributionsServiceUrl: CAPI.contributionsServiceUrl,
 		isImmersive: CAPI.isImmersive,
-		isPhotoEssay: CAPI.config.isPhotoEssay,
+		isPhotoEssay: CAPI.config.isPhotoEssay || false,
 		isSpecialReport: CAPI.isSpecialReport,
-		isLiveBlog: CAPI.config.isLiveBlog,
-		isLive: CAPI.config.isLive,
+		isLiveBlog: CAPI.config.isLiveBlog || false,
+		isLive: CAPI.config.isLive || false,
 		matchUrl: CAPI.matchUrl,
 		elementsToHydrate: CAPI.blocks
 			// Get all elements arrays from all blocks -> [[h][h][x]]


### PR DESCRIPTION
### Before

(Some config params required.)

### After

Some config params optional.

## Why?

These JS config parameters are not guaranteed for interactives. We could split the data model to account for this but at this point it doesn't seem worth it.

Also worth noting that this model is not typed in Frontend at all. It would be good to do that to better make things explicit there and for safety.
