### PR TITLE
extract rounding function

### DIFF
--- a/src/web/browser/coreVitals/coreVitals.ts
+++ b/src/web/browser/coreVitals/coreVitals.ts
@@ -33,24 +33,28 @@ export const coreVitals = (): void => {
 		name: string;
 		value: number;
 	};
+	
+	const nineDigitPrecision = (number: number) => {
+		// The math functions are to make sure the length of number is <= 9
+		return Math.round(value * 1_000_000) / 1_000_000;
+	}
 
 	const addToJson = ({ name, value }: CoreVitalsArgs): void => {
 		switch (name) {
-			// The math functions are to make sure the length of number is <= 9
 			case 'FCP':
-				jsonData.fcp = Math.round(value * 1000000) / 1000000;
+				jsonData.fcp = nineDigitPrecision(value);
 				break;
 			case 'CLS':
-				jsonData.cls = Math.round(value * 1000000) / 1000000;
+				jsonData.cls = nineDigitPrecision(value);
 				break;
 			case 'LCP':
-				jsonData.lcp = Math.round(value * 1000000) / 1000000;
+				jsonData.lcp = nineDigitPrecision(value);
 				break;
 			case 'FID':
-				jsonData.fid = Math.round(value * 1000000) / 1000000;
+				jsonData.fid = nineDigitPrecision(value);
 				break;
 			case 'TTFB':
-				jsonData.ttfb = Math.round(value * 1000000) / 1000000;
+				jsonData.ttfb = nineDigitPrecision(value);
 				break;
 		}
 

--- a/src/web/browser/coreVitals/coreVitals.ts
+++ b/src/web/browser/coreVitals/coreVitals.ts
@@ -34,7 +34,7 @@ export const coreVitals = (): void => {
 		value: number;
 	};
 	
-	const nineDigitPrecision = (number: number) => {
+	const nineDigitPrecision = (value: number) => {
 		// The math functions are to make sure the length of number is <= 9
 		return Math.round(value * 1_000_000) / 1_000_000;
 	}


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Extract the rounding function. May I ask why this was needed?

## Why?

We're looking at implementing a similar thing for commercial metrics.
