### PR TITLE
Remove CLS null check from core vitals data push to send data when reported by the browser for all metrics

### DIFF
--- a/src/web/browser/coreVitals/coreVitals.ts
+++ b/src/web/browser/coreVitals/coreVitals.ts
@@ -77,23 +77,28 @@ export const coreVitals = (): void => {
 				? 'http://performance-events.code.dev-guardianapis.com/core-web-vitals'
 				: 'https://performance-events.guardianapis.com/core-web-vitals';
 
-		// If CLS has been calculated
-		if (jsonData.cls !== null) {
-			// Set page view and browser ID
+		// Browser support
+		// getCLS(): Chromium,
+		// getFCP(): Chromium, Firefox, Safari Technology Preview
+		// getFID(): Chromium, Firefox, Safari, Internet Explorer (with the polyfill)
+		// getLCP(): Chromium
+		// getTTFB(): Chromium, Firefox, Safari, Internet Explorer
 
-			fetch(endpoint, {
-				method: 'POST', // *GET, POST, PUT, DELETE, etc.
-				mode: 'cors', // no-cors, *cors, same-origin
-				cache: 'no-cache', // *default, no-cache, reload, force-cache, only-if-cached
-				credentials: 'same-origin', // include, *same-origin, omit
-				headers: {
-					'Content-Type': 'application/json',
-				},
-				redirect: 'follow',
-				referrerPolicy: 'no-referrer', // no-referrer, *no-referrer-w
-				body: JSON.stringify(jsonData),
-			}).catch(() => {});
-		}
+		// We will send all data whenever any update. This means `null` values will appear in the lake
+		// and need handling.
+
+		fetch(endpoint, {
+			method: 'POST', // *GET, POST, PUT, DELETE, etc.
+			mode: 'cors', // no-cors, *cors, same-origin
+			cache: 'no-cache', // *default, no-cache, reload, force-cache, only-if-cached
+			credentials: 'same-origin', // include, *same-origin, omit
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			redirect: 'follow',
+			referrerPolicy: 'no-referrer', // no-referrer, *no-referrer-w
+			body: JSON.stringify(jsonData),
+		}).catch(() => {});
 	};
 
 	getCLS(addToJson, false);

--- a/src/web/browser/coreVitals/init.ts
+++ b/src/web/browser/coreVitals/init.ts
@@ -5,7 +5,8 @@ import { coreVitals } from './coreVitals';
 const init = async (): Promise<void> => {
 	// Sample 1 out of 100
 	const inSample = Math.floor(Math.random() * 100);
-	if (inSample === 1) {
+	const inLocal = window.location.hostname === 'localhost';
+	if (inSample === 1 || inLocal) {
 		coreVitals();
 	}
 	return Promise.resolve();


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Removes the CLS `null` check so that we fire performance data when reported by the browser immediately. This will mean that we:

- Send data with `null` values
- Send data as reported filling in each metric as it becomes available
- Data will be reported for browsers that don't support CLS

```
// Browser support
// getCLS(): Chromium,
// getFCP(): Chromium, Firefox, Safari Technology Preview
// getFID(): Chromium, Firefox, Safari, Internet Explorer (with the polyfill)
// getLCP(): Chromium
// getTTFB(): Chromium, Firefox, Safari, Internet Explorer
```

This will lead to an increase in data in the lake and requests through the Fastly service - roughly 5 times the current amount (one request for each metric, rather than one request for all metrics).

Confirmation from Guy is that:

- "the dashboard doesn't currently require a page view to have all three metrics"
- "multiple values of the same metric for a given page view, the code picks out the max value for each metric"


### Before

Will only fire when CLS is complete.

### After

#### Fires early on First Contentful Paint
<img width="103" alt="Screen Shot 2021-06-01 at 11 55 03" src="https://user-images.githubusercontent.com/638051/120312299-73664380-c2d0-11eb-8afd-e875625b10ef.png">

#### Fires on First Input Delay with other fields populated
<img width="103" alt="Screen Shot 2021-06-01 at 11 55 31" src="https://user-images.githubusercontent.com/638051/120312297-72cdad00-c2d0-11eb-87eb-0d1b5bf69866.png">

#### Fires on Cumulative Layout Shift with all fields populated
<img width="103" alt="Screen Shot 2021-06-01 at 11 55 45" src="https://user-images.githubusercontent.com/638051/120312293-72351680-c2d0-11eb-82bf-03309573c2b7.png">


## Why?
Improve the data integrity and ensure that we're capturing the widest set of data that we can.
