### PR TITLE
Identity | Sign In Gate | Update fake social test dataLinkNames

### DIFF
--- a/src/web/experiments/tests/sign-in-gate-fake-social.ts
+++ b/src/web/experiments/tests/sign-in-gate-fake-social.ts
@@ -12,7 +12,7 @@ export const signInGateFakeSocial: ABTest = {
 	successMeasure: 'Users sign in or create a Guardian account',
 	audienceCriteria:
 		'3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',
-	dataLinkNames: 'SignInGateMain',
+	dataLinkNames: 'SignInGateFakeSocial',
 	idealOutcome:
 		'Increase the number of users signed in whilst running at a reasonable scale',
 	showForSensitive: false,


### PR DESCRIPTION
## What does this change?
- `dataLinkNames` should be set to the name of the test for correct reporting, in this case it should've been `SignInGateFakeSocial`
