### PR TITLE
Add immersive interactive layout

### DIFF
--- a/src/web/components/Figure.tsx
+++ b/src/web/components/Figure.tsx
@@ -4,13 +4,6 @@ import { css } from 'emotion';
 import { from, until } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
 
-type Props = {
-	children: React.ReactNode;
-	isMainMedia: boolean;
-	role?: RoleType | 'richLink';
-	id?: string;
-};
-
 const roleCss = {
 	inline: css`
 		margin-top: ${space[3]}px;
@@ -129,7 +122,8 @@ const roleCss = {
 	`,
 };
 
-const decidePosition = (role: RoleType | 'richLink') => {
+// Used for vast majority of layouts.
+export const defaultRoleStyles = (role: RoleType | 'richLink') => {
 	switch (role) {
 		case 'inline':
 			return roleCss.inline;
@@ -150,11 +144,23 @@ const decidePosition = (role: RoleType | 'richLink') => {
 	}
 };
 
+type Props = {
+	children: React.ReactNode;
+	isMainMedia: boolean;
+	role?: RoleType | 'richLink';
+	id?: string;
+
+	// Used to style figures based on role type. Parameterised as this varies
+	// (e.g.) on page layout.
+	roleStylesFn?: (role: RoleType | 'richLink') => string;
+};
+
 export const Figure = ({
 	role = 'inline',
 	children,
 	id,
 	isMainMedia,
+	roleStylesFn = defaultRoleStyles,
 }: Props) => {
 	if (isMainMedia) {
 		// Don't add in-body styles for main media elements
@@ -165,7 +171,7 @@ export const Figure = ({
 		return <figure id={id}>{children}</figure>;
 	}
 	return (
-		<figure id={id} className={decidePosition(role)}>
+		<figure id={id} className={roleStylesFn(role)}>
 			{children}
 		</figure>
 	);

--- a/src/web/layouts/DecideLayout.tsx
+++ b/src/web/layouts/DecideLayout.tsx
@@ -15,6 +15,7 @@ import { ShowcaseLayout } from './ShowcaseLayout';
 import { CommentLayout } from './CommentLayout';
 import { ImmersiveLayout } from './ImmersiveLayout';
 import { LiveLayout } from './LiveLayout';
+import { InteractiveImmersiveLayout } from './InteractiveImmersiveLayout';
 
 type Props = {
 	CAPI: CAPIType;
@@ -41,30 +42,28 @@ export const DecideLayout = ({ CAPI, NAV }: Props): JSX.Element => {
 	};
 	const palette = decidePalette(format);
 
+	// TODO we can probably better express this as data
 	switch (display) {
 		case Display.Immersive: {
-			switch (design) {
-				case Design.Comment:
-				case Design.Editorial:
-				case Design.Letter:
-					return (
-						<ImmersiveLayout
-							CAPI={CAPI}
-							NAV={NAV}
-							palette={palette}
-							format={format}
-						/>
-					);
-				default:
-					return (
-						<ImmersiveLayout
-							CAPI={CAPI}
-							NAV={NAV}
-							palette={palette}
-							format={format}
-						/>
-					);
+			if (design === Design.Interactive) {
+				return (
+					<InteractiveImmersiveLayout
+						CAPI={CAPI}
+						NAV={NAV}
+						format={format}
+						palette={palette}
+					/>
+				);
 			}
+
+			return (
+				<ImmersiveLayout
+					CAPI={CAPI}
+					NAV={NAV}
+					palette={palette}
+					format={format}
+				/>
+			);
 		}
 		case Display.NumberedList:
 		case Display.Showcase: {

--- a/src/web/layouts/InteractiveImmersiveLayout.tsx
+++ b/src/web/layouts/InteractiveImmersiveLayout.tsx
@@ -1,0 +1,329 @@
+import React from 'react';
+import { css, cx } from 'emotion';
+
+import {
+	brandBackground,
+	brandBorder,
+	labs,
+	border,
+} from '@guardian/src-foundations/palette';
+import { from } from '@guardian/src-foundations/mq';
+import { Design, Special } from '@guardian/types';
+import type { Format } from '@guardian/types';
+
+import { GuardianLines } from '@root/src/web/components/GuardianLines';
+import { MainMedia } from '@root/src/web/components/MainMedia';
+import { ArticleTitle } from '@root/src/web/components/ArticleTitle';
+import { ArticleHeadline } from '@root/src/web/components/ArticleHeadline';
+import { Footer } from '@root/src/web/components/Footer';
+import { SubNav } from '@root/src/web/components/SubNav/SubNav';
+import { Section } from '@root/src/web/components/Section';
+import { Nav } from '@root/src/web/components/Nav/Nav';
+import { MobileStickyContainer } from '@root/src/web/components/AdSlot';
+import { Caption } from '@root/src/web/components/Caption';
+import { ContainerLayout } from '@root/src/web/components/ContainerLayout';
+import { LabsHeader } from '@frontend/web/components/LabsHeader';
+
+import { getZIndex } from '@frontend/web/lib/getZIndex';
+
+import { Stuck, BannerWrapper } from '@root/src/web/layouts/lib/stickiness';
+import { getCurrentPillar } from '@root/src/web/lib/layoutHelpers';
+import { ElementRenderer } from '../lib/ElementRenderer';
+
+const hasMainMediaStyles = css`
+	height: 100vh;
+	/**
+    100vw is normally enough but don't let the content shrink vertically too
+    much just in case
+    */
+	min-height: 25rem;
+	${from.desktop} {
+		min-height: 31.25rem;
+	}
+	${from.wide} {
+		min-height: 50rem;
+	}
+`;
+
+interface Props {
+	CAPI: CAPIType;
+	NAV: NavType;
+	format: Format;
+	palette: Palette;
+}
+
+const decideCaption = (mainMedia: ImageBlockElement): string => {
+	const caption = [];
+	if (mainMedia && mainMedia.data && mainMedia.data.caption)
+		caption.push(mainMedia.data.caption);
+	if (
+		mainMedia &&
+		mainMedia.displayCredit &&
+		mainMedia.data &&
+		mainMedia.data.credit
+	)
+		caption.push(mainMedia.data.credit);
+	return caption.join(' ');
+};
+
+const Box = ({
+	palette,
+	children,
+}: {
+	palette: Palette;
+	children: React.ReactNode;
+}) => (
+	<div
+		className={css`
+			/*
+				This pseudo css shows a black box to the right of the headline
+				so that the black background of the inverted text stretches
+				all the way right. But only from mobileLandscape because below
+				that we want to show a gap. To work properly it needs to wrap
+				the healine so it inherits the correct height based on the length
+				of the headline text
+			*/
+			${from.mobileLandscape} {
+				position: relative;
+				:after {
+					content: '';
+					display: block;
+					position: absolute;
+					width: 50%;
+					right: 0;
+					background-color: ${palette.background.headline};
+					${getZIndex('immersiveBlackBox')}
+					top: 0;
+					bottom: 0;
+				}
+			}
+		`}
+	>
+		{children}
+	</div>
+);
+
+const Renderer: React.FC<{
+	format: Format;
+	palette: Palette;
+	elements: CAPIElement[];
+	host?: string;
+}> = ({ format, palette, elements, host }) => {
+	// const cleanedElements = elements.map(element =>
+	//     'html' in element ? { ...element, html: clean(element.html) } : element,
+	// );
+	// ^^ Until we decide where to do the "isomorphism split" in this this code is not safe here.
+	//    But should be soon.
+	const output = elements.map((element, index) => (
+		<ElementRenderer
+			format={format}
+			palette={palette}
+			element={element}
+			adTargeting={undefined}
+			host={host}
+			index={index}
+			isMainMedia={false}
+			roleStylesFn={() => ''} // no custom styling per role for immersive interactives!
+		/>
+	));
+
+	return <div>{output}</div>;
+};
+
+export const InteractiveImmersiveLayout = ({
+	CAPI,
+	NAV,
+	format,
+	palette,
+}: Props): JSX.Element => {
+	const {
+		config: { host },
+	} = CAPI;
+
+	const mainMedia = CAPI.mainMediaElements[0] as ImageBlockElement;
+	const captionText = decideCaption(mainMedia);
+
+	const HEADLINE_OFFSET = mainMedia ? 120 : 0;
+
+	const LeftColCaption = () => (
+		<div
+			className={css`
+				margin-top: ${HEADLINE_OFFSET}px;
+				position: absolute;
+				margin-left: 20px;
+			`}
+		>
+			<Caption
+				palette={palette}
+				captionText={captionText}
+				format={format}
+				shouldLimitWidth={true}
+			/>
+		</div>
+	);
+
+	return (
+		<>
+			<div
+				className={css`
+					background-color: ${palette.background.article};
+				`}
+			>
+				<div
+					className={cx(
+						mainMedia && hasMainMediaStyles,
+						css`
+							display: flex;
+							flex-direction: column;
+						`,
+					)}
+				>
+					<header
+						className={css`
+							${getZIndex('headerWrapper')}
+							order: 0;
+						`}
+					>
+						<Section
+							showSideBorders={false}
+							showTopBorder={false}
+							padded={false}
+							backgroundColour={brandBackground.primary}
+						>
+							<Nav
+								format={{
+									...format,
+									theme: getCurrentPillar(CAPI),
+								}}
+								nav={NAV}
+								subscribeUrl={
+									CAPI.nav.readerRevenueLinks.header.subscribe
+								}
+								edition={CAPI.editionId}
+							/>
+						</Section>
+					</header>
+
+					{format.theme === Special.Labs && (
+						<Stuck>
+							<Section
+								showSideBorders={true}
+								showTopBorder={false}
+								backgroundColour={labs[400]}
+								borderColour={border.primary}
+								sectionId="labs-header"
+							>
+								<LabsHeader />
+							</Section>
+						</Stuck>
+					)}
+
+					<MainMedia
+						format={format}
+						palette={palette}
+						elements={CAPI.mainMediaElements}
+						adTargeting={undefined}
+						starRating={
+							format.design === Design.Review && CAPI.starRating
+								? CAPI.starRating
+								: undefined
+						}
+						host={host}
+						hideCaption={true}
+					/>
+				</div>
+				{mainMedia && (
+					<>
+						<div
+							className={css`
+								margin-top: -${HEADLINE_OFFSET}px;
+								/*
+                        This z-index is what ensures the headline title text shows above main media. For
+                        the actual headline we set the z-index deeper in ArticleHeadline itself so that
+                        the text appears above the pseudo Box element
+                    */
+								position: relative;
+								${getZIndex('articleHeadline')};
+							`}
+						>
+							<ContainerLayout
+								verticalMargins={false}
+								padContent={false}
+								padSides={false}
+								leftContent={<LeftColCaption />}
+							>
+								<ArticleTitle
+									format={format}
+									palette={palette}
+									tags={CAPI.tags}
+									sectionLabel={CAPI.sectionLabel}
+									sectionUrl={CAPI.sectionUrl}
+									guardianBaseURL={CAPI.guardianBaseURL}
+									badge={CAPI.badge}
+								/>
+							</ContainerLayout>
+							<Box palette={palette}>
+								<ContainerLayout
+									verticalMargins={false}
+									padContent={false}
+									padSides={false}
+								>
+									<ArticleHeadline
+										format={format}
+										headlineString={CAPI.headline}
+										palette={palette}
+										tags={CAPI.tags}
+										byline={CAPI.author.byline}
+									/>
+								</ContainerLayout>
+							</Box>
+						</div>
+					</>
+				)}
+			</div>
+			<Section
+				showTopBorder={false}
+				showSideBorders={false}
+				shouldCenter={false}
+				padded={false}
+				backgroundColour={palette.background.article}
+			>
+				<main>
+					<Renderer
+						format={format}
+						palette={palette}
+						elements={CAPI.blocks[0] ? CAPI.blocks[0].elements : []}
+						host={host}
+					/>
+				</main>
+			</Section>
+
+			{NAV.subNavSections && (
+				<Section padded={false} sectionId="sub-nav-root">
+					<SubNav
+						subNavSections={NAV.subNavSections}
+						currentNavLink={NAV.currentNavLink}
+						palette={palette}
+					/>
+					<GuardianLines count={4} palette={palette} />
+				</Section>
+			)}
+
+			<Section
+				padded={false}
+				backgroundColour={brandBackground.primary}
+				borderColour={brandBorder.primary}
+				showSideBorders={false}
+			>
+				<Footer
+					pageFooter={CAPI.pageFooter}
+					pillar={format.theme}
+					pillars={NAV.pillars}
+				/>
+			</Section>
+
+			<BannerWrapper />
+			<MobileStickyContainer />
+		</>
+	);
+};

--- a/src/web/lib/ElementRenderer.tsx
+++ b/src/web/lib/ElementRenderer.tsx
@@ -40,7 +40,7 @@ import {
 	WitnessTextBlockComponent,
 } from '@root/src/web/components/elements/WitnessBlockComponent';
 import { ClickToView } from '@root/src/web/components/ClickToView';
-import { Figure } from '@root/src/web/components/Figure';
+import { Figure, defaultRoleStyles } from '@root/src/web/components/Figure';
 
 import {
 	AudioAtom,
@@ -67,6 +67,7 @@ type Props = {
 	isMainMedia: boolean;
 	hideCaption?: boolean;
 	starRating?: number;
+	roleStylesFn?: (role: RoleType | 'richLink') => string;
 };
 
 function decideImageRole(role: RoleType, isLiveBlog: boolean): RoleType {
@@ -89,6 +90,7 @@ export const ElementRenderer = ({
 	hideCaption,
 	isMainMedia,
 	starRating,
+	roleStylesFn = defaultRoleStyles,
 }: Props) => {
 	const isLiveBlog =
 		format.design === Design.LiveBlog || format.design === Design.DeadBlog;
@@ -100,6 +102,7 @@ export const ElementRenderer = ({
 					isMainMedia={isMainMedia}
 					id={element.elementId}
 					role={isLiveBlog ? 'inline' : element.role}
+					roleStylesFn={roleStylesFn}
 				>
 					<AudioAtom
 						id={element.id}
@@ -125,6 +128,7 @@ export const ElementRenderer = ({
 					isMainMedia={isMainMedia}
 					id={element.elementId}
 					role={isLiveBlog ? 'inline' : element.role}
+					roleStylesFn={roleStylesFn}
 				>
 					<CalloutBlockComponent
 						callout={element}
@@ -151,6 +155,7 @@ export const ElementRenderer = ({
 				<Figure
 					isMainMedia={isMainMedia}
 					role={isLiveBlog ? 'inline' : element.role}
+					roleStylesFn={roleStylesFn}
 				>
 					<ChartAtom id={element.id} html={element.html} />
 				</Figure>
@@ -167,6 +172,7 @@ export const ElementRenderer = ({
 				<Figure
 					isMainMedia={isMainMedia}
 					role={isLiveBlog ? 'inline' : element.role}
+					roleStylesFn={roleStylesFn}
 				>
 					<CommentBlockComponent
 						body={element.body}
@@ -183,6 +189,7 @@ export const ElementRenderer = ({
 				<Figure
 					isMainMedia={isMainMedia}
 					role={isLiveBlog ? 'inline' : element.role}
+					roleStylesFn={roleStylesFn}
 				>
 					<DisclaimerBlockComponent html={element.html} />
 				</Figure>
@@ -200,6 +207,7 @@ export const ElementRenderer = ({
 					isMainMedia={isMainMedia}
 					role={isLiveBlog ? 'inline' : element.role}
 					id={element.elementId}
+					roleStylesFn={roleStylesFn}
 				>
 					<ClickToView
 						role={isLiveBlog ? 'inline' : element.role}
@@ -226,6 +234,7 @@ export const ElementRenderer = ({
 							isMainMedia={isMainMedia}
 							role={element.role}
 							id={element.elementId}
+							roleStylesFn={roleStylesFn}
 						>
 							<MainMediaEmbedBlockComponent
 								title={element.alt || ''}
@@ -240,6 +249,7 @@ export const ElementRenderer = ({
 						isMainMedia={isMainMedia}
 						role={isLiveBlog ? 'inline' : element.role}
 						id={element.elementId}
+						roleStylesFn={roleStylesFn}
 					>
 						<ClickToView
 							role={isLiveBlog ? 'inline' : element.role}
@@ -263,6 +273,7 @@ export const ElementRenderer = ({
 					isMainMedia={isMainMedia}
 					role={isLiveBlog ? 'inline' : element.role}
 					id={element.elementId}
+					roleStylesFn={roleStylesFn}
 				>
 					<ClickToView
 						role={isLiveBlog ? 'inline' : element.role}
@@ -284,6 +295,7 @@ export const ElementRenderer = ({
 				<Figure
 					isMainMedia={isMainMedia}
 					role={isLiveBlog ? 'inline' : element.role}
+					roleStylesFn={roleStylesFn}
 				>
 					<ExplainerAtom
 						key={index}
@@ -299,6 +311,7 @@ export const ElementRenderer = ({
 					isMainMedia={isMainMedia}
 					id={element.elementId}
 					role={isLiveBlog ? 'inline' : element.role}
+					roleStylesFn={roleStylesFn}
 				>
 					<GuideAtom
 						id={element.id}
@@ -318,6 +331,7 @@ export const ElementRenderer = ({
 				<Figure
 					isMainMedia={isMainMedia}
 					role={isLiveBlog ? 'inline' : element.role}
+					roleStylesFn={roleStylesFn}
 				>
 					<GuVideoBlockComponent
 						html={element.html}
@@ -335,6 +349,7 @@ export const ElementRenderer = ({
 				<Figure
 					isMainMedia={isMainMedia}
 					role={decideImageRole(element.role, isLiveBlog)}
+					roleStylesFn={roleStylesFn}
 				>
 					<ImageBlockComponent
 						format={format}
@@ -355,6 +370,7 @@ export const ElementRenderer = ({
 					isMainMedia={isMainMedia}
 					role={isLiveBlog ? 'inline' : element.role}
 					id={element.elementId}
+					roleStylesFn={roleStylesFn}
 				>
 					<ClickToView
 						role={isLiveBlog ? 'inline' : element.role}
@@ -376,6 +392,7 @@ export const ElementRenderer = ({
 				<Figure
 					isMainMedia={isMainMedia}
 					role={isLiveBlog ? 'inline' : element.role}
+					roleStylesFn={roleStylesFn}
 				>
 					<InteractiveAtom
 						id={element.id}
@@ -391,6 +408,7 @@ export const ElementRenderer = ({
 					isMainMedia={isMainMedia}
 					role={isLiveBlog ? 'inline' : element.role}
 					id={element.elementId}
+					roleStylesFn={roleStylesFn}
 				>
 					<InteractiveBlockComponent
 						url={element.url}
@@ -410,6 +428,7 @@ export const ElementRenderer = ({
 					isMainMedia={isMainMedia}
 					role={isLiveBlog ? 'inline' : element.role}
 					id={element.elementId}
+					roleStylesFn={roleStylesFn}
 				>
 					<ClickToView
 						role={isLiveBlog ? 'inline' : element.role}
@@ -443,6 +462,7 @@ export const ElementRenderer = ({
 				<Figure
 					isMainMedia={isMainMedia}
 					role={isLiveBlog ? 'inline' : element.role}
+					roleStylesFn={roleStylesFn}
 				>
 					<MultiImageBlockComponent
 						format={format}
@@ -455,7 +475,11 @@ export const ElementRenderer = ({
 			);
 		case 'model.dotcomrendering.pageElements.NumberedTitleBlockElement':
 			return (
-				<Figure isMainMedia={isMainMedia} id={element.elementId}>
+				<Figure
+					isMainMedia={isMainMedia}
+					id={element.elementId}
+					roleStylesFn={roleStylesFn}
+				>
 					<NumberedTitleBlockComponent
 						position={element.position}
 						html={element.html}
@@ -469,6 +493,7 @@ export const ElementRenderer = ({
 					isMainMedia={isMainMedia}
 					id={element.elementId}
 					role={isLiveBlog ? 'inline' : element.role}
+					roleStylesFn={roleStylesFn}
 				>
 					<ProfileAtom
 						id={element.id}
@@ -500,6 +525,7 @@ export const ElementRenderer = ({
 					isMainMedia={isMainMedia}
 					id={element.elementId}
 					role={isLiveBlog ? 'inline' : element.role}
+					roleStylesFn={roleStylesFn}
 				>
 					<QandaAtom
 						id={element.id}
@@ -516,7 +542,11 @@ export const ElementRenderer = ({
 			);
 		case 'model.dotcomrendering.pageElements.QuizAtomBlockElement':
 			return (
-				<Figure isMainMedia={isMainMedia} id={element.elementId}>
+				<Figure
+					isMainMedia={isMainMedia}
+					id={element.elementId}
+					roleStylesFn={roleStylesFn}
+				>
 					<>
 						{element.quizType === 'personality' && (
 							<PersonalityQuizAtom
@@ -541,6 +571,7 @@ export const ElementRenderer = ({
 					isMainMedia={isMainMedia}
 					key={index}
 					role={isLiveBlog ? 'inline' : 'richLink'}
+					roleStylesFn={roleStylesFn}
 				>
 					<DefaultRichLink
 						index={index}
@@ -556,6 +587,7 @@ export const ElementRenderer = ({
 					isMainMedia={isMainMedia}
 					key={index}
 					role={isLiveBlog ? 'inline' : element.role}
+					roleStylesFn={roleStylesFn}
 				>
 					<SoundcloudBlockComponent element={element} />
 				</Figure>
@@ -566,6 +598,7 @@ export const ElementRenderer = ({
 					isMainMedia={isMainMedia}
 					role={isLiveBlog ? 'inline' : element.role}
 					id={element.elementId}
+					roleStylesFn={roleStylesFn}
 				>
 					<ClickToView
 						role={isLiveBlog ? 'inline' : element.role}
@@ -602,6 +635,7 @@ export const ElementRenderer = ({
 				<Figure
 					isMainMedia={isMainMedia}
 					role={isLiveBlog ? 'inline' : element.role}
+					roleStylesFn={roleStylesFn}
 				>
 					<TableBlockComponent element={element} />
 				</Figure>
@@ -624,6 +658,7 @@ export const ElementRenderer = ({
 					isMainMedia={isMainMedia}
 					role={isLiveBlog ? 'inline' : element.role}
 					id={element.elementId}
+					roleStylesFn={roleStylesFn}
 				>
 					<TimelineAtom
 						id={element.id}
@@ -642,6 +677,7 @@ export const ElementRenderer = ({
 					isMainMedia={isMainMedia}
 					key={index}
 					role={isLiveBlog ? 'inline' : element.role}
+					roleStylesFn={roleStylesFn}
 				>
 					<TweetBlockComponent element={element} />
 				</Figure>
@@ -652,6 +688,7 @@ export const ElementRenderer = ({
 					isMainMedia={isMainMedia}
 					role={isLiveBlog ? 'inline' : element.role}
 					id={element.elementId}
+					roleStylesFn={roleStylesFn}
 				>
 					<ClickToView
 						role={isLiveBlog ? 'inline' : element.role}
@@ -678,6 +715,7 @@ export const ElementRenderer = ({
 				<Figure
 					isMainMedia={isMainMedia}
 					role={isLiveBlog ? 'inline' : element.role}
+					roleStylesFn={roleStylesFn}
 				>
 					<VimeoBlockComponent
 						format={format}
@@ -696,6 +734,7 @@ export const ElementRenderer = ({
 				<Figure
 					isMainMedia={isMainMedia}
 					role={isLiveBlog ? 'inline' : element.role}
+					roleStylesFn={roleStylesFn}
 				>
 					<YoutubeEmbedBlockComponent
 						format={format}
@@ -717,6 +756,7 @@ export const ElementRenderer = ({
 					// eslint-disable-next-line jsx-a11y/aria-role
 					role="inline"
 					id={element.elementId}
+					roleStylesFn={roleStylesFn}
 				>
 					<ClickToView
 						// No role given by CAPI
@@ -737,7 +777,10 @@ export const ElementRenderer = ({
 					// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
 					const witnessTypeDataImage = element.witnessTypeData as WitnessTypeDataImage;
 					return (
-						<Figure isMainMedia={isMainMedia}>
+						<Figure
+							isMainMedia={isMainMedia}
+							roleStylesFn={roleStylesFn}
+						>
 							<WitnessImageBlockComponent
 								assets={element.assets}
 								caption={witnessTypeDataImage.caption}
@@ -753,7 +796,10 @@ export const ElementRenderer = ({
 					// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
 					const witnessTypeDataVideo = element.witnessTypeData as WitnessTypeDataVideo;
 					return (
-						<Figure isMainMedia={isMainMedia}>
+						<Figure
+							isMainMedia={isMainMedia}
+							roleStylesFn={roleStylesFn}
+						>
 							<WitnessVideoBlockComponent
 								title={witnessTypeDataVideo.title}
 								description={witnessTypeDataVideo.description}
@@ -768,7 +814,10 @@ export const ElementRenderer = ({
 					// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
 					const witnessTypeDataText = element.witnessTypeData as WitnessTypeDataText;
 					return (
-						<Figure isMainMedia={isMainMedia}>
+						<Figure
+							isMainMedia={isMainMedia}
+							roleStylesFn={roleStylesFn}
+						>
 							<WitnessTextBlockComponent
 								title={witnessTypeDataText.title}
 								description={witnessTypeDataText.description}
@@ -788,6 +837,7 @@ export const ElementRenderer = ({
 					isMainMedia={isMainMedia}
 					role={isLiveBlog ? 'inline' : element.role}
 					id={element.elementId}
+					roleStylesFn={roleStylesFn}
 				>
 					<YoutubeBlockComponent
 						format={format}


### PR DESCRIPTION
## What does this change?

Adds a basic implementation of immersive interactives. Note, this is aiming for a limited kind of visual parity, but nothing else atm. There are bugs and missing features.

Note, I'm not especially happy with the approach to customising/removing role-specific styling for the elements here. Very open to better suggestions.

### Before

Nowt.

### After

E.g. for https://www.theguardian.com/australia-news/ng-interactive/2021/may/11/the-complete-2021-australian-federal-budget-choose-what-matters-to-you.

(DCR endpoint is: http://localhost:3030/Interactive?url=http://localhost:9000/australia-news/ng-interactive/2021/may/11/the-complete-2021-australian-federal-budget-choose-what-matters-to-you.)

![Screenshot 2021-05-13 at 14 08 20](https://user-images.githubusercontent.com/858402/118131363-5be51a80-b3f6-11eb-879c-38600a20d752.png)

## Why?

Another step towards interactives on DCR.
