### PR TITLE
Labs rich links

### DIFF
--- a/src/web/components/RichLink.tsx
+++ b/src/web/components/RichLink.tsx
@@ -98,7 +98,6 @@ const labsRichLinkTitle = css`
 		${textSans.medium({ fontWeight: 'bold' })}
 	}
 	${textSans.small({ fontWeight: 'bold' })}
-
 `;
 
 const richLinkReadMore: (palette: Palette) => ColourType = (palette) => {
@@ -125,9 +124,9 @@ const readMoreTextStyle = css`
 	text-decoration: none;
 `;
 
-const labsReadMoreTextStyle = css `
-${textSans.medium({fontWeight:'regular'})}
-display: inline-block;
+const labsReadMoreTextStyle = css`
+	${textSans.medium({ fontWeight: 'regular' })}
+	display: inline-block;
 	height: 30px;
 	line-height: 25px;
 	padding-left: 4px;
@@ -221,7 +220,7 @@ export const RichLink = ({
 		: false;
 	const isOpinion = cardStyle === 'comment';
 	const mainContributor = getMainContributor(tags);
-const isLabs = format.theme === Special.Labs;
+	const isLabs = format.theme === Special.Labs;
 
 	return (
 		<div
@@ -245,11 +244,11 @@ const isLabs = format.theme === Special.Labs;
 					)}
 					<div className={richLinkElements}>
 						<div className={richLinkHeader}>
-							<div className={cx(
-									isLabs
-										? labsRichLinkTitle
-										: richLinkTitle,
-								)}>
+							<div
+								className={cx(
+									isLabs ? labsRichLinkTitle : richLinkTitle,
+								)}
+							>
 								{isOpinion && (
 									<>
 										<Hide when="above" breakpoint="wide">
@@ -300,11 +299,13 @@ const isLabs = format.theme === Special.Labs;
 						)}
 						<div className={richLinkReadMore(palette)}>
 							<ArrowInCircle />
-							<div className={cx(
+							<div
+								className={cx(
 									isLabs
 										? labsReadMoreTextStyle
 										: readMoreTextStyle,
-								)}>
+								)}
+							>
 								{readMoreText(contentType)}
 							</div>
 						</div>

--- a/src/web/components/RichLink.tsx
+++ b/src/web/components/RichLink.tsx
@@ -8,7 +8,7 @@ import {
 } from '@guardian/src-foundations/palette';
 import { headline, textSans } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
-import type { Format } from '@guardian/types';
+import { Format, Special } from '@guardian/types';
 
 import ArrowInCircle from '@frontend/static/icons/arrow-in-circle.svg';
 
@@ -93,6 +93,14 @@ const richLinkTitle = css`
 	}
 `;
 
+const labsRichLinkTitle = css`
+	${from.wide} {
+		${textSans.medium({ fontWeight: 'bold' })}
+	}
+	${textSans.small({ fontWeight: 'bold' })}
+
+`;
+
 const richLinkReadMore: (palette: Palette) => ColourType = (palette) => {
 	return css`
 		fill: ${palette.fill.richLink};
@@ -115,6 +123,17 @@ const readMoreTextStyle = css`
 	vertical-align: top;
 	font-weight: 500;
 	text-decoration: none;
+`;
+
+const labsReadMoreTextStyle = css `
+${textSans.medium({fontWeight:'regular'})}
+display: inline-block;
+	height: 30px;
+	line-height: 25px;
+	padding-left: 4px;
+	vertical-align: top;
+	text-decoration: none;
+	color: ${neutral[7]};
 `;
 
 const byline = css`
@@ -202,6 +221,7 @@ export const RichLink = ({
 		: false;
 	const isOpinion = cardStyle === 'comment';
 	const mainContributor = getMainContributor(tags);
+const isLabs = format.theme === Special.Labs;
 
 	return (
 		<div
@@ -225,7 +245,11 @@ export const RichLink = ({
 					)}
 					<div className={richLinkElements}>
 						<div className={richLinkHeader}>
-							<div className={richLinkTitle}>
+							<div className={cx(
+									isLabs
+										? labsRichLinkTitle
+										: richLinkTitle,
+								)}>
 								{isOpinion && (
 									<>
 										<Hide when="above" breakpoint="wide">
@@ -276,7 +300,11 @@ export const RichLink = ({
 						)}
 						<div className={richLinkReadMore(palette)}>
 							<ArrowInCircle />
-							<div className={readMoreTextStyle}>
+							<div className={cx(
+									isLabs
+										? labsReadMoreTextStyle
+										: readMoreTextStyle,
+								)}>
 								{readMoreText(contentType)}
 							</div>
 						</div>


### PR DESCRIPTION
### What's changed?
There's some design changes included here to improve accessibility too, hence the difference in appearance from frontend. It now uses the correct sans-serif fonts too

### Frontend
<img width="284" alt="Screen Shot 2021-05-14 at 09 58 19" src="https://user-images.githubusercontent.com/2051501/118277304-90bda400-b4c0-11eb-8370-f88e4cf194a7.png">

### Current DCR
<img width="284" alt="Screen Shot 2021-05-14 at 10 02 26" src="https://user-images.githubusercontent.com/2051501/118277286-8c918680-b4c0-11eb-8740-4cdaf5b31627.png">

### New DCR
<img width="284" alt="Screen Shot 2021-05-14 at 09 58 38" src="https://user-images.githubusercontent.com/2051501/118277299-8f8c7700-b4c0-11eb-8b01-72d03d2ea862.png">