### PR TITLE
Add email prop to RR banner

### DIFF
--- a/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/src/web/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -12,6 +12,7 @@ import {
 	withinLocalNoBannerCachePeriod,
 	setLocalNoBannerCachePeriod,
 	MODULES_VERSION,
+	getEmail,
 } from '@root/src/web/lib/contributions';
 import { getCookie } from '@root/src/web/browser/cookie';
 import {
@@ -52,6 +53,7 @@ type CanShowProps = BaseProps & {
 	remoteBannerConfig: boolean;
 	section: string;
 	isPreview: boolean;
+	idApiUrl: string;
 };
 
 type ReaderRevenueComponentType =
@@ -132,6 +134,7 @@ export const canShowRRBanner: CanShowFunctionType = async ({
 	engagementBannerLastClosedAt,
 	subscriptionBannerLastClosedAt,
 	isPreview,
+	idApiUrl,
 }) => {
 	if (!remoteBannerConfig) return { result: false };
 
@@ -169,24 +172,22 @@ export const canShowRRBanner: CanShowFunctionType = async ({
 	const forcedVariant = getForcedVariant('banner');
 	const queryString = forcedVariant ? `?force=${forcedVariant}` : '';
 
-	return getBanner(
+	const json: { data?: any } = await getBanner(
 		bannerPayload,
 		`${contributionsServiceUrl}/banner${queryString}`,
-	).then((json: { data?: any }) => {
-		if (!json.data) {
-			if (
-				engagementBannerLastClosedAt &&
-				subscriptionBannerLastClosedAt
-			) {
-				setLocalNoBannerCachePeriod();
-			}
-			return { result: false };
+	);
+	if (!json.data) {
+		if (engagementBannerLastClosedAt && subscriptionBannerLastClosedAt) {
+			setLocalNoBannerCachePeriod();
 		}
+		return { result: false };
+	}
 
-		const { module, meta } = json.data;
+	const { module, meta } = json.data;
 
-		return { result: true, meta: { module, meta } };
-	});
+	const email = isSignedIn ? await getEmail(idApiUrl) : undefined;
+
+	return { result: true, meta: { module, meta, email } };
 };
 
 export const canShowPuzzlesBanner: CanShowFunctionType = async ({
@@ -254,6 +255,7 @@ export const canShowPuzzlesBanner: CanShowFunctionType = async ({
 export type BannerProps = {
 	meta: any;
 	module: { url: string; name: string; props: any[] };
+	email?: string;
 };
 
 type RemoteBannerProps = BannerProps & {
@@ -266,6 +268,7 @@ const RemoteBanner = ({
 	displayEvent,
 	meta,
 	module,
+	email,
 }: RemoteBannerProps) => {
 	const [Banner, setBanner] = useState<React.FC>();
 
@@ -326,6 +329,7 @@ const RemoteBanner = ({
 					{...module.props}
 					// @ts-ignore
 					submitComponentEvent={submitComponentEvent}
+					email={email}
 				/>
 				{/* eslint-enable react/jsx-props-no-spreading */}
 			</div>
@@ -335,12 +339,13 @@ const RemoteBanner = ({
 	return null;
 };
 
-export const ReaderRevenueBanner = ({ meta, module }: BannerProps) => (
+export const ReaderRevenueBanner = ({ meta, module, email }: BannerProps) => (
 	<RemoteBanner
 		componentTypeName="ACQUISITIONS_SUBSCRIPTIONS_BANNER"
 		displayEvent="subscription-banner : display"
 		meta={meta}
 		module={module}
+		email={email}
 	/>
 );
 

--- a/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
+++ b/src/web/components/StickyBottomBanner/StickyBottomBanner.tsx
@@ -99,9 +99,14 @@ const buildRRBannerConfigWith = ({
 						),
 						section: CAPI.config.section,
 						isPreview,
+						idApiUrl: CAPI.config.idApiUrl,
 					}),
-				show: ({ meta, module }: BannerProps) => () => (
-					<BannerComponent meta={meta} module={module} />
+				show: ({ meta, module, email }: BannerProps) => () => (
+					<BannerComponent
+						meta={meta}
+						module={module}
+						email={email}
+					/>
 				),
 			},
 			timeoutMillis: DEFAULT_BANNER_TIMEOUT_MILLIS,

--- a/src/web/layouts/lib/stickiness.tsx
+++ b/src/web/layouts/lib/stickiness.tsx
@@ -32,7 +32,7 @@ const bannerWrapper = css`
 	position: fixed !important;
 	bottom: 0;
 	${getZIndexImportant('banner')}
-	max-height: 80vh;
+	max-height: 100vh;
 	overflow: visible;
 	width: 100% !important;
 	background: none !important;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Add email prop to RR banner. This is for the new reminder feature we're adding to the contributions banner (https://github.com/guardian/support-dotcom-components/pull/447)
