### PR TITLE
Add underline to amp analysis title

### DIFF
--- a/src/amp/components/topMeta/TopMeta.tsx
+++ b/src/amp/components/topMeta/TopMeta.tsx
@@ -6,6 +6,7 @@ import { ArticleModel } from '@root/src/amp/types/ArticleModel';
 import { TopMetaNews } from '@root/src/amp/components/topMeta/TopMetaNews';
 import { TopMetaOpinion } from '@root/src/amp/components/topMeta/TopMetaOpinion';
 import { TopMetaPaidContent } from '@root/src/amp/components/topMeta/TopMetaPaidContent';
+import { TopMetaAnalysis } from '@root/src/amp/components/topMeta/TopMetaAnalysis';
 
 export const TopMeta: React.FunctionComponent<{
 	data: ArticleModel;
@@ -19,6 +20,8 @@ export const TopMeta: React.FunctionComponent<{
 		case Design.Comment:
 		case Design.Letter:
 			return <TopMetaOpinion articleData={data} pillar={pillar} />;
+		case Design.Analysis:
+			return <TopMetaAnalysis articleData={data} pillar={pillar} />;
 		default:
 			return (
 				<TopMetaNews

--- a/src/amp/components/topMeta/TopMetaAnalysis.tsx
+++ b/src/amp/components/topMeta/TopMetaAnalysis.tsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import { css, cx } from 'emotion';
+import { palette } from '@guardian/src-foundations';
+import { headline } from '@guardian/src-foundations/typography';
+import { until } from '@guardian/src-foundations/mq';
+import { pillarPalette_DO_NOT_USE } from '@root/src/lib/pillars';
+import { ArticleModel } from '@root/src/amp/types/ArticleModel';
+import { MainMedia } from '@root/src/amp/components/MainMedia';
+import { Byline } from '@root/src/amp/components/topMeta/Byline';
+import { string as curly } from 'curlyquotes';
+import { TopMetaExtras } from '@root/src/amp/components/topMeta/TopMetaExtras';
+import { Standfirst } from '@root/src/amp/components/topMeta/Standfirst';
+import { SeriesLink } from '@root/src/amp/components/topMeta/SeriesLink';
+import { getSharingUrls } from '@root/src/lib/sharing-urls';
+import { getAgeWarning } from '@root/src/lib/age-warning';
+import { Branding } from '@root/src/amp/components/topMeta/Branding';
+import { StarRating } from '@root/src/amp/components/StarRating';
+
+const headerStyle = css`
+	${headline.small()};
+	font-weight: 500;
+	padding-bottom: 24px;
+	padding-top: 3px;
+	color: ${palette.neutral[7]};
+`;
+
+const underlinedStyles = css`
+	background-image: repeating-linear-gradient(
+		to bottom,
+		transparent,
+		transparent 47px,
+		rgba(171, 6, 19, 0.5)
+	);
+	line-height: 48px;
+	background-size: 1rem 48px;
+	${until.tablet} {
+		background-image: repeating-linear-gradient(
+			to bottom,
+			transparent,
+			transparent 39px,
+			rgba(171, 6, 19, 0.5)
+		);
+		line-height: 40px;
+		background-size: 1px 40px;
+	}
+
+	background-position: top left;
+	background-clip: content-box;
+	background-origin: content-box;
+`;
+
+const bylineStyle = (pillar: Theme) => css`
+	${headline.xxxsmall()};
+	color: ${pillarPalette_DO_NOT_USE[pillar].main};
+	padding-bottom: 8px;
+	font-style: italic;
+
+	a {
+		font-weight: 700;
+		color: ${pillarPalette_DO_NOT_USE[pillar].main};
+		text-decoration: none;
+		font-style: normal;
+	}
+`;
+
+const starRatingWrapper = css`
+	margin: 0 0 6px -10px;
+`;
+
+const Headline: React.FC<{
+	headlineText: string;
+	starRating?: number;
+}> = ({ headlineText, starRating }) => {
+	return (
+		<div>
+			<h1 className={cx(headerStyle, underlinedStyles)}>
+				{curly(headlineText)}
+			</h1>
+
+			{starRating !== undefined && (
+				<div className={starRatingWrapper}>
+					<StarRating rating={starRating} size="large" />
+				</div>
+			)}
+		</div>
+	);
+};
+
+export const TopMetaAnalysis: React.FC<{
+	articleData: ArticleModel;
+	adTargeting?: AdTargeting;
+	pillar: Theme;
+}> = ({ articleData, adTargeting, pillar }) => {
+	const { branding } = articleData.commercialProperties[
+		articleData.editionId
+	];
+
+	return (
+		<header>
+			{articleData.mainMediaElements.map((element, i) => (
+				<MainMedia
+					key={i}
+					element={element}
+					pillar={pillar}
+					adTargeting={adTargeting}
+				/>
+			))}
+
+			{!articleData.isImmersive && (
+				<SeriesLink
+					baseURL={articleData.guardianBaseURL}
+					tags={articleData.tags}
+					pillar={pillar}
+					fallbackToSection={true}
+					sectionLabel={articleData.sectionLabel}
+					sectionUrl={articleData.sectionUrl}
+				/>
+			)}
+
+			<Headline
+				headlineText={articleData.headline}
+				starRating={articleData.starRating}
+			/>
+
+			<Standfirst text={articleData.standfirst} pillar={pillar} />
+
+			{branding && <Branding branding={branding} pillar={pillar} />}
+
+			<Byline
+				byline={articleData.author.byline}
+				tags={articleData.tags}
+				pillar={pillar}
+				guardianBaseURL={articleData.guardianBaseURL}
+				className={bylineStyle(pillar)}
+			/>
+
+			<TopMetaExtras
+				sharingUrls={getSharingUrls(
+					articleData.pageId,
+					articleData.webTitle,
+				)}
+				pillar={pillar}
+				ageWarning={getAgeWarning(
+					articleData.tags,
+					articleData.webPublicationDate,
+				)}
+				webPublicationDate={articleData.webPublicationDateDisplay}
+				twitterHandle={articleData.author.twitterHandle}
+			/>
+		</header>
+	);
+};

--- a/src/web/browser/coreVitals/coreVitals.ts
+++ b/src/web/browser/coreVitals/coreVitals.ts
@@ -33,11 +33,11 @@ export const coreVitals = (): void => {
 		name: string;
 		value: number;
 	};
-	
+
 	const nineDigitPrecision = (value: number) => {
 		// The math functions are to make sure the length of number is <= 9
 		return Math.round(value * 1_000_000) / 1_000_000;
-	}
+	};
 
 	const addToJson = ({ name, value }: CoreVitalsArgs): void => {
 		switch (name) {


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Analysis articles on AMP  were missing the underline found elsewhere. 

This adds support for Analysis specific `TopMeta`, with the first specific change being adding underline styles. It follows the existing pattern of each `Design` type needed specific rules having its own `TopMeta...` component.

### Before
![image](https://user-images.githubusercontent.com/9122944/118289271-134c6080-b4cd-11eb-882a-bd18b03a1bc0.png)

### After
![image](https://user-images.githubusercontent.com/9122944/118289251-0d567f80-b4cd-11eb-81c2-b287b252bb1d.png)

## Why?
Editorial request.
