### PR TITLE
Prevent Braze web sdk from auto populating fields

### DIFF
--- a/src/web/browser/coreVitals/coreVitals.ts
+++ b/src/web/browser/coreVitals/coreVitals.ts
@@ -33,11 +33,11 @@ export const coreVitals = (): void => {
 		name: string;
 		value: number;
 	};
-	
+
 	const nineDigitPrecision = (value: number) => {
 		// The math functions are to make sure the length of number is <= 9
 		return Math.round(value * 1_000_000) / 1_000_000;
-	}
+	};
 
 	const addToJson = ({ name, value }: CoreVitalsArgs): void => {
 		switch (name) {

--- a/src/web/lib/braze/initialiseAppboy.ts
+++ b/src/web/lib/braze/initialiseAppboy.ts
@@ -1,11 +1,12 @@
 import type appboy from '@braze/web-sdk-core';
 
-const SDK_OPTIONS = {
+const SDK_OPTIONS: appboy.InitializationOptions = {
 	enableLogging: false,
 	noCookies: true,
 	baseUrl: 'https://sdk.fra-01.braze.eu/api/v3',
 	sessionTimeoutInSeconds: 1,
 	minimumIntervalBetweenTriggerActionsInSeconds: 0,
+	devicePropertyAllowlist: [],
 };
 
 const initialiseAppboy = async (apiKey: string): Promise<typeof appboy> => {


### PR DESCRIPTION
# What does this change?

## Before
No devicePropertyAllowlist set on braze sdk initialization meaning Braze was infering multiple fields on the first time a user loads the sdk.

These fields are listed here:
https://www.braze.com/docs/developer_guide/platform_integration_guides/web/cookies_and_storage/#device-properties

## After
devicePropertyAllowlist set to empty list on braze sdk initialisation

## Why?
Braze is infering certain fields incorrectly, this change prevents that.