### PR TITLE
Update definition of CodeBlockElement

### DIFF
--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -86,7 +86,7 @@ interface QuizAtomBlockElement {
 interface CodeBlockElement {
 	_type: 'model.dotcomrendering.pageElements.CodeBlockElement';
 	elementId: string;
-	code: string;
+	html: string;
 	isMandatory: boolean;
 	language?: Language;
 }

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -1144,8 +1144,8 @@
             },
             "required": [
                 "_type",
-                "html",
                 "elementId",
+                "html",
                 "isMandatory"
             ]
         },

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -1132,7 +1132,7 @@
                 "elementId": {
                     "type": "string"
                 },
-                "code": {
+                "html": {
                     "type": "string"
                 },
                 "isMandatory": {
@@ -1144,7 +1144,7 @@
             },
             "required": [
                 "_type",
-                "code",
+                "html",
                 "elementId",
                 "isMandatory"
             ]

--- a/src/web/lib/ElementRenderer.tsx
+++ b/src/web/lib/ElementRenderer.tsx
@@ -163,7 +163,7 @@ export const ElementRenderer = ({
 		case 'model.dotcomrendering.pageElements.CodeBlockElement':
 			return (
 				<CodeBlockComponent
-					code={element.code}
+					code={element.html}
 					language={element.language}
 				/>
 			);


### PR DESCRIPTION
This corrects the definition of `CodeBlockElement` to match the backend definition. This will prevent pages with `CodeBlockElement`s in them to fail.

Note: When the DCR definition of `CodeBlockElement` was first made, it made sense to call the attribute `code`, but it's called `html` in CAPI and in the backend PageElement, so I am mirroring that here. 

The `CodeBlockComponent`'s corresponding attribute can still be called `code` since this is what it means in that context. 
