### PR TITLE
readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,4 +159,4 @@ If you prefer not to use an editor like VSCode then you can use the following co
 
 <a href="https://www.chromaticqa.com/"><img src="https://cdn-images-1.medium.com/letterbox/147/36/50/50/1*oHHjTjInDOBxIuYHDY2gFA.png?source=logoAvatar-d7276495b101---37816ec27d7a" width="120"/></a>
 
-Thanks to [Chromatic](https://www.chromaticqa.com/) for providing the visual testing platform that helps us catch unexpected changes on time.
+Thanks to [Chromatic](https://www.chromaticqa.com/) for providing the visual testing platform that helps us catch unexpected changes on time

--- a/README.md
+++ b/README.md
@@ -159,4 +159,4 @@ If you prefer not to use an editor like VSCode then you can use the following co
 
 <a href="https://www.chromaticqa.com/"><img src="https://cdn-images-1.medium.com/letterbox/147/36/50/50/1*oHHjTjInDOBxIuYHDY2gFA.png?source=logoAvatar-d7276495b101---37816ec27d7a" width="120"/></a>
 
-Thanks to [Chromatic](https://www.chromaticqa.com/) for providing the visual testing platform that helps us catch unexpected changes on time
+Thanks to [Chromatic](https://www.chromaticqa.com/) for providing the visual testing platform that helps us catch unexpected changes on time.

--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -674,6 +674,7 @@ interface Switches {
 
 // Used for CodeBlockElement
 type Language =
+	| 'text'
 	| 'typescript'
 	| 'javascript'
 	| 'css'

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -1156,6 +1156,7 @@
                 "javascript",
                 "markup",
                 "scala",
+                "text",
                 "typescript"
             ],
             "type": "string"


### PR DESCRIPTION
When the list of Languages was defined in DCR, they forgot to add `text` which is actually being used in CAPI

<img width="1160" alt="Screenshot 2021-05-17 at 14 47 58" src="https://user-images.githubusercontent.com/6035518/118500387-a67cd480-b71f-11eb-807a-3a2580483ddc.png">

