### PR TITLE
Disable Prism.highlight (for the moment)

### DIFF
--- a/src/web/components/elements/CodeBlockComponent.tsx
+++ b/src/web/components/elements/CodeBlockComponent.tsx
@@ -2,7 +2,7 @@
 // stylelint-disable color-no-hex
 import React from 'react';
 import { css } from 'emotion';
-import Prism from 'prismjs';
+// import Prism from 'prismjs';
 
 import { space } from '@guardian/src-foundations';
 
@@ -117,18 +117,25 @@ const codeStyles = css`
 
 export const CodeBlockComponent = ({
 	code,
+	// Igoring language, while Prism.highlight is being fixed.
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	language = 'typescript',
 }: Props) => {
+
+	/*
+	Not using Prism.highlight for the moment because it's broken. Will fix shortly.
+
 	const highlighted = Prism.highlight(
 		code,
 		Prism.languages[language],
 		language,
 	);
+	*/
 
 	return (
 		<pre className={codeStyles}>
 			<code>
-				<div dangerouslySetInnerHTML={{ __html: highlighted }} />
+				<div dangerouslySetInnerHTML={{ __html: code }} />
 			</code>
 		</pre>
 	);

--- a/src/web/components/elements/CodeBlockComponent.tsx
+++ b/src/web/components/elements/CodeBlockComponent.tsx
@@ -121,7 +121,6 @@ export const CodeBlockComponent = ({
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	language = 'typescript',
 }: Props) => {
-
 	/*
 	Not using Prism.highlight for the moment because it's broken. Will fix shortly.
 


### PR DESCRIPTION
Now that Frontend is about to send ( https://github.com/guardian/frontend/pull/23815 ) to `CodeBlockElement`'s `language` to DCR, then  we need to disable Prism.highlight (for the moment), as it is broken.

BEFORE:

<img width="1449" alt="Screenshot 2021-05-17 at 15 43 27" src="https://user-images.githubusercontent.com/6035518/118510927-53a81a80-b729-11eb-9078-a8bf17ea14b0.png">

AFTER:

<img width="1077" alt="Screenshot 2021-05-17 at 15 44 26" src="https://user-images.githubusercontent.com/6035518/118510940-59056500-b729-11eb-91a1-d66fb964d5e9.png">
