### PR TITLE
Redefine CodeBlockElement's language as string

### DIFF
--- a/src/lib/content.d.ts
+++ b/src/lib/content.d.ts
@@ -88,7 +88,7 @@ interface CodeBlockElement {
 	elementId: string;
 	html: string;
 	isMandatory: boolean;
-	language?: Language;
+	language?: string;
 }
 
 interface CommentBlockElement {
@@ -671,16 +671,6 @@ interface TimelineEvent {
 interface Switches {
 	[key: string]: boolean;
 }
-
-// Used for CodeBlockElement
-type Language =
-	| 'text'
-	| 'typescript'
-	| 'javascript'
-	| 'css'
-	| 'markup'
-	| 'scala'
-	| 'elm';
 
 type RatingSizeType = 'large' | 'medium' | 'small';
 

--- a/src/model/json-schema.json
+++ b/src/model/json-schema.json
@@ -1139,7 +1139,7 @@
                     "type": "boolean"
                 },
                 "language": {
-                    "$ref": "#/definitions/Language"
+                    "type": "string"
                 }
             },
             "required": [
@@ -1148,18 +1148,6 @@
                 "html",
                 "isMandatory"
             ]
-        },
-        "Language": {
-            "enum": [
-                "css",
-                "elm",
-                "javascript",
-                "markup",
-                "scala",
-                "text",
-                "typescript"
-            ],
-            "type": "string"
         },
         "CommentBlockElement": {
             "type": "object",

--- a/src/web/components/elements/CodeBlockComponent.tsx
+++ b/src/web/components/elements/CodeBlockComponent.tsx
@@ -8,7 +8,7 @@ import { space } from '@guardian/src-foundations';
 
 type Props = {
 	code: string;
-	language?: Language;
+	language?: string;
 };
 
 const codeStyles = css`


### PR DESCRIPTION
## What does this change?

This moves away from defining the `language` attribute of the `CodeBlockElement` from a union type to a string. The previous definition is overkill and would pose validation duplication on the backend side.
