### PR TITLE
Add amp-sticky-ad component

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -943,6 +943,7 @@ declare namespace JSX {
 		'amp-analytics': any;
 		'amp-pixel': any;
 		'amp-ad': any;
+		'amp-sticky-ad': any;
 		'amp-youtube': any;
 		'amp-geo': any;
 		'amp-consent': any;

--- a/src/amp/components/Ad.tsx
+++ b/src/amp/components/Ad.tsx
@@ -9,6 +9,9 @@ const sizes = [
 	{ width: 250, height: 250 }, // Square
 ];
 
+// Note: amp-sticky-ad has max height of 100
+const stickySizes = [{ width: 320, height: 50 }]; // Mobile Leaderboard
+
 const adClass = css`
 	display: none;
 `;
@@ -107,6 +110,7 @@ interface CommercialConfig {
 }
 
 export const Ad = ({
+	isSticky,
 	adRegion,
 	edition,
 	section,
@@ -114,6 +118,7 @@ export const Ad = ({
 	config,
 	commercialProperties,
 }: {
+	isSticky?: boolean;
 	adRegion: AdRegion;
 	edition: Edition;
 	section: string;
@@ -121,8 +126,18 @@ export const Ad = ({
 	config: CommercialConfig;
 	commercialProperties: CommercialProperties;
 }) => {
-	const { width, height } = sizes[0]; // Set initial size to MPU
-	const multiSizes = sizes.map((e) => `${e.width}x${e.height}`).join(',');
+	let width;
+	let height;
+	let multiSizes;
+
+	if (isSticky) {
+		[{ width, height }] = stickySizes; // Set initial size to Mobile Leaderboard
+		multiSizes = stickySizes.map((e) => `${e.width}x${e.height}`).join(',');
+	} else {
+		[{ width, height }] = sizes; // Set initial size to MPU
+		multiSizes = sizes.map((e) => `${e.width}x${e.height}`).join(',');
+	}
+
 	return (
 		<amp-ad
 			class={cx(adClass, adRegionClasses[adRegion])}

--- a/src/amp/components/Ad.tsx
+++ b/src/amp/components/Ad.tsx
@@ -109,6 +109,16 @@ interface CommercialConfig {
 	usePermutive: boolean;
 }
 
+export interface AdProps {
+	isSticky?: boolean;
+	adRegion: AdRegion;
+	edition: Edition;
+	section: string;
+	contentType: string;
+	config: CommercialConfig;
+	commercialProperties: CommercialProperties;
+}
+
 export const Ad = ({
 	isSticky,
 	adRegion,
@@ -117,15 +127,7 @@ export const Ad = ({
 	contentType,
 	config,
 	commercialProperties,
-}: {
-	isSticky?: boolean;
-	adRegion: AdRegion;
-	edition: Edition;
-	section: string;
-	contentType: string;
-	config: CommercialConfig;
-	commercialProperties: CommercialProperties;
-}) => {
+}: AdProps) => {
 	const adSizes = isSticky ? stickySizes : inlineSizes;
 	const [{ width, height }] = adSizes; // Set initial size as first element (should be the largest)
 	const multiSizes = adSizes.map((e) => `${e.width}x${e.height}`).join(',');

--- a/src/amp/components/Ad.tsx
+++ b/src/amp/components/Ad.tsx
@@ -4,7 +4,7 @@ import { css, cx } from 'emotion';
 import { adJson, stringify } from '@root/src/amp/lib/ad-json';
 
 // Largest size first
-const sizes = [
+const inlineSizes = [
 	{ width: 300, height: 250 }, // MPU
 	{ width: 250, height: 250 }, // Square
 ];
@@ -126,17 +126,9 @@ export const Ad = ({
 	config: CommercialConfig;
 	commercialProperties: CommercialProperties;
 }) => {
-	let width;
-	let height;
-	let multiSizes;
-
-	if (isSticky) {
-		[{ width, height }] = stickySizes; // Set initial size to Mobile Leaderboard
-		multiSizes = stickySizes.map((e) => `${e.width}x${e.height}`).join(',');
-	} else {
-		[{ width, height }] = sizes; // Set initial size to MPU
-		multiSizes = sizes.map((e) => `${e.width}x${e.height}`).join(',');
-	}
+	const adSizes = isSticky ? stickySizes : inlineSizes;
+	const [{ width, height }] = adSizes; // Set initial size as first element (should be the largest)
+	const multiSizes = adSizes.map((e) => `${e.width}x${e.height}`).join(',');
 
 	return (
 		<amp-ad

--- a/src/amp/components/BodyArticle.tsx
+++ b/src/amp/components/BodyArticle.tsx
@@ -20,7 +20,6 @@ import { buildAdTargeting } from '@root/src/lib/ad-targeting';
 import { Epic } from '@root/src/amp/components/Epic';
 import { decideDesign } from '@root/src/web/lib/decideDesign';
 import { decideTheme } from '@root/src/web/lib/decideTheme';
-import { StickyAd } from './StickyAd';
 
 const bulletStyle = (pillar: Theme) => css`
 	.bullet {
@@ -192,18 +191,6 @@ export const Body: React.FC<{
 			/>
 
 			{elements}
-
-			<StickyAd>
-				<Ad
-					isSticky={true}
-					adRegion="US"
-					edition={data.editionId}
-					section={data.sectionName || ''}
-					contentType={adInfo.contentType}
-					config={adConfig}
-					commercialProperties={adInfo.commercialProperties}
-				/>
-			</StickyAd>
 
 			{epic}
 

--- a/src/amp/components/BodyArticle.tsx
+++ b/src/amp/components/BodyArticle.tsx
@@ -20,6 +20,7 @@ import { buildAdTargeting } from '@root/src/lib/ad-targeting';
 import { Epic } from '@root/src/amp/components/Epic';
 import { decideDesign } from '@root/src/web/lib/decideDesign';
 import { decideTheme } from '@root/src/web/lib/decideTheme';
+import { StickyAd } from './StickyAd';
 
 const bulletStyle = (pillar: Theme) => css`
 	.bullet {
@@ -191,6 +192,17 @@ export const Body: React.FC<{
 			/>
 
 			{elements}
+
+			<StickyAd>
+				<Ad
+					adRegion="US"
+					edition={data.editionId}
+					section={data.sectionName || ''}
+					contentType={adInfo.contentType}
+					config={adConfig}
+					commercialProperties={adInfo.commercialProperties}
+				/>
+			</StickyAd>
 
 			{epic}
 

--- a/src/amp/components/BodyArticle.tsx
+++ b/src/amp/components/BodyArticle.tsx
@@ -195,6 +195,7 @@ export const Body: React.FC<{
 
 			<StickyAd>
 				<Ad
+					isSticky={true}
 					adRegion="US"
 					edition={data.editionId}
 					section={data.sectionName || ''}

--- a/src/amp/components/StickyAd.tsx
+++ b/src/amp/components/StickyAd.tsx
@@ -1,5 +1,14 @@
 import React, { ReactChild } from 'react';
 
+/* A wrapper component for <Ad /> which makes the ad show in a sticky footer
+   Add to article like this:
+	<StickyAd>
+		<Ad
+			isSticky={true}
+			...
+		/>
+	</StickyAd>
+*/
 export const StickyAd = ({ children }: { children: ReactChild }) => {
 	return <amp-sticky-ad layout="nodisplay">{children}</amp-sticky-ad>;
 };

--- a/src/amp/components/StickyAd.tsx
+++ b/src/amp/components/StickyAd.tsx
@@ -1,19 +1,19 @@
 import React from 'react';
-import { Ad } from './Ad';
-import type { AdProps } from './Ad';
 
-// This CSS is added to global styles in document.tsx, to add the Advertisment label to the sticky
-export const stickyAdLabel = `
+import { text } from '@guardian/src-foundations/palette';
+import { textSans } from '@guardian/src-foundations/typography';
+import type { AdProps } from './Ad';
+import { Ad } from './Ad';
+
+// This CSS should be imported and added to global styles in amp/server/document.tsx to add the Advertisment label to the sticky
+export const stickyAdLabelCss = `
 amp-sticky-ad:before {
 	content: 'Advertisement';
 	display: block;
-	font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
-	font-size: 0.75rem;
-	line-height: 1.5;
-	font-weight: 400;
-	font-family: 'Helvetica Neue',Helvetica,Arial,'Lucida Grande',sans-serif;
+	${textSans.xsmall()};
+	font-family: 'Helvetica Neue',Helvetica,Arial,'Lucida Grande',sans-serif !important;
 	padding: 3px 10px;
-	color: #767676;
+	color: ${text.supporting};
 	text-align: right;
 }`;
 

--- a/src/amp/components/StickyAd.tsx
+++ b/src/amp/components/StickyAd.tsx
@@ -1,0 +1,5 @@
+import React, { ReactChild } from 'react';
+
+export const StickyAd = ({ children }: { children: ReactChild }) => {
+	return <amp-sticky-ad layout="nodisplay">{children}</amp-sticky-ad>;
+};

--- a/src/amp/components/StickyAd.tsx
+++ b/src/amp/components/StickyAd.tsx
@@ -2,6 +2,21 @@ import React from 'react';
 import { Ad } from './Ad';
 import type { AdProps } from './Ad';
 
+// This CSS is added to global styles in document.tsx, to add the Advertisment label to the sticky
+export const stickyAdLabel = `
+amp-sticky-ad:before {
+	content: 'Advertisement';
+	display: block;
+	font-family: GuardianTextSans,Guardian Text Sans Web,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
+	font-size: 0.75rem;
+	line-height: 1.5;
+	font-weight: 400;
+	font-family: 'Helvetica Neue',Helvetica,Arial,'Lucida Grande',sans-serif;
+	padding: 3px 10px;
+	color: #767676;
+	text-align: right;
+}`;
+
 export const StickyAd = ({
 	adRegion,
 	edition,

--- a/src/amp/components/StickyAd.tsx
+++ b/src/amp/components/StickyAd.tsx
@@ -11,7 +11,7 @@ amp-sticky-ad:before {
 	content: 'Advertisement';
 	display: block;
 	${textSans.xsmall()};
-	font-family: 'Helvetica Neue',Helvetica,Arial,'Lucida Grande',sans-serif !important;
+	font-family: 'Helvetica Neue',Helvetica,Arial,'Lucida Grande',sans-serif;
 	padding: 3px 10px;
 	color: ${text.supporting};
 	text-align: right;

--- a/src/amp/components/StickyAd.tsx
+++ b/src/amp/components/StickyAd.tsx
@@ -1,14 +1,26 @@
-import React, { ReactChild } from 'react';
+import React from 'react';
+import { Ad } from './Ad';
+import type { AdProps } from './Ad';
 
-/* A wrapper component for <Ad /> which makes the ad show in a sticky footer
-   Add to article like this:
-	<StickyAd>
-		<Ad
-			isSticky={true}
-			...
-		/>
-	</StickyAd>
-*/
-export const StickyAd = ({ children }: { children: ReactChild }) => {
-	return <amp-sticky-ad layout="nodisplay">{children}</amp-sticky-ad>;
+export const StickyAd = ({
+	adRegion,
+	edition,
+	section,
+	contentType,
+	config,
+	commercialProperties,
+}: AdProps) => {
+	return (
+		<amp-sticky-ad layout="nodisplay">
+			<Ad
+				isSticky={true}
+				adRegion={adRegion}
+				edition={edition}
+				section={section}
+				contentType={contentType}
+				config={config}
+				commercialProperties={commercialProperties}
+			/>
+		</amp-sticky-ad>
+	);
 };

--- a/src/amp/server/document.tsx
+++ b/src/amp/server/document.tsx
@@ -76,6 +76,7 @@ export const document = ({
     <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
     <script async custom-element="amp-geo" src="https://cdn.ampproject.org/v0/amp-geo-0.1.js"></script>
     <script async custom-element="amp-consent" src="https://cdn.ampproject.org/v0/amp-consent-0.1.js"></script>
+	<script async custom-element="amp-sticky-ad" src="https://cdn.ampproject.org/v0/amp-sticky-ad-1.0.js"></script>
 
     <!-- AMP element which is specific to the live blog -->
     <script async custom-element="amp-live-list" src="https://cdn.ampproject.org/v0/amp-live-list-0.1.js"></script>

--- a/src/amp/server/document.tsx
+++ b/src/amp/server/document.tsx
@@ -5,6 +5,7 @@ import { CacheProvider } from '@emotion/core';
 import { cache } from 'emotion';
 import resetCSS from /* preval */ '@root/src/lib/reset-css';
 import { getFontsCss } from '@root/src/lib/fonts-css';
+import { stickyAdLabel } from '@root/src/amp/components/StickyAd';
 import he from 'he';
 
 interface RenderToStringResult {
@@ -92,6 +93,7 @@ export const document = ({
         ${getFontsCss()}
         ${resetCSS}
         ${css}
+		${stickyAdLabel}
     </style>
 
     </head>

--- a/src/amp/server/document.tsx
+++ b/src/amp/server/document.tsx
@@ -5,7 +5,6 @@ import { CacheProvider } from '@emotion/core';
 import { cache } from 'emotion';
 import resetCSS from /* preval */ '@root/src/lib/reset-css';
 import { getFontsCss } from '@root/src/lib/fonts-css';
-import { stickyAdLabel } from '@root/src/amp/components/StickyAd';
 import he from 'he';
 
 interface RenderToStringResult {
@@ -93,7 +92,6 @@ export const document = ({
         ${getFontsCss()}
         ${resetCSS}
         ${css}
-		${stickyAdLabel}
     </style>
 
     </head>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Add StickyAd component which wraps Ad to make it show in a sticky footer

https://trello.com/c/WW61ZO0F/718-implement-mobile-sticky-on-amp-in-us

### Before

### After

<img width="489" alt="Screenshot 2021-05-19 at 10 03 32" src="https://user-images.githubusercontent.com/19875457/118786732-05f6f380-b88a-11eb-8f7f-cd7fae97bb15.png">


## Why?

An extra option for displaying ads which stay in view on mobile pages