### PR TITLE
Use body-parser for JSON payload [in dev]

### DIFF
--- a/scripts/frontend/dev-server.js
+++ b/scripts/frontend/dev-server.js
@@ -8,6 +8,8 @@ const webpackDevMiddleware = require('webpack-dev-middleware');
 const webpackHotMiddleware = require('webpack-hot-middleware');
 const webpackHotServerMiddleware = require('webpack-hot-server-middleware');
 
+const bodyParser = require('body-parser');
+
 const { siteName, root } = require('./config');
 
 const defaultArticleURL =
@@ -34,7 +36,7 @@ const go = () => {
 	const compiler = webpack(webpackConfig);
 
 	const app = express();
-	app.use(express.json());
+	app.use(bodyParser.json({ limit: '10mb' }));
 
 	app.use(
 		`/static/${siteName}`,


### PR DESCRIPTION
This is uses `bodyParser` to parse the JSON DCR data object on local to prevent a "request entity too large" problem we observed with this url

```
http://localhost:3030/Article?url=http://localhost:9000/info/2018/nov/30/bye-bye-mongo-hello-postgres
```

Note: The DCR data object JSON serialization is well typically below 1Mb, so the 10Mb limit should be enough.

BEFORE:

<img width="681" alt="Screenshot 2021-05-19 at 09 50 30" src="https://user-images.githubusercontent.com/6035518/118794502-8c630380-b891-11eb-800a-72d61f6b6dcf.png">

<img width="1291" alt="Screenshot 2021-05-19 at 09 50 51" src="https://user-images.githubusercontent.com/6035518/118794512-8ff68a80-b891-11eb-83c2-047e8253fcd3.png">

AFTER:

<img width="975" alt="Screenshot 2021-05-19 at 11 02 37" src="https://user-images.githubusercontent.com/6035518/118794700-bfa59280-b891-11eb-92b1-ec0d91148a69.png">



