### PR TITLE
Fix labs photo essay caption colour

### DIFF
--- a/src/web/lib/decidePalette.ts
+++ b/src/web/lib/decidePalette.ts
@@ -124,9 +124,10 @@ const textTwitterHandle = (format: Format): string => {
 
 const textCaption = (format: Format): string => {
 	if (format.theme === Special.SpecialReport) return specialReport[100];
+	if (format.theme === Special.Labs) return neutral[20];
+
 	switch (format.design) {
 		case Design.PhotoEssay:
-			if (format.theme === Special.Labs) return brand[400];
 			return pillarPalette[format.theme].dark;
 		default:
 			return text.supporting;

--- a/src/web/lib/decidePalette.ts
+++ b/src/web/lib/decidePalette.ts
@@ -126,6 +126,7 @@ const textCaption = (format: Format): string => {
 	if (format.theme === Special.SpecialReport) return specialReport[100];
 	switch (format.design) {
 		case Design.PhotoEssay:
+			if (format.theme === Special.Labs) return brand[400]
 			return pillarPalette[format.theme].dark;
 		default:
 			return text.supporting;

--- a/src/web/lib/decidePalette.ts
+++ b/src/web/lib/decidePalette.ts
@@ -126,7 +126,7 @@ const textCaption = (format: Format): string => {
 	if (format.theme === Special.SpecialReport) return specialReport[100];
 	switch (format.design) {
 		case Design.PhotoEssay:
-			if (format.theme === Special.Labs) return brand[400]
+			if (format.theme === Special.Labs) return brand[400];
 			return pillarPalette[format.theme].dark;
 		default:
 			return text.supporting;


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

~~In Labs Photo-essays the caption colour needs to be a darker brand colour (brand-400) instead of using the labs theme colour.~~

Update: Based on discussion, PR will now change *all* labs articles to use neutral.20 as the caption colour, including photo essays.

### Before (PROD/frontend)
Non-Photo Essay:
![image](https://user-images.githubusercontent.com/9575458/118951117-b92b1f80-b952-11eb-8259-89e2781412ec.png)
Photo Essay: 
![image](https://user-images.githubusercontent.com/9575458/118951198-cea04980-b952-11eb-810e-7b97725a42fe.png)


### Before (DCR)
Non-Photo Essay:
![image](https://user-images.githubusercontent.com/9575458/118951339-ebd51800-b952-11eb-8985-69d6a6949f10.png)

Photo Essay:
![image](https://user-images.githubusercontent.com/9575458/118811228-aa862f00-b8a4-11eb-9afd-59aafe1161c0.png)

### After (DCR)
Non-Photo Essay:
![image](https://user-images.githubusercontent.com/9575458/118951441-01e2d880-b953-11eb-8791-b01640cd03f2.png)

Photo Essay:
![image](https://user-images.githubusercontent.com/9575458/118951577-1cb54d00-b953-11eb-9085-d1e59376f08e.png)

## Why?
Bring to parity with frontend
