### PR TITLE
Remove prism.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,6 @@
         "preact-render-to-string": "^5.1.19",
         "prettier-eslint": "^11.0.0",
         "pretty-bytes": "^5.6.0",
-        "prismjs": "^1.23.0",
         "reset-css": "^5.0.1",
         "sanitize-html": "^2.3.2",
         "swr": "^0.5.5",

--- a/src/web/components/elements/CodeBlockComponent.stories.tsx
+++ b/src/web/components/elements/CodeBlockComponent.stories.tsx
@@ -11,18 +11,11 @@ export default {
 
 export const CodeStory = () => {
 	const code = `
-export const CodeBlockComponent = ({
-	code,
-	language = 'text',
-}: Props) => {
-	return (
-		<pre className={codeStyles}>
-			<code>
-				<div dangerouslySetInnerHTML={{ __html: code }} />
-			</code>
-		</pre>
-	);
-};
+wget https://github.com/buger/goreplay/releases/download/v0.16.0.2/gor_0.16.0_x64.tar.gz
+
+tar -xzf gor_0.16.0_x64.tar.gz gor
+
+sudo gor --input-raw :80 --output-http http://apiv2.code.co.uk
     `;
 	return (
 		<ContainerLayout>

--- a/src/web/components/elements/CodeBlockComponent.stories.tsx
+++ b/src/web/components/elements/CodeBlockComponent.stories.tsx
@@ -9,97 +9,27 @@ export default {
 	title: 'Components/CodeBlockComponent',
 };
 
-export const JavascriptStory = () => {
-	const javascript = `
-import React from 'react';
-
-import { ContainerLayout } from '@frontend/web/components/ContainerLayout';
-
-import { CodeBlockComponent } from './CodeBlockComponent';
-
-export default {
-    component: CodeBlockComponent,
-    title: 'Components/CodeBlockComponent',
-};
-
-export const JavascriptStory = () => {
-    return (
-        <ContainerLayout>
-            <CodeBlockComponent code="// this story" language="javascript" />
-        </ContainerLayout>
-    );
-};
-JavascriptStory.story = {
-    name: 'with javascript',
+export const CodeStory = () => {
+	const code = `
+export const CodeBlockComponent = ({
+	code,
+	language = 'text',
+}: Props) => {
+	return (
+		<pre className={codeStyles}>
+			<code>
+				<div dangerouslySetInnerHTML={{ __html: code }} />
+			</code>
+		</pre>
+	);
 };
     `;
 	return (
 		<ContainerLayout>
-			<CodeBlockComponent code={javascript} language="javascript" />
+			<CodeBlockComponent code={code} language="text" />
 		</ContainerLayout>
 	);
 };
-JavascriptStory.story = {
-	name: 'with javascript',
-};
-
-export const ScalaStory = () => {
-	const scala = `
-import akka.http.scaladsl.model.HttpRequest
-import ch.qos.logback.classic.{Logger => LogbackLogger}
-import net.logstash.logback.marker.Markers
-import org.slf4j.{LoggerFactory, Logger => SLFLogger}
-
-import scala.collection.JavaConverters._
-
-object Logging {
-    val rootLogger: LogbackLogger = LoggerFactory.getLogger(SLFLogger.ROOT_LOGGER_NAME).asInstanceOf[LogbackLogger]
-
-    private def setMarkers(request: HttpRequest) = {
-    val markers = Map(
-        "path" -> request.uri.path.toString(),
-        "method" -> request.method.value
-    )
-    Markers.appendEntries(markers.asJava)
-    }
-
-    def infoWithMarkers(message: String, akkaRequest: HttpRequest) =
-    rootLogger.info(setMarkers(akkaRequest), message)
-}
-    `;
-	return (
-		<ContainerLayout>
-			<CodeBlockComponent code={scala} language="scala" />
-		</ContainerLayout>
-	);
-};
-ScalaStory.story = {
-	name: 'with scala',
-};
-
-export const TypescriptStory = () => {
-	const typescript = `
-// CodeBlockElement props
-type Props = {
-    code: string;
-    language?: Language;
-};
-
-// Used for CodeBlockElement
-type Language =
-    | 'typescript'
-    | 'javascript'
-    | 'css'
-    | 'markup'
-    | 'scala'
-    | 'elm';
-`;
-	return (
-		<ContainerLayout>
-			<CodeBlockComponent code={typescript} language="typescript" />
-		</ContainerLayout>
-	);
-};
-TypescriptStory.story = {
-	name: 'with typescript',
+CodeStory.story = {
+	name: 'default',
 };

--- a/src/web/components/elements/CodeBlockComponent.tsx
+++ b/src/web/components/elements/CodeBlockComponent.tsx
@@ -2,8 +2,6 @@
 // stylelint-disable color-no-hex
 import React from 'react';
 import { css } from 'emotion';
-// import Prism from 'prismjs';
-
 import { space } from '@guardian/src-foundations';
 
 type Props = {
@@ -40,97 +38,18 @@ const codeStyles = css`
 	@media print {
 		text-shadow: none;
 	}
-
-	.token.comment,
-	.token.prolog,
-	.token.doctype,
-	.token.cdata {
-		color: slategray;
-	}
-
-	.token.punctuation {
-		color: #999;
-	}
-
-	.token.namespace {
-		opacity: 0.7;
-	}
-
-	.token.property,
-	.token.tag,
-	.token.boolean,
-	.token.number,
-	.token.constant,
-	.token.symbol,
-	.token.deleted {
-		color: #905;
-	}
-
-	.token.selector,
-	.token.attr-name,
-	.token.string,
-	.token.char,
-	.token.builtin,
-	.token.inserted {
-		color: #690;
-	}
-
-	.token.operator,
-	.token.entity,
-	.token.url,
-	.language-css .token.string,
-	.style .token.string {
-		color: #9a6e3a;
-		/* This background color was intended by the author of this theme. */
-		background: hsla(0, 0%, 100%, 0.5);
-	}
-
-	.token.atrule,
-	.token.attr-value,
-	.token.keyword {
-		color: #07a;
-	}
-
-	.token.function,
-	.token.class-name {
-		color: #dd4a68;
-	}
-
-	.token.regex,
-	.token.important,
-	.token.variable {
-		color: #e90;
-	}
-
-	.token.important,
-	.token.bold {
-		font-weight: bold;
-	}
-	.token.italic {
-		font-style: italic;
-	}
-
-	.token.entity {
-		cursor: help;
-	}
 `;
 
 export const CodeBlockComponent = ({
 	code,
-	// Igoring language, while Prism.highlight is being fixed.
+	// Date: May 2021
+	//     The CodeBlockComponent is taking a `language` attribute which comes from CAPI
+	//     for the purpose of syntaxt highlighting, but we decided to not perform that highlighting
+	//     for the moment. Feel free to implement it in the future, for instance using
+	//     https://prismjs.com
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	language = 'typescript',
+	language = 'text',
 }: Props) => {
-	/*
-	Not using Prism.highlight for the moment because it's broken. Will fix shortly.
-
-	const highlighted = Prism.highlight(
-		code,
-		Prism.languages[language],
-		language,
-	);
-	*/
-
 	return (
 		<pre className={codeStyles}>
 			<code>

--- a/yarn.lock
+++ b/yarn.lock
@@ -14850,13 +14850,6 @@ prismjs@^1.21.0, prismjs@~1.22.0:
   optionalDependencies:
     clipboard "^2.0.0"
 
-prismjs@^1.23.0:
-  version "1.23.0"
-  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.23.0.tgz#d3b3967f7d72440690497652a9d40ff046067f33"
-  integrity sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==
-  optionalDependencies:
-    clipboard "^2.0.0"
-
 private@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"


### PR DESCRIPTION
Remove PrismJS that we are not going to use for the moment.  In essence, make this change ( https://github.com/guardian/dotcom-rendering/pull/3002 ) permanent.

![Screenshot 2021-05-19 at 14 43 30](https://user-images.githubusercontent.com/6035518/118823081-9ba57980-b8b0-11eb-918d-7ea4c253917d.png)
