### PR TITLE
ArticleHeadline use Emotion 11

### DIFF
--- a/src/web/components/ArticleHeadline.tsx
+++ b/src/web/components/ArticleHeadline.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from 'emotion';
+import { css } from '@emotion/react';
 
 import { HeadlineTag } from '@root/src/web/components/HeadlineTag';
 import { HeadlineByline } from '@root/src/web/components/HeadlineByline';
@@ -220,13 +220,13 @@ export const ArticleHeadline = ({
 	if (format.display === Display.NumberedList) {
 		return (
 			<h1
-				className={cx(
+				css={[
 					boldFont,
 					topPadding,
 					css`
 						color: ${palette.text.headline};
 					`,
-				)}
+				]}
 			>
 				{curly(headlineString)}
 			</h1>
@@ -239,13 +239,13 @@ export const ArticleHeadline = ({
 					return (
 						// Immersive headlines have two versions, with main media, and (this one) without
 						<h1
-							className={cx(
+							css={[
 								jumboFont,
 								maxWidth,
 								immersiveStyles,
 								displayBlock,
 								reducedBottomPadding,
-							)}
+							]}
 						>
 							{curly(headlineString)}
 						</h1>
@@ -256,13 +256,13 @@ export const ArticleHeadline = ({
 					return (
 						<>
 							<h1
-								className={cx(
+								css={[
 									lightFont,
 									invertedText,
 									css`
 										color: ${palette.text.headline};
 									`,
-								)}
+								]}
 							>
 								{curly(headlineString)}
 							</h1>
@@ -280,16 +280,16 @@ export const ArticleHeadline = ({
 						// Immersive headlines with main media present, are large and inverted with
 						// a black background
 						<h1
-							className={cx(
+							css={[
 								immersiveWrapper,
 								darkBackground(palette),
 								css`
 									color: ${palette.text.headline};
 								`,
-							)}
+							]}
 						>
 							<span
-								className={cx(
+								css={[
 									format.theme === Special.Labs
 										? jumboLabsFont
 										: jumboFont,
@@ -297,7 +297,7 @@ export const ArticleHeadline = ({
 									invertedStyles(palette),
 									immersiveStyles,
 									displayBlock,
-								)}
+								]}
 							>
 								{curly(headlineString)}
 							</span>
@@ -314,13 +314,13 @@ export const ArticleHeadline = ({
 				case Design.Feature:
 					return (
 						<h1
-							className={cx(
+							css={[
 								boldFont,
 								topPadding,
 								css`
 									color: ${palette.text.headline};
 								`,
-							)}
+							]}
 						>
 							{curly(headlineString)}
 						</h1>
@@ -330,13 +330,13 @@ export const ArticleHeadline = ({
 					return (
 						<>
 							<h1
-								className={cx(
+								css={[
 									lightFont,
 									topPadding,
 									css`
 										color: ${palette.text.headline};
 									`,
-								)}
+								]}
 							>
 								{curly(headlineString)}
 							</h1>
@@ -354,13 +354,13 @@ export const ArticleHeadline = ({
 					return (
 						<>
 							<h1
-								className={cx(
+								css={[
 									lightFont,
 									topPadding,
 									css`
 										color: ${palette.text.headline};
 									`,
-								)}
+								]}
 							>
 								{curly(headlineString)}
 							</h1>
@@ -369,14 +369,14 @@ export const ArticleHeadline = ({
 				case Design.Analysis:
 					return (
 						<h1
-							className={cx(
+							css={[
 								standardFont,
 								topPadding,
 								underlinedStyles,
 								css`
 									color: ${palette.text.headline};
 								`,
-							)}
+							]}
 						>
 							{curly(headlineString)}
 						</h1>
@@ -385,29 +385,27 @@ export const ArticleHeadline = ({
 					return (
 						// Inverted headlines have a wrapper div for positioning
 						// and a black background (only for the text)
-						<div
-							className={cx(shiftSlightly, maxWidth, displayFlex)}
-						>
+						<div css={[shiftSlightly, maxWidth, displayFlex]}>
 							<HeadlineTag
 								tagText="Interview"
 								palette={palette}
 							/>
 							<h1
-								className={cx(
+								css={[
 									invertedFont,
 									invertedWrapper,
 									zIndex,
 									css`
 										color: ${palette.text.headline};
 									`,
-								)}
+								]}
 							>
 								<span
-									className={cx(
+									css={[
 										darkBackground(palette),
 										invertedStyles(palette),
 										displayInline,
-									)}
+									]}
 								>
 									{curly(headlineString)}
 								</span>
@@ -425,12 +423,12 @@ export const ArticleHeadline = ({
 				case Design.DeadBlog:
 					return (
 						<h1
-							className={cx(
+							css={[
 								standardFont,
 								css`
 									color: ${palette.text.headline};
 								`,
-							)}
+							]}
 						>
 							{curly(headlineString)}
 						</h1>
@@ -438,7 +436,7 @@ export const ArticleHeadline = ({
 				default:
 					return (
 						<h1
-							className={cx(
+							css={[
 								format.theme === Special.Labs
 									? labsFont
 									: standardFont,
@@ -446,7 +444,7 @@ export const ArticleHeadline = ({
 								css`
 									color: ${palette.text.headline};
 								`,
-							)}
+							]}
 						>
 							{curly(headlineString)}
 						</h1>


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Updates `ArticleHeadline` to use Emotion 11

## Why?
This is a basic example of how we plan on implementing Emotion 11 on a component. We should not see any Visual regression issues and can use this pattern going forward